### PR TITLE
ci(agent-sdk-docs): resolve pdoc3 cross-reference links for Docusaurus

### DIFF
--- a/.github/workflows/agent-sdk-docs-generate.yml
+++ b/.github/workflows/agent-sdk-docs-generate.yml
@@ -128,6 +128,103 @@ jobs:
           done
           echo "Added Docusaurus frontmatter to all generated files (excluding readme.md)"
 
+      - name: Resolve pdoc3 Cross-References
+        run: |
+          # pdoc3 generates same-page anchor links (#SymbolName) that assume
+          # every symbol lives on a single HTML page. In Docusaurus each
+          # module is its own page, so these anchors are broken.
+          #
+          # This step:
+          #   1. Adds <a id="SymbolName"></a> anchors before each
+          #      function/class definition so same-page links work.
+          #   2. Rewrites cross-page #anchor links to relative file paths
+          #      (e.g. index.md#connect) so inter-module references work.
+          python3 << 'PYEOF'
+          import re
+          from collections import defaultdict
+          from pathlib import Path
+
+          base_dir = Path("docs/ai-agents/reference/sdk")
+
+          # ── Build symbol index ──────────────────────────────────────
+          symbol_files: dict[str, set[str]] = defaultdict(set)
+          file_symbols: dict[str, set[str]] = defaultdict(set)
+
+          for md_path in base_dir.rglob("*.md"):
+              if md_path.name.lower() == "readme.md":
+                  continue
+              rel = str(md_path.relative_to(base_dir))
+              content = md_path.read_text(encoding="utf-8")
+              for m in re.finditer(r"^`(\w+)\(", content, re.MULTILINE):
+                  sym = m.group(1)
+                  symbol_files[sym].add(rel)
+                  file_symbols[rel].add(sym)
+
+          print(f"Indexed {len(symbol_files)} symbols across {len(file_symbols)} files")
+
+          # ── Add anchors and resolve links ───────────────────────────
+          for md_path in base_dir.rglob("*.md"):
+              if md_path.name.lower() == "readme.md":
+                  continue
+              rel = str(md_path.relative_to(base_dir))
+              content = md_path.read_text(encoding="utf-8")
+              original = content
+
+              # 1. Insert HTML anchor IDs before symbol definitions.
+              def _add_anchor(m: re.Match) -> str:
+                  return f'<a id="{m.group(1)}"></a>\n\n`{m.group(1)}('
+              content = re.sub(
+                  r"^`(\w+)\(", _add_anchor, content, flags=re.MULTILINE,
+              )
+
+              # 2. Resolve [text](#anchor) links.
+              current_dir = str(Path(rel).parent)
+
+              def _resolve_link(m: re.Match) -> str:
+                  text, anchor = m.group(1), m.group(2)
+
+                  # Same-page symbol — keep the anchor link as-is.
+                  if anchor in file_symbols[rel]:
+                      return m.group(0)
+
+                  candidates = symbol_files.get(anchor)
+                  if not candidates:
+                      # Unknown symbol — drop the link, keep display text.
+                      return text
+
+                  # Pick the best target: prefer index.md in the same
+                  # directory, then any index.md, then first alphabetically.
+                  target = None
+                  for c in sorted(candidates):
+                      if (
+                          Path(c).name == "index.md"
+                          and str(Path(c).parent) == current_dir
+                      ):
+                          target = c
+                          break
+                  if target is None:
+                      for c in sorted(candidates):
+                          if Path(c).name == "index.md":
+                              target = c
+                              break
+                  if target is None:
+                      target = sorted(candidates)[0]
+
+                  from os.path import relpath
+                  target_rel = relpath(target, current_dir)
+                  return f"[{text}]({target_rel}#{anchor})"
+
+              content = re.sub(
+                  r"\[([^\]]+)\]\(#(\w+)\)", _resolve_link, content,
+              )
+
+              if content != original:
+                  md_path.write_text(content, encoding="utf-8")
+                  print(f"Resolved: {md_path}")
+
+          print("Cross-reference resolution complete")
+          PYEOF
+
       - name: Sanitize for MDX Compatibility
         run: |
           # Docusaurus uses MDX which interprets { and } as JSX expressions,

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/auth_strategies.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/auth_strategies.md
@@ -10,6 +10,8 @@ Authentication strategy pattern implementation for HTTP client.
 Functions
 ---------
 
+<a id="extract_secret_value"></a>
+
 `extract_secret_value(value: SecretStr | str | None) ‑> str`
 :   Extract the actual value from SecretStr or return plain string.
     
@@ -38,6 +40,8 @@ Functions
 Classes
 -------
 
+<a id="APIKeyAuthConfig"></a>
+
 `APIKeyAuthConfig(*args, **kwargs)`
 :   Configuration for API key authentication.
     
@@ -57,6 +61,8 @@ Classes
     `prefix: str`
     :   The type of the None singleton.
 
+<a id="APIKeyAuthSecrets"></a>
+
 `APIKeyAuthSecrets(*args, **kwargs)`
 :   Required secrets for API key authentication.
     
@@ -71,6 +77,8 @@ Classes
 
     `api_key: pydantic.types.SecretStr | str`
     :   The type of the None singleton.
+
+<a id="APIKeyAuthStrategy"></a>
 
 `APIKeyAuthStrategy()`
 :   Strategy for API key authentication.
@@ -101,6 +109,8 @@ Classes
         
         Args:
             secrets: API key credentials to validate
+
+<a id="AuthStrategy"></a>
 
 `AuthStrategy()`
 :   Abstract base class for authentication strategies.
@@ -189,6 +199,8 @@ Classes
         Raises:
             AuthenticationError: If required credentials are missing
 
+<a id="AuthStrategyFactory"></a>
+
 `AuthStrategyFactory()`
 :   Factory for creating authentication strategies.
 
@@ -213,6 +225,8 @@ Classes
             auth_type: Authentication type to register
             strategy: Strategy instance to use for this auth type
 
+<a id="BasicAuthSecrets"></a>
+
 `BasicAuthSecrets(*args, **kwargs)`
 :   Required secrets for HTTP Basic authentication.
     
@@ -231,6 +245,8 @@ Classes
 
     `username: pydantic.types.SecretStr | str`
     :   The type of the None singleton.
+
+<a id="BasicAuthStrategy"></a>
 
 `BasicAuthStrategy()`
 :   Strategy for HTTP Basic authentication.
@@ -262,6 +278,8 @@ Classes
         Args:
             secrets: Basic auth credentials to validate
 
+<a id="BearerAuthConfig"></a>
+
 `BearerAuthConfig(*args, **kwargs)`
 :   Configuration for Bearer token authentication.
     
@@ -281,6 +299,8 @@ Classes
     `prefix: str`
     :   The type of the None singleton.
 
+<a id="BearerAuthSecrets"></a>
+
 `BearerAuthSecrets(*args, **kwargs)`
 :   Required secrets for Bearer authentication.
     
@@ -295,6 +315,8 @@ Classes
 
     `token: pydantic.types.SecretStr | str`
     :   The type of the None singleton.
+
+<a id="BearerAuthStrategy"></a>
 
 `BearerAuthStrategy()`
 :   Strategy for Bearer token authentication.
@@ -325,6 +347,8 @@ Classes
         
         Args:
             secrets: Bearer token credentials to validate
+
+<a id="OAuth2AuthConfig"></a>
 
 `OAuth2AuthConfig(*args, **kwargs)`
 :   Configuration for OAuth 2.0 authentication.
@@ -420,6 +444,8 @@ Classes
     `subdomain: str`
     :   The type of the None singleton.
 
+<a id="OAuth2AuthSecrets"></a>
+
 `OAuth2AuthSecrets(*args, **kwargs)`
 :   Required secrets for OAuth 2.0 authentication.
     
@@ -446,6 +472,8 @@ Classes
 
     `access_token: pydantic.types.SecretStr | str`
     :   The type of the None singleton.
+
+<a id="OAuth2AuthStrategy"></a>
 
 `OAuth2AuthStrategy()`
 :   Strategy for OAuth 2.0 authentication with token refresh support.
@@ -552,6 +580,8 @@ Classes
         Raises:
             AuthenticationError: If neither access_token nor refresh_token is present
 
+<a id="OAuth2RefreshSecrets"></a>
+
 `OAuth2RefreshSecrets(*args, **kwargs)`
 :   Extended OAuth2 secrets including optional refresh-related fields.
     
@@ -629,6 +659,8 @@ Classes
     `token_type: str`
     :   The type of the None singleton.
 
+<a id="OAuth2TokenRefresher"></a>
+
 `OAuth2TokenRefresher(http_client: httpx.AsyncClient | None = None, config_values: dict[str, str] | None = None)`
 :   Handles OAuth2 token refresh HTTP requests.
     
@@ -676,6 +708,8 @@ Classes
         
         Raises:
             AuthenticationError: If refresh fails or required fields missing
+
+<a id="TokenRefreshResult"></a>
 
 `TokenRefreshResult(tokens: dict[str, str], extracted_values: dict[str, str] | None = None)`
 :   Result of an OAuth2 token refresh operation.

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/config.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/config.md
@@ -10,14 +10,20 @@ Global SDK configuration for Airbyte credentials.
 Functions
 ---------
 
+<a id="configure"></a>
+
 `configure(*, client_id: str, client_secret: str, organization_id: str | None = None, workspace_name: str = 'default') ‑> None`
 :   Set global SDK credentials. These are used as defaults by connect(), Workspace, and ask().
     
     Calling configure() again overwrites the previous configuration.
     Explicit kwargs passed to connect()/Workspace()/ask() always take priority.
 
+<a id="get_config"></a>
+
 `get_config() ‑> airbyte_agent_sdk.config.SDKConfig | None`
 :   
+
+<a id="resolve_credentials"></a>
 
 `resolve_credentials(*, client_id: str | None = None, client_secret: str | None = None, organization_id: str | None = None, workspace_name: str | None = None) ‑> tuple[str, str, str | None, str]`
 :   Resolve credentials: explicit arg -> global config -> env var.
@@ -27,6 +33,8 @@ Functions
 
 Classes
 -------
+
+<a id="SDKConfig"></a>
 
 `SDKConfig(client_id: str, client_secret: str, organization_id: str | None = None, workspace_name: str = 'default')`
 :   SDKConfig(client_id: 'str', client_secret: 'str', organization_id: 'str | None' = None, workspace_name: 'str' = 'default')

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/airtable/connector.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/airtable/connector.md
@@ -10,6 +10,8 @@ Airtable connector.
 Classes
 -------
 
+<a id="AirtableConnector"></a>
+
 `AirtableConnector(auth_config: AirtableAuthConfig | AirbyteAuthConfig | BaseModel | None = None, on_token_refresh: Any | None = None)`
 :   Type-safe Airtable API connector.
     
@@ -198,6 +200,8 @@ Classes
             for entity in entities:
                 print(f"\{entity['entity_name']\}: \{entity['available_actions']\}")
 
+<a id="BasesQuery"></a>
+
 `BasesQuery(connector: AirtableConnector)`
 :   Query class for Bases entity operations.
     
@@ -240,6 +244,8 @@ Classes
         Returns:
             BasesListResult
 
+<a id="RecordsQuery"></a>
+
 `RecordsQuery(connector: AirtableConnector)`
 :   Query class for Records entity operations.
     
@@ -274,6 +280,8 @@ Classes
         
         Returns:
             RecordsListResult
+
+<a id="TablesQuery"></a>
 
 `TablesQuery(connector: AirtableConnector)`
 :   Query class for Tables entity operations.

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/airtable/index.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/airtable/index.md
@@ -19,6 +19,8 @@ Sub-modules
 Classes
 -------
 
+<a id="AirbyteAuthConfig"></a>
+
 `AirbyteAuthConfig(**data: Any)`
 :   Authentication configuration for Airbyte hosted mode execution.
     
@@ -87,6 +89,8 @@ Classes
     `workspace_name: str | None`
     :   The type of the None singleton.
 
+<a id="AirbyteSearchMeta"></a>
+
 `AirbyteSearchMeta(**data: Any)`
 :   Pagination metadata for search responses.
     
@@ -114,6 +118,8 @@ Classes
 
     `took_ms: int | None`
     :   Time taken to execute the search in milliseconds.
+
+<a id="AirbyteSearchResult"></a>
 
 `AirbyteSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -146,6 +152,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="BasesSearchResult"></a>
+
 `BasesSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -162,6 +170,8 @@ Classes
     * pydantic.main.BaseModel
     * typing.Generic
 
+<a id="TablesSearchResult"></a>
+
 `TablesSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -177,6 +187,8 @@ Classes
     * airbyte_agent_sdk.connectors.airtable.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="AirtableAuthConfig"></a>
 
 `AirtableAuthConfig(**data: Any)`
 :   Personal Access Token
@@ -199,6 +211,8 @@ Classes
 
     `personal_access_token: str`
     :   Airtable Personal Access Token. See https://airtable.com/developers/web/guides/personal-access-tokens
+
+<a id="AirtableConnector"></a>
 
 `AirtableConnector(auth_config: AirtableAuthConfig | AirbyteAuthConfig | BaseModel | None = None, on_token_refresh: Any | None = None)`
 :   Type-safe Airtable API connector.
@@ -388,6 +402,8 @@ Classes
             for entity in entities:
                 print(f"\{entity['entity_name']\}: \{entity['available_actions']\}")
 
+<a id="BasesSearchData"></a>
+
 `BasesSearchData(**data: Any)`
 :   Search result data for bases entity.
     
@@ -415,6 +431,8 @@ Classes
 
     `permission_level: str | None`
     :   Permission level for the base
+
+<a id="TablesSearchData"></a>
 
 `TablesSearchData(**data: Any)`
 :   Search result data for tables entity.

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/airtable/models.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/airtable/models.md
@@ -13,6 +13,8 @@ and response envelope types.
 Classes
 -------
 
+<a id="AirbyteSearchMeta"></a>
+
 `AirbyteSearchMeta(**data: Any)`
 :   Pagination metadata for search responses.
     
@@ -40,6 +42,8 @@ Classes
 
     `took_ms: int | None`
     :   Time taken to execute the search in milliseconds.
+
+<a id="AirbyteSearchResult"></a>
 
 `AirbyteSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -93,6 +97,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="BasesSearchResult"></a>
+
 `BasesSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -130,6 +136,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="TablesSearchResult"></a>
+
 `TablesSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -145,6 +153,8 @@ Classes
     * airbyte_agent_sdk.connectors.airtable.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="AirtableAuthConfig"></a>
 
 `AirtableAuthConfig(**data: Any)`
 :   Personal Access Token
@@ -167,6 +177,8 @@ Classes
 
     `personal_access_token: str`
     :   Airtable Personal Access Token. See https://airtable.com/developers/web/guides/personal-access-tokens
+
+<a id="AirtableCheckResult"></a>
 
 `AirtableCheckResult(**data: Any)`
 :   Result of a health check operation.
@@ -201,6 +213,8 @@ Classes
     `status: str`
     :   Health check status: 'healthy' or 'unhealthy'.
 
+<a id="AirtableExecuteResult"></a>
+
 `AirtableExecuteResult(**data: Any)`
 :   Response envelope with data only.
     
@@ -230,6 +244,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="AirtableExecuteResultWithMeta"></a>
 
 `AirtableExecuteResultWithMeta(**data: Any)`
 :   Response envelope with data and metadata.
@@ -283,6 +299,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="BasesListResult"></a>
+
 `BasesListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -326,6 +344,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="RecordsListResult"></a>
+
 `RecordsListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -368,6 +388,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="TablesListResult"></a>
+
 `TablesListResult(**data: Any)`
 :   Response envelope with data only.
     
@@ -385,6 +407,8 @@ Classes
     * airbyte_agent_sdk.connectors.airtable.models.AirtableExecuteResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="Base"></a>
 
 `Base(**data: Any)`
 :   An Airtable base (workspace)
@@ -414,6 +438,8 @@ Classes
     `permission_level: str | Any | None`
     :   The type of the None singleton.
 
+<a id="BasesList"></a>
+
 `BasesList(**data: Any)`
 :   Paginated list of bases
     
@@ -439,6 +465,8 @@ Classes
     `offset: str | Any | None`
     :   The type of the None singleton.
 
+<a id="BasesListResultMeta"></a>
+
 `BasesListResultMeta(**data: Any)`
 :   Metadata for bases.Action.LIST operation
     
@@ -460,6 +488,8 @@ Classes
 
     `offset: str | Any | None`
     :   The type of the None singleton.
+
+<a id="BasesSearchData"></a>
 
 `BasesSearchData(**data: Any)`
 :   Search result data for bases entity.
@@ -489,6 +519,8 @@ Classes
     `permission_level: str | None`
     :   Permission level for the base
 
+<a id="Record"></a>
+
 `Record(**data: Any)`
 :   A record (row) in an Airtable table
     
@@ -517,6 +549,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="RecordsList"></a>
+
 `RecordsList(**data: Any)`
 :   Paginated list of records
     
@@ -542,6 +576,8 @@ Classes
     `records: list[airbyte_agent_sdk.connectors.airtable.models.Record] | Any`
     :   The type of the None singleton.
 
+<a id="RecordsListResultMeta"></a>
+
 `RecordsListResultMeta(**data: Any)`
 :   Metadata for records.Action.LIST operation
     
@@ -563,6 +599,8 @@ Classes
 
     `offset: str | Any | None`
     :   The type of the None singleton.
+
+<a id="Table"></a>
 
 `Table(**data: Any)`
 :   A table within an Airtable base
@@ -598,6 +636,8 @@ Classes
     `views: list[airbyte_agent_sdk.connectors.airtable.models.View] | Any | None`
     :   The type of the None singleton.
 
+<a id="TableField"></a>
+
 `TableField(**data: Any)`
 :   A field (column) in a table
     
@@ -629,6 +669,8 @@ Classes
     `type_: str | Any | None`
     :   The type of the None singleton.
 
+<a id="TablesList"></a>
+
 `TablesList(**data: Any)`
 :   List of tables in a base
     
@@ -650,6 +692,8 @@ Classes
 
     `tables: list[airbyte_agent_sdk.connectors.airtable.models.Table] | Any`
     :   The type of the None singleton.
+
+<a id="TablesSearchData"></a>
 
 `TablesSearchData(**data: Any)`
 :   Search result data for tables entity.
@@ -684,6 +728,8 @@ Classes
 
     `views: list[typing.Any] | None`
     :   List of views in the table
+
+<a id="View"></a>
 
 `View(**data: Any)`
 :   A view in a table

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/airtable/types.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/airtable/types.md
@@ -10,6 +10,8 @@ Type definitions for airtable connector.
 Classes
 -------
 
+<a id="AirbyteSearchParams"></a>
+
 `AirbyteSearchParams(*args, **kwargs)`
 :   Parameters for Airbyte cache search operations (generic, use entity-specific query types for better type hints).
 
@@ -31,6 +33,8 @@ Classes
     `query: dict[str, typing.Any]`
     :   The type of the None singleton.
 
+<a id="BasesAndCondition"></a>
+
 `BasesAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -50,6 +54,8 @@ Classes
 
     `and: list[airbyte_agent_sdk.connectors.airtable.types.BasesEqCondition | airbyte_agent_sdk.connectors.airtable.types.BasesNeqCondition | airbyte_agent_sdk.connectors.airtable.types.BasesGtCondition | airbyte_agent_sdk.connectors.airtable.types.BasesGteCondition | airbyte_agent_sdk.connectors.airtable.types.BasesLtCondition | airbyte_agent_sdk.connectors.airtable.types.BasesLteCondition | airbyte_agent_sdk.connectors.airtable.types.BasesInCondition | airbyte_agent_sdk.connectors.airtable.types.BasesLikeCondition | airbyte_agent_sdk.connectors.airtable.types.BasesFuzzyCondition | airbyte_agent_sdk.connectors.airtable.types.BasesKeywordCondition | airbyte_agent_sdk.connectors.airtable.types.BasesContainsCondition | airbyte_agent_sdk.connectors.airtable.types.BasesNotCondition | airbyte_agent_sdk.connectors.airtable.types.BasesAndCondition | airbyte_agent_sdk.connectors.airtable.types.BasesOrCondition | airbyte_agent_sdk.connectors.airtable.types.BasesAnyCondition]`
     :   The type of the None singleton.
+
+<a id="BasesAnyCondition"></a>
 
 `BasesAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -71,6 +77,8 @@ Classes
     `any: airbyte_agent_sdk.connectors.airtable.types.BasesAnyValueFilter`
     :   The type of the None singleton.
 
+<a id="BasesAnyValueFilter"></a>
+
 `BasesAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
 
@@ -89,6 +97,8 @@ Classes
     `permission_level: Any`
     :   Permission level for the base
 
+<a id="BasesContainsCondition"></a>
+
 `BasesContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -100,6 +110,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.airtable.types.BasesAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="BasesEqCondition"></a>
 
 `BasesEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -113,6 +125,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.airtable.types.BasesSearchFilter`
     :   The type of the None singleton.
 
+<a id="BasesFuzzyCondition"></a>
+
 `BasesFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -124,6 +138,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.airtable.types.BasesStringFilter`
     :   The type of the None singleton.
+
+<a id="BasesGtCondition"></a>
 
 `BasesGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
@@ -137,6 +153,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.airtable.types.BasesSearchFilter`
     :   The type of the None singleton.
 
+<a id="BasesGteCondition"></a>
+
 `BasesGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -148,6 +166,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.airtable.types.BasesSearchFilter`
     :   The type of the None singleton.
+
+<a id="BasesInCondition"></a>
 
 `BasesInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -169,6 +189,8 @@ Classes
     `in: airbyte_agent_sdk.connectors.airtable.types.BasesInFilter`
     :   The type of the None singleton.
 
+<a id="BasesInFilter"></a>
+
 `BasesInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
 
@@ -187,6 +209,8 @@ Classes
     `permission_level: list[str]`
     :   Permission level for the base
 
+<a id="BasesKeywordCondition"></a>
+
 `BasesKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -198,6 +222,8 @@ Classes
 
     `keyword: airbyte_agent_sdk.connectors.airtable.types.BasesStringFilter`
     :   The type of the None singleton.
+
+<a id="BasesLikeCondition"></a>
 
 `BasesLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
@@ -211,6 +237,8 @@ Classes
     `like: airbyte_agent_sdk.connectors.airtable.types.BasesStringFilter`
     :   The type of the None singleton.
 
+<a id="BasesListParams"></a>
+
 `BasesListParams(*args, **kwargs)`
 :   Parameters for bases.list operation
 
@@ -222,6 +250,8 @@ Classes
 
     `offset: str`
     :   The type of the None singleton.
+
+<a id="BasesLtCondition"></a>
 
 `BasesLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
@@ -235,6 +265,8 @@ Classes
     `lt: airbyte_agent_sdk.connectors.airtable.types.BasesSearchFilter`
     :   The type of the None singleton.
 
+<a id="BasesLteCondition"></a>
+
 `BasesLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
 
@@ -247,6 +279,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.airtable.types.BasesSearchFilter`
     :   The type of the None singleton.
 
+<a id="BasesNeqCondition"></a>
+
 `BasesNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -258,6 +292,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.airtable.types.BasesSearchFilter`
     :   The type of the None singleton.
+
+<a id="BasesNotCondition"></a>
 
 `BasesNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -279,6 +315,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.airtable.types.BasesEqCondition | airbyte_agent_sdk.connectors.airtable.types.BasesNeqCondition | airbyte_agent_sdk.connectors.airtable.types.BasesGtCondition | airbyte_agent_sdk.connectors.airtable.types.BasesGteCondition | airbyte_agent_sdk.connectors.airtable.types.BasesLtCondition | airbyte_agent_sdk.connectors.airtable.types.BasesLteCondition | airbyte_agent_sdk.connectors.airtable.types.BasesInCondition | airbyte_agent_sdk.connectors.airtable.types.BasesLikeCondition | airbyte_agent_sdk.connectors.airtable.types.BasesFuzzyCondition | airbyte_agent_sdk.connectors.airtable.types.BasesKeywordCondition | airbyte_agent_sdk.connectors.airtable.types.BasesContainsCondition | airbyte_agent_sdk.connectors.airtable.types.BasesNotCondition | airbyte_agent_sdk.connectors.airtable.types.BasesAndCondition | airbyte_agent_sdk.connectors.airtable.types.BasesOrCondition | airbyte_agent_sdk.connectors.airtable.types.BasesAnyCondition`
     :   The type of the None singleton.
 
+<a id="BasesOrCondition"></a>
+
 `BasesOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -299,6 +337,8 @@ Classes
     `or: list[airbyte_agent_sdk.connectors.airtable.types.BasesEqCondition | airbyte_agent_sdk.connectors.airtable.types.BasesNeqCondition | airbyte_agent_sdk.connectors.airtable.types.BasesGtCondition | airbyte_agent_sdk.connectors.airtable.types.BasesGteCondition | airbyte_agent_sdk.connectors.airtable.types.BasesLtCondition | airbyte_agent_sdk.connectors.airtable.types.BasesLteCondition | airbyte_agent_sdk.connectors.airtable.types.BasesInCondition | airbyte_agent_sdk.connectors.airtable.types.BasesLikeCondition | airbyte_agent_sdk.connectors.airtable.types.BasesFuzzyCondition | airbyte_agent_sdk.connectors.airtable.types.BasesKeywordCondition | airbyte_agent_sdk.connectors.airtable.types.BasesContainsCondition | airbyte_agent_sdk.connectors.airtable.types.BasesNotCondition | airbyte_agent_sdk.connectors.airtable.types.BasesAndCondition | airbyte_agent_sdk.connectors.airtable.types.BasesOrCondition | airbyte_agent_sdk.connectors.airtable.types.BasesAnyCondition]`
     :   The type of the None singleton.
 
+<a id="BasesSearchFilter"></a>
+
 `BasesSearchFilter(*args, **kwargs)`
 :   Available fields for filtering bases search queries.
 
@@ -317,6 +357,8 @@ Classes
     `permission_level: str | None`
     :   Permission level for the base
 
+<a id="BasesSearchQuery"></a>
+
 `BasesSearchQuery(*args, **kwargs)`
 :   Search query for bases entity.
 
@@ -331,6 +373,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.airtable.types.BasesSortFilter]`
     :   The type of the None singleton.
+
+<a id="BasesSortFilter"></a>
 
 `BasesSortFilter(*args, **kwargs)`
 :   Available fields for sorting bases search results.
@@ -350,6 +394,8 @@ Classes
     `permission_level: Literal['asc', 'desc']`
     :   Permission level for the base
 
+<a id="BasesStringFilter"></a>
+
 `BasesStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -368,6 +414,8 @@ Classes
     `permission_level: str`
     :   Permission level for the base
 
+<a id="RecordsGetParams"></a>
+
 `RecordsGetParams(*args, **kwargs)`
 :   Parameters for records.get operation
 
@@ -385,6 +433,8 @@ Classes
 
     `table_id_or_name: str`
     :   The type of the None singleton.
+
+<a id="RecordsListParams"></a>
 
 `RecordsListParams(*args, **kwargs)`
 :   Parameters for records.list operation
@@ -416,6 +466,8 @@ Classes
     `view: str`
     :   The type of the None singleton.
 
+<a id="TablesAndCondition"></a>
+
 `TablesAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -436,6 +488,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.airtable.types.TablesEqCondition | airbyte_agent_sdk.connectors.airtable.types.TablesNeqCondition | airbyte_agent_sdk.connectors.airtable.types.TablesGtCondition | airbyte_agent_sdk.connectors.airtable.types.TablesGteCondition | airbyte_agent_sdk.connectors.airtable.types.TablesLtCondition | airbyte_agent_sdk.connectors.airtable.types.TablesLteCondition | airbyte_agent_sdk.connectors.airtable.types.TablesInCondition | airbyte_agent_sdk.connectors.airtable.types.TablesLikeCondition | airbyte_agent_sdk.connectors.airtable.types.TablesFuzzyCondition | airbyte_agent_sdk.connectors.airtable.types.TablesKeywordCondition | airbyte_agent_sdk.connectors.airtable.types.TablesContainsCondition | airbyte_agent_sdk.connectors.airtable.types.TablesNotCondition | airbyte_agent_sdk.connectors.airtable.types.TablesAndCondition | airbyte_agent_sdk.connectors.airtable.types.TablesOrCondition | airbyte_agent_sdk.connectors.airtable.types.TablesAnyCondition]`
     :   The type of the None singleton.
 
+<a id="TablesAnyCondition"></a>
+
 `TablesAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -455,6 +509,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.airtable.types.TablesAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="TablesAnyValueFilter"></a>
 
 `TablesAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -480,6 +536,8 @@ Classes
     `views: Any`
     :   List of views in the table
 
+<a id="TablesContainsCondition"></a>
+
 `TablesContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -491,6 +549,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.airtable.types.TablesAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="TablesEqCondition"></a>
 
 `TablesEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -504,6 +564,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.airtable.types.TablesSearchFilter`
     :   The type of the None singleton.
 
+<a id="TablesFuzzyCondition"></a>
+
 `TablesFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -515,6 +577,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.airtable.types.TablesStringFilter`
     :   The type of the None singleton.
+
+<a id="TablesGtCondition"></a>
 
 `TablesGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
@@ -528,6 +592,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.airtable.types.TablesSearchFilter`
     :   The type of the None singleton.
 
+<a id="TablesGteCondition"></a>
+
 `TablesGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -539,6 +605,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.airtable.types.TablesSearchFilter`
     :   The type of the None singleton.
+
+<a id="TablesInCondition"></a>
 
 `TablesInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -559,6 +627,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.airtable.types.TablesInFilter`
     :   The type of the None singleton.
+
+<a id="TablesInFilter"></a>
 
 `TablesInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -584,6 +654,8 @@ Classes
     `views: list[list[typing.Any]]`
     :   List of views in the table
 
+<a id="TablesKeywordCondition"></a>
+
 `TablesKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -595,6 +667,8 @@ Classes
 
     `keyword: airbyte_agent_sdk.connectors.airtable.types.TablesStringFilter`
     :   The type of the None singleton.
+
+<a id="TablesLikeCondition"></a>
 
 `TablesLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
@@ -608,6 +682,8 @@ Classes
     `like: airbyte_agent_sdk.connectors.airtable.types.TablesStringFilter`
     :   The type of the None singleton.
 
+<a id="TablesListParams"></a>
+
 `TablesListParams(*args, **kwargs)`
 :   Parameters for tables.list operation
 
@@ -619,6 +695,8 @@ Classes
 
     `base_id: str`
     :   The type of the None singleton.
+
+<a id="TablesLtCondition"></a>
 
 `TablesLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
@@ -632,6 +710,8 @@ Classes
     `lt: airbyte_agent_sdk.connectors.airtable.types.TablesSearchFilter`
     :   The type of the None singleton.
 
+<a id="TablesLteCondition"></a>
+
 `TablesLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
 
@@ -644,6 +724,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.airtable.types.TablesSearchFilter`
     :   The type of the None singleton.
 
+<a id="TablesNeqCondition"></a>
+
 `TablesNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -655,6 +737,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.airtable.types.TablesSearchFilter`
     :   The type of the None singleton.
+
+<a id="TablesNotCondition"></a>
 
 `TablesNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -676,6 +760,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.airtable.types.TablesEqCondition | airbyte_agent_sdk.connectors.airtable.types.TablesNeqCondition | airbyte_agent_sdk.connectors.airtable.types.TablesGtCondition | airbyte_agent_sdk.connectors.airtable.types.TablesGteCondition | airbyte_agent_sdk.connectors.airtable.types.TablesLtCondition | airbyte_agent_sdk.connectors.airtable.types.TablesLteCondition | airbyte_agent_sdk.connectors.airtable.types.TablesInCondition | airbyte_agent_sdk.connectors.airtable.types.TablesLikeCondition | airbyte_agent_sdk.connectors.airtable.types.TablesFuzzyCondition | airbyte_agent_sdk.connectors.airtable.types.TablesKeywordCondition | airbyte_agent_sdk.connectors.airtable.types.TablesContainsCondition | airbyte_agent_sdk.connectors.airtable.types.TablesNotCondition | airbyte_agent_sdk.connectors.airtable.types.TablesAndCondition | airbyte_agent_sdk.connectors.airtable.types.TablesOrCondition | airbyte_agent_sdk.connectors.airtable.types.TablesAnyCondition`
     :   The type of the None singleton.
 
+<a id="TablesOrCondition"></a>
+
 `TablesOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -695,6 +781,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.airtable.types.TablesEqCondition | airbyte_agent_sdk.connectors.airtable.types.TablesNeqCondition | airbyte_agent_sdk.connectors.airtable.types.TablesGtCondition | airbyte_agent_sdk.connectors.airtable.types.TablesGteCondition | airbyte_agent_sdk.connectors.airtable.types.TablesLtCondition | airbyte_agent_sdk.connectors.airtable.types.TablesLteCondition | airbyte_agent_sdk.connectors.airtable.types.TablesInCondition | airbyte_agent_sdk.connectors.airtable.types.TablesLikeCondition | airbyte_agent_sdk.connectors.airtable.types.TablesFuzzyCondition | airbyte_agent_sdk.connectors.airtable.types.TablesKeywordCondition | airbyte_agent_sdk.connectors.airtable.types.TablesContainsCondition | airbyte_agent_sdk.connectors.airtable.types.TablesNotCondition | airbyte_agent_sdk.connectors.airtable.types.TablesAndCondition | airbyte_agent_sdk.connectors.airtable.types.TablesOrCondition | airbyte_agent_sdk.connectors.airtable.types.TablesAnyCondition]`
     :   The type of the None singleton.
+
+<a id="TablesSearchFilter"></a>
 
 `TablesSearchFilter(*args, **kwargs)`
 :   Available fields for filtering tables search queries.
@@ -720,6 +808,8 @@ Classes
     `views: list[typing.Any] | None`
     :   List of views in the table
 
+<a id="TablesSearchQuery"></a>
+
 `TablesSearchQuery(*args, **kwargs)`
 :   Search query for tables entity.
 
@@ -734,6 +824,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.airtable.types.TablesSortFilter]`
     :   The type of the None singleton.
+
+<a id="TablesSortFilter"></a>
 
 `TablesSortFilter(*args, **kwargs)`
 :   Available fields for sorting tables search results.
@@ -758,6 +850,8 @@ Classes
 
     `views: Literal['asc', 'desc']`
     :   List of views in the table
+
+<a id="TablesStringFilter"></a>
 
 `TablesStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/amazon_ads/connector.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/amazon_ads/connector.md
@@ -10,6 +10,8 @@ Amazon-Ads connector.
 Classes
 -------
 
+<a id="AmazonAdsConnector"></a>
+
 `AmazonAdsConnector(auth_config: AmazonAdsAuthConfig | AirbyteAuthConfig | BaseModel | None = None, on_token_refresh: Any | None = None, region: str | None = None)`
 :   Type-safe Amazon-Ads API connector.
     
@@ -256,6 +258,8 @@ Classes
             for entity in entities:
                 print(f"\{entity['entity_name']\}: \{entity['available_actions']\}")
 
+<a id="PortfoliosQuery"></a>
+
 `PortfoliosQuery(connector: AmazonAdsConnector)`
 :   Query class for Portfolios entity operations.
     
@@ -285,6 +289,8 @@ Classes
         
                 Returns:
                     PortfoliosListResult
+
+<a id="ProfilesQuery"></a>
 
 `ProfilesQuery(connector: AmazonAdsConnector)`
 :   Query class for Profiles entity operations.
@@ -349,6 +355,8 @@ Classes
                 Returns:
                     ProfilesListResult
 
+<a id="SponsoredBrandsAdGroupsQuery"></a>
+
 `SponsoredBrandsAdGroupsQuery(connector: AmazonAdsConnector)`
 :   Query class for SponsoredBrandsAdGroups entity operations.
     
@@ -369,6 +377,8 @@ Classes
         
                 Returns:
                     SponsoredBrandsAdGroupsListResult
+
+<a id="SponsoredBrandsCampaignsQuery"></a>
 
 `SponsoredBrandsCampaignsQuery(connector: AmazonAdsConnector)`
 :   Query class for SponsoredBrandsCampaigns entity operations.
@@ -391,6 +401,8 @@ Classes
                 Returns:
                     SponsoredBrandsCampaignsListResult
 
+<a id="SponsoredProductAdGroupsQuery"></a>
+
 `SponsoredProductAdGroupsQuery(connector: AmazonAdsConnector)`
 :   Query class for SponsoredProductAdGroups entity operations.
     
@@ -411,6 +423,8 @@ Classes
         
                 Returns:
                     SponsoredProductAdGroupsListResult
+
+<a id="SponsoredProductCampaignsQuery"></a>
 
 `SponsoredProductCampaignsQuery(connector: AmazonAdsConnector)`
 :   Query class for SponsoredProductCampaigns entity operations.
@@ -444,6 +458,8 @@ Classes
                 Returns:
                     SponsoredProductCampaignsListResult
 
+<a id="SponsoredProductKeywordsQuery"></a>
+
 `SponsoredProductKeywordsQuery(connector: AmazonAdsConnector)`
 :   Query class for SponsoredProductKeywords entity operations.
     
@@ -464,6 +480,8 @@ Classes
         
                 Returns:
                     SponsoredProductKeywordsListResult
+
+<a id="SponsoredProductNegativeKeywordsQuery"></a>
 
 `SponsoredProductNegativeKeywordsQuery(connector: AmazonAdsConnector)`
 :   Query class for SponsoredProductNegativeKeywords entity operations.
@@ -486,6 +504,8 @@ Classes
                 Returns:
                     SponsoredProductNegativeKeywordsListResult
 
+<a id="SponsoredProductNegativeTargetsQuery"></a>
+
 `SponsoredProductNegativeTargetsQuery(connector: AmazonAdsConnector)`
 :   Query class for SponsoredProductNegativeTargets entity operations.
     
@@ -507,6 +527,8 @@ Classes
                 Returns:
                     SponsoredProductNegativeTargetsListResult
 
+<a id="SponsoredProductProductAdsQuery"></a>
+
 `SponsoredProductProductAdsQuery(connector: AmazonAdsConnector)`
 :   Query class for SponsoredProductProductAds entity operations.
     
@@ -527,6 +549,8 @@ Classes
         
                 Returns:
                     SponsoredProductProductAdsListResult
+
+<a id="SponsoredProductTargetsQuery"></a>
 
 `SponsoredProductTargetsQuery(connector: AmazonAdsConnector)`
 :   Query class for SponsoredProductTargets entity operations.

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/amazon_ads/index.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/amazon_ads/index.md
@@ -19,6 +19,8 @@ Sub-modules
 Classes
 -------
 
+<a id="AirbyteAuthConfig"></a>
+
 `AirbyteAuthConfig(**data: Any)`
 :   Authentication configuration for Airbyte hosted mode execution.
     
@@ -87,6 +89,8 @@ Classes
     `workspace_name: str | None`
     :   The type of the None singleton.
 
+<a id="AirbyteSearchMeta"></a>
+
 `AirbyteSearchMeta(**data: Any)`
 :   Pagination metadata for search responses.
     
@@ -114,6 +118,8 @@ Classes
 
     `took_ms: int | None`
     :   Time taken to execute the search in milliseconds.
+
+<a id="AirbyteSearchResult"></a>
 
 `AirbyteSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -145,6 +151,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="ProfilesSearchResult"></a>
+
 `ProfilesSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -160,6 +168,8 @@ Classes
     * airbyte_agent_sdk.connectors.amazon_ads.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="AmazonAdsAuthConfig"></a>
 
 `AmazonAdsAuthConfig(**data: Any)`
 :   OAuth2 Authentication
@@ -188,6 +198,8 @@ Classes
 
     `refresh_token: str`
     :   The refresh token obtained from the OAuth authorization flow
+
+<a id="AmazonAdsConnector"></a>
 
 `AmazonAdsConnector(auth_config: AmazonAdsAuthConfig | AirbyteAuthConfig | BaseModel | None = None, on_token_refresh: Any | None = None, region: str | None = None)`
 :   Type-safe Amazon-Ads API connector.
@@ -434,6 +446,8 @@ Classes
             entities = connector.list_entities()
             for entity in entities:
                 print(f"\{entity['entity_name']\}: \{entity['available_actions']\}")
+
+<a id="ProfilesSearchData"></a>
 
 `ProfilesSearchData(**data: Any)`
 :   Search result data for profiles entity.

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/amazon_ads/models.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/amazon_ads/models.md
@@ -13,6 +13,8 @@ and response envelope types.
 Classes
 -------
 
+<a id="AccountInfo"></a>
+
 `AccountInfo(**data: Any)`
 :   Information about the advertiser's account associated with a profile
     
@@ -50,6 +52,8 @@ Classes
     `valid_payment_method: bool | Any | None`
     :   The type of the None singleton.
 
+<a id="AirbyteSearchMeta"></a>
+
 `AirbyteSearchMeta(**data: Any)`
 :   Pagination metadata for search responses.
     
@@ -77,6 +81,8 @@ Classes
 
     `took_ms: int | None`
     :   Time taken to execute the search in milliseconds.
+
+<a id="AirbyteSearchResult"></a>
 
 `AirbyteSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -129,6 +135,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="ProfilesSearchResult"></a>
+
 `ProfilesSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -144,6 +152,8 @@ Classes
     * airbyte_agent_sdk.connectors.amazon_ads.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="AmazonAdsAuthConfig"></a>
 
 `AmazonAdsAuthConfig(**data: Any)`
 :   OAuth2 Authentication
@@ -172,6 +182,8 @@ Classes
 
     `refresh_token: str`
     :   The refresh token obtained from the OAuth authorization flow
+
+<a id="AmazonAdsCheckResult"></a>
 
 `AmazonAdsCheckResult(**data: Any)`
 :   Result of a health check operation.
@@ -206,6 +218,8 @@ Classes
     `status: str`
     :   Health check status: 'healthy' or 'unhealthy'.
 
+<a id="AmazonAdsExecuteResult"></a>
+
 `AmazonAdsExecuteResult(**data: Any)`
 :   Response envelope with data only.
     
@@ -235,6 +249,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="AmazonAdsExecuteResultWithMeta"></a>
 
 `AmazonAdsExecuteResultWithMeta(**data: Any)`
 :   Response envelope with data and metadata.
@@ -296,6 +312,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="PortfoliosListResult"></a>
+
 `PortfoliosListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -338,6 +356,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="SponsoredBrandsAdGroupsListResult"></a>
 
 `SponsoredBrandsAdGroupsListResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -382,6 +402,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="SponsoredBrandsCampaignsListResult"></a>
+
 `SponsoredBrandsCampaignsListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -424,6 +446,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="SponsoredProductAdGroupsListResult"></a>
 
 `SponsoredProductAdGroupsListResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -468,6 +492,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="SponsoredProductCampaignsListResult"></a>
+
 `SponsoredProductCampaignsListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -510,6 +536,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="SponsoredProductKeywordsListResult"></a>
 
 `SponsoredProductKeywordsListResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -554,6 +582,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="SponsoredProductNegativeKeywordsListResult"></a>
+
 `SponsoredProductNegativeKeywordsListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -596,6 +626,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="SponsoredProductNegativeTargetsListResult"></a>
 
 `SponsoredProductNegativeTargetsListResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -640,6 +672,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="SponsoredProductProductAdsListResult"></a>
+
 `SponsoredProductProductAdsListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -683,6 +717,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="SponsoredProductTargetsListResult"></a>
+
 `SponsoredProductTargetsListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -725,6 +761,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="ProfilesListResult"></a>
+
 `ProfilesListResult(**data: Any)`
 :   Response envelope with data only.
     
@@ -742,6 +780,8 @@ Classes
     * airbyte_agent_sdk.connectors.amazon_ads.models.AmazonAdsExecuteResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="CampaignBudget"></a>
 
 `CampaignBudget(**data: Any)`
 :   Budget configuration for a campaign
@@ -768,6 +808,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="DynamicBidding"></a>
+
 `DynamicBidding(**data: Any)`
 :   Dynamic bidding settings for a campaign
     
@@ -793,6 +835,8 @@ Classes
     `strategy: str | Any | None`
     :   The type of the None singleton.
 
+<a id="DynamicBiddingPlacementbiddingItem"></a>
+
 `DynamicBiddingPlacementbiddingItem(**data: Any)`
 :   Nested schema for DynamicBidding.placementBidding_item
     
@@ -817,6 +861,8 @@ Classes
 
     `placement: str | Any | None`
     :   The placement type
+
+<a id="Portfolio"></a>
 
 `Portfolio(**data: Any)`
 :   A portfolio is a container for grouping campaigns together for organizational
@@ -862,6 +908,8 @@ Classes
     `state: str | Any | None`
     :   The type of the None singleton.
 
+<a id="PortfolioBudget"></a>
+
 `PortfolioBudget(**data: Any)`
 :   Budget configuration for a portfolio
     
@@ -896,6 +944,8 @@ Classes
     `start_date: str | Any | None`
     :   The type of the None singleton.
 
+<a id="PortfoliosListResultMeta"></a>
+
 `PortfoliosListResultMeta(**data: Any)`
 :   Metadata for portfolios.Action.LIST operation
     
@@ -917,6 +967,8 @@ Classes
 
     `next_token: str | Any | None`
     :   The type of the None singleton.
+
+<a id="Profile"></a>
 
 `Profile(**data: Any)`
 :   An advertising profile represents an advertiser's account in a specific marketplace.
@@ -956,6 +1008,8 @@ Classes
     `timezone: str | Any | None`
     :   The type of the None singleton.
 
+<a id="ProfilesSearchData"></a>
+
 `ProfilesSearchData(**data: Any)`
 :   Search result data for profiles entity.
     
@@ -992,6 +1046,8 @@ Classes
 
     `timezone: str | None`
     :   The type of the None singleton.
+
+<a id="SponsoredBrandsAdGroup"></a>
 
 `SponsoredBrandsAdGroup(**data: Any)`
 :   An ad group within a Sponsored Brands campaign. Ad groups organize ads and targeting
@@ -1031,6 +1087,8 @@ Classes
     `state: str | Any | None`
     :   The type of the None singleton.
 
+<a id="SponsoredBrandsAdGroupsListResultMeta"></a>
+
 `SponsoredBrandsAdGroupsListResultMeta(**data: Any)`
 :   Metadata for sponsored_brands_ad_groups.Action.LIST operation
     
@@ -1052,6 +1110,8 @@ Classes
 
     `next_token: str | Any | None`
     :   The type of the None singleton.
+
+<a id="SponsoredBrandsCampaign"></a>
 
 `SponsoredBrandsCampaign(**data: Any)`
 :   A Sponsored Brands campaign. Sponsored Brands campaigns help drive discovery and sales
@@ -1118,6 +1178,8 @@ Classes
     `tags: dict[str, typing.Any] | Any | None`
     :   The type of the None singleton.
 
+<a id="SponsoredBrandsCampaignsListResultMeta"></a>
+
 `SponsoredBrandsCampaignsListResultMeta(**data: Any)`
 :   Metadata for sponsored_brands_campaigns.Action.LIST operation
     
@@ -1139,6 +1201,8 @@ Classes
 
     `next_token: str | Any | None`
     :   The type of the None singleton.
+
+<a id="SponsoredProductAdGroup"></a>
 
 `SponsoredProductAdGroup(**data: Any)`
 :   An ad group within a Sponsored Products campaign. Ad groups contain ads and targeting
@@ -1178,6 +1242,8 @@ Classes
     `state: str | Any | None`
     :   The type of the None singleton.
 
+<a id="SponsoredProductAdGroupsListResultMeta"></a>
+
 `SponsoredProductAdGroupsListResultMeta(**data: Any)`
 :   Metadata for sponsored_product_ad_groups.Action.LIST operation
     
@@ -1199,6 +1265,8 @@ Classes
 
     `next_token: str | Any | None`
     :   The type of the None singleton.
+
+<a id="SponsoredProductCampaign"></a>
 
 `SponsoredProductCampaign(**data: Any)`
 :   A Sponsored Products campaign promotes individual product listings on Amazon.
@@ -1272,6 +1340,8 @@ Classes
     `targeting_type: str | Any | None`
     :   The type of the None singleton.
 
+<a id="SponsoredProductCampaignsListResultMeta"></a>
+
 `SponsoredProductCampaignsListResultMeta(**data: Any)`
 :   Metadata for sponsored_product_campaigns.Action.LIST operation
     
@@ -1293,6 +1363,8 @@ Classes
 
     `next_token: str | Any | None`
     :   The type of the None singleton.
+
+<a id="SponsoredProductKeyword"></a>
 
 `SponsoredProductKeyword(**data: Any)`
 :   A keyword within a Sponsored Products ad group. Keywords are used in manual targeting
@@ -1338,6 +1410,8 @@ Classes
     `state: str | Any | None`
     :   The type of the None singleton.
 
+<a id="SponsoredProductKeywordsListResultMeta"></a>
+
 `SponsoredProductKeywordsListResultMeta(**data: Any)`
 :   Metadata for sponsored_product_keywords.Action.LIST operation
     
@@ -1359,6 +1433,8 @@ Classes
 
     `next_token: str | Any | None`
     :   The type of the None singleton.
+
+<a id="SponsoredProductNegativeKeyword"></a>
 
 `SponsoredProductNegativeKeyword(**data: Any)`
 :   A negative keyword within a Sponsored Products ad group. Negative keywords prevent
@@ -1401,6 +1477,8 @@ Classes
     `state: str | Any | None`
     :   The type of the None singleton.
 
+<a id="SponsoredProductNegativeKeywordsListResultMeta"></a>
+
 `SponsoredProductNegativeKeywordsListResultMeta(**data: Any)`
 :   Metadata for sponsored_product_negative_keywords.Action.LIST operation
     
@@ -1422,6 +1500,8 @@ Classes
 
     `next_token: str | Any | None`
     :   The type of the None singleton.
+
+<a id="SponsoredProductNegativeTarget"></a>
 
 `SponsoredProductNegativeTarget(**data: Any)`
 :   A negative targeting clause within a Sponsored Products ad group. Negative targeting
@@ -1467,6 +1547,8 @@ Classes
     `target_id: Any`
     :   The type of the None singleton.
 
+<a id="SponsoredProductNegativeTargetExpressionItem"></a>
+
 `SponsoredProductNegativeTargetExpressionItem(**data: Any)`
 :   Nested schema for SponsoredProductNegativeTarget.expression_item
     
@@ -1491,6 +1573,8 @@ Classes
 
     `value: str | Any | None`
     :   The expression value
+
+<a id="SponsoredProductNegativeTargetResolvedexpressionItem"></a>
 
 `SponsoredProductNegativeTargetResolvedexpressionItem(**data: Any)`
 :   Nested schema for SponsoredProductNegativeTarget.resolvedExpression_item
@@ -1517,6 +1601,8 @@ Classes
     `value: str | Any | None`
     :   The resolved expression value
 
+<a id="SponsoredProductNegativeTargetsListResultMeta"></a>
+
 `SponsoredProductNegativeTargetsListResultMeta(**data: Any)`
 :   Metadata for sponsored_product_negative_targets.Action.LIST operation
     
@@ -1538,6 +1624,8 @@ Classes
 
     `next_token: str | Any | None`
     :   The type of the None singleton.
+
+<a id="SponsoredProductProductAd"></a>
 
 `SponsoredProductProductAd(**data: Any)`
 :   A product ad within a Sponsored Products ad group. Product ads associate an
@@ -1580,6 +1668,8 @@ Classes
     `state: str | Any | None`
     :   The type of the None singleton.
 
+<a id="SponsoredProductProductAdsListResultMeta"></a>
+
 `SponsoredProductProductAdsListResultMeta(**data: Any)`
 :   Metadata for sponsored_product_product_ads.Action.LIST operation
     
@@ -1601,6 +1691,8 @@ Classes
 
     `next_token: str | Any | None`
     :   The type of the None singleton.
+
+<a id="SponsoredProductTarget"></a>
 
 `SponsoredProductTarget(**data: Any)`
 :   A targeting clause within a Sponsored Products ad group. Targeting clauses define
@@ -1649,6 +1741,8 @@ Classes
     `target_id: Any`
     :   The type of the None singleton.
 
+<a id="SponsoredProductTargetExpressionItem"></a>
+
 `SponsoredProductTargetExpressionItem(**data: Any)`
 :   Nested schema for SponsoredProductTarget.expression_item
     
@@ -1674,6 +1768,8 @@ Classes
     `value: str | Any | None`
     :   The expression value
 
+<a id="SponsoredProductTargetResolvedexpressionItem"></a>
+
 `SponsoredProductTargetResolvedexpressionItem(**data: Any)`
 :   Nested schema for SponsoredProductTarget.resolvedExpression_item
     
@@ -1698,6 +1794,8 @@ Classes
 
     `value: str | Any | None`
     :   The resolved expression value
+
+<a id="SponsoredProductTargetsListResultMeta"></a>
 
 `SponsoredProductTargetsListResultMeta(**data: Any)`
 :   Metadata for sponsored_product_targets.Action.LIST operation

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/amazon_ads/types.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/amazon_ads/types.md
@@ -10,6 +10,8 @@ Type definitions for amazon-ads connector.
 Classes
 -------
 
+<a id="AirbyteSearchParams"></a>
+
 `AirbyteSearchParams(*args, **kwargs)`
 :   Parameters for Airbyte cache search operations (generic, use entity-specific query types for better type hints).
 
@@ -31,6 +33,8 @@ Classes
     `query: dict[str, typing.Any]`
     :   The type of the None singleton.
 
+<a id="PortfoliosGetParams"></a>
+
 `PortfoliosGetParams(*args, **kwargs)`
 :   Parameters for portfolios.get operation
 
@@ -43,6 +47,8 @@ Classes
     `portfolio_id: str`
     :   The type of the None singleton.
 
+<a id="PortfoliosListParams"></a>
+
 `PortfoliosListParams(*args, **kwargs)`
 :   Parameters for portfolios.list operation
 
@@ -54,6 +60,8 @@ Classes
 
     `include_extended_data_fields: str`
     :   The type of the None singleton.
+
+<a id="ProfilesAndCondition"></a>
 
 `ProfilesAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -75,6 +83,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.amazon_ads.types.ProfilesEqCondition | airbyte_agent_sdk.connectors.amazon_ads.types.ProfilesNeqCondition | airbyte_agent_sdk.connectors.amazon_ads.types.ProfilesGtCondition | airbyte_agent_sdk.connectors.amazon_ads.types.ProfilesGteCondition | airbyte_agent_sdk.connectors.amazon_ads.types.ProfilesLtCondition | airbyte_agent_sdk.connectors.amazon_ads.types.ProfilesLteCondition | airbyte_agent_sdk.connectors.amazon_ads.types.ProfilesInCondition | airbyte_agent_sdk.connectors.amazon_ads.types.ProfilesLikeCondition | airbyte_agent_sdk.connectors.amazon_ads.types.ProfilesFuzzyCondition | airbyte_agent_sdk.connectors.amazon_ads.types.ProfilesKeywordCondition | airbyte_agent_sdk.connectors.amazon_ads.types.ProfilesContainsCondition | airbyte_agent_sdk.connectors.amazon_ads.types.ProfilesNotCondition | airbyte_agent_sdk.connectors.amazon_ads.types.ProfilesAndCondition | airbyte_agent_sdk.connectors.amazon_ads.types.ProfilesOrCondition | airbyte_agent_sdk.connectors.amazon_ads.types.ProfilesAnyCondition]`
     :   The type of the None singleton.
 
+<a id="ProfilesAnyCondition"></a>
+
 `ProfilesAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -94,6 +104,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.amazon_ads.types.ProfilesAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="ProfilesAnyValueFilter"></a>
 
 `ProfilesAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -122,6 +134,8 @@ Classes
     `timezone: Any`
     :   The type of the None singleton.
 
+<a id="ProfilesContainsCondition"></a>
+
 `ProfilesContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -133,6 +147,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.amazon_ads.types.ProfilesAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="ProfilesEqCondition"></a>
 
 `ProfilesEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -146,6 +162,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.amazon_ads.types.ProfilesSearchFilter`
     :   The type of the None singleton.
 
+<a id="ProfilesFuzzyCondition"></a>
+
 `ProfilesFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -157,6 +175,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.amazon_ads.types.ProfilesStringFilter`
     :   The type of the None singleton.
+
+<a id="ProfilesGetParams"></a>
 
 `ProfilesGetParams(*args, **kwargs)`
 :   Parameters for profiles.get operation
@@ -170,6 +190,8 @@ Classes
     `profile_id: str`
     :   The type of the None singleton.
 
+<a id="ProfilesGtCondition"></a>
+
 `ProfilesGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -182,6 +204,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.amazon_ads.types.ProfilesSearchFilter`
     :   The type of the None singleton.
 
+<a id="ProfilesGteCondition"></a>
+
 `ProfilesGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -193,6 +217,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.amazon_ads.types.ProfilesSearchFilter`
     :   The type of the None singleton.
+
+<a id="ProfilesInCondition"></a>
 
 `ProfilesInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -213,6 +239,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.amazon_ads.types.ProfilesInFilter`
     :   The type of the None singleton.
+
+<a id="ProfilesInFilter"></a>
 
 `ProfilesInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -241,6 +269,8 @@ Classes
     `timezone: list[str]`
     :   The type of the None singleton.
 
+<a id="ProfilesKeywordCondition"></a>
+
 `ProfilesKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -252,6 +282,8 @@ Classes
 
     `keyword: airbyte_agent_sdk.connectors.amazon_ads.types.ProfilesStringFilter`
     :   The type of the None singleton.
+
+<a id="ProfilesLikeCondition"></a>
 
 `ProfilesLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
@@ -265,6 +297,8 @@ Classes
     `like: airbyte_agent_sdk.connectors.amazon_ads.types.ProfilesStringFilter`
     :   The type of the None singleton.
 
+<a id="ProfilesListParams"></a>
+
 `ProfilesListParams(*args, **kwargs)`
 :   Parameters for profiles.list operation
 
@@ -276,6 +310,8 @@ Classes
 
     `profile_type_filter: str`
     :   The type of the None singleton.
+
+<a id="ProfilesLtCondition"></a>
 
 `ProfilesLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
@@ -289,6 +325,8 @@ Classes
     `lt: airbyte_agent_sdk.connectors.amazon_ads.types.ProfilesSearchFilter`
     :   The type of the None singleton.
 
+<a id="ProfilesLteCondition"></a>
+
 `ProfilesLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
 
@@ -301,6 +339,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.amazon_ads.types.ProfilesSearchFilter`
     :   The type of the None singleton.
 
+<a id="ProfilesNeqCondition"></a>
+
 `ProfilesNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -312,6 +352,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.amazon_ads.types.ProfilesSearchFilter`
     :   The type of the None singleton.
+
+<a id="ProfilesNotCondition"></a>
 
 `ProfilesNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -333,6 +375,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.amazon_ads.types.ProfilesEqCondition | airbyte_agent_sdk.connectors.amazon_ads.types.ProfilesNeqCondition | airbyte_agent_sdk.connectors.amazon_ads.types.ProfilesGtCondition | airbyte_agent_sdk.connectors.amazon_ads.types.ProfilesGteCondition | airbyte_agent_sdk.connectors.amazon_ads.types.ProfilesLtCondition | airbyte_agent_sdk.connectors.amazon_ads.types.ProfilesLteCondition | airbyte_agent_sdk.connectors.amazon_ads.types.ProfilesInCondition | airbyte_agent_sdk.connectors.amazon_ads.types.ProfilesLikeCondition | airbyte_agent_sdk.connectors.amazon_ads.types.ProfilesFuzzyCondition | airbyte_agent_sdk.connectors.amazon_ads.types.ProfilesKeywordCondition | airbyte_agent_sdk.connectors.amazon_ads.types.ProfilesContainsCondition | airbyte_agent_sdk.connectors.amazon_ads.types.ProfilesNotCondition | airbyte_agent_sdk.connectors.amazon_ads.types.ProfilesAndCondition | airbyte_agent_sdk.connectors.amazon_ads.types.ProfilesOrCondition | airbyte_agent_sdk.connectors.amazon_ads.types.ProfilesAnyCondition`
     :   The type of the None singleton.
 
+<a id="ProfilesOrCondition"></a>
+
 `ProfilesOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -352,6 +396,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.amazon_ads.types.ProfilesEqCondition | airbyte_agent_sdk.connectors.amazon_ads.types.ProfilesNeqCondition | airbyte_agent_sdk.connectors.amazon_ads.types.ProfilesGtCondition | airbyte_agent_sdk.connectors.amazon_ads.types.ProfilesGteCondition | airbyte_agent_sdk.connectors.amazon_ads.types.ProfilesLtCondition | airbyte_agent_sdk.connectors.amazon_ads.types.ProfilesLteCondition | airbyte_agent_sdk.connectors.amazon_ads.types.ProfilesInCondition | airbyte_agent_sdk.connectors.amazon_ads.types.ProfilesLikeCondition | airbyte_agent_sdk.connectors.amazon_ads.types.ProfilesFuzzyCondition | airbyte_agent_sdk.connectors.amazon_ads.types.ProfilesKeywordCondition | airbyte_agent_sdk.connectors.amazon_ads.types.ProfilesContainsCondition | airbyte_agent_sdk.connectors.amazon_ads.types.ProfilesNotCondition | airbyte_agent_sdk.connectors.amazon_ads.types.ProfilesAndCondition | airbyte_agent_sdk.connectors.amazon_ads.types.ProfilesOrCondition | airbyte_agent_sdk.connectors.amazon_ads.types.ProfilesAnyCondition]`
     :   The type of the None singleton.
+
+<a id="ProfilesSearchFilter"></a>
 
 `ProfilesSearchFilter(*args, **kwargs)`
 :   Available fields for filtering profiles search queries.
@@ -380,6 +426,8 @@ Classes
     `timezone: str | None`
     :   The type of the None singleton.
 
+<a id="ProfilesSearchQuery"></a>
+
 `ProfilesSearchQuery(*args, **kwargs)`
 :   Search query for profiles entity.
 
@@ -394,6 +442,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.amazon_ads.types.ProfilesSortFilter]`
     :   The type of the None singleton.
+
+<a id="ProfilesSortFilter"></a>
 
 `ProfilesSortFilter(*args, **kwargs)`
 :   Available fields for sorting profiles search results.
@@ -422,6 +472,8 @@ Classes
     `timezone: Literal['asc', 'desc']`
     :   The type of the None singleton.
 
+<a id="ProfilesStringFilter"></a>
+
 `ProfilesStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -449,6 +501,8 @@ Classes
     `timezone: str`
     :   The type of the None singleton.
 
+<a id="SponsoredBrandsAdGroupsListParams"></a>
+
 `SponsoredBrandsAdGroupsListParams(*args, **kwargs)`
 :   Parameters for sponsored_brands_ad_groups.list operation
 
@@ -467,6 +521,8 @@ Classes
     `state_filter: airbyte_agent_sdk.connectors.amazon_ads.types.SponsoredBrandsAdGroupsListParamsStatefilter`
     :   The type of the None singleton.
 
+<a id="SponsoredBrandsAdGroupsListParamsStatefilter"></a>
+
 `SponsoredBrandsAdGroupsListParamsStatefilter(*args, **kwargs)`
 :   Nested schema for SponsoredBrandsAdGroupsListParams.stateFilter
 
@@ -478,6 +534,8 @@ Classes
 
     `include: str`
     :   The type of the None singleton.
+
+<a id="SponsoredBrandsCampaignsListParams"></a>
 
 `SponsoredBrandsCampaignsListParams(*args, **kwargs)`
 :   Parameters for sponsored_brands_campaigns.list operation
@@ -497,6 +555,8 @@ Classes
     `state_filter: airbyte_agent_sdk.connectors.amazon_ads.types.SponsoredBrandsCampaignsListParamsStatefilter`
     :   The type of the None singleton.
 
+<a id="SponsoredBrandsCampaignsListParamsStatefilter"></a>
+
 `SponsoredBrandsCampaignsListParamsStatefilter(*args, **kwargs)`
 :   Nested schema for SponsoredBrandsCampaignsListParams.stateFilter
 
@@ -508,6 +568,8 @@ Classes
 
     `include: str`
     :   The type of the None singleton.
+
+<a id="SponsoredProductAdGroupsListParams"></a>
 
 `SponsoredProductAdGroupsListParams(*args, **kwargs)`
 :   Parameters for sponsored_product_ad_groups.list operation
@@ -527,6 +589,8 @@ Classes
     `state_filter: airbyte_agent_sdk.connectors.amazon_ads.types.SponsoredProductAdGroupsListParamsStatefilter`
     :   The type of the None singleton.
 
+<a id="SponsoredProductAdGroupsListParamsStatefilter"></a>
+
 `SponsoredProductAdGroupsListParamsStatefilter(*args, **kwargs)`
 :   Nested schema for SponsoredProductAdGroupsListParams.stateFilter
 
@@ -539,6 +603,8 @@ Classes
     `include: str`
     :   The type of the None singleton.
 
+<a id="SponsoredProductCampaignsGetParams"></a>
+
 `SponsoredProductCampaignsGetParams(*args, **kwargs)`
 :   Parameters for sponsored_product_campaigns.get operation
 
@@ -550,6 +616,8 @@ Classes
 
     `campaign_id: str`
     :   The type of the None singleton.
+
+<a id="SponsoredProductCampaignsListParams"></a>
 
 `SponsoredProductCampaignsListParams(*args, **kwargs)`
 :   Parameters for sponsored_product_campaigns.list operation
@@ -569,6 +637,8 @@ Classes
     `state_filter: airbyte_agent_sdk.connectors.amazon_ads.types.SponsoredProductCampaignsListParamsStatefilter`
     :   The type of the None singleton.
 
+<a id="SponsoredProductCampaignsListParamsStatefilter"></a>
+
 `SponsoredProductCampaignsListParamsStatefilter(*args, **kwargs)`
 :   Nested schema for SponsoredProductCampaignsListParams.stateFilter
 
@@ -580,6 +650,8 @@ Classes
 
     `include: str`
     :   The type of the None singleton.
+
+<a id="SponsoredProductKeywordsListParams"></a>
 
 `SponsoredProductKeywordsListParams(*args, **kwargs)`
 :   Parameters for sponsored_product_keywords.list operation
@@ -599,6 +671,8 @@ Classes
     `state_filter: airbyte_agent_sdk.connectors.amazon_ads.types.SponsoredProductKeywordsListParamsStatefilter`
     :   The type of the None singleton.
 
+<a id="SponsoredProductKeywordsListParamsStatefilter"></a>
+
 `SponsoredProductKeywordsListParamsStatefilter(*args, **kwargs)`
 :   Nested schema for SponsoredProductKeywordsListParams.stateFilter
 
@@ -610,6 +684,8 @@ Classes
 
     `include: str`
     :   The type of the None singleton.
+
+<a id="SponsoredProductNegativeKeywordsListParams"></a>
 
 `SponsoredProductNegativeKeywordsListParams(*args, **kwargs)`
 :   Parameters for sponsored_product_negative_keywords.list operation
@@ -629,6 +705,8 @@ Classes
     `state_filter: airbyte_agent_sdk.connectors.amazon_ads.types.SponsoredProductNegativeKeywordsListParamsStatefilter`
     :   The type of the None singleton.
 
+<a id="SponsoredProductNegativeKeywordsListParamsStatefilter"></a>
+
 `SponsoredProductNegativeKeywordsListParamsStatefilter(*args, **kwargs)`
 :   Nested schema for SponsoredProductNegativeKeywordsListParams.stateFilter
 
@@ -640,6 +718,8 @@ Classes
 
     `include: str`
     :   The type of the None singleton.
+
+<a id="SponsoredProductNegativeTargetsListParams"></a>
 
 `SponsoredProductNegativeTargetsListParams(*args, **kwargs)`
 :   Parameters for sponsored_product_negative_targets.list operation
@@ -659,6 +739,8 @@ Classes
     `state_filter: airbyte_agent_sdk.connectors.amazon_ads.types.SponsoredProductNegativeTargetsListParamsStatefilter`
     :   The type of the None singleton.
 
+<a id="SponsoredProductNegativeTargetsListParamsStatefilter"></a>
+
 `SponsoredProductNegativeTargetsListParamsStatefilter(*args, **kwargs)`
 :   Nested schema for SponsoredProductNegativeTargetsListParams.stateFilter
 
@@ -670,6 +752,8 @@ Classes
 
     `include: str`
     :   The type of the None singleton.
+
+<a id="SponsoredProductProductAdsListParams"></a>
 
 `SponsoredProductProductAdsListParams(*args, **kwargs)`
 :   Parameters for sponsored_product_product_ads.list operation
@@ -689,6 +773,8 @@ Classes
     `state_filter: airbyte_agent_sdk.connectors.amazon_ads.types.SponsoredProductProductAdsListParamsStatefilter`
     :   The type of the None singleton.
 
+<a id="SponsoredProductProductAdsListParamsStatefilter"></a>
+
 `SponsoredProductProductAdsListParamsStatefilter(*args, **kwargs)`
 :   Nested schema for SponsoredProductProductAdsListParams.stateFilter
 
@@ -700,6 +786,8 @@ Classes
 
     `include: str`
     :   The type of the None singleton.
+
+<a id="SponsoredProductTargetsListParams"></a>
 
 `SponsoredProductTargetsListParams(*args, **kwargs)`
 :   Parameters for sponsored_product_targets.list operation
@@ -718,6 +806,8 @@ Classes
 
     `state_filter: airbyte_agent_sdk.connectors.amazon_ads.types.SponsoredProductTargetsListParamsStatefilter`
     :   The type of the None singleton.
+
+<a id="SponsoredProductTargetsListParamsStatefilter"></a>
 
 `SponsoredProductTargetsListParamsStatefilter(*args, **kwargs)`
 :   Nested schema for SponsoredProductTargetsListParams.stateFilter

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/amazon_seller_partner/connector.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/amazon_seller_partner/connector.md
@@ -10,6 +10,8 @@ Amazon-Seller-Partner connector.
 Classes
 -------
 
+<a id="AmazonSellerPartnerConnector"></a>
+
 `AmazonSellerPartnerConnector(auth_config: AmazonSellerPartnerAuthConfig | AirbyteAuthConfig | BaseModel | None = None, on_token_refresh: Any | None = None, region: str | None = None)`
 :   Type-safe Amazon-Seller-Partner API connector.
     
@@ -270,6 +272,8 @@ Classes
             for entity in entities:
                 print(f"\{entity['entity_name']\}: \{entity['available_actions']\}")
 
+<a id="CatalogItemsQuery"></a>
+
 `CatalogItemsQuery(connector: AmazonSellerPartnerConnector)`
 :   Query class for CatalogItems entity operations.
     
@@ -304,6 +308,8 @@ Classes
         
         Returns:
             CatalogItemsListResult
+
+<a id="ListFinancialEventGroupsQuery"></a>
 
 `ListFinancialEventGroupsQuery(connector: AmazonSellerPartnerConnector)`
 :   Query class for ListFinancialEventGroups entity operations.
@@ -357,6 +363,8 @@ Classes
         
         Returns:
             ListFinancialEventGroupsListResult
+
+<a id="ListFinancialEventsQuery"></a>
 
 `ListFinancialEventsQuery(connector: AmazonSellerPartnerConnector)`
 :   Query class for ListFinancialEvents entity operations.
@@ -435,6 +443,8 @@ Classes
         Returns:
             ListFinancialEventsListResult
 
+<a id="OrderItemsQuery"></a>
+
 `OrderItemsQuery(connector: AmazonSellerPartnerConnector)`
 :   Query class for OrderItems entity operations.
     
@@ -511,6 +521,8 @@ Classes
         
         Returns:
             OrderItemsListResult
+
+<a id="OrdersQuery"></a>
 
 `OrdersQuery(connector: AmazonSellerPartnerConnector)`
 :   Query class for Orders entity operations.
@@ -601,6 +613,8 @@ Classes
         
         Returns:
             OrdersListResult
+
+<a id="ReportsQuery"></a>
 
 `ReportsQuery(connector: AmazonSellerPartnerConnector)`
 :   Query class for Reports entity operations.

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/amazon_seller_partner/index.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/amazon_seller_partner/index.md
@@ -19,6 +19,8 @@ Sub-modules
 Classes
 -------
 
+<a id="AirbyteAuthConfig"></a>
+
 `AirbyteAuthConfig(**data: Any)`
 :   Authentication configuration for Airbyte hosted mode execution.
     
@@ -87,6 +89,8 @@ Classes
     `workspace_name: str | None`
     :   The type of the None singleton.
 
+<a id="AirbyteSearchMeta"></a>
+
 `AirbyteSearchMeta(**data: Any)`
 :   Pagination metadata for search responses.
     
@@ -114,6 +118,8 @@ Classes
 
     `took_ms: int | None`
     :   Time taken to execute the search in milliseconds.
+
+<a id="AirbyteSearchResult"></a>
 
 `AirbyteSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -148,6 +154,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="ListFinancialEventGroupsSearchResult"></a>
+
 `ListFinancialEventGroupsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -163,6 +171,8 @@ Classes
     * airbyte_agent_sdk.connectors.amazon_seller_partner.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="ListFinancialEventsSearchResult"></a>
 
 `ListFinancialEventsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -180,6 +190,8 @@ Classes
     * pydantic.main.BaseModel
     * typing.Generic
 
+<a id="OrderItemsSearchResult"></a>
+
 `OrderItemsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -196,6 +208,8 @@ Classes
     * pydantic.main.BaseModel
     * typing.Generic
 
+<a id="OrdersSearchResult"></a>
+
 `OrdersSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -211,6 +225,8 @@ Classes
     * airbyte_agent_sdk.connectors.amazon_seller_partner.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="AmazonSellerPartnerAuthConfig"></a>
 
 `AmazonSellerPartnerAuthConfig(**data: Any)`
 :   Login with Amazon OAuth 2.0
@@ -242,6 +258,8 @@ Classes
 
     `refresh_token: str`
     :   The Refresh Token obtained via the OAuth authorization flow.
+
+<a id="AmazonSellerPartnerConnector"></a>
 
 `AmazonSellerPartnerConnector(auth_config: AmazonSellerPartnerAuthConfig | AirbyteAuthConfig | BaseModel | None = None, on_token_refresh: Any | None = None, region: str | None = None)`
 :   Type-safe Amazon-Seller-Partner API connector.
@@ -503,6 +521,8 @@ Classes
             for entity in entities:
                 print(f"\{entity['entity_name']\}: \{entity['available_actions']\}")
 
+<a id="AmazonSellerPartnerReplicationConfig"></a>
+
 `AmazonSellerPartnerReplicationConfig(**data: Any)`
 :   Replication Configuration - Settings for data replication from Amazon Seller Partner.
     
@@ -524,6 +544,8 @@ Classes
 
     `replication_start_date: str`
     :   UTC date and time in ISO 8601 format (e.g. 2024-01-01T00:00:00Z). Any data before this date will not be replicated. This sets the earliest date for order creation and financial event queries. For most sellers, a start date of 1-2 years ago is a good default. Must include the time component and Z timezone suffix.
+
+<a id="ListFinancialEventGroupsSearchData"></a>
 
 `ListFinancialEventGroupsSearchData(**data: Any)`
 :   Search result data for list_financial_event_groups entity.
@@ -576,6 +598,8 @@ Classes
 
     `trace_id: str | None`
     :   Unique identifier for tracing
+
+<a id="ListFinancialEventsSearchData"></a>
 
 `ListFinancialEventsSearchData(**data: Any)`
 :   Search result data for list_financial_events entity.
@@ -700,6 +724,8 @@ Classes
 
     `value_added_service_charge_event_list: list[typing.Any] | None`
     :   List of value-added service charge events
+
+<a id="OrderItemsSearchData"></a>
 
 `OrderItemsSearchData(**data: Any)`
 :   Search result data for order_items entity.
@@ -830,6 +856,8 @@ Classes
 
     `title: str | None`
     :   Title of the product
+
+<a id="OrdersSearchData"></a>
 
 `OrdersSearchData(**data: Any)`
 :   Search result data for orders entity.

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/amazon_seller_partner/models.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/amazon_seller_partner/models.md
@@ -13,6 +13,8 @@ and response envelope types.
 Classes
 -------
 
+<a id="AirbyteSearchMeta"></a>
+
 `AirbyteSearchMeta(**data: Any)`
 :   Pagination metadata for search responses.
     
@@ -40,6 +42,8 @@ Classes
 
     `took_ms: int | None`
     :   Time taken to execute the search in milliseconds.
+
+<a id="AirbyteSearchResult"></a>
 
 `AirbyteSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -95,6 +99,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="ListFinancialEventGroupsSearchResult"></a>
+
 `ListFinancialEventGroupsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -131,6 +137,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="ListFinancialEventsSearchResult"></a>
 
 `ListFinancialEventsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -169,6 +177,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="OrderItemsSearchResult"></a>
+
 `OrderItemsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -206,6 +216,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="OrdersSearchResult"></a>
+
 `OrdersSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -221,6 +233,8 @@ Classes
     * airbyte_agent_sdk.connectors.amazon_seller_partner.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="AmazonSellerPartnerAuthConfig"></a>
 
 `AmazonSellerPartnerAuthConfig(**data: Any)`
 :   Login with Amazon OAuth 2.0
@@ -252,6 +266,8 @@ Classes
 
     `refresh_token: str`
     :   The Refresh Token obtained via the OAuth authorization flow.
+
+<a id="AmazonSellerPartnerCheckResult"></a>
 
 `AmazonSellerPartnerCheckResult(**data: Any)`
 :   Result of a health check operation.
@@ -286,6 +302,8 @@ Classes
     `status: str`
     :   Health check status: 'healthy' or 'unhealthy'.
 
+<a id="AmazonSellerPartnerExecuteResult"></a>
+
 `AmazonSellerPartnerExecuteResult(**data: Any)`
 :   Response envelope with data only.
     
@@ -314,6 +332,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="AmazonSellerPartnerExecuteResultWithMeta"></a>
 
 `AmazonSellerPartnerExecuteResultWithMeta(**data: Any)`
 :   Response envelope with data and metadata.
@@ -371,6 +391,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="ListFinancialEventsListResult"></a>
+
 `ListFinancialEventsListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -413,6 +435,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="CatalogItemsListResult"></a>
 
 `CatalogItemsListResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -457,6 +481,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="ListFinancialEventGroupsListResult"></a>
+
 `ListFinancialEventGroupsListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -499,6 +525,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="OrderItemsListResult"></a>
 
 `OrderItemsListResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -543,6 +571,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="OrdersListResult"></a>
+
 `OrdersListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -586,6 +616,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="ReportsListResult"></a>
+
 `ReportsListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -604,6 +636,8 @@ Classes
     * airbyte_agent_sdk.connectors.amazon_seller_partner.models.AmazonSellerPartnerExecuteResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="AmazonSellerPartnerReplicationConfig"></a>
 
 `AmazonSellerPartnerReplicationConfig(**data: Any)`
 :   Replication Configuration - Settings for data replication from Amazon Seller Partner.
@@ -626,6 +660,8 @@ Classes
 
     `replication_start_date: str`
     :   UTC date and time in ISO 8601 format (e.g. 2024-01-01T00:00:00Z). Any data before this date will not be replicated. This sets the earliest date for order creation and financial event queries. For most sellers, a start date of 1-2 years ago is a good default. Must include the time component and Z timezone suffix.
+
+<a id="CatalogItem"></a>
 
 `CatalogItem(**data: Any)`
 :   Amazon catalog item
@@ -678,6 +714,8 @@ Classes
 
     `vendor_details: list[dict[str, typing.Any]] | Any`
     :   The type of the None singleton.
+
+<a id="CatalogItemSummariesItem"></a>
 
 `CatalogItemSummariesItem(**data: Any)`
 :   Nested schema for CatalogItem.summaries_item
@@ -752,6 +790,8 @@ Classes
     `website_display_group_name: str | Any`
     :   The type of the None singleton.
 
+<a id="CatalogItemSummariesItemBrowseclassification"></a>
+
 `CatalogItemSummariesItemBrowseclassification(**data: Any)`
 :   Nested schema for CatalogItemSummariesItem.browseClassification
     
@@ -776,6 +816,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="CatalogItemsList"></a>
 
 `CatalogItemsList(**data: Any)`
 :   Catalog items search results
@@ -808,6 +850,8 @@ Classes
     `refinements: airbyte_agent_sdk.connectors.amazon_seller_partner.models.CatalogItemsListRefinements | Any`
     :   The type of the None singleton.
 
+<a id="CatalogItemsListPagination"></a>
+
 `CatalogItemsListPagination(**data: Any)`
 :   Nested schema for CatalogItemsList.pagination
     
@@ -832,6 +876,8 @@ Classes
 
     `previous_token: str | Any`
     :   The type of the None singleton.
+
+<a id="CatalogItemsListRefinements"></a>
 
 `CatalogItemsListRefinements(**data: Any)`
 :   Nested schema for CatalogItemsList.refinements
@@ -858,6 +904,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="CatalogItemsListRefinementsBrandsItem"></a>
+
 `CatalogItemsListRefinementsBrandsItem(**data: Any)`
 :   Nested schema for CatalogItemsListRefinements.brands_item
     
@@ -882,6 +930,8 @@ Classes
 
     `number_of_results: int | Any`
     :   The type of the None singleton.
+
+<a id="CatalogItemsListRefinementsClassificationsItem"></a>
 
 `CatalogItemsListRefinementsClassificationsItem(**data: Any)`
 :   Nested schema for CatalogItemsListRefinements.classifications_item
@@ -911,6 +961,8 @@ Classes
     `number_of_results: int | Any`
     :   The type of the None singleton.
 
+<a id="CatalogItemsListResultMeta"></a>
+
 `CatalogItemsListResultMeta(**data: Any)`
 :   Metadata for catalog_items.Action.LIST operation
     
@@ -935,6 +987,8 @@ Classes
 
     `number_of_results: int | Any`
     :   The type of the None singleton.
+
+<a id="FinancialEventGroup"></a>
 
 `FinancialEventGroup(**data: Any)`
 :   A financial event group
@@ -988,6 +1042,8 @@ Classes
     `trace_id: str | Any`
     :   The type of the None singleton.
 
+<a id="FinancialEventGroupBeginningbalance"></a>
+
 `FinancialEventGroupBeginningbalance(**data: Any)`
 :   Beginning balance
     
@@ -1012,6 +1068,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="FinancialEventGroupConvertedtotal"></a>
 
 `FinancialEventGroupConvertedtotal(**data: Any)`
 :   Converted total
@@ -1038,6 +1096,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="FinancialEventGroupList"></a>
+
 `FinancialEventGroupList(**data: Any)`
 :   Paginated list of financial event groups
     
@@ -1059,6 +1119,8 @@ Classes
 
     `payload: airbyte_agent_sdk.connectors.amazon_seller_partner.models.FinancialEventGroupListPayload | Any`
     :   The type of the None singleton.
+
+<a id="FinancialEventGroupListPayload"></a>
 
 `FinancialEventGroupListPayload(**data: Any)`
 :   Nested schema for FinancialEventGroupList.payload
@@ -1085,6 +1147,8 @@ Classes
     `next_token: str | Any`
     :   The type of the None singleton.
 
+<a id="FinancialEventGroupOriginaltotal"></a>
+
 `FinancialEventGroupOriginaltotal(**data: Any)`
 :   Original total in seller's currency
     
@@ -1109,6 +1173,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="FinancialEvents"></a>
 
 `FinancialEvents(**data: Any)`
 :   A collection of financial events grouped by type
@@ -1234,6 +1300,8 @@ Classes
     `value_added_service_charge_event_list: list[dict[str, typing.Any]] | Any`
     :   The type of the None singleton.
 
+<a id="FinancialEventsDebtrecoveryeventlistItem"></a>
+
 `FinancialEventsDebtrecoveryeventlistItem(**data: Any)`
 :   Nested schema for FinancialEvents.DebtRecoveryEventList_item
     
@@ -1265,6 +1333,8 @@ Classes
     `recovery_amount: airbyte_agent_sdk.connectors.amazon_seller_partner.models.FinancialEventsDebtrecoveryeventlistItemRecoveryamount | Any`
     :   The type of the None singleton.
 
+<a id="FinancialEventsDebtrecoveryeventlistItemChargeinstrumentlistItem"></a>
+
 `FinancialEventsDebtrecoveryeventlistItemChargeinstrumentlistItem(**data: Any)`
 :   Nested schema for FinancialEventsDebtrecoveryeventlistItem.ChargeInstrumentList_item
     
@@ -1293,6 +1363,8 @@ Classes
     `tail: str | Any`
     :   The type of the None singleton.
 
+<a id="FinancialEventsDebtrecoveryeventlistItemChargeinstrumentlistItemAmount"></a>
+
 `FinancialEventsDebtrecoveryeventlistItemChargeinstrumentlistItemAmount(**data: Any)`
 :   Nested schema for FinancialEventsDebtrecoveryeventlistItemChargeinstrumentlistItem.Amount
     
@@ -1317,6 +1389,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="FinancialEventsDebtrecoveryeventlistItemDebtrecoveryitemlistItem"></a>
 
 `FinancialEventsDebtrecoveryeventlistItemDebtrecoveryitemlistItem(**data: Any)`
 :   Nested schema for FinancialEventsDebtrecoveryeventlistItem.DebtRecoveryItemList_item
@@ -1349,6 +1423,8 @@ Classes
     `recovery_amount: airbyte_agent_sdk.connectors.amazon_seller_partner.models.FinancialEventsDebtrecoveryeventlistItemDebtrecoveryitemlistItemRecoveryamount | Any`
     :   The type of the None singleton.
 
+<a id="FinancialEventsDebtrecoveryeventlistItemDebtrecoveryitemlistItemOriginalamount"></a>
+
 `FinancialEventsDebtrecoveryeventlistItemDebtrecoveryitemlistItemOriginalamount(**data: Any)`
 :   Nested schema for FinancialEventsDebtrecoveryeventlistItemDebtrecoveryitemlistItem.OriginalAmount
     
@@ -1373,6 +1449,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="FinancialEventsDebtrecoveryeventlistItemDebtrecoveryitemlistItemRecoveryamount"></a>
 
 `FinancialEventsDebtrecoveryeventlistItemDebtrecoveryitemlistItemRecoveryamount(**data: Any)`
 :   Nested schema for FinancialEventsDebtrecoveryeventlistItemDebtrecoveryitemlistItem.RecoveryAmount
@@ -1399,6 +1477,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="FinancialEventsDebtrecoveryeventlistItemRecoveryamount"></a>
+
 `FinancialEventsDebtrecoveryeventlistItemRecoveryamount(**data: Any)`
 :   Nested schema for FinancialEventsDebtrecoveryeventlistItem.RecoveryAmount
     
@@ -1424,6 +1504,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="FinancialEventsResponse"></a>
+
 `FinancialEventsResponse(**data: Any)`
 :   Response wrapper for financial events
     
@@ -1445,6 +1527,8 @@ Classes
 
     `payload: airbyte_agent_sdk.connectors.amazon_seller_partner.models.FinancialEventsResponsePayload | Any`
     :   The type of the None singleton.
+
+<a id="FinancialEventsResponsePayload"></a>
 
 `FinancialEventsResponsePayload(**data: Any)`
 :   Nested schema for FinancialEventsResponse.payload
@@ -1471,6 +1555,8 @@ Classes
     `next_token: str | Any`
     :   The type of the None singleton.
 
+<a id="FinancialEventsServicefeeeventlistItem"></a>
+
 `FinancialEventsServicefeeeventlistItem(**data: Any)`
 :   Nested schema for FinancialEvents.ServiceFeeEventList_item
     
@@ -1492,6 +1578,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="FinancialEventsServicefeeeventlistItemFeelistItem"></a>
 
 `FinancialEventsServicefeeeventlistItemFeelistItem(**data: Any)`
 :   Nested schema for FinancialEventsServicefeeeventlistItem.FeeList_item
@@ -1518,6 +1606,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="FinancialEventsServicefeeeventlistItemFeelistItemFeeamount"></a>
+
 `FinancialEventsServicefeeeventlistItemFeelistItemFeeamount(**data: Any)`
 :   Nested schema for FinancialEventsServicefeeeventlistItemFeelistItem.FeeAmount
     
@@ -1543,6 +1633,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="ListFinancialEventGroupsListResultMeta"></a>
+
 `ListFinancialEventGroupsListResultMeta(**data: Any)`
 :   Metadata for list_financial_event_groups.Action.LIST operation
     
@@ -1564,6 +1656,8 @@ Classes
 
     `next_token: str | Any`
     :   The type of the None singleton.
+
+<a id="ListFinancialEventGroupsSearchData"></a>
 
 `ListFinancialEventGroupsSearchData(**data: Any)`
 :   Search result data for list_financial_event_groups entity.
@@ -1617,6 +1711,8 @@ Classes
     `trace_id: str | None`
     :   Unique identifier for tracing
 
+<a id="ListFinancialEventsListResultMeta"></a>
+
 `ListFinancialEventsListResultMeta(**data: Any)`
 :   Metadata for list_financial_events.Action.LIST operation
     
@@ -1638,6 +1734,8 @@ Classes
 
     `next_token: str | Any`
     :   The type of the None singleton.
+
+<a id="ListFinancialEventsSearchData"></a>
 
 `ListFinancialEventsSearchData(**data: Any)`
 :   Search result data for list_financial_events entity.
@@ -1763,6 +1861,8 @@ Classes
     `value_added_service_charge_event_list: list[typing.Any] | None`
     :   List of value-added service charge events
 
+<a id="Order"></a>
+
 `Order(**data: Any)`
 :   Amazon order object
     
@@ -1881,6 +1981,8 @@ Classes
     `shipping_address: airbyte_agent_sdk.connectors.amazon_seller_partner.models.OrderShippingaddress | Any`
     :   The type of the None singleton.
 
+<a id="OrderAutomatedshippingsettings"></a>
+
 `OrderAutomatedshippingsettings(**data: Any)`
 :   Automated shipping settings
     
@@ -1902,6 +2004,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="OrderDefaultshipfromlocationaddress"></a>
 
 `OrderDefaultshipfromlocationaddress(**data: Any)`
 :   Default ship-from address
@@ -1939,6 +2043,8 @@ Classes
 
     `state_or_region: str | Any`
     :   The type of the None singleton.
+
+<a id="OrderItem"></a>
 
 `OrderItem(**data: Any)`
 :   Amazon order item object
@@ -2058,6 +2164,8 @@ Classes
     `title: str | Any`
     :   The type of the None singleton.
 
+<a id="OrderItemBuyerinfo"></a>
+
 `OrderItemBuyerinfo(**data: Any)`
 :   Buyer information for the item
     
@@ -2089,6 +2197,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="OrderItemBuyerinfoBuyercustomizedinfo"></a>
+
 `OrderItemBuyerinfoBuyercustomizedinfo(**data: Any)`
 :   Nested schema for OrderItemBuyerinfo.BuyerCustomizedInfo
     
@@ -2110,6 +2220,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="OrderItemBuyerinfoGiftwrapprice"></a>
 
 `OrderItemBuyerinfoGiftwrapprice(**data: Any)`
 :   Nested schema for OrderItemBuyerinfo.GiftWrapPrice
@@ -2136,6 +2248,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="OrderItemBuyerrequestedcancel"></a>
+
 `OrderItemBuyerrequestedcancel(**data: Any)`
 :   Buyer cancellation request information
     
@@ -2160,6 +2274,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="OrderItemCodfee"></a>
 
 `OrderItemCodfee(**data: Any)`
 :   Cash on delivery fee
@@ -2186,6 +2302,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="OrderItemCodfeediscount"></a>
+
 `OrderItemCodfeediscount(**data: Any)`
 :   Cash on delivery fee discount
     
@@ -2210,6 +2328,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="OrderItemItemprice"></a>
 
 `OrderItemItemprice(**data: Any)`
 :   Item price
@@ -2236,6 +2356,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="OrderItemItemtax"></a>
+
 `OrderItemItemtax(**data: Any)`
 :   Item tax
     
@@ -2260,6 +2382,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="OrderItemPointsgranted"></a>
 
 `OrderItemPointsgranted(**data: Any)`
 :   Points granted for the purchase
@@ -2286,6 +2410,8 @@ Classes
     `points_number: int | Any`
     :   The type of the None singleton.
 
+<a id="OrderItemPointsgrantedPointsmonetaryvalue"></a>
+
 `OrderItemPointsgrantedPointsmonetaryvalue(**data: Any)`
 :   Nested schema for OrderItemPointsgranted.PointsMonetaryValue
     
@@ -2311,6 +2437,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="OrderItemProductinfo"></a>
+
 `OrderItemProductinfo(**data: Any)`
 :   Product information
     
@@ -2332,6 +2460,8 @@ Classes
 
     `number_of_items: str | Any`
     :   The type of the None singleton.
+
+<a id="OrderItemPromotiondiscount"></a>
 
 `OrderItemPromotiondiscount(**data: Any)`
 :   Promotion discount
@@ -2358,6 +2488,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="OrderItemPromotiondiscounttax"></a>
+
 `OrderItemPromotiondiscounttax(**data: Any)`
 :   Promotion discount tax
     
@@ -2382,6 +2514,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="OrderItemShippingdiscount"></a>
 
 `OrderItemShippingdiscount(**data: Any)`
 :   Shipping discount
@@ -2408,6 +2542,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="OrderItemShippingdiscounttax"></a>
+
 `OrderItemShippingdiscounttax(**data: Any)`
 :   Shipping discount tax
     
@@ -2432,6 +2568,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="OrderItemShippingprice"></a>
 
 `OrderItemShippingprice(**data: Any)`
 :   Shipping price
@@ -2458,6 +2596,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="OrderItemShippingtax"></a>
+
 `OrderItemShippingtax(**data: Any)`
 :   Shipping tax
     
@@ -2482,6 +2622,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="OrderItemTaxcollection"></a>
 
 `OrderItemTaxcollection(**data: Any)`
 :   Tax collection information
@@ -2508,6 +2650,8 @@ Classes
     `responsible_party: str | Any`
     :   The type of the None singleton.
 
+<a id="OrderItemsList"></a>
+
 `OrderItemsList(**data: Any)`
 :   Paginated list of order items
     
@@ -2529,6 +2673,8 @@ Classes
 
     `payload: airbyte_agent_sdk.connectors.amazon_seller_partner.models.OrderItemsListPayload | Any`
     :   The type of the None singleton.
+
+<a id="OrderItemsListPayload"></a>
 
 `OrderItemsListPayload(**data: Any)`
 :   Nested schema for OrderItemsList.payload
@@ -2558,6 +2704,8 @@ Classes
     `order_items: list[airbyte_agent_sdk.connectors.amazon_seller_partner.models.OrderItem] | Any`
     :   The type of the None singleton.
 
+<a id="OrderItemsListResultMeta"></a>
+
 `OrderItemsListResultMeta(**data: Any)`
 :   Metadata for order_items.Action.LIST operation
     
@@ -2579,6 +2727,8 @@ Classes
 
     `next_token: str | Any`
     :   The type of the None singleton.
+
+<a id="OrderItemsSearchData"></a>
 
 `OrderItemsSearchData(**data: Any)`
 :   Search result data for order_items entity.
@@ -2710,6 +2860,8 @@ Classes
     `title: str | None`
     :   Title of the product
 
+<a id="OrderOrdertotal"></a>
+
 `OrderOrdertotal(**data: Any)`
 :   Total amount of the order
     
@@ -2734,6 +2886,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="OrderShippingaddress"></a>
 
 `OrderShippingaddress(**data: Any)`
 :   Shipping address for the order
@@ -2766,6 +2920,8 @@ Classes
     `state_or_region: str | Any`
     :   The type of the None singleton.
 
+<a id="OrdersList"></a>
+
 `OrdersList(**data: Any)`
 :   Paginated list of orders
     
@@ -2787,6 +2943,8 @@ Classes
 
     `payload: airbyte_agent_sdk.connectors.amazon_seller_partner.models.OrdersListPayload | Any`
     :   The type of the None singleton.
+
+<a id="OrdersListPayload"></a>
 
 `OrdersListPayload(**data: Any)`
 :   Nested schema for OrdersList.payload
@@ -2813,6 +2971,8 @@ Classes
     `orders: list[airbyte_agent_sdk.connectors.amazon_seller_partner.models.Order] | Any`
     :   The type of the None singleton.
 
+<a id="OrdersListResultMeta"></a>
+
 `OrdersListResultMeta(**data: Any)`
 :   Metadata for orders.Action.LIST operation
     
@@ -2834,6 +2994,8 @@ Classes
 
     `next_token: str | Any`
     :   The type of the None singleton.
+
+<a id="OrdersSearchData"></a>
 
 `OrdersSearchData(**data: Any)`
 :   Search result data for orders entity.
@@ -2956,6 +3118,8 @@ Classes
     `shipping_address: dict[str, typing.Any] | None`
     :   The address to which the order will be shipped
 
+<a id="Report"></a>
+
 `Report(**data: Any)`
 :   Amazon SP-API report
     
@@ -3008,6 +3172,8 @@ Classes
     `report_type: str | Any`
     :   The type of the None singleton.
 
+<a id="ReportsList"></a>
+
 `ReportsList(**data: Any)`
 :   Paginated list of reports
     
@@ -3032,6 +3198,8 @@ Classes
 
     `reports: list[airbyte_agent_sdk.connectors.amazon_seller_partner.models.Report] | Any`
     :   The type of the None singleton.
+
+<a id="ReportsListResultMeta"></a>
 
 `ReportsListResultMeta(**data: Any)`
 :   Metadata for reports.Action.LIST operation

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/amazon_seller_partner/types.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/amazon_seller_partner/types.md
@@ -10,6 +10,8 @@ Type definitions for amazon-seller-partner connector.
 Classes
 -------
 
+<a id="AirbyteSearchParams"></a>
+
 `AirbyteSearchParams(*args, **kwargs)`
 :   Parameters for Airbyte cache search operations (generic, use entity-specific query types for better type hints).
 
@@ -31,6 +33,8 @@ Classes
     `query: dict[str, typing.Any]`
     :   The type of the None singleton.
 
+<a id="CatalogItemsGetParams"></a>
+
 `CatalogItemsGetParams(*args, **kwargs)`
 :   Parameters for catalog_items.get operation
 
@@ -48,6 +52,8 @@ Classes
 
     `marketplace_ids: str`
     :   The type of the None singleton.
+
+<a id="CatalogItemsListParams"></a>
 
 `CatalogItemsListParams(*args, **kwargs)`
 :   Parameters for catalog_items.list operation
@@ -79,6 +85,8 @@ Classes
     `page_token: str`
     :   The type of the None singleton.
 
+<a id="ListFinancialEventGroupsAndCondition"></a>
+
 `ListFinancialEventGroupsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -99,6 +107,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.amazon_seller_partner.types.ListFinancialEventGroupsEqCondition | airbyte_agent_sdk.connectors.amazon_seller_partner.types.ListFinancialEventGroupsNeqCondition | airbyte_agent_sdk.connectors.amazon_seller_partner.types.ListFinancialEventGroupsGtCondition | airbyte_agent_sdk.connectors.amazon_seller_partner.types.ListFinancialEventGroupsGteCondition | airbyte_agent_sdk.connectors.amazon_seller_partner.types.ListFinancialEventGroupsLtCondition | airbyte_agent_sdk.connectors.amazon_seller_partner.types.ListFinancialEventGroupsLteCondition | airbyte_agent_sdk.connectors.amazon_seller_partner.types.ListFinancialEventGroupsInCondition | airbyte_agent_sdk.connectors.amazon_seller_partner.types.ListFinancialEventGroupsLikeCondition | airbyte_agent_sdk.connectors.amazon_seller_partner.types.ListFinancialEventGroupsFuzzyCondition | airbyte_agent_sdk.connectors.amazon_seller_partner.types.ListFinancialEventGroupsKeywordCondition | airbyte_agent_sdk.connectors.amazon_seller_partner.types.ListFinancialEventGroupsContainsCondition | airbyte_agent_sdk.connectors.amazon_seller_partner.types.ListFinancialEventGroupsNotCondition | airbyte_agent_sdk.connectors.amazon_seller_partner.types.ListFinancialEventGroupsAndCondition | airbyte_agent_sdk.connectors.amazon_seller_partner.types.ListFinancialEventGroupsOrCondition | airbyte_agent_sdk.connectors.amazon_seller_partner.types.ListFinancialEventGroupsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="ListFinancialEventGroupsAnyCondition"></a>
+
 `ListFinancialEventGroupsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -118,6 +128,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.amazon_seller_partner.types.ListFinancialEventGroupsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="ListFinancialEventGroupsAnyValueFilter"></a>
 
 `ListFinancialEventGroupsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -161,6 +173,8 @@ Classes
     `trace_id: Any`
     :   Unique identifier for tracing
 
+<a id="ListFinancialEventGroupsContainsCondition"></a>
+
 `ListFinancialEventGroupsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -172,6 +186,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.amazon_seller_partner.types.ListFinancialEventGroupsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="ListFinancialEventGroupsEqCondition"></a>
 
 `ListFinancialEventGroupsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -185,6 +201,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.amazon_seller_partner.types.ListFinancialEventGroupsSearchFilter`
     :   The type of the None singleton.
 
+<a id="ListFinancialEventGroupsFuzzyCondition"></a>
+
 `ListFinancialEventGroupsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -196,6 +214,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.amazon_seller_partner.types.ListFinancialEventGroupsStringFilter`
     :   The type of the None singleton.
+
+<a id="ListFinancialEventGroupsGtCondition"></a>
 
 `ListFinancialEventGroupsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
@@ -209,6 +229,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.amazon_seller_partner.types.ListFinancialEventGroupsSearchFilter`
     :   The type of the None singleton.
 
+<a id="ListFinancialEventGroupsGteCondition"></a>
+
 `ListFinancialEventGroupsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -220,6 +242,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.amazon_seller_partner.types.ListFinancialEventGroupsSearchFilter`
     :   The type of the None singleton.
+
+<a id="ListFinancialEventGroupsInCondition"></a>
 
 `ListFinancialEventGroupsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -240,6 +264,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.amazon_seller_partner.types.ListFinancialEventGroupsInFilter`
     :   The type of the None singleton.
+
+<a id="ListFinancialEventGroupsInFilter"></a>
 
 `ListFinancialEventGroupsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -283,6 +309,8 @@ Classes
     `trace_id: list[str]`
     :   Unique identifier for tracing
 
+<a id="ListFinancialEventGroupsKeywordCondition"></a>
+
 `ListFinancialEventGroupsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -295,6 +323,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.amazon_seller_partner.types.ListFinancialEventGroupsStringFilter`
     :   The type of the None singleton.
 
+<a id="ListFinancialEventGroupsLikeCondition"></a>
+
 `ListFinancialEventGroupsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -306,6 +336,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.amazon_seller_partner.types.ListFinancialEventGroupsStringFilter`
     :   The type of the None singleton.
+
+<a id="ListFinancialEventGroupsListParams"></a>
 
 `ListFinancialEventGroupsListParams(*args, **kwargs)`
 :   Parameters for list_financial_event_groups.list operation
@@ -328,6 +360,8 @@ Classes
     `next_token: str`
     :   The type of the None singleton.
 
+<a id="ListFinancialEventGroupsLtCondition"></a>
+
 `ListFinancialEventGroupsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -339,6 +373,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.amazon_seller_partner.types.ListFinancialEventGroupsSearchFilter`
     :   The type of the None singleton.
+
+<a id="ListFinancialEventGroupsLteCondition"></a>
 
 `ListFinancialEventGroupsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -352,6 +388,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.amazon_seller_partner.types.ListFinancialEventGroupsSearchFilter`
     :   The type of the None singleton.
 
+<a id="ListFinancialEventGroupsNeqCondition"></a>
+
 `ListFinancialEventGroupsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -363,6 +401,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.amazon_seller_partner.types.ListFinancialEventGroupsSearchFilter`
     :   The type of the None singleton.
+
+<a id="ListFinancialEventGroupsNotCondition"></a>
 
 `ListFinancialEventGroupsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -384,6 +424,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.amazon_seller_partner.types.ListFinancialEventGroupsEqCondition | airbyte_agent_sdk.connectors.amazon_seller_partner.types.ListFinancialEventGroupsNeqCondition | airbyte_agent_sdk.connectors.amazon_seller_partner.types.ListFinancialEventGroupsGtCondition | airbyte_agent_sdk.connectors.amazon_seller_partner.types.ListFinancialEventGroupsGteCondition | airbyte_agent_sdk.connectors.amazon_seller_partner.types.ListFinancialEventGroupsLtCondition | airbyte_agent_sdk.connectors.amazon_seller_partner.types.ListFinancialEventGroupsLteCondition | airbyte_agent_sdk.connectors.amazon_seller_partner.types.ListFinancialEventGroupsInCondition | airbyte_agent_sdk.connectors.amazon_seller_partner.types.ListFinancialEventGroupsLikeCondition | airbyte_agent_sdk.connectors.amazon_seller_partner.types.ListFinancialEventGroupsFuzzyCondition | airbyte_agent_sdk.connectors.amazon_seller_partner.types.ListFinancialEventGroupsKeywordCondition | airbyte_agent_sdk.connectors.amazon_seller_partner.types.ListFinancialEventGroupsContainsCondition | airbyte_agent_sdk.connectors.amazon_seller_partner.types.ListFinancialEventGroupsNotCondition | airbyte_agent_sdk.connectors.amazon_seller_partner.types.ListFinancialEventGroupsAndCondition | airbyte_agent_sdk.connectors.amazon_seller_partner.types.ListFinancialEventGroupsOrCondition | airbyte_agent_sdk.connectors.amazon_seller_partner.types.ListFinancialEventGroupsAnyCondition`
     :   The type of the None singleton.
 
+<a id="ListFinancialEventGroupsOrCondition"></a>
+
 `ListFinancialEventGroupsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -403,6 +445,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.amazon_seller_partner.types.ListFinancialEventGroupsEqCondition | airbyte_agent_sdk.connectors.amazon_seller_partner.types.ListFinancialEventGroupsNeqCondition | airbyte_agent_sdk.connectors.amazon_seller_partner.types.ListFinancialEventGroupsGtCondition | airbyte_agent_sdk.connectors.amazon_seller_partner.types.ListFinancialEventGroupsGteCondition | airbyte_agent_sdk.connectors.amazon_seller_partner.types.ListFinancialEventGroupsLtCondition | airbyte_agent_sdk.connectors.amazon_seller_partner.types.ListFinancialEventGroupsLteCondition | airbyte_agent_sdk.connectors.amazon_seller_partner.types.ListFinancialEventGroupsInCondition | airbyte_agent_sdk.connectors.amazon_seller_partner.types.ListFinancialEventGroupsLikeCondition | airbyte_agent_sdk.connectors.amazon_seller_partner.types.ListFinancialEventGroupsFuzzyCondition | airbyte_agent_sdk.connectors.amazon_seller_partner.types.ListFinancialEventGroupsKeywordCondition | airbyte_agent_sdk.connectors.amazon_seller_partner.types.ListFinancialEventGroupsContainsCondition | airbyte_agent_sdk.connectors.amazon_seller_partner.types.ListFinancialEventGroupsNotCondition | airbyte_agent_sdk.connectors.amazon_seller_partner.types.ListFinancialEventGroupsAndCondition | airbyte_agent_sdk.connectors.amazon_seller_partner.types.ListFinancialEventGroupsOrCondition | airbyte_agent_sdk.connectors.amazon_seller_partner.types.ListFinancialEventGroupsAnyCondition]`
     :   The type of the None singleton.
+
+<a id="ListFinancialEventGroupsSearchFilter"></a>
 
 `ListFinancialEventGroupsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering list_financial_event_groups search queries.
@@ -446,6 +490,8 @@ Classes
     `trace_id: str | None`
     :   Unique identifier for tracing
 
+<a id="ListFinancialEventGroupsSearchQuery"></a>
+
 `ListFinancialEventGroupsSearchQuery(*args, **kwargs)`
 :   Search query for list_financial_event_groups entity.
 
@@ -460,6 +506,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.amazon_seller_partner.types.ListFinancialEventGroupsSortFilter]`
     :   The type of the None singleton.
+
+<a id="ListFinancialEventGroupsSortFilter"></a>
 
 `ListFinancialEventGroupsSortFilter(*args, **kwargs)`
 :   Available fields for sorting list_financial_event_groups search results.
@@ -503,6 +551,8 @@ Classes
     `trace_id: Literal['asc', 'desc']`
     :   Unique identifier for tracing
 
+<a id="ListFinancialEventGroupsStringFilter"></a>
+
 `ListFinancialEventGroupsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -545,6 +595,8 @@ Classes
     `trace_id: str`
     :   Unique identifier for tracing
 
+<a id="ListFinancialEventsAndCondition"></a>
+
 `ListFinancialEventsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -565,6 +617,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.amazon_seller_partner.types.ListFinancialEventsEqCondition | airbyte_agent_sdk.connectors.amazon_seller_partner.types.ListFinancialEventsNeqCondition | airbyte_agent_sdk.connectors.amazon_seller_partner.types.ListFinancialEventsGtCondition | airbyte_agent_sdk.connectors.amazon_seller_partner.types.ListFinancialEventsGteCondition | airbyte_agent_sdk.connectors.amazon_seller_partner.types.ListFinancialEventsLtCondition | airbyte_agent_sdk.connectors.amazon_seller_partner.types.ListFinancialEventsLteCondition | airbyte_agent_sdk.connectors.amazon_seller_partner.types.ListFinancialEventsInCondition | airbyte_agent_sdk.connectors.amazon_seller_partner.types.ListFinancialEventsLikeCondition | airbyte_agent_sdk.connectors.amazon_seller_partner.types.ListFinancialEventsFuzzyCondition | airbyte_agent_sdk.connectors.amazon_seller_partner.types.ListFinancialEventsKeywordCondition | airbyte_agent_sdk.connectors.amazon_seller_partner.types.ListFinancialEventsContainsCondition | airbyte_agent_sdk.connectors.amazon_seller_partner.types.ListFinancialEventsNotCondition | airbyte_agent_sdk.connectors.amazon_seller_partner.types.ListFinancialEventsAndCondition | airbyte_agent_sdk.connectors.amazon_seller_partner.types.ListFinancialEventsOrCondition | airbyte_agent_sdk.connectors.amazon_seller_partner.types.ListFinancialEventsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="ListFinancialEventsAnyCondition"></a>
+
 `ListFinancialEventsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -584,6 +638,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.amazon_seller_partner.types.ListFinancialEventsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="ListFinancialEventsAnyValueFilter"></a>
 
 `ListFinancialEventsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -699,6 +755,8 @@ Classes
     `value_added_service_charge_event_list: Any`
     :   List of value-added service charge events
 
+<a id="ListFinancialEventsContainsCondition"></a>
+
 `ListFinancialEventsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -710,6 +768,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.amazon_seller_partner.types.ListFinancialEventsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="ListFinancialEventsEqCondition"></a>
 
 `ListFinancialEventsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -723,6 +783,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.amazon_seller_partner.types.ListFinancialEventsSearchFilter`
     :   The type of the None singleton.
 
+<a id="ListFinancialEventsFuzzyCondition"></a>
+
 `ListFinancialEventsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -734,6 +796,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.amazon_seller_partner.types.ListFinancialEventsStringFilter`
     :   The type of the None singleton.
+
+<a id="ListFinancialEventsGtCondition"></a>
 
 `ListFinancialEventsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
@@ -747,6 +811,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.amazon_seller_partner.types.ListFinancialEventsSearchFilter`
     :   The type of the None singleton.
 
+<a id="ListFinancialEventsGteCondition"></a>
+
 `ListFinancialEventsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -758,6 +824,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.amazon_seller_partner.types.ListFinancialEventsSearchFilter`
     :   The type of the None singleton.
+
+<a id="ListFinancialEventsInCondition"></a>
 
 `ListFinancialEventsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -778,6 +846,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.amazon_seller_partner.types.ListFinancialEventsInFilter`
     :   The type of the None singleton.
+
+<a id="ListFinancialEventsInFilter"></a>
 
 `ListFinancialEventsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -893,6 +963,8 @@ Classes
     `value_added_service_charge_event_list: list[list[typing.Any]]`
     :   List of value-added service charge events
 
+<a id="ListFinancialEventsKeywordCondition"></a>
+
 `ListFinancialEventsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -905,6 +977,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.amazon_seller_partner.types.ListFinancialEventsStringFilter`
     :   The type of the None singleton.
 
+<a id="ListFinancialEventsLikeCondition"></a>
+
 `ListFinancialEventsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -916,6 +990,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.amazon_seller_partner.types.ListFinancialEventsStringFilter`
     :   The type of the None singleton.
+
+<a id="ListFinancialEventsListParams"></a>
 
 `ListFinancialEventsListParams(*args, **kwargs)`
 :   Parameters for list_financial_events.list operation
@@ -938,6 +1014,8 @@ Classes
     `posted_before: str`
     :   The type of the None singleton.
 
+<a id="ListFinancialEventsLtCondition"></a>
+
 `ListFinancialEventsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -949,6 +1027,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.amazon_seller_partner.types.ListFinancialEventsSearchFilter`
     :   The type of the None singleton.
+
+<a id="ListFinancialEventsLteCondition"></a>
 
 `ListFinancialEventsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -962,6 +1042,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.amazon_seller_partner.types.ListFinancialEventsSearchFilter`
     :   The type of the None singleton.
 
+<a id="ListFinancialEventsNeqCondition"></a>
+
 `ListFinancialEventsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -973,6 +1055,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.amazon_seller_partner.types.ListFinancialEventsSearchFilter`
     :   The type of the None singleton.
+
+<a id="ListFinancialEventsNotCondition"></a>
 
 `ListFinancialEventsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -994,6 +1078,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.amazon_seller_partner.types.ListFinancialEventsEqCondition | airbyte_agent_sdk.connectors.amazon_seller_partner.types.ListFinancialEventsNeqCondition | airbyte_agent_sdk.connectors.amazon_seller_partner.types.ListFinancialEventsGtCondition | airbyte_agent_sdk.connectors.amazon_seller_partner.types.ListFinancialEventsGteCondition | airbyte_agent_sdk.connectors.amazon_seller_partner.types.ListFinancialEventsLtCondition | airbyte_agent_sdk.connectors.amazon_seller_partner.types.ListFinancialEventsLteCondition | airbyte_agent_sdk.connectors.amazon_seller_partner.types.ListFinancialEventsInCondition | airbyte_agent_sdk.connectors.amazon_seller_partner.types.ListFinancialEventsLikeCondition | airbyte_agent_sdk.connectors.amazon_seller_partner.types.ListFinancialEventsFuzzyCondition | airbyte_agent_sdk.connectors.amazon_seller_partner.types.ListFinancialEventsKeywordCondition | airbyte_agent_sdk.connectors.amazon_seller_partner.types.ListFinancialEventsContainsCondition | airbyte_agent_sdk.connectors.amazon_seller_partner.types.ListFinancialEventsNotCondition | airbyte_agent_sdk.connectors.amazon_seller_partner.types.ListFinancialEventsAndCondition | airbyte_agent_sdk.connectors.amazon_seller_partner.types.ListFinancialEventsOrCondition | airbyte_agent_sdk.connectors.amazon_seller_partner.types.ListFinancialEventsAnyCondition`
     :   The type of the None singleton.
 
+<a id="ListFinancialEventsOrCondition"></a>
+
 `ListFinancialEventsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1013,6 +1099,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.amazon_seller_partner.types.ListFinancialEventsEqCondition | airbyte_agent_sdk.connectors.amazon_seller_partner.types.ListFinancialEventsNeqCondition | airbyte_agent_sdk.connectors.amazon_seller_partner.types.ListFinancialEventsGtCondition | airbyte_agent_sdk.connectors.amazon_seller_partner.types.ListFinancialEventsGteCondition | airbyte_agent_sdk.connectors.amazon_seller_partner.types.ListFinancialEventsLtCondition | airbyte_agent_sdk.connectors.amazon_seller_partner.types.ListFinancialEventsLteCondition | airbyte_agent_sdk.connectors.amazon_seller_partner.types.ListFinancialEventsInCondition | airbyte_agent_sdk.connectors.amazon_seller_partner.types.ListFinancialEventsLikeCondition | airbyte_agent_sdk.connectors.amazon_seller_partner.types.ListFinancialEventsFuzzyCondition | airbyte_agent_sdk.connectors.amazon_seller_partner.types.ListFinancialEventsKeywordCondition | airbyte_agent_sdk.connectors.amazon_seller_partner.types.ListFinancialEventsContainsCondition | airbyte_agent_sdk.connectors.amazon_seller_partner.types.ListFinancialEventsNotCondition | airbyte_agent_sdk.connectors.amazon_seller_partner.types.ListFinancialEventsAndCondition | airbyte_agent_sdk.connectors.amazon_seller_partner.types.ListFinancialEventsOrCondition | airbyte_agent_sdk.connectors.amazon_seller_partner.types.ListFinancialEventsAnyCondition]`
     :   The type of the None singleton.
+
+<a id="ListFinancialEventsSearchFilter"></a>
 
 `ListFinancialEventsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering list_financial_events search queries.
@@ -1128,6 +1216,8 @@ Classes
     `value_added_service_charge_event_list: list[typing.Any] | None`
     :   List of value-added service charge events
 
+<a id="ListFinancialEventsSearchQuery"></a>
+
 `ListFinancialEventsSearchQuery(*args, **kwargs)`
 :   Search query for list_financial_events entity.
 
@@ -1142,6 +1232,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.amazon_seller_partner.types.ListFinancialEventsSortFilter]`
     :   The type of the None singleton.
+
+<a id="ListFinancialEventsSortFilter"></a>
 
 `ListFinancialEventsSortFilter(*args, **kwargs)`
 :   Available fields for sorting list_financial_events search results.
@@ -1257,6 +1349,8 @@ Classes
     `value_added_service_charge_event_list: Literal['asc', 'desc']`
     :   List of value-added service charge events
 
+<a id="ListFinancialEventsStringFilter"></a>
+
 `ListFinancialEventsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -1371,6 +1465,8 @@ Classes
     `value_added_service_charge_event_list: str`
     :   List of value-added service charge events
 
+<a id="OrderItemsAndCondition"></a>
+
 `OrderItemsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1391,6 +1487,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.amazon_seller_partner.types.OrderItemsEqCondition | airbyte_agent_sdk.connectors.amazon_seller_partner.types.OrderItemsNeqCondition | airbyte_agent_sdk.connectors.amazon_seller_partner.types.OrderItemsGtCondition | airbyte_agent_sdk.connectors.amazon_seller_partner.types.OrderItemsGteCondition | airbyte_agent_sdk.connectors.amazon_seller_partner.types.OrderItemsLtCondition | airbyte_agent_sdk.connectors.amazon_seller_partner.types.OrderItemsLteCondition | airbyte_agent_sdk.connectors.amazon_seller_partner.types.OrderItemsInCondition | airbyte_agent_sdk.connectors.amazon_seller_partner.types.OrderItemsLikeCondition | airbyte_agent_sdk.connectors.amazon_seller_partner.types.OrderItemsFuzzyCondition | airbyte_agent_sdk.connectors.amazon_seller_partner.types.OrderItemsKeywordCondition | airbyte_agent_sdk.connectors.amazon_seller_partner.types.OrderItemsContainsCondition | airbyte_agent_sdk.connectors.amazon_seller_partner.types.OrderItemsNotCondition | airbyte_agent_sdk.connectors.amazon_seller_partner.types.OrderItemsAndCondition | airbyte_agent_sdk.connectors.amazon_seller_partner.types.OrderItemsOrCondition | airbyte_agent_sdk.connectors.amazon_seller_partner.types.OrderItemsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="OrderItemsAnyCondition"></a>
+
 `OrderItemsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1410,6 +1508,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.amazon_seller_partner.types.OrderItemsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="OrderItemsAnyValueFilter"></a>
 
 `OrderItemsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -1531,6 +1631,8 @@ Classes
     `title: Any`
     :   Title of the product
 
+<a id="OrderItemsContainsCondition"></a>
+
 `OrderItemsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -1542,6 +1644,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.amazon_seller_partner.types.OrderItemsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="OrderItemsEqCondition"></a>
 
 `OrderItemsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -1555,6 +1659,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.amazon_seller_partner.types.OrderItemsSearchFilter`
     :   The type of the None singleton.
 
+<a id="OrderItemsFuzzyCondition"></a>
+
 `OrderItemsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -1566,6 +1672,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.amazon_seller_partner.types.OrderItemsStringFilter`
     :   The type of the None singleton.
+
+<a id="OrderItemsGtCondition"></a>
 
 `OrderItemsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
@@ -1579,6 +1687,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.amazon_seller_partner.types.OrderItemsSearchFilter`
     :   The type of the None singleton.
 
+<a id="OrderItemsGteCondition"></a>
+
 `OrderItemsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -1590,6 +1700,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.amazon_seller_partner.types.OrderItemsSearchFilter`
     :   The type of the None singleton.
+
+<a id="OrderItemsInCondition"></a>
 
 `OrderItemsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -1610,6 +1722,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.amazon_seller_partner.types.OrderItemsInFilter`
     :   The type of the None singleton.
+
+<a id="OrderItemsInFilter"></a>
 
 `OrderItemsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -1731,6 +1845,8 @@ Classes
     `title: list[str]`
     :   Title of the product
 
+<a id="OrderItemsKeywordCondition"></a>
+
 `OrderItemsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -1743,6 +1859,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.amazon_seller_partner.types.OrderItemsStringFilter`
     :   The type of the None singleton.
 
+<a id="OrderItemsLikeCondition"></a>
+
 `OrderItemsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -1754,6 +1872,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.amazon_seller_partner.types.OrderItemsStringFilter`
     :   The type of the None singleton.
+
+<a id="OrderItemsListParams"></a>
 
 `OrderItemsListParams(*args, **kwargs)`
 :   Parameters for order_items.list operation
@@ -1770,6 +1890,8 @@ Classes
     `order_id: str`
     :   The type of the None singleton.
 
+<a id="OrderItemsLtCondition"></a>
+
 `OrderItemsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -1781,6 +1903,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.amazon_seller_partner.types.OrderItemsSearchFilter`
     :   The type of the None singleton.
+
+<a id="OrderItemsLteCondition"></a>
 
 `OrderItemsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -1794,6 +1918,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.amazon_seller_partner.types.OrderItemsSearchFilter`
     :   The type of the None singleton.
 
+<a id="OrderItemsNeqCondition"></a>
+
 `OrderItemsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -1805,6 +1931,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.amazon_seller_partner.types.OrderItemsSearchFilter`
     :   The type of the None singleton.
+
+<a id="OrderItemsNotCondition"></a>
 
 `OrderItemsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -1826,6 +1954,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.amazon_seller_partner.types.OrderItemsEqCondition | airbyte_agent_sdk.connectors.amazon_seller_partner.types.OrderItemsNeqCondition | airbyte_agent_sdk.connectors.amazon_seller_partner.types.OrderItemsGtCondition | airbyte_agent_sdk.connectors.amazon_seller_partner.types.OrderItemsGteCondition | airbyte_agent_sdk.connectors.amazon_seller_partner.types.OrderItemsLtCondition | airbyte_agent_sdk.connectors.amazon_seller_partner.types.OrderItemsLteCondition | airbyte_agent_sdk.connectors.amazon_seller_partner.types.OrderItemsInCondition | airbyte_agent_sdk.connectors.amazon_seller_partner.types.OrderItemsLikeCondition | airbyte_agent_sdk.connectors.amazon_seller_partner.types.OrderItemsFuzzyCondition | airbyte_agent_sdk.connectors.amazon_seller_partner.types.OrderItemsKeywordCondition | airbyte_agent_sdk.connectors.amazon_seller_partner.types.OrderItemsContainsCondition | airbyte_agent_sdk.connectors.amazon_seller_partner.types.OrderItemsNotCondition | airbyte_agent_sdk.connectors.amazon_seller_partner.types.OrderItemsAndCondition | airbyte_agent_sdk.connectors.amazon_seller_partner.types.OrderItemsOrCondition | airbyte_agent_sdk.connectors.amazon_seller_partner.types.OrderItemsAnyCondition`
     :   The type of the None singleton.
 
+<a id="OrderItemsOrCondition"></a>
+
 `OrderItemsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1845,6 +1975,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.amazon_seller_partner.types.OrderItemsEqCondition | airbyte_agent_sdk.connectors.amazon_seller_partner.types.OrderItemsNeqCondition | airbyte_agent_sdk.connectors.amazon_seller_partner.types.OrderItemsGtCondition | airbyte_agent_sdk.connectors.amazon_seller_partner.types.OrderItemsGteCondition | airbyte_agent_sdk.connectors.amazon_seller_partner.types.OrderItemsLtCondition | airbyte_agent_sdk.connectors.amazon_seller_partner.types.OrderItemsLteCondition | airbyte_agent_sdk.connectors.amazon_seller_partner.types.OrderItemsInCondition | airbyte_agent_sdk.connectors.amazon_seller_partner.types.OrderItemsLikeCondition | airbyte_agent_sdk.connectors.amazon_seller_partner.types.OrderItemsFuzzyCondition | airbyte_agent_sdk.connectors.amazon_seller_partner.types.OrderItemsKeywordCondition | airbyte_agent_sdk.connectors.amazon_seller_partner.types.OrderItemsContainsCondition | airbyte_agent_sdk.connectors.amazon_seller_partner.types.OrderItemsNotCondition | airbyte_agent_sdk.connectors.amazon_seller_partner.types.OrderItemsAndCondition | airbyte_agent_sdk.connectors.amazon_seller_partner.types.OrderItemsOrCondition | airbyte_agent_sdk.connectors.amazon_seller_partner.types.OrderItemsAnyCondition]`
     :   The type of the None singleton.
+
+<a id="OrderItemsSearchFilter"></a>
 
 `OrderItemsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering order_items search queries.
@@ -1966,6 +2098,8 @@ Classes
     `title: str | None`
     :   Title of the product
 
+<a id="OrderItemsSearchQuery"></a>
+
 `OrderItemsSearchQuery(*args, **kwargs)`
 :   Search query for order_items entity.
 
@@ -1980,6 +2114,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.amazon_seller_partner.types.OrderItemsSortFilter]`
     :   The type of the None singleton.
+
+<a id="OrderItemsSortFilter"></a>
 
 `OrderItemsSortFilter(*args, **kwargs)`
 :   Available fields for sorting order_items search results.
@@ -2101,6 +2237,8 @@ Classes
     `title: Literal['asc', 'desc']`
     :   Title of the product
 
+<a id="OrderItemsStringFilter"></a>
+
 `OrderItemsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -2221,6 +2359,8 @@ Classes
     `title: str`
     :   Title of the product
 
+<a id="OrdersAndCondition"></a>
+
 `OrdersAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -2241,6 +2381,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.amazon_seller_partner.types.OrdersEqCondition | airbyte_agent_sdk.connectors.amazon_seller_partner.types.OrdersNeqCondition | airbyte_agent_sdk.connectors.amazon_seller_partner.types.OrdersGtCondition | airbyte_agent_sdk.connectors.amazon_seller_partner.types.OrdersGteCondition | airbyte_agent_sdk.connectors.amazon_seller_partner.types.OrdersLtCondition | airbyte_agent_sdk.connectors.amazon_seller_partner.types.OrdersLteCondition | airbyte_agent_sdk.connectors.amazon_seller_partner.types.OrdersInCondition | airbyte_agent_sdk.connectors.amazon_seller_partner.types.OrdersLikeCondition | airbyte_agent_sdk.connectors.amazon_seller_partner.types.OrdersFuzzyCondition | airbyte_agent_sdk.connectors.amazon_seller_partner.types.OrdersKeywordCondition | airbyte_agent_sdk.connectors.amazon_seller_partner.types.OrdersContainsCondition | airbyte_agent_sdk.connectors.amazon_seller_partner.types.OrdersNotCondition | airbyte_agent_sdk.connectors.amazon_seller_partner.types.OrdersAndCondition | airbyte_agent_sdk.connectors.amazon_seller_partner.types.OrdersOrCondition | airbyte_agent_sdk.connectors.amazon_seller_partner.types.OrdersAnyCondition]`
     :   The type of the None singleton.
 
+<a id="OrdersAnyCondition"></a>
+
 `OrdersAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -2260,6 +2402,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.amazon_seller_partner.types.OrdersAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="OrdersAnyValueFilter"></a>
 
 `OrdersAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -2372,6 +2516,8 @@ Classes
     `shipping_address: Any`
     :   The address to which the order will be shipped
 
+<a id="OrdersContainsCondition"></a>
+
 `OrdersContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -2383,6 +2529,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.amazon_seller_partner.types.OrdersAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="OrdersEqCondition"></a>
 
 `OrdersEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -2396,6 +2544,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.amazon_seller_partner.types.OrdersSearchFilter`
     :   The type of the None singleton.
 
+<a id="OrdersFuzzyCondition"></a>
+
 `OrdersFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -2407,6 +2557,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.amazon_seller_partner.types.OrdersStringFilter`
     :   The type of the None singleton.
+
+<a id="OrdersGetParams"></a>
 
 `OrdersGetParams(*args, **kwargs)`
 :   Parameters for orders.get operation
@@ -2420,6 +2572,8 @@ Classes
     `order_id: str`
     :   The type of the None singleton.
 
+<a id="OrdersGtCondition"></a>
+
 `OrdersGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -2432,6 +2586,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.amazon_seller_partner.types.OrdersSearchFilter`
     :   The type of the None singleton.
 
+<a id="OrdersGteCondition"></a>
+
 `OrdersGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -2443,6 +2599,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.amazon_seller_partner.types.OrdersSearchFilter`
     :   The type of the None singleton.
+
+<a id="OrdersInCondition"></a>
 
 `OrdersInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -2463,6 +2621,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.amazon_seller_partner.types.OrdersInFilter`
     :   The type of the None singleton.
+
+<a id="OrdersInFilter"></a>
 
 `OrdersInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -2575,6 +2735,8 @@ Classes
     `shipping_address: list[dict[str, typing.Any]]`
     :   The address to which the order will be shipped
 
+<a id="OrdersKeywordCondition"></a>
+
 `OrdersKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -2587,6 +2749,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.amazon_seller_partner.types.OrdersStringFilter`
     :   The type of the None singleton.
 
+<a id="OrdersLikeCondition"></a>
+
 `OrdersLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -2598,6 +2762,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.amazon_seller_partner.types.OrdersStringFilter`
     :   The type of the None singleton.
+
+<a id="OrdersListParams"></a>
 
 `OrdersListParams(*args, **kwargs)`
 :   Parameters for orders.list operation
@@ -2632,6 +2798,8 @@ Classes
     `order_statuses: str`
     :   The type of the None singleton.
 
+<a id="OrdersLtCondition"></a>
+
 `OrdersLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -2643,6 +2811,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.amazon_seller_partner.types.OrdersSearchFilter`
     :   The type of the None singleton.
+
+<a id="OrdersLteCondition"></a>
 
 `OrdersLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -2656,6 +2826,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.amazon_seller_partner.types.OrdersSearchFilter`
     :   The type of the None singleton.
 
+<a id="OrdersNeqCondition"></a>
+
 `OrdersNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -2667,6 +2839,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.amazon_seller_partner.types.OrdersSearchFilter`
     :   The type of the None singleton.
+
+<a id="OrdersNotCondition"></a>
 
 `OrdersNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -2688,6 +2862,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.amazon_seller_partner.types.OrdersEqCondition | airbyte_agent_sdk.connectors.amazon_seller_partner.types.OrdersNeqCondition | airbyte_agent_sdk.connectors.amazon_seller_partner.types.OrdersGtCondition | airbyte_agent_sdk.connectors.amazon_seller_partner.types.OrdersGteCondition | airbyte_agent_sdk.connectors.amazon_seller_partner.types.OrdersLtCondition | airbyte_agent_sdk.connectors.amazon_seller_partner.types.OrdersLteCondition | airbyte_agent_sdk.connectors.amazon_seller_partner.types.OrdersInCondition | airbyte_agent_sdk.connectors.amazon_seller_partner.types.OrdersLikeCondition | airbyte_agent_sdk.connectors.amazon_seller_partner.types.OrdersFuzzyCondition | airbyte_agent_sdk.connectors.amazon_seller_partner.types.OrdersKeywordCondition | airbyte_agent_sdk.connectors.amazon_seller_partner.types.OrdersContainsCondition | airbyte_agent_sdk.connectors.amazon_seller_partner.types.OrdersNotCondition | airbyte_agent_sdk.connectors.amazon_seller_partner.types.OrdersAndCondition | airbyte_agent_sdk.connectors.amazon_seller_partner.types.OrdersOrCondition | airbyte_agent_sdk.connectors.amazon_seller_partner.types.OrdersAnyCondition`
     :   The type of the None singleton.
 
+<a id="OrdersOrCondition"></a>
+
 `OrdersOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -2707,6 +2883,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.amazon_seller_partner.types.OrdersEqCondition | airbyte_agent_sdk.connectors.amazon_seller_partner.types.OrdersNeqCondition | airbyte_agent_sdk.connectors.amazon_seller_partner.types.OrdersGtCondition | airbyte_agent_sdk.connectors.amazon_seller_partner.types.OrdersGteCondition | airbyte_agent_sdk.connectors.amazon_seller_partner.types.OrdersLtCondition | airbyte_agent_sdk.connectors.amazon_seller_partner.types.OrdersLteCondition | airbyte_agent_sdk.connectors.amazon_seller_partner.types.OrdersInCondition | airbyte_agent_sdk.connectors.amazon_seller_partner.types.OrdersLikeCondition | airbyte_agent_sdk.connectors.amazon_seller_partner.types.OrdersFuzzyCondition | airbyte_agent_sdk.connectors.amazon_seller_partner.types.OrdersKeywordCondition | airbyte_agent_sdk.connectors.amazon_seller_partner.types.OrdersContainsCondition | airbyte_agent_sdk.connectors.amazon_seller_partner.types.OrdersNotCondition | airbyte_agent_sdk.connectors.amazon_seller_partner.types.OrdersAndCondition | airbyte_agent_sdk.connectors.amazon_seller_partner.types.OrdersOrCondition | airbyte_agent_sdk.connectors.amazon_seller_partner.types.OrdersAnyCondition]`
     :   The type of the None singleton.
+
+<a id="OrdersSearchFilter"></a>
 
 `OrdersSearchFilter(*args, **kwargs)`
 :   Available fields for filtering orders search queries.
@@ -2819,6 +2997,8 @@ Classes
     `shipping_address: dict[str, typing.Any] | None`
     :   The address to which the order will be shipped
 
+<a id="OrdersSearchQuery"></a>
+
 `OrdersSearchQuery(*args, **kwargs)`
 :   Search query for orders entity.
 
@@ -2833,6 +3013,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.amazon_seller_partner.types.OrdersSortFilter]`
     :   The type of the None singleton.
+
+<a id="OrdersSortFilter"></a>
 
 `OrdersSortFilter(*args, **kwargs)`
 :   Available fields for sorting orders search results.
@@ -2945,6 +3127,8 @@ Classes
     `shipping_address: Literal['asc', 'desc']`
     :   The address to which the order will be shipped
 
+<a id="OrdersStringFilter"></a>
+
 `OrdersStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -3056,6 +3240,8 @@ Classes
     `shipping_address: str`
     :   The address to which the order will be shipped
 
+<a id="ReportsGetParams"></a>
+
 `ReportsGetParams(*args, **kwargs)`
 :   Parameters for reports.get operation
 
@@ -3067,6 +3253,8 @@ Classes
 
     `report_id: str`
     :   The type of the None singleton.
+
+<a id="ReportsListParams"></a>
 
 `ReportsListParams(*args, **kwargs)`
 :   Parameters for reports.list operation

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/amplitude/connector.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/amplitude/connector.md
@@ -10,6 +10,8 @@ Amplitude connector.
 Classes
 -------
 
+<a id="ActiveUsersQuery"></a>
+
 `ActiveUsersQuery(connector: AmplitudeConnector)`
 :   Query class for ActiveUsers entity operations.
     
@@ -55,6 +57,8 @@ Classes
         
         Returns:
             ActiveUsersListResult
+
+<a id="AmplitudeConnector"></a>
 
 `AmplitudeConnector(auth_config: AmplitudeAuthConfig | AirbyteAuthConfig | BaseModel | None = None, on_token_refresh: Any | None = None)`
 :   Type-safe Amplitude API connector.
@@ -256,6 +260,8 @@ Classes
             for entity in entities:
                 print(f"\{entity['entity_name']\}: \{entity['available_actions']\}")
 
+<a id="AnnotationsQuery"></a>
+
 `AnnotationsQuery(connector: AmplitudeConnector)`
 :   Query class for Annotations entity operations.
     
@@ -305,6 +311,8 @@ Classes
         Returns:
             AnnotationsListResult
 
+<a id="AverageSessionLengthQuery"></a>
+
 `AverageSessionLengthQuery(connector: AmplitudeConnector)`
 :   Query class for AverageSessionLength entity operations.
     
@@ -347,6 +355,8 @@ Classes
         
         Returns:
             AverageSessionLengthListResult
+
+<a id="CohortsQuery"></a>
 
 `CohortsQuery(connector: AmplitudeConnector)`
 :   Query class for Cohorts entity operations.
@@ -418,6 +428,8 @@ Classes
         
         Returns:
             CohortsListResult
+
+<a id="EventsListQuery"></a>
 
 `EventsListQuery(connector: AmplitudeConnector)`
 :   Query class for EventsList entity operations.

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/amplitude/index.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/amplitude/index.md
@@ -19,6 +19,8 @@ Sub-modules
 Classes
 -------
 
+<a id="ActiveUsersSearchData"></a>
+
 `ActiveUsersSearchData(**data: Any)`
 :   Search result data for active_users entity.
     
@@ -43,6 +45,8 @@ Classes
 
     `statistics: dict[str, typing.Any] | None`
     :   The statistics related to the active users for the given date
+
+<a id="AirbyteAuthConfig"></a>
 
 `AirbyteAuthConfig(**data: Any)`
 :   Authentication configuration for Airbyte hosted mode execution.
@@ -112,6 +116,8 @@ Classes
     `workspace_name: str | None`
     :   The type of the None singleton.
 
+<a id="AirbyteSearchMeta"></a>
+
 `AirbyteSearchMeta(**data: Any)`
 :   Pagination metadata for search responses.
     
@@ -139,6 +145,8 @@ Classes
 
     `took_ms: int | None`
     :   Time taken to execute the search in milliseconds.
+
+<a id="AirbyteSearchResult"></a>
 
 `AirbyteSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -174,6 +182,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="ActiveUsersSearchResult"></a>
+
 `ActiveUsersSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -189,6 +199,8 @@ Classes
     * airbyte_agent_sdk.connectors.amplitude.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="AnnotationsSearchResult"></a>
 
 `AnnotationsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -206,6 +218,8 @@ Classes
     * pydantic.main.BaseModel
     * typing.Generic
 
+<a id="AverageSessionLengthSearchResult"></a>
+
 `AverageSessionLengthSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -221,6 +235,8 @@ Classes
     * airbyte_agent_sdk.connectors.amplitude.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="CohortsSearchResult"></a>
 
 `CohortsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -238,6 +254,8 @@ Classes
     * pydantic.main.BaseModel
     * typing.Generic
 
+<a id="EventsListSearchResult"></a>
+
 `EventsListSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -253,6 +271,8 @@ Classes
     * airbyte_agent_sdk.connectors.amplitude.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="AmplitudeAuthConfig"></a>
 
 `AmplitudeAuthConfig(**data: Any)`
 :   API Key Authentication
@@ -278,6 +298,8 @@ Classes
 
     `secret_key: str`
     :   Your Amplitude project secret key. Find it in Settings > Projects in your Amplitude account.
+
+<a id="AmplitudeConnector"></a>
 
 `AmplitudeConnector(auth_config: AmplitudeAuthConfig | AirbyteAuthConfig | BaseModel | None = None, on_token_refresh: Any | None = None)`
 :   Type-safe Amplitude API connector.
@@ -479,6 +501,8 @@ Classes
             for entity in entities:
                 print(f"\{entity['entity_name']\}: \{entity['available_actions']\}")
 
+<a id="AmplitudeReplicationConfig"></a>
+
 `AmplitudeReplicationConfig(**data: Any)`
 :   Replication Configuration - Settings for data replication from Amplitude.
     
@@ -500,6 +524,8 @@ Classes
 
     `start_date: str`
     :   UTC date and time in the format YYYY-MM-DDTHH:mm:ssZ. Any data before this date will not be replicated.
+
+<a id="AnnotationsSearchData"></a>
 
 `AnnotationsSearchData(**data: Any)`
 :   Search result data for annotations entity.
@@ -532,6 +558,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="AverageSessionLengthSearchData"></a>
+
 `AverageSessionLengthSearchData(**data: Any)`
 :   Search result data for average_session_length entity.
     
@@ -556,6 +584,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="CohortsSearchData"></a>
 
 `CohortsSearchData(**data: Any)`
 :   Search result data for cohorts entity.
@@ -653,6 +683,8 @@ Classes
 
     `viewers: list[typing.Any] | None`
     :   Users or viewers who have access to the cohort data
+
+<a id="EventsListSearchData"></a>
 
 `EventsListSearchData(**data: Any)`
 :   Search result data for events_list entity.

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/amplitude/models.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/amplitude/models.md
@@ -13,6 +13,8 @@ and response envelope types.
 Classes
 -------
 
+<a id="ActiveUsersData"></a>
+
 `ActiveUsersData(**data: Any)`
 :   Active or new user count data
     
@@ -47,6 +49,8 @@ Classes
     `x_values: list[str] | Any | None`
     :   The type of the None singleton.
 
+<a id="ActiveUsersDataSeriesmetaItem"></a>
+
 `ActiveUsersDataSeriesmetaItem(**data: Any)`
 :   Nested schema for ActiveUsersData.seriesMeta_item
     
@@ -69,6 +73,8 @@ Classes
     `segment_index: int | Any`
     :   The type of the None singleton.
 
+<a id="ActiveUsersResponse"></a>
+
 `ActiveUsersResponse(**data: Any)`
 :   Active users response wrapper
     
@@ -90,6 +96,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="ActiveUsersSearchData"></a>
 
 `ActiveUsersSearchData(**data: Any)`
 :   Search result data for active_users entity.
@@ -115,6 +123,8 @@ Classes
 
     `statistics: dict[str, typing.Any] | None`
     :   The statistics related to the active users for the given date
+
+<a id="AirbyteSearchMeta"></a>
 
 `AirbyteSearchMeta(**data: Any)`
 :   Pagination metadata for search responses.
@@ -143,6 +153,8 @@ Classes
 
     `took_ms: int | None`
     :   Time taken to execute the search in milliseconds.
+
+<a id="AirbyteSearchResult"></a>
 
 `AirbyteSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -199,6 +211,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="ActiveUsersSearchResult"></a>
+
 `ActiveUsersSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -235,6 +249,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="AnnotationsSearchResult"></a>
 
 `AnnotationsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -273,6 +289,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="AverageSessionLengthSearchResult"></a>
+
 `AverageSessionLengthSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -309,6 +327,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="CohortsSearchResult"></a>
 
 `CohortsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -347,6 +367,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="EventsListSearchResult"></a>
+
 `EventsListSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -362,6 +384,8 @@ Classes
     * airbyte_agent_sdk.connectors.amplitude.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="AmplitudeAuthConfig"></a>
 
 `AmplitudeAuthConfig(**data: Any)`
 :   API Key Authentication
@@ -387,6 +411,8 @@ Classes
 
     `secret_key: str`
     :   Your Amplitude project secret key. Find it in Settings > Projects in your Amplitude account.
+
+<a id="AmplitudeCheckResult"></a>
 
 `AmplitudeCheckResult(**data: Any)`
 :   Result of a health check operation.
@@ -421,6 +447,8 @@ Classes
     `status: str`
     :   Health check status: 'healthy' or 'unhealthy'.
 
+<a id="AmplitudeExecuteResult"></a>
+
 `AmplitudeExecuteResult(**data: Any)`
 :   Response envelope with data only.
     
@@ -454,6 +482,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="AmplitudeExecuteResultWithMeta"></a>
 
 `AmplitudeExecuteResultWithMeta(**data: Any)`
 :   Response envelope with data and metadata.
@@ -501,6 +531,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="ActiveUsersListResult"></a>
+
 `ActiveUsersListResult(**data: Any)`
 :   Response envelope with data only.
     
@@ -541,6 +573,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="AverageSessionLengthListResult"></a>
 
 `AverageSessionLengthListResult(**data: Any)`
 :   Response envelope with data only.
@@ -583,6 +617,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="AnnotationsListResult"></a>
+
 `AnnotationsListResult(**data: Any)`
 :   Response envelope with data only.
     
@@ -623,6 +659,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="CohortsListResult"></a>
 
 `CohortsListResult(**data: Any)`
 :   Response envelope with data only.
@@ -665,6 +703,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="EventsListListResult"></a>
+
 `EventsListListResult(**data: Any)`
 :   Response envelope with data only.
     
@@ -682,6 +722,8 @@ Classes
     * airbyte_agent_sdk.connectors.amplitude.models.AmplitudeExecuteResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="AmplitudeReplicationConfig"></a>
 
 `AmplitudeReplicationConfig(**data: Any)`
 :   Replication Configuration - Settings for data replication from Amplitude.
@@ -704,6 +746,8 @@ Classes
 
     `start_date: str`
     :   UTC date and time in the format YYYY-MM-DDTHH:mm:ssZ. Any data before this date will not be replicated.
+
+<a id="Annotation"></a>
 
 `Annotation(**data: Any)`
 :   A chart annotation object
@@ -736,6 +780,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="AnnotationGetResponse"></a>
+
 `AnnotationGetResponse(**data: Any)`
 :   Single annotation response
     
@@ -757,6 +803,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="AnnotationV3"></a>
 
 `AnnotationV3(**data: Any)`
 :   A chart annotation object (v3 API format)
@@ -798,6 +846,8 @@ Classes
     `start: str | Any | None`
     :   The type of the None singleton.
 
+<a id="AnnotationV3Category"></a>
+
 `AnnotationV3Category(**data: Any)`
 :   The annotation category
     
@@ -823,6 +873,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="AnnotationsList"></a>
+
 `AnnotationsList(**data: Any)`
 :   List of annotations
     
@@ -844,6 +896,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="AnnotationsSearchData"></a>
 
 `AnnotationsSearchData(**data: Any)`
 :   Search result data for annotations entity.
@@ -876,6 +930,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="AverageSessionLengthData"></a>
+
 `AverageSessionLengthData(**data: Any)`
 :   Average session length data
     
@@ -907,6 +963,8 @@ Classes
     `x_values: list[str] | Any | None`
     :   The type of the None singleton.
 
+<a id="AverageSessionLengthDataSeriescollapsedItemItem"></a>
+
 `AverageSessionLengthDataSeriescollapsedItemItem(**data: Any)`
 :   Nested schema for AverageSessionLengthData.seriesCollapsed_item_item
     
@@ -931,6 +989,8 @@ Classes
 
     `value: float | Any`
     :   The type of the None singleton.
+
+<a id="AverageSessionLengthDataSeriesmetaItem"></a>
 
 `AverageSessionLengthDataSeriesmetaItem(**data: Any)`
 :   Nested schema for AverageSessionLengthData.seriesMeta_item
@@ -957,6 +1017,8 @@ Classes
     `session_index: int | Any`
     :   The type of the None singleton.
 
+<a id="AverageSessionLengthResponse"></a>
+
 `AverageSessionLengthResponse(**data: Any)`
 :   Average session length response wrapper
     
@@ -978,6 +1040,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="AverageSessionLengthSearchData"></a>
 
 `AverageSessionLengthSearchData(**data: Any)`
 :   Search result data for average_session_length entity.
@@ -1003,6 +1067,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="Cohort"></a>
 
 `Cohort(**data: Any)`
 :   A user cohort object
@@ -1116,6 +1182,8 @@ Classes
     `viewers: list[str] | Any | None`
     :   The type of the None singleton.
 
+<a id="CohortGetResponse"></a>
+
 `CohortGetResponse(**data: Any)`
 :   Single cohort response wrapper
     
@@ -1138,6 +1206,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="CohortsList"></a>
+
 `CohortsList(**data: Any)`
 :   List of cohorts
     
@@ -1159,6 +1229,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="CohortsSearchData"></a>
 
 `CohortsSearchData(**data: Any)`
 :   Search result data for cohorts entity.
@@ -1257,6 +1329,8 @@ Classes
     `viewers: list[typing.Any] | None`
     :   Users or viewers who have access to the cohort data
 
+<a id="EventType"></a>
+
 `EventType(**data: Any)`
 :   An event type definition with weekly totals
     
@@ -1321,6 +1395,8 @@ Classes
     `waitroom_approved: bool | Any | None`
     :   The type of the None singleton.
 
+<a id="EventsListResponse"></a>
+
 `EventsListResponse(**data: Any)`
 :   List of event types
     
@@ -1342,6 +1418,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="EventsListSearchData"></a>
 
 `EventsListSearchData(**data: Any)`
 :   Search result data for events_list entity.

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/amplitude/types.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/amplitude/types.md
@@ -10,6 +10,8 @@ Type definitions for amplitude connector.
 Classes
 -------
 
+<a id="ActiveUsersAndCondition"></a>
+
 `ActiveUsersAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -29,6 +31,8 @@ Classes
 
     `and: list[airbyte_agent_sdk.connectors.amplitude.types.ActiveUsersEqCondition | airbyte_agent_sdk.connectors.amplitude.types.ActiveUsersNeqCondition | airbyte_agent_sdk.connectors.amplitude.types.ActiveUsersGtCondition | airbyte_agent_sdk.connectors.amplitude.types.ActiveUsersGteCondition | airbyte_agent_sdk.connectors.amplitude.types.ActiveUsersLtCondition | airbyte_agent_sdk.connectors.amplitude.types.ActiveUsersLteCondition | airbyte_agent_sdk.connectors.amplitude.types.ActiveUsersInCondition | airbyte_agent_sdk.connectors.amplitude.types.ActiveUsersLikeCondition | airbyte_agent_sdk.connectors.amplitude.types.ActiveUsersFuzzyCondition | airbyte_agent_sdk.connectors.amplitude.types.ActiveUsersKeywordCondition | airbyte_agent_sdk.connectors.amplitude.types.ActiveUsersContainsCondition | airbyte_agent_sdk.connectors.amplitude.types.ActiveUsersNotCondition | airbyte_agent_sdk.connectors.amplitude.types.ActiveUsersAndCondition | airbyte_agent_sdk.connectors.amplitude.types.ActiveUsersOrCondition | airbyte_agent_sdk.connectors.amplitude.types.ActiveUsersAnyCondition]`
     :   The type of the None singleton.
+
+<a id="ActiveUsersAnyCondition"></a>
 
 `ActiveUsersAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -50,6 +54,8 @@ Classes
     `any: airbyte_agent_sdk.connectors.amplitude.types.ActiveUsersAnyValueFilter`
     :   The type of the None singleton.
 
+<a id="ActiveUsersAnyValueFilter"></a>
+
 `ActiveUsersAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
 
@@ -65,6 +71,8 @@ Classes
     `statistics: Any`
     :   The statistics related to the active users for the given date
 
+<a id="ActiveUsersContainsCondition"></a>
+
 `ActiveUsersContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -76,6 +84,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.amplitude.types.ActiveUsersAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="ActiveUsersEqCondition"></a>
 
 `ActiveUsersEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -89,6 +99,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.amplitude.types.ActiveUsersSearchFilter`
     :   The type of the None singleton.
 
+<a id="ActiveUsersFuzzyCondition"></a>
+
 `ActiveUsersFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -100,6 +112,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.amplitude.types.ActiveUsersStringFilter`
     :   The type of the None singleton.
+
+<a id="ActiveUsersGtCondition"></a>
 
 `ActiveUsersGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
@@ -113,6 +127,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.amplitude.types.ActiveUsersSearchFilter`
     :   The type of the None singleton.
 
+<a id="ActiveUsersGteCondition"></a>
+
 `ActiveUsersGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -124,6 +140,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.amplitude.types.ActiveUsersSearchFilter`
     :   The type of the None singleton.
+
+<a id="ActiveUsersInCondition"></a>
 
 `ActiveUsersInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -145,6 +163,8 @@ Classes
     `in: airbyte_agent_sdk.connectors.amplitude.types.ActiveUsersInFilter`
     :   The type of the None singleton.
 
+<a id="ActiveUsersInFilter"></a>
+
 `ActiveUsersInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
 
@@ -160,6 +180,8 @@ Classes
     `statistics: list[dict[str, typing.Any]]`
     :   The statistics related to the active users for the given date
 
+<a id="ActiveUsersKeywordCondition"></a>
+
 `ActiveUsersKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -172,6 +194,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.amplitude.types.ActiveUsersStringFilter`
     :   The type of the None singleton.
 
+<a id="ActiveUsersLikeCondition"></a>
+
 `ActiveUsersLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -183,6 +207,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.amplitude.types.ActiveUsersStringFilter`
     :   The type of the None singleton.
+
+<a id="ActiveUsersListParams"></a>
 
 `ActiveUsersListParams(*args, **kwargs)`
 :   Parameters for active_users.list operation
@@ -208,6 +234,8 @@ Classes
     `start: str`
     :   The type of the None singleton.
 
+<a id="ActiveUsersLtCondition"></a>
+
 `ActiveUsersLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -219,6 +247,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.amplitude.types.ActiveUsersSearchFilter`
     :   The type of the None singleton.
+
+<a id="ActiveUsersLteCondition"></a>
 
 `ActiveUsersLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -232,6 +262,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.amplitude.types.ActiveUsersSearchFilter`
     :   The type of the None singleton.
 
+<a id="ActiveUsersNeqCondition"></a>
+
 `ActiveUsersNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -243,6 +275,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.amplitude.types.ActiveUsersSearchFilter`
     :   The type of the None singleton.
+
+<a id="ActiveUsersNotCondition"></a>
 
 `ActiveUsersNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -264,6 +298,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.amplitude.types.ActiveUsersEqCondition | airbyte_agent_sdk.connectors.amplitude.types.ActiveUsersNeqCondition | airbyte_agent_sdk.connectors.amplitude.types.ActiveUsersGtCondition | airbyte_agent_sdk.connectors.amplitude.types.ActiveUsersGteCondition | airbyte_agent_sdk.connectors.amplitude.types.ActiveUsersLtCondition | airbyte_agent_sdk.connectors.amplitude.types.ActiveUsersLteCondition | airbyte_agent_sdk.connectors.amplitude.types.ActiveUsersInCondition | airbyte_agent_sdk.connectors.amplitude.types.ActiveUsersLikeCondition | airbyte_agent_sdk.connectors.amplitude.types.ActiveUsersFuzzyCondition | airbyte_agent_sdk.connectors.amplitude.types.ActiveUsersKeywordCondition | airbyte_agent_sdk.connectors.amplitude.types.ActiveUsersContainsCondition | airbyte_agent_sdk.connectors.amplitude.types.ActiveUsersNotCondition | airbyte_agent_sdk.connectors.amplitude.types.ActiveUsersAndCondition | airbyte_agent_sdk.connectors.amplitude.types.ActiveUsersOrCondition | airbyte_agent_sdk.connectors.amplitude.types.ActiveUsersAnyCondition`
     :   The type of the None singleton.
 
+<a id="ActiveUsersOrCondition"></a>
+
 `ActiveUsersOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -284,6 +320,8 @@ Classes
     `or: list[airbyte_agent_sdk.connectors.amplitude.types.ActiveUsersEqCondition | airbyte_agent_sdk.connectors.amplitude.types.ActiveUsersNeqCondition | airbyte_agent_sdk.connectors.amplitude.types.ActiveUsersGtCondition | airbyte_agent_sdk.connectors.amplitude.types.ActiveUsersGteCondition | airbyte_agent_sdk.connectors.amplitude.types.ActiveUsersLtCondition | airbyte_agent_sdk.connectors.amplitude.types.ActiveUsersLteCondition | airbyte_agent_sdk.connectors.amplitude.types.ActiveUsersInCondition | airbyte_agent_sdk.connectors.amplitude.types.ActiveUsersLikeCondition | airbyte_agent_sdk.connectors.amplitude.types.ActiveUsersFuzzyCondition | airbyte_agent_sdk.connectors.amplitude.types.ActiveUsersKeywordCondition | airbyte_agent_sdk.connectors.amplitude.types.ActiveUsersContainsCondition | airbyte_agent_sdk.connectors.amplitude.types.ActiveUsersNotCondition | airbyte_agent_sdk.connectors.amplitude.types.ActiveUsersAndCondition | airbyte_agent_sdk.connectors.amplitude.types.ActiveUsersOrCondition | airbyte_agent_sdk.connectors.amplitude.types.ActiveUsersAnyCondition]`
     :   The type of the None singleton.
 
+<a id="ActiveUsersSearchFilter"></a>
+
 `ActiveUsersSearchFilter(*args, **kwargs)`
 :   Available fields for filtering active_users search queries.
 
@@ -298,6 +336,8 @@ Classes
 
     `statistics: dict[str, typing.Any] | None`
     :   The statistics related to the active users for the given date
+
+<a id="ActiveUsersSearchQuery"></a>
 
 `ActiveUsersSearchQuery(*args, **kwargs)`
 :   Search query for active_users entity.
@@ -314,6 +354,8 @@ Classes
     `sort: list[airbyte_agent_sdk.connectors.amplitude.types.ActiveUsersSortFilter]`
     :   The type of the None singleton.
 
+<a id="ActiveUsersSortFilter"></a>
+
 `ActiveUsersSortFilter(*args, **kwargs)`
 :   Available fields for sorting active_users search results.
 
@@ -329,6 +371,8 @@ Classes
     `statistics: Literal['asc', 'desc']`
     :   The statistics related to the active users for the given date
 
+<a id="ActiveUsersStringFilter"></a>
+
 `ActiveUsersStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -343,6 +387,8 @@ Classes
 
     `statistics: str`
     :   The statistics related to the active users for the given date
+
+<a id="AirbyteSearchParams"></a>
 
 `AirbyteSearchParams(*args, **kwargs)`
 :   Parameters for Airbyte cache search operations (generic, use entity-specific query types for better type hints).
@@ -365,6 +411,8 @@ Classes
     `query: dict[str, typing.Any]`
     :   The type of the None singleton.
 
+<a id="AnnotationsAndCondition"></a>
+
 `AnnotationsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -385,6 +433,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.amplitude.types.AnnotationsEqCondition | airbyte_agent_sdk.connectors.amplitude.types.AnnotationsNeqCondition | airbyte_agent_sdk.connectors.amplitude.types.AnnotationsGtCondition | airbyte_agent_sdk.connectors.amplitude.types.AnnotationsGteCondition | airbyte_agent_sdk.connectors.amplitude.types.AnnotationsLtCondition | airbyte_agent_sdk.connectors.amplitude.types.AnnotationsLteCondition | airbyte_agent_sdk.connectors.amplitude.types.AnnotationsInCondition | airbyte_agent_sdk.connectors.amplitude.types.AnnotationsLikeCondition | airbyte_agent_sdk.connectors.amplitude.types.AnnotationsFuzzyCondition | airbyte_agent_sdk.connectors.amplitude.types.AnnotationsKeywordCondition | airbyte_agent_sdk.connectors.amplitude.types.AnnotationsContainsCondition | airbyte_agent_sdk.connectors.amplitude.types.AnnotationsNotCondition | airbyte_agent_sdk.connectors.amplitude.types.AnnotationsAndCondition | airbyte_agent_sdk.connectors.amplitude.types.AnnotationsOrCondition | airbyte_agent_sdk.connectors.amplitude.types.AnnotationsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="AnnotationsAnyCondition"></a>
+
 `AnnotationsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -404,6 +454,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.amplitude.types.AnnotationsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="AnnotationsAnyValueFilter"></a>
 
 `AnnotationsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -426,6 +478,8 @@ Classes
     `label: Any`
     :   The label assigned to the annotation
 
+<a id="AnnotationsContainsCondition"></a>
+
 `AnnotationsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -437,6 +491,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.amplitude.types.AnnotationsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="AnnotationsEqCondition"></a>
 
 `AnnotationsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -450,6 +506,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.amplitude.types.AnnotationsSearchFilter`
     :   The type of the None singleton.
 
+<a id="AnnotationsFuzzyCondition"></a>
+
 `AnnotationsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -461,6 +519,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.amplitude.types.AnnotationsStringFilter`
     :   The type of the None singleton.
+
+<a id="AnnotationsGetParams"></a>
 
 `AnnotationsGetParams(*args, **kwargs)`
 :   Parameters for annotations.get operation
@@ -474,6 +534,8 @@ Classes
     `annotation_id: str`
     :   The type of the None singleton.
 
+<a id="AnnotationsGtCondition"></a>
+
 `AnnotationsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -486,6 +548,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.amplitude.types.AnnotationsSearchFilter`
     :   The type of the None singleton.
 
+<a id="AnnotationsGteCondition"></a>
+
 `AnnotationsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -497,6 +561,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.amplitude.types.AnnotationsSearchFilter`
     :   The type of the None singleton.
+
+<a id="AnnotationsInCondition"></a>
 
 `AnnotationsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -517,6 +583,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.amplitude.types.AnnotationsInFilter`
     :   The type of the None singleton.
+
+<a id="AnnotationsInFilter"></a>
 
 `AnnotationsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -539,6 +607,8 @@ Classes
     `label: list[str]`
     :   The label assigned to the annotation
 
+<a id="AnnotationsKeywordCondition"></a>
+
 `AnnotationsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -550,6 +620,8 @@ Classes
 
     `keyword: airbyte_agent_sdk.connectors.amplitude.types.AnnotationsStringFilter`
     :   The type of the None singleton.
+
+<a id="AnnotationsLikeCondition"></a>
 
 `AnnotationsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
@@ -563,12 +635,16 @@ Classes
     `like: airbyte_agent_sdk.connectors.amplitude.types.AnnotationsStringFilter`
     :   The type of the None singleton.
 
+<a id="AnnotationsListParams"></a>
+
 `AnnotationsListParams(*args, **kwargs)`
 :   Parameters for annotations.list operation
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="AnnotationsLtCondition"></a>
 
 `AnnotationsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
@@ -582,6 +658,8 @@ Classes
     `lt: airbyte_agent_sdk.connectors.amplitude.types.AnnotationsSearchFilter`
     :   The type of the None singleton.
 
+<a id="AnnotationsLteCondition"></a>
+
 `AnnotationsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
 
@@ -594,6 +672,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.amplitude.types.AnnotationsSearchFilter`
     :   The type of the None singleton.
 
+<a id="AnnotationsNeqCondition"></a>
+
 `AnnotationsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -605,6 +685,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.amplitude.types.AnnotationsSearchFilter`
     :   The type of the None singleton.
+
+<a id="AnnotationsNotCondition"></a>
 
 `AnnotationsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -626,6 +708,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.amplitude.types.AnnotationsEqCondition | airbyte_agent_sdk.connectors.amplitude.types.AnnotationsNeqCondition | airbyte_agent_sdk.connectors.amplitude.types.AnnotationsGtCondition | airbyte_agent_sdk.connectors.amplitude.types.AnnotationsGteCondition | airbyte_agent_sdk.connectors.amplitude.types.AnnotationsLtCondition | airbyte_agent_sdk.connectors.amplitude.types.AnnotationsLteCondition | airbyte_agent_sdk.connectors.amplitude.types.AnnotationsInCondition | airbyte_agent_sdk.connectors.amplitude.types.AnnotationsLikeCondition | airbyte_agent_sdk.connectors.amplitude.types.AnnotationsFuzzyCondition | airbyte_agent_sdk.connectors.amplitude.types.AnnotationsKeywordCondition | airbyte_agent_sdk.connectors.amplitude.types.AnnotationsContainsCondition | airbyte_agent_sdk.connectors.amplitude.types.AnnotationsNotCondition | airbyte_agent_sdk.connectors.amplitude.types.AnnotationsAndCondition | airbyte_agent_sdk.connectors.amplitude.types.AnnotationsOrCondition | airbyte_agent_sdk.connectors.amplitude.types.AnnotationsAnyCondition`
     :   The type of the None singleton.
 
+<a id="AnnotationsOrCondition"></a>
+
 `AnnotationsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -645,6 +729,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.amplitude.types.AnnotationsEqCondition | airbyte_agent_sdk.connectors.amplitude.types.AnnotationsNeqCondition | airbyte_agent_sdk.connectors.amplitude.types.AnnotationsGtCondition | airbyte_agent_sdk.connectors.amplitude.types.AnnotationsGteCondition | airbyte_agent_sdk.connectors.amplitude.types.AnnotationsLtCondition | airbyte_agent_sdk.connectors.amplitude.types.AnnotationsLteCondition | airbyte_agent_sdk.connectors.amplitude.types.AnnotationsInCondition | airbyte_agent_sdk.connectors.amplitude.types.AnnotationsLikeCondition | airbyte_agent_sdk.connectors.amplitude.types.AnnotationsFuzzyCondition | airbyte_agent_sdk.connectors.amplitude.types.AnnotationsKeywordCondition | airbyte_agent_sdk.connectors.amplitude.types.AnnotationsContainsCondition | airbyte_agent_sdk.connectors.amplitude.types.AnnotationsNotCondition | airbyte_agent_sdk.connectors.amplitude.types.AnnotationsAndCondition | airbyte_agent_sdk.connectors.amplitude.types.AnnotationsOrCondition | airbyte_agent_sdk.connectors.amplitude.types.AnnotationsAnyCondition]`
     :   The type of the None singleton.
+
+<a id="AnnotationsSearchFilter"></a>
 
 `AnnotationsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering annotations search queries.
@@ -667,6 +753,8 @@ Classes
     `label: str | None`
     :   The label assigned to the annotation
 
+<a id="AnnotationsSearchQuery"></a>
+
 `AnnotationsSearchQuery(*args, **kwargs)`
 :   Search query for annotations entity.
 
@@ -681,6 +769,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.amplitude.types.AnnotationsSortFilter]`
     :   The type of the None singleton.
+
+<a id="AnnotationsSortFilter"></a>
 
 `AnnotationsSortFilter(*args, **kwargs)`
 :   Available fields for sorting annotations search results.
@@ -703,6 +793,8 @@ Classes
     `label: Literal['asc', 'desc']`
     :   The label assigned to the annotation
 
+<a id="AnnotationsStringFilter"></a>
+
 `AnnotationsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -724,6 +816,8 @@ Classes
     `label: str`
     :   The label assigned to the annotation
 
+<a id="AverageSessionLengthAndCondition"></a>
+
 `AverageSessionLengthAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -743,6 +837,8 @@ Classes
 
     `and: list[airbyte_agent_sdk.connectors.amplitude.types.AverageSessionLengthEqCondition | airbyte_agent_sdk.connectors.amplitude.types.AverageSessionLengthNeqCondition | airbyte_agent_sdk.connectors.amplitude.types.AverageSessionLengthGtCondition | airbyte_agent_sdk.connectors.amplitude.types.AverageSessionLengthGteCondition | airbyte_agent_sdk.connectors.amplitude.types.AverageSessionLengthLtCondition | airbyte_agent_sdk.connectors.amplitude.types.AverageSessionLengthLteCondition | airbyte_agent_sdk.connectors.amplitude.types.AverageSessionLengthInCondition | airbyte_agent_sdk.connectors.amplitude.types.AverageSessionLengthLikeCondition | airbyte_agent_sdk.connectors.amplitude.types.AverageSessionLengthFuzzyCondition | airbyte_agent_sdk.connectors.amplitude.types.AverageSessionLengthKeywordCondition | airbyte_agent_sdk.connectors.amplitude.types.AverageSessionLengthContainsCondition | airbyte_agent_sdk.connectors.amplitude.types.AverageSessionLengthNotCondition | airbyte_agent_sdk.connectors.amplitude.types.AverageSessionLengthAndCondition | airbyte_agent_sdk.connectors.amplitude.types.AverageSessionLengthOrCondition | airbyte_agent_sdk.connectors.amplitude.types.AverageSessionLengthAnyCondition]`
     :   The type of the None singleton.
+
+<a id="AverageSessionLengthAnyCondition"></a>
 
 `AverageSessionLengthAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -764,6 +860,8 @@ Classes
     `any: airbyte_agent_sdk.connectors.amplitude.types.AverageSessionLengthAnyValueFilter`
     :   The type of the None singleton.
 
+<a id="AverageSessionLengthAnyValueFilter"></a>
+
 `AverageSessionLengthAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
 
@@ -779,6 +877,8 @@ Classes
     `length: Any`
     :   The duration of the session in seconds
 
+<a id="AverageSessionLengthContainsCondition"></a>
+
 `AverageSessionLengthContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -790,6 +890,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.amplitude.types.AverageSessionLengthAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="AverageSessionLengthEqCondition"></a>
 
 `AverageSessionLengthEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -803,6 +905,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.amplitude.types.AverageSessionLengthSearchFilter`
     :   The type of the None singleton.
 
+<a id="AverageSessionLengthFuzzyCondition"></a>
+
 `AverageSessionLengthFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -814,6 +918,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.amplitude.types.AverageSessionLengthStringFilter`
     :   The type of the None singleton.
+
+<a id="AverageSessionLengthGtCondition"></a>
 
 `AverageSessionLengthGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
@@ -827,6 +933,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.amplitude.types.AverageSessionLengthSearchFilter`
     :   The type of the None singleton.
 
+<a id="AverageSessionLengthGteCondition"></a>
+
 `AverageSessionLengthGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -838,6 +946,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.amplitude.types.AverageSessionLengthSearchFilter`
     :   The type of the None singleton.
+
+<a id="AverageSessionLengthInCondition"></a>
 
 `AverageSessionLengthInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -859,6 +969,8 @@ Classes
     `in: airbyte_agent_sdk.connectors.amplitude.types.AverageSessionLengthInFilter`
     :   The type of the None singleton.
 
+<a id="AverageSessionLengthInFilter"></a>
+
 `AverageSessionLengthInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
 
@@ -874,6 +986,8 @@ Classes
     `length: list[float]`
     :   The duration of the session in seconds
 
+<a id="AverageSessionLengthKeywordCondition"></a>
+
 `AverageSessionLengthKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -886,6 +1000,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.amplitude.types.AverageSessionLengthStringFilter`
     :   The type of the None singleton.
 
+<a id="AverageSessionLengthLikeCondition"></a>
+
 `AverageSessionLengthLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -897,6 +1013,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.amplitude.types.AverageSessionLengthStringFilter`
     :   The type of the None singleton.
+
+<a id="AverageSessionLengthListParams"></a>
 
 `AverageSessionLengthListParams(*args, **kwargs)`
 :   Parameters for average_session_length.list operation
@@ -913,6 +1031,8 @@ Classes
     `start: str`
     :   The type of the None singleton.
 
+<a id="AverageSessionLengthLtCondition"></a>
+
 `AverageSessionLengthLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -924,6 +1044,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.amplitude.types.AverageSessionLengthSearchFilter`
     :   The type of the None singleton.
+
+<a id="AverageSessionLengthLteCondition"></a>
 
 `AverageSessionLengthLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -937,6 +1059,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.amplitude.types.AverageSessionLengthSearchFilter`
     :   The type of the None singleton.
 
+<a id="AverageSessionLengthNeqCondition"></a>
+
 `AverageSessionLengthNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -948,6 +1072,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.amplitude.types.AverageSessionLengthSearchFilter`
     :   The type of the None singleton.
+
+<a id="AverageSessionLengthNotCondition"></a>
 
 `AverageSessionLengthNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -969,6 +1095,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.amplitude.types.AverageSessionLengthEqCondition | airbyte_agent_sdk.connectors.amplitude.types.AverageSessionLengthNeqCondition | airbyte_agent_sdk.connectors.amplitude.types.AverageSessionLengthGtCondition | airbyte_agent_sdk.connectors.amplitude.types.AverageSessionLengthGteCondition | airbyte_agent_sdk.connectors.amplitude.types.AverageSessionLengthLtCondition | airbyte_agent_sdk.connectors.amplitude.types.AverageSessionLengthLteCondition | airbyte_agent_sdk.connectors.amplitude.types.AverageSessionLengthInCondition | airbyte_agent_sdk.connectors.amplitude.types.AverageSessionLengthLikeCondition | airbyte_agent_sdk.connectors.amplitude.types.AverageSessionLengthFuzzyCondition | airbyte_agent_sdk.connectors.amplitude.types.AverageSessionLengthKeywordCondition | airbyte_agent_sdk.connectors.amplitude.types.AverageSessionLengthContainsCondition | airbyte_agent_sdk.connectors.amplitude.types.AverageSessionLengthNotCondition | airbyte_agent_sdk.connectors.amplitude.types.AverageSessionLengthAndCondition | airbyte_agent_sdk.connectors.amplitude.types.AverageSessionLengthOrCondition | airbyte_agent_sdk.connectors.amplitude.types.AverageSessionLengthAnyCondition`
     :   The type of the None singleton.
 
+<a id="AverageSessionLengthOrCondition"></a>
+
 `AverageSessionLengthOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -989,6 +1117,8 @@ Classes
     `or: list[airbyte_agent_sdk.connectors.amplitude.types.AverageSessionLengthEqCondition | airbyte_agent_sdk.connectors.amplitude.types.AverageSessionLengthNeqCondition | airbyte_agent_sdk.connectors.amplitude.types.AverageSessionLengthGtCondition | airbyte_agent_sdk.connectors.amplitude.types.AverageSessionLengthGteCondition | airbyte_agent_sdk.connectors.amplitude.types.AverageSessionLengthLtCondition | airbyte_agent_sdk.connectors.amplitude.types.AverageSessionLengthLteCondition | airbyte_agent_sdk.connectors.amplitude.types.AverageSessionLengthInCondition | airbyte_agent_sdk.connectors.amplitude.types.AverageSessionLengthLikeCondition | airbyte_agent_sdk.connectors.amplitude.types.AverageSessionLengthFuzzyCondition | airbyte_agent_sdk.connectors.amplitude.types.AverageSessionLengthKeywordCondition | airbyte_agent_sdk.connectors.amplitude.types.AverageSessionLengthContainsCondition | airbyte_agent_sdk.connectors.amplitude.types.AverageSessionLengthNotCondition | airbyte_agent_sdk.connectors.amplitude.types.AverageSessionLengthAndCondition | airbyte_agent_sdk.connectors.amplitude.types.AverageSessionLengthOrCondition | airbyte_agent_sdk.connectors.amplitude.types.AverageSessionLengthAnyCondition]`
     :   The type of the None singleton.
 
+<a id="AverageSessionLengthSearchFilter"></a>
+
 `AverageSessionLengthSearchFilter(*args, **kwargs)`
 :   Available fields for filtering average_session_length search queries.
 
@@ -1003,6 +1133,8 @@ Classes
 
     `length: float | None`
     :   The duration of the session in seconds
+
+<a id="AverageSessionLengthSearchQuery"></a>
 
 `AverageSessionLengthSearchQuery(*args, **kwargs)`
 :   Search query for average_session_length entity.
@@ -1019,6 +1151,8 @@ Classes
     `sort: list[airbyte_agent_sdk.connectors.amplitude.types.AverageSessionLengthSortFilter]`
     :   The type of the None singleton.
 
+<a id="AverageSessionLengthSortFilter"></a>
+
 `AverageSessionLengthSortFilter(*args, **kwargs)`
 :   Available fields for sorting average_session_length search results.
 
@@ -1034,6 +1168,8 @@ Classes
     `length: Literal['asc', 'desc']`
     :   The duration of the session in seconds
 
+<a id="AverageSessionLengthStringFilter"></a>
+
 `AverageSessionLengthStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -1048,6 +1184,8 @@ Classes
 
     `length: str`
     :   The duration of the session in seconds
+
+<a id="CohortsAndCondition"></a>
 
 `CohortsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -1069,6 +1207,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.amplitude.types.CohortsEqCondition | airbyte_agent_sdk.connectors.amplitude.types.CohortsNeqCondition | airbyte_agent_sdk.connectors.amplitude.types.CohortsGtCondition | airbyte_agent_sdk.connectors.amplitude.types.CohortsGteCondition | airbyte_agent_sdk.connectors.amplitude.types.CohortsLtCondition | airbyte_agent_sdk.connectors.amplitude.types.CohortsLteCondition | airbyte_agent_sdk.connectors.amplitude.types.CohortsInCondition | airbyte_agent_sdk.connectors.amplitude.types.CohortsLikeCondition | airbyte_agent_sdk.connectors.amplitude.types.CohortsFuzzyCondition | airbyte_agent_sdk.connectors.amplitude.types.CohortsKeywordCondition | airbyte_agent_sdk.connectors.amplitude.types.CohortsContainsCondition | airbyte_agent_sdk.connectors.amplitude.types.CohortsNotCondition | airbyte_agent_sdk.connectors.amplitude.types.CohortsAndCondition | airbyte_agent_sdk.connectors.amplitude.types.CohortsOrCondition | airbyte_agent_sdk.connectors.amplitude.types.CohortsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="CohortsAnyCondition"></a>
+
 `CohortsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1088,6 +1228,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.amplitude.types.CohortsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="CohortsAnyValueFilter"></a>
 
 `CohortsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -1176,6 +1318,8 @@ Classes
     `viewers: Any`
     :   Users or viewers who have access to the cohort data
 
+<a id="CohortsContainsCondition"></a>
+
 `CohortsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -1187,6 +1331,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.amplitude.types.CohortsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="CohortsEqCondition"></a>
 
 `CohortsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -1200,6 +1346,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.amplitude.types.CohortsSearchFilter`
     :   The type of the None singleton.
 
+<a id="CohortsFuzzyCondition"></a>
+
 `CohortsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -1211,6 +1359,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.amplitude.types.CohortsStringFilter`
     :   The type of the None singleton.
+
+<a id="CohortsGetParams"></a>
 
 `CohortsGetParams(*args, **kwargs)`
 :   Parameters for cohorts.get operation
@@ -1224,6 +1374,8 @@ Classes
     `cohort_id: str`
     :   The type of the None singleton.
 
+<a id="CohortsGtCondition"></a>
+
 `CohortsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -1236,6 +1388,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.amplitude.types.CohortsSearchFilter`
     :   The type of the None singleton.
 
+<a id="CohortsGteCondition"></a>
+
 `CohortsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -1247,6 +1401,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.amplitude.types.CohortsSearchFilter`
     :   The type of the None singleton.
+
+<a id="CohortsInCondition"></a>
 
 `CohortsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -1267,6 +1423,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.amplitude.types.CohortsInFilter`
     :   The type of the None singleton.
+
+<a id="CohortsInFilter"></a>
 
 `CohortsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -1355,6 +1513,8 @@ Classes
     `viewers: list[list[typing.Any]]`
     :   Users or viewers who have access to the cohort data
 
+<a id="CohortsKeywordCondition"></a>
+
 `CohortsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -1366,6 +1526,8 @@ Classes
 
     `keyword: airbyte_agent_sdk.connectors.amplitude.types.CohortsStringFilter`
     :   The type of the None singleton.
+
+<a id="CohortsLikeCondition"></a>
 
 `CohortsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
@@ -1379,12 +1541,16 @@ Classes
     `like: airbyte_agent_sdk.connectors.amplitude.types.CohortsStringFilter`
     :   The type of the None singleton.
 
+<a id="CohortsListParams"></a>
+
 `CohortsListParams(*args, **kwargs)`
 :   Parameters for cohorts.list operation
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="CohortsLtCondition"></a>
 
 `CohortsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
@@ -1398,6 +1564,8 @@ Classes
     `lt: airbyte_agent_sdk.connectors.amplitude.types.CohortsSearchFilter`
     :   The type of the None singleton.
 
+<a id="CohortsLteCondition"></a>
+
 `CohortsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
 
@@ -1410,6 +1578,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.amplitude.types.CohortsSearchFilter`
     :   The type of the None singleton.
 
+<a id="CohortsNeqCondition"></a>
+
 `CohortsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -1421,6 +1591,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.amplitude.types.CohortsSearchFilter`
     :   The type of the None singleton.
+
+<a id="CohortsNotCondition"></a>
 
 `CohortsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -1442,6 +1614,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.amplitude.types.CohortsEqCondition | airbyte_agent_sdk.connectors.amplitude.types.CohortsNeqCondition | airbyte_agent_sdk.connectors.amplitude.types.CohortsGtCondition | airbyte_agent_sdk.connectors.amplitude.types.CohortsGteCondition | airbyte_agent_sdk.connectors.amplitude.types.CohortsLtCondition | airbyte_agent_sdk.connectors.amplitude.types.CohortsLteCondition | airbyte_agent_sdk.connectors.amplitude.types.CohortsInCondition | airbyte_agent_sdk.connectors.amplitude.types.CohortsLikeCondition | airbyte_agent_sdk.connectors.amplitude.types.CohortsFuzzyCondition | airbyte_agent_sdk.connectors.amplitude.types.CohortsKeywordCondition | airbyte_agent_sdk.connectors.amplitude.types.CohortsContainsCondition | airbyte_agent_sdk.connectors.amplitude.types.CohortsNotCondition | airbyte_agent_sdk.connectors.amplitude.types.CohortsAndCondition | airbyte_agent_sdk.connectors.amplitude.types.CohortsOrCondition | airbyte_agent_sdk.connectors.amplitude.types.CohortsAnyCondition`
     :   The type of the None singleton.
 
+<a id="CohortsOrCondition"></a>
+
 `CohortsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1461,6 +1635,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.amplitude.types.CohortsEqCondition | airbyte_agent_sdk.connectors.amplitude.types.CohortsNeqCondition | airbyte_agent_sdk.connectors.amplitude.types.CohortsGtCondition | airbyte_agent_sdk.connectors.amplitude.types.CohortsGteCondition | airbyte_agent_sdk.connectors.amplitude.types.CohortsLtCondition | airbyte_agent_sdk.connectors.amplitude.types.CohortsLteCondition | airbyte_agent_sdk.connectors.amplitude.types.CohortsInCondition | airbyte_agent_sdk.connectors.amplitude.types.CohortsLikeCondition | airbyte_agent_sdk.connectors.amplitude.types.CohortsFuzzyCondition | airbyte_agent_sdk.connectors.amplitude.types.CohortsKeywordCondition | airbyte_agent_sdk.connectors.amplitude.types.CohortsContainsCondition | airbyte_agent_sdk.connectors.amplitude.types.CohortsNotCondition | airbyte_agent_sdk.connectors.amplitude.types.CohortsAndCondition | airbyte_agent_sdk.connectors.amplitude.types.CohortsOrCondition | airbyte_agent_sdk.connectors.amplitude.types.CohortsAnyCondition]`
     :   The type of the None singleton.
+
+<a id="CohortsSearchFilter"></a>
 
 `CohortsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering cohorts search queries.
@@ -1549,6 +1725,8 @@ Classes
     `viewers: list[typing.Any] | None`
     :   Users or viewers who have access to the cohort data
 
+<a id="CohortsSearchQuery"></a>
+
 `CohortsSearchQuery(*args, **kwargs)`
 :   Search query for cohorts entity.
 
@@ -1563,6 +1741,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.amplitude.types.CohortsSortFilter]`
     :   The type of the None singleton.
+
+<a id="CohortsSortFilter"></a>
 
 `CohortsSortFilter(*args, **kwargs)`
 :   Available fields for sorting cohorts search results.
@@ -1651,6 +1831,8 @@ Classes
     `viewers: Literal['asc', 'desc']`
     :   Users or viewers who have access to the cohort data
 
+<a id="CohortsStringFilter"></a>
+
 `CohortsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -1738,6 +1920,8 @@ Classes
     `viewers: str`
     :   Users or viewers who have access to the cohort data
 
+<a id="EventsListAndCondition"></a>
+
 `EventsListAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1758,6 +1942,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.amplitude.types.EventsListEqCondition | airbyte_agent_sdk.connectors.amplitude.types.EventsListNeqCondition | airbyte_agent_sdk.connectors.amplitude.types.EventsListGtCondition | airbyte_agent_sdk.connectors.amplitude.types.EventsListGteCondition | airbyte_agent_sdk.connectors.amplitude.types.EventsListLtCondition | airbyte_agent_sdk.connectors.amplitude.types.EventsListLteCondition | airbyte_agent_sdk.connectors.amplitude.types.EventsListInCondition | airbyte_agent_sdk.connectors.amplitude.types.EventsListLikeCondition | airbyte_agent_sdk.connectors.amplitude.types.EventsListFuzzyCondition | airbyte_agent_sdk.connectors.amplitude.types.EventsListKeywordCondition | airbyte_agent_sdk.connectors.amplitude.types.EventsListContainsCondition | airbyte_agent_sdk.connectors.amplitude.types.EventsListNotCondition | airbyte_agent_sdk.connectors.amplitude.types.EventsListAndCondition | airbyte_agent_sdk.connectors.amplitude.types.EventsListOrCondition | airbyte_agent_sdk.connectors.amplitude.types.EventsListAnyCondition]`
     :   The type of the None singleton.
 
+<a id="EventsListAnyCondition"></a>
+
 `EventsListAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1777,6 +1963,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.amplitude.types.EventsListAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="EventsListAnyValueFilter"></a>
 
 `EventsListAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -1829,6 +2017,8 @@ Classes
     `value: Any`
     :   Raw event name in the data
 
+<a id="EventsListContainsCondition"></a>
+
 `EventsListContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -1840,6 +2030,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.amplitude.types.EventsListAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="EventsListEqCondition"></a>
 
 `EventsListEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -1853,6 +2045,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.amplitude.types.EventsListSearchFilter`
     :   The type of the None singleton.
 
+<a id="EventsListFuzzyCondition"></a>
+
 `EventsListFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -1864,6 +2058,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.amplitude.types.EventsListStringFilter`
     :   The type of the None singleton.
+
+<a id="EventsListGtCondition"></a>
 
 `EventsListGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
@@ -1877,6 +2073,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.amplitude.types.EventsListSearchFilter`
     :   The type of the None singleton.
 
+<a id="EventsListGteCondition"></a>
+
 `EventsListGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -1888,6 +2086,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.amplitude.types.EventsListSearchFilter`
     :   The type of the None singleton.
+
+<a id="EventsListInCondition"></a>
 
 `EventsListInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -1908,6 +2108,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.amplitude.types.EventsListInFilter`
     :   The type of the None singleton.
+
+<a id="EventsListInFilter"></a>
 
 `EventsListInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -1960,6 +2162,8 @@ Classes
     `value: list[str]`
     :   Raw event name in the data
 
+<a id="EventsListKeywordCondition"></a>
+
 `EventsListKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -1971,6 +2175,8 @@ Classes
 
     `keyword: airbyte_agent_sdk.connectors.amplitude.types.EventsListStringFilter`
     :   The type of the None singleton.
+
+<a id="EventsListLikeCondition"></a>
 
 `EventsListLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
@@ -1984,12 +2190,16 @@ Classes
     `like: airbyte_agent_sdk.connectors.amplitude.types.EventsListStringFilter`
     :   The type of the None singleton.
 
+<a id="EventsListListParams"></a>
+
 `EventsListListParams(*args, **kwargs)`
 :   Parameters for events_list.list operation
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="EventsListLtCondition"></a>
 
 `EventsListLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
@@ -2003,6 +2213,8 @@ Classes
     `lt: airbyte_agent_sdk.connectors.amplitude.types.EventsListSearchFilter`
     :   The type of the None singleton.
 
+<a id="EventsListLteCondition"></a>
+
 `EventsListLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
 
@@ -2015,6 +2227,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.amplitude.types.EventsListSearchFilter`
     :   The type of the None singleton.
 
+<a id="EventsListNeqCondition"></a>
+
 `EventsListNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -2026,6 +2240,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.amplitude.types.EventsListSearchFilter`
     :   The type of the None singleton.
+
+<a id="EventsListNotCondition"></a>
 
 `EventsListNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -2047,6 +2263,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.amplitude.types.EventsListEqCondition | airbyte_agent_sdk.connectors.amplitude.types.EventsListNeqCondition | airbyte_agent_sdk.connectors.amplitude.types.EventsListGtCondition | airbyte_agent_sdk.connectors.amplitude.types.EventsListGteCondition | airbyte_agent_sdk.connectors.amplitude.types.EventsListLtCondition | airbyte_agent_sdk.connectors.amplitude.types.EventsListLteCondition | airbyte_agent_sdk.connectors.amplitude.types.EventsListInCondition | airbyte_agent_sdk.connectors.amplitude.types.EventsListLikeCondition | airbyte_agent_sdk.connectors.amplitude.types.EventsListFuzzyCondition | airbyte_agent_sdk.connectors.amplitude.types.EventsListKeywordCondition | airbyte_agent_sdk.connectors.amplitude.types.EventsListContainsCondition | airbyte_agent_sdk.connectors.amplitude.types.EventsListNotCondition | airbyte_agent_sdk.connectors.amplitude.types.EventsListAndCondition | airbyte_agent_sdk.connectors.amplitude.types.EventsListOrCondition | airbyte_agent_sdk.connectors.amplitude.types.EventsListAnyCondition`
     :   The type of the None singleton.
 
+<a id="EventsListOrCondition"></a>
+
 `EventsListOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -2066,6 +2284,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.amplitude.types.EventsListEqCondition | airbyte_agent_sdk.connectors.amplitude.types.EventsListNeqCondition | airbyte_agent_sdk.connectors.amplitude.types.EventsListGtCondition | airbyte_agent_sdk.connectors.amplitude.types.EventsListGteCondition | airbyte_agent_sdk.connectors.amplitude.types.EventsListLtCondition | airbyte_agent_sdk.connectors.amplitude.types.EventsListLteCondition | airbyte_agent_sdk.connectors.amplitude.types.EventsListInCondition | airbyte_agent_sdk.connectors.amplitude.types.EventsListLikeCondition | airbyte_agent_sdk.connectors.amplitude.types.EventsListFuzzyCondition | airbyte_agent_sdk.connectors.amplitude.types.EventsListKeywordCondition | airbyte_agent_sdk.connectors.amplitude.types.EventsListContainsCondition | airbyte_agent_sdk.connectors.amplitude.types.EventsListNotCondition | airbyte_agent_sdk.connectors.amplitude.types.EventsListAndCondition | airbyte_agent_sdk.connectors.amplitude.types.EventsListOrCondition | airbyte_agent_sdk.connectors.amplitude.types.EventsListAnyCondition]`
     :   The type of the None singleton.
+
+<a id="EventsListSearchFilter"></a>
 
 `EventsListSearchFilter(*args, **kwargs)`
 :   Available fields for filtering events_list search queries.
@@ -2118,6 +2338,8 @@ Classes
     `value: str | None`
     :   Raw event name in the data
 
+<a id="EventsListSearchQuery"></a>
+
 `EventsListSearchQuery(*args, **kwargs)`
 :   Search query for events_list entity.
 
@@ -2132,6 +2354,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.amplitude.types.EventsListSortFilter]`
     :   The type of the None singleton.
+
+<a id="EventsListSortFilter"></a>
 
 `EventsListSortFilter(*args, **kwargs)`
 :   Available fields for sorting events_list search results.
@@ -2183,6 +2407,8 @@ Classes
 
     `value: Literal['asc', 'desc']`
     :   Raw event name in the data
+
+<a id="EventsListStringFilter"></a>
 
 `EventsListStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/asana/connector.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/asana/connector.md
@@ -10,6 +10,8 @@ Asana connector.
 Classes
 -------
 
+<a id="AsanaConnector"></a>
+
 `AsanaConnector(auth_config: AsanaAuthConfig | AirbyteAuthConfig | BaseModel | None = None, on_token_refresh: Any | None = None)`
 :   Type-safe Asana API connector.
     
@@ -252,6 +254,8 @@ Classes
             for entity in entities:
                 print(f"\{entity['entity_name']\}: \{entity['available_actions']\}")
 
+<a id="AttachmentsQuery"></a>
+
 `AttachmentsQuery(connector: AsanaConnector)`
 :   Query class for Attachments entity operations.
     
@@ -342,6 +346,8 @@ Classes
         Returns:
             AttachmentsListResult
 
+<a id="ProjectSectionsQuery"></a>
+
 `ProjectSectionsQuery(connector: AsanaConnector)`
 :   Query class for ProjectSections entity operations.
     
@@ -373,6 +379,8 @@ Classes
         Returns:
             ProjectSectionsListResult
 
+<a id="ProjectTasksQuery"></a>
+
 `ProjectTasksQuery(connector: AsanaConnector)`
 :   Query class for ProjectTasks entity operations.
     
@@ -392,6 +400,8 @@ Classes
         
         Returns:
             ProjectTasksListResult
+
+<a id="ProjectsQuery"></a>
 
 `ProjectsQuery(connector: AsanaConnector)`
 :   Query class for Projects entity operations.
@@ -508,6 +518,8 @@ Classes
                 Returns:
                     Project
 
+<a id="SectionTasksQuery"></a>
+
 `SectionTasksQuery(connector: AsanaConnector)`
 :   Query class for SectionTasks entity operations.
     
@@ -541,6 +553,8 @@ Classes
         
         Returns:
             SectionTasksListResult
+
+<a id="SectionsQuery"></a>
 
 `SectionsQuery(connector: AsanaConnector)`
 :   Query class for Sections entity operations.
@@ -613,6 +627,8 @@ Classes
                 Returns:
                     Section
 
+<a id="TagTasksQuery"></a>
+
 `TagTasksQuery(connector: AsanaConnector)`
 :   Query class for TagTasks entity operations.
     
@@ -633,6 +649,8 @@ Classes
         
                 Returns:
                     TagTasksListResult
+
+<a id="TagsQuery"></a>
 
 `TagsQuery(connector: AsanaConnector)`
 :   Query class for Tags entity operations.
@@ -706,6 +724,8 @@ Classes
                 Returns:
                     Tag
 
+<a id="TaskDependenciesQuery"></a>
+
 `TaskDependenciesQuery(connector: AsanaConnector)`
 :   Query class for TaskDependencies entity operations.
     
@@ -724,6 +744,8 @@ Classes
         
         Returns:
             TaskDependenciesListResult
+
+<a id="TaskDependentsQuery"></a>
 
 `TaskDependentsQuery(connector: AsanaConnector)`
 :   Query class for TaskDependents entity operations.
@@ -744,6 +766,8 @@ Classes
         Returns:
             TaskDependentsListResult
 
+<a id="TaskProjectsQuery"></a>
+
 `TaskProjectsQuery(connector: AsanaConnector)`
 :   Query class for TaskProjects entity operations.
     
@@ -762,6 +786,8 @@ Classes
         
         Returns:
             TaskProjectsListResult
+
+<a id="TaskStoriesQuery"></a>
 
 `TaskStoriesQuery(connector: AsanaConnector)`
 :   Query class for TaskStories entity operations.
@@ -783,6 +809,8 @@ Classes
                 Returns:
                     Story
 
+<a id="TaskSubtasksQuery"></a>
+
 `TaskSubtasksQuery(connector: AsanaConnector)`
 :   Query class for TaskSubtasks entity operations.
     
@@ -801,6 +829,8 @@ Classes
         
         Returns:
             TaskSubtasksListResult
+
+<a id="TaskTagsQuery"></a>
 
 `TaskTagsQuery(connector: AsanaConnector)`
 :   Query class for TaskTags entity operations.
@@ -832,6 +862,8 @@ Classes
         
         Returns:
             dict[str, Any]
+
+<a id="TasksQuery"></a>
 
 `TasksQuery(connector: AsanaConnector)`
 :   Query class for Tasks entity operations.
@@ -965,6 +997,8 @@ Classes
                 Returns:
                     Task
 
+<a id="TeamProjectsQuery"></a>
+
 `TeamProjectsQuery(connector: AsanaConnector)`
 :   Query class for TeamProjects entity operations.
     
@@ -985,6 +1019,8 @@ Classes
         Returns:
             TeamProjectsListResult
 
+<a id="TeamUsersQuery"></a>
+
 `TeamUsersQuery(connector: AsanaConnector)`
 :   Query class for TeamUsers entity operations.
     
@@ -1003,6 +1039,8 @@ Classes
         
         Returns:
             TeamUsersListResult
+
+<a id="TeamsQuery"></a>
 
 `TeamsQuery(connector: AsanaConnector)`
 :   Query class for Teams entity operations.
@@ -1050,6 +1088,8 @@ Classes
         Returns:
             Team
 
+<a id="UserTeamsQuery"></a>
+
 `UserTeamsQuery(connector: AsanaConnector)`
 :   Query class for UserTeams entity operations.
     
@@ -1069,6 +1109,8 @@ Classes
         
         Returns:
             UserTeamsListResult
+
+<a id="UsersQuery"></a>
 
 `UsersQuery(connector: AsanaConnector)`
 :   Query class for Users entity operations.
@@ -1128,6 +1170,8 @@ Classes
         Returns:
             UsersListResult
 
+<a id="WorkspaceMembershipsQuery"></a>
+
 `WorkspaceMembershipsQuery(connector: AsanaConnector)`
 :   Query class for WorkspaceMemberships entity operations.
     
@@ -1149,6 +1193,8 @@ Classes
                 Returns:
                     User
 
+<a id="WorkspaceProjectsQuery"></a>
+
 `WorkspaceProjectsQuery(connector: AsanaConnector)`
 :   Query class for WorkspaceProjects entity operations.
     
@@ -1168,6 +1214,8 @@ Classes
         
         Returns:
             WorkspaceProjectsListResult
+
+<a id="WorkspaceTagsQuery"></a>
 
 `WorkspaceTagsQuery(connector: AsanaConnector)`
 :   Query class for WorkspaceTags entity operations.
@@ -1201,6 +1249,8 @@ Classes
         
         Returns:
             WorkspaceTagsListResult
+
+<a id="WorkspaceTaskSearchQuery"></a>
 
 `WorkspaceTaskSearchQuery(connector: AsanaConnector)`
 :   Query class for WorkspaceTaskSearch entity operations.
@@ -1240,6 +1290,8 @@ Classes
                 Returns:
                     WorkspaceTaskSearchListResult
 
+<a id="WorkspaceTeamsQuery"></a>
+
 `WorkspaceTeamsQuery(connector: AsanaConnector)`
 :   Query class for WorkspaceTeams entity operations.
     
@@ -1259,6 +1311,8 @@ Classes
         Returns:
             WorkspaceTeamsListResult
 
+<a id="WorkspaceUsersQuery"></a>
+
 `WorkspaceUsersQuery(connector: AsanaConnector)`
 :   Query class for WorkspaceUsers entity operations.
     
@@ -1277,6 +1331,8 @@ Classes
         
         Returns:
             WorkspaceUsersListResult
+
+<a id="WorkspacesQuery"></a>
 
 `WorkspacesQuery(connector: AsanaConnector)`
 :   Query class for Workspaces entity operations.

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/asana/index.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/asana/index.md
@@ -19,6 +19,8 @@ Sub-modules
 Classes
 -------
 
+<a id="AirbyteAuthConfig"></a>
+
 `AirbyteAuthConfig(**data: Any)`
 :   Authentication configuration for Airbyte hosted mode execution.
     
@@ -87,6 +89,8 @@ Classes
     `workspace_name: str | None`
     :   The type of the None singleton.
 
+<a id="AirbyteSearchMeta"></a>
+
 `AirbyteSearchMeta(**data: Any)`
 :   Pagination metadata for search responses.
     
@@ -114,6 +118,8 @@ Classes
 
     `took_ms: int | None`
     :   Time taken to execute the search in milliseconds.
+
+<a id="AirbyteSearchResult"></a>
 
 `AirbyteSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -152,6 +158,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="AttachmentsSearchResult"></a>
+
 `AttachmentsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -167,6 +175,8 @@ Classes
     * airbyte_agent_sdk.connectors.asana.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="ProjectsSearchResult"></a>
 
 `ProjectsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -184,6 +194,8 @@ Classes
     * pydantic.main.BaseModel
     * typing.Generic
 
+<a id="SectionsSearchResult"></a>
+
 `SectionsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -199,6 +211,8 @@ Classes
     * airbyte_agent_sdk.connectors.asana.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="TagsSearchResult"></a>
 
 `TagsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -216,6 +230,8 @@ Classes
     * pydantic.main.BaseModel
     * typing.Generic
 
+<a id="TasksSearchResult"></a>
+
 `TasksSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -231,6 +247,8 @@ Classes
     * airbyte_agent_sdk.connectors.asana.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="TeamsSearchResult"></a>
 
 `TeamsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -248,6 +266,8 @@ Classes
     * pydantic.main.BaseModel
     * typing.Generic
 
+<a id="UsersSearchResult"></a>
+
 `UsersSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -264,6 +284,8 @@ Classes
     * pydantic.main.BaseModel
     * typing.Generic
 
+<a id="WorkspacesSearchResult"></a>
+
 `WorkspacesSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -279,6 +301,8 @@ Classes
     * airbyte_agent_sdk.connectors.asana.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="AsanaConnector"></a>
 
 `AsanaConnector(auth_config: AsanaAuthConfig | AirbyteAuthConfig | BaseModel | None = None, on_token_refresh: Any | None = None)`
 :   Type-safe Asana API connector.
@@ -522,6 +546,8 @@ Classes
             for entity in entities:
                 print(f"\{entity['entity_name']\}: \{entity['available_actions']\}")
 
+<a id="AttachmentsSearchData"></a>
+
 `AttachmentsSearchData(**data: Any)`
 :   Search result data for attachments entity.
     
@@ -576,6 +602,8 @@ Classes
 
     `view_url: str | None`
     :   The type of the None singleton.
+
+<a id="ProjectsSearchData"></a>
 
 `ProjectsSearchData(**data: Any)`
 :   Search result data for projects entity.
@@ -671,6 +699,8 @@ Classes
     `workspace: dict[str, typing.Any] | None`
     :   The type of the None singleton.
 
+<a id="SectionsSearchData"></a>
+
 `SectionsSearchData(**data: Any)`
 :   Search result data for sections entity.
     
@@ -704,6 +734,8 @@ Classes
 
     `resource_type: str | None`
     :   The type of the None singleton.
+
+<a id="TagsSearchData"></a>
 
 `TagsSearchData(**data: Any)`
 :   Search result data for tags entity.
@@ -744,6 +776,8 @@ Classes
 
     `workspace: dict[str, typing.Any] | None`
     :   The type of the None singleton.
+
+<a id="TasksSearchData"></a>
 
 `TasksSearchData(**data: Any)`
 :   Search result data for tasks entity.
@@ -872,6 +906,8 @@ Classes
     `workspace: dict[str, typing.Any] | None`
     :   The type of the None singleton.
 
+<a id="TeamsSearchData"></a>
+
 `TeamsSearchData(**data: Any)`
 :   Search result data for teams entity.
     
@@ -912,6 +948,8 @@ Classes
     `resource_type: str | None`
     :   The type of the None singleton.
 
+<a id="UsersSearchData"></a>
+
 `UsersSearchData(**data: Any)`
 :   Search result data for users entity.
     
@@ -948,6 +986,8 @@ Classes
 
     `workspaces: list[typing.Any] | None`
     :   The type of the None singleton.
+
+<a id="WorkspacesSearchData"></a>
 
 `WorkspacesSearchData(**data: Any)`
 :   Search result data for workspaces entity.

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/asana/models.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/asana/models.md
@@ -13,6 +13,8 @@ and response envelope types.
 Classes
 -------
 
+<a id="AirbyteSearchMeta"></a>
+
 `AirbyteSearchMeta(**data: Any)`
 :   Pagination metadata for search responses.
     
@@ -40,6 +42,8 @@ Classes
 
     `took_ms: int | None`
     :   Time taken to execute the search in milliseconds.
+
+<a id="AirbyteSearchResult"></a>
 
 `AirbyteSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -99,6 +103,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="AttachmentsSearchResult"></a>
+
 `AttachmentsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -135,6 +141,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="ProjectsSearchResult"></a>
 
 `ProjectsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -173,6 +181,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="SectionsSearchResult"></a>
+
 `SectionsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -209,6 +219,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="TagsSearchResult"></a>
 
 `TagsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -247,6 +259,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="TasksSearchResult"></a>
+
 `TasksSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -283,6 +297,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="TeamsSearchResult"></a>
 
 `TeamsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -321,6 +337,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="UsersSearchResult"></a>
+
 `UsersSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -358,6 +376,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="WorkspacesSearchResult"></a>
+
 `WorkspacesSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -373,6 +393,8 @@ Classes
     * airbyte_agent_sdk.connectors.asana.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="AsanaCheckResult"></a>
 
 `AsanaCheckResult(**data: Any)`
 :   Result of a health check operation.
@@ -407,6 +429,8 @@ Classes
     `status: str`
     :   Health check status: 'healthy' or 'unhealthy'.
 
+<a id="AsanaExecuteResult"></a>
+
 `AsanaExecuteResult(**data: Any)`
 :   Response envelope with data only.
     
@@ -435,6 +459,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="AsanaExecuteResultWithMeta"></a>
 
 `AsanaExecuteResultWithMeta(**data: Any)`
 :   Response envelope with data and metadata.
@@ -507,6 +533,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="AttachmentsListResult"></a>
+
 `AttachmentsListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -549,6 +577,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="ProjectsListResult"></a>
 
 `ProjectsListResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -593,6 +623,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="TaskProjectsListResult"></a>
+
 `TaskProjectsListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -635,6 +667,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="TeamProjectsListResult"></a>
 
 `TeamProjectsListResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -679,6 +713,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="WorkspaceProjectsListResult"></a>
+
 `WorkspaceProjectsListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -721,6 +757,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="ProjectSectionsListResult"></a>
 
 `ProjectSectionsListResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -765,6 +803,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="WorkspaceTagsListResult"></a>
+
 `WorkspaceTagsListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -807,6 +847,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="ProjectTasksListResult"></a>
 
 `ProjectTasksListResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -851,6 +893,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="SectionTasksListResult"></a>
+
 `SectionTasksListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -893,6 +937,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="TagTasksListResult"></a>
 
 `TagTasksListResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -937,6 +983,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="TaskDependenciesListResult"></a>
+
 `TaskDependenciesListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -979,6 +1027,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="TaskDependentsListResult"></a>
 
 `TaskDependentsListResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -1023,6 +1073,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="TaskSubtasksListResult"></a>
+
 `TaskSubtasksListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -1065,6 +1117,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="TasksListResult"></a>
 
 `TasksListResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -1109,6 +1163,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="WorkspaceTaskSearchListResult"></a>
+
 `WorkspaceTaskSearchListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -1151,6 +1207,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="UserTeamsListResult"></a>
 
 `UserTeamsListResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -1195,6 +1253,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="WorkspaceTeamsListResult"></a>
+
 `WorkspaceTeamsListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -1237,6 +1297,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="TeamUsersListResult"></a>
 
 `TeamUsersListResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -1281,6 +1343,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="UsersListResult"></a>
+
 `UsersListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -1323,6 +1387,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="WorkspaceUsersListResult"></a>
 
 `WorkspaceUsersListResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -1367,6 +1433,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="WorkspacesListResult"></a>
+
 `WorkspacesListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -1385,6 +1453,8 @@ Classes
     * airbyte_agent_sdk.connectors.asana.models.AsanaExecuteResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="AsanaOauth2AuthConfig"></a>
 
 `AsanaOauth2AuthConfig(**data: Any)`
 :   OAuth 2
@@ -1417,6 +1487,8 @@ Classes
     `refresh_token: str`
     :   OAuth refresh token for automatic token renewal
 
+<a id="AsanaPersonalAccessTokenAuthConfig"></a>
+
 `AsanaPersonalAccessTokenAuthConfig(**data: Any)`
 :   Personal Access Token
     
@@ -1438,6 +1510,8 @@ Classes
 
     `token: str`
     :   Your Asana Personal Access Token. Generate one at https://app.asana.com/0/my-apps
+
+<a id="Attachment"></a>
 
 `Attachment(**data: Any)`
 :   Full attachment object
@@ -1491,6 +1565,8 @@ Classes
     `view_url: str | Any | None`
     :   The type of the None singleton.
 
+<a id="AttachmentCompact"></a>
+
 `AttachmentCompact(**data: Any)`
 :   Compact attachment object
     
@@ -1521,6 +1597,8 @@ Classes
 
     `resource_type: str | Any`
     :   The type of the None singleton.
+
+<a id="AttachmentParent"></a>
 
 `AttachmentParent(**data: Any)`
 :   The parent object this attachment is attached to
@@ -1553,6 +1631,8 @@ Classes
     `resource_type: str | Any`
     :   The type of the None singleton.
 
+<a id="AttachmentResponse"></a>
+
 `AttachmentResponse(**data: Any)`
 :   Attachment response wrapper
     
@@ -1574,6 +1654,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="AttachmentsList"></a>
 
 `AttachmentsList(**data: Any)`
 :   Paginated list of attachments containing compact attachment objects
@@ -1599,6 +1681,8 @@ Classes
 
     `next_page: airbyte_agent_sdk.connectors.asana.models.AttachmentsListNextPage | Any | None`
     :   The type of the None singleton.
+
+<a id="AttachmentsListNextPage"></a>
 
 `AttachmentsListNextPage(**data: Any)`
 :   Nested schema for AttachmentsList.next_page
@@ -1628,6 +1712,8 @@ Classes
     `uri: str | Any`
     :   The type of the None singleton.
 
+<a id="AttachmentsListResultMeta"></a>
+
 `AttachmentsListResultMeta(**data: Any)`
 :   Metadata for attachments.Action.LIST operation
     
@@ -1649,6 +1735,8 @@ Classes
 
     `next_page: dict[str, typing.Any] | Any | None`
     :   The type of the None singleton.
+
+<a id="AttachmentsSearchData"></a>
 
 `AttachmentsSearchData(**data: Any)`
 :   Search result data for attachments entity.
@@ -1705,6 +1793,8 @@ Classes
     `view_url: str | None`
     :   The type of the None singleton.
 
+<a id="EmptyResponse"></a>
+
 `EmptyResponse(**data: Any)`
 :   Empty response returned by delete operations
     
@@ -1726,6 +1816,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="Project"></a>
 
 `Project(**data: Any)`
 :   Full project object
@@ -1836,6 +1928,8 @@ Classes
     `workspace: airbyte_agent_sdk.connectors.asana.models.ProjectWorkspace | Any`
     :   The type of the None singleton.
 
+<a id="ProjectCompact"></a>
+
 `ProjectCompact(**data: Any)`
 :   Compact project object
     
@@ -1863,6 +1957,8 @@ Classes
 
     `resource_type: str | Any`
     :   The type of the None singleton.
+
+<a id="ProjectCompletedBy"></a>
 
 `ProjectCompletedBy(**data: Any)`
 :   Nested schema for Project.completed_by
@@ -1892,6 +1988,8 @@ Classes
     `resource_type: str | Any`
     :   The type of the None singleton.
 
+<a id="ProjectCreateParams"></a>
+
 `ProjectCreateParams(**data: Any)`
 :   Parameters for creating a new project
     
@@ -1913,6 +2011,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="ProjectCreateParamsData"></a>
 
 `ProjectCreateParamsData(**data: Any)`
 :   Nested schema for ProjectCreateParams.data
@@ -1966,6 +2066,8 @@ Classes
     `workspace: str | Any`
     :   GID of the workspace to create the project in
 
+<a id="ProjectCurrentStatus"></a>
+
 `ProjectCurrentStatus(**data: Any)`
 :   Nested schema for Project.current_status
     
@@ -2012,6 +2114,8 @@ Classes
     `title: str | Any`
     :   The type of the None singleton.
 
+<a id="ProjectCurrentStatusAuthor"></a>
+
 `ProjectCurrentStatusAuthor(**data: Any)`
 :   Nested schema for ProjectCurrentStatus.author
     
@@ -2040,6 +2144,8 @@ Classes
     `resource_type: str | Any`
     :   The type of the None singleton.
 
+<a id="ProjectCurrentStatusCreatedBy"></a>
+
 `ProjectCurrentStatusCreatedBy(**data: Any)`
 :   Nested schema for ProjectCurrentStatus.created_by
     
@@ -2067,6 +2173,8 @@ Classes
 
     `resource_type: str | Any`
     :   The type of the None singleton.
+
+<a id="ProjectCurrentStatusUpdate"></a>
 
 `ProjectCurrentStatusUpdate(**data: Any)`
 :   Nested schema for Project.current_status_update
@@ -2099,6 +2207,8 @@ Classes
     `title: str | Any`
     :   The type of the None singleton.
 
+<a id="ProjectFollowersItem"></a>
+
 `ProjectFollowersItem(**data: Any)`
 :   Nested schema for Project.followers_item
     
@@ -2126,6 +2236,8 @@ Classes
 
     `resource_type: str | Any`
     :   The type of the None singleton.
+
+<a id="ProjectMembersItem"></a>
 
 `ProjectMembersItem(**data: Any)`
 :   Nested schema for Project.members_item
@@ -2155,6 +2267,8 @@ Classes
     `resource_type: str | Any`
     :   The type of the None singleton.
 
+<a id="ProjectOwner"></a>
+
 `ProjectOwner(**data: Any)`
 :   Nested schema for Project.owner
     
@@ -2183,6 +2297,8 @@ Classes
     `resource_type: str | Any`
     :   The type of the None singleton.
 
+<a id="ProjectResponse"></a>
+
 `ProjectResponse(**data: Any)`
 :   Project response wrapper
     
@@ -2204,6 +2320,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="ProjectSectionsListResultMeta"></a>
 
 `ProjectSectionsListResultMeta(**data: Any)`
 :   Metadata for project_sections.Action.LIST operation
@@ -2227,6 +2345,8 @@ Classes
     `next_page: dict[str, typing.Any] | Any | None`
     :   The type of the None singleton.
 
+<a id="ProjectTasksListResultMeta"></a>
+
 `ProjectTasksListResultMeta(**data: Any)`
 :   Metadata for project_tasks.Action.LIST operation
     
@@ -2248,6 +2368,8 @@ Classes
 
     `next_page: dict[str, typing.Any] | Any | None`
     :   The type of the None singleton.
+
+<a id="ProjectTeam"></a>
 
 `ProjectTeam(**data: Any)`
 :   Nested schema for Project.team
@@ -2277,6 +2399,8 @@ Classes
     `resource_type: str | Any`
     :   The type of the None singleton.
 
+<a id="ProjectUpdateParams"></a>
+
 `ProjectUpdateParams(**data: Any)`
 :   Parameters for updating an existing project
     
@@ -2298,6 +2422,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="ProjectUpdateParamsData"></a>
 
 `ProjectUpdateParamsData(**data: Any)`
 :   Nested schema for ProjectUpdateParams.data
@@ -2342,6 +2468,8 @@ Classes
     `start_on: str | Any`
     :   Start date in YYYY-MM-DD format
 
+<a id="ProjectWorkspace"></a>
+
 `ProjectWorkspace(**data: Any)`
 :   Nested schema for Project.workspace
     
@@ -2370,6 +2498,8 @@ Classes
     `resource_type: str | Any`
     :   The type of the None singleton.
 
+<a id="ProjectsList"></a>
+
 `ProjectsList(**data: Any)`
 :   Paginated list of projects containing compact project objects
     
@@ -2394,6 +2524,8 @@ Classes
 
     `next_page: airbyte_agent_sdk.connectors.asana.models.ProjectsListNextPage | Any | None`
     :   The type of the None singleton.
+
+<a id="ProjectsListNextPage"></a>
 
 `ProjectsListNextPage(**data: Any)`
 :   Nested schema for ProjectsList.next_page
@@ -2423,6 +2555,8 @@ Classes
     `uri: str | Any`
     :   The type of the None singleton.
 
+<a id="ProjectsListResultMeta"></a>
+
 `ProjectsListResultMeta(**data: Any)`
 :   Metadata for projects.Action.LIST operation
     
@@ -2444,6 +2578,8 @@ Classes
 
     `next_page: dict[str, typing.Any] | Any | None`
     :   The type of the None singleton.
+
+<a id="ProjectsSearchData"></a>
 
 `ProjectsSearchData(**data: Any)`
 :   Search result data for projects entity.
@@ -2539,6 +2675,8 @@ Classes
     `workspace: dict[str, typing.Any] | None`
     :   The type of the None singleton.
 
+<a id="Section"></a>
+
 `Section(**data: Any)`
 :   Full section object
     
@@ -2573,6 +2711,8 @@ Classes
     `resource_type: str | Any`
     :   The type of the None singleton.
 
+<a id="SectionAddTaskParams"></a>
+
 `SectionAddTaskParams(**data: Any)`
 :   Parameters for adding a task to a section
     
@@ -2594,6 +2734,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="SectionAddTaskParamsData"></a>
 
 `SectionAddTaskParamsData(**data: Any)`
 :   Nested schema for SectionAddTaskParams.data
@@ -2623,6 +2765,8 @@ Classes
     `task: str | Any`
     :   The GID of the task to add to this section
 
+<a id="SectionCompact"></a>
+
 `SectionCompact(**data: Any)`
 :   Compact section object
     
@@ -2651,6 +2795,8 @@ Classes
     `resource_type: str | Any`
     :   The type of the None singleton.
 
+<a id="SectionCreateParams"></a>
+
 `SectionCreateParams(**data: Any)`
 :   Parameters for creating a new section in a project
     
@@ -2672,6 +2818,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="SectionCreateParamsData"></a>
 
 `SectionCreateParamsData(**data: Any)`
 :   Nested schema for SectionCreateParams.data
@@ -2701,6 +2849,8 @@ Classes
     `name: str | Any`
     :   The name of the section (this is displayed as the column header in board view)
 
+<a id="SectionProject"></a>
+
 `SectionProject(**data: Any)`
 :   Nested schema for Section.project
     
@@ -2729,6 +2879,8 @@ Classes
     `resource_type: str | Any`
     :   The type of the None singleton.
 
+<a id="SectionResponse"></a>
+
 `SectionResponse(**data: Any)`
 :   Section response wrapper
     
@@ -2750,6 +2902,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="SectionTasksListResultMeta"></a>
 
 `SectionTasksListResultMeta(**data: Any)`
 :   Metadata for section_tasks.Action.LIST operation
@@ -2773,6 +2927,8 @@ Classes
     `next_page: dict[str, typing.Any] | Any | None`
     :   The type of the None singleton.
 
+<a id="SectionUpdateParams"></a>
+
 `SectionUpdateParams(**data: Any)`
 :   Parameters for updating an existing section
     
@@ -2795,6 +2951,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="SectionUpdateParamsData"></a>
+
 `SectionUpdateParamsData(**data: Any)`
 :   Nested schema for SectionUpdateParams.data
     
@@ -2816,6 +2974,8 @@ Classes
 
     `name: str | Any`
     :   The new name of the section
+
+<a id="SectionsList"></a>
 
 `SectionsList(**data: Any)`
 :   Paginated list of sections containing compact section objects
@@ -2841,6 +3001,8 @@ Classes
 
     `next_page: airbyte_agent_sdk.connectors.asana.models.SectionsListNextPage | Any | None`
     :   The type of the None singleton.
+
+<a id="SectionsListNextPage"></a>
 
 `SectionsListNextPage(**data: Any)`
 :   Nested schema for SectionsList.next_page
@@ -2869,6 +3031,8 @@ Classes
 
     `uri: str | Any`
     :   The type of the None singleton.
+
+<a id="SectionsSearchData"></a>
 
 `SectionsSearchData(**data: Any)`
 :   Search result data for sections entity.
@@ -2903,6 +3067,8 @@ Classes
 
     `resource_type: str | None`
     :   The type of the None singleton.
+
+<a id="Story"></a>
 
 `Story(**data: Any)`
 :   A story represents an activity associated with an object in Asana
@@ -2953,6 +3119,8 @@ Classes
     `type_: str | Any`
     :   The type of the None singleton.
 
+<a id="StoryCreateParams"></a>
+
 `StoryCreateParams(**data: Any)`
 :   Parameters for creating a comment (story) on a task
     
@@ -2974,6 +3142,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="StoryCreateParamsData"></a>
 
 `StoryCreateParamsData(**data: Any)`
 :   Nested schema for StoryCreateParams.data
@@ -3003,6 +3173,8 @@ Classes
     `text: str | Any`
     :   The plain text body of the comment
 
+<a id="StoryCreatedBy"></a>
+
 `StoryCreatedBy(**data: Any)`
 :   Nested schema for Story.created_by
     
@@ -3031,6 +3203,8 @@ Classes
     `resource_type: str | Any`
     :   The type of the None singleton.
 
+<a id="StoryResponse"></a>
+
 `StoryResponse(**data: Any)`
 :   Story response wrapper
     
@@ -3052,6 +3226,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="StoryTarget"></a>
 
 `StoryTarget(**data: Any)`
 :   Nested schema for Story.target
@@ -3080,6 +3256,8 @@ Classes
 
     `resource_type: str | Any`
     :   The type of the None singleton.
+
+<a id="Tag"></a>
 
 `Tag(**data: Any)`
 :   Full tag object
@@ -3127,6 +3305,8 @@ Classes
     `workspace: airbyte_agent_sdk.connectors.asana.models.TagWorkspace | Any`
     :   The type of the None singleton.
 
+<a id="TagCompact"></a>
+
 `TagCompact(**data: Any)`
 :   Compact tag object
     
@@ -3155,6 +3335,8 @@ Classes
     `resource_type: str | Any`
     :   The type of the None singleton.
 
+<a id="TagCreateParams"></a>
+
 `TagCreateParams(**data: Any)`
 :   Parameters for creating a new tag in a workspace
     
@@ -3176,6 +3358,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="TagCreateParamsData"></a>
 
 `TagCreateParamsData(**data: Any)`
 :   Nested schema for TagCreateParams.data
@@ -3205,6 +3389,8 @@ Classes
     `notes: str | Any`
     :   Free-form textual description of the tag
 
+<a id="TagResponse"></a>
+
 `TagResponse(**data: Any)`
 :   Tag response wrapper
     
@@ -3226,6 +3412,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="TagTasksListResultMeta"></a>
 
 `TagTasksListResultMeta(**data: Any)`
 :   Metadata for tag_tasks.Action.LIST operation
@@ -3249,6 +3437,8 @@ Classes
     `next_page: dict[str, typing.Any] | Any | None`
     :   The type of the None singleton.
 
+<a id="TagUpdateParams"></a>
+
 `TagUpdateParams(**data: Any)`
 :   Parameters for updating an existing tag
     
@@ -3270,6 +3460,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="TagUpdateParamsData"></a>
 
 `TagUpdateParamsData(**data: Any)`
 :   Nested schema for TagUpdateParams.data
@@ -3299,6 +3491,8 @@ Classes
     `notes: str | Any`
     :   Free-form textual description of the tag
 
+<a id="TagWorkspace"></a>
+
 `TagWorkspace(**data: Any)`
 :   Nested schema for Tag.workspace
     
@@ -3327,6 +3521,8 @@ Classes
     `resource_type: str | Any`
     :   The type of the None singleton.
 
+<a id="TagsList"></a>
+
 `TagsList(**data: Any)`
 :   Paginated list of tags containing compact tag objects
     
@@ -3351,6 +3547,8 @@ Classes
 
     `next_page: airbyte_agent_sdk.connectors.asana.models.TagsListNextPage | Any | None`
     :   The type of the None singleton.
+
+<a id="TagsListNextPage"></a>
 
 `TagsListNextPage(**data: Any)`
 :   Nested schema for TagsList.next_page
@@ -3379,6 +3577,8 @@ Classes
 
     `uri: str | Any`
     :   The type of the None singleton.
+
+<a id="TagsSearchData"></a>
 
 `TagsSearchData(**data: Any)`
 :   Search result data for tags entity.
@@ -3420,6 +3620,8 @@ Classes
     `workspace: dict[str, typing.Any] | None`
     :   The type of the None singleton.
 
+<a id="Task"></a>
+
 `Task(**data: Any)`
 :   Full task object
     
@@ -3441,6 +3643,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="TaskAddTagParams"></a>
 
 `TaskAddTagParams(**data: Any)`
 :   Parameters for adding a tag to a task
@@ -3464,6 +3668,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="TaskAddTagParamsData"></a>
+
 `TaskAddTagParamsData(**data: Any)`
 :   Nested schema for TaskAddTagParams.data
     
@@ -3485,6 +3691,8 @@ Classes
 
     `tag: str | Any`
     :   The GID of the tag to add to the task
+
+<a id="TaskCompact"></a>
 
 `TaskCompact(**data: Any)`
 :   Compact task object
@@ -3520,6 +3728,8 @@ Classes
     `resource_type: str | Any`
     :   The type of the None singleton.
 
+<a id="TaskCompactCreatedBy"></a>
+
 `TaskCompactCreatedBy(**data: Any)`
 :   User who created the task
     
@@ -3545,6 +3755,8 @@ Classes
     `resource_type: str | Any`
     :   The type of the None singleton.
 
+<a id="TaskCreateParams"></a>
+
 `TaskCreateParams(**data: Any)`
 :   Parameters for creating a new task
     
@@ -3566,6 +3778,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="TaskCreateParamsData"></a>
 
 `TaskCreateParamsData(**data: Any)`
 :   Nested schema for TaskCreateParams.data
@@ -3628,6 +3842,8 @@ Classes
     `workspace: str | Any`
     :   GID of the workspace to create the task in
 
+<a id="TaskDependenciesListResultMeta"></a>
+
 `TaskDependenciesListResultMeta(**data: Any)`
 :   Metadata for task_dependencies.Action.LIST operation
     
@@ -3649,6 +3865,8 @@ Classes
 
     `next_page: dict[str, typing.Any] | Any | None`
     :   The type of the None singleton.
+
+<a id="TaskDependentsListResultMeta"></a>
 
 `TaskDependentsListResultMeta(**data: Any)`
 :   Metadata for task_dependents.Action.LIST operation
@@ -3672,6 +3890,8 @@ Classes
     `next_page: dict[str, typing.Any] | Any | None`
     :   The type of the None singleton.
 
+<a id="TaskProjectsListResultMeta"></a>
+
 `TaskProjectsListResultMeta(**data: Any)`
 :   Metadata for task_projects.Action.LIST operation
     
@@ -3693,6 +3913,8 @@ Classes
 
     `next_page: dict[str, typing.Any] | Any | None`
     :   The type of the None singleton.
+
+<a id="TaskRemoveTagParams"></a>
 
 `TaskRemoveTagParams(**data: Any)`
 :   Parameters for removing a tag from a task
@@ -3716,6 +3938,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="TaskRemoveTagParamsData"></a>
+
 `TaskRemoveTagParamsData(**data: Any)`
 :   Nested schema for TaskRemoveTagParams.data
     
@@ -3737,6 +3961,8 @@ Classes
 
     `tag: str | Any`
     :   The GID of the tag to remove from the task
+
+<a id="TaskResponse"></a>
 
 `TaskResponse(**data: Any)`
 :   Task response wrapper
@@ -3760,6 +3986,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="TaskSubtasksListResultMeta"></a>
+
 `TaskSubtasksListResultMeta(**data: Any)`
 :   Metadata for task_subtasks.Action.LIST operation
     
@@ -3782,6 +4010,8 @@ Classes
     `next_page: dict[str, typing.Any] | Any | None`
     :   The type of the None singleton.
 
+<a id="TaskUpdateParams"></a>
+
 `TaskUpdateParams(**data: Any)`
 :   Parameters for updating an existing task
     
@@ -3803,6 +4033,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="TaskUpdateParamsData"></a>
 
 `TaskUpdateParamsData(**data: Any)`
 :   Nested schema for TaskUpdateParams.data
@@ -3847,6 +4079,8 @@ Classes
     `start_on: str | Any`
     :   Start date in YYYY-MM-DD format
 
+<a id="TasksList"></a>
+
 `TasksList(**data: Any)`
 :   Paginated list of tasks containing compact task objects
     
@@ -3871,6 +4105,8 @@ Classes
 
     `next_page: airbyte_agent_sdk.connectors.asana.models.TasksListNextPage | Any | None`
     :   The type of the None singleton.
+
+<a id="TasksListNextPage"></a>
 
 `TasksListNextPage(**data: Any)`
 :   Nested schema for TasksList.next_page
@@ -3900,6 +4136,8 @@ Classes
     `uri: str | Any`
     :   The type of the None singleton.
 
+<a id="TasksListResultMeta"></a>
+
 `TasksListResultMeta(**data: Any)`
 :   Metadata for tasks.Action.LIST operation
     
@@ -3921,6 +4159,8 @@ Classes
 
     `next_page: dict[str, typing.Any] | Any | None`
     :   The type of the None singleton.
+
+<a id="TasksSearchData"></a>
 
 `TasksSearchData(**data: Any)`
 :   Search result data for tasks entity.
@@ -4049,6 +4289,8 @@ Classes
     `workspace: dict[str, typing.Any] | None`
     :   The type of the None singleton.
 
+<a id="Team"></a>
+
 `Team(**data: Any)`
 :   Full team object
     
@@ -4083,6 +4325,8 @@ Classes
     `resource_type: str | Any`
     :   The type of the None singleton.
 
+<a id="TeamCompact"></a>
+
 `TeamCompact(**data: Any)`
 :   Compact team object
     
@@ -4110,6 +4354,8 @@ Classes
 
     `resource_type: str | Any`
     :   The type of the None singleton.
+
+<a id="TeamOrganization"></a>
 
 `TeamOrganization(**data: Any)`
 :   Nested schema for Team.organization
@@ -4139,6 +4385,8 @@ Classes
     `resource_type: str | Any`
     :   The type of the None singleton.
 
+<a id="TeamProjectsListResultMeta"></a>
+
 `TeamProjectsListResultMeta(**data: Any)`
 :   Metadata for team_projects.Action.LIST operation
     
@@ -4160,6 +4408,8 @@ Classes
 
     `next_page: dict[str, typing.Any] | Any | None`
     :   The type of the None singleton.
+
+<a id="TeamResponse"></a>
 
 `TeamResponse(**data: Any)`
 :   Team response wrapper
@@ -4183,6 +4433,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="TeamUsersListResultMeta"></a>
+
 `TeamUsersListResultMeta(**data: Any)`
 :   Metadata for team_users.Action.LIST operation
     
@@ -4204,6 +4456,8 @@ Classes
 
     `next_page: dict[str, typing.Any] | Any | None`
     :   The type of the None singleton.
+
+<a id="TeamsList"></a>
 
 `TeamsList(**data: Any)`
 :   Paginated list of teams containing compact team objects
@@ -4229,6 +4483,8 @@ Classes
 
     `next_page: airbyte_agent_sdk.connectors.asana.models.TeamsListNextPage | Any | None`
     :   The type of the None singleton.
+
+<a id="TeamsListNextPage"></a>
 
 `TeamsListNextPage(**data: Any)`
 :   Nested schema for TeamsList.next_page
@@ -4257,6 +4513,8 @@ Classes
 
     `uri: str | Any`
     :   The type of the None singleton.
+
+<a id="TeamsSearchData"></a>
 
 `TeamsSearchData(**data: Any)`
 :   Search result data for teams entity.
@@ -4298,6 +4556,8 @@ Classes
     `resource_type: str | None`
     :   The type of the None singleton.
 
+<a id="User"></a>
+
 `User(**data: Any)`
 :   Full user object
     
@@ -4335,6 +4595,8 @@ Classes
     `workspaces: list[airbyte_agent_sdk.connectors.asana.models.UserWorkspacesItem] | Any`
     :   The type of the None singleton.
 
+<a id="UserCompact"></a>
+
 `UserCompact(**data: Any)`
 :   Compact user object
     
@@ -4363,6 +4625,8 @@ Classes
     `resource_type: str | Any`
     :   The type of the None singleton.
 
+<a id="UserResponse"></a>
+
 `UserResponse(**data: Any)`
 :   User response wrapper
     
@@ -4385,6 +4649,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="UserTeamsListResultMeta"></a>
+
 `UserTeamsListResultMeta(**data: Any)`
 :   Metadata for user_teams.Action.LIST operation
     
@@ -4406,6 +4672,8 @@ Classes
 
     `next_page: dict[str, typing.Any] | Any | None`
     :   The type of the None singleton.
+
+<a id="UserWorkspacesItem"></a>
 
 `UserWorkspacesItem(**data: Any)`
 :   Nested schema for User.workspaces_item
@@ -4435,6 +4703,8 @@ Classes
     `resource_type: str | Any`
     :   The type of the None singleton.
 
+<a id="UsersList"></a>
+
 `UsersList(**data: Any)`
 :   Paginated list of users containing compact user objects
     
@@ -4459,6 +4729,8 @@ Classes
 
     `next_page: airbyte_agent_sdk.connectors.asana.models.UsersListNextPage | Any | None`
     :   The type of the None singleton.
+
+<a id="UsersListNextPage"></a>
 
 `UsersListNextPage(**data: Any)`
 :   Nested schema for UsersList.next_page
@@ -4488,6 +4760,8 @@ Classes
     `uri: str | Any`
     :   The type of the None singleton.
 
+<a id="UsersListResultMeta"></a>
+
 `UsersListResultMeta(**data: Any)`
 :   Metadata for users.Action.LIST operation
     
@@ -4509,6 +4783,8 @@ Classes
 
     `next_page: dict[str, typing.Any] | Any | None`
     :   The type of the None singleton.
+
+<a id="UsersSearchData"></a>
 
 `UsersSearchData(**data: Any)`
 :   Search result data for users entity.
@@ -4547,6 +4823,8 @@ Classes
     `workspaces: list[typing.Any] | None`
     :   The type of the None singleton.
 
+<a id="Workspace"></a>
+
 `Workspace(**data: Any)`
 :   Full workspace object
     
@@ -4581,6 +4859,8 @@ Classes
     `resource_type: str | Any`
     :   The type of the None singleton.
 
+<a id="WorkspaceAddUserParams"></a>
+
 `WorkspaceAddUserParams(**data: Any)`
 :   Parameters for adding a user to a workspace or organization
     
@@ -4603,6 +4883,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="WorkspaceAddUserParamsData"></a>
+
 `WorkspaceAddUserParamsData(**data: Any)`
 :   Nested schema for WorkspaceAddUserParams.data
     
@@ -4624,6 +4906,8 @@ Classes
 
     `user: str | Any`
     :   A user GID or email address to add to the workspace
+
+<a id="WorkspaceCompact"></a>
 
 `WorkspaceCompact(**data: Any)`
 :   Compact workspace object
@@ -4653,6 +4937,8 @@ Classes
     `resource_type: str | Any`
     :   The type of the None singleton.
 
+<a id="WorkspaceProjectsListResultMeta"></a>
+
 `WorkspaceProjectsListResultMeta(**data: Any)`
 :   Metadata for workspace_projects.Action.LIST operation
     
@@ -4674,6 +4960,8 @@ Classes
 
     `next_page: dict[str, typing.Any] | Any | None`
     :   The type of the None singleton.
+
+<a id="WorkspaceResponse"></a>
 
 `WorkspaceResponse(**data: Any)`
 :   Workspace response wrapper
@@ -4697,6 +4985,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="WorkspaceTagsListResultMeta"></a>
+
 `WorkspaceTagsListResultMeta(**data: Any)`
 :   Metadata for workspace_tags.Action.LIST operation
     
@@ -4718,6 +5008,8 @@ Classes
 
     `next_page: dict[str, typing.Any] | Any | None`
     :   The type of the None singleton.
+
+<a id="WorkspaceTaskSearchListResultMeta"></a>
 
 `WorkspaceTaskSearchListResultMeta(**data: Any)`
 :   Metadata for workspace_task_search.Action.LIST operation
@@ -4741,6 +5033,8 @@ Classes
     `next_page: dict[str, typing.Any] | Any | None`
     :   The type of the None singleton.
 
+<a id="WorkspaceTeamsListResultMeta"></a>
+
 `WorkspaceTeamsListResultMeta(**data: Any)`
 :   Metadata for workspace_teams.Action.LIST operation
     
@@ -4763,6 +5057,8 @@ Classes
     `next_page: dict[str, typing.Any] | Any | None`
     :   The type of the None singleton.
 
+<a id="WorkspaceUsersListResultMeta"></a>
+
 `WorkspaceUsersListResultMeta(**data: Any)`
 :   Metadata for workspace_users.Action.LIST operation
     
@@ -4784,6 +5080,8 @@ Classes
 
     `next_page: dict[str, typing.Any] | Any | None`
     :   The type of the None singleton.
+
+<a id="WorkspacesList"></a>
 
 `WorkspacesList(**data: Any)`
 :   Paginated list of workspaces containing compact workspace objects
@@ -4809,6 +5107,8 @@ Classes
 
     `next_page: airbyte_agent_sdk.connectors.asana.models.WorkspacesListNextPage | Any | None`
     :   The type of the None singleton.
+
+<a id="WorkspacesListNextPage"></a>
 
 `WorkspacesListNextPage(**data: Any)`
 :   Nested schema for WorkspacesList.next_page
@@ -4838,6 +5138,8 @@ Classes
     `uri: str | Any`
     :   The type of the None singleton.
 
+<a id="WorkspacesListResultMeta"></a>
+
 `WorkspacesListResultMeta(**data: Any)`
 :   Metadata for workspaces.Action.LIST operation
     
@@ -4859,6 +5161,8 @@ Classes
 
     `next_page: dict[str, typing.Any] | Any | None`
     :   The type of the None singleton.
+
+<a id="WorkspacesSearchData"></a>
 
 `WorkspacesSearchData(**data: Any)`
 :   Search result data for workspaces entity.

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/asana/types.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/asana/types.md
@@ -10,6 +10,8 @@ Type definitions for asana connector.
 Classes
 -------
 
+<a id="AirbyteSearchParams"></a>
+
 `AirbyteSearchParams(*args, **kwargs)`
 :   Parameters for Airbyte cache search operations (generic, use entity-specific query types for better type hints).
 
@@ -31,6 +33,8 @@ Classes
     `query: dict[str, typing.Any]`
     :   The type of the None singleton.
 
+<a id="AttachmentsAndCondition"></a>
+
 `AttachmentsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -51,6 +55,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.asana.types.AttachmentsEqCondition | airbyte_agent_sdk.connectors.asana.types.AttachmentsNeqCondition | airbyte_agent_sdk.connectors.asana.types.AttachmentsGtCondition | airbyte_agent_sdk.connectors.asana.types.AttachmentsGteCondition | airbyte_agent_sdk.connectors.asana.types.AttachmentsLtCondition | airbyte_agent_sdk.connectors.asana.types.AttachmentsLteCondition | airbyte_agent_sdk.connectors.asana.types.AttachmentsInCondition | airbyte_agent_sdk.connectors.asana.types.AttachmentsLikeCondition | airbyte_agent_sdk.connectors.asana.types.AttachmentsFuzzyCondition | airbyte_agent_sdk.connectors.asana.types.AttachmentsKeywordCondition | airbyte_agent_sdk.connectors.asana.types.AttachmentsContainsCondition | airbyte_agent_sdk.connectors.asana.types.AttachmentsNotCondition | airbyte_agent_sdk.connectors.asana.types.AttachmentsAndCondition | airbyte_agent_sdk.connectors.asana.types.AttachmentsOrCondition | airbyte_agent_sdk.connectors.asana.types.AttachmentsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="AttachmentsAnyCondition"></a>
+
 `AttachmentsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -70,6 +76,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.asana.types.AttachmentsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="AttachmentsAnyValueFilter"></a>
 
 `AttachmentsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -116,6 +124,8 @@ Classes
     `view_url: Any`
     :   The type of the None singleton.
 
+<a id="AttachmentsContainsCondition"></a>
+
 `AttachmentsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -127,6 +137,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.asana.types.AttachmentsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="AttachmentsDownloadParams"></a>
 
 `AttachmentsDownloadParams(*args, **kwargs)`
 :   Parameters for attachments.download operation
@@ -143,6 +155,8 @@ Classes
     `range_header: str`
     :   The type of the None singleton.
 
+<a id="AttachmentsEqCondition"></a>
+
 `AttachmentsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
 
@@ -154,6 +168,8 @@ Classes
 
     `eq: airbyte_agent_sdk.connectors.asana.types.AttachmentsSearchFilter`
     :   The type of the None singleton.
+
+<a id="AttachmentsFuzzyCondition"></a>
 
 `AttachmentsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
@@ -167,6 +183,8 @@ Classes
     `fuzzy: airbyte_agent_sdk.connectors.asana.types.AttachmentsStringFilter`
     :   The type of the None singleton.
 
+<a id="AttachmentsGetParams"></a>
+
 `AttachmentsGetParams(*args, **kwargs)`
 :   Parameters for attachments.get operation
 
@@ -178,6 +196,8 @@ Classes
 
     `attachment_gid: str`
     :   The type of the None singleton.
+
+<a id="AttachmentsGtCondition"></a>
 
 `AttachmentsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
@@ -191,6 +211,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.asana.types.AttachmentsSearchFilter`
     :   The type of the None singleton.
 
+<a id="AttachmentsGteCondition"></a>
+
 `AttachmentsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -202,6 +224,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.asana.types.AttachmentsSearchFilter`
     :   The type of the None singleton.
+
+<a id="AttachmentsInCondition"></a>
 
 `AttachmentsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -222,6 +246,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.asana.types.AttachmentsInFilter`
     :   The type of the None singleton.
+
+<a id="AttachmentsInFilter"></a>
 
 `AttachmentsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -268,6 +294,8 @@ Classes
     `view_url: list[str]`
     :   The type of the None singleton.
 
+<a id="AttachmentsKeywordCondition"></a>
+
 `AttachmentsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -280,6 +308,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.asana.types.AttachmentsStringFilter`
     :   The type of the None singleton.
 
+<a id="AttachmentsLikeCondition"></a>
+
 `AttachmentsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -291,6 +321,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.asana.types.AttachmentsStringFilter`
     :   The type of the None singleton.
+
+<a id="AttachmentsListParams"></a>
 
 `AttachmentsListParams(*args, **kwargs)`
 :   Parameters for attachments.list operation
@@ -310,6 +342,8 @@ Classes
     `parent: str`
     :   The type of the None singleton.
 
+<a id="AttachmentsLtCondition"></a>
+
 `AttachmentsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -321,6 +355,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.asana.types.AttachmentsSearchFilter`
     :   The type of the None singleton.
+
+<a id="AttachmentsLteCondition"></a>
 
 `AttachmentsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -334,6 +370,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.asana.types.AttachmentsSearchFilter`
     :   The type of the None singleton.
 
+<a id="AttachmentsNeqCondition"></a>
+
 `AttachmentsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -345,6 +383,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.asana.types.AttachmentsSearchFilter`
     :   The type of the None singleton.
+
+<a id="AttachmentsNotCondition"></a>
 
 `AttachmentsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -366,6 +406,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.asana.types.AttachmentsEqCondition | airbyte_agent_sdk.connectors.asana.types.AttachmentsNeqCondition | airbyte_agent_sdk.connectors.asana.types.AttachmentsGtCondition | airbyte_agent_sdk.connectors.asana.types.AttachmentsGteCondition | airbyte_agent_sdk.connectors.asana.types.AttachmentsLtCondition | airbyte_agent_sdk.connectors.asana.types.AttachmentsLteCondition | airbyte_agent_sdk.connectors.asana.types.AttachmentsInCondition | airbyte_agent_sdk.connectors.asana.types.AttachmentsLikeCondition | airbyte_agent_sdk.connectors.asana.types.AttachmentsFuzzyCondition | airbyte_agent_sdk.connectors.asana.types.AttachmentsKeywordCondition | airbyte_agent_sdk.connectors.asana.types.AttachmentsContainsCondition | airbyte_agent_sdk.connectors.asana.types.AttachmentsNotCondition | airbyte_agent_sdk.connectors.asana.types.AttachmentsAndCondition | airbyte_agent_sdk.connectors.asana.types.AttachmentsOrCondition | airbyte_agent_sdk.connectors.asana.types.AttachmentsAnyCondition`
     :   The type of the None singleton.
 
+<a id="AttachmentsOrCondition"></a>
+
 `AttachmentsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -385,6 +427,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.asana.types.AttachmentsEqCondition | airbyte_agent_sdk.connectors.asana.types.AttachmentsNeqCondition | airbyte_agent_sdk.connectors.asana.types.AttachmentsGtCondition | airbyte_agent_sdk.connectors.asana.types.AttachmentsGteCondition | airbyte_agent_sdk.connectors.asana.types.AttachmentsLtCondition | airbyte_agent_sdk.connectors.asana.types.AttachmentsLteCondition | airbyte_agent_sdk.connectors.asana.types.AttachmentsInCondition | airbyte_agent_sdk.connectors.asana.types.AttachmentsLikeCondition | airbyte_agent_sdk.connectors.asana.types.AttachmentsFuzzyCondition | airbyte_agent_sdk.connectors.asana.types.AttachmentsKeywordCondition | airbyte_agent_sdk.connectors.asana.types.AttachmentsContainsCondition | airbyte_agent_sdk.connectors.asana.types.AttachmentsNotCondition | airbyte_agent_sdk.connectors.asana.types.AttachmentsAndCondition | airbyte_agent_sdk.connectors.asana.types.AttachmentsOrCondition | airbyte_agent_sdk.connectors.asana.types.AttachmentsAnyCondition]`
     :   The type of the None singleton.
+
+<a id="AttachmentsSearchFilter"></a>
 
 `AttachmentsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering attachments search queries.
@@ -431,6 +475,8 @@ Classes
     `view_url: str | None`
     :   The type of the None singleton.
 
+<a id="AttachmentsSearchQuery"></a>
+
 `AttachmentsSearchQuery(*args, **kwargs)`
 :   Search query for attachments entity.
 
@@ -445,6 +491,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.asana.types.AttachmentsSortFilter]`
     :   The type of the None singleton.
+
+<a id="AttachmentsSortFilter"></a>
 
 `AttachmentsSortFilter(*args, **kwargs)`
 :   Available fields for sorting attachments search results.
@@ -491,6 +539,8 @@ Classes
     `view_url: Literal['asc', 'desc']`
     :   The type of the None singleton.
 
+<a id="AttachmentsStringFilter"></a>
+
 `AttachmentsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -536,6 +586,8 @@ Classes
     `view_url: str`
     :   The type of the None singleton.
 
+<a id="ProjectSectionsCreateParams"></a>
+
 `ProjectSectionsCreateParams(*args, **kwargs)`
 :   Parameters for project_sections.create operation
 
@@ -550,6 +602,8 @@ Classes
 
     `project_gid: str`
     :   The type of the None singleton.
+
+<a id="ProjectSectionsCreateParamsData"></a>
 
 `ProjectSectionsCreateParamsData(*args, **kwargs)`
 :   Nested schema for ProjectSectionsCreateParams.data
@@ -569,6 +623,8 @@ Classes
     `name: str`
     :   The type of the None singleton.
 
+<a id="ProjectSectionsListParams"></a>
+
 `ProjectSectionsListParams(*args, **kwargs)`
 :   Parameters for project_sections.list operation
 
@@ -586,6 +642,8 @@ Classes
 
     `project_gid: str`
     :   The type of the None singleton.
+
+<a id="ProjectTasksListParams"></a>
 
 `ProjectTasksListParams(*args, **kwargs)`
 :   Parameters for project_tasks.list operation
@@ -608,6 +666,8 @@ Classes
     `project_gid: str`
     :   The type of the None singleton.
 
+<a id="ProjectsAndCondition"></a>
+
 `ProjectsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -628,6 +688,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.asana.types.ProjectsEqCondition | airbyte_agent_sdk.connectors.asana.types.ProjectsNeqCondition | airbyte_agent_sdk.connectors.asana.types.ProjectsGtCondition | airbyte_agent_sdk.connectors.asana.types.ProjectsGteCondition | airbyte_agent_sdk.connectors.asana.types.ProjectsLtCondition | airbyte_agent_sdk.connectors.asana.types.ProjectsLteCondition | airbyte_agent_sdk.connectors.asana.types.ProjectsInCondition | airbyte_agent_sdk.connectors.asana.types.ProjectsLikeCondition | airbyte_agent_sdk.connectors.asana.types.ProjectsFuzzyCondition | airbyte_agent_sdk.connectors.asana.types.ProjectsKeywordCondition | airbyte_agent_sdk.connectors.asana.types.ProjectsContainsCondition | airbyte_agent_sdk.connectors.asana.types.ProjectsNotCondition | airbyte_agent_sdk.connectors.asana.types.ProjectsAndCondition | airbyte_agent_sdk.connectors.asana.types.ProjectsOrCondition | airbyte_agent_sdk.connectors.asana.types.ProjectsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="ProjectsAnyCondition"></a>
+
 `ProjectsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -647,6 +709,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.asana.types.ProjectsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="ProjectsAnyValueFilter"></a>
 
 `ProjectsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -732,6 +796,8 @@ Classes
     `workspace: Any`
     :   The type of the None singleton.
 
+<a id="ProjectsContainsCondition"></a>
+
 `ProjectsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -744,6 +810,8 @@ Classes
     `contains: airbyte_agent_sdk.connectors.asana.types.ProjectsAnyValueFilter`
     :   The type of the None singleton.
 
+<a id="ProjectsCreateParams"></a>
+
 `ProjectsCreateParams(*args, **kwargs)`
 :   Parameters for projects.create operation
 
@@ -755,6 +823,8 @@ Classes
 
     `data: airbyte_agent_sdk.connectors.asana.types.ProjectsCreateParamsData`
     :   The type of the None singleton.
+
+<a id="ProjectsCreateParamsData"></a>
 
 `ProjectsCreateParamsData(*args, **kwargs)`
 :   Nested schema for ProjectsCreateParams.data
@@ -798,6 +868,8 @@ Classes
     `workspace: str`
     :   The type of the None singleton.
 
+<a id="ProjectsDeleteParams"></a>
+
 `ProjectsDeleteParams(*args, **kwargs)`
 :   Parameters for projects.delete operation
 
@@ -809,6 +881,8 @@ Classes
 
     `project_gid: str`
     :   The type of the None singleton.
+
+<a id="ProjectsEqCondition"></a>
 
 `ProjectsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -822,6 +896,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.asana.types.ProjectsSearchFilter`
     :   The type of the None singleton.
 
+<a id="ProjectsFuzzyCondition"></a>
+
 `ProjectsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -833,6 +909,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.asana.types.ProjectsStringFilter`
     :   The type of the None singleton.
+
+<a id="ProjectsGetParams"></a>
 
 `ProjectsGetParams(*args, **kwargs)`
 :   Parameters for projects.get operation
@@ -846,6 +924,8 @@ Classes
     `project_gid: str`
     :   The type of the None singleton.
 
+<a id="ProjectsGtCondition"></a>
+
 `ProjectsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -858,6 +938,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.asana.types.ProjectsSearchFilter`
     :   The type of the None singleton.
 
+<a id="ProjectsGteCondition"></a>
+
 `ProjectsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -869,6 +951,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.asana.types.ProjectsSearchFilter`
     :   The type of the None singleton.
+
+<a id="ProjectsInCondition"></a>
 
 `ProjectsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -889,6 +973,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.asana.types.ProjectsInFilter`
     :   The type of the None singleton.
+
+<a id="ProjectsInFilter"></a>
 
 `ProjectsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -974,6 +1060,8 @@ Classes
     `workspace: list[dict[str, typing.Any]]`
     :   The type of the None singleton.
 
+<a id="ProjectsKeywordCondition"></a>
+
 `ProjectsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -986,6 +1074,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.asana.types.ProjectsStringFilter`
     :   The type of the None singleton.
 
+<a id="ProjectsLikeCondition"></a>
+
 `ProjectsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -997,6 +1087,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.asana.types.ProjectsStringFilter`
     :   The type of the None singleton.
+
+<a id="ProjectsListParams"></a>
 
 `ProjectsListParams(*args, **kwargs)`
 :   Parameters for projects.list operation
@@ -1022,6 +1114,8 @@ Classes
     `workspace: str`
     :   The type of the None singleton.
 
+<a id="ProjectsLtCondition"></a>
+
 `ProjectsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -1033,6 +1127,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.asana.types.ProjectsSearchFilter`
     :   The type of the None singleton.
+
+<a id="ProjectsLteCondition"></a>
 
 `ProjectsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -1046,6 +1142,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.asana.types.ProjectsSearchFilter`
     :   The type of the None singleton.
 
+<a id="ProjectsNeqCondition"></a>
+
 `ProjectsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -1057,6 +1155,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.asana.types.ProjectsSearchFilter`
     :   The type of the None singleton.
+
+<a id="ProjectsNotCondition"></a>
 
 `ProjectsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -1078,6 +1178,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.asana.types.ProjectsEqCondition | airbyte_agent_sdk.connectors.asana.types.ProjectsNeqCondition | airbyte_agent_sdk.connectors.asana.types.ProjectsGtCondition | airbyte_agent_sdk.connectors.asana.types.ProjectsGteCondition | airbyte_agent_sdk.connectors.asana.types.ProjectsLtCondition | airbyte_agent_sdk.connectors.asana.types.ProjectsLteCondition | airbyte_agent_sdk.connectors.asana.types.ProjectsInCondition | airbyte_agent_sdk.connectors.asana.types.ProjectsLikeCondition | airbyte_agent_sdk.connectors.asana.types.ProjectsFuzzyCondition | airbyte_agent_sdk.connectors.asana.types.ProjectsKeywordCondition | airbyte_agent_sdk.connectors.asana.types.ProjectsContainsCondition | airbyte_agent_sdk.connectors.asana.types.ProjectsNotCondition | airbyte_agent_sdk.connectors.asana.types.ProjectsAndCondition | airbyte_agent_sdk.connectors.asana.types.ProjectsOrCondition | airbyte_agent_sdk.connectors.asana.types.ProjectsAnyCondition`
     :   The type of the None singleton.
 
+<a id="ProjectsOrCondition"></a>
+
 `ProjectsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1097,6 +1199,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.asana.types.ProjectsEqCondition | airbyte_agent_sdk.connectors.asana.types.ProjectsNeqCondition | airbyte_agent_sdk.connectors.asana.types.ProjectsGtCondition | airbyte_agent_sdk.connectors.asana.types.ProjectsGteCondition | airbyte_agent_sdk.connectors.asana.types.ProjectsLtCondition | airbyte_agent_sdk.connectors.asana.types.ProjectsLteCondition | airbyte_agent_sdk.connectors.asana.types.ProjectsInCondition | airbyte_agent_sdk.connectors.asana.types.ProjectsLikeCondition | airbyte_agent_sdk.connectors.asana.types.ProjectsFuzzyCondition | airbyte_agent_sdk.connectors.asana.types.ProjectsKeywordCondition | airbyte_agent_sdk.connectors.asana.types.ProjectsContainsCondition | airbyte_agent_sdk.connectors.asana.types.ProjectsNotCondition | airbyte_agent_sdk.connectors.asana.types.ProjectsAndCondition | airbyte_agent_sdk.connectors.asana.types.ProjectsOrCondition | airbyte_agent_sdk.connectors.asana.types.ProjectsAnyCondition]`
     :   The type of the None singleton.
+
+<a id="ProjectsSearchFilter"></a>
 
 `ProjectsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering projects search queries.
@@ -1182,6 +1286,8 @@ Classes
     `workspace: dict[str, typing.Any] | None`
     :   The type of the None singleton.
 
+<a id="ProjectsSearchQuery"></a>
+
 `ProjectsSearchQuery(*args, **kwargs)`
 :   Search query for projects entity.
 
@@ -1196,6 +1302,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.asana.types.ProjectsSortFilter]`
     :   The type of the None singleton.
+
+<a id="ProjectsSortFilter"></a>
 
 `ProjectsSortFilter(*args, **kwargs)`
 :   Available fields for sorting projects search results.
@@ -1281,6 +1389,8 @@ Classes
     `workspace: Literal['asc', 'desc']`
     :   The type of the None singleton.
 
+<a id="ProjectsStringFilter"></a>
+
 `ProjectsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -1365,6 +1475,8 @@ Classes
     `workspace: str`
     :   The type of the None singleton.
 
+<a id="ProjectsUpdateParams"></a>
+
 `ProjectsUpdateParams(*args, **kwargs)`
 :   Parameters for projects.update operation
 
@@ -1379,6 +1491,8 @@ Classes
 
     `project_gid: str`
     :   The type of the None singleton.
+
+<a id="ProjectsUpdateParamsData"></a>
 
 `ProjectsUpdateParamsData(*args, **kwargs)`
 :   Nested schema for ProjectsUpdateParams.data
@@ -1413,6 +1527,8 @@ Classes
     `start_on: str`
     :   The type of the None singleton.
 
+<a id="SectionTasksCreateParams"></a>
+
 `SectionTasksCreateParams(*args, **kwargs)`
 :   Parameters for section_tasks.create operation
 
@@ -1427,6 +1543,8 @@ Classes
 
     `section_gid: str`
     :   The type of the None singleton.
+
+<a id="SectionTasksCreateParamsData"></a>
 
 `SectionTasksCreateParamsData(*args, **kwargs)`
 :   Nested schema for SectionTasksCreateParams.data
@@ -1445,6 +1563,8 @@ Classes
 
     `task: str`
     :   The type of the None singleton.
+
+<a id="SectionTasksListParams"></a>
 
 `SectionTasksListParams(*args, **kwargs)`
 :   Parameters for section_tasks.list operation
@@ -1467,6 +1587,8 @@ Classes
     `section_gid: str`
     :   The type of the None singleton.
 
+<a id="SectionsAndCondition"></a>
+
 `SectionsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1487,6 +1609,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.asana.types.SectionsEqCondition | airbyte_agent_sdk.connectors.asana.types.SectionsNeqCondition | airbyte_agent_sdk.connectors.asana.types.SectionsGtCondition | airbyte_agent_sdk.connectors.asana.types.SectionsGteCondition | airbyte_agent_sdk.connectors.asana.types.SectionsLtCondition | airbyte_agent_sdk.connectors.asana.types.SectionsLteCondition | airbyte_agent_sdk.connectors.asana.types.SectionsInCondition | airbyte_agent_sdk.connectors.asana.types.SectionsLikeCondition | airbyte_agent_sdk.connectors.asana.types.SectionsFuzzyCondition | airbyte_agent_sdk.connectors.asana.types.SectionsKeywordCondition | airbyte_agent_sdk.connectors.asana.types.SectionsContainsCondition | airbyte_agent_sdk.connectors.asana.types.SectionsNotCondition | airbyte_agent_sdk.connectors.asana.types.SectionsAndCondition | airbyte_agent_sdk.connectors.asana.types.SectionsOrCondition | airbyte_agent_sdk.connectors.asana.types.SectionsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="SectionsAnyCondition"></a>
+
 `SectionsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1506,6 +1630,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.asana.types.SectionsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="SectionsAnyValueFilter"></a>
 
 `SectionsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -1531,6 +1657,8 @@ Classes
     `resource_type: Any`
     :   The type of the None singleton.
 
+<a id="SectionsContainsCondition"></a>
+
 `SectionsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -1542,6 +1670,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.asana.types.SectionsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="SectionsDeleteParams"></a>
 
 `SectionsDeleteParams(*args, **kwargs)`
 :   Parameters for sections.delete operation
@@ -1555,6 +1685,8 @@ Classes
     `section_gid: str`
     :   The type of the None singleton.
 
+<a id="SectionsEqCondition"></a>
+
 `SectionsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
 
@@ -1566,6 +1698,8 @@ Classes
 
     `eq: airbyte_agent_sdk.connectors.asana.types.SectionsSearchFilter`
     :   The type of the None singleton.
+
+<a id="SectionsFuzzyCondition"></a>
 
 `SectionsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
@@ -1579,6 +1713,8 @@ Classes
     `fuzzy: airbyte_agent_sdk.connectors.asana.types.SectionsStringFilter`
     :   The type of the None singleton.
 
+<a id="SectionsGetParams"></a>
+
 `SectionsGetParams(*args, **kwargs)`
 :   Parameters for sections.get operation
 
@@ -1590,6 +1726,8 @@ Classes
 
     `section_gid: str`
     :   The type of the None singleton.
+
+<a id="SectionsGtCondition"></a>
 
 `SectionsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
@@ -1603,6 +1741,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.asana.types.SectionsSearchFilter`
     :   The type of the None singleton.
 
+<a id="SectionsGteCondition"></a>
+
 `SectionsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -1614,6 +1754,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.asana.types.SectionsSearchFilter`
     :   The type of the None singleton.
+
+<a id="SectionsInCondition"></a>
 
 `SectionsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -1634,6 +1776,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.asana.types.SectionsInFilter`
     :   The type of the None singleton.
+
+<a id="SectionsInFilter"></a>
 
 `SectionsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -1659,6 +1803,8 @@ Classes
     `resource_type: list[str]`
     :   The type of the None singleton.
 
+<a id="SectionsKeywordCondition"></a>
+
 `SectionsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -1670,6 +1816,8 @@ Classes
 
     `keyword: airbyte_agent_sdk.connectors.asana.types.SectionsStringFilter`
     :   The type of the None singleton.
+
+<a id="SectionsLikeCondition"></a>
 
 `SectionsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
@@ -1683,6 +1831,8 @@ Classes
     `like: airbyte_agent_sdk.connectors.asana.types.SectionsStringFilter`
     :   The type of the None singleton.
 
+<a id="SectionsLtCondition"></a>
+
 `SectionsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -1694,6 +1844,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.asana.types.SectionsSearchFilter`
     :   The type of the None singleton.
+
+<a id="SectionsLteCondition"></a>
 
 `SectionsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -1707,6 +1859,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.asana.types.SectionsSearchFilter`
     :   The type of the None singleton.
 
+<a id="SectionsNeqCondition"></a>
+
 `SectionsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -1718,6 +1872,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.asana.types.SectionsSearchFilter`
     :   The type of the None singleton.
+
+<a id="SectionsNotCondition"></a>
 
 `SectionsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -1739,6 +1895,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.asana.types.SectionsEqCondition | airbyte_agent_sdk.connectors.asana.types.SectionsNeqCondition | airbyte_agent_sdk.connectors.asana.types.SectionsGtCondition | airbyte_agent_sdk.connectors.asana.types.SectionsGteCondition | airbyte_agent_sdk.connectors.asana.types.SectionsLtCondition | airbyte_agent_sdk.connectors.asana.types.SectionsLteCondition | airbyte_agent_sdk.connectors.asana.types.SectionsInCondition | airbyte_agent_sdk.connectors.asana.types.SectionsLikeCondition | airbyte_agent_sdk.connectors.asana.types.SectionsFuzzyCondition | airbyte_agent_sdk.connectors.asana.types.SectionsKeywordCondition | airbyte_agent_sdk.connectors.asana.types.SectionsContainsCondition | airbyte_agent_sdk.connectors.asana.types.SectionsNotCondition | airbyte_agent_sdk.connectors.asana.types.SectionsAndCondition | airbyte_agent_sdk.connectors.asana.types.SectionsOrCondition | airbyte_agent_sdk.connectors.asana.types.SectionsAnyCondition`
     :   The type of the None singleton.
 
+<a id="SectionsOrCondition"></a>
+
 `SectionsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1758,6 +1916,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.asana.types.SectionsEqCondition | airbyte_agent_sdk.connectors.asana.types.SectionsNeqCondition | airbyte_agent_sdk.connectors.asana.types.SectionsGtCondition | airbyte_agent_sdk.connectors.asana.types.SectionsGteCondition | airbyte_agent_sdk.connectors.asana.types.SectionsLtCondition | airbyte_agent_sdk.connectors.asana.types.SectionsLteCondition | airbyte_agent_sdk.connectors.asana.types.SectionsInCondition | airbyte_agent_sdk.connectors.asana.types.SectionsLikeCondition | airbyte_agent_sdk.connectors.asana.types.SectionsFuzzyCondition | airbyte_agent_sdk.connectors.asana.types.SectionsKeywordCondition | airbyte_agent_sdk.connectors.asana.types.SectionsContainsCondition | airbyte_agent_sdk.connectors.asana.types.SectionsNotCondition | airbyte_agent_sdk.connectors.asana.types.SectionsAndCondition | airbyte_agent_sdk.connectors.asana.types.SectionsOrCondition | airbyte_agent_sdk.connectors.asana.types.SectionsAnyCondition]`
     :   The type of the None singleton.
+
+<a id="SectionsSearchFilter"></a>
 
 `SectionsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering sections search queries.
@@ -1783,6 +1943,8 @@ Classes
     `resource_type: str | None`
     :   The type of the None singleton.
 
+<a id="SectionsSearchQuery"></a>
+
 `SectionsSearchQuery(*args, **kwargs)`
 :   Search query for sections entity.
 
@@ -1797,6 +1959,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.asana.types.SectionsSortFilter]`
     :   The type of the None singleton.
+
+<a id="SectionsSortFilter"></a>
 
 `SectionsSortFilter(*args, **kwargs)`
 :   Available fields for sorting sections search results.
@@ -1822,6 +1986,8 @@ Classes
     `resource_type: Literal['asc', 'desc']`
     :   The type of the None singleton.
 
+<a id="SectionsStringFilter"></a>
+
 `SectionsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -1846,6 +2012,8 @@ Classes
     `resource_type: str`
     :   The type of the None singleton.
 
+<a id="SectionsUpdateParams"></a>
+
 `SectionsUpdateParams(*args, **kwargs)`
 :   Parameters for sections.update operation
 
@@ -1861,6 +2029,8 @@ Classes
     `section_gid: str`
     :   The type of the None singleton.
 
+<a id="SectionsUpdateParamsData"></a>
+
 `SectionsUpdateParamsData(*args, **kwargs)`
 :   Nested schema for SectionsUpdateParams.data
 
@@ -1872,6 +2042,8 @@ Classes
 
     `name: str`
     :   The type of the None singleton.
+
+<a id="TagTasksListParams"></a>
 
 `TagTasksListParams(*args, **kwargs)`
 :   Parameters for tag_tasks.list operation
@@ -1890,6 +2062,8 @@ Classes
 
     `tag_gid: str`
     :   The type of the None singleton.
+
+<a id="TagsAndCondition"></a>
 
 `TagsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -1911,6 +2085,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.asana.types.TagsEqCondition | airbyte_agent_sdk.connectors.asana.types.TagsNeqCondition | airbyte_agent_sdk.connectors.asana.types.TagsGtCondition | airbyte_agent_sdk.connectors.asana.types.TagsGteCondition | airbyte_agent_sdk.connectors.asana.types.TagsLtCondition | airbyte_agent_sdk.connectors.asana.types.TagsLteCondition | airbyte_agent_sdk.connectors.asana.types.TagsInCondition | airbyte_agent_sdk.connectors.asana.types.TagsLikeCondition | airbyte_agent_sdk.connectors.asana.types.TagsFuzzyCondition | airbyte_agent_sdk.connectors.asana.types.TagsKeywordCondition | airbyte_agent_sdk.connectors.asana.types.TagsContainsCondition | airbyte_agent_sdk.connectors.asana.types.TagsNotCondition | airbyte_agent_sdk.connectors.asana.types.TagsAndCondition | airbyte_agent_sdk.connectors.asana.types.TagsOrCondition | airbyte_agent_sdk.connectors.asana.types.TagsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="TagsAnyCondition"></a>
+
 `TagsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1930,6 +2106,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.asana.types.TagsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="TagsAnyValueFilter"></a>
 
 `TagsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -1961,6 +2139,8 @@ Classes
     `workspace: Any`
     :   The type of the None singleton.
 
+<a id="TagsContainsCondition"></a>
+
 `TagsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -1972,6 +2152,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.asana.types.TagsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="TagsDeleteParams"></a>
 
 `TagsDeleteParams(*args, **kwargs)`
 :   Parameters for tags.delete operation
@@ -1985,6 +2167,8 @@ Classes
     `tag_gid: str`
     :   The type of the None singleton.
 
+<a id="TagsEqCondition"></a>
+
 `TagsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
 
@@ -1996,6 +2180,8 @@ Classes
 
     `eq: airbyte_agent_sdk.connectors.asana.types.TagsSearchFilter`
     :   The type of the None singleton.
+
+<a id="TagsFuzzyCondition"></a>
 
 `TagsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
@@ -2009,6 +2195,8 @@ Classes
     `fuzzy: airbyte_agent_sdk.connectors.asana.types.TagsStringFilter`
     :   The type of the None singleton.
 
+<a id="TagsGetParams"></a>
+
 `TagsGetParams(*args, **kwargs)`
 :   Parameters for tags.get operation
 
@@ -2020,6 +2208,8 @@ Classes
 
     `tag_gid: str`
     :   The type of the None singleton.
+
+<a id="TagsGtCondition"></a>
 
 `TagsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
@@ -2033,6 +2223,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.asana.types.TagsSearchFilter`
     :   The type of the None singleton.
 
+<a id="TagsGteCondition"></a>
+
 `TagsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -2044,6 +2236,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.asana.types.TagsSearchFilter`
     :   The type of the None singleton.
+
+<a id="TagsInCondition"></a>
 
 `TagsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -2064,6 +2258,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.asana.types.TagsInFilter`
     :   The type of the None singleton.
+
+<a id="TagsInFilter"></a>
 
 `TagsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -2095,6 +2291,8 @@ Classes
     `workspace: list[dict[str, typing.Any]]`
     :   The type of the None singleton.
 
+<a id="TagsKeywordCondition"></a>
+
 `TagsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -2106,6 +2304,8 @@ Classes
 
     `keyword: airbyte_agent_sdk.connectors.asana.types.TagsStringFilter`
     :   The type of the None singleton.
+
+<a id="TagsLikeCondition"></a>
 
 `TagsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
@@ -2119,6 +2319,8 @@ Classes
     `like: airbyte_agent_sdk.connectors.asana.types.TagsStringFilter`
     :   The type of the None singleton.
 
+<a id="TagsLtCondition"></a>
+
 `TagsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -2130,6 +2332,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.asana.types.TagsSearchFilter`
     :   The type of the None singleton.
+
+<a id="TagsLteCondition"></a>
 
 `TagsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -2143,6 +2347,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.asana.types.TagsSearchFilter`
     :   The type of the None singleton.
 
+<a id="TagsNeqCondition"></a>
+
 `TagsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -2154,6 +2360,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.asana.types.TagsSearchFilter`
     :   The type of the None singleton.
+
+<a id="TagsNotCondition"></a>
 
 `TagsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -2175,6 +2383,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.asana.types.TagsEqCondition | airbyte_agent_sdk.connectors.asana.types.TagsNeqCondition | airbyte_agent_sdk.connectors.asana.types.TagsGtCondition | airbyte_agent_sdk.connectors.asana.types.TagsGteCondition | airbyte_agent_sdk.connectors.asana.types.TagsLtCondition | airbyte_agent_sdk.connectors.asana.types.TagsLteCondition | airbyte_agent_sdk.connectors.asana.types.TagsInCondition | airbyte_agent_sdk.connectors.asana.types.TagsLikeCondition | airbyte_agent_sdk.connectors.asana.types.TagsFuzzyCondition | airbyte_agent_sdk.connectors.asana.types.TagsKeywordCondition | airbyte_agent_sdk.connectors.asana.types.TagsContainsCondition | airbyte_agent_sdk.connectors.asana.types.TagsNotCondition | airbyte_agent_sdk.connectors.asana.types.TagsAndCondition | airbyte_agent_sdk.connectors.asana.types.TagsOrCondition | airbyte_agent_sdk.connectors.asana.types.TagsAnyCondition`
     :   The type of the None singleton.
 
+<a id="TagsOrCondition"></a>
+
 `TagsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -2194,6 +2404,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.asana.types.TagsEqCondition | airbyte_agent_sdk.connectors.asana.types.TagsNeqCondition | airbyte_agent_sdk.connectors.asana.types.TagsGtCondition | airbyte_agent_sdk.connectors.asana.types.TagsGteCondition | airbyte_agent_sdk.connectors.asana.types.TagsLtCondition | airbyte_agent_sdk.connectors.asana.types.TagsLteCondition | airbyte_agent_sdk.connectors.asana.types.TagsInCondition | airbyte_agent_sdk.connectors.asana.types.TagsLikeCondition | airbyte_agent_sdk.connectors.asana.types.TagsFuzzyCondition | airbyte_agent_sdk.connectors.asana.types.TagsKeywordCondition | airbyte_agent_sdk.connectors.asana.types.TagsContainsCondition | airbyte_agent_sdk.connectors.asana.types.TagsNotCondition | airbyte_agent_sdk.connectors.asana.types.TagsAndCondition | airbyte_agent_sdk.connectors.asana.types.TagsOrCondition | airbyte_agent_sdk.connectors.asana.types.TagsAnyCondition]`
     :   The type of the None singleton.
+
+<a id="TagsSearchFilter"></a>
 
 `TagsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering tags search queries.
@@ -2225,6 +2437,8 @@ Classes
     `workspace: dict[str, typing.Any] | None`
     :   The type of the None singleton.
 
+<a id="TagsSearchQuery"></a>
+
 `TagsSearchQuery(*args, **kwargs)`
 :   Search query for tags entity.
 
@@ -2239,6 +2453,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.asana.types.TagsSortFilter]`
     :   The type of the None singleton.
+
+<a id="TagsSortFilter"></a>
 
 `TagsSortFilter(*args, **kwargs)`
 :   Available fields for sorting tags search results.
@@ -2270,6 +2486,8 @@ Classes
     `workspace: Literal['asc', 'desc']`
     :   The type of the None singleton.
 
+<a id="TagsStringFilter"></a>
+
 `TagsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -2300,6 +2518,8 @@ Classes
     `workspace: str`
     :   The type of the None singleton.
 
+<a id="TagsUpdateParams"></a>
+
 `TagsUpdateParams(*args, **kwargs)`
 :   Parameters for tags.update operation
 
@@ -2314,6 +2534,8 @@ Classes
 
     `tag_gid: str`
     :   The type of the None singleton.
+
+<a id="TagsUpdateParamsData"></a>
 
 `TagsUpdateParamsData(*args, **kwargs)`
 :   Nested schema for TagsUpdateParams.data
@@ -2333,6 +2555,8 @@ Classes
     `notes: str`
     :   The type of the None singleton.
 
+<a id="TaskDependenciesListParams"></a>
+
 `TaskDependenciesListParams(*args, **kwargs)`
 :   Parameters for task_dependencies.list operation
 
@@ -2350,6 +2574,8 @@ Classes
 
     `task_gid: str`
     :   The type of the None singleton.
+
+<a id="TaskDependentsListParams"></a>
 
 `TaskDependentsListParams(*args, **kwargs)`
 :   Parameters for task_dependents.list operation
@@ -2369,6 +2595,8 @@ Classes
     `task_gid: str`
     :   The type of the None singleton.
 
+<a id="TaskProjectsListParams"></a>
+
 `TaskProjectsListParams(*args, **kwargs)`
 :   Parameters for task_projects.list operation
 
@@ -2387,6 +2615,8 @@ Classes
     `task_gid: str`
     :   The type of the None singleton.
 
+<a id="TaskStoriesCreateParams"></a>
+
 `TaskStoriesCreateParams(*args, **kwargs)`
 :   Parameters for task_stories.create operation
 
@@ -2401,6 +2631,8 @@ Classes
 
     `task_gid: str`
     :   The type of the None singleton.
+
+<a id="TaskStoriesCreateParamsData"></a>
 
 `TaskStoriesCreateParamsData(*args, **kwargs)`
 :   Nested schema for TaskStoriesCreateParams.data
@@ -2420,6 +2652,8 @@ Classes
     `text: str`
     :   The type of the None singleton.
 
+<a id="TaskSubtasksListParams"></a>
+
 `TaskSubtasksListParams(*args, **kwargs)`
 :   Parameters for task_subtasks.list operation
 
@@ -2438,6 +2672,8 @@ Classes
     `task_gid: str`
     :   The type of the None singleton.
 
+<a id="TaskTagsCreateParams"></a>
+
 `TaskTagsCreateParams(*args, **kwargs)`
 :   Parameters for task_tags.create operation
 
@@ -2453,6 +2689,8 @@ Classes
     `task_gid: str`
     :   The type of the None singleton.
 
+<a id="TaskTagsCreateParamsData"></a>
+
 `TaskTagsCreateParamsData(*args, **kwargs)`
 :   Nested schema for TaskTagsCreateParams.data
 
@@ -2464,6 +2702,8 @@ Classes
 
     `tag: str`
     :   The type of the None singleton.
+
+<a id="TaskTagsDeleteParams"></a>
 
 `TaskTagsDeleteParams(*args, **kwargs)`
 :   Parameters for task_tags.delete operation
@@ -2480,6 +2720,8 @@ Classes
     `task_gid: str`
     :   The type of the None singleton.
 
+<a id="TaskTagsDeleteParamsData"></a>
+
 `TaskTagsDeleteParamsData(*args, **kwargs)`
 :   Nested schema for TaskTagsDeleteParams.data
 
@@ -2491,6 +2733,8 @@ Classes
 
     `tag: str`
     :   The type of the None singleton.
+
+<a id="TasksAndCondition"></a>
 
 `TasksAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -2512,6 +2756,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.asana.types.TasksEqCondition | airbyte_agent_sdk.connectors.asana.types.TasksNeqCondition | airbyte_agent_sdk.connectors.asana.types.TasksGtCondition | airbyte_agent_sdk.connectors.asana.types.TasksGteCondition | airbyte_agent_sdk.connectors.asana.types.TasksLtCondition | airbyte_agent_sdk.connectors.asana.types.TasksLteCondition | airbyte_agent_sdk.connectors.asana.types.TasksInCondition | airbyte_agent_sdk.connectors.asana.types.TasksLikeCondition | airbyte_agent_sdk.connectors.asana.types.TasksFuzzyCondition | airbyte_agent_sdk.connectors.asana.types.TasksKeywordCondition | airbyte_agent_sdk.connectors.asana.types.TasksContainsCondition | airbyte_agent_sdk.connectors.asana.types.TasksNotCondition | airbyte_agent_sdk.connectors.asana.types.TasksAndCondition | airbyte_agent_sdk.connectors.asana.types.TasksOrCondition | airbyte_agent_sdk.connectors.asana.types.TasksAnyCondition]`
     :   The type of the None singleton.
 
+<a id="TasksAnyCondition"></a>
+
 `TasksAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -2531,6 +2777,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.asana.types.TasksAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="TasksAnyValueFilter"></a>
 
 `TasksAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -2649,6 +2897,8 @@ Classes
     `workspace: Any`
     :   The type of the None singleton.
 
+<a id="TasksContainsCondition"></a>
+
 `TasksContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -2661,6 +2911,8 @@ Classes
     `contains: airbyte_agent_sdk.connectors.asana.types.TasksAnyValueFilter`
     :   The type of the None singleton.
 
+<a id="TasksCreateParams"></a>
+
 `TasksCreateParams(*args, **kwargs)`
 :   Parameters for tasks.create operation
 
@@ -2672,6 +2924,8 @@ Classes
 
     `data: airbyte_agent_sdk.connectors.asana.types.TasksCreateParamsData`
     :   The type of the None singleton.
+
+<a id="TasksCreateParamsData"></a>
 
 `TasksCreateParamsData(*args, **kwargs)`
 :   Nested schema for TasksCreateParams.data
@@ -2724,6 +2978,8 @@ Classes
     `workspace: str`
     :   The type of the None singleton.
 
+<a id="TasksDeleteParams"></a>
+
 `TasksDeleteParams(*args, **kwargs)`
 :   Parameters for tasks.delete operation
 
@@ -2735,6 +2991,8 @@ Classes
 
     `task_gid: str`
     :   The type of the None singleton.
+
+<a id="TasksEqCondition"></a>
 
 `TasksEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -2748,6 +3006,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.asana.types.TasksSearchFilter`
     :   The type of the None singleton.
 
+<a id="TasksFuzzyCondition"></a>
+
 `TasksFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -2759,6 +3019,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.asana.types.TasksStringFilter`
     :   The type of the None singleton.
+
+<a id="TasksGetParams"></a>
 
 `TasksGetParams(*args, **kwargs)`
 :   Parameters for tasks.get operation
@@ -2772,6 +3034,8 @@ Classes
     `task_gid: str`
     :   The type of the None singleton.
 
+<a id="TasksGtCondition"></a>
+
 `TasksGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -2784,6 +3048,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.asana.types.TasksSearchFilter`
     :   The type of the None singleton.
 
+<a id="TasksGteCondition"></a>
+
 `TasksGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -2795,6 +3061,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.asana.types.TasksSearchFilter`
     :   The type of the None singleton.
+
+<a id="TasksInCondition"></a>
 
 `TasksInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -2815,6 +3083,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.asana.types.TasksInFilter`
     :   The type of the None singleton.
+
+<a id="TasksInFilter"></a>
 
 `TasksInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -2933,6 +3203,8 @@ Classes
     `workspace: list[dict[str, typing.Any]]`
     :   The type of the None singleton.
 
+<a id="TasksKeywordCondition"></a>
+
 `TasksKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -2945,6 +3217,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.asana.types.TasksStringFilter`
     :   The type of the None singleton.
 
+<a id="TasksLikeCondition"></a>
+
 `TasksLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -2956,6 +3230,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.asana.types.TasksStringFilter`
     :   The type of the None singleton.
+
+<a id="TasksListParams"></a>
 
 `TasksListParams(*args, **kwargs)`
 :   Parameters for tasks.list operation
@@ -2990,6 +3266,8 @@ Classes
     `workspace: str`
     :   The type of the None singleton.
 
+<a id="TasksLtCondition"></a>
+
 `TasksLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -3001,6 +3279,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.asana.types.TasksSearchFilter`
     :   The type of the None singleton.
+
+<a id="TasksLteCondition"></a>
 
 `TasksLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -3014,6 +3294,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.asana.types.TasksSearchFilter`
     :   The type of the None singleton.
 
+<a id="TasksNeqCondition"></a>
+
 `TasksNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -3025,6 +3307,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.asana.types.TasksSearchFilter`
     :   The type of the None singleton.
+
+<a id="TasksNotCondition"></a>
 
 `TasksNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -3046,6 +3330,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.asana.types.TasksEqCondition | airbyte_agent_sdk.connectors.asana.types.TasksNeqCondition | airbyte_agent_sdk.connectors.asana.types.TasksGtCondition | airbyte_agent_sdk.connectors.asana.types.TasksGteCondition | airbyte_agent_sdk.connectors.asana.types.TasksLtCondition | airbyte_agent_sdk.connectors.asana.types.TasksLteCondition | airbyte_agent_sdk.connectors.asana.types.TasksInCondition | airbyte_agent_sdk.connectors.asana.types.TasksLikeCondition | airbyte_agent_sdk.connectors.asana.types.TasksFuzzyCondition | airbyte_agent_sdk.connectors.asana.types.TasksKeywordCondition | airbyte_agent_sdk.connectors.asana.types.TasksContainsCondition | airbyte_agent_sdk.connectors.asana.types.TasksNotCondition | airbyte_agent_sdk.connectors.asana.types.TasksAndCondition | airbyte_agent_sdk.connectors.asana.types.TasksOrCondition | airbyte_agent_sdk.connectors.asana.types.TasksAnyCondition`
     :   The type of the None singleton.
 
+<a id="TasksOrCondition"></a>
+
 `TasksOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -3065,6 +3351,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.asana.types.TasksEqCondition | airbyte_agent_sdk.connectors.asana.types.TasksNeqCondition | airbyte_agent_sdk.connectors.asana.types.TasksGtCondition | airbyte_agent_sdk.connectors.asana.types.TasksGteCondition | airbyte_agent_sdk.connectors.asana.types.TasksLtCondition | airbyte_agent_sdk.connectors.asana.types.TasksLteCondition | airbyte_agent_sdk.connectors.asana.types.TasksInCondition | airbyte_agent_sdk.connectors.asana.types.TasksLikeCondition | airbyte_agent_sdk.connectors.asana.types.TasksFuzzyCondition | airbyte_agent_sdk.connectors.asana.types.TasksKeywordCondition | airbyte_agent_sdk.connectors.asana.types.TasksContainsCondition | airbyte_agent_sdk.connectors.asana.types.TasksNotCondition | airbyte_agent_sdk.connectors.asana.types.TasksAndCondition | airbyte_agent_sdk.connectors.asana.types.TasksOrCondition | airbyte_agent_sdk.connectors.asana.types.TasksAnyCondition]`
     :   The type of the None singleton.
+
+<a id="TasksSearchFilter"></a>
 
 `TasksSearchFilter(*args, **kwargs)`
 :   Available fields for filtering tasks search queries.
@@ -3183,6 +3471,8 @@ Classes
     `workspace: dict[str, typing.Any] | None`
     :   The type of the None singleton.
 
+<a id="TasksSearchQuery"></a>
+
 `TasksSearchQuery(*args, **kwargs)`
 :   Search query for tasks entity.
 
@@ -3197,6 +3487,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.asana.types.TasksSortFilter]`
     :   The type of the None singleton.
+
+<a id="TasksSortFilter"></a>
 
 `TasksSortFilter(*args, **kwargs)`
 :   Available fields for sorting tasks search results.
@@ -3315,6 +3607,8 @@ Classes
     `workspace: Literal['asc', 'desc']`
     :   The type of the None singleton.
 
+<a id="TasksStringFilter"></a>
+
 `TasksStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -3432,6 +3726,8 @@ Classes
     `workspace: str`
     :   The type of the None singleton.
 
+<a id="TasksUpdateParams"></a>
+
 `TasksUpdateParams(*args, **kwargs)`
 :   Parameters for tasks.update operation
 
@@ -3446,6 +3742,8 @@ Classes
 
     `task_gid: str`
     :   The type of the None singleton.
+
+<a id="TasksUpdateParamsData"></a>
 
 `TasksUpdateParamsData(*args, **kwargs)`
 :   Nested schema for TasksUpdateParams.data
@@ -3480,6 +3778,8 @@ Classes
     `start_on: str`
     :   The type of the None singleton.
 
+<a id="TeamProjectsListParams"></a>
+
 `TeamProjectsListParams(*args, **kwargs)`
 :   Parameters for team_projects.list operation
 
@@ -3501,6 +3801,8 @@ Classes
     `team_gid: str`
     :   The type of the None singleton.
 
+<a id="TeamUsersListParams"></a>
+
 `TeamUsersListParams(*args, **kwargs)`
 :   Parameters for team_users.list operation
 
@@ -3518,6 +3820,8 @@ Classes
 
     `team_gid: str`
     :   The type of the None singleton.
+
+<a id="TeamsAndCondition"></a>
 
 `TeamsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -3539,6 +3843,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.asana.types.TeamsEqCondition | airbyte_agent_sdk.connectors.asana.types.TeamsNeqCondition | airbyte_agent_sdk.connectors.asana.types.TeamsGtCondition | airbyte_agent_sdk.connectors.asana.types.TeamsGteCondition | airbyte_agent_sdk.connectors.asana.types.TeamsLtCondition | airbyte_agent_sdk.connectors.asana.types.TeamsLteCondition | airbyte_agent_sdk.connectors.asana.types.TeamsInCondition | airbyte_agent_sdk.connectors.asana.types.TeamsLikeCondition | airbyte_agent_sdk.connectors.asana.types.TeamsFuzzyCondition | airbyte_agent_sdk.connectors.asana.types.TeamsKeywordCondition | airbyte_agent_sdk.connectors.asana.types.TeamsContainsCondition | airbyte_agent_sdk.connectors.asana.types.TeamsNotCondition | airbyte_agent_sdk.connectors.asana.types.TeamsAndCondition | airbyte_agent_sdk.connectors.asana.types.TeamsOrCondition | airbyte_agent_sdk.connectors.asana.types.TeamsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="TeamsAnyCondition"></a>
+
 `TeamsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -3558,6 +3864,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.asana.types.TeamsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="TeamsAnyValueFilter"></a>
 
 `TeamsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -3589,6 +3897,8 @@ Classes
     `resource_type: Any`
     :   The type of the None singleton.
 
+<a id="TeamsContainsCondition"></a>
+
 `TeamsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -3600,6 +3910,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.asana.types.TeamsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="TeamsEqCondition"></a>
 
 `TeamsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -3613,6 +3925,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.asana.types.TeamsSearchFilter`
     :   The type of the None singleton.
 
+<a id="TeamsFuzzyCondition"></a>
+
 `TeamsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -3624,6 +3938,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.asana.types.TeamsStringFilter`
     :   The type of the None singleton.
+
+<a id="TeamsGetParams"></a>
 
 `TeamsGetParams(*args, **kwargs)`
 :   Parameters for teams.get operation
@@ -3637,6 +3953,8 @@ Classes
     `team_gid: str`
     :   The type of the None singleton.
 
+<a id="TeamsGtCondition"></a>
+
 `TeamsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -3649,6 +3967,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.asana.types.TeamsSearchFilter`
     :   The type of the None singleton.
 
+<a id="TeamsGteCondition"></a>
+
 `TeamsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -3660,6 +3980,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.asana.types.TeamsSearchFilter`
     :   The type of the None singleton.
+
+<a id="TeamsInCondition"></a>
 
 `TeamsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -3680,6 +4002,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.asana.types.TeamsInFilter`
     :   The type of the None singleton.
+
+<a id="TeamsInFilter"></a>
 
 `TeamsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -3711,6 +4035,8 @@ Classes
     `resource_type: list[str]`
     :   The type of the None singleton.
 
+<a id="TeamsKeywordCondition"></a>
+
 `TeamsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -3722,6 +4048,8 @@ Classes
 
     `keyword: airbyte_agent_sdk.connectors.asana.types.TeamsStringFilter`
     :   The type of the None singleton.
+
+<a id="TeamsLikeCondition"></a>
 
 `TeamsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
@@ -3735,6 +4063,8 @@ Classes
     `like: airbyte_agent_sdk.connectors.asana.types.TeamsStringFilter`
     :   The type of the None singleton.
 
+<a id="TeamsLtCondition"></a>
+
 `TeamsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -3746,6 +4076,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.asana.types.TeamsSearchFilter`
     :   The type of the None singleton.
+
+<a id="TeamsLteCondition"></a>
 
 `TeamsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -3759,6 +4091,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.asana.types.TeamsSearchFilter`
     :   The type of the None singleton.
 
+<a id="TeamsNeqCondition"></a>
+
 `TeamsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -3770,6 +4104,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.asana.types.TeamsSearchFilter`
     :   The type of the None singleton.
+
+<a id="TeamsNotCondition"></a>
 
 `TeamsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -3791,6 +4127,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.asana.types.TeamsEqCondition | airbyte_agent_sdk.connectors.asana.types.TeamsNeqCondition | airbyte_agent_sdk.connectors.asana.types.TeamsGtCondition | airbyte_agent_sdk.connectors.asana.types.TeamsGteCondition | airbyte_agent_sdk.connectors.asana.types.TeamsLtCondition | airbyte_agent_sdk.connectors.asana.types.TeamsLteCondition | airbyte_agent_sdk.connectors.asana.types.TeamsInCondition | airbyte_agent_sdk.connectors.asana.types.TeamsLikeCondition | airbyte_agent_sdk.connectors.asana.types.TeamsFuzzyCondition | airbyte_agent_sdk.connectors.asana.types.TeamsKeywordCondition | airbyte_agent_sdk.connectors.asana.types.TeamsContainsCondition | airbyte_agent_sdk.connectors.asana.types.TeamsNotCondition | airbyte_agent_sdk.connectors.asana.types.TeamsAndCondition | airbyte_agent_sdk.connectors.asana.types.TeamsOrCondition | airbyte_agent_sdk.connectors.asana.types.TeamsAnyCondition`
     :   The type of the None singleton.
 
+<a id="TeamsOrCondition"></a>
+
 `TeamsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -3810,6 +4148,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.asana.types.TeamsEqCondition | airbyte_agent_sdk.connectors.asana.types.TeamsNeqCondition | airbyte_agent_sdk.connectors.asana.types.TeamsGtCondition | airbyte_agent_sdk.connectors.asana.types.TeamsGteCondition | airbyte_agent_sdk.connectors.asana.types.TeamsLtCondition | airbyte_agent_sdk.connectors.asana.types.TeamsLteCondition | airbyte_agent_sdk.connectors.asana.types.TeamsInCondition | airbyte_agent_sdk.connectors.asana.types.TeamsLikeCondition | airbyte_agent_sdk.connectors.asana.types.TeamsFuzzyCondition | airbyte_agent_sdk.connectors.asana.types.TeamsKeywordCondition | airbyte_agent_sdk.connectors.asana.types.TeamsContainsCondition | airbyte_agent_sdk.connectors.asana.types.TeamsNotCondition | airbyte_agent_sdk.connectors.asana.types.TeamsAndCondition | airbyte_agent_sdk.connectors.asana.types.TeamsOrCondition | airbyte_agent_sdk.connectors.asana.types.TeamsAnyCondition]`
     :   The type of the None singleton.
+
+<a id="TeamsSearchFilter"></a>
 
 `TeamsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering teams search queries.
@@ -3841,6 +4181,8 @@ Classes
     `resource_type: str | None`
     :   The type of the None singleton.
 
+<a id="TeamsSearchQuery"></a>
+
 `TeamsSearchQuery(*args, **kwargs)`
 :   Search query for teams entity.
 
@@ -3855,6 +4197,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.asana.types.TeamsSortFilter]`
     :   The type of the None singleton.
+
+<a id="TeamsSortFilter"></a>
 
 `TeamsSortFilter(*args, **kwargs)`
 :   Available fields for sorting teams search results.
@@ -3886,6 +4230,8 @@ Classes
     `resource_type: Literal['asc', 'desc']`
     :   The type of the None singleton.
 
+<a id="TeamsStringFilter"></a>
+
 `TeamsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -3916,6 +4262,8 @@ Classes
     `resource_type: str`
     :   The type of the None singleton.
 
+<a id="UserTeamsListParams"></a>
+
 `UserTeamsListParams(*args, **kwargs)`
 :   Parameters for user_teams.list operation
 
@@ -3937,6 +4285,8 @@ Classes
     `user_gid: str`
     :   The type of the None singleton.
 
+<a id="UsersAndCondition"></a>
+
 `UsersAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -3957,6 +4307,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.asana.types.UsersEqCondition | airbyte_agent_sdk.connectors.asana.types.UsersNeqCondition | airbyte_agent_sdk.connectors.asana.types.UsersGtCondition | airbyte_agent_sdk.connectors.asana.types.UsersGteCondition | airbyte_agent_sdk.connectors.asana.types.UsersLtCondition | airbyte_agent_sdk.connectors.asana.types.UsersLteCondition | airbyte_agent_sdk.connectors.asana.types.UsersInCondition | airbyte_agent_sdk.connectors.asana.types.UsersLikeCondition | airbyte_agent_sdk.connectors.asana.types.UsersFuzzyCondition | airbyte_agent_sdk.connectors.asana.types.UsersKeywordCondition | airbyte_agent_sdk.connectors.asana.types.UsersContainsCondition | airbyte_agent_sdk.connectors.asana.types.UsersNotCondition | airbyte_agent_sdk.connectors.asana.types.UsersAndCondition | airbyte_agent_sdk.connectors.asana.types.UsersOrCondition | airbyte_agent_sdk.connectors.asana.types.UsersAnyCondition]`
     :   The type of the None singleton.
 
+<a id="UsersAnyCondition"></a>
+
 `UsersAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -3976,6 +4328,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.asana.types.UsersAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="UsersAnyValueFilter"></a>
 
 `UsersAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -4004,6 +4358,8 @@ Classes
     `workspaces: Any`
     :   The type of the None singleton.
 
+<a id="UsersContainsCondition"></a>
+
 `UsersContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -4015,6 +4371,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.asana.types.UsersAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="UsersEqCondition"></a>
 
 `UsersEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -4028,6 +4386,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.asana.types.UsersSearchFilter`
     :   The type of the None singleton.
 
+<a id="UsersFuzzyCondition"></a>
+
 `UsersFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -4039,6 +4399,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.asana.types.UsersStringFilter`
     :   The type of the None singleton.
+
+<a id="UsersGetParams"></a>
 
 `UsersGetParams(*args, **kwargs)`
 :   Parameters for users.get operation
@@ -4052,6 +4414,8 @@ Classes
     `user_gid: str`
     :   The type of the None singleton.
 
+<a id="UsersGtCondition"></a>
+
 `UsersGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -4064,6 +4428,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.asana.types.UsersSearchFilter`
     :   The type of the None singleton.
 
+<a id="UsersGteCondition"></a>
+
 `UsersGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -4075,6 +4441,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.asana.types.UsersSearchFilter`
     :   The type of the None singleton.
+
+<a id="UsersInCondition"></a>
 
 `UsersInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -4095,6 +4463,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.asana.types.UsersInFilter`
     :   The type of the None singleton.
+
+<a id="UsersInFilter"></a>
 
 `UsersInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -4123,6 +4493,8 @@ Classes
     `workspaces: list[list[typing.Any]]`
     :   The type of the None singleton.
 
+<a id="UsersKeywordCondition"></a>
+
 `UsersKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -4135,6 +4507,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.asana.types.UsersStringFilter`
     :   The type of the None singleton.
 
+<a id="UsersLikeCondition"></a>
+
 `UsersLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -4146,6 +4520,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.asana.types.UsersStringFilter`
     :   The type of the None singleton.
+
+<a id="UsersListParams"></a>
 
 `UsersListParams(*args, **kwargs)`
 :   Parameters for users.list operation
@@ -4168,6 +4544,8 @@ Classes
     `workspace: str`
     :   The type of the None singleton.
 
+<a id="UsersLtCondition"></a>
+
 `UsersLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -4179,6 +4557,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.asana.types.UsersSearchFilter`
     :   The type of the None singleton.
+
+<a id="UsersLteCondition"></a>
 
 `UsersLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -4192,6 +4572,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.asana.types.UsersSearchFilter`
     :   The type of the None singleton.
 
+<a id="UsersNeqCondition"></a>
+
 `UsersNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -4203,6 +4585,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.asana.types.UsersSearchFilter`
     :   The type of the None singleton.
+
+<a id="UsersNotCondition"></a>
 
 `UsersNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -4224,6 +4608,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.asana.types.UsersEqCondition | airbyte_agent_sdk.connectors.asana.types.UsersNeqCondition | airbyte_agent_sdk.connectors.asana.types.UsersGtCondition | airbyte_agent_sdk.connectors.asana.types.UsersGteCondition | airbyte_agent_sdk.connectors.asana.types.UsersLtCondition | airbyte_agent_sdk.connectors.asana.types.UsersLteCondition | airbyte_agent_sdk.connectors.asana.types.UsersInCondition | airbyte_agent_sdk.connectors.asana.types.UsersLikeCondition | airbyte_agent_sdk.connectors.asana.types.UsersFuzzyCondition | airbyte_agent_sdk.connectors.asana.types.UsersKeywordCondition | airbyte_agent_sdk.connectors.asana.types.UsersContainsCondition | airbyte_agent_sdk.connectors.asana.types.UsersNotCondition | airbyte_agent_sdk.connectors.asana.types.UsersAndCondition | airbyte_agent_sdk.connectors.asana.types.UsersOrCondition | airbyte_agent_sdk.connectors.asana.types.UsersAnyCondition`
     :   The type of the None singleton.
 
+<a id="UsersOrCondition"></a>
+
 `UsersOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -4243,6 +4629,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.asana.types.UsersEqCondition | airbyte_agent_sdk.connectors.asana.types.UsersNeqCondition | airbyte_agent_sdk.connectors.asana.types.UsersGtCondition | airbyte_agent_sdk.connectors.asana.types.UsersGteCondition | airbyte_agent_sdk.connectors.asana.types.UsersLtCondition | airbyte_agent_sdk.connectors.asana.types.UsersLteCondition | airbyte_agent_sdk.connectors.asana.types.UsersInCondition | airbyte_agent_sdk.connectors.asana.types.UsersLikeCondition | airbyte_agent_sdk.connectors.asana.types.UsersFuzzyCondition | airbyte_agent_sdk.connectors.asana.types.UsersKeywordCondition | airbyte_agent_sdk.connectors.asana.types.UsersContainsCondition | airbyte_agent_sdk.connectors.asana.types.UsersNotCondition | airbyte_agent_sdk.connectors.asana.types.UsersAndCondition | airbyte_agent_sdk.connectors.asana.types.UsersOrCondition | airbyte_agent_sdk.connectors.asana.types.UsersAnyCondition]`
     :   The type of the None singleton.
+
+<a id="UsersSearchFilter"></a>
 
 `UsersSearchFilter(*args, **kwargs)`
 :   Available fields for filtering users search queries.
@@ -4271,6 +4659,8 @@ Classes
     `workspaces: list[typing.Any] | None`
     :   The type of the None singleton.
 
+<a id="UsersSearchQuery"></a>
+
 `UsersSearchQuery(*args, **kwargs)`
 :   Search query for users entity.
 
@@ -4285,6 +4675,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.asana.types.UsersSortFilter]`
     :   The type of the None singleton.
+
+<a id="UsersSortFilter"></a>
 
 `UsersSortFilter(*args, **kwargs)`
 :   Available fields for sorting users search results.
@@ -4313,6 +4705,8 @@ Classes
     `workspaces: Literal['asc', 'desc']`
     :   The type of the None singleton.
 
+<a id="UsersStringFilter"></a>
+
 `UsersStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -4340,6 +4734,8 @@ Classes
     `workspaces: str`
     :   The type of the None singleton.
 
+<a id="WorkspaceMembershipsCreateParams"></a>
+
 `WorkspaceMembershipsCreateParams(*args, **kwargs)`
 :   Parameters for workspace_memberships.create operation
 
@@ -4355,6 +4751,8 @@ Classes
     `workspace_gid: str`
     :   The type of the None singleton.
 
+<a id="WorkspaceMembershipsCreateParamsData"></a>
+
 `WorkspaceMembershipsCreateParamsData(*args, **kwargs)`
 :   Nested schema for WorkspaceMembershipsCreateParams.data
 
@@ -4366,6 +4764,8 @@ Classes
 
     `user: str`
     :   The type of the None singleton.
+
+<a id="WorkspaceProjectsListParams"></a>
 
 `WorkspaceProjectsListParams(*args, **kwargs)`
 :   Parameters for workspace_projects.list operation
@@ -4388,6 +4788,8 @@ Classes
     `workspace_gid: str`
     :   The type of the None singleton.
 
+<a id="WorkspaceTagsCreateParams"></a>
+
 `WorkspaceTagsCreateParams(*args, **kwargs)`
 :   Parameters for workspace_tags.create operation
 
@@ -4402,6 +4804,8 @@ Classes
 
     `workspace_gid: str`
     :   The type of the None singleton.
+
+<a id="WorkspaceTagsCreateParamsData"></a>
 
 `WorkspaceTagsCreateParamsData(*args, **kwargs)`
 :   Nested schema for WorkspaceTagsCreateParams.data
@@ -4421,6 +4825,8 @@ Classes
     `notes: str`
     :   The type of the None singleton.
 
+<a id="WorkspaceTagsListParams"></a>
+
 `WorkspaceTagsListParams(*args, **kwargs)`
 :   Parameters for workspace_tags.list operation
 
@@ -4438,6 +4844,8 @@ Classes
 
     `workspace_gid: str`
     :   The type of the None singleton.
+
+<a id="WorkspaceTaskSearchListParams"></a>
 
 `WorkspaceTaskSearchListParams(*args, **kwargs)`
 :   Parameters for workspace_task_search.list operation
@@ -4505,6 +4913,8 @@ Classes
     `workspace_gid: str`
     :   The type of the None singleton.
 
+<a id="WorkspaceTeamsListParams"></a>
+
 `WorkspaceTeamsListParams(*args, **kwargs)`
 :   Parameters for workspace_teams.list operation
 
@@ -4523,6 +4933,8 @@ Classes
     `workspace_gid: str`
     :   The type of the None singleton.
 
+<a id="WorkspaceUsersListParams"></a>
+
 `WorkspaceUsersListParams(*args, **kwargs)`
 :   Parameters for workspace_users.list operation
 
@@ -4540,6 +4952,8 @@ Classes
 
     `workspace_gid: str`
     :   The type of the None singleton.
+
+<a id="WorkspacesAndCondition"></a>
 
 `WorkspacesAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -4561,6 +4975,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.asana.types.WorkspacesEqCondition | airbyte_agent_sdk.connectors.asana.types.WorkspacesNeqCondition | airbyte_agent_sdk.connectors.asana.types.WorkspacesGtCondition | airbyte_agent_sdk.connectors.asana.types.WorkspacesGteCondition | airbyte_agent_sdk.connectors.asana.types.WorkspacesLtCondition | airbyte_agent_sdk.connectors.asana.types.WorkspacesLteCondition | airbyte_agent_sdk.connectors.asana.types.WorkspacesInCondition | airbyte_agent_sdk.connectors.asana.types.WorkspacesLikeCondition | airbyte_agent_sdk.connectors.asana.types.WorkspacesFuzzyCondition | airbyte_agent_sdk.connectors.asana.types.WorkspacesKeywordCondition | airbyte_agent_sdk.connectors.asana.types.WorkspacesContainsCondition | airbyte_agent_sdk.connectors.asana.types.WorkspacesNotCondition | airbyte_agent_sdk.connectors.asana.types.WorkspacesAndCondition | airbyte_agent_sdk.connectors.asana.types.WorkspacesOrCondition | airbyte_agent_sdk.connectors.asana.types.WorkspacesAnyCondition]`
     :   The type of the None singleton.
 
+<a id="WorkspacesAnyCondition"></a>
+
 `WorkspacesAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -4580,6 +4996,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.asana.types.WorkspacesAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="WorkspacesAnyValueFilter"></a>
 
 `WorkspacesAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -4605,6 +5023,8 @@ Classes
     `resource_type: Any`
     :   The type of the None singleton.
 
+<a id="WorkspacesContainsCondition"></a>
+
 `WorkspacesContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -4616,6 +5036,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.asana.types.WorkspacesAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="WorkspacesEqCondition"></a>
 
 `WorkspacesEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -4629,6 +5051,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.asana.types.WorkspacesSearchFilter`
     :   The type of the None singleton.
 
+<a id="WorkspacesFuzzyCondition"></a>
+
 `WorkspacesFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -4640,6 +5064,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.asana.types.WorkspacesStringFilter`
     :   The type of the None singleton.
+
+<a id="WorkspacesGetParams"></a>
 
 `WorkspacesGetParams(*args, **kwargs)`
 :   Parameters for workspaces.get operation
@@ -4653,6 +5079,8 @@ Classes
     `workspace_gid: str`
     :   The type of the None singleton.
 
+<a id="WorkspacesGtCondition"></a>
+
 `WorkspacesGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -4665,6 +5093,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.asana.types.WorkspacesSearchFilter`
     :   The type of the None singleton.
 
+<a id="WorkspacesGteCondition"></a>
+
 `WorkspacesGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -4676,6 +5106,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.asana.types.WorkspacesSearchFilter`
     :   The type of the None singleton.
+
+<a id="WorkspacesInCondition"></a>
 
 `WorkspacesInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -4696,6 +5128,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.asana.types.WorkspacesInFilter`
     :   The type of the None singleton.
+
+<a id="WorkspacesInFilter"></a>
 
 `WorkspacesInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -4721,6 +5155,8 @@ Classes
     `resource_type: list[str]`
     :   The type of the None singleton.
 
+<a id="WorkspacesKeywordCondition"></a>
+
 `WorkspacesKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -4733,6 +5169,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.asana.types.WorkspacesStringFilter`
     :   The type of the None singleton.
 
+<a id="WorkspacesLikeCondition"></a>
+
 `WorkspacesLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -4744,6 +5182,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.asana.types.WorkspacesStringFilter`
     :   The type of the None singleton.
+
+<a id="WorkspacesListParams"></a>
 
 `WorkspacesListParams(*args, **kwargs)`
 :   Parameters for workspaces.list operation
@@ -4760,6 +5200,8 @@ Classes
     `offset: str`
     :   The type of the None singleton.
 
+<a id="WorkspacesLtCondition"></a>
+
 `WorkspacesLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -4771,6 +5213,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.asana.types.WorkspacesSearchFilter`
     :   The type of the None singleton.
+
+<a id="WorkspacesLteCondition"></a>
 
 `WorkspacesLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -4784,6 +5228,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.asana.types.WorkspacesSearchFilter`
     :   The type of the None singleton.
 
+<a id="WorkspacesNeqCondition"></a>
+
 `WorkspacesNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -4795,6 +5241,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.asana.types.WorkspacesSearchFilter`
     :   The type of the None singleton.
+
+<a id="WorkspacesNotCondition"></a>
 
 `WorkspacesNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -4816,6 +5264,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.asana.types.WorkspacesEqCondition | airbyte_agent_sdk.connectors.asana.types.WorkspacesNeqCondition | airbyte_agent_sdk.connectors.asana.types.WorkspacesGtCondition | airbyte_agent_sdk.connectors.asana.types.WorkspacesGteCondition | airbyte_agent_sdk.connectors.asana.types.WorkspacesLtCondition | airbyte_agent_sdk.connectors.asana.types.WorkspacesLteCondition | airbyte_agent_sdk.connectors.asana.types.WorkspacesInCondition | airbyte_agent_sdk.connectors.asana.types.WorkspacesLikeCondition | airbyte_agent_sdk.connectors.asana.types.WorkspacesFuzzyCondition | airbyte_agent_sdk.connectors.asana.types.WorkspacesKeywordCondition | airbyte_agent_sdk.connectors.asana.types.WorkspacesContainsCondition | airbyte_agent_sdk.connectors.asana.types.WorkspacesNotCondition | airbyte_agent_sdk.connectors.asana.types.WorkspacesAndCondition | airbyte_agent_sdk.connectors.asana.types.WorkspacesOrCondition | airbyte_agent_sdk.connectors.asana.types.WorkspacesAnyCondition`
     :   The type of the None singleton.
 
+<a id="WorkspacesOrCondition"></a>
+
 `WorkspacesOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -4835,6 +5285,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.asana.types.WorkspacesEqCondition | airbyte_agent_sdk.connectors.asana.types.WorkspacesNeqCondition | airbyte_agent_sdk.connectors.asana.types.WorkspacesGtCondition | airbyte_agent_sdk.connectors.asana.types.WorkspacesGteCondition | airbyte_agent_sdk.connectors.asana.types.WorkspacesLtCondition | airbyte_agent_sdk.connectors.asana.types.WorkspacesLteCondition | airbyte_agent_sdk.connectors.asana.types.WorkspacesInCondition | airbyte_agent_sdk.connectors.asana.types.WorkspacesLikeCondition | airbyte_agent_sdk.connectors.asana.types.WorkspacesFuzzyCondition | airbyte_agent_sdk.connectors.asana.types.WorkspacesKeywordCondition | airbyte_agent_sdk.connectors.asana.types.WorkspacesContainsCondition | airbyte_agent_sdk.connectors.asana.types.WorkspacesNotCondition | airbyte_agent_sdk.connectors.asana.types.WorkspacesAndCondition | airbyte_agent_sdk.connectors.asana.types.WorkspacesOrCondition | airbyte_agent_sdk.connectors.asana.types.WorkspacesAnyCondition]`
     :   The type of the None singleton.
+
+<a id="WorkspacesSearchFilter"></a>
 
 `WorkspacesSearchFilter(*args, **kwargs)`
 :   Available fields for filtering workspaces search queries.
@@ -4860,6 +5312,8 @@ Classes
     `resource_type: str | None`
     :   The type of the None singleton.
 
+<a id="WorkspacesSearchQuery"></a>
+
 `WorkspacesSearchQuery(*args, **kwargs)`
 :   Search query for workspaces entity.
 
@@ -4874,6 +5328,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.asana.types.WorkspacesSortFilter]`
     :   The type of the None singleton.
+
+<a id="WorkspacesSortFilter"></a>
 
 `WorkspacesSortFilter(*args, **kwargs)`
 :   Available fields for sorting workspaces search results.
@@ -4898,6 +5354,8 @@ Classes
 
     `resource_type: Literal['asc', 'desc']`
     :   The type of the None singleton.
+
+<a id="WorkspacesStringFilter"></a>
 
 `WorkspacesStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/ashby/connector.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/ashby/connector.md
@@ -10,6 +10,8 @@ Ashby connector.
 Classes
 -------
 
+<a id="ApplicationsQuery"></a>
+
 `ApplicationsQuery(connector: AshbyConnector)`
 :   Query class for Applications entity operations.
     
@@ -60,6 +62,8 @@ Classes
         Returns:
             ApplicationsListResult
 
+<a id="ArchiveReasonsQuery"></a>
+
 `ArchiveReasonsQuery(connector: AshbyConnector)`
 :   Query class for ArchiveReasons entity operations.
     
@@ -77,6 +81,8 @@ Classes
         
         Returns:
             ArchiveReasonsListResult
+
+<a id="AshbyConnector"></a>
 
 `AshbyConnector(auth_config: AshbyAuthConfig | AirbyteAuthConfig | BaseModel | None = None, on_token_refresh: Any | None = None)`
 :   Type-safe Ashby API connector.
@@ -278,6 +284,8 @@ Classes
             for entity in entities:
                 print(f"\{entity['entity_name']\}: \{entity['available_actions']\}")
 
+<a id="CandidateTagsQuery"></a>
+
 `CandidateTagsQuery(connector: AshbyConnector)`
 :   Query class for CandidateTags entity operations.
     
@@ -295,6 +303,8 @@ Classes
         
         Returns:
             CandidateTagsListResult
+
+<a id="CandidatesQuery"></a>
 
 `CandidatesQuery(connector: AshbyConnector)`
 :   Query class for Candidates entity operations.
@@ -346,6 +356,8 @@ Classes
         Returns:
             CandidatesListResult
 
+<a id="CustomFieldsQuery"></a>
+
 `CustomFieldsQuery(connector: AshbyConnector)`
 :   Query class for CustomFields entity operations.
     
@@ -363,6 +375,8 @@ Classes
         
         Returns:
             CustomFieldsListResult
+
+<a id="DepartmentsQuery"></a>
 
 `DepartmentsQuery(connector: AshbyConnector)`
 :   Query class for Departments entity operations.
@@ -392,6 +406,8 @@ Classes
         Returns:
             DepartmentsListResult
 
+<a id="FeedbackFormDefinitionsQuery"></a>
+
 `FeedbackFormDefinitionsQuery(connector: AshbyConnector)`
 :   Query class for FeedbackFormDefinitions entity operations.
     
@@ -409,6 +425,8 @@ Classes
         
         Returns:
             FeedbackFormDefinitionsListResult
+
+<a id="JobPostingsQuery"></a>
 
 `JobPostingsQuery(connector: AshbyConnector)`
 :   Query class for JobPostings entity operations.
@@ -460,6 +478,8 @@ Classes
         Returns:
             JobPostingsListResult
 
+<a id="JobsQuery"></a>
+
 `JobsQuery(connector: AshbyConnector)`
 :   Query class for Jobs entity operations.
     
@@ -510,6 +530,8 @@ Classes
         Returns:
             JobsListResult
 
+<a id="LocationsQuery"></a>
+
 `LocationsQuery(connector: AshbyConnector)`
 :   Query class for Locations entity operations.
     
@@ -538,6 +560,8 @@ Classes
         Returns:
             LocationsListResult
 
+<a id="SourcesQuery"></a>
+
 `SourcesQuery(connector: AshbyConnector)`
 :   Query class for Sources entity operations.
     
@@ -555,6 +579,8 @@ Classes
         
         Returns:
             SourcesListResult
+
+<a id="UsersQuery"></a>
 
 `UsersQuery(connector: AshbyConnector)`
 :   Query class for Users entity operations.

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/ashby/index.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/ashby/index.md
@@ -19,6 +19,8 @@ Sub-modules
 Classes
 -------
 
+<a id="AirbyteAuthConfig"></a>
+
 `AirbyteAuthConfig(**data: Any)`
 :   Authentication configuration for Airbyte hosted mode execution.
     
@@ -87,6 +89,8 @@ Classes
     `workspace_name: str | None`
     :   The type of the None singleton.
 
+<a id="AirbyteSearchMeta"></a>
+
 `AirbyteSearchMeta(**data: Any)`
 :   Pagination metadata for search responses.
     
@@ -114,6 +118,8 @@ Classes
 
     `took_ms: int | None`
     :   Time taken to execute the search in milliseconds.
+
+<a id="AirbyteSearchResult"></a>
 
 `AirbyteSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -149,6 +155,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="ApplicationsSearchResult"></a>
+
 `ApplicationsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -164,6 +172,8 @@ Classes
     * airbyte_agent_sdk.connectors.ashby.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="CandidatesSearchResult"></a>
 
 `CandidatesSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -181,6 +191,8 @@ Classes
     * pydantic.main.BaseModel
     * typing.Generic
 
+<a id="JobPostingsSearchResult"></a>
+
 `JobPostingsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -196,6 +208,8 @@ Classes
     * airbyte_agent_sdk.connectors.ashby.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="JobsSearchResult"></a>
 
 `JobsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -213,6 +227,8 @@ Classes
     * pydantic.main.BaseModel
     * typing.Generic
 
+<a id="UsersSearchResult"></a>
+
 `UsersSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -228,6 +244,8 @@ Classes
     * airbyte_agent_sdk.connectors.ashby.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="ApplicationsSearchData"></a>
 
 `ApplicationsSearchData(**data: Any)`
 :   Search result data for applications entity.
@@ -247,6 +265,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="AshbyAuthConfig"></a>
 
 `AshbyAuthConfig(**data: Any)`
 :   API Key Authentication
@@ -269,6 +289,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="AshbyConnector"></a>
 
 `AshbyConnector(auth_config: AshbyAuthConfig | AirbyteAuthConfig | BaseModel | None = None, on_token_refresh: Any | None = None)`
 :   Type-safe Ashby API connector.
@@ -470,6 +492,8 @@ Classes
             for entity in entities:
                 print(f"\{entity['entity_name']\}: \{entity['available_actions']\}")
 
+<a id="AshbyReplicationConfig"></a>
+
 `AshbyReplicationConfig(**data: Any)`
 :   Replication Configuration - Settings for data replication from Ashby.
     
@@ -492,6 +516,8 @@ Classes
     `start_date: str`
     :   The date from which to start replicating data, in the format YYYY-MM-DDT00:00:00Z.
 
+<a id="CandidatesSearchData"></a>
+
 `CandidatesSearchData(**data: Any)`
 :   Search result data for candidates entity.
     
@@ -510,6 +536,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="JobPostingsSearchData"></a>
 
 `JobPostingsSearchData(**data: Any)`
 :   Search result data for job_postings entity.
@@ -530,6 +558,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="JobsSearchData"></a>
+
 `JobsSearchData(**data: Any)`
 :   Search result data for jobs entity.
     
@@ -548,6 +578,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="UsersSearchData"></a>
 
 `UsersSearchData(**data: Any)`
 :   Search result data for users entity.

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/ashby/models.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/ashby/models.md
@@ -13,6 +13,8 @@ and response envelope types.
 Classes
 -------
 
+<a id="AirbyteSearchMeta"></a>
+
 `AirbyteSearchMeta(**data: Any)`
 :   Pagination metadata for search responses.
     
@@ -40,6 +42,8 @@ Classes
 
     `took_ms: int | None`
     :   Time taken to execute the search in milliseconds.
+
+<a id="AirbyteSearchResult"></a>
 
 `AirbyteSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -96,6 +100,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="ApplicationsSearchResult"></a>
+
 `ApplicationsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -132,6 +138,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="CandidatesSearchResult"></a>
 
 `CandidatesSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -170,6 +178,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="JobPostingsSearchResult"></a>
+
 `JobPostingsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -206,6 +216,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="JobsSearchResult"></a>
 
 `JobsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -244,6 +256,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="UsersSearchResult"></a>
+
 `UsersSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -259,6 +273,8 @@ Classes
     * airbyte_agent_sdk.connectors.ashby.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="Application"></a>
 
 `Application(**data: Any)`
 :   Application object
@@ -327,6 +343,8 @@ Classes
     `updated_at: str | Any | None`
     :   The type of the None singleton.
 
+<a id="ApplicationHiringteamItem"></a>
+
 `ApplicationHiringteamItem(**data: Any)`
 :   Nested schema for Application.hiringTeam_item
     
@@ -361,6 +379,8 @@ Classes
     `user_id: str | Any | None`
     :   The type of the None singleton.
 
+<a id="ApplicationsListResultMeta"></a>
+
 `ApplicationsListResultMeta(**data: Any)`
 :   Metadata for applications.Action.LIST operation
     
@@ -386,6 +406,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="ApplicationsSearchData"></a>
+
 `ApplicationsSearchData(**data: Any)`
 :   Search result data for applications entity.
     
@@ -404,6 +426,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="ArchiveReason"></a>
 
 `ArchiveReason(**data: Any)`
 :   Archive reason object
@@ -436,6 +460,8 @@ Classes
     `text: str | Any | None`
     :   The type of the None singleton.
 
+<a id="ArchiveReasonsListResultMeta"></a>
+
 `ArchiveReasonsListResultMeta(**data: Any)`
 :   Metadata for archive_reasons.Action.LIST operation
     
@@ -461,6 +487,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="AshbyAuthConfig"></a>
+
 `AshbyAuthConfig(**data: Any)`
 :   API Key Authentication
     
@@ -482,6 +510,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="AshbyCheckResult"></a>
 
 `AshbyCheckResult(**data: Any)`
 :   Result of a health check operation.
@@ -516,6 +546,8 @@ Classes
     `status: str`
     :   Health check status: 'healthy' or 'unhealthy'.
 
+<a id="AshbyExecuteResult"></a>
+
 `AshbyExecuteResult(**data: Any)`
 :   Response envelope with data only.
     
@@ -544,6 +576,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="AshbyExecuteResultWithMeta"></a>
 
 `AshbyExecuteResultWithMeta(**data: Any)`
 :   Response envelope with data and metadata.
@@ -607,6 +641,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="ApplicationsListResult"></a>
+
 `ApplicationsListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -649,6 +685,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="ArchiveReasonsListResult"></a>
 
 `ArchiveReasonsListResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -693,6 +731,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="CandidateTagsListResult"></a>
+
 `CandidateTagsListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -735,6 +775,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="CandidatesListResult"></a>
 
 `CandidatesListResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -779,6 +821,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="CustomFieldsListResult"></a>
+
 `CustomFieldsListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -821,6 +865,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="DepartmentsListResult"></a>
 
 `DepartmentsListResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -865,6 +911,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="FeedbackFormDefinitionsListResult"></a>
+
 `FeedbackFormDefinitionsListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -907,6 +955,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="JobPostingsListResult"></a>
 
 `JobPostingsListResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -951,6 +1001,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="JobsListResult"></a>
+
 `JobsListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -993,6 +1045,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="LocationsListResult"></a>
 
 `LocationsListResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -1037,6 +1091,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="SourcesListResult"></a>
+
 `SourcesListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -1080,6 +1136,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="UsersListResult"></a>
+
 `UsersListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -1098,6 +1156,8 @@ Classes
     * airbyte_agent_sdk.connectors.ashby.models.AshbyExecuteResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="AshbyReplicationConfig"></a>
 
 `AshbyReplicationConfig(**data: Any)`
 :   Replication Configuration - Settings for data replication from Ashby.
@@ -1120,6 +1180,8 @@ Classes
 
     `start_date: str`
     :   The date from which to start replicating data, in the format YYYY-MM-DDT00:00:00Z.
+
+<a id="Candidate"></a>
 
 `Candidate(**data: Any)`
 :   Candidate object
@@ -1185,6 +1247,8 @@ Classes
     `updated_at: str | Any | None`
     :   The type of the None singleton.
 
+<a id="CandidateEmailaddressesItem"></a>
+
 `CandidateEmailaddressesItem(**data: Any)`
 :   Nested schema for Candidate.emailAddresses_item
     
@@ -1212,6 +1276,8 @@ Classes
 
     `value: str | Any | None`
     :   The type of the None singleton.
+
+<a id="CandidatePhonenumbersItem"></a>
 
 `CandidatePhonenumbersItem(**data: Any)`
 :   Nested schema for Candidate.phoneNumbers_item
@@ -1241,6 +1307,8 @@ Classes
     `value: str | Any | None`
     :   The type of the None singleton.
 
+<a id="CandidateSociallinksItem"></a>
+
 `CandidateSociallinksItem(**data: Any)`
 :   Nested schema for Candidate.socialLinks_item
     
@@ -1265,6 +1333,8 @@ Classes
 
     `url: str | Any | None`
     :   The type of the None singleton.
+
+<a id="CandidateTag"></a>
 
 `CandidateTag(**data: Any)`
 :   Candidate tag object
@@ -1294,6 +1364,8 @@ Classes
     `title: str | Any | None`
     :   The type of the None singleton.
 
+<a id="CandidateTagsItem"></a>
+
 `CandidateTagsItem(**data: Any)`
 :   Nested schema for Candidate.tags_item
     
@@ -1322,6 +1394,8 @@ Classes
     `title: str | Any | None`
     :   The type of the None singleton.
 
+<a id="CandidateTagsListResultMeta"></a>
+
 `CandidateTagsListResultMeta(**data: Any)`
 :   Metadata for candidate_tags.Action.LIST operation
     
@@ -1346,6 +1420,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="CandidatesListResultMeta"></a>
 
 `CandidatesListResultMeta(**data: Any)`
 :   Metadata for candidates.Action.LIST operation
@@ -1372,6 +1448,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="CandidatesSearchData"></a>
+
 `CandidatesSearchData(**data: Any)`
 :   Search result data for candidates entity.
     
@@ -1390,6 +1468,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="CustomField"></a>
 
 `CustomField(**data: Any)`
 :   Custom field definition
@@ -1428,6 +1508,8 @@ Classes
     `title: str | Any | None`
     :   The type of the None singleton.
 
+<a id="CustomFieldsListResultMeta"></a>
+
 `CustomFieldsListResultMeta(**data: Any)`
 :   Metadata for custom_fields.Action.LIST operation
     
@@ -1452,6 +1534,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="Department"></a>
 
 `Department(**data: Any)`
 :   Department object
@@ -1496,6 +1580,8 @@ Classes
     `updated_at: str | Any | None`
     :   The type of the None singleton.
 
+<a id="DepartmentsListResultMeta"></a>
+
 `DepartmentsListResultMeta(**data: Any)`
 :   Metadata for departments.Action.LIST operation
     
@@ -1520,6 +1606,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="FeedbackFormDefinition"></a>
 
 `FeedbackFormDefinition(**data: Any)`
 :   Feedback form definition
@@ -1561,6 +1649,8 @@ Classes
     `title: str | Any | None`
     :   The type of the None singleton.
 
+<a id="FeedbackFormDefinitionsListResultMeta"></a>
+
 `FeedbackFormDefinitionsListResultMeta(**data: Any)`
 :   Metadata for feedback_form_definitions.Action.LIST operation
     
@@ -1585,6 +1675,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="Job"></a>
 
 `Job(**data: Any)`
 :   Job object
@@ -1662,6 +1754,8 @@ Classes
     `updated_at: str | Any | None`
     :   The type of the None singleton.
 
+<a id="JobCustomfieldsItem"></a>
+
 `JobCustomfieldsItem(**data: Any)`
 :   Nested schema for Job.customFields_item
     
@@ -1696,6 +1790,8 @@ Classes
     `value_label: str | Any | None`
     :   The type of the None singleton.
 
+<a id="JobHiringteamItem"></a>
+
 `JobHiringteamItem(**data: Any)`
 :   Nested schema for Job.hiringTeam_item
     
@@ -1729,6 +1825,8 @@ Classes
 
     `user_id: str | Any | None`
     :   The type of the None singleton.
+
+<a id="JobPosting"></a>
 
 `JobPosting(**data: Any)`
 :   Job posting object
@@ -1803,6 +1901,8 @@ Classes
     `workplace_type: str | Any | None`
     :   The type of the None singleton.
 
+<a id="JobPostingsListResultMeta"></a>
+
 `JobPostingsListResultMeta(**data: Any)`
 :   Metadata for job_postings.Action.LIST operation
     
@@ -1828,6 +1928,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="JobPostingsSearchData"></a>
+
 `JobPostingsSearchData(**data: Any)`
 :   Search result data for job_postings entity.
     
@@ -1846,6 +1948,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="JobsListResultMeta"></a>
 
 `JobsListResultMeta(**data: Any)`
 :   Metadata for jobs.Action.LIST operation
@@ -1872,6 +1976,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="JobsSearchData"></a>
+
 `JobsSearchData(**data: Any)`
 :   Search result data for jobs entity.
     
@@ -1890,6 +1996,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="Location"></a>
 
 `Location(**data: Any)`
 :   Location object
@@ -1940,6 +2048,8 @@ Classes
     `workplace_type: str | Any | None`
     :   The type of the None singleton.
 
+<a id="LocationsListResultMeta"></a>
+
 `LocationsListResultMeta(**data: Any)`
 :   Metadata for locations.Action.LIST operation
     
@@ -1964,6 +2074,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="Source"></a>
 
 `Source(**data: Any)`
 :   Candidate source object
@@ -1996,6 +2108,8 @@ Classes
     `title: str | Any | None`
     :   The type of the None singleton.
 
+<a id="SourcesListResultMeta"></a>
+
 `SourcesListResultMeta(**data: Any)`
 :   Metadata for sources.Action.LIST operation
     
@@ -2020,6 +2134,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="User"></a>
 
 `User(**data: Any)`
 :   User object
@@ -2061,6 +2177,8 @@ Classes
     `updated_at: str | Any | None`
     :   The type of the None singleton.
 
+<a id="UsersListResultMeta"></a>
+
 `UsersListResultMeta(**data: Any)`
 :   Metadata for users.Action.LIST operation
     
@@ -2085,6 +2203,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="UsersSearchData"></a>
 
 `UsersSearchData(**data: Any)`
 :   Search result data for users entity.

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/ashby/types.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/ashby/types.md
@@ -10,6 +10,8 @@ Type definitions for ashby connector.
 Classes
 -------
 
+<a id="AirbyteSearchParams"></a>
+
 `AirbyteSearchParams(*args, **kwargs)`
 :   Parameters for Airbyte cache search operations (generic, use entity-specific query types for better type hints).
 
@@ -31,6 +33,8 @@ Classes
     `query: dict[str, typing.Any]`
     :   The type of the None singleton.
 
+<a id="ApplicationsAndCondition"></a>
+
 `ApplicationsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -50,6 +54,8 @@ Classes
 
     `and: list[airbyte_agent_sdk.connectors.ashby.types.ApplicationsEqCondition | airbyte_agent_sdk.connectors.ashby.types.ApplicationsNeqCondition | airbyte_agent_sdk.connectors.ashby.types.ApplicationsGtCondition | airbyte_agent_sdk.connectors.ashby.types.ApplicationsGteCondition | airbyte_agent_sdk.connectors.ashby.types.ApplicationsLtCondition | airbyte_agent_sdk.connectors.ashby.types.ApplicationsLteCondition | airbyte_agent_sdk.connectors.ashby.types.ApplicationsInCondition | airbyte_agent_sdk.connectors.ashby.types.ApplicationsLikeCondition | airbyte_agent_sdk.connectors.ashby.types.ApplicationsFuzzyCondition | airbyte_agent_sdk.connectors.ashby.types.ApplicationsKeywordCondition | airbyte_agent_sdk.connectors.ashby.types.ApplicationsContainsCondition | airbyte_agent_sdk.connectors.ashby.types.ApplicationsNotCondition | airbyte_agent_sdk.connectors.ashby.types.ApplicationsAndCondition | airbyte_agent_sdk.connectors.ashby.types.ApplicationsOrCondition | airbyte_agent_sdk.connectors.ashby.types.ApplicationsAnyCondition]`
     :   The type of the None singleton.
+
+<a id="ApplicationsAnyCondition"></a>
 
 `ApplicationsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -71,12 +77,16 @@ Classes
     `any: airbyte_agent_sdk.connectors.ashby.types.ApplicationsAnyValueFilter`
     :   The type of the None singleton.
 
+<a id="ApplicationsAnyValueFilter"></a>
+
 `ApplicationsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="ApplicationsContainsCondition"></a>
 
 `ApplicationsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
@@ -90,6 +100,8 @@ Classes
     `contains: airbyte_agent_sdk.connectors.ashby.types.ApplicationsAnyValueFilter`
     :   The type of the None singleton.
 
+<a id="ApplicationsEqCondition"></a>
+
 `ApplicationsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
 
@@ -101,6 +113,8 @@ Classes
 
     `eq: airbyte_agent_sdk.connectors.ashby.types.ApplicationsSearchFilter`
     :   The type of the None singleton.
+
+<a id="ApplicationsFuzzyCondition"></a>
 
 `ApplicationsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
@@ -114,6 +128,8 @@ Classes
     `fuzzy: airbyte_agent_sdk.connectors.ashby.types.ApplicationsStringFilter`
     :   The type of the None singleton.
 
+<a id="ApplicationsGetParams"></a>
+
 `ApplicationsGetParams(*args, **kwargs)`
 :   Parameters for applications.get operation
 
@@ -125,6 +141,8 @@ Classes
 
     `application_id: str`
     :   The type of the None singleton.
+
+<a id="ApplicationsGtCondition"></a>
 
 `ApplicationsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
@@ -138,6 +156,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.ashby.types.ApplicationsSearchFilter`
     :   The type of the None singleton.
 
+<a id="ApplicationsGteCondition"></a>
+
 `ApplicationsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -149,6 +169,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.ashby.types.ApplicationsSearchFilter`
     :   The type of the None singleton.
+
+<a id="ApplicationsInCondition"></a>
 
 `ApplicationsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -170,12 +192,16 @@ Classes
     `in: airbyte_agent_sdk.connectors.ashby.types.ApplicationsInFilter`
     :   The type of the None singleton.
 
+<a id="ApplicationsInFilter"></a>
+
 `ApplicationsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="ApplicationsKeywordCondition"></a>
 
 `ApplicationsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
@@ -189,6 +215,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.ashby.types.ApplicationsStringFilter`
     :   The type of the None singleton.
 
+<a id="ApplicationsLikeCondition"></a>
+
 `ApplicationsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -200,6 +228,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.ashby.types.ApplicationsStringFilter`
     :   The type of the None singleton.
+
+<a id="ApplicationsListParams"></a>
 
 `ApplicationsListParams(*args, **kwargs)`
 :   Parameters for applications.list operation
@@ -216,6 +246,8 @@ Classes
     `limit: int`
     :   The type of the None singleton.
 
+<a id="ApplicationsLtCondition"></a>
+
 `ApplicationsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -227,6 +259,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.ashby.types.ApplicationsSearchFilter`
     :   The type of the None singleton.
+
+<a id="ApplicationsLteCondition"></a>
 
 `ApplicationsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -240,6 +274,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.ashby.types.ApplicationsSearchFilter`
     :   The type of the None singleton.
 
+<a id="ApplicationsNeqCondition"></a>
+
 `ApplicationsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -251,6 +287,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.ashby.types.ApplicationsSearchFilter`
     :   The type of the None singleton.
+
+<a id="ApplicationsNotCondition"></a>
 
 `ApplicationsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -272,6 +310,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.ashby.types.ApplicationsEqCondition | airbyte_agent_sdk.connectors.ashby.types.ApplicationsNeqCondition | airbyte_agent_sdk.connectors.ashby.types.ApplicationsGtCondition | airbyte_agent_sdk.connectors.ashby.types.ApplicationsGteCondition | airbyte_agent_sdk.connectors.ashby.types.ApplicationsLtCondition | airbyte_agent_sdk.connectors.ashby.types.ApplicationsLteCondition | airbyte_agent_sdk.connectors.ashby.types.ApplicationsInCondition | airbyte_agent_sdk.connectors.ashby.types.ApplicationsLikeCondition | airbyte_agent_sdk.connectors.ashby.types.ApplicationsFuzzyCondition | airbyte_agent_sdk.connectors.ashby.types.ApplicationsKeywordCondition | airbyte_agent_sdk.connectors.ashby.types.ApplicationsContainsCondition | airbyte_agent_sdk.connectors.ashby.types.ApplicationsNotCondition | airbyte_agent_sdk.connectors.ashby.types.ApplicationsAndCondition | airbyte_agent_sdk.connectors.ashby.types.ApplicationsOrCondition | airbyte_agent_sdk.connectors.ashby.types.ApplicationsAnyCondition`
     :   The type of the None singleton.
 
+<a id="ApplicationsOrCondition"></a>
+
 `ApplicationsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -292,12 +332,16 @@ Classes
     `or: list[airbyte_agent_sdk.connectors.ashby.types.ApplicationsEqCondition | airbyte_agent_sdk.connectors.ashby.types.ApplicationsNeqCondition | airbyte_agent_sdk.connectors.ashby.types.ApplicationsGtCondition | airbyte_agent_sdk.connectors.ashby.types.ApplicationsGteCondition | airbyte_agent_sdk.connectors.ashby.types.ApplicationsLtCondition | airbyte_agent_sdk.connectors.ashby.types.ApplicationsLteCondition | airbyte_agent_sdk.connectors.ashby.types.ApplicationsInCondition | airbyte_agent_sdk.connectors.ashby.types.ApplicationsLikeCondition | airbyte_agent_sdk.connectors.ashby.types.ApplicationsFuzzyCondition | airbyte_agent_sdk.connectors.ashby.types.ApplicationsKeywordCondition | airbyte_agent_sdk.connectors.ashby.types.ApplicationsContainsCondition | airbyte_agent_sdk.connectors.ashby.types.ApplicationsNotCondition | airbyte_agent_sdk.connectors.ashby.types.ApplicationsAndCondition | airbyte_agent_sdk.connectors.ashby.types.ApplicationsOrCondition | airbyte_agent_sdk.connectors.ashby.types.ApplicationsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="ApplicationsSearchFilter"></a>
+
 `ApplicationsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering applications search queries.
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="ApplicationsSearchQuery"></a>
 
 `ApplicationsSearchQuery(*args, **kwargs)`
 :   Search query for applications entity.
@@ -314,6 +358,8 @@ Classes
     `sort: list[airbyte_agent_sdk.connectors.ashby.types.ApplicationsSortFilter]`
     :   The type of the None singleton.
 
+<a id="ApplicationsSortFilter"></a>
+
 `ApplicationsSortFilter(*args, **kwargs)`
 :   Available fields for sorting applications search results.
 
@@ -321,12 +367,16 @@ Classes
 
     * builtins.dict
 
+<a id="ApplicationsStringFilter"></a>
+
 `ApplicationsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="ArchiveReasonsListParams"></a>
 
 `ArchiveReasonsListParams(*args, **kwargs)`
 :   Parameters for archive_reasons.list operation
@@ -343,6 +393,8 @@ Classes
     `limit: int`
     :   The type of the None singleton.
 
+<a id="CandidateTagsListParams"></a>
+
 `CandidateTagsListParams(*args, **kwargs)`
 :   Parameters for candidate_tags.list operation
 
@@ -357,6 +409,8 @@ Classes
 
     `limit: int`
     :   The type of the None singleton.
+
+<a id="CandidatesAndCondition"></a>
 
 `CandidatesAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -378,6 +432,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.ashby.types.CandidatesEqCondition | airbyte_agent_sdk.connectors.ashby.types.CandidatesNeqCondition | airbyte_agent_sdk.connectors.ashby.types.CandidatesGtCondition | airbyte_agent_sdk.connectors.ashby.types.CandidatesGteCondition | airbyte_agent_sdk.connectors.ashby.types.CandidatesLtCondition | airbyte_agent_sdk.connectors.ashby.types.CandidatesLteCondition | airbyte_agent_sdk.connectors.ashby.types.CandidatesInCondition | airbyte_agent_sdk.connectors.ashby.types.CandidatesLikeCondition | airbyte_agent_sdk.connectors.ashby.types.CandidatesFuzzyCondition | airbyte_agent_sdk.connectors.ashby.types.CandidatesKeywordCondition | airbyte_agent_sdk.connectors.ashby.types.CandidatesContainsCondition | airbyte_agent_sdk.connectors.ashby.types.CandidatesNotCondition | airbyte_agent_sdk.connectors.ashby.types.CandidatesAndCondition | airbyte_agent_sdk.connectors.ashby.types.CandidatesOrCondition | airbyte_agent_sdk.connectors.ashby.types.CandidatesAnyCondition]`
     :   The type of the None singleton.
 
+<a id="CandidatesAnyCondition"></a>
+
 `CandidatesAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -398,12 +454,16 @@ Classes
     `any: airbyte_agent_sdk.connectors.ashby.types.CandidatesAnyValueFilter`
     :   The type of the None singleton.
 
+<a id="CandidatesAnyValueFilter"></a>
+
 `CandidatesAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="CandidatesContainsCondition"></a>
 
 `CandidatesContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
@@ -417,6 +477,8 @@ Classes
     `contains: airbyte_agent_sdk.connectors.ashby.types.CandidatesAnyValueFilter`
     :   The type of the None singleton.
 
+<a id="CandidatesEqCondition"></a>
+
 `CandidatesEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
 
@@ -428,6 +490,8 @@ Classes
 
     `eq: airbyte_agent_sdk.connectors.ashby.types.CandidatesSearchFilter`
     :   The type of the None singleton.
+
+<a id="CandidatesFuzzyCondition"></a>
 
 `CandidatesFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
@@ -441,6 +505,8 @@ Classes
     `fuzzy: airbyte_agent_sdk.connectors.ashby.types.CandidatesStringFilter`
     :   The type of the None singleton.
 
+<a id="CandidatesGetParams"></a>
+
 `CandidatesGetParams(*args, **kwargs)`
 :   Parameters for candidates.get operation
 
@@ -452,6 +518,8 @@ Classes
 
     `id: str`
     :   The type of the None singleton.
+
+<a id="CandidatesGtCondition"></a>
 
 `CandidatesGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
@@ -465,6 +533,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.ashby.types.CandidatesSearchFilter`
     :   The type of the None singleton.
 
+<a id="CandidatesGteCondition"></a>
+
 `CandidatesGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -476,6 +546,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.ashby.types.CandidatesSearchFilter`
     :   The type of the None singleton.
+
+<a id="CandidatesInCondition"></a>
 
 `CandidatesInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -497,12 +569,16 @@ Classes
     `in: airbyte_agent_sdk.connectors.ashby.types.CandidatesInFilter`
     :   The type of the None singleton.
 
+<a id="CandidatesInFilter"></a>
+
 `CandidatesInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="CandidatesKeywordCondition"></a>
 
 `CandidatesKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
@@ -516,6 +592,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.ashby.types.CandidatesStringFilter`
     :   The type of the None singleton.
 
+<a id="CandidatesLikeCondition"></a>
+
 `CandidatesLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -527,6 +605,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.ashby.types.CandidatesStringFilter`
     :   The type of the None singleton.
+
+<a id="CandidatesListParams"></a>
 
 `CandidatesListParams(*args, **kwargs)`
 :   Parameters for candidates.list operation
@@ -543,6 +623,8 @@ Classes
     `limit: int`
     :   The type of the None singleton.
 
+<a id="CandidatesLtCondition"></a>
+
 `CandidatesLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -554,6 +636,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.ashby.types.CandidatesSearchFilter`
     :   The type of the None singleton.
+
+<a id="CandidatesLteCondition"></a>
 
 `CandidatesLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -567,6 +651,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.ashby.types.CandidatesSearchFilter`
     :   The type of the None singleton.
 
+<a id="CandidatesNeqCondition"></a>
+
 `CandidatesNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -578,6 +664,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.ashby.types.CandidatesSearchFilter`
     :   The type of the None singleton.
+
+<a id="CandidatesNotCondition"></a>
 
 `CandidatesNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -599,6 +687,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.ashby.types.CandidatesEqCondition | airbyte_agent_sdk.connectors.ashby.types.CandidatesNeqCondition | airbyte_agent_sdk.connectors.ashby.types.CandidatesGtCondition | airbyte_agent_sdk.connectors.ashby.types.CandidatesGteCondition | airbyte_agent_sdk.connectors.ashby.types.CandidatesLtCondition | airbyte_agent_sdk.connectors.ashby.types.CandidatesLteCondition | airbyte_agent_sdk.connectors.ashby.types.CandidatesInCondition | airbyte_agent_sdk.connectors.ashby.types.CandidatesLikeCondition | airbyte_agent_sdk.connectors.ashby.types.CandidatesFuzzyCondition | airbyte_agent_sdk.connectors.ashby.types.CandidatesKeywordCondition | airbyte_agent_sdk.connectors.ashby.types.CandidatesContainsCondition | airbyte_agent_sdk.connectors.ashby.types.CandidatesNotCondition | airbyte_agent_sdk.connectors.ashby.types.CandidatesAndCondition | airbyte_agent_sdk.connectors.ashby.types.CandidatesOrCondition | airbyte_agent_sdk.connectors.ashby.types.CandidatesAnyCondition`
     :   The type of the None singleton.
 
+<a id="CandidatesOrCondition"></a>
+
 `CandidatesOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -619,12 +709,16 @@ Classes
     `or: list[airbyte_agent_sdk.connectors.ashby.types.CandidatesEqCondition | airbyte_agent_sdk.connectors.ashby.types.CandidatesNeqCondition | airbyte_agent_sdk.connectors.ashby.types.CandidatesGtCondition | airbyte_agent_sdk.connectors.ashby.types.CandidatesGteCondition | airbyte_agent_sdk.connectors.ashby.types.CandidatesLtCondition | airbyte_agent_sdk.connectors.ashby.types.CandidatesLteCondition | airbyte_agent_sdk.connectors.ashby.types.CandidatesInCondition | airbyte_agent_sdk.connectors.ashby.types.CandidatesLikeCondition | airbyte_agent_sdk.connectors.ashby.types.CandidatesFuzzyCondition | airbyte_agent_sdk.connectors.ashby.types.CandidatesKeywordCondition | airbyte_agent_sdk.connectors.ashby.types.CandidatesContainsCondition | airbyte_agent_sdk.connectors.ashby.types.CandidatesNotCondition | airbyte_agent_sdk.connectors.ashby.types.CandidatesAndCondition | airbyte_agent_sdk.connectors.ashby.types.CandidatesOrCondition | airbyte_agent_sdk.connectors.ashby.types.CandidatesAnyCondition]`
     :   The type of the None singleton.
 
+<a id="CandidatesSearchFilter"></a>
+
 `CandidatesSearchFilter(*args, **kwargs)`
 :   Available fields for filtering candidates search queries.
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="CandidatesSearchQuery"></a>
 
 `CandidatesSearchQuery(*args, **kwargs)`
 :   Search query for candidates entity.
@@ -641,6 +735,8 @@ Classes
     `sort: list[airbyte_agent_sdk.connectors.ashby.types.CandidatesSortFilter]`
     :   The type of the None singleton.
 
+<a id="CandidatesSortFilter"></a>
+
 `CandidatesSortFilter(*args, **kwargs)`
 :   Available fields for sorting candidates search results.
 
@@ -648,12 +744,16 @@ Classes
 
     * builtins.dict
 
+<a id="CandidatesStringFilter"></a>
+
 `CandidatesStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="CustomFieldsListParams"></a>
 
 `CustomFieldsListParams(*args, **kwargs)`
 :   Parameters for custom_fields.list operation
@@ -670,6 +770,8 @@ Classes
     `limit: int`
     :   The type of the None singleton.
 
+<a id="DepartmentsGetParams"></a>
+
 `DepartmentsGetParams(*args, **kwargs)`
 :   Parameters for departments.get operation
 
@@ -681,6 +783,8 @@ Classes
 
     `department_id: str`
     :   The type of the None singleton.
+
+<a id="DepartmentsListParams"></a>
 
 `DepartmentsListParams(*args, **kwargs)`
 :   Parameters for departments.list operation
@@ -697,6 +801,8 @@ Classes
     `limit: int`
     :   The type of the None singleton.
 
+<a id="FeedbackFormDefinitionsListParams"></a>
+
 `FeedbackFormDefinitionsListParams(*args, **kwargs)`
 :   Parameters for feedback_form_definitions.list operation
 
@@ -711,6 +817,8 @@ Classes
 
     `limit: int`
     :   The type of the None singleton.
+
+<a id="JobPostingsAndCondition"></a>
 
 `JobPostingsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -732,6 +840,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.ashby.types.JobPostingsEqCondition | airbyte_agent_sdk.connectors.ashby.types.JobPostingsNeqCondition | airbyte_agent_sdk.connectors.ashby.types.JobPostingsGtCondition | airbyte_agent_sdk.connectors.ashby.types.JobPostingsGteCondition | airbyte_agent_sdk.connectors.ashby.types.JobPostingsLtCondition | airbyte_agent_sdk.connectors.ashby.types.JobPostingsLteCondition | airbyte_agent_sdk.connectors.ashby.types.JobPostingsInCondition | airbyte_agent_sdk.connectors.ashby.types.JobPostingsLikeCondition | airbyte_agent_sdk.connectors.ashby.types.JobPostingsFuzzyCondition | airbyte_agent_sdk.connectors.ashby.types.JobPostingsKeywordCondition | airbyte_agent_sdk.connectors.ashby.types.JobPostingsContainsCondition | airbyte_agent_sdk.connectors.ashby.types.JobPostingsNotCondition | airbyte_agent_sdk.connectors.ashby.types.JobPostingsAndCondition | airbyte_agent_sdk.connectors.ashby.types.JobPostingsOrCondition | airbyte_agent_sdk.connectors.ashby.types.JobPostingsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="JobPostingsAnyCondition"></a>
+
 `JobPostingsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -752,12 +862,16 @@ Classes
     `any: airbyte_agent_sdk.connectors.ashby.types.JobPostingsAnyValueFilter`
     :   The type of the None singleton.
 
+<a id="JobPostingsAnyValueFilter"></a>
+
 `JobPostingsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="JobPostingsContainsCondition"></a>
 
 `JobPostingsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
@@ -771,6 +885,8 @@ Classes
     `contains: airbyte_agent_sdk.connectors.ashby.types.JobPostingsAnyValueFilter`
     :   The type of the None singleton.
 
+<a id="JobPostingsEqCondition"></a>
+
 `JobPostingsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
 
@@ -782,6 +898,8 @@ Classes
 
     `eq: airbyte_agent_sdk.connectors.ashby.types.JobPostingsSearchFilter`
     :   The type of the None singleton.
+
+<a id="JobPostingsFuzzyCondition"></a>
 
 `JobPostingsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
@@ -795,6 +913,8 @@ Classes
     `fuzzy: airbyte_agent_sdk.connectors.ashby.types.JobPostingsStringFilter`
     :   The type of the None singleton.
 
+<a id="JobPostingsGetParams"></a>
+
 `JobPostingsGetParams(*args, **kwargs)`
 :   Parameters for job_postings.get operation
 
@@ -806,6 +926,8 @@ Classes
 
     `job_posting_id: str`
     :   The type of the None singleton.
+
+<a id="JobPostingsGtCondition"></a>
 
 `JobPostingsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
@@ -819,6 +941,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.ashby.types.JobPostingsSearchFilter`
     :   The type of the None singleton.
 
+<a id="JobPostingsGteCondition"></a>
+
 `JobPostingsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -830,6 +954,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.ashby.types.JobPostingsSearchFilter`
     :   The type of the None singleton.
+
+<a id="JobPostingsInCondition"></a>
 
 `JobPostingsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -851,12 +977,16 @@ Classes
     `in: airbyte_agent_sdk.connectors.ashby.types.JobPostingsInFilter`
     :   The type of the None singleton.
 
+<a id="JobPostingsInFilter"></a>
+
 `JobPostingsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="JobPostingsKeywordCondition"></a>
 
 `JobPostingsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
@@ -870,6 +1000,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.ashby.types.JobPostingsStringFilter`
     :   The type of the None singleton.
 
+<a id="JobPostingsLikeCondition"></a>
+
 `JobPostingsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -881,6 +1013,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.ashby.types.JobPostingsStringFilter`
     :   The type of the None singleton.
+
+<a id="JobPostingsListParams"></a>
 
 `JobPostingsListParams(*args, **kwargs)`
 :   Parameters for job_postings.list operation
@@ -897,6 +1031,8 @@ Classes
     `limit: int`
     :   The type of the None singleton.
 
+<a id="JobPostingsLtCondition"></a>
+
 `JobPostingsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -908,6 +1044,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.ashby.types.JobPostingsSearchFilter`
     :   The type of the None singleton.
+
+<a id="JobPostingsLteCondition"></a>
 
 `JobPostingsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -921,6 +1059,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.ashby.types.JobPostingsSearchFilter`
     :   The type of the None singleton.
 
+<a id="JobPostingsNeqCondition"></a>
+
 `JobPostingsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -932,6 +1072,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.ashby.types.JobPostingsSearchFilter`
     :   The type of the None singleton.
+
+<a id="JobPostingsNotCondition"></a>
 
 `JobPostingsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -953,6 +1095,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.ashby.types.JobPostingsEqCondition | airbyte_agent_sdk.connectors.ashby.types.JobPostingsNeqCondition | airbyte_agent_sdk.connectors.ashby.types.JobPostingsGtCondition | airbyte_agent_sdk.connectors.ashby.types.JobPostingsGteCondition | airbyte_agent_sdk.connectors.ashby.types.JobPostingsLtCondition | airbyte_agent_sdk.connectors.ashby.types.JobPostingsLteCondition | airbyte_agent_sdk.connectors.ashby.types.JobPostingsInCondition | airbyte_agent_sdk.connectors.ashby.types.JobPostingsLikeCondition | airbyte_agent_sdk.connectors.ashby.types.JobPostingsFuzzyCondition | airbyte_agent_sdk.connectors.ashby.types.JobPostingsKeywordCondition | airbyte_agent_sdk.connectors.ashby.types.JobPostingsContainsCondition | airbyte_agent_sdk.connectors.ashby.types.JobPostingsNotCondition | airbyte_agent_sdk.connectors.ashby.types.JobPostingsAndCondition | airbyte_agent_sdk.connectors.ashby.types.JobPostingsOrCondition | airbyte_agent_sdk.connectors.ashby.types.JobPostingsAnyCondition`
     :   The type of the None singleton.
 
+<a id="JobPostingsOrCondition"></a>
+
 `JobPostingsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -973,12 +1117,16 @@ Classes
     `or: list[airbyte_agent_sdk.connectors.ashby.types.JobPostingsEqCondition | airbyte_agent_sdk.connectors.ashby.types.JobPostingsNeqCondition | airbyte_agent_sdk.connectors.ashby.types.JobPostingsGtCondition | airbyte_agent_sdk.connectors.ashby.types.JobPostingsGteCondition | airbyte_agent_sdk.connectors.ashby.types.JobPostingsLtCondition | airbyte_agent_sdk.connectors.ashby.types.JobPostingsLteCondition | airbyte_agent_sdk.connectors.ashby.types.JobPostingsInCondition | airbyte_agent_sdk.connectors.ashby.types.JobPostingsLikeCondition | airbyte_agent_sdk.connectors.ashby.types.JobPostingsFuzzyCondition | airbyte_agent_sdk.connectors.ashby.types.JobPostingsKeywordCondition | airbyte_agent_sdk.connectors.ashby.types.JobPostingsContainsCondition | airbyte_agent_sdk.connectors.ashby.types.JobPostingsNotCondition | airbyte_agent_sdk.connectors.ashby.types.JobPostingsAndCondition | airbyte_agent_sdk.connectors.ashby.types.JobPostingsOrCondition | airbyte_agent_sdk.connectors.ashby.types.JobPostingsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="JobPostingsSearchFilter"></a>
+
 `JobPostingsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering job_postings search queries.
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="JobPostingsSearchQuery"></a>
 
 `JobPostingsSearchQuery(*args, **kwargs)`
 :   Search query for job_postings entity.
@@ -995,6 +1143,8 @@ Classes
     `sort: list[airbyte_agent_sdk.connectors.ashby.types.JobPostingsSortFilter]`
     :   The type of the None singleton.
 
+<a id="JobPostingsSortFilter"></a>
+
 `JobPostingsSortFilter(*args, **kwargs)`
 :   Available fields for sorting job_postings search results.
 
@@ -1002,12 +1152,16 @@ Classes
 
     * builtins.dict
 
+<a id="JobPostingsStringFilter"></a>
+
 `JobPostingsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="JobsAndCondition"></a>
 
 `JobsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -1029,6 +1183,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.ashby.types.JobsEqCondition | airbyte_agent_sdk.connectors.ashby.types.JobsNeqCondition | airbyte_agent_sdk.connectors.ashby.types.JobsGtCondition | airbyte_agent_sdk.connectors.ashby.types.JobsGteCondition | airbyte_agent_sdk.connectors.ashby.types.JobsLtCondition | airbyte_agent_sdk.connectors.ashby.types.JobsLteCondition | airbyte_agent_sdk.connectors.ashby.types.JobsInCondition | airbyte_agent_sdk.connectors.ashby.types.JobsLikeCondition | airbyte_agent_sdk.connectors.ashby.types.JobsFuzzyCondition | airbyte_agent_sdk.connectors.ashby.types.JobsKeywordCondition | airbyte_agent_sdk.connectors.ashby.types.JobsContainsCondition | airbyte_agent_sdk.connectors.ashby.types.JobsNotCondition | airbyte_agent_sdk.connectors.ashby.types.JobsAndCondition | airbyte_agent_sdk.connectors.ashby.types.JobsOrCondition | airbyte_agent_sdk.connectors.ashby.types.JobsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="JobsAnyCondition"></a>
+
 `JobsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1049,12 +1205,16 @@ Classes
     `any: airbyte_agent_sdk.connectors.ashby.types.JobsAnyValueFilter`
     :   The type of the None singleton.
 
+<a id="JobsAnyValueFilter"></a>
+
 `JobsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="JobsContainsCondition"></a>
 
 `JobsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
@@ -1068,6 +1228,8 @@ Classes
     `contains: airbyte_agent_sdk.connectors.ashby.types.JobsAnyValueFilter`
     :   The type of the None singleton.
 
+<a id="JobsEqCondition"></a>
+
 `JobsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
 
@@ -1079,6 +1241,8 @@ Classes
 
     `eq: airbyte_agent_sdk.connectors.ashby.types.JobsSearchFilter`
     :   The type of the None singleton.
+
+<a id="JobsFuzzyCondition"></a>
 
 `JobsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
@@ -1092,6 +1256,8 @@ Classes
     `fuzzy: airbyte_agent_sdk.connectors.ashby.types.JobsStringFilter`
     :   The type of the None singleton.
 
+<a id="JobsGetParams"></a>
+
 `JobsGetParams(*args, **kwargs)`
 :   Parameters for jobs.get operation
 
@@ -1103,6 +1269,8 @@ Classes
 
     `id: str`
     :   The type of the None singleton.
+
+<a id="JobsGtCondition"></a>
 
 `JobsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
@@ -1116,6 +1284,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.ashby.types.JobsSearchFilter`
     :   The type of the None singleton.
 
+<a id="JobsGteCondition"></a>
+
 `JobsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -1127,6 +1297,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.ashby.types.JobsSearchFilter`
     :   The type of the None singleton.
+
+<a id="JobsInCondition"></a>
 
 `JobsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -1148,12 +1320,16 @@ Classes
     `in: airbyte_agent_sdk.connectors.ashby.types.JobsInFilter`
     :   The type of the None singleton.
 
+<a id="JobsInFilter"></a>
+
 `JobsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="JobsKeywordCondition"></a>
 
 `JobsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
@@ -1167,6 +1343,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.ashby.types.JobsStringFilter`
     :   The type of the None singleton.
 
+<a id="JobsLikeCondition"></a>
+
 `JobsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -1178,6 +1356,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.ashby.types.JobsStringFilter`
     :   The type of the None singleton.
+
+<a id="JobsListParams"></a>
 
 `JobsListParams(*args, **kwargs)`
 :   Parameters for jobs.list operation
@@ -1194,6 +1374,8 @@ Classes
     `limit: int`
     :   The type of the None singleton.
 
+<a id="JobsLtCondition"></a>
+
 `JobsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -1205,6 +1387,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.ashby.types.JobsSearchFilter`
     :   The type of the None singleton.
+
+<a id="JobsLteCondition"></a>
 
 `JobsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -1218,6 +1402,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.ashby.types.JobsSearchFilter`
     :   The type of the None singleton.
 
+<a id="JobsNeqCondition"></a>
+
 `JobsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -1229,6 +1415,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.ashby.types.JobsSearchFilter`
     :   The type of the None singleton.
+
+<a id="JobsNotCondition"></a>
 
 `JobsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -1250,6 +1438,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.ashby.types.JobsEqCondition | airbyte_agent_sdk.connectors.ashby.types.JobsNeqCondition | airbyte_agent_sdk.connectors.ashby.types.JobsGtCondition | airbyte_agent_sdk.connectors.ashby.types.JobsGteCondition | airbyte_agent_sdk.connectors.ashby.types.JobsLtCondition | airbyte_agent_sdk.connectors.ashby.types.JobsLteCondition | airbyte_agent_sdk.connectors.ashby.types.JobsInCondition | airbyte_agent_sdk.connectors.ashby.types.JobsLikeCondition | airbyte_agent_sdk.connectors.ashby.types.JobsFuzzyCondition | airbyte_agent_sdk.connectors.ashby.types.JobsKeywordCondition | airbyte_agent_sdk.connectors.ashby.types.JobsContainsCondition | airbyte_agent_sdk.connectors.ashby.types.JobsNotCondition | airbyte_agent_sdk.connectors.ashby.types.JobsAndCondition | airbyte_agent_sdk.connectors.ashby.types.JobsOrCondition | airbyte_agent_sdk.connectors.ashby.types.JobsAnyCondition`
     :   The type of the None singleton.
 
+<a id="JobsOrCondition"></a>
+
 `JobsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1270,12 +1460,16 @@ Classes
     `or: list[airbyte_agent_sdk.connectors.ashby.types.JobsEqCondition | airbyte_agent_sdk.connectors.ashby.types.JobsNeqCondition | airbyte_agent_sdk.connectors.ashby.types.JobsGtCondition | airbyte_agent_sdk.connectors.ashby.types.JobsGteCondition | airbyte_agent_sdk.connectors.ashby.types.JobsLtCondition | airbyte_agent_sdk.connectors.ashby.types.JobsLteCondition | airbyte_agent_sdk.connectors.ashby.types.JobsInCondition | airbyte_agent_sdk.connectors.ashby.types.JobsLikeCondition | airbyte_agent_sdk.connectors.ashby.types.JobsFuzzyCondition | airbyte_agent_sdk.connectors.ashby.types.JobsKeywordCondition | airbyte_agent_sdk.connectors.ashby.types.JobsContainsCondition | airbyte_agent_sdk.connectors.ashby.types.JobsNotCondition | airbyte_agent_sdk.connectors.ashby.types.JobsAndCondition | airbyte_agent_sdk.connectors.ashby.types.JobsOrCondition | airbyte_agent_sdk.connectors.ashby.types.JobsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="JobsSearchFilter"></a>
+
 `JobsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering jobs search queries.
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="JobsSearchQuery"></a>
 
 `JobsSearchQuery(*args, **kwargs)`
 :   Search query for jobs entity.
@@ -1292,6 +1486,8 @@ Classes
     `sort: list[airbyte_agent_sdk.connectors.ashby.types.JobsSortFilter]`
     :   The type of the None singleton.
 
+<a id="JobsSortFilter"></a>
+
 `JobsSortFilter(*args, **kwargs)`
 :   Available fields for sorting jobs search results.
 
@@ -1299,12 +1495,16 @@ Classes
 
     * builtins.dict
 
+<a id="JobsStringFilter"></a>
+
 `JobsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="LocationsGetParams"></a>
 
 `LocationsGetParams(*args, **kwargs)`
 :   Parameters for locations.get operation
@@ -1317,6 +1517,8 @@ Classes
 
     `location_id: str`
     :   The type of the None singleton.
+
+<a id="LocationsListParams"></a>
 
 `LocationsListParams(*args, **kwargs)`
 :   Parameters for locations.list operation
@@ -1333,6 +1535,8 @@ Classes
     `limit: int`
     :   The type of the None singleton.
 
+<a id="SourcesListParams"></a>
+
 `SourcesListParams(*args, **kwargs)`
 :   Parameters for sources.list operation
 
@@ -1347,6 +1551,8 @@ Classes
 
     `limit: int`
     :   The type of the None singleton.
+
+<a id="UsersAndCondition"></a>
 
 `UsersAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -1368,6 +1574,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.ashby.types.UsersEqCondition | airbyte_agent_sdk.connectors.ashby.types.UsersNeqCondition | airbyte_agent_sdk.connectors.ashby.types.UsersGtCondition | airbyte_agent_sdk.connectors.ashby.types.UsersGteCondition | airbyte_agent_sdk.connectors.ashby.types.UsersLtCondition | airbyte_agent_sdk.connectors.ashby.types.UsersLteCondition | airbyte_agent_sdk.connectors.ashby.types.UsersInCondition | airbyte_agent_sdk.connectors.ashby.types.UsersLikeCondition | airbyte_agent_sdk.connectors.ashby.types.UsersFuzzyCondition | airbyte_agent_sdk.connectors.ashby.types.UsersKeywordCondition | airbyte_agent_sdk.connectors.ashby.types.UsersContainsCondition | airbyte_agent_sdk.connectors.ashby.types.UsersNotCondition | airbyte_agent_sdk.connectors.ashby.types.UsersAndCondition | airbyte_agent_sdk.connectors.ashby.types.UsersOrCondition | airbyte_agent_sdk.connectors.ashby.types.UsersAnyCondition]`
     :   The type of the None singleton.
 
+<a id="UsersAnyCondition"></a>
+
 `UsersAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1388,12 +1596,16 @@ Classes
     `any: airbyte_agent_sdk.connectors.ashby.types.UsersAnyValueFilter`
     :   The type of the None singleton.
 
+<a id="UsersAnyValueFilter"></a>
+
 `UsersAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="UsersContainsCondition"></a>
 
 `UsersContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
@@ -1407,6 +1619,8 @@ Classes
     `contains: airbyte_agent_sdk.connectors.ashby.types.UsersAnyValueFilter`
     :   The type of the None singleton.
 
+<a id="UsersEqCondition"></a>
+
 `UsersEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
 
@@ -1418,6 +1632,8 @@ Classes
 
     `eq: airbyte_agent_sdk.connectors.ashby.types.UsersSearchFilter`
     :   The type of the None singleton.
+
+<a id="UsersFuzzyCondition"></a>
 
 `UsersFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
@@ -1431,6 +1647,8 @@ Classes
     `fuzzy: airbyte_agent_sdk.connectors.ashby.types.UsersStringFilter`
     :   The type of the None singleton.
 
+<a id="UsersGetParams"></a>
+
 `UsersGetParams(*args, **kwargs)`
 :   Parameters for users.get operation
 
@@ -1442,6 +1660,8 @@ Classes
 
     `user_id: str`
     :   The type of the None singleton.
+
+<a id="UsersGtCondition"></a>
 
 `UsersGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
@@ -1455,6 +1675,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.ashby.types.UsersSearchFilter`
     :   The type of the None singleton.
 
+<a id="UsersGteCondition"></a>
+
 `UsersGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -1466,6 +1688,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.ashby.types.UsersSearchFilter`
     :   The type of the None singleton.
+
+<a id="UsersInCondition"></a>
 
 `UsersInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -1487,12 +1711,16 @@ Classes
     `in: airbyte_agent_sdk.connectors.ashby.types.UsersInFilter`
     :   The type of the None singleton.
 
+<a id="UsersInFilter"></a>
+
 `UsersInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="UsersKeywordCondition"></a>
 
 `UsersKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
@@ -1506,6 +1734,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.ashby.types.UsersStringFilter`
     :   The type of the None singleton.
 
+<a id="UsersLikeCondition"></a>
+
 `UsersLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -1517,6 +1747,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.ashby.types.UsersStringFilter`
     :   The type of the None singleton.
+
+<a id="UsersListParams"></a>
 
 `UsersListParams(*args, **kwargs)`
 :   Parameters for users.list operation
@@ -1533,6 +1765,8 @@ Classes
     `limit: int`
     :   The type of the None singleton.
 
+<a id="UsersLtCondition"></a>
+
 `UsersLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -1544,6 +1778,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.ashby.types.UsersSearchFilter`
     :   The type of the None singleton.
+
+<a id="UsersLteCondition"></a>
 
 `UsersLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -1557,6 +1793,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.ashby.types.UsersSearchFilter`
     :   The type of the None singleton.
 
+<a id="UsersNeqCondition"></a>
+
 `UsersNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -1568,6 +1806,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.ashby.types.UsersSearchFilter`
     :   The type of the None singleton.
+
+<a id="UsersNotCondition"></a>
 
 `UsersNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -1589,6 +1829,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.ashby.types.UsersEqCondition | airbyte_agent_sdk.connectors.ashby.types.UsersNeqCondition | airbyte_agent_sdk.connectors.ashby.types.UsersGtCondition | airbyte_agent_sdk.connectors.ashby.types.UsersGteCondition | airbyte_agent_sdk.connectors.ashby.types.UsersLtCondition | airbyte_agent_sdk.connectors.ashby.types.UsersLteCondition | airbyte_agent_sdk.connectors.ashby.types.UsersInCondition | airbyte_agent_sdk.connectors.ashby.types.UsersLikeCondition | airbyte_agent_sdk.connectors.ashby.types.UsersFuzzyCondition | airbyte_agent_sdk.connectors.ashby.types.UsersKeywordCondition | airbyte_agent_sdk.connectors.ashby.types.UsersContainsCondition | airbyte_agent_sdk.connectors.ashby.types.UsersNotCondition | airbyte_agent_sdk.connectors.ashby.types.UsersAndCondition | airbyte_agent_sdk.connectors.ashby.types.UsersOrCondition | airbyte_agent_sdk.connectors.ashby.types.UsersAnyCondition`
     :   The type of the None singleton.
 
+<a id="UsersOrCondition"></a>
+
 `UsersOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1609,12 +1851,16 @@ Classes
     `or: list[airbyte_agent_sdk.connectors.ashby.types.UsersEqCondition | airbyte_agent_sdk.connectors.ashby.types.UsersNeqCondition | airbyte_agent_sdk.connectors.ashby.types.UsersGtCondition | airbyte_agent_sdk.connectors.ashby.types.UsersGteCondition | airbyte_agent_sdk.connectors.ashby.types.UsersLtCondition | airbyte_agent_sdk.connectors.ashby.types.UsersLteCondition | airbyte_agent_sdk.connectors.ashby.types.UsersInCondition | airbyte_agent_sdk.connectors.ashby.types.UsersLikeCondition | airbyte_agent_sdk.connectors.ashby.types.UsersFuzzyCondition | airbyte_agent_sdk.connectors.ashby.types.UsersKeywordCondition | airbyte_agent_sdk.connectors.ashby.types.UsersContainsCondition | airbyte_agent_sdk.connectors.ashby.types.UsersNotCondition | airbyte_agent_sdk.connectors.ashby.types.UsersAndCondition | airbyte_agent_sdk.connectors.ashby.types.UsersOrCondition | airbyte_agent_sdk.connectors.ashby.types.UsersAnyCondition]`
     :   The type of the None singleton.
 
+<a id="UsersSearchFilter"></a>
+
 `UsersSearchFilter(*args, **kwargs)`
 :   Available fields for filtering users search queries.
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="UsersSearchQuery"></a>
 
 `UsersSearchQuery(*args, **kwargs)`
 :   Search query for users entity.
@@ -1631,12 +1877,16 @@ Classes
     `sort: list[airbyte_agent_sdk.connectors.ashby.types.UsersSortFilter]`
     :   The type of the None singleton.
 
+<a id="UsersSortFilter"></a>
+
 `UsersSortFilter(*args, **kwargs)`
 :   Available fields for sorting users search results.
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="UsersStringFilter"></a>
 
 `UsersStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/chargebee/connector.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/chargebee/connector.md
@@ -10,6 +10,8 @@ Chargebee connector.
 Classes
 -------
 
+<a id="ChargebeeConnector"></a>
+
 `ChargebeeConnector(auth_config: ChargebeeAuthConfig | AirbyteAuthConfig | BaseModel | None = None, on_token_refresh: Any | None = None, site: str | None = None)`
 :   Type-safe Chargebee API connector.
     
@@ -210,6 +212,8 @@ Classes
             for entity in entities:
                 print(f"\{entity['entity_name']\}: \{entity['available_actions']\}")
 
+<a id="CouponQuery"></a>
+
 `CouponQuery(connector: ChargebeeConnector)`
 :   Query class for Coupon entity operations.
     
@@ -287,6 +291,8 @@ Classes
         
         Returns:
             CouponListResult
+
+<a id="CreditNoteQuery"></a>
 
 `CreditNoteQuery(connector: ChargebeeConnector)`
 :   Query class for CreditNote entity operations.
@@ -386,6 +392,8 @@ Classes
         
         Returns:
             CreditNoteListResult
+
+<a id="CustomerQuery"></a>
 
 `CustomerQuery(connector: ChargebeeConnector)`
 :   Query class for Customer entity operations.
@@ -500,6 +508,8 @@ Classes
         Returns:
             CustomerListResult
 
+<a id="EventQuery"></a>
+
 `EventQuery(connector: ChargebeeConnector)`
 :   Query class for Event entity operations.
     
@@ -560,6 +570,8 @@ Classes
         
         Returns:
             EventListResult
+
+<a id="InvoiceQuery"></a>
 
 `InvoiceQuery(connector: ChargebeeConnector)`
 :   Query class for Invoice entity operations.
@@ -680,6 +692,8 @@ Classes
         Returns:
             InvoiceListResult
 
+<a id="ItemPriceQuery"></a>
+
 `ItemPriceQuery(connector: ChargebeeConnector)`
 :   Query class for ItemPrice entity operations.
     
@@ -767,6 +781,8 @@ Classes
         Returns:
             ItemPriceListResult
 
+<a id="ItemQuery"></a>
+
 `ItemQuery(connector: ChargebeeConnector)`
 :   Query class for Item entity operations.
     
@@ -842,6 +858,8 @@ Classes
         
         Returns:
             ItemListResult
+
+<a id="OrderQuery"></a>
 
 `OrderQuery(connector: ChargebeeConnector)`
 :   Query class for Order entity operations.
@@ -953,6 +971,8 @@ Classes
         Returns:
             OrderListResult
 
+<a id="PaymentSourceQuery"></a>
+
 `PaymentSourceQuery(connector: ChargebeeConnector)`
 :   Query class for PaymentSource entity operations.
     
@@ -1024,6 +1044,8 @@ Classes
         
         Returns:
             PaymentSourceListResult
+
+<a id="SubscriptionQuery"></a>
 
 `SubscriptionQuery(connector: ChargebeeConnector)`
 :   Query class for Subscription entity operations.
@@ -1150,6 +1172,8 @@ Classes
         
         Returns:
             SubscriptionListResult
+
+<a id="TransactionQuery"></a>
 
 `TransactionQuery(connector: ChargebeeConnector)`
 :   Query class for Transaction entity operations.

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/chargebee/index.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/chargebee/index.md
@@ -19,6 +19,8 @@ Sub-modules
 Classes
 -------
 
+<a id="AirbyteAuthConfig"></a>
+
 `AirbyteAuthConfig(**data: Any)`
 :   Authentication configuration for Airbyte hosted mode execution.
     
@@ -87,6 +89,8 @@ Classes
     `workspace_name: str | None`
     :   The type of the None singleton.
 
+<a id="AirbyteSearchMeta"></a>
+
 `AirbyteSearchMeta(**data: Any)`
 :   Pagination metadata for search responses.
     
@@ -114,6 +118,8 @@ Classes
 
     `took_ms: int | None`
     :   Time taken to execute the search in milliseconds.
+
+<a id="AirbyteSearchResult"></a>
 
 `AirbyteSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -155,6 +161,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="CouponSearchResult"></a>
+
 `CouponSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -170,6 +178,8 @@ Classes
     * airbyte_agent_sdk.connectors.chargebee.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="CreditNoteSearchResult"></a>
 
 `CreditNoteSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -187,6 +197,8 @@ Classes
     * pydantic.main.BaseModel
     * typing.Generic
 
+<a id="CustomerSearchResult"></a>
+
 `CustomerSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -202,6 +214,8 @@ Classes
     * airbyte_agent_sdk.connectors.chargebee.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="EventSearchResult"></a>
 
 `EventSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -219,6 +233,8 @@ Classes
     * pydantic.main.BaseModel
     * typing.Generic
 
+<a id="InvoiceSearchResult"></a>
+
 `InvoiceSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -234,6 +250,8 @@ Classes
     * airbyte_agent_sdk.connectors.chargebee.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="ItemPriceSearchResult"></a>
 
 `ItemPriceSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -251,6 +269,8 @@ Classes
     * pydantic.main.BaseModel
     * typing.Generic
 
+<a id="ItemSearchResult"></a>
+
 `ItemSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -266,6 +286,8 @@ Classes
     * airbyte_agent_sdk.connectors.chargebee.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="OrderSearchResult"></a>
 
 `OrderSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -283,6 +305,8 @@ Classes
     * pydantic.main.BaseModel
     * typing.Generic
 
+<a id="PaymentSourceSearchResult"></a>
+
 `PaymentSourceSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -298,6 +322,8 @@ Classes
     * airbyte_agent_sdk.connectors.chargebee.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="SubscriptionSearchResult"></a>
 
 `SubscriptionSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -315,6 +341,8 @@ Classes
     * pydantic.main.BaseModel
     * typing.Generic
 
+<a id="TransactionSearchResult"></a>
+
 `TransactionSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -330,6 +358,8 @@ Classes
     * airbyte_agent_sdk.connectors.chargebee.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="ChargebeeAuthConfig"></a>
 
 `ChargebeeAuthConfig(**data: Any)`
 :   API Key Authentication
@@ -352,6 +382,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="ChargebeeConnector"></a>
 
 `ChargebeeConnector(auth_config: ChargebeeAuthConfig | AirbyteAuthConfig | BaseModel | None = None, on_token_refresh: Any | None = None, site: str | None = None)`
 :   Type-safe Chargebee API connector.
@@ -553,6 +585,8 @@ Classes
             for entity in entities:
                 print(f"\{entity['entity_name']\}: \{entity['available_actions']\}")
 
+<a id="ChargebeeReplicationConfig"></a>
+
 `ChargebeeReplicationConfig(**data: Any)`
 :   Replication Configuration - Settings for data replication from Chargebee.
     
@@ -574,6 +608,8 @@ Classes
 
     `start_date: str`
     :   UTC date and time in the format YYYY-MM-DDTHH:mm:ssZ. Data before this date is excluded.
+
+<a id="CouponSearchData"></a>
 
 `CouponSearchData(**data: Any)`
 :   Search result data for coupon entity.
@@ -677,6 +713,8 @@ Classes
 
     `valid_till: int | None`
     :   Date until which the coupon is valid for use.
+
+<a id="CreditNoteSearchData"></a>
 
 `CreditNoteSearchData(**data: Any)`
 :   Search result data for credit_note entity.
@@ -843,6 +881,8 @@ Classes
 
     `voided_at: int | None`
     :   The date when the credit note was voided.
+
+<a id="CustomerSearchData"></a>
 
 `CustomerSearchData(**data: Any)`
 :   Search result data for customer entity.
@@ -1052,6 +1092,8 @@ Classes
     `vat_number_validated_time: int | None`
     :   Date and time when the VAT number was validated.
 
+<a id="EventSearchData"></a>
+
 `EventSearchData(**data: Any)`
 :   Search result data for event entity.
     
@@ -1103,6 +1145,8 @@ Classes
 
     `webhooks: list[typing.Any] | None`
     :   List of webhooks associated with the event.
+
+<a id="InvoiceSearchData"></a>
 
 `InvoiceSearchData(**data: Any)`
 :   Search result data for invoice entity.
@@ -1330,6 +1374,8 @@ Classes
     `write_off_amount: int | None`
     :   Amount written off
 
+<a id="ItemPriceSearchData"></a>
+
 `ItemPriceSearchData(**data: Any)`
 :   Search result data for item_price entity.
     
@@ -1460,6 +1506,8 @@ Classes
     `updated_at: int | None`
     :   Date and time when the item price was last updated.
 
+<a id="ItemSearchData"></a>
+
 `ItemSearchData(**data: Any)`
 :   Search result data for item entity.
     
@@ -1556,6 +1604,8 @@ Classes
 
     `usage_calculation: str | None`
     :   Calculation method used for item usage
+
+<a id="OrderSearchData"></a>
 
 `OrderSearchData(**data: Any)`
 :   Search result data for order entity.
@@ -1756,6 +1806,8 @@ Classes
     `updated_at: int | None`
     :   Timestamp when the order data was last updated.
 
+<a id="PaymentSourceSearchData"></a>
+
 `PaymentSourceSearchData(**data: Any)`
 :   Search result data for payment_source entity.
     
@@ -1840,6 +1892,8 @@ Classes
 
     `upi: dict[str, typing.Any] | None`
     :   Data related to UPI payment source
+
+<a id="SubscriptionSearchData"></a>
 
 `SubscriptionSearchData(**data: Any)`
 :   Search result data for subscription entity.
@@ -2087,6 +2141,8 @@ Classes
 
     `updated_at: int | None`
     :   The date and time when the subscription was last updated.
+
+<a id="TransactionSearchData"></a>
 
 `TransactionSearchData(**data: Any)`
 :   Search result data for transaction entity.

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/chargebee/models.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/chargebee/models.md
@@ -13,6 +13,8 @@ and response envelope types.
 Classes
 -------
 
+<a id="AirbyteSearchMeta"></a>
+
 `AirbyteSearchMeta(**data: Any)`
 :   Pagination metadata for search responses.
     
@@ -40,6 +42,8 @@ Classes
 
     `took_ms: int | None`
     :   Time taken to execute the search in milliseconds.
+
+<a id="AirbyteSearchResult"></a>
 
 `AirbyteSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -102,6 +106,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="CouponSearchResult"></a>
+
 `CouponSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -138,6 +144,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="CreditNoteSearchResult"></a>
 
 `CreditNoteSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -176,6 +184,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="CustomerSearchResult"></a>
+
 `CustomerSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -212,6 +222,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="EventSearchResult"></a>
 
 `EventSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -250,6 +262,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="InvoiceSearchResult"></a>
+
 `InvoiceSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -286,6 +300,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="ItemPriceSearchResult"></a>
 
 `ItemPriceSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -324,6 +340,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="ItemSearchResult"></a>
+
 `ItemSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -360,6 +378,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="OrderSearchResult"></a>
 
 `OrderSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -398,6 +418,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="PaymentSourceSearchResult"></a>
+
 `PaymentSourceSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -434,6 +456,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="SubscriptionSearchResult"></a>
 
 `SubscriptionSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -472,6 +496,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="TransactionSearchResult"></a>
+
 `TransactionSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -487,6 +513,8 @@ Classes
     * airbyte_agent_sdk.connectors.chargebee.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="ChargebeeAuthConfig"></a>
 
 `ChargebeeAuthConfig(**data: Any)`
 :   API Key Authentication
@@ -509,6 +537,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="ChargebeeCheckResult"></a>
 
 `ChargebeeCheckResult(**data: Any)`
 :   Result of a health check operation.
@@ -543,6 +573,8 @@ Classes
     `status: str`
     :   Health check status: 'healthy' or 'unhealthy'.
 
+<a id="ChargebeeExecuteResult"></a>
+
 `ChargebeeExecuteResult(**data: Any)`
 :   Response envelope with data only.
     
@@ -571,6 +603,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="ChargebeeExecuteResultWithMeta"></a>
 
 `ChargebeeExecuteResultWithMeta(**data: Any)`
 :   Response envelope with data and metadata.
@@ -633,6 +667,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="CouponListResult"></a>
+
 `CouponListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -675,6 +711,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="CreditNoteListResult"></a>
 
 `CreditNoteListResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -719,6 +757,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="CustomerListResult"></a>
+
 `CustomerListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -761,6 +801,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="EventListResult"></a>
 
 `EventListResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -805,6 +847,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="InvoiceListResult"></a>
+
 `InvoiceListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -847,6 +891,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="ItemPriceListResult"></a>
 
 `ItemPriceListResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -891,6 +937,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="ItemListResult"></a>
+
 `ItemListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -933,6 +981,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="OrderListResult"></a>
 
 `OrderListResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -977,6 +1027,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="PaymentSourceListResult"></a>
+
 `PaymentSourceListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -1019,6 +1071,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="SubscriptionListResult"></a>
 
 `SubscriptionListResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -1063,6 +1117,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="TransactionListResult"></a>
+
 `TransactionListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -1081,6 +1137,8 @@ Classes
     * airbyte_agent_sdk.connectors.chargebee.models.ChargebeeExecuteResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="ChargebeeReplicationConfig"></a>
 
 `ChargebeeReplicationConfig(**data: Any)`
 :   Replication Configuration - Settings for data replication from Chargebee.
@@ -1103,6 +1161,8 @@ Classes
 
     `start_date: str`
     :   UTC date and time in the format YYYY-MM-DDTHH:mm:ssZ. Data before this date is excluded.
+
+<a id="Coupon"></a>
 
 `Coupon(**data: Any)`
 :   Chargebee coupon object
@@ -1216,6 +1276,8 @@ Classes
     `valid_till: int | Any`
     :   The type of the None singleton.
 
+<a id="CouponList"></a>
+
 `CouponList(**data: Any)`
 :   Paginated list of coupons
     
@@ -1241,6 +1303,8 @@ Classes
     `next_offset: str | Any`
     :   The type of the None singleton.
 
+<a id="CouponListListItem"></a>
+
 `CouponListListItem(**data: Any)`
 :   Nested schema for CouponList.list_item
     
@@ -1263,6 +1327,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="CouponListResultMeta"></a>
+
 `CouponListResultMeta(**data: Any)`
 :   Metadata for coupon.Action.LIST operation
     
@@ -1284,6 +1350,8 @@ Classes
 
     `next_offset: str | Any`
     :   The type of the None singleton.
+
+<a id="CouponSearchData"></a>
 
 `CouponSearchData(**data: Any)`
 :   Search result data for coupon entity.
@@ -1388,6 +1456,8 @@ Classes
     `valid_till: int | None`
     :   Date until which the coupon is valid for use.
 
+<a id="CouponWrapper"></a>
+
 `CouponWrapper(**data: Any)`
 :   CouponWrapper type definition
     
@@ -1409,6 +1479,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="CreditNote"></a>
 
 `CreditNote(**data: Any)`
 :   Chargebee credit note object
@@ -1564,6 +1636,8 @@ Classes
     `voided_at: int | Any`
     :   The type of the None singleton.
 
+<a id="CreditNoteList"></a>
+
 `CreditNoteList(**data: Any)`
 :   Paginated list of credit notes
     
@@ -1589,6 +1663,8 @@ Classes
     `next_offset: str | Any`
     :   The type of the None singleton.
 
+<a id="CreditNoteListListItem"></a>
+
 `CreditNoteListListItem(**data: Any)`
 :   Nested schema for CreditNoteList.list_item
     
@@ -1611,6 +1687,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="CreditNoteListResultMeta"></a>
+
 `CreditNoteListResultMeta(**data: Any)`
 :   Metadata for credit_note.Action.LIST operation
     
@@ -1632,6 +1710,8 @@ Classes
 
     `next_offset: str | Any`
     :   The type of the None singleton.
+
+<a id="CreditNoteSearchData"></a>
 
 `CreditNoteSearchData(**data: Any)`
 :   Search result data for credit_note entity.
@@ -1799,6 +1879,8 @@ Classes
     `voided_at: int | None`
     :   The date when the credit note was voided.
 
+<a id="CreditNoteWrapper"></a>
+
 `CreditNoteWrapper(**data: Any)`
 :   CreditNoteWrapper type definition
     
@@ -1820,6 +1902,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="Customer"></a>
 
 `Customer(**data: Any)`
 :   Chargebee customer object
@@ -2029,6 +2113,8 @@ Classes
     `vat_number_validated_time: int | Any`
     :   The type of the None singleton.
 
+<a id="CustomerList"></a>
+
 `CustomerList(**data: Any)`
 :   Paginated list of customers
     
@@ -2054,6 +2140,8 @@ Classes
     `next_offset: str | Any`
     :   The type of the None singleton.
 
+<a id="CustomerListListItem"></a>
+
 `CustomerListListItem(**data: Any)`
 :   Nested schema for CustomerList.list_item
     
@@ -2076,6 +2164,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="CustomerListResultMeta"></a>
+
 `CustomerListResultMeta(**data: Any)`
 :   Metadata for customer.Action.LIST operation
     
@@ -2097,6 +2187,8 @@ Classes
 
     `next_offset: str | Any`
     :   The type of the None singleton.
+
+<a id="CustomerSearchData"></a>
 
 `CustomerSearchData(**data: Any)`
 :   Search result data for customer entity.
@@ -2306,6 +2398,8 @@ Classes
     `vat_number_validated_time: int | None`
     :   Date and time when the VAT number was validated.
 
+<a id="CustomerWrapper"></a>
+
 `CustomerWrapper(**data: Any)`
 :   CustomerWrapper type definition
     
@@ -2327,6 +2421,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="Event"></a>
 
 `Event(**data: Any)`
 :   Chargebee event object
@@ -2380,6 +2476,8 @@ Classes
     `webhooks: list[dict[str, typing.Any]] | Any`
     :   The type of the None singleton.
 
+<a id="EventList"></a>
+
 `EventList(**data: Any)`
 :   Paginated list of events
     
@@ -2405,6 +2503,8 @@ Classes
     `next_offset: str | Any`
     :   The type of the None singleton.
 
+<a id="EventListListItem"></a>
+
 `EventListListItem(**data: Any)`
 :   Nested schema for EventList.list_item
     
@@ -2427,6 +2527,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="EventListResultMeta"></a>
+
 `EventListResultMeta(**data: Any)`
 :   Metadata for event.Action.LIST operation
     
@@ -2448,6 +2550,8 @@ Classes
 
     `next_offset: str | Any`
     :   The type of the None singleton.
+
+<a id="EventSearchData"></a>
 
 `EventSearchData(**data: Any)`
 :   Search result data for event entity.
@@ -2501,6 +2605,8 @@ Classes
     `webhooks: list[typing.Any] | None`
     :   List of webhooks associated with the event.
 
+<a id="EventWrapper"></a>
+
 `EventWrapper(**data: Any)`
 :   EventWrapper type definition
     
@@ -2522,6 +2628,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="Invoice"></a>
 
 `Invoice(**data: Any)`
 :   Chargebee invoice object
@@ -2716,6 +2824,8 @@ Classes
     `write_off_amount: int | Any`
     :   The type of the None singleton.
 
+<a id="InvoiceList"></a>
+
 `InvoiceList(**data: Any)`
 :   Paginated list of invoices
     
@@ -2741,6 +2851,8 @@ Classes
     `next_offset: str | Any`
     :   The type of the None singleton.
 
+<a id="InvoiceListListItem"></a>
+
 `InvoiceListListItem(**data: Any)`
 :   Nested schema for InvoiceList.list_item
     
@@ -2763,6 +2875,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="InvoiceListResultMeta"></a>
+
 `InvoiceListResultMeta(**data: Any)`
 :   Metadata for invoice.Action.LIST operation
     
@@ -2784,6 +2898,8 @@ Classes
 
     `next_offset: str | Any`
     :   The type of the None singleton.
+
+<a id="InvoiceSearchData"></a>
 
 `InvoiceSearchData(**data: Any)`
 :   Search result data for invoice entity.
@@ -3011,6 +3127,8 @@ Classes
     `write_off_amount: int | None`
     :   Amount written off
 
+<a id="InvoiceWrapper"></a>
+
 `InvoiceWrapper(**data: Any)`
 :   InvoiceWrapper type definition
     
@@ -3032,6 +3150,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="Item"></a>
 
 `Item(**data: Any)`
 :   Chargebee item object (Product Catalog 2.0)
@@ -3142,6 +3262,8 @@ Classes
     `usage_calculation: str | Any`
     :   The type of the None singleton.
 
+<a id="ItemList"></a>
+
 `ItemList(**data: Any)`
 :   Paginated list of items
     
@@ -3167,6 +3289,8 @@ Classes
     `next_offset: str | Any`
     :   The type of the None singleton.
 
+<a id="ItemListListItem"></a>
+
 `ItemListListItem(**data: Any)`
 :   Nested schema for ItemList.list_item
     
@@ -3189,6 +3313,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="ItemListResultMeta"></a>
+
 `ItemListResultMeta(**data: Any)`
 :   Metadata for item.Action.LIST operation
     
@@ -3210,6 +3336,8 @@ Classes
 
     `next_offset: str | Any`
     :   The type of the None singleton.
+
+<a id="ItemPrice"></a>
 
 `ItemPrice(**data: Any)`
 :   Chargebee item price object (Product Catalog 2.0)
@@ -3347,6 +3475,8 @@ Classes
     `updated_at: int | Any`
     :   The type of the None singleton.
 
+<a id="ItemPriceList"></a>
+
 `ItemPriceList(**data: Any)`
 :   Paginated list of item prices
     
@@ -3372,6 +3502,8 @@ Classes
     `next_offset: str | Any`
     :   The type of the None singleton.
 
+<a id="ItemPriceListListItem"></a>
+
 `ItemPriceListListItem(**data: Any)`
 :   Nested schema for ItemPriceList.list_item
     
@@ -3394,6 +3526,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="ItemPriceListResultMeta"></a>
+
 `ItemPriceListResultMeta(**data: Any)`
 :   Metadata for item_price.Action.LIST operation
     
@@ -3415,6 +3549,8 @@ Classes
 
     `next_offset: str | Any`
     :   The type of the None singleton.
+
+<a id="ItemPriceSearchData"></a>
 
 `ItemPriceSearchData(**data: Any)`
 :   Search result data for item_price entity.
@@ -3546,6 +3682,8 @@ Classes
     `updated_at: int | None`
     :   Date and time when the item price was last updated.
 
+<a id="ItemPriceWrapper"></a>
+
 `ItemPriceWrapper(**data: Any)`
 :   ItemPriceWrapper type definition
     
@@ -3567,6 +3705,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="ItemSearchData"></a>
 
 `ItemSearchData(**data: Any)`
 :   Search result data for item entity.
@@ -3665,6 +3805,8 @@ Classes
     `usage_calculation: str | None`
     :   Calculation method used for item usage
 
+<a id="ItemWrapper"></a>
+
 `ItemWrapper(**data: Any)`
 :   ItemWrapper type definition
     
@@ -3686,6 +3828,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="Order"></a>
 
 `Order(**data: Any)`
 :   Chargebee order object
@@ -3880,6 +4024,8 @@ Classes
     `updated_at: int | Any`
     :   The type of the None singleton.
 
+<a id="OrderList"></a>
+
 `OrderList(**data: Any)`
 :   Paginated list of orders
     
@@ -3905,6 +4051,8 @@ Classes
     `next_offset: str | Any`
     :   The type of the None singleton.
 
+<a id="OrderListListItem"></a>
+
 `OrderListListItem(**data: Any)`
 :   Nested schema for OrderList.list_item
     
@@ -3927,6 +4075,8 @@ Classes
     `order: airbyte_agent_sdk.connectors.chargebee.models.Order | Any`
     :   The type of the None singleton.
 
+<a id="OrderListResultMeta"></a>
+
 `OrderListResultMeta(**data: Any)`
 :   Metadata for order.Action.LIST operation
     
@@ -3948,6 +4098,8 @@ Classes
 
     `next_offset: str | Any`
     :   The type of the None singleton.
+
+<a id="OrderSearchData"></a>
 
 `OrderSearchData(**data: Any)`
 :   Search result data for order entity.
@@ -4148,6 +4300,8 @@ Classes
     `updated_at: int | None`
     :   Timestamp when the order data was last updated.
 
+<a id="OrderWrapper"></a>
+
 `OrderWrapper(**data: Any)`
 :   OrderWrapper type definition
     
@@ -4169,6 +4323,8 @@ Classes
 
     `order: airbyte_agent_sdk.connectors.chargebee.models.Order | Any`
     :   The type of the None singleton.
+
+<a id="PaymentSource"></a>
 
 `PaymentSource(**data: Any)`
 :   Chargebee payment source object
@@ -4255,6 +4411,8 @@ Classes
     `upi: dict[str, typing.Any] | Any`
     :   The type of the None singleton.
 
+<a id="PaymentSourceList"></a>
+
 `PaymentSourceList(**data: Any)`
 :   Paginated list of payment sources
     
@@ -4280,6 +4438,8 @@ Classes
     `next_offset: str | Any`
     :   The type of the None singleton.
 
+<a id="PaymentSourceListListItem"></a>
+
 `PaymentSourceListListItem(**data: Any)`
 :   Nested schema for PaymentSourceList.list_item
     
@@ -4302,6 +4462,8 @@ Classes
     `payment_source: airbyte_agent_sdk.connectors.chargebee.models.PaymentSource | Any`
     :   The type of the None singleton.
 
+<a id="PaymentSourceListResultMeta"></a>
+
 `PaymentSourceListResultMeta(**data: Any)`
 :   Metadata for payment_source.Action.LIST operation
     
@@ -4323,6 +4485,8 @@ Classes
 
     `next_offset: str | Any`
     :   The type of the None singleton.
+
+<a id="PaymentSourceSearchData"></a>
 
 `PaymentSourceSearchData(**data: Any)`
 :   Search result data for payment_source entity.
@@ -4409,6 +4573,8 @@ Classes
     `upi: dict[str, typing.Any] | None`
     :   Data related to UPI payment source
 
+<a id="PaymentSourceWrapper"></a>
+
 `PaymentSourceWrapper(**data: Any)`
 :   PaymentSourceWrapper type definition
     
@@ -4430,6 +4596,8 @@ Classes
 
     `payment_source: airbyte_agent_sdk.connectors.chargebee.models.PaymentSource | Any`
     :   The type of the None singleton.
+
+<a id="Subscription"></a>
 
 `Subscription(**data: Any)`
 :   Chargebee subscription object
@@ -4648,6 +4816,8 @@ Classes
     `updated_at: int | Any`
     :   The type of the None singleton.
 
+<a id="SubscriptionList"></a>
+
 `SubscriptionList(**data: Any)`
 :   Paginated list of subscriptions
     
@@ -4673,6 +4843,8 @@ Classes
     `next_offset: str | Any`
     :   The type of the None singleton.
 
+<a id="SubscriptionListListItem"></a>
+
 `SubscriptionListListItem(**data: Any)`
 :   Nested schema for SubscriptionList.list_item
     
@@ -4695,6 +4867,8 @@ Classes
     `subscription: airbyte_agent_sdk.connectors.chargebee.models.Subscription | Any`
     :   The type of the None singleton.
 
+<a id="SubscriptionListResultMeta"></a>
+
 `SubscriptionListResultMeta(**data: Any)`
 :   Metadata for subscription.Action.LIST operation
     
@@ -4716,6 +4890,8 @@ Classes
 
     `next_offset: str | Any`
     :   The type of the None singleton.
+
+<a id="SubscriptionSearchData"></a>
 
 `SubscriptionSearchData(**data: Any)`
 :   Search result data for subscription entity.
@@ -4964,6 +5140,8 @@ Classes
     `updated_at: int | None`
     :   The date and time when the subscription was last updated.
 
+<a id="SubscriptionWrapper"></a>
+
 `SubscriptionWrapper(**data: Any)`
 :   SubscriptionWrapper type definition
     
@@ -4985,6 +5163,8 @@ Classes
 
     `subscription: airbyte_agent_sdk.connectors.chargebee.models.Subscription | Any`
     :   The type of the None singleton.
+
+<a id="Transaction"></a>
 
 `Transaction(**data: Any)`
 :   Chargebee transaction object
@@ -5146,6 +5326,8 @@ Classes
     `voided_at: int | Any`
     :   The type of the None singleton.
 
+<a id="TransactionList"></a>
+
 `TransactionList(**data: Any)`
 :   Paginated list of transactions
     
@@ -5171,6 +5353,8 @@ Classes
     `next_offset: str | Any`
     :   The type of the None singleton.
 
+<a id="TransactionListListItem"></a>
+
 `TransactionListListItem(**data: Any)`
 :   Nested schema for TransactionList.list_item
     
@@ -5193,6 +5377,8 @@ Classes
     `transaction: airbyte_agent_sdk.connectors.chargebee.models.Transaction | Any`
     :   The type of the None singleton.
 
+<a id="TransactionListResultMeta"></a>
+
 `TransactionListResultMeta(**data: Any)`
 :   Metadata for transaction.Action.LIST operation
     
@@ -5214,6 +5400,8 @@ Classes
 
     `next_offset: str | Any`
     :   The type of the None singleton.
+
+<a id="TransactionSearchData"></a>
 
 `TransactionSearchData(**data: Any)`
 :   Search result data for transaction entity.
@@ -5398,6 +5586,8 @@ Classes
 
     `voided_at: int | None`
     :   Date when the transaction was voided.
+
+<a id="TransactionWrapper"></a>
 
 `TransactionWrapper(**data: Any)`
 :   TransactionWrapper type definition

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/chargebee/types.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/chargebee/types.md
@@ -10,6 +10,8 @@ Type definitions for chargebee connector.
 Classes
 -------
 
+<a id="AirbyteSearchParams"></a>
+
 `AirbyteSearchParams(*args, **kwargs)`
 :   Parameters for Airbyte cache search operations (generic, use entity-specific query types for better type hints).
 
@@ -31,6 +33,8 @@ Classes
     `query: dict[str, typing.Any]`
     :   The type of the None singleton.
 
+<a id="CouponAndCondition"></a>
+
 `CouponAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -51,6 +55,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.chargebee.types.CouponEqCondition | airbyte_agent_sdk.connectors.chargebee.types.CouponNeqCondition | airbyte_agent_sdk.connectors.chargebee.types.CouponGtCondition | airbyte_agent_sdk.connectors.chargebee.types.CouponGteCondition | airbyte_agent_sdk.connectors.chargebee.types.CouponLtCondition | airbyte_agent_sdk.connectors.chargebee.types.CouponLteCondition | airbyte_agent_sdk.connectors.chargebee.types.CouponInCondition | airbyte_agent_sdk.connectors.chargebee.types.CouponLikeCondition | airbyte_agent_sdk.connectors.chargebee.types.CouponFuzzyCondition | airbyte_agent_sdk.connectors.chargebee.types.CouponKeywordCondition | airbyte_agent_sdk.connectors.chargebee.types.CouponContainsCondition | airbyte_agent_sdk.connectors.chargebee.types.CouponNotCondition | airbyte_agent_sdk.connectors.chargebee.types.CouponAndCondition | airbyte_agent_sdk.connectors.chargebee.types.CouponOrCondition | airbyte_agent_sdk.connectors.chargebee.types.CouponAnyCondition]`
     :   The type of the None singleton.
 
+<a id="CouponAnyCondition"></a>
+
 `CouponAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -70,6 +76,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.chargebee.types.CouponAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="CouponAnyValueFilter"></a>
 
 `CouponAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -164,6 +172,8 @@ Classes
     `valid_till: Any`
     :   Date until which the coupon is valid for use.
 
+<a id="CouponContainsCondition"></a>
+
 `CouponContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -175,6 +185,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.chargebee.types.CouponAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="CouponEqCondition"></a>
 
 `CouponEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -188,6 +200,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.chargebee.types.CouponSearchFilter`
     :   The type of the None singleton.
 
+<a id="CouponFuzzyCondition"></a>
+
 `CouponFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -199,6 +213,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.chargebee.types.CouponStringFilter`
     :   The type of the None singleton.
+
+<a id="CouponGetParams"></a>
 
 `CouponGetParams(*args, **kwargs)`
 :   Parameters for coupon.get operation
@@ -212,6 +228,8 @@ Classes
     `id: str`
     :   The type of the None singleton.
 
+<a id="CouponGtCondition"></a>
+
 `CouponGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -224,6 +242,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.chargebee.types.CouponSearchFilter`
     :   The type of the None singleton.
 
+<a id="CouponGteCondition"></a>
+
 `CouponGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -235,6 +255,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.chargebee.types.CouponSearchFilter`
     :   The type of the None singleton.
+
+<a id="CouponInCondition"></a>
 
 `CouponInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -255,6 +277,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.chargebee.types.CouponInFilter`
     :   The type of the None singleton.
+
+<a id="CouponInFilter"></a>
 
 `CouponInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -349,6 +373,8 @@ Classes
     `valid_till: list[int]`
     :   Date until which the coupon is valid for use.
 
+<a id="CouponKeywordCondition"></a>
+
 `CouponKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -361,6 +387,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.chargebee.types.CouponStringFilter`
     :   The type of the None singleton.
 
+<a id="CouponLikeCondition"></a>
+
 `CouponLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -372,6 +400,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.chargebee.types.CouponStringFilter`
     :   The type of the None singleton.
+
+<a id="CouponListParams"></a>
 
 `CouponListParams(*args, **kwargs)`
 :   Parameters for coupon.list operation
@@ -388,6 +418,8 @@ Classes
     `offset: str`
     :   The type of the None singleton.
 
+<a id="CouponLtCondition"></a>
+
 `CouponLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -399,6 +431,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.chargebee.types.CouponSearchFilter`
     :   The type of the None singleton.
+
+<a id="CouponLteCondition"></a>
 
 `CouponLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -412,6 +446,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.chargebee.types.CouponSearchFilter`
     :   The type of the None singleton.
 
+<a id="CouponNeqCondition"></a>
+
 `CouponNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -423,6 +459,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.chargebee.types.CouponSearchFilter`
     :   The type of the None singleton.
+
+<a id="CouponNotCondition"></a>
 
 `CouponNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -444,6 +482,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.chargebee.types.CouponEqCondition | airbyte_agent_sdk.connectors.chargebee.types.CouponNeqCondition | airbyte_agent_sdk.connectors.chargebee.types.CouponGtCondition | airbyte_agent_sdk.connectors.chargebee.types.CouponGteCondition | airbyte_agent_sdk.connectors.chargebee.types.CouponLtCondition | airbyte_agent_sdk.connectors.chargebee.types.CouponLteCondition | airbyte_agent_sdk.connectors.chargebee.types.CouponInCondition | airbyte_agent_sdk.connectors.chargebee.types.CouponLikeCondition | airbyte_agent_sdk.connectors.chargebee.types.CouponFuzzyCondition | airbyte_agent_sdk.connectors.chargebee.types.CouponKeywordCondition | airbyte_agent_sdk.connectors.chargebee.types.CouponContainsCondition | airbyte_agent_sdk.connectors.chargebee.types.CouponNotCondition | airbyte_agent_sdk.connectors.chargebee.types.CouponAndCondition | airbyte_agent_sdk.connectors.chargebee.types.CouponOrCondition | airbyte_agent_sdk.connectors.chargebee.types.CouponAnyCondition`
     :   The type of the None singleton.
 
+<a id="CouponOrCondition"></a>
+
 `CouponOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -463,6 +503,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.chargebee.types.CouponEqCondition | airbyte_agent_sdk.connectors.chargebee.types.CouponNeqCondition | airbyte_agent_sdk.connectors.chargebee.types.CouponGtCondition | airbyte_agent_sdk.connectors.chargebee.types.CouponGteCondition | airbyte_agent_sdk.connectors.chargebee.types.CouponLtCondition | airbyte_agent_sdk.connectors.chargebee.types.CouponLteCondition | airbyte_agent_sdk.connectors.chargebee.types.CouponInCondition | airbyte_agent_sdk.connectors.chargebee.types.CouponLikeCondition | airbyte_agent_sdk.connectors.chargebee.types.CouponFuzzyCondition | airbyte_agent_sdk.connectors.chargebee.types.CouponKeywordCondition | airbyte_agent_sdk.connectors.chargebee.types.CouponContainsCondition | airbyte_agent_sdk.connectors.chargebee.types.CouponNotCondition | airbyte_agent_sdk.connectors.chargebee.types.CouponAndCondition | airbyte_agent_sdk.connectors.chargebee.types.CouponOrCondition | airbyte_agent_sdk.connectors.chargebee.types.CouponAnyCondition]`
     :   The type of the None singleton.
+
+<a id="CouponSearchFilter"></a>
 
 `CouponSearchFilter(*args, **kwargs)`
 :   Available fields for filtering coupon search queries.
@@ -557,6 +599,8 @@ Classes
     `valid_till: int | None`
     :   Date until which the coupon is valid for use.
 
+<a id="CouponSearchQuery"></a>
+
 `CouponSearchQuery(*args, **kwargs)`
 :   Search query for coupon entity.
 
@@ -571,6 +615,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.chargebee.types.CouponSortFilter]`
     :   The type of the None singleton.
+
+<a id="CouponSortFilter"></a>
 
 `CouponSortFilter(*args, **kwargs)`
 :   Available fields for sorting coupon search results.
@@ -665,6 +711,8 @@ Classes
     `valid_till: Literal['asc', 'desc']`
     :   Date until which the coupon is valid for use.
 
+<a id="CouponStringFilter"></a>
+
 `CouponStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -758,6 +806,8 @@ Classes
     `valid_till: str`
     :   Date until which the coupon is valid for use.
 
+<a id="CreditNoteAndCondition"></a>
+
 `CreditNoteAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -778,6 +828,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.chargebee.types.CreditNoteEqCondition | airbyte_agent_sdk.connectors.chargebee.types.CreditNoteNeqCondition | airbyte_agent_sdk.connectors.chargebee.types.CreditNoteGtCondition | airbyte_agent_sdk.connectors.chargebee.types.CreditNoteGteCondition | airbyte_agent_sdk.connectors.chargebee.types.CreditNoteLtCondition | airbyte_agent_sdk.connectors.chargebee.types.CreditNoteLteCondition | airbyte_agent_sdk.connectors.chargebee.types.CreditNoteInCondition | airbyte_agent_sdk.connectors.chargebee.types.CreditNoteLikeCondition | airbyte_agent_sdk.connectors.chargebee.types.CreditNoteFuzzyCondition | airbyte_agent_sdk.connectors.chargebee.types.CreditNoteKeywordCondition | airbyte_agent_sdk.connectors.chargebee.types.CreditNoteContainsCondition | airbyte_agent_sdk.connectors.chargebee.types.CreditNoteNotCondition | airbyte_agent_sdk.connectors.chargebee.types.CreditNoteAndCondition | airbyte_agent_sdk.connectors.chargebee.types.CreditNoteOrCondition | airbyte_agent_sdk.connectors.chargebee.types.CreditNoteAnyCondition]`
     :   The type of the None singleton.
 
+<a id="CreditNoteAnyCondition"></a>
+
 `CreditNoteAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -797,6 +849,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.chargebee.types.CreditNoteAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="CreditNoteAnyValueFilter"></a>
 
 `CreditNoteAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -954,6 +1008,8 @@ Classes
     `voided_at: Any`
     :   The date when the credit note was voided.
 
+<a id="CreditNoteContainsCondition"></a>
+
 `CreditNoteContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -965,6 +1021,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.chargebee.types.CreditNoteAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="CreditNoteEqCondition"></a>
 
 `CreditNoteEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -978,6 +1036,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.chargebee.types.CreditNoteSearchFilter`
     :   The type of the None singleton.
 
+<a id="CreditNoteFuzzyCondition"></a>
+
 `CreditNoteFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -989,6 +1049,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.chargebee.types.CreditNoteStringFilter`
     :   The type of the None singleton.
+
+<a id="CreditNoteGetParams"></a>
 
 `CreditNoteGetParams(*args, **kwargs)`
 :   Parameters for credit_note.get operation
@@ -1002,6 +1064,8 @@ Classes
     `id: str`
     :   The type of the None singleton.
 
+<a id="CreditNoteGtCondition"></a>
+
 `CreditNoteGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -1014,6 +1078,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.chargebee.types.CreditNoteSearchFilter`
     :   The type of the None singleton.
 
+<a id="CreditNoteGteCondition"></a>
+
 `CreditNoteGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -1025,6 +1091,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.chargebee.types.CreditNoteSearchFilter`
     :   The type of the None singleton.
+
+<a id="CreditNoteInCondition"></a>
 
 `CreditNoteInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -1045,6 +1113,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.chargebee.types.CreditNoteInFilter`
     :   The type of the None singleton.
+
+<a id="CreditNoteInFilter"></a>
 
 `CreditNoteInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -1202,6 +1272,8 @@ Classes
     `voided_at: list[int]`
     :   The date when the credit note was voided.
 
+<a id="CreditNoteKeywordCondition"></a>
+
 `CreditNoteKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -1214,6 +1286,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.chargebee.types.CreditNoteStringFilter`
     :   The type of the None singleton.
 
+<a id="CreditNoteLikeCondition"></a>
+
 `CreditNoteLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -1225,6 +1299,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.chargebee.types.CreditNoteStringFilter`
     :   The type of the None singleton.
+
+<a id="CreditNoteListParams"></a>
 
 `CreditNoteListParams(*args, **kwargs)`
 :   Parameters for credit_note.list operation
@@ -1241,6 +1317,8 @@ Classes
     `offset: str`
     :   The type of the None singleton.
 
+<a id="CreditNoteLtCondition"></a>
+
 `CreditNoteLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -1252,6 +1330,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.chargebee.types.CreditNoteSearchFilter`
     :   The type of the None singleton.
+
+<a id="CreditNoteLteCondition"></a>
 
 `CreditNoteLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -1265,6 +1345,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.chargebee.types.CreditNoteSearchFilter`
     :   The type of the None singleton.
 
+<a id="CreditNoteNeqCondition"></a>
+
 `CreditNoteNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -1276,6 +1358,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.chargebee.types.CreditNoteSearchFilter`
     :   The type of the None singleton.
+
+<a id="CreditNoteNotCondition"></a>
 
 `CreditNoteNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -1297,6 +1381,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.chargebee.types.CreditNoteEqCondition | airbyte_agent_sdk.connectors.chargebee.types.CreditNoteNeqCondition | airbyte_agent_sdk.connectors.chargebee.types.CreditNoteGtCondition | airbyte_agent_sdk.connectors.chargebee.types.CreditNoteGteCondition | airbyte_agent_sdk.connectors.chargebee.types.CreditNoteLtCondition | airbyte_agent_sdk.connectors.chargebee.types.CreditNoteLteCondition | airbyte_agent_sdk.connectors.chargebee.types.CreditNoteInCondition | airbyte_agent_sdk.connectors.chargebee.types.CreditNoteLikeCondition | airbyte_agent_sdk.connectors.chargebee.types.CreditNoteFuzzyCondition | airbyte_agent_sdk.connectors.chargebee.types.CreditNoteKeywordCondition | airbyte_agent_sdk.connectors.chargebee.types.CreditNoteContainsCondition | airbyte_agent_sdk.connectors.chargebee.types.CreditNoteNotCondition | airbyte_agent_sdk.connectors.chargebee.types.CreditNoteAndCondition | airbyte_agent_sdk.connectors.chargebee.types.CreditNoteOrCondition | airbyte_agent_sdk.connectors.chargebee.types.CreditNoteAnyCondition`
     :   The type of the None singleton.
 
+<a id="CreditNoteOrCondition"></a>
+
 `CreditNoteOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1316,6 +1402,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.chargebee.types.CreditNoteEqCondition | airbyte_agent_sdk.connectors.chargebee.types.CreditNoteNeqCondition | airbyte_agent_sdk.connectors.chargebee.types.CreditNoteGtCondition | airbyte_agent_sdk.connectors.chargebee.types.CreditNoteGteCondition | airbyte_agent_sdk.connectors.chargebee.types.CreditNoteLtCondition | airbyte_agent_sdk.connectors.chargebee.types.CreditNoteLteCondition | airbyte_agent_sdk.connectors.chargebee.types.CreditNoteInCondition | airbyte_agent_sdk.connectors.chargebee.types.CreditNoteLikeCondition | airbyte_agent_sdk.connectors.chargebee.types.CreditNoteFuzzyCondition | airbyte_agent_sdk.connectors.chargebee.types.CreditNoteKeywordCondition | airbyte_agent_sdk.connectors.chargebee.types.CreditNoteContainsCondition | airbyte_agent_sdk.connectors.chargebee.types.CreditNoteNotCondition | airbyte_agent_sdk.connectors.chargebee.types.CreditNoteAndCondition | airbyte_agent_sdk.connectors.chargebee.types.CreditNoteOrCondition | airbyte_agent_sdk.connectors.chargebee.types.CreditNoteAnyCondition]`
     :   The type of the None singleton.
+
+<a id="CreditNoteSearchFilter"></a>
 
 `CreditNoteSearchFilter(*args, **kwargs)`
 :   Available fields for filtering credit_note search queries.
@@ -1473,6 +1561,8 @@ Classes
     `voided_at: int | None`
     :   The date when the credit note was voided.
 
+<a id="CreditNoteSearchQuery"></a>
+
 `CreditNoteSearchQuery(*args, **kwargs)`
 :   Search query for credit_note entity.
 
@@ -1487,6 +1577,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.chargebee.types.CreditNoteSortFilter]`
     :   The type of the None singleton.
+
+<a id="CreditNoteSortFilter"></a>
 
 `CreditNoteSortFilter(*args, **kwargs)`
 :   Available fields for sorting credit_note search results.
@@ -1644,6 +1736,8 @@ Classes
     `voided_at: Literal['asc', 'desc']`
     :   The date when the credit note was voided.
 
+<a id="CreditNoteStringFilter"></a>
+
 `CreditNoteStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -1800,6 +1894,8 @@ Classes
     `voided_at: str`
     :   The date when the credit note was voided.
 
+<a id="CustomerAndCondition"></a>
+
 `CustomerAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1820,6 +1916,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.chargebee.types.CustomerEqCondition | airbyte_agent_sdk.connectors.chargebee.types.CustomerNeqCondition | airbyte_agent_sdk.connectors.chargebee.types.CustomerGtCondition | airbyte_agent_sdk.connectors.chargebee.types.CustomerGteCondition | airbyte_agent_sdk.connectors.chargebee.types.CustomerLtCondition | airbyte_agent_sdk.connectors.chargebee.types.CustomerLteCondition | airbyte_agent_sdk.connectors.chargebee.types.CustomerInCondition | airbyte_agent_sdk.connectors.chargebee.types.CustomerLikeCondition | airbyte_agent_sdk.connectors.chargebee.types.CustomerFuzzyCondition | airbyte_agent_sdk.connectors.chargebee.types.CustomerKeywordCondition | airbyte_agent_sdk.connectors.chargebee.types.CustomerContainsCondition | airbyte_agent_sdk.connectors.chargebee.types.CustomerNotCondition | airbyte_agent_sdk.connectors.chargebee.types.CustomerAndCondition | airbyte_agent_sdk.connectors.chargebee.types.CustomerOrCondition | airbyte_agent_sdk.connectors.chargebee.types.CustomerAnyCondition]`
     :   The type of the None singleton.
 
+<a id="CustomerAnyCondition"></a>
+
 `CustomerAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1839,6 +1937,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.chargebee.types.CustomerAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="CustomerAnyValueFilter"></a>
 
 `CustomerAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -2038,6 +2138,8 @@ Classes
     `vat_number_validated_time: Any`
     :   Date and time when the VAT number was validated.
 
+<a id="CustomerContainsCondition"></a>
+
 `CustomerContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -2049,6 +2151,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.chargebee.types.CustomerAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="CustomerEqCondition"></a>
 
 `CustomerEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -2062,6 +2166,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.chargebee.types.CustomerSearchFilter`
     :   The type of the None singleton.
 
+<a id="CustomerFuzzyCondition"></a>
+
 `CustomerFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -2073,6 +2179,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.chargebee.types.CustomerStringFilter`
     :   The type of the None singleton.
+
+<a id="CustomerGetParams"></a>
 
 `CustomerGetParams(*args, **kwargs)`
 :   Parameters for customer.get operation
@@ -2086,6 +2194,8 @@ Classes
     `id: str`
     :   The type of the None singleton.
 
+<a id="CustomerGtCondition"></a>
+
 `CustomerGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -2098,6 +2208,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.chargebee.types.CustomerSearchFilter`
     :   The type of the None singleton.
 
+<a id="CustomerGteCondition"></a>
+
 `CustomerGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -2109,6 +2221,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.chargebee.types.CustomerSearchFilter`
     :   The type of the None singleton.
+
+<a id="CustomerInCondition"></a>
 
 `CustomerInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -2129,6 +2243,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.chargebee.types.CustomerInFilter`
     :   The type of the None singleton.
+
+<a id="CustomerInFilter"></a>
 
 `CustomerInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -2328,6 +2444,8 @@ Classes
     `vat_number_validated_time: list[int]`
     :   Date and time when the VAT number was validated.
 
+<a id="CustomerKeywordCondition"></a>
+
 `CustomerKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -2340,6 +2458,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.chargebee.types.CustomerStringFilter`
     :   The type of the None singleton.
 
+<a id="CustomerLikeCondition"></a>
+
 `CustomerLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -2351,6 +2471,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.chargebee.types.CustomerStringFilter`
     :   The type of the None singleton.
+
+<a id="CustomerListParams"></a>
 
 `CustomerListParams(*args, **kwargs)`
 :   Parameters for customer.list operation
@@ -2367,6 +2489,8 @@ Classes
     `offset: str`
     :   The type of the None singleton.
 
+<a id="CustomerLtCondition"></a>
+
 `CustomerLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -2378,6 +2502,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.chargebee.types.CustomerSearchFilter`
     :   The type of the None singleton.
+
+<a id="CustomerLteCondition"></a>
 
 `CustomerLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -2391,6 +2517,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.chargebee.types.CustomerSearchFilter`
     :   The type of the None singleton.
 
+<a id="CustomerNeqCondition"></a>
+
 `CustomerNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -2402,6 +2530,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.chargebee.types.CustomerSearchFilter`
     :   The type of the None singleton.
+
+<a id="CustomerNotCondition"></a>
 
 `CustomerNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -2423,6 +2553,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.chargebee.types.CustomerEqCondition | airbyte_agent_sdk.connectors.chargebee.types.CustomerNeqCondition | airbyte_agent_sdk.connectors.chargebee.types.CustomerGtCondition | airbyte_agent_sdk.connectors.chargebee.types.CustomerGteCondition | airbyte_agent_sdk.connectors.chargebee.types.CustomerLtCondition | airbyte_agent_sdk.connectors.chargebee.types.CustomerLteCondition | airbyte_agent_sdk.connectors.chargebee.types.CustomerInCondition | airbyte_agent_sdk.connectors.chargebee.types.CustomerLikeCondition | airbyte_agent_sdk.connectors.chargebee.types.CustomerFuzzyCondition | airbyte_agent_sdk.connectors.chargebee.types.CustomerKeywordCondition | airbyte_agent_sdk.connectors.chargebee.types.CustomerContainsCondition | airbyte_agent_sdk.connectors.chargebee.types.CustomerNotCondition | airbyte_agent_sdk.connectors.chargebee.types.CustomerAndCondition | airbyte_agent_sdk.connectors.chargebee.types.CustomerOrCondition | airbyte_agent_sdk.connectors.chargebee.types.CustomerAnyCondition`
     :   The type of the None singleton.
 
+<a id="CustomerOrCondition"></a>
+
 `CustomerOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -2442,6 +2574,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.chargebee.types.CustomerEqCondition | airbyte_agent_sdk.connectors.chargebee.types.CustomerNeqCondition | airbyte_agent_sdk.connectors.chargebee.types.CustomerGtCondition | airbyte_agent_sdk.connectors.chargebee.types.CustomerGteCondition | airbyte_agent_sdk.connectors.chargebee.types.CustomerLtCondition | airbyte_agent_sdk.connectors.chargebee.types.CustomerLteCondition | airbyte_agent_sdk.connectors.chargebee.types.CustomerInCondition | airbyte_agent_sdk.connectors.chargebee.types.CustomerLikeCondition | airbyte_agent_sdk.connectors.chargebee.types.CustomerFuzzyCondition | airbyte_agent_sdk.connectors.chargebee.types.CustomerKeywordCondition | airbyte_agent_sdk.connectors.chargebee.types.CustomerContainsCondition | airbyte_agent_sdk.connectors.chargebee.types.CustomerNotCondition | airbyte_agent_sdk.connectors.chargebee.types.CustomerAndCondition | airbyte_agent_sdk.connectors.chargebee.types.CustomerOrCondition | airbyte_agent_sdk.connectors.chargebee.types.CustomerAnyCondition]`
     :   The type of the None singleton.
+
+<a id="CustomerSearchFilter"></a>
 
 `CustomerSearchFilter(*args, **kwargs)`
 :   Available fields for filtering customer search queries.
@@ -2641,6 +2775,8 @@ Classes
     `vat_number_validated_time: int | None`
     :   Date and time when the VAT number was validated.
 
+<a id="CustomerSearchQuery"></a>
+
 `CustomerSearchQuery(*args, **kwargs)`
 :   Search query for customer entity.
 
@@ -2655,6 +2791,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.chargebee.types.CustomerSortFilter]`
     :   The type of the None singleton.
+
+<a id="CustomerSortFilter"></a>
 
 `CustomerSortFilter(*args, **kwargs)`
 :   Available fields for sorting customer search results.
@@ -2854,6 +2992,8 @@ Classes
     `vat_number_validated_time: Literal['asc', 'desc']`
     :   Date and time when the VAT number was validated.
 
+<a id="CustomerStringFilter"></a>
+
 `CustomerStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -3052,6 +3192,8 @@ Classes
     `vat_number_validated_time: str`
     :   Date and time when the VAT number was validated.
 
+<a id="EventAndCondition"></a>
+
 `EventAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -3072,6 +3214,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.chargebee.types.EventEqCondition | airbyte_agent_sdk.connectors.chargebee.types.EventNeqCondition | airbyte_agent_sdk.connectors.chargebee.types.EventGtCondition | airbyte_agent_sdk.connectors.chargebee.types.EventGteCondition | airbyte_agent_sdk.connectors.chargebee.types.EventLtCondition | airbyte_agent_sdk.connectors.chargebee.types.EventLteCondition | airbyte_agent_sdk.connectors.chargebee.types.EventInCondition | airbyte_agent_sdk.connectors.chargebee.types.EventLikeCondition | airbyte_agent_sdk.connectors.chargebee.types.EventFuzzyCondition | airbyte_agent_sdk.connectors.chargebee.types.EventKeywordCondition | airbyte_agent_sdk.connectors.chargebee.types.EventContainsCondition | airbyte_agent_sdk.connectors.chargebee.types.EventNotCondition | airbyte_agent_sdk.connectors.chargebee.types.EventAndCondition | airbyte_agent_sdk.connectors.chargebee.types.EventOrCondition | airbyte_agent_sdk.connectors.chargebee.types.EventAnyCondition]`
     :   The type of the None singleton.
 
+<a id="EventAnyCondition"></a>
+
 `EventAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -3091,6 +3235,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.chargebee.types.EventAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="EventAnyValueFilter"></a>
 
 `EventAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -3134,6 +3280,8 @@ Classes
     `webhooks: Any`
     :   List of webhooks associated with the event.
 
+<a id="EventContainsCondition"></a>
+
 `EventContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -3145,6 +3293,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.chargebee.types.EventAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="EventEqCondition"></a>
 
 `EventEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -3158,6 +3308,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.chargebee.types.EventSearchFilter`
     :   The type of the None singleton.
 
+<a id="EventFuzzyCondition"></a>
+
 `EventFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -3169,6 +3321,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.chargebee.types.EventStringFilter`
     :   The type of the None singleton.
+
+<a id="EventGetParams"></a>
 
 `EventGetParams(*args, **kwargs)`
 :   Parameters for event.get operation
@@ -3182,6 +3336,8 @@ Classes
     `id: str`
     :   The type of the None singleton.
 
+<a id="EventGtCondition"></a>
+
 `EventGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -3194,6 +3350,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.chargebee.types.EventSearchFilter`
     :   The type of the None singleton.
 
+<a id="EventGteCondition"></a>
+
 `EventGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -3205,6 +3363,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.chargebee.types.EventSearchFilter`
     :   The type of the None singleton.
+
+<a id="EventInCondition"></a>
 
 `EventInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -3225,6 +3385,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.chargebee.types.EventInFilter`
     :   The type of the None singleton.
+
+<a id="EventInFilter"></a>
 
 `EventInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -3268,6 +3430,8 @@ Classes
     `webhooks: list[list[typing.Any]]`
     :   List of webhooks associated with the event.
 
+<a id="EventKeywordCondition"></a>
+
 `EventKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -3280,6 +3444,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.chargebee.types.EventStringFilter`
     :   The type of the None singleton.
 
+<a id="EventLikeCondition"></a>
+
 `EventLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -3291,6 +3457,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.chargebee.types.EventStringFilter`
     :   The type of the None singleton.
+
+<a id="EventListParams"></a>
 
 `EventListParams(*args, **kwargs)`
 :   Parameters for event.list operation
@@ -3307,6 +3475,8 @@ Classes
     `offset: str`
     :   The type of the None singleton.
 
+<a id="EventLtCondition"></a>
+
 `EventLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -3318,6 +3488,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.chargebee.types.EventSearchFilter`
     :   The type of the None singleton.
+
+<a id="EventLteCondition"></a>
 
 `EventLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -3331,6 +3503,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.chargebee.types.EventSearchFilter`
     :   The type of the None singleton.
 
+<a id="EventNeqCondition"></a>
+
 `EventNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -3342,6 +3516,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.chargebee.types.EventSearchFilter`
     :   The type of the None singleton.
+
+<a id="EventNotCondition"></a>
 
 `EventNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -3363,6 +3539,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.chargebee.types.EventEqCondition | airbyte_agent_sdk.connectors.chargebee.types.EventNeqCondition | airbyte_agent_sdk.connectors.chargebee.types.EventGtCondition | airbyte_agent_sdk.connectors.chargebee.types.EventGteCondition | airbyte_agent_sdk.connectors.chargebee.types.EventLtCondition | airbyte_agent_sdk.connectors.chargebee.types.EventLteCondition | airbyte_agent_sdk.connectors.chargebee.types.EventInCondition | airbyte_agent_sdk.connectors.chargebee.types.EventLikeCondition | airbyte_agent_sdk.connectors.chargebee.types.EventFuzzyCondition | airbyte_agent_sdk.connectors.chargebee.types.EventKeywordCondition | airbyte_agent_sdk.connectors.chargebee.types.EventContainsCondition | airbyte_agent_sdk.connectors.chargebee.types.EventNotCondition | airbyte_agent_sdk.connectors.chargebee.types.EventAndCondition | airbyte_agent_sdk.connectors.chargebee.types.EventOrCondition | airbyte_agent_sdk.connectors.chargebee.types.EventAnyCondition`
     :   The type of the None singleton.
 
+<a id="EventOrCondition"></a>
+
 `EventOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -3382,6 +3560,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.chargebee.types.EventEqCondition | airbyte_agent_sdk.connectors.chargebee.types.EventNeqCondition | airbyte_agent_sdk.connectors.chargebee.types.EventGtCondition | airbyte_agent_sdk.connectors.chargebee.types.EventGteCondition | airbyte_agent_sdk.connectors.chargebee.types.EventLtCondition | airbyte_agent_sdk.connectors.chargebee.types.EventLteCondition | airbyte_agent_sdk.connectors.chargebee.types.EventInCondition | airbyte_agent_sdk.connectors.chargebee.types.EventLikeCondition | airbyte_agent_sdk.connectors.chargebee.types.EventFuzzyCondition | airbyte_agent_sdk.connectors.chargebee.types.EventKeywordCondition | airbyte_agent_sdk.connectors.chargebee.types.EventContainsCondition | airbyte_agent_sdk.connectors.chargebee.types.EventNotCondition | airbyte_agent_sdk.connectors.chargebee.types.EventAndCondition | airbyte_agent_sdk.connectors.chargebee.types.EventOrCondition | airbyte_agent_sdk.connectors.chargebee.types.EventAnyCondition]`
     :   The type of the None singleton.
+
+<a id="EventSearchFilter"></a>
 
 `EventSearchFilter(*args, **kwargs)`
 :   Available fields for filtering event search queries.
@@ -3425,6 +3605,8 @@ Classes
     `webhooks: list[typing.Any] | None`
     :   List of webhooks associated with the event.
 
+<a id="EventSearchQuery"></a>
+
 `EventSearchQuery(*args, **kwargs)`
 :   Search query for event entity.
 
@@ -3439,6 +3621,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.chargebee.types.EventSortFilter]`
     :   The type of the None singleton.
+
+<a id="EventSortFilter"></a>
 
 `EventSortFilter(*args, **kwargs)`
 :   Available fields for sorting event search results.
@@ -3482,6 +3666,8 @@ Classes
     `webhooks: Literal['asc', 'desc']`
     :   List of webhooks associated with the event.
 
+<a id="EventStringFilter"></a>
+
 `EventStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -3524,6 +3710,8 @@ Classes
     `webhooks: str`
     :   List of webhooks associated with the event.
 
+<a id="InvoiceAndCondition"></a>
+
 `InvoiceAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -3544,6 +3732,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.chargebee.types.InvoiceEqCondition | airbyte_agent_sdk.connectors.chargebee.types.InvoiceNeqCondition | airbyte_agent_sdk.connectors.chargebee.types.InvoiceGtCondition | airbyte_agent_sdk.connectors.chargebee.types.InvoiceGteCondition | airbyte_agent_sdk.connectors.chargebee.types.InvoiceLtCondition | airbyte_agent_sdk.connectors.chargebee.types.InvoiceLteCondition | airbyte_agent_sdk.connectors.chargebee.types.InvoiceInCondition | airbyte_agent_sdk.connectors.chargebee.types.InvoiceLikeCondition | airbyte_agent_sdk.connectors.chargebee.types.InvoiceFuzzyCondition | airbyte_agent_sdk.connectors.chargebee.types.InvoiceKeywordCondition | airbyte_agent_sdk.connectors.chargebee.types.InvoiceContainsCondition | airbyte_agent_sdk.connectors.chargebee.types.InvoiceNotCondition | airbyte_agent_sdk.connectors.chargebee.types.InvoiceAndCondition | airbyte_agent_sdk.connectors.chargebee.types.InvoiceOrCondition | airbyte_agent_sdk.connectors.chargebee.types.InvoiceAnyCondition]`
     :   The type of the None singleton.
 
+<a id="InvoiceAnyCondition"></a>
+
 `InvoiceAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -3563,6 +3753,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.chargebee.types.InvoiceAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="InvoiceAnyValueFilter"></a>
 
 `InvoiceAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -3780,6 +3972,8 @@ Classes
     `write_off_amount: Any`
     :   Amount written off
 
+<a id="InvoiceContainsCondition"></a>
+
 `InvoiceContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -3791,6 +3985,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.chargebee.types.InvoiceAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="InvoiceEqCondition"></a>
 
 `InvoiceEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -3804,6 +4000,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.chargebee.types.InvoiceSearchFilter`
     :   The type of the None singleton.
 
+<a id="InvoiceFuzzyCondition"></a>
+
 `InvoiceFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -3815,6 +4013,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.chargebee.types.InvoiceStringFilter`
     :   The type of the None singleton.
+
+<a id="InvoiceGetParams"></a>
 
 `InvoiceGetParams(*args, **kwargs)`
 :   Parameters for invoice.get operation
@@ -3828,6 +4028,8 @@ Classes
     `id: str`
     :   The type of the None singleton.
 
+<a id="InvoiceGtCondition"></a>
+
 `InvoiceGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -3840,6 +4042,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.chargebee.types.InvoiceSearchFilter`
     :   The type of the None singleton.
 
+<a id="InvoiceGteCondition"></a>
+
 `InvoiceGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -3851,6 +4055,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.chargebee.types.InvoiceSearchFilter`
     :   The type of the None singleton.
+
+<a id="InvoiceInCondition"></a>
 
 `InvoiceInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -3871,6 +4077,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.chargebee.types.InvoiceInFilter`
     :   The type of the None singleton.
+
+<a id="InvoiceInFilter"></a>
 
 `InvoiceInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -4088,6 +4296,8 @@ Classes
     `write_off_amount: list[int]`
     :   Amount written off
 
+<a id="InvoiceKeywordCondition"></a>
+
 `InvoiceKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -4100,6 +4310,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.chargebee.types.InvoiceStringFilter`
     :   The type of the None singleton.
 
+<a id="InvoiceLikeCondition"></a>
+
 `InvoiceLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -4111,6 +4323,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.chargebee.types.InvoiceStringFilter`
     :   The type of the None singleton.
+
+<a id="InvoiceListParams"></a>
 
 `InvoiceListParams(*args, **kwargs)`
 :   Parameters for invoice.list operation
@@ -4127,6 +4341,8 @@ Classes
     `offset: str`
     :   The type of the None singleton.
 
+<a id="InvoiceLtCondition"></a>
+
 `InvoiceLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -4138,6 +4354,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.chargebee.types.InvoiceSearchFilter`
     :   The type of the None singleton.
+
+<a id="InvoiceLteCondition"></a>
 
 `InvoiceLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -4151,6 +4369,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.chargebee.types.InvoiceSearchFilter`
     :   The type of the None singleton.
 
+<a id="InvoiceNeqCondition"></a>
+
 `InvoiceNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -4162,6 +4382,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.chargebee.types.InvoiceSearchFilter`
     :   The type of the None singleton.
+
+<a id="InvoiceNotCondition"></a>
 
 `InvoiceNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -4183,6 +4405,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.chargebee.types.InvoiceEqCondition | airbyte_agent_sdk.connectors.chargebee.types.InvoiceNeqCondition | airbyte_agent_sdk.connectors.chargebee.types.InvoiceGtCondition | airbyte_agent_sdk.connectors.chargebee.types.InvoiceGteCondition | airbyte_agent_sdk.connectors.chargebee.types.InvoiceLtCondition | airbyte_agent_sdk.connectors.chargebee.types.InvoiceLteCondition | airbyte_agent_sdk.connectors.chargebee.types.InvoiceInCondition | airbyte_agent_sdk.connectors.chargebee.types.InvoiceLikeCondition | airbyte_agent_sdk.connectors.chargebee.types.InvoiceFuzzyCondition | airbyte_agent_sdk.connectors.chargebee.types.InvoiceKeywordCondition | airbyte_agent_sdk.connectors.chargebee.types.InvoiceContainsCondition | airbyte_agent_sdk.connectors.chargebee.types.InvoiceNotCondition | airbyte_agent_sdk.connectors.chargebee.types.InvoiceAndCondition | airbyte_agent_sdk.connectors.chargebee.types.InvoiceOrCondition | airbyte_agent_sdk.connectors.chargebee.types.InvoiceAnyCondition`
     :   The type of the None singleton.
 
+<a id="InvoiceOrCondition"></a>
+
 `InvoiceOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -4202,6 +4426,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.chargebee.types.InvoiceEqCondition | airbyte_agent_sdk.connectors.chargebee.types.InvoiceNeqCondition | airbyte_agent_sdk.connectors.chargebee.types.InvoiceGtCondition | airbyte_agent_sdk.connectors.chargebee.types.InvoiceGteCondition | airbyte_agent_sdk.connectors.chargebee.types.InvoiceLtCondition | airbyte_agent_sdk.connectors.chargebee.types.InvoiceLteCondition | airbyte_agent_sdk.connectors.chargebee.types.InvoiceInCondition | airbyte_agent_sdk.connectors.chargebee.types.InvoiceLikeCondition | airbyte_agent_sdk.connectors.chargebee.types.InvoiceFuzzyCondition | airbyte_agent_sdk.connectors.chargebee.types.InvoiceKeywordCondition | airbyte_agent_sdk.connectors.chargebee.types.InvoiceContainsCondition | airbyte_agent_sdk.connectors.chargebee.types.InvoiceNotCondition | airbyte_agent_sdk.connectors.chargebee.types.InvoiceAndCondition | airbyte_agent_sdk.connectors.chargebee.types.InvoiceOrCondition | airbyte_agent_sdk.connectors.chargebee.types.InvoiceAnyCondition]`
     :   The type of the None singleton.
+
+<a id="InvoiceSearchFilter"></a>
 
 `InvoiceSearchFilter(*args, **kwargs)`
 :   Available fields for filtering invoice search queries.
@@ -4419,6 +4645,8 @@ Classes
     `write_off_amount: int | None`
     :   Amount written off
 
+<a id="InvoiceSearchQuery"></a>
+
 `InvoiceSearchQuery(*args, **kwargs)`
 :   Search query for invoice entity.
 
@@ -4433,6 +4661,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.chargebee.types.InvoiceSortFilter]`
     :   The type of the None singleton.
+
+<a id="InvoiceSortFilter"></a>
 
 `InvoiceSortFilter(*args, **kwargs)`
 :   Available fields for sorting invoice search results.
@@ -4650,6 +4880,8 @@ Classes
     `write_off_amount: Literal['asc', 'desc']`
     :   Amount written off
 
+<a id="InvoiceStringFilter"></a>
+
 `InvoiceStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -4866,6 +5098,8 @@ Classes
     `write_off_amount: str`
     :   Amount written off
 
+<a id="ItemAndCondition"></a>
+
 `ItemAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -4886,6 +5120,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.chargebee.types.ItemEqCondition | airbyte_agent_sdk.connectors.chargebee.types.ItemNeqCondition | airbyte_agent_sdk.connectors.chargebee.types.ItemGtCondition | airbyte_agent_sdk.connectors.chargebee.types.ItemGteCondition | airbyte_agent_sdk.connectors.chargebee.types.ItemLtCondition | airbyte_agent_sdk.connectors.chargebee.types.ItemLteCondition | airbyte_agent_sdk.connectors.chargebee.types.ItemInCondition | airbyte_agent_sdk.connectors.chargebee.types.ItemLikeCondition | airbyte_agent_sdk.connectors.chargebee.types.ItemFuzzyCondition | airbyte_agent_sdk.connectors.chargebee.types.ItemKeywordCondition | airbyte_agent_sdk.connectors.chargebee.types.ItemContainsCondition | airbyte_agent_sdk.connectors.chargebee.types.ItemNotCondition | airbyte_agent_sdk.connectors.chargebee.types.ItemAndCondition | airbyte_agent_sdk.connectors.chargebee.types.ItemOrCondition | airbyte_agent_sdk.connectors.chargebee.types.ItemAnyCondition]`
     :   The type of the None singleton.
 
+<a id="ItemAnyCondition"></a>
+
 `ItemAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -4905,6 +5141,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.chargebee.types.ItemAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="ItemAnyValueFilter"></a>
 
 `ItemAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -4993,6 +5231,8 @@ Classes
     `usage_calculation: Any`
     :   Calculation method used for item usage
 
+<a id="ItemContainsCondition"></a>
+
 `ItemContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -5004,6 +5244,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.chargebee.types.ItemAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="ItemEqCondition"></a>
 
 `ItemEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -5017,6 +5259,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.chargebee.types.ItemSearchFilter`
     :   The type of the None singleton.
 
+<a id="ItemFuzzyCondition"></a>
+
 `ItemFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -5028,6 +5272,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.chargebee.types.ItemStringFilter`
     :   The type of the None singleton.
+
+<a id="ItemGetParams"></a>
 
 `ItemGetParams(*args, **kwargs)`
 :   Parameters for item.get operation
@@ -5041,6 +5287,8 @@ Classes
     `id: str`
     :   The type of the None singleton.
 
+<a id="ItemGtCondition"></a>
+
 `ItemGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -5053,6 +5301,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.chargebee.types.ItemSearchFilter`
     :   The type of the None singleton.
 
+<a id="ItemGteCondition"></a>
+
 `ItemGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -5064,6 +5314,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.chargebee.types.ItemSearchFilter`
     :   The type of the None singleton.
+
+<a id="ItemInCondition"></a>
 
 `ItemInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -5084,6 +5336,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.chargebee.types.ItemInFilter`
     :   The type of the None singleton.
+
+<a id="ItemInFilter"></a>
 
 `ItemInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -5172,6 +5426,8 @@ Classes
     `usage_calculation: list[str]`
     :   Calculation method used for item usage
 
+<a id="ItemKeywordCondition"></a>
+
 `ItemKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -5184,6 +5440,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.chargebee.types.ItemStringFilter`
     :   The type of the None singleton.
 
+<a id="ItemLikeCondition"></a>
+
 `ItemLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -5195,6 +5453,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.chargebee.types.ItemStringFilter`
     :   The type of the None singleton.
+
+<a id="ItemListParams"></a>
 
 `ItemListParams(*args, **kwargs)`
 :   Parameters for item.list operation
@@ -5211,6 +5471,8 @@ Classes
     `offset: str`
     :   The type of the None singleton.
 
+<a id="ItemLtCondition"></a>
+
 `ItemLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -5222,6 +5484,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.chargebee.types.ItemSearchFilter`
     :   The type of the None singleton.
+
+<a id="ItemLteCondition"></a>
 
 `ItemLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -5235,6 +5499,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.chargebee.types.ItemSearchFilter`
     :   The type of the None singleton.
 
+<a id="ItemNeqCondition"></a>
+
 `ItemNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -5246,6 +5512,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.chargebee.types.ItemSearchFilter`
     :   The type of the None singleton.
+
+<a id="ItemNotCondition"></a>
 
 `ItemNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -5267,6 +5535,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.chargebee.types.ItemEqCondition | airbyte_agent_sdk.connectors.chargebee.types.ItemNeqCondition | airbyte_agent_sdk.connectors.chargebee.types.ItemGtCondition | airbyte_agent_sdk.connectors.chargebee.types.ItemGteCondition | airbyte_agent_sdk.connectors.chargebee.types.ItemLtCondition | airbyte_agent_sdk.connectors.chargebee.types.ItemLteCondition | airbyte_agent_sdk.connectors.chargebee.types.ItemInCondition | airbyte_agent_sdk.connectors.chargebee.types.ItemLikeCondition | airbyte_agent_sdk.connectors.chargebee.types.ItemFuzzyCondition | airbyte_agent_sdk.connectors.chargebee.types.ItemKeywordCondition | airbyte_agent_sdk.connectors.chargebee.types.ItemContainsCondition | airbyte_agent_sdk.connectors.chargebee.types.ItemNotCondition | airbyte_agent_sdk.connectors.chargebee.types.ItemAndCondition | airbyte_agent_sdk.connectors.chargebee.types.ItemOrCondition | airbyte_agent_sdk.connectors.chargebee.types.ItemAnyCondition`
     :   The type of the None singleton.
 
+<a id="ItemOrCondition"></a>
+
 `ItemOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -5286,6 +5556,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.chargebee.types.ItemEqCondition | airbyte_agent_sdk.connectors.chargebee.types.ItemNeqCondition | airbyte_agent_sdk.connectors.chargebee.types.ItemGtCondition | airbyte_agent_sdk.connectors.chargebee.types.ItemGteCondition | airbyte_agent_sdk.connectors.chargebee.types.ItemLtCondition | airbyte_agent_sdk.connectors.chargebee.types.ItemLteCondition | airbyte_agent_sdk.connectors.chargebee.types.ItemInCondition | airbyte_agent_sdk.connectors.chargebee.types.ItemLikeCondition | airbyte_agent_sdk.connectors.chargebee.types.ItemFuzzyCondition | airbyte_agent_sdk.connectors.chargebee.types.ItemKeywordCondition | airbyte_agent_sdk.connectors.chargebee.types.ItemContainsCondition | airbyte_agent_sdk.connectors.chargebee.types.ItemNotCondition | airbyte_agent_sdk.connectors.chargebee.types.ItemAndCondition | airbyte_agent_sdk.connectors.chargebee.types.ItemOrCondition | airbyte_agent_sdk.connectors.chargebee.types.ItemAnyCondition]`
     :   The type of the None singleton.
+
+<a id="ItemPriceAndCondition"></a>
 
 `ItemPriceAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -5307,6 +5579,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.chargebee.types.ItemPriceEqCondition | airbyte_agent_sdk.connectors.chargebee.types.ItemPriceNeqCondition | airbyte_agent_sdk.connectors.chargebee.types.ItemPriceGtCondition | airbyte_agent_sdk.connectors.chargebee.types.ItemPriceGteCondition | airbyte_agent_sdk.connectors.chargebee.types.ItemPriceLtCondition | airbyte_agent_sdk.connectors.chargebee.types.ItemPriceLteCondition | airbyte_agent_sdk.connectors.chargebee.types.ItemPriceInCondition | airbyte_agent_sdk.connectors.chargebee.types.ItemPriceLikeCondition | airbyte_agent_sdk.connectors.chargebee.types.ItemPriceFuzzyCondition | airbyte_agent_sdk.connectors.chargebee.types.ItemPriceKeywordCondition | airbyte_agent_sdk.connectors.chargebee.types.ItemPriceContainsCondition | airbyte_agent_sdk.connectors.chargebee.types.ItemPriceNotCondition | airbyte_agent_sdk.connectors.chargebee.types.ItemPriceAndCondition | airbyte_agent_sdk.connectors.chargebee.types.ItemPriceOrCondition | airbyte_agent_sdk.connectors.chargebee.types.ItemPriceAnyCondition]`
     :   The type of the None singleton.
 
+<a id="ItemPriceAnyCondition"></a>
+
 `ItemPriceAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -5326,6 +5600,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.chargebee.types.ItemPriceAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="ItemPriceAnyValueFilter"></a>
 
 `ItemPriceAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -5447,6 +5723,8 @@ Classes
     `updated_at: Any`
     :   Date and time when the item price was last updated.
 
+<a id="ItemPriceContainsCondition"></a>
+
 `ItemPriceContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -5458,6 +5736,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.chargebee.types.ItemPriceAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="ItemPriceEqCondition"></a>
 
 `ItemPriceEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -5471,6 +5751,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.chargebee.types.ItemPriceSearchFilter`
     :   The type of the None singleton.
 
+<a id="ItemPriceFuzzyCondition"></a>
+
 `ItemPriceFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -5482,6 +5764,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.chargebee.types.ItemPriceStringFilter`
     :   The type of the None singleton.
+
+<a id="ItemPriceGetParams"></a>
 
 `ItemPriceGetParams(*args, **kwargs)`
 :   Parameters for item_price.get operation
@@ -5495,6 +5779,8 @@ Classes
     `id: str`
     :   The type of the None singleton.
 
+<a id="ItemPriceGtCondition"></a>
+
 `ItemPriceGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -5507,6 +5793,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.chargebee.types.ItemPriceSearchFilter`
     :   The type of the None singleton.
 
+<a id="ItemPriceGteCondition"></a>
+
 `ItemPriceGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -5518,6 +5806,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.chargebee.types.ItemPriceSearchFilter`
     :   The type of the None singleton.
+
+<a id="ItemPriceInCondition"></a>
 
 `ItemPriceInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -5538,6 +5828,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.chargebee.types.ItemPriceInFilter`
     :   The type of the None singleton.
+
+<a id="ItemPriceInFilter"></a>
 
 `ItemPriceInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -5659,6 +5951,8 @@ Classes
     `updated_at: list[int]`
     :   Date and time when the item price was last updated.
 
+<a id="ItemPriceKeywordCondition"></a>
+
 `ItemPriceKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -5671,6 +5965,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.chargebee.types.ItemPriceStringFilter`
     :   The type of the None singleton.
 
+<a id="ItemPriceLikeCondition"></a>
+
 `ItemPriceLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -5682,6 +5978,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.chargebee.types.ItemPriceStringFilter`
     :   The type of the None singleton.
+
+<a id="ItemPriceListParams"></a>
 
 `ItemPriceListParams(*args, **kwargs)`
 :   Parameters for item_price.list operation
@@ -5698,6 +5996,8 @@ Classes
     `offset: str`
     :   The type of the None singleton.
 
+<a id="ItemPriceLtCondition"></a>
+
 `ItemPriceLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -5709,6 +6009,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.chargebee.types.ItemPriceSearchFilter`
     :   The type of the None singleton.
+
+<a id="ItemPriceLteCondition"></a>
 
 `ItemPriceLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -5722,6 +6024,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.chargebee.types.ItemPriceSearchFilter`
     :   The type of the None singleton.
 
+<a id="ItemPriceNeqCondition"></a>
+
 `ItemPriceNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -5733,6 +6037,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.chargebee.types.ItemPriceSearchFilter`
     :   The type of the None singleton.
+
+<a id="ItemPriceNotCondition"></a>
 
 `ItemPriceNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -5754,6 +6060,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.chargebee.types.ItemPriceEqCondition | airbyte_agent_sdk.connectors.chargebee.types.ItemPriceNeqCondition | airbyte_agent_sdk.connectors.chargebee.types.ItemPriceGtCondition | airbyte_agent_sdk.connectors.chargebee.types.ItemPriceGteCondition | airbyte_agent_sdk.connectors.chargebee.types.ItemPriceLtCondition | airbyte_agent_sdk.connectors.chargebee.types.ItemPriceLteCondition | airbyte_agent_sdk.connectors.chargebee.types.ItemPriceInCondition | airbyte_agent_sdk.connectors.chargebee.types.ItemPriceLikeCondition | airbyte_agent_sdk.connectors.chargebee.types.ItemPriceFuzzyCondition | airbyte_agent_sdk.connectors.chargebee.types.ItemPriceKeywordCondition | airbyte_agent_sdk.connectors.chargebee.types.ItemPriceContainsCondition | airbyte_agent_sdk.connectors.chargebee.types.ItemPriceNotCondition | airbyte_agent_sdk.connectors.chargebee.types.ItemPriceAndCondition | airbyte_agent_sdk.connectors.chargebee.types.ItemPriceOrCondition | airbyte_agent_sdk.connectors.chargebee.types.ItemPriceAnyCondition`
     :   The type of the None singleton.
 
+<a id="ItemPriceOrCondition"></a>
+
 `ItemPriceOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -5773,6 +6081,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.chargebee.types.ItemPriceEqCondition | airbyte_agent_sdk.connectors.chargebee.types.ItemPriceNeqCondition | airbyte_agent_sdk.connectors.chargebee.types.ItemPriceGtCondition | airbyte_agent_sdk.connectors.chargebee.types.ItemPriceGteCondition | airbyte_agent_sdk.connectors.chargebee.types.ItemPriceLtCondition | airbyte_agent_sdk.connectors.chargebee.types.ItemPriceLteCondition | airbyte_agent_sdk.connectors.chargebee.types.ItemPriceInCondition | airbyte_agent_sdk.connectors.chargebee.types.ItemPriceLikeCondition | airbyte_agent_sdk.connectors.chargebee.types.ItemPriceFuzzyCondition | airbyte_agent_sdk.connectors.chargebee.types.ItemPriceKeywordCondition | airbyte_agent_sdk.connectors.chargebee.types.ItemPriceContainsCondition | airbyte_agent_sdk.connectors.chargebee.types.ItemPriceNotCondition | airbyte_agent_sdk.connectors.chargebee.types.ItemPriceAndCondition | airbyte_agent_sdk.connectors.chargebee.types.ItemPriceOrCondition | airbyte_agent_sdk.connectors.chargebee.types.ItemPriceAnyCondition]`
     :   The type of the None singleton.
+
+<a id="ItemPriceSearchFilter"></a>
 
 `ItemPriceSearchFilter(*args, **kwargs)`
 :   Available fields for filtering item_price search queries.
@@ -5894,6 +6204,8 @@ Classes
     `updated_at: int | None`
     :   Date and time when the item price was last updated.
 
+<a id="ItemPriceSearchQuery"></a>
+
 `ItemPriceSearchQuery(*args, **kwargs)`
 :   Search query for item_price entity.
 
@@ -5908,6 +6220,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.chargebee.types.ItemPriceSortFilter]`
     :   The type of the None singleton.
+
+<a id="ItemPriceSortFilter"></a>
 
 `ItemPriceSortFilter(*args, **kwargs)`
 :   Available fields for sorting item_price search results.
@@ -6029,6 +6343,8 @@ Classes
     `updated_at: Literal['asc', 'desc']`
     :   Date and time when the item price was last updated.
 
+<a id="ItemPriceStringFilter"></a>
+
 `ItemPriceStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -6149,6 +6465,8 @@ Classes
     `updated_at: str`
     :   Date and time when the item price was last updated.
 
+<a id="ItemSearchFilter"></a>
+
 `ItemSearchFilter(*args, **kwargs)`
 :   Available fields for filtering item search queries.
 
@@ -6236,6 +6554,8 @@ Classes
     `usage_calculation: str | None`
     :   Calculation method used for item usage
 
+<a id="ItemSearchQuery"></a>
+
 `ItemSearchQuery(*args, **kwargs)`
 :   Search query for item entity.
 
@@ -6250,6 +6570,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.chargebee.types.ItemSortFilter]`
     :   The type of the None singleton.
+
+<a id="ItemSortFilter"></a>
 
 `ItemSortFilter(*args, **kwargs)`
 :   Available fields for sorting item search results.
@@ -6338,6 +6660,8 @@ Classes
     `usage_calculation: Literal['asc', 'desc']`
     :   Calculation method used for item usage
 
+<a id="ItemStringFilter"></a>
+
 `ItemStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -6425,6 +6749,8 @@ Classes
     `usage_calculation: str`
     :   Calculation method used for item usage
 
+<a id="OrderAndCondition"></a>
+
 `OrderAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -6445,6 +6771,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.chargebee.types.OrderEqCondition | airbyte_agent_sdk.connectors.chargebee.types.OrderNeqCondition | airbyte_agent_sdk.connectors.chargebee.types.OrderGtCondition | airbyte_agent_sdk.connectors.chargebee.types.OrderGteCondition | airbyte_agent_sdk.connectors.chargebee.types.OrderLtCondition | airbyte_agent_sdk.connectors.chargebee.types.OrderLteCondition | airbyte_agent_sdk.connectors.chargebee.types.OrderInCondition | airbyte_agent_sdk.connectors.chargebee.types.OrderLikeCondition | airbyte_agent_sdk.connectors.chargebee.types.OrderFuzzyCondition | airbyte_agent_sdk.connectors.chargebee.types.OrderKeywordCondition | airbyte_agent_sdk.connectors.chargebee.types.OrderContainsCondition | airbyte_agent_sdk.connectors.chargebee.types.OrderNotCondition | airbyte_agent_sdk.connectors.chargebee.types.OrderAndCondition | airbyte_agent_sdk.connectors.chargebee.types.OrderOrCondition | airbyte_agent_sdk.connectors.chargebee.types.OrderAnyCondition]`
     :   The type of the None singleton.
 
+<a id="OrderAnyCondition"></a>
+
 `OrderAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -6464,6 +6792,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.chargebee.types.OrderAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="OrderAnyValueFilter"></a>
 
 `OrderAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -6654,6 +6984,8 @@ Classes
     `updated_at: Any`
     :   Timestamp when the order data was last updated.
 
+<a id="OrderContainsCondition"></a>
+
 `OrderContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -6665,6 +6997,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.chargebee.types.OrderAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="OrderEqCondition"></a>
 
 `OrderEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -6678,6 +7012,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.chargebee.types.OrderSearchFilter`
     :   The type of the None singleton.
 
+<a id="OrderFuzzyCondition"></a>
+
 `OrderFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -6689,6 +7025,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.chargebee.types.OrderStringFilter`
     :   The type of the None singleton.
+
+<a id="OrderGetParams"></a>
 
 `OrderGetParams(*args, **kwargs)`
 :   Parameters for order.get operation
@@ -6702,6 +7040,8 @@ Classes
     `id: str`
     :   The type of the None singleton.
 
+<a id="OrderGtCondition"></a>
+
 `OrderGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -6714,6 +7054,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.chargebee.types.OrderSearchFilter`
     :   The type of the None singleton.
 
+<a id="OrderGteCondition"></a>
+
 `OrderGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -6725,6 +7067,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.chargebee.types.OrderSearchFilter`
     :   The type of the None singleton.
+
+<a id="OrderInCondition"></a>
 
 `OrderInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -6745,6 +7089,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.chargebee.types.OrderInFilter`
     :   The type of the None singleton.
+
+<a id="OrderInFilter"></a>
 
 `OrderInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -6935,6 +7281,8 @@ Classes
     `updated_at: list[int]`
     :   Timestamp when the order data was last updated.
 
+<a id="OrderKeywordCondition"></a>
+
 `OrderKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -6947,6 +7295,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.chargebee.types.OrderStringFilter`
     :   The type of the None singleton.
 
+<a id="OrderLikeCondition"></a>
+
 `OrderLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -6958,6 +7308,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.chargebee.types.OrderStringFilter`
     :   The type of the None singleton.
+
+<a id="OrderListParams"></a>
 
 `OrderListParams(*args, **kwargs)`
 :   Parameters for order.list operation
@@ -6974,6 +7326,8 @@ Classes
     `offset: str`
     :   The type of the None singleton.
 
+<a id="OrderLtCondition"></a>
+
 `OrderLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -6985,6 +7339,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.chargebee.types.OrderSearchFilter`
     :   The type of the None singleton.
+
+<a id="OrderLteCondition"></a>
 
 `OrderLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -6998,6 +7354,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.chargebee.types.OrderSearchFilter`
     :   The type of the None singleton.
 
+<a id="OrderNeqCondition"></a>
+
 `OrderNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -7009,6 +7367,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.chargebee.types.OrderSearchFilter`
     :   The type of the None singleton.
+
+<a id="OrderNotCondition"></a>
 
 `OrderNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -7030,6 +7390,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.chargebee.types.OrderEqCondition | airbyte_agent_sdk.connectors.chargebee.types.OrderNeqCondition | airbyte_agent_sdk.connectors.chargebee.types.OrderGtCondition | airbyte_agent_sdk.connectors.chargebee.types.OrderGteCondition | airbyte_agent_sdk.connectors.chargebee.types.OrderLtCondition | airbyte_agent_sdk.connectors.chargebee.types.OrderLteCondition | airbyte_agent_sdk.connectors.chargebee.types.OrderInCondition | airbyte_agent_sdk.connectors.chargebee.types.OrderLikeCondition | airbyte_agent_sdk.connectors.chargebee.types.OrderFuzzyCondition | airbyte_agent_sdk.connectors.chargebee.types.OrderKeywordCondition | airbyte_agent_sdk.connectors.chargebee.types.OrderContainsCondition | airbyte_agent_sdk.connectors.chargebee.types.OrderNotCondition | airbyte_agent_sdk.connectors.chargebee.types.OrderAndCondition | airbyte_agent_sdk.connectors.chargebee.types.OrderOrCondition | airbyte_agent_sdk.connectors.chargebee.types.OrderAnyCondition`
     :   The type of the None singleton.
 
+<a id="OrderOrCondition"></a>
+
 `OrderOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -7049,6 +7411,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.chargebee.types.OrderEqCondition | airbyte_agent_sdk.connectors.chargebee.types.OrderNeqCondition | airbyte_agent_sdk.connectors.chargebee.types.OrderGtCondition | airbyte_agent_sdk.connectors.chargebee.types.OrderGteCondition | airbyte_agent_sdk.connectors.chargebee.types.OrderLtCondition | airbyte_agent_sdk.connectors.chargebee.types.OrderLteCondition | airbyte_agent_sdk.connectors.chargebee.types.OrderInCondition | airbyte_agent_sdk.connectors.chargebee.types.OrderLikeCondition | airbyte_agent_sdk.connectors.chargebee.types.OrderFuzzyCondition | airbyte_agent_sdk.connectors.chargebee.types.OrderKeywordCondition | airbyte_agent_sdk.connectors.chargebee.types.OrderContainsCondition | airbyte_agent_sdk.connectors.chargebee.types.OrderNotCondition | airbyte_agent_sdk.connectors.chargebee.types.OrderAndCondition | airbyte_agent_sdk.connectors.chargebee.types.OrderOrCondition | airbyte_agent_sdk.connectors.chargebee.types.OrderAnyCondition]`
     :   The type of the None singleton.
+
+<a id="OrderSearchFilter"></a>
 
 `OrderSearchFilter(*args, **kwargs)`
 :   Available fields for filtering order search queries.
@@ -7239,6 +7603,8 @@ Classes
     `updated_at: int | None`
     :   Timestamp when the order data was last updated.
 
+<a id="OrderSearchQuery"></a>
+
 `OrderSearchQuery(*args, **kwargs)`
 :   Search query for order entity.
 
@@ -7253,6 +7619,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.chargebee.types.OrderSortFilter]`
     :   The type of the None singleton.
+
+<a id="OrderSortFilter"></a>
 
 `OrderSortFilter(*args, **kwargs)`
 :   Available fields for sorting order search results.
@@ -7443,6 +7811,8 @@ Classes
     `updated_at: Literal['asc', 'desc']`
     :   Timestamp when the order data was last updated.
 
+<a id="OrderStringFilter"></a>
+
 `OrderStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -7632,6 +8002,8 @@ Classes
     `updated_at: str`
     :   Timestamp when the order data was last updated.
 
+<a id="PaymentSourceAndCondition"></a>
+
 `PaymentSourceAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -7652,6 +8024,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.chargebee.types.PaymentSourceEqCondition | airbyte_agent_sdk.connectors.chargebee.types.PaymentSourceNeqCondition | airbyte_agent_sdk.connectors.chargebee.types.PaymentSourceGtCondition | airbyte_agent_sdk.connectors.chargebee.types.PaymentSourceGteCondition | airbyte_agent_sdk.connectors.chargebee.types.PaymentSourceLtCondition | airbyte_agent_sdk.connectors.chargebee.types.PaymentSourceLteCondition | airbyte_agent_sdk.connectors.chargebee.types.PaymentSourceInCondition | airbyte_agent_sdk.connectors.chargebee.types.PaymentSourceLikeCondition | airbyte_agent_sdk.connectors.chargebee.types.PaymentSourceFuzzyCondition | airbyte_agent_sdk.connectors.chargebee.types.PaymentSourceKeywordCondition | airbyte_agent_sdk.connectors.chargebee.types.PaymentSourceContainsCondition | airbyte_agent_sdk.connectors.chargebee.types.PaymentSourceNotCondition | airbyte_agent_sdk.connectors.chargebee.types.PaymentSourceAndCondition | airbyte_agent_sdk.connectors.chargebee.types.PaymentSourceOrCondition | airbyte_agent_sdk.connectors.chargebee.types.PaymentSourceAnyCondition]`
     :   The type of the None singleton.
 
+<a id="PaymentSourceAnyCondition"></a>
+
 `PaymentSourceAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -7671,6 +8045,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.chargebee.types.PaymentSourceAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="PaymentSourceAnyValueFilter"></a>
 
 `PaymentSourceAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -7747,6 +8123,8 @@ Classes
     `upi: Any`
     :   Data related to UPI payment source
 
+<a id="PaymentSourceContainsCondition"></a>
+
 `PaymentSourceContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -7758,6 +8136,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.chargebee.types.PaymentSourceAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="PaymentSourceEqCondition"></a>
 
 `PaymentSourceEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -7771,6 +8151,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.chargebee.types.PaymentSourceSearchFilter`
     :   The type of the None singleton.
 
+<a id="PaymentSourceFuzzyCondition"></a>
+
 `PaymentSourceFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -7782,6 +8164,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.chargebee.types.PaymentSourceStringFilter`
     :   The type of the None singleton.
+
+<a id="PaymentSourceGetParams"></a>
 
 `PaymentSourceGetParams(*args, **kwargs)`
 :   Parameters for payment_source.get operation
@@ -7795,6 +8179,8 @@ Classes
     `id: str`
     :   The type of the None singleton.
 
+<a id="PaymentSourceGtCondition"></a>
+
 `PaymentSourceGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -7807,6 +8193,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.chargebee.types.PaymentSourceSearchFilter`
     :   The type of the None singleton.
 
+<a id="PaymentSourceGteCondition"></a>
+
 `PaymentSourceGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -7818,6 +8206,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.chargebee.types.PaymentSourceSearchFilter`
     :   The type of the None singleton.
+
+<a id="PaymentSourceInCondition"></a>
 
 `PaymentSourceInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -7838,6 +8228,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.chargebee.types.PaymentSourceInFilter`
     :   The type of the None singleton.
+
+<a id="PaymentSourceInFilter"></a>
 
 `PaymentSourceInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -7914,6 +8306,8 @@ Classes
     `upi: list[dict[str, typing.Any]]`
     :   Data related to UPI payment source
 
+<a id="PaymentSourceKeywordCondition"></a>
+
 `PaymentSourceKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -7926,6 +8320,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.chargebee.types.PaymentSourceStringFilter`
     :   The type of the None singleton.
 
+<a id="PaymentSourceLikeCondition"></a>
+
 `PaymentSourceLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -7937,6 +8333,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.chargebee.types.PaymentSourceStringFilter`
     :   The type of the None singleton.
+
+<a id="PaymentSourceListParams"></a>
 
 `PaymentSourceListParams(*args, **kwargs)`
 :   Parameters for payment_source.list operation
@@ -7953,6 +8351,8 @@ Classes
     `offset: str`
     :   The type of the None singleton.
 
+<a id="PaymentSourceLtCondition"></a>
+
 `PaymentSourceLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -7964,6 +8364,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.chargebee.types.PaymentSourceSearchFilter`
     :   The type of the None singleton.
+
+<a id="PaymentSourceLteCondition"></a>
 
 `PaymentSourceLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -7977,6 +8379,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.chargebee.types.PaymentSourceSearchFilter`
     :   The type of the None singleton.
 
+<a id="PaymentSourceNeqCondition"></a>
+
 `PaymentSourceNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -7988,6 +8392,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.chargebee.types.PaymentSourceSearchFilter`
     :   The type of the None singleton.
+
+<a id="PaymentSourceNotCondition"></a>
 
 `PaymentSourceNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -8009,6 +8415,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.chargebee.types.PaymentSourceEqCondition | airbyte_agent_sdk.connectors.chargebee.types.PaymentSourceNeqCondition | airbyte_agent_sdk.connectors.chargebee.types.PaymentSourceGtCondition | airbyte_agent_sdk.connectors.chargebee.types.PaymentSourceGteCondition | airbyte_agent_sdk.connectors.chargebee.types.PaymentSourceLtCondition | airbyte_agent_sdk.connectors.chargebee.types.PaymentSourceLteCondition | airbyte_agent_sdk.connectors.chargebee.types.PaymentSourceInCondition | airbyte_agent_sdk.connectors.chargebee.types.PaymentSourceLikeCondition | airbyte_agent_sdk.connectors.chargebee.types.PaymentSourceFuzzyCondition | airbyte_agent_sdk.connectors.chargebee.types.PaymentSourceKeywordCondition | airbyte_agent_sdk.connectors.chargebee.types.PaymentSourceContainsCondition | airbyte_agent_sdk.connectors.chargebee.types.PaymentSourceNotCondition | airbyte_agent_sdk.connectors.chargebee.types.PaymentSourceAndCondition | airbyte_agent_sdk.connectors.chargebee.types.PaymentSourceOrCondition | airbyte_agent_sdk.connectors.chargebee.types.PaymentSourceAnyCondition`
     :   The type of the None singleton.
 
+<a id="PaymentSourceOrCondition"></a>
+
 `PaymentSourceOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -8028,6 +8436,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.chargebee.types.PaymentSourceEqCondition | airbyte_agent_sdk.connectors.chargebee.types.PaymentSourceNeqCondition | airbyte_agent_sdk.connectors.chargebee.types.PaymentSourceGtCondition | airbyte_agent_sdk.connectors.chargebee.types.PaymentSourceGteCondition | airbyte_agent_sdk.connectors.chargebee.types.PaymentSourceLtCondition | airbyte_agent_sdk.connectors.chargebee.types.PaymentSourceLteCondition | airbyte_agent_sdk.connectors.chargebee.types.PaymentSourceInCondition | airbyte_agent_sdk.connectors.chargebee.types.PaymentSourceLikeCondition | airbyte_agent_sdk.connectors.chargebee.types.PaymentSourceFuzzyCondition | airbyte_agent_sdk.connectors.chargebee.types.PaymentSourceKeywordCondition | airbyte_agent_sdk.connectors.chargebee.types.PaymentSourceContainsCondition | airbyte_agent_sdk.connectors.chargebee.types.PaymentSourceNotCondition | airbyte_agent_sdk.connectors.chargebee.types.PaymentSourceAndCondition | airbyte_agent_sdk.connectors.chargebee.types.PaymentSourceOrCondition | airbyte_agent_sdk.connectors.chargebee.types.PaymentSourceAnyCondition]`
     :   The type of the None singleton.
+
+<a id="PaymentSourceSearchFilter"></a>
 
 `PaymentSourceSearchFilter(*args, **kwargs)`
 :   Available fields for filtering payment_source search queries.
@@ -8104,6 +8514,8 @@ Classes
     `upi: dict[str, typing.Any] | None`
     :   Data related to UPI payment source
 
+<a id="PaymentSourceSearchQuery"></a>
+
 `PaymentSourceSearchQuery(*args, **kwargs)`
 :   Search query for payment_source entity.
 
@@ -8118,6 +8530,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.chargebee.types.PaymentSourceSortFilter]`
     :   The type of the None singleton.
+
+<a id="PaymentSourceSortFilter"></a>
 
 `PaymentSourceSortFilter(*args, **kwargs)`
 :   Available fields for sorting payment_source search results.
@@ -8194,6 +8608,8 @@ Classes
     `upi: Literal['asc', 'desc']`
     :   Data related to UPI payment source
 
+<a id="PaymentSourceStringFilter"></a>
+
 `PaymentSourceStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -8269,6 +8685,8 @@ Classes
     `upi: str`
     :   Data related to UPI payment source
 
+<a id="SubscriptionAndCondition"></a>
+
 `SubscriptionAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -8289,6 +8707,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.chargebee.types.SubscriptionEqCondition | airbyte_agent_sdk.connectors.chargebee.types.SubscriptionNeqCondition | airbyte_agent_sdk.connectors.chargebee.types.SubscriptionGtCondition | airbyte_agent_sdk.connectors.chargebee.types.SubscriptionGteCondition | airbyte_agent_sdk.connectors.chargebee.types.SubscriptionLtCondition | airbyte_agent_sdk.connectors.chargebee.types.SubscriptionLteCondition | airbyte_agent_sdk.connectors.chargebee.types.SubscriptionInCondition | airbyte_agent_sdk.connectors.chargebee.types.SubscriptionLikeCondition | airbyte_agent_sdk.connectors.chargebee.types.SubscriptionFuzzyCondition | airbyte_agent_sdk.connectors.chargebee.types.SubscriptionKeywordCondition | airbyte_agent_sdk.connectors.chargebee.types.SubscriptionContainsCondition | airbyte_agent_sdk.connectors.chargebee.types.SubscriptionNotCondition | airbyte_agent_sdk.connectors.chargebee.types.SubscriptionAndCondition | airbyte_agent_sdk.connectors.chargebee.types.SubscriptionOrCondition | airbyte_agent_sdk.connectors.chargebee.types.SubscriptionAnyCondition]`
     :   The type of the None singleton.
 
+<a id="SubscriptionAnyCondition"></a>
+
 `SubscriptionAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -8308,6 +8728,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.chargebee.types.SubscriptionAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="SubscriptionAnyValueFilter"></a>
 
 `SubscriptionAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -8546,6 +8968,8 @@ Classes
     `updated_at: Any`
     :   The date and time when the subscription was last updated.
 
+<a id="SubscriptionContainsCondition"></a>
+
 `SubscriptionContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -8557,6 +8981,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.chargebee.types.SubscriptionAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="SubscriptionEqCondition"></a>
 
 `SubscriptionEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -8570,6 +8996,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.chargebee.types.SubscriptionSearchFilter`
     :   The type of the None singleton.
 
+<a id="SubscriptionFuzzyCondition"></a>
+
 `SubscriptionFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -8581,6 +9009,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.chargebee.types.SubscriptionStringFilter`
     :   The type of the None singleton.
+
+<a id="SubscriptionGetParams"></a>
 
 `SubscriptionGetParams(*args, **kwargs)`
 :   Parameters for subscription.get operation
@@ -8594,6 +9024,8 @@ Classes
     `id: str`
     :   The type of the None singleton.
 
+<a id="SubscriptionGtCondition"></a>
+
 `SubscriptionGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -8606,6 +9038,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.chargebee.types.SubscriptionSearchFilter`
     :   The type of the None singleton.
 
+<a id="SubscriptionGteCondition"></a>
+
 `SubscriptionGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -8617,6 +9051,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.chargebee.types.SubscriptionSearchFilter`
     :   The type of the None singleton.
+
+<a id="SubscriptionInCondition"></a>
 
 `SubscriptionInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -8637,6 +9073,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.chargebee.types.SubscriptionInFilter`
     :   The type of the None singleton.
+
+<a id="SubscriptionInFilter"></a>
 
 `SubscriptionInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -8875,6 +9313,8 @@ Classes
     `updated_at: list[int]`
     :   The date and time when the subscription was last updated.
 
+<a id="SubscriptionKeywordCondition"></a>
+
 `SubscriptionKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -8887,6 +9327,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.chargebee.types.SubscriptionStringFilter`
     :   The type of the None singleton.
 
+<a id="SubscriptionLikeCondition"></a>
+
 `SubscriptionLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -8898,6 +9340,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.chargebee.types.SubscriptionStringFilter`
     :   The type of the None singleton.
+
+<a id="SubscriptionListParams"></a>
 
 `SubscriptionListParams(*args, **kwargs)`
 :   Parameters for subscription.list operation
@@ -8914,6 +9358,8 @@ Classes
     `offset: str`
     :   The type of the None singleton.
 
+<a id="SubscriptionLtCondition"></a>
+
 `SubscriptionLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -8925,6 +9371,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.chargebee.types.SubscriptionSearchFilter`
     :   The type of the None singleton.
+
+<a id="SubscriptionLteCondition"></a>
 
 `SubscriptionLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -8938,6 +9386,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.chargebee.types.SubscriptionSearchFilter`
     :   The type of the None singleton.
 
+<a id="SubscriptionNeqCondition"></a>
+
 `SubscriptionNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -8949,6 +9399,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.chargebee.types.SubscriptionSearchFilter`
     :   The type of the None singleton.
+
+<a id="SubscriptionNotCondition"></a>
 
 `SubscriptionNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -8970,6 +9422,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.chargebee.types.SubscriptionEqCondition | airbyte_agent_sdk.connectors.chargebee.types.SubscriptionNeqCondition | airbyte_agent_sdk.connectors.chargebee.types.SubscriptionGtCondition | airbyte_agent_sdk.connectors.chargebee.types.SubscriptionGteCondition | airbyte_agent_sdk.connectors.chargebee.types.SubscriptionLtCondition | airbyte_agent_sdk.connectors.chargebee.types.SubscriptionLteCondition | airbyte_agent_sdk.connectors.chargebee.types.SubscriptionInCondition | airbyte_agent_sdk.connectors.chargebee.types.SubscriptionLikeCondition | airbyte_agent_sdk.connectors.chargebee.types.SubscriptionFuzzyCondition | airbyte_agent_sdk.connectors.chargebee.types.SubscriptionKeywordCondition | airbyte_agent_sdk.connectors.chargebee.types.SubscriptionContainsCondition | airbyte_agent_sdk.connectors.chargebee.types.SubscriptionNotCondition | airbyte_agent_sdk.connectors.chargebee.types.SubscriptionAndCondition | airbyte_agent_sdk.connectors.chargebee.types.SubscriptionOrCondition | airbyte_agent_sdk.connectors.chargebee.types.SubscriptionAnyCondition`
     :   The type of the None singleton.
 
+<a id="SubscriptionOrCondition"></a>
+
 `SubscriptionOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -8989,6 +9443,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.chargebee.types.SubscriptionEqCondition | airbyte_agent_sdk.connectors.chargebee.types.SubscriptionNeqCondition | airbyte_agent_sdk.connectors.chargebee.types.SubscriptionGtCondition | airbyte_agent_sdk.connectors.chargebee.types.SubscriptionGteCondition | airbyte_agent_sdk.connectors.chargebee.types.SubscriptionLtCondition | airbyte_agent_sdk.connectors.chargebee.types.SubscriptionLteCondition | airbyte_agent_sdk.connectors.chargebee.types.SubscriptionInCondition | airbyte_agent_sdk.connectors.chargebee.types.SubscriptionLikeCondition | airbyte_agent_sdk.connectors.chargebee.types.SubscriptionFuzzyCondition | airbyte_agent_sdk.connectors.chargebee.types.SubscriptionKeywordCondition | airbyte_agent_sdk.connectors.chargebee.types.SubscriptionContainsCondition | airbyte_agent_sdk.connectors.chargebee.types.SubscriptionNotCondition | airbyte_agent_sdk.connectors.chargebee.types.SubscriptionAndCondition | airbyte_agent_sdk.connectors.chargebee.types.SubscriptionOrCondition | airbyte_agent_sdk.connectors.chargebee.types.SubscriptionAnyCondition]`
     :   The type of the None singleton.
+
+<a id="SubscriptionSearchFilter"></a>
 
 `SubscriptionSearchFilter(*args, **kwargs)`
 :   Available fields for filtering subscription search queries.
@@ -9227,6 +9683,8 @@ Classes
     `updated_at: int | None`
     :   The date and time when the subscription was last updated.
 
+<a id="SubscriptionSearchQuery"></a>
+
 `SubscriptionSearchQuery(*args, **kwargs)`
 :   Search query for subscription entity.
 
@@ -9241,6 +9699,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.chargebee.types.SubscriptionSortFilter]`
     :   The type of the None singleton.
+
+<a id="SubscriptionSortFilter"></a>
 
 `SubscriptionSortFilter(*args, **kwargs)`
 :   Available fields for sorting subscription search results.
@@ -9479,6 +9939,8 @@ Classes
     `updated_at: Literal['asc', 'desc']`
     :   The date and time when the subscription was last updated.
 
+<a id="SubscriptionStringFilter"></a>
+
 `SubscriptionStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -9716,6 +10178,8 @@ Classes
     `updated_at: str`
     :   The date and time when the subscription was last updated.
 
+<a id="TransactionAndCondition"></a>
+
 `TransactionAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -9736,6 +10200,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.chargebee.types.TransactionEqCondition | airbyte_agent_sdk.connectors.chargebee.types.TransactionNeqCondition | airbyte_agent_sdk.connectors.chargebee.types.TransactionGtCondition | airbyte_agent_sdk.connectors.chargebee.types.TransactionGteCondition | airbyte_agent_sdk.connectors.chargebee.types.TransactionLtCondition | airbyte_agent_sdk.connectors.chargebee.types.TransactionLteCondition | airbyte_agent_sdk.connectors.chargebee.types.TransactionInCondition | airbyte_agent_sdk.connectors.chargebee.types.TransactionLikeCondition | airbyte_agent_sdk.connectors.chargebee.types.TransactionFuzzyCondition | airbyte_agent_sdk.connectors.chargebee.types.TransactionKeywordCondition | airbyte_agent_sdk.connectors.chargebee.types.TransactionContainsCondition | airbyte_agent_sdk.connectors.chargebee.types.TransactionNotCondition | airbyte_agent_sdk.connectors.chargebee.types.TransactionAndCondition | airbyte_agent_sdk.connectors.chargebee.types.TransactionOrCondition | airbyte_agent_sdk.connectors.chargebee.types.TransactionAnyCondition]`
     :   The type of the None singleton.
 
+<a id="TransactionAnyCondition"></a>
+
 `TransactionAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -9755,6 +10221,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.chargebee.types.TransactionAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="TransactionAnyValueFilter"></a>
 
 `TransactionAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -9930,6 +10398,8 @@ Classes
     `voided_at: Any`
     :   Date when the transaction was voided.
 
+<a id="TransactionContainsCondition"></a>
+
 `TransactionContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -9941,6 +10411,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.chargebee.types.TransactionAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="TransactionEqCondition"></a>
 
 `TransactionEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -9954,6 +10426,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.chargebee.types.TransactionSearchFilter`
     :   The type of the None singleton.
 
+<a id="TransactionFuzzyCondition"></a>
+
 `TransactionFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -9965,6 +10439,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.chargebee.types.TransactionStringFilter`
     :   The type of the None singleton.
+
+<a id="TransactionGetParams"></a>
 
 `TransactionGetParams(*args, **kwargs)`
 :   Parameters for transaction.get operation
@@ -9978,6 +10454,8 @@ Classes
     `id: str`
     :   The type of the None singleton.
 
+<a id="TransactionGtCondition"></a>
+
 `TransactionGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -9990,6 +10468,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.chargebee.types.TransactionSearchFilter`
     :   The type of the None singleton.
 
+<a id="TransactionGteCondition"></a>
+
 `TransactionGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -10001,6 +10481,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.chargebee.types.TransactionSearchFilter`
     :   The type of the None singleton.
+
+<a id="TransactionInCondition"></a>
 
 `TransactionInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -10021,6 +10503,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.chargebee.types.TransactionInFilter`
     :   The type of the None singleton.
+
+<a id="TransactionInFilter"></a>
 
 `TransactionInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -10196,6 +10680,8 @@ Classes
     `voided_at: list[int]`
     :   Date when the transaction was voided.
 
+<a id="TransactionKeywordCondition"></a>
+
 `TransactionKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -10208,6 +10694,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.chargebee.types.TransactionStringFilter`
     :   The type of the None singleton.
 
+<a id="TransactionLikeCondition"></a>
+
 `TransactionLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -10219,6 +10707,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.chargebee.types.TransactionStringFilter`
     :   The type of the None singleton.
+
+<a id="TransactionListParams"></a>
 
 `TransactionListParams(*args, **kwargs)`
 :   Parameters for transaction.list operation
@@ -10235,6 +10725,8 @@ Classes
     `offset: str`
     :   The type of the None singleton.
 
+<a id="TransactionLtCondition"></a>
+
 `TransactionLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -10246,6 +10738,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.chargebee.types.TransactionSearchFilter`
     :   The type of the None singleton.
+
+<a id="TransactionLteCondition"></a>
 
 `TransactionLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -10259,6 +10753,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.chargebee.types.TransactionSearchFilter`
     :   The type of the None singleton.
 
+<a id="TransactionNeqCondition"></a>
+
 `TransactionNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -10270,6 +10766,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.chargebee.types.TransactionSearchFilter`
     :   The type of the None singleton.
+
+<a id="TransactionNotCondition"></a>
 
 `TransactionNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -10291,6 +10789,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.chargebee.types.TransactionEqCondition | airbyte_agent_sdk.connectors.chargebee.types.TransactionNeqCondition | airbyte_agent_sdk.connectors.chargebee.types.TransactionGtCondition | airbyte_agent_sdk.connectors.chargebee.types.TransactionGteCondition | airbyte_agent_sdk.connectors.chargebee.types.TransactionLtCondition | airbyte_agent_sdk.connectors.chargebee.types.TransactionLteCondition | airbyte_agent_sdk.connectors.chargebee.types.TransactionInCondition | airbyte_agent_sdk.connectors.chargebee.types.TransactionLikeCondition | airbyte_agent_sdk.connectors.chargebee.types.TransactionFuzzyCondition | airbyte_agent_sdk.connectors.chargebee.types.TransactionKeywordCondition | airbyte_agent_sdk.connectors.chargebee.types.TransactionContainsCondition | airbyte_agent_sdk.connectors.chargebee.types.TransactionNotCondition | airbyte_agent_sdk.connectors.chargebee.types.TransactionAndCondition | airbyte_agent_sdk.connectors.chargebee.types.TransactionOrCondition | airbyte_agent_sdk.connectors.chargebee.types.TransactionAnyCondition`
     :   The type of the None singleton.
 
+<a id="TransactionOrCondition"></a>
+
 `TransactionOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -10310,6 +10810,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.chargebee.types.TransactionEqCondition | airbyte_agent_sdk.connectors.chargebee.types.TransactionNeqCondition | airbyte_agent_sdk.connectors.chargebee.types.TransactionGtCondition | airbyte_agent_sdk.connectors.chargebee.types.TransactionGteCondition | airbyte_agent_sdk.connectors.chargebee.types.TransactionLtCondition | airbyte_agent_sdk.connectors.chargebee.types.TransactionLteCondition | airbyte_agent_sdk.connectors.chargebee.types.TransactionInCondition | airbyte_agent_sdk.connectors.chargebee.types.TransactionLikeCondition | airbyte_agent_sdk.connectors.chargebee.types.TransactionFuzzyCondition | airbyte_agent_sdk.connectors.chargebee.types.TransactionKeywordCondition | airbyte_agent_sdk.connectors.chargebee.types.TransactionContainsCondition | airbyte_agent_sdk.connectors.chargebee.types.TransactionNotCondition | airbyte_agent_sdk.connectors.chargebee.types.TransactionAndCondition | airbyte_agent_sdk.connectors.chargebee.types.TransactionOrCondition | airbyte_agent_sdk.connectors.chargebee.types.TransactionAnyCondition]`
     :   The type of the None singleton.
+
+<a id="TransactionSearchFilter"></a>
 
 `TransactionSearchFilter(*args, **kwargs)`
 :   Available fields for filtering transaction search queries.
@@ -10485,6 +10987,8 @@ Classes
     `voided_at: int | None`
     :   Date when the transaction was voided.
 
+<a id="TransactionSearchQuery"></a>
+
 `TransactionSearchQuery(*args, **kwargs)`
 :   Search query for transaction entity.
 
@@ -10499,6 +11003,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.chargebee.types.TransactionSortFilter]`
     :   The type of the None singleton.
+
+<a id="TransactionSortFilter"></a>
 
 `TransactionSortFilter(*args, **kwargs)`
 :   Available fields for sorting transaction search results.
@@ -10673,6 +11179,8 @@ Classes
 
     `voided_at: Literal['asc', 'desc']`
     :   Date when the transaction was voided.
+
+<a id="TransactionStringFilter"></a>
 
 `TransactionStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/clickup_api/connector.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/clickup_api/connector.md
@@ -10,6 +10,8 @@ Clickup-Api connector.
 Classes
 -------
 
+<a id="ClickupApiConnector"></a>
+
 `ClickupApiConnector(auth_config: ClickupApiAuthConfig | AirbyteAuthConfig | BaseModel | None = None, on_token_refresh: Any | None = None)`
 :   Type-safe Clickup-Api API connector.
     
@@ -198,6 +200,8 @@ Classes
             for entity in entities:
                 print(f"\{entity['entity_name']\}: \{entity['available_actions']\}")
 
+<a id="CommentsQuery"></a>
+
 `CommentsQuery(connector: ClickupApiConnector)`
 :   Query class for Comments entity operations.
     
@@ -251,6 +255,8 @@ Classes
         Returns:
             CommentUpdateResponse
 
+<a id="DocsQuery"></a>
+
 `DocsQuery(connector: ClickupApiConnector)`
 :   Query class for Docs entity operations.
     
@@ -280,6 +286,8 @@ Classes
         Returns:
             DocsListResult
 
+<a id="FoldersQuery"></a>
+
 `FoldersQuery(connector: ClickupApiConnector)`
 :   Query class for Folders entity operations.
     
@@ -306,6 +314,8 @@ Classes
         
         Returns:
             FoldersListResult
+
+<a id="GoalsQuery"></a>
 
 `GoalsQuery(connector: ClickupApiConnector)`
 :   Query class for Goals entity operations.
@@ -334,6 +344,8 @@ Classes
         Returns:
             GoalsListResult
 
+<a id="ListsQuery"></a>
+
 `ListsQuery(connector: ClickupApiConnector)`
 :   Query class for Lists entity operations.
     
@@ -361,6 +373,8 @@ Classes
         Returns:
             ListsListResult
 
+<a id="MembersQuery"></a>
+
 `MembersQuery(connector: ClickupApiConnector)`
 :   Query class for Members entity operations.
     
@@ -377,6 +391,8 @@ Classes
         
         Returns:
             MembersListResult
+
+<a id="SpacesQuery"></a>
 
 `SpacesQuery(connector: ClickupApiConnector)`
 :   Query class for Spaces entity operations.
@@ -404,6 +420,8 @@ Classes
         
         Returns:
             SpacesListResult
+
+<a id="TasksQuery"></a>
 
 `TasksQuery(connector: ClickupApiConnector)`
 :   Query class for Tasks entity operations.
@@ -464,6 +482,8 @@ Classes
         Returns:
             TasksListResult
 
+<a id="TeamsQuery"></a>
+
 `TeamsQuery(connector: ClickupApiConnector)`
 :   Query class for Teams entity operations.
     
@@ -476,6 +496,8 @@ Classes
         
         Returns:
             TeamsListResult
+
+<a id="TimeTrackingQuery"></a>
 
 `TimeTrackingQuery(connector: ClickupApiConnector)`
 :   Query class for TimeTracking entity operations.
@@ -508,6 +530,8 @@ Classes
         Returns:
             TimeTrackingListResult
 
+<a id="UserQuery"></a>
+
 `UserQuery(connector: ClickupApiConnector)`
 :   Query class for User entity operations.
     
@@ -520,6 +544,8 @@ Classes
         
         Returns:
             User
+
+<a id="ViewTasksQuery"></a>
 
 `ViewTasksQuery(connector: ClickupApiConnector)`
 :   Query class for ViewTasks entity operations.
@@ -538,6 +564,8 @@ Classes
         
         Returns:
             ViewTasksListResult
+
+<a id="ViewsQuery"></a>
 
 `ViewsQuery(connector: ClickupApiConnector)`
 :   Query class for Views entity operations.

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/clickup_api/index.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/clickup_api/index.md
@@ -19,6 +19,8 @@ Sub-modules
 Classes
 -------
 
+<a id="AirbyteAuthConfig"></a>
+
 `AirbyteAuthConfig(**data: Any)`
 :   Authentication configuration for Airbyte hosted mode execution.
     
@@ -87,6 +89,8 @@ Classes
     `workspace_name: str | None`
     :   The type of the None singleton.
 
+<a id="ClickupApiAuthConfig"></a>
+
 `ClickupApiAuthConfig(**data: Any)`
 :   API Key Authentication
     
@@ -108,6 +112,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="ClickupApiConnector"></a>
 
 `ClickupApiConnector(auth_config: ClickupApiAuthConfig | AirbyteAuthConfig | BaseModel | None = None, on_token_refresh: Any | None = None)`
 :   Type-safe Clickup-Api API connector.

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/clickup_api/models.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/clickup_api/models.md
@@ -13,6 +13,8 @@ and response envelope types.
 Classes
 -------
 
+<a id="ClickupApiAuthConfig"></a>
+
 `ClickupApiAuthConfig(**data: Any)`
 :   API Key Authentication
     
@@ -34,6 +36,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="ClickupApiCheckResult"></a>
 
 `ClickupApiCheckResult(**data: Any)`
 :   Result of a health check operation.
@@ -67,6 +71,8 @@ Classes
 
     `status: str`
     :   Health check status: 'healthy' or 'unhealthy'.
+
+<a id="ClickupApiExecuteResult"></a>
 
 `ClickupApiExecuteResult(**data: Any)`
 :   Response envelope with data only.
@@ -105,6 +111,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="ClickupApiExecuteResultWithMeta"></a>
 
 `ClickupApiExecuteResultWithMeta(**data: Any)`
 :   Response envelope with data and metadata.
@@ -160,6 +168,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="DocsListResult"></a>
+
 `DocsListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -202,6 +212,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="TasksApiSearchResult"></a>
 
 `TasksApiSearchResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -246,6 +258,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="TasksListResult"></a>
+
 `TasksListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -289,6 +303,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="ViewTasksListResult"></a>
+
 `ViewTasksListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -331,6 +347,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="CommentsListResult"></a>
+
 `CommentsListResult(**data: Any)`
 :   Response envelope with data only.
     
@@ -371,6 +389,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="FoldersListResult"></a>
 
 `FoldersListResult(**data: Any)`
 :   Response envelope with data only.
@@ -413,6 +433,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="GoalsListResult"></a>
+
 `GoalsListResult(**data: Any)`
 :   Response envelope with data only.
     
@@ -453,6 +475,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="ListsListResult"></a>
 
 `ListsListResult(**data: Any)`
 :   Response envelope with data only.
@@ -495,6 +519,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="MembersListResult"></a>
+
 `MembersListResult(**data: Any)`
 :   Response envelope with data only.
     
@@ -535,6 +561,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="SpacesListResult"></a>
 
 `SpacesListResult(**data: Any)`
 :   Response envelope with data only.
@@ -577,6 +605,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="TeamsListResult"></a>
+
 `TeamsListResult(**data: Any)`
 :   Response envelope with data only.
     
@@ -617,6 +647,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="TimeTrackingListResult"></a>
 
 `TimeTrackingListResult(**data: Any)`
 :   Response envelope with data only.
@@ -659,6 +691,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="ViewsListResult"></a>
+
 `ViewsListResult(**data: Any)`
 :   Response envelope with data only.
     
@@ -676,6 +710,8 @@ Classes
     * airbyte_agent_sdk.connectors.clickup_api.models.ClickupApiExecuteResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="Comment"></a>
 
 `Comment(**data: Any)`
 :   Comment type definition
@@ -723,6 +759,8 @@ Classes
     `user: dict[str, typing.Any] | Any`
     :   The type of the None singleton.
 
+<a id="CommentCreateParams"></a>
+
 `CommentCreateParams(**data: Any)`
 :   CommentCreateParams type definition
     
@@ -750,6 +788,8 @@ Classes
 
     `notify_all: bool | Any`
     :   The type of the None singleton.
+
+<a id="CommentCreateResponse"></a>
 
 `CommentCreateResponse(**data: Any)`
 :   CommentCreateResponse type definition
@@ -782,6 +822,8 @@ Classes
     `version: dict[str, typing.Any] | Any | None`
     :   The type of the None singleton.
 
+<a id="CommentUpdateParams"></a>
+
 `CommentUpdateParams(**data: Any)`
 :   CommentUpdateParams type definition
     
@@ -810,6 +852,8 @@ Classes
     `resolved: bool | Any`
     :   The type of the None singleton.
 
+<a id="CommentUpdateResponse"></a>
+
 `CommentUpdateResponse(**data: Any)`
 :   CommentUpdateResponse type definition
     
@@ -828,6 +872,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="CommentsListResponse"></a>
 
 `CommentsListResponse(**data: Any)`
 :   CommentsListResponse type definition
@@ -850,6 +896,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="Doc"></a>
 
 `Doc(**data: Any)`
 :   Doc type definition
@@ -903,6 +951,8 @@ Classes
     `workspace_id: int | Any | None`
     :   The type of the None singleton.
 
+<a id="DocsListResponse"></a>
+
 `DocsListResponse(**data: Any)`
 :   DocsListResponse type definition
     
@@ -928,6 +978,8 @@ Classes
     `next_cursor: str | Any | None`
     :   The type of the None singleton.
 
+<a id="DocsListResultMeta"></a>
+
 `DocsListResultMeta(**data: Any)`
 :   Metadata for docs.Action.LIST operation
     
@@ -949,6 +1001,8 @@ Classes
 
     `next_cursor: str | Any | None`
     :   The type of the None singleton.
+
+<a id="Folder"></a>
 
 `Folder(**data: Any)`
 :   Folder type definition
@@ -1004,6 +1058,8 @@ Classes
 
     `task_count: str | Any | None`
     :   The type of the None singleton.
+
+<a id="FolderListsItem"></a>
 
 `FolderListsItem(**data: Any)`
 :   Nested schema for Folder.lists_item
@@ -1069,6 +1125,8 @@ Classes
     `task_count: int | Any | None`
     :   Number of tasks
 
+<a id="FolderListsItemStatusesItem"></a>
+
 `FolderListsItemStatusesItem(**data: Any)`
 :   Nested schema for FolderListsItem.statuses_item
     
@@ -1106,6 +1164,8 @@ Classes
     `type_: str | Any`
     :   Status type (open, custom, closed)
 
+<a id="FolderSpace"></a>
+
 `FolderSpace(**data: Any)`
 :   Parent space reference
     
@@ -1133,6 +1193,8 @@ Classes
 
     `name: str | Any`
     :   Space name
+
+<a id="FolderStatusesItem"></a>
 
 `FolderStatusesItem(**data: Any)`
 :   Nested schema for Folder.statuses_item
@@ -1168,6 +1230,8 @@ Classes
     `type_: str | Any`
     :   Status type (open, custom, closed)
 
+<a id="FoldersListResponse"></a>
+
 `FoldersListResponse(**data: Any)`
 :   FoldersListResponse type definition
     
@@ -1189,6 +1253,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="Goal"></a>
 
 `Goal(**data: Any)`
 :   Goal type definition
@@ -1266,6 +1332,8 @@ Classes
     `team_id: str | Any`
     :   The type of the None singleton.
 
+<a id="GoalResponse"></a>
+
 `GoalResponse(**data: Any)`
 :   GoalResponse type definition
     
@@ -1287,6 +1355,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="GoalsListResponse"></a>
 
 `GoalsListResponse(**data: Any)`
 :   GoalsListResponse type definition
@@ -1312,6 +1382,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="List"></a>
 
 `List(**data: Any)`
 :   List type definition
@@ -1386,6 +1458,8 @@ Classes
     `task_count: int | Any | None`
     :   The type of the None singleton.
 
+<a id="ListFolder"></a>
+
 `ListFolder(**data: Any)`
 :   Parent folder reference
     
@@ -1417,6 +1491,8 @@ Classes
     `name: str | Any`
     :   Folder name
 
+<a id="ListSpace"></a>
+
 `ListSpace(**data: Any)`
 :   Parent space reference
     
@@ -1444,6 +1520,8 @@ Classes
 
     `name: str | Any`
     :   Space name
+
+<a id="ListStatusesItem"></a>
 
 `ListStatusesItem(**data: Any)`
 :   Nested schema for List.statuses_item
@@ -1482,6 +1560,8 @@ Classes
     `type_: str | Any`
     :   Status type (open, custom, closed)
 
+<a id="ListsListResponse"></a>
+
 `ListsListResponse(**data: Any)`
 :   ListsListResponse type definition
     
@@ -1503,6 +1583,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="Member"></a>
 
 `Member(**data: Any)`
 :   Member type definition
@@ -1541,6 +1623,8 @@ Classes
     `username: str | Any`
     :   The type of the None singleton.
 
+<a id="MembersListResponse"></a>
+
 `MembersListResponse(**data: Any)`
 :   MembersListResponse type definition
     
@@ -1562,6 +1646,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="Space"></a>
 
 `Space(**data: Any)`
 :   Space type definition
@@ -1611,6 +1697,8 @@ Classes
 
     `statuses: list[airbyte_agent_sdk.connectors.clickup_api.models.SpaceStatusesItem] | Any`
     :   The type of the None singleton.
+
+<a id="SpaceFeatures"></a>
 
 `SpaceFeatures(**data: Any)`
 :   Feature flags for the space
@@ -1691,6 +1779,8 @@ Classes
     `time_tracking: airbyte_agent_sdk.connectors.clickup_api.models.SpaceFeaturesTimeTracking | Any`
     :   Time tracking feature settings
 
+<a id="SpaceFeaturesCheckUnresolved"></a>
+
 `SpaceFeaturesCheckUnresolved(**data: Any)`
 :   Check unresolved feature settings
     
@@ -1722,6 +1812,8 @@ Classes
     `subtasks: bool | Any | None`
     :   Check unresolved subtasks
 
+<a id="SpaceFeaturesCustomFields"></a>
+
 `SpaceFeaturesCustomFields(**data: Any)`
 :   Custom fields feature settings
     
@@ -1744,6 +1836,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="SpaceFeaturesCustomItems"></a>
+
 `SpaceFeaturesCustomItems(**data: Any)`
 :   Custom items feature settings
     
@@ -1765,6 +1859,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="SpaceFeaturesDependencyEnforcement"></a>
 
 `SpaceFeaturesDependencyEnforcement(**data: Any)`
 :   Dependency enforcement settings
@@ -1791,6 +1887,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="SpaceFeaturesDependencyWarning"></a>
+
 `SpaceFeaturesDependencyWarning(**data: Any)`
 :   Dependency warning feature settings
     
@@ -1812,6 +1910,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="SpaceFeaturesDueDates"></a>
 
 `SpaceFeaturesDueDates(**data: Any)`
 :   Due dates feature settings
@@ -1844,6 +1944,8 @@ Classes
     `start_date: bool | Any`
     :   Whether start dates are enabled
 
+<a id="SpaceFeaturesEmails"></a>
+
 `SpaceFeaturesEmails(**data: Any)`
 :   Emails feature settings
     
@@ -1865,6 +1967,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="SpaceFeaturesMilestones"></a>
 
 `SpaceFeaturesMilestones(**data: Any)`
 :   Milestones feature settings
@@ -1888,6 +1992,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="SpaceFeaturesMultipleAssignees"></a>
+
 `SpaceFeaturesMultipleAssignees(**data: Any)`
 :   Multiple assignees feature settings
     
@@ -1910,6 +2016,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="SpaceFeaturesPoints"></a>
+
 `SpaceFeaturesPoints(**data: Any)`
 :   Points feature settings
     
@@ -1931,6 +2039,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="SpaceFeaturesPriorities"></a>
 
 `SpaceFeaturesPriorities(**data: Any)`
 :   Priorities feature settings
@@ -1956,6 +2066,8 @@ Classes
 
     `priorities: list[airbyte_agent_sdk.connectors.clickup_api.models.SpaceFeaturesPrioritiesPrioritiesItem] | Any`
     :   Priority levels
+
+<a id="SpaceFeaturesPrioritiesPrioritiesItem"></a>
 
 `SpaceFeaturesPrioritiesPrioritiesItem(**data: Any)`
 :   Nested schema for SpaceFeaturesPriorities.priorities_item
@@ -1988,6 +2100,8 @@ Classes
     `priority: str | Any`
     :   Priority name
 
+<a id="SpaceFeaturesRemapDependencies"></a>
+
 `SpaceFeaturesRemapDependencies(**data: Any)`
 :   Remap dependencies feature settings
     
@@ -2009,6 +2123,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="SpaceFeaturesRescheduleClosedDependencies"></a>
 
 `SpaceFeaturesRescheduleClosedDependencies(**data: Any)`
 :   Reschedule closed dependencies settings
@@ -2032,6 +2148,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="SpaceFeaturesSprints"></a>
+
 `SpaceFeaturesSprints(**data: Any)`
 :   Sprints feature settings
     
@@ -2053,6 +2171,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="SpaceFeaturesStatusPies"></a>
 
 `SpaceFeaturesStatusPies(**data: Any)`
 :   Status pies feature settings
@@ -2076,6 +2196,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="SpaceFeaturesTags"></a>
+
 `SpaceFeaturesTags(**data: Any)`
 :   Tags feature settings
     
@@ -2097,6 +2219,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="SpaceFeaturesTimeEstimates"></a>
 
 `SpaceFeaturesTimeEstimates(**data: Any)`
 :   Time estimates feature settings
@@ -2125,6 +2249,8 @@ Classes
 
     `rollup: bool | Any`
     :   Whether time estimate rollup is enabled
+
+<a id="SpaceFeaturesTimeTracking"></a>
 
 `SpaceFeaturesTimeTracking(**data: Any)`
 :   Time tracking feature settings
@@ -2156,6 +2282,8 @@ Classes
 
     `rollup: bool | Any`
     :   Whether time rollup is enabled
+
+<a id="SpaceStatusesItem"></a>
 
 `SpaceStatusesItem(**data: Any)`
 :   Nested schema for Space.statuses_item
@@ -2191,6 +2319,8 @@ Classes
     `type_: str | Any`
     :   Status type (open, custom, closed)
 
+<a id="SpacesListResponse"></a>
+
 `SpacesListResponse(**data: Any)`
 :   SpacesListResponse type definition
     
@@ -2212,6 +2342,8 @@ Classes
 
     `spaces: list[airbyte_agent_sdk.connectors.clickup_api.models.Space] | Any`
     :   The type of the None singleton.
+
+<a id="Task"></a>
 
 `Task(**data: Any)`
 :   Task type definition
@@ -2352,6 +2484,8 @@ Classes
     `watchers: list[airbyte_agent_sdk.connectors.clickup_api.models.TaskWatchersItem] | Any`
     :   The type of the None singleton.
 
+<a id="TaskCreator"></a>
+
 `TaskCreator(**data: Any)`
 :   Task creator
     
@@ -2386,6 +2520,8 @@ Classes
     `username: str | Any`
     :   Creator username
 
+<a id="TaskStatus"></a>
+
 `TaskStatus(**data: Any)`
 :   Task status
     
@@ -2419,6 +2555,8 @@ Classes
 
     `type_: str | Any`
     :   Status type (open, custom, closed)
+
+<a id="TaskWatchersItem"></a>
 
 `TaskWatchersItem(**data: Any)`
 :   Nested schema for Task.watchers_item
@@ -2457,6 +2595,8 @@ Classes
     `username: str | Any`
     :   Watcher username
 
+<a id="TasksApiSearchResultMeta"></a>
+
 `TasksApiSearchResultMeta(**data: Any)`
 :   Metadata for tasks.Action.API_SEARCH operation
     
@@ -2478,6 +2618,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="TasksListResponse"></a>
 
 `TasksListResponse(**data: Any)`
 :   TasksListResponse type definition
@@ -2504,6 +2646,8 @@ Classes
     `tasks: list[airbyte_agent_sdk.connectors.clickup_api.models.Task] | Any`
     :   The type of the None singleton.
 
+<a id="TasksListResultMeta"></a>
+
 `TasksListResultMeta(**data: Any)`
 :   Metadata for tasks.Action.LIST operation
     
@@ -2525,6 +2669,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="Team"></a>
 
 `Team(**data: Any)`
 :   Team type definition
@@ -2560,6 +2706,8 @@ Classes
     `name: str | Any`
     :   The type of the None singleton.
 
+<a id="TeamMembersItem"></a>
+
 `TeamMembersItem(**data: Any)`
 :   Nested schema for Team.members_item
     
@@ -2581,6 +2729,8 @@ Classes
 
     `user: airbyte_agent_sdk.connectors.clickup_api.models.TeamMembersItemUser | Any`
     :   Member user details
+
+<a id="TeamMembersItemUser"></a>
 
 `TeamMembersItemUser(**data: Any)`
 :   Member user details
@@ -2640,6 +2790,8 @@ Classes
     `username: str | Any`
     :   Username
 
+<a id="TeamsListResponse"></a>
+
 `TeamsListResponse(**data: Any)`
 :   TeamsListResponse type definition
     
@@ -2662,6 +2814,8 @@ Classes
     `teams: list[airbyte_agent_sdk.connectors.clickup_api.models.Team] | Any`
     :   The type of the None singleton.
 
+<a id="TimeEntriesListResponse"></a>
+
 `TimeEntriesListResponse(**data: Any)`
 :   TimeEntriesListResponse type definition
     
@@ -2683,6 +2837,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="TimeEntry"></a>
 
 `TimeEntry(**data: Any)`
 :   TimeEntry type definition
@@ -2736,6 +2892,8 @@ Classes
     `wid: str | Any | None`
     :   The type of the None singleton.
 
+<a id="TimeEntryResponse"></a>
+
 `TimeEntryResponse(**data: Any)`
 :   TimeEntryResponse type definition
     
@@ -2757,6 +2915,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="User"></a>
 
 `User(**data: Any)`
 :   User type definition
@@ -2804,6 +2964,8 @@ Classes
     `week_start_day: int | Any | None`
     :   The type of the None singleton.
 
+<a id="UserResponse"></a>
+
 `UserResponse(**data: Any)`
 :   UserResponse type definition
     
@@ -2825,6 +2987,8 @@ Classes
 
     `user: airbyte_agent_sdk.connectors.clickup_api.models.User | Any`
     :   The type of the None singleton.
+
+<a id="View"></a>
 
 `View(**data: Any)`
 :   View type definition
@@ -2905,6 +3069,8 @@ Classes
     `visibility: str | Any | None`
     :   The type of the None singleton.
 
+<a id="ViewParent"></a>
+
 `ViewParent(**data: Any)`
 :   Parent reference
     
@@ -2930,6 +3096,8 @@ Classes
     `type_: Any`
     :   Parent entity type
 
+<a id="ViewResponse"></a>
+
 `ViewResponse(**data: Any)`
 :   ViewResponse type definition
     
@@ -2952,6 +3120,8 @@ Classes
     `view: airbyte_agent_sdk.connectors.clickup_api.models.View | Any`
     :   The type of the None singleton.
 
+<a id="ViewTasksListResultMeta"></a>
+
 `ViewTasksListResultMeta(**data: Any)`
 :   Metadata for view_tasks.Action.LIST operation
     
@@ -2973,6 +3143,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="ViewsListResponse"></a>
 
 `ViewsListResponse(**data: Any)`
 :   ViewsListResponse type definition

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/clickup_api/types.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/clickup_api/types.md
@@ -10,6 +10,8 @@ Type definitions for clickup-api connector.
 Classes
 -------
 
+<a id="CommentsCreateParams"></a>
+
 `CommentsCreateParams(*args, **kwargs)`
 :   Parameters for comments.create operation
 
@@ -31,6 +33,8 @@ Classes
     `task_id: str`
     :   The type of the None singleton.
 
+<a id="CommentsGetParams"></a>
+
 `CommentsGetParams(*args, **kwargs)`
 :   Parameters for comments.get operation
 
@@ -43,6 +47,8 @@ Classes
     `comment_id: str`
     :   The type of the None singleton.
 
+<a id="CommentsListParams"></a>
+
 `CommentsListParams(*args, **kwargs)`
 :   Parameters for comments.list operation
 
@@ -54,6 +60,8 @@ Classes
 
     `task_id: str`
     :   The type of the None singleton.
+
+<a id="CommentsUpdateParams"></a>
 
 `CommentsUpdateParams(*args, **kwargs)`
 :   Parameters for comments.update operation
@@ -76,6 +84,8 @@ Classes
     `resolved: bool`
     :   The type of the None singleton.
 
+<a id="DocsGetParams"></a>
+
 `DocsGetParams(*args, **kwargs)`
 :   Parameters for docs.get operation
 
@@ -90,6 +100,8 @@ Classes
 
     `workspace_id: str`
     :   The type of the None singleton.
+
+<a id="DocsListParams"></a>
 
 `DocsListParams(*args, **kwargs)`
 :   Parameters for docs.list operation
@@ -106,6 +118,8 @@ Classes
     `workspace_id: str`
     :   The type of the None singleton.
 
+<a id="FoldersGetParams"></a>
+
 `FoldersGetParams(*args, **kwargs)`
 :   Parameters for folders.get operation
 
@@ -117,6 +131,8 @@ Classes
 
     `folder_id: str`
     :   The type of the None singleton.
+
+<a id="FoldersListParams"></a>
 
 `FoldersListParams(*args, **kwargs)`
 :   Parameters for folders.list operation
@@ -130,6 +146,8 @@ Classes
     `space_id: str`
     :   The type of the None singleton.
 
+<a id="GoalsGetParams"></a>
+
 `GoalsGetParams(*args, **kwargs)`
 :   Parameters for goals.get operation
 
@@ -141,6 +159,8 @@ Classes
 
     `goal_id: str`
     :   The type of the None singleton.
+
+<a id="GoalsListParams"></a>
 
 `GoalsListParams(*args, **kwargs)`
 :   Parameters for goals.list operation
@@ -154,6 +174,8 @@ Classes
     `team_id: str`
     :   The type of the None singleton.
 
+<a id="ListsGetParams"></a>
+
 `ListsGetParams(*args, **kwargs)`
 :   Parameters for lists.get operation
 
@@ -165,6 +187,8 @@ Classes
 
     `list_id: str`
     :   The type of the None singleton.
+
+<a id="ListsListParams"></a>
 
 `ListsListParams(*args, **kwargs)`
 :   Parameters for lists.list operation
@@ -178,6 +202,8 @@ Classes
     `folder_id: str`
     :   The type of the None singleton.
 
+<a id="MembersListParams"></a>
+
 `MembersListParams(*args, **kwargs)`
 :   Parameters for members.list operation
 
@@ -189,6 +215,8 @@ Classes
 
     `task_id: str`
     :   The type of the None singleton.
+
+<a id="SpacesGetParams"></a>
 
 `SpacesGetParams(*args, **kwargs)`
 :   Parameters for spaces.get operation
@@ -202,6 +230,8 @@ Classes
     `space_id: str`
     :   The type of the None singleton.
 
+<a id="SpacesListParams"></a>
+
 `SpacesListParams(*args, **kwargs)`
 :   Parameters for spaces.list operation
 
@@ -213,6 +243,8 @@ Classes
 
     `team_id: str`
     :   The type of the None singleton.
+
+<a id="TasksApiSearchParams"></a>
 
 `TasksApiSearchParams(*args, **kwargs)`
 :   Parameters for tasks.api_search operation
@@ -268,6 +300,8 @@ Classes
     `team_id: str`
     :   The type of the None singleton.
 
+<a id="TasksGetParams"></a>
+
 `TasksGetParams(*args, **kwargs)`
 :   Parameters for tasks.get operation
 
@@ -286,6 +320,8 @@ Classes
     `task_id: str`
     :   The type of the None singleton.
 
+<a id="TasksListParams"></a>
+
 `TasksListParams(*args, **kwargs)`
 :   Parameters for tasks.list operation
 
@@ -301,12 +337,16 @@ Classes
     `page: int`
     :   The type of the None singleton.
 
+<a id="TeamsListParams"></a>
+
 `TeamsListParams(*args, **kwargs)`
 :   Parameters for teams.list operation
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="TimeTrackingGetParams"></a>
 
 `TimeTrackingGetParams(*args, **kwargs)`
 :   Parameters for time_tracking.get operation
@@ -322,6 +362,8 @@ Classes
 
     `time_entry_id: str`
     :   The type of the None singleton.
+
+<a id="TimeTrackingListParams"></a>
 
 `TimeTrackingListParams(*args, **kwargs)`
 :   Parameters for time_tracking.list operation
@@ -344,12 +386,16 @@ Classes
     `team_id: str`
     :   The type of the None singleton.
 
+<a id="UserGetParams"></a>
+
 `UserGetParams(*args, **kwargs)`
 :   Parameters for user.get operation
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="ViewTasksListParams"></a>
 
 `ViewTasksListParams(*args, **kwargs)`
 :   Parameters for view_tasks.list operation
@@ -366,6 +412,8 @@ Classes
     `view_id: str`
     :   The type of the None singleton.
 
+<a id="ViewsGetParams"></a>
+
 `ViewsGetParams(*args, **kwargs)`
 :   Parameters for views.get operation
 
@@ -377,6 +425,8 @@ Classes
 
     `view_id: str`
     :   The type of the None singleton.
+
+<a id="ViewsListParams"></a>
 
 `ViewsListParams(*args, **kwargs)`
 :   Parameters for views.list operation

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/confluence/connector.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/confluence/connector.md
@@ -10,6 +10,8 @@ Confluence connector.
 Classes
 -------
 
+<a id="AuditQuery"></a>
+
 `AuditQuery(connector: ConfluenceConnector)`
 :   Query class for Audit entity operations.
     
@@ -63,6 +65,8 @@ Classes
         
         Returns:
             AuditListResult
+
+<a id="BlogPostsQuery"></a>
 
 `BlogPostsQuery(connector: ConfluenceConnector)`
 :   Query class for BlogPosts entity operations.
@@ -129,6 +133,8 @@ Classes
         
         Returns:
             BlogPostsListResult
+
+<a id="ConfluenceConnector"></a>
 
 `ConfluenceConnector(auth_config: ConfluenceAuthConfig | AirbyteAuthConfig | BaseModel | None = None, on_token_refresh: Any | None = None, subdomain: str | None = None)`
 :   Type-safe Confluence API connector.
@@ -318,6 +324,8 @@ Classes
             for entity in entities:
                 print(f"\{entity['entity_name']\}: \{entity['available_actions']\}")
 
+<a id="GroupsQuery"></a>
+
 `GroupsQuery(connector: ConfluenceConnector)`
 :   Query class for Groups entity operations.
     
@@ -361,6 +369,8 @@ Classes
         
         Returns:
             GroupsListResult
+
+<a id="PagesQuery"></a>
 
 `PagesQuery(connector: ConfluenceConnector)`
 :   Query class for Pages entity operations.
@@ -432,6 +442,8 @@ Classes
         
         Returns:
             PagesListResult
+
+<a id="SpacesQuery"></a>
 
 `SpacesQuery(connector: ConfluenceConnector)`
 :   Query class for Spaces entity operations.

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/confluence/index.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/confluence/index.md
@@ -19,6 +19,8 @@ Sub-modules
 Classes
 -------
 
+<a id="AirbyteAuthConfig"></a>
+
 `AirbyteAuthConfig(**data: Any)`
 :   Authentication configuration for Airbyte hosted mode execution.
     
@@ -87,6 +89,8 @@ Classes
     `workspace_name: str | None`
     :   The type of the None singleton.
 
+<a id="AirbyteSearchMeta"></a>
+
 `AirbyteSearchMeta(**data: Any)`
 :   Pagination metadata for search responses.
     
@@ -114,6 +118,8 @@ Classes
 
     `took_ms: int | None`
     :   Time taken to execute the search in milliseconds.
+
+<a id="AirbyteSearchResult"></a>
 
 `AirbyteSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -149,6 +155,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="AuditSearchResult"></a>
+
 `AuditSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -164,6 +172,8 @@ Classes
     * airbyte_agent_sdk.connectors.confluence.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="BlogPostsSearchResult"></a>
 
 `BlogPostsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -181,6 +191,8 @@ Classes
     * pydantic.main.BaseModel
     * typing.Generic
 
+<a id="GroupsSearchResult"></a>
+
 `GroupsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -196,6 +208,8 @@ Classes
     * airbyte_agent_sdk.connectors.confluence.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="PagesSearchResult"></a>
 
 `PagesSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -213,6 +227,8 @@ Classes
     * pydantic.main.BaseModel
     * typing.Generic
 
+<a id="SpacesSearchResult"></a>
+
 `SpacesSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -228,6 +244,8 @@ Classes
     * airbyte_agent_sdk.connectors.confluence.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="AuditSearchData"></a>
 
 `AuditSearchData(**data: Any)`
 :   Search result data for audit entity.
@@ -281,6 +299,8 @@ Classes
     `sys_admin: bool | None`
     :   Indicates if the user triggering the audit event is a system admin.
 
+<a id="BlogPostsSearchData"></a>
+
 `BlogPostsSearchData(**data: Any)`
 :   Search result data for blog_posts entity.
     
@@ -327,6 +347,8 @@ Classes
     `version: dict[str, typing.Any] | None`
     :   Version information
 
+<a id="ConfluenceAuthConfig"></a>
+
 `ConfluenceAuthConfig(**data: Any)`
 :   Confluence API Token Authentication - Authenticate using your Atlassian account email and API token
     
@@ -351,6 +373,8 @@ Classes
 
     `username: str`
     :   Your Atlassian account email address
+
+<a id="ConfluenceConnector"></a>
 
 `ConfluenceConnector(auth_config: ConfluenceAuthConfig | AirbyteAuthConfig | BaseModel | None = None, on_token_refresh: Any | None = None, subdomain: str | None = None)`
 :   Type-safe Confluence API connector.
@@ -540,6 +564,8 @@ Classes
             for entity in entities:
                 print(f"\{entity['entity_name']\}: \{entity['available_actions']\}")
 
+<a id="GroupsSearchData"></a>
+
 `GroupsSearchData(**data: Any)`
 :   Search result data for groups entity.
     
@@ -570,6 +596,8 @@ Classes
 
     `type_: str | None`
     :   The type of group
+
+<a id="PagesSearchData"></a>
 
 `PagesSearchData(**data: Any)`
 :   Search result data for pages entity.
@@ -631,6 +659,8 @@ Classes
 
     `version: dict[str, typing.Any] | None`
     :   Version information
+
+<a id="SpacesSearchData"></a>
 
 `SpacesSearchData(**data: Any)`
 :   Search result data for spaces entity.

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/confluence/models.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/confluence/models.md
@@ -13,6 +13,8 @@ and response envelope types.
 Classes
 -------
 
+<a id="AirbyteSearchMeta"></a>
+
 `AirbyteSearchMeta(**data: Any)`
 :   Pagination metadata for search responses.
     
@@ -40,6 +42,8 @@ Classes
 
     `took_ms: int | None`
     :   Time taken to execute the search in milliseconds.
+
+<a id="AirbyteSearchResult"></a>
 
 `AirbyteSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -96,6 +100,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="AuditSearchResult"></a>
+
 `AuditSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -132,6 +138,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="BlogPostsSearchResult"></a>
 
 `BlogPostsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -170,6 +178,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="GroupsSearchResult"></a>
+
 `GroupsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -206,6 +216,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="PagesSearchResult"></a>
 
 `PagesSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -244,6 +256,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="SpacesSearchResult"></a>
+
 `SpacesSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -259,6 +273,8 @@ Classes
     * airbyte_agent_sdk.connectors.confluence.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="AuditListResultMeta"></a>
 
 `AuditListResultMeta(**data: Any)`
 :   Metadata for audit.Action.LIST operation
@@ -290,6 +306,8 @@ Classes
 
     `start: int | Any`
     :   The type of the None singleton.
+
+<a id="AuditRecord"></a>
 
 `AuditRecord(**data: Any)`
 :   Confluence audit record
@@ -343,6 +361,8 @@ Classes
     `sys_admin: bool | Any`
     :   The type of the None singleton.
 
+<a id="AuditRecordAffectedobject"></a>
+
 `AuditRecordAffectedobject(**data: Any)`
 :   Object affected by the audit event
     
@@ -368,6 +388,8 @@ Classes
     `object_type: str | Any`
     :   Type of the affected object
 
+<a id="AuditRecordAssociatedobjectsItem"></a>
+
 `AuditRecordAssociatedobjectsItem(**data: Any)`
 :   Nested schema for AuditRecord.associatedObjects_item
     
@@ -392,6 +414,8 @@ Classes
 
     `object_type: str | Any`
     :   Type of the associated object
+
+<a id="AuditRecordAuthor"></a>
 
 `AuditRecordAuthor(**data: Any)`
 :   User who triggered the audit event
@@ -433,6 +457,8 @@ Classes
     `type_: str | Any`
     :   Author type
 
+<a id="AuditRecordsList"></a>
+
 `AuditRecordsList(**data: Any)`
 :   Paginated list of audit records
     
@@ -467,6 +493,8 @@ Classes
     `start: int | Any`
     :   The type of the None singleton.
 
+<a id="AuditRecordsListLinks"></a>
+
 `AuditRecordsListLinks(**data: Any)`
 :   Nested schema for AuditRecordsList._links
     
@@ -497,6 +525,8 @@ Classes
 
     `self: str | Any`
     :   The type of the None singleton.
+
+<a id="AuditSearchData"></a>
 
 `AuditSearchData(**data: Any)`
 :   Search result data for audit entity.
@@ -550,6 +580,8 @@ Classes
     `sys_admin: bool | None`
     :   Indicates if the user triggering the audit event is a system admin.
 
+<a id="BlogPost"></a>
+
 `BlogPost(**data: Any)`
 :   Confluence blog post object
     
@@ -596,6 +628,8 @@ Classes
     `version: airbyte_agent_sdk.connectors.confluence.models.BlogPostVersion | Any`
     :   The type of the None singleton.
 
+<a id="BlogPostBody"></a>
+
 `BlogPostBody(**data: Any)`
 :   Blog post body content
     
@@ -620,6 +654,8 @@ Classes
 
     `storage: dict[str, typing.Any] | Any`
     :   Storage format body
+
+<a id="BlogPostLinks"></a>
 
 `BlogPostLinks(**data: Any)`
 :   Links related to the blog post
@@ -654,6 +690,8 @@ Classes
 
     `webui: str | Any`
     :   Web UI link
+
+<a id="BlogPostVersion"></a>
 
 `BlogPostVersion(**data: Any)`
 :   Version information
@@ -692,6 +730,8 @@ Classes
     `number: int | Any`
     :   Version number
 
+<a id="BlogPostsList"></a>
+
 `BlogPostsList(**data: Any)`
 :   Paginated list of blog posts
     
@@ -716,6 +756,8 @@ Classes
 
     `results: list[airbyte_agent_sdk.connectors.confluence.models.BlogPost] | Any`
     :   The type of the None singleton.
+
+<a id="BlogPostsListLinks"></a>
 
 `BlogPostsListLinks(**data: Any)`
 :   Nested schema for BlogPostsList._links
@@ -742,6 +784,8 @@ Classes
     `next: str | Any`
     :   URL for the next page of results
 
+<a id="BlogPostsListResultMeta"></a>
+
 `BlogPostsListResultMeta(**data: Any)`
 :   Metadata for blog_posts.Action.LIST operation
     
@@ -763,6 +807,8 @@ Classes
 
     `next: str | Any`
     :   The type of the None singleton.
+
+<a id="BlogPostsSearchData"></a>
 
 `BlogPostsSearchData(**data: Any)`
 :   Search result data for blog_posts entity.
@@ -810,6 +856,8 @@ Classes
     `version: dict[str, typing.Any] | None`
     :   Version information
 
+<a id="ConfluenceAuthConfig"></a>
+
 `ConfluenceAuthConfig(**data: Any)`
 :   Confluence API Token Authentication - Authenticate using your Atlassian account email and API token
     
@@ -834,6 +882,8 @@ Classes
 
     `username: str`
     :   Your Atlassian account email address
+
+<a id="ConfluenceCheckResult"></a>
 
 `ConfluenceCheckResult(**data: Any)`
 :   Result of a health check operation.
@@ -868,6 +918,8 @@ Classes
     `status: str`
     :   Health check status: 'healthy' or 'unhealthy'.
 
+<a id="ConfluenceExecuteResult"></a>
+
 `ConfluenceExecuteResult(**data: Any)`
 :   Response envelope with data only.
     
@@ -896,6 +948,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="ConfluenceExecuteResultWithMeta"></a>
 
 `ConfluenceExecuteResultWithMeta(**data: Any)`
 :   Response envelope with data and metadata.
@@ -952,6 +1006,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="AuditListResult"></a>
+
 `AuditListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -994,6 +1050,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="BlogPostsListResult"></a>
 
 `BlogPostsListResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -1038,6 +1096,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="GroupsListResult"></a>
+
 `GroupsListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -1080,6 +1140,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="PagesListResult"></a>
 
 `PagesListResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -1124,6 +1186,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="SpacesListResult"></a>
+
 `SpacesListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -1142,6 +1206,8 @@ Classes
     * airbyte_agent_sdk.connectors.confluence.models.ConfluenceExecuteResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="Group"></a>
 
 `Group(**data: Any)`
 :   Confluence group object
@@ -1183,6 +1249,8 @@ Classes
     `usage_type: str | Any`
     :   The type of the None singleton.
 
+<a id="GroupLinks"></a>
+
 `GroupLinks(**data: Any)`
 :   Links related to the group
     
@@ -1204,6 +1272,8 @@ Classes
 
     `self: str | Any`
     :   Self link
+
+<a id="GroupsList"></a>
 
 `GroupsList(**data: Any)`
 :   Paginated list of groups
@@ -1239,6 +1309,8 @@ Classes
     `start: int | Any`
     :   The type of the None singleton.
 
+<a id="GroupsListLinks"></a>
+
 `GroupsListLinks(**data: Any)`
 :   Nested schema for GroupsList._links
     
@@ -1269,6 +1341,8 @@ Classes
 
     `self: str | Any`
     :   The type of the None singleton.
+
+<a id="GroupsListResultMeta"></a>
 
 `GroupsListResultMeta(**data: Any)`
 :   Metadata for groups.Action.LIST operation
@@ -1301,6 +1375,8 @@ Classes
     `start: int | Any`
     :   The type of the None singleton.
 
+<a id="GroupsSearchData"></a>
+
 `GroupsSearchData(**data: Any)`
 :   Search result data for groups entity.
     
@@ -1331,6 +1407,8 @@ Classes
 
     `type_: str | None`
     :   The type of group
+
+<a id="Page"></a>
 
 `Page(**data: Any)`
 :   Confluence page object
@@ -1393,6 +1471,8 @@ Classes
     `version: airbyte_agent_sdk.connectors.confluence.models.PageVersion | Any`
     :   The type of the None singleton.
 
+<a id="PageBody"></a>
+
 `PageBody(**data: Any)`
 :   Page body content
     
@@ -1417,6 +1497,8 @@ Classes
 
     `storage: dict[str, typing.Any] | Any`
     :   Storage format body
+
+<a id="PageLinks"></a>
 
 `PageLinks(**data: Any)`
 :   Links related to the page
@@ -1451,6 +1533,8 @@ Classes
 
     `webui: str | Any`
     :   Web UI link
+
+<a id="PageVersion"></a>
 
 `PageVersion(**data: Any)`
 :   Version information
@@ -1489,6 +1573,8 @@ Classes
     `number: int | Any`
     :   Version number
 
+<a id="PagesList"></a>
+
 `PagesList(**data: Any)`
 :   Paginated list of pages
     
@@ -1513,6 +1599,8 @@ Classes
 
     `results: list[airbyte_agent_sdk.connectors.confluence.models.Page] | Any`
     :   The type of the None singleton.
+
+<a id="PagesListLinks"></a>
 
 `PagesListLinks(**data: Any)`
 :   Nested schema for PagesList._links
@@ -1539,6 +1627,8 @@ Classes
     `next: str | Any`
     :   URL for the next page of results
 
+<a id="PagesListResultMeta"></a>
+
 `PagesListResultMeta(**data: Any)`
 :   Metadata for pages.Action.LIST operation
     
@@ -1560,6 +1650,8 @@ Classes
 
     `next: str | Any`
     :   The type of the None singleton.
+
+<a id="PagesSearchData"></a>
 
 `PagesSearchData(**data: Any)`
 :   Search result data for pages entity.
@@ -1622,6 +1714,8 @@ Classes
     `version: dict[str, typing.Any] | None`
     :   Version information
 
+<a id="Space"></a>
+
 `Space(**data: Any)`
 :   Confluence space object
     
@@ -1680,6 +1774,8 @@ Classes
     `type_: str | Any`
     :   The type of the None singleton.
 
+<a id="SpaceLinks"></a>
+
 `SpaceLinks(**data: Any)`
 :   Links related to the space
     
@@ -1704,6 +1800,8 @@ Classes
 
     `webui: str | Any`
     :   Web UI link
+
+<a id="SpacesList"></a>
 
 `SpacesList(**data: Any)`
 :   Paginated list of spaces
@@ -1730,6 +1828,8 @@ Classes
     `results: list[airbyte_agent_sdk.connectors.confluence.models.Space] | Any`
     :   The type of the None singleton.
 
+<a id="SpacesListLinks"></a>
+
 `SpacesListLinks(**data: Any)`
 :   Nested schema for SpacesList._links
     
@@ -1755,6 +1855,8 @@ Classes
     `next: str | Any`
     :   URL for the next page of results
 
+<a id="SpacesListResultMeta"></a>
+
 `SpacesListResultMeta(**data: Any)`
 :   Metadata for spaces.Action.LIST operation
     
@@ -1776,6 +1878,8 @@ Classes
 
     `next: str | Any`
     :   The type of the None singleton.
+
+<a id="SpacesSearchData"></a>
 
 `SpacesSearchData(**data: Any)`
 :   Search result data for spaces entity.

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/confluence/types.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/confluence/types.md
@@ -10,6 +10,8 @@ Type definitions for confluence connector.
 Classes
 -------
 
+<a id="AirbyteSearchParams"></a>
+
 `AirbyteSearchParams(*args, **kwargs)`
 :   Parameters for Airbyte cache search operations (generic, use entity-specific query types for better type hints).
 
@@ -31,6 +33,8 @@ Classes
     `query: dict[str, typing.Any]`
     :   The type of the None singleton.
 
+<a id="AuditAndCondition"></a>
+
 `AuditAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -51,6 +55,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.confluence.types.AuditEqCondition | airbyte_agent_sdk.connectors.confluence.types.AuditNeqCondition | airbyte_agent_sdk.connectors.confluence.types.AuditGtCondition | airbyte_agent_sdk.connectors.confluence.types.AuditGteCondition | airbyte_agent_sdk.connectors.confluence.types.AuditLtCondition | airbyte_agent_sdk.connectors.confluence.types.AuditLteCondition | airbyte_agent_sdk.connectors.confluence.types.AuditInCondition | airbyte_agent_sdk.connectors.confluence.types.AuditLikeCondition | airbyte_agent_sdk.connectors.confluence.types.AuditFuzzyCondition | airbyte_agent_sdk.connectors.confluence.types.AuditKeywordCondition | airbyte_agent_sdk.connectors.confluence.types.AuditContainsCondition | airbyte_agent_sdk.connectors.confluence.types.AuditNotCondition | airbyte_agent_sdk.connectors.confluence.types.AuditAndCondition | airbyte_agent_sdk.connectors.confluence.types.AuditOrCondition | airbyte_agent_sdk.connectors.confluence.types.AuditAnyCondition]`
     :   The type of the None singleton.
 
+<a id="AuditAnyCondition"></a>
+
 `AuditAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -70,6 +76,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.confluence.types.AuditAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="AuditAnyValueFilter"></a>
 
 `AuditAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -113,6 +121,8 @@ Classes
     `sys_admin: Any`
     :   Indicates if the user triggering the audit event is a system admin.
 
+<a id="AuditContainsCondition"></a>
+
 `AuditContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -124,6 +134,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.confluence.types.AuditAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="AuditEqCondition"></a>
 
 `AuditEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -137,6 +149,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.confluence.types.AuditSearchFilter`
     :   The type of the None singleton.
 
+<a id="AuditFuzzyCondition"></a>
+
 `AuditFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -148,6 +162,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.confluence.types.AuditStringFilter`
     :   The type of the None singleton.
+
+<a id="AuditGtCondition"></a>
 
 `AuditGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
@@ -161,6 +177,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.confluence.types.AuditSearchFilter`
     :   The type of the None singleton.
 
+<a id="AuditGteCondition"></a>
+
 `AuditGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -172,6 +190,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.confluence.types.AuditSearchFilter`
     :   The type of the None singleton.
+
+<a id="AuditInCondition"></a>
 
 `AuditInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -192,6 +212,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.confluence.types.AuditInFilter`
     :   The type of the None singleton.
+
+<a id="AuditInFilter"></a>
 
 `AuditInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -235,6 +257,8 @@ Classes
     `sys_admin: list[bool]`
     :   Indicates if the user triggering the audit event is a system admin.
 
+<a id="AuditKeywordCondition"></a>
+
 `AuditKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -247,6 +271,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.confluence.types.AuditStringFilter`
     :   The type of the None singleton.
 
+<a id="AuditLikeCondition"></a>
+
 `AuditLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -258,6 +284,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.confluence.types.AuditStringFilter`
     :   The type of the None singleton.
+
+<a id="AuditListParams"></a>
 
 `AuditListParams(*args, **kwargs)`
 :   Parameters for audit.list operation
@@ -283,6 +311,8 @@ Classes
     `start_date: str`
     :   The type of the None singleton.
 
+<a id="AuditLtCondition"></a>
+
 `AuditLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -294,6 +324,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.confluence.types.AuditSearchFilter`
     :   The type of the None singleton.
+
+<a id="AuditLteCondition"></a>
 
 `AuditLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -307,6 +339,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.confluence.types.AuditSearchFilter`
     :   The type of the None singleton.
 
+<a id="AuditNeqCondition"></a>
+
 `AuditNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -318,6 +352,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.confluence.types.AuditSearchFilter`
     :   The type of the None singleton.
+
+<a id="AuditNotCondition"></a>
 
 `AuditNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -339,6 +375,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.confluence.types.AuditEqCondition | airbyte_agent_sdk.connectors.confluence.types.AuditNeqCondition | airbyte_agent_sdk.connectors.confluence.types.AuditGtCondition | airbyte_agent_sdk.connectors.confluence.types.AuditGteCondition | airbyte_agent_sdk.connectors.confluence.types.AuditLtCondition | airbyte_agent_sdk.connectors.confluence.types.AuditLteCondition | airbyte_agent_sdk.connectors.confluence.types.AuditInCondition | airbyte_agent_sdk.connectors.confluence.types.AuditLikeCondition | airbyte_agent_sdk.connectors.confluence.types.AuditFuzzyCondition | airbyte_agent_sdk.connectors.confluence.types.AuditKeywordCondition | airbyte_agent_sdk.connectors.confluence.types.AuditContainsCondition | airbyte_agent_sdk.connectors.confluence.types.AuditNotCondition | airbyte_agent_sdk.connectors.confluence.types.AuditAndCondition | airbyte_agent_sdk.connectors.confluence.types.AuditOrCondition | airbyte_agent_sdk.connectors.confluence.types.AuditAnyCondition`
     :   The type of the None singleton.
 
+<a id="AuditOrCondition"></a>
+
 `AuditOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -358,6 +396,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.confluence.types.AuditEqCondition | airbyte_agent_sdk.connectors.confluence.types.AuditNeqCondition | airbyte_agent_sdk.connectors.confluence.types.AuditGtCondition | airbyte_agent_sdk.connectors.confluence.types.AuditGteCondition | airbyte_agent_sdk.connectors.confluence.types.AuditLtCondition | airbyte_agent_sdk.connectors.confluence.types.AuditLteCondition | airbyte_agent_sdk.connectors.confluence.types.AuditInCondition | airbyte_agent_sdk.connectors.confluence.types.AuditLikeCondition | airbyte_agent_sdk.connectors.confluence.types.AuditFuzzyCondition | airbyte_agent_sdk.connectors.confluence.types.AuditKeywordCondition | airbyte_agent_sdk.connectors.confluence.types.AuditContainsCondition | airbyte_agent_sdk.connectors.confluence.types.AuditNotCondition | airbyte_agent_sdk.connectors.confluence.types.AuditAndCondition | airbyte_agent_sdk.connectors.confluence.types.AuditOrCondition | airbyte_agent_sdk.connectors.confluence.types.AuditAnyCondition]`
     :   The type of the None singleton.
+
+<a id="AuditSearchFilter"></a>
 
 `AuditSearchFilter(*args, **kwargs)`
 :   Available fields for filtering audit search queries.
@@ -401,6 +441,8 @@ Classes
     `sys_admin: bool | None`
     :   Indicates if the user triggering the audit event is a system admin.
 
+<a id="AuditSearchQuery"></a>
+
 `AuditSearchQuery(*args, **kwargs)`
 :   Search query for audit entity.
 
@@ -415,6 +457,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.confluence.types.AuditSortFilter]`
     :   The type of the None singleton.
+
+<a id="AuditSortFilter"></a>
 
 `AuditSortFilter(*args, **kwargs)`
 :   Available fields for sorting audit search results.
@@ -458,6 +502,8 @@ Classes
     `sys_admin: Literal['asc', 'desc']`
     :   Indicates if the user triggering the audit event is a system admin.
 
+<a id="AuditStringFilter"></a>
+
 `AuditStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -500,6 +546,8 @@ Classes
     `sys_admin: str`
     :   Indicates if the user triggering the audit event is a system admin.
 
+<a id="BlogPostsAndCondition"></a>
+
 `BlogPostsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -520,6 +568,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.confluence.types.BlogPostsEqCondition | airbyte_agent_sdk.connectors.confluence.types.BlogPostsNeqCondition | airbyte_agent_sdk.connectors.confluence.types.BlogPostsGtCondition | airbyte_agent_sdk.connectors.confluence.types.BlogPostsGteCondition | airbyte_agent_sdk.connectors.confluence.types.BlogPostsLtCondition | airbyte_agent_sdk.connectors.confluence.types.BlogPostsLteCondition | airbyte_agent_sdk.connectors.confluence.types.BlogPostsInCondition | airbyte_agent_sdk.connectors.confluence.types.BlogPostsLikeCondition | airbyte_agent_sdk.connectors.confluence.types.BlogPostsFuzzyCondition | airbyte_agent_sdk.connectors.confluence.types.BlogPostsKeywordCondition | airbyte_agent_sdk.connectors.confluence.types.BlogPostsContainsCondition | airbyte_agent_sdk.connectors.confluence.types.BlogPostsNotCondition | airbyte_agent_sdk.connectors.confluence.types.BlogPostsAndCondition | airbyte_agent_sdk.connectors.confluence.types.BlogPostsOrCondition | airbyte_agent_sdk.connectors.confluence.types.BlogPostsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="BlogPostsAnyCondition"></a>
+
 `BlogPostsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -539,6 +589,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.confluence.types.BlogPostsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="BlogPostsAnyValueFilter"></a>
 
 `BlogPostsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -576,6 +628,8 @@ Classes
     `version: Any`
     :   Version information
 
+<a id="BlogPostsContainsCondition"></a>
+
 `BlogPostsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -587,6 +641,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.confluence.types.BlogPostsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="BlogPostsEqCondition"></a>
 
 `BlogPostsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -600,6 +656,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.confluence.types.BlogPostsSearchFilter`
     :   The type of the None singleton.
 
+<a id="BlogPostsFuzzyCondition"></a>
+
 `BlogPostsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -611,6 +669,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.confluence.types.BlogPostsStringFilter`
     :   The type of the None singleton.
+
+<a id="BlogPostsGetParams"></a>
 
 `BlogPostsGetParams(*args, **kwargs)`
 :   Parameters for blog_posts.get operation
@@ -630,6 +690,8 @@ Classes
     `version: int`
     :   The type of the None singleton.
 
+<a id="BlogPostsGtCondition"></a>
+
 `BlogPostsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -642,6 +704,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.confluence.types.BlogPostsSearchFilter`
     :   The type of the None singleton.
 
+<a id="BlogPostsGteCondition"></a>
+
 `BlogPostsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -653,6 +717,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.confluence.types.BlogPostsSearchFilter`
     :   The type of the None singleton.
+
+<a id="BlogPostsInCondition"></a>
 
 `BlogPostsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -673,6 +739,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.confluence.types.BlogPostsInFilter`
     :   The type of the None singleton.
+
+<a id="BlogPostsInFilter"></a>
 
 `BlogPostsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -710,6 +778,8 @@ Classes
     `version: list[dict[str, typing.Any]]`
     :   Version information
 
+<a id="BlogPostsKeywordCondition"></a>
+
 `BlogPostsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -722,6 +792,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.confluence.types.BlogPostsStringFilter`
     :   The type of the None singleton.
 
+<a id="BlogPostsLikeCondition"></a>
+
 `BlogPostsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -733,6 +805,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.confluence.types.BlogPostsStringFilter`
     :   The type of the None singleton.
+
+<a id="BlogPostsListParams"></a>
 
 `BlogPostsListParams(*args, **kwargs)`
 :   Parameters for blog_posts.list operation
@@ -764,6 +838,8 @@ Classes
     `title: str`
     :   The type of the None singleton.
 
+<a id="BlogPostsLtCondition"></a>
+
 `BlogPostsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -775,6 +851,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.confluence.types.BlogPostsSearchFilter`
     :   The type of the None singleton.
+
+<a id="BlogPostsLteCondition"></a>
 
 `BlogPostsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -788,6 +866,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.confluence.types.BlogPostsSearchFilter`
     :   The type of the None singleton.
 
+<a id="BlogPostsNeqCondition"></a>
+
 `BlogPostsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -799,6 +879,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.confluence.types.BlogPostsSearchFilter`
     :   The type of the None singleton.
+
+<a id="BlogPostsNotCondition"></a>
 
 `BlogPostsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -820,6 +902,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.confluence.types.BlogPostsEqCondition | airbyte_agent_sdk.connectors.confluence.types.BlogPostsNeqCondition | airbyte_agent_sdk.connectors.confluence.types.BlogPostsGtCondition | airbyte_agent_sdk.connectors.confluence.types.BlogPostsGteCondition | airbyte_agent_sdk.connectors.confluence.types.BlogPostsLtCondition | airbyte_agent_sdk.connectors.confluence.types.BlogPostsLteCondition | airbyte_agent_sdk.connectors.confluence.types.BlogPostsInCondition | airbyte_agent_sdk.connectors.confluence.types.BlogPostsLikeCondition | airbyte_agent_sdk.connectors.confluence.types.BlogPostsFuzzyCondition | airbyte_agent_sdk.connectors.confluence.types.BlogPostsKeywordCondition | airbyte_agent_sdk.connectors.confluence.types.BlogPostsContainsCondition | airbyte_agent_sdk.connectors.confluence.types.BlogPostsNotCondition | airbyte_agent_sdk.connectors.confluence.types.BlogPostsAndCondition | airbyte_agent_sdk.connectors.confluence.types.BlogPostsOrCondition | airbyte_agent_sdk.connectors.confluence.types.BlogPostsAnyCondition`
     :   The type of the None singleton.
 
+<a id="BlogPostsOrCondition"></a>
+
 `BlogPostsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -839,6 +923,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.confluence.types.BlogPostsEqCondition | airbyte_agent_sdk.connectors.confluence.types.BlogPostsNeqCondition | airbyte_agent_sdk.connectors.confluence.types.BlogPostsGtCondition | airbyte_agent_sdk.connectors.confluence.types.BlogPostsGteCondition | airbyte_agent_sdk.connectors.confluence.types.BlogPostsLtCondition | airbyte_agent_sdk.connectors.confluence.types.BlogPostsLteCondition | airbyte_agent_sdk.connectors.confluence.types.BlogPostsInCondition | airbyte_agent_sdk.connectors.confluence.types.BlogPostsLikeCondition | airbyte_agent_sdk.connectors.confluence.types.BlogPostsFuzzyCondition | airbyte_agent_sdk.connectors.confluence.types.BlogPostsKeywordCondition | airbyte_agent_sdk.connectors.confluence.types.BlogPostsContainsCondition | airbyte_agent_sdk.connectors.confluence.types.BlogPostsNotCondition | airbyte_agent_sdk.connectors.confluence.types.BlogPostsAndCondition | airbyte_agent_sdk.connectors.confluence.types.BlogPostsOrCondition | airbyte_agent_sdk.connectors.confluence.types.BlogPostsAnyCondition]`
     :   The type of the None singleton.
+
+<a id="BlogPostsSearchFilter"></a>
 
 `BlogPostsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering blog_posts search queries.
@@ -876,6 +962,8 @@ Classes
     `version: dict[str, typing.Any] | None`
     :   Version information
 
+<a id="BlogPostsSearchQuery"></a>
+
 `BlogPostsSearchQuery(*args, **kwargs)`
 :   Search query for blog_posts entity.
 
@@ -890,6 +978,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.confluence.types.BlogPostsSortFilter]`
     :   The type of the None singleton.
+
+<a id="BlogPostsSortFilter"></a>
 
 `BlogPostsSortFilter(*args, **kwargs)`
 :   Available fields for sorting blog_posts search results.
@@ -927,6 +1017,8 @@ Classes
     `version: Literal['asc', 'desc']`
     :   Version information
 
+<a id="BlogPostsStringFilter"></a>
+
 `BlogPostsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -963,6 +1055,8 @@ Classes
     `version: str`
     :   Version information
 
+<a id="GroupsAndCondition"></a>
+
 `GroupsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -983,6 +1077,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.confluence.types.GroupsEqCondition | airbyte_agent_sdk.connectors.confluence.types.GroupsNeqCondition | airbyte_agent_sdk.connectors.confluence.types.GroupsGtCondition | airbyte_agent_sdk.connectors.confluence.types.GroupsGteCondition | airbyte_agent_sdk.connectors.confluence.types.GroupsLtCondition | airbyte_agent_sdk.connectors.confluence.types.GroupsLteCondition | airbyte_agent_sdk.connectors.confluence.types.GroupsInCondition | airbyte_agent_sdk.connectors.confluence.types.GroupsLikeCondition | airbyte_agent_sdk.connectors.confluence.types.GroupsFuzzyCondition | airbyte_agent_sdk.connectors.confluence.types.GroupsKeywordCondition | airbyte_agent_sdk.connectors.confluence.types.GroupsContainsCondition | airbyte_agent_sdk.connectors.confluence.types.GroupsNotCondition | airbyte_agent_sdk.connectors.confluence.types.GroupsAndCondition | airbyte_agent_sdk.connectors.confluence.types.GroupsOrCondition | airbyte_agent_sdk.connectors.confluence.types.GroupsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="GroupsAnyCondition"></a>
+
 `GroupsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1002,6 +1098,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.confluence.types.GroupsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="GroupsAnyValueFilter"></a>
 
 `GroupsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -1024,6 +1122,8 @@ Classes
     `type_: Any`
     :   The type of group
 
+<a id="GroupsContainsCondition"></a>
+
 `GroupsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -1035,6 +1135,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.confluence.types.GroupsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="GroupsEqCondition"></a>
 
 `GroupsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -1048,6 +1150,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.confluence.types.GroupsSearchFilter`
     :   The type of the None singleton.
 
+<a id="GroupsFuzzyCondition"></a>
+
 `GroupsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -1059,6 +1163,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.confluence.types.GroupsStringFilter`
     :   The type of the None singleton.
+
+<a id="GroupsGtCondition"></a>
 
 `GroupsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
@@ -1072,6 +1178,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.confluence.types.GroupsSearchFilter`
     :   The type of the None singleton.
 
+<a id="GroupsGteCondition"></a>
+
 `GroupsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -1083,6 +1191,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.confluence.types.GroupsSearchFilter`
     :   The type of the None singleton.
+
+<a id="GroupsInCondition"></a>
 
 `GroupsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -1103,6 +1213,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.confluence.types.GroupsInFilter`
     :   The type of the None singleton.
+
+<a id="GroupsInFilter"></a>
 
 `GroupsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -1125,6 +1237,8 @@ Classes
     `type_: list[str]`
     :   The type of group
 
+<a id="GroupsKeywordCondition"></a>
+
 `GroupsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -1137,6 +1251,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.confluence.types.GroupsStringFilter`
     :   The type of the None singleton.
 
+<a id="GroupsLikeCondition"></a>
+
 `GroupsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -1148,6 +1264,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.confluence.types.GroupsStringFilter`
     :   The type of the None singleton.
+
+<a id="GroupsListParams"></a>
 
 `GroupsListParams(*args, **kwargs)`
 :   Parameters for groups.list operation
@@ -1164,6 +1282,8 @@ Classes
     `start: int`
     :   The type of the None singleton.
 
+<a id="GroupsLtCondition"></a>
+
 `GroupsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -1175,6 +1295,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.confluence.types.GroupsSearchFilter`
     :   The type of the None singleton.
+
+<a id="GroupsLteCondition"></a>
 
 `GroupsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -1188,6 +1310,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.confluence.types.GroupsSearchFilter`
     :   The type of the None singleton.
 
+<a id="GroupsNeqCondition"></a>
+
 `GroupsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -1199,6 +1323,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.confluence.types.GroupsSearchFilter`
     :   The type of the None singleton.
+
+<a id="GroupsNotCondition"></a>
 
 `GroupsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -1220,6 +1346,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.confluence.types.GroupsEqCondition | airbyte_agent_sdk.connectors.confluence.types.GroupsNeqCondition | airbyte_agent_sdk.connectors.confluence.types.GroupsGtCondition | airbyte_agent_sdk.connectors.confluence.types.GroupsGteCondition | airbyte_agent_sdk.connectors.confluence.types.GroupsLtCondition | airbyte_agent_sdk.connectors.confluence.types.GroupsLteCondition | airbyte_agent_sdk.connectors.confluence.types.GroupsInCondition | airbyte_agent_sdk.connectors.confluence.types.GroupsLikeCondition | airbyte_agent_sdk.connectors.confluence.types.GroupsFuzzyCondition | airbyte_agent_sdk.connectors.confluence.types.GroupsKeywordCondition | airbyte_agent_sdk.connectors.confluence.types.GroupsContainsCondition | airbyte_agent_sdk.connectors.confluence.types.GroupsNotCondition | airbyte_agent_sdk.connectors.confluence.types.GroupsAndCondition | airbyte_agent_sdk.connectors.confluence.types.GroupsOrCondition | airbyte_agent_sdk.connectors.confluence.types.GroupsAnyCondition`
     :   The type of the None singleton.
 
+<a id="GroupsOrCondition"></a>
+
 `GroupsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1239,6 +1367,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.confluence.types.GroupsEqCondition | airbyte_agent_sdk.connectors.confluence.types.GroupsNeqCondition | airbyte_agent_sdk.connectors.confluence.types.GroupsGtCondition | airbyte_agent_sdk.connectors.confluence.types.GroupsGteCondition | airbyte_agent_sdk.connectors.confluence.types.GroupsLtCondition | airbyte_agent_sdk.connectors.confluence.types.GroupsLteCondition | airbyte_agent_sdk.connectors.confluence.types.GroupsInCondition | airbyte_agent_sdk.connectors.confluence.types.GroupsLikeCondition | airbyte_agent_sdk.connectors.confluence.types.GroupsFuzzyCondition | airbyte_agent_sdk.connectors.confluence.types.GroupsKeywordCondition | airbyte_agent_sdk.connectors.confluence.types.GroupsContainsCondition | airbyte_agent_sdk.connectors.confluence.types.GroupsNotCondition | airbyte_agent_sdk.connectors.confluence.types.GroupsAndCondition | airbyte_agent_sdk.connectors.confluence.types.GroupsOrCondition | airbyte_agent_sdk.connectors.confluence.types.GroupsAnyCondition]`
     :   The type of the None singleton.
+
+<a id="GroupsSearchFilter"></a>
 
 `GroupsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering groups search queries.
@@ -1261,6 +1391,8 @@ Classes
     `type_: str | None`
     :   The type of group
 
+<a id="GroupsSearchQuery"></a>
+
 `GroupsSearchQuery(*args, **kwargs)`
 :   Search query for groups entity.
 
@@ -1275,6 +1407,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.confluence.types.GroupsSortFilter]`
     :   The type of the None singleton.
+
+<a id="GroupsSortFilter"></a>
 
 `GroupsSortFilter(*args, **kwargs)`
 :   Available fields for sorting groups search results.
@@ -1297,6 +1431,8 @@ Classes
     `type_: Literal['asc', 'desc']`
     :   The type of group
 
+<a id="GroupsStringFilter"></a>
+
 `GroupsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -1318,6 +1454,8 @@ Classes
     `type_: str`
     :   The type of group
 
+<a id="PagesAndCondition"></a>
+
 `PagesAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1338,6 +1476,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.confluence.types.PagesEqCondition | airbyte_agent_sdk.connectors.confluence.types.PagesNeqCondition | airbyte_agent_sdk.connectors.confluence.types.PagesGtCondition | airbyte_agent_sdk.connectors.confluence.types.PagesGteCondition | airbyte_agent_sdk.connectors.confluence.types.PagesLtCondition | airbyte_agent_sdk.connectors.confluence.types.PagesLteCondition | airbyte_agent_sdk.connectors.confluence.types.PagesInCondition | airbyte_agent_sdk.connectors.confluence.types.PagesLikeCondition | airbyte_agent_sdk.connectors.confluence.types.PagesFuzzyCondition | airbyte_agent_sdk.connectors.confluence.types.PagesKeywordCondition | airbyte_agent_sdk.connectors.confluence.types.PagesContainsCondition | airbyte_agent_sdk.connectors.confluence.types.PagesNotCondition | airbyte_agent_sdk.connectors.confluence.types.PagesAndCondition | airbyte_agent_sdk.connectors.confluence.types.PagesOrCondition | airbyte_agent_sdk.connectors.confluence.types.PagesAnyCondition]`
     :   The type of the None singleton.
 
+<a id="PagesAnyCondition"></a>
+
 `PagesAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1357,6 +1497,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.confluence.types.PagesAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="PagesAnyValueFilter"></a>
 
 `PagesAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -1409,6 +1551,8 @@ Classes
     `version: Any`
     :   Version information
 
+<a id="PagesContainsCondition"></a>
+
 `PagesContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -1420,6 +1564,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.confluence.types.PagesAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="PagesEqCondition"></a>
 
 `PagesEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -1433,6 +1579,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.confluence.types.PagesSearchFilter`
     :   The type of the None singleton.
 
+<a id="PagesFuzzyCondition"></a>
+
 `PagesFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -1444,6 +1592,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.confluence.types.PagesStringFilter`
     :   The type of the None singleton.
+
+<a id="PagesGetParams"></a>
 
 `PagesGetParams(*args, **kwargs)`
 :   Parameters for pages.get operation
@@ -1463,6 +1613,8 @@ Classes
     `version: int`
     :   The type of the None singleton.
 
+<a id="PagesGtCondition"></a>
+
 `PagesGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -1475,6 +1627,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.confluence.types.PagesSearchFilter`
     :   The type of the None singleton.
 
+<a id="PagesGteCondition"></a>
+
 `PagesGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -1486,6 +1640,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.confluence.types.PagesSearchFilter`
     :   The type of the None singleton.
+
+<a id="PagesInCondition"></a>
 
 `PagesInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -1506,6 +1662,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.confluence.types.PagesInFilter`
     :   The type of the None singleton.
+
+<a id="PagesInFilter"></a>
 
 `PagesInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -1558,6 +1716,8 @@ Classes
     `version: list[dict[str, typing.Any]]`
     :   Version information
 
+<a id="PagesKeywordCondition"></a>
+
 `PagesKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -1570,6 +1730,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.confluence.types.PagesStringFilter`
     :   The type of the None singleton.
 
+<a id="PagesLikeCondition"></a>
+
 `PagesLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -1581,6 +1743,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.confluence.types.PagesStringFilter`
     :   The type of the None singleton.
+
+<a id="PagesListParams"></a>
 
 `PagesListParams(*args, **kwargs)`
 :   Parameters for pages.list operation
@@ -1612,6 +1776,8 @@ Classes
     `title: str`
     :   The type of the None singleton.
 
+<a id="PagesLtCondition"></a>
+
 `PagesLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -1623,6 +1789,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.confluence.types.PagesSearchFilter`
     :   The type of the None singleton.
+
+<a id="PagesLteCondition"></a>
 
 `PagesLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -1636,6 +1804,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.confluence.types.PagesSearchFilter`
     :   The type of the None singleton.
 
+<a id="PagesNeqCondition"></a>
+
 `PagesNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -1647,6 +1817,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.confluence.types.PagesSearchFilter`
     :   The type of the None singleton.
+
+<a id="PagesNotCondition"></a>
 
 `PagesNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -1668,6 +1840,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.confluence.types.PagesEqCondition | airbyte_agent_sdk.connectors.confluence.types.PagesNeqCondition | airbyte_agent_sdk.connectors.confluence.types.PagesGtCondition | airbyte_agent_sdk.connectors.confluence.types.PagesGteCondition | airbyte_agent_sdk.connectors.confluence.types.PagesLtCondition | airbyte_agent_sdk.connectors.confluence.types.PagesLteCondition | airbyte_agent_sdk.connectors.confluence.types.PagesInCondition | airbyte_agent_sdk.connectors.confluence.types.PagesLikeCondition | airbyte_agent_sdk.connectors.confluence.types.PagesFuzzyCondition | airbyte_agent_sdk.connectors.confluence.types.PagesKeywordCondition | airbyte_agent_sdk.connectors.confluence.types.PagesContainsCondition | airbyte_agent_sdk.connectors.confluence.types.PagesNotCondition | airbyte_agent_sdk.connectors.confluence.types.PagesAndCondition | airbyte_agent_sdk.connectors.confluence.types.PagesOrCondition | airbyte_agent_sdk.connectors.confluence.types.PagesAnyCondition`
     :   The type of the None singleton.
 
+<a id="PagesOrCondition"></a>
+
 `PagesOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1687,6 +1861,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.confluence.types.PagesEqCondition | airbyte_agent_sdk.connectors.confluence.types.PagesNeqCondition | airbyte_agent_sdk.connectors.confluence.types.PagesGtCondition | airbyte_agent_sdk.connectors.confluence.types.PagesGteCondition | airbyte_agent_sdk.connectors.confluence.types.PagesLtCondition | airbyte_agent_sdk.connectors.confluence.types.PagesLteCondition | airbyte_agent_sdk.connectors.confluence.types.PagesInCondition | airbyte_agent_sdk.connectors.confluence.types.PagesLikeCondition | airbyte_agent_sdk.connectors.confluence.types.PagesFuzzyCondition | airbyte_agent_sdk.connectors.confluence.types.PagesKeywordCondition | airbyte_agent_sdk.connectors.confluence.types.PagesContainsCondition | airbyte_agent_sdk.connectors.confluence.types.PagesNotCondition | airbyte_agent_sdk.connectors.confluence.types.PagesAndCondition | airbyte_agent_sdk.connectors.confluence.types.PagesOrCondition | airbyte_agent_sdk.connectors.confluence.types.PagesAnyCondition]`
     :   The type of the None singleton.
+
+<a id="PagesSearchFilter"></a>
 
 `PagesSearchFilter(*args, **kwargs)`
 :   Available fields for filtering pages search queries.
@@ -1739,6 +1915,8 @@ Classes
     `version: dict[str, typing.Any] | None`
     :   Version information
 
+<a id="PagesSearchQuery"></a>
+
 `PagesSearchQuery(*args, **kwargs)`
 :   Search query for pages entity.
 
@@ -1753,6 +1931,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.confluence.types.PagesSortFilter]`
     :   The type of the None singleton.
+
+<a id="PagesSortFilter"></a>
 
 `PagesSortFilter(*args, **kwargs)`
 :   Available fields for sorting pages search results.
@@ -1805,6 +1985,8 @@ Classes
     `version: Literal['asc', 'desc']`
     :   Version information
 
+<a id="PagesStringFilter"></a>
+
 `PagesStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -1856,6 +2038,8 @@ Classes
     `version: str`
     :   Version information
 
+<a id="SpacesAndCondition"></a>
+
 `SpacesAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1876,6 +2060,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.confluence.types.SpacesEqCondition | airbyte_agent_sdk.connectors.confluence.types.SpacesNeqCondition | airbyte_agent_sdk.connectors.confluence.types.SpacesGtCondition | airbyte_agent_sdk.connectors.confluence.types.SpacesGteCondition | airbyte_agent_sdk.connectors.confluence.types.SpacesLtCondition | airbyte_agent_sdk.connectors.confluence.types.SpacesLteCondition | airbyte_agent_sdk.connectors.confluence.types.SpacesInCondition | airbyte_agent_sdk.connectors.confluence.types.SpacesLikeCondition | airbyte_agent_sdk.connectors.confluence.types.SpacesFuzzyCondition | airbyte_agent_sdk.connectors.confluence.types.SpacesKeywordCondition | airbyte_agent_sdk.connectors.confluence.types.SpacesContainsCondition | airbyte_agent_sdk.connectors.confluence.types.SpacesNotCondition | airbyte_agent_sdk.connectors.confluence.types.SpacesAndCondition | airbyte_agent_sdk.connectors.confluence.types.SpacesOrCondition | airbyte_agent_sdk.connectors.confluence.types.SpacesAnyCondition]`
     :   The type of the None singleton.
 
+<a id="SpacesAnyCondition"></a>
+
 `SpacesAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1895,6 +2081,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.confluence.types.SpacesAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="SpacesAnyValueFilter"></a>
 
 `SpacesAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -1938,6 +2126,8 @@ Classes
     `type_: Any`
     :   Space type (global or personal)
 
+<a id="SpacesContainsCondition"></a>
+
 `SpacesContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -1949,6 +2139,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.confluence.types.SpacesAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="SpacesEqCondition"></a>
 
 `SpacesEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -1962,6 +2154,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.confluence.types.SpacesSearchFilter`
     :   The type of the None singleton.
 
+<a id="SpacesFuzzyCondition"></a>
+
 `SpacesFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -1973,6 +2167,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.confluence.types.SpacesStringFilter`
     :   The type of the None singleton.
+
+<a id="SpacesGetParams"></a>
 
 `SpacesGetParams(*args, **kwargs)`
 :   Parameters for spaces.get operation
@@ -1989,6 +2185,8 @@ Classes
     `id: str`
     :   The type of the None singleton.
 
+<a id="SpacesGtCondition"></a>
+
 `SpacesGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -2001,6 +2199,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.confluence.types.SpacesSearchFilter`
     :   The type of the None singleton.
 
+<a id="SpacesGteCondition"></a>
+
 `SpacesGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -2012,6 +2212,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.confluence.types.SpacesSearchFilter`
     :   The type of the None singleton.
+
+<a id="SpacesInCondition"></a>
 
 `SpacesInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -2032,6 +2234,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.confluence.types.SpacesInFilter`
     :   The type of the None singleton.
+
+<a id="SpacesInFilter"></a>
 
 `SpacesInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -2075,6 +2279,8 @@ Classes
     `type_: list[str]`
     :   Space type (global or personal)
 
+<a id="SpacesKeywordCondition"></a>
+
 `SpacesKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -2087,6 +2293,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.confluence.types.SpacesStringFilter`
     :   The type of the None singleton.
 
+<a id="SpacesLikeCondition"></a>
+
 `SpacesLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -2098,6 +2306,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.confluence.types.SpacesStringFilter`
     :   The type of the None singleton.
+
+<a id="SpacesListParams"></a>
 
 `SpacesListParams(*args, **kwargs)`
 :   Parameters for spaces.list operation
@@ -2128,6 +2338,8 @@ Classes
     `keys(self, /) ‑> list[str]`
     :   Return a set-like object providing a view on the dict's keys.
 
+<a id="SpacesLtCondition"></a>
+
 `SpacesLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -2139,6 +2351,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.confluence.types.SpacesSearchFilter`
     :   The type of the None singleton.
+
+<a id="SpacesLteCondition"></a>
 
 `SpacesLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -2152,6 +2366,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.confluence.types.SpacesSearchFilter`
     :   The type of the None singleton.
 
+<a id="SpacesNeqCondition"></a>
+
 `SpacesNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -2163,6 +2379,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.confluence.types.SpacesSearchFilter`
     :   The type of the None singleton.
+
+<a id="SpacesNotCondition"></a>
 
 `SpacesNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -2184,6 +2402,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.confluence.types.SpacesEqCondition | airbyte_agent_sdk.connectors.confluence.types.SpacesNeqCondition | airbyte_agent_sdk.connectors.confluence.types.SpacesGtCondition | airbyte_agent_sdk.connectors.confluence.types.SpacesGteCondition | airbyte_agent_sdk.connectors.confluence.types.SpacesLtCondition | airbyte_agent_sdk.connectors.confluence.types.SpacesLteCondition | airbyte_agent_sdk.connectors.confluence.types.SpacesInCondition | airbyte_agent_sdk.connectors.confluence.types.SpacesLikeCondition | airbyte_agent_sdk.connectors.confluence.types.SpacesFuzzyCondition | airbyte_agent_sdk.connectors.confluence.types.SpacesKeywordCondition | airbyte_agent_sdk.connectors.confluence.types.SpacesContainsCondition | airbyte_agent_sdk.connectors.confluence.types.SpacesNotCondition | airbyte_agent_sdk.connectors.confluence.types.SpacesAndCondition | airbyte_agent_sdk.connectors.confluence.types.SpacesOrCondition | airbyte_agent_sdk.connectors.confluence.types.SpacesAnyCondition`
     :   The type of the None singleton.
 
+<a id="SpacesOrCondition"></a>
+
 `SpacesOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -2203,6 +2423,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.confluence.types.SpacesEqCondition | airbyte_agent_sdk.connectors.confluence.types.SpacesNeqCondition | airbyte_agent_sdk.connectors.confluence.types.SpacesGtCondition | airbyte_agent_sdk.connectors.confluence.types.SpacesGteCondition | airbyte_agent_sdk.connectors.confluence.types.SpacesLtCondition | airbyte_agent_sdk.connectors.confluence.types.SpacesLteCondition | airbyte_agent_sdk.connectors.confluence.types.SpacesInCondition | airbyte_agent_sdk.connectors.confluence.types.SpacesLikeCondition | airbyte_agent_sdk.connectors.confluence.types.SpacesFuzzyCondition | airbyte_agent_sdk.connectors.confluence.types.SpacesKeywordCondition | airbyte_agent_sdk.connectors.confluence.types.SpacesContainsCondition | airbyte_agent_sdk.connectors.confluence.types.SpacesNotCondition | airbyte_agent_sdk.connectors.confluence.types.SpacesAndCondition | airbyte_agent_sdk.connectors.confluence.types.SpacesOrCondition | airbyte_agent_sdk.connectors.confluence.types.SpacesAnyCondition]`
     :   The type of the None singleton.
+
+<a id="SpacesSearchFilter"></a>
 
 `SpacesSearchFilter(*args, **kwargs)`
 :   Available fields for filtering spaces search queries.
@@ -2246,6 +2468,8 @@ Classes
     `type_: str | None`
     :   Space type (global or personal)
 
+<a id="SpacesSearchQuery"></a>
+
 `SpacesSearchQuery(*args, **kwargs)`
 :   Search query for spaces entity.
 
@@ -2260,6 +2484,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.confluence.types.SpacesSortFilter]`
     :   The type of the None singleton.
+
+<a id="SpacesSortFilter"></a>
 
 `SpacesSortFilter(*args, **kwargs)`
 :   Available fields for sorting spaces search results.
@@ -2302,6 +2528,8 @@ Classes
 
     `type_: Literal['asc', 'desc']`
     :   Space type (global or personal)
+
+<a id="SpacesStringFilter"></a>
 
 `SpacesStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/facebook_marketing/connector.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/facebook_marketing/connector.md
@@ -10,6 +10,8 @@ Facebook-Marketing connector.
 Classes
 -------
 
+<a id="AdAccountQuery"></a>
+
 `AdAccountQuery(connector: FacebookMarketingConnector)`
 :   Query class for AdAccount entity operations.
     
@@ -60,6 +62,8 @@ Classes
         
         Returns:
             AdAccount
+
+<a id="AdAccountsQuery"></a>
 
 `AdAccountsQuery(connector: FacebookMarketingConnector)`
 :   Query class for AdAccounts entity operations.
@@ -113,6 +117,8 @@ Classes
         Returns:
             AdAccountsListResult
 
+<a id="AdCreativesQuery"></a>
+
 `AdCreativesQuery(connector: FacebookMarketingConnector)`
 :   Query class for AdCreatives entity operations.
     
@@ -165,6 +171,8 @@ Classes
         Returns:
             AdCreativesListResult
 
+<a id="AdLibraryQuery"></a>
+
 `AdLibraryQuery(connector: FacebookMarketingConnector)`
 :   Query class for AdLibrary entity operations.
     
@@ -196,6 +204,8 @@ Classes
         
         Returns:
             AdLibraryListResult
+
+<a id="AdSetsQuery"></a>
 
 `AdSetsQuery(connector: FacebookMarketingConnector)`
 :   Query class for AdSets entity operations.
@@ -284,6 +294,8 @@ Classes
         Returns:
             UpdateResponse
 
+<a id="AdsInsightsQuery"></a>
+
 `AdsInsightsQuery(connector: FacebookMarketingConnector)`
 :   Query class for AdsInsights entity operations.
     
@@ -348,6 +360,8 @@ Classes
         
         Returns:
             AdsInsightsListResult
+
+<a id="AdsQuery"></a>
 
 `AdsQuery(connector: FacebookMarketingConnector)`
 :   Query class for Ads entity operations.
@@ -430,6 +444,8 @@ Classes
         
         Returns:
             UpdateResponse
+
+<a id="CampaignsQuery"></a>
 
 `CampaignsQuery(connector: FacebookMarketingConnector)`
 :   Query class for Campaigns entity operations.
@@ -517,6 +533,8 @@ Classes
         Returns:
             UpdateResponse
 
+<a id="CurrentUserQuery"></a>
+
 `CurrentUserQuery(connector: FacebookMarketingConnector)`
 :   Query class for CurrentUser entity operations.
     
@@ -533,6 +551,8 @@ Classes
         
         Returns:
             CurrentUser
+
+<a id="CustomConversionsQuery"></a>
 
 `CustomConversionsQuery(connector: FacebookMarketingConnector)`
 :   Query class for CustomConversions entity operations.
@@ -584,6 +604,8 @@ Classes
         
         Returns:
             CustomConversionsListResult
+
+<a id="FacebookMarketingConnector"></a>
 
 `FacebookMarketingConnector(auth_config: FacebookMarketingAuthConfig | AirbyteAuthConfig | BaseModel | None = None, on_token_refresh: Any | None = None)`
 :   Type-safe Facebook-Marketing API connector.
@@ -841,6 +863,8 @@ Classes
             for entity in entities:
                 print(f"\{entity['entity_name']\}: \{entity['available_actions']\}")
 
+<a id="ImagesQuery"></a>
+
 `ImagesQuery(connector: FacebookMarketingConnector)`
 :   Query class for Images entity operations.
     
@@ -894,6 +918,8 @@ Classes
         Returns:
             ImagesListResult
 
+<a id="PixelStatsQuery"></a>
+
 `PixelStatsQuery(connector: FacebookMarketingConnector)`
 :   Query class for PixelStats entity operations.
     
@@ -913,6 +939,8 @@ Classes
         
         Returns:
             PixelStatsListResult
+
+<a id="PixelsQuery"></a>
 
 `PixelsQuery(connector: FacebookMarketingConnector)`
 :   Query class for Pixels entity operations.
@@ -944,6 +972,8 @@ Classes
         
         Returns:
             PixelsListResult
+
+<a id="VideosQuery"></a>
 
 `VideosQuery(connector: FacebookMarketingConnector)`
 :   Query class for Videos entity operations.

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/facebook_marketing/index.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/facebook_marketing/index.md
@@ -19,6 +19,8 @@ Sub-modules
 Classes
 -------
 
+<a id="AdAccountSearchData"></a>
+
 `AdAccountSearchData(**data: Any)`
 :   Search result data for ad_account entity.
     
@@ -70,6 +72,8 @@ Classes
 
     `timezone_name: str | None`
     :   Timezone name
+
+<a id="AdAccountsSearchData"></a>
 
 `AdAccountsSearchData(**data: Any)`
 :   Search result data for ad_accounts entity.
@@ -123,6 +127,8 @@ Classes
     `timezone_name: str | None`
     :   Timezone name
 
+<a id="AdCreativesSearchData"></a>
+
 `AdCreativesSearchData(**data: Any)`
 :   Search result data for ad_creatives entity.
     
@@ -171,6 +177,8 @@ Classes
 
     `title: str | None`
     :   Ad title
+
+<a id="AdSetsSearchData"></a>
 
 `AdSetsSearchData(**data: Any)`
 :   Search result data for ad_sets entity.
@@ -232,6 +240,8 @@ Classes
 
     `updated_time: str | None`
     :   Last update time
+
+<a id="AdsInsightsSearchData"></a>
 
 `AdsInsightsSearchData(**data: Any)`
 :   Search result data for ads_insights entity.
@@ -309,6 +319,8 @@ Classes
     `spend: float | None`
     :   Amount spent
 
+<a id="AdsSearchData"></a>
+
 `AdsSearchData(**data: Any)`
 :   Search result data for ads entity.
     
@@ -354,6 +366,8 @@ Classes
 
     `updated_time: str | None`
     :   Last update time
+
+<a id="AirbyteAuthConfig"></a>
 
 `AirbyteAuthConfig(**data: Any)`
 :   Authentication configuration for Airbyte hosted mode execution.
@@ -423,6 +437,8 @@ Classes
     `workspace_name: str | None`
     :   The type of the None singleton.
 
+<a id="AirbyteSearchMeta"></a>
+
 `AirbyteSearchMeta(**data: Any)`
 :   Pagination metadata for search responses.
     
@@ -450,6 +466,8 @@ Classes
 
     `took_ms: int | None`
     :   Time taken to execute the search in milliseconds.
+
+<a id="AirbyteSearchResult"></a>
 
 `AirbyteSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -490,6 +508,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="AdAccountSearchResult"></a>
+
 `AdAccountSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -505,6 +525,8 @@ Classes
     * airbyte_agent_sdk.connectors.facebook_marketing.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="AdAccountsSearchResult"></a>
 
 `AdAccountsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -522,6 +544,8 @@ Classes
     * pydantic.main.BaseModel
     * typing.Generic
 
+<a id="AdCreativesSearchResult"></a>
+
 `AdCreativesSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -537,6 +561,8 @@ Classes
     * airbyte_agent_sdk.connectors.facebook_marketing.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="AdSetsSearchResult"></a>
 
 `AdSetsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -554,6 +580,8 @@ Classes
     * pydantic.main.BaseModel
     * typing.Generic
 
+<a id="AdsInsightsSearchResult"></a>
+
 `AdsInsightsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -569,6 +597,8 @@ Classes
     * airbyte_agent_sdk.connectors.facebook_marketing.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="AdsSearchResult"></a>
 
 `AdsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -586,6 +616,8 @@ Classes
     * pydantic.main.BaseModel
     * typing.Generic
 
+<a id="CampaignsSearchResult"></a>
+
 `CampaignsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -601,6 +633,8 @@ Classes
     * airbyte_agent_sdk.connectors.facebook_marketing.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="CustomConversionsSearchResult"></a>
 
 `CustomConversionsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -618,6 +652,8 @@ Classes
     * pydantic.main.BaseModel
     * typing.Generic
 
+<a id="ImagesSearchResult"></a>
+
 `ImagesSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -634,6 +670,8 @@ Classes
     * pydantic.main.BaseModel
     * typing.Generic
 
+<a id="VideosSearchResult"></a>
+
 `VideosSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -649,6 +687,8 @@ Classes
     * airbyte_agent_sdk.connectors.facebook_marketing.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="CampaignsSearchData"></a>
 
 `CampaignsSearchData(**data: Any)`
 :   Search result data for campaigns entity.
@@ -708,6 +748,8 @@ Classes
     `updated_time: str | None`
     :   Last update time
 
+<a id="CustomConversionsSearchData"></a>
+
 `CustomConversionsSearchData(**data: Any)`
 :   Search result data for custom_conversions entity.
     
@@ -753,6 +795,8 @@ Classes
 
     `name: str | None`
     :   Custom Conversion name
+
+<a id="FacebookMarketingConnector"></a>
 
 `FacebookMarketingConnector(auth_config: FacebookMarketingAuthConfig | AirbyteAuthConfig | BaseModel | None = None, on_token_refresh: Any | None = None)`
 :   Type-safe Facebook-Marketing API connector.
@@ -1010,6 +1054,8 @@ Classes
             for entity in entities:
                 print(f"\{entity['entity_name']\}: \{entity['available_actions']\}")
 
+<a id="FacebookMarketingReplicationConfig"></a>
+
 `FacebookMarketingReplicationConfig(**data: Any)`
 :   Replication Configuration - Settings for data replication from Facebook Marketing.
     
@@ -1031,6 +1077,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="ImagesSearchData"></a>
 
 `ImagesSearchData(**data: Any)`
 :   Search result data for images entity.
@@ -1083,6 +1131,8 @@ Classes
 
     `width: int | None`
     :   Image width
+
+<a id="VideosSearchData"></a>
 
 `VideosSearchData(**data: Any)`
 :   Search result data for videos entity.

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/facebook_marketing/models.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/facebook_marketing/models.md
@@ -13,6 +13,8 @@ and response envelope types.
 Classes
 -------
 
+<a id="Ad"></a>
+
 `Ad(**data: Any)`
 :   Facebook Ad
     
@@ -91,6 +93,8 @@ Classes
 
     `updated_time: str | Any | None`
     :   The type of the None singleton.
+
+<a id="AdAccount"></a>
 
 `AdAccount(**data: Any)`
 :   Facebook Ad Account
@@ -210,6 +214,8 @@ Classes
     `timezone_offset_hours_utc: float | Any | None`
     :   The type of the None singleton.
 
+<a id="AdAccountListItem"></a>
+
 `AdAccountListItem(**data: Any)`
 :   Facebook Ad Account in list response
     
@@ -274,6 +280,8 @@ Classes
     `timezone_name: str | Any | None`
     :   The type of the None singleton.
 
+<a id="AdAccountSearchData"></a>
+
 `AdAccountSearchData(**data: Any)`
 :   Search result data for ad_account entity.
     
@@ -326,6 +334,8 @@ Classes
     `timezone_name: str | None`
     :   Timezone name
 
+<a id="AdAccountsList"></a>
+
 `AdAccountsList(**data: Any)`
 :   List of Facebook Ad Accounts
     
@@ -351,6 +361,8 @@ Classes
     `paging: airbyte_agent_sdk.connectors.facebook_marketing.models.Paging | Any`
     :   The type of the None singleton.
 
+<a id="AdAccountsListResultMeta"></a>
+
 `AdAccountsListResultMeta(**data: Any)`
 :   Metadata for ad_accounts.Action.LIST operation
     
@@ -372,6 +384,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="AdAccountsSearchData"></a>
 
 `AdAccountsSearchData(**data: Any)`
 :   Search result data for ad_accounts entity.
@@ -425,6 +439,8 @@ Classes
     `timezone_name: str | None`
     :   Timezone name
 
+<a id="AdCreateParams"></a>
+
 `AdCreateParams(**data: Any)`
 :   Parameters for creating a new ad. Note - requires a Facebook Page to be connected to the ad account.
     
@@ -462,6 +478,8 @@ Classes
     `tracking_specs: str | Any | None`
     :   The type of the None singleton.
 
+<a id="AdCreateResponse"></a>
+
 `AdCreateResponse(**data: Any)`
 :   Response from creating an ad
     
@@ -483,6 +501,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="AdCreative"></a>
 
 `AdCreative(**data: Any)`
 :   Facebook Ad Creative
@@ -554,6 +574,8 @@ Classes
     `url_tags: str | Any | None`
     :   The type of the None singleton.
 
+<a id="AdCreativeRef"></a>
+
 `AdCreativeRef(**data: Any)`
 :   AdCreativeRef type definition
     
@@ -578,6 +600,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="AdCreativesList"></a>
 
 `AdCreativesList(**data: Any)`
 :   AdCreativesList type definition
@@ -604,6 +628,8 @@ Classes
     `paging: airbyte_agent_sdk.connectors.facebook_marketing.models.Paging | Any`
     :   The type of the None singleton.
 
+<a id="AdCreativesListResultMeta"></a>
+
 `AdCreativesListResultMeta(**data: Any)`
 :   Metadata for ad_creatives.Action.LIST operation
     
@@ -625,6 +651,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="AdCreativesSearchData"></a>
 
 `AdCreativesSearchData(**data: Any)`
 :   Search result data for ad_creatives entity.
@@ -675,6 +703,8 @@ Classes
     `title: str | None`
     :   Ad title
 
+<a id="AdLabel"></a>
+
 `AdLabel(**data: Any)`
 :   AdLabel type definition
     
@@ -705,6 +735,8 @@ Classes
 
     `updated_time: str | Any | None`
     :   The type of the None singleton.
+
+<a id="AdLibraryAd"></a>
 
 `AdLibraryAd(**data: Any)`
 :   An archived ad from the Facebook Ad Library, containing ad creative content, delivery information, spend data, and demographic reach breakdowns.
@@ -809,6 +841,8 @@ Classes
     `total_reach_by_location: list[dict[str, typing.Any]] | Any | None`
     :   The type of the None singleton.
 
+<a id="AdLibraryAdDeliveryByRegionItem"></a>
+
 `AdLibraryAdDeliveryByRegionItem(**data: Any)`
 :   Nested schema for AdLibraryAd.delivery_by_region_item
     
@@ -833,6 +867,8 @@ Classes
 
     `region: str | Any | None`
     :   Region name
+
+<a id="AdLibraryAdDemographicDistributionItem"></a>
 
 `AdLibraryAdDemographicDistributionItem(**data: Any)`
 :   Nested schema for AdLibraryAd.demographic_distribution_item
@@ -862,6 +898,8 @@ Classes
     `percentage: str | Any | None`
     :   Percentage of audience in this demographic
 
+<a id="AdLibraryAdEstimatedAudienceSize"></a>
+
 `AdLibraryAdEstimatedAudienceSize(**data: Any)`
 :   Estimated audience size range
     
@@ -886,6 +924,8 @@ Classes
 
     `upper_bound: int | Any | None`
     :   Upper bound of the estimated audience size
+
+<a id="AdLibraryAdImpressions"></a>
 
 `AdLibraryAdImpressions(**data: Any)`
 :   Number of impressions as a range
@@ -912,6 +952,8 @@ Classes
     `upper_bound: int | Any | None`
     :   Upper bound of impressions
 
+<a id="AdLibraryAdSpend"></a>
+
 `AdLibraryAdSpend(**data: Any)`
 :   Amount spent on the ad as a range
     
@@ -936,6 +978,8 @@ Classes
 
     `upper_bound: int | Any | None`
     :   Upper bound of spend
+
+<a id="AdLibraryList"></a>
 
 `AdLibraryList(**data: Any)`
 :   AdLibraryList type definition
@@ -962,6 +1006,8 @@ Classes
     `paging: airbyte_agent_sdk.connectors.facebook_marketing.models.Paging | Any`
     :   The type of the None singleton.
 
+<a id="AdLibraryListResultMeta"></a>
+
 `AdLibraryListResultMeta(**data: Any)`
 :   Metadata for ad_library.Action.LIST operation
     
@@ -983,6 +1029,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="AdSet"></a>
 
 `AdSet(**data: Any)`
 :   Facebook Ad Set
@@ -1063,6 +1111,8 @@ Classes
     `updated_time: str | Any | None`
     :   The type of the None singleton.
 
+<a id="AdSetCreateParams"></a>
+
 `AdSetCreateParams(**data: Any)`
 :   Parameters for creating a new ad set
     
@@ -1115,6 +1165,8 @@ Classes
     `targeting: str | Any`
     :   The type of the None singleton.
 
+<a id="AdSetCreateResponse"></a>
+
 `AdSetCreateResponse(**data: Any)`
 :   Response from creating an ad set
     
@@ -1136,6 +1188,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="AdSetUpdateParams"></a>
 
 `AdSetUpdateParams(**data: Any)`
 :   Parameters for updating an ad set
@@ -1180,6 +1234,8 @@ Classes
     `targeting: str | Any | None`
     :   The type of the None singleton.
 
+<a id="AdSetsList"></a>
+
 `AdSetsList(**data: Any)`
 :   AdSetsList type definition
     
@@ -1205,6 +1261,8 @@ Classes
     `paging: airbyte_agent_sdk.connectors.facebook_marketing.models.Paging | Any`
     :   The type of the None singleton.
 
+<a id="AdSetsListResultMeta"></a>
+
 `AdSetsListResultMeta(**data: Any)`
 :   Metadata for ad_sets.Action.LIST operation
     
@@ -1226,6 +1284,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="AdSetsSearchData"></a>
 
 `AdSetsSearchData(**data: Any)`
 :   Search result data for ad_sets entity.
@@ -1288,6 +1348,8 @@ Classes
     `updated_time: str | None`
     :   Last update time
 
+<a id="AdUpdateParams"></a>
+
 `AdUpdateParams(**data: Any)`
 :   Parameters for updating an ad
     
@@ -1321,6 +1383,8 @@ Classes
 
     `tracking_specs: str | Any | None`
     :   The type of the None singleton.
+
+<a id="AdsActionStats"></a>
 
 `AdsActionStats(**data: Any)`
 :   Action statistics for Facebook ads
@@ -1370,6 +1434,8 @@ Classes
 
     `value: float | Any | None`
     :   The type of the None singleton.
+
+<a id="AdsInsight"></a>
 
 `AdsInsight(**data: Any)`
 :   Facebook Ads Insight
@@ -1447,6 +1513,8 @@ Classes
     `spend: float | Any | None`
     :   The type of the None singleton.
 
+<a id="AdsInsightsList"></a>
+
 `AdsInsightsList(**data: Any)`
 :   AdsInsightsList type definition
     
@@ -1472,6 +1540,8 @@ Classes
     `paging: airbyte_agent_sdk.connectors.facebook_marketing.models.Paging | Any`
     :   The type of the None singleton.
 
+<a id="AdsInsightsListResultMeta"></a>
+
 `AdsInsightsListResultMeta(**data: Any)`
 :   Metadata for ads_insights.Action.LIST operation
     
@@ -1493,6 +1563,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="AdsInsightsSearchData"></a>
 
 `AdsInsightsSearchData(**data: Any)`
 :   Search result data for ads_insights entity.
@@ -1570,6 +1642,8 @@ Classes
     `spend: float | None`
     :   Amount spent
 
+<a id="AdsList"></a>
+
 `AdsList(**data: Any)`
 :   AdsList type definition
     
@@ -1595,6 +1669,8 @@ Classes
     `paging: airbyte_agent_sdk.connectors.facebook_marketing.models.Paging | Any`
     :   The type of the None singleton.
 
+<a id="AdsListResultMeta"></a>
+
 `AdsListResultMeta(**data: Any)`
 :   Metadata for ads.Action.LIST operation
     
@@ -1616,6 +1692,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="AdsSearchData"></a>
 
 `AdsSearchData(**data: Any)`
 :   Search result data for ads entity.
@@ -1663,6 +1741,8 @@ Classes
     `updated_time: str | None`
     :   Last update time
 
+<a id="AirbyteSearchMeta"></a>
+
 `AirbyteSearchMeta(**data: Any)`
 :   Pagination metadata for search responses.
     
@@ -1690,6 +1770,8 @@ Classes
 
     `took_ms: int | None`
     :   Time taken to execute the search in milliseconds.
+
+<a id="AirbyteSearchResult"></a>
 
 `AirbyteSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -1751,6 +1833,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="AdAccountSearchResult"></a>
+
 `AdAccountSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -1787,6 +1871,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="AdAccountsSearchResult"></a>
 
 `AdAccountsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -1825,6 +1911,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="AdCreativesSearchResult"></a>
+
 `AdCreativesSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -1861,6 +1949,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="AdSetsSearchResult"></a>
 
 `AdSetsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -1899,6 +1989,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="AdsInsightsSearchResult"></a>
+
 `AdsInsightsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -1935,6 +2027,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="AdsSearchResult"></a>
 
 `AdsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -1973,6 +2067,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="CampaignsSearchResult"></a>
+
 `CampaignsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -2009,6 +2105,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="CustomConversionsSearchResult"></a>
 
 `CustomConversionsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -2047,6 +2145,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="ImagesSearchResult"></a>
+
 `ImagesSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -2084,6 +2184,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="VideosSearchResult"></a>
+
 `VideosSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -2099,6 +2201,8 @@ Classes
     * airbyte_agent_sdk.connectors.facebook_marketing.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="BidConstraints"></a>
 
 `BidConstraints(**data: Any)`
 :   BidConstraints type definition
@@ -2121,6 +2225,8 @@ Classes
 
     `roas_average_floor: int | Any | None`
     :   The type of the None singleton.
+
+<a id="BidInfo"></a>
 
 `BidInfo(**data: Any)`
 :   BidInfo type definition
@@ -2156,6 +2262,8 @@ Classes
     `social: int | Any | None`
     :   The type of the None singleton.
 
+<a id="BusinessRef"></a>
+
 `BusinessRef(**data: Any)`
 :   Reference to a Facebook Business
     
@@ -2180,6 +2288,8 @@ Classes
 
     `name: str | Any | None`
     :   The type of the None singleton.
+
+<a id="Campaign"></a>
 
 `Campaign(**data: Any)`
 :   Facebook Ad Campaign
@@ -2275,6 +2385,8 @@ Classes
     `updated_time: str | Any | None`
     :   The type of the None singleton.
 
+<a id="CampaignCreateParams"></a>
+
 `CampaignCreateParams(**data: Any)`
 :   Parameters for creating a new campaign
     
@@ -2318,6 +2430,8 @@ Classes
     `status: str | Any`
     :   The type of the None singleton.
 
+<a id="CampaignCreateResponse"></a>
+
 `CampaignCreateResponse(**data: Any)`
 :   Response from creating a campaign
     
@@ -2339,6 +2453,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="CampaignUpdateParams"></a>
 
 `CampaignUpdateParams(**data: Any)`
 :   Parameters for updating a campaign
@@ -2377,6 +2493,8 @@ Classes
     `status: str | Any | None`
     :   The type of the None singleton.
 
+<a id="CampaignsList"></a>
+
 `CampaignsList(**data: Any)`
 :   CampaignsList type definition
     
@@ -2402,6 +2520,8 @@ Classes
     `paging: airbyte_agent_sdk.connectors.facebook_marketing.models.Paging | Any`
     :   The type of the None singleton.
 
+<a id="CampaignsListResultMeta"></a>
+
 `CampaignsListResultMeta(**data: Any)`
 :   Metadata for campaigns.Action.LIST operation
     
@@ -2423,6 +2543,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="CampaignsSearchData"></a>
 
 `CampaignsSearchData(**data: Any)`
 :   Search result data for campaigns entity.
@@ -2482,6 +2604,8 @@ Classes
     `updated_time: str | None`
     :   Last update time
 
+<a id="CurrentUser"></a>
+
 `CurrentUser(**data: Any)`
 :   Current Facebook user associated with the access token
     
@@ -2506,6 +2630,8 @@ Classes
 
     `name: str | Any | None`
     :   The type of the None singleton.
+
+<a id="CustomConversion"></a>
 
 `CustomConversion(**data: Any)`
 :   Facebook Custom Conversion
@@ -2577,6 +2703,8 @@ Classes
     `rule: str | Any | None`
     :   The type of the None singleton.
 
+<a id="CustomConversionsList"></a>
+
 `CustomConversionsList(**data: Any)`
 :   CustomConversionsList type definition
     
@@ -2602,6 +2730,8 @@ Classes
     `paging: airbyte_agent_sdk.connectors.facebook_marketing.models.Paging | Any`
     :   The type of the None singleton.
 
+<a id="CustomConversionsListResultMeta"></a>
+
 `CustomConversionsListResultMeta(**data: Any)`
 :   Metadata for custom_conversions.Action.LIST operation
     
@@ -2623,6 +2753,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="CustomConversionsSearchData"></a>
 
 `CustomConversionsSearchData(**data: Any)`
 :   Search result data for custom_conversions entity.
@@ -2670,6 +2802,8 @@ Classes
     `name: str | None`
     :   Custom Conversion name
 
+<a id="DataSource"></a>
+
 `DataSource(**data: Any)`
 :   DataSource type definition
     
@@ -2697,6 +2831,8 @@ Classes
 
     `source_type: str | Any | None`
     :   The type of the None singleton.
+
+<a id="FacebookMarketingCheckResult"></a>
 
 `FacebookMarketingCheckResult(**data: Any)`
 :   Result of a health check operation.
@@ -2731,6 +2867,8 @@ Classes
     `status: str`
     :   Health check status: 'healthy' or 'unhealthy'.
 
+<a id="FacebookMarketingExecuteResult"></a>
+
 `FacebookMarketingExecuteResult(**data: Any)`
 :   Response envelope with data only.
     
@@ -2760,6 +2898,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="FacebookMarketingExecuteResultWithMeta"></a>
 
 `FacebookMarketingExecuteResultWithMeta(**data: Any)`
 :   Response envelope with data and metadata.
@@ -2822,6 +2962,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="AdAccountsListResult"></a>
+
 `AdAccountsListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -2864,6 +3006,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="AdCreativesListResult"></a>
 
 `AdCreativesListResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -2908,6 +3052,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="AdLibraryListResult"></a>
+
 `AdLibraryListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -2950,6 +3096,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="AdSetsListResult"></a>
 
 `AdSetsListResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -2994,6 +3142,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="AdsListResult"></a>
+
 `AdsListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -3036,6 +3186,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="AdsInsightsListResult"></a>
 
 `AdsInsightsListResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -3080,6 +3232,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="CampaignsListResult"></a>
+
 `CampaignsListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -3122,6 +3276,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="CustomConversionsListResult"></a>
 
 `CustomConversionsListResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -3166,6 +3322,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="ImagesListResult"></a>
+
 `ImagesListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -3208,6 +3366,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="PixelsListResult"></a>
 
 `PixelsListResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -3252,6 +3412,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="VideosListResult"></a>
+
 `VideosListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -3294,6 +3456,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="PixelStatsListResult"></a>
+
 `PixelStatsListResult(**data: Any)`
 :   Response envelope with data only.
     
@@ -3311,6 +3475,8 @@ Classes
     * airbyte_agent_sdk.connectors.facebook_marketing.models.FacebookMarketingExecuteResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="FacebookMarketingOauth20AuthenticationAuthConfig"></a>
 
 `FacebookMarketingOauth20AuthenticationAuthConfig(**data: Any)`
 :   OAuth 2.0 Authentication
@@ -3340,6 +3506,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="FacebookMarketingReplicationConfig"></a>
+
 `FacebookMarketingReplicationConfig(**data: Any)`
 :   Replication Configuration - Settings for data replication from Facebook Marketing.
     
@@ -3362,6 +3530,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="FacebookMarketingServiceAccountKeyAuthenticationAuthConfig"></a>
+
 `FacebookMarketingServiceAccountKeyAuthenticationAuthConfig(**data: Any)`
 :   Service Account Key Authentication
     
@@ -3383,6 +3553,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="Image"></a>
 
 `Image(**data: Any)`
 :   Image type definition
@@ -3454,6 +3626,8 @@ Classes
     `width: int | Any | None`
     :   The type of the None singleton.
 
+<a id="ImagesList"></a>
+
 `ImagesList(**data: Any)`
 :   ImagesList type definition
     
@@ -3479,6 +3653,8 @@ Classes
     `paging: airbyte_agent_sdk.connectors.facebook_marketing.models.Paging | Any`
     :   The type of the None singleton.
 
+<a id="ImagesListResultMeta"></a>
+
 `ImagesListResultMeta(**data: Any)`
 :   Metadata for images.Action.LIST operation
     
@@ -3500,6 +3676,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="ImagesSearchData"></a>
 
 `ImagesSearchData(**data: Any)`
 :   Search result data for images entity.
@@ -3553,6 +3731,8 @@ Classes
     `width: int | None`
     :   Image width
 
+<a id="IssueInfo"></a>
+
 `IssueInfo(**data: Any)`
 :   IssueInfo type definition
     
@@ -3587,6 +3767,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="LearningStageInfo"></a>
+
 `LearningStageInfo(**data: Any)`
 :   LearningStageInfo type definition
     
@@ -3618,6 +3800,8 @@ Classes
     `status: str | Any | None`
     :   The type of the None singleton.
 
+<a id="Paging"></a>
+
 `Paging(**data: Any)`
 :   Paging type definition
     
@@ -3646,6 +3830,8 @@ Classes
     `previous: str | Any | None`
     :   The type of the None singleton.
 
+<a id="PagingCursors"></a>
+
 `PagingCursors(**data: Any)`
 :   Nested schema for Paging.cursors
     
@@ -3670,6 +3856,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="Pixel"></a>
 
 `Pixel(**data: Any)`
 :   Facebook Ads Pixel
@@ -3729,6 +3917,8 @@ Classes
     `owner_business: airbyte_agent_sdk.connectors.facebook_marketing.models.PixelOwnerBusiness | Any | None`
     :   The type of the None singleton.
 
+<a id="PixelCreator"></a>
+
 `PixelCreator(**data: Any)`
 :   User who created the pixel
     
@@ -3753,6 +3943,8 @@ Classes
 
     `name: str | Any | None`
     :   Creator user name
+
+<a id="PixelOwnerAdAccount"></a>
 
 `PixelOwnerAdAccount(**data: Any)`
 :   Ad account that owns the pixel
@@ -3779,6 +3971,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="PixelOwnerBusiness"></a>
+
 `PixelOwnerBusiness(**data: Any)`
 :   Business that owns the pixel
     
@@ -3803,6 +3997,8 @@ Classes
 
     `name: str | Any | None`
     :   Owner business name
+
+<a id="PixelStat"></a>
 
 `PixelStat(**data: Any)`
 :   Facebook Pixel event stat entry showing event counts and quality metrics
@@ -3844,6 +4040,8 @@ Classes
     `total_matched_count: int | Any | None`
     :   The type of the None singleton.
 
+<a id="PixelStatDataItem"></a>
+
 `PixelStatDataItem(**data: Any)`
 :   Nested schema for PixelStat.data_item
     
@@ -3869,6 +4067,8 @@ Classes
     `value: int | Any | None`
     :   Event count at the timestamp
 
+<a id="PixelStatsList"></a>
+
 `PixelStatsList(**data: Any)`
 :   PixelStatsList type definition
     
@@ -3890,6 +4090,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="PixelsList"></a>
 
 `PixelsList(**data: Any)`
 :   PixelsList type definition
@@ -3916,6 +4118,8 @@ Classes
     `paging: airbyte_agent_sdk.connectors.facebook_marketing.models.Paging | Any`
     :   The type of the None singleton.
 
+<a id="PixelsListResultMeta"></a>
+
 `PixelsListResultMeta(**data: Any)`
 :   Metadata for pixels.Action.LIST operation
     
@@ -3937,6 +4141,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="PromotedObject"></a>
 
 `PromotedObject(**data: Any)`
 :   PromotedObject type definition
@@ -3981,6 +4187,8 @@ Classes
     `product_set_id: str | Any | None`
     :   The type of the None singleton.
 
+<a id="Recommendation"></a>
+
 `Recommendation(**data: Any)`
 :   Recommendation type definition
     
@@ -4018,6 +4226,8 @@ Classes
     `title: str | Any | None`
     :   The type of the None singleton.
 
+<a id="UpdateResponse"></a>
+
 `UpdateResponse(**data: Any)`
 :   Generic response from update operations
     
@@ -4039,6 +4249,8 @@ Classes
 
     `success: bool | Any`
     :   The type of the None singleton.
+
+<a id="Video"></a>
 
 `Video(**data: Any)`
 :   Video type definition
@@ -4149,6 +4361,8 @@ Classes
     `views: int | Any | None`
     :   The type of the None singleton.
 
+<a id="VideoFormat"></a>
+
 `VideoFormat(**data: Any)`
 :   VideoFormat type definition
     
@@ -4183,6 +4397,8 @@ Classes
     `width: int | Any | None`
     :   The type of the None singleton.
 
+<a id="VideosList"></a>
+
 `VideosList(**data: Any)`
 :   VideosList type definition
     
@@ -4208,6 +4424,8 @@ Classes
     `paging: airbyte_agent_sdk.connectors.facebook_marketing.models.Paging | Any`
     :   The type of the None singleton.
 
+<a id="VideosListResultMeta"></a>
+
 `VideosListResultMeta(**data: Any)`
 :   Metadata for videos.Action.LIST operation
     
@@ -4229,6 +4447,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="VideosSearchData"></a>
 
 `VideosSearchData(**data: Any)`
 :   Search result data for videos entity.

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/facebook_marketing/types.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/facebook_marketing/types.md
@@ -10,6 +10,8 @@ Type definitions for facebook-marketing connector.
 Classes
 -------
 
+<a id="AdAccountAndCondition"></a>
+
 `AdAccountAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -30,6 +32,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.facebook_marketing.types.AdAccountEqCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdAccountNeqCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdAccountGtCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdAccountGteCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdAccountLtCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdAccountLteCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdAccountInCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdAccountLikeCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdAccountFuzzyCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdAccountKeywordCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdAccountContainsCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdAccountNotCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdAccountAndCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdAccountOrCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdAccountAnyCondition]`
     :   The type of the None singleton.
 
+<a id="AdAccountAnyCondition"></a>
+
 `AdAccountAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -49,6 +53,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.facebook_marketing.types.AdAccountAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="AdAccountAnyValueFilter"></a>
 
 `AdAccountAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -92,6 +98,8 @@ Classes
     `timezone_name: Any`
     :   Timezone name
 
+<a id="AdAccountContainsCondition"></a>
+
 `AdAccountContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -103,6 +111,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.facebook_marketing.types.AdAccountAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="AdAccountEqCondition"></a>
 
 `AdAccountEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -116,6 +126,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.facebook_marketing.types.AdAccountSearchFilter`
     :   The type of the None singleton.
 
+<a id="AdAccountFuzzyCondition"></a>
+
 `AdAccountFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -127,6 +139,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.facebook_marketing.types.AdAccountStringFilter`
     :   The type of the None singleton.
+
+<a id="AdAccountGetParams"></a>
 
 `AdAccountGetParams(*args, **kwargs)`
 :   Parameters for ad_account.get operation
@@ -143,6 +157,8 @@ Classes
     `fields: str`
     :   The type of the None singleton.
 
+<a id="AdAccountGtCondition"></a>
+
 `AdAccountGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -155,6 +171,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.facebook_marketing.types.AdAccountSearchFilter`
     :   The type of the None singleton.
 
+<a id="AdAccountGteCondition"></a>
+
 `AdAccountGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -166,6 +184,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.facebook_marketing.types.AdAccountSearchFilter`
     :   The type of the None singleton.
+
+<a id="AdAccountInCondition"></a>
 
 `AdAccountInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -186,6 +206,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.facebook_marketing.types.AdAccountInFilter`
     :   The type of the None singleton.
+
+<a id="AdAccountInFilter"></a>
 
 `AdAccountInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -229,6 +251,8 @@ Classes
     `timezone_name: list[str]`
     :   Timezone name
 
+<a id="AdAccountKeywordCondition"></a>
+
 `AdAccountKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -240,6 +264,8 @@ Classes
 
     `keyword: airbyte_agent_sdk.connectors.facebook_marketing.types.AdAccountStringFilter`
     :   The type of the None singleton.
+
+<a id="AdAccountLikeCondition"></a>
 
 `AdAccountLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
@@ -253,6 +279,8 @@ Classes
     `like: airbyte_agent_sdk.connectors.facebook_marketing.types.AdAccountStringFilter`
     :   The type of the None singleton.
 
+<a id="AdAccountLtCondition"></a>
+
 `AdAccountLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -264,6 +292,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.facebook_marketing.types.AdAccountSearchFilter`
     :   The type of the None singleton.
+
+<a id="AdAccountLteCondition"></a>
 
 `AdAccountLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -277,6 +307,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.facebook_marketing.types.AdAccountSearchFilter`
     :   The type of the None singleton.
 
+<a id="AdAccountNeqCondition"></a>
+
 `AdAccountNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -288,6 +320,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.facebook_marketing.types.AdAccountSearchFilter`
     :   The type of the None singleton.
+
+<a id="AdAccountNotCondition"></a>
 
 `AdAccountNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -309,6 +343,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.facebook_marketing.types.AdAccountEqCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdAccountNeqCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdAccountGtCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdAccountGteCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdAccountLtCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdAccountLteCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdAccountInCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdAccountLikeCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdAccountFuzzyCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdAccountKeywordCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdAccountContainsCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdAccountNotCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdAccountAndCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdAccountOrCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdAccountAnyCondition`
     :   The type of the None singleton.
 
+<a id="AdAccountOrCondition"></a>
+
 `AdAccountOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -328,6 +364,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.facebook_marketing.types.AdAccountEqCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdAccountNeqCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdAccountGtCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdAccountGteCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdAccountLtCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdAccountLteCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdAccountInCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdAccountLikeCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdAccountFuzzyCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdAccountKeywordCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdAccountContainsCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdAccountNotCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdAccountAndCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdAccountOrCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdAccountAnyCondition]`
     :   The type of the None singleton.
+
+<a id="AdAccountSearchFilter"></a>
 
 `AdAccountSearchFilter(*args, **kwargs)`
 :   Available fields for filtering ad_account search queries.
@@ -371,6 +409,8 @@ Classes
     `timezone_name: str | None`
     :   Timezone name
 
+<a id="AdAccountSearchQuery"></a>
+
 `AdAccountSearchQuery(*args, **kwargs)`
 :   Search query for ad_account entity.
 
@@ -385,6 +425,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.facebook_marketing.types.AdAccountSortFilter]`
     :   The type of the None singleton.
+
+<a id="AdAccountSortFilter"></a>
 
 `AdAccountSortFilter(*args, **kwargs)`
 :   Available fields for sorting ad_account search results.
@@ -428,6 +470,8 @@ Classes
     `timezone_name: Literal['asc', 'desc']`
     :   Timezone name
 
+<a id="AdAccountStringFilter"></a>
+
 `AdAccountStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -470,6 +514,8 @@ Classes
     `timezone_name: str`
     :   Timezone name
 
+<a id="AdAccountsAndCondition"></a>
+
 `AdAccountsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -490,6 +536,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.facebook_marketing.types.AdAccountsEqCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdAccountsNeqCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdAccountsGtCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdAccountsGteCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdAccountsLtCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdAccountsLteCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdAccountsInCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdAccountsLikeCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdAccountsFuzzyCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdAccountsKeywordCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdAccountsContainsCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdAccountsNotCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdAccountsAndCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdAccountsOrCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdAccountsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="AdAccountsAnyCondition"></a>
+
 `AdAccountsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -509,6 +557,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.facebook_marketing.types.AdAccountsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="AdAccountsAnyValueFilter"></a>
 
 `AdAccountsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -552,6 +602,8 @@ Classes
     `timezone_name: Any`
     :   Timezone name
 
+<a id="AdAccountsContainsCondition"></a>
+
 `AdAccountsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -563,6 +615,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.facebook_marketing.types.AdAccountsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="AdAccountsEqCondition"></a>
 
 `AdAccountsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -576,6 +630,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.facebook_marketing.types.AdAccountsSearchFilter`
     :   The type of the None singleton.
 
+<a id="AdAccountsFuzzyCondition"></a>
+
 `AdAccountsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -587,6 +643,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.facebook_marketing.types.AdAccountsStringFilter`
     :   The type of the None singleton.
+
+<a id="AdAccountsGtCondition"></a>
 
 `AdAccountsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
@@ -600,6 +658,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.facebook_marketing.types.AdAccountsSearchFilter`
     :   The type of the None singleton.
 
+<a id="AdAccountsGteCondition"></a>
+
 `AdAccountsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -611,6 +671,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.facebook_marketing.types.AdAccountsSearchFilter`
     :   The type of the None singleton.
+
+<a id="AdAccountsInCondition"></a>
 
 `AdAccountsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -631,6 +693,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.facebook_marketing.types.AdAccountsInFilter`
     :   The type of the None singleton.
+
+<a id="AdAccountsInFilter"></a>
 
 `AdAccountsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -674,6 +738,8 @@ Classes
     `timezone_name: list[str]`
     :   Timezone name
 
+<a id="AdAccountsKeywordCondition"></a>
+
 `AdAccountsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -686,6 +752,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.facebook_marketing.types.AdAccountsStringFilter`
     :   The type of the None singleton.
 
+<a id="AdAccountsLikeCondition"></a>
+
 `AdAccountsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -697,6 +765,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.facebook_marketing.types.AdAccountsStringFilter`
     :   The type of the None singleton.
+
+<a id="AdAccountsListParams"></a>
 
 `AdAccountsListParams(*args, **kwargs)`
 :   Parameters for ad_accounts.list operation
@@ -716,6 +786,8 @@ Classes
     `limit: int`
     :   The type of the None singleton.
 
+<a id="AdAccountsLtCondition"></a>
+
 `AdAccountsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -727,6 +799,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.facebook_marketing.types.AdAccountsSearchFilter`
     :   The type of the None singleton.
+
+<a id="AdAccountsLteCondition"></a>
 
 `AdAccountsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -740,6 +814,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.facebook_marketing.types.AdAccountsSearchFilter`
     :   The type of the None singleton.
 
+<a id="AdAccountsNeqCondition"></a>
+
 `AdAccountsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -751,6 +827,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.facebook_marketing.types.AdAccountsSearchFilter`
     :   The type of the None singleton.
+
+<a id="AdAccountsNotCondition"></a>
 
 `AdAccountsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -772,6 +850,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.facebook_marketing.types.AdAccountsEqCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdAccountsNeqCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdAccountsGtCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdAccountsGteCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdAccountsLtCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdAccountsLteCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdAccountsInCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdAccountsLikeCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdAccountsFuzzyCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdAccountsKeywordCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdAccountsContainsCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdAccountsNotCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdAccountsAndCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdAccountsOrCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdAccountsAnyCondition`
     :   The type of the None singleton.
 
+<a id="AdAccountsOrCondition"></a>
+
 `AdAccountsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -791,6 +871,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.facebook_marketing.types.AdAccountsEqCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdAccountsNeqCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdAccountsGtCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdAccountsGteCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdAccountsLtCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdAccountsLteCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdAccountsInCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdAccountsLikeCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdAccountsFuzzyCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdAccountsKeywordCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdAccountsContainsCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdAccountsNotCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdAccountsAndCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdAccountsOrCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdAccountsAnyCondition]`
     :   The type of the None singleton.
+
+<a id="AdAccountsSearchFilter"></a>
 
 `AdAccountsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering ad_accounts search queries.
@@ -834,6 +916,8 @@ Classes
     `timezone_name: str | None`
     :   Timezone name
 
+<a id="AdAccountsSearchQuery"></a>
+
 `AdAccountsSearchQuery(*args, **kwargs)`
 :   Search query for ad_accounts entity.
 
@@ -848,6 +932,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.facebook_marketing.types.AdAccountsSortFilter]`
     :   The type of the None singleton.
+
+<a id="AdAccountsSortFilter"></a>
 
 `AdAccountsSortFilter(*args, **kwargs)`
 :   Available fields for sorting ad_accounts search results.
@@ -891,6 +977,8 @@ Classes
     `timezone_name: Literal['asc', 'desc']`
     :   Timezone name
 
+<a id="AdAccountsStringFilter"></a>
+
 `AdAccountsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -933,6 +1021,8 @@ Classes
     `timezone_name: str`
     :   Timezone name
 
+<a id="AdCreativesAndCondition"></a>
+
 `AdCreativesAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -953,6 +1043,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.facebook_marketing.types.AdCreativesEqCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdCreativesNeqCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdCreativesGtCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdCreativesGteCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdCreativesLtCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdCreativesLteCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdCreativesInCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdCreativesLikeCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdCreativesFuzzyCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdCreativesKeywordCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdCreativesContainsCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdCreativesNotCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdCreativesAndCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdCreativesOrCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdCreativesAnyCondition]`
     :   The type of the None singleton.
 
+<a id="AdCreativesAnyCondition"></a>
+
 `AdCreativesAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -972,6 +1064,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.facebook_marketing.types.AdCreativesAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="AdCreativesAnyValueFilter"></a>
 
 `AdCreativesAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -1012,6 +1106,8 @@ Classes
     `title: Any`
     :   Ad title
 
+<a id="AdCreativesContainsCondition"></a>
+
 `AdCreativesContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -1023,6 +1119,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.facebook_marketing.types.AdCreativesAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="AdCreativesEqCondition"></a>
 
 `AdCreativesEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -1036,6 +1134,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.facebook_marketing.types.AdCreativesSearchFilter`
     :   The type of the None singleton.
 
+<a id="AdCreativesFuzzyCondition"></a>
+
 `AdCreativesFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -1047,6 +1147,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.facebook_marketing.types.AdCreativesStringFilter`
     :   The type of the None singleton.
+
+<a id="AdCreativesGtCondition"></a>
 
 `AdCreativesGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
@@ -1060,6 +1162,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.facebook_marketing.types.AdCreativesSearchFilter`
     :   The type of the None singleton.
 
+<a id="AdCreativesGteCondition"></a>
+
 `AdCreativesGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -1071,6 +1175,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.facebook_marketing.types.AdCreativesSearchFilter`
     :   The type of the None singleton.
+
+<a id="AdCreativesInCondition"></a>
 
 `AdCreativesInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -1091,6 +1197,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.facebook_marketing.types.AdCreativesInFilter`
     :   The type of the None singleton.
+
+<a id="AdCreativesInFilter"></a>
 
 `AdCreativesInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -1131,6 +1239,8 @@ Classes
     `title: list[str]`
     :   Ad title
 
+<a id="AdCreativesKeywordCondition"></a>
+
 `AdCreativesKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -1143,6 +1253,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.facebook_marketing.types.AdCreativesStringFilter`
     :   The type of the None singleton.
 
+<a id="AdCreativesLikeCondition"></a>
+
 `AdCreativesLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -1154,6 +1266,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.facebook_marketing.types.AdCreativesStringFilter`
     :   The type of the None singleton.
+
+<a id="AdCreativesListParams"></a>
 
 `AdCreativesListParams(*args, **kwargs)`
 :   Parameters for ad_creatives.list operation
@@ -1176,6 +1290,8 @@ Classes
     `limit: int`
     :   The type of the None singleton.
 
+<a id="AdCreativesLtCondition"></a>
+
 `AdCreativesLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -1187,6 +1303,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.facebook_marketing.types.AdCreativesSearchFilter`
     :   The type of the None singleton.
+
+<a id="AdCreativesLteCondition"></a>
 
 `AdCreativesLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -1200,6 +1318,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.facebook_marketing.types.AdCreativesSearchFilter`
     :   The type of the None singleton.
 
+<a id="AdCreativesNeqCondition"></a>
+
 `AdCreativesNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -1211,6 +1331,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.facebook_marketing.types.AdCreativesSearchFilter`
     :   The type of the None singleton.
+
+<a id="AdCreativesNotCondition"></a>
 
 `AdCreativesNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -1232,6 +1354,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.facebook_marketing.types.AdCreativesEqCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdCreativesNeqCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdCreativesGtCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdCreativesGteCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdCreativesLtCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdCreativesLteCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdCreativesInCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdCreativesLikeCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdCreativesFuzzyCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdCreativesKeywordCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdCreativesContainsCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdCreativesNotCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdCreativesAndCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdCreativesOrCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdCreativesAnyCondition`
     :   The type of the None singleton.
 
+<a id="AdCreativesOrCondition"></a>
+
 `AdCreativesOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1251,6 +1375,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.facebook_marketing.types.AdCreativesEqCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdCreativesNeqCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdCreativesGtCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdCreativesGteCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdCreativesLtCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdCreativesLteCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdCreativesInCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdCreativesLikeCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdCreativesFuzzyCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdCreativesKeywordCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdCreativesContainsCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdCreativesNotCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdCreativesAndCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdCreativesOrCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdCreativesAnyCondition]`
     :   The type of the None singleton.
+
+<a id="AdCreativesSearchFilter"></a>
 
 `AdCreativesSearchFilter(*args, **kwargs)`
 :   Available fields for filtering ad_creatives search queries.
@@ -1291,6 +1417,8 @@ Classes
     `title: str | None`
     :   Ad title
 
+<a id="AdCreativesSearchQuery"></a>
+
 `AdCreativesSearchQuery(*args, **kwargs)`
 :   Search query for ad_creatives entity.
 
@@ -1305,6 +1433,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.facebook_marketing.types.AdCreativesSortFilter]`
     :   The type of the None singleton.
+
+<a id="AdCreativesSortFilter"></a>
 
 `AdCreativesSortFilter(*args, **kwargs)`
 :   Available fields for sorting ad_creatives search results.
@@ -1345,6 +1475,8 @@ Classes
     `title: Literal['asc', 'desc']`
     :   Ad title
 
+<a id="AdCreativesStringFilter"></a>
+
 `AdCreativesStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -1383,6 +1515,8 @@ Classes
 
     `title: str`
     :   Ad title
+
+<a id="AdLibraryListParams"></a>
 
 `AdLibraryListParams(*args, **kwargs)`
 :   Parameters for ad_library.list operation
@@ -1441,6 +1575,8 @@ Classes
     `unmask_removed_content: bool`
     :   The type of the None singleton.
 
+<a id="AdSetsAndCondition"></a>
+
 `AdSetsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1461,6 +1597,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.facebook_marketing.types.AdSetsEqCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdSetsNeqCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdSetsGtCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdSetsGteCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdSetsLtCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdSetsLteCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdSetsInCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdSetsLikeCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdSetsFuzzyCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdSetsKeywordCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdSetsContainsCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdSetsNotCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdSetsAndCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdSetsOrCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdSetsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="AdSetsAnyCondition"></a>
+
 `AdSetsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1480,6 +1618,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.facebook_marketing.types.AdSetsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="AdSetsAnyValueFilter"></a>
 
 `AdSetsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -1532,6 +1672,8 @@ Classes
     `updated_time: Any`
     :   Last update time
 
+<a id="AdSetsContainsCondition"></a>
+
 `AdSetsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -1543,6 +1685,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.facebook_marketing.types.AdSetsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="AdSetsCreateParams"></a>
 
 `AdSetsCreateParams(*args, **kwargs)`
 :   Parameters for ad_sets.create operation
@@ -1556,6 +1700,8 @@ Classes
     `account_id: str`
     :   The type of the None singleton.
 
+<a id="AdSetsEqCondition"></a>
+
 `AdSetsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
 
@@ -1568,6 +1714,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.facebook_marketing.types.AdSetsSearchFilter`
     :   The type of the None singleton.
 
+<a id="AdSetsFuzzyCondition"></a>
+
 `AdSetsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -1579,6 +1727,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.facebook_marketing.types.AdSetsStringFilter`
     :   The type of the None singleton.
+
+<a id="AdSetsGetParams"></a>
 
 `AdSetsGetParams(*args, **kwargs)`
 :   Parameters for ad_sets.get operation
@@ -1595,6 +1745,8 @@ Classes
     `fields: str`
     :   The type of the None singleton.
 
+<a id="AdSetsGtCondition"></a>
+
 `AdSetsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -1607,6 +1759,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.facebook_marketing.types.AdSetsSearchFilter`
     :   The type of the None singleton.
 
+<a id="AdSetsGteCondition"></a>
+
 `AdSetsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -1618,6 +1772,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.facebook_marketing.types.AdSetsSearchFilter`
     :   The type of the None singleton.
+
+<a id="AdSetsInCondition"></a>
 
 `AdSetsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -1638,6 +1794,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.facebook_marketing.types.AdSetsInFilter`
     :   The type of the None singleton.
+
+<a id="AdSetsInFilter"></a>
 
 `AdSetsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -1690,6 +1848,8 @@ Classes
     `updated_time: list[str]`
     :   Last update time
 
+<a id="AdSetsKeywordCondition"></a>
+
 `AdSetsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -1702,6 +1862,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.facebook_marketing.types.AdSetsStringFilter`
     :   The type of the None singleton.
 
+<a id="AdSetsLikeCondition"></a>
+
 `AdSetsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -1713,6 +1875,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.facebook_marketing.types.AdSetsStringFilter`
     :   The type of the None singleton.
+
+<a id="AdSetsListParams"></a>
 
 `AdSetsListParams(*args, **kwargs)`
 :   Parameters for ad_sets.list operation
@@ -1735,6 +1899,8 @@ Classes
     `limit: int`
     :   The type of the None singleton.
 
+<a id="AdSetsLtCondition"></a>
+
 `AdSetsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -1746,6 +1912,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.facebook_marketing.types.AdSetsSearchFilter`
     :   The type of the None singleton.
+
+<a id="AdSetsLteCondition"></a>
 
 `AdSetsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -1759,6 +1927,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.facebook_marketing.types.AdSetsSearchFilter`
     :   The type of the None singleton.
 
+<a id="AdSetsNeqCondition"></a>
+
 `AdSetsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -1770,6 +1940,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.facebook_marketing.types.AdSetsSearchFilter`
     :   The type of the None singleton.
+
+<a id="AdSetsNotCondition"></a>
 
 `AdSetsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -1791,6 +1963,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.facebook_marketing.types.AdSetsEqCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdSetsNeqCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdSetsGtCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdSetsGteCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdSetsLtCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdSetsLteCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdSetsInCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdSetsLikeCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdSetsFuzzyCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdSetsKeywordCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdSetsContainsCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdSetsNotCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdSetsAndCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdSetsOrCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdSetsAnyCondition`
     :   The type of the None singleton.
 
+<a id="AdSetsOrCondition"></a>
+
 `AdSetsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1810,6 +1984,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.facebook_marketing.types.AdSetsEqCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdSetsNeqCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdSetsGtCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdSetsGteCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdSetsLtCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdSetsLteCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdSetsInCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdSetsLikeCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdSetsFuzzyCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdSetsKeywordCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdSetsContainsCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdSetsNotCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdSetsAndCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdSetsOrCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdSetsAnyCondition]`
     :   The type of the None singleton.
+
+<a id="AdSetsSearchFilter"></a>
 
 `AdSetsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering ad_sets search queries.
@@ -1862,6 +2038,8 @@ Classes
     `updated_time: str | None`
     :   Last update time
 
+<a id="AdSetsSearchQuery"></a>
+
 `AdSetsSearchQuery(*args, **kwargs)`
 :   Search query for ad_sets entity.
 
@@ -1876,6 +2054,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.facebook_marketing.types.AdSetsSortFilter]`
     :   The type of the None singleton.
+
+<a id="AdSetsSortFilter"></a>
 
 `AdSetsSortFilter(*args, **kwargs)`
 :   Available fields for sorting ad_sets search results.
@@ -1928,6 +2108,8 @@ Classes
     `updated_time: Literal['asc', 'desc']`
     :   Last update time
 
+<a id="AdSetsStringFilter"></a>
+
 `AdSetsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -1979,6 +2161,8 @@ Classes
     `updated_time: str`
     :   Last update time
 
+<a id="AdSetsUpdateParams"></a>
+
 `AdSetsUpdateParams(*args, **kwargs)`
 :   Parameters for ad_sets.update operation
 
@@ -1990,6 +2174,8 @@ Classes
 
     `adset_id: str`
     :   The type of the None singleton.
+
+<a id="AdsAndCondition"></a>
 
 `AdsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -2011,6 +2197,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.facebook_marketing.types.AdsEqCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdsNeqCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdsGtCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdsGteCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdsLtCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdsLteCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdsInCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdsLikeCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdsFuzzyCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdsKeywordCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdsContainsCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdsNotCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdsAndCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdsOrCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="AdsAnyCondition"></a>
+
 `AdsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -2030,6 +2218,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.facebook_marketing.types.AdsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="AdsAnyValueFilter"></a>
 
 `AdsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -2067,6 +2257,8 @@ Classes
     `updated_time: Any`
     :   Last update time
 
+<a id="AdsContainsCondition"></a>
+
 `AdsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -2078,6 +2270,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.facebook_marketing.types.AdsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="AdsCreateParams"></a>
 
 `AdsCreateParams(*args, **kwargs)`
 :   Parameters for ads.create operation
@@ -2091,6 +2285,8 @@ Classes
     `account_id: str`
     :   The type of the None singleton.
 
+<a id="AdsEqCondition"></a>
+
 `AdsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
 
@@ -2103,6 +2299,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.facebook_marketing.types.AdsSearchFilter`
     :   The type of the None singleton.
 
+<a id="AdsFuzzyCondition"></a>
+
 `AdsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -2114,6 +2312,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.facebook_marketing.types.AdsStringFilter`
     :   The type of the None singleton.
+
+<a id="AdsGetParams"></a>
 
 `AdsGetParams(*args, **kwargs)`
 :   Parameters for ads.get operation
@@ -2130,6 +2330,8 @@ Classes
     `fields: str`
     :   The type of the None singleton.
 
+<a id="AdsGtCondition"></a>
+
 `AdsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -2142,6 +2344,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.facebook_marketing.types.AdsSearchFilter`
     :   The type of the None singleton.
 
+<a id="AdsGteCondition"></a>
+
 `AdsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -2153,6 +2357,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.facebook_marketing.types.AdsSearchFilter`
     :   The type of the None singleton.
+
+<a id="AdsInCondition"></a>
 
 `AdsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -2173,6 +2379,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.facebook_marketing.types.AdsInFilter`
     :   The type of the None singleton.
+
+<a id="AdsInFilter"></a>
 
 `AdsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -2210,6 +2418,8 @@ Classes
     `updated_time: list[str]`
     :   Last update time
 
+<a id="AdsInsightsAndCondition"></a>
+
 `AdsInsightsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -2230,6 +2440,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.facebook_marketing.types.AdsInsightsEqCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdsInsightsNeqCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdsInsightsGtCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdsInsightsGteCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdsInsightsLtCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdsInsightsLteCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdsInsightsInCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdsInsightsLikeCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdsInsightsFuzzyCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdsInsightsKeywordCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdsInsightsContainsCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdsInsightsNotCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdsInsightsAndCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdsInsightsOrCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdsInsightsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="AdsInsightsAnyCondition"></a>
+
 `AdsInsightsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -2249,6 +2461,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.facebook_marketing.types.AdsInsightsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="AdsInsightsAnyValueFilter"></a>
 
 `AdsInsightsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -2316,6 +2530,8 @@ Classes
     `spend: Any`
     :   Amount spent
 
+<a id="AdsInsightsContainsCondition"></a>
+
 `AdsInsightsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -2327,6 +2543,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.facebook_marketing.types.AdsInsightsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="AdsInsightsEqCondition"></a>
 
 `AdsInsightsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -2340,6 +2558,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.facebook_marketing.types.AdsInsightsSearchFilter`
     :   The type of the None singleton.
 
+<a id="AdsInsightsFuzzyCondition"></a>
+
 `AdsInsightsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -2351,6 +2571,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.facebook_marketing.types.AdsInsightsStringFilter`
     :   The type of the None singleton.
+
+<a id="AdsInsightsGtCondition"></a>
 
 `AdsInsightsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
@@ -2364,6 +2586,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.facebook_marketing.types.AdsInsightsSearchFilter`
     :   The type of the None singleton.
 
+<a id="AdsInsightsGteCondition"></a>
+
 `AdsInsightsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -2375,6 +2599,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.facebook_marketing.types.AdsInsightsSearchFilter`
     :   The type of the None singleton.
+
+<a id="AdsInsightsInCondition"></a>
 
 `AdsInsightsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -2395,6 +2621,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.facebook_marketing.types.AdsInsightsInFilter`
     :   The type of the None singleton.
+
+<a id="AdsInsightsInFilter"></a>
 
 `AdsInsightsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -2462,6 +2690,8 @@ Classes
     `spend: list[float]`
     :   Amount spent
 
+<a id="AdsInsightsKeywordCondition"></a>
+
 `AdsInsightsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -2474,6 +2704,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.facebook_marketing.types.AdsInsightsStringFilter`
     :   The type of the None singleton.
 
+<a id="AdsInsightsLikeCondition"></a>
+
 `AdsInsightsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -2485,6 +2717,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.facebook_marketing.types.AdsInsightsStringFilter`
     :   The type of the None singleton.
+
+<a id="AdsInsightsListParams"></a>
 
 `AdsInsightsListParams(*args, **kwargs)`
 :   Parameters for ads_insights.list operation
@@ -2519,6 +2753,8 @@ Classes
     `time_range: str`
     :   The type of the None singleton.
 
+<a id="AdsInsightsLtCondition"></a>
+
 `AdsInsightsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -2530,6 +2766,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.facebook_marketing.types.AdsInsightsSearchFilter`
     :   The type of the None singleton.
+
+<a id="AdsInsightsLteCondition"></a>
 
 `AdsInsightsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -2543,6 +2781,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.facebook_marketing.types.AdsInsightsSearchFilter`
     :   The type of the None singleton.
 
+<a id="AdsInsightsNeqCondition"></a>
+
 `AdsInsightsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -2554,6 +2794,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.facebook_marketing.types.AdsInsightsSearchFilter`
     :   The type of the None singleton.
+
+<a id="AdsInsightsNotCondition"></a>
 
 `AdsInsightsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -2575,6 +2817,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.facebook_marketing.types.AdsInsightsEqCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdsInsightsNeqCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdsInsightsGtCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdsInsightsGteCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdsInsightsLtCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdsInsightsLteCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdsInsightsInCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdsInsightsLikeCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdsInsightsFuzzyCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdsInsightsKeywordCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdsInsightsContainsCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdsInsightsNotCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdsInsightsAndCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdsInsightsOrCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdsInsightsAnyCondition`
     :   The type of the None singleton.
 
+<a id="AdsInsightsOrCondition"></a>
+
 `AdsInsightsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -2594,6 +2838,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.facebook_marketing.types.AdsInsightsEqCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdsInsightsNeqCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdsInsightsGtCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdsInsightsGteCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdsInsightsLtCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdsInsightsLteCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdsInsightsInCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdsInsightsLikeCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdsInsightsFuzzyCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdsInsightsKeywordCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdsInsightsContainsCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdsInsightsNotCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdsInsightsAndCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdsInsightsOrCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdsInsightsAnyCondition]`
     :   The type of the None singleton.
+
+<a id="AdsInsightsSearchFilter"></a>
 
 `AdsInsightsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering ads_insights search queries.
@@ -2661,6 +2907,8 @@ Classes
     `spend: float | None`
     :   Amount spent
 
+<a id="AdsInsightsSearchQuery"></a>
+
 `AdsInsightsSearchQuery(*args, **kwargs)`
 :   Search query for ads_insights entity.
 
@@ -2675,6 +2923,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.facebook_marketing.types.AdsInsightsSortFilter]`
     :   The type of the None singleton.
+
+<a id="AdsInsightsSortFilter"></a>
 
 `AdsInsightsSortFilter(*args, **kwargs)`
 :   Available fields for sorting ads_insights search results.
@@ -2742,6 +2992,8 @@ Classes
     `spend: Literal['asc', 'desc']`
     :   Amount spent
 
+<a id="AdsInsightsStringFilter"></a>
+
 `AdsInsightsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -2808,6 +3060,8 @@ Classes
     `spend: str`
     :   Amount spent
 
+<a id="AdsKeywordCondition"></a>
+
 `AdsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -2820,6 +3074,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.facebook_marketing.types.AdsStringFilter`
     :   The type of the None singleton.
 
+<a id="AdsLikeCondition"></a>
+
 `AdsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -2831,6 +3087,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.facebook_marketing.types.AdsStringFilter`
     :   The type of the None singleton.
+
+<a id="AdsListParams"></a>
 
 `AdsListParams(*args, **kwargs)`
 :   Parameters for ads.list operation
@@ -2853,6 +3111,8 @@ Classes
     `limit: int`
     :   The type of the None singleton.
 
+<a id="AdsLtCondition"></a>
+
 `AdsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -2864,6 +3124,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.facebook_marketing.types.AdsSearchFilter`
     :   The type of the None singleton.
+
+<a id="AdsLteCondition"></a>
 
 `AdsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -2877,6 +3139,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.facebook_marketing.types.AdsSearchFilter`
     :   The type of the None singleton.
 
+<a id="AdsNeqCondition"></a>
+
 `AdsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -2888,6 +3152,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.facebook_marketing.types.AdsSearchFilter`
     :   The type of the None singleton.
+
+<a id="AdsNotCondition"></a>
 
 `AdsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -2909,6 +3175,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.facebook_marketing.types.AdsEqCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdsNeqCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdsGtCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdsGteCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdsLtCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdsLteCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdsInCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdsLikeCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdsFuzzyCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdsKeywordCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdsContainsCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdsNotCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdsAndCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdsOrCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdsAnyCondition`
     :   The type of the None singleton.
 
+<a id="AdsOrCondition"></a>
+
 `AdsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -2928,6 +3196,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.facebook_marketing.types.AdsEqCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdsNeqCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdsGtCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdsGteCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdsLtCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdsLteCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdsInCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdsLikeCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdsFuzzyCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdsKeywordCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdsContainsCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdsNotCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdsAndCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdsOrCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.AdsAnyCondition]`
     :   The type of the None singleton.
+
+<a id="AdsSearchFilter"></a>
 
 `AdsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering ads search queries.
@@ -2965,6 +3235,8 @@ Classes
     `updated_time: str | None`
     :   Last update time
 
+<a id="AdsSearchQuery"></a>
+
 `AdsSearchQuery(*args, **kwargs)`
 :   Search query for ads entity.
 
@@ -2979,6 +3251,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.facebook_marketing.types.AdsSortFilter]`
     :   The type of the None singleton.
+
+<a id="AdsSortFilter"></a>
 
 `AdsSortFilter(*args, **kwargs)`
 :   Available fields for sorting ads search results.
@@ -3016,6 +3290,8 @@ Classes
     `updated_time: Literal['asc', 'desc']`
     :   Last update time
 
+<a id="AdsStringFilter"></a>
+
 `AdsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -3052,6 +3328,8 @@ Classes
     `updated_time: str`
     :   Last update time
 
+<a id="AdsUpdateParams"></a>
+
 `AdsUpdateParams(*args, **kwargs)`
 :   Parameters for ads.update operation
 
@@ -3063,6 +3341,8 @@ Classes
 
     `ad_id: str`
     :   The type of the None singleton.
+
+<a id="AirbyteSearchParams"></a>
 
 `AirbyteSearchParams(*args, **kwargs)`
 :   Parameters for Airbyte cache search operations (generic, use entity-specific query types for better type hints).
@@ -3085,6 +3365,8 @@ Classes
     `query: dict[str, typing.Any]`
     :   The type of the None singleton.
 
+<a id="CampaignsAndCondition"></a>
+
 `CampaignsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -3105,6 +3387,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.facebook_marketing.types.CampaignsEqCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.CampaignsNeqCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.CampaignsGtCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.CampaignsGteCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.CampaignsLtCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.CampaignsLteCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.CampaignsInCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.CampaignsLikeCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.CampaignsFuzzyCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.CampaignsKeywordCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.CampaignsContainsCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.CampaignsNotCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.CampaignsAndCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.CampaignsOrCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.CampaignsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="CampaignsAnyCondition"></a>
+
 `CampaignsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -3124,6 +3408,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.facebook_marketing.types.CampaignsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="CampaignsAnyValueFilter"></a>
 
 `CampaignsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -3173,6 +3459,8 @@ Classes
     `updated_time: Any`
     :   Last update time
 
+<a id="CampaignsContainsCondition"></a>
+
 `CampaignsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -3184,6 +3472,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.facebook_marketing.types.CampaignsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="CampaignsCreateParams"></a>
 
 `CampaignsCreateParams(*args, **kwargs)`
 :   Parameters for campaigns.create operation
@@ -3197,6 +3487,8 @@ Classes
     `account_id: str`
     :   The type of the None singleton.
 
+<a id="CampaignsEqCondition"></a>
+
 `CampaignsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
 
@@ -3209,6 +3501,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.facebook_marketing.types.CampaignsSearchFilter`
     :   The type of the None singleton.
 
+<a id="CampaignsFuzzyCondition"></a>
+
 `CampaignsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -3220,6 +3514,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.facebook_marketing.types.CampaignsStringFilter`
     :   The type of the None singleton.
+
+<a id="CampaignsGetParams"></a>
 
 `CampaignsGetParams(*args, **kwargs)`
 :   Parameters for campaigns.get operation
@@ -3236,6 +3532,8 @@ Classes
     `fields: str`
     :   The type of the None singleton.
 
+<a id="CampaignsGtCondition"></a>
+
 `CampaignsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -3248,6 +3546,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.facebook_marketing.types.CampaignsSearchFilter`
     :   The type of the None singleton.
 
+<a id="CampaignsGteCondition"></a>
+
 `CampaignsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -3259,6 +3559,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.facebook_marketing.types.CampaignsSearchFilter`
     :   The type of the None singleton.
+
+<a id="CampaignsInCondition"></a>
 
 `CampaignsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -3279,6 +3581,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.facebook_marketing.types.CampaignsInFilter`
     :   The type of the None singleton.
+
+<a id="CampaignsInFilter"></a>
 
 `CampaignsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -3328,6 +3632,8 @@ Classes
     `updated_time: list[str]`
     :   Last update time
 
+<a id="CampaignsKeywordCondition"></a>
+
 `CampaignsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -3340,6 +3646,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.facebook_marketing.types.CampaignsStringFilter`
     :   The type of the None singleton.
 
+<a id="CampaignsLikeCondition"></a>
+
 `CampaignsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -3351,6 +3659,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.facebook_marketing.types.CampaignsStringFilter`
     :   The type of the None singleton.
+
+<a id="CampaignsListParams"></a>
 
 `CampaignsListParams(*args, **kwargs)`
 :   Parameters for campaigns.list operation
@@ -3373,6 +3683,8 @@ Classes
     `limit: int`
     :   The type of the None singleton.
 
+<a id="CampaignsLtCondition"></a>
+
 `CampaignsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -3384,6 +3696,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.facebook_marketing.types.CampaignsSearchFilter`
     :   The type of the None singleton.
+
+<a id="CampaignsLteCondition"></a>
 
 `CampaignsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -3397,6 +3711,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.facebook_marketing.types.CampaignsSearchFilter`
     :   The type of the None singleton.
 
+<a id="CampaignsNeqCondition"></a>
+
 `CampaignsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -3408,6 +3724,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.facebook_marketing.types.CampaignsSearchFilter`
     :   The type of the None singleton.
+
+<a id="CampaignsNotCondition"></a>
 
 `CampaignsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -3429,6 +3747,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.facebook_marketing.types.CampaignsEqCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.CampaignsNeqCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.CampaignsGtCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.CampaignsGteCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.CampaignsLtCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.CampaignsLteCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.CampaignsInCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.CampaignsLikeCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.CampaignsFuzzyCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.CampaignsKeywordCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.CampaignsContainsCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.CampaignsNotCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.CampaignsAndCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.CampaignsOrCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.CampaignsAnyCondition`
     :   The type of the None singleton.
 
+<a id="CampaignsOrCondition"></a>
+
 `CampaignsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -3448,6 +3768,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.facebook_marketing.types.CampaignsEqCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.CampaignsNeqCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.CampaignsGtCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.CampaignsGteCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.CampaignsLtCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.CampaignsLteCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.CampaignsInCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.CampaignsLikeCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.CampaignsFuzzyCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.CampaignsKeywordCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.CampaignsContainsCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.CampaignsNotCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.CampaignsAndCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.CampaignsOrCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.CampaignsAnyCondition]`
     :   The type of the None singleton.
+
+<a id="CampaignsSearchFilter"></a>
 
 `CampaignsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering campaigns search queries.
@@ -3497,6 +3819,8 @@ Classes
     `updated_time: str | None`
     :   Last update time
 
+<a id="CampaignsSearchQuery"></a>
+
 `CampaignsSearchQuery(*args, **kwargs)`
 :   Search query for campaigns entity.
 
@@ -3511,6 +3835,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.facebook_marketing.types.CampaignsSortFilter]`
     :   The type of the None singleton.
+
+<a id="CampaignsSortFilter"></a>
 
 `CampaignsSortFilter(*args, **kwargs)`
 :   Available fields for sorting campaigns search results.
@@ -3560,6 +3886,8 @@ Classes
     `updated_time: Literal['asc', 'desc']`
     :   Last update time
 
+<a id="CampaignsStringFilter"></a>
+
 `CampaignsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -3608,6 +3936,8 @@ Classes
     `updated_time: str`
     :   Last update time
 
+<a id="CampaignsUpdateParams"></a>
+
 `CampaignsUpdateParams(*args, **kwargs)`
 :   Parameters for campaigns.update operation
 
@@ -3620,6 +3950,8 @@ Classes
     `campaign_id: str`
     :   The type of the None singleton.
 
+<a id="CurrentUserGetParams"></a>
+
 `CurrentUserGetParams(*args, **kwargs)`
 :   Parameters for current_user.get operation
 
@@ -3631,6 +3963,8 @@ Classes
 
     `fields: str`
     :   The type of the None singleton.
+
+<a id="CustomConversionsAndCondition"></a>
 
 `CustomConversionsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -3652,6 +3986,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.facebook_marketing.types.CustomConversionsEqCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.CustomConversionsNeqCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.CustomConversionsGtCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.CustomConversionsGteCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.CustomConversionsLtCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.CustomConversionsLteCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.CustomConversionsInCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.CustomConversionsLikeCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.CustomConversionsFuzzyCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.CustomConversionsKeywordCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.CustomConversionsContainsCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.CustomConversionsNotCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.CustomConversionsAndCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.CustomConversionsOrCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.CustomConversionsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="CustomConversionsAnyCondition"></a>
+
 `CustomConversionsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -3671,6 +4007,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.facebook_marketing.types.CustomConversionsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="CustomConversionsAnyValueFilter"></a>
 
 `CustomConversionsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -3708,6 +4046,8 @@ Classes
     `name: Any`
     :   Custom Conversion name
 
+<a id="CustomConversionsContainsCondition"></a>
+
 `CustomConversionsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -3719,6 +4059,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.facebook_marketing.types.CustomConversionsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="CustomConversionsEqCondition"></a>
 
 `CustomConversionsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -3732,6 +4074,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.facebook_marketing.types.CustomConversionsSearchFilter`
     :   The type of the None singleton.
 
+<a id="CustomConversionsFuzzyCondition"></a>
+
 `CustomConversionsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -3743,6 +4087,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.facebook_marketing.types.CustomConversionsStringFilter`
     :   The type of the None singleton.
+
+<a id="CustomConversionsGtCondition"></a>
 
 `CustomConversionsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
@@ -3756,6 +4102,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.facebook_marketing.types.CustomConversionsSearchFilter`
     :   The type of the None singleton.
 
+<a id="CustomConversionsGteCondition"></a>
+
 `CustomConversionsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -3767,6 +4115,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.facebook_marketing.types.CustomConversionsSearchFilter`
     :   The type of the None singleton.
+
+<a id="CustomConversionsInCondition"></a>
 
 `CustomConversionsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -3787,6 +4137,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.facebook_marketing.types.CustomConversionsInFilter`
     :   The type of the None singleton.
+
+<a id="CustomConversionsInFilter"></a>
 
 `CustomConversionsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -3824,6 +4176,8 @@ Classes
     `name: list[str]`
     :   Custom Conversion name
 
+<a id="CustomConversionsKeywordCondition"></a>
+
 `CustomConversionsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -3836,6 +4190,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.facebook_marketing.types.CustomConversionsStringFilter`
     :   The type of the None singleton.
 
+<a id="CustomConversionsLikeCondition"></a>
+
 `CustomConversionsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -3847,6 +4203,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.facebook_marketing.types.CustomConversionsStringFilter`
     :   The type of the None singleton.
+
+<a id="CustomConversionsListParams"></a>
 
 `CustomConversionsListParams(*args, **kwargs)`
 :   Parameters for custom_conversions.list operation
@@ -3869,6 +4227,8 @@ Classes
     `limit: int`
     :   The type of the None singleton.
 
+<a id="CustomConversionsLtCondition"></a>
+
 `CustomConversionsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -3880,6 +4240,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.facebook_marketing.types.CustomConversionsSearchFilter`
     :   The type of the None singleton.
+
+<a id="CustomConversionsLteCondition"></a>
 
 `CustomConversionsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -3893,6 +4255,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.facebook_marketing.types.CustomConversionsSearchFilter`
     :   The type of the None singleton.
 
+<a id="CustomConversionsNeqCondition"></a>
+
 `CustomConversionsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -3904,6 +4268,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.facebook_marketing.types.CustomConversionsSearchFilter`
     :   The type of the None singleton.
+
+<a id="CustomConversionsNotCondition"></a>
 
 `CustomConversionsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -3925,6 +4291,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.facebook_marketing.types.CustomConversionsEqCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.CustomConversionsNeqCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.CustomConversionsGtCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.CustomConversionsGteCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.CustomConversionsLtCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.CustomConversionsLteCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.CustomConversionsInCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.CustomConversionsLikeCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.CustomConversionsFuzzyCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.CustomConversionsKeywordCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.CustomConversionsContainsCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.CustomConversionsNotCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.CustomConversionsAndCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.CustomConversionsOrCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.CustomConversionsAnyCondition`
     :   The type of the None singleton.
 
+<a id="CustomConversionsOrCondition"></a>
+
 `CustomConversionsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -3944,6 +4312,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.facebook_marketing.types.CustomConversionsEqCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.CustomConversionsNeqCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.CustomConversionsGtCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.CustomConversionsGteCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.CustomConversionsLtCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.CustomConversionsLteCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.CustomConversionsInCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.CustomConversionsLikeCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.CustomConversionsFuzzyCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.CustomConversionsKeywordCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.CustomConversionsContainsCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.CustomConversionsNotCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.CustomConversionsAndCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.CustomConversionsOrCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.CustomConversionsAnyCondition]`
     :   The type of the None singleton.
+
+<a id="CustomConversionsSearchFilter"></a>
 
 `CustomConversionsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering custom_conversions search queries.
@@ -3981,6 +4351,8 @@ Classes
     `name: str | None`
     :   Custom Conversion name
 
+<a id="CustomConversionsSearchQuery"></a>
+
 `CustomConversionsSearchQuery(*args, **kwargs)`
 :   Search query for custom_conversions entity.
 
@@ -3995,6 +4367,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.facebook_marketing.types.CustomConversionsSortFilter]`
     :   The type of the None singleton.
+
+<a id="CustomConversionsSortFilter"></a>
 
 `CustomConversionsSortFilter(*args, **kwargs)`
 :   Available fields for sorting custom_conversions search results.
@@ -4032,6 +4406,8 @@ Classes
     `name: Literal['asc', 'desc']`
     :   Custom Conversion name
 
+<a id="CustomConversionsStringFilter"></a>
+
 `CustomConversionsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -4068,6 +4444,8 @@ Classes
     `name: str`
     :   Custom Conversion name
 
+<a id="ImagesAndCondition"></a>
+
 `ImagesAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -4088,6 +4466,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.facebook_marketing.types.ImagesEqCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.ImagesNeqCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.ImagesGtCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.ImagesGteCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.ImagesLtCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.ImagesLteCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.ImagesInCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.ImagesLikeCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.ImagesFuzzyCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.ImagesKeywordCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.ImagesContainsCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.ImagesNotCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.ImagesAndCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.ImagesOrCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.ImagesAnyCondition]`
     :   The type of the None singleton.
 
+<a id="ImagesAnyCondition"></a>
+
 `ImagesAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -4107,6 +4487,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.facebook_marketing.types.ImagesAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="ImagesAnyValueFilter"></a>
 
 `ImagesAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -4150,6 +4532,8 @@ Classes
     `width: Any`
     :   Image width
 
+<a id="ImagesContainsCondition"></a>
+
 `ImagesContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -4161,6 +4545,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.facebook_marketing.types.ImagesAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="ImagesEqCondition"></a>
 
 `ImagesEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -4174,6 +4560,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.facebook_marketing.types.ImagesSearchFilter`
     :   The type of the None singleton.
 
+<a id="ImagesFuzzyCondition"></a>
+
 `ImagesFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -4185,6 +4573,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.facebook_marketing.types.ImagesStringFilter`
     :   The type of the None singleton.
+
+<a id="ImagesGtCondition"></a>
 
 `ImagesGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
@@ -4198,6 +4588,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.facebook_marketing.types.ImagesSearchFilter`
     :   The type of the None singleton.
 
+<a id="ImagesGteCondition"></a>
+
 `ImagesGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -4209,6 +4601,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.facebook_marketing.types.ImagesSearchFilter`
     :   The type of the None singleton.
+
+<a id="ImagesInCondition"></a>
 
 `ImagesInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -4229,6 +4623,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.facebook_marketing.types.ImagesInFilter`
     :   The type of the None singleton.
+
+<a id="ImagesInFilter"></a>
 
 `ImagesInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -4272,6 +4668,8 @@ Classes
     `width: list[int]`
     :   Image width
 
+<a id="ImagesKeywordCondition"></a>
+
 `ImagesKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -4284,6 +4682,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.facebook_marketing.types.ImagesStringFilter`
     :   The type of the None singleton.
 
+<a id="ImagesLikeCondition"></a>
+
 `ImagesLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -4295,6 +4695,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.facebook_marketing.types.ImagesStringFilter`
     :   The type of the None singleton.
+
+<a id="ImagesListParams"></a>
 
 `ImagesListParams(*args, **kwargs)`
 :   Parameters for images.list operation
@@ -4317,6 +4719,8 @@ Classes
     `limit: int`
     :   The type of the None singleton.
 
+<a id="ImagesLtCondition"></a>
+
 `ImagesLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -4328,6 +4732,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.facebook_marketing.types.ImagesSearchFilter`
     :   The type of the None singleton.
+
+<a id="ImagesLteCondition"></a>
 
 `ImagesLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -4341,6 +4747,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.facebook_marketing.types.ImagesSearchFilter`
     :   The type of the None singleton.
 
+<a id="ImagesNeqCondition"></a>
+
 `ImagesNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -4352,6 +4760,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.facebook_marketing.types.ImagesSearchFilter`
     :   The type of the None singleton.
+
+<a id="ImagesNotCondition"></a>
 
 `ImagesNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -4373,6 +4783,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.facebook_marketing.types.ImagesEqCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.ImagesNeqCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.ImagesGtCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.ImagesGteCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.ImagesLtCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.ImagesLteCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.ImagesInCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.ImagesLikeCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.ImagesFuzzyCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.ImagesKeywordCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.ImagesContainsCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.ImagesNotCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.ImagesAndCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.ImagesOrCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.ImagesAnyCondition`
     :   The type of the None singleton.
 
+<a id="ImagesOrCondition"></a>
+
 `ImagesOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -4392,6 +4804,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.facebook_marketing.types.ImagesEqCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.ImagesNeqCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.ImagesGtCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.ImagesGteCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.ImagesLtCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.ImagesLteCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.ImagesInCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.ImagesLikeCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.ImagesFuzzyCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.ImagesKeywordCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.ImagesContainsCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.ImagesNotCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.ImagesAndCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.ImagesOrCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.ImagesAnyCondition]`
     :   The type of the None singleton.
+
+<a id="ImagesSearchFilter"></a>
 
 `ImagesSearchFilter(*args, **kwargs)`
 :   Available fields for filtering images search queries.
@@ -4435,6 +4849,8 @@ Classes
     `width: int | None`
     :   Image width
 
+<a id="ImagesSearchQuery"></a>
+
 `ImagesSearchQuery(*args, **kwargs)`
 :   Search query for images entity.
 
@@ -4449,6 +4865,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.facebook_marketing.types.ImagesSortFilter]`
     :   The type of the None singleton.
+
+<a id="ImagesSortFilter"></a>
 
 `ImagesSortFilter(*args, **kwargs)`
 :   Available fields for sorting images search results.
@@ -4492,6 +4910,8 @@ Classes
     `width: Literal['asc', 'desc']`
     :   Image width
 
+<a id="ImagesStringFilter"></a>
+
 `ImagesStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -4534,6 +4954,8 @@ Classes
     `width: str`
     :   Image width
 
+<a id="PixelStatsListParams"></a>
+
 `PixelStatsListParams(*args, **kwargs)`
 :   Parameters for pixel_stats.list operation
 
@@ -4555,6 +4977,8 @@ Classes
     `start_time: str`
     :   The type of the None singleton.
 
+<a id="PixelsGetParams"></a>
+
 `PixelsGetParams(*args, **kwargs)`
 :   Parameters for pixels.get operation
 
@@ -4569,6 +4993,8 @@ Classes
 
     `pixel_id: str`
     :   The type of the None singleton.
+
+<a id="PixelsListParams"></a>
 
 `PixelsListParams(*args, **kwargs)`
 :   Parameters for pixels.list operation
@@ -4591,6 +5017,8 @@ Classes
     `limit: int`
     :   The type of the None singleton.
 
+<a id="VideosAndCondition"></a>
+
 `VideosAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -4611,6 +5039,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.facebook_marketing.types.VideosEqCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.VideosNeqCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.VideosGtCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.VideosGteCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.VideosLtCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.VideosLteCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.VideosInCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.VideosLikeCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.VideosFuzzyCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.VideosKeywordCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.VideosContainsCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.VideosNotCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.VideosAndCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.VideosOrCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.VideosAnyCondition]`
     :   The type of the None singleton.
 
+<a id="VideosAnyCondition"></a>
+
 `VideosAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -4630,6 +5060,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.facebook_marketing.types.VideosAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="VideosAnyValueFilter"></a>
 
 `VideosAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -4670,6 +5102,8 @@ Classes
     `views: Any`
     :   Number of views
 
+<a id="VideosContainsCondition"></a>
+
 `VideosContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -4681,6 +5115,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.facebook_marketing.types.VideosAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="VideosEqCondition"></a>
 
 `VideosEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -4694,6 +5130,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.facebook_marketing.types.VideosSearchFilter`
     :   The type of the None singleton.
 
+<a id="VideosFuzzyCondition"></a>
+
 `VideosFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -4705,6 +5143,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.facebook_marketing.types.VideosStringFilter`
     :   The type of the None singleton.
+
+<a id="VideosGtCondition"></a>
 
 `VideosGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
@@ -4718,6 +5158,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.facebook_marketing.types.VideosSearchFilter`
     :   The type of the None singleton.
 
+<a id="VideosGteCondition"></a>
+
 `VideosGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -4729,6 +5171,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.facebook_marketing.types.VideosSearchFilter`
     :   The type of the None singleton.
+
+<a id="VideosInCondition"></a>
 
 `VideosInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -4749,6 +5193,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.facebook_marketing.types.VideosInFilter`
     :   The type of the None singleton.
+
+<a id="VideosInFilter"></a>
 
 `VideosInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -4789,6 +5235,8 @@ Classes
     `views: list[int]`
     :   Number of views
 
+<a id="VideosKeywordCondition"></a>
+
 `VideosKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -4801,6 +5249,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.facebook_marketing.types.VideosStringFilter`
     :   The type of the None singleton.
 
+<a id="VideosLikeCondition"></a>
+
 `VideosLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -4812,6 +5262,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.facebook_marketing.types.VideosStringFilter`
     :   The type of the None singleton.
+
+<a id="VideosListParams"></a>
 
 `VideosListParams(*args, **kwargs)`
 :   Parameters for videos.list operation
@@ -4834,6 +5286,8 @@ Classes
     `limit: int`
     :   The type of the None singleton.
 
+<a id="VideosLtCondition"></a>
+
 `VideosLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -4845,6 +5299,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.facebook_marketing.types.VideosSearchFilter`
     :   The type of the None singleton.
+
+<a id="VideosLteCondition"></a>
 
 `VideosLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -4858,6 +5314,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.facebook_marketing.types.VideosSearchFilter`
     :   The type of the None singleton.
 
+<a id="VideosNeqCondition"></a>
+
 `VideosNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -4869,6 +5327,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.facebook_marketing.types.VideosSearchFilter`
     :   The type of the None singleton.
+
+<a id="VideosNotCondition"></a>
 
 `VideosNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -4890,6 +5350,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.facebook_marketing.types.VideosEqCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.VideosNeqCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.VideosGtCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.VideosGteCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.VideosLtCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.VideosLteCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.VideosInCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.VideosLikeCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.VideosFuzzyCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.VideosKeywordCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.VideosContainsCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.VideosNotCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.VideosAndCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.VideosOrCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.VideosAnyCondition`
     :   The type of the None singleton.
 
+<a id="VideosOrCondition"></a>
+
 `VideosOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -4909,6 +5371,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.facebook_marketing.types.VideosEqCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.VideosNeqCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.VideosGtCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.VideosGteCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.VideosLtCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.VideosLteCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.VideosInCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.VideosLikeCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.VideosFuzzyCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.VideosKeywordCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.VideosContainsCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.VideosNotCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.VideosAndCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.VideosOrCondition | airbyte_agent_sdk.connectors.facebook_marketing.types.VideosAnyCondition]`
     :   The type of the None singleton.
+
+<a id="VideosSearchFilter"></a>
 
 `VideosSearchFilter(*args, **kwargs)`
 :   Available fields for filtering videos search queries.
@@ -4949,6 +5413,8 @@ Classes
     `views: int | None`
     :   Number of views
 
+<a id="VideosSearchQuery"></a>
+
 `VideosSearchQuery(*args, **kwargs)`
 :   Search query for videos entity.
 
@@ -4963,6 +5429,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.facebook_marketing.types.VideosSortFilter]`
     :   The type of the None singleton.
+
+<a id="VideosSortFilter"></a>
 
 `VideosSortFilter(*args, **kwargs)`
 :   Available fields for sorting videos search results.
@@ -5002,6 +5470,8 @@ Classes
 
     `views: Literal['asc', 'desc']`
     :   Number of views
+
+<a id="VideosStringFilter"></a>
 
 `VideosStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/freshdesk/connector.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/freshdesk/connector.md
@@ -10,6 +10,8 @@ Freshdesk connector.
 Classes
 -------
 
+<a id="AgentsQuery"></a>
+
 `AgentsQuery(connector: FreshdeskConnector)`
 :   Query class for Agents entity operations.
     
@@ -71,6 +73,8 @@ Classes
         Returns:
             AgentsListResult
 
+<a id="CompaniesQuery"></a>
+
 `CompaniesQuery(connector: FreshdeskConnector)`
 :   Query class for Companies entity operations.
     
@@ -98,6 +102,8 @@ Classes
         
         Returns:
             CompaniesListResult
+
+<a id="ContactsQuery"></a>
 
 `ContactsQuery(connector: FreshdeskConnector)`
 :   Query class for Contacts entity operations.
@@ -127,6 +133,8 @@ Classes
         
         Returns:
             ContactsListResult
+
+<a id="FreshdeskConnector"></a>
 
 `FreshdeskConnector(auth_config: FreshdeskAuthConfig | AirbyteAuthConfig | BaseModel | None = None, on_token_refresh: Any | None = None, subdomain: str | None = None)`
 :   Type-safe Freshdesk API connector.
@@ -316,6 +324,8 @@ Classes
             for entity in entities:
                 print(f"\{entity['entity_name']\}: \{entity['available_actions']\}")
 
+<a id="GroupsQuery"></a>
+
 `GroupsQuery(connector: FreshdeskConnector)`
 :   Query class for Groups entity operations.
     
@@ -376,6 +386,8 @@ Classes
         Returns:
             GroupsListResult
 
+<a id="RolesQuery"></a>
+
 `RolesQuery(connector: FreshdeskConnector)`
 :   Query class for Roles entity operations.
     
@@ -404,6 +416,8 @@ Classes
         Returns:
             RolesListResult
 
+<a id="SatisfactionRatingsQuery"></a>
+
 `SatisfactionRatingsQuery(connector: FreshdeskConnector)`
 :   Query class for SatisfactionRatings entity operations.
     
@@ -423,6 +437,8 @@ Classes
         Returns:
             SatisfactionRatingsListResult
 
+<a id="SurveysQuery"></a>
+
 `SurveysQuery(connector: FreshdeskConnector)`
 :   Query class for Surveys entity operations.
     
@@ -441,6 +457,8 @@ Classes
         Returns:
             SurveysListResult
 
+<a id="TicketFieldsQuery"></a>
+
 `TicketFieldsQuery(connector: FreshdeskConnector)`
 :   Query class for TicketFields entity operations.
     
@@ -458,6 +476,8 @@ Classes
         
         Returns:
             TicketFieldsListResult
+
+<a id="TicketsQuery"></a>
 
 `TicketsQuery(connector: FreshdeskConnector)`
 :   Query class for Tickets entity operations.
@@ -545,6 +565,8 @@ Classes
         
         Returns:
             TicketsListResult
+
+<a id="TimeEntriesQuery"></a>
 
 `TimeEntriesQuery(connector: FreshdeskConnector)`
 :   Query class for TimeEntries entity operations.

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/freshdesk/index.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/freshdesk/index.md
@@ -19,6 +19,8 @@ Sub-modules
 Classes
 -------
 
+<a id="AgentsSearchData"></a>
+
 `AgentsSearchData(**data: Any)`
 :   Search result data for agents entity.
     
@@ -70,6 +72,8 @@ Classes
 
     `updated_at: str | None`
     :   Agent last update timestamp
+
+<a id="AirbyteAuthConfig"></a>
 
 `AirbyteAuthConfig(**data: Any)`
 :   Authentication configuration for Airbyte hosted mode execution.
@@ -139,6 +143,8 @@ Classes
     `workspace_name: str | None`
     :   The type of the None singleton.
 
+<a id="AirbyteSearchMeta"></a>
+
 `AirbyteSearchMeta(**data: Any)`
 :   Pagination metadata for search responses.
     
@@ -166,6 +172,8 @@ Classes
 
     `took_ms: int | None`
     :   Time taken to execute the search in milliseconds.
+
+<a id="AirbyteSearchResult"></a>
 
 `AirbyteSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -199,6 +207,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="AgentsSearchResult"></a>
+
 `AgentsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -214,6 +224,8 @@ Classes
     * airbyte_agent_sdk.connectors.freshdesk.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="GroupsSearchResult"></a>
 
 `GroupsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -231,6 +243,8 @@ Classes
     * pydantic.main.BaseModel
     * typing.Generic
 
+<a id="TicketsSearchResult"></a>
+
 `TicketsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -246,6 +260,8 @@ Classes
     * airbyte_agent_sdk.connectors.freshdesk.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="FreshdeskAuthConfig"></a>
 
 `FreshdeskAuthConfig(**data: Any)`
 :   API Key Authentication
@@ -268,6 +284,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="FreshdeskConnector"></a>
 
 `FreshdeskConnector(auth_config: FreshdeskAuthConfig | AirbyteAuthConfig | BaseModel | None = None, on_token_refresh: Any | None = None, subdomain: str | None = None)`
 :   Type-safe Freshdesk API connector.
@@ -457,6 +475,8 @@ Classes
             for entity in entities:
                 print(f"\{entity['entity_name']\}: \{entity['available_actions']\}")
 
+<a id="GroupsSearchData"></a>
+
 `GroupsSearchData(**data: Any)`
 :   Search result data for groups entity.
     
@@ -505,6 +525,8 @@ Classes
 
     `updated_at: str | None`
     :   Group last update timestamp
+
+<a id="TicketsSearchData"></a>
 
 `TicketsSearchData(**data: Any)`
 :   Search result data for tickets entity.

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/freshdesk/models.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/freshdesk/models.md
@@ -13,6 +13,8 @@ and response envelope types.
 Classes
 -------
 
+<a id="Agent"></a>
+
 `Agent(**data: Any)`
 :   A Freshdesk agent
     
@@ -101,6 +103,8 @@ Classes
     `updated_at: str | Any | None`
     :   The type of the None singleton.
 
+<a id="AgentContact"></a>
+
 `AgentContact(**data: Any)`
 :   Contact details of the agent
     
@@ -153,6 +157,8 @@ Classes
     `updated_at: str | Any | None`
     :   Contact update timestamp
 
+<a id="AgentsListResultMeta"></a>
+
 `AgentsListResultMeta(**data: Any)`
 :   Metadata for agents.Action.LIST operation
     
@@ -174,6 +180,8 @@ Classes
 
     `next: str | Any | None`
     :   The type of the None singleton.
+
+<a id="AgentsSearchData"></a>
 
 `AgentsSearchData(**data: Any)`
 :   Search result data for agents entity.
@@ -227,6 +235,8 @@ Classes
     `updated_at: str | None`
     :   Agent last update timestamp
 
+<a id="AirbyteSearchMeta"></a>
+
 `AirbyteSearchMeta(**data: Any)`
 :   Pagination metadata for search responses.
     
@@ -254,6 +264,8 @@ Classes
 
     `took_ms: int | None`
     :   Time taken to execute the search in milliseconds.
+
+<a id="AirbyteSearchResult"></a>
 
 `AirbyteSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -308,6 +320,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="AgentsSearchResult"></a>
+
 `AgentsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -344,6 +358,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="GroupsSearchResult"></a>
 
 `GroupsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -382,6 +398,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="TicketsSearchResult"></a>
+
 `TicketsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -397,6 +415,8 @@ Classes
     * airbyte_agent_sdk.connectors.freshdesk.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="CompaniesListResultMeta"></a>
 
 `CompaniesListResultMeta(**data: Any)`
 :   Metadata for companies.Action.LIST operation
@@ -419,6 +439,8 @@ Classes
 
     `next: str | Any | None`
     :   The type of the None singleton.
+
+<a id="Company"></a>
 
 `Company(**data: Any)`
 :   A Freshdesk company
@@ -480,6 +502,8 @@ Classes
 
     `updated_at: str | Any | None`
     :   The type of the None singleton.
+
+<a id="Contact"></a>
 
 `Contact(**data: Any)`
 :   A Freshdesk contact (customer)
@@ -596,6 +620,8 @@ Classes
     `visitor_id: str | Any | None`
     :   The type of the None singleton.
 
+<a id="ContactsListResultMeta"></a>
+
 `ContactsListResultMeta(**data: Any)`
 :   Metadata for contacts.Action.LIST operation
     
@@ -618,6 +644,8 @@ Classes
     `next: str | Any | None`
     :   The type of the None singleton.
 
+<a id="FreshdeskAuthConfig"></a>
+
 `FreshdeskAuthConfig(**data: Any)`
 :   API Key Authentication
     
@@ -639,6 +667,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="FreshdeskCheckResult"></a>
 
 `FreshdeskCheckResult(**data: Any)`
 :   Result of a health check operation.
@@ -673,6 +703,8 @@ Classes
     `status: str`
     :   Health check status: 'healthy' or 'unhealthy'.
 
+<a id="FreshdeskExecuteResult"></a>
+
 `FreshdeskExecuteResult(**data: Any)`
 :   Response envelope with data only.
     
@@ -701,6 +733,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="FreshdeskExecuteResultWithMeta"></a>
 
 `FreshdeskExecuteResultWithMeta(**data: Any)`
 :   Response envelope with data and metadata.
@@ -762,6 +796,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="AgentsListResult"></a>
+
 `AgentsListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -804,6 +840,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="CompaniesListResult"></a>
 
 `CompaniesListResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -848,6 +886,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="ContactsListResult"></a>
+
 `ContactsListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -890,6 +930,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="GroupsListResult"></a>
 
 `GroupsListResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -934,6 +976,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="RolesListResult"></a>
+
 `RolesListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -976,6 +1020,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="SatisfactionRatingsListResult"></a>
 
 `SatisfactionRatingsListResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -1020,6 +1066,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="SurveysListResult"></a>
+
 `SurveysListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -1062,6 +1110,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="TicketFieldsListResult"></a>
 
 `TicketFieldsListResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -1106,6 +1156,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="TicketsListResult"></a>
+
 `TicketsListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -1149,6 +1201,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="TimeEntriesListResult"></a>
+
 `TimeEntriesListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -1167,6 +1221,8 @@ Classes
     * airbyte_agent_sdk.connectors.freshdesk.models.FreshdeskExecuteResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="Group"></a>
 
 `Group(**data: Any)`
 :   A Freshdesk group
@@ -1226,6 +1282,8 @@ Classes
     `updated_at: str | Any | None`
     :   The type of the None singleton.
 
+<a id="GroupsListResultMeta"></a>
+
 `GroupsListResultMeta(**data: Any)`
 :   Metadata for groups.Action.LIST operation
     
@@ -1247,6 +1305,8 @@ Classes
 
     `next: str | Any | None`
     :   The type of the None singleton.
+
+<a id="GroupsSearchData"></a>
 
 `GroupsSearchData(**data: Any)`
 :   Search result data for groups entity.
@@ -1297,6 +1357,8 @@ Classes
     `updated_at: str | None`
     :   Group last update timestamp
 
+<a id="Role"></a>
+
 `Role(**data: Any)`
 :   A Freshdesk role
     
@@ -1337,6 +1399,8 @@ Classes
     `updated_at: str | Any | None`
     :   The type of the None singleton.
 
+<a id="RolesListResultMeta"></a>
+
 `RolesListResultMeta(**data: Any)`
 :   Metadata for roles.Action.LIST operation
     
@@ -1358,6 +1422,8 @@ Classes
 
     `next: str | Any | None`
     :   The type of the None singleton.
+
+<a id="SatisfactionRating"></a>
 
 `SatisfactionRating(**data: Any)`
 :   A Freshdesk satisfaction rating
@@ -1408,6 +1474,8 @@ Classes
     `user_id: int | Any | None`
     :   The type of the None singleton.
 
+<a id="SatisfactionRatingsListResultMeta"></a>
+
 `SatisfactionRatingsListResultMeta(**data: Any)`
 :   Metadata for satisfaction_ratings.Action.LIST operation
     
@@ -1429,6 +1497,8 @@ Classes
 
     `next: str | Any | None`
     :   The type of the None singleton.
+
+<a id="Survey"></a>
 
 `Survey(**data: Any)`
 :   A Freshdesk survey
@@ -1467,6 +1537,8 @@ Classes
     `updated_at: str | Any | None`
     :   The type of the None singleton.
 
+<a id="SurveyQuestionsItem"></a>
+
 `SurveyQuestionsItem(**data: Any)`
 :   Nested schema for Survey.questions_item
     
@@ -1495,6 +1567,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="SurveysListResultMeta"></a>
+
 `SurveysListResultMeta(**data: Any)`
 :   Metadata for surveys.Action.LIST operation
     
@@ -1516,6 +1590,8 @@ Classes
 
     `next: str | Any | None`
     :   The type of the None singleton.
+
+<a id="Ticket"></a>
 
 `Ticket(**data: Any)`
 :   A Freshdesk support ticket
@@ -1653,6 +1729,8 @@ Classes
     `updated_at: str | Any | None`
     :   The type of the None singleton.
 
+<a id="TicketField"></a>
+
 `TicketField(**data: Any)`
 :   A Freshdesk ticket field definition
     
@@ -1729,6 +1807,8 @@ Classes
     `updated_at: str | Any | None`
     :   The type of the None singleton.
 
+<a id="TicketFieldsListResultMeta"></a>
+
 `TicketFieldsListResultMeta(**data: Any)`
 :   Metadata for ticket_fields.Action.LIST operation
     
@@ -1751,6 +1831,8 @@ Classes
     `next: str | Any | None`
     :   The type of the None singleton.
 
+<a id="TicketsListResultMeta"></a>
+
 `TicketsListResultMeta(**data: Any)`
 :   Metadata for tickets.Action.LIST operation
     
@@ -1772,6 +1854,8 @@ Classes
 
     `next: str | Any | None`
     :   The type of the None singleton.
+
+<a id="TicketsSearchData"></a>
 
 `TicketsSearchData(**data: Any)`
 :   Search result data for tickets entity.
@@ -1894,6 +1978,8 @@ Classes
     `updated_at: str | None`
     :   Ticket last update timestamp
 
+<a id="TimeEntriesListResultMeta"></a>
+
 `TimeEntriesListResultMeta(**data: Any)`
 :   Metadata for time_entries.Action.LIST operation
     
@@ -1915,6 +2001,8 @@ Classes
 
     `next: str | Any | None`
     :   The type of the None singleton.
+
+<a id="TimeEntry"></a>
 
 `TimeEntry(**data: Any)`
 :   A Freshdesk time entry

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/freshdesk/types.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/freshdesk/types.md
@@ -10,6 +10,8 @@ Type definitions for freshdesk connector.
 Classes
 -------
 
+<a id="AgentsAndCondition"></a>
+
 `AgentsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -30,6 +32,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.freshdesk.types.AgentsEqCondition | airbyte_agent_sdk.connectors.freshdesk.types.AgentsNeqCondition | airbyte_agent_sdk.connectors.freshdesk.types.AgentsGtCondition | airbyte_agent_sdk.connectors.freshdesk.types.AgentsGteCondition | airbyte_agent_sdk.connectors.freshdesk.types.AgentsLtCondition | airbyte_agent_sdk.connectors.freshdesk.types.AgentsLteCondition | airbyte_agent_sdk.connectors.freshdesk.types.AgentsInCondition | airbyte_agent_sdk.connectors.freshdesk.types.AgentsLikeCondition | airbyte_agent_sdk.connectors.freshdesk.types.AgentsFuzzyCondition | airbyte_agent_sdk.connectors.freshdesk.types.AgentsKeywordCondition | airbyte_agent_sdk.connectors.freshdesk.types.AgentsContainsCondition | airbyte_agent_sdk.connectors.freshdesk.types.AgentsNotCondition | airbyte_agent_sdk.connectors.freshdesk.types.AgentsAndCondition | airbyte_agent_sdk.connectors.freshdesk.types.AgentsOrCondition | airbyte_agent_sdk.connectors.freshdesk.types.AgentsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="AgentsAnyCondition"></a>
+
 `AgentsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -49,6 +53,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.freshdesk.types.AgentsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="AgentsAnyValueFilter"></a>
 
 `AgentsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -92,6 +98,8 @@ Classes
     `updated_at: Any`
     :   Agent last update timestamp
 
+<a id="AgentsContainsCondition"></a>
+
 `AgentsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -103,6 +111,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.freshdesk.types.AgentsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="AgentsEqCondition"></a>
 
 `AgentsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -116,6 +126,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.freshdesk.types.AgentsSearchFilter`
     :   The type of the None singleton.
 
+<a id="AgentsFuzzyCondition"></a>
+
 `AgentsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -127,6 +139,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.freshdesk.types.AgentsStringFilter`
     :   The type of the None singleton.
+
+<a id="AgentsGetParams"></a>
 
 `AgentsGetParams(*args, **kwargs)`
 :   Parameters for agents.get operation
@@ -140,6 +154,8 @@ Classes
     `id: str`
     :   The type of the None singleton.
 
+<a id="AgentsGtCondition"></a>
+
 `AgentsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -152,6 +168,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.freshdesk.types.AgentsSearchFilter`
     :   The type of the None singleton.
 
+<a id="AgentsGteCondition"></a>
+
 `AgentsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -163,6 +181,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.freshdesk.types.AgentsSearchFilter`
     :   The type of the None singleton.
+
+<a id="AgentsInCondition"></a>
 
 `AgentsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -183,6 +203,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.freshdesk.types.AgentsInFilter`
     :   The type of the None singleton.
+
+<a id="AgentsInFilter"></a>
 
 `AgentsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -226,6 +248,8 @@ Classes
     `updated_at: list[str]`
     :   Agent last update timestamp
 
+<a id="AgentsKeywordCondition"></a>
+
 `AgentsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -238,6 +262,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.freshdesk.types.AgentsStringFilter`
     :   The type of the None singleton.
 
+<a id="AgentsLikeCondition"></a>
+
 `AgentsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -249,6 +275,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.freshdesk.types.AgentsStringFilter`
     :   The type of the None singleton.
+
+<a id="AgentsListParams"></a>
 
 `AgentsListParams(*args, **kwargs)`
 :   Parameters for agents.list operation
@@ -265,6 +293,8 @@ Classes
     `per_page: int`
     :   The type of the None singleton.
 
+<a id="AgentsLtCondition"></a>
+
 `AgentsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -276,6 +306,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.freshdesk.types.AgentsSearchFilter`
     :   The type of the None singleton.
+
+<a id="AgentsLteCondition"></a>
 
 `AgentsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -289,6 +321,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.freshdesk.types.AgentsSearchFilter`
     :   The type of the None singleton.
 
+<a id="AgentsNeqCondition"></a>
+
 `AgentsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -300,6 +334,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.freshdesk.types.AgentsSearchFilter`
     :   The type of the None singleton.
+
+<a id="AgentsNotCondition"></a>
 
 `AgentsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -321,6 +357,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.freshdesk.types.AgentsEqCondition | airbyte_agent_sdk.connectors.freshdesk.types.AgentsNeqCondition | airbyte_agent_sdk.connectors.freshdesk.types.AgentsGtCondition | airbyte_agent_sdk.connectors.freshdesk.types.AgentsGteCondition | airbyte_agent_sdk.connectors.freshdesk.types.AgentsLtCondition | airbyte_agent_sdk.connectors.freshdesk.types.AgentsLteCondition | airbyte_agent_sdk.connectors.freshdesk.types.AgentsInCondition | airbyte_agent_sdk.connectors.freshdesk.types.AgentsLikeCondition | airbyte_agent_sdk.connectors.freshdesk.types.AgentsFuzzyCondition | airbyte_agent_sdk.connectors.freshdesk.types.AgentsKeywordCondition | airbyte_agent_sdk.connectors.freshdesk.types.AgentsContainsCondition | airbyte_agent_sdk.connectors.freshdesk.types.AgentsNotCondition | airbyte_agent_sdk.connectors.freshdesk.types.AgentsAndCondition | airbyte_agent_sdk.connectors.freshdesk.types.AgentsOrCondition | airbyte_agent_sdk.connectors.freshdesk.types.AgentsAnyCondition`
     :   The type of the None singleton.
 
+<a id="AgentsOrCondition"></a>
+
 `AgentsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -340,6 +378,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.freshdesk.types.AgentsEqCondition | airbyte_agent_sdk.connectors.freshdesk.types.AgentsNeqCondition | airbyte_agent_sdk.connectors.freshdesk.types.AgentsGtCondition | airbyte_agent_sdk.connectors.freshdesk.types.AgentsGteCondition | airbyte_agent_sdk.connectors.freshdesk.types.AgentsLtCondition | airbyte_agent_sdk.connectors.freshdesk.types.AgentsLteCondition | airbyte_agent_sdk.connectors.freshdesk.types.AgentsInCondition | airbyte_agent_sdk.connectors.freshdesk.types.AgentsLikeCondition | airbyte_agent_sdk.connectors.freshdesk.types.AgentsFuzzyCondition | airbyte_agent_sdk.connectors.freshdesk.types.AgentsKeywordCondition | airbyte_agent_sdk.connectors.freshdesk.types.AgentsContainsCondition | airbyte_agent_sdk.connectors.freshdesk.types.AgentsNotCondition | airbyte_agent_sdk.connectors.freshdesk.types.AgentsAndCondition | airbyte_agent_sdk.connectors.freshdesk.types.AgentsOrCondition | airbyte_agent_sdk.connectors.freshdesk.types.AgentsAnyCondition]`
     :   The type of the None singleton.
+
+<a id="AgentsSearchFilter"></a>
 
 `AgentsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering agents search queries.
@@ -383,6 +423,8 @@ Classes
     `updated_at: str | None`
     :   Agent last update timestamp
 
+<a id="AgentsSearchQuery"></a>
+
 `AgentsSearchQuery(*args, **kwargs)`
 :   Search query for agents entity.
 
@@ -397,6 +439,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.freshdesk.types.AgentsSortFilter]`
     :   The type of the None singleton.
+
+<a id="AgentsSortFilter"></a>
 
 `AgentsSortFilter(*args, **kwargs)`
 :   Available fields for sorting agents search results.
@@ -440,6 +484,8 @@ Classes
     `updated_at: Literal['asc', 'desc']`
     :   Agent last update timestamp
 
+<a id="AgentsStringFilter"></a>
+
 `AgentsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -482,6 +528,8 @@ Classes
     `updated_at: str`
     :   Agent last update timestamp
 
+<a id="AirbyteSearchParams"></a>
+
 `AirbyteSearchParams(*args, **kwargs)`
 :   Parameters for Airbyte cache search operations (generic, use entity-specific query types for better type hints).
 
@@ -503,6 +551,8 @@ Classes
     `query: dict[str, typing.Any]`
     :   The type of the None singleton.
 
+<a id="CompaniesGetParams"></a>
+
 `CompaniesGetParams(*args, **kwargs)`
 :   Parameters for companies.get operation
 
@@ -514,6 +564,8 @@ Classes
 
     `id: str`
     :   The type of the None singleton.
+
+<a id="CompaniesListParams"></a>
 
 `CompaniesListParams(*args, **kwargs)`
 :   Parameters for companies.list operation
@@ -530,6 +582,8 @@ Classes
     `per_page: int`
     :   The type of the None singleton.
 
+<a id="ContactsGetParams"></a>
+
 `ContactsGetParams(*args, **kwargs)`
 :   Parameters for contacts.get operation
 
@@ -541,6 +595,8 @@ Classes
 
     `id: str`
     :   The type of the None singleton.
+
+<a id="ContactsListParams"></a>
 
 `ContactsListParams(*args, **kwargs)`
 :   Parameters for contacts.list operation
@@ -559,6 +615,8 @@ Classes
 
     `updated_since: str`
     :   The type of the None singleton.
+
+<a id="GroupsAndCondition"></a>
 
 `GroupsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -580,6 +638,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.freshdesk.types.GroupsEqCondition | airbyte_agent_sdk.connectors.freshdesk.types.GroupsNeqCondition | airbyte_agent_sdk.connectors.freshdesk.types.GroupsGtCondition | airbyte_agent_sdk.connectors.freshdesk.types.GroupsGteCondition | airbyte_agent_sdk.connectors.freshdesk.types.GroupsLtCondition | airbyte_agent_sdk.connectors.freshdesk.types.GroupsLteCondition | airbyte_agent_sdk.connectors.freshdesk.types.GroupsInCondition | airbyte_agent_sdk.connectors.freshdesk.types.GroupsLikeCondition | airbyte_agent_sdk.connectors.freshdesk.types.GroupsFuzzyCondition | airbyte_agent_sdk.connectors.freshdesk.types.GroupsKeywordCondition | airbyte_agent_sdk.connectors.freshdesk.types.GroupsContainsCondition | airbyte_agent_sdk.connectors.freshdesk.types.GroupsNotCondition | airbyte_agent_sdk.connectors.freshdesk.types.GroupsAndCondition | airbyte_agent_sdk.connectors.freshdesk.types.GroupsOrCondition | airbyte_agent_sdk.connectors.freshdesk.types.GroupsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="GroupsAnyCondition"></a>
+
 `GroupsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -599,6 +659,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.freshdesk.types.GroupsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="GroupsAnyValueFilter"></a>
 
 `GroupsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -639,6 +701,8 @@ Classes
     `updated_at: Any`
     :   Group last update timestamp
 
+<a id="GroupsContainsCondition"></a>
+
 `GroupsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -650,6 +714,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.freshdesk.types.GroupsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="GroupsEqCondition"></a>
 
 `GroupsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -663,6 +729,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.freshdesk.types.GroupsSearchFilter`
     :   The type of the None singleton.
 
+<a id="GroupsFuzzyCondition"></a>
+
 `GroupsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -674,6 +742,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.freshdesk.types.GroupsStringFilter`
     :   The type of the None singleton.
+
+<a id="GroupsGetParams"></a>
 
 `GroupsGetParams(*args, **kwargs)`
 :   Parameters for groups.get operation
@@ -687,6 +757,8 @@ Classes
     `id: str`
     :   The type of the None singleton.
 
+<a id="GroupsGtCondition"></a>
+
 `GroupsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -699,6 +771,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.freshdesk.types.GroupsSearchFilter`
     :   The type of the None singleton.
 
+<a id="GroupsGteCondition"></a>
+
 `GroupsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -710,6 +784,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.freshdesk.types.GroupsSearchFilter`
     :   The type of the None singleton.
+
+<a id="GroupsInCondition"></a>
 
 `GroupsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -730,6 +806,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.freshdesk.types.GroupsInFilter`
     :   The type of the None singleton.
+
+<a id="GroupsInFilter"></a>
 
 `GroupsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -770,6 +848,8 @@ Classes
     `updated_at: list[str]`
     :   Group last update timestamp
 
+<a id="GroupsKeywordCondition"></a>
+
 `GroupsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -782,6 +862,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.freshdesk.types.GroupsStringFilter`
     :   The type of the None singleton.
 
+<a id="GroupsLikeCondition"></a>
+
 `GroupsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -793,6 +875,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.freshdesk.types.GroupsStringFilter`
     :   The type of the None singleton.
+
+<a id="GroupsListParams"></a>
 
 `GroupsListParams(*args, **kwargs)`
 :   Parameters for groups.list operation
@@ -809,6 +893,8 @@ Classes
     `per_page: int`
     :   The type of the None singleton.
 
+<a id="GroupsLtCondition"></a>
+
 `GroupsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -820,6 +906,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.freshdesk.types.GroupsSearchFilter`
     :   The type of the None singleton.
+
+<a id="GroupsLteCondition"></a>
 
 `GroupsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -833,6 +921,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.freshdesk.types.GroupsSearchFilter`
     :   The type of the None singleton.
 
+<a id="GroupsNeqCondition"></a>
+
 `GroupsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -844,6 +934,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.freshdesk.types.GroupsSearchFilter`
     :   The type of the None singleton.
+
+<a id="GroupsNotCondition"></a>
 
 `GroupsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -865,6 +957,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.freshdesk.types.GroupsEqCondition | airbyte_agent_sdk.connectors.freshdesk.types.GroupsNeqCondition | airbyte_agent_sdk.connectors.freshdesk.types.GroupsGtCondition | airbyte_agent_sdk.connectors.freshdesk.types.GroupsGteCondition | airbyte_agent_sdk.connectors.freshdesk.types.GroupsLtCondition | airbyte_agent_sdk.connectors.freshdesk.types.GroupsLteCondition | airbyte_agent_sdk.connectors.freshdesk.types.GroupsInCondition | airbyte_agent_sdk.connectors.freshdesk.types.GroupsLikeCondition | airbyte_agent_sdk.connectors.freshdesk.types.GroupsFuzzyCondition | airbyte_agent_sdk.connectors.freshdesk.types.GroupsKeywordCondition | airbyte_agent_sdk.connectors.freshdesk.types.GroupsContainsCondition | airbyte_agent_sdk.connectors.freshdesk.types.GroupsNotCondition | airbyte_agent_sdk.connectors.freshdesk.types.GroupsAndCondition | airbyte_agent_sdk.connectors.freshdesk.types.GroupsOrCondition | airbyte_agent_sdk.connectors.freshdesk.types.GroupsAnyCondition`
     :   The type of the None singleton.
 
+<a id="GroupsOrCondition"></a>
+
 `GroupsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -884,6 +978,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.freshdesk.types.GroupsEqCondition | airbyte_agent_sdk.connectors.freshdesk.types.GroupsNeqCondition | airbyte_agent_sdk.connectors.freshdesk.types.GroupsGtCondition | airbyte_agent_sdk.connectors.freshdesk.types.GroupsGteCondition | airbyte_agent_sdk.connectors.freshdesk.types.GroupsLtCondition | airbyte_agent_sdk.connectors.freshdesk.types.GroupsLteCondition | airbyte_agent_sdk.connectors.freshdesk.types.GroupsInCondition | airbyte_agent_sdk.connectors.freshdesk.types.GroupsLikeCondition | airbyte_agent_sdk.connectors.freshdesk.types.GroupsFuzzyCondition | airbyte_agent_sdk.connectors.freshdesk.types.GroupsKeywordCondition | airbyte_agent_sdk.connectors.freshdesk.types.GroupsContainsCondition | airbyte_agent_sdk.connectors.freshdesk.types.GroupsNotCondition | airbyte_agent_sdk.connectors.freshdesk.types.GroupsAndCondition | airbyte_agent_sdk.connectors.freshdesk.types.GroupsOrCondition | airbyte_agent_sdk.connectors.freshdesk.types.GroupsAnyCondition]`
     :   The type of the None singleton.
+
+<a id="GroupsSearchFilter"></a>
 
 `GroupsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering groups search queries.
@@ -924,6 +1020,8 @@ Classes
     `updated_at: str | None`
     :   Group last update timestamp
 
+<a id="GroupsSearchQuery"></a>
+
 `GroupsSearchQuery(*args, **kwargs)`
 :   Search query for groups entity.
 
@@ -938,6 +1036,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.freshdesk.types.GroupsSortFilter]`
     :   The type of the None singleton.
+
+<a id="GroupsSortFilter"></a>
 
 `GroupsSortFilter(*args, **kwargs)`
 :   Available fields for sorting groups search results.
@@ -978,6 +1078,8 @@ Classes
     `updated_at: Literal['asc', 'desc']`
     :   Group last update timestamp
 
+<a id="GroupsStringFilter"></a>
+
 `GroupsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -1017,6 +1119,8 @@ Classes
     `updated_at: str`
     :   Group last update timestamp
 
+<a id="RolesGetParams"></a>
+
 `RolesGetParams(*args, **kwargs)`
 :   Parameters for roles.get operation
 
@@ -1028,6 +1132,8 @@ Classes
 
     `id: str`
     :   The type of the None singleton.
+
+<a id="RolesListParams"></a>
 
 `RolesListParams(*args, **kwargs)`
 :   Parameters for roles.list operation
@@ -1043,6 +1149,8 @@ Classes
 
     `per_page: int`
     :   The type of the None singleton.
+
+<a id="SatisfactionRatingsListParams"></a>
 
 `SatisfactionRatingsListParams(*args, **kwargs)`
 :   Parameters for satisfaction_ratings.list operation
@@ -1062,6 +1170,8 @@ Classes
     `per_page: int`
     :   The type of the None singleton.
 
+<a id="SurveysListParams"></a>
+
 `SurveysListParams(*args, **kwargs)`
 :   Parameters for surveys.list operation
 
@@ -1077,6 +1187,8 @@ Classes
     `per_page: int`
     :   The type of the None singleton.
 
+<a id="TicketFieldsListParams"></a>
+
 `TicketFieldsListParams(*args, **kwargs)`
 :   Parameters for ticket_fields.list operation
 
@@ -1091,6 +1203,8 @@ Classes
 
     `per_page: int`
     :   The type of the None singleton.
+
+<a id="TicketsAndCondition"></a>
 
 `TicketsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -1112,6 +1226,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.freshdesk.types.TicketsEqCondition | airbyte_agent_sdk.connectors.freshdesk.types.TicketsNeqCondition | airbyte_agent_sdk.connectors.freshdesk.types.TicketsGtCondition | airbyte_agent_sdk.connectors.freshdesk.types.TicketsGteCondition | airbyte_agent_sdk.connectors.freshdesk.types.TicketsLtCondition | airbyte_agent_sdk.connectors.freshdesk.types.TicketsLteCondition | airbyte_agent_sdk.connectors.freshdesk.types.TicketsInCondition | airbyte_agent_sdk.connectors.freshdesk.types.TicketsLikeCondition | airbyte_agent_sdk.connectors.freshdesk.types.TicketsFuzzyCondition | airbyte_agent_sdk.connectors.freshdesk.types.TicketsKeywordCondition | airbyte_agent_sdk.connectors.freshdesk.types.TicketsContainsCondition | airbyte_agent_sdk.connectors.freshdesk.types.TicketsNotCondition | airbyte_agent_sdk.connectors.freshdesk.types.TicketsAndCondition | airbyte_agent_sdk.connectors.freshdesk.types.TicketsOrCondition | airbyte_agent_sdk.connectors.freshdesk.types.TicketsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="TicketsAnyCondition"></a>
+
 `TicketsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1131,6 +1247,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.freshdesk.types.TicketsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="TicketsAnyValueFilter"></a>
 
 `TicketsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -1243,6 +1361,8 @@ Classes
     `updated_at: Any`
     :   Ticket last update timestamp
 
+<a id="TicketsContainsCondition"></a>
+
 `TicketsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -1254,6 +1374,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.freshdesk.types.TicketsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="TicketsEqCondition"></a>
 
 `TicketsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -1267,6 +1389,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.freshdesk.types.TicketsSearchFilter`
     :   The type of the None singleton.
 
+<a id="TicketsFuzzyCondition"></a>
+
 `TicketsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -1278,6 +1402,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.freshdesk.types.TicketsStringFilter`
     :   The type of the None singleton.
+
+<a id="TicketsGetParams"></a>
 
 `TicketsGetParams(*args, **kwargs)`
 :   Parameters for tickets.get operation
@@ -1291,6 +1417,8 @@ Classes
     `id: str`
     :   The type of the None singleton.
 
+<a id="TicketsGtCondition"></a>
+
 `TicketsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -1303,6 +1431,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.freshdesk.types.TicketsSearchFilter`
     :   The type of the None singleton.
 
+<a id="TicketsGteCondition"></a>
+
 `TicketsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -1314,6 +1444,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.freshdesk.types.TicketsSearchFilter`
     :   The type of the None singleton.
+
+<a id="TicketsInCondition"></a>
 
 `TicketsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -1334,6 +1466,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.freshdesk.types.TicketsInFilter`
     :   The type of the None singleton.
+
+<a id="TicketsInFilter"></a>
 
 `TicketsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -1446,6 +1580,8 @@ Classes
     `updated_at: list[str]`
     :   Ticket last update timestamp
 
+<a id="TicketsKeywordCondition"></a>
+
 `TicketsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -1458,6 +1594,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.freshdesk.types.TicketsStringFilter`
     :   The type of the None singleton.
 
+<a id="TicketsLikeCondition"></a>
+
 `TicketsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -1469,6 +1607,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.freshdesk.types.TicketsStringFilter`
     :   The type of the None singleton.
+
+<a id="TicketsListParams"></a>
 
 `TicketsListParams(*args, **kwargs)`
 :   Parameters for tickets.list operation
@@ -1494,6 +1634,8 @@ Classes
     `updated_since: str`
     :   The type of the None singleton.
 
+<a id="TicketsLtCondition"></a>
+
 `TicketsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -1505,6 +1647,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.freshdesk.types.TicketsSearchFilter`
     :   The type of the None singleton.
+
+<a id="TicketsLteCondition"></a>
 
 `TicketsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -1518,6 +1662,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.freshdesk.types.TicketsSearchFilter`
     :   The type of the None singleton.
 
+<a id="TicketsNeqCondition"></a>
+
 `TicketsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -1529,6 +1675,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.freshdesk.types.TicketsSearchFilter`
     :   The type of the None singleton.
+
+<a id="TicketsNotCondition"></a>
 
 `TicketsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -1550,6 +1698,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.freshdesk.types.TicketsEqCondition | airbyte_agent_sdk.connectors.freshdesk.types.TicketsNeqCondition | airbyte_agent_sdk.connectors.freshdesk.types.TicketsGtCondition | airbyte_agent_sdk.connectors.freshdesk.types.TicketsGteCondition | airbyte_agent_sdk.connectors.freshdesk.types.TicketsLtCondition | airbyte_agent_sdk.connectors.freshdesk.types.TicketsLteCondition | airbyte_agent_sdk.connectors.freshdesk.types.TicketsInCondition | airbyte_agent_sdk.connectors.freshdesk.types.TicketsLikeCondition | airbyte_agent_sdk.connectors.freshdesk.types.TicketsFuzzyCondition | airbyte_agent_sdk.connectors.freshdesk.types.TicketsKeywordCondition | airbyte_agent_sdk.connectors.freshdesk.types.TicketsContainsCondition | airbyte_agent_sdk.connectors.freshdesk.types.TicketsNotCondition | airbyte_agent_sdk.connectors.freshdesk.types.TicketsAndCondition | airbyte_agent_sdk.connectors.freshdesk.types.TicketsOrCondition | airbyte_agent_sdk.connectors.freshdesk.types.TicketsAnyCondition`
     :   The type of the None singleton.
 
+<a id="TicketsOrCondition"></a>
+
 `TicketsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1569,6 +1719,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.freshdesk.types.TicketsEqCondition | airbyte_agent_sdk.connectors.freshdesk.types.TicketsNeqCondition | airbyte_agent_sdk.connectors.freshdesk.types.TicketsGtCondition | airbyte_agent_sdk.connectors.freshdesk.types.TicketsGteCondition | airbyte_agent_sdk.connectors.freshdesk.types.TicketsLtCondition | airbyte_agent_sdk.connectors.freshdesk.types.TicketsLteCondition | airbyte_agent_sdk.connectors.freshdesk.types.TicketsInCondition | airbyte_agent_sdk.connectors.freshdesk.types.TicketsLikeCondition | airbyte_agent_sdk.connectors.freshdesk.types.TicketsFuzzyCondition | airbyte_agent_sdk.connectors.freshdesk.types.TicketsKeywordCondition | airbyte_agent_sdk.connectors.freshdesk.types.TicketsContainsCondition | airbyte_agent_sdk.connectors.freshdesk.types.TicketsNotCondition | airbyte_agent_sdk.connectors.freshdesk.types.TicketsAndCondition | airbyte_agent_sdk.connectors.freshdesk.types.TicketsOrCondition | airbyte_agent_sdk.connectors.freshdesk.types.TicketsAnyCondition]`
     :   The type of the None singleton.
+
+<a id="TicketsSearchFilter"></a>
 
 `TicketsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering tickets search queries.
@@ -1681,6 +1833,8 @@ Classes
     `updated_at: str | None`
     :   Ticket last update timestamp
 
+<a id="TicketsSearchQuery"></a>
+
 `TicketsSearchQuery(*args, **kwargs)`
 :   Search query for tickets entity.
 
@@ -1695,6 +1849,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.freshdesk.types.TicketsSortFilter]`
     :   The type of the None singleton.
+
+<a id="TicketsSortFilter"></a>
 
 `TicketsSortFilter(*args, **kwargs)`
 :   Available fields for sorting tickets search results.
@@ -1807,6 +1963,8 @@ Classes
     `updated_at: Literal['asc', 'desc']`
     :   Ticket last update timestamp
 
+<a id="TicketsStringFilter"></a>
+
 `TicketsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -1917,6 +2075,8 @@ Classes
 
     `updated_at: str`
     :   Ticket last update timestamp
+
+<a id="TimeEntriesListParams"></a>
 
 `TimeEntriesListParams(*args, **kwargs)`
 :   Parameters for time_entries.list operation

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/github/connector.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/github/connector.md
@@ -10,6 +10,8 @@ Github connector.
 Classes
 -------
 
+<a id="BranchesQuery"></a>
+
 `BranchesQuery(connector: GithubConnector)`
 :   Query class for Branches entity operations.
     
@@ -65,6 +67,8 @@ Classes
         
         Returns:
             BranchesListResult
+
+<a id="CommentsQuery"></a>
 
 `CommentsQuery(connector: GithubConnector)`
 :   Query class for Comments entity operations.
@@ -142,6 +146,8 @@ Classes
         Returns:
             CommentsListResult
 
+<a id="CommitsQuery"></a>
+
 `CommitsQuery(connector: GithubConnector)`
 :   Query class for Commits entity operations.
     
@@ -177,6 +183,8 @@ Classes
         Returns:
             CommitsListResult
 
+<a id="DirectoryContentQuery"></a>
+
 `DirectoryContentQuery(connector: GithubConnector)`
 :   Query class for DirectoryContent entity operations.
     
@@ -200,6 +208,8 @@ Classes
         
                 Returns:
                     DirectoryContentListResult
+
+<a id="DiscussionsQuery"></a>
 
 `DiscussionsQuery(connector: GithubConnector)`
 :   Query class for Discussions entity operations.
@@ -250,6 +260,8 @@ Classes
         Returns:
             DiscussionsListResult
 
+<a id="FileContentQuery"></a>
+
 `FileContentQuery(connector: GithubConnector)`
 :   Query class for FileContent entity operations.
     
@@ -272,6 +284,8 @@ Classes
         
                 Returns:
                     dict[str, Any]
+
+<a id="GithubConnector"></a>
 
 `GithubConnector(auth_config: GithubAuthConfig | AirbyteAuthConfig | BaseModel | None = None, on_token_refresh: Any | None = None)`
 :   Type-safe Github API connector.
@@ -529,6 +543,8 @@ Classes
             for entity in entities:
                 print(f"\{entity['entity_name']\}: \{entity['available_actions']\}")
 
+<a id="IssuesQuery"></a>
+
 `IssuesQuery(connector: GithubConnector)`
 :   Query class for Issues entity operations.
     
@@ -640,6 +656,8 @@ Classes
                 Returns:
                     IssueResponse
 
+<a id="LabelsQuery"></a>
+
 `LabelsQuery(connector: GithubConnector)`
 :   Query class for Labels entity operations.
     
@@ -673,6 +691,8 @@ Classes
         
         Returns:
             LabelsListResult
+
+<a id="MilestonesQuery"></a>
 
 `MilestonesQuery(connector: GithubConnector)`
 :   Query class for Milestones entity operations.
@@ -709,6 +729,8 @@ Classes
         Returns:
             MilestonesListResult
 
+<a id="OrgRepositoriesQuery"></a>
+
 `OrgRepositoriesQuery(connector: GithubConnector)`
 :   Query class for OrgRepositories entity operations.
     
@@ -728,6 +750,8 @@ Classes
         
         Returns:
             OrgRepositoriesListResult
+
+<a id="OrganizationsQuery"></a>
 
 `OrganizationsQuery(connector: GithubConnector)`
 :   Query class for Organizations entity operations.
@@ -782,6 +806,8 @@ Classes
         Returns:
             OrganizationsListResult
 
+<a id="PrCommentsQuery"></a>
+
 `PrCommentsQuery(connector: GithubConnector)`
 :   Query class for PrComments entity operations.
     
@@ -820,6 +846,8 @@ Classes
         Returns:
             PrCommentsListResult
 
+<a id="ProjectItemsQuery"></a>
+
 `ProjectItemsQuery(connector: GithubConnector)`
 :   Query class for ProjectItems entity operations.
     
@@ -842,6 +870,8 @@ Classes
         
                 Returns:
                     ProjectItemsListResult
+
+<a id="ProjectsQuery"></a>
 
 `ProjectsQuery(connector: GithubConnector)`
 :   Query class for Projects entity operations.
@@ -876,6 +906,8 @@ Classes
         
                 Returns:
                     ProjectsListResult
+
+<a id="PullRequestsQuery"></a>
 
 `PullRequestsQuery(connector: GithubConnector)`
 :   Query class for PullRequests entity operations.
@@ -966,6 +998,8 @@ Classes
         Returns:
             PullRequestsListResult
 
+<a id="ReleasesQuery"></a>
+
 `ReleasesQuery(connector: GithubConnector)`
 :   Query class for Releases entity operations.
     
@@ -999,6 +1033,8 @@ Classes
         
         Returns:
             ReleasesListResult
+
+<a id="RepositoriesQuery"></a>
 
 `RepositoriesQuery(connector: GithubConnector)`
 :   Query class for Repositories entity operations.
@@ -1075,6 +1111,8 @@ Classes
                 Returns:
                     RepositoriesListResult
 
+<a id="ReviewsQuery"></a>
+
 `ReviewsQuery(connector: GithubConnector)`
 :   Query class for Reviews entity operations.
     
@@ -1096,6 +1134,8 @@ Classes
         
         Returns:
             ReviewsListResult
+
+<a id="StargazersQuery"></a>
 
 `StargazersQuery(connector: GithubConnector)`
 :   Query class for Stargazers entity operations.
@@ -1139,6 +1179,8 @@ Classes
         
         Returns:
             StargazersListResult
+
+<a id="TagsQuery"></a>
 
 `TagsQuery(connector: GithubConnector)`
 :   Query class for Tags entity operations.
@@ -1196,6 +1238,8 @@ Classes
         Returns:
             TagsListResult
 
+<a id="TeamsQuery"></a>
+
 `TeamsQuery(connector: GithubConnector)`
 :   Query class for Teams entity operations.
     
@@ -1249,6 +1293,8 @@ Classes
         
         Returns:
             TeamsListResult
+
+<a id="UsersQuery"></a>
 
 `UsersQuery(connector: GithubConnector)`
 :   Query class for Users entity operations.
@@ -1316,6 +1362,8 @@ Classes
         Returns:
             UsersListResult
 
+<a id="ViewerQuery"></a>
+
 `ViewerQuery(connector: GithubConnector)`
 :   Query class for Viewer entity operations.
     
@@ -1335,6 +1383,8 @@ Classes
         
                 Returns:
                     dict[str, Any]
+
+<a id="ViewerRepositoriesQuery"></a>
 
 `ViewerRepositoriesQuery(connector: GithubConnector)`
 :   Query class for ViewerRepositories entity operations.

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/github/index.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/github/index.md
@@ -19,6 +19,8 @@ Sub-modules
 Classes
 -------
 
+<a id="AirbyteAuthConfig"></a>
+
 `AirbyteAuthConfig(**data: Any)`
 :   Authentication configuration for Airbyte hosted mode execution.
     
@@ -87,6 +89,8 @@ Classes
     `workspace_name: str | None`
     :   The type of the None singleton.
 
+<a id="AirbyteSearchMeta"></a>
+
 `AirbyteSearchMeta(**data: Any)`
 :   Pagination metadata for search responses.
     
@@ -114,6 +118,8 @@ Classes
 
     `took_ms: int | None`
     :   Time taken to execute the search in milliseconds.
+
+<a id="AirbyteSearchResult"></a>
 
 `AirbyteSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -154,6 +160,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="BranchesSearchResult"></a>
+
 `BranchesSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -169,6 +177,8 @@ Classes
     * airbyte_agent_sdk.connectors.github.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="CommentsSearchResult"></a>
 
 `CommentsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -186,6 +196,8 @@ Classes
     * pydantic.main.BaseModel
     * typing.Generic
 
+<a id="IssuesSearchResult"></a>
+
 `IssuesSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -201,6 +213,8 @@ Classes
     * airbyte_agent_sdk.connectors.github.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="OrganizationsSearchResult"></a>
 
 `OrganizationsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -218,6 +232,8 @@ Classes
     * pydantic.main.BaseModel
     * typing.Generic
 
+<a id="PullRequestsSearchResult"></a>
+
 `PullRequestsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -233,6 +249,8 @@ Classes
     * airbyte_agent_sdk.connectors.github.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="RepositoriesSearchResult"></a>
 
 `RepositoriesSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -250,6 +268,8 @@ Classes
     * pydantic.main.BaseModel
     * typing.Generic
 
+<a id="StargazersSearchResult"></a>
+
 `StargazersSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -265,6 +285,8 @@ Classes
     * airbyte_agent_sdk.connectors.github.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="TagsSearchResult"></a>
 
 `TagsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -282,6 +304,8 @@ Classes
     * pydantic.main.BaseModel
     * typing.Generic
 
+<a id="TeamsSearchResult"></a>
+
 `TeamsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -298,6 +322,8 @@ Classes
     * pydantic.main.BaseModel
     * typing.Generic
 
+<a id="UsersSearchResult"></a>
+
 `UsersSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -313,6 +339,8 @@ Classes
     * airbyte_agent_sdk.connectors.github.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="BranchesSearchData"></a>
 
 `BranchesSearchData(**data: Any)`
 :   Search result data for branches entity.
@@ -333,6 +361,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="CommentsSearchData"></a>
+
 `CommentsSearchData(**data: Any)`
 :   Search result data for comments entity.
     
@@ -351,6 +381,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="GithubConnector"></a>
 
 `GithubConnector(auth_config: GithubAuthConfig | AirbyteAuthConfig | BaseModel | None = None, on_token_refresh: Any | None = None)`
 :   Type-safe Github API connector.
@@ -608,6 +640,8 @@ Classes
             for entity in entities:
                 print(f"\{entity['entity_name']\}: \{entity['available_actions']\}")
 
+<a id="GithubReplicationConfig"></a>
+
 `GithubReplicationConfig(**data: Any)`
 :   Replication Configuration - Settings for data replication from GitHub.
     
@@ -630,6 +664,8 @@ Classes
     `repositories: str`
     :   List of GitHub organizations/repositories, e.g. `airbytehq/airbyte` for single repository, `airbytehq/*` for all repositories from organization
 
+<a id="IssuesSearchData"></a>
+
 `IssuesSearchData(**data: Any)`
 :   Search result data for issues entity.
     
@@ -648,6 +684,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="OrganizationsSearchData"></a>
 
 `OrganizationsSearchData(**data: Any)`
 :   Search result data for organizations entity.
@@ -668,6 +706,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="PullRequestsSearchData"></a>
+
 `PullRequestsSearchData(**data: Any)`
 :   Search result data for pull_requests entity.
     
@@ -686,6 +726,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="RepositoriesSearchData"></a>
 
 `RepositoriesSearchData(**data: Any)`
 :   Search result data for repositories entity.
@@ -706,6 +748,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="StargazersSearchData"></a>
+
 `StargazersSearchData(**data: Any)`
 :   Search result data for stargazers entity.
     
@@ -724,6 +768,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="TagsSearchData"></a>
 
 `TagsSearchData(**data: Any)`
 :   Search result data for tags entity.
@@ -744,6 +790,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="TeamsSearchData"></a>
+
 `TeamsSearchData(**data: Any)`
 :   Search result data for teams entity.
     
@@ -762,6 +810,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="UsersSearchData"></a>
 
 `UsersSearchData(**data: Any)`
 :   Search result data for users entity.

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/github/models.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/github/models.md
@@ -13,6 +13,8 @@ and response envelope types.
 Classes
 -------
 
+<a id="AirbyteSearchMeta"></a>
+
 `AirbyteSearchMeta(**data: Any)`
 :   Pagination metadata for search responses.
     
@@ -40,6 +42,8 @@ Classes
 
     `took_ms: int | None`
     :   Time taken to execute the search in milliseconds.
+
+<a id="AirbyteSearchResult"></a>
 
 `AirbyteSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -101,6 +105,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="BranchesSearchResult"></a>
+
 `BranchesSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -137,6 +143,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="CommentsSearchResult"></a>
 
 `CommentsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -175,6 +183,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="IssuesSearchResult"></a>
+
 `IssuesSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -211,6 +221,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="OrganizationsSearchResult"></a>
 
 `OrganizationsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -249,6 +261,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="PullRequestsSearchResult"></a>
+
 `PullRequestsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -285,6 +299,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="RepositoriesSearchResult"></a>
 
 `RepositoriesSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -323,6 +339,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="StargazersSearchResult"></a>
+
 `StargazersSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -359,6 +377,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="TagsSearchResult"></a>
 
 `TagsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -397,6 +417,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="TeamsSearchResult"></a>
+
 `TeamsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -434,6 +456,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="UsersSearchResult"></a>
+
 `UsersSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -449,6 +473,8 @@ Classes
     * airbyte_agent_sdk.connectors.github.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="BranchesListResultMeta"></a>
 
 `BranchesListResultMeta(**data: Any)`
 :   Metadata for branches.Action.LIST operation
@@ -475,6 +501,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="BranchesSearchData"></a>
+
 `BranchesSearchData(**data: Any)`
 :   Search result data for branches entity.
     
@@ -493,6 +521,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="CommentCreateParams"></a>
 
 `CommentCreateParams(**data: Any)`
 :   CommentCreateParams type definition
@@ -515,6 +545,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="CommentResponse"></a>
 
 `CommentResponse(**data: Any)`
 :   CommentResponse type definition
@@ -571,6 +603,8 @@ Classes
     `user: airbyte_agent_sdk.connectors.github.models.CommentResponseUser | Any | None`
     :   The type of the None singleton.
 
+<a id="CommentResponseReactions"></a>
+
 `CommentResponseReactions(**data: Any)`
 :   Reaction counts
     
@@ -617,6 +651,8 @@ Classes
     `url: str | Any`
     :   The type of the None singleton.
 
+<a id="CommentResponseUser"></a>
+
 `CommentResponseUser(**data: Any)`
 :   The user who created the comment
     
@@ -660,6 +696,8 @@ Classes
     `url: str | Any`
     :   The type of the None singleton.
 
+<a id="CommentsListResultMeta"></a>
+
 `CommentsListResultMeta(**data: Any)`
 :   Metadata for comments.Action.LIST operation
     
@@ -685,6 +723,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="CommentsSearchData"></a>
+
 `CommentsSearchData(**data: Any)`
 :   Search result data for comments entity.
     
@@ -703,6 +743,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="CommitsListResultMeta"></a>
 
 `CommitsListResultMeta(**data: Any)`
 :   Metadata for commits.Action.LIST operation
@@ -728,6 +770,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="DiscussionsApiSearchResultMeta"></a>
 
 `DiscussionsApiSearchResultMeta(**data: Any)`
 :   Metadata for discussions.Action.API_SEARCH operation
@@ -757,6 +801,8 @@ Classes
     `total_count: int | Any`
     :   The type of the None singleton.
 
+<a id="DiscussionsListResultMeta"></a>
+
 `DiscussionsListResultMeta(**data: Any)`
 :   Metadata for discussions.Action.LIST operation
     
@@ -781,6 +827,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="GithubCheckResult"></a>
 
 `GithubCheckResult(**data: Any)`
 :   Result of a health check operation.
@@ -815,6 +863,8 @@ Classes
     `status: str`
     :   Health check status: 'healthy' or 'unhealthy'.
 
+<a id="GithubExecuteResult"></a>
+
 `GithubExecuteResult(**data: Any)`
 :   Response envelope with data only.
     
@@ -844,6 +894,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="GithubExecuteResultWithMeta"></a>
 
 `GithubExecuteResultWithMeta(**data: Any)`
 :   Response envelope with data and metadata.
@@ -921,6 +973,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="BranchesListResult"></a>
+
 `BranchesListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -963,6 +1017,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="CommentsListResult"></a>
 
 `CommentsListResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -1007,6 +1063,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="CommitsListResult"></a>
+
 `CommitsListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -1049,6 +1107,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="DiscussionsApiSearchResult"></a>
 
 `DiscussionsApiSearchResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -1093,6 +1153,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="DiscussionsListResult"></a>
+
 `DiscussionsListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -1135,6 +1197,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="IssuesApiSearchResult"></a>
 
 `IssuesApiSearchResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -1179,6 +1243,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="IssuesListResult"></a>
+
 `IssuesListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -1221,6 +1287,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="LabelsListResult"></a>
 
 `LabelsListResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -1265,6 +1333,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="MilestonesListResult"></a>
+
 `MilestonesListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -1307,6 +1377,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="OrgRepositoriesListResult"></a>
 
 `OrgRepositoriesListResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -1351,6 +1423,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="OrganizationsListResult"></a>
+
 `OrganizationsListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -1393,6 +1467,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="PrCommentsListResult"></a>
 
 `PrCommentsListResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -1437,6 +1513,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="ProjectItemsListResult"></a>
+
 `ProjectItemsListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -1479,6 +1557,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="ProjectsListResult"></a>
 
 `ProjectsListResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -1523,6 +1603,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="PullRequestsApiSearchResult"></a>
+
 `PullRequestsApiSearchResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -1565,6 +1647,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="PullRequestsListResult"></a>
 
 `PullRequestsListResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -1609,6 +1693,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="ReleasesListResult"></a>
+
 `ReleasesListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -1651,6 +1737,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="RepositoriesApiSearchResult"></a>
 
 `RepositoriesApiSearchResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -1695,6 +1783,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="RepositoriesListResult"></a>
+
 `RepositoriesListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -1737,6 +1827,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="ReviewsListResult"></a>
 
 `ReviewsListResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -1781,6 +1873,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="StargazersListResult"></a>
+
 `StargazersListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -1823,6 +1917,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="TagsListResult"></a>
 
 `TagsListResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -1867,6 +1963,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="TeamsListResult"></a>
+
 `TeamsListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -1909,6 +2007,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="UsersApiSearchResult"></a>
 
 `UsersApiSearchResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -1953,6 +2053,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="UsersListResult"></a>
+
 `UsersListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -1996,6 +2098,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="ViewerRepositoriesListResult"></a>
+
 `ViewerRepositoriesListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -2038,6 +2142,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="DirectoryContentListResult"></a>
+
 `DirectoryContentListResult(**data: Any)`
 :   Response envelope with data only.
     
@@ -2055,6 +2161,8 @@ Classes
     * airbyte_agent_sdk.connectors.github.models.GithubExecuteResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="GithubOauth2AuthConfig"></a>
 
 `GithubOauth2AuthConfig(**data: Any)`
 :   OAuth 2
@@ -2078,6 +2186,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="GithubPersonalAccessTokenAuthConfig"></a>
+
 `GithubPersonalAccessTokenAuthConfig(**data: Any)`
 :   Personal Access Token
     
@@ -2100,6 +2210,8 @@ Classes
     `token: str`
     :   GitHub personal access token (fine-grained or classic)
 
+<a id="GithubReplicationConfig"></a>
+
 `GithubReplicationConfig(**data: Any)`
 :   Replication Configuration - Settings for data replication from GitHub.
     
@@ -2121,6 +2233,8 @@ Classes
 
     `repositories: str`
     :   List of GitHub organizations/repositories, e.g. `airbytehq/airbyte` for single repository, `airbytehq/*` for all repositories from organization
+
+<a id="IssueCreateParams"></a>
 
 `IssueCreateParams(**data: Any)`
 :   IssueCreateParams type definition
@@ -2155,6 +2269,8 @@ Classes
 
     `title: str | Any`
     :   The type of the None singleton.
+
+<a id="IssueResponse"></a>
 
 `IssueResponse(**data: Any)`
 :   IssueResponse type definition
@@ -2277,6 +2393,8 @@ Classes
     `user: airbyte_agent_sdk.connectors.github.models.IssueResponseUser | Any | None`
     :   The type of the None singleton.
 
+<a id="IssueResponseAssignee"></a>
+
 `IssueResponseAssignee(**data: Any)`
 :   Primary user assigned to this issue
     
@@ -2319,6 +2437,8 @@ Classes
 
     `url: str | Any`
     :   The type of the None singleton.
+
+<a id="IssueResponseAssigneesItem"></a>
 
 `IssueResponseAssigneesItem(**data: Any)`
 :   Nested schema for IssueResponse.assignees_item
@@ -2363,6 +2483,8 @@ Classes
     `url: str | Any`
     :   The type of the None singleton.
 
+<a id="IssueResponseIssueDependenciesSummary"></a>
+
 `IssueResponseIssueDependenciesSummary(**data: Any)`
 :   Summary of issue dependencies
     
@@ -2393,6 +2515,8 @@ Classes
 
     `total_blocking: int | Any`
     :   The type of the None singleton.
+
+<a id="IssueResponseLabelsItem"></a>
 
 `IssueResponseLabelsItem(**data: Any)`
 :   Nested schema for IssueResponse.labels_item
@@ -2433,6 +2557,8 @@ Classes
 
     `url: str | Any`
     :   The type of the None singleton.
+
+<a id="IssueResponseReactions"></a>
 
 `IssueResponseReactions(**data: Any)`
 :   Reaction counts
@@ -2480,6 +2606,8 @@ Classes
     `url: str | Any`
     :   The type of the None singleton.
 
+<a id="IssueResponseSubIssuesSummary"></a>
+
 `IssueResponseSubIssuesSummary(**data: Any)`
 :   Summary of sub-issues
     
@@ -2507,6 +2635,8 @@ Classes
 
     `total: int | Any`
     :   The type of the None singleton.
+
+<a id="IssueResponseUser"></a>
 
 `IssueResponseUser(**data: Any)`
 :   The user who created the issue
@@ -2551,6 +2681,8 @@ Classes
     `url: str | Any`
     :   The type of the None singleton.
 
+<a id="IssueUpdateParams"></a>
+
 `IssueUpdateParams(**data: Any)`
 :   IssueUpdateParams type definition
     
@@ -2591,6 +2723,8 @@ Classes
     `title: str | Any`
     :   The type of the None singleton.
 
+<a id="IssuesApiSearchResultMeta"></a>
+
 `IssuesApiSearchResultMeta(**data: Any)`
 :   Metadata for issues.Action.API_SEARCH operation
     
@@ -2619,6 +2753,8 @@ Classes
     `total_count: int | Any`
     :   The type of the None singleton.
 
+<a id="IssuesListResultMeta"></a>
+
 `IssuesListResultMeta(**data: Any)`
 :   Metadata for issues.Action.LIST operation
     
@@ -2644,6 +2780,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="IssuesSearchData"></a>
+
 `IssuesSearchData(**data: Any)`
 :   Search result data for issues entity.
     
@@ -2662,6 +2800,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="LabelsListResultMeta"></a>
 
 `LabelsListResultMeta(**data: Any)`
 :   Metadata for labels.Action.LIST operation
@@ -2688,6 +2828,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="MilestonesListResultMeta"></a>
+
 `MilestonesListResultMeta(**data: Any)`
 :   Metadata for milestones.Action.LIST operation
     
@@ -2712,6 +2854,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="OrgRepositoriesListResultMeta"></a>
 
 `OrgRepositoriesListResultMeta(**data: Any)`
 :   Metadata for org_repositories.Action.LIST operation
@@ -2738,6 +2882,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="OrganizationsListResultMeta"></a>
+
 `OrganizationsListResultMeta(**data: Any)`
 :   Metadata for organizations.Action.LIST operation
     
@@ -2763,6 +2909,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="OrganizationsSearchData"></a>
+
 `OrganizationsSearchData(**data: Any)`
 :   Search result data for organizations entity.
     
@@ -2781,6 +2929,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="PrCommentsListResultMeta"></a>
 
 `PrCommentsListResultMeta(**data: Any)`
 :   Metadata for pr_comments.Action.LIST operation
@@ -2807,6 +2957,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="ProjectItemsListResultMeta"></a>
+
 `ProjectItemsListResultMeta(**data: Any)`
 :   Metadata for project_items.Action.LIST operation
     
@@ -2832,6 +2984,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="ProjectsListResultMeta"></a>
+
 `ProjectsListResultMeta(**data: Any)`
 :   Metadata for projects.Action.LIST operation
     
@@ -2856,6 +3010,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="PullRequestCreateParams"></a>
 
 `PullRequestCreateParams(**data: Any)`
 :   PullRequestCreateParams type definition
@@ -2893,6 +3049,8 @@ Classes
 
     `title: str | Any`
     :   The type of the None singleton.
+
+<a id="PullRequestResponse"></a>
 
 `PullRequestResponse(**data: Any)`
 :   PullRequestResponse type definition
@@ -3006,6 +3164,8 @@ Classes
     `user: airbyte_agent_sdk.connectors.github.models.PullRequestResponseUser | Any | None`
     :   The type of the None singleton.
 
+<a id="PullRequestResponseAssigneesItem"></a>
+
 `PullRequestResponseAssigneesItem(**data: Any)`
 :   Nested schema for PullRequestResponse.assignees_item
     
@@ -3049,6 +3209,8 @@ Classes
     `url: str | Any`
     :   The type of the None singleton.
 
+<a id="PullRequestResponseBase"></a>
+
 `PullRequestResponseBase(**data: Any)`
 :   The base branch
     
@@ -3077,6 +3239,8 @@ Classes
     `sha: str | Any`
     :   The type of the None singleton.
 
+<a id="PullRequestResponseHead"></a>
+
 `PullRequestResponseHead(**data: Any)`
 :   The head branch
     
@@ -3104,6 +3268,8 @@ Classes
 
     `sha: str | Any`
     :   The type of the None singleton.
+
+<a id="PullRequestResponseLabelsItem"></a>
 
 `PullRequestResponseLabelsItem(**data: Any)`
 :   Nested schema for PullRequestResponse.labels_item
@@ -3144,6 +3310,8 @@ Classes
 
     `url: str | Any`
     :   The type of the None singleton.
+
+<a id="PullRequestResponseUser"></a>
 
 `PullRequestResponseUser(**data: Any)`
 :   The user who created the pull request
@@ -3188,6 +3356,8 @@ Classes
     `url: str | Any`
     :   The type of the None singleton.
 
+<a id="PullRequestsApiSearchResultMeta"></a>
+
 `PullRequestsApiSearchResultMeta(**data: Any)`
 :   Metadata for pull_requests.Action.API_SEARCH operation
     
@@ -3216,6 +3386,8 @@ Classes
     `total_count: int | Any`
     :   The type of the None singleton.
 
+<a id="PullRequestsListResultMeta"></a>
+
 `PullRequestsListResultMeta(**data: Any)`
 :   Metadata for pull_requests.Action.LIST operation
     
@@ -3241,6 +3413,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="PullRequestsSearchData"></a>
+
 `PullRequestsSearchData(**data: Any)`
 :   Search result data for pull_requests entity.
     
@@ -3259,6 +3433,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="ReleasesListResultMeta"></a>
 
 `ReleasesListResultMeta(**data: Any)`
 :   Metadata for releases.Action.LIST operation
@@ -3284,6 +3460,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="RepositoriesApiSearchResultMeta"></a>
 
 `RepositoriesApiSearchResultMeta(**data: Any)`
 :   Metadata for repositories.Action.API_SEARCH operation
@@ -3313,6 +3491,8 @@ Classes
     `total_count: int | Any`
     :   The type of the None singleton.
 
+<a id="RepositoriesListResultMeta"></a>
+
 `RepositoriesListResultMeta(**data: Any)`
 :   Metadata for repositories.Action.LIST operation
     
@@ -3338,6 +3518,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="RepositoriesSearchData"></a>
+
 `RepositoriesSearchData(**data: Any)`
 :   Search result data for repositories entity.
     
@@ -3356,6 +3538,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="ReviewsListResultMeta"></a>
 
 `ReviewsListResultMeta(**data: Any)`
 :   Metadata for reviews.Action.LIST operation
@@ -3382,6 +3566,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="StargazersListResultMeta"></a>
+
 `StargazersListResultMeta(**data: Any)`
 :   Metadata for stargazers.Action.LIST operation
     
@@ -3407,6 +3593,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="StargazersSearchData"></a>
+
 `StargazersSearchData(**data: Any)`
 :   Search result data for stargazers entity.
     
@@ -3425,6 +3613,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="TagsListResultMeta"></a>
 
 `TagsListResultMeta(**data: Any)`
 :   Metadata for tags.Action.LIST operation
@@ -3451,6 +3641,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="TagsSearchData"></a>
+
 `TagsSearchData(**data: Any)`
 :   Search result data for tags entity.
     
@@ -3469,6 +3661,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="TeamsListResultMeta"></a>
 
 `TeamsListResultMeta(**data: Any)`
 :   Metadata for teams.Action.LIST operation
@@ -3495,6 +3689,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="TeamsSearchData"></a>
+
 `TeamsSearchData(**data: Any)`
 :   Search result data for teams entity.
     
@@ -3513,6 +3709,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="UsersApiSearchResultMeta"></a>
 
 `UsersApiSearchResultMeta(**data: Any)`
 :   Metadata for users.Action.API_SEARCH operation
@@ -3542,6 +3740,8 @@ Classes
     `total_count: int | Any`
     :   The type of the None singleton.
 
+<a id="UsersListResultMeta"></a>
+
 `UsersListResultMeta(**data: Any)`
 :   Metadata for users.Action.LIST operation
     
@@ -3567,6 +3767,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="UsersSearchData"></a>
+
 `UsersSearchData(**data: Any)`
 :   Search result data for users entity.
     
@@ -3585,6 +3787,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="ViewerRepositoriesListResultMeta"></a>
 
 `ViewerRepositoriesListResultMeta(**data: Any)`
 :   Metadata for viewer_repositories.Action.LIST operation

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/github/types.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/github/types.md
@@ -10,6 +10,8 @@ Type definitions for github connector.
 Classes
 -------
 
+<a id="AirbyteSearchParams"></a>
+
 `AirbyteSearchParams(*args, **kwargs)`
 :   Parameters for Airbyte cache search operations (generic, use entity-specific query types for better type hints).
 
@@ -31,6 +33,8 @@ Classes
     `query: dict[str, typing.Any]`
     :   The type of the None singleton.
 
+<a id="BranchesAndCondition"></a>
+
 `BranchesAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -50,6 +54,8 @@ Classes
 
     `and: list[airbyte_agent_sdk.connectors.github.types.BranchesEqCondition | airbyte_agent_sdk.connectors.github.types.BranchesNeqCondition | airbyte_agent_sdk.connectors.github.types.BranchesGtCondition | airbyte_agent_sdk.connectors.github.types.BranchesGteCondition | airbyte_agent_sdk.connectors.github.types.BranchesLtCondition | airbyte_agent_sdk.connectors.github.types.BranchesLteCondition | airbyte_agent_sdk.connectors.github.types.BranchesInCondition | airbyte_agent_sdk.connectors.github.types.BranchesLikeCondition | airbyte_agent_sdk.connectors.github.types.BranchesFuzzyCondition | airbyte_agent_sdk.connectors.github.types.BranchesKeywordCondition | airbyte_agent_sdk.connectors.github.types.BranchesContainsCondition | airbyte_agent_sdk.connectors.github.types.BranchesNotCondition | airbyte_agent_sdk.connectors.github.types.BranchesAndCondition | airbyte_agent_sdk.connectors.github.types.BranchesOrCondition | airbyte_agent_sdk.connectors.github.types.BranchesAnyCondition]`
     :   The type of the None singleton.
+
+<a id="BranchesAnyCondition"></a>
 
 `BranchesAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -71,12 +77,16 @@ Classes
     `any: airbyte_agent_sdk.connectors.github.types.BranchesAnyValueFilter`
     :   The type of the None singleton.
 
+<a id="BranchesAnyValueFilter"></a>
+
 `BranchesAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="BranchesContainsCondition"></a>
 
 `BranchesContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
@@ -90,6 +100,8 @@ Classes
     `contains: airbyte_agent_sdk.connectors.github.types.BranchesAnyValueFilter`
     :   The type of the None singleton.
 
+<a id="BranchesEqCondition"></a>
+
 `BranchesEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
 
@@ -102,6 +114,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.github.types.BranchesSearchFilter`
     :   The type of the None singleton.
 
+<a id="BranchesFuzzyCondition"></a>
+
 `BranchesFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -113,6 +127,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.github.types.BranchesStringFilter`
     :   The type of the None singleton.
+
+<a id="BranchesGetParams"></a>
 
 `BranchesGetParams(*args, **kwargs)`
 :   Parameters for branches.get operation
@@ -135,6 +151,8 @@ Classes
     `repo: str`
     :   The type of the None singleton.
 
+<a id="BranchesGtCondition"></a>
+
 `BranchesGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -147,6 +165,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.github.types.BranchesSearchFilter`
     :   The type of the None singleton.
 
+<a id="BranchesGteCondition"></a>
+
 `BranchesGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -158,6 +178,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.github.types.BranchesSearchFilter`
     :   The type of the None singleton.
+
+<a id="BranchesInCondition"></a>
 
 `BranchesInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -179,12 +201,16 @@ Classes
     `in: airbyte_agent_sdk.connectors.github.types.BranchesInFilter`
     :   The type of the None singleton.
 
+<a id="BranchesInFilter"></a>
+
 `BranchesInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="BranchesKeywordCondition"></a>
 
 `BranchesKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
@@ -198,6 +224,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.github.types.BranchesStringFilter`
     :   The type of the None singleton.
 
+<a id="BranchesLikeCondition"></a>
+
 `BranchesLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -209,6 +237,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.github.types.BranchesStringFilter`
     :   The type of the None singleton.
+
+<a id="BranchesListParams"></a>
 
 `BranchesListParams(*args, **kwargs)`
 :   Parameters for branches.list operation
@@ -234,6 +264,8 @@ Classes
     `repo: str`
     :   The type of the None singleton.
 
+<a id="BranchesLtCondition"></a>
+
 `BranchesLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -245,6 +277,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.github.types.BranchesSearchFilter`
     :   The type of the None singleton.
+
+<a id="BranchesLteCondition"></a>
 
 `BranchesLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -258,6 +292,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.github.types.BranchesSearchFilter`
     :   The type of the None singleton.
 
+<a id="BranchesNeqCondition"></a>
+
 `BranchesNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -269,6 +305,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.github.types.BranchesSearchFilter`
     :   The type of the None singleton.
+
+<a id="BranchesNotCondition"></a>
 
 `BranchesNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -290,6 +328,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.github.types.BranchesEqCondition | airbyte_agent_sdk.connectors.github.types.BranchesNeqCondition | airbyte_agent_sdk.connectors.github.types.BranchesGtCondition | airbyte_agent_sdk.connectors.github.types.BranchesGteCondition | airbyte_agent_sdk.connectors.github.types.BranchesLtCondition | airbyte_agent_sdk.connectors.github.types.BranchesLteCondition | airbyte_agent_sdk.connectors.github.types.BranchesInCondition | airbyte_agent_sdk.connectors.github.types.BranchesLikeCondition | airbyte_agent_sdk.connectors.github.types.BranchesFuzzyCondition | airbyte_agent_sdk.connectors.github.types.BranchesKeywordCondition | airbyte_agent_sdk.connectors.github.types.BranchesContainsCondition | airbyte_agent_sdk.connectors.github.types.BranchesNotCondition | airbyte_agent_sdk.connectors.github.types.BranchesAndCondition | airbyte_agent_sdk.connectors.github.types.BranchesOrCondition | airbyte_agent_sdk.connectors.github.types.BranchesAnyCondition`
     :   The type of the None singleton.
 
+<a id="BranchesOrCondition"></a>
+
 `BranchesOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -310,12 +350,16 @@ Classes
     `or: list[airbyte_agent_sdk.connectors.github.types.BranchesEqCondition | airbyte_agent_sdk.connectors.github.types.BranchesNeqCondition | airbyte_agent_sdk.connectors.github.types.BranchesGtCondition | airbyte_agent_sdk.connectors.github.types.BranchesGteCondition | airbyte_agent_sdk.connectors.github.types.BranchesLtCondition | airbyte_agent_sdk.connectors.github.types.BranchesLteCondition | airbyte_agent_sdk.connectors.github.types.BranchesInCondition | airbyte_agent_sdk.connectors.github.types.BranchesLikeCondition | airbyte_agent_sdk.connectors.github.types.BranchesFuzzyCondition | airbyte_agent_sdk.connectors.github.types.BranchesKeywordCondition | airbyte_agent_sdk.connectors.github.types.BranchesContainsCondition | airbyte_agent_sdk.connectors.github.types.BranchesNotCondition | airbyte_agent_sdk.connectors.github.types.BranchesAndCondition | airbyte_agent_sdk.connectors.github.types.BranchesOrCondition | airbyte_agent_sdk.connectors.github.types.BranchesAnyCondition]`
     :   The type of the None singleton.
 
+<a id="BranchesSearchFilter"></a>
+
 `BranchesSearchFilter(*args, **kwargs)`
 :   Available fields for filtering branches search queries.
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="BranchesSearchQuery"></a>
 
 `BranchesSearchQuery(*args, **kwargs)`
 :   Search query for branches entity.
@@ -332,6 +376,8 @@ Classes
     `sort: list[airbyte_agent_sdk.connectors.github.types.BranchesSortFilter]`
     :   The type of the None singleton.
 
+<a id="BranchesSortFilter"></a>
+
 `BranchesSortFilter(*args, **kwargs)`
 :   Available fields for sorting branches search results.
 
@@ -339,12 +385,16 @@ Classes
 
     * builtins.dict
 
+<a id="BranchesStringFilter"></a>
+
 `BranchesStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="CommentsAndCondition"></a>
 
 `CommentsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -366,6 +416,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.github.types.CommentsEqCondition | airbyte_agent_sdk.connectors.github.types.CommentsNeqCondition | airbyte_agent_sdk.connectors.github.types.CommentsGtCondition | airbyte_agent_sdk.connectors.github.types.CommentsGteCondition | airbyte_agent_sdk.connectors.github.types.CommentsLtCondition | airbyte_agent_sdk.connectors.github.types.CommentsLteCondition | airbyte_agent_sdk.connectors.github.types.CommentsInCondition | airbyte_agent_sdk.connectors.github.types.CommentsLikeCondition | airbyte_agent_sdk.connectors.github.types.CommentsFuzzyCondition | airbyte_agent_sdk.connectors.github.types.CommentsKeywordCondition | airbyte_agent_sdk.connectors.github.types.CommentsContainsCondition | airbyte_agent_sdk.connectors.github.types.CommentsNotCondition | airbyte_agent_sdk.connectors.github.types.CommentsAndCondition | airbyte_agent_sdk.connectors.github.types.CommentsOrCondition | airbyte_agent_sdk.connectors.github.types.CommentsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="CommentsAnyCondition"></a>
+
 `CommentsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -386,12 +438,16 @@ Classes
     `any: airbyte_agent_sdk.connectors.github.types.CommentsAnyValueFilter`
     :   The type of the None singleton.
 
+<a id="CommentsAnyValueFilter"></a>
+
 `CommentsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="CommentsContainsCondition"></a>
 
 `CommentsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
@@ -404,6 +460,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.github.types.CommentsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="CommentsCreateParams"></a>
 
 `CommentsCreateParams(*args, **kwargs)`
 :   Parameters for comments.create operation
@@ -426,6 +484,8 @@ Classes
     `repo: str`
     :   The type of the None singleton.
 
+<a id="CommentsEqCondition"></a>
+
 `CommentsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
 
@@ -438,6 +498,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.github.types.CommentsSearchFilter`
     :   The type of the None singleton.
 
+<a id="CommentsFuzzyCondition"></a>
+
 `CommentsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -449,6 +511,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.github.types.CommentsStringFilter`
     :   The type of the None singleton.
+
+<a id="CommentsGetParams"></a>
 
 `CommentsGetParams(*args, **kwargs)`
 :   Parameters for comments.get operation
@@ -465,6 +529,8 @@ Classes
     `id: str`
     :   The type of the None singleton.
 
+<a id="CommentsGtCondition"></a>
+
 `CommentsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -477,6 +543,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.github.types.CommentsSearchFilter`
     :   The type of the None singleton.
 
+<a id="CommentsGteCondition"></a>
+
 `CommentsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -488,6 +556,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.github.types.CommentsSearchFilter`
     :   The type of the None singleton.
+
+<a id="CommentsInCondition"></a>
 
 `CommentsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -509,12 +579,16 @@ Classes
     `in: airbyte_agent_sdk.connectors.github.types.CommentsInFilter`
     :   The type of the None singleton.
 
+<a id="CommentsInFilter"></a>
+
 `CommentsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="CommentsKeywordCondition"></a>
 
 `CommentsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
@@ -528,6 +602,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.github.types.CommentsStringFilter`
     :   The type of the None singleton.
 
+<a id="CommentsLikeCondition"></a>
+
 `CommentsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -539,6 +615,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.github.types.CommentsStringFilter`
     :   The type of the None singleton.
+
+<a id="CommentsListParams"></a>
 
 `CommentsListParams(*args, **kwargs)`
 :   Parameters for comments.list operation
@@ -567,6 +645,8 @@ Classes
     `repo: str`
     :   The type of the None singleton.
 
+<a id="CommentsLtCondition"></a>
+
 `CommentsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -578,6 +658,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.github.types.CommentsSearchFilter`
     :   The type of the None singleton.
+
+<a id="CommentsLteCondition"></a>
 
 `CommentsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -591,6 +673,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.github.types.CommentsSearchFilter`
     :   The type of the None singleton.
 
+<a id="CommentsNeqCondition"></a>
+
 `CommentsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -602,6 +686,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.github.types.CommentsSearchFilter`
     :   The type of the None singleton.
+
+<a id="CommentsNotCondition"></a>
 
 `CommentsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -623,6 +709,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.github.types.CommentsEqCondition | airbyte_agent_sdk.connectors.github.types.CommentsNeqCondition | airbyte_agent_sdk.connectors.github.types.CommentsGtCondition | airbyte_agent_sdk.connectors.github.types.CommentsGteCondition | airbyte_agent_sdk.connectors.github.types.CommentsLtCondition | airbyte_agent_sdk.connectors.github.types.CommentsLteCondition | airbyte_agent_sdk.connectors.github.types.CommentsInCondition | airbyte_agent_sdk.connectors.github.types.CommentsLikeCondition | airbyte_agent_sdk.connectors.github.types.CommentsFuzzyCondition | airbyte_agent_sdk.connectors.github.types.CommentsKeywordCondition | airbyte_agent_sdk.connectors.github.types.CommentsContainsCondition | airbyte_agent_sdk.connectors.github.types.CommentsNotCondition | airbyte_agent_sdk.connectors.github.types.CommentsAndCondition | airbyte_agent_sdk.connectors.github.types.CommentsOrCondition | airbyte_agent_sdk.connectors.github.types.CommentsAnyCondition`
     :   The type of the None singleton.
 
+<a id="CommentsOrCondition"></a>
+
 `CommentsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -643,12 +731,16 @@ Classes
     `or: list[airbyte_agent_sdk.connectors.github.types.CommentsEqCondition | airbyte_agent_sdk.connectors.github.types.CommentsNeqCondition | airbyte_agent_sdk.connectors.github.types.CommentsGtCondition | airbyte_agent_sdk.connectors.github.types.CommentsGteCondition | airbyte_agent_sdk.connectors.github.types.CommentsLtCondition | airbyte_agent_sdk.connectors.github.types.CommentsLteCondition | airbyte_agent_sdk.connectors.github.types.CommentsInCondition | airbyte_agent_sdk.connectors.github.types.CommentsLikeCondition | airbyte_agent_sdk.connectors.github.types.CommentsFuzzyCondition | airbyte_agent_sdk.connectors.github.types.CommentsKeywordCondition | airbyte_agent_sdk.connectors.github.types.CommentsContainsCondition | airbyte_agent_sdk.connectors.github.types.CommentsNotCondition | airbyte_agent_sdk.connectors.github.types.CommentsAndCondition | airbyte_agent_sdk.connectors.github.types.CommentsOrCondition | airbyte_agent_sdk.connectors.github.types.CommentsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="CommentsSearchFilter"></a>
+
 `CommentsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering comments search queries.
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="CommentsSearchQuery"></a>
 
 `CommentsSearchQuery(*args, **kwargs)`
 :   Search query for comments entity.
@@ -665,6 +757,8 @@ Classes
     `sort: list[airbyte_agent_sdk.connectors.github.types.CommentsSortFilter]`
     :   The type of the None singleton.
 
+<a id="CommentsSortFilter"></a>
+
 `CommentsSortFilter(*args, **kwargs)`
 :   Available fields for sorting comments search results.
 
@@ -672,12 +766,16 @@ Classes
 
     * builtins.dict
 
+<a id="CommentsStringFilter"></a>
+
 `CommentsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="CommitsGetParams"></a>
 
 `CommitsGetParams(*args, **kwargs)`
 :   Parameters for commits.get operation
@@ -699,6 +797,8 @@ Classes
 
     `sha: str`
     :   The type of the None singleton.
+
+<a id="CommitsListParams"></a>
 
 `CommitsListParams(*args, **kwargs)`
 :   Parameters for commits.list operation
@@ -727,6 +827,8 @@ Classes
     `repo: str`
     :   The type of the None singleton.
 
+<a id="DirectoryContentListParams"></a>
+
 `DirectoryContentListParams(*args, **kwargs)`
 :   Parameters for directory_content.list operation
 
@@ -751,6 +853,8 @@ Classes
     `repo: str`
     :   The type of the None singleton.
 
+<a id="DiscussionsApiSearchParams"></a>
+
 `DiscussionsApiSearchParams(*args, **kwargs)`
 :   Parameters for discussions.api_search operation
 
@@ -772,6 +876,8 @@ Classes
     `query: str`
     :   The type of the None singleton.
 
+<a id="DiscussionsGetParams"></a>
+
 `DiscussionsGetParams(*args, **kwargs)`
 :   Parameters for discussions.get operation
 
@@ -792,6 +898,8 @@ Classes
 
     `repo: str`
     :   The type of the None singleton.
+
+<a id="DiscussionsListParams"></a>
 
 `DiscussionsListParams(*args, **kwargs)`
 :   Parameters for discussions.list operation
@@ -823,6 +931,8 @@ Classes
     `states: list[str]`
     :   The type of the None singleton.
 
+<a id="FileContentGetParams"></a>
+
 `FileContentGetParams(*args, **kwargs)`
 :   Parameters for file_content.get operation
 
@@ -847,6 +957,8 @@ Classes
     `repo: str`
     :   The type of the None singleton.
 
+<a id="IssuesAndCondition"></a>
+
 `IssuesAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -866,6 +978,8 @@ Classes
 
     `and: list[airbyte_agent_sdk.connectors.github.types.IssuesEqCondition | airbyte_agent_sdk.connectors.github.types.IssuesNeqCondition | airbyte_agent_sdk.connectors.github.types.IssuesGtCondition | airbyte_agent_sdk.connectors.github.types.IssuesGteCondition | airbyte_agent_sdk.connectors.github.types.IssuesLtCondition | airbyte_agent_sdk.connectors.github.types.IssuesLteCondition | airbyte_agent_sdk.connectors.github.types.IssuesInCondition | airbyte_agent_sdk.connectors.github.types.IssuesLikeCondition | airbyte_agent_sdk.connectors.github.types.IssuesFuzzyCondition | airbyte_agent_sdk.connectors.github.types.IssuesKeywordCondition | airbyte_agent_sdk.connectors.github.types.IssuesContainsCondition | airbyte_agent_sdk.connectors.github.types.IssuesNotCondition | airbyte_agent_sdk.connectors.github.types.IssuesAndCondition | airbyte_agent_sdk.connectors.github.types.IssuesOrCondition | airbyte_agent_sdk.connectors.github.types.IssuesAnyCondition]`
     :   The type of the None singleton.
+
+<a id="IssuesAnyCondition"></a>
 
 `IssuesAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -887,12 +1001,16 @@ Classes
     `any: airbyte_agent_sdk.connectors.github.types.IssuesAnyValueFilter`
     :   The type of the None singleton.
 
+<a id="IssuesAnyValueFilter"></a>
+
 `IssuesAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="IssuesApiSearchParams"></a>
 
 `IssuesApiSearchParams(*args, **kwargs)`
 :   Parameters for issues.api_search operation
@@ -915,6 +1033,8 @@ Classes
     `query: str`
     :   The type of the None singleton.
 
+<a id="IssuesContainsCondition"></a>
+
 `IssuesContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -926,6 +1046,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.github.types.IssuesAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="IssuesCreateParams"></a>
 
 `IssuesCreateParams(*args, **kwargs)`
 :   Parameters for issues.create operation
@@ -957,6 +1079,8 @@ Classes
     `title: str`
     :   The type of the None singleton.
 
+<a id="IssuesEqCondition"></a>
+
 `IssuesEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
 
@@ -969,6 +1093,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.github.types.IssuesSearchFilter`
     :   The type of the None singleton.
 
+<a id="IssuesFuzzyCondition"></a>
+
 `IssuesFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -980,6 +1106,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.github.types.IssuesStringFilter`
     :   The type of the None singleton.
+
+<a id="IssuesGetParams"></a>
 
 `IssuesGetParams(*args, **kwargs)`
 :   Parameters for issues.get operation
@@ -1002,6 +1130,8 @@ Classes
     `repo: str`
     :   The type of the None singleton.
 
+<a id="IssuesGtCondition"></a>
+
 `IssuesGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -1014,6 +1144,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.github.types.IssuesSearchFilter`
     :   The type of the None singleton.
 
+<a id="IssuesGteCondition"></a>
+
 `IssuesGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -1025,6 +1157,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.github.types.IssuesSearchFilter`
     :   The type of the None singleton.
+
+<a id="IssuesInCondition"></a>
 
 `IssuesInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -1046,12 +1180,16 @@ Classes
     `in: airbyte_agent_sdk.connectors.github.types.IssuesInFilter`
     :   The type of the None singleton.
 
+<a id="IssuesInFilter"></a>
+
 `IssuesInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="IssuesKeywordCondition"></a>
 
 `IssuesKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
@@ -1065,6 +1203,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.github.types.IssuesStringFilter`
     :   The type of the None singleton.
 
+<a id="IssuesLikeCondition"></a>
+
 `IssuesLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -1076,6 +1216,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.github.types.IssuesStringFilter`
     :   The type of the None singleton.
+
+<a id="IssuesListParams"></a>
 
 `IssuesListParams(*args, **kwargs)`
 :   Parameters for issues.list operation
@@ -1104,6 +1246,8 @@ Classes
     `states: list[str]`
     :   The type of the None singleton.
 
+<a id="IssuesLtCondition"></a>
+
 `IssuesLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -1115,6 +1259,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.github.types.IssuesSearchFilter`
     :   The type of the None singleton.
+
+<a id="IssuesLteCondition"></a>
 
 `IssuesLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -1128,6 +1274,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.github.types.IssuesSearchFilter`
     :   The type of the None singleton.
 
+<a id="IssuesNeqCondition"></a>
+
 `IssuesNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -1139,6 +1287,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.github.types.IssuesSearchFilter`
     :   The type of the None singleton.
+
+<a id="IssuesNotCondition"></a>
 
 `IssuesNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -1160,6 +1310,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.github.types.IssuesEqCondition | airbyte_agent_sdk.connectors.github.types.IssuesNeqCondition | airbyte_agent_sdk.connectors.github.types.IssuesGtCondition | airbyte_agent_sdk.connectors.github.types.IssuesGteCondition | airbyte_agent_sdk.connectors.github.types.IssuesLtCondition | airbyte_agent_sdk.connectors.github.types.IssuesLteCondition | airbyte_agent_sdk.connectors.github.types.IssuesInCondition | airbyte_agent_sdk.connectors.github.types.IssuesLikeCondition | airbyte_agent_sdk.connectors.github.types.IssuesFuzzyCondition | airbyte_agent_sdk.connectors.github.types.IssuesKeywordCondition | airbyte_agent_sdk.connectors.github.types.IssuesContainsCondition | airbyte_agent_sdk.connectors.github.types.IssuesNotCondition | airbyte_agent_sdk.connectors.github.types.IssuesAndCondition | airbyte_agent_sdk.connectors.github.types.IssuesOrCondition | airbyte_agent_sdk.connectors.github.types.IssuesAnyCondition`
     :   The type of the None singleton.
 
+<a id="IssuesOrCondition"></a>
+
 `IssuesOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1180,12 +1332,16 @@ Classes
     `or: list[airbyte_agent_sdk.connectors.github.types.IssuesEqCondition | airbyte_agent_sdk.connectors.github.types.IssuesNeqCondition | airbyte_agent_sdk.connectors.github.types.IssuesGtCondition | airbyte_agent_sdk.connectors.github.types.IssuesGteCondition | airbyte_agent_sdk.connectors.github.types.IssuesLtCondition | airbyte_agent_sdk.connectors.github.types.IssuesLteCondition | airbyte_agent_sdk.connectors.github.types.IssuesInCondition | airbyte_agent_sdk.connectors.github.types.IssuesLikeCondition | airbyte_agent_sdk.connectors.github.types.IssuesFuzzyCondition | airbyte_agent_sdk.connectors.github.types.IssuesKeywordCondition | airbyte_agent_sdk.connectors.github.types.IssuesContainsCondition | airbyte_agent_sdk.connectors.github.types.IssuesNotCondition | airbyte_agent_sdk.connectors.github.types.IssuesAndCondition | airbyte_agent_sdk.connectors.github.types.IssuesOrCondition | airbyte_agent_sdk.connectors.github.types.IssuesAnyCondition]`
     :   The type of the None singleton.
 
+<a id="IssuesSearchFilter"></a>
+
 `IssuesSearchFilter(*args, **kwargs)`
 :   Available fields for filtering issues search queries.
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="IssuesSearchQuery"></a>
 
 `IssuesSearchQuery(*args, **kwargs)`
 :   Search query for issues entity.
@@ -1202,6 +1358,8 @@ Classes
     `sort: list[airbyte_agent_sdk.connectors.github.types.IssuesSortFilter]`
     :   The type of the None singleton.
 
+<a id="IssuesSortFilter"></a>
+
 `IssuesSortFilter(*args, **kwargs)`
 :   Available fields for sorting issues search results.
 
@@ -1209,12 +1367,16 @@ Classes
 
     * builtins.dict
 
+<a id="IssuesStringFilter"></a>
+
 `IssuesStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="IssuesUpdateParams"></a>
 
 `IssuesUpdateParams(*args, **kwargs)`
 :   Parameters for issues.update operation
@@ -1255,6 +1417,8 @@ Classes
     `title: str`
     :   The type of the None singleton.
 
+<a id="LabelsGetParams"></a>
+
 `LabelsGetParams(*args, **kwargs)`
 :   Parameters for labels.get operation
 
@@ -1275,6 +1439,8 @@ Classes
 
     `repo: str`
     :   The type of the None singleton.
+
+<a id="LabelsListParams"></a>
 
 `LabelsListParams(*args, **kwargs)`
 :   Parameters for labels.list operation
@@ -1300,6 +1466,8 @@ Classes
     `repo: str`
     :   The type of the None singleton.
 
+<a id="MilestonesGetParams"></a>
+
 `MilestonesGetParams(*args, **kwargs)`
 :   Parameters for milestones.get operation
 
@@ -1320,6 +1488,8 @@ Classes
 
     `repo: str`
     :   The type of the None singleton.
+
+<a id="MilestonesListParams"></a>
 
 `MilestonesListParams(*args, **kwargs)`
 :   Parameters for milestones.list operation
@@ -1348,6 +1518,8 @@ Classes
     `states: list[str]`
     :   The type of the None singleton.
 
+<a id="OrgRepositoriesListParams"></a>
+
 `OrgRepositoriesListParams(*args, **kwargs)`
 :   Parameters for org_repositories.list operation
 
@@ -1369,6 +1541,8 @@ Classes
     `per_page: int`
     :   The type of the None singleton.
 
+<a id="OrganizationsAndCondition"></a>
+
 `OrganizationsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1388,6 +1562,8 @@ Classes
 
     `and: list[airbyte_agent_sdk.connectors.github.types.OrganizationsEqCondition | airbyte_agent_sdk.connectors.github.types.OrganizationsNeqCondition | airbyte_agent_sdk.connectors.github.types.OrganizationsGtCondition | airbyte_agent_sdk.connectors.github.types.OrganizationsGteCondition | airbyte_agent_sdk.connectors.github.types.OrganizationsLtCondition | airbyte_agent_sdk.connectors.github.types.OrganizationsLteCondition | airbyte_agent_sdk.connectors.github.types.OrganizationsInCondition | airbyte_agent_sdk.connectors.github.types.OrganizationsLikeCondition | airbyte_agent_sdk.connectors.github.types.OrganizationsFuzzyCondition | airbyte_agent_sdk.connectors.github.types.OrganizationsKeywordCondition | airbyte_agent_sdk.connectors.github.types.OrganizationsContainsCondition | airbyte_agent_sdk.connectors.github.types.OrganizationsNotCondition | airbyte_agent_sdk.connectors.github.types.OrganizationsAndCondition | airbyte_agent_sdk.connectors.github.types.OrganizationsOrCondition | airbyte_agent_sdk.connectors.github.types.OrganizationsAnyCondition]`
     :   The type of the None singleton.
+
+<a id="OrganizationsAnyCondition"></a>
 
 `OrganizationsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -1409,12 +1585,16 @@ Classes
     `any: airbyte_agent_sdk.connectors.github.types.OrganizationsAnyValueFilter`
     :   The type of the None singleton.
 
+<a id="OrganizationsAnyValueFilter"></a>
+
 `OrganizationsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="OrganizationsContainsCondition"></a>
 
 `OrganizationsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
@@ -1428,6 +1608,8 @@ Classes
     `contains: airbyte_agent_sdk.connectors.github.types.OrganizationsAnyValueFilter`
     :   The type of the None singleton.
 
+<a id="OrganizationsEqCondition"></a>
+
 `OrganizationsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
 
@@ -1440,6 +1622,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.github.types.OrganizationsSearchFilter`
     :   The type of the None singleton.
 
+<a id="OrganizationsFuzzyCondition"></a>
+
 `OrganizationsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -1451,6 +1635,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.github.types.OrganizationsStringFilter`
     :   The type of the None singleton.
+
+<a id="OrganizationsGetParams"></a>
 
 `OrganizationsGetParams(*args, **kwargs)`
 :   Parameters for organizations.get operation
@@ -1467,6 +1653,8 @@ Classes
     `org: str`
     :   The type of the None singleton.
 
+<a id="OrganizationsGtCondition"></a>
+
 `OrganizationsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -1479,6 +1667,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.github.types.OrganizationsSearchFilter`
     :   The type of the None singleton.
 
+<a id="OrganizationsGteCondition"></a>
+
 `OrganizationsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -1490,6 +1680,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.github.types.OrganizationsSearchFilter`
     :   The type of the None singleton.
+
+<a id="OrganizationsInCondition"></a>
 
 `OrganizationsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -1511,12 +1703,16 @@ Classes
     `in: airbyte_agent_sdk.connectors.github.types.OrganizationsInFilter`
     :   The type of the None singleton.
 
+<a id="OrganizationsInFilter"></a>
+
 `OrganizationsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="OrganizationsKeywordCondition"></a>
 
 `OrganizationsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
@@ -1530,6 +1726,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.github.types.OrganizationsStringFilter`
     :   The type of the None singleton.
 
+<a id="OrganizationsLikeCondition"></a>
+
 `OrganizationsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -1541,6 +1739,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.github.types.OrganizationsStringFilter`
     :   The type of the None singleton.
+
+<a id="OrganizationsListParams"></a>
 
 `OrganizationsListParams(*args, **kwargs)`
 :   Parameters for organizations.list operation
@@ -1563,6 +1763,8 @@ Classes
     `username: str`
     :   The type of the None singleton.
 
+<a id="OrganizationsLtCondition"></a>
+
 `OrganizationsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -1574,6 +1776,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.github.types.OrganizationsSearchFilter`
     :   The type of the None singleton.
+
+<a id="OrganizationsLteCondition"></a>
 
 `OrganizationsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -1587,6 +1791,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.github.types.OrganizationsSearchFilter`
     :   The type of the None singleton.
 
+<a id="OrganizationsNeqCondition"></a>
+
 `OrganizationsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -1598,6 +1804,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.github.types.OrganizationsSearchFilter`
     :   The type of the None singleton.
+
+<a id="OrganizationsNotCondition"></a>
 
 `OrganizationsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -1619,6 +1827,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.github.types.OrganizationsEqCondition | airbyte_agent_sdk.connectors.github.types.OrganizationsNeqCondition | airbyte_agent_sdk.connectors.github.types.OrganizationsGtCondition | airbyte_agent_sdk.connectors.github.types.OrganizationsGteCondition | airbyte_agent_sdk.connectors.github.types.OrganizationsLtCondition | airbyte_agent_sdk.connectors.github.types.OrganizationsLteCondition | airbyte_agent_sdk.connectors.github.types.OrganizationsInCondition | airbyte_agent_sdk.connectors.github.types.OrganizationsLikeCondition | airbyte_agent_sdk.connectors.github.types.OrganizationsFuzzyCondition | airbyte_agent_sdk.connectors.github.types.OrganizationsKeywordCondition | airbyte_agent_sdk.connectors.github.types.OrganizationsContainsCondition | airbyte_agent_sdk.connectors.github.types.OrganizationsNotCondition | airbyte_agent_sdk.connectors.github.types.OrganizationsAndCondition | airbyte_agent_sdk.connectors.github.types.OrganizationsOrCondition | airbyte_agent_sdk.connectors.github.types.OrganizationsAnyCondition`
     :   The type of the None singleton.
 
+<a id="OrganizationsOrCondition"></a>
+
 `OrganizationsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1639,12 +1849,16 @@ Classes
     `or: list[airbyte_agent_sdk.connectors.github.types.OrganizationsEqCondition | airbyte_agent_sdk.connectors.github.types.OrganizationsNeqCondition | airbyte_agent_sdk.connectors.github.types.OrganizationsGtCondition | airbyte_agent_sdk.connectors.github.types.OrganizationsGteCondition | airbyte_agent_sdk.connectors.github.types.OrganizationsLtCondition | airbyte_agent_sdk.connectors.github.types.OrganizationsLteCondition | airbyte_agent_sdk.connectors.github.types.OrganizationsInCondition | airbyte_agent_sdk.connectors.github.types.OrganizationsLikeCondition | airbyte_agent_sdk.connectors.github.types.OrganizationsFuzzyCondition | airbyte_agent_sdk.connectors.github.types.OrganizationsKeywordCondition | airbyte_agent_sdk.connectors.github.types.OrganizationsContainsCondition | airbyte_agent_sdk.connectors.github.types.OrganizationsNotCondition | airbyte_agent_sdk.connectors.github.types.OrganizationsAndCondition | airbyte_agent_sdk.connectors.github.types.OrganizationsOrCondition | airbyte_agent_sdk.connectors.github.types.OrganizationsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="OrganizationsSearchFilter"></a>
+
 `OrganizationsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering organizations search queries.
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="OrganizationsSearchQuery"></a>
 
 `OrganizationsSearchQuery(*args, **kwargs)`
 :   Search query for organizations entity.
@@ -1661,6 +1875,8 @@ Classes
     `sort: list[airbyte_agent_sdk.connectors.github.types.OrganizationsSortFilter]`
     :   The type of the None singleton.
 
+<a id="OrganizationsSortFilter"></a>
+
 `OrganizationsSortFilter(*args, **kwargs)`
 :   Available fields for sorting organizations search results.
 
@@ -1668,12 +1884,16 @@ Classes
 
     * builtins.dict
 
+<a id="OrganizationsStringFilter"></a>
+
 `OrganizationsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="PrCommentsGetParams"></a>
 
 `PrCommentsGetParams(*args, **kwargs)`
 :   Parameters for pr_comments.get operation
@@ -1689,6 +1909,8 @@ Classes
 
     `id: str`
     :   The type of the None singleton.
+
+<a id="PrCommentsListParams"></a>
 
 `PrCommentsListParams(*args, **kwargs)`
 :   Parameters for pr_comments.list operation
@@ -1717,6 +1939,8 @@ Classes
     `repo: str`
     :   The type of the None singleton.
 
+<a id="ProjectItemsListParams"></a>
+
 `ProjectItemsListParams(*args, **kwargs)`
 :   Parameters for project_items.list operation
 
@@ -1741,6 +1965,8 @@ Classes
     `project_number: int`
     :   The type of the None singleton.
 
+<a id="ProjectsGetParams"></a>
+
 `ProjectsGetParams(*args, **kwargs)`
 :   Parameters for projects.get operation
 
@@ -1758,6 +1984,8 @@ Classes
 
     `project_number: int`
     :   The type of the None singleton.
+
+<a id="ProjectsListParams"></a>
 
 `ProjectsListParams(*args, **kwargs)`
 :   Parameters for projects.list operation
@@ -1780,6 +2008,8 @@ Classes
     `per_page: int`
     :   The type of the None singleton.
 
+<a id="PullRequestsAndCondition"></a>
+
 `PullRequestsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1799,6 +2029,8 @@ Classes
 
     `and: list[airbyte_agent_sdk.connectors.github.types.PullRequestsEqCondition | airbyte_agent_sdk.connectors.github.types.PullRequestsNeqCondition | airbyte_agent_sdk.connectors.github.types.PullRequestsGtCondition | airbyte_agent_sdk.connectors.github.types.PullRequestsGteCondition | airbyte_agent_sdk.connectors.github.types.PullRequestsLtCondition | airbyte_agent_sdk.connectors.github.types.PullRequestsLteCondition | airbyte_agent_sdk.connectors.github.types.PullRequestsInCondition | airbyte_agent_sdk.connectors.github.types.PullRequestsLikeCondition | airbyte_agent_sdk.connectors.github.types.PullRequestsFuzzyCondition | airbyte_agent_sdk.connectors.github.types.PullRequestsKeywordCondition | airbyte_agent_sdk.connectors.github.types.PullRequestsContainsCondition | airbyte_agent_sdk.connectors.github.types.PullRequestsNotCondition | airbyte_agent_sdk.connectors.github.types.PullRequestsAndCondition | airbyte_agent_sdk.connectors.github.types.PullRequestsOrCondition | airbyte_agent_sdk.connectors.github.types.PullRequestsAnyCondition]`
     :   The type of the None singleton.
+
+<a id="PullRequestsAnyCondition"></a>
 
 `PullRequestsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -1820,12 +2052,16 @@ Classes
     `any: airbyte_agent_sdk.connectors.github.types.PullRequestsAnyValueFilter`
     :   The type of the None singleton.
 
+<a id="PullRequestsAnyValueFilter"></a>
+
 `PullRequestsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="PullRequestsApiSearchParams"></a>
 
 `PullRequestsApiSearchParams(*args, **kwargs)`
 :   Parameters for pull_requests.api_search operation
@@ -1848,6 +2084,8 @@ Classes
     `query: str`
     :   The type of the None singleton.
 
+<a id="PullRequestsContainsCondition"></a>
+
 `PullRequestsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -1859,6 +2097,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.github.types.PullRequestsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="PullRequestsCreateParams"></a>
 
 `PullRequestsCreateParams(*args, **kwargs)`
 :   Parameters for pull_requests.create operation
@@ -1893,6 +2133,8 @@ Classes
     `title: str`
     :   The type of the None singleton.
 
+<a id="PullRequestsEqCondition"></a>
+
 `PullRequestsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
 
@@ -1905,6 +2147,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.github.types.PullRequestsSearchFilter`
     :   The type of the None singleton.
 
+<a id="PullRequestsFuzzyCondition"></a>
+
 `PullRequestsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -1916,6 +2160,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.github.types.PullRequestsStringFilter`
     :   The type of the None singleton.
+
+<a id="PullRequestsGetParams"></a>
 
 `PullRequestsGetParams(*args, **kwargs)`
 :   Parameters for pull_requests.get operation
@@ -1938,6 +2184,8 @@ Classes
     `repo: str`
     :   The type of the None singleton.
 
+<a id="PullRequestsGtCondition"></a>
+
 `PullRequestsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -1950,6 +2198,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.github.types.PullRequestsSearchFilter`
     :   The type of the None singleton.
 
+<a id="PullRequestsGteCondition"></a>
+
 `PullRequestsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -1961,6 +2211,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.github.types.PullRequestsSearchFilter`
     :   The type of the None singleton.
+
+<a id="PullRequestsInCondition"></a>
 
 `PullRequestsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -1982,12 +2234,16 @@ Classes
     `in: airbyte_agent_sdk.connectors.github.types.PullRequestsInFilter`
     :   The type of the None singleton.
 
+<a id="PullRequestsInFilter"></a>
+
 `PullRequestsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="PullRequestsKeywordCondition"></a>
 
 `PullRequestsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
@@ -2001,6 +2257,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.github.types.PullRequestsStringFilter`
     :   The type of the None singleton.
 
+<a id="PullRequestsLikeCondition"></a>
+
 `PullRequestsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -2012,6 +2270,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.github.types.PullRequestsStringFilter`
     :   The type of the None singleton.
+
+<a id="PullRequestsListParams"></a>
 
 `PullRequestsListParams(*args, **kwargs)`
 :   Parameters for pull_requests.list operation
@@ -2040,6 +2300,8 @@ Classes
     `states: list[str]`
     :   The type of the None singleton.
 
+<a id="PullRequestsLtCondition"></a>
+
 `PullRequestsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -2051,6 +2313,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.github.types.PullRequestsSearchFilter`
     :   The type of the None singleton.
+
+<a id="PullRequestsLteCondition"></a>
 
 `PullRequestsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -2064,6 +2328,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.github.types.PullRequestsSearchFilter`
     :   The type of the None singleton.
 
+<a id="PullRequestsNeqCondition"></a>
+
 `PullRequestsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -2075,6 +2341,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.github.types.PullRequestsSearchFilter`
     :   The type of the None singleton.
+
+<a id="PullRequestsNotCondition"></a>
 
 `PullRequestsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -2096,6 +2364,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.github.types.PullRequestsEqCondition | airbyte_agent_sdk.connectors.github.types.PullRequestsNeqCondition | airbyte_agent_sdk.connectors.github.types.PullRequestsGtCondition | airbyte_agent_sdk.connectors.github.types.PullRequestsGteCondition | airbyte_agent_sdk.connectors.github.types.PullRequestsLtCondition | airbyte_agent_sdk.connectors.github.types.PullRequestsLteCondition | airbyte_agent_sdk.connectors.github.types.PullRequestsInCondition | airbyte_agent_sdk.connectors.github.types.PullRequestsLikeCondition | airbyte_agent_sdk.connectors.github.types.PullRequestsFuzzyCondition | airbyte_agent_sdk.connectors.github.types.PullRequestsKeywordCondition | airbyte_agent_sdk.connectors.github.types.PullRequestsContainsCondition | airbyte_agent_sdk.connectors.github.types.PullRequestsNotCondition | airbyte_agent_sdk.connectors.github.types.PullRequestsAndCondition | airbyte_agent_sdk.connectors.github.types.PullRequestsOrCondition | airbyte_agent_sdk.connectors.github.types.PullRequestsAnyCondition`
     :   The type of the None singleton.
 
+<a id="PullRequestsOrCondition"></a>
+
 `PullRequestsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -2116,12 +2386,16 @@ Classes
     `or: list[airbyte_agent_sdk.connectors.github.types.PullRequestsEqCondition | airbyte_agent_sdk.connectors.github.types.PullRequestsNeqCondition | airbyte_agent_sdk.connectors.github.types.PullRequestsGtCondition | airbyte_agent_sdk.connectors.github.types.PullRequestsGteCondition | airbyte_agent_sdk.connectors.github.types.PullRequestsLtCondition | airbyte_agent_sdk.connectors.github.types.PullRequestsLteCondition | airbyte_agent_sdk.connectors.github.types.PullRequestsInCondition | airbyte_agent_sdk.connectors.github.types.PullRequestsLikeCondition | airbyte_agent_sdk.connectors.github.types.PullRequestsFuzzyCondition | airbyte_agent_sdk.connectors.github.types.PullRequestsKeywordCondition | airbyte_agent_sdk.connectors.github.types.PullRequestsContainsCondition | airbyte_agent_sdk.connectors.github.types.PullRequestsNotCondition | airbyte_agent_sdk.connectors.github.types.PullRequestsAndCondition | airbyte_agent_sdk.connectors.github.types.PullRequestsOrCondition | airbyte_agent_sdk.connectors.github.types.PullRequestsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="PullRequestsSearchFilter"></a>
+
 `PullRequestsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering pull_requests search queries.
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="PullRequestsSearchQuery"></a>
 
 `PullRequestsSearchQuery(*args, **kwargs)`
 :   Search query for pull_requests entity.
@@ -2138,6 +2412,8 @@ Classes
     `sort: list[airbyte_agent_sdk.connectors.github.types.PullRequestsSortFilter]`
     :   The type of the None singleton.
 
+<a id="PullRequestsSortFilter"></a>
+
 `PullRequestsSortFilter(*args, **kwargs)`
 :   Available fields for sorting pull_requests search results.
 
@@ -2145,12 +2421,16 @@ Classes
 
     * builtins.dict
 
+<a id="PullRequestsStringFilter"></a>
+
 `PullRequestsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="ReleasesGetParams"></a>
 
 `ReleasesGetParams(*args, **kwargs)`
 :   Parameters for releases.get operation
@@ -2172,6 +2452,8 @@ Classes
 
     `tag: str`
     :   The type of the None singleton.
+
+<a id="ReleasesListParams"></a>
 
 `ReleasesListParams(*args, **kwargs)`
 :   Parameters for releases.list operation
@@ -2197,6 +2479,8 @@ Classes
     `repo: str`
     :   The type of the None singleton.
 
+<a id="RepositoriesAndCondition"></a>
+
 `RepositoriesAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -2216,6 +2500,8 @@ Classes
 
     `and: list[airbyte_agent_sdk.connectors.github.types.RepositoriesEqCondition | airbyte_agent_sdk.connectors.github.types.RepositoriesNeqCondition | airbyte_agent_sdk.connectors.github.types.RepositoriesGtCondition | airbyte_agent_sdk.connectors.github.types.RepositoriesGteCondition | airbyte_agent_sdk.connectors.github.types.RepositoriesLtCondition | airbyte_agent_sdk.connectors.github.types.RepositoriesLteCondition | airbyte_agent_sdk.connectors.github.types.RepositoriesInCondition | airbyte_agent_sdk.connectors.github.types.RepositoriesLikeCondition | airbyte_agent_sdk.connectors.github.types.RepositoriesFuzzyCondition | airbyte_agent_sdk.connectors.github.types.RepositoriesKeywordCondition | airbyte_agent_sdk.connectors.github.types.RepositoriesContainsCondition | airbyte_agent_sdk.connectors.github.types.RepositoriesNotCondition | airbyte_agent_sdk.connectors.github.types.RepositoriesAndCondition | airbyte_agent_sdk.connectors.github.types.RepositoriesOrCondition | airbyte_agent_sdk.connectors.github.types.RepositoriesAnyCondition]`
     :   The type of the None singleton.
+
+<a id="RepositoriesAnyCondition"></a>
 
 `RepositoriesAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -2237,12 +2523,16 @@ Classes
     `any: airbyte_agent_sdk.connectors.github.types.RepositoriesAnyValueFilter`
     :   The type of the None singleton.
 
+<a id="RepositoriesAnyValueFilter"></a>
+
 `RepositoriesAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="RepositoriesApiSearchParams"></a>
 
 `RepositoriesApiSearchParams(*args, **kwargs)`
 :   Parameters for repositories.api_search operation
@@ -2265,6 +2555,8 @@ Classes
     `query: str`
     :   The type of the None singleton.
 
+<a id="RepositoriesContainsCondition"></a>
+
 `RepositoriesContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -2276,6 +2568,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.github.types.RepositoriesAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="RepositoriesEqCondition"></a>
 
 `RepositoriesEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -2289,6 +2583,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.github.types.RepositoriesSearchFilter`
     :   The type of the None singleton.
 
+<a id="RepositoriesFuzzyCondition"></a>
+
 `RepositoriesFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -2300,6 +2596,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.github.types.RepositoriesStringFilter`
     :   The type of the None singleton.
+
+<a id="RepositoriesGetParams"></a>
 
 `RepositoriesGetParams(*args, **kwargs)`
 :   Parameters for repositories.get operation
@@ -2319,6 +2617,8 @@ Classes
     `repo: str`
     :   The type of the None singleton.
 
+<a id="RepositoriesGtCondition"></a>
+
 `RepositoriesGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -2331,6 +2631,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.github.types.RepositoriesSearchFilter`
     :   The type of the None singleton.
 
+<a id="RepositoriesGteCondition"></a>
+
 `RepositoriesGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -2342,6 +2644,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.github.types.RepositoriesSearchFilter`
     :   The type of the None singleton.
+
+<a id="RepositoriesInCondition"></a>
 
 `RepositoriesInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -2363,12 +2667,16 @@ Classes
     `in: airbyte_agent_sdk.connectors.github.types.RepositoriesInFilter`
     :   The type of the None singleton.
 
+<a id="RepositoriesInFilter"></a>
+
 `RepositoriesInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="RepositoriesKeywordCondition"></a>
 
 `RepositoriesKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
@@ -2382,6 +2690,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.github.types.RepositoriesStringFilter`
     :   The type of the None singleton.
 
+<a id="RepositoriesLikeCondition"></a>
+
 `RepositoriesLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -2393,6 +2703,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.github.types.RepositoriesStringFilter`
     :   The type of the None singleton.
+
+<a id="RepositoriesListParams"></a>
 
 `RepositoriesListParams(*args, **kwargs)`
 :   Parameters for repositories.list operation
@@ -2415,6 +2727,8 @@ Classes
     `username: str`
     :   The type of the None singleton.
 
+<a id="RepositoriesLtCondition"></a>
+
 `RepositoriesLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -2426,6 +2740,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.github.types.RepositoriesSearchFilter`
     :   The type of the None singleton.
+
+<a id="RepositoriesLteCondition"></a>
 
 `RepositoriesLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -2439,6 +2755,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.github.types.RepositoriesSearchFilter`
     :   The type of the None singleton.
 
+<a id="RepositoriesNeqCondition"></a>
+
 `RepositoriesNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -2450,6 +2768,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.github.types.RepositoriesSearchFilter`
     :   The type of the None singleton.
+
+<a id="RepositoriesNotCondition"></a>
 
 `RepositoriesNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -2471,6 +2791,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.github.types.RepositoriesEqCondition | airbyte_agent_sdk.connectors.github.types.RepositoriesNeqCondition | airbyte_agent_sdk.connectors.github.types.RepositoriesGtCondition | airbyte_agent_sdk.connectors.github.types.RepositoriesGteCondition | airbyte_agent_sdk.connectors.github.types.RepositoriesLtCondition | airbyte_agent_sdk.connectors.github.types.RepositoriesLteCondition | airbyte_agent_sdk.connectors.github.types.RepositoriesInCondition | airbyte_agent_sdk.connectors.github.types.RepositoriesLikeCondition | airbyte_agent_sdk.connectors.github.types.RepositoriesFuzzyCondition | airbyte_agent_sdk.connectors.github.types.RepositoriesKeywordCondition | airbyte_agent_sdk.connectors.github.types.RepositoriesContainsCondition | airbyte_agent_sdk.connectors.github.types.RepositoriesNotCondition | airbyte_agent_sdk.connectors.github.types.RepositoriesAndCondition | airbyte_agent_sdk.connectors.github.types.RepositoriesOrCondition | airbyte_agent_sdk.connectors.github.types.RepositoriesAnyCondition`
     :   The type of the None singleton.
 
+<a id="RepositoriesOrCondition"></a>
+
 `RepositoriesOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -2491,12 +2813,16 @@ Classes
     `or: list[airbyte_agent_sdk.connectors.github.types.RepositoriesEqCondition | airbyte_agent_sdk.connectors.github.types.RepositoriesNeqCondition | airbyte_agent_sdk.connectors.github.types.RepositoriesGtCondition | airbyte_agent_sdk.connectors.github.types.RepositoriesGteCondition | airbyte_agent_sdk.connectors.github.types.RepositoriesLtCondition | airbyte_agent_sdk.connectors.github.types.RepositoriesLteCondition | airbyte_agent_sdk.connectors.github.types.RepositoriesInCondition | airbyte_agent_sdk.connectors.github.types.RepositoriesLikeCondition | airbyte_agent_sdk.connectors.github.types.RepositoriesFuzzyCondition | airbyte_agent_sdk.connectors.github.types.RepositoriesKeywordCondition | airbyte_agent_sdk.connectors.github.types.RepositoriesContainsCondition | airbyte_agent_sdk.connectors.github.types.RepositoriesNotCondition | airbyte_agent_sdk.connectors.github.types.RepositoriesAndCondition | airbyte_agent_sdk.connectors.github.types.RepositoriesOrCondition | airbyte_agent_sdk.connectors.github.types.RepositoriesAnyCondition]`
     :   The type of the None singleton.
 
+<a id="RepositoriesSearchFilter"></a>
+
 `RepositoriesSearchFilter(*args, **kwargs)`
 :   Available fields for filtering repositories search queries.
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="RepositoriesSearchQuery"></a>
 
 `RepositoriesSearchQuery(*args, **kwargs)`
 :   Search query for repositories entity.
@@ -2513,6 +2839,8 @@ Classes
     `sort: list[airbyte_agent_sdk.connectors.github.types.RepositoriesSortFilter]`
     :   The type of the None singleton.
 
+<a id="RepositoriesSortFilter"></a>
+
 `RepositoriesSortFilter(*args, **kwargs)`
 :   Available fields for sorting repositories search results.
 
@@ -2520,12 +2848,16 @@ Classes
 
     * builtins.dict
 
+<a id="RepositoriesStringFilter"></a>
+
 `RepositoriesStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="ReviewsListParams"></a>
 
 `ReviewsListParams(*args, **kwargs)`
 :   Parameters for reviews.list operation
@@ -2554,6 +2886,8 @@ Classes
     `repo: str`
     :   The type of the None singleton.
 
+<a id="StargazersAndCondition"></a>
+
 `StargazersAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -2573,6 +2907,8 @@ Classes
 
     `and: list[airbyte_agent_sdk.connectors.github.types.StargazersEqCondition | airbyte_agent_sdk.connectors.github.types.StargazersNeqCondition | airbyte_agent_sdk.connectors.github.types.StargazersGtCondition | airbyte_agent_sdk.connectors.github.types.StargazersGteCondition | airbyte_agent_sdk.connectors.github.types.StargazersLtCondition | airbyte_agent_sdk.connectors.github.types.StargazersLteCondition | airbyte_agent_sdk.connectors.github.types.StargazersInCondition | airbyte_agent_sdk.connectors.github.types.StargazersLikeCondition | airbyte_agent_sdk.connectors.github.types.StargazersFuzzyCondition | airbyte_agent_sdk.connectors.github.types.StargazersKeywordCondition | airbyte_agent_sdk.connectors.github.types.StargazersContainsCondition | airbyte_agent_sdk.connectors.github.types.StargazersNotCondition | airbyte_agent_sdk.connectors.github.types.StargazersAndCondition | airbyte_agent_sdk.connectors.github.types.StargazersOrCondition | airbyte_agent_sdk.connectors.github.types.StargazersAnyCondition]`
     :   The type of the None singleton.
+
+<a id="StargazersAnyCondition"></a>
 
 `StargazersAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -2594,12 +2930,16 @@ Classes
     `any: airbyte_agent_sdk.connectors.github.types.StargazersAnyValueFilter`
     :   The type of the None singleton.
 
+<a id="StargazersAnyValueFilter"></a>
+
 `StargazersAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="StargazersContainsCondition"></a>
 
 `StargazersContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
@@ -2613,6 +2953,8 @@ Classes
     `contains: airbyte_agent_sdk.connectors.github.types.StargazersAnyValueFilter`
     :   The type of the None singleton.
 
+<a id="StargazersEqCondition"></a>
+
 `StargazersEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
 
@@ -2624,6 +2966,8 @@ Classes
 
     `eq: airbyte_agent_sdk.connectors.github.types.StargazersSearchFilter`
     :   The type of the None singleton.
+
+<a id="StargazersFuzzyCondition"></a>
 
 `StargazersFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
@@ -2637,6 +2981,8 @@ Classes
     `fuzzy: airbyte_agent_sdk.connectors.github.types.StargazersStringFilter`
     :   The type of the None singleton.
 
+<a id="StargazersGtCondition"></a>
+
 `StargazersGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -2649,6 +2995,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.github.types.StargazersSearchFilter`
     :   The type of the None singleton.
 
+<a id="StargazersGteCondition"></a>
+
 `StargazersGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -2660,6 +3008,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.github.types.StargazersSearchFilter`
     :   The type of the None singleton.
+
+<a id="StargazersInCondition"></a>
 
 `StargazersInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -2681,12 +3031,16 @@ Classes
     `in: airbyte_agent_sdk.connectors.github.types.StargazersInFilter`
     :   The type of the None singleton.
 
+<a id="StargazersInFilter"></a>
+
 `StargazersInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="StargazersKeywordCondition"></a>
 
 `StargazersKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
@@ -2700,6 +3054,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.github.types.StargazersStringFilter`
     :   The type of the None singleton.
 
+<a id="StargazersLikeCondition"></a>
+
 `StargazersLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -2711,6 +3067,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.github.types.StargazersStringFilter`
     :   The type of the None singleton.
+
+<a id="StargazersListParams"></a>
 
 `StargazersListParams(*args, **kwargs)`
 :   Parameters for stargazers.list operation
@@ -2736,6 +3094,8 @@ Classes
     `repo: str`
     :   The type of the None singleton.
 
+<a id="StargazersLtCondition"></a>
+
 `StargazersLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -2747,6 +3107,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.github.types.StargazersSearchFilter`
     :   The type of the None singleton.
+
+<a id="StargazersLteCondition"></a>
 
 `StargazersLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -2760,6 +3122,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.github.types.StargazersSearchFilter`
     :   The type of the None singleton.
 
+<a id="StargazersNeqCondition"></a>
+
 `StargazersNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -2771,6 +3135,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.github.types.StargazersSearchFilter`
     :   The type of the None singleton.
+
+<a id="StargazersNotCondition"></a>
 
 `StargazersNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -2792,6 +3158,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.github.types.StargazersEqCondition | airbyte_agent_sdk.connectors.github.types.StargazersNeqCondition | airbyte_agent_sdk.connectors.github.types.StargazersGtCondition | airbyte_agent_sdk.connectors.github.types.StargazersGteCondition | airbyte_agent_sdk.connectors.github.types.StargazersLtCondition | airbyte_agent_sdk.connectors.github.types.StargazersLteCondition | airbyte_agent_sdk.connectors.github.types.StargazersInCondition | airbyte_agent_sdk.connectors.github.types.StargazersLikeCondition | airbyte_agent_sdk.connectors.github.types.StargazersFuzzyCondition | airbyte_agent_sdk.connectors.github.types.StargazersKeywordCondition | airbyte_agent_sdk.connectors.github.types.StargazersContainsCondition | airbyte_agent_sdk.connectors.github.types.StargazersNotCondition | airbyte_agent_sdk.connectors.github.types.StargazersAndCondition | airbyte_agent_sdk.connectors.github.types.StargazersOrCondition | airbyte_agent_sdk.connectors.github.types.StargazersAnyCondition`
     :   The type of the None singleton.
 
+<a id="StargazersOrCondition"></a>
+
 `StargazersOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -2812,12 +3180,16 @@ Classes
     `or: list[airbyte_agent_sdk.connectors.github.types.StargazersEqCondition | airbyte_agent_sdk.connectors.github.types.StargazersNeqCondition | airbyte_agent_sdk.connectors.github.types.StargazersGtCondition | airbyte_agent_sdk.connectors.github.types.StargazersGteCondition | airbyte_agent_sdk.connectors.github.types.StargazersLtCondition | airbyte_agent_sdk.connectors.github.types.StargazersLteCondition | airbyte_agent_sdk.connectors.github.types.StargazersInCondition | airbyte_agent_sdk.connectors.github.types.StargazersLikeCondition | airbyte_agent_sdk.connectors.github.types.StargazersFuzzyCondition | airbyte_agent_sdk.connectors.github.types.StargazersKeywordCondition | airbyte_agent_sdk.connectors.github.types.StargazersContainsCondition | airbyte_agent_sdk.connectors.github.types.StargazersNotCondition | airbyte_agent_sdk.connectors.github.types.StargazersAndCondition | airbyte_agent_sdk.connectors.github.types.StargazersOrCondition | airbyte_agent_sdk.connectors.github.types.StargazersAnyCondition]`
     :   The type of the None singleton.
 
+<a id="StargazersSearchFilter"></a>
+
 `StargazersSearchFilter(*args, **kwargs)`
 :   Available fields for filtering stargazers search queries.
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="StargazersSearchQuery"></a>
 
 `StargazersSearchQuery(*args, **kwargs)`
 :   Search query for stargazers entity.
@@ -2834,6 +3206,8 @@ Classes
     `sort: list[airbyte_agent_sdk.connectors.github.types.StargazersSortFilter]`
     :   The type of the None singleton.
 
+<a id="StargazersSortFilter"></a>
+
 `StargazersSortFilter(*args, **kwargs)`
 :   Available fields for sorting stargazers search results.
 
@@ -2841,12 +3215,16 @@ Classes
 
     * builtins.dict
 
+<a id="StargazersStringFilter"></a>
+
 `StargazersStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="TagsAndCondition"></a>
 
 `TagsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -2868,6 +3246,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.github.types.TagsEqCondition | airbyte_agent_sdk.connectors.github.types.TagsNeqCondition | airbyte_agent_sdk.connectors.github.types.TagsGtCondition | airbyte_agent_sdk.connectors.github.types.TagsGteCondition | airbyte_agent_sdk.connectors.github.types.TagsLtCondition | airbyte_agent_sdk.connectors.github.types.TagsLteCondition | airbyte_agent_sdk.connectors.github.types.TagsInCondition | airbyte_agent_sdk.connectors.github.types.TagsLikeCondition | airbyte_agent_sdk.connectors.github.types.TagsFuzzyCondition | airbyte_agent_sdk.connectors.github.types.TagsKeywordCondition | airbyte_agent_sdk.connectors.github.types.TagsContainsCondition | airbyte_agent_sdk.connectors.github.types.TagsNotCondition | airbyte_agent_sdk.connectors.github.types.TagsAndCondition | airbyte_agent_sdk.connectors.github.types.TagsOrCondition | airbyte_agent_sdk.connectors.github.types.TagsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="TagsAnyCondition"></a>
+
 `TagsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -2888,12 +3268,16 @@ Classes
     `any: airbyte_agent_sdk.connectors.github.types.TagsAnyValueFilter`
     :   The type of the None singleton.
 
+<a id="TagsAnyValueFilter"></a>
+
 `TagsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="TagsContainsCondition"></a>
 
 `TagsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
@@ -2907,6 +3291,8 @@ Classes
     `contains: airbyte_agent_sdk.connectors.github.types.TagsAnyValueFilter`
     :   The type of the None singleton.
 
+<a id="TagsEqCondition"></a>
+
 `TagsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
 
@@ -2919,6 +3305,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.github.types.TagsSearchFilter`
     :   The type of the None singleton.
 
+<a id="TagsFuzzyCondition"></a>
+
 `TagsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -2930,6 +3318,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.github.types.TagsStringFilter`
     :   The type of the None singleton.
+
+<a id="TagsGetParams"></a>
 
 `TagsGetParams(*args, **kwargs)`
 :   Parameters for tags.get operation
@@ -2952,6 +3342,8 @@ Classes
     `tag: str`
     :   The type of the None singleton.
 
+<a id="TagsGtCondition"></a>
+
 `TagsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -2964,6 +3356,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.github.types.TagsSearchFilter`
     :   The type of the None singleton.
 
+<a id="TagsGteCondition"></a>
+
 `TagsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -2975,6 +3369,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.github.types.TagsSearchFilter`
     :   The type of the None singleton.
+
+<a id="TagsInCondition"></a>
 
 `TagsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -2996,12 +3392,16 @@ Classes
     `in: airbyte_agent_sdk.connectors.github.types.TagsInFilter`
     :   The type of the None singleton.
 
+<a id="TagsInFilter"></a>
+
 `TagsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="TagsKeywordCondition"></a>
 
 `TagsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
@@ -3015,6 +3415,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.github.types.TagsStringFilter`
     :   The type of the None singleton.
 
+<a id="TagsLikeCondition"></a>
+
 `TagsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -3026,6 +3428,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.github.types.TagsStringFilter`
     :   The type of the None singleton.
+
+<a id="TagsListParams"></a>
 
 `TagsListParams(*args, **kwargs)`
 :   Parameters for tags.list operation
@@ -3051,6 +3455,8 @@ Classes
     `repo: str`
     :   The type of the None singleton.
 
+<a id="TagsLtCondition"></a>
+
 `TagsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -3062,6 +3468,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.github.types.TagsSearchFilter`
     :   The type of the None singleton.
+
+<a id="TagsLteCondition"></a>
 
 `TagsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -3075,6 +3483,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.github.types.TagsSearchFilter`
     :   The type of the None singleton.
 
+<a id="TagsNeqCondition"></a>
+
 `TagsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -3086,6 +3496,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.github.types.TagsSearchFilter`
     :   The type of the None singleton.
+
+<a id="TagsNotCondition"></a>
 
 `TagsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -3107,6 +3519,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.github.types.TagsEqCondition | airbyte_agent_sdk.connectors.github.types.TagsNeqCondition | airbyte_agent_sdk.connectors.github.types.TagsGtCondition | airbyte_agent_sdk.connectors.github.types.TagsGteCondition | airbyte_agent_sdk.connectors.github.types.TagsLtCondition | airbyte_agent_sdk.connectors.github.types.TagsLteCondition | airbyte_agent_sdk.connectors.github.types.TagsInCondition | airbyte_agent_sdk.connectors.github.types.TagsLikeCondition | airbyte_agent_sdk.connectors.github.types.TagsFuzzyCondition | airbyte_agent_sdk.connectors.github.types.TagsKeywordCondition | airbyte_agent_sdk.connectors.github.types.TagsContainsCondition | airbyte_agent_sdk.connectors.github.types.TagsNotCondition | airbyte_agent_sdk.connectors.github.types.TagsAndCondition | airbyte_agent_sdk.connectors.github.types.TagsOrCondition | airbyte_agent_sdk.connectors.github.types.TagsAnyCondition`
     :   The type of the None singleton.
 
+<a id="TagsOrCondition"></a>
+
 `TagsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -3127,12 +3541,16 @@ Classes
     `or: list[airbyte_agent_sdk.connectors.github.types.TagsEqCondition | airbyte_agent_sdk.connectors.github.types.TagsNeqCondition | airbyte_agent_sdk.connectors.github.types.TagsGtCondition | airbyte_agent_sdk.connectors.github.types.TagsGteCondition | airbyte_agent_sdk.connectors.github.types.TagsLtCondition | airbyte_agent_sdk.connectors.github.types.TagsLteCondition | airbyte_agent_sdk.connectors.github.types.TagsInCondition | airbyte_agent_sdk.connectors.github.types.TagsLikeCondition | airbyte_agent_sdk.connectors.github.types.TagsFuzzyCondition | airbyte_agent_sdk.connectors.github.types.TagsKeywordCondition | airbyte_agent_sdk.connectors.github.types.TagsContainsCondition | airbyte_agent_sdk.connectors.github.types.TagsNotCondition | airbyte_agent_sdk.connectors.github.types.TagsAndCondition | airbyte_agent_sdk.connectors.github.types.TagsOrCondition | airbyte_agent_sdk.connectors.github.types.TagsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="TagsSearchFilter"></a>
+
 `TagsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering tags search queries.
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="TagsSearchQuery"></a>
 
 `TagsSearchQuery(*args, **kwargs)`
 :   Search query for tags entity.
@@ -3149,6 +3567,8 @@ Classes
     `sort: list[airbyte_agent_sdk.connectors.github.types.TagsSortFilter]`
     :   The type of the None singleton.
 
+<a id="TagsSortFilter"></a>
+
 `TagsSortFilter(*args, **kwargs)`
 :   Available fields for sorting tags search results.
 
@@ -3156,12 +3576,16 @@ Classes
 
     * builtins.dict
 
+<a id="TagsStringFilter"></a>
+
 `TagsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="TeamsAndCondition"></a>
 
 `TeamsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -3183,6 +3607,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.github.types.TeamsEqCondition | airbyte_agent_sdk.connectors.github.types.TeamsNeqCondition | airbyte_agent_sdk.connectors.github.types.TeamsGtCondition | airbyte_agent_sdk.connectors.github.types.TeamsGteCondition | airbyte_agent_sdk.connectors.github.types.TeamsLtCondition | airbyte_agent_sdk.connectors.github.types.TeamsLteCondition | airbyte_agent_sdk.connectors.github.types.TeamsInCondition | airbyte_agent_sdk.connectors.github.types.TeamsLikeCondition | airbyte_agent_sdk.connectors.github.types.TeamsFuzzyCondition | airbyte_agent_sdk.connectors.github.types.TeamsKeywordCondition | airbyte_agent_sdk.connectors.github.types.TeamsContainsCondition | airbyte_agent_sdk.connectors.github.types.TeamsNotCondition | airbyte_agent_sdk.connectors.github.types.TeamsAndCondition | airbyte_agent_sdk.connectors.github.types.TeamsOrCondition | airbyte_agent_sdk.connectors.github.types.TeamsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="TeamsAnyCondition"></a>
+
 `TeamsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -3203,12 +3629,16 @@ Classes
     `any: airbyte_agent_sdk.connectors.github.types.TeamsAnyValueFilter`
     :   The type of the None singleton.
 
+<a id="TeamsAnyValueFilter"></a>
+
 `TeamsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="TeamsContainsCondition"></a>
 
 `TeamsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
@@ -3222,6 +3652,8 @@ Classes
     `contains: airbyte_agent_sdk.connectors.github.types.TeamsAnyValueFilter`
     :   The type of the None singleton.
 
+<a id="TeamsEqCondition"></a>
+
 `TeamsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
 
@@ -3234,6 +3666,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.github.types.TeamsSearchFilter`
     :   The type of the None singleton.
 
+<a id="TeamsFuzzyCondition"></a>
+
 `TeamsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -3245,6 +3679,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.github.types.TeamsStringFilter`
     :   The type of the None singleton.
+
+<a id="TeamsGetParams"></a>
 
 `TeamsGetParams(*args, **kwargs)`
 :   Parameters for teams.get operation
@@ -3264,6 +3700,8 @@ Classes
     `team_slug: str`
     :   The type of the None singleton.
 
+<a id="TeamsGtCondition"></a>
+
 `TeamsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -3276,6 +3714,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.github.types.TeamsSearchFilter`
     :   The type of the None singleton.
 
+<a id="TeamsGteCondition"></a>
+
 `TeamsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -3287,6 +3727,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.github.types.TeamsSearchFilter`
     :   The type of the None singleton.
+
+<a id="TeamsInCondition"></a>
 
 `TeamsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -3308,12 +3750,16 @@ Classes
     `in: airbyte_agent_sdk.connectors.github.types.TeamsInFilter`
     :   The type of the None singleton.
 
+<a id="TeamsInFilter"></a>
+
 `TeamsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="TeamsKeywordCondition"></a>
 
 `TeamsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
@@ -3327,6 +3773,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.github.types.TeamsStringFilter`
     :   The type of the None singleton.
 
+<a id="TeamsLikeCondition"></a>
+
 `TeamsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -3338,6 +3786,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.github.types.TeamsStringFilter`
     :   The type of the None singleton.
+
+<a id="TeamsListParams"></a>
 
 `TeamsListParams(*args, **kwargs)`
 :   Parameters for teams.list operation
@@ -3360,6 +3810,8 @@ Classes
     `per_page: int`
     :   The type of the None singleton.
 
+<a id="TeamsLtCondition"></a>
+
 `TeamsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -3371,6 +3823,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.github.types.TeamsSearchFilter`
     :   The type of the None singleton.
+
+<a id="TeamsLteCondition"></a>
 
 `TeamsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -3384,6 +3838,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.github.types.TeamsSearchFilter`
     :   The type of the None singleton.
 
+<a id="TeamsNeqCondition"></a>
+
 `TeamsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -3395,6 +3851,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.github.types.TeamsSearchFilter`
     :   The type of the None singleton.
+
+<a id="TeamsNotCondition"></a>
 
 `TeamsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -3416,6 +3874,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.github.types.TeamsEqCondition | airbyte_agent_sdk.connectors.github.types.TeamsNeqCondition | airbyte_agent_sdk.connectors.github.types.TeamsGtCondition | airbyte_agent_sdk.connectors.github.types.TeamsGteCondition | airbyte_agent_sdk.connectors.github.types.TeamsLtCondition | airbyte_agent_sdk.connectors.github.types.TeamsLteCondition | airbyte_agent_sdk.connectors.github.types.TeamsInCondition | airbyte_agent_sdk.connectors.github.types.TeamsLikeCondition | airbyte_agent_sdk.connectors.github.types.TeamsFuzzyCondition | airbyte_agent_sdk.connectors.github.types.TeamsKeywordCondition | airbyte_agent_sdk.connectors.github.types.TeamsContainsCondition | airbyte_agent_sdk.connectors.github.types.TeamsNotCondition | airbyte_agent_sdk.connectors.github.types.TeamsAndCondition | airbyte_agent_sdk.connectors.github.types.TeamsOrCondition | airbyte_agent_sdk.connectors.github.types.TeamsAnyCondition`
     :   The type of the None singleton.
 
+<a id="TeamsOrCondition"></a>
+
 `TeamsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -3436,12 +3896,16 @@ Classes
     `or: list[airbyte_agent_sdk.connectors.github.types.TeamsEqCondition | airbyte_agent_sdk.connectors.github.types.TeamsNeqCondition | airbyte_agent_sdk.connectors.github.types.TeamsGtCondition | airbyte_agent_sdk.connectors.github.types.TeamsGteCondition | airbyte_agent_sdk.connectors.github.types.TeamsLtCondition | airbyte_agent_sdk.connectors.github.types.TeamsLteCondition | airbyte_agent_sdk.connectors.github.types.TeamsInCondition | airbyte_agent_sdk.connectors.github.types.TeamsLikeCondition | airbyte_agent_sdk.connectors.github.types.TeamsFuzzyCondition | airbyte_agent_sdk.connectors.github.types.TeamsKeywordCondition | airbyte_agent_sdk.connectors.github.types.TeamsContainsCondition | airbyte_agent_sdk.connectors.github.types.TeamsNotCondition | airbyte_agent_sdk.connectors.github.types.TeamsAndCondition | airbyte_agent_sdk.connectors.github.types.TeamsOrCondition | airbyte_agent_sdk.connectors.github.types.TeamsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="TeamsSearchFilter"></a>
+
 `TeamsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering teams search queries.
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="TeamsSearchQuery"></a>
 
 `TeamsSearchQuery(*args, **kwargs)`
 :   Search query for teams entity.
@@ -3458,6 +3922,8 @@ Classes
     `sort: list[airbyte_agent_sdk.connectors.github.types.TeamsSortFilter]`
     :   The type of the None singleton.
 
+<a id="TeamsSortFilter"></a>
+
 `TeamsSortFilter(*args, **kwargs)`
 :   Available fields for sorting teams search results.
 
@@ -3465,12 +3931,16 @@ Classes
 
     * builtins.dict
 
+<a id="TeamsStringFilter"></a>
+
 `TeamsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="UsersAndCondition"></a>
 
 `UsersAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -3492,6 +3962,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.github.types.UsersEqCondition | airbyte_agent_sdk.connectors.github.types.UsersNeqCondition | airbyte_agent_sdk.connectors.github.types.UsersGtCondition | airbyte_agent_sdk.connectors.github.types.UsersGteCondition | airbyte_agent_sdk.connectors.github.types.UsersLtCondition | airbyte_agent_sdk.connectors.github.types.UsersLteCondition | airbyte_agent_sdk.connectors.github.types.UsersInCondition | airbyte_agent_sdk.connectors.github.types.UsersLikeCondition | airbyte_agent_sdk.connectors.github.types.UsersFuzzyCondition | airbyte_agent_sdk.connectors.github.types.UsersKeywordCondition | airbyte_agent_sdk.connectors.github.types.UsersContainsCondition | airbyte_agent_sdk.connectors.github.types.UsersNotCondition | airbyte_agent_sdk.connectors.github.types.UsersAndCondition | airbyte_agent_sdk.connectors.github.types.UsersOrCondition | airbyte_agent_sdk.connectors.github.types.UsersAnyCondition]`
     :   The type of the None singleton.
 
+<a id="UsersAnyCondition"></a>
+
 `UsersAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -3512,12 +3984,16 @@ Classes
     `any: airbyte_agent_sdk.connectors.github.types.UsersAnyValueFilter`
     :   The type of the None singleton.
 
+<a id="UsersAnyValueFilter"></a>
+
 `UsersAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="UsersApiSearchParams"></a>
 
 `UsersApiSearchParams(*args, **kwargs)`
 :   Parameters for users.api_search operation
@@ -3540,6 +4016,8 @@ Classes
     `query: str`
     :   The type of the None singleton.
 
+<a id="UsersContainsCondition"></a>
+
 `UsersContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -3551,6 +4029,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.github.types.UsersAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="UsersEqCondition"></a>
 
 `UsersEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -3564,6 +4044,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.github.types.UsersSearchFilter`
     :   The type of the None singleton.
 
+<a id="UsersFuzzyCondition"></a>
+
 `UsersFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -3575,6 +4057,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.github.types.UsersStringFilter`
     :   The type of the None singleton.
+
+<a id="UsersGetParams"></a>
 
 `UsersGetParams(*args, **kwargs)`
 :   Parameters for users.get operation
@@ -3591,6 +4075,8 @@ Classes
     `username: str`
     :   The type of the None singleton.
 
+<a id="UsersGtCondition"></a>
+
 `UsersGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -3603,6 +4089,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.github.types.UsersSearchFilter`
     :   The type of the None singleton.
 
+<a id="UsersGteCondition"></a>
+
 `UsersGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -3614,6 +4102,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.github.types.UsersSearchFilter`
     :   The type of the None singleton.
+
+<a id="UsersInCondition"></a>
 
 `UsersInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -3635,12 +4125,16 @@ Classes
     `in: airbyte_agent_sdk.connectors.github.types.UsersInFilter`
     :   The type of the None singleton.
 
+<a id="UsersInFilter"></a>
+
 `UsersInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="UsersKeywordCondition"></a>
 
 `UsersKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
@@ -3654,6 +4148,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.github.types.UsersStringFilter`
     :   The type of the None singleton.
 
+<a id="UsersLikeCondition"></a>
+
 `UsersLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -3665,6 +4161,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.github.types.UsersStringFilter`
     :   The type of the None singleton.
+
+<a id="UsersListParams"></a>
 
 `UsersListParams(*args, **kwargs)`
 :   Parameters for users.list operation
@@ -3687,6 +4185,8 @@ Classes
     `per_page: int`
     :   The type of the None singleton.
 
+<a id="UsersLtCondition"></a>
+
 `UsersLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -3698,6 +4198,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.github.types.UsersSearchFilter`
     :   The type of the None singleton.
+
+<a id="UsersLteCondition"></a>
 
 `UsersLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -3711,6 +4213,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.github.types.UsersSearchFilter`
     :   The type of the None singleton.
 
+<a id="UsersNeqCondition"></a>
+
 `UsersNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -3722,6 +4226,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.github.types.UsersSearchFilter`
     :   The type of the None singleton.
+
+<a id="UsersNotCondition"></a>
 
 `UsersNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -3743,6 +4249,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.github.types.UsersEqCondition | airbyte_agent_sdk.connectors.github.types.UsersNeqCondition | airbyte_agent_sdk.connectors.github.types.UsersGtCondition | airbyte_agent_sdk.connectors.github.types.UsersGteCondition | airbyte_agent_sdk.connectors.github.types.UsersLtCondition | airbyte_agent_sdk.connectors.github.types.UsersLteCondition | airbyte_agent_sdk.connectors.github.types.UsersInCondition | airbyte_agent_sdk.connectors.github.types.UsersLikeCondition | airbyte_agent_sdk.connectors.github.types.UsersFuzzyCondition | airbyte_agent_sdk.connectors.github.types.UsersKeywordCondition | airbyte_agent_sdk.connectors.github.types.UsersContainsCondition | airbyte_agent_sdk.connectors.github.types.UsersNotCondition | airbyte_agent_sdk.connectors.github.types.UsersAndCondition | airbyte_agent_sdk.connectors.github.types.UsersOrCondition | airbyte_agent_sdk.connectors.github.types.UsersAnyCondition`
     :   The type of the None singleton.
 
+<a id="UsersOrCondition"></a>
+
 `UsersOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -3763,12 +4271,16 @@ Classes
     `or: list[airbyte_agent_sdk.connectors.github.types.UsersEqCondition | airbyte_agent_sdk.connectors.github.types.UsersNeqCondition | airbyte_agent_sdk.connectors.github.types.UsersGtCondition | airbyte_agent_sdk.connectors.github.types.UsersGteCondition | airbyte_agent_sdk.connectors.github.types.UsersLtCondition | airbyte_agent_sdk.connectors.github.types.UsersLteCondition | airbyte_agent_sdk.connectors.github.types.UsersInCondition | airbyte_agent_sdk.connectors.github.types.UsersLikeCondition | airbyte_agent_sdk.connectors.github.types.UsersFuzzyCondition | airbyte_agent_sdk.connectors.github.types.UsersKeywordCondition | airbyte_agent_sdk.connectors.github.types.UsersContainsCondition | airbyte_agent_sdk.connectors.github.types.UsersNotCondition | airbyte_agent_sdk.connectors.github.types.UsersAndCondition | airbyte_agent_sdk.connectors.github.types.UsersOrCondition | airbyte_agent_sdk.connectors.github.types.UsersAnyCondition]`
     :   The type of the None singleton.
 
+<a id="UsersSearchFilter"></a>
+
 `UsersSearchFilter(*args, **kwargs)`
 :   Available fields for filtering users search queries.
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="UsersSearchQuery"></a>
 
 `UsersSearchQuery(*args, **kwargs)`
 :   Search query for users entity.
@@ -3785,6 +4297,8 @@ Classes
     `sort: list[airbyte_agent_sdk.connectors.github.types.UsersSortFilter]`
     :   The type of the None singleton.
 
+<a id="UsersSortFilter"></a>
+
 `UsersSortFilter(*args, **kwargs)`
 :   Available fields for sorting users search results.
 
@@ -3792,12 +4306,16 @@ Classes
 
     * builtins.dict
 
+<a id="UsersStringFilter"></a>
+
 `UsersStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="ViewerGetParams"></a>
 
 `ViewerGetParams(*args, **kwargs)`
 :   Parameters for viewer.get operation
@@ -3810,6 +4328,8 @@ Classes
 
     `fields: list[str]`
     :   The type of the None singleton.
+
+<a id="ViewerRepositoriesListParams"></a>
 
 `ViewerRepositoriesListParams(*args, **kwargs)`
 :   Parameters for viewer_repositories.list operation

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/gitlab/connector.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/gitlab/connector.md
@@ -10,6 +10,8 @@ Gitlab connector.
 Classes
 -------
 
+<a id="BranchesQuery"></a>
+
 `BranchesQuery(connector: GitlabConnector)`
 :   Query class for Branches entity operations.
     
@@ -73,6 +75,8 @@ Classes
         
         Returns:
             BranchesListResult
+
+<a id="CommitsQuery"></a>
 
 `CommitsQuery(connector: GitlabConnector)`
 :   Query class for Commits entity operations.
@@ -146,6 +150,8 @@ Classes
         
         Returns:
             CommitsListResult
+
+<a id="GitlabConnector"></a>
 
 `GitlabConnector(auth_config: GitlabAuthConfig | AirbyteAuthConfig | BaseModel | None = None, on_token_refresh: Any | None = None, api_url: str | None = None)`
 :   Type-safe Gitlab API connector.
@@ -403,6 +409,8 @@ Classes
             for entity in entities:
                 print(f"\{entity['entity_name']\}: \{entity['available_actions']\}")
 
+<a id="GroupMembersQuery"></a>
+
 `GroupMembersQuery(connector: GitlabConnector)`
 :   Query class for GroupMembers entity operations.
     
@@ -469,6 +477,8 @@ Classes
         Returns:
             GroupMembersListResult
 
+<a id="GroupMilestonesQuery"></a>
+
 `GroupMilestonesQuery(connector: GitlabConnector)`
 :   Query class for GroupMilestones entity operations.
     
@@ -534,6 +544,8 @@ Classes
         
         Returns:
             GroupMilestonesListResult
+
+<a id="GroupsQuery"></a>
 
 `GroupsQuery(connector: GitlabConnector)`
 :   Query class for Groups entity operations.
@@ -613,6 +625,8 @@ Classes
         
         Returns:
             GroupsListResult
+
+<a id="IssuesQuery"></a>
 
 `IssuesQuery(connector: GitlabConnector)`
 :   Query class for Issues entity operations.
@@ -710,6 +724,8 @@ Classes
         
         Returns:
             IssuesListResult
+
+<a id="MergeRequestsQuery"></a>
 
 `MergeRequestsQuery(connector: GitlabConnector)`
 :   Query class for MergeRequests entity operations.
@@ -821,6 +837,8 @@ Classes
         Returns:
             MergeRequestsListResult
 
+<a id="PipelinesQuery"></a>
+
 `PipelinesQuery(connector: GitlabConnector)`
 :   Query class for Pipelines entity operations.
     
@@ -888,6 +906,8 @@ Classes
         Returns:
             PipelinesListResult
 
+<a id="ProjectMembersQuery"></a>
+
 `ProjectMembersQuery(connector: GitlabConnector)`
 :   Query class for ProjectMembers entity operations.
     
@@ -954,6 +974,8 @@ Classes
         Returns:
             ProjectMembersListResult
 
+<a id="ProjectMilestonesQuery"></a>
+
 `ProjectMilestonesQuery(connector: GitlabConnector)`
 :   Query class for ProjectMilestones entity operations.
     
@@ -1019,6 +1041,8 @@ Classes
         
         Returns:
             ProjectMilestonesListResult
+
+<a id="ProjectsQuery"></a>
 
 `ProjectsQuery(connector: GitlabConnector)`
 :   Query class for Projects entity operations.
@@ -1155,6 +1179,8 @@ Classes
         Returns:
             ProjectsListResult
 
+<a id="ReleasesQuery"></a>
+
 `ReleasesQuery(connector: GitlabConnector)`
 :   Query class for Releases entity operations.
     
@@ -1226,6 +1252,8 @@ Classes
         Returns:
             ReleasesListResult
 
+<a id="TagsQuery"></a>
+
 `TagsQuery(connector: GitlabConnector)`
 :   Query class for Tags entity operations.
     
@@ -1288,6 +1316,8 @@ Classes
         
         Returns:
             TagsListResult
+
+<a id="UsersQuery"></a>
 
 `UsersQuery(connector: GitlabConnector)`
 :   Query class for Users entity operations.

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/gitlab/index.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/gitlab/index.md
@@ -19,6 +19,8 @@ Sub-modules
 Classes
 -------
 
+<a id="AirbyteAuthConfig"></a>
+
 `AirbyteAuthConfig(**data: Any)`
 :   Authentication configuration for Airbyte hosted mode execution.
     
@@ -87,6 +89,8 @@ Classes
     `workspace_name: str | None`
     :   The type of the None singleton.
 
+<a id="AirbyteSearchMeta"></a>
+
 `AirbyteSearchMeta(**data: Any)`
 :   Pagination metadata for search responses.
     
@@ -114,6 +118,8 @@ Classes
 
     `took_ms: int | None`
     :   Time taken to execute the search in milliseconds.
+
+<a id="AirbyteSearchResult"></a>
 
 `AirbyteSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -158,6 +164,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="BranchesSearchResult"></a>
+
 `BranchesSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -173,6 +181,8 @@ Classes
     * airbyte_agent_sdk.connectors.gitlab.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="CommitsSearchResult"></a>
 
 `CommitsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -190,6 +200,8 @@ Classes
     * pydantic.main.BaseModel
     * typing.Generic
 
+<a id="GroupMembersSearchResult"></a>
+
 `GroupMembersSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -205,6 +217,8 @@ Classes
     * airbyte_agent_sdk.connectors.gitlab.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="GroupMilestonesSearchResult"></a>
 
 `GroupMilestonesSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -222,6 +236,8 @@ Classes
     * pydantic.main.BaseModel
     * typing.Generic
 
+<a id="GroupsSearchResult"></a>
+
 `GroupsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -237,6 +253,8 @@ Classes
     * airbyte_agent_sdk.connectors.gitlab.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="IssuesSearchResult"></a>
 
 `IssuesSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -254,6 +272,8 @@ Classes
     * pydantic.main.BaseModel
     * typing.Generic
 
+<a id="MergeRequestsSearchResult"></a>
+
 `MergeRequestsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -269,6 +289,8 @@ Classes
     * airbyte_agent_sdk.connectors.gitlab.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="PipelinesSearchResult"></a>
 
 `PipelinesSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -286,6 +308,8 @@ Classes
     * pydantic.main.BaseModel
     * typing.Generic
 
+<a id="ProjectMembersSearchResult"></a>
+
 `ProjectMembersSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -301,6 +325,8 @@ Classes
     * airbyte_agent_sdk.connectors.gitlab.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="ProjectMilestonesSearchResult"></a>
 
 `ProjectMilestonesSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -318,6 +344,8 @@ Classes
     * pydantic.main.BaseModel
     * typing.Generic
 
+<a id="ProjectsSearchResult"></a>
+
 `ProjectsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -333,6 +361,8 @@ Classes
     * airbyte_agent_sdk.connectors.gitlab.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="ReleasesSearchResult"></a>
 
 `ReleasesSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -350,6 +380,8 @@ Classes
     * pydantic.main.BaseModel
     * typing.Generic
 
+<a id="TagsSearchResult"></a>
+
 `TagsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -366,6 +398,8 @@ Classes
     * pydantic.main.BaseModel
     * typing.Generic
 
+<a id="UsersSearchResult"></a>
+
 `UsersSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -381,6 +415,8 @@ Classes
     * airbyte_agent_sdk.connectors.gitlab.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="BranchesSearchData"></a>
 
 `BranchesSearchData(**data: Any)`
 :   Search result data for branches entity.
@@ -433,6 +469,8 @@ Classes
 
     `web_url: str | None`
     :   Web URL of the branch
+
+<a id="CommitsSearchData"></a>
 
 `CommitsSearchData(**data: Any)`
 :   Search result data for commits entity.
@@ -500,6 +538,8 @@ Classes
 
     `web_url: str | None`
     :   Web URL of the commit
+
+<a id="GitlabConnector"></a>
 
 `GitlabConnector(auth_config: GitlabAuthConfig | AirbyteAuthConfig | BaseModel | None = None, on_token_refresh: Any | None = None, api_url: str | None = None)`
 :   Type-safe Gitlab API connector.
@@ -757,6 +797,8 @@ Classes
             for entity in entities:
                 print(f"\{entity['entity_name']\}: \{entity['available_actions']\}")
 
+<a id="GitlabReplicationConfig"></a>
+
 `GitlabReplicationConfig(**data: Any)`
 :   Replication Configuration - Settings for data replication from GitLab.
     
@@ -778,6 +820,8 @@ Classes
 
     `start_date: str | None`
     :   UTC date and time in the format YYYY-MM-DDTHH:mm:ssZ from which to start replicating data. If not set, all data will be replicated.
+
+<a id="GroupMembersSearchData"></a>
 
 `GroupMembersSearchData(**data: Any)`
 :   Search result data for group_members entity.
@@ -837,6 +881,8 @@ Classes
     `web_url: str | None`
     :   Web URL of the member profile
 
+<a id="GroupMilestonesSearchData"></a>
+
 `GroupMilestonesSearchData(**data: Any)`
 :   Search result data for group_milestones entity.
     
@@ -891,6 +937,8 @@ Classes
 
     `web_url: str | None`
     :   Web URL of the milestone
+
+<a id="GroupsSearchData"></a>
 
 `GroupsSearchData(**data: Any)`
 :   Search result data for groups entity.
@@ -985,6 +1033,8 @@ Classes
 
     `web_url: str | None`
     :   Web URL of the group
+
+<a id="IssuesSearchData"></a>
 
 `IssuesSearchData(**data: Any)`
 :   Search result data for issues entity.
@@ -1115,6 +1165,8 @@ Classes
 
     `weight: int | None`
     :   Weight of the issue
+
+<a id="MergeRequestsSearchData"></a>
 
 `MergeRequestsSearchData(**data: Any)`
 :   Search result data for merge_requests entity.
@@ -1285,6 +1337,8 @@ Classes
     `work_in_progress: bool | None`
     :   Whether the merge request is a work in progress
 
+<a id="PipelinesSearchData"></a>
+
 `PipelinesSearchData(**data: Any)`
 :   Search result data for pipelines entity.
     
@@ -1336,6 +1390,8 @@ Classes
 
     `web_url: str | None`
     :   Web URL of the pipeline
+
+<a id="ProjectMembersSearchData"></a>
 
 `ProjectMembersSearchData(**data: Any)`
 :   Search result data for project_members entity.
@@ -1395,6 +1451,8 @@ Classes
     `web_url: str | None`
     :   Web URL of the member profile
 
+<a id="ProjectMilestonesSearchData"></a>
+
 `ProjectMilestonesSearchData(**data: Any)`
 :   Search result data for project_milestones entity.
     
@@ -1449,6 +1507,8 @@ Classes
 
     `web_url: str | None`
     :   Web URL of the milestone
+
+<a id="ProjectsSearchData"></a>
 
 `ProjectsSearchData(**data: Any)`
 :   Search result data for projects entity.
@@ -1706,6 +1766,8 @@ Classes
     `wiki_enabled: bool | None`
     :   Whether wiki is enabled
 
+<a id="ReleasesSearchData"></a>
+
 `ReleasesSearchData(**data: Any)`
 :   Search result data for releases entity.
     
@@ -1776,6 +1838,8 @@ Classes
     `upcoming_release: bool | None`
     :   Whether this is an upcoming release
 
+<a id="TagsSearchData"></a>
+
 `TagsSearchData(**data: Any)`
 :   Search result data for tags entity.
     
@@ -1818,6 +1882,8 @@ Classes
 
     `target: str | None`
     :   SHA the tag points to
+
+<a id="UsersSearchData"></a>
 
 `UsersSearchData(**data: Any)`
 :   Search result data for users entity.

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/gitlab/models.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/gitlab/models.md
@@ -13,6 +13,8 @@ and response envelope types.
 Classes
 -------
 
+<a id="AirbyteSearchMeta"></a>
+
 `AirbyteSearchMeta(**data: Any)`
 :   Pagination metadata for search responses.
     
@@ -40,6 +42,8 @@ Classes
 
     `took_ms: int | None`
     :   Time taken to execute the search in milliseconds.
+
+<a id="AirbyteSearchResult"></a>
 
 `AirbyteSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -105,6 +109,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="BranchesSearchResult"></a>
+
 `BranchesSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -141,6 +147,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="CommitsSearchResult"></a>
 
 `CommitsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -179,6 +187,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="GroupMembersSearchResult"></a>
+
 `GroupMembersSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -215,6 +225,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="GroupMilestonesSearchResult"></a>
 
 `GroupMilestonesSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -253,6 +265,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="GroupsSearchResult"></a>
+
 `GroupsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -289,6 +303,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="IssuesSearchResult"></a>
 
 `IssuesSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -327,6 +343,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="MergeRequestsSearchResult"></a>
+
 `MergeRequestsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -363,6 +381,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="PipelinesSearchResult"></a>
 
 `PipelinesSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -401,6 +421,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="ProjectMembersSearchResult"></a>
+
 `ProjectMembersSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -437,6 +459,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="ProjectMilestonesSearchResult"></a>
 
 `ProjectMilestonesSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -475,6 +499,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="ProjectsSearchResult"></a>
+
 `ProjectsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -511,6 +537,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="ReleasesSearchResult"></a>
 
 `ReleasesSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -549,6 +577,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="TagsSearchResult"></a>
+
 `TagsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -586,6 +616,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="UsersSearchResult"></a>
+
 `UsersSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -601,6 +633,8 @@ Classes
     * airbyte_agent_sdk.connectors.gitlab.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="Branch"></a>
 
 `Branch(**data: Any)`
 :   GitLab branch
@@ -648,6 +682,8 @@ Classes
     `web_url: str | Any`
     :   The type of the None singleton.
 
+<a id="BranchesListResultMeta"></a>
+
 `BranchesListResultMeta(**data: Any)`
 :   Metadata for branches.Action.LIST operation
     
@@ -669,6 +705,8 @@ Classes
 
     `next: str | Any | None`
     :   The type of the None singleton.
+
+<a id="BranchesSearchData"></a>
 
 `BranchesSearchData(**data: Any)`
 :   Search result data for branches entity.
@@ -721,6 +759,8 @@ Classes
 
     `web_url: str | None`
     :   Web URL of the branch
+
+<a id="Commit"></a>
 
 `Commit(**data: Any)`
 :   GitLab commit
@@ -789,6 +829,8 @@ Classes
     `web_url: str | Any`
     :   The type of the None singleton.
 
+<a id="CommitStats"></a>
+
 `CommitStats(**data: Any)`
 :   Commit stats
     
@@ -817,6 +859,8 @@ Classes
     `total: int | Any`
     :   Total changes
 
+<a id="CommitsListResultMeta"></a>
+
 `CommitsListResultMeta(**data: Any)`
 :   Metadata for commits.Action.LIST operation
     
@@ -838,6 +882,8 @@ Classes
 
     `next: str | Any | None`
     :   The type of the None singleton.
+
+<a id="CommitsSearchData"></a>
 
 `CommitsSearchData(**data: Any)`
 :   Search result data for commits entity.
@@ -906,6 +952,8 @@ Classes
     `web_url: str | None`
     :   Web URL of the commit
 
+<a id="GitlabCheckResult"></a>
+
 `GitlabCheckResult(**data: Any)`
 :   Result of a health check operation.
     
@@ -939,6 +987,8 @@ Classes
     `status: str`
     :   Health check status: 'healthy' or 'unhealthy'.
 
+<a id="GitlabExecuteResult"></a>
+
 `GitlabExecuteResult(**data: Any)`
 :   Response envelope with data only.
     
@@ -967,6 +1017,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="GitlabExecuteResultWithMeta"></a>
 
 `GitlabExecuteResultWithMeta(**data: Any)`
 :   Response envelope with data and metadata.
@@ -1032,6 +1084,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="BranchesListResult"></a>
+
 `BranchesListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -1074,6 +1128,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="CommitsListResult"></a>
 
 `CommitsListResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -1118,6 +1174,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="GroupsListResult"></a>
+
 `GroupsListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -1160,6 +1218,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="IssuesListResult"></a>
 
 `IssuesListResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -1204,6 +1264,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="GroupMembersListResult"></a>
+
 `GroupMembersListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -1246,6 +1308,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="ProjectMembersListResult"></a>
 
 `ProjectMembersListResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -1290,6 +1354,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="MergeRequestsListResult"></a>
+
 `MergeRequestsListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -1332,6 +1398,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="GroupMilestonesListResult"></a>
 
 `GroupMilestonesListResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -1376,6 +1444,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="ProjectMilestonesListResult"></a>
+
 `ProjectMilestonesListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -1418,6 +1488,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="PipelinesListResult"></a>
 
 `PipelinesListResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -1462,6 +1534,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="ProjectsListResult"></a>
+
 `ProjectsListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -1504,6 +1578,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="ReleasesListResult"></a>
 
 `ReleasesListResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -1548,6 +1624,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="TagsListResult"></a>
+
 `TagsListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -1591,6 +1669,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="UsersListResult"></a>
+
 `UsersListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -1609,6 +1689,8 @@ Classes
     * airbyte_agent_sdk.connectors.gitlab.models.GitlabExecuteResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="GitlabOauth20AuthConfig"></a>
 
 `GitlabOauth20AuthConfig(**data: Any)`
 :   OAuth2.0
@@ -1641,6 +1723,8 @@ Classes
     `refresh_token: str`
     :   The key to refresh the expired access token.
 
+<a id="GitlabPersonalAccessTokenAuthConfig"></a>
+
 `GitlabPersonalAccessTokenAuthConfig(**data: Any)`
 :   Personal Access Token
     
@@ -1663,6 +1747,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="GitlabReplicationConfig"></a>
+
 `GitlabReplicationConfig(**data: Any)`
 :   Replication Configuration - Settings for data replication from GitLab.
     
@@ -1684,6 +1770,8 @@ Classes
 
     `start_date: str | None`
     :   UTC date and time in the format YYYY-MM-DDTHH:mm:ssZ from which to start replicating data. If not set, all data will be replicated.
+
+<a id="Group"></a>
 
 `Group(**data: Any)`
 :   GitLab group
@@ -1854,6 +1942,8 @@ Classes
     `wiki_access_level: str | Any | None`
     :   The type of the None singleton.
 
+<a id="GroupMembersListResultMeta"></a>
+
 `GroupMembersListResultMeta(**data: Any)`
 :   Metadata for group_members.Action.LIST operation
     
@@ -1875,6 +1965,8 @@ Classes
 
     `next: str | Any | None`
     :   The type of the None singleton.
+
+<a id="GroupMembersSearchData"></a>
 
 `GroupMembersSearchData(**data: Any)`
 :   Search result data for group_members entity.
@@ -1934,6 +2026,8 @@ Classes
     `web_url: str | None`
     :   Web URL of the member profile
 
+<a id="GroupMilestonesListResultMeta"></a>
+
 `GroupMilestonesListResultMeta(**data: Any)`
 :   Metadata for group_milestones.Action.LIST operation
     
@@ -1955,6 +2049,8 @@ Classes
 
     `next: str | Any | None`
     :   The type of the None singleton.
+
+<a id="GroupMilestonesSearchData"></a>
 
 `GroupMilestonesSearchData(**data: Any)`
 :   Search result data for group_milestones entity.
@@ -2011,6 +2107,8 @@ Classes
     `web_url: str | None`
     :   Web URL of the milestone
 
+<a id="GroupsListResultMeta"></a>
+
 `GroupsListResultMeta(**data: Any)`
 :   Metadata for groups.Action.LIST operation
     
@@ -2032,6 +2130,8 @@ Classes
 
     `next: str | Any | None`
     :   The type of the None singleton.
+
+<a id="GroupsSearchData"></a>
 
 `GroupsSearchData(**data: Any)`
 :   Search result data for groups entity.
@@ -2126,6 +2226,8 @@ Classes
 
     `web_url: str | None`
     :   Web URL of the group
+
+<a id="Issue"></a>
 
 `Issue(**data: Any)`
 :   GitLab issue
@@ -2278,6 +2380,8 @@ Classes
     `weight: int | Any | None`
     :   The type of the None singleton.
 
+<a id="IssuesListResultMeta"></a>
+
 `IssuesListResultMeta(**data: Any)`
 :   Metadata for issues.Action.LIST operation
     
@@ -2299,6 +2403,8 @@ Classes
 
     `next: str | Any | None`
     :   The type of the None singleton.
+
+<a id="IssuesSearchData"></a>
 
 `IssuesSearchData(**data: Any)`
 :   Search result data for issues entity.
@@ -2430,6 +2536,8 @@ Classes
     `weight: int | None`
     :   Weight of the issue
 
+<a id="Member"></a>
+
 `Member(**data: Any)`
 :   GitLab group or project member
     
@@ -2487,6 +2595,8 @@ Classes
 
     `web_url: str | Any`
     :   The type of the None singleton.
+
+<a id="MergeRequest"></a>
 
 `MergeRequest(**data: Any)`
 :   GitLab merge request
@@ -2693,6 +2803,8 @@ Classes
     `work_in_progress: bool | Any | None`
     :   The type of the None singleton.
 
+<a id="MergeRequestsListResultMeta"></a>
+
 `MergeRequestsListResultMeta(**data: Any)`
 :   Metadata for merge_requests.Action.LIST operation
     
@@ -2714,6 +2826,8 @@ Classes
 
     `next: str | Any | None`
     :   The type of the None singleton.
+
+<a id="MergeRequestsSearchData"></a>
 
 `MergeRequestsSearchData(**data: Any)`
 :   Search result data for merge_requests entity.
@@ -2884,6 +2998,8 @@ Classes
     `work_in_progress: bool | None`
     :   Whether the merge request is a work in progress
 
+<a id="Milestone"></a>
+
 `Milestone(**data: Any)`
 :   GitLab milestone
     
@@ -2942,6 +3058,8 @@ Classes
     `web_url: str | Any`
     :   The type of the None singleton.
 
+<a id="Pipeline"></a>
+
 `Pipeline(**data: Any)`
 :   GitLab CI/CD pipeline
     
@@ -2994,6 +3112,8 @@ Classes
     `web_url: str | Any`
     :   The type of the None singleton.
 
+<a id="PipelinesListResultMeta"></a>
+
 `PipelinesListResultMeta(**data: Any)`
 :   Metadata for pipelines.Action.LIST operation
     
@@ -3015,6 +3135,8 @@ Classes
 
     `next: str | Any | None`
     :   The type of the None singleton.
+
+<a id="PipelinesSearchData"></a>
 
 `PipelinesSearchData(**data: Any)`
 :   Search result data for pipelines entity.
@@ -3067,6 +3189,8 @@ Classes
 
     `web_url: str | None`
     :   Web URL of the pipeline
+
+<a id="Project"></a>
 
 `Project(**data: Any)`
 :   GitLab project
@@ -3450,6 +3574,8 @@ Classes
     `wiki_enabled: bool | Any | None`
     :   The type of the None singleton.
 
+<a id="ProjectMembersListResultMeta"></a>
+
 `ProjectMembersListResultMeta(**data: Any)`
 :   Metadata for project_members.Action.LIST operation
     
@@ -3471,6 +3597,8 @@ Classes
 
     `next: str | Any | None`
     :   The type of the None singleton.
+
+<a id="ProjectMembersSearchData"></a>
 
 `ProjectMembersSearchData(**data: Any)`
 :   Search result data for project_members entity.
@@ -3530,6 +3658,8 @@ Classes
     `web_url: str | None`
     :   Web URL of the member profile
 
+<a id="ProjectMilestonesListResultMeta"></a>
+
 `ProjectMilestonesListResultMeta(**data: Any)`
 :   Metadata for project_milestones.Action.LIST operation
     
@@ -3551,6 +3681,8 @@ Classes
 
     `next: str | Any | None`
     :   The type of the None singleton.
+
+<a id="ProjectMilestonesSearchData"></a>
 
 `ProjectMilestonesSearchData(**data: Any)`
 :   Search result data for project_milestones entity.
@@ -3607,6 +3739,8 @@ Classes
     `web_url: str | None`
     :   Web URL of the milestone
 
+<a id="ProjectsListResultMeta"></a>
+
 `ProjectsListResultMeta(**data: Any)`
 :   Metadata for projects.Action.LIST operation
     
@@ -3628,6 +3762,8 @@ Classes
 
     `next: str | Any | None`
     :   The type of the None singleton.
+
+<a id="ProjectsSearchData"></a>
 
 `ProjectsSearchData(**data: Any)`
 :   Search result data for projects entity.
@@ -3885,6 +4021,8 @@ Classes
     `wiki_enabled: bool | None`
     :   Whether wiki is enabled
 
+<a id="Release"></a>
+
 `Release(**data: Any)`
 :   GitLab release
     
@@ -3946,6 +4084,8 @@ Classes
     `upcoming_release: bool | Any`
     :   The type of the None singleton.
 
+<a id="ReleasesListResultMeta"></a>
+
 `ReleasesListResultMeta(**data: Any)`
 :   Metadata for releases.Action.LIST operation
     
@@ -3967,6 +4107,8 @@ Classes
 
     `next: str | Any | None`
     :   The type of the None singleton.
+
+<a id="ReleasesSearchData"></a>
 
 `ReleasesSearchData(**data: Any)`
 :   Search result data for releases entity.
@@ -4038,6 +4180,8 @@ Classes
     `upcoming_release: bool | None`
     :   Whether this is an upcoming release
 
+<a id="Tag"></a>
+
 `Tag(**data: Any)`
 :   GitLab repository tag
     
@@ -4078,6 +4222,8 @@ Classes
     `target: str | Any`
     :   The type of the None singleton.
 
+<a id="TagsListResultMeta"></a>
+
 `TagsListResultMeta(**data: Any)`
 :   Metadata for tags.Action.LIST operation
     
@@ -4099,6 +4245,8 @@ Classes
 
     `next: str | Any | None`
     :   The type of the None singleton.
+
+<a id="TagsSearchData"></a>
 
 `TagsSearchData(**data: Any)`
 :   Search result data for tags entity.
@@ -4143,6 +4291,8 @@ Classes
     `target: str | None`
     :   SHA the tag points to
 
+<a id="User"></a>
+
 `User(**data: Any)`
 :   GitLab user
     
@@ -4186,6 +4336,8 @@ Classes
     `web_url: str | Any`
     :   The type of the None singleton.
 
+<a id="UsersListResultMeta"></a>
+
 `UsersListResultMeta(**data: Any)`
 :   Metadata for users.Action.LIST operation
     
@@ -4207,6 +4359,8 @@ Classes
 
     `next: str | Any | None`
     :   The type of the None singleton.
+
+<a id="UsersSearchData"></a>
 
 `UsersSearchData(**data: Any)`
 :   Search result data for users entity.

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/gitlab/types.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/gitlab/types.md
@@ -10,6 +10,8 @@ Type definitions for gitlab connector.
 Classes
 -------
 
+<a id="AirbyteSearchParams"></a>
+
 `AirbyteSearchParams(*args, **kwargs)`
 :   Parameters for Airbyte cache search operations (generic, use entity-specific query types for better type hints).
 
@@ -31,6 +33,8 @@ Classes
     `query: dict[str, typing.Any]`
     :   The type of the None singleton.
 
+<a id="BranchesAndCondition"></a>
+
 `BranchesAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -51,6 +55,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.gitlab.types.BranchesEqCondition | airbyte_agent_sdk.connectors.gitlab.types.BranchesNeqCondition | airbyte_agent_sdk.connectors.gitlab.types.BranchesGtCondition | airbyte_agent_sdk.connectors.gitlab.types.BranchesGteCondition | airbyte_agent_sdk.connectors.gitlab.types.BranchesLtCondition | airbyte_agent_sdk.connectors.gitlab.types.BranchesLteCondition | airbyte_agent_sdk.connectors.gitlab.types.BranchesInCondition | airbyte_agent_sdk.connectors.gitlab.types.BranchesLikeCondition | airbyte_agent_sdk.connectors.gitlab.types.BranchesFuzzyCondition | airbyte_agent_sdk.connectors.gitlab.types.BranchesKeywordCondition | airbyte_agent_sdk.connectors.gitlab.types.BranchesContainsCondition | airbyte_agent_sdk.connectors.gitlab.types.BranchesNotCondition | airbyte_agent_sdk.connectors.gitlab.types.BranchesAndCondition | airbyte_agent_sdk.connectors.gitlab.types.BranchesOrCondition | airbyte_agent_sdk.connectors.gitlab.types.BranchesAnyCondition]`
     :   The type of the None singleton.
 
+<a id="BranchesAnyCondition"></a>
+
 `BranchesAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -70,6 +76,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.gitlab.types.BranchesAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="BranchesAnyValueFilter"></a>
 
 `BranchesAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -113,6 +121,8 @@ Classes
     `web_url: Any`
     :   Web URL of the branch
 
+<a id="BranchesContainsCondition"></a>
+
 `BranchesContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -124,6 +134,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.gitlab.types.BranchesAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="BranchesEqCondition"></a>
 
 `BranchesEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -137,6 +149,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.gitlab.types.BranchesSearchFilter`
     :   The type of the None singleton.
 
+<a id="BranchesFuzzyCondition"></a>
+
 `BranchesFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -148,6 +162,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.gitlab.types.BranchesStringFilter`
     :   The type of the None singleton.
+
+<a id="BranchesGetParams"></a>
 
 `BranchesGetParams(*args, **kwargs)`
 :   Parameters for branches.get operation
@@ -164,6 +180,8 @@ Classes
     `project_id: str`
     :   The type of the None singleton.
 
+<a id="BranchesGtCondition"></a>
+
 `BranchesGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -176,6 +194,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.gitlab.types.BranchesSearchFilter`
     :   The type of the None singleton.
 
+<a id="BranchesGteCondition"></a>
+
 `BranchesGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -187,6 +207,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.gitlab.types.BranchesSearchFilter`
     :   The type of the None singleton.
+
+<a id="BranchesInCondition"></a>
 
 `BranchesInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -207,6 +229,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.gitlab.types.BranchesInFilter`
     :   The type of the None singleton.
+
+<a id="BranchesInFilter"></a>
 
 `BranchesInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -250,6 +274,8 @@ Classes
     `web_url: list[str]`
     :   Web URL of the branch
 
+<a id="BranchesKeywordCondition"></a>
+
 `BranchesKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -262,6 +288,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.gitlab.types.BranchesStringFilter`
     :   The type of the None singleton.
 
+<a id="BranchesLikeCondition"></a>
+
 `BranchesLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -273,6 +301,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.gitlab.types.BranchesStringFilter`
     :   The type of the None singleton.
+
+<a id="BranchesListParams"></a>
 
 `BranchesListParams(*args, **kwargs)`
 :   Parameters for branches.list operation
@@ -295,6 +325,8 @@ Classes
     `search: str`
     :   The type of the None singleton.
 
+<a id="BranchesLtCondition"></a>
+
 `BranchesLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -306,6 +338,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.gitlab.types.BranchesSearchFilter`
     :   The type of the None singleton.
+
+<a id="BranchesLteCondition"></a>
 
 `BranchesLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -319,6 +353,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.gitlab.types.BranchesSearchFilter`
     :   The type of the None singleton.
 
+<a id="BranchesNeqCondition"></a>
+
 `BranchesNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -330,6 +366,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.gitlab.types.BranchesSearchFilter`
     :   The type of the None singleton.
+
+<a id="BranchesNotCondition"></a>
 
 `BranchesNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -351,6 +389,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.gitlab.types.BranchesEqCondition | airbyte_agent_sdk.connectors.gitlab.types.BranchesNeqCondition | airbyte_agent_sdk.connectors.gitlab.types.BranchesGtCondition | airbyte_agent_sdk.connectors.gitlab.types.BranchesGteCondition | airbyte_agent_sdk.connectors.gitlab.types.BranchesLtCondition | airbyte_agent_sdk.connectors.gitlab.types.BranchesLteCondition | airbyte_agent_sdk.connectors.gitlab.types.BranchesInCondition | airbyte_agent_sdk.connectors.gitlab.types.BranchesLikeCondition | airbyte_agent_sdk.connectors.gitlab.types.BranchesFuzzyCondition | airbyte_agent_sdk.connectors.gitlab.types.BranchesKeywordCondition | airbyte_agent_sdk.connectors.gitlab.types.BranchesContainsCondition | airbyte_agent_sdk.connectors.gitlab.types.BranchesNotCondition | airbyte_agent_sdk.connectors.gitlab.types.BranchesAndCondition | airbyte_agent_sdk.connectors.gitlab.types.BranchesOrCondition | airbyte_agent_sdk.connectors.gitlab.types.BranchesAnyCondition`
     :   The type of the None singleton.
 
+<a id="BranchesOrCondition"></a>
+
 `BranchesOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -370,6 +410,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.gitlab.types.BranchesEqCondition | airbyte_agent_sdk.connectors.gitlab.types.BranchesNeqCondition | airbyte_agent_sdk.connectors.gitlab.types.BranchesGtCondition | airbyte_agent_sdk.connectors.gitlab.types.BranchesGteCondition | airbyte_agent_sdk.connectors.gitlab.types.BranchesLtCondition | airbyte_agent_sdk.connectors.gitlab.types.BranchesLteCondition | airbyte_agent_sdk.connectors.gitlab.types.BranchesInCondition | airbyte_agent_sdk.connectors.gitlab.types.BranchesLikeCondition | airbyte_agent_sdk.connectors.gitlab.types.BranchesFuzzyCondition | airbyte_agent_sdk.connectors.gitlab.types.BranchesKeywordCondition | airbyte_agent_sdk.connectors.gitlab.types.BranchesContainsCondition | airbyte_agent_sdk.connectors.gitlab.types.BranchesNotCondition | airbyte_agent_sdk.connectors.gitlab.types.BranchesAndCondition | airbyte_agent_sdk.connectors.gitlab.types.BranchesOrCondition | airbyte_agent_sdk.connectors.gitlab.types.BranchesAnyCondition]`
     :   The type of the None singleton.
+
+<a id="BranchesSearchFilter"></a>
 
 `BranchesSearchFilter(*args, **kwargs)`
 :   Available fields for filtering branches search queries.
@@ -413,6 +455,8 @@ Classes
     `web_url: str | None`
     :   Web URL of the branch
 
+<a id="BranchesSearchQuery"></a>
+
 `BranchesSearchQuery(*args, **kwargs)`
 :   Search query for branches entity.
 
@@ -427,6 +471,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.gitlab.types.BranchesSortFilter]`
     :   The type of the None singleton.
+
+<a id="BranchesSortFilter"></a>
 
 `BranchesSortFilter(*args, **kwargs)`
 :   Available fields for sorting branches search results.
@@ -470,6 +516,8 @@ Classes
     `web_url: Literal['asc', 'desc']`
     :   Web URL of the branch
 
+<a id="BranchesStringFilter"></a>
+
 `BranchesStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -512,6 +560,8 @@ Classes
     `web_url: str`
     :   Web URL of the branch
 
+<a id="CommitsAndCondition"></a>
+
 `CommitsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -532,6 +582,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.gitlab.types.CommitsEqCondition | airbyte_agent_sdk.connectors.gitlab.types.CommitsNeqCondition | airbyte_agent_sdk.connectors.gitlab.types.CommitsGtCondition | airbyte_agent_sdk.connectors.gitlab.types.CommitsGteCondition | airbyte_agent_sdk.connectors.gitlab.types.CommitsLtCondition | airbyte_agent_sdk.connectors.gitlab.types.CommitsLteCondition | airbyte_agent_sdk.connectors.gitlab.types.CommitsInCondition | airbyte_agent_sdk.connectors.gitlab.types.CommitsLikeCondition | airbyte_agent_sdk.connectors.gitlab.types.CommitsFuzzyCondition | airbyte_agent_sdk.connectors.gitlab.types.CommitsKeywordCondition | airbyte_agent_sdk.connectors.gitlab.types.CommitsContainsCondition | airbyte_agent_sdk.connectors.gitlab.types.CommitsNotCondition | airbyte_agent_sdk.connectors.gitlab.types.CommitsAndCondition | airbyte_agent_sdk.connectors.gitlab.types.CommitsOrCondition | airbyte_agent_sdk.connectors.gitlab.types.CommitsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="CommitsAnyCondition"></a>
+
 `CommitsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -551,6 +603,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.gitlab.types.CommitsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="CommitsAnyValueFilter"></a>
 
 `CommitsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -609,6 +663,8 @@ Classes
     `web_url: Any`
     :   Web URL of the commit
 
+<a id="CommitsContainsCondition"></a>
+
 `CommitsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -620,6 +676,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.gitlab.types.CommitsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="CommitsEqCondition"></a>
 
 `CommitsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -633,6 +691,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.gitlab.types.CommitsSearchFilter`
     :   The type of the None singleton.
 
+<a id="CommitsFuzzyCondition"></a>
+
 `CommitsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -644,6 +704,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.gitlab.types.CommitsStringFilter`
     :   The type of the None singleton.
+
+<a id="CommitsGetParams"></a>
 
 `CommitsGetParams(*args, **kwargs)`
 :   Parameters for commits.get operation
@@ -663,6 +725,8 @@ Classes
     `stats: bool`
     :   The type of the None singleton.
 
+<a id="CommitsGtCondition"></a>
+
 `CommitsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -675,6 +739,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.gitlab.types.CommitsSearchFilter`
     :   The type of the None singleton.
 
+<a id="CommitsGteCondition"></a>
+
 `CommitsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -686,6 +752,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.gitlab.types.CommitsSearchFilter`
     :   The type of the None singleton.
+
+<a id="CommitsInCondition"></a>
 
 `CommitsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -706,6 +774,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.gitlab.types.CommitsInFilter`
     :   The type of the None singleton.
+
+<a id="CommitsInFilter"></a>
 
 `CommitsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -764,6 +834,8 @@ Classes
     `web_url: list[str]`
     :   Web URL of the commit
 
+<a id="CommitsKeywordCondition"></a>
+
 `CommitsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -776,6 +848,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.gitlab.types.CommitsStringFilter`
     :   The type of the None singleton.
 
+<a id="CommitsLikeCondition"></a>
+
 `CommitsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -787,6 +861,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.gitlab.types.CommitsStringFilter`
     :   The type of the None singleton.
+
+<a id="CommitsListParams"></a>
 
 `CommitsListParams(*args, **kwargs)`
 :   Parameters for commits.list operation
@@ -818,6 +894,8 @@ Classes
     `with_stats: bool`
     :   The type of the None singleton.
 
+<a id="CommitsLtCondition"></a>
+
 `CommitsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -829,6 +907,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.gitlab.types.CommitsSearchFilter`
     :   The type of the None singleton.
+
+<a id="CommitsLteCondition"></a>
 
 `CommitsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -842,6 +922,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.gitlab.types.CommitsSearchFilter`
     :   The type of the None singleton.
 
+<a id="CommitsNeqCondition"></a>
+
 `CommitsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -853,6 +935,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.gitlab.types.CommitsSearchFilter`
     :   The type of the None singleton.
+
+<a id="CommitsNotCondition"></a>
 
 `CommitsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -874,6 +958,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.gitlab.types.CommitsEqCondition | airbyte_agent_sdk.connectors.gitlab.types.CommitsNeqCondition | airbyte_agent_sdk.connectors.gitlab.types.CommitsGtCondition | airbyte_agent_sdk.connectors.gitlab.types.CommitsGteCondition | airbyte_agent_sdk.connectors.gitlab.types.CommitsLtCondition | airbyte_agent_sdk.connectors.gitlab.types.CommitsLteCondition | airbyte_agent_sdk.connectors.gitlab.types.CommitsInCondition | airbyte_agent_sdk.connectors.gitlab.types.CommitsLikeCondition | airbyte_agent_sdk.connectors.gitlab.types.CommitsFuzzyCondition | airbyte_agent_sdk.connectors.gitlab.types.CommitsKeywordCondition | airbyte_agent_sdk.connectors.gitlab.types.CommitsContainsCondition | airbyte_agent_sdk.connectors.gitlab.types.CommitsNotCondition | airbyte_agent_sdk.connectors.gitlab.types.CommitsAndCondition | airbyte_agent_sdk.connectors.gitlab.types.CommitsOrCondition | airbyte_agent_sdk.connectors.gitlab.types.CommitsAnyCondition`
     :   The type of the None singleton.
 
+<a id="CommitsOrCondition"></a>
+
 `CommitsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -893,6 +979,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.gitlab.types.CommitsEqCondition | airbyte_agent_sdk.connectors.gitlab.types.CommitsNeqCondition | airbyte_agent_sdk.connectors.gitlab.types.CommitsGtCondition | airbyte_agent_sdk.connectors.gitlab.types.CommitsGteCondition | airbyte_agent_sdk.connectors.gitlab.types.CommitsLtCondition | airbyte_agent_sdk.connectors.gitlab.types.CommitsLteCondition | airbyte_agent_sdk.connectors.gitlab.types.CommitsInCondition | airbyte_agent_sdk.connectors.gitlab.types.CommitsLikeCondition | airbyte_agent_sdk.connectors.gitlab.types.CommitsFuzzyCondition | airbyte_agent_sdk.connectors.gitlab.types.CommitsKeywordCondition | airbyte_agent_sdk.connectors.gitlab.types.CommitsContainsCondition | airbyte_agent_sdk.connectors.gitlab.types.CommitsNotCondition | airbyte_agent_sdk.connectors.gitlab.types.CommitsAndCondition | airbyte_agent_sdk.connectors.gitlab.types.CommitsOrCondition | airbyte_agent_sdk.connectors.gitlab.types.CommitsAnyCondition]`
     :   The type of the None singleton.
+
+<a id="CommitsSearchFilter"></a>
 
 `CommitsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering commits search queries.
@@ -951,6 +1039,8 @@ Classes
     `web_url: str | None`
     :   Web URL of the commit
 
+<a id="CommitsSearchQuery"></a>
+
 `CommitsSearchQuery(*args, **kwargs)`
 :   Search query for commits entity.
 
@@ -965,6 +1055,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.gitlab.types.CommitsSortFilter]`
     :   The type of the None singleton.
+
+<a id="CommitsSortFilter"></a>
 
 `CommitsSortFilter(*args, **kwargs)`
 :   Available fields for sorting commits search results.
@@ -1023,6 +1115,8 @@ Classes
     `web_url: Literal['asc', 'desc']`
     :   Web URL of the commit
 
+<a id="CommitsStringFilter"></a>
+
 `CommitsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -1080,6 +1174,8 @@ Classes
     `web_url: str`
     :   Web URL of the commit
 
+<a id="GroupMembersAndCondition"></a>
+
 `GroupMembersAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1100,6 +1196,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.gitlab.types.GroupMembersEqCondition | airbyte_agent_sdk.connectors.gitlab.types.GroupMembersNeqCondition | airbyte_agent_sdk.connectors.gitlab.types.GroupMembersGtCondition | airbyte_agent_sdk.connectors.gitlab.types.GroupMembersGteCondition | airbyte_agent_sdk.connectors.gitlab.types.GroupMembersLtCondition | airbyte_agent_sdk.connectors.gitlab.types.GroupMembersLteCondition | airbyte_agent_sdk.connectors.gitlab.types.GroupMembersInCondition | airbyte_agent_sdk.connectors.gitlab.types.GroupMembersLikeCondition | airbyte_agent_sdk.connectors.gitlab.types.GroupMembersFuzzyCondition | airbyte_agent_sdk.connectors.gitlab.types.GroupMembersKeywordCondition | airbyte_agent_sdk.connectors.gitlab.types.GroupMembersContainsCondition | airbyte_agent_sdk.connectors.gitlab.types.GroupMembersNotCondition | airbyte_agent_sdk.connectors.gitlab.types.GroupMembersAndCondition | airbyte_agent_sdk.connectors.gitlab.types.GroupMembersOrCondition | airbyte_agent_sdk.connectors.gitlab.types.GroupMembersAnyCondition]`
     :   The type of the None singleton.
 
+<a id="GroupMembersAnyCondition"></a>
+
 `GroupMembersAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1119,6 +1217,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.gitlab.types.GroupMembersAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="GroupMembersAnyValueFilter"></a>
 
 `GroupMembersAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -1168,6 +1268,8 @@ Classes
     `web_url: Any`
     :   Web URL of the member profile
 
+<a id="GroupMembersContainsCondition"></a>
+
 `GroupMembersContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -1179,6 +1281,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.gitlab.types.GroupMembersAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="GroupMembersEqCondition"></a>
 
 `GroupMembersEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -1192,6 +1296,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.gitlab.types.GroupMembersSearchFilter`
     :   The type of the None singleton.
 
+<a id="GroupMembersFuzzyCondition"></a>
+
 `GroupMembersFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -1203,6 +1309,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.gitlab.types.GroupMembersStringFilter`
     :   The type of the None singleton.
+
+<a id="GroupMembersGetParams"></a>
 
 `GroupMembersGetParams(*args, **kwargs)`
 :   Parameters for group_members.get operation
@@ -1219,6 +1327,8 @@ Classes
     `user_id: str`
     :   The type of the None singleton.
 
+<a id="GroupMembersGtCondition"></a>
+
 `GroupMembersGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -1231,6 +1341,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.gitlab.types.GroupMembersSearchFilter`
     :   The type of the None singleton.
 
+<a id="GroupMembersGteCondition"></a>
+
 `GroupMembersGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -1242,6 +1354,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.gitlab.types.GroupMembersSearchFilter`
     :   The type of the None singleton.
+
+<a id="GroupMembersInCondition"></a>
 
 `GroupMembersInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -1262,6 +1376,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.gitlab.types.GroupMembersInFilter`
     :   The type of the None singleton.
+
+<a id="GroupMembersInFilter"></a>
 
 `GroupMembersInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -1311,6 +1427,8 @@ Classes
     `web_url: list[str]`
     :   Web URL of the member profile
 
+<a id="GroupMembersKeywordCondition"></a>
+
 `GroupMembersKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -1323,6 +1441,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.gitlab.types.GroupMembersStringFilter`
     :   The type of the None singleton.
 
+<a id="GroupMembersLikeCondition"></a>
+
 `GroupMembersLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -1334,6 +1454,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.gitlab.types.GroupMembersStringFilter`
     :   The type of the None singleton.
+
+<a id="GroupMembersListParams"></a>
 
 `GroupMembersListParams(*args, **kwargs)`
 :   Parameters for group_members.list operation
@@ -1356,6 +1478,8 @@ Classes
     `query: str`
     :   The type of the None singleton.
 
+<a id="GroupMembersLtCondition"></a>
+
 `GroupMembersLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -1367,6 +1491,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.gitlab.types.GroupMembersSearchFilter`
     :   The type of the None singleton.
+
+<a id="GroupMembersLteCondition"></a>
 
 `GroupMembersLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -1380,6 +1506,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.gitlab.types.GroupMembersSearchFilter`
     :   The type of the None singleton.
 
+<a id="GroupMembersNeqCondition"></a>
+
 `GroupMembersNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -1391,6 +1519,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.gitlab.types.GroupMembersSearchFilter`
     :   The type of the None singleton.
+
+<a id="GroupMembersNotCondition"></a>
 
 `GroupMembersNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -1412,6 +1542,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.gitlab.types.GroupMembersEqCondition | airbyte_agent_sdk.connectors.gitlab.types.GroupMembersNeqCondition | airbyte_agent_sdk.connectors.gitlab.types.GroupMembersGtCondition | airbyte_agent_sdk.connectors.gitlab.types.GroupMembersGteCondition | airbyte_agent_sdk.connectors.gitlab.types.GroupMembersLtCondition | airbyte_agent_sdk.connectors.gitlab.types.GroupMembersLteCondition | airbyte_agent_sdk.connectors.gitlab.types.GroupMembersInCondition | airbyte_agent_sdk.connectors.gitlab.types.GroupMembersLikeCondition | airbyte_agent_sdk.connectors.gitlab.types.GroupMembersFuzzyCondition | airbyte_agent_sdk.connectors.gitlab.types.GroupMembersKeywordCondition | airbyte_agent_sdk.connectors.gitlab.types.GroupMembersContainsCondition | airbyte_agent_sdk.connectors.gitlab.types.GroupMembersNotCondition | airbyte_agent_sdk.connectors.gitlab.types.GroupMembersAndCondition | airbyte_agent_sdk.connectors.gitlab.types.GroupMembersOrCondition | airbyte_agent_sdk.connectors.gitlab.types.GroupMembersAnyCondition`
     :   The type of the None singleton.
 
+<a id="GroupMembersOrCondition"></a>
+
 `GroupMembersOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1431,6 +1563,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.gitlab.types.GroupMembersEqCondition | airbyte_agent_sdk.connectors.gitlab.types.GroupMembersNeqCondition | airbyte_agent_sdk.connectors.gitlab.types.GroupMembersGtCondition | airbyte_agent_sdk.connectors.gitlab.types.GroupMembersGteCondition | airbyte_agent_sdk.connectors.gitlab.types.GroupMembersLtCondition | airbyte_agent_sdk.connectors.gitlab.types.GroupMembersLteCondition | airbyte_agent_sdk.connectors.gitlab.types.GroupMembersInCondition | airbyte_agent_sdk.connectors.gitlab.types.GroupMembersLikeCondition | airbyte_agent_sdk.connectors.gitlab.types.GroupMembersFuzzyCondition | airbyte_agent_sdk.connectors.gitlab.types.GroupMembersKeywordCondition | airbyte_agent_sdk.connectors.gitlab.types.GroupMembersContainsCondition | airbyte_agent_sdk.connectors.gitlab.types.GroupMembersNotCondition | airbyte_agent_sdk.connectors.gitlab.types.GroupMembersAndCondition | airbyte_agent_sdk.connectors.gitlab.types.GroupMembersOrCondition | airbyte_agent_sdk.connectors.gitlab.types.GroupMembersAnyCondition]`
     :   The type of the None singleton.
+
+<a id="GroupMembersSearchFilter"></a>
 
 `GroupMembersSearchFilter(*args, **kwargs)`
 :   Available fields for filtering group_members search queries.
@@ -1480,6 +1614,8 @@ Classes
     `web_url: str | None`
     :   Web URL of the member profile
 
+<a id="GroupMembersSearchQuery"></a>
+
 `GroupMembersSearchQuery(*args, **kwargs)`
 :   Search query for group_members entity.
 
@@ -1494,6 +1630,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.gitlab.types.GroupMembersSortFilter]`
     :   The type of the None singleton.
+
+<a id="GroupMembersSortFilter"></a>
 
 `GroupMembersSortFilter(*args, **kwargs)`
 :   Available fields for sorting group_members search results.
@@ -1543,6 +1681,8 @@ Classes
     `web_url: Literal['asc', 'desc']`
     :   Web URL of the member profile
 
+<a id="GroupMembersStringFilter"></a>
+
 `GroupMembersStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -1591,6 +1731,8 @@ Classes
     `web_url: str`
     :   Web URL of the member profile
 
+<a id="GroupMilestonesAndCondition"></a>
+
 `GroupMilestonesAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1611,6 +1753,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.gitlab.types.GroupMilestonesEqCondition | airbyte_agent_sdk.connectors.gitlab.types.GroupMilestonesNeqCondition | airbyte_agent_sdk.connectors.gitlab.types.GroupMilestonesGtCondition | airbyte_agent_sdk.connectors.gitlab.types.GroupMilestonesGteCondition | airbyte_agent_sdk.connectors.gitlab.types.GroupMilestonesLtCondition | airbyte_agent_sdk.connectors.gitlab.types.GroupMilestonesLteCondition | airbyte_agent_sdk.connectors.gitlab.types.GroupMilestonesInCondition | airbyte_agent_sdk.connectors.gitlab.types.GroupMilestonesLikeCondition | airbyte_agent_sdk.connectors.gitlab.types.GroupMilestonesFuzzyCondition | airbyte_agent_sdk.connectors.gitlab.types.GroupMilestonesKeywordCondition | airbyte_agent_sdk.connectors.gitlab.types.GroupMilestonesContainsCondition | airbyte_agent_sdk.connectors.gitlab.types.GroupMilestonesNotCondition | airbyte_agent_sdk.connectors.gitlab.types.GroupMilestonesAndCondition | airbyte_agent_sdk.connectors.gitlab.types.GroupMilestonesOrCondition | airbyte_agent_sdk.connectors.gitlab.types.GroupMilestonesAnyCondition]`
     :   The type of the None singleton.
 
+<a id="GroupMilestonesAnyCondition"></a>
+
 `GroupMilestonesAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1630,6 +1774,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.gitlab.types.GroupMilestonesAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="GroupMilestonesAnyValueFilter"></a>
 
 `GroupMilestonesAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -1676,6 +1822,8 @@ Classes
     `web_url: Any`
     :   Web URL of the milestone
 
+<a id="GroupMilestonesContainsCondition"></a>
+
 `GroupMilestonesContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -1687,6 +1835,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.gitlab.types.GroupMilestonesAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="GroupMilestonesEqCondition"></a>
 
 `GroupMilestonesEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -1700,6 +1850,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.gitlab.types.GroupMilestonesSearchFilter`
     :   The type of the None singleton.
 
+<a id="GroupMilestonesFuzzyCondition"></a>
+
 `GroupMilestonesFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -1711,6 +1863,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.gitlab.types.GroupMilestonesStringFilter`
     :   The type of the None singleton.
+
+<a id="GroupMilestonesGetParams"></a>
 
 `GroupMilestonesGetParams(*args, **kwargs)`
 :   Parameters for group_milestones.get operation
@@ -1727,6 +1881,8 @@ Classes
     `milestone_id: str`
     :   The type of the None singleton.
 
+<a id="GroupMilestonesGtCondition"></a>
+
 `GroupMilestonesGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -1739,6 +1895,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.gitlab.types.GroupMilestonesSearchFilter`
     :   The type of the None singleton.
 
+<a id="GroupMilestonesGteCondition"></a>
+
 `GroupMilestonesGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -1750,6 +1908,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.gitlab.types.GroupMilestonesSearchFilter`
     :   The type of the None singleton.
+
+<a id="GroupMilestonesInCondition"></a>
 
 `GroupMilestonesInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -1770,6 +1930,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.gitlab.types.GroupMilestonesInFilter`
     :   The type of the None singleton.
+
+<a id="GroupMilestonesInFilter"></a>
 
 `GroupMilestonesInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -1816,6 +1978,8 @@ Classes
     `web_url: list[str]`
     :   Web URL of the milestone
 
+<a id="GroupMilestonesKeywordCondition"></a>
+
 `GroupMilestonesKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -1828,6 +1992,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.gitlab.types.GroupMilestonesStringFilter`
     :   The type of the None singleton.
 
+<a id="GroupMilestonesLikeCondition"></a>
+
 `GroupMilestonesLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -1839,6 +2005,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.gitlab.types.GroupMilestonesStringFilter`
     :   The type of the None singleton.
+
+<a id="GroupMilestonesListParams"></a>
 
 `GroupMilestonesListParams(*args, **kwargs)`
 :   Parameters for group_milestones.list operation
@@ -1864,6 +2032,8 @@ Classes
     `state: str`
     :   The type of the None singleton.
 
+<a id="GroupMilestonesLtCondition"></a>
+
 `GroupMilestonesLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -1875,6 +2045,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.gitlab.types.GroupMilestonesSearchFilter`
     :   The type of the None singleton.
+
+<a id="GroupMilestonesLteCondition"></a>
 
 `GroupMilestonesLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -1888,6 +2060,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.gitlab.types.GroupMilestonesSearchFilter`
     :   The type of the None singleton.
 
+<a id="GroupMilestonesNeqCondition"></a>
+
 `GroupMilestonesNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -1899,6 +2073,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.gitlab.types.GroupMilestonesSearchFilter`
     :   The type of the None singleton.
+
+<a id="GroupMilestonesNotCondition"></a>
 
 `GroupMilestonesNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -1920,6 +2096,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.gitlab.types.GroupMilestonesEqCondition | airbyte_agent_sdk.connectors.gitlab.types.GroupMilestonesNeqCondition | airbyte_agent_sdk.connectors.gitlab.types.GroupMilestonesGtCondition | airbyte_agent_sdk.connectors.gitlab.types.GroupMilestonesGteCondition | airbyte_agent_sdk.connectors.gitlab.types.GroupMilestonesLtCondition | airbyte_agent_sdk.connectors.gitlab.types.GroupMilestonesLteCondition | airbyte_agent_sdk.connectors.gitlab.types.GroupMilestonesInCondition | airbyte_agent_sdk.connectors.gitlab.types.GroupMilestonesLikeCondition | airbyte_agent_sdk.connectors.gitlab.types.GroupMilestonesFuzzyCondition | airbyte_agent_sdk.connectors.gitlab.types.GroupMilestonesKeywordCondition | airbyte_agent_sdk.connectors.gitlab.types.GroupMilestonesContainsCondition | airbyte_agent_sdk.connectors.gitlab.types.GroupMilestonesNotCondition | airbyte_agent_sdk.connectors.gitlab.types.GroupMilestonesAndCondition | airbyte_agent_sdk.connectors.gitlab.types.GroupMilestonesOrCondition | airbyte_agent_sdk.connectors.gitlab.types.GroupMilestonesAnyCondition`
     :   The type of the None singleton.
 
+<a id="GroupMilestonesOrCondition"></a>
+
 `GroupMilestonesOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1939,6 +2117,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.gitlab.types.GroupMilestonesEqCondition | airbyte_agent_sdk.connectors.gitlab.types.GroupMilestonesNeqCondition | airbyte_agent_sdk.connectors.gitlab.types.GroupMilestonesGtCondition | airbyte_agent_sdk.connectors.gitlab.types.GroupMilestonesGteCondition | airbyte_agent_sdk.connectors.gitlab.types.GroupMilestonesLtCondition | airbyte_agent_sdk.connectors.gitlab.types.GroupMilestonesLteCondition | airbyte_agent_sdk.connectors.gitlab.types.GroupMilestonesInCondition | airbyte_agent_sdk.connectors.gitlab.types.GroupMilestonesLikeCondition | airbyte_agent_sdk.connectors.gitlab.types.GroupMilestonesFuzzyCondition | airbyte_agent_sdk.connectors.gitlab.types.GroupMilestonesKeywordCondition | airbyte_agent_sdk.connectors.gitlab.types.GroupMilestonesContainsCondition | airbyte_agent_sdk.connectors.gitlab.types.GroupMilestonesNotCondition | airbyte_agent_sdk.connectors.gitlab.types.GroupMilestonesAndCondition | airbyte_agent_sdk.connectors.gitlab.types.GroupMilestonesOrCondition | airbyte_agent_sdk.connectors.gitlab.types.GroupMilestonesAnyCondition]`
     :   The type of the None singleton.
+
+<a id="GroupMilestonesSearchFilter"></a>
 
 `GroupMilestonesSearchFilter(*args, **kwargs)`
 :   Available fields for filtering group_milestones search queries.
@@ -1985,6 +2165,8 @@ Classes
     `web_url: str | None`
     :   Web URL of the milestone
 
+<a id="GroupMilestonesSearchQuery"></a>
+
 `GroupMilestonesSearchQuery(*args, **kwargs)`
 :   Search query for group_milestones entity.
 
@@ -1999,6 +2181,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.gitlab.types.GroupMilestonesSortFilter]`
     :   The type of the None singleton.
+
+<a id="GroupMilestonesSortFilter"></a>
 
 `GroupMilestonesSortFilter(*args, **kwargs)`
 :   Available fields for sorting group_milestones search results.
@@ -2045,6 +2229,8 @@ Classes
     `web_url: Literal['asc', 'desc']`
     :   Web URL of the milestone
 
+<a id="GroupMilestonesStringFilter"></a>
+
 `GroupMilestonesStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -2090,6 +2276,8 @@ Classes
     `web_url: str`
     :   Web URL of the milestone
 
+<a id="GroupsAndCondition"></a>
+
 `GroupsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -2110,6 +2298,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.gitlab.types.GroupsEqCondition | airbyte_agent_sdk.connectors.gitlab.types.GroupsNeqCondition | airbyte_agent_sdk.connectors.gitlab.types.GroupsGtCondition | airbyte_agent_sdk.connectors.gitlab.types.GroupsGteCondition | airbyte_agent_sdk.connectors.gitlab.types.GroupsLtCondition | airbyte_agent_sdk.connectors.gitlab.types.GroupsLteCondition | airbyte_agent_sdk.connectors.gitlab.types.GroupsInCondition | airbyte_agent_sdk.connectors.gitlab.types.GroupsLikeCondition | airbyte_agent_sdk.connectors.gitlab.types.GroupsFuzzyCondition | airbyte_agent_sdk.connectors.gitlab.types.GroupsKeywordCondition | airbyte_agent_sdk.connectors.gitlab.types.GroupsContainsCondition | airbyte_agent_sdk.connectors.gitlab.types.GroupsNotCondition | airbyte_agent_sdk.connectors.gitlab.types.GroupsAndCondition | airbyte_agent_sdk.connectors.gitlab.types.GroupsOrCondition | airbyte_agent_sdk.connectors.gitlab.types.GroupsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="GroupsAnyCondition"></a>
+
 `GroupsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -2129,6 +2319,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.gitlab.types.GroupsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="GroupsAnyValueFilter"></a>
 
 `GroupsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -2214,6 +2406,8 @@ Classes
     `web_url: Any`
     :   Web URL of the group
 
+<a id="GroupsContainsCondition"></a>
+
 `GroupsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -2225,6 +2419,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.gitlab.types.GroupsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="GroupsEqCondition"></a>
 
 `GroupsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -2238,6 +2434,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.gitlab.types.GroupsSearchFilter`
     :   The type of the None singleton.
 
+<a id="GroupsFuzzyCondition"></a>
+
 `GroupsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -2249,6 +2447,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.gitlab.types.GroupsStringFilter`
     :   The type of the None singleton.
+
+<a id="GroupsGetParams"></a>
 
 `GroupsGetParams(*args, **kwargs)`
 :   Parameters for groups.get operation
@@ -2262,6 +2462,8 @@ Classes
     `id: str`
     :   The type of the None singleton.
 
+<a id="GroupsGtCondition"></a>
+
 `GroupsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -2274,6 +2476,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.gitlab.types.GroupsSearchFilter`
     :   The type of the None singleton.
 
+<a id="GroupsGteCondition"></a>
+
 `GroupsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -2285,6 +2489,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.gitlab.types.GroupsSearchFilter`
     :   The type of the None singleton.
+
+<a id="GroupsInCondition"></a>
 
 `GroupsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -2305,6 +2511,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.gitlab.types.GroupsInFilter`
     :   The type of the None singleton.
+
+<a id="GroupsInFilter"></a>
 
 `GroupsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -2390,6 +2598,8 @@ Classes
     `web_url: list[str]`
     :   Web URL of the group
 
+<a id="GroupsKeywordCondition"></a>
+
 `GroupsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -2402,6 +2612,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.gitlab.types.GroupsStringFilter`
     :   The type of the None singleton.
 
+<a id="GroupsLikeCondition"></a>
+
 `GroupsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -2413,6 +2625,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.gitlab.types.GroupsStringFilter`
     :   The type of the None singleton.
+
+<a id="GroupsListParams"></a>
 
 `GroupsListParams(*args, **kwargs)`
 :   Parameters for groups.list operation
@@ -2441,6 +2655,8 @@ Classes
     `sort: str`
     :   The type of the None singleton.
 
+<a id="GroupsLtCondition"></a>
+
 `GroupsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -2452,6 +2668,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.gitlab.types.GroupsSearchFilter`
     :   The type of the None singleton.
+
+<a id="GroupsLteCondition"></a>
 
 `GroupsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -2465,6 +2683,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.gitlab.types.GroupsSearchFilter`
     :   The type of the None singleton.
 
+<a id="GroupsNeqCondition"></a>
+
 `GroupsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -2476,6 +2696,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.gitlab.types.GroupsSearchFilter`
     :   The type of the None singleton.
+
+<a id="GroupsNotCondition"></a>
 
 `GroupsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -2497,6 +2719,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.gitlab.types.GroupsEqCondition | airbyte_agent_sdk.connectors.gitlab.types.GroupsNeqCondition | airbyte_agent_sdk.connectors.gitlab.types.GroupsGtCondition | airbyte_agent_sdk.connectors.gitlab.types.GroupsGteCondition | airbyte_agent_sdk.connectors.gitlab.types.GroupsLtCondition | airbyte_agent_sdk.connectors.gitlab.types.GroupsLteCondition | airbyte_agent_sdk.connectors.gitlab.types.GroupsInCondition | airbyte_agent_sdk.connectors.gitlab.types.GroupsLikeCondition | airbyte_agent_sdk.connectors.gitlab.types.GroupsFuzzyCondition | airbyte_agent_sdk.connectors.gitlab.types.GroupsKeywordCondition | airbyte_agent_sdk.connectors.gitlab.types.GroupsContainsCondition | airbyte_agent_sdk.connectors.gitlab.types.GroupsNotCondition | airbyte_agent_sdk.connectors.gitlab.types.GroupsAndCondition | airbyte_agent_sdk.connectors.gitlab.types.GroupsOrCondition | airbyte_agent_sdk.connectors.gitlab.types.GroupsAnyCondition`
     :   The type of the None singleton.
 
+<a id="GroupsOrCondition"></a>
+
 `GroupsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -2516,6 +2740,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.gitlab.types.GroupsEqCondition | airbyte_agent_sdk.connectors.gitlab.types.GroupsNeqCondition | airbyte_agent_sdk.connectors.gitlab.types.GroupsGtCondition | airbyte_agent_sdk.connectors.gitlab.types.GroupsGteCondition | airbyte_agent_sdk.connectors.gitlab.types.GroupsLtCondition | airbyte_agent_sdk.connectors.gitlab.types.GroupsLteCondition | airbyte_agent_sdk.connectors.gitlab.types.GroupsInCondition | airbyte_agent_sdk.connectors.gitlab.types.GroupsLikeCondition | airbyte_agent_sdk.connectors.gitlab.types.GroupsFuzzyCondition | airbyte_agent_sdk.connectors.gitlab.types.GroupsKeywordCondition | airbyte_agent_sdk.connectors.gitlab.types.GroupsContainsCondition | airbyte_agent_sdk.connectors.gitlab.types.GroupsNotCondition | airbyte_agent_sdk.connectors.gitlab.types.GroupsAndCondition | airbyte_agent_sdk.connectors.gitlab.types.GroupsOrCondition | airbyte_agent_sdk.connectors.gitlab.types.GroupsAnyCondition]`
     :   The type of the None singleton.
+
+<a id="GroupsSearchFilter"></a>
 
 `GroupsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering groups search queries.
@@ -2601,6 +2827,8 @@ Classes
     `web_url: str | None`
     :   Web URL of the group
 
+<a id="GroupsSearchQuery"></a>
+
 `GroupsSearchQuery(*args, **kwargs)`
 :   Search query for groups entity.
 
@@ -2615,6 +2843,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.gitlab.types.GroupsSortFilter]`
     :   The type of the None singleton.
+
+<a id="GroupsSortFilter"></a>
 
 `GroupsSortFilter(*args, **kwargs)`
 :   Available fields for sorting groups search results.
@@ -2700,6 +2930,8 @@ Classes
     `web_url: Literal['asc', 'desc']`
     :   Web URL of the group
 
+<a id="GroupsStringFilter"></a>
+
 `GroupsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -2784,6 +3016,8 @@ Classes
     `web_url: str`
     :   Web URL of the group
 
+<a id="IssuesAndCondition"></a>
+
 `IssuesAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -2804,6 +3038,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.gitlab.types.IssuesEqCondition | airbyte_agent_sdk.connectors.gitlab.types.IssuesNeqCondition | airbyte_agent_sdk.connectors.gitlab.types.IssuesGtCondition | airbyte_agent_sdk.connectors.gitlab.types.IssuesGteCondition | airbyte_agent_sdk.connectors.gitlab.types.IssuesLtCondition | airbyte_agent_sdk.connectors.gitlab.types.IssuesLteCondition | airbyte_agent_sdk.connectors.gitlab.types.IssuesInCondition | airbyte_agent_sdk.connectors.gitlab.types.IssuesLikeCondition | airbyte_agent_sdk.connectors.gitlab.types.IssuesFuzzyCondition | airbyte_agent_sdk.connectors.gitlab.types.IssuesKeywordCondition | airbyte_agent_sdk.connectors.gitlab.types.IssuesContainsCondition | airbyte_agent_sdk.connectors.gitlab.types.IssuesNotCondition | airbyte_agent_sdk.connectors.gitlab.types.IssuesAndCondition | airbyte_agent_sdk.connectors.gitlab.types.IssuesOrCondition | airbyte_agent_sdk.connectors.gitlab.types.IssuesAnyCondition]`
     :   The type of the None singleton.
 
+<a id="IssuesAnyCondition"></a>
+
 `IssuesAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -2823,6 +3059,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.gitlab.types.IssuesAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="IssuesAnyValueFilter"></a>
 
 `IssuesAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -2944,6 +3182,8 @@ Classes
     `weight: Any`
     :   Weight of the issue
 
+<a id="IssuesContainsCondition"></a>
+
 `IssuesContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -2955,6 +3195,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.gitlab.types.IssuesAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="IssuesEqCondition"></a>
 
 `IssuesEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -2968,6 +3210,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.gitlab.types.IssuesSearchFilter`
     :   The type of the None singleton.
 
+<a id="IssuesFuzzyCondition"></a>
+
 `IssuesFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -2979,6 +3223,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.gitlab.types.IssuesStringFilter`
     :   The type of the None singleton.
+
+<a id="IssuesGetParams"></a>
 
 `IssuesGetParams(*args, **kwargs)`
 :   Parameters for issues.get operation
@@ -2995,6 +3241,8 @@ Classes
     `project_id: str`
     :   The type of the None singleton.
 
+<a id="IssuesGtCondition"></a>
+
 `IssuesGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -3007,6 +3255,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.gitlab.types.IssuesSearchFilter`
     :   The type of the None singleton.
 
+<a id="IssuesGteCondition"></a>
+
 `IssuesGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -3018,6 +3268,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.gitlab.types.IssuesSearchFilter`
     :   The type of the None singleton.
+
+<a id="IssuesInCondition"></a>
 
 `IssuesInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -3038,6 +3290,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.gitlab.types.IssuesInFilter`
     :   The type of the None singleton.
+
+<a id="IssuesInFilter"></a>
 
 `IssuesInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -3159,6 +3413,8 @@ Classes
     `weight: list[int]`
     :   Weight of the issue
 
+<a id="IssuesKeywordCondition"></a>
+
 `IssuesKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -3171,6 +3427,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.gitlab.types.IssuesStringFilter`
     :   The type of the None singleton.
 
+<a id="IssuesLikeCondition"></a>
+
 `IssuesLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -3182,6 +3440,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.gitlab.types.IssuesStringFilter`
     :   The type of the None singleton.
+
+<a id="IssuesListParams"></a>
 
 `IssuesListParams(*args, **kwargs)`
 :   Parameters for issues.list operation
@@ -3225,6 +3485,8 @@ Classes
     `updated_before: str`
     :   The type of the None singleton.
 
+<a id="IssuesLtCondition"></a>
+
 `IssuesLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -3236,6 +3498,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.gitlab.types.IssuesSearchFilter`
     :   The type of the None singleton.
+
+<a id="IssuesLteCondition"></a>
 
 `IssuesLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -3249,6 +3513,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.gitlab.types.IssuesSearchFilter`
     :   The type of the None singleton.
 
+<a id="IssuesNeqCondition"></a>
+
 `IssuesNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -3260,6 +3526,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.gitlab.types.IssuesSearchFilter`
     :   The type of the None singleton.
+
+<a id="IssuesNotCondition"></a>
 
 `IssuesNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -3281,6 +3549,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.gitlab.types.IssuesEqCondition | airbyte_agent_sdk.connectors.gitlab.types.IssuesNeqCondition | airbyte_agent_sdk.connectors.gitlab.types.IssuesGtCondition | airbyte_agent_sdk.connectors.gitlab.types.IssuesGteCondition | airbyte_agent_sdk.connectors.gitlab.types.IssuesLtCondition | airbyte_agent_sdk.connectors.gitlab.types.IssuesLteCondition | airbyte_agent_sdk.connectors.gitlab.types.IssuesInCondition | airbyte_agent_sdk.connectors.gitlab.types.IssuesLikeCondition | airbyte_agent_sdk.connectors.gitlab.types.IssuesFuzzyCondition | airbyte_agent_sdk.connectors.gitlab.types.IssuesKeywordCondition | airbyte_agent_sdk.connectors.gitlab.types.IssuesContainsCondition | airbyte_agent_sdk.connectors.gitlab.types.IssuesNotCondition | airbyte_agent_sdk.connectors.gitlab.types.IssuesAndCondition | airbyte_agent_sdk.connectors.gitlab.types.IssuesOrCondition | airbyte_agent_sdk.connectors.gitlab.types.IssuesAnyCondition`
     :   The type of the None singleton.
 
+<a id="IssuesOrCondition"></a>
+
 `IssuesOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -3300,6 +3570,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.gitlab.types.IssuesEqCondition | airbyte_agent_sdk.connectors.gitlab.types.IssuesNeqCondition | airbyte_agent_sdk.connectors.gitlab.types.IssuesGtCondition | airbyte_agent_sdk.connectors.gitlab.types.IssuesGteCondition | airbyte_agent_sdk.connectors.gitlab.types.IssuesLtCondition | airbyte_agent_sdk.connectors.gitlab.types.IssuesLteCondition | airbyte_agent_sdk.connectors.gitlab.types.IssuesInCondition | airbyte_agent_sdk.connectors.gitlab.types.IssuesLikeCondition | airbyte_agent_sdk.connectors.gitlab.types.IssuesFuzzyCondition | airbyte_agent_sdk.connectors.gitlab.types.IssuesKeywordCondition | airbyte_agent_sdk.connectors.gitlab.types.IssuesContainsCondition | airbyte_agent_sdk.connectors.gitlab.types.IssuesNotCondition | airbyte_agent_sdk.connectors.gitlab.types.IssuesAndCondition | airbyte_agent_sdk.connectors.gitlab.types.IssuesOrCondition | airbyte_agent_sdk.connectors.gitlab.types.IssuesAnyCondition]`
     :   The type of the None singleton.
+
+<a id="IssuesSearchFilter"></a>
 
 `IssuesSearchFilter(*args, **kwargs)`
 :   Available fields for filtering issues search queries.
@@ -3421,6 +3693,8 @@ Classes
     `weight: int | None`
     :   Weight of the issue
 
+<a id="IssuesSearchQuery"></a>
+
 `IssuesSearchQuery(*args, **kwargs)`
 :   Search query for issues entity.
 
@@ -3435,6 +3709,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.gitlab.types.IssuesSortFilter]`
     :   The type of the None singleton.
+
+<a id="IssuesSortFilter"></a>
 
 `IssuesSortFilter(*args, **kwargs)`
 :   Available fields for sorting issues search results.
@@ -3556,6 +3832,8 @@ Classes
     `weight: Literal['asc', 'desc']`
     :   Weight of the issue
 
+<a id="IssuesStringFilter"></a>
+
 `IssuesStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -3676,6 +3954,8 @@ Classes
     `weight: str`
     :   Weight of the issue
 
+<a id="MergeRequestsAndCondition"></a>
+
 `MergeRequestsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -3696,6 +3976,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.gitlab.types.MergeRequestsEqCondition | airbyte_agent_sdk.connectors.gitlab.types.MergeRequestsNeqCondition | airbyte_agent_sdk.connectors.gitlab.types.MergeRequestsGtCondition | airbyte_agent_sdk.connectors.gitlab.types.MergeRequestsGteCondition | airbyte_agent_sdk.connectors.gitlab.types.MergeRequestsLtCondition | airbyte_agent_sdk.connectors.gitlab.types.MergeRequestsLteCondition | airbyte_agent_sdk.connectors.gitlab.types.MergeRequestsInCondition | airbyte_agent_sdk.connectors.gitlab.types.MergeRequestsLikeCondition | airbyte_agent_sdk.connectors.gitlab.types.MergeRequestsFuzzyCondition | airbyte_agent_sdk.connectors.gitlab.types.MergeRequestsKeywordCondition | airbyte_agent_sdk.connectors.gitlab.types.MergeRequestsContainsCondition | airbyte_agent_sdk.connectors.gitlab.types.MergeRequestsNotCondition | airbyte_agent_sdk.connectors.gitlab.types.MergeRequestsAndCondition | airbyte_agent_sdk.connectors.gitlab.types.MergeRequestsOrCondition | airbyte_agent_sdk.connectors.gitlab.types.MergeRequestsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="MergeRequestsAnyCondition"></a>
+
 `MergeRequestsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -3715,6 +3997,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.gitlab.types.MergeRequestsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="MergeRequestsAnyValueFilter"></a>
 
 `MergeRequestsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -3875,6 +4159,8 @@ Classes
     `work_in_progress: Any`
     :   Whether the merge request is a work in progress
 
+<a id="MergeRequestsContainsCondition"></a>
+
 `MergeRequestsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -3886,6 +4172,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.gitlab.types.MergeRequestsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="MergeRequestsEqCondition"></a>
 
 `MergeRequestsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -3899,6 +4187,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.gitlab.types.MergeRequestsSearchFilter`
     :   The type of the None singleton.
 
+<a id="MergeRequestsFuzzyCondition"></a>
+
 `MergeRequestsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -3910,6 +4200,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.gitlab.types.MergeRequestsStringFilter`
     :   The type of the None singleton.
+
+<a id="MergeRequestsGetParams"></a>
 
 `MergeRequestsGetParams(*args, **kwargs)`
 :   Parameters for merge_requests.get operation
@@ -3926,6 +4218,8 @@ Classes
     `project_id: str`
     :   The type of the None singleton.
 
+<a id="MergeRequestsGtCondition"></a>
+
 `MergeRequestsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -3938,6 +4232,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.gitlab.types.MergeRequestsSearchFilter`
     :   The type of the None singleton.
 
+<a id="MergeRequestsGteCondition"></a>
+
 `MergeRequestsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -3949,6 +4245,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.gitlab.types.MergeRequestsSearchFilter`
     :   The type of the None singleton.
+
+<a id="MergeRequestsInCondition"></a>
 
 `MergeRequestsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -3969,6 +4267,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.gitlab.types.MergeRequestsInFilter`
     :   The type of the None singleton.
+
+<a id="MergeRequestsInFilter"></a>
 
 `MergeRequestsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -4129,6 +4429,8 @@ Classes
     `work_in_progress: list[bool]`
     :   Whether the merge request is a work in progress
 
+<a id="MergeRequestsKeywordCondition"></a>
+
 `MergeRequestsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -4141,6 +4443,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.gitlab.types.MergeRequestsStringFilter`
     :   The type of the None singleton.
 
+<a id="MergeRequestsLikeCondition"></a>
+
 `MergeRequestsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -4152,6 +4456,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.gitlab.types.MergeRequestsStringFilter`
     :   The type of the None singleton.
+
+<a id="MergeRequestsListParams"></a>
 
 `MergeRequestsListParams(*args, **kwargs)`
 :   Parameters for merge_requests.list operation
@@ -4195,6 +4501,8 @@ Classes
     `updated_before: str`
     :   The type of the None singleton.
 
+<a id="MergeRequestsLtCondition"></a>
+
 `MergeRequestsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -4206,6 +4514,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.gitlab.types.MergeRequestsSearchFilter`
     :   The type of the None singleton.
+
+<a id="MergeRequestsLteCondition"></a>
 
 `MergeRequestsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -4219,6 +4529,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.gitlab.types.MergeRequestsSearchFilter`
     :   The type of the None singleton.
 
+<a id="MergeRequestsNeqCondition"></a>
+
 `MergeRequestsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -4230,6 +4542,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.gitlab.types.MergeRequestsSearchFilter`
     :   The type of the None singleton.
+
+<a id="MergeRequestsNotCondition"></a>
 
 `MergeRequestsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -4251,6 +4565,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.gitlab.types.MergeRequestsEqCondition | airbyte_agent_sdk.connectors.gitlab.types.MergeRequestsNeqCondition | airbyte_agent_sdk.connectors.gitlab.types.MergeRequestsGtCondition | airbyte_agent_sdk.connectors.gitlab.types.MergeRequestsGteCondition | airbyte_agent_sdk.connectors.gitlab.types.MergeRequestsLtCondition | airbyte_agent_sdk.connectors.gitlab.types.MergeRequestsLteCondition | airbyte_agent_sdk.connectors.gitlab.types.MergeRequestsInCondition | airbyte_agent_sdk.connectors.gitlab.types.MergeRequestsLikeCondition | airbyte_agent_sdk.connectors.gitlab.types.MergeRequestsFuzzyCondition | airbyte_agent_sdk.connectors.gitlab.types.MergeRequestsKeywordCondition | airbyte_agent_sdk.connectors.gitlab.types.MergeRequestsContainsCondition | airbyte_agent_sdk.connectors.gitlab.types.MergeRequestsNotCondition | airbyte_agent_sdk.connectors.gitlab.types.MergeRequestsAndCondition | airbyte_agent_sdk.connectors.gitlab.types.MergeRequestsOrCondition | airbyte_agent_sdk.connectors.gitlab.types.MergeRequestsAnyCondition`
     :   The type of the None singleton.
 
+<a id="MergeRequestsOrCondition"></a>
+
 `MergeRequestsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -4270,6 +4586,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.gitlab.types.MergeRequestsEqCondition | airbyte_agent_sdk.connectors.gitlab.types.MergeRequestsNeqCondition | airbyte_agent_sdk.connectors.gitlab.types.MergeRequestsGtCondition | airbyte_agent_sdk.connectors.gitlab.types.MergeRequestsGteCondition | airbyte_agent_sdk.connectors.gitlab.types.MergeRequestsLtCondition | airbyte_agent_sdk.connectors.gitlab.types.MergeRequestsLteCondition | airbyte_agent_sdk.connectors.gitlab.types.MergeRequestsInCondition | airbyte_agent_sdk.connectors.gitlab.types.MergeRequestsLikeCondition | airbyte_agent_sdk.connectors.gitlab.types.MergeRequestsFuzzyCondition | airbyte_agent_sdk.connectors.gitlab.types.MergeRequestsKeywordCondition | airbyte_agent_sdk.connectors.gitlab.types.MergeRequestsContainsCondition | airbyte_agent_sdk.connectors.gitlab.types.MergeRequestsNotCondition | airbyte_agent_sdk.connectors.gitlab.types.MergeRequestsAndCondition | airbyte_agent_sdk.connectors.gitlab.types.MergeRequestsOrCondition | airbyte_agent_sdk.connectors.gitlab.types.MergeRequestsAnyCondition]`
     :   The type of the None singleton.
+
+<a id="MergeRequestsSearchFilter"></a>
 
 `MergeRequestsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering merge_requests search queries.
@@ -4430,6 +4748,8 @@ Classes
     `work_in_progress: bool | None`
     :   Whether the merge request is a work in progress
 
+<a id="MergeRequestsSearchQuery"></a>
+
 `MergeRequestsSearchQuery(*args, **kwargs)`
 :   Search query for merge_requests entity.
 
@@ -4444,6 +4764,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.gitlab.types.MergeRequestsSortFilter]`
     :   The type of the None singleton.
+
+<a id="MergeRequestsSortFilter"></a>
 
 `MergeRequestsSortFilter(*args, **kwargs)`
 :   Available fields for sorting merge_requests search results.
@@ -4604,6 +4926,8 @@ Classes
     `work_in_progress: Literal['asc', 'desc']`
     :   Whether the merge request is a work in progress
 
+<a id="MergeRequestsStringFilter"></a>
+
 `MergeRequestsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -4763,6 +5087,8 @@ Classes
     `work_in_progress: str`
     :   Whether the merge request is a work in progress
 
+<a id="PipelinesAndCondition"></a>
+
 `PipelinesAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -4783,6 +5109,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.gitlab.types.PipelinesEqCondition | airbyte_agent_sdk.connectors.gitlab.types.PipelinesNeqCondition | airbyte_agent_sdk.connectors.gitlab.types.PipelinesGtCondition | airbyte_agent_sdk.connectors.gitlab.types.PipelinesGteCondition | airbyte_agent_sdk.connectors.gitlab.types.PipelinesLtCondition | airbyte_agent_sdk.connectors.gitlab.types.PipelinesLteCondition | airbyte_agent_sdk.connectors.gitlab.types.PipelinesInCondition | airbyte_agent_sdk.connectors.gitlab.types.PipelinesLikeCondition | airbyte_agent_sdk.connectors.gitlab.types.PipelinesFuzzyCondition | airbyte_agent_sdk.connectors.gitlab.types.PipelinesKeywordCondition | airbyte_agent_sdk.connectors.gitlab.types.PipelinesContainsCondition | airbyte_agent_sdk.connectors.gitlab.types.PipelinesNotCondition | airbyte_agent_sdk.connectors.gitlab.types.PipelinesAndCondition | airbyte_agent_sdk.connectors.gitlab.types.PipelinesOrCondition | airbyte_agent_sdk.connectors.gitlab.types.PipelinesAnyCondition]`
     :   The type of the None singleton.
 
+<a id="PipelinesAnyCondition"></a>
+
 `PipelinesAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -4802,6 +5130,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.gitlab.types.PipelinesAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="PipelinesAnyValueFilter"></a>
 
 `PipelinesAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -4845,6 +5175,8 @@ Classes
     `web_url: Any`
     :   Web URL of the pipeline
 
+<a id="PipelinesContainsCondition"></a>
+
 `PipelinesContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -4856,6 +5188,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.gitlab.types.PipelinesAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="PipelinesEqCondition"></a>
 
 `PipelinesEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -4869,6 +5203,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.gitlab.types.PipelinesSearchFilter`
     :   The type of the None singleton.
 
+<a id="PipelinesFuzzyCondition"></a>
+
 `PipelinesFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -4880,6 +5216,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.gitlab.types.PipelinesStringFilter`
     :   The type of the None singleton.
+
+<a id="PipelinesGetParams"></a>
 
 `PipelinesGetParams(*args, **kwargs)`
 :   Parameters for pipelines.get operation
@@ -4896,6 +5234,8 @@ Classes
     `project_id: str`
     :   The type of the None singleton.
 
+<a id="PipelinesGtCondition"></a>
+
 `PipelinesGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -4908,6 +5248,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.gitlab.types.PipelinesSearchFilter`
     :   The type of the None singleton.
 
+<a id="PipelinesGteCondition"></a>
+
 `PipelinesGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -4919,6 +5261,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.gitlab.types.PipelinesSearchFilter`
     :   The type of the None singleton.
+
+<a id="PipelinesInCondition"></a>
 
 `PipelinesInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -4939,6 +5283,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.gitlab.types.PipelinesInFilter`
     :   The type of the None singleton.
+
+<a id="PipelinesInFilter"></a>
 
 `PipelinesInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -4982,6 +5328,8 @@ Classes
     `web_url: list[str]`
     :   Web URL of the pipeline
 
+<a id="PipelinesKeywordCondition"></a>
+
 `PipelinesKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -4994,6 +5342,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.gitlab.types.PipelinesStringFilter`
     :   The type of the None singleton.
 
+<a id="PipelinesLikeCondition"></a>
+
 `PipelinesLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -5005,6 +5355,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.gitlab.types.PipelinesStringFilter`
     :   The type of the None singleton.
+
+<a id="PipelinesListParams"></a>
 
 `PipelinesListParams(*args, **kwargs)`
 :   Parameters for pipelines.list operation
@@ -5036,6 +5388,8 @@ Classes
     `status: str`
     :   The type of the None singleton.
 
+<a id="PipelinesLtCondition"></a>
+
 `PipelinesLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -5047,6 +5401,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.gitlab.types.PipelinesSearchFilter`
     :   The type of the None singleton.
+
+<a id="PipelinesLteCondition"></a>
 
 `PipelinesLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -5060,6 +5416,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.gitlab.types.PipelinesSearchFilter`
     :   The type of the None singleton.
 
+<a id="PipelinesNeqCondition"></a>
+
 `PipelinesNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -5071,6 +5429,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.gitlab.types.PipelinesSearchFilter`
     :   The type of the None singleton.
+
+<a id="PipelinesNotCondition"></a>
 
 `PipelinesNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -5092,6 +5452,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.gitlab.types.PipelinesEqCondition | airbyte_agent_sdk.connectors.gitlab.types.PipelinesNeqCondition | airbyte_agent_sdk.connectors.gitlab.types.PipelinesGtCondition | airbyte_agent_sdk.connectors.gitlab.types.PipelinesGteCondition | airbyte_agent_sdk.connectors.gitlab.types.PipelinesLtCondition | airbyte_agent_sdk.connectors.gitlab.types.PipelinesLteCondition | airbyte_agent_sdk.connectors.gitlab.types.PipelinesInCondition | airbyte_agent_sdk.connectors.gitlab.types.PipelinesLikeCondition | airbyte_agent_sdk.connectors.gitlab.types.PipelinesFuzzyCondition | airbyte_agent_sdk.connectors.gitlab.types.PipelinesKeywordCondition | airbyte_agent_sdk.connectors.gitlab.types.PipelinesContainsCondition | airbyte_agent_sdk.connectors.gitlab.types.PipelinesNotCondition | airbyte_agent_sdk.connectors.gitlab.types.PipelinesAndCondition | airbyte_agent_sdk.connectors.gitlab.types.PipelinesOrCondition | airbyte_agent_sdk.connectors.gitlab.types.PipelinesAnyCondition`
     :   The type of the None singleton.
 
+<a id="PipelinesOrCondition"></a>
+
 `PipelinesOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -5111,6 +5473,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.gitlab.types.PipelinesEqCondition | airbyte_agent_sdk.connectors.gitlab.types.PipelinesNeqCondition | airbyte_agent_sdk.connectors.gitlab.types.PipelinesGtCondition | airbyte_agent_sdk.connectors.gitlab.types.PipelinesGteCondition | airbyte_agent_sdk.connectors.gitlab.types.PipelinesLtCondition | airbyte_agent_sdk.connectors.gitlab.types.PipelinesLteCondition | airbyte_agent_sdk.connectors.gitlab.types.PipelinesInCondition | airbyte_agent_sdk.connectors.gitlab.types.PipelinesLikeCondition | airbyte_agent_sdk.connectors.gitlab.types.PipelinesFuzzyCondition | airbyte_agent_sdk.connectors.gitlab.types.PipelinesKeywordCondition | airbyte_agent_sdk.connectors.gitlab.types.PipelinesContainsCondition | airbyte_agent_sdk.connectors.gitlab.types.PipelinesNotCondition | airbyte_agent_sdk.connectors.gitlab.types.PipelinesAndCondition | airbyte_agent_sdk.connectors.gitlab.types.PipelinesOrCondition | airbyte_agent_sdk.connectors.gitlab.types.PipelinesAnyCondition]`
     :   The type of the None singleton.
+
+<a id="PipelinesSearchFilter"></a>
 
 `PipelinesSearchFilter(*args, **kwargs)`
 :   Available fields for filtering pipelines search queries.
@@ -5154,6 +5518,8 @@ Classes
     `web_url: str | None`
     :   Web URL of the pipeline
 
+<a id="PipelinesSearchQuery"></a>
+
 `PipelinesSearchQuery(*args, **kwargs)`
 :   Search query for pipelines entity.
 
@@ -5168,6 +5534,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.gitlab.types.PipelinesSortFilter]`
     :   The type of the None singleton.
+
+<a id="PipelinesSortFilter"></a>
 
 `PipelinesSortFilter(*args, **kwargs)`
 :   Available fields for sorting pipelines search results.
@@ -5211,6 +5579,8 @@ Classes
     `web_url: Literal['asc', 'desc']`
     :   Web URL of the pipeline
 
+<a id="PipelinesStringFilter"></a>
+
 `PipelinesStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -5253,6 +5623,8 @@ Classes
     `web_url: str`
     :   Web URL of the pipeline
 
+<a id="ProjectMembersAndCondition"></a>
+
 `ProjectMembersAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -5273,6 +5645,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.gitlab.types.ProjectMembersEqCondition | airbyte_agent_sdk.connectors.gitlab.types.ProjectMembersNeqCondition | airbyte_agent_sdk.connectors.gitlab.types.ProjectMembersGtCondition | airbyte_agent_sdk.connectors.gitlab.types.ProjectMembersGteCondition | airbyte_agent_sdk.connectors.gitlab.types.ProjectMembersLtCondition | airbyte_agent_sdk.connectors.gitlab.types.ProjectMembersLteCondition | airbyte_agent_sdk.connectors.gitlab.types.ProjectMembersInCondition | airbyte_agent_sdk.connectors.gitlab.types.ProjectMembersLikeCondition | airbyte_agent_sdk.connectors.gitlab.types.ProjectMembersFuzzyCondition | airbyte_agent_sdk.connectors.gitlab.types.ProjectMembersKeywordCondition | airbyte_agent_sdk.connectors.gitlab.types.ProjectMembersContainsCondition | airbyte_agent_sdk.connectors.gitlab.types.ProjectMembersNotCondition | airbyte_agent_sdk.connectors.gitlab.types.ProjectMembersAndCondition | airbyte_agent_sdk.connectors.gitlab.types.ProjectMembersOrCondition | airbyte_agent_sdk.connectors.gitlab.types.ProjectMembersAnyCondition]`
     :   The type of the None singleton.
 
+<a id="ProjectMembersAnyCondition"></a>
+
 `ProjectMembersAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -5292,6 +5666,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.gitlab.types.ProjectMembersAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="ProjectMembersAnyValueFilter"></a>
 
 `ProjectMembersAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -5341,6 +5717,8 @@ Classes
     `web_url: Any`
     :   Web URL of the member profile
 
+<a id="ProjectMembersContainsCondition"></a>
+
 `ProjectMembersContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -5352,6 +5730,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.gitlab.types.ProjectMembersAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="ProjectMembersEqCondition"></a>
 
 `ProjectMembersEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -5365,6 +5745,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.gitlab.types.ProjectMembersSearchFilter`
     :   The type of the None singleton.
 
+<a id="ProjectMembersFuzzyCondition"></a>
+
 `ProjectMembersFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -5376,6 +5758,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.gitlab.types.ProjectMembersStringFilter`
     :   The type of the None singleton.
+
+<a id="ProjectMembersGetParams"></a>
 
 `ProjectMembersGetParams(*args, **kwargs)`
 :   Parameters for project_members.get operation
@@ -5392,6 +5776,8 @@ Classes
     `user_id: str`
     :   The type of the None singleton.
 
+<a id="ProjectMembersGtCondition"></a>
+
 `ProjectMembersGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -5404,6 +5790,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.gitlab.types.ProjectMembersSearchFilter`
     :   The type of the None singleton.
 
+<a id="ProjectMembersGteCondition"></a>
+
 `ProjectMembersGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -5415,6 +5803,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.gitlab.types.ProjectMembersSearchFilter`
     :   The type of the None singleton.
+
+<a id="ProjectMembersInCondition"></a>
 
 `ProjectMembersInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -5435,6 +5825,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.gitlab.types.ProjectMembersInFilter`
     :   The type of the None singleton.
+
+<a id="ProjectMembersInFilter"></a>
 
 `ProjectMembersInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -5484,6 +5876,8 @@ Classes
     `web_url: list[str]`
     :   Web URL of the member profile
 
+<a id="ProjectMembersKeywordCondition"></a>
+
 `ProjectMembersKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -5496,6 +5890,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.gitlab.types.ProjectMembersStringFilter`
     :   The type of the None singleton.
 
+<a id="ProjectMembersLikeCondition"></a>
+
 `ProjectMembersLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -5507,6 +5903,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.gitlab.types.ProjectMembersStringFilter`
     :   The type of the None singleton.
+
+<a id="ProjectMembersListParams"></a>
 
 `ProjectMembersListParams(*args, **kwargs)`
 :   Parameters for project_members.list operation
@@ -5529,6 +5927,8 @@ Classes
     `query: str`
     :   The type of the None singleton.
 
+<a id="ProjectMembersLtCondition"></a>
+
 `ProjectMembersLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -5540,6 +5940,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.gitlab.types.ProjectMembersSearchFilter`
     :   The type of the None singleton.
+
+<a id="ProjectMembersLteCondition"></a>
 
 `ProjectMembersLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -5553,6 +5955,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.gitlab.types.ProjectMembersSearchFilter`
     :   The type of the None singleton.
 
+<a id="ProjectMembersNeqCondition"></a>
+
 `ProjectMembersNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -5564,6 +5968,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.gitlab.types.ProjectMembersSearchFilter`
     :   The type of the None singleton.
+
+<a id="ProjectMembersNotCondition"></a>
 
 `ProjectMembersNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -5585,6 +5991,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.gitlab.types.ProjectMembersEqCondition | airbyte_agent_sdk.connectors.gitlab.types.ProjectMembersNeqCondition | airbyte_agent_sdk.connectors.gitlab.types.ProjectMembersGtCondition | airbyte_agent_sdk.connectors.gitlab.types.ProjectMembersGteCondition | airbyte_agent_sdk.connectors.gitlab.types.ProjectMembersLtCondition | airbyte_agent_sdk.connectors.gitlab.types.ProjectMembersLteCondition | airbyte_agent_sdk.connectors.gitlab.types.ProjectMembersInCondition | airbyte_agent_sdk.connectors.gitlab.types.ProjectMembersLikeCondition | airbyte_agent_sdk.connectors.gitlab.types.ProjectMembersFuzzyCondition | airbyte_agent_sdk.connectors.gitlab.types.ProjectMembersKeywordCondition | airbyte_agent_sdk.connectors.gitlab.types.ProjectMembersContainsCondition | airbyte_agent_sdk.connectors.gitlab.types.ProjectMembersNotCondition | airbyte_agent_sdk.connectors.gitlab.types.ProjectMembersAndCondition | airbyte_agent_sdk.connectors.gitlab.types.ProjectMembersOrCondition | airbyte_agent_sdk.connectors.gitlab.types.ProjectMembersAnyCondition`
     :   The type of the None singleton.
 
+<a id="ProjectMembersOrCondition"></a>
+
 `ProjectMembersOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -5604,6 +6012,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.gitlab.types.ProjectMembersEqCondition | airbyte_agent_sdk.connectors.gitlab.types.ProjectMembersNeqCondition | airbyte_agent_sdk.connectors.gitlab.types.ProjectMembersGtCondition | airbyte_agent_sdk.connectors.gitlab.types.ProjectMembersGteCondition | airbyte_agent_sdk.connectors.gitlab.types.ProjectMembersLtCondition | airbyte_agent_sdk.connectors.gitlab.types.ProjectMembersLteCondition | airbyte_agent_sdk.connectors.gitlab.types.ProjectMembersInCondition | airbyte_agent_sdk.connectors.gitlab.types.ProjectMembersLikeCondition | airbyte_agent_sdk.connectors.gitlab.types.ProjectMembersFuzzyCondition | airbyte_agent_sdk.connectors.gitlab.types.ProjectMembersKeywordCondition | airbyte_agent_sdk.connectors.gitlab.types.ProjectMembersContainsCondition | airbyte_agent_sdk.connectors.gitlab.types.ProjectMembersNotCondition | airbyte_agent_sdk.connectors.gitlab.types.ProjectMembersAndCondition | airbyte_agent_sdk.connectors.gitlab.types.ProjectMembersOrCondition | airbyte_agent_sdk.connectors.gitlab.types.ProjectMembersAnyCondition]`
     :   The type of the None singleton.
+
+<a id="ProjectMembersSearchFilter"></a>
 
 `ProjectMembersSearchFilter(*args, **kwargs)`
 :   Available fields for filtering project_members search queries.
@@ -5653,6 +6063,8 @@ Classes
     `web_url: str | None`
     :   Web URL of the member profile
 
+<a id="ProjectMembersSearchQuery"></a>
+
 `ProjectMembersSearchQuery(*args, **kwargs)`
 :   Search query for project_members entity.
 
@@ -5667,6 +6079,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.gitlab.types.ProjectMembersSortFilter]`
     :   The type of the None singleton.
+
+<a id="ProjectMembersSortFilter"></a>
 
 `ProjectMembersSortFilter(*args, **kwargs)`
 :   Available fields for sorting project_members search results.
@@ -5716,6 +6130,8 @@ Classes
     `web_url: Literal['asc', 'desc']`
     :   Web URL of the member profile
 
+<a id="ProjectMembersStringFilter"></a>
+
 `ProjectMembersStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -5764,6 +6180,8 @@ Classes
     `web_url: str`
     :   Web URL of the member profile
 
+<a id="ProjectMilestonesAndCondition"></a>
+
 `ProjectMilestonesAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -5784,6 +6202,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.gitlab.types.ProjectMilestonesEqCondition | airbyte_agent_sdk.connectors.gitlab.types.ProjectMilestonesNeqCondition | airbyte_agent_sdk.connectors.gitlab.types.ProjectMilestonesGtCondition | airbyte_agent_sdk.connectors.gitlab.types.ProjectMilestonesGteCondition | airbyte_agent_sdk.connectors.gitlab.types.ProjectMilestonesLtCondition | airbyte_agent_sdk.connectors.gitlab.types.ProjectMilestonesLteCondition | airbyte_agent_sdk.connectors.gitlab.types.ProjectMilestonesInCondition | airbyte_agent_sdk.connectors.gitlab.types.ProjectMilestonesLikeCondition | airbyte_agent_sdk.connectors.gitlab.types.ProjectMilestonesFuzzyCondition | airbyte_agent_sdk.connectors.gitlab.types.ProjectMilestonesKeywordCondition | airbyte_agent_sdk.connectors.gitlab.types.ProjectMilestonesContainsCondition | airbyte_agent_sdk.connectors.gitlab.types.ProjectMilestonesNotCondition | airbyte_agent_sdk.connectors.gitlab.types.ProjectMilestonesAndCondition | airbyte_agent_sdk.connectors.gitlab.types.ProjectMilestonesOrCondition | airbyte_agent_sdk.connectors.gitlab.types.ProjectMilestonesAnyCondition]`
     :   The type of the None singleton.
 
+<a id="ProjectMilestonesAnyCondition"></a>
+
 `ProjectMilestonesAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -5803,6 +6223,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.gitlab.types.ProjectMilestonesAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="ProjectMilestonesAnyValueFilter"></a>
 
 `ProjectMilestonesAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -5849,6 +6271,8 @@ Classes
     `web_url: Any`
     :   Web URL of the milestone
 
+<a id="ProjectMilestonesContainsCondition"></a>
+
 `ProjectMilestonesContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -5860,6 +6284,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.gitlab.types.ProjectMilestonesAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="ProjectMilestonesEqCondition"></a>
 
 `ProjectMilestonesEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -5873,6 +6299,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.gitlab.types.ProjectMilestonesSearchFilter`
     :   The type of the None singleton.
 
+<a id="ProjectMilestonesFuzzyCondition"></a>
+
 `ProjectMilestonesFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -5884,6 +6312,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.gitlab.types.ProjectMilestonesStringFilter`
     :   The type of the None singleton.
+
+<a id="ProjectMilestonesGetParams"></a>
 
 `ProjectMilestonesGetParams(*args, **kwargs)`
 :   Parameters for project_milestones.get operation
@@ -5900,6 +6330,8 @@ Classes
     `project_id: str`
     :   The type of the None singleton.
 
+<a id="ProjectMilestonesGtCondition"></a>
+
 `ProjectMilestonesGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -5912,6 +6344,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.gitlab.types.ProjectMilestonesSearchFilter`
     :   The type of the None singleton.
 
+<a id="ProjectMilestonesGteCondition"></a>
+
 `ProjectMilestonesGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -5923,6 +6357,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.gitlab.types.ProjectMilestonesSearchFilter`
     :   The type of the None singleton.
+
+<a id="ProjectMilestonesInCondition"></a>
 
 `ProjectMilestonesInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -5943,6 +6379,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.gitlab.types.ProjectMilestonesInFilter`
     :   The type of the None singleton.
+
+<a id="ProjectMilestonesInFilter"></a>
 
 `ProjectMilestonesInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -5989,6 +6427,8 @@ Classes
     `web_url: list[str]`
     :   Web URL of the milestone
 
+<a id="ProjectMilestonesKeywordCondition"></a>
+
 `ProjectMilestonesKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -6001,6 +6441,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.gitlab.types.ProjectMilestonesStringFilter`
     :   The type of the None singleton.
 
+<a id="ProjectMilestonesLikeCondition"></a>
+
 `ProjectMilestonesLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -6012,6 +6454,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.gitlab.types.ProjectMilestonesStringFilter`
     :   The type of the None singleton.
+
+<a id="ProjectMilestonesListParams"></a>
 
 `ProjectMilestonesListParams(*args, **kwargs)`
 :   Parameters for project_milestones.list operation
@@ -6037,6 +6481,8 @@ Classes
     `state: str`
     :   The type of the None singleton.
 
+<a id="ProjectMilestonesLtCondition"></a>
+
 `ProjectMilestonesLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -6048,6 +6494,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.gitlab.types.ProjectMilestonesSearchFilter`
     :   The type of the None singleton.
+
+<a id="ProjectMilestonesLteCondition"></a>
 
 `ProjectMilestonesLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -6061,6 +6509,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.gitlab.types.ProjectMilestonesSearchFilter`
     :   The type of the None singleton.
 
+<a id="ProjectMilestonesNeqCondition"></a>
+
 `ProjectMilestonesNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -6072,6 +6522,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.gitlab.types.ProjectMilestonesSearchFilter`
     :   The type of the None singleton.
+
+<a id="ProjectMilestonesNotCondition"></a>
 
 `ProjectMilestonesNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -6093,6 +6545,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.gitlab.types.ProjectMilestonesEqCondition | airbyte_agent_sdk.connectors.gitlab.types.ProjectMilestonesNeqCondition | airbyte_agent_sdk.connectors.gitlab.types.ProjectMilestonesGtCondition | airbyte_agent_sdk.connectors.gitlab.types.ProjectMilestonesGteCondition | airbyte_agent_sdk.connectors.gitlab.types.ProjectMilestonesLtCondition | airbyte_agent_sdk.connectors.gitlab.types.ProjectMilestonesLteCondition | airbyte_agent_sdk.connectors.gitlab.types.ProjectMilestonesInCondition | airbyte_agent_sdk.connectors.gitlab.types.ProjectMilestonesLikeCondition | airbyte_agent_sdk.connectors.gitlab.types.ProjectMilestonesFuzzyCondition | airbyte_agent_sdk.connectors.gitlab.types.ProjectMilestonesKeywordCondition | airbyte_agent_sdk.connectors.gitlab.types.ProjectMilestonesContainsCondition | airbyte_agent_sdk.connectors.gitlab.types.ProjectMilestonesNotCondition | airbyte_agent_sdk.connectors.gitlab.types.ProjectMilestonesAndCondition | airbyte_agent_sdk.connectors.gitlab.types.ProjectMilestonesOrCondition | airbyte_agent_sdk.connectors.gitlab.types.ProjectMilestonesAnyCondition`
     :   The type of the None singleton.
 
+<a id="ProjectMilestonesOrCondition"></a>
+
 `ProjectMilestonesOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -6112,6 +6566,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.gitlab.types.ProjectMilestonesEqCondition | airbyte_agent_sdk.connectors.gitlab.types.ProjectMilestonesNeqCondition | airbyte_agent_sdk.connectors.gitlab.types.ProjectMilestonesGtCondition | airbyte_agent_sdk.connectors.gitlab.types.ProjectMilestonesGteCondition | airbyte_agent_sdk.connectors.gitlab.types.ProjectMilestonesLtCondition | airbyte_agent_sdk.connectors.gitlab.types.ProjectMilestonesLteCondition | airbyte_agent_sdk.connectors.gitlab.types.ProjectMilestonesInCondition | airbyte_agent_sdk.connectors.gitlab.types.ProjectMilestonesLikeCondition | airbyte_agent_sdk.connectors.gitlab.types.ProjectMilestonesFuzzyCondition | airbyte_agent_sdk.connectors.gitlab.types.ProjectMilestonesKeywordCondition | airbyte_agent_sdk.connectors.gitlab.types.ProjectMilestonesContainsCondition | airbyte_agent_sdk.connectors.gitlab.types.ProjectMilestonesNotCondition | airbyte_agent_sdk.connectors.gitlab.types.ProjectMilestonesAndCondition | airbyte_agent_sdk.connectors.gitlab.types.ProjectMilestonesOrCondition | airbyte_agent_sdk.connectors.gitlab.types.ProjectMilestonesAnyCondition]`
     :   The type of the None singleton.
+
+<a id="ProjectMilestonesSearchFilter"></a>
 
 `ProjectMilestonesSearchFilter(*args, **kwargs)`
 :   Available fields for filtering project_milestones search queries.
@@ -6158,6 +6614,8 @@ Classes
     `web_url: str | None`
     :   Web URL of the milestone
 
+<a id="ProjectMilestonesSearchQuery"></a>
+
 `ProjectMilestonesSearchQuery(*args, **kwargs)`
 :   Search query for project_milestones entity.
 
@@ -6172,6 +6630,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.gitlab.types.ProjectMilestonesSortFilter]`
     :   The type of the None singleton.
+
+<a id="ProjectMilestonesSortFilter"></a>
 
 `ProjectMilestonesSortFilter(*args, **kwargs)`
 :   Available fields for sorting project_milestones search results.
@@ -6218,6 +6678,8 @@ Classes
     `web_url: Literal['asc', 'desc']`
     :   Web URL of the milestone
 
+<a id="ProjectMilestonesStringFilter"></a>
+
 `ProjectMilestonesStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -6263,6 +6725,8 @@ Classes
     `web_url: str`
     :   Web URL of the milestone
 
+<a id="ProjectsAndCondition"></a>
+
 `ProjectsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -6283,6 +6747,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.gitlab.types.ProjectsEqCondition | airbyte_agent_sdk.connectors.gitlab.types.ProjectsNeqCondition | airbyte_agent_sdk.connectors.gitlab.types.ProjectsGtCondition | airbyte_agent_sdk.connectors.gitlab.types.ProjectsGteCondition | airbyte_agent_sdk.connectors.gitlab.types.ProjectsLtCondition | airbyte_agent_sdk.connectors.gitlab.types.ProjectsLteCondition | airbyte_agent_sdk.connectors.gitlab.types.ProjectsInCondition | airbyte_agent_sdk.connectors.gitlab.types.ProjectsLikeCondition | airbyte_agent_sdk.connectors.gitlab.types.ProjectsFuzzyCondition | airbyte_agent_sdk.connectors.gitlab.types.ProjectsKeywordCondition | airbyte_agent_sdk.connectors.gitlab.types.ProjectsContainsCondition | airbyte_agent_sdk.connectors.gitlab.types.ProjectsNotCondition | airbyte_agent_sdk.connectors.gitlab.types.ProjectsAndCondition | airbyte_agent_sdk.connectors.gitlab.types.ProjectsOrCondition | airbyte_agent_sdk.connectors.gitlab.types.ProjectsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="ProjectsAnyCondition"></a>
+
 `ProjectsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -6302,6 +6768,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.gitlab.types.ProjectsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="ProjectsAnyValueFilter"></a>
 
 `ProjectsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -6549,6 +7017,8 @@ Classes
     `wiki_enabled: Any`
     :   Whether wiki is enabled
 
+<a id="ProjectsContainsCondition"></a>
+
 `ProjectsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -6560,6 +7030,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.gitlab.types.ProjectsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="ProjectsEqCondition"></a>
 
 `ProjectsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -6573,6 +7045,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.gitlab.types.ProjectsSearchFilter`
     :   The type of the None singleton.
 
+<a id="ProjectsFuzzyCondition"></a>
+
 `ProjectsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -6584,6 +7058,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.gitlab.types.ProjectsStringFilter`
     :   The type of the None singleton.
+
+<a id="ProjectsGetParams"></a>
 
 `ProjectsGetParams(*args, **kwargs)`
 :   Parameters for projects.get operation
@@ -6600,6 +7076,8 @@ Classes
     `statistics: bool`
     :   The type of the None singleton.
 
+<a id="ProjectsGtCondition"></a>
+
 `ProjectsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -6612,6 +7090,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.gitlab.types.ProjectsSearchFilter`
     :   The type of the None singleton.
 
+<a id="ProjectsGteCondition"></a>
+
 `ProjectsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -6623,6 +7103,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.gitlab.types.ProjectsSearchFilter`
     :   The type of the None singleton.
+
+<a id="ProjectsInCondition"></a>
 
 `ProjectsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -6643,6 +7125,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.gitlab.types.ProjectsInFilter`
     :   The type of the None singleton.
+
+<a id="ProjectsInFilter"></a>
 
 `ProjectsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -6890,6 +7374,8 @@ Classes
     `wiki_enabled: list[bool]`
     :   Whether wiki is enabled
 
+<a id="ProjectsKeywordCondition"></a>
+
 `ProjectsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -6902,6 +7388,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.gitlab.types.ProjectsStringFilter`
     :   The type of the None singleton.
 
+<a id="ProjectsLikeCondition"></a>
+
 `ProjectsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -6913,6 +7401,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.gitlab.types.ProjectsStringFilter`
     :   The type of the None singleton.
+
+<a id="ProjectsListParams"></a>
 
 `ProjectsListParams(*args, **kwargs)`
 :   Parameters for projects.list operation
@@ -6944,6 +7434,8 @@ Classes
     `sort: str`
     :   The type of the None singleton.
 
+<a id="ProjectsLtCondition"></a>
+
 `ProjectsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -6955,6 +7447,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.gitlab.types.ProjectsSearchFilter`
     :   The type of the None singleton.
+
+<a id="ProjectsLteCondition"></a>
 
 `ProjectsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -6968,6 +7462,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.gitlab.types.ProjectsSearchFilter`
     :   The type of the None singleton.
 
+<a id="ProjectsNeqCondition"></a>
+
 `ProjectsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -6979,6 +7475,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.gitlab.types.ProjectsSearchFilter`
     :   The type of the None singleton.
+
+<a id="ProjectsNotCondition"></a>
 
 `ProjectsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -7000,6 +7498,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.gitlab.types.ProjectsEqCondition | airbyte_agent_sdk.connectors.gitlab.types.ProjectsNeqCondition | airbyte_agent_sdk.connectors.gitlab.types.ProjectsGtCondition | airbyte_agent_sdk.connectors.gitlab.types.ProjectsGteCondition | airbyte_agent_sdk.connectors.gitlab.types.ProjectsLtCondition | airbyte_agent_sdk.connectors.gitlab.types.ProjectsLteCondition | airbyte_agent_sdk.connectors.gitlab.types.ProjectsInCondition | airbyte_agent_sdk.connectors.gitlab.types.ProjectsLikeCondition | airbyte_agent_sdk.connectors.gitlab.types.ProjectsFuzzyCondition | airbyte_agent_sdk.connectors.gitlab.types.ProjectsKeywordCondition | airbyte_agent_sdk.connectors.gitlab.types.ProjectsContainsCondition | airbyte_agent_sdk.connectors.gitlab.types.ProjectsNotCondition | airbyte_agent_sdk.connectors.gitlab.types.ProjectsAndCondition | airbyte_agent_sdk.connectors.gitlab.types.ProjectsOrCondition | airbyte_agent_sdk.connectors.gitlab.types.ProjectsAnyCondition`
     :   The type of the None singleton.
 
+<a id="ProjectsOrCondition"></a>
+
 `ProjectsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -7019,6 +7519,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.gitlab.types.ProjectsEqCondition | airbyte_agent_sdk.connectors.gitlab.types.ProjectsNeqCondition | airbyte_agent_sdk.connectors.gitlab.types.ProjectsGtCondition | airbyte_agent_sdk.connectors.gitlab.types.ProjectsGteCondition | airbyte_agent_sdk.connectors.gitlab.types.ProjectsLtCondition | airbyte_agent_sdk.connectors.gitlab.types.ProjectsLteCondition | airbyte_agent_sdk.connectors.gitlab.types.ProjectsInCondition | airbyte_agent_sdk.connectors.gitlab.types.ProjectsLikeCondition | airbyte_agent_sdk.connectors.gitlab.types.ProjectsFuzzyCondition | airbyte_agent_sdk.connectors.gitlab.types.ProjectsKeywordCondition | airbyte_agent_sdk.connectors.gitlab.types.ProjectsContainsCondition | airbyte_agent_sdk.connectors.gitlab.types.ProjectsNotCondition | airbyte_agent_sdk.connectors.gitlab.types.ProjectsAndCondition | airbyte_agent_sdk.connectors.gitlab.types.ProjectsOrCondition | airbyte_agent_sdk.connectors.gitlab.types.ProjectsAnyCondition]`
     :   The type of the None singleton.
+
+<a id="ProjectsSearchFilter"></a>
 
 `ProjectsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering projects search queries.
@@ -7266,6 +7768,8 @@ Classes
     `wiki_enabled: bool | None`
     :   Whether wiki is enabled
 
+<a id="ProjectsSearchQuery"></a>
+
 `ProjectsSearchQuery(*args, **kwargs)`
 :   Search query for projects entity.
 
@@ -7280,6 +7784,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.gitlab.types.ProjectsSortFilter]`
     :   The type of the None singleton.
+
+<a id="ProjectsSortFilter"></a>
 
 `ProjectsSortFilter(*args, **kwargs)`
 :   Available fields for sorting projects search results.
@@ -7527,6 +8033,8 @@ Classes
     `wiki_enabled: Literal['asc', 'desc']`
     :   Whether wiki is enabled
 
+<a id="ProjectsStringFilter"></a>
+
 `ProjectsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -7773,6 +8281,8 @@ Classes
     `wiki_enabled: str`
     :   Whether wiki is enabled
 
+<a id="ReleasesAndCondition"></a>
+
 `ReleasesAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -7793,6 +8303,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.gitlab.types.ReleasesEqCondition | airbyte_agent_sdk.connectors.gitlab.types.ReleasesNeqCondition | airbyte_agent_sdk.connectors.gitlab.types.ReleasesGtCondition | airbyte_agent_sdk.connectors.gitlab.types.ReleasesGteCondition | airbyte_agent_sdk.connectors.gitlab.types.ReleasesLtCondition | airbyte_agent_sdk.connectors.gitlab.types.ReleasesLteCondition | airbyte_agent_sdk.connectors.gitlab.types.ReleasesInCondition | airbyte_agent_sdk.connectors.gitlab.types.ReleasesLikeCondition | airbyte_agent_sdk.connectors.gitlab.types.ReleasesFuzzyCondition | airbyte_agent_sdk.connectors.gitlab.types.ReleasesKeywordCondition | airbyte_agent_sdk.connectors.gitlab.types.ReleasesContainsCondition | airbyte_agent_sdk.connectors.gitlab.types.ReleasesNotCondition | airbyte_agent_sdk.connectors.gitlab.types.ReleasesAndCondition | airbyte_agent_sdk.connectors.gitlab.types.ReleasesOrCondition | airbyte_agent_sdk.connectors.gitlab.types.ReleasesAnyCondition]`
     :   The type of the None singleton.
 
+<a id="ReleasesAnyCondition"></a>
+
 `ReleasesAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -7812,6 +8324,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.gitlab.types.ReleasesAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="ReleasesAnyValueFilter"></a>
 
 `ReleasesAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -7873,6 +8387,8 @@ Classes
     `upcoming_release: Any`
     :   Whether this is an upcoming release
 
+<a id="ReleasesContainsCondition"></a>
+
 `ReleasesContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -7884,6 +8400,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.gitlab.types.ReleasesAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="ReleasesEqCondition"></a>
 
 `ReleasesEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -7897,6 +8415,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.gitlab.types.ReleasesSearchFilter`
     :   The type of the None singleton.
 
+<a id="ReleasesFuzzyCondition"></a>
+
 `ReleasesFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -7908,6 +8428,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.gitlab.types.ReleasesStringFilter`
     :   The type of the None singleton.
+
+<a id="ReleasesGetParams"></a>
 
 `ReleasesGetParams(*args, **kwargs)`
 :   Parameters for releases.get operation
@@ -7924,6 +8446,8 @@ Classes
     `tag_name: str`
     :   The type of the None singleton.
 
+<a id="ReleasesGtCondition"></a>
+
 `ReleasesGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -7936,6 +8460,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.gitlab.types.ReleasesSearchFilter`
     :   The type of the None singleton.
 
+<a id="ReleasesGteCondition"></a>
+
 `ReleasesGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -7947,6 +8473,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.gitlab.types.ReleasesSearchFilter`
     :   The type of the None singleton.
+
+<a id="ReleasesInCondition"></a>
 
 `ReleasesInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -7967,6 +8495,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.gitlab.types.ReleasesInFilter`
     :   The type of the None singleton.
+
+<a id="ReleasesInFilter"></a>
 
 `ReleasesInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -8028,6 +8558,8 @@ Classes
     `upcoming_release: list[bool]`
     :   Whether this is an upcoming release
 
+<a id="ReleasesKeywordCondition"></a>
+
 `ReleasesKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -8040,6 +8572,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.gitlab.types.ReleasesStringFilter`
     :   The type of the None singleton.
 
+<a id="ReleasesLikeCondition"></a>
+
 `ReleasesLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -8051,6 +8585,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.gitlab.types.ReleasesStringFilter`
     :   The type of the None singleton.
+
+<a id="ReleasesListParams"></a>
 
 `ReleasesListParams(*args, **kwargs)`
 :   Parameters for releases.list operation
@@ -8076,6 +8612,8 @@ Classes
     `sort: str`
     :   The type of the None singleton.
 
+<a id="ReleasesLtCondition"></a>
+
 `ReleasesLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -8087,6 +8625,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.gitlab.types.ReleasesSearchFilter`
     :   The type of the None singleton.
+
+<a id="ReleasesLteCondition"></a>
 
 `ReleasesLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -8100,6 +8640,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.gitlab.types.ReleasesSearchFilter`
     :   The type of the None singleton.
 
+<a id="ReleasesNeqCondition"></a>
+
 `ReleasesNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -8111,6 +8653,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.gitlab.types.ReleasesSearchFilter`
     :   The type of the None singleton.
+
+<a id="ReleasesNotCondition"></a>
 
 `ReleasesNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -8132,6 +8676,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.gitlab.types.ReleasesEqCondition | airbyte_agent_sdk.connectors.gitlab.types.ReleasesNeqCondition | airbyte_agent_sdk.connectors.gitlab.types.ReleasesGtCondition | airbyte_agent_sdk.connectors.gitlab.types.ReleasesGteCondition | airbyte_agent_sdk.connectors.gitlab.types.ReleasesLtCondition | airbyte_agent_sdk.connectors.gitlab.types.ReleasesLteCondition | airbyte_agent_sdk.connectors.gitlab.types.ReleasesInCondition | airbyte_agent_sdk.connectors.gitlab.types.ReleasesLikeCondition | airbyte_agent_sdk.connectors.gitlab.types.ReleasesFuzzyCondition | airbyte_agent_sdk.connectors.gitlab.types.ReleasesKeywordCondition | airbyte_agent_sdk.connectors.gitlab.types.ReleasesContainsCondition | airbyte_agent_sdk.connectors.gitlab.types.ReleasesNotCondition | airbyte_agent_sdk.connectors.gitlab.types.ReleasesAndCondition | airbyte_agent_sdk.connectors.gitlab.types.ReleasesOrCondition | airbyte_agent_sdk.connectors.gitlab.types.ReleasesAnyCondition`
     :   The type of the None singleton.
 
+<a id="ReleasesOrCondition"></a>
+
 `ReleasesOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -8151,6 +8697,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.gitlab.types.ReleasesEqCondition | airbyte_agent_sdk.connectors.gitlab.types.ReleasesNeqCondition | airbyte_agent_sdk.connectors.gitlab.types.ReleasesGtCondition | airbyte_agent_sdk.connectors.gitlab.types.ReleasesGteCondition | airbyte_agent_sdk.connectors.gitlab.types.ReleasesLtCondition | airbyte_agent_sdk.connectors.gitlab.types.ReleasesLteCondition | airbyte_agent_sdk.connectors.gitlab.types.ReleasesInCondition | airbyte_agent_sdk.connectors.gitlab.types.ReleasesLikeCondition | airbyte_agent_sdk.connectors.gitlab.types.ReleasesFuzzyCondition | airbyte_agent_sdk.connectors.gitlab.types.ReleasesKeywordCondition | airbyte_agent_sdk.connectors.gitlab.types.ReleasesContainsCondition | airbyte_agent_sdk.connectors.gitlab.types.ReleasesNotCondition | airbyte_agent_sdk.connectors.gitlab.types.ReleasesAndCondition | airbyte_agent_sdk.connectors.gitlab.types.ReleasesOrCondition | airbyte_agent_sdk.connectors.gitlab.types.ReleasesAnyCondition]`
     :   The type of the None singleton.
+
+<a id="ReleasesSearchFilter"></a>
 
 `ReleasesSearchFilter(*args, **kwargs)`
 :   Available fields for filtering releases search queries.
@@ -8212,6 +8760,8 @@ Classes
     `upcoming_release: bool | None`
     :   Whether this is an upcoming release
 
+<a id="ReleasesSearchQuery"></a>
+
 `ReleasesSearchQuery(*args, **kwargs)`
 :   Search query for releases entity.
 
@@ -8226,6 +8776,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.gitlab.types.ReleasesSortFilter]`
     :   The type of the None singleton.
+
+<a id="ReleasesSortFilter"></a>
 
 `ReleasesSortFilter(*args, **kwargs)`
 :   Available fields for sorting releases search results.
@@ -8287,6 +8839,8 @@ Classes
     `upcoming_release: Literal['asc', 'desc']`
     :   Whether this is an upcoming release
 
+<a id="ReleasesStringFilter"></a>
+
 `ReleasesStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -8347,6 +8901,8 @@ Classes
     `upcoming_release: str`
     :   Whether this is an upcoming release
 
+<a id="TagsAndCondition"></a>
+
 `TagsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -8367,6 +8923,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.gitlab.types.TagsEqCondition | airbyte_agent_sdk.connectors.gitlab.types.TagsNeqCondition | airbyte_agent_sdk.connectors.gitlab.types.TagsGtCondition | airbyte_agent_sdk.connectors.gitlab.types.TagsGteCondition | airbyte_agent_sdk.connectors.gitlab.types.TagsLtCondition | airbyte_agent_sdk.connectors.gitlab.types.TagsLteCondition | airbyte_agent_sdk.connectors.gitlab.types.TagsInCondition | airbyte_agent_sdk.connectors.gitlab.types.TagsLikeCondition | airbyte_agent_sdk.connectors.gitlab.types.TagsFuzzyCondition | airbyte_agent_sdk.connectors.gitlab.types.TagsKeywordCondition | airbyte_agent_sdk.connectors.gitlab.types.TagsContainsCondition | airbyte_agent_sdk.connectors.gitlab.types.TagsNotCondition | airbyte_agent_sdk.connectors.gitlab.types.TagsAndCondition | airbyte_agent_sdk.connectors.gitlab.types.TagsOrCondition | airbyte_agent_sdk.connectors.gitlab.types.TagsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="TagsAnyCondition"></a>
+
 `TagsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -8386,6 +8944,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.gitlab.types.TagsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="TagsAnyValueFilter"></a>
 
 `TagsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -8420,6 +8980,8 @@ Classes
     `target: Any`
     :   SHA the tag points to
 
+<a id="TagsContainsCondition"></a>
+
 `TagsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -8431,6 +8993,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.gitlab.types.TagsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="TagsEqCondition"></a>
 
 `TagsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -8444,6 +9008,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.gitlab.types.TagsSearchFilter`
     :   The type of the None singleton.
 
+<a id="TagsFuzzyCondition"></a>
+
 `TagsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -8455,6 +9021,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.gitlab.types.TagsStringFilter`
     :   The type of the None singleton.
+
+<a id="TagsGetParams"></a>
 
 `TagsGetParams(*args, **kwargs)`
 :   Parameters for tags.get operation
@@ -8471,6 +9039,8 @@ Classes
     `tag_name: str`
     :   The type of the None singleton.
 
+<a id="TagsGtCondition"></a>
+
 `TagsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -8483,6 +9053,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.gitlab.types.TagsSearchFilter`
     :   The type of the None singleton.
 
+<a id="TagsGteCondition"></a>
+
 `TagsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -8494,6 +9066,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.gitlab.types.TagsSearchFilter`
     :   The type of the None singleton.
+
+<a id="TagsInCondition"></a>
 
 `TagsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -8514,6 +9088,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.gitlab.types.TagsInFilter`
     :   The type of the None singleton.
+
+<a id="TagsInFilter"></a>
 
 `TagsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -8548,6 +9124,8 @@ Classes
     `target: list[str]`
     :   SHA the tag points to
 
+<a id="TagsKeywordCondition"></a>
+
 `TagsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -8560,6 +9138,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.gitlab.types.TagsStringFilter`
     :   The type of the None singleton.
 
+<a id="TagsLikeCondition"></a>
+
 `TagsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -8571,6 +9151,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.gitlab.types.TagsStringFilter`
     :   The type of the None singleton.
+
+<a id="TagsListParams"></a>
 
 `TagsListParams(*args, **kwargs)`
 :   Parameters for tags.list operation
@@ -8599,6 +9181,8 @@ Classes
     `sort: str`
     :   The type of the None singleton.
 
+<a id="TagsLtCondition"></a>
+
 `TagsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -8610,6 +9194,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.gitlab.types.TagsSearchFilter`
     :   The type of the None singleton.
+
+<a id="TagsLteCondition"></a>
 
 `TagsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -8623,6 +9209,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.gitlab.types.TagsSearchFilter`
     :   The type of the None singleton.
 
+<a id="TagsNeqCondition"></a>
+
 `TagsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -8634,6 +9222,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.gitlab.types.TagsSearchFilter`
     :   The type of the None singleton.
+
+<a id="TagsNotCondition"></a>
 
 `TagsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -8655,6 +9245,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.gitlab.types.TagsEqCondition | airbyte_agent_sdk.connectors.gitlab.types.TagsNeqCondition | airbyte_agent_sdk.connectors.gitlab.types.TagsGtCondition | airbyte_agent_sdk.connectors.gitlab.types.TagsGteCondition | airbyte_agent_sdk.connectors.gitlab.types.TagsLtCondition | airbyte_agent_sdk.connectors.gitlab.types.TagsLteCondition | airbyte_agent_sdk.connectors.gitlab.types.TagsInCondition | airbyte_agent_sdk.connectors.gitlab.types.TagsLikeCondition | airbyte_agent_sdk.connectors.gitlab.types.TagsFuzzyCondition | airbyte_agent_sdk.connectors.gitlab.types.TagsKeywordCondition | airbyte_agent_sdk.connectors.gitlab.types.TagsContainsCondition | airbyte_agent_sdk.connectors.gitlab.types.TagsNotCondition | airbyte_agent_sdk.connectors.gitlab.types.TagsAndCondition | airbyte_agent_sdk.connectors.gitlab.types.TagsOrCondition | airbyte_agent_sdk.connectors.gitlab.types.TagsAnyCondition`
     :   The type of the None singleton.
 
+<a id="TagsOrCondition"></a>
+
 `TagsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -8674,6 +9266,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.gitlab.types.TagsEqCondition | airbyte_agent_sdk.connectors.gitlab.types.TagsNeqCondition | airbyte_agent_sdk.connectors.gitlab.types.TagsGtCondition | airbyte_agent_sdk.connectors.gitlab.types.TagsGteCondition | airbyte_agent_sdk.connectors.gitlab.types.TagsLtCondition | airbyte_agent_sdk.connectors.gitlab.types.TagsLteCondition | airbyte_agent_sdk.connectors.gitlab.types.TagsInCondition | airbyte_agent_sdk.connectors.gitlab.types.TagsLikeCondition | airbyte_agent_sdk.connectors.gitlab.types.TagsFuzzyCondition | airbyte_agent_sdk.connectors.gitlab.types.TagsKeywordCondition | airbyte_agent_sdk.connectors.gitlab.types.TagsContainsCondition | airbyte_agent_sdk.connectors.gitlab.types.TagsNotCondition | airbyte_agent_sdk.connectors.gitlab.types.TagsAndCondition | airbyte_agent_sdk.connectors.gitlab.types.TagsOrCondition | airbyte_agent_sdk.connectors.gitlab.types.TagsAnyCondition]`
     :   The type of the None singleton.
+
+<a id="TagsSearchFilter"></a>
 
 `TagsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering tags search queries.
@@ -8708,6 +9302,8 @@ Classes
     `target: str | None`
     :   SHA the tag points to
 
+<a id="TagsSearchQuery"></a>
+
 `TagsSearchQuery(*args, **kwargs)`
 :   Search query for tags entity.
 
@@ -8722,6 +9318,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.gitlab.types.TagsSortFilter]`
     :   The type of the None singleton.
+
+<a id="TagsSortFilter"></a>
 
 `TagsSortFilter(*args, **kwargs)`
 :   Available fields for sorting tags search results.
@@ -8756,6 +9354,8 @@ Classes
     `target: Literal['asc', 'desc']`
     :   SHA the tag points to
 
+<a id="TagsStringFilter"></a>
+
 `TagsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -8789,6 +9389,8 @@ Classes
     `target: str`
     :   SHA the tag points to
 
+<a id="UsersAndCondition"></a>
+
 `UsersAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -8809,6 +9411,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.gitlab.types.UsersEqCondition | airbyte_agent_sdk.connectors.gitlab.types.UsersNeqCondition | airbyte_agent_sdk.connectors.gitlab.types.UsersGtCondition | airbyte_agent_sdk.connectors.gitlab.types.UsersGteCondition | airbyte_agent_sdk.connectors.gitlab.types.UsersLtCondition | airbyte_agent_sdk.connectors.gitlab.types.UsersLteCondition | airbyte_agent_sdk.connectors.gitlab.types.UsersInCondition | airbyte_agent_sdk.connectors.gitlab.types.UsersLikeCondition | airbyte_agent_sdk.connectors.gitlab.types.UsersFuzzyCondition | airbyte_agent_sdk.connectors.gitlab.types.UsersKeywordCondition | airbyte_agent_sdk.connectors.gitlab.types.UsersContainsCondition | airbyte_agent_sdk.connectors.gitlab.types.UsersNotCondition | airbyte_agent_sdk.connectors.gitlab.types.UsersAndCondition | airbyte_agent_sdk.connectors.gitlab.types.UsersOrCondition | airbyte_agent_sdk.connectors.gitlab.types.UsersAnyCondition]`
     :   The type of the None singleton.
 
+<a id="UsersAnyCondition"></a>
+
 `UsersAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -8828,6 +9432,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.gitlab.types.UsersAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="UsersAnyValueFilter"></a>
 
 `UsersAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -8859,6 +9465,8 @@ Classes
     `web_url: Any`
     :   Web URL of the user profile
 
+<a id="UsersContainsCondition"></a>
+
 `UsersContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -8870,6 +9478,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.gitlab.types.UsersAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="UsersEqCondition"></a>
 
 `UsersEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -8883,6 +9493,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.gitlab.types.UsersSearchFilter`
     :   The type of the None singleton.
 
+<a id="UsersFuzzyCondition"></a>
+
 `UsersFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -8894,6 +9506,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.gitlab.types.UsersStringFilter`
     :   The type of the None singleton.
+
+<a id="UsersGetParams"></a>
 
 `UsersGetParams(*args, **kwargs)`
 :   Parameters for users.get operation
@@ -8907,6 +9521,8 @@ Classes
     `id: str`
     :   The type of the None singleton.
 
+<a id="UsersGtCondition"></a>
+
 `UsersGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -8919,6 +9535,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.gitlab.types.UsersSearchFilter`
     :   The type of the None singleton.
 
+<a id="UsersGteCondition"></a>
+
 `UsersGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -8930,6 +9548,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.gitlab.types.UsersSearchFilter`
     :   The type of the None singleton.
+
+<a id="UsersInCondition"></a>
 
 `UsersInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -8950,6 +9570,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.gitlab.types.UsersInFilter`
     :   The type of the None singleton.
+
+<a id="UsersInFilter"></a>
 
 `UsersInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -8981,6 +9603,8 @@ Classes
     `web_url: list[str]`
     :   Web URL of the user profile
 
+<a id="UsersKeywordCondition"></a>
+
 `UsersKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -8993,6 +9617,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.gitlab.types.UsersStringFilter`
     :   The type of the None singleton.
 
+<a id="UsersLikeCondition"></a>
+
 `UsersLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -9004,6 +9630,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.gitlab.types.UsersStringFilter`
     :   The type of the None singleton.
+
+<a id="UsersListParams"></a>
 
 `UsersListParams(*args, **kwargs)`
 :   Parameters for users.list operation
@@ -9026,6 +9654,8 @@ Classes
     `search: str`
     :   The type of the None singleton.
 
+<a id="UsersLtCondition"></a>
+
 `UsersLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -9037,6 +9667,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.gitlab.types.UsersSearchFilter`
     :   The type of the None singleton.
+
+<a id="UsersLteCondition"></a>
 
 `UsersLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -9050,6 +9682,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.gitlab.types.UsersSearchFilter`
     :   The type of the None singleton.
 
+<a id="UsersNeqCondition"></a>
+
 `UsersNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -9061,6 +9695,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.gitlab.types.UsersSearchFilter`
     :   The type of the None singleton.
+
+<a id="UsersNotCondition"></a>
 
 `UsersNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -9082,6 +9718,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.gitlab.types.UsersEqCondition | airbyte_agent_sdk.connectors.gitlab.types.UsersNeqCondition | airbyte_agent_sdk.connectors.gitlab.types.UsersGtCondition | airbyte_agent_sdk.connectors.gitlab.types.UsersGteCondition | airbyte_agent_sdk.connectors.gitlab.types.UsersLtCondition | airbyte_agent_sdk.connectors.gitlab.types.UsersLteCondition | airbyte_agent_sdk.connectors.gitlab.types.UsersInCondition | airbyte_agent_sdk.connectors.gitlab.types.UsersLikeCondition | airbyte_agent_sdk.connectors.gitlab.types.UsersFuzzyCondition | airbyte_agent_sdk.connectors.gitlab.types.UsersKeywordCondition | airbyte_agent_sdk.connectors.gitlab.types.UsersContainsCondition | airbyte_agent_sdk.connectors.gitlab.types.UsersNotCondition | airbyte_agent_sdk.connectors.gitlab.types.UsersAndCondition | airbyte_agent_sdk.connectors.gitlab.types.UsersOrCondition | airbyte_agent_sdk.connectors.gitlab.types.UsersAnyCondition`
     :   The type of the None singleton.
 
+<a id="UsersOrCondition"></a>
+
 `UsersOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -9101,6 +9739,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.gitlab.types.UsersEqCondition | airbyte_agent_sdk.connectors.gitlab.types.UsersNeqCondition | airbyte_agent_sdk.connectors.gitlab.types.UsersGtCondition | airbyte_agent_sdk.connectors.gitlab.types.UsersGteCondition | airbyte_agent_sdk.connectors.gitlab.types.UsersLtCondition | airbyte_agent_sdk.connectors.gitlab.types.UsersLteCondition | airbyte_agent_sdk.connectors.gitlab.types.UsersInCondition | airbyte_agent_sdk.connectors.gitlab.types.UsersLikeCondition | airbyte_agent_sdk.connectors.gitlab.types.UsersFuzzyCondition | airbyte_agent_sdk.connectors.gitlab.types.UsersKeywordCondition | airbyte_agent_sdk.connectors.gitlab.types.UsersContainsCondition | airbyte_agent_sdk.connectors.gitlab.types.UsersNotCondition | airbyte_agent_sdk.connectors.gitlab.types.UsersAndCondition | airbyte_agent_sdk.connectors.gitlab.types.UsersOrCondition | airbyte_agent_sdk.connectors.gitlab.types.UsersAnyCondition]`
     :   The type of the None singleton.
+
+<a id="UsersSearchFilter"></a>
 
 `UsersSearchFilter(*args, **kwargs)`
 :   Available fields for filtering users search queries.
@@ -9132,6 +9772,8 @@ Classes
     `web_url: str | None`
     :   Web URL of the user profile
 
+<a id="UsersSearchQuery"></a>
+
 `UsersSearchQuery(*args, **kwargs)`
 :   Search query for users entity.
 
@@ -9146,6 +9788,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.gitlab.types.UsersSortFilter]`
     :   The type of the None singleton.
+
+<a id="UsersSortFilter"></a>
 
 `UsersSortFilter(*args, **kwargs)`
 :   Available fields for sorting users search results.
@@ -9176,6 +9820,8 @@ Classes
 
     `web_url: Literal['asc', 'desc']`
     :   Web URL of the user profile
+
+<a id="UsersStringFilter"></a>
 
 `UsersStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/gmail/connector.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/gmail/connector.md
@@ -10,6 +10,8 @@ Gmail connector.
 Classes
 -------
 
+<a id="DraftsQuery"></a>
+
 `DraftsQuery(connector: GmailConnector)`
 :   Query class for Drafts entity operations.
     
@@ -72,6 +74,8 @@ Classes
         Returns:
             Draft
 
+<a id="DraftsSendQuery"></a>
+
 `DraftsSendQuery(connector: GmailConnector)`
 :   Query class for DraftsSend entity operations.
     
@@ -88,6 +92,8 @@ Classes
         
         Returns:
             Message
+
+<a id="GmailConnector"></a>
 
 `GmailConnector(auth_config: GmailAuthConfig | AirbyteAuthConfig | BaseModel | None = None, on_token_refresh: Any | None = None)`
 :   Type-safe Gmail API connector.
@@ -345,6 +351,8 @@ Classes
             for entity in entities:
                 print(f"\{entity['entity_name']\}: \{entity['available_actions']\}")
 
+<a id="LabelsQuery"></a>
+
 `LabelsQuery(connector: GmailConnector)`
 :   Query class for Labels entity operations.
     
@@ -405,6 +413,8 @@ Classes
         
         Returns:
             Label
+
+<a id="MessagesQuery"></a>
 
 `MessagesQuery(connector: GmailConnector)`
 :   Query class for Messages entity operations.
@@ -467,6 +477,8 @@ Classes
                 Returns:
                     Message
 
+<a id="MessagesTrashQuery"></a>
+
 `MessagesTrashQuery(connector: GmailConnector)`
 :   Query class for MessagesTrash entity operations.
     
@@ -483,6 +495,8 @@ Classes
         
         Returns:
             Message
+
+<a id="MessagesUntrashQuery"></a>
 
 `MessagesUntrashQuery(connector: GmailConnector)`
 :   Query class for MessagesUntrash entity operations.
@@ -501,6 +515,8 @@ Classes
         Returns:
             Message
 
+<a id="ProfileQuery"></a>
+
 `ProfileQuery(connector: GmailConnector)`
 :   Query class for Profile entity operations.
     
@@ -513,6 +529,8 @@ Classes
         
         Returns:
             Profile
+
+<a id="ThreadsQuery"></a>
 
 `ThreadsQuery(connector: GmailConnector)`
 :   Query class for Threads entity operations.

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/gmail/index.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/gmail/index.md
@@ -19,6 +19,8 @@ Sub-modules
 Classes
 -------
 
+<a id="AirbyteAuthConfig"></a>
+
 `AirbyteAuthConfig(**data: Any)`
 :   Authentication configuration for Airbyte hosted mode execution.
     
@@ -87,6 +89,8 @@ Classes
     `workspace_name: str | None`
     :   The type of the None singleton.
 
+<a id="GmailAuthConfig"></a>
+
 `GmailAuthConfig(**data: Any)`
 :   OAuth 2.0 Authentication
     
@@ -117,6 +121,8 @@ Classes
 
     `refresh_token: str`
     :   Your Google OAuth2 Refresh Token
+
+<a id="GmailConnector"></a>
 
 `GmailConnector(auth_config: GmailAuthConfig | AirbyteAuthConfig | BaseModel | None = None, on_token_refresh: Any | None = None)`
 :   Type-safe Gmail API connector.
@@ -373,6 +379,8 @@ Classes
             entities = connector.list_entities()
             for entity in entities:
                 print(f"\{entity['entity_name']\}: \{entity['available_actions']\}")
+
+<a id="GmailReplicationConfig"></a>
 
 `GmailReplicationConfig(**data: Any)`
 :   Replication Configuration - Settings for data replication from Gmail.

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/gmail/models.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/gmail/models.md
@@ -13,6 +13,8 @@ and response envelope types.
 Classes
 -------
 
+<a id="Draft"></a>
+
 `Draft(**data: Any)`
 :   A Gmail draft message
     
@@ -38,6 +40,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="DraftCreateParams"></a>
+
 `DraftCreateParams(**data: Any)`
 :   Parameters for creating or updating a draft
     
@@ -59,6 +63,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="DraftCreateParamsMessage"></a>
 
 `DraftCreateParamsMessage(**data: Any)`
 :   The draft message content
@@ -85,6 +91,8 @@ Classes
     `thread_id: str | Any`
     :   The thread ID for the draft (for threading in a conversation)
 
+<a id="DraftRef"></a>
+
 `DraftRef(**data: Any)`
 :   A lightweight reference to a draft (used in list responses)
     
@@ -110,6 +118,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="DraftSendParams"></a>
+
 `DraftSendParams(**data: Any)`
 :   Parameters for sending an existing draft
     
@@ -131,6 +141,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="DraftsListResponse"></a>
 
 `DraftsListResponse(**data: Any)`
 :   Response from listing drafts
@@ -160,6 +172,8 @@ Classes
     `result_size_estimate: int | Any | None`
     :   The type of the None singleton.
 
+<a id="DraftsListResultMeta"></a>
+
 `DraftsListResultMeta(**data: Any)`
 :   Metadata for drafts.Action.LIST operation
     
@@ -184,6 +198,8 @@ Classes
 
     `result_size_estimate: int | Any | None`
     :   The type of the None singleton.
+
+<a id="GmailAuthConfig"></a>
 
 `GmailAuthConfig(**data: Any)`
 :   OAuth 2.0 Authentication
@@ -215,6 +231,8 @@ Classes
 
     `refresh_token: str`
     :   Your Google OAuth2 Refresh Token
+
+<a id="GmailCheckResult"></a>
 
 `GmailCheckResult(**data: Any)`
 :   Result of a health check operation.
@@ -249,6 +267,8 @@ Classes
     `status: str`
     :   Health check status: 'healthy' or 'unhealthy'.
 
+<a id="GmailExecuteResult"></a>
+
 `GmailExecuteResult(**data: Any)`
 :   Response envelope with data only.
     
@@ -278,6 +298,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="GmailExecuteResultWithMeta"></a>
 
 `GmailExecuteResultWithMeta(**data: Any)`
 :   Response envelope with data and metadata.
@@ -332,6 +354,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="DraftsListResult"></a>
+
 `DraftsListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -374,6 +398,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="MessagesListResult"></a>
 
 `MessagesListResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -418,6 +444,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="ThreadsListResult"></a>
+
 `ThreadsListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -460,6 +488,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="LabelsListResult"></a>
+
 `LabelsListResult(**data: Any)`
 :   Response envelope with data only.
     
@@ -477,6 +507,8 @@ Classes
     * airbyte_agent_sdk.connectors.gmail.models.GmailExecuteResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="GmailReplicationConfig"></a>
 
 `GmailReplicationConfig(**data: Any)`
 :   Replication Configuration - Settings for data replication from Gmail.
@@ -499,6 +531,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="Label"></a>
 
 `Label(**data: Any)`
 :   A Gmail label used to organize messages and threads
@@ -549,6 +583,8 @@ Classes
     `type_: str | Any | None`
     :   The type of the None singleton.
 
+<a id="LabelColor"></a>
+
 `LabelColor(**data: Any)`
 :   The color to assign to a label
     
@@ -573,6 +609,8 @@ Classes
 
     `text_color: str | Any | None`
     :   The type of the None singleton.
+
+<a id="LabelCreateParams"></a>
 
 `LabelCreateParams(**data: Any)`
 :   Parameters for creating a label
@@ -605,6 +643,8 @@ Classes
     `name: str | Any`
     :   The type of the None singleton.
 
+<a id="LabelCreateParamsColor"></a>
+
 `LabelCreateParamsColor(**data: Any)`
 :   The color to assign to the label
     
@@ -629,6 +669,8 @@ Classes
 
     `text_color: str | Any`
     :   The text color of the label as a hex string (#RRGGBB)
+
+<a id="LabelUpdateParams"></a>
 
 `LabelUpdateParams(**data: Any)`
 :   Parameters for updating a label
@@ -664,6 +706,8 @@ Classes
     `name: str | Any`
     :   The type of the None singleton.
 
+<a id="LabelUpdateParamsColor"></a>
+
 `LabelUpdateParamsColor(**data: Any)`
 :   The color to assign to the label
     
@@ -689,6 +733,8 @@ Classes
     `text_color: str | Any`
     :   The text color of the label as a hex string (#RRGGBB)
 
+<a id="LabelsListResponse"></a>
+
 `LabelsListResponse(**data: Any)`
 :   Response from listing labels
     
@@ -710,6 +756,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="Message"></a>
 
 `Message(**data: Any)`
 :   A Gmail email message
@@ -757,6 +805,8 @@ Classes
     `thread_id: str | Any | None`
     :   The type of the None singleton.
 
+<a id="MessageHeader"></a>
+
 `MessageHeader(**data: Any)`
 :   A single email header key-value pair
     
@@ -782,6 +832,8 @@ Classes
     `value: str | Any | None`
     :   The type of the None singleton.
 
+<a id="MessageModifyParams"></a>
+
 `MessageModifyParams(**data: Any)`
 :   Parameters for modifying message labels
     
@@ -806,6 +858,8 @@ Classes
 
     `remove_label_ids: list[str] | Any`
     :   The type of the None singleton.
+
+<a id="MessagePart"></a>
 
 `MessagePart(**data: Any)`
 :   A single MIME message part
@@ -844,6 +898,8 @@ Classes
     `parts: list[dict[str, typing.Any]] | Any | None`
     :   The type of the None singleton.
 
+<a id="MessagePartBody"></a>
+
 `MessagePartBody(**data: Any)`
 :   The body data of a MIME message part
     
@@ -872,6 +928,8 @@ Classes
     `size: int | Any | None`
     :   The type of the None singleton.
 
+<a id="MessageRef"></a>
+
 `MessageRef(**data: Any)`
 :   A lightweight reference to a message (used in list responses)
     
@@ -897,6 +955,8 @@ Classes
     `thread_id: str | Any | None`
     :   The type of the None singleton.
 
+<a id="MessageSendParams"></a>
+
 `MessageSendParams(**data: Any)`
 :   Parameters for sending a message
     
@@ -921,6 +981,8 @@ Classes
 
     `thread_id: str | Any`
     :   The type of the None singleton.
+
+<a id="MessagesListResponse"></a>
 
 `MessagesListResponse(**data: Any)`
 :   Response from listing messages
@@ -950,6 +1012,8 @@ Classes
     `result_size_estimate: int | Any | None`
     :   The type of the None singleton.
 
+<a id="MessagesListResultMeta"></a>
+
 `MessagesListResultMeta(**data: Any)`
 :   Metadata for messages.Action.LIST operation
     
@@ -974,6 +1038,8 @@ Classes
 
     `result_size_estimate: int | Any | None`
     :   The type of the None singleton.
+
+<a id="Profile"></a>
 
 `Profile(**data: Any)`
 :   Gmail user profile information
@@ -1006,6 +1072,8 @@ Classes
     `threads_total: int | Any | None`
     :   The type of the None singleton.
 
+<a id="Thread"></a>
+
 `Thread(**data: Any)`
 :   A Gmail thread (email conversation)
     
@@ -1037,6 +1105,8 @@ Classes
     `snippet: str | Any | None`
     :   The type of the None singleton.
 
+<a id="ThreadRef"></a>
+
 `ThreadRef(**data: Any)`
 :   A lightweight reference to a thread (used in list responses)
     
@@ -1065,6 +1135,8 @@ Classes
     `snippet: str | Any | None`
     :   The type of the None singleton.
 
+<a id="ThreadsListResponse"></a>
+
 `ThreadsListResponse(**data: Any)`
 :   Response from listing threads
     
@@ -1092,6 +1164,8 @@ Classes
 
     `threads: list[airbyte_agent_sdk.connectors.gmail.models.ThreadRef] | Any`
     :   The type of the None singleton.
+
+<a id="ThreadsListResultMeta"></a>
 
 `ThreadsListResultMeta(**data: Any)`
 :   Metadata for threads.Action.LIST operation

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/gmail/types.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/gmail/types.md
@@ -10,6 +10,8 @@ Type definitions for gmail connector.
 Classes
 -------
 
+<a id="DraftsCreateParams"></a>
+
 `DraftsCreateParams(*args, **kwargs)`
 :   Parameters for drafts.create operation
 
@@ -21,6 +23,8 @@ Classes
 
     `message: airbyte_agent_sdk.connectors.gmail.types.DraftsCreateParamsMessage`
     :   The type of the None singleton.
+
+<a id="DraftsCreateParamsMessage"></a>
 
 `DraftsCreateParamsMessage(*args, **kwargs)`
 :   The draft message content
@@ -37,6 +41,8 @@ Classes
     `threadId: str`
     :   The type of the None singleton.
 
+<a id="DraftsDeleteParams"></a>
+
 `DraftsDeleteParams(*args, **kwargs)`
 :   Parameters for drafts.delete operation
 
@@ -48,6 +54,8 @@ Classes
 
     `draft_id: str`
     :   The type of the None singleton.
+
+<a id="DraftsGetParams"></a>
 
 `DraftsGetParams(*args, **kwargs)`
 :   Parameters for drafts.get operation
@@ -63,6 +71,8 @@ Classes
 
     `format: str`
     :   The type of the None singleton.
+
+<a id="DraftsListParams"></a>
 
 `DraftsListParams(*args, **kwargs)`
 :   Parameters for drafts.list operation
@@ -85,6 +95,8 @@ Classes
     `q: str`
     :   The type of the None singleton.
 
+<a id="DraftsSendCreateParams"></a>
+
 `DraftsSendCreateParams(*args, **kwargs)`
 :   Parameters for drafts_send.create operation
 
@@ -96,6 +108,8 @@ Classes
 
     `id: str`
     :   The type of the None singleton.
+
+<a id="DraftsUpdateParams"></a>
 
 `DraftsUpdateParams(*args, **kwargs)`
 :   Parameters for drafts.update operation
@@ -112,6 +126,8 @@ Classes
     `message: airbyte_agent_sdk.connectors.gmail.types.DraftsUpdateParamsMessage`
     :   The type of the None singleton.
 
+<a id="DraftsUpdateParamsMessage"></a>
+
 `DraftsUpdateParamsMessage(*args, **kwargs)`
 :   The draft message content
 
@@ -126,6 +142,8 @@ Classes
 
     `threadId: str`
     :   The type of the None singleton.
+
+<a id="LabelsCreateParams"></a>
 
 `LabelsCreateParams(*args, **kwargs)`
 :   Parameters for labels.create operation
@@ -148,6 +166,8 @@ Classes
     `name: str`
     :   The type of the None singleton.
 
+<a id="LabelsCreateParamsColor"></a>
+
 `LabelsCreateParamsColor(*args, **kwargs)`
 :   The color to assign to the label
 
@@ -163,6 +183,8 @@ Classes
     `textColor: str`
     :   The type of the None singleton.
 
+<a id="LabelsDeleteParams"></a>
+
 `LabelsDeleteParams(*args, **kwargs)`
 :   Parameters for labels.delete operation
 
@@ -174,6 +196,8 @@ Classes
 
     `label_id: str`
     :   The type of the None singleton.
+
+<a id="LabelsGetParams"></a>
 
 `LabelsGetParams(*args, **kwargs)`
 :   Parameters for labels.get operation
@@ -187,12 +211,16 @@ Classes
     `label_id: str`
     :   The type of the None singleton.
 
+<a id="LabelsListParams"></a>
+
 `LabelsListParams(*args, **kwargs)`
 :   Parameters for labels.list operation
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="LabelsUpdateParams"></a>
 
 `LabelsUpdateParams(*args, **kwargs)`
 :   Parameters for labels.update operation
@@ -221,6 +249,8 @@ Classes
     `name: str`
     :   The type of the None singleton.
 
+<a id="LabelsUpdateParamsColor"></a>
+
 `LabelsUpdateParamsColor(*args, **kwargs)`
 :   The color to assign to the label
 
@@ -236,6 +266,8 @@ Classes
     `textColor: str`
     :   The type of the None singleton.
 
+<a id="MessagesCreateParams"></a>
+
 `MessagesCreateParams(*args, **kwargs)`
 :   Parameters for messages.create operation
 
@@ -250,6 +282,8 @@ Classes
 
     `thread_id: str`
     :   The type of the None singleton.
+
+<a id="MessagesGetParams"></a>
 
 `MessagesGetParams(*args, **kwargs)`
 :   Parameters for messages.get operation
@@ -268,6 +302,8 @@ Classes
 
     `metadata_headers: str`
     :   The type of the None singleton.
+
+<a id="MessagesListParams"></a>
 
 `MessagesListParams(*args, **kwargs)`
 :   Parameters for messages.list operation
@@ -293,6 +329,8 @@ Classes
     `q: str`
     :   The type of the None singleton.
 
+<a id="MessagesTrashCreateParams"></a>
+
 `MessagesTrashCreateParams(*args, **kwargs)`
 :   Parameters for messages_trash.create operation
 
@@ -305,6 +343,8 @@ Classes
     `message_id: str`
     :   The type of the None singleton.
 
+<a id="MessagesUntrashCreateParams"></a>
+
 `MessagesUntrashCreateParams(*args, **kwargs)`
 :   Parameters for messages_untrash.create operation
 
@@ -316,6 +356,8 @@ Classes
 
     `message_id: str`
     :   The type of the None singleton.
+
+<a id="MessagesUpdateParams"></a>
 
 `MessagesUpdateParams(*args, **kwargs)`
 :   Parameters for messages.update operation
@@ -335,12 +377,16 @@ Classes
     `remove_label_ids: list[str]`
     :   The type of the None singleton.
 
+<a id="ProfileGetParams"></a>
+
 `ProfileGetParams(*args, **kwargs)`
 :   Parameters for profile.get operation
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="ThreadsGetParams"></a>
 
 `ThreadsGetParams(*args, **kwargs)`
 :   Parameters for threads.get operation
@@ -359,6 +405,8 @@ Classes
 
     `thread_id: str`
     :   The type of the None singleton.
+
+<a id="ThreadsListParams"></a>
 
 `ThreadsListParams(*args, **kwargs)`
 :   Parameters for threads.list operation

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/gong/connector.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/gong/connector.md
@@ -10,6 +10,8 @@ Gong connector.
 Classes
 -------
 
+<a id="CallAudioQuery"></a>
+
 `CallAudioQuery(connector: GongConnector)`
 :   Query class for CallAudio entity operations.
     
@@ -48,6 +50,8 @@ Classes
                 Returns:
                     str: Path to the downloaded file
 
+<a id="CallTranscriptsQuery"></a>
+
 `CallTranscriptsQuery(connector: GongConnector)`
 :   Query class for CallTranscripts entity operations.
     
@@ -65,6 +69,8 @@ Classes
         
         Returns:
             CallTranscriptsListResult
+
+<a id="CallVideoQuery"></a>
 
 `CallVideoQuery(connector: GongConnector)`
 :   Query class for CallVideo entity operations.
@@ -103,6 +109,8 @@ Classes
         
                 Returns:
                     str: Path to the downloaded file
+
+<a id="CallsExtensiveQuery"></a>
 
 `CallsExtensiveQuery(connector: GongConnector)`
 :   Query class for CallsExtensive entity operations.
@@ -153,6 +161,8 @@ Classes
         
         Returns:
             CallsExtensiveListResult
+
+<a id="CallsQuery"></a>
 
 `CallsQuery(connector: GongConnector)`
 :   Query class for Calls entity operations.
@@ -225,6 +235,8 @@ Classes
         Returns:
             CallsListResult
 
+<a id="CoachingQuery"></a>
+
 `CoachingQuery(connector: GongConnector)`
 :   Query class for Coaching entity operations.
     
@@ -244,6 +256,8 @@ Classes
         
         Returns:
             CoachingListResult
+
+<a id="GongConnector"></a>
 
 `GongConnector(auth_config: GongAuthConfig | AirbyteAuthConfig | BaseModel | None = None, on_token_refresh: Any | None = None)`
 :   Type-safe Gong API connector.
@@ -487,6 +501,8 @@ Classes
             for entity in entities:
                 print(f"\{entity['entity_name']\}: \{entity['available_actions']\}")
 
+<a id="LibraryFolderContentQuery"></a>
+
 `LibraryFolderContentQuery(connector: GongConnector)`
 :   Query class for LibraryFolderContent entity operations.
     
@@ -505,6 +521,8 @@ Classes
         Returns:
             LibraryFolderContentListResult
 
+<a id="LibraryFoldersQuery"></a>
+
 `LibraryFoldersQuery(connector: GongConnector)`
 :   Query class for LibraryFolders entity operations.
     
@@ -521,6 +539,8 @@ Classes
         
         Returns:
             LibraryFoldersListResult
+
+<a id="SettingsScorecardsQuery"></a>
 
 `SettingsScorecardsQuery(connector: GongConnector)`
 :   Query class for SettingsScorecards entity operations.
@@ -569,6 +589,8 @@ Classes
         Returns:
             SettingsScorecardsListResult
 
+<a id="SettingsTrackersQuery"></a>
+
 `SettingsTrackersQuery(connector: GongConnector)`
 :   Query class for SettingsTrackers entity operations.
     
@@ -585,6 +607,8 @@ Classes
         
         Returns:
             SettingsTrackersListResult
+
+<a id="StatsActivityAggregateQuery"></a>
 
 `StatsActivityAggregateQuery(connector: GongConnector)`
 :   Query class for StatsActivityAggregate entity operations.
@@ -603,6 +627,8 @@ Classes
         Returns:
             StatsActivityAggregateListResult
 
+<a id="StatsActivityDayByDayQuery"></a>
+
 `StatsActivityDayByDayQuery(connector: GongConnector)`
 :   Query class for StatsActivityDayByDay entity operations.
     
@@ -619,6 +645,8 @@ Classes
         
         Returns:
             StatsActivityDayByDayListResult
+
+<a id="StatsActivityScorecardsQuery"></a>
 
 `StatsActivityScorecardsQuery(connector: GongConnector)`
 :   Query class for StatsActivityScorecards entity operations.
@@ -670,6 +698,8 @@ Classes
         Returns:
             StatsActivityScorecardsListResult
 
+<a id="StatsInteractionQuery"></a>
+
 `StatsInteractionQuery(connector: GongConnector)`
 :   Query class for StatsInteraction entity operations.
     
@@ -686,6 +716,8 @@ Classes
         
         Returns:
             StatsInteractionListResult
+
+<a id="UsersQuery"></a>
 
 `UsersQuery(connector: GongConnector)`
 :   Query class for Users entity operations.
@@ -751,6 +783,8 @@ Classes
         
         Returns:
             UsersListResult
+
+<a id="WorkspacesQuery"></a>
 
 `WorkspacesQuery(connector: GongConnector)`
 :   Query class for Workspaces entity operations.

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/gong/index.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/gong/index.md
@@ -19,6 +19,8 @@ Sub-modules
 Classes
 -------
 
+<a id="AirbyteAuthConfig"></a>
+
 `AirbyteAuthConfig(**data: Any)`
 :   Authentication configuration for Airbyte hosted mode execution.
     
@@ -87,6 +89,8 @@ Classes
     `workspace_name: str | None`
     :   The type of the None singleton.
 
+<a id="AirbyteSearchMeta"></a>
+
 `AirbyteSearchMeta(**data: Any)`
 :   Pagination metadata for search responses.
     
@@ -114,6 +118,8 @@ Classes
 
     `took_ms: int | None`
     :   Time taken to execute the search in milliseconds.
+
+<a id="AirbyteSearchResult"></a>
 
 `AirbyteSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -149,6 +155,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="CallsExtensiveSearchResult"></a>
+
 `CallsExtensiveSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -164,6 +172,8 @@ Classes
     * airbyte_agent_sdk.connectors.gong.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="CallsSearchResult"></a>
 
 `CallsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -181,6 +191,8 @@ Classes
     * pydantic.main.BaseModel
     * typing.Generic
 
+<a id="SettingsScorecardsSearchResult"></a>
+
 `SettingsScorecardsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -196,6 +208,8 @@ Classes
     * airbyte_agent_sdk.connectors.gong.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="StatsActivityScorecardsSearchResult"></a>
 
 `StatsActivityScorecardsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -213,6 +227,8 @@ Classes
     * pydantic.main.BaseModel
     * typing.Generic
 
+<a id="UsersSearchResult"></a>
+
 `UsersSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -228,6 +244,8 @@ Classes
     * airbyte_agent_sdk.connectors.gong.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="CallsExtensiveSearchData"></a>
 
 `CallsExtensiveSearchData(**data: Any)`
 :   Search result data for calls_extensive entity.
@@ -274,6 +292,8 @@ Classes
 
     `startdatetime: str | None`
     :   Datetime for extensive calls.
+
+<a id="CallsSearchData"></a>
 
 `CallsSearchData(**data: Any)`
 :   Search result data for calls entity.
@@ -353,6 +373,8 @@ Classes
 
     `workspace_id: str | None`
     :   Identifier for the workspace to which the call belongs.
+
+<a id="GongConnector"></a>
 
 `GongConnector(auth_config: GongAuthConfig | AirbyteAuthConfig | BaseModel | None = None, on_token_refresh: Any | None = None)`
 :   Type-safe Gong API connector.
@@ -596,6 +618,8 @@ Classes
             for entity in entities:
                 print(f"\{entity['entity_name']\}: \{entity['available_actions']\}")
 
+<a id="SettingsScorecardsSearchData"></a>
+
 `SettingsScorecardsSearchData(**data: Any)`
 :   Search result data for settings_scorecards entity.
     
@@ -638,6 +662,8 @@ Classes
 
     `workspace_id: str | None`
     :   The unique identifier of the workspace associated with the scorecard
+
+<a id="StatsActivityScorecardsSearchData"></a>
 
 `StatsActivityScorecardsSearchData(**data: Any)`
 :   Search result data for stats_activity_scorecards entity.
@@ -687,6 +713,8 @@ Classes
 
     `visibility_type: str | None`
     :   Type indicating the visibility permissions for the answered scorecard.
+
+<a id="UsersSearchData"></a>
 
 `UsersSearchData(**data: Any)`
 :   Search result data for users entity.

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/gong/models.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/gong/models.md
@@ -13,6 +13,8 @@ and response envelope types.
 Classes
 -------
 
+<a id="ActivityAggregateResponse"></a>
+
 `ActivityAggregateResponse(**data: Any)`
 :   Response containing aggregated activity statistics
     
@@ -50,6 +52,8 @@ Classes
     `users_aggregate_activity_stats: list[airbyte_agent_sdk.connectors.gong.models.UserAggregateActivity] | Any`
     :   The type of the None singleton.
 
+<a id="ActivityDayByDayResponse"></a>
+
 `ActivityDayByDayResponse(**data: Any)`
 :   Response containing daily activity statistics
     
@@ -78,6 +82,8 @@ Classes
     `users_detailed_activities: list[airbyte_agent_sdk.connectors.gong.models.UserDetailedActivity] | Any`
     :   The type of the None singleton.
 
+<a id="AirbyteSearchMeta"></a>
+
 `AirbyteSearchMeta(**data: Any)`
 :   Pagination metadata for search responses.
     
@@ -105,6 +111,8 @@ Classes
 
     `took_ms: int | None`
     :   Time taken to execute the search in milliseconds.
+
+<a id="AirbyteSearchResult"></a>
 
 `AirbyteSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -161,6 +169,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="CallsExtensiveSearchResult"></a>
+
 `CallsExtensiveSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -197,6 +207,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="CallsSearchResult"></a>
 
 `CallsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -235,6 +247,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="SettingsScorecardsSearchResult"></a>
+
 `SettingsScorecardsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -271,6 +285,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="StatsActivityScorecardsSearchResult"></a>
 
 `StatsActivityScorecardsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -309,6 +325,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="UsersSearchResult"></a>
+
 `UsersSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -324,6 +342,8 @@ Classes
     * airbyte_agent_sdk.connectors.gong.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="AnsweredScorecard"></a>
 
 `AnsweredScorecard(**data: Any)`
 :   A completed scorecard
@@ -389,6 +409,8 @@ Classes
     `visibility_type: str | Any`
     :   The type of the None singleton.
 
+<a id="AnsweredScorecardAnswer"></a>
+
 `AnsweredScorecardAnswer(**data: Any)`
 :   An answer to a scorecard question
     
@@ -432,6 +454,8 @@ Classes
     `selected_options: list[str] | Any | None`
     :   The type of the None singleton.
 
+<a id="AnsweredScorecardsResponse"></a>
+
 `AnsweredScorecardsResponse(**data: Any)`
 :   Response containing answered scorecards
     
@@ -459,6 +483,8 @@ Classes
 
     `request_id: str | Any`
     :   The type of the None singleton.
+
+<a id="Call"></a>
 
 `Call(**data: Any)`
 :   Call object
@@ -539,6 +565,8 @@ Classes
     `workspace_id: str | Any`
     :   The type of the None singleton.
 
+<a id="CallResponse"></a>
+
 `CallResponse(**data: Any)`
 :   Response containing single call
     
@@ -564,6 +592,8 @@ Classes
     `request_id: str | Any`
     :   The type of the None singleton.
 
+<a id="CallTranscript"></a>
+
 `CallTranscript(**data: Any)`
 :   Call transcript object
     
@@ -588,6 +618,8 @@ Classes
 
     `transcript: list[airbyte_agent_sdk.connectors.gong.models.CallTranscriptTranscriptItem] | Any`
     :   The type of the None singleton.
+
+<a id="CallTranscriptTranscriptItem"></a>
 
 `CallTranscriptTranscriptItem(**data: Any)`
 :   Nested schema for CallTranscript.transcript_item
@@ -617,6 +649,8 @@ Classes
     `topic: str | Any | None`
     :   Topic
 
+<a id="CallTranscriptTranscriptItemSentencesItem"></a>
+
 `CallTranscriptTranscriptItemSentencesItem(**data: Any)`
 :   Nested schema for CallTranscriptTranscriptItem.sentences_item
     
@@ -644,6 +678,8 @@ Classes
 
     `text: str | Any`
     :   Sentence text
+
+<a id="CallTranscriptsListResultMeta"></a>
 
 `CallTranscriptsListResultMeta(**data: Any)`
 :   Metadata for call_transcripts.Action.LIST operation
@@ -673,6 +709,8 @@ Classes
     `total_records: int | Any`
     :   The type of the None singleton.
 
+<a id="CallsExtensiveListResultMeta"></a>
+
 `CallsExtensiveListResultMeta(**data: Any)`
 :   Metadata for calls_extensive.Action.LIST operation
     
@@ -700,6 +738,8 @@ Classes
 
     `total_records: int | Any`
     :   The type of the None singleton.
+
+<a id="CallsExtensiveSearchData"></a>
 
 `CallsExtensiveSearchData(**data: Any)`
 :   Search result data for calls_extensive entity.
@@ -747,6 +787,8 @@ Classes
     `startdatetime: str | None`
     :   Datetime for extensive calls.
 
+<a id="CallsListResultMeta"></a>
+
 `CallsListResultMeta(**data: Any)`
 :   Metadata for calls.Action.LIST operation
     
@@ -775,6 +817,8 @@ Classes
     `total_records: int | Any`
     :   The type of the None singleton.
 
+<a id="CallsResponse"></a>
+
 `CallsResponse(**data: Any)`
 :   Response containing list of calls
     
@@ -802,6 +846,8 @@ Classes
 
     `request_id: str | Any`
     :   The type of the None singleton.
+
+<a id="CallsSearchData"></a>
 
 `CallsSearchData(**data: Any)`
 :   Search result data for calls entity.
@@ -882,6 +928,8 @@ Classes
     `workspace_id: str | None`
     :   Identifier for the workspace to which the call belongs.
 
+<a id="CoachingData"></a>
+
 `CoachingData(**data: Any)`
 :   Coaching data for a user
     
@@ -915,6 +963,8 @@ Classes
 
     `user_name: str | Any`
     :   The type of the None singleton.
+
+<a id="CoachingMetrics"></a>
 
 `CoachingMetrics(**data: Any)`
 :   Coaching metrics for a user
@@ -950,6 +1000,8 @@ Classes
     `scorecards_filled: int | Any`
     :   The type of the None singleton.
 
+<a id="CoachingResponse"></a>
+
 `CoachingResponse(**data: Any)`
 :   Response containing coaching metrics
     
@@ -980,6 +1032,8 @@ Classes
 
     `to_date_time: str | Any`
     :   The type of the None singleton.
+
+<a id="DailyActivityStats"></a>
 
 `DailyActivityStats(**data: Any)`
 :   Daily activity statistics with call IDs
@@ -1051,6 +1105,8 @@ Classes
     `to_date: str | Any`
     :   The type of the None singleton.
 
+<a id="ExtensiveCall"></a>
+
 `ExtensiveCall(**data: Any)`
 :   Detailed call object with extended information
     
@@ -1088,6 +1144,8 @@ Classes
     `parties: list[airbyte_agent_sdk.connectors.gong.models.ExtensiveCallPartiesItem] | Any`
     :   The type of the None singleton.
 
+<a id="ExtensiveCallCollaboration"></a>
+
 `ExtensiveCallCollaboration(**data: Any)`
 :   Collaboration data
     
@@ -1109,6 +1167,8 @@ Classes
 
     `public_comments: list[dict[str, typing.Any]] | Any`
     :   The type of the None singleton.
+
+<a id="ExtensiveCallContent"></a>
 
 `ExtensiveCallContent(**data: Any)`
 :   Content data including topics and trackers
@@ -1138,6 +1198,8 @@ Classes
     `trackers: list[airbyte_agent_sdk.connectors.gong.models.ExtensiveCallContentTrackersItem] | Any`
     :   The type of the None singleton.
 
+<a id="ExtensiveCallContentTopicsItem"></a>
+
 `ExtensiveCallContentTopicsItem(**data: Any)`
 :   Nested schema for ExtensiveCallContent.topics_item
     
@@ -1162,6 +1224,8 @@ Classes
 
     `name: str | Any`
     :   The type of the None singleton.
+
+<a id="ExtensiveCallContentTrackersItem"></a>
 
 `ExtensiveCallContentTrackersItem(**data: Any)`
 :   Nested schema for ExtensiveCallContent.trackers_item
@@ -1197,6 +1261,8 @@ Classes
     `type_: str | Any`
     :   The type of the None singleton.
 
+<a id="ExtensiveCallInteraction"></a>
+
 `ExtensiveCallInteraction(**data: Any)`
 :   Interaction statistics
     
@@ -1221,6 +1287,8 @@ Classes
 
     `questions: airbyte_agent_sdk.connectors.gong.models.ExtensiveCallInteractionQuestions | Any`
     :   The type of the None singleton.
+
+<a id="ExtensiveCallInteractionInteractionstatsItem"></a>
 
 `ExtensiveCallInteractionInteractionstatsItem(**data: Any)`
 :   Nested schema for ExtensiveCallInteraction.interactionStats_item
@@ -1247,6 +1315,8 @@ Classes
     `value: float | Any`
     :   Stat value
 
+<a id="ExtensiveCallInteractionQuestions"></a>
+
 `ExtensiveCallInteractionQuestions(**data: Any)`
 :   Nested schema for ExtensiveCallInteraction.questions
     
@@ -1272,6 +1342,8 @@ Classes
     `non_company_count: int | Any`
     :   The type of the None singleton.
 
+<a id="ExtensiveCallMedia"></a>
+
 `ExtensiveCallMedia(**data: Any)`
 :   Media URLs
     
@@ -1296,6 +1368,8 @@ Classes
 
     `video_url: str | Any`
     :   The type of the None singleton.
+
+<a id="ExtensiveCallMetadata"></a>
 
 `ExtensiveCallMetadata(**data: Any)`
 :   Call metadata
@@ -1376,6 +1450,8 @@ Classes
     `workspace_id: str | Any`
     :   Workspace ID
 
+<a id="ExtensiveCallPartiesItem"></a>
+
 `ExtensiveCallPartiesItem(**data: Any)`
 :   Nested schema for ExtensiveCall.parties_item
     
@@ -1425,6 +1501,8 @@ Classes
     `user_id: str | Any`
     :   Gong user ID if internal
 
+<a id="ExtensiveCallPartiesItemContextItem"></a>
+
 `ExtensiveCallPartiesItemContextItem(**data: Any)`
 :   Nested schema for ExtensiveCallPartiesItem.context_item
     
@@ -1449,6 +1527,8 @@ Classes
 
     `system: str | Any`
     :   CRM system name (e.g., Salesforce, HubSpot)
+
+<a id="ExtensiveCallPartiesItemContextItemObjectsItem"></a>
 
 `ExtensiveCallPartiesItemContextItemObjectsItem(**data: Any)`
 :   Nested schema for ExtensiveCallPartiesItemContextItem.objects_item
@@ -1478,6 +1558,8 @@ Classes
     `object_type: str | Any`
     :   CRM object type (Account, Contact, Opportunity, Lead)
 
+<a id="ExtensiveCallPartiesItemContextItemObjectsItemFieldsItem"></a>
+
 `ExtensiveCallPartiesItemContextItemObjectsItemFieldsItem(**data: Any)`
 :   Nested schema for ExtensiveCallPartiesItemContextItemObjectsItem.fields_item
     
@@ -1502,6 +1584,8 @@ Classes
 
     `value: Any`
     :   Field value
+
+<a id="ExtensiveCallsResponse"></a>
 
 `ExtensiveCallsResponse(**data: Any)`
 :   Response containing detailed call data
@@ -1530,6 +1614,8 @@ Classes
 
     `request_id: str | Any`
     :   The type of the None singleton.
+
+<a id="FolderCall"></a>
 
 `FolderCall(**data: Any)`
 :   Call within a library folder
@@ -1567,6 +1653,8 @@ Classes
 
     `url: str | Any`
     :   The type of the None singleton.
+
+<a id="FolderContentResponse"></a>
 
 `FolderContentResponse(**data: Any)`
 :   Response containing calls in a folder
@@ -1608,6 +1696,8 @@ Classes
     `updated: str | Any`
     :   The type of the None singleton.
 
+<a id="GongAccessKeyAuthenticationAuthConfig"></a>
+
 `GongAccessKeyAuthenticationAuthConfig(**data: Any)`
 :   Access Key Authentication
     
@@ -1632,6 +1722,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="GongCheckResult"></a>
 
 `GongCheckResult(**data: Any)`
 :   Result of a health check operation.
@@ -1666,6 +1758,8 @@ Classes
     `status: str`
     :   Health check status: 'healthy' or 'unhealthy'.
 
+<a id="GongExecuteResult"></a>
+
 `GongExecuteResult(**data: Any)`
 :   Response envelope with data only.
     
@@ -1699,6 +1793,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="GongExecuteResultWithMeta"></a>
 
 `GongExecuteResultWithMeta(**data: Any)`
 :   Response envelope with data and metadata.
@@ -1759,6 +1855,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="StatsActivityScorecardsListResult"></a>
+
 `StatsActivityScorecardsListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -1801,6 +1899,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="CallTranscriptsListResult"></a>
 
 `CallTranscriptsListResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -1845,6 +1945,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="CallsListResult"></a>
+
 `CallsListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -1887,6 +1989,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="CallsExtensiveListResult"></a>
 
 `CallsExtensiveListResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -1931,6 +2035,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="LibraryFolderContentListResult"></a>
+
 `LibraryFolderContentListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -1973,6 +2079,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="StatsActivityAggregateListResult"></a>
 
 `StatsActivityAggregateListResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -2017,6 +2125,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="StatsActivityDayByDayListResult"></a>
+
 `StatsActivityDayByDayListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -2059,6 +2169,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="StatsInteractionListResult"></a>
 
 `StatsInteractionListResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -2103,6 +2215,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="UsersListResult"></a>
+
 `UsersListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -2145,6 +2259,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="CoachingListResult"></a>
+
 `CoachingListResult(**data: Any)`
 :   Response envelope with data only.
     
@@ -2185,6 +2301,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="LibraryFoldersListResult"></a>
 
 `LibraryFoldersListResult(**data: Any)`
 :   Response envelope with data only.
@@ -2227,6 +2345,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="SettingsScorecardsListResult"></a>
+
 `SettingsScorecardsListResult(**data: Any)`
 :   Response envelope with data only.
     
@@ -2267,6 +2387,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="SettingsTrackersListResult"></a>
 
 `SettingsTrackersListResult(**data: Any)`
 :   Response envelope with data only.
@@ -2309,6 +2431,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="WorkspacesListResult"></a>
+
 `WorkspacesListResult(**data: Any)`
 :   Response envelope with data only.
     
@@ -2326,6 +2450,8 @@ Classes
     * airbyte_agent_sdk.connectors.gong.models.GongExecuteResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="GongOauth20AuthenticationAuthConfig"></a>
 
 `GongOauth20AuthenticationAuthConfig(**data: Any)`
 :   OAuth 2.0 Authentication
@@ -2357,6 +2483,8 @@ Classes
 
     `refresh_token: str`
     :   Your Gong OAuth2 Refresh Token. Note: Gong uses single-use refresh tokens.
+
+<a id="InteractionStatsResponse"></a>
 
 `InteractionStatsResponse(**data: Any)`
 :   Response containing interaction statistics
@@ -2395,6 +2523,8 @@ Classes
     `to_date_time: str | Any`
     :   The type of the None singleton.
 
+<a id="LibraryFolder"></a>
+
 `LibraryFolder(**data: Any)`
 :   Library folder structure
     
@@ -2429,6 +2559,8 @@ Classes
     `updated: str | Any`
     :   The type of the None singleton.
 
+<a id="LibraryFolderContentListResultMeta"></a>
+
 `LibraryFolderContentListResultMeta(**data: Any)`
 :   Metadata for library_folder_content.Action.LIST operation
     
@@ -2457,6 +2589,8 @@ Classes
     `total_records: int | Any`
     :   The type of the None singleton.
 
+<a id="LibraryFoldersResponse"></a>
+
 `LibraryFoldersResponse(**data: Any)`
 :   Response containing library folder structure
     
@@ -2481,6 +2615,8 @@ Classes
 
     `request_id: str | Any`
     :   The type of the None singleton.
+
+<a id="PaginationRecords"></a>
 
 `PaginationRecords(**data: Any)`
 :   Pagination metadata
@@ -2513,6 +2649,8 @@ Classes
     `total_records: int | Any`
     :   The type of the None singleton.
 
+<a id="PersonInteractionStat"></a>
+
 `PersonInteractionStat(**data: Any)`
 :   Individual interaction statistic
     
@@ -2537,6 +2675,8 @@ Classes
 
     `value: float | Any`
     :   The type of the None singleton.
+
+<a id="Scorecard"></a>
 
 `Scorecard(**data: Any)`
 :   Scorecard configuration
@@ -2583,6 +2723,8 @@ Classes
 
     `workspace_id: str | Any | None`
     :   The type of the None singleton.
+
+<a id="ScorecardQuestion"></a>
 
 `ScorecardQuestion(**data: Any)`
 :   A question within a scorecard
@@ -2642,6 +2784,8 @@ Classes
     `updater_user_id: str | Any`
     :   The type of the None singleton.
 
+<a id="ScorecardQuestionAnsweroptionsItem"></a>
+
 `ScorecardQuestionAnsweroptionsItem(**data: Any)`
 :   Nested schema for ScorecardQuestion.answerOptions_item
     
@@ -2670,6 +2814,8 @@ Classes
     `score: float | Any`
     :   The type of the None singleton.
 
+<a id="ScorecardsResponse"></a>
+
 `ScorecardsResponse(**data: Any)`
 :   Response containing list of scorecards
     
@@ -2694,6 +2840,8 @@ Classes
 
     `scorecards: list[airbyte_agent_sdk.connectors.gong.models.Scorecard] | Any`
     :   The type of the None singleton.
+
+<a id="SettingsScorecardsSearchData"></a>
 
 `SettingsScorecardsSearchData(**data: Any)`
 :   Search result data for settings_scorecards entity.
@@ -2738,6 +2886,8 @@ Classes
     `workspace_id: str | None`
     :   The unique identifier of the workspace associated with the scorecard
 
+<a id="StatsActivityAggregateListResultMeta"></a>
+
 `StatsActivityAggregateListResultMeta(**data: Any)`
 :   Metadata for stats_activity_aggregate.Action.LIST operation
     
@@ -2765,6 +2915,8 @@ Classes
 
     `total_records: int | Any`
     :   The type of the None singleton.
+
+<a id="StatsActivityDayByDayListResultMeta"></a>
 
 `StatsActivityDayByDayListResultMeta(**data: Any)`
 :   Metadata for stats_activity_day_by_day.Action.LIST operation
@@ -2794,6 +2946,8 @@ Classes
     `total_records: int | Any`
     :   The type of the None singleton.
 
+<a id="StatsActivityScorecardsListResultMeta"></a>
+
 `StatsActivityScorecardsListResultMeta(**data: Any)`
 :   Metadata for stats_activity_scorecards.Action.LIST operation
     
@@ -2821,6 +2975,8 @@ Classes
 
     `total_records: int | Any`
     :   The type of the None singleton.
+
+<a id="StatsActivityScorecardsSearchData"></a>
 
 `StatsActivityScorecardsSearchData(**data: Any)`
 :   Search result data for stats_activity_scorecards entity.
@@ -2871,6 +3027,8 @@ Classes
     `visibility_type: str | None`
     :   Type indicating the visibility permissions for the answered scorecard.
 
+<a id="StatsInteractionListResultMeta"></a>
+
 `StatsInteractionListResultMeta(**data: Any)`
 :   Metadata for stats_interaction.Action.LIST operation
     
@@ -2898,6 +3056,8 @@ Classes
 
     `total_records: int | Any`
     :   The type of the None singleton.
+
+<a id="Tracker"></a>
 
 `Tracker(**data: Any)`
 :   Keyword tracker configuration
@@ -2963,6 +3123,8 @@ Classes
     `workspace_id: str | Any | None`
     :   The type of the None singleton.
 
+<a id="TrackerLanguagekeywordsItem"></a>
+
 `TrackerLanguagekeywordsItem(**data: Any)`
 :   Nested schema for Tracker.languageKeywords_item
     
@@ -2991,6 +3153,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="TrackersResponse"></a>
+
 `TrackersResponse(**data: Any)`
 :   Response containing list of trackers
     
@@ -3015,6 +3179,8 @@ Classes
 
     `request_id: str | Any`
     :   The type of the None singleton.
+
+<a id="TranscriptsResponse"></a>
 
 `TranscriptsResponse(**data: Any)`
 :   Response containing call transcripts
@@ -3043,6 +3209,8 @@ Classes
 
     `request_id: str | Any`
     :   The type of the None singleton.
+
+<a id="User"></a>
 
 `User(**data: Any)`
 :   User object
@@ -3111,6 +3279,8 @@ Classes
     `trusted_email_address: str | Any | None`
     :   The type of the None singleton.
 
+<a id="UserAggregateActivity"></a>
+
 `UserAggregateActivity(**data: Any)`
 :   User with aggregated activity statistics
     
@@ -3138,6 +3308,8 @@ Classes
 
     `user_id: str | Any`
     :   The type of the None singleton.
+
+<a id="UserAggregateActivityStats"></a>
 
 `UserAggregateActivityStats(**data: Any)`
 :   Aggregated activity statistics for a user
@@ -3203,6 +3375,8 @@ Classes
     `own_calls_listened_to: int | Any`
     :   The type of the None singleton.
 
+<a id="UserDetailedActivity"></a>
+
 `UserDetailedActivity(**data: Any)`
 :   User with detailed daily activity statistics
     
@@ -3230,6 +3404,8 @@ Classes
 
     `user_id: str | Any`
     :   The type of the None singleton.
+
+<a id="UserInteractionStats"></a>
 
 `UserInteractionStats(**data: Any)`
 :   User with interaction statistics
@@ -3259,6 +3435,8 @@ Classes
     `user_id: str | Any`
     :   The type of the None singleton.
 
+<a id="UserResponse"></a>
+
 `UserResponse(**data: Any)`
 :   Response containing single user
     
@@ -3283,6 +3461,8 @@ Classes
 
     `user: airbyte_agent_sdk.connectors.gong.models.User | Any`
     :   The type of the None singleton.
+
+<a id="UserSettings"></a>
 
 `UserSettings(**data: Any)`
 :   User settings
@@ -3324,6 +3504,8 @@ Classes
     `web_conferences_recorded: bool | Any`
     :   The type of the None singleton.
 
+<a id="UserSpokenlanguagesItem"></a>
+
 `UserSpokenlanguagesItem(**data: Any)`
 :   Nested schema for User.spokenLanguages_item
     
@@ -3348,6 +3530,8 @@ Classes
 
     `primary: bool | Any`
     :   The type of the None singleton.
+
+<a id="UsersListResultMeta"></a>
 
 `UsersListResultMeta(**data: Any)`
 :   Metadata for users.Action.LIST operation
@@ -3377,6 +3561,8 @@ Classes
     `total_records: int | Any`
     :   The type of the None singleton.
 
+<a id="UsersResponse"></a>
+
 `UsersResponse(**data: Any)`
 :   Response containing list of users
     
@@ -3404,6 +3590,8 @@ Classes
 
     `users: list[airbyte_agent_sdk.connectors.gong.models.User] | Any`
     :   The type of the None singleton.
+
+<a id="UsersSearchData"></a>
 
 `UsersSearchData(**data: Any)`
 :   Search result data for users entity.
@@ -3472,6 +3660,8 @@ Classes
     `trusted_email_address: str | None`
     :   An email address that is considered trusted for the user
 
+<a id="Workspace"></a>
+
 `Workspace(**data: Any)`
 :   Workspace object
     
@@ -3502,6 +3692,8 @@ Classes
 
     `workspace_id: str | Any`
     :   The type of the None singleton.
+
+<a id="WorkspacesResponse"></a>
 
 `WorkspacesResponse(**data: Any)`
 :   Response containing list of workspaces

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/gong/types.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/gong/types.md
@@ -10,6 +10,8 @@ Type definitions for gong connector.
 Classes
 -------
 
+<a id="AirbyteSearchParams"></a>
+
 `AirbyteSearchParams(*args, **kwargs)`
 :   Parameters for Airbyte cache search operations (generic, use entity-specific query types for better type hints).
 
@@ -31,6 +33,8 @@ Classes
     `query: dict[str, typing.Any]`
     :   The type of the None singleton.
 
+<a id="CallAudioDownloadParams"></a>
+
 `CallAudioDownloadParams(*args, **kwargs)`
 :   Parameters for call_audio.download operation
 
@@ -49,6 +53,8 @@ Classes
     `range_header: str`
     :   The type of the None singleton.
 
+<a id="CallAudioDownloadParamsContentselector"></a>
+
 `CallAudioDownloadParamsContentselector(*args, **kwargs)`
 :   Nested schema for CallAudioDownloadParams.contentSelector
 
@@ -60,6 +66,8 @@ Classes
 
     `exposedFields: airbyte_agent_sdk.connectors.gong.types.CallAudioDownloadParamsContentselectorExposedfields`
     :   The type of the None singleton.
+
+<a id="CallAudioDownloadParamsContentselectorExposedfields"></a>
 
 `CallAudioDownloadParamsContentselectorExposedfields(*args, **kwargs)`
 :   Nested schema for CallAudioDownloadParamsContentselector.exposedFields
@@ -73,6 +81,8 @@ Classes
     `media: bool`
     :   The type of the None singleton.
 
+<a id="CallAudioDownloadParamsFilter"></a>
+
 `CallAudioDownloadParamsFilter(*args, **kwargs)`
 :   Nested schema for CallAudioDownloadParams.filter
 
@@ -84,6 +94,8 @@ Classes
 
     `callIds: list[str]`
     :   The type of the None singleton.
+
+<a id="CallTranscriptsListParams"></a>
 
 `CallTranscriptsListParams(*args, **kwargs)`
 :   Parameters for call_transcripts.list operation
@@ -99,6 +111,8 @@ Classes
 
     `filter: airbyte_agent_sdk.connectors.gong.types.CallTranscriptsListParamsFilter`
     :   The type of the None singleton.
+
+<a id="CallTranscriptsListParamsFilter"></a>
 
 `CallTranscriptsListParamsFilter(*args, **kwargs)`
 :   Nested schema for CallTranscriptsListParams.filter
@@ -118,6 +132,8 @@ Classes
     `toDateTime: str`
     :   The type of the None singleton.
 
+<a id="CallVideoDownloadParams"></a>
+
 `CallVideoDownloadParams(*args, **kwargs)`
 :   Parameters for call_video.download operation
 
@@ -136,6 +152,8 @@ Classes
     `range_header: str`
     :   The type of the None singleton.
 
+<a id="CallVideoDownloadParamsContentselector"></a>
+
 `CallVideoDownloadParamsContentselector(*args, **kwargs)`
 :   Nested schema for CallVideoDownloadParams.contentSelector
 
@@ -147,6 +165,8 @@ Classes
 
     `exposedFields: airbyte_agent_sdk.connectors.gong.types.CallVideoDownloadParamsContentselectorExposedfields`
     :   The type of the None singleton.
+
+<a id="CallVideoDownloadParamsContentselectorExposedfields"></a>
 
 `CallVideoDownloadParamsContentselectorExposedfields(*args, **kwargs)`
 :   Nested schema for CallVideoDownloadParamsContentselector.exposedFields
@@ -160,6 +180,8 @@ Classes
     `media: bool`
     :   The type of the None singleton.
 
+<a id="CallVideoDownloadParamsFilter"></a>
+
 `CallVideoDownloadParamsFilter(*args, **kwargs)`
 :   Nested schema for CallVideoDownloadParams.filter
 
@@ -171,6 +193,8 @@ Classes
 
     `callIds: list[str]`
     :   The type of the None singleton.
+
+<a id="CallsAndCondition"></a>
 
 `CallsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -192,6 +216,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.gong.types.CallsEqCondition | airbyte_agent_sdk.connectors.gong.types.CallsNeqCondition | airbyte_agent_sdk.connectors.gong.types.CallsGtCondition | airbyte_agent_sdk.connectors.gong.types.CallsGteCondition | airbyte_agent_sdk.connectors.gong.types.CallsLtCondition | airbyte_agent_sdk.connectors.gong.types.CallsLteCondition | airbyte_agent_sdk.connectors.gong.types.CallsInCondition | airbyte_agent_sdk.connectors.gong.types.CallsLikeCondition | airbyte_agent_sdk.connectors.gong.types.CallsFuzzyCondition | airbyte_agent_sdk.connectors.gong.types.CallsKeywordCondition | airbyte_agent_sdk.connectors.gong.types.CallsContainsCondition | airbyte_agent_sdk.connectors.gong.types.CallsNotCondition | airbyte_agent_sdk.connectors.gong.types.CallsAndCondition | airbyte_agent_sdk.connectors.gong.types.CallsOrCondition | airbyte_agent_sdk.connectors.gong.types.CallsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="CallsAnyCondition"></a>
+
 `CallsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -211,6 +237,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.gong.types.CallsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="CallsAnyValueFilter"></a>
 
 `CallsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -281,6 +309,8 @@ Classes
     `workspace_id: Any`
     :   Identifier for the workspace to which the call belongs.
 
+<a id="CallsContainsCondition"></a>
+
 `CallsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -293,6 +323,8 @@ Classes
     `contains: airbyte_agent_sdk.connectors.gong.types.CallsAnyValueFilter`
     :   The type of the None singleton.
 
+<a id="CallsEqCondition"></a>
+
 `CallsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
 
@@ -304,6 +336,8 @@ Classes
 
     `eq: airbyte_agent_sdk.connectors.gong.types.CallsSearchFilter`
     :   The type of the None singleton.
+
+<a id="CallsExtensiveAndCondition"></a>
 
 `CallsExtensiveAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -325,6 +359,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.gong.types.CallsExtensiveEqCondition | airbyte_agent_sdk.connectors.gong.types.CallsExtensiveNeqCondition | airbyte_agent_sdk.connectors.gong.types.CallsExtensiveGtCondition | airbyte_agent_sdk.connectors.gong.types.CallsExtensiveGteCondition | airbyte_agent_sdk.connectors.gong.types.CallsExtensiveLtCondition | airbyte_agent_sdk.connectors.gong.types.CallsExtensiveLteCondition | airbyte_agent_sdk.connectors.gong.types.CallsExtensiveInCondition | airbyte_agent_sdk.connectors.gong.types.CallsExtensiveLikeCondition | airbyte_agent_sdk.connectors.gong.types.CallsExtensiveFuzzyCondition | airbyte_agent_sdk.connectors.gong.types.CallsExtensiveKeywordCondition | airbyte_agent_sdk.connectors.gong.types.CallsExtensiveContainsCondition | airbyte_agent_sdk.connectors.gong.types.CallsExtensiveNotCondition | airbyte_agent_sdk.connectors.gong.types.CallsExtensiveAndCondition | airbyte_agent_sdk.connectors.gong.types.CallsExtensiveOrCondition | airbyte_agent_sdk.connectors.gong.types.CallsExtensiveAnyCondition]`
     :   The type of the None singleton.
 
+<a id="CallsExtensiveAnyCondition"></a>
+
 `CallsExtensiveAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -344,6 +380,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.gong.types.CallsExtensiveAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="CallsExtensiveAnyValueFilter"></a>
 
 `CallsExtensiveAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -381,6 +419,8 @@ Classes
     `startdatetime: Any`
     :   Datetime for extensive calls.
 
+<a id="CallsExtensiveContainsCondition"></a>
+
 `CallsExtensiveContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -392,6 +432,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.gong.types.CallsExtensiveAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="CallsExtensiveEqCondition"></a>
 
 `CallsExtensiveEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -405,6 +447,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.gong.types.CallsExtensiveSearchFilter`
     :   The type of the None singleton.
 
+<a id="CallsExtensiveFuzzyCondition"></a>
+
 `CallsExtensiveFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -416,6 +460,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.gong.types.CallsExtensiveStringFilter`
     :   The type of the None singleton.
+
+<a id="CallsExtensiveGtCondition"></a>
 
 `CallsExtensiveGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
@@ -429,6 +475,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.gong.types.CallsExtensiveSearchFilter`
     :   The type of the None singleton.
 
+<a id="CallsExtensiveGteCondition"></a>
+
 `CallsExtensiveGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -440,6 +488,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.gong.types.CallsExtensiveSearchFilter`
     :   The type of the None singleton.
+
+<a id="CallsExtensiveInCondition"></a>
 
 `CallsExtensiveInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -460,6 +510,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.gong.types.CallsExtensiveInFilter`
     :   The type of the None singleton.
+
+<a id="CallsExtensiveInFilter"></a>
 
 `CallsExtensiveInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -497,6 +549,8 @@ Classes
     `startdatetime: list[str]`
     :   Datetime for extensive calls.
 
+<a id="CallsExtensiveKeywordCondition"></a>
+
 `CallsExtensiveKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -509,6 +563,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.gong.types.CallsExtensiveStringFilter`
     :   The type of the None singleton.
 
+<a id="CallsExtensiveLikeCondition"></a>
+
 `CallsExtensiveLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -520,6 +576,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.gong.types.CallsExtensiveStringFilter`
     :   The type of the None singleton.
+
+<a id="CallsExtensiveListParams"></a>
 
 `CallsExtensiveListParams(*args, **kwargs)`
 :   Parameters for calls_extensive.list operation
@@ -539,6 +597,8 @@ Classes
     `filter: airbyte_agent_sdk.connectors.gong.types.CallsExtensiveListParamsFilter`
     :   The type of the None singleton.
 
+<a id="CallsExtensiveListParamsContentselector"></a>
+
 `CallsExtensiveListParamsContentselector(*args, **kwargs)`
 :   Select which content to include in the response
 
@@ -556,6 +616,8 @@ Classes
 
     `exposedFields: airbyte_agent_sdk.connectors.gong.types.CallsExtensiveListParamsContentselectorExposedfields`
     :   The type of the None singleton.
+
+<a id="CallsExtensiveListParamsContentselectorExposedfields"></a>
 
 `CallsExtensiveListParamsContentselectorExposedfields(*args, **kwargs)`
 :   Specify which fields to include in the response
@@ -581,6 +643,8 @@ Classes
     `parties: bool`
     :   The type of the None singleton.
 
+<a id="CallsExtensiveListParamsContentselectorExposedfieldsCollaboration"></a>
+
 `CallsExtensiveListParamsContentselectorExposedfieldsCollaboration(*args, **kwargs)`
 :   Nested schema for CallsExtensiveListParamsContentselectorExposedfields.collaboration
 
@@ -592,6 +656,8 @@ Classes
 
     `publicComments: bool`
     :   The type of the None singleton.
+
+<a id="CallsExtensiveListParamsContentselectorExposedfieldsContent"></a>
 
 `CallsExtensiveListParamsContentselectorExposedfieldsContent(*args, **kwargs)`
 :   Nested schema for CallsExtensiveListParamsContentselectorExposedfields.content
@@ -632,6 +698,8 @@ Classes
     `trackers: bool`
     :   The type of the None singleton.
 
+<a id="CallsExtensiveListParamsContentselectorExposedfieldsInteraction"></a>
+
 `CallsExtensiveListParamsContentselectorExposedfieldsInteraction(*args, **kwargs)`
 :   Nested schema for CallsExtensiveListParamsContentselectorExposedfields.interaction
 
@@ -652,6 +720,8 @@ Classes
 
     `video: bool`
     :   The type of the None singleton.
+
+<a id="CallsExtensiveListParamsFilter"></a>
 
 `CallsExtensiveListParamsFilter(*args, **kwargs)`
 :   Nested schema for CallsExtensiveListParams.filter
@@ -674,6 +744,8 @@ Classes
     `workspaceId: str`
     :   The type of the None singleton.
 
+<a id="CallsExtensiveLtCondition"></a>
+
 `CallsExtensiveLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -685,6 +757,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.gong.types.CallsExtensiveSearchFilter`
     :   The type of the None singleton.
+
+<a id="CallsExtensiveLteCondition"></a>
 
 `CallsExtensiveLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -698,6 +772,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.gong.types.CallsExtensiveSearchFilter`
     :   The type of the None singleton.
 
+<a id="CallsExtensiveNeqCondition"></a>
+
 `CallsExtensiveNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -709,6 +785,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.gong.types.CallsExtensiveSearchFilter`
     :   The type of the None singleton.
+
+<a id="CallsExtensiveNotCondition"></a>
 
 `CallsExtensiveNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -730,6 +808,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.gong.types.CallsExtensiveEqCondition | airbyte_agent_sdk.connectors.gong.types.CallsExtensiveNeqCondition | airbyte_agent_sdk.connectors.gong.types.CallsExtensiveGtCondition | airbyte_agent_sdk.connectors.gong.types.CallsExtensiveGteCondition | airbyte_agent_sdk.connectors.gong.types.CallsExtensiveLtCondition | airbyte_agent_sdk.connectors.gong.types.CallsExtensiveLteCondition | airbyte_agent_sdk.connectors.gong.types.CallsExtensiveInCondition | airbyte_agent_sdk.connectors.gong.types.CallsExtensiveLikeCondition | airbyte_agent_sdk.connectors.gong.types.CallsExtensiveFuzzyCondition | airbyte_agent_sdk.connectors.gong.types.CallsExtensiveKeywordCondition | airbyte_agent_sdk.connectors.gong.types.CallsExtensiveContainsCondition | airbyte_agent_sdk.connectors.gong.types.CallsExtensiveNotCondition | airbyte_agent_sdk.connectors.gong.types.CallsExtensiveAndCondition | airbyte_agent_sdk.connectors.gong.types.CallsExtensiveOrCondition | airbyte_agent_sdk.connectors.gong.types.CallsExtensiveAnyCondition`
     :   The type of the None singleton.
 
+<a id="CallsExtensiveOrCondition"></a>
+
 `CallsExtensiveOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -749,6 +829,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.gong.types.CallsExtensiveEqCondition | airbyte_agent_sdk.connectors.gong.types.CallsExtensiveNeqCondition | airbyte_agent_sdk.connectors.gong.types.CallsExtensiveGtCondition | airbyte_agent_sdk.connectors.gong.types.CallsExtensiveGteCondition | airbyte_agent_sdk.connectors.gong.types.CallsExtensiveLtCondition | airbyte_agent_sdk.connectors.gong.types.CallsExtensiveLteCondition | airbyte_agent_sdk.connectors.gong.types.CallsExtensiveInCondition | airbyte_agent_sdk.connectors.gong.types.CallsExtensiveLikeCondition | airbyte_agent_sdk.connectors.gong.types.CallsExtensiveFuzzyCondition | airbyte_agent_sdk.connectors.gong.types.CallsExtensiveKeywordCondition | airbyte_agent_sdk.connectors.gong.types.CallsExtensiveContainsCondition | airbyte_agent_sdk.connectors.gong.types.CallsExtensiveNotCondition | airbyte_agent_sdk.connectors.gong.types.CallsExtensiveAndCondition | airbyte_agent_sdk.connectors.gong.types.CallsExtensiveOrCondition | airbyte_agent_sdk.connectors.gong.types.CallsExtensiveAnyCondition]`
     :   The type of the None singleton.
+
+<a id="CallsExtensiveSearchFilter"></a>
 
 `CallsExtensiveSearchFilter(*args, **kwargs)`
 :   Available fields for filtering calls_extensive search queries.
@@ -786,6 +868,8 @@ Classes
     `startdatetime: str | None`
     :   Datetime for extensive calls.
 
+<a id="CallsExtensiveSearchQuery"></a>
+
 `CallsExtensiveSearchQuery(*args, **kwargs)`
 :   Search query for calls_extensive entity.
 
@@ -800,6 +884,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.gong.types.CallsExtensiveSortFilter]`
     :   The type of the None singleton.
+
+<a id="CallsExtensiveSortFilter"></a>
 
 `CallsExtensiveSortFilter(*args, **kwargs)`
 :   Available fields for sorting calls_extensive search results.
@@ -837,6 +923,8 @@ Classes
     `startdatetime: Literal['asc', 'desc']`
     :   Datetime for extensive calls.
 
+<a id="CallsExtensiveStringFilter"></a>
+
 `CallsExtensiveStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -873,6 +961,8 @@ Classes
     `startdatetime: str`
     :   Datetime for extensive calls.
 
+<a id="CallsFuzzyCondition"></a>
+
 `CallsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -884,6 +974,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.gong.types.CallsStringFilter`
     :   The type of the None singleton.
+
+<a id="CallsGetParams"></a>
 
 `CallsGetParams(*args, **kwargs)`
 :   Parameters for calls.get operation
@@ -897,6 +989,8 @@ Classes
     `id: str`
     :   The type of the None singleton.
 
+<a id="CallsGtCondition"></a>
+
 `CallsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -909,6 +1003,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.gong.types.CallsSearchFilter`
     :   The type of the None singleton.
 
+<a id="CallsGteCondition"></a>
+
 `CallsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -920,6 +1016,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.gong.types.CallsSearchFilter`
     :   The type of the None singleton.
+
+<a id="CallsInCondition"></a>
 
 `CallsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -940,6 +1038,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.gong.types.CallsInFilter`
     :   The type of the None singleton.
+
+<a id="CallsInFilter"></a>
 
 `CallsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -1010,6 +1110,8 @@ Classes
     `workspace_id: list[str]`
     :   Identifier for the workspace to which the call belongs.
 
+<a id="CallsKeywordCondition"></a>
+
 `CallsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -1022,6 +1124,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.gong.types.CallsStringFilter`
     :   The type of the None singleton.
 
+<a id="CallsLikeCondition"></a>
+
 `CallsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -1033,6 +1137,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.gong.types.CallsStringFilter`
     :   The type of the None singleton.
+
+<a id="CallsListParams"></a>
 
 `CallsListParams(*args, **kwargs)`
 :   Parameters for calls.list operation
@@ -1052,6 +1158,8 @@ Classes
     `to_date_time: str`
     :   The type of the None singleton.
 
+<a id="CallsLtCondition"></a>
+
 `CallsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -1063,6 +1171,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.gong.types.CallsSearchFilter`
     :   The type of the None singleton.
+
+<a id="CallsLteCondition"></a>
 
 `CallsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -1076,6 +1186,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.gong.types.CallsSearchFilter`
     :   The type of the None singleton.
 
+<a id="CallsNeqCondition"></a>
+
 `CallsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -1087,6 +1199,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.gong.types.CallsSearchFilter`
     :   The type of the None singleton.
+
+<a id="CallsNotCondition"></a>
 
 `CallsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -1108,6 +1222,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.gong.types.CallsEqCondition | airbyte_agent_sdk.connectors.gong.types.CallsNeqCondition | airbyte_agent_sdk.connectors.gong.types.CallsGtCondition | airbyte_agent_sdk.connectors.gong.types.CallsGteCondition | airbyte_agent_sdk.connectors.gong.types.CallsLtCondition | airbyte_agent_sdk.connectors.gong.types.CallsLteCondition | airbyte_agent_sdk.connectors.gong.types.CallsInCondition | airbyte_agent_sdk.connectors.gong.types.CallsLikeCondition | airbyte_agent_sdk.connectors.gong.types.CallsFuzzyCondition | airbyte_agent_sdk.connectors.gong.types.CallsKeywordCondition | airbyte_agent_sdk.connectors.gong.types.CallsContainsCondition | airbyte_agent_sdk.connectors.gong.types.CallsNotCondition | airbyte_agent_sdk.connectors.gong.types.CallsAndCondition | airbyte_agent_sdk.connectors.gong.types.CallsOrCondition | airbyte_agent_sdk.connectors.gong.types.CallsAnyCondition`
     :   The type of the None singleton.
 
+<a id="CallsOrCondition"></a>
+
 `CallsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1127,6 +1243,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.gong.types.CallsEqCondition | airbyte_agent_sdk.connectors.gong.types.CallsNeqCondition | airbyte_agent_sdk.connectors.gong.types.CallsGtCondition | airbyte_agent_sdk.connectors.gong.types.CallsGteCondition | airbyte_agent_sdk.connectors.gong.types.CallsLtCondition | airbyte_agent_sdk.connectors.gong.types.CallsLteCondition | airbyte_agent_sdk.connectors.gong.types.CallsInCondition | airbyte_agent_sdk.connectors.gong.types.CallsLikeCondition | airbyte_agent_sdk.connectors.gong.types.CallsFuzzyCondition | airbyte_agent_sdk.connectors.gong.types.CallsKeywordCondition | airbyte_agent_sdk.connectors.gong.types.CallsContainsCondition | airbyte_agent_sdk.connectors.gong.types.CallsNotCondition | airbyte_agent_sdk.connectors.gong.types.CallsAndCondition | airbyte_agent_sdk.connectors.gong.types.CallsOrCondition | airbyte_agent_sdk.connectors.gong.types.CallsAnyCondition]`
     :   The type of the None singleton.
+
+<a id="CallsSearchFilter"></a>
 
 `CallsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering calls search queries.
@@ -1197,6 +1315,8 @@ Classes
     `workspace_id: str | None`
     :   Identifier for the workspace to which the call belongs.
 
+<a id="CallsSearchQuery"></a>
+
 `CallsSearchQuery(*args, **kwargs)`
 :   Search query for calls entity.
 
@@ -1211,6 +1331,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.gong.types.CallsSortFilter]`
     :   The type of the None singleton.
+
+<a id="CallsSortFilter"></a>
 
 `CallsSortFilter(*args, **kwargs)`
 :   Available fields for sorting calls search results.
@@ -1281,6 +1403,8 @@ Classes
     `workspace_id: Literal['asc', 'desc']`
     :   Identifier for the workspace to which the call belongs.
 
+<a id="CallsStringFilter"></a>
+
 `CallsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -1350,6 +1474,8 @@ Classes
     `workspace_id: str`
     :   Identifier for the workspace to which the call belongs.
 
+<a id="CoachingListParams"></a>
+
 `CoachingListParams(*args, **kwargs)`
 :   Parameters for coaching.list operation
 
@@ -1371,6 +1497,8 @@ Classes
     `workspace_id: str`
     :   The type of the None singleton.
 
+<a id="LibraryFolderContentListParams"></a>
+
 `LibraryFolderContentListParams(*args, **kwargs)`
 :   Parameters for library_folder_content.list operation
 
@@ -1386,6 +1514,8 @@ Classes
     `folder_id: str`
     :   The type of the None singleton.
 
+<a id="LibraryFoldersListParams"></a>
+
 `LibraryFoldersListParams(*args, **kwargs)`
 :   Parameters for library_folders.list operation
 
@@ -1397,6 +1527,8 @@ Classes
 
     `workspace_id: str`
     :   The type of the None singleton.
+
+<a id="SettingsScorecardsAndCondition"></a>
 
 `SettingsScorecardsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -1418,6 +1550,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.gong.types.SettingsScorecardsEqCondition | airbyte_agent_sdk.connectors.gong.types.SettingsScorecardsNeqCondition | airbyte_agent_sdk.connectors.gong.types.SettingsScorecardsGtCondition | airbyte_agent_sdk.connectors.gong.types.SettingsScorecardsGteCondition | airbyte_agent_sdk.connectors.gong.types.SettingsScorecardsLtCondition | airbyte_agent_sdk.connectors.gong.types.SettingsScorecardsLteCondition | airbyte_agent_sdk.connectors.gong.types.SettingsScorecardsInCondition | airbyte_agent_sdk.connectors.gong.types.SettingsScorecardsLikeCondition | airbyte_agent_sdk.connectors.gong.types.SettingsScorecardsFuzzyCondition | airbyte_agent_sdk.connectors.gong.types.SettingsScorecardsKeywordCondition | airbyte_agent_sdk.connectors.gong.types.SettingsScorecardsContainsCondition | airbyte_agent_sdk.connectors.gong.types.SettingsScorecardsNotCondition | airbyte_agent_sdk.connectors.gong.types.SettingsScorecardsAndCondition | airbyte_agent_sdk.connectors.gong.types.SettingsScorecardsOrCondition | airbyte_agent_sdk.connectors.gong.types.SettingsScorecardsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="SettingsScorecardsAnyCondition"></a>
+
 `SettingsScorecardsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1437,6 +1571,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.gong.types.SettingsScorecardsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="SettingsScorecardsAnyValueFilter"></a>
 
 `SettingsScorecardsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -1471,6 +1607,8 @@ Classes
     `workspace_id: Any`
     :   The unique identifier of the workspace associated with the scorecard
 
+<a id="SettingsScorecardsContainsCondition"></a>
+
 `SettingsScorecardsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -1482,6 +1620,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.gong.types.SettingsScorecardsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="SettingsScorecardsEqCondition"></a>
 
 `SettingsScorecardsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -1495,6 +1635,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.gong.types.SettingsScorecardsSearchFilter`
     :   The type of the None singleton.
 
+<a id="SettingsScorecardsFuzzyCondition"></a>
+
 `SettingsScorecardsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -1506,6 +1648,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.gong.types.SettingsScorecardsStringFilter`
     :   The type of the None singleton.
+
+<a id="SettingsScorecardsGtCondition"></a>
 
 `SettingsScorecardsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
@@ -1519,6 +1663,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.gong.types.SettingsScorecardsSearchFilter`
     :   The type of the None singleton.
 
+<a id="SettingsScorecardsGteCondition"></a>
+
 `SettingsScorecardsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -1530,6 +1676,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.gong.types.SettingsScorecardsSearchFilter`
     :   The type of the None singleton.
+
+<a id="SettingsScorecardsInCondition"></a>
 
 `SettingsScorecardsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -1550,6 +1698,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.gong.types.SettingsScorecardsInFilter`
     :   The type of the None singleton.
+
+<a id="SettingsScorecardsInFilter"></a>
 
 `SettingsScorecardsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -1584,6 +1734,8 @@ Classes
     `workspace_id: list[str]`
     :   The unique identifier of the workspace associated with the scorecard
 
+<a id="SettingsScorecardsKeywordCondition"></a>
+
 `SettingsScorecardsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -1595,6 +1747,8 @@ Classes
 
     `keyword: airbyte_agent_sdk.connectors.gong.types.SettingsScorecardsStringFilter`
     :   The type of the None singleton.
+
+<a id="SettingsScorecardsLikeCondition"></a>
 
 `SettingsScorecardsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
@@ -1608,6 +1762,8 @@ Classes
     `like: airbyte_agent_sdk.connectors.gong.types.SettingsScorecardsStringFilter`
     :   The type of the None singleton.
 
+<a id="SettingsScorecardsListParams"></a>
+
 `SettingsScorecardsListParams(*args, **kwargs)`
 :   Parameters for settings_scorecards.list operation
 
@@ -1619,6 +1775,8 @@ Classes
 
     `workspace_id: str`
     :   The type of the None singleton.
+
+<a id="SettingsScorecardsLtCondition"></a>
 
 `SettingsScorecardsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
@@ -1632,6 +1790,8 @@ Classes
     `lt: airbyte_agent_sdk.connectors.gong.types.SettingsScorecardsSearchFilter`
     :   The type of the None singleton.
 
+<a id="SettingsScorecardsLteCondition"></a>
+
 `SettingsScorecardsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
 
@@ -1644,6 +1804,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.gong.types.SettingsScorecardsSearchFilter`
     :   The type of the None singleton.
 
+<a id="SettingsScorecardsNeqCondition"></a>
+
 `SettingsScorecardsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -1655,6 +1817,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.gong.types.SettingsScorecardsSearchFilter`
     :   The type of the None singleton.
+
+<a id="SettingsScorecardsNotCondition"></a>
 
 `SettingsScorecardsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -1676,6 +1840,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.gong.types.SettingsScorecardsEqCondition | airbyte_agent_sdk.connectors.gong.types.SettingsScorecardsNeqCondition | airbyte_agent_sdk.connectors.gong.types.SettingsScorecardsGtCondition | airbyte_agent_sdk.connectors.gong.types.SettingsScorecardsGteCondition | airbyte_agent_sdk.connectors.gong.types.SettingsScorecardsLtCondition | airbyte_agent_sdk.connectors.gong.types.SettingsScorecardsLteCondition | airbyte_agent_sdk.connectors.gong.types.SettingsScorecardsInCondition | airbyte_agent_sdk.connectors.gong.types.SettingsScorecardsLikeCondition | airbyte_agent_sdk.connectors.gong.types.SettingsScorecardsFuzzyCondition | airbyte_agent_sdk.connectors.gong.types.SettingsScorecardsKeywordCondition | airbyte_agent_sdk.connectors.gong.types.SettingsScorecardsContainsCondition | airbyte_agent_sdk.connectors.gong.types.SettingsScorecardsNotCondition | airbyte_agent_sdk.connectors.gong.types.SettingsScorecardsAndCondition | airbyte_agent_sdk.connectors.gong.types.SettingsScorecardsOrCondition | airbyte_agent_sdk.connectors.gong.types.SettingsScorecardsAnyCondition`
     :   The type of the None singleton.
 
+<a id="SettingsScorecardsOrCondition"></a>
+
 `SettingsScorecardsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1695,6 +1861,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.gong.types.SettingsScorecardsEqCondition | airbyte_agent_sdk.connectors.gong.types.SettingsScorecardsNeqCondition | airbyte_agent_sdk.connectors.gong.types.SettingsScorecardsGtCondition | airbyte_agent_sdk.connectors.gong.types.SettingsScorecardsGteCondition | airbyte_agent_sdk.connectors.gong.types.SettingsScorecardsLtCondition | airbyte_agent_sdk.connectors.gong.types.SettingsScorecardsLteCondition | airbyte_agent_sdk.connectors.gong.types.SettingsScorecardsInCondition | airbyte_agent_sdk.connectors.gong.types.SettingsScorecardsLikeCondition | airbyte_agent_sdk.connectors.gong.types.SettingsScorecardsFuzzyCondition | airbyte_agent_sdk.connectors.gong.types.SettingsScorecardsKeywordCondition | airbyte_agent_sdk.connectors.gong.types.SettingsScorecardsContainsCondition | airbyte_agent_sdk.connectors.gong.types.SettingsScorecardsNotCondition | airbyte_agent_sdk.connectors.gong.types.SettingsScorecardsAndCondition | airbyte_agent_sdk.connectors.gong.types.SettingsScorecardsOrCondition | airbyte_agent_sdk.connectors.gong.types.SettingsScorecardsAnyCondition]`
     :   The type of the None singleton.
+
+<a id="SettingsScorecardsSearchFilter"></a>
 
 `SettingsScorecardsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering settings_scorecards search queries.
@@ -1729,6 +1897,8 @@ Classes
     `workspace_id: str | None`
     :   The unique identifier of the workspace associated with the scorecard
 
+<a id="SettingsScorecardsSearchQuery"></a>
+
 `SettingsScorecardsSearchQuery(*args, **kwargs)`
 :   Search query for settings_scorecards entity.
 
@@ -1743,6 +1913,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.gong.types.SettingsScorecardsSortFilter]`
     :   The type of the None singleton.
+
+<a id="SettingsScorecardsSortFilter"></a>
 
 `SettingsScorecardsSortFilter(*args, **kwargs)`
 :   Available fields for sorting settings_scorecards search results.
@@ -1777,6 +1949,8 @@ Classes
     `workspace_id: Literal['asc', 'desc']`
     :   The unique identifier of the workspace associated with the scorecard
 
+<a id="SettingsScorecardsStringFilter"></a>
+
 `SettingsScorecardsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -1810,6 +1984,8 @@ Classes
     `workspace_id: str`
     :   The unique identifier of the workspace associated with the scorecard
 
+<a id="SettingsTrackersListParams"></a>
+
 `SettingsTrackersListParams(*args, **kwargs)`
 :   Parameters for settings_trackers.list operation
 
@@ -1822,6 +1998,8 @@ Classes
     `workspace_id: str`
     :   The type of the None singleton.
 
+<a id="StatsActivityAggregateListParams"></a>
+
 `StatsActivityAggregateListParams(*args, **kwargs)`
 :   Parameters for stats_activity_aggregate.list operation
 
@@ -1833,6 +2011,8 @@ Classes
 
     `filter: airbyte_agent_sdk.connectors.gong.types.StatsActivityAggregateListParamsFilter`
     :   The type of the None singleton.
+
+<a id="StatsActivityAggregateListParamsFilter"></a>
 
 `StatsActivityAggregateListParamsFilter(*args, **kwargs)`
 :   Nested schema for StatsActivityAggregateListParams.filter
@@ -1852,6 +2032,8 @@ Classes
     `userIds: list[str]`
     :   The type of the None singleton.
 
+<a id="StatsActivityDayByDayListParams"></a>
+
 `StatsActivityDayByDayListParams(*args, **kwargs)`
 :   Parameters for stats_activity_day_by_day.list operation
 
@@ -1863,6 +2045,8 @@ Classes
 
     `filter: airbyte_agent_sdk.connectors.gong.types.StatsActivityDayByDayListParamsFilter`
     :   The type of the None singleton.
+
+<a id="StatsActivityDayByDayListParamsFilter"></a>
 
 `StatsActivityDayByDayListParamsFilter(*args, **kwargs)`
 :   Nested schema for StatsActivityDayByDayListParams.filter
@@ -1881,6 +2065,8 @@ Classes
 
     `userIds: list[str]`
     :   The type of the None singleton.
+
+<a id="StatsActivityScorecardsAndCondition"></a>
 
 `StatsActivityScorecardsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -1902,6 +2088,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.gong.types.StatsActivityScorecardsEqCondition | airbyte_agent_sdk.connectors.gong.types.StatsActivityScorecardsNeqCondition | airbyte_agent_sdk.connectors.gong.types.StatsActivityScorecardsGtCondition | airbyte_agent_sdk.connectors.gong.types.StatsActivityScorecardsGteCondition | airbyte_agent_sdk.connectors.gong.types.StatsActivityScorecardsLtCondition | airbyte_agent_sdk.connectors.gong.types.StatsActivityScorecardsLteCondition | airbyte_agent_sdk.connectors.gong.types.StatsActivityScorecardsInCondition | airbyte_agent_sdk.connectors.gong.types.StatsActivityScorecardsLikeCondition | airbyte_agent_sdk.connectors.gong.types.StatsActivityScorecardsFuzzyCondition | airbyte_agent_sdk.connectors.gong.types.StatsActivityScorecardsKeywordCondition | airbyte_agent_sdk.connectors.gong.types.StatsActivityScorecardsContainsCondition | airbyte_agent_sdk.connectors.gong.types.StatsActivityScorecardsNotCondition | airbyte_agent_sdk.connectors.gong.types.StatsActivityScorecardsAndCondition | airbyte_agent_sdk.connectors.gong.types.StatsActivityScorecardsOrCondition | airbyte_agent_sdk.connectors.gong.types.StatsActivityScorecardsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="StatsActivityScorecardsAnyCondition"></a>
+
 `StatsActivityScorecardsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1921,6 +2109,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.gong.types.StatsActivityScorecardsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="StatsActivityScorecardsAnyValueFilter"></a>
 
 `StatsActivityScorecardsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -1961,6 +2151,8 @@ Classes
     `visibility_type: Any`
     :   Type indicating the visibility permissions for the answered scorecard.
 
+<a id="StatsActivityScorecardsContainsCondition"></a>
+
 `StatsActivityScorecardsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -1972,6 +2164,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.gong.types.StatsActivityScorecardsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="StatsActivityScorecardsEqCondition"></a>
 
 `StatsActivityScorecardsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -1985,6 +2179,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.gong.types.StatsActivityScorecardsSearchFilter`
     :   The type of the None singleton.
 
+<a id="StatsActivityScorecardsFuzzyCondition"></a>
+
 `StatsActivityScorecardsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -1996,6 +2192,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.gong.types.StatsActivityScorecardsStringFilter`
     :   The type of the None singleton.
+
+<a id="StatsActivityScorecardsGtCondition"></a>
 
 `StatsActivityScorecardsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
@@ -2009,6 +2207,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.gong.types.StatsActivityScorecardsSearchFilter`
     :   The type of the None singleton.
 
+<a id="StatsActivityScorecardsGteCondition"></a>
+
 `StatsActivityScorecardsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -2020,6 +2220,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.gong.types.StatsActivityScorecardsSearchFilter`
     :   The type of the None singleton.
+
+<a id="StatsActivityScorecardsInCondition"></a>
 
 `StatsActivityScorecardsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -2040,6 +2242,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.gong.types.StatsActivityScorecardsInFilter`
     :   The type of the None singleton.
+
+<a id="StatsActivityScorecardsInFilter"></a>
 
 `StatsActivityScorecardsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -2080,6 +2284,8 @@ Classes
     `visibility_type: list[str]`
     :   Type indicating the visibility permissions for the answered scorecard.
 
+<a id="StatsActivityScorecardsKeywordCondition"></a>
+
 `StatsActivityScorecardsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -2092,6 +2298,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.gong.types.StatsActivityScorecardsStringFilter`
     :   The type of the None singleton.
 
+<a id="StatsActivityScorecardsLikeCondition"></a>
+
 `StatsActivityScorecardsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -2103,6 +2311,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.gong.types.StatsActivityScorecardsStringFilter`
     :   The type of the None singleton.
+
+<a id="StatsActivityScorecardsListParams"></a>
 
 `StatsActivityScorecardsListParams(*args, **kwargs)`
 :   Parameters for stats_activity_scorecards.list operation
@@ -2118,6 +2328,8 @@ Classes
 
     `filter: airbyte_agent_sdk.connectors.gong.types.StatsActivityScorecardsListParamsFilter`
     :   The type of the None singleton.
+
+<a id="StatsActivityScorecardsListParamsFilter"></a>
 
 `StatsActivityScorecardsListParamsFilter(*args, **kwargs)`
 :   Nested schema for StatsActivityScorecardsListParams.filter
@@ -2146,6 +2358,8 @@ Classes
     `toDateTime: str`
     :   The type of the None singleton.
 
+<a id="StatsActivityScorecardsLtCondition"></a>
+
 `StatsActivityScorecardsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -2157,6 +2371,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.gong.types.StatsActivityScorecardsSearchFilter`
     :   The type of the None singleton.
+
+<a id="StatsActivityScorecardsLteCondition"></a>
 
 `StatsActivityScorecardsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -2170,6 +2386,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.gong.types.StatsActivityScorecardsSearchFilter`
     :   The type of the None singleton.
 
+<a id="StatsActivityScorecardsNeqCondition"></a>
+
 `StatsActivityScorecardsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -2181,6 +2399,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.gong.types.StatsActivityScorecardsSearchFilter`
     :   The type of the None singleton.
+
+<a id="StatsActivityScorecardsNotCondition"></a>
 
 `StatsActivityScorecardsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -2202,6 +2422,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.gong.types.StatsActivityScorecardsEqCondition | airbyte_agent_sdk.connectors.gong.types.StatsActivityScorecardsNeqCondition | airbyte_agent_sdk.connectors.gong.types.StatsActivityScorecardsGtCondition | airbyte_agent_sdk.connectors.gong.types.StatsActivityScorecardsGteCondition | airbyte_agent_sdk.connectors.gong.types.StatsActivityScorecardsLtCondition | airbyte_agent_sdk.connectors.gong.types.StatsActivityScorecardsLteCondition | airbyte_agent_sdk.connectors.gong.types.StatsActivityScorecardsInCondition | airbyte_agent_sdk.connectors.gong.types.StatsActivityScorecardsLikeCondition | airbyte_agent_sdk.connectors.gong.types.StatsActivityScorecardsFuzzyCondition | airbyte_agent_sdk.connectors.gong.types.StatsActivityScorecardsKeywordCondition | airbyte_agent_sdk.connectors.gong.types.StatsActivityScorecardsContainsCondition | airbyte_agent_sdk.connectors.gong.types.StatsActivityScorecardsNotCondition | airbyte_agent_sdk.connectors.gong.types.StatsActivityScorecardsAndCondition | airbyte_agent_sdk.connectors.gong.types.StatsActivityScorecardsOrCondition | airbyte_agent_sdk.connectors.gong.types.StatsActivityScorecardsAnyCondition`
     :   The type of the None singleton.
 
+<a id="StatsActivityScorecardsOrCondition"></a>
+
 `StatsActivityScorecardsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -2221,6 +2443,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.gong.types.StatsActivityScorecardsEqCondition | airbyte_agent_sdk.connectors.gong.types.StatsActivityScorecardsNeqCondition | airbyte_agent_sdk.connectors.gong.types.StatsActivityScorecardsGtCondition | airbyte_agent_sdk.connectors.gong.types.StatsActivityScorecardsGteCondition | airbyte_agent_sdk.connectors.gong.types.StatsActivityScorecardsLtCondition | airbyte_agent_sdk.connectors.gong.types.StatsActivityScorecardsLteCondition | airbyte_agent_sdk.connectors.gong.types.StatsActivityScorecardsInCondition | airbyte_agent_sdk.connectors.gong.types.StatsActivityScorecardsLikeCondition | airbyte_agent_sdk.connectors.gong.types.StatsActivityScorecardsFuzzyCondition | airbyte_agent_sdk.connectors.gong.types.StatsActivityScorecardsKeywordCondition | airbyte_agent_sdk.connectors.gong.types.StatsActivityScorecardsContainsCondition | airbyte_agent_sdk.connectors.gong.types.StatsActivityScorecardsNotCondition | airbyte_agent_sdk.connectors.gong.types.StatsActivityScorecardsAndCondition | airbyte_agent_sdk.connectors.gong.types.StatsActivityScorecardsOrCondition | airbyte_agent_sdk.connectors.gong.types.StatsActivityScorecardsAnyCondition]`
     :   The type of the None singleton.
+
+<a id="StatsActivityScorecardsSearchFilter"></a>
 
 `StatsActivityScorecardsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering stats_activity_scorecards search queries.
@@ -2261,6 +2485,8 @@ Classes
     `visibility_type: str | None`
     :   Type indicating the visibility permissions for the answered scorecard.
 
+<a id="StatsActivityScorecardsSearchQuery"></a>
+
 `StatsActivityScorecardsSearchQuery(*args, **kwargs)`
 :   Search query for stats_activity_scorecards entity.
 
@@ -2275,6 +2501,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.gong.types.StatsActivityScorecardsSortFilter]`
     :   The type of the None singleton.
+
+<a id="StatsActivityScorecardsSortFilter"></a>
 
 `StatsActivityScorecardsSortFilter(*args, **kwargs)`
 :   Available fields for sorting stats_activity_scorecards search results.
@@ -2315,6 +2543,8 @@ Classes
     `visibility_type: Literal['asc', 'desc']`
     :   Type indicating the visibility permissions for the answered scorecard.
 
+<a id="StatsActivityScorecardsStringFilter"></a>
+
 `StatsActivityScorecardsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -2354,6 +2584,8 @@ Classes
     `visibility_type: str`
     :   Type indicating the visibility permissions for the answered scorecard.
 
+<a id="StatsInteractionListParams"></a>
+
 `StatsInteractionListParams(*args, **kwargs)`
 :   Parameters for stats_interaction.list operation
 
@@ -2365,6 +2597,8 @@ Classes
 
     `filter: airbyte_agent_sdk.connectors.gong.types.StatsInteractionListParamsFilter`
     :   The type of the None singleton.
+
+<a id="StatsInteractionListParamsFilter"></a>
 
 `StatsInteractionListParamsFilter(*args, **kwargs)`
 :   Nested schema for StatsInteractionListParams.filter
@@ -2383,6 +2617,8 @@ Classes
 
     `userIds: list[str]`
     :   The type of the None singleton.
+
+<a id="UsersAndCondition"></a>
 
 `UsersAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -2404,6 +2640,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.gong.types.UsersEqCondition | airbyte_agent_sdk.connectors.gong.types.UsersNeqCondition | airbyte_agent_sdk.connectors.gong.types.UsersGtCondition | airbyte_agent_sdk.connectors.gong.types.UsersGteCondition | airbyte_agent_sdk.connectors.gong.types.UsersLtCondition | airbyte_agent_sdk.connectors.gong.types.UsersLteCondition | airbyte_agent_sdk.connectors.gong.types.UsersInCondition | airbyte_agent_sdk.connectors.gong.types.UsersLikeCondition | airbyte_agent_sdk.connectors.gong.types.UsersFuzzyCondition | airbyte_agent_sdk.connectors.gong.types.UsersKeywordCondition | airbyte_agent_sdk.connectors.gong.types.UsersContainsCondition | airbyte_agent_sdk.connectors.gong.types.UsersNotCondition | airbyte_agent_sdk.connectors.gong.types.UsersAndCondition | airbyte_agent_sdk.connectors.gong.types.UsersOrCondition | airbyte_agent_sdk.connectors.gong.types.UsersAnyCondition]`
     :   The type of the None singleton.
 
+<a id="UsersAnyCondition"></a>
+
 `UsersAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -2423,6 +2661,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.gong.types.UsersAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="UsersAnyValueFilter"></a>
 
 `UsersAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -2481,6 +2721,8 @@ Classes
     `trusted_email_address: Any`
     :   An email address that is considered trusted for the user
 
+<a id="UsersContainsCondition"></a>
+
 `UsersContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -2492,6 +2734,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.gong.types.UsersAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="UsersEqCondition"></a>
 
 `UsersEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -2505,6 +2749,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.gong.types.UsersSearchFilter`
     :   The type of the None singleton.
 
+<a id="UsersFuzzyCondition"></a>
+
 `UsersFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -2516,6 +2762,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.gong.types.UsersStringFilter`
     :   The type of the None singleton.
+
+<a id="UsersGetParams"></a>
 
 `UsersGetParams(*args, **kwargs)`
 :   Parameters for users.get operation
@@ -2529,6 +2777,8 @@ Classes
     `id: str`
     :   The type of the None singleton.
 
+<a id="UsersGtCondition"></a>
+
 `UsersGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -2541,6 +2791,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.gong.types.UsersSearchFilter`
     :   The type of the None singleton.
 
+<a id="UsersGteCondition"></a>
+
 `UsersGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -2552,6 +2804,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.gong.types.UsersSearchFilter`
     :   The type of the None singleton.
+
+<a id="UsersInCondition"></a>
 
 `UsersInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -2572,6 +2826,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.gong.types.UsersInFilter`
     :   The type of the None singleton.
+
+<a id="UsersInFilter"></a>
 
 `UsersInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -2630,6 +2886,8 @@ Classes
     `trusted_email_address: list[str]`
     :   An email address that is considered trusted for the user
 
+<a id="UsersKeywordCondition"></a>
+
 `UsersKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -2641,6 +2899,8 @@ Classes
 
     `keyword: airbyte_agent_sdk.connectors.gong.types.UsersStringFilter`
     :   The type of the None singleton.
+
+<a id="UsersLikeCondition"></a>
 
 `UsersLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
@@ -2654,6 +2914,8 @@ Classes
     `like: airbyte_agent_sdk.connectors.gong.types.UsersStringFilter`
     :   The type of the None singleton.
 
+<a id="UsersListParams"></a>
+
 `UsersListParams(*args, **kwargs)`
 :   Parameters for users.list operation
 
@@ -2665,6 +2927,8 @@ Classes
 
     `cursor: str`
     :   The type of the None singleton.
+
+<a id="UsersLtCondition"></a>
 
 `UsersLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
@@ -2678,6 +2942,8 @@ Classes
     `lt: airbyte_agent_sdk.connectors.gong.types.UsersSearchFilter`
     :   The type of the None singleton.
 
+<a id="UsersLteCondition"></a>
+
 `UsersLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
 
@@ -2690,6 +2956,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.gong.types.UsersSearchFilter`
     :   The type of the None singleton.
 
+<a id="UsersNeqCondition"></a>
+
 `UsersNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -2701,6 +2969,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.gong.types.UsersSearchFilter`
     :   The type of the None singleton.
+
+<a id="UsersNotCondition"></a>
 
 `UsersNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -2722,6 +2992,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.gong.types.UsersEqCondition | airbyte_agent_sdk.connectors.gong.types.UsersNeqCondition | airbyte_agent_sdk.connectors.gong.types.UsersGtCondition | airbyte_agent_sdk.connectors.gong.types.UsersGteCondition | airbyte_agent_sdk.connectors.gong.types.UsersLtCondition | airbyte_agent_sdk.connectors.gong.types.UsersLteCondition | airbyte_agent_sdk.connectors.gong.types.UsersInCondition | airbyte_agent_sdk.connectors.gong.types.UsersLikeCondition | airbyte_agent_sdk.connectors.gong.types.UsersFuzzyCondition | airbyte_agent_sdk.connectors.gong.types.UsersKeywordCondition | airbyte_agent_sdk.connectors.gong.types.UsersContainsCondition | airbyte_agent_sdk.connectors.gong.types.UsersNotCondition | airbyte_agent_sdk.connectors.gong.types.UsersAndCondition | airbyte_agent_sdk.connectors.gong.types.UsersOrCondition | airbyte_agent_sdk.connectors.gong.types.UsersAnyCondition`
     :   The type of the None singleton.
 
+<a id="UsersOrCondition"></a>
+
 `UsersOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -2741,6 +3013,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.gong.types.UsersEqCondition | airbyte_agent_sdk.connectors.gong.types.UsersNeqCondition | airbyte_agent_sdk.connectors.gong.types.UsersGtCondition | airbyte_agent_sdk.connectors.gong.types.UsersGteCondition | airbyte_agent_sdk.connectors.gong.types.UsersLtCondition | airbyte_agent_sdk.connectors.gong.types.UsersLteCondition | airbyte_agent_sdk.connectors.gong.types.UsersInCondition | airbyte_agent_sdk.connectors.gong.types.UsersLikeCondition | airbyte_agent_sdk.connectors.gong.types.UsersFuzzyCondition | airbyte_agent_sdk.connectors.gong.types.UsersKeywordCondition | airbyte_agent_sdk.connectors.gong.types.UsersContainsCondition | airbyte_agent_sdk.connectors.gong.types.UsersNotCondition | airbyte_agent_sdk.connectors.gong.types.UsersAndCondition | airbyte_agent_sdk.connectors.gong.types.UsersOrCondition | airbyte_agent_sdk.connectors.gong.types.UsersAnyCondition]`
     :   The type of the None singleton.
+
+<a id="UsersSearchFilter"></a>
 
 `UsersSearchFilter(*args, **kwargs)`
 :   Available fields for filtering users search queries.
@@ -2799,6 +3073,8 @@ Classes
     `trusted_email_address: str | None`
     :   An email address that is considered trusted for the user
 
+<a id="UsersSearchQuery"></a>
+
 `UsersSearchQuery(*args, **kwargs)`
 :   Search query for users entity.
 
@@ -2813,6 +3089,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.gong.types.UsersSortFilter]`
     :   The type of the None singleton.
+
+<a id="UsersSortFilter"></a>
 
 `UsersSortFilter(*args, **kwargs)`
 :   Available fields for sorting users search results.
@@ -2871,6 +3149,8 @@ Classes
     `trusted_email_address: Literal['asc', 'desc']`
     :   An email address that is considered trusted for the user
 
+<a id="UsersStringFilter"></a>
+
 `UsersStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -2927,6 +3207,8 @@ Classes
 
     `trusted_email_address: str`
     :   An email address that is considered trusted for the user
+
+<a id="WorkspacesListParams"></a>
 
 `WorkspacesListParams(*args, **kwargs)`
 :   Parameters for workspaces.list operation

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/google_ads/connector.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/google_ads/connector.md
@@ -10,6 +10,8 @@ Google-Ads connector.
 Classes
 -------
 
+<a id="AccessibleCustomersQuery"></a>
+
 `AccessibleCustomersQuery(connector: GoogleAdsConnector)`
 :   Query class for AccessibleCustomers entity operations.
     
@@ -22,6 +24,8 @@ Classes
         
         Returns:
             AccessibleCustomersListResult
+
+<a id="AccountsQuery"></a>
 
 `AccountsQuery(connector: GoogleAdsConnector)`
 :   Query class for Accounts entity operations.
@@ -86,6 +90,8 @@ Classes
         Returns:
             AccountsListResult
 
+<a id="AdGroupAdLabelsQuery"></a>
+
 `AdGroupAdLabelsQuery(connector: GoogleAdsConnector)`
 :   Query class for AdGroupAdLabels entity operations.
     
@@ -132,6 +138,8 @@ Classes
         
         Returns:
             AdGroupAdLabelsListResult
+
+<a id="AdGroupAdsQuery"></a>
 
 `AdGroupAdsQuery(connector: GoogleAdsConnector)`
 :   Query class for AdGroupAds entity operations.
@@ -193,6 +201,8 @@ Classes
         Returns:
             AdGroupAdsListResult
 
+<a id="AdGroupLabelsQuery"></a>
+
 `AdGroupLabelsQuery(connector: GoogleAdsConnector)`
 :   Query class for AdGroupLabels entity operations.
     
@@ -250,6 +260,8 @@ Classes
         
         Returns:
             AdGroupLabelsListResult
+
+<a id="AdGroupsQuery"></a>
 
 `AdGroupsQuery(connector: GoogleAdsConnector)`
 :   Query class for AdGroups entity operations.
@@ -326,6 +338,8 @@ Classes
         Returns:
             AdGroupMutateResponse
 
+<a id="CampaignLabelsQuery"></a>
+
 `CampaignLabelsQuery(connector: GoogleAdsConnector)`
 :   Query class for CampaignLabels entity operations.
     
@@ -383,6 +397,8 @@ Classes
         
         Returns:
             CampaignLabelsListResult
+
+<a id="CampaignsQuery"></a>
 
 `CampaignsQuery(connector: GoogleAdsConnector)`
 :   Query class for Campaigns entity operations.
@@ -466,6 +482,8 @@ Classes
         
         Returns:
             CampaignMutateResponse
+
+<a id="GoogleAdsConnector"></a>
 
 `GoogleAdsConnector(auth_config: GoogleAdsAuthConfig | AirbyteAuthConfig | BaseModel | None = None, on_token_refresh: Any | None = None)`
 :   Type-safe Google-Ads API connector.
@@ -722,6 +740,8 @@ Classes
             entities = connector.list_entities()
             for entity in entities:
                 print(f"\{entity['entity_name']\}: \{entity['available_actions']\}")
+
+<a id="LabelsQuery"></a>
 
 `LabelsQuery(connector: GoogleAdsConnector)`
 :   Query class for Labels entity operations.

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/google_ads/index.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/google_ads/index.md
@@ -19,6 +19,8 @@ Sub-modules
 Classes
 -------
 
+<a id="AccountsSearchData"></a>
+
 `AccountsSearchData(**data: Any)`
 :   Search result data for accounts entity.
     
@@ -101,6 +103,8 @@ Classes
     `segments_date: str | None`
     :   Date segment for the report row
 
+<a id="AdGroupAdLabelsSearchData"></a>
+
 `AdGroupAdLabelsSearchData(**data: Any)`
 :   Search result data for ad_group_ad_labels entity.
     
@@ -134,6 +138,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="AdGroupAdsSearchData"></a>
 
 `AdGroupAdsSearchData(**data: Any)`
 :   Search result data for ad_group_ads entity.
@@ -208,6 +214,8 @@ Classes
     `segments_date: str | None`
     :   Date segment for the report row
 
+<a id="AdGroupLabelsSearchData"></a>
+
 `AdGroupLabelsSearchData(**data: Any)`
 :   Search result data for ad_group_labels entity.
     
@@ -241,6 +249,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="AdGroupsSearchData"></a>
 
 `AdGroupsSearchData(**data: Any)`
 :   Search result data for ad_groups entity.
@@ -327,6 +337,8 @@ Classes
     `segments_date: str | None`
     :   Date segment for the report row
 
+<a id="AirbyteAuthConfig"></a>
+
 `AirbyteAuthConfig(**data: Any)`
 :   Authentication configuration for Airbyte hosted mode execution.
     
@@ -395,6 +407,8 @@ Classes
     `workspace_name: str | None`
     :   The type of the None singleton.
 
+<a id="AirbyteSearchMeta"></a>
+
 `AirbyteSearchMeta(**data: Any)`
 :   Pagination metadata for search responses.
     
@@ -422,6 +436,8 @@ Classes
 
     `took_ms: int | None`
     :   Time taken to execute the search in milliseconds.
+
+<a id="AirbyteSearchResult"></a>
 
 `AirbyteSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -459,6 +475,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="AccountsSearchResult"></a>
+
 `AccountsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -474,6 +492,8 @@ Classes
     * airbyte_agent_sdk.connectors.google_ads.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="AdGroupAdLabelsSearchResult"></a>
 
 `AdGroupAdLabelsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -491,6 +511,8 @@ Classes
     * pydantic.main.BaseModel
     * typing.Generic
 
+<a id="AdGroupAdsSearchResult"></a>
+
 `AdGroupAdsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -506,6 +528,8 @@ Classes
     * airbyte_agent_sdk.connectors.google_ads.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="AdGroupLabelsSearchResult"></a>
 
 `AdGroupLabelsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -523,6 +547,8 @@ Classes
     * pydantic.main.BaseModel
     * typing.Generic
 
+<a id="AdGroupsSearchResult"></a>
+
 `AdGroupsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -538,6 +564,8 @@ Classes
     * airbyte_agent_sdk.connectors.google_ads.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="CampaignLabelsSearchResult"></a>
 
 `CampaignLabelsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -555,6 +583,8 @@ Classes
     * pydantic.main.BaseModel
     * typing.Generic
 
+<a id="CampaignsSearchResult"></a>
+
 `CampaignsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -570,6 +600,8 @@ Classes
     * airbyte_agent_sdk.connectors.google_ads.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="CampaignLabelsSearchData"></a>
 
 `CampaignLabelsSearchData(**data: Any)`
 :   Search result data for campaign_labels entity.
@@ -604,6 +636,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="CampaignsSearchData"></a>
 
 `CampaignsSearchData(**data: Any)`
 :   Search result data for campaigns entity.
@@ -714,6 +748,8 @@ Classes
     `segments_hour: int | None`
     :   Hour segment
 
+<a id="GoogleAdsAuthConfig"></a>
+
 `GoogleAdsAuthConfig(**data: Any)`
 :   OAuth2 Authentication
     
@@ -744,6 +780,8 @@ Classes
 
     `refresh_token: str`
     :   OAuth2 refresh token
+
+<a id="GoogleAdsConnector"></a>
 
 `GoogleAdsConnector(auth_config: GoogleAdsAuthConfig | AirbyteAuthConfig | BaseModel | None = None, on_token_refresh: Any | None = None)`
 :   Type-safe Google-Ads API connector.
@@ -1000,6 +1038,8 @@ Classes
             entities = connector.list_entities()
             for entity in entities:
                 print(f"\{entity['entity_name']\}: \{entity['available_actions']\}")
+
+<a id="GoogleAdsReplicationConfig"></a>
 
 `GoogleAdsReplicationConfig(**data: Any)`
 :   Replication Configuration - Settings for data replication from Google Ads.

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/google_ads/models.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/google_ads/models.md
@@ -13,6 +13,8 @@ and response envelope types.
 Classes
 -------
 
+<a id="AccessibleCustomerResourceName"></a>
+
 `AccessibleCustomerResourceName(**data: Any)`
 :   Resource name of an accessible customer (e.g., customers/1234567890)
     
@@ -31,6 +33,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="AccessibleCustomersList"></a>
 
 `AccessibleCustomersList(**data: Any)`
 :   List of accessible customer resource names
@@ -54,6 +58,8 @@ Classes
     `resource_names: list[airbyte_agent_sdk.connectors.google_ads.models.AccessibleCustomerResourceName] | Any`
     :   The type of the None singleton.
 
+<a id="Account"></a>
+
 `Account(**data: Any)`
 :   Google Ads customer account
     
@@ -75,6 +81,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="AccountCustomer"></a>
 
 `AccountCustomer(**data: Any)`
 :   Nested schema for Account.customer
@@ -146,6 +154,8 @@ Classes
     `tracking_url_template: str | Any`
     :   The type of the None singleton.
 
+<a id="AccountCustomerCallreportingsetting"></a>
+
 `AccountCustomerCallreportingsetting(**data: Any)`
 :   Nested schema for AccountCustomer.callReportingSetting
     
@@ -174,6 +184,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="AccountCustomerConversiontrackingsetting"></a>
+
 `AccountCustomerConversiontrackingsetting(**data: Any)`
 :   Nested schema for AccountCustomer.conversionTrackingSetting
     
@@ -199,6 +211,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="AccountCustomerRemarketingsetting"></a>
+
 `AccountCustomerRemarketingsetting(**data: Any)`
 :   Nested schema for AccountCustomer.remarketingSetting
     
@@ -220,6 +234,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="AccountSearchResponse"></a>
 
 `AccountSearchResponse(**data: Any)`
 :   Search response containing account data
@@ -252,6 +268,8 @@ Classes
     `results: list[airbyte_agent_sdk.connectors.google_ads.models.Account] | Any`
     :   The type of the None singleton.
 
+<a id="AccountsListResultMeta"></a>
+
 `AccountsListResultMeta(**data: Any)`
 :   Metadata for accounts.Action.LIST operation
     
@@ -273,6 +291,8 @@ Classes
 
     `next_page_token: str | Any`
     :   The type of the None singleton.
+
+<a id="AccountsSearchData"></a>
 
 `AccountsSearchData(**data: Any)`
 :   Search result data for accounts entity.
@@ -356,6 +376,8 @@ Classes
     `segments_date: str | None`
     :   Date segment for the report row
 
+<a id="AdGroup"></a>
+
 `AdGroup(**data: Any)`
 :   Google Ads ad group
     
@@ -387,6 +409,8 @@ Classes
     `segments: airbyte_agent_sdk.connectors.google_ads.models.AdGroupSegments | Any`
     :   The type of the None singleton.
 
+<a id="AdGroupAd"></a>
+
 `AdGroupAd(**data: Any)`
 :   Google Ads ad group ad
     
@@ -415,6 +439,8 @@ Classes
     `segments: airbyte_agent_sdk.connectors.google_ads.models.AdGroupAdSegments | Any`
     :   The type of the None singleton.
 
+<a id="AdGroupAdAdgroup"></a>
+
 `AdGroupAdAdgroup(**data: Any)`
 :   Nested schema for AdGroupAd.adGroup
     
@@ -439,6 +465,8 @@ Classes
 
     `resource_name: str | Any`
     :   Parent ad group resource name
+
+<a id="AdGroupAdAdgroupad"></a>
 
 `AdGroupAdAdgroupad(**data: Any)`
 :   Nested schema for AdGroupAd.adGroupAd
@@ -479,6 +507,8 @@ Classes
 
     `status: str | Any`
     :   The type of the None singleton.
+
+<a id="AdGroupAdAdgroupadAd"></a>
 
 `AdGroupAdAdgroupadAd(**data: Any)`
 :   Nested schema for AdGroupAdAdgroupad.ad
@@ -526,6 +556,8 @@ Classes
     `type_: str | Any`
     :   The type of the None singleton.
 
+<a id="AdGroupAdAdgroupadPolicysummary"></a>
+
 `AdGroupAdAdgroupadPolicysummary(**data: Any)`
 :   Nested schema for AdGroupAdAdgroupad.policySummary
     
@@ -550,6 +582,8 @@ Classes
 
     `review_status: str | Any`
     :   The type of the None singleton.
+
+<a id="AdGroupAdLabel"></a>
 
 `AdGroupAdLabel(**data: Any)`
 :   Ad group ad label association
@@ -579,6 +613,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="AdGroupAdLabelAdgroupad"></a>
+
 `AdGroupAdLabelAdgroupad(**data: Any)`
 :   Nested schema for AdGroupAdLabel.adGroupAd
     
@@ -601,6 +637,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="AdGroupAdLabelAdgroupadAd"></a>
+
 `AdGroupAdLabelAdgroupadAd(**data: Any)`
 :   Nested schema for AdGroupAdLabelAdgroupad.ad
     
@@ -622,6 +660,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="AdGroupAdLabelAdgroupadlabel"></a>
 
 `AdGroupAdLabelAdgroupadlabel(**data: Any)`
 :   Nested schema for AdGroupAdLabel.adGroupAdLabel
@@ -651,6 +691,8 @@ Classes
     `resource_name: str | Any`
     :   The type of the None singleton.
 
+<a id="AdGroupAdLabelLabel"></a>
+
 `AdGroupAdLabelLabel(**data: Any)`
 :   Nested schema for AdGroupAdLabel.label
     
@@ -678,6 +720,8 @@ Classes
 
     `resource_name: str | Any`
     :   The type of the None singleton.
+
+<a id="AdGroupAdLabelSearchResponse"></a>
 
 `AdGroupAdLabelSearchResponse(**data: Any)`
 :   Search response containing ad group ad label data
@@ -710,6 +754,8 @@ Classes
     `results: list[airbyte_agent_sdk.connectors.google_ads.models.AdGroupAdLabel] | Any`
     :   The type of the None singleton.
 
+<a id="AdGroupAdLabelsListResultMeta"></a>
+
 `AdGroupAdLabelsListResultMeta(**data: Any)`
 :   Metadata for ad_group_ad_labels.Action.LIST operation
     
@@ -731,6 +777,8 @@ Classes
 
     `next_page_token: str | Any`
     :   The type of the None singleton.
+
+<a id="AdGroupAdLabelsSearchData"></a>
 
 `AdGroupAdLabelsSearchData(**data: Any)`
 :   Search result data for ad_group_ad_labels entity.
@@ -766,6 +814,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="AdGroupAdSearchResponse"></a>
+
 `AdGroupAdSearchResponse(**data: Any)`
 :   Search response containing ad group ad data
     
@@ -797,6 +847,8 @@ Classes
     `results: list[airbyte_agent_sdk.connectors.google_ads.models.AdGroupAd] | Any`
     :   The type of the None singleton.
 
+<a id="AdGroupAdSegments"></a>
+
 `AdGroupAdSegments(**data: Any)`
 :   Nested schema for AdGroupAd.segments
     
@@ -818,6 +870,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="AdGroupAdgroup"></a>
 
 `AdGroupAdgroup(**data: Any)`
 :   Nested schema for AdGroup.adGroup
@@ -895,6 +949,8 @@ Classes
     `type_: str | Any`
     :   The type of the None singleton.
 
+<a id="AdGroupAdsListResultMeta"></a>
+
 `AdGroupAdsListResultMeta(**data: Any)`
 :   Metadata for ad_group_ads.Action.LIST operation
     
@@ -916,6 +972,8 @@ Classes
 
     `next_page_token: str | Any`
     :   The type of the None singleton.
+
+<a id="AdGroupAdsSearchData"></a>
 
 `AdGroupAdsSearchData(**data: Any)`
 :   Search result data for ad_group_ads entity.
@@ -990,6 +1048,8 @@ Classes
     `segments_date: str | None`
     :   Date segment for the report row
 
+<a id="AdGroupCampaign"></a>
+
 `AdGroupCampaign(**data: Any)`
 :   Nested schema for AdGroup.campaign
     
@@ -1014,6 +1074,8 @@ Classes
 
     `resource_name: str | Any`
     :   Parent campaign resource name
+
+<a id="AdGroupLabel"></a>
 
 `AdGroupLabel(**data: Any)`
 :   Ad group label association
@@ -1043,6 +1105,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="AdGroupLabelAdgroup"></a>
+
 `AdGroupLabelAdgroup(**data: Any)`
 :   Nested schema for AdGroupLabel.adGroup
     
@@ -1064,6 +1128,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="AdGroupLabelAdgrouplabel"></a>
 
 `AdGroupLabelAdgrouplabel(**data: Any)`
 :   Nested schema for AdGroupLabel.adGroupLabel
@@ -1093,6 +1159,8 @@ Classes
     `resource_name: str | Any`
     :   The type of the None singleton.
 
+<a id="AdGroupLabelLabel"></a>
+
 `AdGroupLabelLabel(**data: Any)`
 :   Nested schema for AdGroupLabel.label
     
@@ -1121,6 +1189,8 @@ Classes
     `resource_name: str | Any`
     :   The type of the None singleton.
 
+<a id="AdGroupLabelMutateRequest"></a>
+
 `AdGroupLabelMutateRequest(**data: Any)`
 :   Request to create ad group-label associations
     
@@ -1143,6 +1213,8 @@ Classes
     `operations: list[airbyte_agent_sdk.connectors.google_ads.models.AdGroupLabelMutateRequestOperationsItem] | Any`
     :   The type of the None singleton.
 
+<a id="AdGroupLabelMutateRequestOperationsItem"></a>
+
 `AdGroupLabelMutateRequestOperationsItem(**data: Any)`
 :   Nested schema for AdGroupLabelMutateRequest.operations_item
     
@@ -1164,6 +1236,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="AdGroupLabelMutateRequestOperationsItemCreate"></a>
 
 `AdGroupLabelMutateRequestOperationsItemCreate(**data: Any)`
 :   Ad group label association to create
@@ -1190,6 +1264,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="AdGroupLabelMutateResponse"></a>
+
 `AdGroupLabelMutateResponse(**data: Any)`
 :   Response from ad group label mutate operation
     
@@ -1212,6 +1288,8 @@ Classes
     `results: list[airbyte_agent_sdk.connectors.google_ads.models.AdGroupLabelMutateResponseResultsItem] | Any`
     :   The type of the None singleton.
 
+<a id="AdGroupLabelMutateResponseResultsItem"></a>
+
 `AdGroupLabelMutateResponseResultsItem(**data: Any)`
 :   Nested schema for AdGroupLabelMutateResponse.results_item
     
@@ -1233,6 +1311,8 @@ Classes
 
     `resource_name: str | Any`
     :   Resource name of the created ad group label association
+
+<a id="AdGroupLabelSearchResponse"></a>
 
 `AdGroupLabelSearchResponse(**data: Any)`
 :   Search response containing ad group label data
@@ -1265,6 +1345,8 @@ Classes
     `results: list[airbyte_agent_sdk.connectors.google_ads.models.AdGroupLabel] | Any`
     :   The type of the None singleton.
 
+<a id="AdGroupLabelsListResultMeta"></a>
+
 `AdGroupLabelsListResultMeta(**data: Any)`
 :   Metadata for ad_group_labels.Action.LIST operation
     
@@ -1286,6 +1368,8 @@ Classes
 
     `next_page_token: str | Any`
     :   The type of the None singleton.
+
+<a id="AdGroupLabelsSearchData"></a>
 
 `AdGroupLabelsSearchData(**data: Any)`
 :   Search result data for ad_group_labels entity.
@@ -1321,6 +1405,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="AdGroupMetrics"></a>
+
 `AdGroupMetrics(**data: Any)`
 :   Nested schema for AdGroup.metrics
     
@@ -1343,6 +1429,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="AdGroupMutateRequest"></a>
+
 `AdGroupMutateRequest(**data: Any)`
 :   Request to mutate (update) ad groups
     
@@ -1364,6 +1452,8 @@ Classes
 
     `operations: list[airbyte_agent_sdk.connectors.google_ads.models.AdGroupMutateRequestOperationsItem] | Any`
     :   The type of the None singleton.
+
+<a id="AdGroupMutateRequestOperationsItem"></a>
 
 `AdGroupMutateRequestOperationsItem(**data: Any)`
 :   Nested schema for AdGroupMutateRequest.operations_item
@@ -1389,6 +1479,8 @@ Classes
 
     `update_mask: str | Any`
     :   Comma-separated list of field paths to update (e.g., name,status,cpcBidMicros)
+
+<a id="AdGroupMutateRequestOperationsItemUpdate"></a>
 
 `AdGroupMutateRequestOperationsItemUpdate(**data: Any)`
 :   Ad group fields to update
@@ -1421,6 +1513,8 @@ Classes
     `status: str | Any`
     :   Ad group status (ENABLED or PAUSED)
 
+<a id="AdGroupMutateResponse"></a>
+
 `AdGroupMutateResponse(**data: Any)`
 :   Response from ad group mutate operation
     
@@ -1443,6 +1537,8 @@ Classes
     `results: list[airbyte_agent_sdk.connectors.google_ads.models.AdGroupMutateResponseResultsItem] | Any`
     :   The type of the None singleton.
 
+<a id="AdGroupMutateResponseResultsItem"></a>
+
 `AdGroupMutateResponseResultsItem(**data: Any)`
 :   Nested schema for AdGroupMutateResponse.results_item
     
@@ -1464,6 +1560,8 @@ Classes
 
     `resource_name: str | Any`
     :   Resource name of the mutated ad group
+
+<a id="AdGroupSearchResponse"></a>
 
 `AdGroupSearchResponse(**data: Any)`
 :   Search response containing ad group data
@@ -1496,6 +1594,8 @@ Classes
     `results: list[airbyte_agent_sdk.connectors.google_ads.models.AdGroup] | Any`
     :   The type of the None singleton.
 
+<a id="AdGroupSegments"></a>
+
 `AdGroupSegments(**data: Any)`
 :   Nested schema for AdGroup.segments
     
@@ -1518,6 +1618,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="AdGroupsListResultMeta"></a>
+
 `AdGroupsListResultMeta(**data: Any)`
 :   Metadata for ad_groups.Action.LIST operation
     
@@ -1539,6 +1641,8 @@ Classes
 
     `next_page_token: str | Any`
     :   The type of the None singleton.
+
+<a id="AdGroupsSearchData"></a>
 
 `AdGroupsSearchData(**data: Any)`
 :   Search result data for ad_groups entity.
@@ -1625,6 +1729,8 @@ Classes
     `segments_date: str | None`
     :   Date segment for the report row
 
+<a id="AirbyteSearchMeta"></a>
+
 `AirbyteSearchMeta(**data: Any)`
 :   Pagination metadata for search responses.
     
@@ -1652,6 +1758,8 @@ Classes
 
     `took_ms: int | None`
     :   Time taken to execute the search in milliseconds.
+
+<a id="AirbyteSearchResult"></a>
 
 `AirbyteSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -1710,6 +1818,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="AccountsSearchResult"></a>
+
 `AccountsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -1746,6 +1856,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="AdGroupAdLabelsSearchResult"></a>
 
 `AdGroupAdLabelsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -1784,6 +1896,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="AdGroupAdsSearchResult"></a>
+
 `AdGroupAdsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -1820,6 +1934,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="AdGroupLabelsSearchResult"></a>
 
 `AdGroupLabelsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -1858,6 +1974,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="AdGroupsSearchResult"></a>
+
 `AdGroupsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -1894,6 +2012,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="CampaignLabelsSearchResult"></a>
 
 `CampaignLabelsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -1932,6 +2052,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="CampaignsSearchResult"></a>
+
 `CampaignsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -1947,6 +2069,8 @@ Classes
     * airbyte_agent_sdk.connectors.google_ads.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="Campaign"></a>
 
 `Campaign(**data: Any)`
 :   Google Ads campaign
@@ -1978,6 +2102,8 @@ Classes
 
     `segments: airbyte_agent_sdk.connectors.google_ads.models.CampaignSegments | Any`
     :   The type of the None singleton.
+
+<a id="CampaignCampaign"></a>
 
 `CampaignCampaign(**data: Any)`
 :   Nested schema for Campaign.campaign
@@ -2040,6 +2166,8 @@ Classes
     `status: str | Any`
     :   Campaign status
 
+<a id="CampaignCampaignNetworksettings"></a>
+
 `CampaignCampaignNetworksettings(**data: Any)`
 :   Nested schema for CampaignCampaign.networkSettings
     
@@ -2071,6 +2199,8 @@ Classes
     `target_search_network: bool | Any`
     :   The type of the None singleton.
 
+<a id="CampaignCampaignbudget"></a>
+
 `CampaignCampaignbudget(**data: Any)`
 :   Nested schema for Campaign.campaignBudget
     
@@ -2095,6 +2225,8 @@ Classes
 
     `resource_name: str | Any`
     :   Resource name of the campaign budget
+
+<a id="CampaignLabel"></a>
 
 `CampaignLabel(**data: Any)`
 :   Campaign label association
@@ -2124,6 +2256,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="CampaignLabelCampaign"></a>
+
 `CampaignLabelCampaign(**data: Any)`
 :   Nested schema for CampaignLabel.campaign
     
@@ -2145,6 +2279,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="CampaignLabelCampaignlabel"></a>
 
 `CampaignLabelCampaignlabel(**data: Any)`
 :   Nested schema for CampaignLabel.campaignLabel
@@ -2174,6 +2310,8 @@ Classes
     `resource_name: str | Any`
     :   The type of the None singleton.
 
+<a id="CampaignLabelLabel"></a>
+
 `CampaignLabelLabel(**data: Any)`
 :   Nested schema for CampaignLabel.label
     
@@ -2202,6 +2340,8 @@ Classes
     `resource_name: str | Any`
     :   The type of the None singleton.
 
+<a id="CampaignLabelMutateRequest"></a>
+
 `CampaignLabelMutateRequest(**data: Any)`
 :   Request to create campaign-label associations
     
@@ -2224,6 +2364,8 @@ Classes
     `operations: list[airbyte_agent_sdk.connectors.google_ads.models.CampaignLabelMutateRequestOperationsItem] | Any`
     :   The type of the None singleton.
 
+<a id="CampaignLabelMutateRequestOperationsItem"></a>
+
 `CampaignLabelMutateRequestOperationsItem(**data: Any)`
 :   Nested schema for CampaignLabelMutateRequest.operations_item
     
@@ -2245,6 +2387,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="CampaignLabelMutateRequestOperationsItemCreate"></a>
 
 `CampaignLabelMutateRequestOperationsItemCreate(**data: Any)`
 :   Campaign label association to create
@@ -2271,6 +2415,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="CampaignLabelMutateResponse"></a>
+
 `CampaignLabelMutateResponse(**data: Any)`
 :   Response from campaign label mutate operation
     
@@ -2293,6 +2439,8 @@ Classes
     `results: list[airbyte_agent_sdk.connectors.google_ads.models.CampaignLabelMutateResponseResultsItem] | Any`
     :   The type of the None singleton.
 
+<a id="CampaignLabelMutateResponseResultsItem"></a>
+
 `CampaignLabelMutateResponseResultsItem(**data: Any)`
 :   Nested schema for CampaignLabelMutateResponse.results_item
     
@@ -2314,6 +2462,8 @@ Classes
 
     `resource_name: str | Any`
     :   Resource name of the created campaign label association
+
+<a id="CampaignLabelSearchResponse"></a>
 
 `CampaignLabelSearchResponse(**data: Any)`
 :   Search response containing campaign label data
@@ -2346,6 +2496,8 @@ Classes
     `results: list[airbyte_agent_sdk.connectors.google_ads.models.CampaignLabel] | Any`
     :   The type of the None singleton.
 
+<a id="CampaignLabelsListResultMeta"></a>
+
 `CampaignLabelsListResultMeta(**data: Any)`
 :   Metadata for campaign_labels.Action.LIST operation
     
@@ -2367,6 +2519,8 @@ Classes
 
     `next_page_token: str | Any`
     :   The type of the None singleton.
+
+<a id="CampaignLabelsSearchData"></a>
 
 `CampaignLabelsSearchData(**data: Any)`
 :   Search result data for campaign_labels entity.
@@ -2401,6 +2555,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="CampaignMetrics"></a>
 
 `CampaignMetrics(**data: Any)`
 :   Nested schema for Campaign.metrics
@@ -2448,6 +2604,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="CampaignMutateRequest"></a>
+
 `CampaignMutateRequest(**data: Any)`
 :   Request to mutate (update) campaigns
     
@@ -2469,6 +2627,8 @@ Classes
 
     `operations: list[airbyte_agent_sdk.connectors.google_ads.models.CampaignMutateRequestOperationsItem] | Any`
     :   The type of the None singleton.
+
+<a id="CampaignMutateRequestOperationsItem"></a>
 
 `CampaignMutateRequestOperationsItem(**data: Any)`
 :   Nested schema for CampaignMutateRequest.operations_item
@@ -2494,6 +2654,8 @@ Classes
 
     `update_mask: str | Any`
     :   Comma-separated list of field paths to update (e.g., name,status)
+
+<a id="CampaignMutateRequestOperationsItemUpdate"></a>
 
 `CampaignMutateRequestOperationsItemUpdate(**data: Any)`
 :   Campaign fields to update
@@ -2523,6 +2685,8 @@ Classes
     `status: str | Any`
     :   Campaign status (ENABLED or PAUSED)
 
+<a id="CampaignMutateResponse"></a>
+
 `CampaignMutateResponse(**data: Any)`
 :   Response from campaign mutate operation
     
@@ -2545,6 +2709,8 @@ Classes
     `results: list[airbyte_agent_sdk.connectors.google_ads.models.CampaignMutateResponseResultsItem] | Any`
     :   The type of the None singleton.
 
+<a id="CampaignMutateResponseResultsItem"></a>
+
 `CampaignMutateResponseResultsItem(**data: Any)`
 :   Nested schema for CampaignMutateResponse.results_item
     
@@ -2566,6 +2732,8 @@ Classes
 
     `resource_name: str | Any`
     :   Resource name of the mutated campaign
+
+<a id="CampaignSearchResponse"></a>
 
 `CampaignSearchResponse(**data: Any)`
 :   Search response containing campaign data
@@ -2598,6 +2766,8 @@ Classes
     `results: list[airbyte_agent_sdk.connectors.google_ads.models.Campaign] | Any`
     :   The type of the None singleton.
 
+<a id="CampaignSegments"></a>
+
 `CampaignSegments(**data: Any)`
 :   Nested schema for Campaign.segments
     
@@ -2620,6 +2790,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="CampaignsListResultMeta"></a>
+
 `CampaignsListResultMeta(**data: Any)`
 :   Metadata for campaigns.Action.LIST operation
     
@@ -2641,6 +2813,8 @@ Classes
 
     `next_page_token: str | Any`
     :   The type of the None singleton.
+
+<a id="CampaignsSearchData"></a>
 
 `CampaignsSearchData(**data: Any)`
 :   Search result data for campaigns entity.
@@ -2751,6 +2925,8 @@ Classes
     `segments_hour: int | None`
     :   Hour segment
 
+<a id="GoogleAdsAuthConfig"></a>
+
 `GoogleAdsAuthConfig(**data: Any)`
 :   OAuth2 Authentication
     
@@ -2781,6 +2957,8 @@ Classes
 
     `refresh_token: str`
     :   OAuth2 refresh token
+
+<a id="GoogleAdsCheckResult"></a>
 
 `GoogleAdsCheckResult(**data: Any)`
 :   Result of a health check operation.
@@ -2815,6 +2993,8 @@ Classes
     `status: str`
     :   Health check status: 'healthy' or 'unhealthy'.
 
+<a id="GoogleAdsExecuteResult"></a>
+
 `GoogleAdsExecuteResult(**data: Any)`
 :   Response envelope with data only.
     
@@ -2844,6 +3024,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="GoogleAdsExecuteResultWithMeta"></a>
 
 `GoogleAdsExecuteResultWithMeta(**data: Any)`
 :   Response envelope with data and metadata.
@@ -2902,6 +3084,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="AccountsListResult"></a>
+
 `AccountsListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -2944,6 +3128,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="AdGroupAdLabelsListResult"></a>
 
 `AdGroupAdLabelsListResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -2988,6 +3174,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="AdGroupAdsListResult"></a>
+
 `AdGroupAdsListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -3030,6 +3218,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="AdGroupLabelsListResult"></a>
 
 `AdGroupLabelsListResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -3074,6 +3264,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="AdGroupsListResult"></a>
+
 `AdGroupsListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -3116,6 +3308,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="CampaignLabelsListResult"></a>
 
 `CampaignLabelsListResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -3160,6 +3354,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="CampaignsListResult"></a>
+
 `CampaignsListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -3202,6 +3398,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="AccessibleCustomersListResult"></a>
+
 `AccessibleCustomersListResult(**data: Any)`
 :   Response envelope with data only.
     
@@ -3219,6 +3417,8 @@ Classes
     * airbyte_agent_sdk.connectors.google_ads.models.GoogleAdsExecuteResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="GoogleAdsReplicationConfig"></a>
 
 `GoogleAdsReplicationConfig(**data: Any)`
 :   Replication Configuration - Settings for data replication from Google Ads.
@@ -3248,6 +3448,8 @@ Classes
     `start_date: str | None`
     :   UTC date in YYYY-MM-DD format from which to start replicating data. Defaults to 2 years ago if not specified.
 
+<a id="LabelMutateRequest"></a>
+
 `LabelMutateRequest(**data: Any)`
 :   Request to create labels
     
@@ -3270,6 +3472,8 @@ Classes
     `operations: list[airbyte_agent_sdk.connectors.google_ads.models.LabelMutateRequestOperationsItem] | Any`
     :   The type of the None singleton.
 
+<a id="LabelMutateRequestOperationsItem"></a>
+
 `LabelMutateRequestOperationsItem(**data: Any)`
 :   Nested schema for LabelMutateRequest.operations_item
     
@@ -3291,6 +3495,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="LabelMutateRequestOperationsItemCreate"></a>
 
 `LabelMutateRequestOperationsItemCreate(**data: Any)`
 :   Label to create
@@ -3320,6 +3526,8 @@ Classes
     `text_label: airbyte_agent_sdk.connectors.google_ads.models.LabelMutateRequestOperationsItemCreateTextlabel | Any`
     :   Text label styling
 
+<a id="LabelMutateRequestOperationsItemCreateTextlabel"></a>
+
 `LabelMutateRequestOperationsItemCreateTextlabel(**data: Any)`
 :   Text label styling
     
@@ -3345,6 +3553,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="LabelMutateResponse"></a>
+
 `LabelMutateResponse(**data: Any)`
 :   Response from label mutate operation
     
@@ -3366,6 +3576,8 @@ Classes
 
     `results: list[airbyte_agent_sdk.connectors.google_ads.models.LabelMutateResponseResultsItem] | Any`
     :   The type of the None singleton.
+
+<a id="LabelMutateResponseResultsItem"></a>
 
 `LabelMutateResponseResultsItem(**data: Any)`
 :   Nested schema for LabelMutateResponse.results_item

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/google_ads/types.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/google_ads/types.md
@@ -10,12 +10,16 @@ Type definitions for google-ads connector.
 Classes
 -------
 
+<a id="AccessibleCustomersListParams"></a>
+
 `AccessibleCustomersListParams(*args, **kwargs)`
 :   Parameters for accessible_customers.list operation
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="AccountsAndCondition"></a>
 
 `AccountsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -37,6 +41,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.google_ads.types.AccountsEqCondition | airbyte_agent_sdk.connectors.google_ads.types.AccountsNeqCondition | airbyte_agent_sdk.connectors.google_ads.types.AccountsGtCondition | airbyte_agent_sdk.connectors.google_ads.types.AccountsGteCondition | airbyte_agent_sdk.connectors.google_ads.types.AccountsLtCondition | airbyte_agent_sdk.connectors.google_ads.types.AccountsLteCondition | airbyte_agent_sdk.connectors.google_ads.types.AccountsInCondition | airbyte_agent_sdk.connectors.google_ads.types.AccountsLikeCondition | airbyte_agent_sdk.connectors.google_ads.types.AccountsFuzzyCondition | airbyte_agent_sdk.connectors.google_ads.types.AccountsKeywordCondition | airbyte_agent_sdk.connectors.google_ads.types.AccountsContainsCondition | airbyte_agent_sdk.connectors.google_ads.types.AccountsNotCondition | airbyte_agent_sdk.connectors.google_ads.types.AccountsAndCondition | airbyte_agent_sdk.connectors.google_ads.types.AccountsOrCondition | airbyte_agent_sdk.connectors.google_ads.types.AccountsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="AccountsAnyCondition"></a>
+
 `AccountsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -56,6 +62,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.google_ads.types.AccountsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="AccountsAnyValueFilter"></a>
 
 `AccountsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -129,6 +137,8 @@ Classes
     `segments_date: Any`
     :   Date segment for the report row
 
+<a id="AccountsContainsCondition"></a>
+
 `AccountsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -140,6 +150,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.google_ads.types.AccountsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="AccountsEqCondition"></a>
 
 `AccountsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -153,6 +165,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.google_ads.types.AccountsSearchFilter`
     :   The type of the None singleton.
 
+<a id="AccountsFuzzyCondition"></a>
+
 `AccountsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -164,6 +178,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.google_ads.types.AccountsStringFilter`
     :   The type of the None singleton.
+
+<a id="AccountsGtCondition"></a>
 
 `AccountsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
@@ -177,6 +193,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.google_ads.types.AccountsSearchFilter`
     :   The type of the None singleton.
 
+<a id="AccountsGteCondition"></a>
+
 `AccountsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -188,6 +206,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.google_ads.types.AccountsSearchFilter`
     :   The type of the None singleton.
+
+<a id="AccountsInCondition"></a>
 
 `AccountsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -208,6 +228,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.google_ads.types.AccountsInFilter`
     :   The type of the None singleton.
+
+<a id="AccountsInFilter"></a>
 
 `AccountsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -281,6 +303,8 @@ Classes
     `segments_date: list[str]`
     :   Date segment for the report row
 
+<a id="AccountsKeywordCondition"></a>
+
 `AccountsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -293,6 +317,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.google_ads.types.AccountsStringFilter`
     :   The type of the None singleton.
 
+<a id="AccountsLikeCondition"></a>
+
 `AccountsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -304,6 +330,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.google_ads.types.AccountsStringFilter`
     :   The type of the None singleton.
+
+<a id="AccountsListParams"></a>
 
 `AccountsListParams(*args, **kwargs)`
 :   Parameters for accounts.list operation
@@ -326,6 +354,8 @@ Classes
     `query: str`
     :   The type of the None singleton.
 
+<a id="AccountsLtCondition"></a>
+
 `AccountsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -337,6 +367,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.google_ads.types.AccountsSearchFilter`
     :   The type of the None singleton.
+
+<a id="AccountsLteCondition"></a>
 
 `AccountsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -350,6 +382,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.google_ads.types.AccountsSearchFilter`
     :   The type of the None singleton.
 
+<a id="AccountsNeqCondition"></a>
+
 `AccountsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -361,6 +395,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.google_ads.types.AccountsSearchFilter`
     :   The type of the None singleton.
+
+<a id="AccountsNotCondition"></a>
 
 `AccountsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -382,6 +418,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.google_ads.types.AccountsEqCondition | airbyte_agent_sdk.connectors.google_ads.types.AccountsNeqCondition | airbyte_agent_sdk.connectors.google_ads.types.AccountsGtCondition | airbyte_agent_sdk.connectors.google_ads.types.AccountsGteCondition | airbyte_agent_sdk.connectors.google_ads.types.AccountsLtCondition | airbyte_agent_sdk.connectors.google_ads.types.AccountsLteCondition | airbyte_agent_sdk.connectors.google_ads.types.AccountsInCondition | airbyte_agent_sdk.connectors.google_ads.types.AccountsLikeCondition | airbyte_agent_sdk.connectors.google_ads.types.AccountsFuzzyCondition | airbyte_agent_sdk.connectors.google_ads.types.AccountsKeywordCondition | airbyte_agent_sdk.connectors.google_ads.types.AccountsContainsCondition | airbyte_agent_sdk.connectors.google_ads.types.AccountsNotCondition | airbyte_agent_sdk.connectors.google_ads.types.AccountsAndCondition | airbyte_agent_sdk.connectors.google_ads.types.AccountsOrCondition | airbyte_agent_sdk.connectors.google_ads.types.AccountsAnyCondition`
     :   The type of the None singleton.
 
+<a id="AccountsOrCondition"></a>
+
 `AccountsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -401,6 +439,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.google_ads.types.AccountsEqCondition | airbyte_agent_sdk.connectors.google_ads.types.AccountsNeqCondition | airbyte_agent_sdk.connectors.google_ads.types.AccountsGtCondition | airbyte_agent_sdk.connectors.google_ads.types.AccountsGteCondition | airbyte_agent_sdk.connectors.google_ads.types.AccountsLtCondition | airbyte_agent_sdk.connectors.google_ads.types.AccountsLteCondition | airbyte_agent_sdk.connectors.google_ads.types.AccountsInCondition | airbyte_agent_sdk.connectors.google_ads.types.AccountsLikeCondition | airbyte_agent_sdk.connectors.google_ads.types.AccountsFuzzyCondition | airbyte_agent_sdk.connectors.google_ads.types.AccountsKeywordCondition | airbyte_agent_sdk.connectors.google_ads.types.AccountsContainsCondition | airbyte_agent_sdk.connectors.google_ads.types.AccountsNotCondition | airbyte_agent_sdk.connectors.google_ads.types.AccountsAndCondition | airbyte_agent_sdk.connectors.google_ads.types.AccountsOrCondition | airbyte_agent_sdk.connectors.google_ads.types.AccountsAnyCondition]`
     :   The type of the None singleton.
+
+<a id="AccountsSearchFilter"></a>
 
 `AccountsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering accounts search queries.
@@ -474,6 +514,8 @@ Classes
     `segments_date: str | None`
     :   Date segment for the report row
 
+<a id="AccountsSearchQuery"></a>
+
 `AccountsSearchQuery(*args, **kwargs)`
 :   Search query for accounts entity.
 
@@ -488,6 +530,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.google_ads.types.AccountsSortFilter]`
     :   The type of the None singleton.
+
+<a id="AccountsSortFilter"></a>
 
 `AccountsSortFilter(*args, **kwargs)`
 :   Available fields for sorting accounts search results.
@@ -561,6 +605,8 @@ Classes
     `segments_date: Literal['asc', 'desc']`
     :   Date segment for the report row
 
+<a id="AccountsStringFilter"></a>
+
 `AccountsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -633,6 +679,8 @@ Classes
     `segments_date: str`
     :   Date segment for the report row
 
+<a id="AdGroupAdLabelsAndCondition"></a>
+
 `AdGroupAdLabelsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -653,6 +701,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.google_ads.types.AdGroupAdLabelsEqCondition | airbyte_agent_sdk.connectors.google_ads.types.AdGroupAdLabelsNeqCondition | airbyte_agent_sdk.connectors.google_ads.types.AdGroupAdLabelsGtCondition | airbyte_agent_sdk.connectors.google_ads.types.AdGroupAdLabelsGteCondition | airbyte_agent_sdk.connectors.google_ads.types.AdGroupAdLabelsLtCondition | airbyte_agent_sdk.connectors.google_ads.types.AdGroupAdLabelsLteCondition | airbyte_agent_sdk.connectors.google_ads.types.AdGroupAdLabelsInCondition | airbyte_agent_sdk.connectors.google_ads.types.AdGroupAdLabelsLikeCondition | airbyte_agent_sdk.connectors.google_ads.types.AdGroupAdLabelsFuzzyCondition | airbyte_agent_sdk.connectors.google_ads.types.AdGroupAdLabelsKeywordCondition | airbyte_agent_sdk.connectors.google_ads.types.AdGroupAdLabelsContainsCondition | airbyte_agent_sdk.connectors.google_ads.types.AdGroupAdLabelsNotCondition | airbyte_agent_sdk.connectors.google_ads.types.AdGroupAdLabelsAndCondition | airbyte_agent_sdk.connectors.google_ads.types.AdGroupAdLabelsOrCondition | airbyte_agent_sdk.connectors.google_ads.types.AdGroupAdLabelsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="AdGroupAdLabelsAnyCondition"></a>
+
 `AdGroupAdLabelsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -672,6 +722,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.google_ads.types.AdGroupAdLabelsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="AdGroupAdLabelsAnyValueFilter"></a>
 
 `AdGroupAdLabelsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -697,6 +749,8 @@ Classes
     `label_resource_name: Any`
     :   Resource name of the label
 
+<a id="AdGroupAdLabelsContainsCondition"></a>
+
 `AdGroupAdLabelsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -708,6 +762,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.google_ads.types.AdGroupAdLabelsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="AdGroupAdLabelsEqCondition"></a>
 
 `AdGroupAdLabelsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -721,6 +777,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.google_ads.types.AdGroupAdLabelsSearchFilter`
     :   The type of the None singleton.
 
+<a id="AdGroupAdLabelsFuzzyCondition"></a>
+
 `AdGroupAdLabelsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -732,6 +790,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.google_ads.types.AdGroupAdLabelsStringFilter`
     :   The type of the None singleton.
+
+<a id="AdGroupAdLabelsGtCondition"></a>
 
 `AdGroupAdLabelsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
@@ -745,6 +805,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.google_ads.types.AdGroupAdLabelsSearchFilter`
     :   The type of the None singleton.
 
+<a id="AdGroupAdLabelsGteCondition"></a>
+
 `AdGroupAdLabelsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -756,6 +818,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.google_ads.types.AdGroupAdLabelsSearchFilter`
     :   The type of the None singleton.
+
+<a id="AdGroupAdLabelsInCondition"></a>
 
 `AdGroupAdLabelsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -776,6 +840,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.google_ads.types.AdGroupAdLabelsInFilter`
     :   The type of the None singleton.
+
+<a id="AdGroupAdLabelsInFilter"></a>
 
 `AdGroupAdLabelsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -801,6 +867,8 @@ Classes
     `label_resource_name: list[str]`
     :   Resource name of the label
 
+<a id="AdGroupAdLabelsKeywordCondition"></a>
+
 `AdGroupAdLabelsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -813,6 +881,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.google_ads.types.AdGroupAdLabelsStringFilter`
     :   The type of the None singleton.
 
+<a id="AdGroupAdLabelsLikeCondition"></a>
+
 `AdGroupAdLabelsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -824,6 +894,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.google_ads.types.AdGroupAdLabelsStringFilter`
     :   The type of the None singleton.
+
+<a id="AdGroupAdLabelsListParams"></a>
 
 `AdGroupAdLabelsListParams(*args, **kwargs)`
 :   Parameters for ad_group_ad_labels.list operation
@@ -846,6 +918,8 @@ Classes
     `query: str`
     :   The type of the None singleton.
 
+<a id="AdGroupAdLabelsLtCondition"></a>
+
 `AdGroupAdLabelsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -857,6 +931,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.google_ads.types.AdGroupAdLabelsSearchFilter`
     :   The type of the None singleton.
+
+<a id="AdGroupAdLabelsLteCondition"></a>
 
 `AdGroupAdLabelsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -870,6 +946,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.google_ads.types.AdGroupAdLabelsSearchFilter`
     :   The type of the None singleton.
 
+<a id="AdGroupAdLabelsNeqCondition"></a>
+
 `AdGroupAdLabelsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -881,6 +959,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.google_ads.types.AdGroupAdLabelsSearchFilter`
     :   The type of the None singleton.
+
+<a id="AdGroupAdLabelsNotCondition"></a>
 
 `AdGroupAdLabelsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -902,6 +982,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.google_ads.types.AdGroupAdLabelsEqCondition | airbyte_agent_sdk.connectors.google_ads.types.AdGroupAdLabelsNeqCondition | airbyte_agent_sdk.connectors.google_ads.types.AdGroupAdLabelsGtCondition | airbyte_agent_sdk.connectors.google_ads.types.AdGroupAdLabelsGteCondition | airbyte_agent_sdk.connectors.google_ads.types.AdGroupAdLabelsLtCondition | airbyte_agent_sdk.connectors.google_ads.types.AdGroupAdLabelsLteCondition | airbyte_agent_sdk.connectors.google_ads.types.AdGroupAdLabelsInCondition | airbyte_agent_sdk.connectors.google_ads.types.AdGroupAdLabelsLikeCondition | airbyte_agent_sdk.connectors.google_ads.types.AdGroupAdLabelsFuzzyCondition | airbyte_agent_sdk.connectors.google_ads.types.AdGroupAdLabelsKeywordCondition | airbyte_agent_sdk.connectors.google_ads.types.AdGroupAdLabelsContainsCondition | airbyte_agent_sdk.connectors.google_ads.types.AdGroupAdLabelsNotCondition | airbyte_agent_sdk.connectors.google_ads.types.AdGroupAdLabelsAndCondition | airbyte_agent_sdk.connectors.google_ads.types.AdGroupAdLabelsOrCondition | airbyte_agent_sdk.connectors.google_ads.types.AdGroupAdLabelsAnyCondition`
     :   The type of the None singleton.
 
+<a id="AdGroupAdLabelsOrCondition"></a>
+
 `AdGroupAdLabelsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -921,6 +1003,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.google_ads.types.AdGroupAdLabelsEqCondition | airbyte_agent_sdk.connectors.google_ads.types.AdGroupAdLabelsNeqCondition | airbyte_agent_sdk.connectors.google_ads.types.AdGroupAdLabelsGtCondition | airbyte_agent_sdk.connectors.google_ads.types.AdGroupAdLabelsGteCondition | airbyte_agent_sdk.connectors.google_ads.types.AdGroupAdLabelsLtCondition | airbyte_agent_sdk.connectors.google_ads.types.AdGroupAdLabelsLteCondition | airbyte_agent_sdk.connectors.google_ads.types.AdGroupAdLabelsInCondition | airbyte_agent_sdk.connectors.google_ads.types.AdGroupAdLabelsLikeCondition | airbyte_agent_sdk.connectors.google_ads.types.AdGroupAdLabelsFuzzyCondition | airbyte_agent_sdk.connectors.google_ads.types.AdGroupAdLabelsKeywordCondition | airbyte_agent_sdk.connectors.google_ads.types.AdGroupAdLabelsContainsCondition | airbyte_agent_sdk.connectors.google_ads.types.AdGroupAdLabelsNotCondition | airbyte_agent_sdk.connectors.google_ads.types.AdGroupAdLabelsAndCondition | airbyte_agent_sdk.connectors.google_ads.types.AdGroupAdLabelsOrCondition | airbyte_agent_sdk.connectors.google_ads.types.AdGroupAdLabelsAnyCondition]`
     :   The type of the None singleton.
+
+<a id="AdGroupAdLabelsSearchFilter"></a>
 
 `AdGroupAdLabelsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering ad_group_ad_labels search queries.
@@ -946,6 +1030,8 @@ Classes
     `label_resource_name: str | None`
     :   Resource name of the label
 
+<a id="AdGroupAdLabelsSearchQuery"></a>
+
 `AdGroupAdLabelsSearchQuery(*args, **kwargs)`
 :   Search query for ad_group_ad_labels entity.
 
@@ -960,6 +1046,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.google_ads.types.AdGroupAdLabelsSortFilter]`
     :   The type of the None singleton.
+
+<a id="AdGroupAdLabelsSortFilter"></a>
 
 `AdGroupAdLabelsSortFilter(*args, **kwargs)`
 :   Available fields for sorting ad_group_ad_labels search results.
@@ -985,6 +1073,8 @@ Classes
     `label_resource_name: Literal['asc', 'desc']`
     :   Resource name of the label
 
+<a id="AdGroupAdLabelsStringFilter"></a>
+
 `AdGroupAdLabelsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -1009,6 +1099,8 @@ Classes
     `label_resource_name: str`
     :   Resource name of the label
 
+<a id="AdGroupAdsAndCondition"></a>
+
 `AdGroupAdsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1029,6 +1121,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.google_ads.types.AdGroupAdsEqCondition | airbyte_agent_sdk.connectors.google_ads.types.AdGroupAdsNeqCondition | airbyte_agent_sdk.connectors.google_ads.types.AdGroupAdsGtCondition | airbyte_agent_sdk.connectors.google_ads.types.AdGroupAdsGteCondition | airbyte_agent_sdk.connectors.google_ads.types.AdGroupAdsLtCondition | airbyte_agent_sdk.connectors.google_ads.types.AdGroupAdsLteCondition | airbyte_agent_sdk.connectors.google_ads.types.AdGroupAdsInCondition | airbyte_agent_sdk.connectors.google_ads.types.AdGroupAdsLikeCondition | airbyte_agent_sdk.connectors.google_ads.types.AdGroupAdsFuzzyCondition | airbyte_agent_sdk.connectors.google_ads.types.AdGroupAdsKeywordCondition | airbyte_agent_sdk.connectors.google_ads.types.AdGroupAdsContainsCondition | airbyte_agent_sdk.connectors.google_ads.types.AdGroupAdsNotCondition | airbyte_agent_sdk.connectors.google_ads.types.AdGroupAdsAndCondition | airbyte_agent_sdk.connectors.google_ads.types.AdGroupAdsOrCondition | airbyte_agent_sdk.connectors.google_ads.types.AdGroupAdsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="AdGroupAdsAnyCondition"></a>
+
 `AdGroupAdsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1048,6 +1142,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.google_ads.types.AdGroupAdsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="AdGroupAdsAnyValueFilter"></a>
 
 `AdGroupAdsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -1112,6 +1208,8 @@ Classes
     `segments_date: Any`
     :   Date segment for the report row
 
+<a id="AdGroupAdsContainsCondition"></a>
+
 `AdGroupAdsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -1123,6 +1221,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.google_ads.types.AdGroupAdsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="AdGroupAdsEqCondition"></a>
 
 `AdGroupAdsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -1136,6 +1236,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.google_ads.types.AdGroupAdsSearchFilter`
     :   The type of the None singleton.
 
+<a id="AdGroupAdsFuzzyCondition"></a>
+
 `AdGroupAdsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -1147,6 +1249,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.google_ads.types.AdGroupAdsStringFilter`
     :   The type of the None singleton.
+
+<a id="AdGroupAdsGtCondition"></a>
 
 `AdGroupAdsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
@@ -1160,6 +1264,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.google_ads.types.AdGroupAdsSearchFilter`
     :   The type of the None singleton.
 
+<a id="AdGroupAdsGteCondition"></a>
+
 `AdGroupAdsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -1171,6 +1277,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.google_ads.types.AdGroupAdsSearchFilter`
     :   The type of the None singleton.
+
+<a id="AdGroupAdsInCondition"></a>
 
 `AdGroupAdsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -1191,6 +1299,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.google_ads.types.AdGroupAdsInFilter`
     :   The type of the None singleton.
+
+<a id="AdGroupAdsInFilter"></a>
 
 `AdGroupAdsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -1255,6 +1365,8 @@ Classes
     `segments_date: list[str]`
     :   Date segment for the report row
 
+<a id="AdGroupAdsKeywordCondition"></a>
+
 `AdGroupAdsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -1267,6 +1379,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.google_ads.types.AdGroupAdsStringFilter`
     :   The type of the None singleton.
 
+<a id="AdGroupAdsLikeCondition"></a>
+
 `AdGroupAdsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -1278,6 +1392,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.google_ads.types.AdGroupAdsStringFilter`
     :   The type of the None singleton.
+
+<a id="AdGroupAdsListParams"></a>
 
 `AdGroupAdsListParams(*args, **kwargs)`
 :   Parameters for ad_group_ads.list operation
@@ -1300,6 +1416,8 @@ Classes
     `query: str`
     :   The type of the None singleton.
 
+<a id="AdGroupAdsLtCondition"></a>
+
 `AdGroupAdsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -1311,6 +1429,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.google_ads.types.AdGroupAdsSearchFilter`
     :   The type of the None singleton.
+
+<a id="AdGroupAdsLteCondition"></a>
 
 `AdGroupAdsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -1324,6 +1444,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.google_ads.types.AdGroupAdsSearchFilter`
     :   The type of the None singleton.
 
+<a id="AdGroupAdsNeqCondition"></a>
+
 `AdGroupAdsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -1335,6 +1457,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.google_ads.types.AdGroupAdsSearchFilter`
     :   The type of the None singleton.
+
+<a id="AdGroupAdsNotCondition"></a>
 
 `AdGroupAdsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -1356,6 +1480,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.google_ads.types.AdGroupAdsEqCondition | airbyte_agent_sdk.connectors.google_ads.types.AdGroupAdsNeqCondition | airbyte_agent_sdk.connectors.google_ads.types.AdGroupAdsGtCondition | airbyte_agent_sdk.connectors.google_ads.types.AdGroupAdsGteCondition | airbyte_agent_sdk.connectors.google_ads.types.AdGroupAdsLtCondition | airbyte_agent_sdk.connectors.google_ads.types.AdGroupAdsLteCondition | airbyte_agent_sdk.connectors.google_ads.types.AdGroupAdsInCondition | airbyte_agent_sdk.connectors.google_ads.types.AdGroupAdsLikeCondition | airbyte_agent_sdk.connectors.google_ads.types.AdGroupAdsFuzzyCondition | airbyte_agent_sdk.connectors.google_ads.types.AdGroupAdsKeywordCondition | airbyte_agent_sdk.connectors.google_ads.types.AdGroupAdsContainsCondition | airbyte_agent_sdk.connectors.google_ads.types.AdGroupAdsNotCondition | airbyte_agent_sdk.connectors.google_ads.types.AdGroupAdsAndCondition | airbyte_agent_sdk.connectors.google_ads.types.AdGroupAdsOrCondition | airbyte_agent_sdk.connectors.google_ads.types.AdGroupAdsAnyCondition`
     :   The type of the None singleton.
 
+<a id="AdGroupAdsOrCondition"></a>
+
 `AdGroupAdsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1375,6 +1501,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.google_ads.types.AdGroupAdsEqCondition | airbyte_agent_sdk.connectors.google_ads.types.AdGroupAdsNeqCondition | airbyte_agent_sdk.connectors.google_ads.types.AdGroupAdsGtCondition | airbyte_agent_sdk.connectors.google_ads.types.AdGroupAdsGteCondition | airbyte_agent_sdk.connectors.google_ads.types.AdGroupAdsLtCondition | airbyte_agent_sdk.connectors.google_ads.types.AdGroupAdsLteCondition | airbyte_agent_sdk.connectors.google_ads.types.AdGroupAdsInCondition | airbyte_agent_sdk.connectors.google_ads.types.AdGroupAdsLikeCondition | airbyte_agent_sdk.connectors.google_ads.types.AdGroupAdsFuzzyCondition | airbyte_agent_sdk.connectors.google_ads.types.AdGroupAdsKeywordCondition | airbyte_agent_sdk.connectors.google_ads.types.AdGroupAdsContainsCondition | airbyte_agent_sdk.connectors.google_ads.types.AdGroupAdsNotCondition | airbyte_agent_sdk.connectors.google_ads.types.AdGroupAdsAndCondition | airbyte_agent_sdk.connectors.google_ads.types.AdGroupAdsOrCondition | airbyte_agent_sdk.connectors.google_ads.types.AdGroupAdsAnyCondition]`
     :   The type of the None singleton.
+
+<a id="AdGroupAdsSearchFilter"></a>
 
 `AdGroupAdsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering ad_group_ads search queries.
@@ -1439,6 +1567,8 @@ Classes
     `segments_date: str | None`
     :   Date segment for the report row
 
+<a id="AdGroupAdsSearchQuery"></a>
+
 `AdGroupAdsSearchQuery(*args, **kwargs)`
 :   Search query for ad_group_ads entity.
 
@@ -1453,6 +1583,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.google_ads.types.AdGroupAdsSortFilter]`
     :   The type of the None singleton.
+
+<a id="AdGroupAdsSortFilter"></a>
 
 `AdGroupAdsSortFilter(*args, **kwargs)`
 :   Available fields for sorting ad_group_ads search results.
@@ -1517,6 +1649,8 @@ Classes
     `segments_date: Literal['asc', 'desc']`
     :   Date segment for the report row
 
+<a id="AdGroupAdsStringFilter"></a>
+
 `AdGroupAdsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -1580,6 +1714,8 @@ Classes
     `segments_date: str`
     :   Date segment for the report row
 
+<a id="AdGroupLabelsAndCondition"></a>
+
 `AdGroupLabelsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1600,6 +1736,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.google_ads.types.AdGroupLabelsEqCondition | airbyte_agent_sdk.connectors.google_ads.types.AdGroupLabelsNeqCondition | airbyte_agent_sdk.connectors.google_ads.types.AdGroupLabelsGtCondition | airbyte_agent_sdk.connectors.google_ads.types.AdGroupLabelsGteCondition | airbyte_agent_sdk.connectors.google_ads.types.AdGroupLabelsLtCondition | airbyte_agent_sdk.connectors.google_ads.types.AdGroupLabelsLteCondition | airbyte_agent_sdk.connectors.google_ads.types.AdGroupLabelsInCondition | airbyte_agent_sdk.connectors.google_ads.types.AdGroupLabelsLikeCondition | airbyte_agent_sdk.connectors.google_ads.types.AdGroupLabelsFuzzyCondition | airbyte_agent_sdk.connectors.google_ads.types.AdGroupLabelsKeywordCondition | airbyte_agent_sdk.connectors.google_ads.types.AdGroupLabelsContainsCondition | airbyte_agent_sdk.connectors.google_ads.types.AdGroupLabelsNotCondition | airbyte_agent_sdk.connectors.google_ads.types.AdGroupLabelsAndCondition | airbyte_agent_sdk.connectors.google_ads.types.AdGroupLabelsOrCondition | airbyte_agent_sdk.connectors.google_ads.types.AdGroupLabelsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="AdGroupLabelsAnyCondition"></a>
+
 `AdGroupLabelsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1619,6 +1757,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.google_ads.types.AdGroupLabelsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="AdGroupLabelsAnyValueFilter"></a>
 
 `AdGroupLabelsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -1644,6 +1784,8 @@ Classes
     `label_resource_name: Any`
     :   Resource name of the label
 
+<a id="AdGroupLabelsContainsCondition"></a>
+
 `AdGroupLabelsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -1655,6 +1797,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.google_ads.types.AdGroupLabelsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="AdGroupLabelsCreateParams"></a>
 
 `AdGroupLabelsCreateParams(*args, **kwargs)`
 :   Parameters for ad_group_labels.create operation
@@ -1671,6 +1815,8 @@ Classes
     `operations: list[airbyte_agent_sdk.connectors.google_ads.types.AdGroupLabelsCreateParamsOperationsItem]`
     :   The type of the None singleton.
 
+<a id="AdGroupLabelsCreateParamsOperationsItem"></a>
+
 `AdGroupLabelsCreateParamsOperationsItem(*args, **kwargs)`
 :   Nested schema for AdGroupLabelsCreateParams.operations_item
 
@@ -1682,6 +1828,8 @@ Classes
 
     `create: airbyte_agent_sdk.connectors.google_ads.types.AdGroupLabelsCreateParamsOperationsItemCreate`
     :   The type of the None singleton.
+
+<a id="AdGroupLabelsCreateParamsOperationsItemCreate"></a>
 
 `AdGroupLabelsCreateParamsOperationsItemCreate(*args, **kwargs)`
 :   Ad group label association to create
@@ -1698,6 +1846,8 @@ Classes
     `label: str`
     :   The type of the None singleton.
 
+<a id="AdGroupLabelsEqCondition"></a>
+
 `AdGroupLabelsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
 
@@ -1709,6 +1859,8 @@ Classes
 
     `eq: airbyte_agent_sdk.connectors.google_ads.types.AdGroupLabelsSearchFilter`
     :   The type of the None singleton.
+
+<a id="AdGroupLabelsFuzzyCondition"></a>
 
 `AdGroupLabelsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
@@ -1722,6 +1874,8 @@ Classes
     `fuzzy: airbyte_agent_sdk.connectors.google_ads.types.AdGroupLabelsStringFilter`
     :   The type of the None singleton.
 
+<a id="AdGroupLabelsGtCondition"></a>
+
 `AdGroupLabelsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -1734,6 +1888,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.google_ads.types.AdGroupLabelsSearchFilter`
     :   The type of the None singleton.
 
+<a id="AdGroupLabelsGteCondition"></a>
+
 `AdGroupLabelsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -1745,6 +1901,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.google_ads.types.AdGroupLabelsSearchFilter`
     :   The type of the None singleton.
+
+<a id="AdGroupLabelsInCondition"></a>
 
 `AdGroupLabelsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -1765,6 +1923,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.google_ads.types.AdGroupLabelsInFilter`
     :   The type of the None singleton.
+
+<a id="AdGroupLabelsInFilter"></a>
 
 `AdGroupLabelsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -1790,6 +1950,8 @@ Classes
     `label_resource_name: list[str]`
     :   Resource name of the label
 
+<a id="AdGroupLabelsKeywordCondition"></a>
+
 `AdGroupLabelsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -1802,6 +1964,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.google_ads.types.AdGroupLabelsStringFilter`
     :   The type of the None singleton.
 
+<a id="AdGroupLabelsLikeCondition"></a>
+
 `AdGroupLabelsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -1813,6 +1977,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.google_ads.types.AdGroupLabelsStringFilter`
     :   The type of the None singleton.
+
+<a id="AdGroupLabelsListParams"></a>
 
 `AdGroupLabelsListParams(*args, **kwargs)`
 :   Parameters for ad_group_labels.list operation
@@ -1835,6 +2001,8 @@ Classes
     `query: str`
     :   The type of the None singleton.
 
+<a id="AdGroupLabelsLtCondition"></a>
+
 `AdGroupLabelsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -1846,6 +2014,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.google_ads.types.AdGroupLabelsSearchFilter`
     :   The type of the None singleton.
+
+<a id="AdGroupLabelsLteCondition"></a>
 
 `AdGroupLabelsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -1859,6 +2029,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.google_ads.types.AdGroupLabelsSearchFilter`
     :   The type of the None singleton.
 
+<a id="AdGroupLabelsNeqCondition"></a>
+
 `AdGroupLabelsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -1870,6 +2042,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.google_ads.types.AdGroupLabelsSearchFilter`
     :   The type of the None singleton.
+
+<a id="AdGroupLabelsNotCondition"></a>
 
 `AdGroupLabelsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -1891,6 +2065,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.google_ads.types.AdGroupLabelsEqCondition | airbyte_agent_sdk.connectors.google_ads.types.AdGroupLabelsNeqCondition | airbyte_agent_sdk.connectors.google_ads.types.AdGroupLabelsGtCondition | airbyte_agent_sdk.connectors.google_ads.types.AdGroupLabelsGteCondition | airbyte_agent_sdk.connectors.google_ads.types.AdGroupLabelsLtCondition | airbyte_agent_sdk.connectors.google_ads.types.AdGroupLabelsLteCondition | airbyte_agent_sdk.connectors.google_ads.types.AdGroupLabelsInCondition | airbyte_agent_sdk.connectors.google_ads.types.AdGroupLabelsLikeCondition | airbyte_agent_sdk.connectors.google_ads.types.AdGroupLabelsFuzzyCondition | airbyte_agent_sdk.connectors.google_ads.types.AdGroupLabelsKeywordCondition | airbyte_agent_sdk.connectors.google_ads.types.AdGroupLabelsContainsCondition | airbyte_agent_sdk.connectors.google_ads.types.AdGroupLabelsNotCondition | airbyte_agent_sdk.connectors.google_ads.types.AdGroupLabelsAndCondition | airbyte_agent_sdk.connectors.google_ads.types.AdGroupLabelsOrCondition | airbyte_agent_sdk.connectors.google_ads.types.AdGroupLabelsAnyCondition`
     :   The type of the None singleton.
 
+<a id="AdGroupLabelsOrCondition"></a>
+
 `AdGroupLabelsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1910,6 +2086,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.google_ads.types.AdGroupLabelsEqCondition | airbyte_agent_sdk.connectors.google_ads.types.AdGroupLabelsNeqCondition | airbyte_agent_sdk.connectors.google_ads.types.AdGroupLabelsGtCondition | airbyte_agent_sdk.connectors.google_ads.types.AdGroupLabelsGteCondition | airbyte_agent_sdk.connectors.google_ads.types.AdGroupLabelsLtCondition | airbyte_agent_sdk.connectors.google_ads.types.AdGroupLabelsLteCondition | airbyte_agent_sdk.connectors.google_ads.types.AdGroupLabelsInCondition | airbyte_agent_sdk.connectors.google_ads.types.AdGroupLabelsLikeCondition | airbyte_agent_sdk.connectors.google_ads.types.AdGroupLabelsFuzzyCondition | airbyte_agent_sdk.connectors.google_ads.types.AdGroupLabelsKeywordCondition | airbyte_agent_sdk.connectors.google_ads.types.AdGroupLabelsContainsCondition | airbyte_agent_sdk.connectors.google_ads.types.AdGroupLabelsNotCondition | airbyte_agent_sdk.connectors.google_ads.types.AdGroupLabelsAndCondition | airbyte_agent_sdk.connectors.google_ads.types.AdGroupLabelsOrCondition | airbyte_agent_sdk.connectors.google_ads.types.AdGroupLabelsAnyCondition]`
     :   The type of the None singleton.
+
+<a id="AdGroupLabelsSearchFilter"></a>
 
 `AdGroupLabelsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering ad_group_labels search queries.
@@ -1935,6 +2113,8 @@ Classes
     `label_resource_name: str | None`
     :   Resource name of the label
 
+<a id="AdGroupLabelsSearchQuery"></a>
+
 `AdGroupLabelsSearchQuery(*args, **kwargs)`
 :   Search query for ad_group_labels entity.
 
@@ -1949,6 +2129,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.google_ads.types.AdGroupLabelsSortFilter]`
     :   The type of the None singleton.
+
+<a id="AdGroupLabelsSortFilter"></a>
 
 `AdGroupLabelsSortFilter(*args, **kwargs)`
 :   Available fields for sorting ad_group_labels search results.
@@ -1974,6 +2156,8 @@ Classes
     `label_resource_name: Literal['asc', 'desc']`
     :   Resource name of the label
 
+<a id="AdGroupLabelsStringFilter"></a>
+
 `AdGroupLabelsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -1998,6 +2182,8 @@ Classes
     `label_resource_name: str`
     :   Resource name of the label
 
+<a id="AdGroupsAndCondition"></a>
+
 `AdGroupsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -2018,6 +2204,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.google_ads.types.AdGroupsEqCondition | airbyte_agent_sdk.connectors.google_ads.types.AdGroupsNeqCondition | airbyte_agent_sdk.connectors.google_ads.types.AdGroupsGtCondition | airbyte_agent_sdk.connectors.google_ads.types.AdGroupsGteCondition | airbyte_agent_sdk.connectors.google_ads.types.AdGroupsLtCondition | airbyte_agent_sdk.connectors.google_ads.types.AdGroupsLteCondition | airbyte_agent_sdk.connectors.google_ads.types.AdGroupsInCondition | airbyte_agent_sdk.connectors.google_ads.types.AdGroupsLikeCondition | airbyte_agent_sdk.connectors.google_ads.types.AdGroupsFuzzyCondition | airbyte_agent_sdk.connectors.google_ads.types.AdGroupsKeywordCondition | airbyte_agent_sdk.connectors.google_ads.types.AdGroupsContainsCondition | airbyte_agent_sdk.connectors.google_ads.types.AdGroupsNotCondition | airbyte_agent_sdk.connectors.google_ads.types.AdGroupsAndCondition | airbyte_agent_sdk.connectors.google_ads.types.AdGroupsOrCondition | airbyte_agent_sdk.connectors.google_ads.types.AdGroupsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="AdGroupsAnyCondition"></a>
+
 `AdGroupsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -2037,6 +2225,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.google_ads.types.AdGroupsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="AdGroupsAnyValueFilter"></a>
 
 `AdGroupsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -2113,6 +2303,8 @@ Classes
     `segments_date: Any`
     :   Date segment for the report row
 
+<a id="AdGroupsContainsCondition"></a>
+
 `AdGroupsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -2124,6 +2316,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.google_ads.types.AdGroupsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="AdGroupsEqCondition"></a>
 
 `AdGroupsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -2137,6 +2331,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.google_ads.types.AdGroupsSearchFilter`
     :   The type of the None singleton.
 
+<a id="AdGroupsFuzzyCondition"></a>
+
 `AdGroupsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -2148,6 +2344,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.google_ads.types.AdGroupsStringFilter`
     :   The type of the None singleton.
+
+<a id="AdGroupsGtCondition"></a>
 
 `AdGroupsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
@@ -2161,6 +2359,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.google_ads.types.AdGroupsSearchFilter`
     :   The type of the None singleton.
 
+<a id="AdGroupsGteCondition"></a>
+
 `AdGroupsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -2172,6 +2372,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.google_ads.types.AdGroupsSearchFilter`
     :   The type of the None singleton.
+
+<a id="AdGroupsInCondition"></a>
 
 `AdGroupsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -2192,6 +2394,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.google_ads.types.AdGroupsInFilter`
     :   The type of the None singleton.
+
+<a id="AdGroupsInFilter"></a>
 
 `AdGroupsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -2268,6 +2472,8 @@ Classes
     `segments_date: list[str]`
     :   Date segment for the report row
 
+<a id="AdGroupsKeywordCondition"></a>
+
 `AdGroupsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -2280,6 +2486,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.google_ads.types.AdGroupsStringFilter`
     :   The type of the None singleton.
 
+<a id="AdGroupsLikeCondition"></a>
+
 `AdGroupsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -2291,6 +2499,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.google_ads.types.AdGroupsStringFilter`
     :   The type of the None singleton.
+
+<a id="AdGroupsListParams"></a>
 
 `AdGroupsListParams(*args, **kwargs)`
 :   Parameters for ad_groups.list operation
@@ -2313,6 +2523,8 @@ Classes
     `query: str`
     :   The type of the None singleton.
 
+<a id="AdGroupsLtCondition"></a>
+
 `AdGroupsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -2324,6 +2536,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.google_ads.types.AdGroupsSearchFilter`
     :   The type of the None singleton.
+
+<a id="AdGroupsLteCondition"></a>
 
 `AdGroupsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -2337,6 +2551,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.google_ads.types.AdGroupsSearchFilter`
     :   The type of the None singleton.
 
+<a id="AdGroupsNeqCondition"></a>
+
 `AdGroupsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -2348,6 +2564,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.google_ads.types.AdGroupsSearchFilter`
     :   The type of the None singleton.
+
+<a id="AdGroupsNotCondition"></a>
 
 `AdGroupsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -2369,6 +2587,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.google_ads.types.AdGroupsEqCondition | airbyte_agent_sdk.connectors.google_ads.types.AdGroupsNeqCondition | airbyte_agent_sdk.connectors.google_ads.types.AdGroupsGtCondition | airbyte_agent_sdk.connectors.google_ads.types.AdGroupsGteCondition | airbyte_agent_sdk.connectors.google_ads.types.AdGroupsLtCondition | airbyte_agent_sdk.connectors.google_ads.types.AdGroupsLteCondition | airbyte_agent_sdk.connectors.google_ads.types.AdGroupsInCondition | airbyte_agent_sdk.connectors.google_ads.types.AdGroupsLikeCondition | airbyte_agent_sdk.connectors.google_ads.types.AdGroupsFuzzyCondition | airbyte_agent_sdk.connectors.google_ads.types.AdGroupsKeywordCondition | airbyte_agent_sdk.connectors.google_ads.types.AdGroupsContainsCondition | airbyte_agent_sdk.connectors.google_ads.types.AdGroupsNotCondition | airbyte_agent_sdk.connectors.google_ads.types.AdGroupsAndCondition | airbyte_agent_sdk.connectors.google_ads.types.AdGroupsOrCondition | airbyte_agent_sdk.connectors.google_ads.types.AdGroupsAnyCondition`
     :   The type of the None singleton.
 
+<a id="AdGroupsOrCondition"></a>
+
 `AdGroupsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -2388,6 +2608,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.google_ads.types.AdGroupsEqCondition | airbyte_agent_sdk.connectors.google_ads.types.AdGroupsNeqCondition | airbyte_agent_sdk.connectors.google_ads.types.AdGroupsGtCondition | airbyte_agent_sdk.connectors.google_ads.types.AdGroupsGteCondition | airbyte_agent_sdk.connectors.google_ads.types.AdGroupsLtCondition | airbyte_agent_sdk.connectors.google_ads.types.AdGroupsLteCondition | airbyte_agent_sdk.connectors.google_ads.types.AdGroupsInCondition | airbyte_agent_sdk.connectors.google_ads.types.AdGroupsLikeCondition | airbyte_agent_sdk.connectors.google_ads.types.AdGroupsFuzzyCondition | airbyte_agent_sdk.connectors.google_ads.types.AdGroupsKeywordCondition | airbyte_agent_sdk.connectors.google_ads.types.AdGroupsContainsCondition | airbyte_agent_sdk.connectors.google_ads.types.AdGroupsNotCondition | airbyte_agent_sdk.connectors.google_ads.types.AdGroupsAndCondition | airbyte_agent_sdk.connectors.google_ads.types.AdGroupsOrCondition | airbyte_agent_sdk.connectors.google_ads.types.AdGroupsAnyCondition]`
     :   The type of the None singleton.
+
+<a id="AdGroupsSearchFilter"></a>
 
 `AdGroupsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering ad_groups search queries.
@@ -2464,6 +2686,8 @@ Classes
     `segments_date: str | None`
     :   Date segment for the report row
 
+<a id="AdGroupsSearchQuery"></a>
+
 `AdGroupsSearchQuery(*args, **kwargs)`
 :   Search query for ad_groups entity.
 
@@ -2478,6 +2702,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.google_ads.types.AdGroupsSortFilter]`
     :   The type of the None singleton.
+
+<a id="AdGroupsSortFilter"></a>
 
 `AdGroupsSortFilter(*args, **kwargs)`
 :   Available fields for sorting ad_groups search results.
@@ -2554,6 +2780,8 @@ Classes
     `segments_date: Literal['asc', 'desc']`
     :   Date segment for the report row
 
+<a id="AdGroupsStringFilter"></a>
+
 `AdGroupsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -2629,6 +2857,8 @@ Classes
     `segments_date: str`
     :   Date segment for the report row
 
+<a id="AdGroupsUpdateParams"></a>
+
 `AdGroupsUpdateParams(*args, **kwargs)`
 :   Parameters for ad_groups.update operation
 
@@ -2643,6 +2873,8 @@ Classes
 
     `operations: list[airbyte_agent_sdk.connectors.google_ads.types.AdGroupsUpdateParamsOperationsItem]`
     :   The type of the None singleton.
+
+<a id="AdGroupsUpdateParamsOperationsItem"></a>
 
 `AdGroupsUpdateParamsOperationsItem(*args, **kwargs)`
 :   Nested schema for AdGroupsUpdateParams.operations_item
@@ -2663,6 +2895,8 @@ Classes
         If E is present and has a .keys() method, then does:  for k in E.keys(): D[k] = E[k]
         If E is present and lacks a .keys() method, then does:  for k, v in E: D[k] = v
         In either case, this is followed by: for k in F:  D[k] = F[k]
+
+<a id="AdGroupsUpdateParamsOperationsItemUpdate"></a>
 
 `AdGroupsUpdateParamsOperationsItemUpdate(*args, **kwargs)`
 :   Ad group fields to update
@@ -2685,6 +2919,8 @@ Classes
     `status: str`
     :   The type of the None singleton.
 
+<a id="AirbyteSearchParams"></a>
+
 `AirbyteSearchParams(*args, **kwargs)`
 :   Parameters for Airbyte cache search operations (generic, use entity-specific query types for better type hints).
 
@@ -2706,6 +2942,8 @@ Classes
     `query: dict[str, typing.Any]`
     :   The type of the None singleton.
 
+<a id="CampaignLabelsAndCondition"></a>
+
 `CampaignLabelsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -2726,6 +2964,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.google_ads.types.CampaignLabelsEqCondition | airbyte_agent_sdk.connectors.google_ads.types.CampaignLabelsNeqCondition | airbyte_agent_sdk.connectors.google_ads.types.CampaignLabelsGtCondition | airbyte_agent_sdk.connectors.google_ads.types.CampaignLabelsGteCondition | airbyte_agent_sdk.connectors.google_ads.types.CampaignLabelsLtCondition | airbyte_agent_sdk.connectors.google_ads.types.CampaignLabelsLteCondition | airbyte_agent_sdk.connectors.google_ads.types.CampaignLabelsInCondition | airbyte_agent_sdk.connectors.google_ads.types.CampaignLabelsLikeCondition | airbyte_agent_sdk.connectors.google_ads.types.CampaignLabelsFuzzyCondition | airbyte_agent_sdk.connectors.google_ads.types.CampaignLabelsKeywordCondition | airbyte_agent_sdk.connectors.google_ads.types.CampaignLabelsContainsCondition | airbyte_agent_sdk.connectors.google_ads.types.CampaignLabelsNotCondition | airbyte_agent_sdk.connectors.google_ads.types.CampaignLabelsAndCondition | airbyte_agent_sdk.connectors.google_ads.types.CampaignLabelsOrCondition | airbyte_agent_sdk.connectors.google_ads.types.CampaignLabelsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="CampaignLabelsAnyCondition"></a>
+
 `CampaignLabelsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -2745,6 +2985,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.google_ads.types.CampaignLabelsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="CampaignLabelsAnyValueFilter"></a>
 
 `CampaignLabelsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -2770,6 +3012,8 @@ Classes
     `label_resource_name: Any`
     :   Resource name of the label
 
+<a id="CampaignLabelsContainsCondition"></a>
+
 `CampaignLabelsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -2781,6 +3025,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.google_ads.types.CampaignLabelsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="CampaignLabelsCreateParams"></a>
 
 `CampaignLabelsCreateParams(*args, **kwargs)`
 :   Parameters for campaign_labels.create operation
@@ -2797,6 +3043,8 @@ Classes
     `operations: list[airbyte_agent_sdk.connectors.google_ads.types.CampaignLabelsCreateParamsOperationsItem]`
     :   The type of the None singleton.
 
+<a id="CampaignLabelsCreateParamsOperationsItem"></a>
+
 `CampaignLabelsCreateParamsOperationsItem(*args, **kwargs)`
 :   Nested schema for CampaignLabelsCreateParams.operations_item
 
@@ -2808,6 +3056,8 @@ Classes
 
     `create: airbyte_agent_sdk.connectors.google_ads.types.CampaignLabelsCreateParamsOperationsItemCreate`
     :   The type of the None singleton.
+
+<a id="CampaignLabelsCreateParamsOperationsItemCreate"></a>
 
 `CampaignLabelsCreateParamsOperationsItemCreate(*args, **kwargs)`
 :   Campaign label association to create
@@ -2824,6 +3074,8 @@ Classes
     `label: str`
     :   The type of the None singleton.
 
+<a id="CampaignLabelsEqCondition"></a>
+
 `CampaignLabelsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
 
@@ -2835,6 +3087,8 @@ Classes
 
     `eq: airbyte_agent_sdk.connectors.google_ads.types.CampaignLabelsSearchFilter`
     :   The type of the None singleton.
+
+<a id="CampaignLabelsFuzzyCondition"></a>
 
 `CampaignLabelsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
@@ -2848,6 +3102,8 @@ Classes
     `fuzzy: airbyte_agent_sdk.connectors.google_ads.types.CampaignLabelsStringFilter`
     :   The type of the None singleton.
 
+<a id="CampaignLabelsGtCondition"></a>
+
 `CampaignLabelsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -2860,6 +3116,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.google_ads.types.CampaignLabelsSearchFilter`
     :   The type of the None singleton.
 
+<a id="CampaignLabelsGteCondition"></a>
+
 `CampaignLabelsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -2871,6 +3129,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.google_ads.types.CampaignLabelsSearchFilter`
     :   The type of the None singleton.
+
+<a id="CampaignLabelsInCondition"></a>
 
 `CampaignLabelsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -2891,6 +3151,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.google_ads.types.CampaignLabelsInFilter`
     :   The type of the None singleton.
+
+<a id="CampaignLabelsInFilter"></a>
 
 `CampaignLabelsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -2916,6 +3178,8 @@ Classes
     `label_resource_name: list[str]`
     :   Resource name of the label
 
+<a id="CampaignLabelsKeywordCondition"></a>
+
 `CampaignLabelsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -2928,6 +3192,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.google_ads.types.CampaignLabelsStringFilter`
     :   The type of the None singleton.
 
+<a id="CampaignLabelsLikeCondition"></a>
+
 `CampaignLabelsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -2939,6 +3205,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.google_ads.types.CampaignLabelsStringFilter`
     :   The type of the None singleton.
+
+<a id="CampaignLabelsListParams"></a>
 
 `CampaignLabelsListParams(*args, **kwargs)`
 :   Parameters for campaign_labels.list operation
@@ -2961,6 +3229,8 @@ Classes
     `query: str`
     :   The type of the None singleton.
 
+<a id="CampaignLabelsLtCondition"></a>
+
 `CampaignLabelsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -2972,6 +3242,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.google_ads.types.CampaignLabelsSearchFilter`
     :   The type of the None singleton.
+
+<a id="CampaignLabelsLteCondition"></a>
 
 `CampaignLabelsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -2985,6 +3257,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.google_ads.types.CampaignLabelsSearchFilter`
     :   The type of the None singleton.
 
+<a id="CampaignLabelsNeqCondition"></a>
+
 `CampaignLabelsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -2996,6 +3270,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.google_ads.types.CampaignLabelsSearchFilter`
     :   The type of the None singleton.
+
+<a id="CampaignLabelsNotCondition"></a>
 
 `CampaignLabelsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -3017,6 +3293,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.google_ads.types.CampaignLabelsEqCondition | airbyte_agent_sdk.connectors.google_ads.types.CampaignLabelsNeqCondition | airbyte_agent_sdk.connectors.google_ads.types.CampaignLabelsGtCondition | airbyte_agent_sdk.connectors.google_ads.types.CampaignLabelsGteCondition | airbyte_agent_sdk.connectors.google_ads.types.CampaignLabelsLtCondition | airbyte_agent_sdk.connectors.google_ads.types.CampaignLabelsLteCondition | airbyte_agent_sdk.connectors.google_ads.types.CampaignLabelsInCondition | airbyte_agent_sdk.connectors.google_ads.types.CampaignLabelsLikeCondition | airbyte_agent_sdk.connectors.google_ads.types.CampaignLabelsFuzzyCondition | airbyte_agent_sdk.connectors.google_ads.types.CampaignLabelsKeywordCondition | airbyte_agent_sdk.connectors.google_ads.types.CampaignLabelsContainsCondition | airbyte_agent_sdk.connectors.google_ads.types.CampaignLabelsNotCondition | airbyte_agent_sdk.connectors.google_ads.types.CampaignLabelsAndCondition | airbyte_agent_sdk.connectors.google_ads.types.CampaignLabelsOrCondition | airbyte_agent_sdk.connectors.google_ads.types.CampaignLabelsAnyCondition`
     :   The type of the None singleton.
 
+<a id="CampaignLabelsOrCondition"></a>
+
 `CampaignLabelsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -3036,6 +3314,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.google_ads.types.CampaignLabelsEqCondition | airbyte_agent_sdk.connectors.google_ads.types.CampaignLabelsNeqCondition | airbyte_agent_sdk.connectors.google_ads.types.CampaignLabelsGtCondition | airbyte_agent_sdk.connectors.google_ads.types.CampaignLabelsGteCondition | airbyte_agent_sdk.connectors.google_ads.types.CampaignLabelsLtCondition | airbyte_agent_sdk.connectors.google_ads.types.CampaignLabelsLteCondition | airbyte_agent_sdk.connectors.google_ads.types.CampaignLabelsInCondition | airbyte_agent_sdk.connectors.google_ads.types.CampaignLabelsLikeCondition | airbyte_agent_sdk.connectors.google_ads.types.CampaignLabelsFuzzyCondition | airbyte_agent_sdk.connectors.google_ads.types.CampaignLabelsKeywordCondition | airbyte_agent_sdk.connectors.google_ads.types.CampaignLabelsContainsCondition | airbyte_agent_sdk.connectors.google_ads.types.CampaignLabelsNotCondition | airbyte_agent_sdk.connectors.google_ads.types.CampaignLabelsAndCondition | airbyte_agent_sdk.connectors.google_ads.types.CampaignLabelsOrCondition | airbyte_agent_sdk.connectors.google_ads.types.CampaignLabelsAnyCondition]`
     :   The type of the None singleton.
+
+<a id="CampaignLabelsSearchFilter"></a>
 
 `CampaignLabelsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering campaign_labels search queries.
@@ -3061,6 +3341,8 @@ Classes
     `label_resource_name: str | None`
     :   Resource name of the label
 
+<a id="CampaignLabelsSearchQuery"></a>
+
 `CampaignLabelsSearchQuery(*args, **kwargs)`
 :   Search query for campaign_labels entity.
 
@@ -3075,6 +3357,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.google_ads.types.CampaignLabelsSortFilter]`
     :   The type of the None singleton.
+
+<a id="CampaignLabelsSortFilter"></a>
 
 `CampaignLabelsSortFilter(*args, **kwargs)`
 :   Available fields for sorting campaign_labels search results.
@@ -3100,6 +3384,8 @@ Classes
     `label_resource_name: Literal['asc', 'desc']`
     :   Resource name of the label
 
+<a id="CampaignLabelsStringFilter"></a>
+
 `CampaignLabelsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -3124,6 +3410,8 @@ Classes
     `label_resource_name: str`
     :   Resource name of the label
 
+<a id="CampaignsAndCondition"></a>
+
 `CampaignsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -3144,6 +3432,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.google_ads.types.CampaignsEqCondition | airbyte_agent_sdk.connectors.google_ads.types.CampaignsNeqCondition | airbyte_agent_sdk.connectors.google_ads.types.CampaignsGtCondition | airbyte_agent_sdk.connectors.google_ads.types.CampaignsGteCondition | airbyte_agent_sdk.connectors.google_ads.types.CampaignsLtCondition | airbyte_agent_sdk.connectors.google_ads.types.CampaignsLteCondition | airbyte_agent_sdk.connectors.google_ads.types.CampaignsInCondition | airbyte_agent_sdk.connectors.google_ads.types.CampaignsLikeCondition | airbyte_agent_sdk.connectors.google_ads.types.CampaignsFuzzyCondition | airbyte_agent_sdk.connectors.google_ads.types.CampaignsKeywordCondition | airbyte_agent_sdk.connectors.google_ads.types.CampaignsContainsCondition | airbyte_agent_sdk.connectors.google_ads.types.CampaignsNotCondition | airbyte_agent_sdk.connectors.google_ads.types.CampaignsAndCondition | airbyte_agent_sdk.connectors.google_ads.types.CampaignsOrCondition | airbyte_agent_sdk.connectors.google_ads.types.CampaignsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="CampaignsAnyCondition"></a>
+
 `CampaignsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -3163,6 +3453,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.google_ads.types.CampaignsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="CampaignsAnyValueFilter"></a>
 
 `CampaignsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -3263,6 +3555,8 @@ Classes
     `segments_hour: Any`
     :   Hour segment
 
+<a id="CampaignsContainsCondition"></a>
+
 `CampaignsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -3274,6 +3568,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.google_ads.types.CampaignsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="CampaignsEqCondition"></a>
 
 `CampaignsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -3287,6 +3583,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.google_ads.types.CampaignsSearchFilter`
     :   The type of the None singleton.
 
+<a id="CampaignsFuzzyCondition"></a>
+
 `CampaignsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -3298,6 +3596,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.google_ads.types.CampaignsStringFilter`
     :   The type of the None singleton.
+
+<a id="CampaignsGtCondition"></a>
 
 `CampaignsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
@@ -3311,6 +3611,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.google_ads.types.CampaignsSearchFilter`
     :   The type of the None singleton.
 
+<a id="CampaignsGteCondition"></a>
+
 `CampaignsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -3322,6 +3624,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.google_ads.types.CampaignsSearchFilter`
     :   The type of the None singleton.
+
+<a id="CampaignsInCondition"></a>
 
 `CampaignsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -3342,6 +3646,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.google_ads.types.CampaignsInFilter`
     :   The type of the None singleton.
+
+<a id="CampaignsInFilter"></a>
 
 `CampaignsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -3442,6 +3748,8 @@ Classes
     `segments_hour: list[int]`
     :   Hour segment
 
+<a id="CampaignsKeywordCondition"></a>
+
 `CampaignsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -3454,6 +3762,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.google_ads.types.CampaignsStringFilter`
     :   The type of the None singleton.
 
+<a id="CampaignsLikeCondition"></a>
+
 `CampaignsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -3465,6 +3775,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.google_ads.types.CampaignsStringFilter`
     :   The type of the None singleton.
+
+<a id="CampaignsListParams"></a>
 
 `CampaignsListParams(*args, **kwargs)`
 :   Parameters for campaigns.list operation
@@ -3487,6 +3799,8 @@ Classes
     `query: str`
     :   The type of the None singleton.
 
+<a id="CampaignsLtCondition"></a>
+
 `CampaignsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -3498,6 +3812,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.google_ads.types.CampaignsSearchFilter`
     :   The type of the None singleton.
+
+<a id="CampaignsLteCondition"></a>
 
 `CampaignsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -3511,6 +3827,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.google_ads.types.CampaignsSearchFilter`
     :   The type of the None singleton.
 
+<a id="CampaignsNeqCondition"></a>
+
 `CampaignsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -3522,6 +3840,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.google_ads.types.CampaignsSearchFilter`
     :   The type of the None singleton.
+
+<a id="CampaignsNotCondition"></a>
 
 `CampaignsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -3543,6 +3863,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.google_ads.types.CampaignsEqCondition | airbyte_agent_sdk.connectors.google_ads.types.CampaignsNeqCondition | airbyte_agent_sdk.connectors.google_ads.types.CampaignsGtCondition | airbyte_agent_sdk.connectors.google_ads.types.CampaignsGteCondition | airbyte_agent_sdk.connectors.google_ads.types.CampaignsLtCondition | airbyte_agent_sdk.connectors.google_ads.types.CampaignsLteCondition | airbyte_agent_sdk.connectors.google_ads.types.CampaignsInCondition | airbyte_agent_sdk.connectors.google_ads.types.CampaignsLikeCondition | airbyte_agent_sdk.connectors.google_ads.types.CampaignsFuzzyCondition | airbyte_agent_sdk.connectors.google_ads.types.CampaignsKeywordCondition | airbyte_agent_sdk.connectors.google_ads.types.CampaignsContainsCondition | airbyte_agent_sdk.connectors.google_ads.types.CampaignsNotCondition | airbyte_agent_sdk.connectors.google_ads.types.CampaignsAndCondition | airbyte_agent_sdk.connectors.google_ads.types.CampaignsOrCondition | airbyte_agent_sdk.connectors.google_ads.types.CampaignsAnyCondition`
     :   The type of the None singleton.
 
+<a id="CampaignsOrCondition"></a>
+
 `CampaignsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -3562,6 +3884,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.google_ads.types.CampaignsEqCondition | airbyte_agent_sdk.connectors.google_ads.types.CampaignsNeqCondition | airbyte_agent_sdk.connectors.google_ads.types.CampaignsGtCondition | airbyte_agent_sdk.connectors.google_ads.types.CampaignsGteCondition | airbyte_agent_sdk.connectors.google_ads.types.CampaignsLtCondition | airbyte_agent_sdk.connectors.google_ads.types.CampaignsLteCondition | airbyte_agent_sdk.connectors.google_ads.types.CampaignsInCondition | airbyte_agent_sdk.connectors.google_ads.types.CampaignsLikeCondition | airbyte_agent_sdk.connectors.google_ads.types.CampaignsFuzzyCondition | airbyte_agent_sdk.connectors.google_ads.types.CampaignsKeywordCondition | airbyte_agent_sdk.connectors.google_ads.types.CampaignsContainsCondition | airbyte_agent_sdk.connectors.google_ads.types.CampaignsNotCondition | airbyte_agent_sdk.connectors.google_ads.types.CampaignsAndCondition | airbyte_agent_sdk.connectors.google_ads.types.CampaignsOrCondition | airbyte_agent_sdk.connectors.google_ads.types.CampaignsAnyCondition]`
     :   The type of the None singleton.
+
+<a id="CampaignsSearchFilter"></a>
 
 `CampaignsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering campaigns search queries.
@@ -3662,6 +3986,8 @@ Classes
     `segments_hour: int | None`
     :   Hour segment
 
+<a id="CampaignsSearchQuery"></a>
+
 `CampaignsSearchQuery(*args, **kwargs)`
 :   Search query for campaigns entity.
 
@@ -3676,6 +4002,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.google_ads.types.CampaignsSortFilter]`
     :   The type of the None singleton.
+
+<a id="CampaignsSortFilter"></a>
 
 `CampaignsSortFilter(*args, **kwargs)`
 :   Available fields for sorting campaigns search results.
@@ -3776,6 +4104,8 @@ Classes
     `segments_hour: Literal['asc', 'desc']`
     :   Hour segment
 
+<a id="CampaignsStringFilter"></a>
+
 `CampaignsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -3875,6 +4205,8 @@ Classes
     `segments_hour: str`
     :   Hour segment
 
+<a id="CampaignsUpdateParams"></a>
+
 `CampaignsUpdateParams(*args, **kwargs)`
 :   Parameters for campaigns.update operation
 
@@ -3889,6 +4221,8 @@ Classes
 
     `operations: list[airbyte_agent_sdk.connectors.google_ads.types.CampaignsUpdateParamsOperationsItem]`
     :   The type of the None singleton.
+
+<a id="CampaignsUpdateParamsOperationsItem"></a>
 
 `CampaignsUpdateParamsOperationsItem(*args, **kwargs)`
 :   Nested schema for CampaignsUpdateParams.operations_item
@@ -3910,6 +4244,8 @@ Classes
         If E is present and lacks a .keys() method, then does:  for k, v in E: D[k] = v
         In either case, this is followed by: for k in F:  D[k] = F[k]
 
+<a id="CampaignsUpdateParamsOperationsItemUpdate"></a>
+
 `CampaignsUpdateParamsOperationsItemUpdate(*args, **kwargs)`
 :   Campaign fields to update
 
@@ -3928,6 +4264,8 @@ Classes
     `status: str`
     :   The type of the None singleton.
 
+<a id="LabelsCreateParams"></a>
+
 `LabelsCreateParams(*args, **kwargs)`
 :   Parameters for labels.create operation
 
@@ -3943,6 +4281,8 @@ Classes
     `operations: list[airbyte_agent_sdk.connectors.google_ads.types.LabelsCreateParamsOperationsItem]`
     :   The type of the None singleton.
 
+<a id="LabelsCreateParamsOperationsItem"></a>
+
 `LabelsCreateParamsOperationsItem(*args, **kwargs)`
 :   Nested schema for LabelsCreateParams.operations_item
 
@@ -3954,6 +4294,8 @@ Classes
 
     `create: airbyte_agent_sdk.connectors.google_ads.types.LabelsCreateParamsOperationsItemCreate`
     :   The type of the None singleton.
+
+<a id="LabelsCreateParamsOperationsItemCreate"></a>
 
 `LabelsCreateParamsOperationsItemCreate(*args, **kwargs)`
 :   Label to create
@@ -3972,6 +4314,8 @@ Classes
 
     `textLabel: airbyte_agent_sdk.connectors.google_ads.types.LabelsCreateParamsOperationsItemCreateTextlabel`
     :   The type of the None singleton.
+
+<a id="LabelsCreateParamsOperationsItemCreateTextlabel"></a>
 
 `LabelsCreateParamsOperationsItemCreateTextlabel(*args, **kwargs)`
 :   Text label styling

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/google_analytics_data_api/connector.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/google_analytics_data_api/connector.md
@@ -10,6 +10,8 @@ Google-Analytics-Data-Api connector.
 Classes
 -------
 
+<a id="DailyActiveUsersQuery"></a>
+
 `DailyActiveUsersQuery(connector: GoogleAnalyticsDataApiConnector)`
 :   Query class for DailyActiveUsers entity operations.
     
@@ -59,6 +61,8 @@ Classes
         
         Returns:
             DailyActiveUsersListResult
+
+<a id="DevicesQuery"></a>
 
 `DevicesQuery(connector: GoogleAnalyticsDataApiConnector)`
 :   Query class for Devices entity operations.
@@ -120,6 +124,8 @@ Classes
         Returns:
             DevicesListResult
 
+<a id="FourWeeklyActiveUsersQuery"></a>
+
 `FourWeeklyActiveUsersQuery(connector: GoogleAnalyticsDataApiConnector)`
 :   Query class for FourWeeklyActiveUsers entity operations.
     
@@ -169,6 +175,8 @@ Classes
         
         Returns:
             FourWeeklyActiveUsersListResult
+
+<a id="GoogleAnalyticsDataApiConnector"></a>
 
 `GoogleAnalyticsDataApiConnector(auth_config: GoogleAnalyticsDataApiAuthConfig | AirbyteAuthConfig | BaseModel | None = None, on_token_refresh: Any | None = None)`
 :   Type-safe Google-Analytics-Data-Api API connector.
@@ -426,6 +434,8 @@ Classes
             for entity in entities:
                 print(f"\{entity['entity_name']\}: \{entity['available_actions']\}")
 
+<a id="LocationsQuery"></a>
+
 `LocationsQuery(connector: GoogleAnalyticsDataApiConnector)`
 :   Query class for Locations entity operations.
     
@@ -486,6 +496,8 @@ Classes
         Returns:
             LocationsListResult
 
+<a id="PagesQuery"></a>
+
 `PagesQuery(connector: GoogleAnalyticsDataApiConnector)`
 :   Query class for Pages entity operations.
     
@@ -538,6 +550,8 @@ Classes
         
         Returns:
             PagesListResult
+
+<a id="TrafficSourcesQuery"></a>
 
 `TrafficSourcesQuery(connector: GoogleAnalyticsDataApiConnector)`
 :   Query class for TrafficSources entity operations.
@@ -598,6 +612,8 @@ Classes
         Returns:
             TrafficSourcesListResult
 
+<a id="WebsiteOverviewQuery"></a>
+
 `WebsiteOverviewQuery(connector: GoogleAnalyticsDataApiConnector)`
 :   Query class for WebsiteOverview entity operations.
     
@@ -654,6 +670,8 @@ Classes
         
         Returns:
             WebsiteOverviewListResult
+
+<a id="WeeklyActiveUsersQuery"></a>
 
 `WeeklyActiveUsersQuery(connector: GoogleAnalyticsDataApiConnector)`
 :   Query class for WeeklyActiveUsers entity operations.

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/google_analytics_data_api/index.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/google_analytics_data_api/index.md
@@ -19,6 +19,8 @@ Sub-modules
 Classes
 -------
 
+<a id="AirbyteAuthConfig"></a>
+
 `AirbyteAuthConfig(**data: Any)`
 :   Authentication configuration for Airbyte hosted mode execution.
     
@@ -87,6 +89,8 @@ Classes
     `workspace_name: str | None`
     :   The type of the None singleton.
 
+<a id="AirbyteSearchMeta"></a>
+
 `AirbyteSearchMeta(**data: Any)`
 :   Pagination metadata for search responses.
     
@@ -114,6 +118,8 @@ Classes
 
     `took_ms: int | None`
     :   Time taken to execute the search in milliseconds.
+
+<a id="AirbyteSearchResult"></a>
 
 `AirbyteSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -152,6 +158,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="DailyActiveUsersSearchResult"></a>
+
 `DailyActiveUsersSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -167,6 +175,8 @@ Classes
     * airbyte_agent_sdk.connectors.google_analytics_data_api.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="DevicesSearchResult"></a>
 
 `DevicesSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -184,6 +194,8 @@ Classes
     * pydantic.main.BaseModel
     * typing.Generic
 
+<a id="FourWeeklyActiveUsersSearchResult"></a>
+
 `FourWeeklyActiveUsersSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -199,6 +211,8 @@ Classes
     * airbyte_agent_sdk.connectors.google_analytics_data_api.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="LocationsSearchResult"></a>
 
 `LocationsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -216,6 +230,8 @@ Classes
     * pydantic.main.BaseModel
     * typing.Generic
 
+<a id="PagesSearchResult"></a>
+
 `PagesSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -231,6 +247,8 @@ Classes
     * airbyte_agent_sdk.connectors.google_analytics_data_api.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="TrafficSourcesSearchResult"></a>
 
 `TrafficSourcesSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -248,6 +266,8 @@ Classes
     * pydantic.main.BaseModel
     * typing.Generic
 
+<a id="WebsiteOverviewSearchResult"></a>
+
 `WebsiteOverviewSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -264,6 +284,8 @@ Classes
     * pydantic.main.BaseModel
     * typing.Generic
 
+<a id="WeeklyActiveUsersSearchResult"></a>
+
 `WeeklyActiveUsersSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -279,6 +301,8 @@ Classes
     * airbyte_agent_sdk.connectors.google_analytics_data_api.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="DailyActiveUsersSearchData"></a>
 
 `DailyActiveUsersSearchData(**data: Any)`
 :   Search result data for daily_active_users entity.
@@ -313,6 +337,8 @@ Classes
 
     `start_date: str | None`
     :   Start date of the reporting period
+
+<a id="DevicesSearchData"></a>
 
 `DevicesSearchData(**data: Any)`
 :   Search result data for devices entity.
@@ -378,6 +404,8 @@ Classes
     `total_users: int | None`
     :   Total number of unique users
 
+<a id="FourWeeklyActiveUsersSearchData"></a>
+
 `FourWeeklyActiveUsersSearchData(**data: Any)`
 :   Search result data for four_weekly_active_users entity.
     
@@ -412,6 +440,8 @@ Classes
     `start_date: str | None`
     :   Start date of the reporting period
 
+<a id="GoogleAnalyticsDataApiAuthConfig"></a>
+
 `GoogleAnalyticsDataApiAuthConfig(**data: Any)`
 :   OAuth 2.0 Authentication
     
@@ -439,6 +469,8 @@ Classes
 
     `refresh_token: str`
     :   OAuth 2.0 Refresh Token for obtaining new access tokens
+
+<a id="GoogleAnalyticsDataApiConnector"></a>
 
 `GoogleAnalyticsDataApiConnector(auth_config: GoogleAnalyticsDataApiAuthConfig | AirbyteAuthConfig | BaseModel | None = None, on_token_refresh: Any | None = None)`
 :   Type-safe Google-Analytics-Data-Api API connector.
@@ -696,6 +728,8 @@ Classes
             for entity in entities:
                 print(f"\{entity['entity_name']\}: \{entity['available_actions']\}")
 
+<a id="GoogleAnalyticsDataApiReplicationConfig"></a>
+
 `GoogleAnalyticsDataApiReplicationConfig(**data: Any)`
 :   Replication Configuration - Settings for data replication from Google Analytics.
     
@@ -717,6 +751,8 @@ Classes
 
     `property_ids: str`
     :   A list of GA4 Property IDs to replicate data from.
+
+<a id="LocationsSearchData"></a>
 
 `LocationsSearchData(**data: Any)`
 :   Search result data for locations entity.
@@ -782,6 +818,8 @@ Classes
     `total_users: int | None`
     :   Total number of unique users
 
+<a id="PagesSearchData"></a>
+
 `PagesSearchData(**data: Any)`
 :   Search result data for pages entity.
     
@@ -824,6 +862,8 @@ Classes
 
     `start_date: str | None`
     :   Start date of the reporting period
+
+<a id="TrafficSourcesSearchData"></a>
 
 `TrafficSourcesSearchData(**data: Any)`
 :   Search result data for traffic_sources entity.
@@ -886,6 +926,8 @@ Classes
     `total_users: int | None`
     :   Total number of unique users
 
+<a id="WebsiteOverviewSearchData"></a>
+
 `WebsiteOverviewSearchData(**data: Any)`
 :   Search result data for website_overview entity.
     
@@ -940,6 +982,8 @@ Classes
 
     `total_users: int | None`
     :   Total number of unique users
+
+<a id="WeeklyActiveUsersSearchData"></a>
 
 `WeeklyActiveUsersSearchData(**data: Any)`
 :   Search result data for weekly_active_users entity.

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/google_analytics_data_api/models.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/google_analytics_data_api/models.md
@@ -13,6 +13,8 @@ and response envelope types.
 Classes
 -------
 
+<a id="AirbyteSearchMeta"></a>
+
 `AirbyteSearchMeta(**data: Any)`
 :   Pagination metadata for search responses.
     
@@ -40,6 +42,8 @@ Classes
 
     `took_ms: int | None`
     :   Time taken to execute the search in milliseconds.
+
+<a id="AirbyteSearchResult"></a>
 
 `AirbyteSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -99,6 +103,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="DailyActiveUsersSearchResult"></a>
+
 `DailyActiveUsersSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -135,6 +141,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="DevicesSearchResult"></a>
 
 `DevicesSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -173,6 +181,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="FourWeeklyActiveUsersSearchResult"></a>
+
 `FourWeeklyActiveUsersSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -209,6 +219,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="LocationsSearchResult"></a>
 
 `LocationsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -247,6 +259,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="PagesSearchResult"></a>
+
 `PagesSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -283,6 +297,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="TrafficSourcesSearchResult"></a>
 
 `TrafficSourcesSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -321,6 +337,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="WebsiteOverviewSearchResult"></a>
+
 `WebsiteOverviewSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -358,6 +376,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="WeeklyActiveUsersSearchResult"></a>
+
 `WeeklyActiveUsersSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -373,6 +393,8 @@ Classes
     * airbyte_agent_sdk.connectors.google_analytics_data_api.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="DailyActiveUsersListResultMeta"></a>
 
 `DailyActiveUsersListResultMeta(**data: Any)`
 :   Metadata for daily_active_users.Action.LIST operation
@@ -395,6 +417,8 @@ Classes
 
     `row_count: int | Any`
     :   The type of the None singleton.
+
+<a id="DailyActiveUsersRequest"></a>
 
 `DailyActiveUsersRequest(**data: Any)`
 :   Request body for daily active users report
@@ -433,6 +457,8 @@ Classes
     `return_property_quota: bool | Any`
     :   The type of the None singleton.
 
+<a id="DailyActiveUsersRequestDaterangesItem"></a>
+
 `DailyActiveUsersRequestDaterangesItem(**data: Any)`
 :   Nested schema for DailyActiveUsersRequest.dateRanges_item
     
@@ -458,6 +484,8 @@ Classes
     `start_date: str | Any`
     :   Start date in YYYY-MM-DD format or relative (e.g., 30daysAgo)
 
+<a id="DailyActiveUsersRequestDimensionsItem"></a>
+
 `DailyActiveUsersRequestDimensionsItem(**data: Any)`
 :   Nested schema for DailyActiveUsersRequest.dimensions_item
     
@@ -480,6 +508,8 @@ Classes
     `name: str | Any`
     :   The type of the None singleton.
 
+<a id="DailyActiveUsersRequestMetricsItem"></a>
+
 `DailyActiveUsersRequestMetricsItem(**data: Any)`
 :   Nested schema for DailyActiveUsersRequest.metrics_item
     
@@ -501,6 +531,8 @@ Classes
 
     `name: str | Any`
     :   The type of the None singleton.
+
+<a id="DailyActiveUsersSearchData"></a>
 
 `DailyActiveUsersSearchData(**data: Any)`
 :   Search result data for daily_active_users entity.
@@ -536,6 +568,8 @@ Classes
     `start_date: str | None`
     :   Start date of the reporting period
 
+<a id="DevicesListResultMeta"></a>
+
 `DevicesListResultMeta(**data: Any)`
 :   Metadata for devices.Action.LIST operation
     
@@ -557,6 +591,8 @@ Classes
 
     `row_count: int | Any`
     :   The type of the None singleton.
+
+<a id="DevicesRequest"></a>
 
 `DevicesRequest(**data: Any)`
 :   Request body for devices report
@@ -595,6 +631,8 @@ Classes
     `return_property_quota: bool | Any`
     :   The type of the None singleton.
 
+<a id="DevicesRequestDaterangesItem"></a>
+
 `DevicesRequestDaterangesItem(**data: Any)`
 :   Nested schema for DevicesRequest.dateRanges_item
     
@@ -620,6 +658,8 @@ Classes
     `start_date: str | Any`
     :   Start date in YYYY-MM-DD format or relative (e.g., 30daysAgo)
 
+<a id="DevicesRequestDimensionsItem"></a>
+
 `DevicesRequestDimensionsItem(**data: Any)`
 :   Nested schema for DevicesRequest.dimensions_item
     
@@ -642,6 +682,8 @@ Classes
     `name: str | Any`
     :   The type of the None singleton.
 
+<a id="DevicesRequestMetricsItem"></a>
+
 `DevicesRequestMetricsItem(**data: Any)`
 :   Nested schema for DevicesRequest.metrics_item
     
@@ -663,6 +705,8 @@ Classes
 
     `name: str | Any`
     :   The type of the None singleton.
+
+<a id="DevicesSearchData"></a>
 
 `DevicesSearchData(**data: Any)`
 :   Search result data for devices entity.
@@ -728,6 +772,8 @@ Classes
     `total_users: int | None`
     :   Total number of unique users
 
+<a id="DimensionHeader"></a>
+
 `DimensionHeader(**data: Any)`
 :   DimensionHeader type definition
     
@@ -749,6 +795,8 @@ Classes
 
     `name: str | Any`
     :   The type of the None singleton.
+
+<a id="DimensionValue"></a>
 
 `DimensionValue(**data: Any)`
 :   DimensionValue type definition
@@ -772,6 +820,8 @@ Classes
     `value: str | Any`
     :   The type of the None singleton.
 
+<a id="FourWeeklyActiveUsersListResultMeta"></a>
+
 `FourWeeklyActiveUsersListResultMeta(**data: Any)`
 :   Metadata for four_weekly_active_users.Action.LIST operation
     
@@ -793,6 +843,8 @@ Classes
 
     `row_count: int | Any`
     :   The type of the None singleton.
+
+<a id="FourWeeklyActiveUsersRequest"></a>
 
 `FourWeeklyActiveUsersRequest(**data: Any)`
 :   Request body for four-weekly active users report
@@ -831,6 +883,8 @@ Classes
     `return_property_quota: bool | Any`
     :   The type of the None singleton.
 
+<a id="FourWeeklyActiveUsersRequestDaterangesItem"></a>
+
 `FourWeeklyActiveUsersRequestDaterangesItem(**data: Any)`
 :   Nested schema for FourWeeklyActiveUsersRequest.dateRanges_item
     
@@ -856,6 +910,8 @@ Classes
     `start_date: str | Any`
     :   Start date in YYYY-MM-DD format or relative (e.g., 30daysAgo)
 
+<a id="FourWeeklyActiveUsersRequestDimensionsItem"></a>
+
 `FourWeeklyActiveUsersRequestDimensionsItem(**data: Any)`
 :   Nested schema for FourWeeklyActiveUsersRequest.dimensions_item
     
@@ -878,6 +934,8 @@ Classes
     `name: str | Any`
     :   The type of the None singleton.
 
+<a id="FourWeeklyActiveUsersRequestMetricsItem"></a>
+
 `FourWeeklyActiveUsersRequestMetricsItem(**data: Any)`
 :   Nested schema for FourWeeklyActiveUsersRequest.metrics_item
     
@@ -899,6 +957,8 @@ Classes
 
     `name: str | Any`
     :   The type of the None singleton.
+
+<a id="FourWeeklyActiveUsersSearchData"></a>
 
 `FourWeeklyActiveUsersSearchData(**data: Any)`
 :   Search result data for four_weekly_active_users entity.
@@ -934,6 +994,8 @@ Classes
     `start_date: str | None`
     :   Start date of the reporting period
 
+<a id="GoogleAnalyticsDataApiAuthConfig"></a>
+
 `GoogleAnalyticsDataApiAuthConfig(**data: Any)`
 :   OAuth 2.0 Authentication
     
@@ -961,6 +1023,8 @@ Classes
 
     `refresh_token: str`
     :   OAuth 2.0 Refresh Token for obtaining new access tokens
+
+<a id="GoogleAnalyticsDataApiCheckResult"></a>
 
 `GoogleAnalyticsDataApiCheckResult(**data: Any)`
 :   Result of a health check operation.
@@ -995,6 +1059,8 @@ Classes
     `status: str`
     :   Health check status: 'healthy' or 'unhealthy'.
 
+<a id="GoogleAnalyticsDataApiExecuteResult"></a>
+
 `GoogleAnalyticsDataApiExecuteResult(**data: Any)`
 :   Response envelope with data only.
     
@@ -1023,6 +1089,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="GoogleAnalyticsDataApiExecuteResultWithMeta"></a>
 
 `GoogleAnalyticsDataApiExecuteResultWithMeta(**data: Any)`
 :   Response envelope with data and metadata.
@@ -1082,6 +1150,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="DailyActiveUsersListResult"></a>
+
 `DailyActiveUsersListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -1124,6 +1194,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="DevicesListResult"></a>
 
 `DevicesListResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -1168,6 +1240,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="FourWeeklyActiveUsersListResult"></a>
+
 `FourWeeklyActiveUsersListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -1210,6 +1284,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="LocationsListResult"></a>
 
 `LocationsListResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -1254,6 +1330,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="PagesListResult"></a>
+
 `PagesListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -1296,6 +1374,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="TrafficSourcesListResult"></a>
 
 `TrafficSourcesListResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -1340,6 +1420,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="WebsiteOverviewListResult"></a>
+
 `WebsiteOverviewListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -1383,6 +1465,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="WeeklyActiveUsersListResult"></a>
+
 `WeeklyActiveUsersListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -1401,6 +1485,8 @@ Classes
     * airbyte_agent_sdk.connectors.google_analytics_data_api.models.GoogleAnalyticsDataApiExecuteResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="GoogleAnalyticsDataApiReplicationConfig"></a>
 
 `GoogleAnalyticsDataApiReplicationConfig(**data: Any)`
 :   Replication Configuration - Settings for data replication from Google Analytics.
@@ -1424,6 +1510,8 @@ Classes
     `property_ids: str`
     :   A list of GA4 Property IDs to replicate data from.
 
+<a id="LocationsListResultMeta"></a>
+
 `LocationsListResultMeta(**data: Any)`
 :   Metadata for locations.Action.LIST operation
     
@@ -1445,6 +1533,8 @@ Classes
 
     `row_count: int | Any`
     :   The type of the None singleton.
+
+<a id="LocationsRequest"></a>
 
 `LocationsRequest(**data: Any)`
 :   Request body for locations report
@@ -1483,6 +1573,8 @@ Classes
     `return_property_quota: bool | Any`
     :   The type of the None singleton.
 
+<a id="LocationsRequestDaterangesItem"></a>
+
 `LocationsRequestDaterangesItem(**data: Any)`
 :   Nested schema for LocationsRequest.dateRanges_item
     
@@ -1508,6 +1600,8 @@ Classes
     `start_date: str | Any`
     :   Start date in YYYY-MM-DD format or relative (e.g., 30daysAgo)
 
+<a id="LocationsRequestDimensionsItem"></a>
+
 `LocationsRequestDimensionsItem(**data: Any)`
 :   Nested schema for LocationsRequest.dimensions_item
     
@@ -1530,6 +1624,8 @@ Classes
     `name: str | Any`
     :   The type of the None singleton.
 
+<a id="LocationsRequestMetricsItem"></a>
+
 `LocationsRequestMetricsItem(**data: Any)`
 :   Nested schema for LocationsRequest.metrics_item
     
@@ -1551,6 +1647,8 @@ Classes
 
     `name: str | Any`
     :   The type of the None singleton.
+
+<a id="LocationsSearchData"></a>
 
 `LocationsSearchData(**data: Any)`
 :   Search result data for locations entity.
@@ -1616,6 +1714,8 @@ Classes
     `total_users: int | None`
     :   Total number of unique users
 
+<a id="MetricHeader"></a>
+
 `MetricHeader(**data: Any)`
 :   MetricHeader type definition
     
@@ -1641,6 +1741,8 @@ Classes
     `type_: str | Any`
     :   The type of the None singleton.
 
+<a id="MetricValue"></a>
+
 `MetricValue(**data: Any)`
 :   MetricValue type definition
     
@@ -1663,6 +1765,8 @@ Classes
     `value: str | Any`
     :   The type of the None singleton.
 
+<a id="PagesListResultMeta"></a>
+
 `PagesListResultMeta(**data: Any)`
 :   Metadata for pages.Action.LIST operation
     
@@ -1684,6 +1788,8 @@ Classes
 
     `row_count: int | Any`
     :   The type of the None singleton.
+
+<a id="PagesRequest"></a>
 
 `PagesRequest(**data: Any)`
 :   Request body for pages report
@@ -1722,6 +1828,8 @@ Classes
     `return_property_quota: bool | Any`
     :   The type of the None singleton.
 
+<a id="PagesRequestDaterangesItem"></a>
+
 `PagesRequestDaterangesItem(**data: Any)`
 :   Nested schema for PagesRequest.dateRanges_item
     
@@ -1747,6 +1855,8 @@ Classes
     `start_date: str | Any`
     :   Start date in YYYY-MM-DD format or relative (e.g., 30daysAgo)
 
+<a id="PagesRequestDimensionsItem"></a>
+
 `PagesRequestDimensionsItem(**data: Any)`
 :   Nested schema for PagesRequest.dimensions_item
     
@@ -1769,6 +1879,8 @@ Classes
     `name: str | Any`
     :   The type of the None singleton.
 
+<a id="PagesRequestMetricsItem"></a>
+
 `PagesRequestMetricsItem(**data: Any)`
 :   Nested schema for PagesRequest.metrics_item
     
@@ -1790,6 +1902,8 @@ Classes
 
     `name: str | Any`
     :   The type of the None singleton.
+
+<a id="PagesSearchData"></a>
 
 `PagesSearchData(**data: Any)`
 :   Search result data for pages entity.
@@ -1834,6 +1948,8 @@ Classes
     `start_date: str | None`
     :   Start date of the reporting period
 
+<a id="Row"></a>
+
 `Row(**data: Any)`
 :   Row type definition
     
@@ -1858,6 +1974,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="RunReportResponse"></a>
 
 `RunReportResponse(**data: Any)`
 :   Response from the runReport endpoint
@@ -1899,6 +2017,8 @@ Classes
     `rows: list[airbyte_agent_sdk.connectors.google_analytics_data_api.models.Row] | Any`
     :   The type of the None singleton.
 
+<a id="RunReportResponseMetadata"></a>
+
 `RunReportResponseMetadata(**data: Any)`
 :   Nested schema for RunReportResponse.metadata
     
@@ -1923,6 +2043,8 @@ Classes
 
     `time_zone: str | Any`
     :   The property's current timezone
+
+<a id="RunReportResponsePropertyquota"></a>
 
 `RunReportResponsePropertyquota(**data: Any)`
 :   Quota status for this Analytics property
@@ -1961,6 +2083,8 @@ Classes
     `tokens_per_project_per_hour: airbyte_agent_sdk.connectors.google_analytics_data_api.models.RunReportResponsePropertyquotaTokensperprojectperhour | Any`
     :   The type of the None singleton.
 
+<a id="RunReportResponsePropertyquotaConcurrentrequests"></a>
+
 `RunReportResponsePropertyquotaConcurrentrequests(**data: Any)`
 :   Nested schema for RunReportResponsePropertyquota.concurrentRequests
     
@@ -1985,6 +2109,8 @@ Classes
 
     `remaining: int | Any`
     :   The type of the None singleton.
+
+<a id="RunReportResponsePropertyquotaPotentiallythresholdedrequestsperhour"></a>
 
 `RunReportResponsePropertyquotaPotentiallythresholdedrequestsperhour(**data: Any)`
 :   Nested schema for RunReportResponsePropertyquota.potentiallyThresholdedRequestsPerHour
@@ -2011,6 +2137,8 @@ Classes
     `remaining: int | Any`
     :   The type of the None singleton.
 
+<a id="RunReportResponsePropertyquotaServererrorsperprojectperhour"></a>
+
 `RunReportResponsePropertyquotaServererrorsperprojectperhour(**data: Any)`
 :   Nested schema for RunReportResponsePropertyquota.serverErrorsPerProjectPerHour
     
@@ -2035,6 +2163,8 @@ Classes
 
     `remaining: int | Any`
     :   The type of the None singleton.
+
+<a id="RunReportResponsePropertyquotaTokensperday"></a>
 
 `RunReportResponsePropertyquotaTokensperday(**data: Any)`
 :   Nested schema for RunReportResponsePropertyquota.tokensPerDay
@@ -2061,6 +2191,8 @@ Classes
     `remaining: int | Any`
     :   The type of the None singleton.
 
+<a id="RunReportResponsePropertyquotaTokensperhour"></a>
+
 `RunReportResponsePropertyquotaTokensperhour(**data: Any)`
 :   Nested schema for RunReportResponsePropertyquota.tokensPerHour
     
@@ -2085,6 +2217,8 @@ Classes
 
     `remaining: int | Any`
     :   The type of the None singleton.
+
+<a id="RunReportResponsePropertyquotaTokensperprojectperhour"></a>
 
 `RunReportResponsePropertyquotaTokensperprojectperhour(**data: Any)`
 :   Nested schema for RunReportResponsePropertyquota.tokensPerProjectPerHour
@@ -2111,6 +2245,8 @@ Classes
     `remaining: int | Any`
     :   The type of the None singleton.
 
+<a id="TrafficSourcesListResultMeta"></a>
+
 `TrafficSourcesListResultMeta(**data: Any)`
 :   Metadata for traffic_sources.Action.LIST operation
     
@@ -2132,6 +2268,8 @@ Classes
 
     `row_count: int | Any`
     :   The type of the None singleton.
+
+<a id="TrafficSourcesRequest"></a>
 
 `TrafficSourcesRequest(**data: Any)`
 :   Request body for traffic sources report
@@ -2170,6 +2308,8 @@ Classes
     `return_property_quota: bool | Any`
     :   The type of the None singleton.
 
+<a id="TrafficSourcesRequestDaterangesItem"></a>
+
 `TrafficSourcesRequestDaterangesItem(**data: Any)`
 :   Nested schema for TrafficSourcesRequest.dateRanges_item
     
@@ -2195,6 +2335,8 @@ Classes
     `start_date: str | Any`
     :   Start date in YYYY-MM-DD format or relative (e.g., 30daysAgo)
 
+<a id="TrafficSourcesRequestDimensionsItem"></a>
+
 `TrafficSourcesRequestDimensionsItem(**data: Any)`
 :   Nested schema for TrafficSourcesRequest.dimensions_item
     
@@ -2217,6 +2359,8 @@ Classes
     `name: str | Any`
     :   The type of the None singleton.
 
+<a id="TrafficSourcesRequestMetricsItem"></a>
+
 `TrafficSourcesRequestMetricsItem(**data: Any)`
 :   Nested schema for TrafficSourcesRequest.metrics_item
     
@@ -2238,6 +2382,8 @@ Classes
 
     `name: str | Any`
     :   The type of the None singleton.
+
+<a id="TrafficSourcesSearchData"></a>
 
 `TrafficSourcesSearchData(**data: Any)`
 :   Search result data for traffic_sources entity.
@@ -2300,6 +2446,8 @@ Classes
     `total_users: int | None`
     :   Total number of unique users
 
+<a id="WebsiteOverviewListResultMeta"></a>
+
 `WebsiteOverviewListResultMeta(**data: Any)`
 :   Metadata for website_overview.Action.LIST operation
     
@@ -2321,6 +2469,8 @@ Classes
 
     `row_count: int | Any`
     :   The type of the None singleton.
+
+<a id="WebsiteOverviewRequest"></a>
 
 `WebsiteOverviewRequest(**data: Any)`
 :   Request body for website overview report
@@ -2359,6 +2509,8 @@ Classes
     `return_property_quota: bool | Any`
     :   The type of the None singleton.
 
+<a id="WebsiteOverviewRequestDaterangesItem"></a>
+
 `WebsiteOverviewRequestDaterangesItem(**data: Any)`
 :   Nested schema for WebsiteOverviewRequest.dateRanges_item
     
@@ -2384,6 +2536,8 @@ Classes
     `start_date: str | Any`
     :   Start date in YYYY-MM-DD format or relative (e.g., 30daysAgo)
 
+<a id="WebsiteOverviewRequestDimensionsItem"></a>
+
 `WebsiteOverviewRequestDimensionsItem(**data: Any)`
 :   Nested schema for WebsiteOverviewRequest.dimensions_item
     
@@ -2406,6 +2560,8 @@ Classes
     `name: str | Any`
     :   The type of the None singleton.
 
+<a id="WebsiteOverviewRequestMetricsItem"></a>
+
 `WebsiteOverviewRequestMetricsItem(**data: Any)`
 :   Nested schema for WebsiteOverviewRequest.metrics_item
     
@@ -2427,6 +2583,8 @@ Classes
 
     `name: str | Any`
     :   The type of the None singleton.
+
+<a id="WebsiteOverviewSearchData"></a>
 
 `WebsiteOverviewSearchData(**data: Any)`
 :   Search result data for website_overview entity.
@@ -2483,6 +2641,8 @@ Classes
     `total_users: int | None`
     :   Total number of unique users
 
+<a id="WeeklyActiveUsersListResultMeta"></a>
+
 `WeeklyActiveUsersListResultMeta(**data: Any)`
 :   Metadata for weekly_active_users.Action.LIST operation
     
@@ -2504,6 +2664,8 @@ Classes
 
     `row_count: int | Any`
     :   The type of the None singleton.
+
+<a id="WeeklyActiveUsersRequest"></a>
 
 `WeeklyActiveUsersRequest(**data: Any)`
 :   Request body for weekly active users report
@@ -2542,6 +2704,8 @@ Classes
     `return_property_quota: bool | Any`
     :   The type of the None singleton.
 
+<a id="WeeklyActiveUsersRequestDaterangesItem"></a>
+
 `WeeklyActiveUsersRequestDaterangesItem(**data: Any)`
 :   Nested schema for WeeklyActiveUsersRequest.dateRanges_item
     
@@ -2567,6 +2731,8 @@ Classes
     `start_date: str | Any`
     :   Start date in YYYY-MM-DD format or relative (e.g., 30daysAgo)
 
+<a id="WeeklyActiveUsersRequestDimensionsItem"></a>
+
 `WeeklyActiveUsersRequestDimensionsItem(**data: Any)`
 :   Nested schema for WeeklyActiveUsersRequest.dimensions_item
     
@@ -2589,6 +2755,8 @@ Classes
     `name: str | Any`
     :   The type of the None singleton.
 
+<a id="WeeklyActiveUsersRequestMetricsItem"></a>
+
 `WeeklyActiveUsersRequestMetricsItem(**data: Any)`
 :   Nested schema for WeeklyActiveUsersRequest.metrics_item
     
@@ -2610,6 +2778,8 @@ Classes
 
     `name: str | Any`
     :   The type of the None singleton.
+
+<a id="WeeklyActiveUsersSearchData"></a>
 
 `WeeklyActiveUsersSearchData(**data: Any)`
 :   Search result data for weekly_active_users entity.

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/google_analytics_data_api/types.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/google_analytics_data_api/types.md
@@ -10,6 +10,8 @@ Type definitions for google-analytics-data-api connector.
 Classes
 -------
 
+<a id="AirbyteSearchParams"></a>
+
 `AirbyteSearchParams(*args, **kwargs)`
 :   Parameters for Airbyte cache search operations (generic, use entity-specific query types for better type hints).
 
@@ -31,6 +33,8 @@ Classes
     `query: dict[str, typing.Any]`
     :   The type of the None singleton.
 
+<a id="DailyActiveUsersAndCondition"></a>
+
 `DailyActiveUsersAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -51,6 +55,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.google_analytics_data_api.types.DailyActiveUsersEqCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.DailyActiveUsersNeqCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.DailyActiveUsersGtCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.DailyActiveUsersGteCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.DailyActiveUsersLtCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.DailyActiveUsersLteCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.DailyActiveUsersInCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.DailyActiveUsersLikeCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.DailyActiveUsersFuzzyCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.DailyActiveUsersKeywordCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.DailyActiveUsersContainsCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.DailyActiveUsersNotCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.DailyActiveUsersAndCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.DailyActiveUsersOrCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.DailyActiveUsersAnyCondition]`
     :   The type of the None singleton.
 
+<a id="DailyActiveUsersAnyCondition"></a>
+
 `DailyActiveUsersAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -70,6 +76,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.google_analytics_data_api.types.DailyActiveUsersAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="DailyActiveUsersAnyValueFilter"></a>
 
 `DailyActiveUsersAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -95,6 +103,8 @@ Classes
     `start_date: Any`
     :   Start date of the reporting period
 
+<a id="DailyActiveUsersContainsCondition"></a>
+
 `DailyActiveUsersContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -106,6 +116,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.google_analytics_data_api.types.DailyActiveUsersAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="DailyActiveUsersEqCondition"></a>
 
 `DailyActiveUsersEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -119,6 +131,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.google_analytics_data_api.types.DailyActiveUsersSearchFilter`
     :   The type of the None singleton.
 
+<a id="DailyActiveUsersFuzzyCondition"></a>
+
 `DailyActiveUsersFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -130,6 +144,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.google_analytics_data_api.types.DailyActiveUsersStringFilter`
     :   The type of the None singleton.
+
+<a id="DailyActiveUsersGtCondition"></a>
 
 `DailyActiveUsersGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
@@ -143,6 +159,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.google_analytics_data_api.types.DailyActiveUsersSearchFilter`
     :   The type of the None singleton.
 
+<a id="DailyActiveUsersGteCondition"></a>
+
 `DailyActiveUsersGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -154,6 +172,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.google_analytics_data_api.types.DailyActiveUsersSearchFilter`
     :   The type of the None singleton.
+
+<a id="DailyActiveUsersInCondition"></a>
 
 `DailyActiveUsersInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -174,6 +194,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.google_analytics_data_api.types.DailyActiveUsersInFilter`
     :   The type of the None singleton.
+
+<a id="DailyActiveUsersInFilter"></a>
 
 `DailyActiveUsersInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -199,6 +221,8 @@ Classes
     `start_date: list[str]`
     :   Start date of the reporting period
 
+<a id="DailyActiveUsersKeywordCondition"></a>
+
 `DailyActiveUsersKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -211,6 +235,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.google_analytics_data_api.types.DailyActiveUsersStringFilter`
     :   The type of the None singleton.
 
+<a id="DailyActiveUsersLikeCondition"></a>
+
 `DailyActiveUsersLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -222,6 +248,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.google_analytics_data_api.types.DailyActiveUsersStringFilter`
     :   The type of the None singleton.
+
+<a id="DailyActiveUsersListParams"></a>
 
 `DailyActiveUsersListParams(*args, **kwargs)`
 :   Parameters for daily_active_users.list operation
@@ -253,6 +281,8 @@ Classes
     `return_property_quota: bool`
     :   The type of the None singleton.
 
+<a id="DailyActiveUsersListParamsDaterangesItem"></a>
+
 `DailyActiveUsersListParamsDaterangesItem(*args, **kwargs)`
 :   Nested schema for DailyActiveUsersListParams.dateRanges_item
 
@@ -268,6 +298,8 @@ Classes
     `startDate: str`
     :   The type of the None singleton.
 
+<a id="DailyActiveUsersListParamsDimensionsItem"></a>
+
 `DailyActiveUsersListParamsDimensionsItem(*args, **kwargs)`
 :   Nested schema for DailyActiveUsersListParams.dimensions_item
 
@@ -279,6 +311,8 @@ Classes
 
     `name: str`
     :   The type of the None singleton.
+
+<a id="DailyActiveUsersListParamsMetricsItem"></a>
 
 `DailyActiveUsersListParamsMetricsItem(*args, **kwargs)`
 :   Nested schema for DailyActiveUsersListParams.metrics_item
@@ -292,6 +326,8 @@ Classes
     `name: str`
     :   The type of the None singleton.
 
+<a id="DailyActiveUsersLtCondition"></a>
+
 `DailyActiveUsersLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -303,6 +339,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.google_analytics_data_api.types.DailyActiveUsersSearchFilter`
     :   The type of the None singleton.
+
+<a id="DailyActiveUsersLteCondition"></a>
 
 `DailyActiveUsersLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -316,6 +354,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.google_analytics_data_api.types.DailyActiveUsersSearchFilter`
     :   The type of the None singleton.
 
+<a id="DailyActiveUsersNeqCondition"></a>
+
 `DailyActiveUsersNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -327,6 +367,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.google_analytics_data_api.types.DailyActiveUsersSearchFilter`
     :   The type of the None singleton.
+
+<a id="DailyActiveUsersNotCondition"></a>
 
 `DailyActiveUsersNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -348,6 +390,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.google_analytics_data_api.types.DailyActiveUsersEqCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.DailyActiveUsersNeqCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.DailyActiveUsersGtCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.DailyActiveUsersGteCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.DailyActiveUsersLtCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.DailyActiveUsersLteCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.DailyActiveUsersInCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.DailyActiveUsersLikeCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.DailyActiveUsersFuzzyCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.DailyActiveUsersKeywordCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.DailyActiveUsersContainsCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.DailyActiveUsersNotCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.DailyActiveUsersAndCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.DailyActiveUsersOrCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.DailyActiveUsersAnyCondition`
     :   The type of the None singleton.
 
+<a id="DailyActiveUsersOrCondition"></a>
+
 `DailyActiveUsersOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -367,6 +411,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.google_analytics_data_api.types.DailyActiveUsersEqCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.DailyActiveUsersNeqCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.DailyActiveUsersGtCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.DailyActiveUsersGteCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.DailyActiveUsersLtCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.DailyActiveUsersLteCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.DailyActiveUsersInCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.DailyActiveUsersLikeCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.DailyActiveUsersFuzzyCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.DailyActiveUsersKeywordCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.DailyActiveUsersContainsCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.DailyActiveUsersNotCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.DailyActiveUsersAndCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.DailyActiveUsersOrCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.DailyActiveUsersAnyCondition]`
     :   The type of the None singleton.
+
+<a id="DailyActiveUsersSearchFilter"></a>
 
 `DailyActiveUsersSearchFilter(*args, **kwargs)`
 :   Available fields for filtering daily_active_users search queries.
@@ -392,6 +438,8 @@ Classes
     `start_date: str | None`
     :   Start date of the reporting period
 
+<a id="DailyActiveUsersSearchQuery"></a>
+
 `DailyActiveUsersSearchQuery(*args, **kwargs)`
 :   Search query for daily_active_users entity.
 
@@ -406,6 +454,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.google_analytics_data_api.types.DailyActiveUsersSortFilter]`
     :   The type of the None singleton.
+
+<a id="DailyActiveUsersSortFilter"></a>
 
 `DailyActiveUsersSortFilter(*args, **kwargs)`
 :   Available fields for sorting daily_active_users search results.
@@ -431,6 +481,8 @@ Classes
     `start_date: Literal['asc', 'desc']`
     :   Start date of the reporting period
 
+<a id="DailyActiveUsersStringFilter"></a>
+
 `DailyActiveUsersStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -455,6 +507,8 @@ Classes
     `start_date: str`
     :   Start date of the reporting period
 
+<a id="DevicesAndCondition"></a>
+
 `DevicesAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -475,6 +529,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.google_analytics_data_api.types.DevicesEqCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.DevicesNeqCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.DevicesGtCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.DevicesGteCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.DevicesLtCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.DevicesLteCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.DevicesInCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.DevicesLikeCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.DevicesFuzzyCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.DevicesKeywordCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.DevicesContainsCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.DevicesNotCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.DevicesAndCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.DevicesOrCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.DevicesAnyCondition]`
     :   The type of the None singleton.
 
+<a id="DevicesAnyCondition"></a>
+
 `DevicesAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -494,6 +550,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.google_analytics_data_api.types.DevicesAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="DevicesAnyValueFilter"></a>
 
 `DevicesAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -549,6 +607,8 @@ Classes
     `total_users: Any`
     :   Total number of unique users
 
+<a id="DevicesContainsCondition"></a>
+
 `DevicesContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -560,6 +620,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.google_analytics_data_api.types.DevicesAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="DevicesEqCondition"></a>
 
 `DevicesEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -573,6 +635,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.google_analytics_data_api.types.DevicesSearchFilter`
     :   The type of the None singleton.
 
+<a id="DevicesFuzzyCondition"></a>
+
 `DevicesFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -584,6 +648,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.google_analytics_data_api.types.DevicesStringFilter`
     :   The type of the None singleton.
+
+<a id="DevicesGtCondition"></a>
 
 `DevicesGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
@@ -597,6 +663,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.google_analytics_data_api.types.DevicesSearchFilter`
     :   The type of the None singleton.
 
+<a id="DevicesGteCondition"></a>
+
 `DevicesGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -608,6 +676,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.google_analytics_data_api.types.DevicesSearchFilter`
     :   The type of the None singleton.
+
+<a id="DevicesInCondition"></a>
 
 `DevicesInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -628,6 +698,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.google_analytics_data_api.types.DevicesInFilter`
     :   The type of the None singleton.
+
+<a id="DevicesInFilter"></a>
 
 `DevicesInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -683,6 +755,8 @@ Classes
     `total_users: list[int]`
     :   Total number of unique users
 
+<a id="DevicesKeywordCondition"></a>
+
 `DevicesKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -695,6 +769,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.google_analytics_data_api.types.DevicesStringFilter`
     :   The type of the None singleton.
 
+<a id="DevicesLikeCondition"></a>
+
 `DevicesLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -706,6 +782,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.google_analytics_data_api.types.DevicesStringFilter`
     :   The type of the None singleton.
+
+<a id="DevicesListParams"></a>
 
 `DevicesListParams(*args, **kwargs)`
 :   Parameters for devices.list operation
@@ -737,6 +815,8 @@ Classes
     `return_property_quota: bool`
     :   The type of the None singleton.
 
+<a id="DevicesListParamsDaterangesItem"></a>
+
 `DevicesListParamsDaterangesItem(*args, **kwargs)`
 :   Nested schema for DevicesListParams.dateRanges_item
 
@@ -752,6 +832,8 @@ Classes
     `startDate: str`
     :   The type of the None singleton.
 
+<a id="DevicesListParamsDimensionsItem"></a>
+
 `DevicesListParamsDimensionsItem(*args, **kwargs)`
 :   Nested schema for DevicesListParams.dimensions_item
 
@@ -763,6 +845,8 @@ Classes
 
     `name: str`
     :   The type of the None singleton.
+
+<a id="DevicesListParamsMetricsItem"></a>
 
 `DevicesListParamsMetricsItem(*args, **kwargs)`
 :   Nested schema for DevicesListParams.metrics_item
@@ -776,6 +860,8 @@ Classes
     `name: str`
     :   The type of the None singleton.
 
+<a id="DevicesLtCondition"></a>
+
 `DevicesLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -787,6 +873,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.google_analytics_data_api.types.DevicesSearchFilter`
     :   The type of the None singleton.
+
+<a id="DevicesLteCondition"></a>
 
 `DevicesLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -800,6 +888,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.google_analytics_data_api.types.DevicesSearchFilter`
     :   The type of the None singleton.
 
+<a id="DevicesNeqCondition"></a>
+
 `DevicesNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -811,6 +901,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.google_analytics_data_api.types.DevicesSearchFilter`
     :   The type of the None singleton.
+
+<a id="DevicesNotCondition"></a>
 
 `DevicesNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -832,6 +924,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.google_analytics_data_api.types.DevicesEqCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.DevicesNeqCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.DevicesGtCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.DevicesGteCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.DevicesLtCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.DevicesLteCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.DevicesInCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.DevicesLikeCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.DevicesFuzzyCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.DevicesKeywordCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.DevicesContainsCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.DevicesNotCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.DevicesAndCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.DevicesOrCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.DevicesAnyCondition`
     :   The type of the None singleton.
 
+<a id="DevicesOrCondition"></a>
+
 `DevicesOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -851,6 +945,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.google_analytics_data_api.types.DevicesEqCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.DevicesNeqCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.DevicesGtCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.DevicesGteCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.DevicesLtCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.DevicesLteCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.DevicesInCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.DevicesLikeCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.DevicesFuzzyCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.DevicesKeywordCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.DevicesContainsCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.DevicesNotCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.DevicesAndCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.DevicesOrCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.DevicesAnyCondition]`
     :   The type of the None singleton.
+
+<a id="DevicesSearchFilter"></a>
 
 `DevicesSearchFilter(*args, **kwargs)`
 :   Available fields for filtering devices search queries.
@@ -906,6 +1002,8 @@ Classes
     `total_users: int | None`
     :   Total number of unique users
 
+<a id="DevicesSearchQuery"></a>
+
 `DevicesSearchQuery(*args, **kwargs)`
 :   Search query for devices entity.
 
@@ -920,6 +1018,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.google_analytics_data_api.types.DevicesSortFilter]`
     :   The type of the None singleton.
+
+<a id="DevicesSortFilter"></a>
 
 `DevicesSortFilter(*args, **kwargs)`
 :   Available fields for sorting devices search results.
@@ -975,6 +1075,8 @@ Classes
     `total_users: Literal['asc', 'desc']`
     :   Total number of unique users
 
+<a id="DevicesStringFilter"></a>
+
 `DevicesStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -1029,6 +1131,8 @@ Classes
     `total_users: str`
     :   Total number of unique users
 
+<a id="FourWeeklyActiveUsersAndCondition"></a>
+
 `FourWeeklyActiveUsersAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1049,6 +1153,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.google_analytics_data_api.types.FourWeeklyActiveUsersEqCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.FourWeeklyActiveUsersNeqCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.FourWeeklyActiveUsersGtCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.FourWeeklyActiveUsersGteCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.FourWeeklyActiveUsersLtCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.FourWeeklyActiveUsersLteCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.FourWeeklyActiveUsersInCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.FourWeeklyActiveUsersLikeCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.FourWeeklyActiveUsersFuzzyCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.FourWeeklyActiveUsersKeywordCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.FourWeeklyActiveUsersContainsCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.FourWeeklyActiveUsersNotCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.FourWeeklyActiveUsersAndCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.FourWeeklyActiveUsersOrCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.FourWeeklyActiveUsersAnyCondition]`
     :   The type of the None singleton.
 
+<a id="FourWeeklyActiveUsersAnyCondition"></a>
+
 `FourWeeklyActiveUsersAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1068,6 +1174,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.google_analytics_data_api.types.FourWeeklyActiveUsersAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="FourWeeklyActiveUsersAnyValueFilter"></a>
 
 `FourWeeklyActiveUsersAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -1093,6 +1201,8 @@ Classes
     `start_date: Any`
     :   Start date of the reporting period
 
+<a id="FourWeeklyActiveUsersContainsCondition"></a>
+
 `FourWeeklyActiveUsersContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -1104,6 +1214,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.google_analytics_data_api.types.FourWeeklyActiveUsersAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="FourWeeklyActiveUsersEqCondition"></a>
 
 `FourWeeklyActiveUsersEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -1117,6 +1229,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.google_analytics_data_api.types.FourWeeklyActiveUsersSearchFilter`
     :   The type of the None singleton.
 
+<a id="FourWeeklyActiveUsersFuzzyCondition"></a>
+
 `FourWeeklyActiveUsersFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -1128,6 +1242,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.google_analytics_data_api.types.FourWeeklyActiveUsersStringFilter`
     :   The type of the None singleton.
+
+<a id="FourWeeklyActiveUsersGtCondition"></a>
 
 `FourWeeklyActiveUsersGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
@@ -1141,6 +1257,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.google_analytics_data_api.types.FourWeeklyActiveUsersSearchFilter`
     :   The type of the None singleton.
 
+<a id="FourWeeklyActiveUsersGteCondition"></a>
+
 `FourWeeklyActiveUsersGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -1152,6 +1270,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.google_analytics_data_api.types.FourWeeklyActiveUsersSearchFilter`
     :   The type of the None singleton.
+
+<a id="FourWeeklyActiveUsersInCondition"></a>
 
 `FourWeeklyActiveUsersInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -1172,6 +1292,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.google_analytics_data_api.types.FourWeeklyActiveUsersInFilter`
     :   The type of the None singleton.
+
+<a id="FourWeeklyActiveUsersInFilter"></a>
 
 `FourWeeklyActiveUsersInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -1197,6 +1319,8 @@ Classes
     `start_date: list[str]`
     :   Start date of the reporting period
 
+<a id="FourWeeklyActiveUsersKeywordCondition"></a>
+
 `FourWeeklyActiveUsersKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -1209,6 +1333,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.google_analytics_data_api.types.FourWeeklyActiveUsersStringFilter`
     :   The type of the None singleton.
 
+<a id="FourWeeklyActiveUsersLikeCondition"></a>
+
 `FourWeeklyActiveUsersLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -1220,6 +1346,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.google_analytics_data_api.types.FourWeeklyActiveUsersStringFilter`
     :   The type of the None singleton.
+
+<a id="FourWeeklyActiveUsersListParams"></a>
 
 `FourWeeklyActiveUsersListParams(*args, **kwargs)`
 :   Parameters for four_weekly_active_users.list operation
@@ -1251,6 +1379,8 @@ Classes
     `return_property_quota: bool`
     :   The type of the None singleton.
 
+<a id="FourWeeklyActiveUsersListParamsDaterangesItem"></a>
+
 `FourWeeklyActiveUsersListParamsDaterangesItem(*args, **kwargs)`
 :   Nested schema for FourWeeklyActiveUsersListParams.dateRanges_item
 
@@ -1266,6 +1396,8 @@ Classes
     `startDate: str`
     :   The type of the None singleton.
 
+<a id="FourWeeklyActiveUsersListParamsDimensionsItem"></a>
+
 `FourWeeklyActiveUsersListParamsDimensionsItem(*args, **kwargs)`
 :   Nested schema for FourWeeklyActiveUsersListParams.dimensions_item
 
@@ -1277,6 +1409,8 @@ Classes
 
     `name: str`
     :   The type of the None singleton.
+
+<a id="FourWeeklyActiveUsersListParamsMetricsItem"></a>
 
 `FourWeeklyActiveUsersListParamsMetricsItem(*args, **kwargs)`
 :   Nested schema for FourWeeklyActiveUsersListParams.metrics_item
@@ -1290,6 +1424,8 @@ Classes
     `name: str`
     :   The type of the None singleton.
 
+<a id="FourWeeklyActiveUsersLtCondition"></a>
+
 `FourWeeklyActiveUsersLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -1301,6 +1437,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.google_analytics_data_api.types.FourWeeklyActiveUsersSearchFilter`
     :   The type of the None singleton.
+
+<a id="FourWeeklyActiveUsersLteCondition"></a>
 
 `FourWeeklyActiveUsersLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -1314,6 +1452,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.google_analytics_data_api.types.FourWeeklyActiveUsersSearchFilter`
     :   The type of the None singleton.
 
+<a id="FourWeeklyActiveUsersNeqCondition"></a>
+
 `FourWeeklyActiveUsersNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -1325,6 +1465,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.google_analytics_data_api.types.FourWeeklyActiveUsersSearchFilter`
     :   The type of the None singleton.
+
+<a id="FourWeeklyActiveUsersNotCondition"></a>
 
 `FourWeeklyActiveUsersNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -1346,6 +1488,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.google_analytics_data_api.types.FourWeeklyActiveUsersEqCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.FourWeeklyActiveUsersNeqCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.FourWeeklyActiveUsersGtCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.FourWeeklyActiveUsersGteCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.FourWeeklyActiveUsersLtCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.FourWeeklyActiveUsersLteCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.FourWeeklyActiveUsersInCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.FourWeeklyActiveUsersLikeCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.FourWeeklyActiveUsersFuzzyCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.FourWeeklyActiveUsersKeywordCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.FourWeeklyActiveUsersContainsCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.FourWeeklyActiveUsersNotCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.FourWeeklyActiveUsersAndCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.FourWeeklyActiveUsersOrCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.FourWeeklyActiveUsersAnyCondition`
     :   The type of the None singleton.
 
+<a id="FourWeeklyActiveUsersOrCondition"></a>
+
 `FourWeeklyActiveUsersOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1365,6 +1509,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.google_analytics_data_api.types.FourWeeklyActiveUsersEqCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.FourWeeklyActiveUsersNeqCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.FourWeeklyActiveUsersGtCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.FourWeeklyActiveUsersGteCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.FourWeeklyActiveUsersLtCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.FourWeeklyActiveUsersLteCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.FourWeeklyActiveUsersInCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.FourWeeklyActiveUsersLikeCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.FourWeeklyActiveUsersFuzzyCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.FourWeeklyActiveUsersKeywordCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.FourWeeklyActiveUsersContainsCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.FourWeeklyActiveUsersNotCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.FourWeeklyActiveUsersAndCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.FourWeeklyActiveUsersOrCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.FourWeeklyActiveUsersAnyCondition]`
     :   The type of the None singleton.
+
+<a id="FourWeeklyActiveUsersSearchFilter"></a>
 
 `FourWeeklyActiveUsersSearchFilter(*args, **kwargs)`
 :   Available fields for filtering four_weekly_active_users search queries.
@@ -1390,6 +1536,8 @@ Classes
     `start_date: str | None`
     :   Start date of the reporting period
 
+<a id="FourWeeklyActiveUsersSearchQuery"></a>
+
 `FourWeeklyActiveUsersSearchQuery(*args, **kwargs)`
 :   Search query for four_weekly_active_users entity.
 
@@ -1404,6 +1552,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.google_analytics_data_api.types.FourWeeklyActiveUsersSortFilter]`
     :   The type of the None singleton.
+
+<a id="FourWeeklyActiveUsersSortFilter"></a>
 
 `FourWeeklyActiveUsersSortFilter(*args, **kwargs)`
 :   Available fields for sorting four_weekly_active_users search results.
@@ -1429,6 +1579,8 @@ Classes
     `start_date: Literal['asc', 'desc']`
     :   Start date of the reporting period
 
+<a id="FourWeeklyActiveUsersStringFilter"></a>
+
 `FourWeeklyActiveUsersStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -1453,6 +1605,8 @@ Classes
     `start_date: str`
     :   Start date of the reporting period
 
+<a id="LocationsAndCondition"></a>
+
 `LocationsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1473,6 +1627,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.google_analytics_data_api.types.LocationsEqCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.LocationsNeqCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.LocationsGtCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.LocationsGteCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.LocationsLtCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.LocationsLteCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.LocationsInCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.LocationsLikeCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.LocationsFuzzyCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.LocationsKeywordCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.LocationsContainsCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.LocationsNotCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.LocationsAndCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.LocationsOrCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.LocationsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="LocationsAnyCondition"></a>
+
 `LocationsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1492,6 +1648,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.google_analytics_data_api.types.LocationsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="LocationsAnyValueFilter"></a>
 
 `LocationsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -1547,6 +1705,8 @@ Classes
     `total_users: Any`
     :   Total number of unique users
 
+<a id="LocationsContainsCondition"></a>
+
 `LocationsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -1558,6 +1718,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.google_analytics_data_api.types.LocationsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="LocationsEqCondition"></a>
 
 `LocationsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -1571,6 +1733,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.google_analytics_data_api.types.LocationsSearchFilter`
     :   The type of the None singleton.
 
+<a id="LocationsFuzzyCondition"></a>
+
 `LocationsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -1582,6 +1746,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.google_analytics_data_api.types.LocationsStringFilter`
     :   The type of the None singleton.
+
+<a id="LocationsGtCondition"></a>
 
 `LocationsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
@@ -1595,6 +1761,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.google_analytics_data_api.types.LocationsSearchFilter`
     :   The type of the None singleton.
 
+<a id="LocationsGteCondition"></a>
+
 `LocationsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -1606,6 +1774,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.google_analytics_data_api.types.LocationsSearchFilter`
     :   The type of the None singleton.
+
+<a id="LocationsInCondition"></a>
 
 `LocationsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -1626,6 +1796,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.google_analytics_data_api.types.LocationsInFilter`
     :   The type of the None singleton.
+
+<a id="LocationsInFilter"></a>
 
 `LocationsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -1681,6 +1853,8 @@ Classes
     `total_users: list[int]`
     :   Total number of unique users
 
+<a id="LocationsKeywordCondition"></a>
+
 `LocationsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -1693,6 +1867,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.google_analytics_data_api.types.LocationsStringFilter`
     :   The type of the None singleton.
 
+<a id="LocationsLikeCondition"></a>
+
 `LocationsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -1704,6 +1880,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.google_analytics_data_api.types.LocationsStringFilter`
     :   The type of the None singleton.
+
+<a id="LocationsListParams"></a>
 
 `LocationsListParams(*args, **kwargs)`
 :   Parameters for locations.list operation
@@ -1735,6 +1913,8 @@ Classes
     `return_property_quota: bool`
     :   The type of the None singleton.
 
+<a id="LocationsListParamsDaterangesItem"></a>
+
 `LocationsListParamsDaterangesItem(*args, **kwargs)`
 :   Nested schema for LocationsListParams.dateRanges_item
 
@@ -1750,6 +1930,8 @@ Classes
     `startDate: str`
     :   The type of the None singleton.
 
+<a id="LocationsListParamsDimensionsItem"></a>
+
 `LocationsListParamsDimensionsItem(*args, **kwargs)`
 :   Nested schema for LocationsListParams.dimensions_item
 
@@ -1761,6 +1943,8 @@ Classes
 
     `name: str`
     :   The type of the None singleton.
+
+<a id="LocationsListParamsMetricsItem"></a>
 
 `LocationsListParamsMetricsItem(*args, **kwargs)`
 :   Nested schema for LocationsListParams.metrics_item
@@ -1774,6 +1958,8 @@ Classes
     `name: str`
     :   The type of the None singleton.
 
+<a id="LocationsLtCondition"></a>
+
 `LocationsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -1785,6 +1971,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.google_analytics_data_api.types.LocationsSearchFilter`
     :   The type of the None singleton.
+
+<a id="LocationsLteCondition"></a>
 
 `LocationsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -1798,6 +1986,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.google_analytics_data_api.types.LocationsSearchFilter`
     :   The type of the None singleton.
 
+<a id="LocationsNeqCondition"></a>
+
 `LocationsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -1809,6 +1999,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.google_analytics_data_api.types.LocationsSearchFilter`
     :   The type of the None singleton.
+
+<a id="LocationsNotCondition"></a>
 
 `LocationsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -1830,6 +2022,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.google_analytics_data_api.types.LocationsEqCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.LocationsNeqCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.LocationsGtCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.LocationsGteCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.LocationsLtCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.LocationsLteCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.LocationsInCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.LocationsLikeCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.LocationsFuzzyCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.LocationsKeywordCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.LocationsContainsCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.LocationsNotCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.LocationsAndCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.LocationsOrCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.LocationsAnyCondition`
     :   The type of the None singleton.
 
+<a id="LocationsOrCondition"></a>
+
 `LocationsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1849,6 +2043,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.google_analytics_data_api.types.LocationsEqCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.LocationsNeqCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.LocationsGtCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.LocationsGteCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.LocationsLtCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.LocationsLteCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.LocationsInCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.LocationsLikeCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.LocationsFuzzyCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.LocationsKeywordCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.LocationsContainsCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.LocationsNotCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.LocationsAndCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.LocationsOrCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.LocationsAnyCondition]`
     :   The type of the None singleton.
+
+<a id="LocationsSearchFilter"></a>
 
 `LocationsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering locations search queries.
@@ -1904,6 +2100,8 @@ Classes
     `total_users: int | None`
     :   Total number of unique users
 
+<a id="LocationsSearchQuery"></a>
+
 `LocationsSearchQuery(*args, **kwargs)`
 :   Search query for locations entity.
 
@@ -1918,6 +2116,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.google_analytics_data_api.types.LocationsSortFilter]`
     :   The type of the None singleton.
+
+<a id="LocationsSortFilter"></a>
 
 `LocationsSortFilter(*args, **kwargs)`
 :   Available fields for sorting locations search results.
@@ -1973,6 +2173,8 @@ Classes
     `total_users: Literal['asc', 'desc']`
     :   Total number of unique users
 
+<a id="LocationsStringFilter"></a>
+
 `LocationsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -2027,6 +2229,8 @@ Classes
     `total_users: str`
     :   Total number of unique users
 
+<a id="PagesAndCondition"></a>
+
 `PagesAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -2047,6 +2251,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.google_analytics_data_api.types.PagesEqCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.PagesNeqCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.PagesGtCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.PagesGteCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.PagesLtCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.PagesLteCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.PagesInCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.PagesLikeCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.PagesFuzzyCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.PagesKeywordCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.PagesContainsCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.PagesNotCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.PagesAndCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.PagesOrCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.PagesAnyCondition]`
     :   The type of the None singleton.
 
+<a id="PagesAnyCondition"></a>
+
 `PagesAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -2066,6 +2272,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.google_analytics_data_api.types.PagesAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="PagesAnyValueFilter"></a>
 
 `PagesAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -2100,6 +2308,8 @@ Classes
     `start_date: Any`
     :   Start date of the reporting period
 
+<a id="PagesContainsCondition"></a>
+
 `PagesContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -2111,6 +2321,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.google_analytics_data_api.types.PagesAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="PagesEqCondition"></a>
 
 `PagesEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -2124,6 +2336,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.google_analytics_data_api.types.PagesSearchFilter`
     :   The type of the None singleton.
 
+<a id="PagesFuzzyCondition"></a>
+
 `PagesFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -2135,6 +2349,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.google_analytics_data_api.types.PagesStringFilter`
     :   The type of the None singleton.
+
+<a id="PagesGtCondition"></a>
 
 `PagesGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
@@ -2148,6 +2364,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.google_analytics_data_api.types.PagesSearchFilter`
     :   The type of the None singleton.
 
+<a id="PagesGteCondition"></a>
+
 `PagesGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -2159,6 +2377,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.google_analytics_data_api.types.PagesSearchFilter`
     :   The type of the None singleton.
+
+<a id="PagesInCondition"></a>
 
 `PagesInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -2179,6 +2399,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.google_analytics_data_api.types.PagesInFilter`
     :   The type of the None singleton.
+
+<a id="PagesInFilter"></a>
 
 `PagesInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -2213,6 +2435,8 @@ Classes
     `start_date: list[str]`
     :   Start date of the reporting period
 
+<a id="PagesKeywordCondition"></a>
+
 `PagesKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -2225,6 +2449,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.google_analytics_data_api.types.PagesStringFilter`
     :   The type of the None singleton.
 
+<a id="PagesLikeCondition"></a>
+
 `PagesLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -2236,6 +2462,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.google_analytics_data_api.types.PagesStringFilter`
     :   The type of the None singleton.
+
+<a id="PagesListParams"></a>
 
 `PagesListParams(*args, **kwargs)`
 :   Parameters for pages.list operation
@@ -2267,6 +2495,8 @@ Classes
     `return_property_quota: bool`
     :   The type of the None singleton.
 
+<a id="PagesListParamsDaterangesItem"></a>
+
 `PagesListParamsDaterangesItem(*args, **kwargs)`
 :   Nested schema for PagesListParams.dateRanges_item
 
@@ -2282,6 +2512,8 @@ Classes
     `startDate: str`
     :   The type of the None singleton.
 
+<a id="PagesListParamsDimensionsItem"></a>
+
 `PagesListParamsDimensionsItem(*args, **kwargs)`
 :   Nested schema for PagesListParams.dimensions_item
 
@@ -2293,6 +2525,8 @@ Classes
 
     `name: str`
     :   The type of the None singleton.
+
+<a id="PagesListParamsMetricsItem"></a>
 
 `PagesListParamsMetricsItem(*args, **kwargs)`
 :   Nested schema for PagesListParams.metrics_item
@@ -2306,6 +2540,8 @@ Classes
     `name: str`
     :   The type of the None singleton.
 
+<a id="PagesLtCondition"></a>
+
 `PagesLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -2317,6 +2553,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.google_analytics_data_api.types.PagesSearchFilter`
     :   The type of the None singleton.
+
+<a id="PagesLteCondition"></a>
 
 `PagesLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -2330,6 +2568,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.google_analytics_data_api.types.PagesSearchFilter`
     :   The type of the None singleton.
 
+<a id="PagesNeqCondition"></a>
+
 `PagesNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -2341,6 +2581,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.google_analytics_data_api.types.PagesSearchFilter`
     :   The type of the None singleton.
+
+<a id="PagesNotCondition"></a>
 
 `PagesNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -2362,6 +2604,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.google_analytics_data_api.types.PagesEqCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.PagesNeqCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.PagesGtCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.PagesGteCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.PagesLtCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.PagesLteCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.PagesInCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.PagesLikeCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.PagesFuzzyCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.PagesKeywordCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.PagesContainsCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.PagesNotCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.PagesAndCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.PagesOrCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.PagesAnyCondition`
     :   The type of the None singleton.
 
+<a id="PagesOrCondition"></a>
+
 `PagesOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -2381,6 +2625,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.google_analytics_data_api.types.PagesEqCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.PagesNeqCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.PagesGtCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.PagesGteCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.PagesLtCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.PagesLteCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.PagesInCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.PagesLikeCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.PagesFuzzyCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.PagesKeywordCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.PagesContainsCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.PagesNotCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.PagesAndCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.PagesOrCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.PagesAnyCondition]`
     :   The type of the None singleton.
+
+<a id="PagesSearchFilter"></a>
 
 `PagesSearchFilter(*args, **kwargs)`
 :   Available fields for filtering pages search queries.
@@ -2415,6 +2661,8 @@ Classes
     `start_date: str | None`
     :   Start date of the reporting period
 
+<a id="PagesSearchQuery"></a>
+
 `PagesSearchQuery(*args, **kwargs)`
 :   Search query for pages entity.
 
@@ -2429,6 +2677,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.google_analytics_data_api.types.PagesSortFilter]`
     :   The type of the None singleton.
+
+<a id="PagesSortFilter"></a>
 
 `PagesSortFilter(*args, **kwargs)`
 :   Available fields for sorting pages search results.
@@ -2463,6 +2713,8 @@ Classes
     `start_date: Literal['asc', 'desc']`
     :   Start date of the reporting period
 
+<a id="PagesStringFilter"></a>
+
 `PagesStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -2496,6 +2748,8 @@ Classes
     `start_date: str`
     :   Start date of the reporting period
 
+<a id="TrafficSourcesAndCondition"></a>
+
 `TrafficSourcesAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -2516,6 +2770,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.google_analytics_data_api.types.TrafficSourcesEqCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.TrafficSourcesNeqCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.TrafficSourcesGtCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.TrafficSourcesGteCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.TrafficSourcesLtCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.TrafficSourcesLteCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.TrafficSourcesInCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.TrafficSourcesLikeCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.TrafficSourcesFuzzyCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.TrafficSourcesKeywordCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.TrafficSourcesContainsCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.TrafficSourcesNotCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.TrafficSourcesAndCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.TrafficSourcesOrCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.TrafficSourcesAnyCondition]`
     :   The type of the None singleton.
 
+<a id="TrafficSourcesAnyCondition"></a>
+
 `TrafficSourcesAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -2535,6 +2791,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.google_analytics_data_api.types.TrafficSourcesAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="TrafficSourcesAnyValueFilter"></a>
 
 `TrafficSourcesAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -2587,6 +2845,8 @@ Classes
     `total_users: Any`
     :   Total number of unique users
 
+<a id="TrafficSourcesContainsCondition"></a>
+
 `TrafficSourcesContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -2598,6 +2858,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.google_analytics_data_api.types.TrafficSourcesAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="TrafficSourcesEqCondition"></a>
 
 `TrafficSourcesEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -2611,6 +2873,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.google_analytics_data_api.types.TrafficSourcesSearchFilter`
     :   The type of the None singleton.
 
+<a id="TrafficSourcesFuzzyCondition"></a>
+
 `TrafficSourcesFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -2622,6 +2886,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.google_analytics_data_api.types.TrafficSourcesStringFilter`
     :   The type of the None singleton.
+
+<a id="TrafficSourcesGtCondition"></a>
 
 `TrafficSourcesGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
@@ -2635,6 +2901,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.google_analytics_data_api.types.TrafficSourcesSearchFilter`
     :   The type of the None singleton.
 
+<a id="TrafficSourcesGteCondition"></a>
+
 `TrafficSourcesGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -2646,6 +2914,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.google_analytics_data_api.types.TrafficSourcesSearchFilter`
     :   The type of the None singleton.
+
+<a id="TrafficSourcesInCondition"></a>
 
 `TrafficSourcesInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -2666,6 +2936,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.google_analytics_data_api.types.TrafficSourcesInFilter`
     :   The type of the None singleton.
+
+<a id="TrafficSourcesInFilter"></a>
 
 `TrafficSourcesInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -2718,6 +2990,8 @@ Classes
     `total_users: list[int]`
     :   Total number of unique users
 
+<a id="TrafficSourcesKeywordCondition"></a>
+
 `TrafficSourcesKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -2730,6 +3004,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.google_analytics_data_api.types.TrafficSourcesStringFilter`
     :   The type of the None singleton.
 
+<a id="TrafficSourcesLikeCondition"></a>
+
 `TrafficSourcesLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -2741,6 +3017,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.google_analytics_data_api.types.TrafficSourcesStringFilter`
     :   The type of the None singleton.
+
+<a id="TrafficSourcesListParams"></a>
 
 `TrafficSourcesListParams(*args, **kwargs)`
 :   Parameters for traffic_sources.list operation
@@ -2772,6 +3050,8 @@ Classes
     `return_property_quota: bool`
     :   The type of the None singleton.
 
+<a id="TrafficSourcesListParamsDaterangesItem"></a>
+
 `TrafficSourcesListParamsDaterangesItem(*args, **kwargs)`
 :   Nested schema for TrafficSourcesListParams.dateRanges_item
 
@@ -2787,6 +3067,8 @@ Classes
     `startDate: str`
     :   The type of the None singleton.
 
+<a id="TrafficSourcesListParamsDimensionsItem"></a>
+
 `TrafficSourcesListParamsDimensionsItem(*args, **kwargs)`
 :   Nested schema for TrafficSourcesListParams.dimensions_item
 
@@ -2798,6 +3080,8 @@ Classes
 
     `name: str`
     :   The type of the None singleton.
+
+<a id="TrafficSourcesListParamsMetricsItem"></a>
 
 `TrafficSourcesListParamsMetricsItem(*args, **kwargs)`
 :   Nested schema for TrafficSourcesListParams.metrics_item
@@ -2811,6 +3095,8 @@ Classes
     `name: str`
     :   The type of the None singleton.
 
+<a id="TrafficSourcesLtCondition"></a>
+
 `TrafficSourcesLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -2822,6 +3108,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.google_analytics_data_api.types.TrafficSourcesSearchFilter`
     :   The type of the None singleton.
+
+<a id="TrafficSourcesLteCondition"></a>
 
 `TrafficSourcesLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -2835,6 +3123,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.google_analytics_data_api.types.TrafficSourcesSearchFilter`
     :   The type of the None singleton.
 
+<a id="TrafficSourcesNeqCondition"></a>
+
 `TrafficSourcesNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -2846,6 +3136,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.google_analytics_data_api.types.TrafficSourcesSearchFilter`
     :   The type of the None singleton.
+
+<a id="TrafficSourcesNotCondition"></a>
 
 `TrafficSourcesNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -2867,6 +3159,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.google_analytics_data_api.types.TrafficSourcesEqCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.TrafficSourcesNeqCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.TrafficSourcesGtCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.TrafficSourcesGteCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.TrafficSourcesLtCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.TrafficSourcesLteCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.TrafficSourcesInCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.TrafficSourcesLikeCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.TrafficSourcesFuzzyCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.TrafficSourcesKeywordCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.TrafficSourcesContainsCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.TrafficSourcesNotCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.TrafficSourcesAndCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.TrafficSourcesOrCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.TrafficSourcesAnyCondition`
     :   The type of the None singleton.
 
+<a id="TrafficSourcesOrCondition"></a>
+
 `TrafficSourcesOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -2886,6 +3180,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.google_analytics_data_api.types.TrafficSourcesEqCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.TrafficSourcesNeqCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.TrafficSourcesGtCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.TrafficSourcesGteCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.TrafficSourcesLtCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.TrafficSourcesLteCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.TrafficSourcesInCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.TrafficSourcesLikeCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.TrafficSourcesFuzzyCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.TrafficSourcesKeywordCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.TrafficSourcesContainsCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.TrafficSourcesNotCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.TrafficSourcesAndCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.TrafficSourcesOrCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.TrafficSourcesAnyCondition]`
     :   The type of the None singleton.
+
+<a id="TrafficSourcesSearchFilter"></a>
 
 `TrafficSourcesSearchFilter(*args, **kwargs)`
 :   Available fields for filtering traffic_sources search queries.
@@ -2938,6 +3234,8 @@ Classes
     `total_users: int | None`
     :   Total number of unique users
 
+<a id="TrafficSourcesSearchQuery"></a>
+
 `TrafficSourcesSearchQuery(*args, **kwargs)`
 :   Search query for traffic_sources entity.
 
@@ -2952,6 +3250,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.google_analytics_data_api.types.TrafficSourcesSortFilter]`
     :   The type of the None singleton.
+
+<a id="TrafficSourcesSortFilter"></a>
 
 `TrafficSourcesSortFilter(*args, **kwargs)`
 :   Available fields for sorting traffic_sources search results.
@@ -3004,6 +3304,8 @@ Classes
     `total_users: Literal['asc', 'desc']`
     :   Total number of unique users
 
+<a id="TrafficSourcesStringFilter"></a>
+
 `TrafficSourcesStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -3055,6 +3357,8 @@ Classes
     `total_users: str`
     :   Total number of unique users
 
+<a id="WebsiteOverviewAndCondition"></a>
+
 `WebsiteOverviewAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -3075,6 +3379,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.google_analytics_data_api.types.WebsiteOverviewEqCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.WebsiteOverviewNeqCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.WebsiteOverviewGtCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.WebsiteOverviewGteCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.WebsiteOverviewLtCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.WebsiteOverviewLteCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.WebsiteOverviewInCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.WebsiteOverviewLikeCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.WebsiteOverviewFuzzyCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.WebsiteOverviewKeywordCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.WebsiteOverviewContainsCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.WebsiteOverviewNotCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.WebsiteOverviewAndCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.WebsiteOverviewOrCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.WebsiteOverviewAnyCondition]`
     :   The type of the None singleton.
 
+<a id="WebsiteOverviewAnyCondition"></a>
+
 `WebsiteOverviewAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -3094,6 +3400,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.google_analytics_data_api.types.WebsiteOverviewAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="WebsiteOverviewAnyValueFilter"></a>
 
 `WebsiteOverviewAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -3140,6 +3448,8 @@ Classes
     `total_users: Any`
     :   Total number of unique users
 
+<a id="WebsiteOverviewContainsCondition"></a>
+
 `WebsiteOverviewContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -3151,6 +3461,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.google_analytics_data_api.types.WebsiteOverviewAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="WebsiteOverviewEqCondition"></a>
 
 `WebsiteOverviewEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -3164,6 +3476,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.google_analytics_data_api.types.WebsiteOverviewSearchFilter`
     :   The type of the None singleton.
 
+<a id="WebsiteOverviewFuzzyCondition"></a>
+
 `WebsiteOverviewFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -3175,6 +3489,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.google_analytics_data_api.types.WebsiteOverviewStringFilter`
     :   The type of the None singleton.
+
+<a id="WebsiteOverviewGtCondition"></a>
 
 `WebsiteOverviewGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
@@ -3188,6 +3504,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.google_analytics_data_api.types.WebsiteOverviewSearchFilter`
     :   The type of the None singleton.
 
+<a id="WebsiteOverviewGteCondition"></a>
+
 `WebsiteOverviewGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -3199,6 +3517,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.google_analytics_data_api.types.WebsiteOverviewSearchFilter`
     :   The type of the None singleton.
+
+<a id="WebsiteOverviewInCondition"></a>
 
 `WebsiteOverviewInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -3219,6 +3539,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.google_analytics_data_api.types.WebsiteOverviewInFilter`
     :   The type of the None singleton.
+
+<a id="WebsiteOverviewInFilter"></a>
 
 `WebsiteOverviewInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -3265,6 +3587,8 @@ Classes
     `total_users: list[int]`
     :   Total number of unique users
 
+<a id="WebsiteOverviewKeywordCondition"></a>
+
 `WebsiteOverviewKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -3277,6 +3601,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.google_analytics_data_api.types.WebsiteOverviewStringFilter`
     :   The type of the None singleton.
 
+<a id="WebsiteOverviewLikeCondition"></a>
+
 `WebsiteOverviewLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -3288,6 +3614,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.google_analytics_data_api.types.WebsiteOverviewStringFilter`
     :   The type of the None singleton.
+
+<a id="WebsiteOverviewListParams"></a>
 
 `WebsiteOverviewListParams(*args, **kwargs)`
 :   Parameters for website_overview.list operation
@@ -3319,6 +3647,8 @@ Classes
     `return_property_quota: bool`
     :   The type of the None singleton.
 
+<a id="WebsiteOverviewListParamsDaterangesItem"></a>
+
 `WebsiteOverviewListParamsDaterangesItem(*args, **kwargs)`
 :   Nested schema for WebsiteOverviewListParams.dateRanges_item
 
@@ -3334,6 +3664,8 @@ Classes
     `startDate: str`
     :   The type of the None singleton.
 
+<a id="WebsiteOverviewListParamsDimensionsItem"></a>
+
 `WebsiteOverviewListParamsDimensionsItem(*args, **kwargs)`
 :   Nested schema for WebsiteOverviewListParams.dimensions_item
 
@@ -3345,6 +3677,8 @@ Classes
 
     `name: str`
     :   The type of the None singleton.
+
+<a id="WebsiteOverviewListParamsMetricsItem"></a>
 
 `WebsiteOverviewListParamsMetricsItem(*args, **kwargs)`
 :   Nested schema for WebsiteOverviewListParams.metrics_item
@@ -3358,6 +3692,8 @@ Classes
     `name: str`
     :   The type of the None singleton.
 
+<a id="WebsiteOverviewLtCondition"></a>
+
 `WebsiteOverviewLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -3369,6 +3705,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.google_analytics_data_api.types.WebsiteOverviewSearchFilter`
     :   The type of the None singleton.
+
+<a id="WebsiteOverviewLteCondition"></a>
 
 `WebsiteOverviewLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -3382,6 +3720,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.google_analytics_data_api.types.WebsiteOverviewSearchFilter`
     :   The type of the None singleton.
 
+<a id="WebsiteOverviewNeqCondition"></a>
+
 `WebsiteOverviewNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -3393,6 +3733,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.google_analytics_data_api.types.WebsiteOverviewSearchFilter`
     :   The type of the None singleton.
+
+<a id="WebsiteOverviewNotCondition"></a>
 
 `WebsiteOverviewNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -3414,6 +3756,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.google_analytics_data_api.types.WebsiteOverviewEqCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.WebsiteOverviewNeqCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.WebsiteOverviewGtCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.WebsiteOverviewGteCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.WebsiteOverviewLtCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.WebsiteOverviewLteCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.WebsiteOverviewInCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.WebsiteOverviewLikeCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.WebsiteOverviewFuzzyCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.WebsiteOverviewKeywordCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.WebsiteOverviewContainsCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.WebsiteOverviewNotCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.WebsiteOverviewAndCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.WebsiteOverviewOrCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.WebsiteOverviewAnyCondition`
     :   The type of the None singleton.
 
+<a id="WebsiteOverviewOrCondition"></a>
+
 `WebsiteOverviewOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -3433,6 +3777,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.google_analytics_data_api.types.WebsiteOverviewEqCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.WebsiteOverviewNeqCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.WebsiteOverviewGtCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.WebsiteOverviewGteCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.WebsiteOverviewLtCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.WebsiteOverviewLteCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.WebsiteOverviewInCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.WebsiteOverviewLikeCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.WebsiteOverviewFuzzyCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.WebsiteOverviewKeywordCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.WebsiteOverviewContainsCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.WebsiteOverviewNotCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.WebsiteOverviewAndCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.WebsiteOverviewOrCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.WebsiteOverviewAnyCondition]`
     :   The type of the None singleton.
+
+<a id="WebsiteOverviewSearchFilter"></a>
 
 `WebsiteOverviewSearchFilter(*args, **kwargs)`
 :   Available fields for filtering website_overview search queries.
@@ -3479,6 +3825,8 @@ Classes
     `total_users: int | None`
     :   Total number of unique users
 
+<a id="WebsiteOverviewSearchQuery"></a>
+
 `WebsiteOverviewSearchQuery(*args, **kwargs)`
 :   Search query for website_overview entity.
 
@@ -3493,6 +3841,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.google_analytics_data_api.types.WebsiteOverviewSortFilter]`
     :   The type of the None singleton.
+
+<a id="WebsiteOverviewSortFilter"></a>
 
 `WebsiteOverviewSortFilter(*args, **kwargs)`
 :   Available fields for sorting website_overview search results.
@@ -3539,6 +3889,8 @@ Classes
     `total_users: Literal['asc', 'desc']`
     :   Total number of unique users
 
+<a id="WebsiteOverviewStringFilter"></a>
+
 `WebsiteOverviewStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -3584,6 +3936,8 @@ Classes
     `total_users: str`
     :   Total number of unique users
 
+<a id="WeeklyActiveUsersAndCondition"></a>
+
 `WeeklyActiveUsersAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -3604,6 +3958,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.google_analytics_data_api.types.WeeklyActiveUsersEqCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.WeeklyActiveUsersNeqCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.WeeklyActiveUsersGtCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.WeeklyActiveUsersGteCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.WeeklyActiveUsersLtCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.WeeklyActiveUsersLteCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.WeeklyActiveUsersInCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.WeeklyActiveUsersLikeCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.WeeklyActiveUsersFuzzyCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.WeeklyActiveUsersKeywordCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.WeeklyActiveUsersContainsCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.WeeklyActiveUsersNotCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.WeeklyActiveUsersAndCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.WeeklyActiveUsersOrCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.WeeklyActiveUsersAnyCondition]`
     :   The type of the None singleton.
 
+<a id="WeeklyActiveUsersAnyCondition"></a>
+
 `WeeklyActiveUsersAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -3623,6 +3979,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.google_analytics_data_api.types.WeeklyActiveUsersAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="WeeklyActiveUsersAnyValueFilter"></a>
 
 `WeeklyActiveUsersAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -3648,6 +4006,8 @@ Classes
     `start_date: Any`
     :   Start date of the reporting period
 
+<a id="WeeklyActiveUsersContainsCondition"></a>
+
 `WeeklyActiveUsersContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -3659,6 +4019,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.google_analytics_data_api.types.WeeklyActiveUsersAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="WeeklyActiveUsersEqCondition"></a>
 
 `WeeklyActiveUsersEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -3672,6 +4034,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.google_analytics_data_api.types.WeeklyActiveUsersSearchFilter`
     :   The type of the None singleton.
 
+<a id="WeeklyActiveUsersFuzzyCondition"></a>
+
 `WeeklyActiveUsersFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -3683,6 +4047,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.google_analytics_data_api.types.WeeklyActiveUsersStringFilter`
     :   The type of the None singleton.
+
+<a id="WeeklyActiveUsersGtCondition"></a>
 
 `WeeklyActiveUsersGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
@@ -3696,6 +4062,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.google_analytics_data_api.types.WeeklyActiveUsersSearchFilter`
     :   The type of the None singleton.
 
+<a id="WeeklyActiveUsersGteCondition"></a>
+
 `WeeklyActiveUsersGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -3707,6 +4075,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.google_analytics_data_api.types.WeeklyActiveUsersSearchFilter`
     :   The type of the None singleton.
+
+<a id="WeeklyActiveUsersInCondition"></a>
 
 `WeeklyActiveUsersInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -3727,6 +4097,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.google_analytics_data_api.types.WeeklyActiveUsersInFilter`
     :   The type of the None singleton.
+
+<a id="WeeklyActiveUsersInFilter"></a>
 
 `WeeklyActiveUsersInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -3752,6 +4124,8 @@ Classes
     `start_date: list[str]`
     :   Start date of the reporting period
 
+<a id="WeeklyActiveUsersKeywordCondition"></a>
+
 `WeeklyActiveUsersKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -3764,6 +4138,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.google_analytics_data_api.types.WeeklyActiveUsersStringFilter`
     :   The type of the None singleton.
 
+<a id="WeeklyActiveUsersLikeCondition"></a>
+
 `WeeklyActiveUsersLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -3775,6 +4151,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.google_analytics_data_api.types.WeeklyActiveUsersStringFilter`
     :   The type of the None singleton.
+
+<a id="WeeklyActiveUsersListParams"></a>
 
 `WeeklyActiveUsersListParams(*args, **kwargs)`
 :   Parameters for weekly_active_users.list operation
@@ -3806,6 +4184,8 @@ Classes
     `return_property_quota: bool`
     :   The type of the None singleton.
 
+<a id="WeeklyActiveUsersListParamsDaterangesItem"></a>
+
 `WeeklyActiveUsersListParamsDaterangesItem(*args, **kwargs)`
 :   Nested schema for WeeklyActiveUsersListParams.dateRanges_item
 
@@ -3821,6 +4201,8 @@ Classes
     `startDate: str`
     :   The type of the None singleton.
 
+<a id="WeeklyActiveUsersListParamsDimensionsItem"></a>
+
 `WeeklyActiveUsersListParamsDimensionsItem(*args, **kwargs)`
 :   Nested schema for WeeklyActiveUsersListParams.dimensions_item
 
@@ -3832,6 +4214,8 @@ Classes
 
     `name: str`
     :   The type of the None singleton.
+
+<a id="WeeklyActiveUsersListParamsMetricsItem"></a>
 
 `WeeklyActiveUsersListParamsMetricsItem(*args, **kwargs)`
 :   Nested schema for WeeklyActiveUsersListParams.metrics_item
@@ -3845,6 +4229,8 @@ Classes
     `name: str`
     :   The type of the None singleton.
 
+<a id="WeeklyActiveUsersLtCondition"></a>
+
 `WeeklyActiveUsersLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -3856,6 +4242,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.google_analytics_data_api.types.WeeklyActiveUsersSearchFilter`
     :   The type of the None singleton.
+
+<a id="WeeklyActiveUsersLteCondition"></a>
 
 `WeeklyActiveUsersLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -3869,6 +4257,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.google_analytics_data_api.types.WeeklyActiveUsersSearchFilter`
     :   The type of the None singleton.
 
+<a id="WeeklyActiveUsersNeqCondition"></a>
+
 `WeeklyActiveUsersNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -3880,6 +4270,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.google_analytics_data_api.types.WeeklyActiveUsersSearchFilter`
     :   The type of the None singleton.
+
+<a id="WeeklyActiveUsersNotCondition"></a>
 
 `WeeklyActiveUsersNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -3901,6 +4293,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.google_analytics_data_api.types.WeeklyActiveUsersEqCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.WeeklyActiveUsersNeqCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.WeeklyActiveUsersGtCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.WeeklyActiveUsersGteCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.WeeklyActiveUsersLtCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.WeeklyActiveUsersLteCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.WeeklyActiveUsersInCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.WeeklyActiveUsersLikeCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.WeeklyActiveUsersFuzzyCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.WeeklyActiveUsersKeywordCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.WeeklyActiveUsersContainsCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.WeeklyActiveUsersNotCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.WeeklyActiveUsersAndCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.WeeklyActiveUsersOrCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.WeeklyActiveUsersAnyCondition`
     :   The type of the None singleton.
 
+<a id="WeeklyActiveUsersOrCondition"></a>
+
 `WeeklyActiveUsersOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -3920,6 +4314,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.google_analytics_data_api.types.WeeklyActiveUsersEqCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.WeeklyActiveUsersNeqCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.WeeklyActiveUsersGtCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.WeeklyActiveUsersGteCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.WeeklyActiveUsersLtCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.WeeklyActiveUsersLteCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.WeeklyActiveUsersInCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.WeeklyActiveUsersLikeCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.WeeklyActiveUsersFuzzyCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.WeeklyActiveUsersKeywordCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.WeeklyActiveUsersContainsCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.WeeklyActiveUsersNotCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.WeeklyActiveUsersAndCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.WeeklyActiveUsersOrCondition | airbyte_agent_sdk.connectors.google_analytics_data_api.types.WeeklyActiveUsersAnyCondition]`
     :   The type of the None singleton.
+
+<a id="WeeklyActiveUsersSearchFilter"></a>
 
 `WeeklyActiveUsersSearchFilter(*args, **kwargs)`
 :   Available fields for filtering weekly_active_users search queries.
@@ -3945,6 +4341,8 @@ Classes
     `start_date: str | None`
     :   Start date of the reporting period
 
+<a id="WeeklyActiveUsersSearchQuery"></a>
+
 `WeeklyActiveUsersSearchQuery(*args, **kwargs)`
 :   Search query for weekly_active_users entity.
 
@@ -3959,6 +4357,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.google_analytics_data_api.types.WeeklyActiveUsersSortFilter]`
     :   The type of the None singleton.
+
+<a id="WeeklyActiveUsersSortFilter"></a>
 
 `WeeklyActiveUsersSortFilter(*args, **kwargs)`
 :   Available fields for sorting weekly_active_users search results.
@@ -3983,6 +4383,8 @@ Classes
 
     `start_date: Literal['asc', 'desc']`
     :   Start date of the reporting period
+
+<a id="WeeklyActiveUsersStringFilter"></a>
 
 `WeeklyActiveUsersStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/google_drive/connector.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/google_drive/connector.md
@@ -10,6 +10,8 @@ Google-Drive connector.
 Classes
 -------
 
+<a id="AboutQuery"></a>
+
 `AboutQuery(connector: GoogleDriveConnector)`
 :   Query class for About entity operations.
     
@@ -26,6 +28,8 @@ Classes
         
         Returns:
             About
+
+<a id="ChangesQuery"></a>
 
 `ChangesQuery(connector: GoogleDriveConnector)`
 :   Query class for Changes entity operations.
@@ -51,6 +55,8 @@ Classes
         Returns:
             ChangesListResult
 
+<a id="ChangesStartPageTokenQuery"></a>
+
 `ChangesStartPageTokenQuery(connector: GoogleDriveConnector)`
 :   Query class for ChangesStartPageToken entity operations.
     
@@ -68,6 +74,8 @@ Classes
         
         Returns:
             StartPageToken
+
+<a id="CommentsQuery"></a>
 
 `CommentsQuery(connector: GoogleDriveConnector)`
 :   Query class for Comments entity operations.
@@ -104,6 +112,8 @@ Classes
         Returns:
             CommentsListResult
 
+<a id="DrivesQuery"></a>
+
 `DrivesQuery(connector: GoogleDriveConnector)`
 :   Query class for Drives entity operations.
     
@@ -134,6 +144,8 @@ Classes
         
         Returns:
             DrivesListResult
+
+<a id="FilesExportQuery"></a>
 
 `FilesExportQuery(connector: GoogleDriveConnector)`
 :   Query class for FilesExport entity operations.
@@ -198,6 +210,8 @@ Classes
         
                 Returns:
                     str: Path to the downloaded file
+
+<a id="FilesQuery"></a>
 
 `FilesQuery(connector: GoogleDriveConnector)`
 :   Query class for Files entity operations.
@@ -321,6 +335,8 @@ Classes
                 Returns:
                     File
 
+<a id="FilesUploadQuery"></a>
+
 `FilesUploadQuery(connector: GoogleDriveConnector)`
 :   Query class for FilesUpload entity operations.
     
@@ -347,6 +363,8 @@ Classes
         
                 Returns:
                     File
+
+<a id="GoogleDriveConnector"></a>
 
 `GoogleDriveConnector(auth_config: GoogleDriveAuthConfig | AirbyteAuthConfig | BaseModel | None = None, on_token_refresh: Any | None = None)`
 :   Type-safe Google-Drive API connector.
@@ -604,6 +622,8 @@ Classes
             for entity in entities:
                 print(f"\{entity['entity_name']\}: \{entity['available_actions']\}")
 
+<a id="PermissionsQuery"></a>
+
 `PermissionsQuery(connector: GoogleDriveConnector)`
 :   Query class for Permissions entity operations.
     
@@ -637,6 +657,8 @@ Classes
         
         Returns:
             PermissionsListResult
+
+<a id="RepliesQuery"></a>
 
 `RepliesQuery(connector: GoogleDriveConnector)`
 :   Query class for Replies entity operations.
@@ -673,6 +695,8 @@ Classes
         
         Returns:
             RepliesListResult
+
+<a id="RevisionsQuery"></a>
 
 `RevisionsQuery(connector: GoogleDriveConnector)`
 :   Query class for Revisions entity operations.

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/google_drive/index.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/google_drive/index.md
@@ -19,6 +19,8 @@ Sub-modules
 Classes
 -------
 
+<a id="AirbyteAuthConfig"></a>
+
 `AirbyteAuthConfig(**data: Any)`
 :   Authentication configuration for Airbyte hosted mode execution.
     
@@ -87,6 +89,8 @@ Classes
     `workspace_name: str | None`
     :   The type of the None singleton.
 
+<a id="GoogleDriveAuthConfig"></a>
+
 `GoogleDriveAuthConfig(**data: Any)`
 :   OAuth 2.0 Authentication
     
@@ -117,6 +121,8 @@ Classes
 
     `refresh_token: str`
     :   Your Google OAuth2 Refresh Token
+
+<a id="GoogleDriveConnector"></a>
 
 `GoogleDriveConnector(auth_config: GoogleDriveAuthConfig | AirbyteAuthConfig | BaseModel | None = None, on_token_refresh: Any | None = None)`
 :   Type-safe Google-Drive API connector.
@@ -373,6 +379,8 @@ Classes
             entities = connector.list_entities()
             for entity in entities:
                 print(f"\{entity['entity_name']\}: \{entity['available_actions']\}")
+
+<a id="GoogleDriveReplicationConfig"></a>
 
 `GoogleDriveReplicationConfig(**data: Any)`
 :   Replication Configuration - Settings for data replication from Google Drive.

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/google_drive/models.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/google_drive/models.md
@@ -13,6 +13,8 @@ and response envelope types.
 Classes
 -------
 
+<a id="About"></a>
+
 `About(**data: Any)`
 :   Information about the user, the user's Drive, and system capabilities
     
@@ -71,6 +73,8 @@ Classes
     `user: Any`
     :   The type of the None singleton.
 
+<a id="AboutDrivethemesItem"></a>
+
 `AboutDrivethemesItem(**data: Any)`
 :   Nested schema for About.driveThemes_item
     
@@ -98,6 +102,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="AboutStoragequota"></a>
 
 `AboutStoragequota(**data: Any)`
 :   The user's storage quota limits and usage
@@ -130,6 +136,8 @@ Classes
     `usage_in_drive_trash: str | Any | None`
     :   The usage by trashed files in Google Drive
 
+<a id="AboutTeamdrivethemesItem"></a>
+
 `AboutTeamdrivethemesItem(**data: Any)`
 :   Nested schema for About.teamDriveThemes_item
     
@@ -157,6 +165,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="Change"></a>
 
 `Change(**data: Any)`
 :   A change to a file or shared drive
@@ -204,6 +214,8 @@ Classes
     `type_: str | Any | None`
     :   The type of the None singleton.
 
+<a id="ChangesListResponse"></a>
+
 `ChangesListResponse(**data: Any)`
 :   A list of changes for a user
     
@@ -235,6 +247,8 @@ Classes
     `next_page_token: str | Any | None`
     :   The type of the None singleton.
 
+<a id="ChangesListResultMeta"></a>
+
 `ChangesListResultMeta(**data: Any)`
 :   Metadata for changes.Action.LIST operation
     
@@ -259,6 +273,8 @@ Classes
 
     `next_page_token: str | Any | None`
     :   The type of the None singleton.
+
+<a id="Comment"></a>
 
 `Comment(**data: Any)`
 :   A comment on a file
@@ -321,6 +337,8 @@ Classes
     `resolved: bool | Any | None`
     :   The type of the None singleton.
 
+<a id="CommentQuotedfilecontent"></a>
+
 `CommentQuotedfilecontent(**data: Any)`
 :   The file content to which the comment refers
     
@@ -345,6 +363,8 @@ Classes
 
     `value: str | Any | None`
     :   The type of the None singleton.
+
+<a id="CommentsListResponse"></a>
 
 `CommentsListResponse(**data: Any)`
 :   A list of comments on a file
@@ -374,6 +394,8 @@ Classes
     `next_page_token: str | Any | None`
     :   The type of the None singleton.
 
+<a id="CommentsListResultMeta"></a>
+
 `CommentsListResultMeta(**data: Any)`
 :   Metadata for comments.Action.LIST operation
     
@@ -395,6 +417,8 @@ Classes
 
     `next_page_token: str | Any | None`
     :   The type of the None singleton.
+
+<a id="Drive"></a>
 
 `Drive(**data: Any)`
 :   Representation of a shared drive
@@ -451,6 +475,8 @@ Classes
     `theme_id: str | Any | None`
     :   The type of the None singleton.
 
+<a id="DriveBackgroundimagefile"></a>
+
 `DriveBackgroundimagefile(**data: Any)`
 :   An image file and cropping parameters for the background image
     
@@ -481,6 +507,8 @@ Classes
 
     `y_coordinate: float | Any | None`
     :   The type of the None singleton.
+
+<a id="DriveCapabilities"></a>
 
 `DriveCapabilities(**data: Any)`
 :   Capabilities the current user has on this shared drive
@@ -561,6 +589,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="DriveRestrictions"></a>
+
 `DriveRestrictions(**data: Any)`
 :   A set of restrictions that apply to this shared drive
     
@@ -595,6 +625,8 @@ Classes
     `sharing_folders_requires_organizer_permission: bool | Any | None`
     :   The type of the None singleton.
 
+<a id="DrivesListResponse"></a>
+
 `DrivesListResponse(**data: Any)`
 :   A list of shared drives
     
@@ -623,6 +655,8 @@ Classes
     `next_page_token: str | Any | None`
     :   The type of the None singleton.
 
+<a id="DrivesListResultMeta"></a>
+
 `DrivesListResultMeta(**data: Any)`
 :   Metadata for drives.Action.LIST operation
     
@@ -644,6 +678,8 @@ Classes
 
     `next_page_token: str | Any | None`
     :   The type of the None singleton.
+
+<a id="File"></a>
 
 `File(**data: Any)`
 :   The metadata for a file
@@ -838,6 +874,8 @@ Classes
     `writers_can_share: bool | Any | None`
     :   The type of the None singleton.
 
+<a id="FileCapabilities"></a>
+
 `FileCapabilities(**data: Any)`
 :   Capabilities the current user has on this file
     
@@ -893,6 +931,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="FileContentrestrictionsItem"></a>
+
 `FileContentrestrictionsItem(**data: Any)`
 :   Nested schema for File.contentRestrictions_item
     
@@ -927,6 +967,8 @@ Classes
     `type_: str | Any | None`
     :   The type of the None singleton.
 
+<a id="FileCreateParams"></a>
+
 `FileCreateParams(**data: Any)`
 :   Parameters for creating a new file or folder
     
@@ -957,6 +999,8 @@ Classes
 
     `parents: list[str] | Any`
     :   The type of the None singleton.
+
+<a id="FileImagemediametadata"></a>
 
 `FileImagemediametadata(**data: Any)`
 :   Additional metadata about image media
@@ -1040,6 +1084,8 @@ Classes
     `width: int | Any | None`
     :   The type of the None singleton.
 
+<a id="FileImagemediametadataLocation"></a>
+
 `FileImagemediametadataLocation(**data: Any)`
 :   Nested schema for FileImagemediametadata.location
     
@@ -1068,6 +1114,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="FileLabelinfo"></a>
+
 `FileLabelinfo(**data: Any)`
 :   An overview of the labels on the file
     
@@ -1089,6 +1137,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="FileLinksharemetadata"></a>
 
 `FileLinksharemetadata(**data: Any)`
 :   Contains details about the link URLs
@@ -1114,6 +1164,8 @@ Classes
 
     `security_update_enabled: bool | Any | None`
     :   The type of the None singleton.
+
+<a id="FileShortcutdetails"></a>
 
 `FileShortcutdetails(**data: Any)`
 :   Shortcut file details
@@ -1143,6 +1195,8 @@ Classes
     `target_resource_key: str | Any | None`
     :   The type of the None singleton.
 
+<a id="FileUpdateParams"></a>
+
 `FileUpdateParams(**data: Any)`
 :   Parameters for updating file metadata
     
@@ -1170,6 +1224,8 @@ Classes
 
     `name: str | Any`
     :   The type of the None singleton.
+
+<a id="FileUploadParams"></a>
 
 `FileUploadParams(**data: Any)`
 :   Parameters for uploading a file with content
@@ -1208,6 +1264,8 @@ Classes
     `parents: list[str] | Any`
     :   The type of the None singleton.
 
+<a id="FileVideomediametadata"></a>
+
 `FileVideomediametadata(**data: Any)`
 :   Additional metadata about video media
     
@@ -1235,6 +1293,8 @@ Classes
 
     `width: int | Any | None`
     :   The type of the None singleton.
+
+<a id="FilesListResponse"></a>
 
 `FilesListResponse(**data: Any)`
 :   A list of files
@@ -1267,6 +1327,8 @@ Classes
     `next_page_token: str | Any | None`
     :   The type of the None singleton.
 
+<a id="FilesListResultMeta"></a>
+
 `FilesListResultMeta(**data: Any)`
 :   Metadata for files.Action.LIST operation
     
@@ -1291,6 +1353,8 @@ Classes
 
     `next_page_token: str | Any | None`
     :   The type of the None singleton.
+
+<a id="GoogleDriveAuthConfig"></a>
 
 `GoogleDriveAuthConfig(**data: Any)`
 :   OAuth 2.0 Authentication
@@ -1322,6 +1386,8 @@ Classes
 
     `refresh_token: str`
     :   Your Google OAuth2 Refresh Token
+
+<a id="GoogleDriveCheckResult"></a>
 
 `GoogleDriveCheckResult(**data: Any)`
 :   Result of a health check operation.
@@ -1356,6 +1422,8 @@ Classes
     `status: str`
     :   Health check status: 'healthy' or 'unhealthy'.
 
+<a id="GoogleDriveExecuteResult"></a>
+
 `GoogleDriveExecuteResult(**data: Any)`
 :   Response envelope with data only.
     
@@ -1384,6 +1452,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="GoogleDriveExecuteResultWithMeta"></a>
 
 `GoogleDriveExecuteResultWithMeta(**data: Any)`
 :   Response envelope with data and metadata.
@@ -1442,6 +1512,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="ChangesListResult"></a>
+
 `ChangesListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -1484,6 +1556,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="CommentsListResult"></a>
 
 `CommentsListResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -1528,6 +1602,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="DrivesListResult"></a>
+
 `DrivesListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -1570,6 +1646,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="FilesListResult"></a>
 
 `FilesListResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -1614,6 +1692,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="PermissionsListResult"></a>
+
 `PermissionsListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -1656,6 +1736,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="RepliesListResult"></a>
 
 `RepliesListResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -1700,6 +1782,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="RevisionsListResult"></a>
+
 `RevisionsListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -1718,6 +1802,8 @@ Classes
     * airbyte_agent_sdk.connectors.google_drive.models.GoogleDriveExecuteResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="GoogleDriveReplicationConfig"></a>
 
 `GoogleDriveReplicationConfig(**data: Any)`
 :   Replication Configuration - Settings for data replication from Google Drive.
@@ -1743,6 +1829,8 @@ Classes
 
     `streams: str`
     :   Configuration for file streams to sync from Google Drive
+
+<a id="Permission"></a>
 
 `Permission(**data: Any)`
 :   A permission for a file
@@ -1808,6 +1896,8 @@ Classes
     `view: str | Any | None`
     :   The type of the None singleton.
 
+<a id="PermissionPermissiondetailsItem"></a>
+
 `PermissionPermissiondetailsItem(**data: Any)`
 :   Nested schema for Permission.permissionDetails_item
     
@@ -1838,6 +1928,8 @@ Classes
 
     `role: str | Any | None`
     :   The type of the None singleton.
+
+<a id="PermissionTeamdrivepermissiondetailsItem"></a>
 
 `PermissionTeamdrivepermissiondetailsItem(**data: Any)`
 :   Nested schema for Permission.teamDrivePermissionDetails_item
@@ -1870,6 +1962,8 @@ Classes
     `team_drive_permission_type: str | Any | None`
     :   The type of the None singleton.
 
+<a id="PermissionsListResponse"></a>
+
 `PermissionsListResponse(**data: Any)`
 :   A list of permissions for a file
     
@@ -1898,6 +1992,8 @@ Classes
     `permissions: list[airbyte_agent_sdk.connectors.google_drive.models.Permission] | Any`
     :   The type of the None singleton.
 
+<a id="PermissionsListResultMeta"></a>
+
 `PermissionsListResultMeta(**data: Any)`
 :   Metadata for permissions.Action.LIST operation
     
@@ -1919,6 +2015,8 @@ Classes
 
     `next_page_token: str | Any | None`
     :   The type of the None singleton.
+
+<a id="RepliesListResponse"></a>
 
 `RepliesListResponse(**data: Any)`
 :   A list of replies to a comment
@@ -1948,6 +2046,8 @@ Classes
     `replies: list[airbyte_agent_sdk.connectors.google_drive.models.Reply] | Any`
     :   The type of the None singleton.
 
+<a id="RepliesListResultMeta"></a>
+
 `RepliesListResultMeta(**data: Any)`
 :   Metadata for replies.Action.LIST operation
     
@@ -1969,6 +2069,8 @@ Classes
 
     `next_page_token: str | Any | None`
     :   The type of the None singleton.
+
+<a id="Reply"></a>
 
 `Reply(**data: Any)`
 :   A reply to a comment on a file
@@ -2015,6 +2117,8 @@ Classes
 
     `modified_time: str | Any | None`
     :   The type of the None singleton.
+
+<a id="Revision"></a>
 
 `Revision(**data: Any)`
 :   The metadata for a revision to a file
@@ -2077,6 +2181,8 @@ Classes
     `size: str | Any | None`
     :   The type of the None singleton.
 
+<a id="RevisionsListResponse"></a>
+
 `RevisionsListResponse(**data: Any)`
 :   A list of revisions of a file
     
@@ -2105,6 +2211,8 @@ Classes
     `revisions: list[airbyte_agent_sdk.connectors.google_drive.models.Revision] | Any`
     :   The type of the None singleton.
 
+<a id="RevisionsListResultMeta"></a>
+
 `RevisionsListResultMeta(**data: Any)`
 :   Metadata for revisions.Action.LIST operation
     
@@ -2126,6 +2234,8 @@ Classes
 
     `next_page_token: str | Any | None`
     :   The type of the None singleton.
+
+<a id="StartPageToken"></a>
 
 `StartPageToken(**data: Any)`
 :   The starting page token for listing changes
@@ -2151,6 +2261,8 @@ Classes
 
     `start_page_token: str | Any`
     :   The type of the None singleton.
+
+<a id="User"></a>
 
 `User(**data: Any)`
 :   Information about a Drive user

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/google_drive/types.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/google_drive/types.md
@@ -10,6 +10,8 @@ Type definitions for google-drive connector.
 Classes
 -------
 
+<a id="AboutGetParams"></a>
+
 `AboutGetParams(*args, **kwargs)`
 :   Parameters for about.get operation
 
@@ -21,6 +23,8 @@ Classes
 
     `fields: str`
     :   The type of the None singleton.
+
+<a id="ChangesListParams"></a>
 
 `ChangesListParams(*args, **kwargs)`
 :   Parameters for changes.list operation
@@ -55,6 +59,8 @@ Classes
     `supports_all_drives: bool`
     :   The type of the None singleton.
 
+<a id="ChangesStartPageTokenGetParams"></a>
+
 `ChangesStartPageTokenGetParams(*args, **kwargs)`
 :   Parameters for changes_start_page_token.get operation
 
@@ -69,6 +75,8 @@ Classes
 
     `supports_all_drives: bool`
     :   The type of the None singleton.
+
+<a id="CommentsGetParams"></a>
 
 `CommentsGetParams(*args, **kwargs)`
 :   Parameters for comments.get operation
@@ -90,6 +98,8 @@ Classes
 
     `include_deleted: bool`
     :   The type of the None singleton.
+
+<a id="CommentsListParams"></a>
 
 `CommentsListParams(*args, **kwargs)`
 :   Parameters for comments.list operation
@@ -118,6 +128,8 @@ Classes
     `start_modified_time: str`
     :   The type of the None singleton.
 
+<a id="DrivesGetParams"></a>
+
 `DrivesGetParams(*args, **kwargs)`
 :   Parameters for drives.get operation
 
@@ -132,6 +144,8 @@ Classes
 
     `use_domain_admin_access: bool`
     :   The type of the None singleton.
+
+<a id="DrivesListParams"></a>
 
 `DrivesListParams(*args, **kwargs)`
 :   Parameters for drives.list operation
@@ -154,6 +168,8 @@ Classes
     `use_domain_admin_access: bool`
     :   The type of the None singleton.
 
+<a id="FilesCreateParams"></a>
+
 `FilesCreateParams(*args, **kwargs)`
 :   Parameters for files.create operation
 
@@ -175,6 +191,8 @@ Classes
     `parents: list[str]`
     :   The type of the None singleton.
 
+<a id="FilesDeleteParams"></a>
+
 `FilesDeleteParams(*args, **kwargs)`
 :   Parameters for files.delete operation
 
@@ -189,6 +207,8 @@ Classes
 
     `supports_all_drives: bool`
     :   The type of the None singleton.
+
+<a id="FilesDownloadParams"></a>
 
 `FilesDownloadParams(*args, **kwargs)`
 :   Parameters for files.download operation
@@ -214,6 +234,8 @@ Classes
     `supports_all_drives: bool`
     :   The type of the None singleton.
 
+<a id="FilesExportDownloadParams"></a>
+
 `FilesExportDownloadParams(*args, **kwargs)`
 :   Parameters for files_export.download operation
 
@@ -232,6 +254,8 @@ Classes
     `range_header: str`
     :   The type of the None singleton.
 
+<a id="FilesGetParams"></a>
+
 `FilesGetParams(*args, **kwargs)`
 :   Parameters for files.get operation
 
@@ -249,6 +273,8 @@ Classes
 
     `supports_all_drives: bool`
     :   The type of the None singleton.
+
+<a id="FilesListParams"></a>
 
 `FilesListParams(*args, **kwargs)`
 :   Parameters for files.list operation
@@ -289,6 +315,8 @@ Classes
     `supports_all_drives: bool`
     :   The type of the None singleton.
 
+<a id="FilesUpdateParams"></a>
+
 `FilesUpdateParams(*args, **kwargs)`
 :   Parameters for files.update operation
 
@@ -318,6 +346,8 @@ Classes
 
     `supports_all_drives: bool`
     :   The type of the None singleton.
+
+<a id="FilesUploadCreateParams"></a>
 
 `FilesUploadCreateParams(*args, **kwargs)`
 :   Parameters for files_upload.create operation
@@ -352,6 +382,8 @@ Classes
     `upload_type: str`
     :   The type of the None singleton.
 
+<a id="PermissionsGetParams"></a>
+
 `PermissionsGetParams(*args, **kwargs)`
 :   Parameters for permissions.get operation
 
@@ -372,6 +404,8 @@ Classes
 
     `use_domain_admin_access: bool`
     :   The type of the None singleton.
+
+<a id="PermissionsListParams"></a>
 
 `PermissionsListParams(*args, **kwargs)`
 :   Parameters for permissions.list operation
@@ -397,6 +431,8 @@ Classes
     `use_domain_admin_access: bool`
     :   The type of the None singleton.
 
+<a id="RepliesGetParams"></a>
+
 `RepliesGetParams(*args, **kwargs)`
 :   Parameters for replies.get operation
 
@@ -420,6 +456,8 @@ Classes
 
     `reply_id: str`
     :   The type of the None singleton.
+
+<a id="RepliesListParams"></a>
 
 `RepliesListParams(*args, **kwargs)`
 :   Parameters for replies.list operation
@@ -448,6 +486,8 @@ Classes
     `page_token: str`
     :   The type of the None singleton.
 
+<a id="RevisionsGetParams"></a>
+
 `RevisionsGetParams(*args, **kwargs)`
 :   Parameters for revisions.get operation
 
@@ -462,6 +502,8 @@ Classes
 
     `revision_id: str`
     :   The type of the None singleton.
+
+<a id="RevisionsListParams"></a>
 
 `RevisionsListParams(*args, **kwargs)`
 :   Parameters for revisions.list operation

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/google_search_console/connector.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/google_search_console/connector.md
@@ -10,6 +10,8 @@ Google-Search-Console connector.
 Classes
 -------
 
+<a id="GoogleSearchConsoleConnector"></a>
+
 `GoogleSearchConsoleConnector(auth_config: GoogleSearchConsoleAuthConfig | AirbyteAuthConfig | BaseModel | None = None, on_token_refresh: Any | None = None)`
 :   Type-safe Google-Search-Console API connector.
     
@@ -266,6 +268,8 @@ Classes
             for entity in entities:
                 print(f"\{entity['entity_name']\}: \{entity['available_actions']\}")
 
+<a id="SearchAnalyticsAllFieldsQuery"></a>
+
 `SearchAnalyticsAllFieldsQuery(connector: GoogleSearchConsoleConnector)`
 :   Query class for SearchAnalyticsAllFields entity operations.
     
@@ -328,6 +332,8 @@ Classes
         Returns:
             SearchAnalyticsAllFieldsListResult
 
+<a id="SearchAnalyticsByCountryQuery"></a>
+
 `SearchAnalyticsByCountryQuery(connector: GoogleSearchConsoleConnector)`
 :   Query class for SearchAnalyticsByCountry entity operations.
     
@@ -387,6 +393,8 @@ Classes
         Returns:
             SearchAnalyticsByCountryListResult
 
+<a id="SearchAnalyticsByDateQuery"></a>
+
 `SearchAnalyticsByDateQuery(connector: GoogleSearchConsoleConnector)`
 :   Query class for SearchAnalyticsByDate entity operations.
     
@@ -444,6 +452,8 @@ Classes
         
         Returns:
             SearchAnalyticsByDateListResult
+
+<a id="SearchAnalyticsByDeviceQuery"></a>
 
 `SearchAnalyticsByDeviceQuery(connector: GoogleSearchConsoleConnector)`
 :   Query class for SearchAnalyticsByDevice entity operations.
@@ -504,6 +514,8 @@ Classes
         Returns:
             SearchAnalyticsByDeviceListResult
 
+<a id="SearchAnalyticsByPageQuery"></a>
+
 `SearchAnalyticsByPageQuery(connector: GoogleSearchConsoleConnector)`
 :   Query class for SearchAnalyticsByPage entity operations.
     
@@ -563,6 +575,8 @@ Classes
         Returns:
             SearchAnalyticsByPageListResult
 
+<a id="SearchAnalyticsByQueryQuery"></a>
+
 `SearchAnalyticsByQueryQuery(connector: GoogleSearchConsoleConnector)`
 :   Query class for SearchAnalyticsByQuery entity operations.
     
@@ -621,6 +635,8 @@ Classes
         
         Returns:
             SearchAnalyticsByQueryListResult
+
+<a id="SitemapsQuery"></a>
 
 `SitemapsQuery(connector: GoogleSearchConsoleConnector)`
 :   Query class for Sitemaps entity operations.
@@ -682,6 +698,8 @@ Classes
         
         Returns:
             SitemapsListResult
+
+<a id="SitesQuery"></a>
 
 `SitesQuery(connector: GoogleSearchConsoleConnector)`
 :   Query class for Sites entity operations.

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/google_search_console/index.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/google_search_console/index.md
@@ -19,6 +19,8 @@ Sub-modules
 Classes
 -------
 
+<a id="AirbyteAuthConfig"></a>
+
 `AirbyteAuthConfig(**data: Any)`
 :   Authentication configuration for Airbyte hosted mode execution.
     
@@ -87,6 +89,8 @@ Classes
     `workspace_name: str | None`
     :   The type of the None singleton.
 
+<a id="AirbyteSearchMeta"></a>
+
 `AirbyteSearchMeta(**data: Any)`
 :   Pagination metadata for search responses.
     
@@ -114,6 +118,8 @@ Classes
 
     `took_ms: int | None`
     :   Time taken to execute the search in milliseconds.
+
+<a id="AirbyteSearchResult"></a>
 
 `AirbyteSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -152,6 +158,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="SearchAnalyticsAllFieldsSearchResult"></a>
+
 `SearchAnalyticsAllFieldsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -167,6 +175,8 @@ Classes
     * airbyte_agent_sdk.connectors.google_search_console.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="SearchAnalyticsByCountrySearchResult"></a>
 
 `SearchAnalyticsByCountrySearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -184,6 +194,8 @@ Classes
     * pydantic.main.BaseModel
     * typing.Generic
 
+<a id="SearchAnalyticsByDateSearchResult"></a>
+
 `SearchAnalyticsByDateSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -199,6 +211,8 @@ Classes
     * airbyte_agent_sdk.connectors.google_search_console.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="SearchAnalyticsByDeviceSearchResult"></a>
 
 `SearchAnalyticsByDeviceSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -216,6 +230,8 @@ Classes
     * pydantic.main.BaseModel
     * typing.Generic
 
+<a id="SearchAnalyticsByPageSearchResult"></a>
+
 `SearchAnalyticsByPageSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -231,6 +247,8 @@ Classes
     * airbyte_agent_sdk.connectors.google_search_console.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="SearchAnalyticsByQuerySearchResult"></a>
 
 `SearchAnalyticsByQuerySearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -248,6 +266,8 @@ Classes
     * pydantic.main.BaseModel
     * typing.Generic
 
+<a id="SitemapsSearchResult"></a>
+
 `SitemapsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -264,6 +284,8 @@ Classes
     * pydantic.main.BaseModel
     * typing.Generic
 
+<a id="SitesSearchResult"></a>
+
 `SitesSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -279,6 +301,8 @@ Classes
     * airbyte_agent_sdk.connectors.google_search_console.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="GoogleSearchConsoleAuthConfig"></a>
 
 `GoogleSearchConsoleAuthConfig(**data: Any)`
 :   OAuth2 Authentication
@@ -307,6 +331,8 @@ Classes
 
     `refresh_token: str`
     :   The refresh token for obtaining new access tokens.
+
+<a id="GoogleSearchConsoleConnector"></a>
 
 `GoogleSearchConsoleConnector(auth_config: GoogleSearchConsoleAuthConfig | AirbyteAuthConfig | BaseModel | None = None, on_token_refresh: Any | None = None)`
 :   Type-safe Google-Search-Console API connector.
@@ -564,6 +590,8 @@ Classes
             for entity in entities:
                 print(f"\{entity['entity_name']\}: \{entity['available_actions']\}")
 
+<a id="GoogleSearchConsoleReplicationConfig"></a>
+
 `GoogleSearchConsoleReplicationConfig(**data: Any)`
 :   Replication Configuration - Settings for data replication from Google Search Console.
     
@@ -588,6 +616,8 @@ Classes
 
     `start_date: str | None`
     :   UTC date in the format YYYY-MM-DD. Any data before this date will not be replicated.
+
+<a id="SearchAnalyticsAllFieldsSearchData"></a>
 
 `SearchAnalyticsAllFieldsSearchData(**data: Any)`
 :   Search result data for search_analytics_all_fields entity.
@@ -641,6 +671,8 @@ Classes
     `site_url: str | None`
     :   The URL of the site from which the data originates
 
+<a id="SearchAnalyticsByCountrySearchData"></a>
+
 `SearchAnalyticsByCountrySearchData(**data: Any)`
 :   Search result data for search_analytics_by_country entity.
     
@@ -684,6 +716,8 @@ Classes
     `site_url: str | None`
     :   The URL of the site for which the search analytics data is being reported
 
+<a id="SearchAnalyticsByDateSearchData"></a>
+
 `SearchAnalyticsByDateSearchData(**data: Any)`
 :   Search result data for search_analytics_by_date entity.
     
@@ -723,6 +757,8 @@ Classes
 
     `site_url: str | None`
     :   The URL of the site for which the search analytics data is being reported
+
+<a id="SearchAnalyticsByDeviceSearchData"></a>
 
 `SearchAnalyticsByDeviceSearchData(**data: Any)`
 :   Search result data for search_analytics_by_device entity.
@@ -767,6 +803,8 @@ Classes
     `site_url: str | None`
     :   The URL of the site for which search analytics data is being provided
 
+<a id="SearchAnalyticsByPageSearchData"></a>
+
 `SearchAnalyticsByPageSearchData(**data: Any)`
 :   Search result data for search_analytics_by_page entity.
     
@@ -810,6 +848,8 @@ Classes
     `site_url: str | None`
     :   The URL of the site for which the search analytics data is being reported
 
+<a id="SearchAnalyticsByQuerySearchData"></a>
+
 `SearchAnalyticsByQuerySearchData(**data: Any)`
 :   Search result data for search_analytics_by_query entity.
     
@@ -852,6 +892,8 @@ Classes
 
     `site_url: str | None`
     :   The URL of the site for which the search analytics data is captured
+
+<a id="SitemapsSearchData"></a>
 
 `SitemapsSearchData(**data: Any)`
 :   Search result data for sitemaps entity.
@@ -898,6 +940,8 @@ Classes
 
     `warnings: str | None`
     :   Warnings encountered while processing the sitemaps
+
+<a id="SitesSearchData"></a>
 
 `SitesSearchData(**data: Any)`
 :   Search result data for sites entity.

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/google_search_console/models.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/google_search_console/models.md
@@ -13,6 +13,8 @@ and response envelope types.
 Classes
 -------
 
+<a id="AirbyteSearchMeta"></a>
+
 `AirbyteSearchMeta(**data: Any)`
 :   Pagination metadata for search responses.
     
@@ -40,6 +42,8 @@ Classes
 
     `took_ms: int | None`
     :   Time taken to execute the search in milliseconds.
+
+<a id="AirbyteSearchResult"></a>
 
 `AirbyteSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -99,6 +103,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="SearchAnalyticsAllFieldsSearchResult"></a>
+
 `SearchAnalyticsAllFieldsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -135,6 +141,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="SearchAnalyticsByCountrySearchResult"></a>
 
 `SearchAnalyticsByCountrySearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -173,6 +181,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="SearchAnalyticsByDateSearchResult"></a>
+
 `SearchAnalyticsByDateSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -209,6 +219,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="SearchAnalyticsByDeviceSearchResult"></a>
 
 `SearchAnalyticsByDeviceSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -247,6 +259,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="SearchAnalyticsByPageSearchResult"></a>
+
 `SearchAnalyticsByPageSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -283,6 +297,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="SearchAnalyticsByQuerySearchResult"></a>
 
 `SearchAnalyticsByQuerySearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -321,6 +337,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="SitemapsSearchResult"></a>
+
 `SitemapsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -358,6 +376,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="SitesSearchResult"></a>
+
 `SitesSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -373,6 +393,8 @@ Classes
     * airbyte_agent_sdk.connectors.google_search_console.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="GoogleSearchConsoleAuthConfig"></a>
 
 `GoogleSearchConsoleAuthConfig(**data: Any)`
 :   OAuth2 Authentication
@@ -401,6 +423,8 @@ Classes
 
     `refresh_token: str`
     :   The refresh token for obtaining new access tokens.
+
+<a id="GoogleSearchConsoleCheckResult"></a>
 
 `GoogleSearchConsoleCheckResult(**data: Any)`
 :   Result of a health check operation.
@@ -435,6 +459,8 @@ Classes
     `status: str`
     :   Health check status: 'healthy' or 'unhealthy'.
 
+<a id="GoogleSearchConsoleExecuteResult"></a>
+
 `GoogleSearchConsoleExecuteResult(**data: Any)`
 :   Response envelope with data only.
     
@@ -465,6 +491,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="GoogleSearchConsoleExecuteResultWithMeta"></a>
 
 `GoogleSearchConsoleExecuteResultWithMeta(**data: Any)`
 :   Response envelope with data and metadata.
@@ -522,6 +550,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="SearchAnalyticsAllFieldsListResult"></a>
+
 `SearchAnalyticsAllFieldsListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -564,6 +594,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="SearchAnalyticsByCountryListResult"></a>
 
 `SearchAnalyticsByCountryListResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -608,6 +640,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="SearchAnalyticsByDateListResult"></a>
+
 `SearchAnalyticsByDateListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -650,6 +684,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="SearchAnalyticsByDeviceListResult"></a>
 
 `SearchAnalyticsByDeviceListResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -694,6 +730,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="SearchAnalyticsByPageListResult"></a>
+
 `SearchAnalyticsByPageListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -737,6 +775,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="SearchAnalyticsByQueryListResult"></a>
+
 `SearchAnalyticsByQueryListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -779,6 +819,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="SitesListResult"></a>
+
 `SitesListResult(**data: Any)`
 :   Response envelope with data only.
     
@@ -820,6 +862,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="SitemapsListResult"></a>
+
 `SitemapsListResult(**data: Any)`
 :   Response envelope with data only.
     
@@ -837,6 +881,8 @@ Classes
     * airbyte_agent_sdk.connectors.google_search_console.models.GoogleSearchConsoleExecuteResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="GoogleSearchConsoleReplicationConfig"></a>
 
 `GoogleSearchConsoleReplicationConfig(**data: Any)`
 :   Replication Configuration - Settings for data replication from Google Search Console.
@@ -863,6 +909,8 @@ Classes
     `start_date: str | None`
     :   UTC date in the format YYYY-MM-DD. Any data before this date will not be replicated.
 
+<a id="SearchAnalyticsAllFieldsListResultMeta"></a>
+
 `SearchAnalyticsAllFieldsListResultMeta(**data: Any)`
 :   Metadata for search_analytics_all_fields.Action.LIST operation
     
@@ -884,6 +932,8 @@ Classes
 
     `response_aggregation_type: str | Any | None`
     :   The type of the None singleton.
+
+<a id="SearchAnalyticsAllFieldsRequest"></a>
 
 `SearchAnalyticsAllFieldsRequest(**data: Any)`
 :   Request body for search analytics query grouped by all dimensions.
@@ -927,6 +977,8 @@ Classes
 
     `type_: str | Any`
     :   The type of the None singleton.
+
+<a id="SearchAnalyticsAllFieldsSearchData"></a>
 
 `SearchAnalyticsAllFieldsSearchData(**data: Any)`
 :   Search result data for search_analytics_all_fields entity.
@@ -980,6 +1032,8 @@ Classes
     `site_url: str | None`
     :   The URL of the site from which the data originates
 
+<a id="SearchAnalyticsByCountryListResultMeta"></a>
+
 `SearchAnalyticsByCountryListResultMeta(**data: Any)`
 :   Metadata for search_analytics_by_country.Action.LIST operation
     
@@ -1001,6 +1055,8 @@ Classes
 
     `response_aggregation_type: str | Any | None`
     :   The type of the None singleton.
+
+<a id="SearchAnalyticsByCountryRequest"></a>
 
 `SearchAnalyticsByCountryRequest(**data: Any)`
 :   Request body for search analytics query grouped by date and country.
@@ -1045,6 +1101,8 @@ Classes
     `type_: str | Any`
     :   The type of the None singleton.
 
+<a id="SearchAnalyticsByCountrySearchData"></a>
+
 `SearchAnalyticsByCountrySearchData(**data: Any)`
 :   Search result data for search_analytics_by_country entity.
     
@@ -1088,6 +1146,8 @@ Classes
     `site_url: str | None`
     :   The URL of the site for which the search analytics data is being reported
 
+<a id="SearchAnalyticsByDateListResultMeta"></a>
+
 `SearchAnalyticsByDateListResultMeta(**data: Any)`
 :   Metadata for search_analytics_by_date.Action.LIST operation
     
@@ -1109,6 +1169,8 @@ Classes
 
     `response_aggregation_type: str | Any | None`
     :   The type of the None singleton.
+
+<a id="SearchAnalyticsByDateRequest"></a>
 
 `SearchAnalyticsByDateRequest(**data: Any)`
 :   Request body for search analytics query grouped by date.
@@ -1153,6 +1215,8 @@ Classes
     `type_: str | Any`
     :   The type of the None singleton.
 
+<a id="SearchAnalyticsByDateSearchData"></a>
+
 `SearchAnalyticsByDateSearchData(**data: Any)`
 :   Search result data for search_analytics_by_date entity.
     
@@ -1193,6 +1257,8 @@ Classes
     `site_url: str | None`
     :   The URL of the site for which the search analytics data is being reported
 
+<a id="SearchAnalyticsByDeviceListResultMeta"></a>
+
 `SearchAnalyticsByDeviceListResultMeta(**data: Any)`
 :   Metadata for search_analytics_by_device.Action.LIST operation
     
@@ -1214,6 +1280,8 @@ Classes
 
     `response_aggregation_type: str | Any | None`
     :   The type of the None singleton.
+
+<a id="SearchAnalyticsByDeviceRequest"></a>
 
 `SearchAnalyticsByDeviceRequest(**data: Any)`
 :   Request body for search analytics query grouped by date and device.
@@ -1258,6 +1326,8 @@ Classes
     `type_: str | Any`
     :   The type of the None singleton.
 
+<a id="SearchAnalyticsByDeviceSearchData"></a>
+
 `SearchAnalyticsByDeviceSearchData(**data: Any)`
 :   Search result data for search_analytics_by_device entity.
     
@@ -1301,6 +1371,8 @@ Classes
     `site_url: str | None`
     :   The URL of the site for which search analytics data is being provided
 
+<a id="SearchAnalyticsByPageListResultMeta"></a>
+
 `SearchAnalyticsByPageListResultMeta(**data: Any)`
 :   Metadata for search_analytics_by_page.Action.LIST operation
     
@@ -1322,6 +1394,8 @@ Classes
 
     `response_aggregation_type: str | Any | None`
     :   The type of the None singleton.
+
+<a id="SearchAnalyticsByPageRequest"></a>
 
 `SearchAnalyticsByPageRequest(**data: Any)`
 :   Request body for search analytics query grouped by date and page.
@@ -1366,6 +1440,8 @@ Classes
     `type_: str | Any`
     :   The type of the None singleton.
 
+<a id="SearchAnalyticsByPageSearchData"></a>
+
 `SearchAnalyticsByPageSearchData(**data: Any)`
 :   Search result data for search_analytics_by_page entity.
     
@@ -1409,6 +1485,8 @@ Classes
     `site_url: str | None`
     :   The URL of the site for which the search analytics data is being reported
 
+<a id="SearchAnalyticsByQueryListResultMeta"></a>
+
 `SearchAnalyticsByQueryListResultMeta(**data: Any)`
 :   Metadata for search_analytics_by_query.Action.LIST operation
     
@@ -1430,6 +1508,8 @@ Classes
 
     `response_aggregation_type: str | Any | None`
     :   The type of the None singleton.
+
+<a id="SearchAnalyticsByQueryRequest"></a>
 
 `SearchAnalyticsByQueryRequest(**data: Any)`
 :   Request body for search analytics query grouped by date and query.
@@ -1474,6 +1554,8 @@ Classes
     `type_: str | Any`
     :   The type of the None singleton.
 
+<a id="SearchAnalyticsByQuerySearchData"></a>
+
 `SearchAnalyticsByQuerySearchData(**data: Any)`
 :   Search result data for search_analytics_by_query entity.
     
@@ -1517,6 +1599,8 @@ Classes
     `site_url: str | None`
     :   The URL of the site for which the search analytics data is captured
 
+<a id="SearchAnalyticsResponse"></a>
+
 `SearchAnalyticsResponse(**data: Any)`
 :   Response containing search analytics data.
     
@@ -1541,6 +1625,8 @@ Classes
 
     `rows: list[airbyte_agent_sdk.connectors.google_search_console.models.SearchAnalyticsRow] | Any`
     :   The type of the None singleton.
+
+<a id="SearchAnalyticsRow"></a>
 
 `SearchAnalyticsRow(**data: Any)`
 :   A row of search analytics data.
@@ -1576,6 +1662,8 @@ Classes
     `position: float | Any | None`
     :   The type of the None singleton.
 
+<a id="Site"></a>
+
 `Site(**data: Any)`
 :   A Search Console site resource.
     
@@ -1600,6 +1688,8 @@ Classes
 
     `site_url: str | Any | None`
     :   The type of the None singleton.
+
+<a id="Sitemap"></a>
 
 `Sitemap(**data: Any)`
 :   A sitemap resource with details about a submitted sitemap.
@@ -1647,6 +1737,8 @@ Classes
     `warnings: str | Any | None`
     :   The type of the None singleton.
 
+<a id="SitemapContent"></a>
+
 `SitemapContent(**data: Any)`
 :   Information about a specific content type in a sitemap.
     
@@ -1675,6 +1767,8 @@ Classes
     `type_: str | Any | None`
     :   The type of the None singleton.
 
+<a id="SitemapsList"></a>
+
 `SitemapsList(**data: Any)`
 :   Response containing a list of sitemaps.
     
@@ -1696,6 +1790,8 @@ Classes
 
     `sitemap: list[airbyte_agent_sdk.connectors.google_search_console.models.Sitemap] | Any`
     :   The type of the None singleton.
+
+<a id="SitemapsSearchData"></a>
 
 `SitemapsSearchData(**data: Any)`
 :   Search result data for sitemaps entity.
@@ -1743,6 +1839,8 @@ Classes
     `warnings: str | None`
     :   Warnings encountered while processing the sitemaps
 
+<a id="SitesList"></a>
+
 `SitesList(**data: Any)`
 :   Response containing a list of sites.
     
@@ -1764,6 +1862,8 @@ Classes
 
     `site_entry: list[airbyte_agent_sdk.connectors.google_search_console.models.Site] | Any`
     :   The type of the None singleton.
+
+<a id="SitesSearchData"></a>
 
 `SitesSearchData(**data: Any)`
 :   Search result data for sites entity.

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/google_search_console/types.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/google_search_console/types.md
@@ -10,6 +10,8 @@ Type definitions for google-search-console connector.
 Classes
 -------
 
+<a id="AirbyteSearchParams"></a>
+
 `AirbyteSearchParams(*args, **kwargs)`
 :   Parameters for Airbyte cache search operations (generic, use entity-specific query types for better type hints).
 
@@ -31,6 +33,8 @@ Classes
     `query: dict[str, typing.Any]`
     :   The type of the None singleton.
 
+<a id="SearchAnalyticsAllFieldsAndCondition"></a>
+
 `SearchAnalyticsAllFieldsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -51,6 +55,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsAllFieldsEqCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsAllFieldsNeqCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsAllFieldsGtCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsAllFieldsGteCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsAllFieldsLtCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsAllFieldsLteCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsAllFieldsInCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsAllFieldsLikeCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsAllFieldsFuzzyCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsAllFieldsKeywordCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsAllFieldsContainsCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsAllFieldsNotCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsAllFieldsAndCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsAllFieldsOrCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsAllFieldsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="SearchAnalyticsAllFieldsAnyCondition"></a>
+
 `SearchAnalyticsAllFieldsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -70,6 +76,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsAllFieldsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="SearchAnalyticsAllFieldsAnyValueFilter"></a>
 
 `SearchAnalyticsAllFieldsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -113,6 +121,8 @@ Classes
     `site_url: Any`
     :   The URL of the site from which the data originates
 
+<a id="SearchAnalyticsAllFieldsContainsCondition"></a>
+
 `SearchAnalyticsAllFieldsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -124,6 +134,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsAllFieldsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="SearchAnalyticsAllFieldsEqCondition"></a>
 
 `SearchAnalyticsAllFieldsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -137,6 +149,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsAllFieldsSearchFilter`
     :   The type of the None singleton.
 
+<a id="SearchAnalyticsAllFieldsFuzzyCondition"></a>
+
 `SearchAnalyticsAllFieldsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -148,6 +162,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsAllFieldsStringFilter`
     :   The type of the None singleton.
+
+<a id="SearchAnalyticsAllFieldsGtCondition"></a>
 
 `SearchAnalyticsAllFieldsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
@@ -161,6 +177,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsAllFieldsSearchFilter`
     :   The type of the None singleton.
 
+<a id="SearchAnalyticsAllFieldsGteCondition"></a>
+
 `SearchAnalyticsAllFieldsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -172,6 +190,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsAllFieldsSearchFilter`
     :   The type of the None singleton.
+
+<a id="SearchAnalyticsAllFieldsInCondition"></a>
 
 `SearchAnalyticsAllFieldsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -192,6 +212,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsAllFieldsInFilter`
     :   The type of the None singleton.
+
+<a id="SearchAnalyticsAllFieldsInFilter"></a>
 
 `SearchAnalyticsAllFieldsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -235,6 +257,8 @@ Classes
     `site_url: list[str]`
     :   The URL of the site from which the data originates
 
+<a id="SearchAnalyticsAllFieldsKeywordCondition"></a>
+
 `SearchAnalyticsAllFieldsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -247,6 +271,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsAllFieldsStringFilter`
     :   The type of the None singleton.
 
+<a id="SearchAnalyticsAllFieldsLikeCondition"></a>
+
 `SearchAnalyticsAllFieldsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -258,6 +284,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsAllFieldsStringFilter`
     :   The type of the None singleton.
+
+<a id="SearchAnalyticsAllFieldsListParams"></a>
 
 `SearchAnalyticsAllFieldsListParams(*args, **kwargs)`
 :   Parameters for search_analytics_all_fields.list operation
@@ -295,6 +323,8 @@ Classes
     `type: str`
     :   The type of the None singleton.
 
+<a id="SearchAnalyticsAllFieldsLtCondition"></a>
+
 `SearchAnalyticsAllFieldsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -306,6 +336,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsAllFieldsSearchFilter`
     :   The type of the None singleton.
+
+<a id="SearchAnalyticsAllFieldsLteCondition"></a>
 
 `SearchAnalyticsAllFieldsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -319,6 +351,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsAllFieldsSearchFilter`
     :   The type of the None singleton.
 
+<a id="SearchAnalyticsAllFieldsNeqCondition"></a>
+
 `SearchAnalyticsAllFieldsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -330,6 +364,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsAllFieldsSearchFilter`
     :   The type of the None singleton.
+
+<a id="SearchAnalyticsAllFieldsNotCondition"></a>
 
 `SearchAnalyticsAllFieldsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -351,6 +387,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsAllFieldsEqCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsAllFieldsNeqCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsAllFieldsGtCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsAllFieldsGteCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsAllFieldsLtCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsAllFieldsLteCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsAllFieldsInCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsAllFieldsLikeCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsAllFieldsFuzzyCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsAllFieldsKeywordCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsAllFieldsContainsCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsAllFieldsNotCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsAllFieldsAndCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsAllFieldsOrCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsAllFieldsAnyCondition`
     :   The type of the None singleton.
 
+<a id="SearchAnalyticsAllFieldsOrCondition"></a>
+
 `SearchAnalyticsAllFieldsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -370,6 +408,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsAllFieldsEqCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsAllFieldsNeqCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsAllFieldsGtCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsAllFieldsGteCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsAllFieldsLtCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsAllFieldsLteCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsAllFieldsInCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsAllFieldsLikeCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsAllFieldsFuzzyCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsAllFieldsKeywordCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsAllFieldsContainsCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsAllFieldsNotCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsAllFieldsAndCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsAllFieldsOrCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsAllFieldsAnyCondition]`
     :   The type of the None singleton.
+
+<a id="SearchAnalyticsAllFieldsSearchFilter"></a>
 
 `SearchAnalyticsAllFieldsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering search_analytics_all_fields search queries.
@@ -413,6 +453,8 @@ Classes
     `site_url: str | None`
     :   The URL of the site from which the data originates
 
+<a id="SearchAnalyticsAllFieldsSearchQuery"></a>
+
 `SearchAnalyticsAllFieldsSearchQuery(*args, **kwargs)`
 :   Search query for search_analytics_all_fields entity.
 
@@ -427,6 +469,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsAllFieldsSortFilter]`
     :   The type of the None singleton.
+
+<a id="SearchAnalyticsAllFieldsSortFilter"></a>
 
 `SearchAnalyticsAllFieldsSortFilter(*args, **kwargs)`
 :   Available fields for sorting search_analytics_all_fields search results.
@@ -470,6 +514,8 @@ Classes
     `site_url: Literal['asc', 'desc']`
     :   The URL of the site from which the data originates
 
+<a id="SearchAnalyticsAllFieldsStringFilter"></a>
+
 `SearchAnalyticsAllFieldsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -512,6 +558,8 @@ Classes
     `site_url: str`
     :   The URL of the site from which the data originates
 
+<a id="SearchAnalyticsByCountryAndCondition"></a>
+
 `SearchAnalyticsByCountryAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -532,6 +580,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByCountryEqCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByCountryNeqCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByCountryGtCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByCountryGteCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByCountryLtCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByCountryLteCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByCountryInCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByCountryLikeCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByCountryFuzzyCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByCountryKeywordCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByCountryContainsCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByCountryNotCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByCountryAndCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByCountryOrCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByCountryAnyCondition]`
     :   The type of the None singleton.
 
+<a id="SearchAnalyticsByCountryAnyCondition"></a>
+
 `SearchAnalyticsByCountryAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -551,6 +601,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByCountryAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="SearchAnalyticsByCountryAnyValueFilter"></a>
 
 `SearchAnalyticsByCountryAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -585,6 +637,8 @@ Classes
     `site_url: Any`
     :   The URL of the site for which the search analytics data is being reported
 
+<a id="SearchAnalyticsByCountryContainsCondition"></a>
+
 `SearchAnalyticsByCountryContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -596,6 +650,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByCountryAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="SearchAnalyticsByCountryEqCondition"></a>
 
 `SearchAnalyticsByCountryEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -609,6 +665,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByCountrySearchFilter`
     :   The type of the None singleton.
 
+<a id="SearchAnalyticsByCountryFuzzyCondition"></a>
+
 `SearchAnalyticsByCountryFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -620,6 +678,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByCountryStringFilter`
     :   The type of the None singleton.
+
+<a id="SearchAnalyticsByCountryGtCondition"></a>
 
 `SearchAnalyticsByCountryGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
@@ -633,6 +693,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByCountrySearchFilter`
     :   The type of the None singleton.
 
+<a id="SearchAnalyticsByCountryGteCondition"></a>
+
 `SearchAnalyticsByCountryGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -644,6 +706,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByCountrySearchFilter`
     :   The type of the None singleton.
+
+<a id="SearchAnalyticsByCountryInCondition"></a>
 
 `SearchAnalyticsByCountryInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -664,6 +728,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByCountryInFilter`
     :   The type of the None singleton.
+
+<a id="SearchAnalyticsByCountryInFilter"></a>
 
 `SearchAnalyticsByCountryInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -698,6 +764,8 @@ Classes
     `site_url: list[str]`
     :   The URL of the site for which the search analytics data is being reported
 
+<a id="SearchAnalyticsByCountryKeywordCondition"></a>
+
 `SearchAnalyticsByCountryKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -710,6 +778,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByCountryStringFilter`
     :   The type of the None singleton.
 
+<a id="SearchAnalyticsByCountryLikeCondition"></a>
+
 `SearchAnalyticsByCountryLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -721,6 +791,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByCountryStringFilter`
     :   The type of the None singleton.
+
+<a id="SearchAnalyticsByCountryListParams"></a>
 
 `SearchAnalyticsByCountryListParams(*args, **kwargs)`
 :   Parameters for search_analytics_by_country.list operation
@@ -758,6 +830,8 @@ Classes
     `type: str`
     :   The type of the None singleton.
 
+<a id="SearchAnalyticsByCountryLtCondition"></a>
+
 `SearchAnalyticsByCountryLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -769,6 +843,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByCountrySearchFilter`
     :   The type of the None singleton.
+
+<a id="SearchAnalyticsByCountryLteCondition"></a>
 
 `SearchAnalyticsByCountryLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -782,6 +858,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByCountrySearchFilter`
     :   The type of the None singleton.
 
+<a id="SearchAnalyticsByCountryNeqCondition"></a>
+
 `SearchAnalyticsByCountryNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -793,6 +871,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByCountrySearchFilter`
     :   The type of the None singleton.
+
+<a id="SearchAnalyticsByCountryNotCondition"></a>
 
 `SearchAnalyticsByCountryNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -814,6 +894,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByCountryEqCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByCountryNeqCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByCountryGtCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByCountryGteCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByCountryLtCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByCountryLteCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByCountryInCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByCountryLikeCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByCountryFuzzyCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByCountryKeywordCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByCountryContainsCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByCountryNotCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByCountryAndCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByCountryOrCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByCountryAnyCondition`
     :   The type of the None singleton.
 
+<a id="SearchAnalyticsByCountryOrCondition"></a>
+
 `SearchAnalyticsByCountryOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -833,6 +915,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByCountryEqCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByCountryNeqCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByCountryGtCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByCountryGteCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByCountryLtCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByCountryLteCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByCountryInCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByCountryLikeCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByCountryFuzzyCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByCountryKeywordCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByCountryContainsCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByCountryNotCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByCountryAndCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByCountryOrCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByCountryAnyCondition]`
     :   The type of the None singleton.
+
+<a id="SearchAnalyticsByCountrySearchFilter"></a>
 
 `SearchAnalyticsByCountrySearchFilter(*args, **kwargs)`
 :   Available fields for filtering search_analytics_by_country search queries.
@@ -867,6 +951,8 @@ Classes
     `site_url: str | None`
     :   The URL of the site for which the search analytics data is being reported
 
+<a id="SearchAnalyticsByCountrySearchQuery"></a>
+
 `SearchAnalyticsByCountrySearchQuery(*args, **kwargs)`
 :   Search query for search_analytics_by_country entity.
 
@@ -881,6 +967,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByCountrySortFilter]`
     :   The type of the None singleton.
+
+<a id="SearchAnalyticsByCountrySortFilter"></a>
 
 `SearchAnalyticsByCountrySortFilter(*args, **kwargs)`
 :   Available fields for sorting search_analytics_by_country search results.
@@ -915,6 +1003,8 @@ Classes
     `site_url: Literal['asc', 'desc']`
     :   The URL of the site for which the search analytics data is being reported
 
+<a id="SearchAnalyticsByCountryStringFilter"></a>
+
 `SearchAnalyticsByCountryStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -948,6 +1038,8 @@ Classes
     `site_url: str`
     :   The URL of the site for which the search analytics data is being reported
 
+<a id="SearchAnalyticsByDateAndCondition"></a>
+
 `SearchAnalyticsByDateAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -968,6 +1060,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByDateEqCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByDateNeqCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByDateGtCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByDateGteCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByDateLtCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByDateLteCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByDateInCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByDateLikeCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByDateFuzzyCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByDateKeywordCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByDateContainsCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByDateNotCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByDateAndCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByDateOrCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByDateAnyCondition]`
     :   The type of the None singleton.
 
+<a id="SearchAnalyticsByDateAnyCondition"></a>
+
 `SearchAnalyticsByDateAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -987,6 +1081,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByDateAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="SearchAnalyticsByDateAnyValueFilter"></a>
 
 `SearchAnalyticsByDateAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -1018,6 +1114,8 @@ Classes
     `site_url: Any`
     :   The URL of the site for which the search analytics data is being reported
 
+<a id="SearchAnalyticsByDateContainsCondition"></a>
+
 `SearchAnalyticsByDateContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -1029,6 +1127,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByDateAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="SearchAnalyticsByDateEqCondition"></a>
 
 `SearchAnalyticsByDateEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -1042,6 +1142,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByDateSearchFilter`
     :   The type of the None singleton.
 
+<a id="SearchAnalyticsByDateFuzzyCondition"></a>
+
 `SearchAnalyticsByDateFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -1053,6 +1155,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByDateStringFilter`
     :   The type of the None singleton.
+
+<a id="SearchAnalyticsByDateGtCondition"></a>
 
 `SearchAnalyticsByDateGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
@@ -1066,6 +1170,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByDateSearchFilter`
     :   The type of the None singleton.
 
+<a id="SearchAnalyticsByDateGteCondition"></a>
+
 `SearchAnalyticsByDateGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -1077,6 +1183,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByDateSearchFilter`
     :   The type of the None singleton.
+
+<a id="SearchAnalyticsByDateInCondition"></a>
 
 `SearchAnalyticsByDateInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -1097,6 +1205,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByDateInFilter`
     :   The type of the None singleton.
+
+<a id="SearchAnalyticsByDateInFilter"></a>
 
 `SearchAnalyticsByDateInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -1128,6 +1238,8 @@ Classes
     `site_url: list[str]`
     :   The URL of the site for which the search analytics data is being reported
 
+<a id="SearchAnalyticsByDateKeywordCondition"></a>
+
 `SearchAnalyticsByDateKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -1140,6 +1252,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByDateStringFilter`
     :   The type of the None singleton.
 
+<a id="SearchAnalyticsByDateLikeCondition"></a>
+
 `SearchAnalyticsByDateLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -1151,6 +1265,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByDateStringFilter`
     :   The type of the None singleton.
+
+<a id="SearchAnalyticsByDateListParams"></a>
 
 `SearchAnalyticsByDateListParams(*args, **kwargs)`
 :   Parameters for search_analytics_by_date.list operation
@@ -1188,6 +1304,8 @@ Classes
     `type: str`
     :   The type of the None singleton.
 
+<a id="SearchAnalyticsByDateLtCondition"></a>
+
 `SearchAnalyticsByDateLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -1199,6 +1317,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByDateSearchFilter`
     :   The type of the None singleton.
+
+<a id="SearchAnalyticsByDateLteCondition"></a>
 
 `SearchAnalyticsByDateLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -1212,6 +1332,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByDateSearchFilter`
     :   The type of the None singleton.
 
+<a id="SearchAnalyticsByDateNeqCondition"></a>
+
 `SearchAnalyticsByDateNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -1223,6 +1345,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByDateSearchFilter`
     :   The type of the None singleton.
+
+<a id="SearchAnalyticsByDateNotCondition"></a>
 
 `SearchAnalyticsByDateNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -1244,6 +1368,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByDateEqCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByDateNeqCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByDateGtCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByDateGteCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByDateLtCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByDateLteCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByDateInCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByDateLikeCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByDateFuzzyCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByDateKeywordCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByDateContainsCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByDateNotCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByDateAndCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByDateOrCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByDateAnyCondition`
     :   The type of the None singleton.
 
+<a id="SearchAnalyticsByDateOrCondition"></a>
+
 `SearchAnalyticsByDateOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1263,6 +1389,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByDateEqCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByDateNeqCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByDateGtCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByDateGteCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByDateLtCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByDateLteCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByDateInCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByDateLikeCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByDateFuzzyCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByDateKeywordCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByDateContainsCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByDateNotCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByDateAndCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByDateOrCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByDateAnyCondition]`
     :   The type of the None singleton.
+
+<a id="SearchAnalyticsByDateSearchFilter"></a>
 
 `SearchAnalyticsByDateSearchFilter(*args, **kwargs)`
 :   Available fields for filtering search_analytics_by_date search queries.
@@ -1294,6 +1422,8 @@ Classes
     `site_url: str | None`
     :   The URL of the site for which the search analytics data is being reported
 
+<a id="SearchAnalyticsByDateSearchQuery"></a>
+
 `SearchAnalyticsByDateSearchQuery(*args, **kwargs)`
 :   Search query for search_analytics_by_date entity.
 
@@ -1308,6 +1438,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByDateSortFilter]`
     :   The type of the None singleton.
+
+<a id="SearchAnalyticsByDateSortFilter"></a>
 
 `SearchAnalyticsByDateSortFilter(*args, **kwargs)`
 :   Available fields for sorting search_analytics_by_date search results.
@@ -1339,6 +1471,8 @@ Classes
     `site_url: Literal['asc', 'desc']`
     :   The URL of the site for which the search analytics data is being reported
 
+<a id="SearchAnalyticsByDateStringFilter"></a>
+
 `SearchAnalyticsByDateStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -1369,6 +1503,8 @@ Classes
     `site_url: str`
     :   The URL of the site for which the search analytics data is being reported
 
+<a id="SearchAnalyticsByDeviceAndCondition"></a>
+
 `SearchAnalyticsByDeviceAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1389,6 +1525,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByDeviceEqCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByDeviceNeqCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByDeviceGtCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByDeviceGteCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByDeviceLtCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByDeviceLteCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByDeviceInCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByDeviceLikeCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByDeviceFuzzyCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByDeviceKeywordCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByDeviceContainsCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByDeviceNotCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByDeviceAndCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByDeviceOrCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByDeviceAnyCondition]`
     :   The type of the None singleton.
 
+<a id="SearchAnalyticsByDeviceAnyCondition"></a>
+
 `SearchAnalyticsByDeviceAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1408,6 +1546,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByDeviceAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="SearchAnalyticsByDeviceAnyValueFilter"></a>
 
 `SearchAnalyticsByDeviceAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -1442,6 +1582,8 @@ Classes
     `site_url: Any`
     :   The URL of the site for which search analytics data is being provided
 
+<a id="SearchAnalyticsByDeviceContainsCondition"></a>
+
 `SearchAnalyticsByDeviceContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -1453,6 +1595,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByDeviceAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="SearchAnalyticsByDeviceEqCondition"></a>
 
 `SearchAnalyticsByDeviceEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -1466,6 +1610,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByDeviceSearchFilter`
     :   The type of the None singleton.
 
+<a id="SearchAnalyticsByDeviceFuzzyCondition"></a>
+
 `SearchAnalyticsByDeviceFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -1477,6 +1623,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByDeviceStringFilter`
     :   The type of the None singleton.
+
+<a id="SearchAnalyticsByDeviceGtCondition"></a>
 
 `SearchAnalyticsByDeviceGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
@@ -1490,6 +1638,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByDeviceSearchFilter`
     :   The type of the None singleton.
 
+<a id="SearchAnalyticsByDeviceGteCondition"></a>
+
 `SearchAnalyticsByDeviceGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -1501,6 +1651,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByDeviceSearchFilter`
     :   The type of the None singleton.
+
+<a id="SearchAnalyticsByDeviceInCondition"></a>
 
 `SearchAnalyticsByDeviceInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -1521,6 +1673,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByDeviceInFilter`
     :   The type of the None singleton.
+
+<a id="SearchAnalyticsByDeviceInFilter"></a>
 
 `SearchAnalyticsByDeviceInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -1555,6 +1709,8 @@ Classes
     `site_url: list[str]`
     :   The URL of the site for which search analytics data is being provided
 
+<a id="SearchAnalyticsByDeviceKeywordCondition"></a>
+
 `SearchAnalyticsByDeviceKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -1567,6 +1723,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByDeviceStringFilter`
     :   The type of the None singleton.
 
+<a id="SearchAnalyticsByDeviceLikeCondition"></a>
+
 `SearchAnalyticsByDeviceLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -1578,6 +1736,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByDeviceStringFilter`
     :   The type of the None singleton.
+
+<a id="SearchAnalyticsByDeviceListParams"></a>
 
 `SearchAnalyticsByDeviceListParams(*args, **kwargs)`
 :   Parameters for search_analytics_by_device.list operation
@@ -1615,6 +1775,8 @@ Classes
     `type: str`
     :   The type of the None singleton.
 
+<a id="SearchAnalyticsByDeviceLtCondition"></a>
+
 `SearchAnalyticsByDeviceLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -1626,6 +1788,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByDeviceSearchFilter`
     :   The type of the None singleton.
+
+<a id="SearchAnalyticsByDeviceLteCondition"></a>
 
 `SearchAnalyticsByDeviceLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -1639,6 +1803,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByDeviceSearchFilter`
     :   The type of the None singleton.
 
+<a id="SearchAnalyticsByDeviceNeqCondition"></a>
+
 `SearchAnalyticsByDeviceNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -1650,6 +1816,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByDeviceSearchFilter`
     :   The type of the None singleton.
+
+<a id="SearchAnalyticsByDeviceNotCondition"></a>
 
 `SearchAnalyticsByDeviceNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -1671,6 +1839,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByDeviceEqCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByDeviceNeqCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByDeviceGtCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByDeviceGteCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByDeviceLtCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByDeviceLteCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByDeviceInCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByDeviceLikeCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByDeviceFuzzyCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByDeviceKeywordCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByDeviceContainsCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByDeviceNotCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByDeviceAndCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByDeviceOrCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByDeviceAnyCondition`
     :   The type of the None singleton.
 
+<a id="SearchAnalyticsByDeviceOrCondition"></a>
+
 `SearchAnalyticsByDeviceOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1690,6 +1860,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByDeviceEqCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByDeviceNeqCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByDeviceGtCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByDeviceGteCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByDeviceLtCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByDeviceLteCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByDeviceInCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByDeviceLikeCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByDeviceFuzzyCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByDeviceKeywordCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByDeviceContainsCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByDeviceNotCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByDeviceAndCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByDeviceOrCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByDeviceAnyCondition]`
     :   The type of the None singleton.
+
+<a id="SearchAnalyticsByDeviceSearchFilter"></a>
 
 `SearchAnalyticsByDeviceSearchFilter(*args, **kwargs)`
 :   Available fields for filtering search_analytics_by_device search queries.
@@ -1724,6 +1896,8 @@ Classes
     `site_url: str | None`
     :   The URL of the site for which search analytics data is being provided
 
+<a id="SearchAnalyticsByDeviceSearchQuery"></a>
+
 `SearchAnalyticsByDeviceSearchQuery(*args, **kwargs)`
 :   Search query for search_analytics_by_device entity.
 
@@ -1738,6 +1912,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByDeviceSortFilter]`
     :   The type of the None singleton.
+
+<a id="SearchAnalyticsByDeviceSortFilter"></a>
 
 `SearchAnalyticsByDeviceSortFilter(*args, **kwargs)`
 :   Available fields for sorting search_analytics_by_device search results.
@@ -1772,6 +1948,8 @@ Classes
     `site_url: Literal['asc', 'desc']`
     :   The URL of the site for which search analytics data is being provided
 
+<a id="SearchAnalyticsByDeviceStringFilter"></a>
+
 `SearchAnalyticsByDeviceStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -1805,6 +1983,8 @@ Classes
     `site_url: str`
     :   The URL of the site for which search analytics data is being provided
 
+<a id="SearchAnalyticsByPageAndCondition"></a>
+
 `SearchAnalyticsByPageAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1825,6 +2005,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByPageEqCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByPageNeqCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByPageGtCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByPageGteCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByPageLtCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByPageLteCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByPageInCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByPageLikeCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByPageFuzzyCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByPageKeywordCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByPageContainsCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByPageNotCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByPageAndCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByPageOrCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByPageAnyCondition]`
     :   The type of the None singleton.
 
+<a id="SearchAnalyticsByPageAnyCondition"></a>
+
 `SearchAnalyticsByPageAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1844,6 +2026,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByPageAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="SearchAnalyticsByPageAnyValueFilter"></a>
 
 `SearchAnalyticsByPageAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -1878,6 +2062,8 @@ Classes
     `site_url: Any`
     :   The URL of the site for which the search analytics data is being reported
 
+<a id="SearchAnalyticsByPageContainsCondition"></a>
+
 `SearchAnalyticsByPageContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -1889,6 +2075,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByPageAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="SearchAnalyticsByPageEqCondition"></a>
 
 `SearchAnalyticsByPageEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -1902,6 +2090,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByPageSearchFilter`
     :   The type of the None singleton.
 
+<a id="SearchAnalyticsByPageFuzzyCondition"></a>
+
 `SearchAnalyticsByPageFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -1913,6 +2103,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByPageStringFilter`
     :   The type of the None singleton.
+
+<a id="SearchAnalyticsByPageGtCondition"></a>
 
 `SearchAnalyticsByPageGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
@@ -1926,6 +2118,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByPageSearchFilter`
     :   The type of the None singleton.
 
+<a id="SearchAnalyticsByPageGteCondition"></a>
+
 `SearchAnalyticsByPageGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -1937,6 +2131,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByPageSearchFilter`
     :   The type of the None singleton.
+
+<a id="SearchAnalyticsByPageInCondition"></a>
 
 `SearchAnalyticsByPageInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -1957,6 +2153,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByPageInFilter`
     :   The type of the None singleton.
+
+<a id="SearchAnalyticsByPageInFilter"></a>
 
 `SearchAnalyticsByPageInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -1991,6 +2189,8 @@ Classes
     `site_url: list[str]`
     :   The URL of the site for which the search analytics data is being reported
 
+<a id="SearchAnalyticsByPageKeywordCondition"></a>
+
 `SearchAnalyticsByPageKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -2003,6 +2203,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByPageStringFilter`
     :   The type of the None singleton.
 
+<a id="SearchAnalyticsByPageLikeCondition"></a>
+
 `SearchAnalyticsByPageLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -2014,6 +2216,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByPageStringFilter`
     :   The type of the None singleton.
+
+<a id="SearchAnalyticsByPageListParams"></a>
 
 `SearchAnalyticsByPageListParams(*args, **kwargs)`
 :   Parameters for search_analytics_by_page.list operation
@@ -2051,6 +2255,8 @@ Classes
     `type: str`
     :   The type of the None singleton.
 
+<a id="SearchAnalyticsByPageLtCondition"></a>
+
 `SearchAnalyticsByPageLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -2062,6 +2268,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByPageSearchFilter`
     :   The type of the None singleton.
+
+<a id="SearchAnalyticsByPageLteCondition"></a>
 
 `SearchAnalyticsByPageLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -2075,6 +2283,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByPageSearchFilter`
     :   The type of the None singleton.
 
+<a id="SearchAnalyticsByPageNeqCondition"></a>
+
 `SearchAnalyticsByPageNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -2086,6 +2296,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByPageSearchFilter`
     :   The type of the None singleton.
+
+<a id="SearchAnalyticsByPageNotCondition"></a>
 
 `SearchAnalyticsByPageNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -2107,6 +2319,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByPageEqCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByPageNeqCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByPageGtCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByPageGteCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByPageLtCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByPageLteCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByPageInCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByPageLikeCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByPageFuzzyCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByPageKeywordCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByPageContainsCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByPageNotCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByPageAndCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByPageOrCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByPageAnyCondition`
     :   The type of the None singleton.
 
+<a id="SearchAnalyticsByPageOrCondition"></a>
+
 `SearchAnalyticsByPageOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -2126,6 +2340,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByPageEqCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByPageNeqCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByPageGtCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByPageGteCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByPageLtCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByPageLteCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByPageInCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByPageLikeCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByPageFuzzyCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByPageKeywordCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByPageContainsCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByPageNotCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByPageAndCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByPageOrCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByPageAnyCondition]`
     :   The type of the None singleton.
+
+<a id="SearchAnalyticsByPageSearchFilter"></a>
 
 `SearchAnalyticsByPageSearchFilter(*args, **kwargs)`
 :   Available fields for filtering search_analytics_by_page search queries.
@@ -2160,6 +2376,8 @@ Classes
     `site_url: str | None`
     :   The URL of the site for which the search analytics data is being reported
 
+<a id="SearchAnalyticsByPageSearchQuery"></a>
+
 `SearchAnalyticsByPageSearchQuery(*args, **kwargs)`
 :   Search query for search_analytics_by_page entity.
 
@@ -2174,6 +2392,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByPageSortFilter]`
     :   The type of the None singleton.
+
+<a id="SearchAnalyticsByPageSortFilter"></a>
 
 `SearchAnalyticsByPageSortFilter(*args, **kwargs)`
 :   Available fields for sorting search_analytics_by_page search results.
@@ -2208,6 +2428,8 @@ Classes
     `site_url: Literal['asc', 'desc']`
     :   The URL of the site for which the search analytics data is being reported
 
+<a id="SearchAnalyticsByPageStringFilter"></a>
+
 `SearchAnalyticsByPageStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -2241,6 +2463,8 @@ Classes
     `site_url: str`
     :   The URL of the site for which the search analytics data is being reported
 
+<a id="SearchAnalyticsByQueryAndCondition"></a>
+
 `SearchAnalyticsByQueryAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -2261,6 +2485,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByQueryEqCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByQueryNeqCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByQueryGtCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByQueryGteCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByQueryLtCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByQueryLteCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByQueryInCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByQueryLikeCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByQueryFuzzyCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByQueryKeywordCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByQueryContainsCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByQueryNotCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByQueryAndCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByQueryOrCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByQueryAnyCondition]`
     :   The type of the None singleton.
 
+<a id="SearchAnalyticsByQueryAnyCondition"></a>
+
 `SearchAnalyticsByQueryAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -2280,6 +2506,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByQueryAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="SearchAnalyticsByQueryAnyValueFilter"></a>
 
 `SearchAnalyticsByQueryAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -2314,6 +2542,8 @@ Classes
     `site_url: Any`
     :   The URL of the site for which the search analytics data is captured
 
+<a id="SearchAnalyticsByQueryContainsCondition"></a>
+
 `SearchAnalyticsByQueryContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -2325,6 +2555,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByQueryAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="SearchAnalyticsByQueryEqCondition"></a>
 
 `SearchAnalyticsByQueryEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -2338,6 +2570,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByQuerySearchFilter`
     :   The type of the None singleton.
 
+<a id="SearchAnalyticsByQueryFuzzyCondition"></a>
+
 `SearchAnalyticsByQueryFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -2349,6 +2583,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByQueryStringFilter`
     :   The type of the None singleton.
+
+<a id="SearchAnalyticsByQueryGtCondition"></a>
 
 `SearchAnalyticsByQueryGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
@@ -2362,6 +2598,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByQuerySearchFilter`
     :   The type of the None singleton.
 
+<a id="SearchAnalyticsByQueryGteCondition"></a>
+
 `SearchAnalyticsByQueryGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -2373,6 +2611,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByQuerySearchFilter`
     :   The type of the None singleton.
+
+<a id="SearchAnalyticsByQueryInCondition"></a>
 
 `SearchAnalyticsByQueryInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -2393,6 +2633,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByQueryInFilter`
     :   The type of the None singleton.
+
+<a id="SearchAnalyticsByQueryInFilter"></a>
 
 `SearchAnalyticsByQueryInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -2427,6 +2669,8 @@ Classes
     `site_url: list[str]`
     :   The URL of the site for which the search analytics data is captured
 
+<a id="SearchAnalyticsByQueryKeywordCondition"></a>
+
 `SearchAnalyticsByQueryKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -2439,6 +2683,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByQueryStringFilter`
     :   The type of the None singleton.
 
+<a id="SearchAnalyticsByQueryLikeCondition"></a>
+
 `SearchAnalyticsByQueryLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -2450,6 +2696,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByQueryStringFilter`
     :   The type of the None singleton.
+
+<a id="SearchAnalyticsByQueryListParams"></a>
 
 `SearchAnalyticsByQueryListParams(*args, **kwargs)`
 :   Parameters for search_analytics_by_query.list operation
@@ -2487,6 +2735,8 @@ Classes
     `type: str`
     :   The type of the None singleton.
 
+<a id="SearchAnalyticsByQueryLtCondition"></a>
+
 `SearchAnalyticsByQueryLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -2498,6 +2748,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByQuerySearchFilter`
     :   The type of the None singleton.
+
+<a id="SearchAnalyticsByQueryLteCondition"></a>
 
 `SearchAnalyticsByQueryLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -2511,6 +2763,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByQuerySearchFilter`
     :   The type of the None singleton.
 
+<a id="SearchAnalyticsByQueryNeqCondition"></a>
+
 `SearchAnalyticsByQueryNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -2522,6 +2776,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByQuerySearchFilter`
     :   The type of the None singleton.
+
+<a id="SearchAnalyticsByQueryNotCondition"></a>
 
 `SearchAnalyticsByQueryNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -2543,6 +2799,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByQueryEqCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByQueryNeqCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByQueryGtCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByQueryGteCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByQueryLtCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByQueryLteCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByQueryInCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByQueryLikeCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByQueryFuzzyCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByQueryKeywordCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByQueryContainsCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByQueryNotCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByQueryAndCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByQueryOrCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByQueryAnyCondition`
     :   The type of the None singleton.
 
+<a id="SearchAnalyticsByQueryOrCondition"></a>
+
 `SearchAnalyticsByQueryOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -2562,6 +2820,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByQueryEqCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByQueryNeqCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByQueryGtCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByQueryGteCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByQueryLtCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByQueryLteCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByQueryInCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByQueryLikeCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByQueryFuzzyCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByQueryKeywordCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByQueryContainsCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByQueryNotCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByQueryAndCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByQueryOrCondition | airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByQueryAnyCondition]`
     :   The type of the None singleton.
+
+<a id="SearchAnalyticsByQuerySearchFilter"></a>
 
 `SearchAnalyticsByQuerySearchFilter(*args, **kwargs)`
 :   Available fields for filtering search_analytics_by_query search queries.
@@ -2596,6 +2856,8 @@ Classes
     `site_url: str | None`
     :   The URL of the site for which the search analytics data is captured
 
+<a id="SearchAnalyticsByQuerySearchQuery"></a>
+
 `SearchAnalyticsByQuerySearchQuery(*args, **kwargs)`
 :   Search query for search_analytics_by_query entity.
 
@@ -2610,6 +2872,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.google_search_console.types.SearchAnalyticsByQuerySortFilter]`
     :   The type of the None singleton.
+
+<a id="SearchAnalyticsByQuerySortFilter"></a>
 
 `SearchAnalyticsByQuerySortFilter(*args, **kwargs)`
 :   Available fields for sorting search_analytics_by_query search results.
@@ -2644,6 +2908,8 @@ Classes
     `site_url: Literal['asc', 'desc']`
     :   The URL of the site for which the search analytics data is captured
 
+<a id="SearchAnalyticsByQueryStringFilter"></a>
+
 `SearchAnalyticsByQueryStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -2677,6 +2943,8 @@ Classes
     `site_url: str`
     :   The URL of the site for which the search analytics data is captured
 
+<a id="SitemapsAndCondition"></a>
+
 `SitemapsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -2697,6 +2965,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.google_search_console.types.SitemapsEqCondition | airbyte_agent_sdk.connectors.google_search_console.types.SitemapsNeqCondition | airbyte_agent_sdk.connectors.google_search_console.types.SitemapsGtCondition | airbyte_agent_sdk.connectors.google_search_console.types.SitemapsGteCondition | airbyte_agent_sdk.connectors.google_search_console.types.SitemapsLtCondition | airbyte_agent_sdk.connectors.google_search_console.types.SitemapsLteCondition | airbyte_agent_sdk.connectors.google_search_console.types.SitemapsInCondition | airbyte_agent_sdk.connectors.google_search_console.types.SitemapsLikeCondition | airbyte_agent_sdk.connectors.google_search_console.types.SitemapsFuzzyCondition | airbyte_agent_sdk.connectors.google_search_console.types.SitemapsKeywordCondition | airbyte_agent_sdk.connectors.google_search_console.types.SitemapsContainsCondition | airbyte_agent_sdk.connectors.google_search_console.types.SitemapsNotCondition | airbyte_agent_sdk.connectors.google_search_console.types.SitemapsAndCondition | airbyte_agent_sdk.connectors.google_search_console.types.SitemapsOrCondition | airbyte_agent_sdk.connectors.google_search_console.types.SitemapsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="SitemapsAnyCondition"></a>
+
 `SitemapsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -2716,6 +2986,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.google_search_console.types.SitemapsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="SitemapsAnyValueFilter"></a>
 
 `SitemapsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -2753,6 +3025,8 @@ Classes
     `warnings: Any`
     :   Warnings encountered while processing the sitemaps
 
+<a id="SitemapsContainsCondition"></a>
+
 `SitemapsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -2764,6 +3038,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.google_search_console.types.SitemapsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="SitemapsEqCondition"></a>
 
 `SitemapsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -2777,6 +3053,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.google_search_console.types.SitemapsSearchFilter`
     :   The type of the None singleton.
 
+<a id="SitemapsFuzzyCondition"></a>
+
 `SitemapsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -2788,6 +3066,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.google_search_console.types.SitemapsStringFilter`
     :   The type of the None singleton.
+
+<a id="SitemapsGetParams"></a>
 
 `SitemapsGetParams(*args, **kwargs)`
 :   Parameters for sitemaps.get operation
@@ -2804,6 +3084,8 @@ Classes
     `site_url: str`
     :   The type of the None singleton.
 
+<a id="SitemapsGtCondition"></a>
+
 `SitemapsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -2816,6 +3098,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.google_search_console.types.SitemapsSearchFilter`
     :   The type of the None singleton.
 
+<a id="SitemapsGteCondition"></a>
+
 `SitemapsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -2827,6 +3111,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.google_search_console.types.SitemapsSearchFilter`
     :   The type of the None singleton.
+
+<a id="SitemapsInCondition"></a>
 
 `SitemapsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -2847,6 +3133,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.google_search_console.types.SitemapsInFilter`
     :   The type of the None singleton.
+
+<a id="SitemapsInFilter"></a>
 
 `SitemapsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -2884,6 +3172,8 @@ Classes
     `warnings: list[str]`
     :   Warnings encountered while processing the sitemaps
 
+<a id="SitemapsKeywordCondition"></a>
+
 `SitemapsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -2895,6 +3185,8 @@ Classes
 
     `keyword: airbyte_agent_sdk.connectors.google_search_console.types.SitemapsStringFilter`
     :   The type of the None singleton.
+
+<a id="SitemapsLikeCondition"></a>
 
 `SitemapsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
@@ -2908,6 +3200,8 @@ Classes
     `like: airbyte_agent_sdk.connectors.google_search_console.types.SitemapsStringFilter`
     :   The type of the None singleton.
 
+<a id="SitemapsListParams"></a>
+
 `SitemapsListParams(*args, **kwargs)`
 :   Parameters for sitemaps.list operation
 
@@ -2919,6 +3213,8 @@ Classes
 
     `site_url: str`
     :   The type of the None singleton.
+
+<a id="SitemapsLtCondition"></a>
 
 `SitemapsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
@@ -2932,6 +3228,8 @@ Classes
     `lt: airbyte_agent_sdk.connectors.google_search_console.types.SitemapsSearchFilter`
     :   The type of the None singleton.
 
+<a id="SitemapsLteCondition"></a>
+
 `SitemapsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
 
@@ -2944,6 +3242,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.google_search_console.types.SitemapsSearchFilter`
     :   The type of the None singleton.
 
+<a id="SitemapsNeqCondition"></a>
+
 `SitemapsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -2955,6 +3255,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.google_search_console.types.SitemapsSearchFilter`
     :   The type of the None singleton.
+
+<a id="SitemapsNotCondition"></a>
 
 `SitemapsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -2976,6 +3278,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.google_search_console.types.SitemapsEqCondition | airbyte_agent_sdk.connectors.google_search_console.types.SitemapsNeqCondition | airbyte_agent_sdk.connectors.google_search_console.types.SitemapsGtCondition | airbyte_agent_sdk.connectors.google_search_console.types.SitemapsGteCondition | airbyte_agent_sdk.connectors.google_search_console.types.SitemapsLtCondition | airbyte_agent_sdk.connectors.google_search_console.types.SitemapsLteCondition | airbyte_agent_sdk.connectors.google_search_console.types.SitemapsInCondition | airbyte_agent_sdk.connectors.google_search_console.types.SitemapsLikeCondition | airbyte_agent_sdk.connectors.google_search_console.types.SitemapsFuzzyCondition | airbyte_agent_sdk.connectors.google_search_console.types.SitemapsKeywordCondition | airbyte_agent_sdk.connectors.google_search_console.types.SitemapsContainsCondition | airbyte_agent_sdk.connectors.google_search_console.types.SitemapsNotCondition | airbyte_agent_sdk.connectors.google_search_console.types.SitemapsAndCondition | airbyte_agent_sdk.connectors.google_search_console.types.SitemapsOrCondition | airbyte_agent_sdk.connectors.google_search_console.types.SitemapsAnyCondition`
     :   The type of the None singleton.
 
+<a id="SitemapsOrCondition"></a>
+
 `SitemapsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -2995,6 +3299,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.google_search_console.types.SitemapsEqCondition | airbyte_agent_sdk.connectors.google_search_console.types.SitemapsNeqCondition | airbyte_agent_sdk.connectors.google_search_console.types.SitemapsGtCondition | airbyte_agent_sdk.connectors.google_search_console.types.SitemapsGteCondition | airbyte_agent_sdk.connectors.google_search_console.types.SitemapsLtCondition | airbyte_agent_sdk.connectors.google_search_console.types.SitemapsLteCondition | airbyte_agent_sdk.connectors.google_search_console.types.SitemapsInCondition | airbyte_agent_sdk.connectors.google_search_console.types.SitemapsLikeCondition | airbyte_agent_sdk.connectors.google_search_console.types.SitemapsFuzzyCondition | airbyte_agent_sdk.connectors.google_search_console.types.SitemapsKeywordCondition | airbyte_agent_sdk.connectors.google_search_console.types.SitemapsContainsCondition | airbyte_agent_sdk.connectors.google_search_console.types.SitemapsNotCondition | airbyte_agent_sdk.connectors.google_search_console.types.SitemapsAndCondition | airbyte_agent_sdk.connectors.google_search_console.types.SitemapsOrCondition | airbyte_agent_sdk.connectors.google_search_console.types.SitemapsAnyCondition]`
     :   The type of the None singleton.
+
+<a id="SitemapsSearchFilter"></a>
 
 `SitemapsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering sitemaps search queries.
@@ -3032,6 +3338,8 @@ Classes
     `warnings: str | None`
     :   Warnings encountered while processing the sitemaps
 
+<a id="SitemapsSearchQuery"></a>
+
 `SitemapsSearchQuery(*args, **kwargs)`
 :   Search query for sitemaps entity.
 
@@ -3046,6 +3354,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.google_search_console.types.SitemapsSortFilter]`
     :   The type of the None singleton.
+
+<a id="SitemapsSortFilter"></a>
 
 `SitemapsSortFilter(*args, **kwargs)`
 :   Available fields for sorting sitemaps search results.
@@ -3083,6 +3393,8 @@ Classes
     `warnings: Literal['asc', 'desc']`
     :   Warnings encountered while processing the sitemaps
 
+<a id="SitemapsStringFilter"></a>
+
 `SitemapsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -3119,6 +3431,8 @@ Classes
     `warnings: str`
     :   Warnings encountered while processing the sitemaps
 
+<a id="SitesAndCondition"></a>
+
 `SitesAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -3138,6 +3452,8 @@ Classes
 
     `and: list[airbyte_agent_sdk.connectors.google_search_console.types.SitesEqCondition | airbyte_agent_sdk.connectors.google_search_console.types.SitesNeqCondition | airbyte_agent_sdk.connectors.google_search_console.types.SitesGtCondition | airbyte_agent_sdk.connectors.google_search_console.types.SitesGteCondition | airbyte_agent_sdk.connectors.google_search_console.types.SitesLtCondition | airbyte_agent_sdk.connectors.google_search_console.types.SitesLteCondition | airbyte_agent_sdk.connectors.google_search_console.types.SitesInCondition | airbyte_agent_sdk.connectors.google_search_console.types.SitesLikeCondition | airbyte_agent_sdk.connectors.google_search_console.types.SitesFuzzyCondition | airbyte_agent_sdk.connectors.google_search_console.types.SitesKeywordCondition | airbyte_agent_sdk.connectors.google_search_console.types.SitesContainsCondition | airbyte_agent_sdk.connectors.google_search_console.types.SitesNotCondition | airbyte_agent_sdk.connectors.google_search_console.types.SitesAndCondition | airbyte_agent_sdk.connectors.google_search_console.types.SitesOrCondition | airbyte_agent_sdk.connectors.google_search_console.types.SitesAnyCondition]`
     :   The type of the None singleton.
+
+<a id="SitesAnyCondition"></a>
 
 `SitesAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -3159,6 +3475,8 @@ Classes
     `any: airbyte_agent_sdk.connectors.google_search_console.types.SitesAnyValueFilter`
     :   The type of the None singleton.
 
+<a id="SitesAnyValueFilter"></a>
+
 `SitesAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
 
@@ -3174,6 +3492,8 @@ Classes
     `site_url: Any`
     :   The URL of the site data being fetched
 
+<a id="SitesContainsCondition"></a>
+
 `SitesContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -3185,6 +3505,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.google_search_console.types.SitesAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="SitesEqCondition"></a>
 
 `SitesEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -3198,6 +3520,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.google_search_console.types.SitesSearchFilter`
     :   The type of the None singleton.
 
+<a id="SitesFuzzyCondition"></a>
+
 `SitesFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -3209,6 +3533,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.google_search_console.types.SitesStringFilter`
     :   The type of the None singleton.
+
+<a id="SitesGetParams"></a>
 
 `SitesGetParams(*args, **kwargs)`
 :   Parameters for sites.get operation
@@ -3222,6 +3548,8 @@ Classes
     `site_url: str`
     :   The type of the None singleton.
 
+<a id="SitesGtCondition"></a>
+
 `SitesGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -3234,6 +3562,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.google_search_console.types.SitesSearchFilter`
     :   The type of the None singleton.
 
+<a id="SitesGteCondition"></a>
+
 `SitesGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -3245,6 +3575,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.google_search_console.types.SitesSearchFilter`
     :   The type of the None singleton.
+
+<a id="SitesInCondition"></a>
 
 `SitesInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -3266,6 +3598,8 @@ Classes
     `in: airbyte_agent_sdk.connectors.google_search_console.types.SitesInFilter`
     :   The type of the None singleton.
 
+<a id="SitesInFilter"></a>
+
 `SitesInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
 
@@ -3281,6 +3615,8 @@ Classes
     `site_url: list[str]`
     :   The URL of the site data being fetched
 
+<a id="SitesKeywordCondition"></a>
+
 `SitesKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -3292,6 +3628,8 @@ Classes
 
     `keyword: airbyte_agent_sdk.connectors.google_search_console.types.SitesStringFilter`
     :   The type of the None singleton.
+
+<a id="SitesLikeCondition"></a>
 
 `SitesLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
@@ -3305,12 +3643,16 @@ Classes
     `like: airbyte_agent_sdk.connectors.google_search_console.types.SitesStringFilter`
     :   The type of the None singleton.
 
+<a id="SitesListParams"></a>
+
 `SitesListParams(*args, **kwargs)`
 :   Parameters for sites.list operation
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="SitesLtCondition"></a>
 
 `SitesLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
@@ -3324,6 +3666,8 @@ Classes
     `lt: airbyte_agent_sdk.connectors.google_search_console.types.SitesSearchFilter`
     :   The type of the None singleton.
 
+<a id="SitesLteCondition"></a>
+
 `SitesLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
 
@@ -3336,6 +3680,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.google_search_console.types.SitesSearchFilter`
     :   The type of the None singleton.
 
+<a id="SitesNeqCondition"></a>
+
 `SitesNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -3347,6 +3693,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.google_search_console.types.SitesSearchFilter`
     :   The type of the None singleton.
+
+<a id="SitesNotCondition"></a>
 
 `SitesNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -3368,6 +3716,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.google_search_console.types.SitesEqCondition | airbyte_agent_sdk.connectors.google_search_console.types.SitesNeqCondition | airbyte_agent_sdk.connectors.google_search_console.types.SitesGtCondition | airbyte_agent_sdk.connectors.google_search_console.types.SitesGteCondition | airbyte_agent_sdk.connectors.google_search_console.types.SitesLtCondition | airbyte_agent_sdk.connectors.google_search_console.types.SitesLteCondition | airbyte_agent_sdk.connectors.google_search_console.types.SitesInCondition | airbyte_agent_sdk.connectors.google_search_console.types.SitesLikeCondition | airbyte_agent_sdk.connectors.google_search_console.types.SitesFuzzyCondition | airbyte_agent_sdk.connectors.google_search_console.types.SitesKeywordCondition | airbyte_agent_sdk.connectors.google_search_console.types.SitesContainsCondition | airbyte_agent_sdk.connectors.google_search_console.types.SitesNotCondition | airbyte_agent_sdk.connectors.google_search_console.types.SitesAndCondition | airbyte_agent_sdk.connectors.google_search_console.types.SitesOrCondition | airbyte_agent_sdk.connectors.google_search_console.types.SitesAnyCondition`
     :   The type of the None singleton.
 
+<a id="SitesOrCondition"></a>
+
 `SitesOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -3388,6 +3738,8 @@ Classes
     `or: list[airbyte_agent_sdk.connectors.google_search_console.types.SitesEqCondition | airbyte_agent_sdk.connectors.google_search_console.types.SitesNeqCondition | airbyte_agent_sdk.connectors.google_search_console.types.SitesGtCondition | airbyte_agent_sdk.connectors.google_search_console.types.SitesGteCondition | airbyte_agent_sdk.connectors.google_search_console.types.SitesLtCondition | airbyte_agent_sdk.connectors.google_search_console.types.SitesLteCondition | airbyte_agent_sdk.connectors.google_search_console.types.SitesInCondition | airbyte_agent_sdk.connectors.google_search_console.types.SitesLikeCondition | airbyte_agent_sdk.connectors.google_search_console.types.SitesFuzzyCondition | airbyte_agent_sdk.connectors.google_search_console.types.SitesKeywordCondition | airbyte_agent_sdk.connectors.google_search_console.types.SitesContainsCondition | airbyte_agent_sdk.connectors.google_search_console.types.SitesNotCondition | airbyte_agent_sdk.connectors.google_search_console.types.SitesAndCondition | airbyte_agent_sdk.connectors.google_search_console.types.SitesOrCondition | airbyte_agent_sdk.connectors.google_search_console.types.SitesAnyCondition]`
     :   The type of the None singleton.
 
+<a id="SitesSearchFilter"></a>
+
 `SitesSearchFilter(*args, **kwargs)`
 :   Available fields for filtering sites search queries.
 
@@ -3402,6 +3754,8 @@ Classes
 
     `site_url: str | None`
     :   The URL of the site data being fetched
+
+<a id="SitesSearchQuery"></a>
 
 `SitesSearchQuery(*args, **kwargs)`
 :   Search query for sites entity.
@@ -3418,6 +3772,8 @@ Classes
     `sort: list[airbyte_agent_sdk.connectors.google_search_console.types.SitesSortFilter]`
     :   The type of the None singleton.
 
+<a id="SitesSortFilter"></a>
+
 `SitesSortFilter(*args, **kwargs)`
 :   Available fields for sorting sites search results.
 
@@ -3432,6 +3788,8 @@ Classes
 
     `site_url: Literal['asc', 'desc']`
     :   The URL of the site data being fetched
+
+<a id="SitesStringFilter"></a>
 
 `SitesStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/granola/connector.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/granola/connector.md
@@ -10,6 +10,8 @@ Granola connector.
 Classes
 -------
 
+<a id="GranolaConnector"></a>
+
 `GranolaConnector(auth_config: GranolaAuthConfig | AirbyteAuthConfig | BaseModel | None = None, on_token_refresh: Any | None = None)`
 :   Type-safe Granola API connector.
     
@@ -197,6 +199,8 @@ Classes
             entities = connector.list_entities()
             for entity in entities:
                 print(f"\{entity['entity_name']\}: \{entity['available_actions']\}")
+
+<a id="NotesQuery"></a>
 
 `NotesQuery(connector: GranolaConnector)`
 :   Query class for Notes entity operations.

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/granola/index.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/granola/index.md
@@ -19,6 +19,8 @@ Sub-modules
 Classes
 -------
 
+<a id="AirbyteAuthConfig"></a>
+
 `AirbyteAuthConfig(**data: Any)`
 :   Authentication configuration for Airbyte hosted mode execution.
     
@@ -87,6 +89,8 @@ Classes
     `workspace_name: str | None`
     :   The type of the None singleton.
 
+<a id="AirbyteSearchMeta"></a>
+
 `AirbyteSearchMeta(**data: Any)`
 :   Pagination metadata for search responses.
     
@@ -114,6 +118,8 @@ Classes
 
     `took_ms: int | None`
     :   Time taken to execute the search in milliseconds.
+
+<a id="AirbyteSearchResult"></a>
 
 `AirbyteSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -145,6 +151,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="NotesSearchResult"></a>
+
 `NotesSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -160,6 +168,8 @@ Classes
     * airbyte_agent_sdk.connectors.granola.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="GranolaAuthConfig"></a>
 
 `GranolaAuthConfig(**data: Any)`
 :   API Key Authentication
@@ -182,6 +192,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="GranolaConnector"></a>
 
 `GranolaConnector(auth_config: GranolaAuthConfig | AirbyteAuthConfig | BaseModel | None = None, on_token_refresh: Any | None = None)`
 :   Type-safe Granola API connector.
@@ -370,6 +382,8 @@ Classes
             entities = connector.list_entities()
             for entity in entities:
                 print(f"\{entity['entity_name']\}: \{entity['available_actions']\}")
+
+<a id="NotesSearchData"></a>
 
 `NotesSearchData(**data: Any)`
 :   Search result data for notes entity.

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/granola/models.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/granola/models.md
@@ -13,6 +13,8 @@ and response envelope types.
 Classes
 -------
 
+<a id="AirbyteSearchMeta"></a>
+
 `AirbyteSearchMeta(**data: Any)`
 :   Pagination metadata for search responses.
     
@@ -40,6 +42,8 @@ Classes
 
     `took_ms: int | None`
     :   Time taken to execute the search in milliseconds.
+
+<a id="AirbyteSearchResult"></a>
 
 `AirbyteSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -92,6 +96,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="NotesSearchResult"></a>
+
 `NotesSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -107,6 +113,8 @@ Classes
     * airbyte_agent_sdk.connectors.granola.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="Attendee"></a>
 
 `Attendee(**data: Any)`
 :   A meeting attendee
@@ -132,6 +140,8 @@ Classes
 
     `name: str | Any | None`
     :   The type of the None singleton.
+
+<a id="CalendarEvent"></a>
 
 `CalendarEvent(**data: Any)`
 :   Associated calendar event details
@@ -170,6 +180,8 @@ Classes
     `scheduled_start_time: str | Any | None`
     :   The type of the None singleton.
 
+<a id="CalendarEventInvitee"></a>
+
 `CalendarEventInvitee(**data: Any)`
 :   A calendar event invitee
     
@@ -191,6 +203,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="FolderMembership"></a>
 
 `FolderMembership(**data: Any)`
 :   Folder the note belongs to
@@ -220,6 +234,8 @@ Classes
     `object_: str | Any | None`
     :   The type of the None singleton.
 
+<a id="GranolaAuthConfig"></a>
+
 `GranolaAuthConfig(**data: Any)`
 :   API Key Authentication
     
@@ -241,6 +257,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="GranolaCheckResult"></a>
 
 `GranolaCheckResult(**data: Any)`
 :   Result of a health check operation.
@@ -275,6 +293,8 @@ Classes
     `status: str`
     :   Health check status: 'healthy' or 'unhealthy'.
 
+<a id="GranolaExecuteResult"></a>
+
 `GranolaExecuteResult(**data: Any)`
 :   Response envelope with data only.
     
@@ -303,6 +323,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="GranolaExecuteResultWithMeta"></a>
 
 `GranolaExecuteResultWithMeta(**data: Any)`
 :   Response envelope with data and metadata.
@@ -355,6 +377,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="NotesListResult"></a>
+
 `NotesListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -373,6 +397,8 @@ Classes
     * airbyte_agent_sdk.connectors.granola.models.GranolaExecuteResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="Note"></a>
 
 `Note(**data: Any)`
 :   A Granola meeting note
@@ -429,6 +455,8 @@ Classes
     `updated_at: str | Any | None`
     :   The type of the None singleton.
 
+<a id="NotesList"></a>
+
 `NotesList(**data: Any)`
 :   Paginated list of notes
     
@@ -457,6 +485,8 @@ Classes
     `notes: list[airbyte_agent_sdk.connectors.granola.models.Note] | Any`
     :   The type of the None singleton.
 
+<a id="NotesListResultMeta"></a>
+
 `NotesListResultMeta(**data: Any)`
 :   Metadata for notes.Action.LIST operation
     
@@ -481,6 +511,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="NotesSearchData"></a>
 
 `NotesSearchData(**data: Any)`
 :   Search result data for notes entity.
@@ -537,6 +569,8 @@ Classes
     `updated_at: str | None`
     :   The last update time of the note in ISO 8601 format.
 
+<a id="Owner"></a>
+
 `Owner(**data: Any)`
 :   The owner of the note
     
@@ -561,6 +595,8 @@ Classes
 
     `name: str | Any | None`
     :   The type of the None singleton.
+
+<a id="TranscriptEntry"></a>
 
 `TranscriptEntry(**data: Any)`
 :   A single transcript entry
@@ -592,6 +628,8 @@ Classes
 
     `text: str | Any | None`
     :   The type of the None singleton.
+
+<a id="TranscriptSpeaker"></a>
 
 `TranscriptSpeaker(**data: Any)`
 :   Speaker information in transcript

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/granola/types.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/granola/types.md
@@ -10,6 +10,8 @@ Type definitions for granola connector.
 Classes
 -------
 
+<a id="AirbyteSearchParams"></a>
+
 `AirbyteSearchParams(*args, **kwargs)`
 :   Parameters for Airbyte cache search operations (generic, use entity-specific query types for better type hints).
 
@@ -31,6 +33,8 @@ Classes
     `query: dict[str, typing.Any]`
     :   The type of the None singleton.
 
+<a id="NotesAndCondition"></a>
+
 `NotesAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -51,6 +55,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.granola.types.NotesEqCondition | airbyte_agent_sdk.connectors.granola.types.NotesNeqCondition | airbyte_agent_sdk.connectors.granola.types.NotesGtCondition | airbyte_agent_sdk.connectors.granola.types.NotesGteCondition | airbyte_agent_sdk.connectors.granola.types.NotesLtCondition | airbyte_agent_sdk.connectors.granola.types.NotesLteCondition | airbyte_agent_sdk.connectors.granola.types.NotesInCondition | airbyte_agent_sdk.connectors.granola.types.NotesLikeCondition | airbyte_agent_sdk.connectors.granola.types.NotesFuzzyCondition | airbyte_agent_sdk.connectors.granola.types.NotesKeywordCondition | airbyte_agent_sdk.connectors.granola.types.NotesContainsCondition | airbyte_agent_sdk.connectors.granola.types.NotesNotCondition | airbyte_agent_sdk.connectors.granola.types.NotesAndCondition | airbyte_agent_sdk.connectors.granola.types.NotesOrCondition | airbyte_agent_sdk.connectors.granola.types.NotesAnyCondition]`
     :   The type of the None singleton.
 
+<a id="NotesAnyCondition"></a>
+
 `NotesAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -70,6 +76,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.granola.types.NotesAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="NotesAnyValueFilter"></a>
 
 `NotesAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -116,6 +124,8 @@ Classes
     `updated_at: Any`
     :   The last update time of the note in ISO 8601 format.
 
+<a id="NotesContainsCondition"></a>
+
 `NotesContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -127,6 +137,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.granola.types.NotesAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="NotesEqCondition"></a>
 
 `NotesEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -140,6 +152,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.granola.types.NotesSearchFilter`
     :   The type of the None singleton.
 
+<a id="NotesFuzzyCondition"></a>
+
 `NotesFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -151,6 +165,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.granola.types.NotesStringFilter`
     :   The type of the None singleton.
+
+<a id="NotesGetParams"></a>
 
 `NotesGetParams(*args, **kwargs)`
 :   Parameters for notes.get operation
@@ -167,6 +183,8 @@ Classes
     `note_id: str`
     :   The type of the None singleton.
 
+<a id="NotesGtCondition"></a>
+
 `NotesGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -179,6 +197,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.granola.types.NotesSearchFilter`
     :   The type of the None singleton.
 
+<a id="NotesGteCondition"></a>
+
 `NotesGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -190,6 +210,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.granola.types.NotesSearchFilter`
     :   The type of the None singleton.
+
+<a id="NotesInCondition"></a>
 
 `NotesInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -210,6 +232,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.granola.types.NotesInFilter`
     :   The type of the None singleton.
+
+<a id="NotesInFilter"></a>
 
 `NotesInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -256,6 +280,8 @@ Classes
     `updated_at: list[str]`
     :   The last update time of the note in ISO 8601 format.
 
+<a id="NotesKeywordCondition"></a>
+
 `NotesKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -268,6 +294,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.granola.types.NotesStringFilter`
     :   The type of the None singleton.
 
+<a id="NotesLikeCondition"></a>
+
 `NotesLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -279,6 +307,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.granola.types.NotesStringFilter`
     :   The type of the None singleton.
+
+<a id="NotesListParams"></a>
 
 `NotesListParams(*args, **kwargs)`
 :   Parameters for notes.list operation
@@ -301,6 +331,8 @@ Classes
     `page_size: int`
     :   The type of the None singleton.
 
+<a id="NotesLtCondition"></a>
+
 `NotesLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -312,6 +344,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.granola.types.NotesSearchFilter`
     :   The type of the None singleton.
+
+<a id="NotesLteCondition"></a>
 
 `NotesLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -325,6 +359,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.granola.types.NotesSearchFilter`
     :   The type of the None singleton.
 
+<a id="NotesNeqCondition"></a>
+
 `NotesNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -336,6 +372,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.granola.types.NotesSearchFilter`
     :   The type of the None singleton.
+
+<a id="NotesNotCondition"></a>
 
 `NotesNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -357,6 +395,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.granola.types.NotesEqCondition | airbyte_agent_sdk.connectors.granola.types.NotesNeqCondition | airbyte_agent_sdk.connectors.granola.types.NotesGtCondition | airbyte_agent_sdk.connectors.granola.types.NotesGteCondition | airbyte_agent_sdk.connectors.granola.types.NotesLtCondition | airbyte_agent_sdk.connectors.granola.types.NotesLteCondition | airbyte_agent_sdk.connectors.granola.types.NotesInCondition | airbyte_agent_sdk.connectors.granola.types.NotesLikeCondition | airbyte_agent_sdk.connectors.granola.types.NotesFuzzyCondition | airbyte_agent_sdk.connectors.granola.types.NotesKeywordCondition | airbyte_agent_sdk.connectors.granola.types.NotesContainsCondition | airbyte_agent_sdk.connectors.granola.types.NotesNotCondition | airbyte_agent_sdk.connectors.granola.types.NotesAndCondition | airbyte_agent_sdk.connectors.granola.types.NotesOrCondition | airbyte_agent_sdk.connectors.granola.types.NotesAnyCondition`
     :   The type of the None singleton.
 
+<a id="NotesOrCondition"></a>
+
 `NotesOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -376,6 +416,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.granola.types.NotesEqCondition | airbyte_agent_sdk.connectors.granola.types.NotesNeqCondition | airbyte_agent_sdk.connectors.granola.types.NotesGtCondition | airbyte_agent_sdk.connectors.granola.types.NotesGteCondition | airbyte_agent_sdk.connectors.granola.types.NotesLtCondition | airbyte_agent_sdk.connectors.granola.types.NotesLteCondition | airbyte_agent_sdk.connectors.granola.types.NotesInCondition | airbyte_agent_sdk.connectors.granola.types.NotesLikeCondition | airbyte_agent_sdk.connectors.granola.types.NotesFuzzyCondition | airbyte_agent_sdk.connectors.granola.types.NotesKeywordCondition | airbyte_agent_sdk.connectors.granola.types.NotesContainsCondition | airbyte_agent_sdk.connectors.granola.types.NotesNotCondition | airbyte_agent_sdk.connectors.granola.types.NotesAndCondition | airbyte_agent_sdk.connectors.granola.types.NotesOrCondition | airbyte_agent_sdk.connectors.granola.types.NotesAnyCondition]`
     :   The type of the None singleton.
+
+<a id="NotesSearchFilter"></a>
 
 `NotesSearchFilter(*args, **kwargs)`
 :   Available fields for filtering notes search queries.
@@ -422,6 +464,8 @@ Classes
     `updated_at: str | None`
     :   The last update time of the note in ISO 8601 format.
 
+<a id="NotesSearchQuery"></a>
+
 `NotesSearchQuery(*args, **kwargs)`
 :   Search query for notes entity.
 
@@ -436,6 +480,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.granola.types.NotesSortFilter]`
     :   The type of the None singleton.
+
+<a id="NotesSortFilter"></a>
 
 `NotesSortFilter(*args, **kwargs)`
 :   Available fields for sorting notes search results.
@@ -481,6 +527,8 @@ Classes
 
     `updated_at: Literal['asc', 'desc']`
     :   The last update time of the note in ISO 8601 format.
+
+<a id="NotesStringFilter"></a>
 
 `NotesStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/greenhouse/connector.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/greenhouse/connector.md
@@ -10,6 +10,8 @@ Greenhouse connector.
 Classes
 -------
 
+<a id="ApplicationAttachmentQuery"></a>
+
 `ApplicationAttachmentQuery(connector: GreenhouseConnector)`
 :   Query class for ApplicationAttachment entity operations.
     
@@ -47,6 +49,8 @@ Classes
         
                 Returns:
                     str: Path to the downloaded file
+
+<a id="ApplicationsQuery"></a>
 
 `ApplicationsQuery(connector: GreenhouseConnector)`
 :   Query class for Applications entity operations.
@@ -123,6 +127,8 @@ Classes
         Returns:
             ApplicationsListResult
 
+<a id="CandidateAttachmentQuery"></a>
+
 `CandidateAttachmentQuery(connector: GreenhouseConnector)`
 :   Query class for CandidateAttachment entity operations.
     
@@ -160,6 +166,8 @@ Classes
         
                 Returns:
                     str: Path to the downloaded file
+
+<a id="CandidatesQuery"></a>
 
 `CandidatesQuery(connector: GreenhouseConnector)`
 :   Query class for Candidates entity operations.
@@ -237,6 +245,8 @@ Classes
         Returns:
             CandidatesListResult
 
+<a id="DepartmentsQuery"></a>
+
 `DepartmentsQuery(connector: GreenhouseConnector)`
 :   Query class for Departments entity operations.
     
@@ -293,6 +303,8 @@ Classes
         
         Returns:
             DepartmentsListResult
+
+<a id="GreenhouseConnector"></a>
 
 `GreenhouseConnector(auth_config: GreenhouseAuthConfig | AirbyteAuthConfig | BaseModel | None = None, on_token_refresh: Any | None = None)`
 :   Type-safe Greenhouse API connector.
@@ -482,6 +494,8 @@ Classes
             for entity in entities:
                 print(f"\{entity['entity_name']\}: \{entity['available_actions']\}")
 
+<a id="JobPostsQuery"></a>
+
 `JobPostsQuery(connector: GreenhouseConnector)`
 :   Query class for JobPosts entity operations.
     
@@ -548,6 +562,8 @@ Classes
         
         Returns:
             JobPostsListResult
+
+<a id="JobsQuery"></a>
 
 `JobsQuery(connector: GreenhouseConnector)`
 :   Query class for Jobs entity operations.
@@ -617,6 +633,8 @@ Classes
         Returns:
             JobsListResult
 
+<a id="OffersQuery"></a>
+
 `OffersQuery(connector: GreenhouseConnector)`
 :   Query class for Offers entity operations.
     
@@ -684,6 +702,8 @@ Classes
         Returns:
             OffersListResult
 
+<a id="OfficesQuery"></a>
+
 `OfficesQuery(connector: GreenhouseConnector)`
 :   Query class for Offices entity operations.
     
@@ -743,6 +763,8 @@ Classes
         Returns:
             OfficesListResult
 
+<a id="ScheduledInterviewsQuery"></a>
+
 `ScheduledInterviewsQuery(connector: GreenhouseConnector)`
 :   Query class for ScheduledInterviews entity operations.
     
@@ -776,6 +798,8 @@ Classes
         
         Returns:
             ScheduledInterviewsListResult
+
+<a id="SourcesQuery"></a>
 
 `SourcesQuery(connector: GreenhouseConnector)`
 :   Query class for Sources entity operations.
@@ -819,6 +843,8 @@ Classes
         
         Returns:
             SourcesListResult
+
+<a id="UsersQuery"></a>
 
 `UsersQuery(connector: GreenhouseConnector)`
 :   Query class for Users entity operations.

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/greenhouse/index.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/greenhouse/index.md
@@ -19,6 +19,8 @@ Sub-modules
 Classes
 -------
 
+<a id="AirbyteAuthConfig"></a>
+
 `AirbyteAuthConfig(**data: Any)`
 :   Authentication configuration for Airbyte hosted mode execution.
     
@@ -87,6 +89,8 @@ Classes
     `workspace_name: str | None`
     :   The type of the None singleton.
 
+<a id="AirbyteSearchMeta"></a>
+
 `AirbyteSearchMeta(**data: Any)`
 :   Pagination metadata for search responses.
     
@@ -114,6 +118,8 @@ Classes
 
     `took_ms: int | None`
     :   Time taken to execute the search in milliseconds.
+
+<a id="AirbyteSearchResult"></a>
 
 `AirbyteSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -153,6 +159,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="ApplicationsSearchResult"></a>
+
 `ApplicationsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -168,6 +176,8 @@ Classes
     * airbyte_agent_sdk.connectors.greenhouse.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="CandidatesSearchResult"></a>
 
 `CandidatesSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -185,6 +195,8 @@ Classes
     * pydantic.main.BaseModel
     * typing.Generic
 
+<a id="DepartmentsSearchResult"></a>
+
 `DepartmentsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -200,6 +212,8 @@ Classes
     * airbyte_agent_sdk.connectors.greenhouse.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="JobPostsSearchResult"></a>
 
 `JobPostsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -217,6 +231,8 @@ Classes
     * pydantic.main.BaseModel
     * typing.Generic
 
+<a id="JobsSearchResult"></a>
+
 `JobsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -232,6 +248,8 @@ Classes
     * airbyte_agent_sdk.connectors.greenhouse.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="OffersSearchResult"></a>
 
 `OffersSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -249,6 +267,8 @@ Classes
     * pydantic.main.BaseModel
     * typing.Generic
 
+<a id="OfficesSearchResult"></a>
+
 `OfficesSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -264,6 +284,8 @@ Classes
     * airbyte_agent_sdk.connectors.greenhouse.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="SourcesSearchResult"></a>
 
 `SourcesSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -281,6 +303,8 @@ Classes
     * pydantic.main.BaseModel
     * typing.Generic
 
+<a id="UsersSearchResult"></a>
+
 `UsersSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -296,6 +320,8 @@ Classes
     * airbyte_agent_sdk.connectors.greenhouse.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="ApplicationsSearchData"></a>
 
 `ApplicationsSearchData(**data: Any)`
 :   Search result data for applications entity.
@@ -375,6 +401,8 @@ Classes
 
     `status: str | None`
     :   Status of the application.
+
+<a id="CandidatesSearchData"></a>
 
 `CandidatesSearchData(**data: Any)`
 :   Search result data for candidates entity.
@@ -473,6 +501,8 @@ Classes
     `website_addresses: list[typing.Any] | None`
     :   List of candidate's website addresses
 
+<a id="DepartmentsSearchData"></a>
+
 `DepartmentsSearchData(**data: Any)`
 :   Search result data for departments entity.
     
@@ -513,6 +543,8 @@ Classes
     `parent_id: int | None`
     :   Unique ID of the parent department of this department.
 
+<a id="GreenhouseAuthConfig"></a>
+
 `GreenhouseAuthConfig(**data: Any)`
 :   Harvest API Key Authentication
     
@@ -534,6 +566,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="GreenhouseConnector"></a>
 
 `GreenhouseConnector(auth_config: GreenhouseAuthConfig | AirbyteAuthConfig | BaseModel | None = None, on_token_refresh: Any | None = None)`
 :   Type-safe Greenhouse API connector.
@@ -723,6 +757,8 @@ Classes
             for entity in entities:
                 print(f"\{entity['entity_name']\}: \{entity['available_actions']\}")
 
+<a id="JobPostsSearchData"></a>
+
 `JobPostsSearchData(**data: Any)`
 :   Search result data for job_posts entity.
     
@@ -786,6 +822,8 @@ Classes
 
     `updated_at: str | None`
     :   Date and time when the job post was last updated.
+
+<a id="JobsSearchData"></a>
 
 `JobsSearchData(**data: Any)`
 :   Search result data for jobs entity.
@@ -860,6 +898,8 @@ Classes
     `updated_at: str | None`
     :   The date and time the job was last updated
 
+<a id="OffersSearchData"></a>
+
 `OffersSearchData(**data: Any)`
 :   Search result data for offers entity.
     
@@ -921,6 +961,8 @@ Classes
     `version: int | None`
     :   Version of the offer data
 
+<a id="OfficesSearchData"></a>
+
 `OfficesSearchData(**data: Any)`
 :   Search result data for offices entity.
     
@@ -967,6 +1009,8 @@ Classes
     `primary_contact_user_id: int | None`
     :   User ID of the primary contact person for this office
 
+<a id="SourcesSearchData"></a>
+
 `SourcesSearchData(**data: Any)`
 :   Search result data for sources entity.
     
@@ -994,6 +1038,8 @@ Classes
 
     `type_: dict[str, typing.Any] | None`
     :   Type of the data source
+
+<a id="UsersSearchData"></a>
 
 `UsersSearchData(**data: Any)`
 :   Search result data for users entity.

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/greenhouse/models.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/greenhouse/models.md
@@ -13,6 +13,8 @@ and response envelope types.
 Classes
 -------
 
+<a id="AirbyteSearchMeta"></a>
+
 `AirbyteSearchMeta(**data: Any)`
 :   Pagination metadata for search responses.
     
@@ -40,6 +42,8 @@ Classes
 
     `took_ms: int | None`
     :   Time taken to execute the search in milliseconds.
+
+<a id="AirbyteSearchResult"></a>
 
 `AirbyteSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -100,6 +104,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="ApplicationsSearchResult"></a>
+
 `ApplicationsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -136,6 +142,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="CandidatesSearchResult"></a>
 
 `CandidatesSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -174,6 +182,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="DepartmentsSearchResult"></a>
+
 `DepartmentsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -210,6 +220,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="JobPostsSearchResult"></a>
 
 `JobPostsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -248,6 +260,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="JobsSearchResult"></a>
+
 `JobsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -284,6 +298,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="OffersSearchResult"></a>
 
 `OffersSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -322,6 +338,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="OfficesSearchResult"></a>
+
 `OfficesSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -358,6 +376,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="SourcesSearchResult"></a>
 
 `SourcesSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -396,6 +416,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="UsersSearchResult"></a>
+
 `UsersSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -411,6 +433,8 @@ Classes
     * airbyte_agent_sdk.connectors.greenhouse.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="Application"></a>
 
 `Application(**data: Any)`
 :   Greenhouse application object
@@ -494,6 +518,8 @@ Classes
     `status: str | Any`
     :   The type of the None singleton.
 
+<a id="ApplicationsListResultMeta"></a>
+
 `ApplicationsListResultMeta(**data: Any)`
 :   Metadata for applications.Action.LIST operation
     
@@ -515,6 +541,8 @@ Classes
 
     `next: str | Any | None`
     :   The type of the None singleton.
+
+<a id="ApplicationsSearchData"></a>
 
 `ApplicationsSearchData(**data: Any)`
 :   Search result data for applications entity.
@@ -595,6 +623,8 @@ Classes
     `status: str | None`
     :   Status of the application.
 
+<a id="Attachment"></a>
+
 `Attachment(**data: Any)`
 :   File attachment (resume, cover letter, etc.)
     
@@ -625,6 +655,8 @@ Classes
 
     `url: str | Any`
     :   The type of the None singleton.
+
+<a id="Candidate"></a>
 
 `Candidate(**data: Any)`
 :   Greenhouse candidate object
@@ -711,6 +743,8 @@ Classes
     `website_addresses: list[dict[str, typing.Any]] | Any`
     :   The type of the None singleton.
 
+<a id="CandidatesListResultMeta"></a>
+
 `CandidatesListResultMeta(**data: Any)`
 :   Metadata for candidates.Action.LIST operation
     
@@ -732,6 +766,8 @@ Classes
 
     `next: str | Any | None`
     :   The type of the None singleton.
+
+<a id="CandidatesSearchData"></a>
 
 `CandidatesSearchData(**data: Any)`
 :   Search result data for candidates entity.
@@ -830,6 +866,8 @@ Classes
     `website_addresses: list[typing.Any] | None`
     :   List of candidate's website addresses
 
+<a id="Department"></a>
+
 `Department(**data: Any)`
 :   Greenhouse department object
     
@@ -870,6 +908,8 @@ Classes
     `parent_id: int | Any | None`
     :   The type of the None singleton.
 
+<a id="DepartmentsListResultMeta"></a>
+
 `DepartmentsListResultMeta(**data: Any)`
 :   Metadata for departments.Action.LIST operation
     
@@ -891,6 +931,8 @@ Classes
 
     `next: str | Any | None`
     :   The type of the None singleton.
+
+<a id="DepartmentsSearchData"></a>
 
 `DepartmentsSearchData(**data: Any)`
 :   Search result data for departments entity.
@@ -932,6 +974,8 @@ Classes
     `parent_id: int | None`
     :   Unique ID of the parent department of this department.
 
+<a id="GreenhouseAuthConfig"></a>
+
 `GreenhouseAuthConfig(**data: Any)`
 :   Harvest API Key Authentication
     
@@ -953,6 +997,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="GreenhouseCheckResult"></a>
 
 `GreenhouseCheckResult(**data: Any)`
 :   Result of a health check operation.
@@ -987,6 +1033,8 @@ Classes
     `status: str`
     :   Health check status: 'healthy' or 'unhealthy'.
 
+<a id="GreenhouseExecuteResult"></a>
+
 `GreenhouseExecuteResult(**data: Any)`
 :   Response envelope with data only.
     
@@ -1015,6 +1063,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="GreenhouseExecuteResultWithMeta"></a>
 
 `GreenhouseExecuteResultWithMeta(**data: Any)`
 :   Response envelope with data and metadata.
@@ -1076,6 +1126,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="ApplicationsListResult"></a>
+
 `ApplicationsListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -1118,6 +1170,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="CandidatesListResult"></a>
 
 `CandidatesListResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -1162,6 +1216,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="DepartmentsListResult"></a>
+
 `DepartmentsListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -1204,6 +1260,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="JobPostsListResult"></a>
 
 `JobPostsListResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -1248,6 +1306,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="JobsListResult"></a>
+
 `JobsListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -1290,6 +1350,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="OffersListResult"></a>
 
 `OffersListResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -1334,6 +1396,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="OfficesListResult"></a>
+
 `OfficesListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -1376,6 +1440,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="ScheduledInterviewsListResult"></a>
 
 `ScheduledInterviewsListResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -1420,6 +1486,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="SourcesListResult"></a>
+
 `SourcesListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -1463,6 +1531,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="UsersListResult"></a>
+
 `UsersListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -1481,6 +1551,8 @@ Classes
     * airbyte_agent_sdk.connectors.greenhouse.models.GreenhouseExecuteResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="Job"></a>
 
 `Job(**data: Any)`
 :   Greenhouse job object
@@ -1546,6 +1618,8 @@ Classes
     `updated_at: str | Any`
     :   The type of the None singleton.
 
+<a id="JobPost"></a>
+
 `JobPost(**data: Any)`
 :   Greenhouse job post object
     
@@ -1610,6 +1684,8 @@ Classes
     `updated_at: str | Any`
     :   The type of the None singleton.
 
+<a id="JobPostsListResultMeta"></a>
+
 `JobPostsListResultMeta(**data: Any)`
 :   Metadata for job_posts.Action.LIST operation
     
@@ -1631,6 +1707,8 @@ Classes
 
     `next: str | Any | None`
     :   The type of the None singleton.
+
+<a id="JobPostsSearchData"></a>
 
 `JobPostsSearchData(**data: Any)`
 :   Search result data for job_posts entity.
@@ -1696,6 +1774,8 @@ Classes
     `updated_at: str | None`
     :   Date and time when the job post was last updated.
 
+<a id="JobsListResultMeta"></a>
+
 `JobsListResultMeta(**data: Any)`
 :   Metadata for jobs.Action.LIST operation
     
@@ -1717,6 +1797,8 @@ Classes
 
     `next: str | Any | None`
     :   The type of the None singleton.
+
+<a id="JobsSearchData"></a>
 
 `JobsSearchData(**data: Any)`
 :   Search result data for jobs entity.
@@ -1791,6 +1873,8 @@ Classes
     `updated_at: str | None`
     :   The date and time the job was last updated
 
+<a id="Offer"></a>
+
 `Offer(**data: Any)`
 :   Greenhouse offer object
     
@@ -1849,6 +1933,8 @@ Classes
     `version: int | Any`
     :   The type of the None singleton.
 
+<a id="OffersListResultMeta"></a>
+
 `OffersListResultMeta(**data: Any)`
 :   Metadata for offers.Action.LIST operation
     
@@ -1870,6 +1956,8 @@ Classes
 
     `next: str | Any | None`
     :   The type of the None singleton.
+
+<a id="OffersSearchData"></a>
 
 `OffersSearchData(**data: Any)`
 :   Search result data for offers entity.
@@ -1932,6 +2020,8 @@ Classes
     `version: int | None`
     :   Version of the offer data
 
+<a id="Office"></a>
+
 `Office(**data: Any)`
 :   Greenhouse office object
     
@@ -1978,6 +2068,8 @@ Classes
     `primary_contact_user_id: int | Any | None`
     :   The type of the None singleton.
 
+<a id="OfficesListResultMeta"></a>
+
 `OfficesListResultMeta(**data: Any)`
 :   Metadata for offices.Action.LIST operation
     
@@ -1999,6 +2091,8 @@ Classes
 
     `next: str | Any | None`
     :   The type of the None singleton.
+
+<a id="OfficesSearchData"></a>
 
 `OfficesSearchData(**data: Any)`
 :   Search result data for offices entity.
@@ -2045,6 +2139,8 @@ Classes
 
     `primary_contact_user_id: int | None`
     :   User ID of the primary contact person for this office
+
+<a id="ScheduledInterview"></a>
 
 `ScheduledInterview(**data: Any)`
 :   Greenhouse scheduled interview object
@@ -2104,6 +2200,8 @@ Classes
     `video_conferencing_url: str | Any | None`
     :   The type of the None singleton.
 
+<a id="ScheduledInterviewsListResultMeta"></a>
+
 `ScheduledInterviewsListResultMeta(**data: Any)`
 :   Metadata for scheduled_interviews.Action.LIST operation
     
@@ -2125,6 +2223,8 @@ Classes
 
     `next: str | Any | None`
     :   The type of the None singleton.
+
+<a id="Source"></a>
 
 `Source(**data: Any)`
 :   Greenhouse source object
@@ -2154,6 +2254,8 @@ Classes
     `type_: dict[str, typing.Any] | Any | None`
     :   The type of the None singleton.
 
+<a id="SourcesListResultMeta"></a>
+
 `SourcesListResultMeta(**data: Any)`
 :   Metadata for sources.Action.LIST operation
     
@@ -2175,6 +2277,8 @@ Classes
 
     `next: str | Any | None`
     :   The type of the None singleton.
+
+<a id="SourcesSearchData"></a>
 
 `SourcesSearchData(**data: Any)`
 :   Search result data for sources entity.
@@ -2203,6 +2307,8 @@ Classes
 
     `type_: dict[str, typing.Any] | None`
     :   Type of the data source
+
+<a id="User"></a>
 
 `User(**data: Any)`
 :   Greenhouse user object
@@ -2265,6 +2371,8 @@ Classes
     `updated_at: str | Any`
     :   The type of the None singleton.
 
+<a id="UsersListResultMeta"></a>
+
 `UsersListResultMeta(**data: Any)`
 :   Metadata for users.Action.LIST operation
     
@@ -2286,6 +2394,8 @@ Classes
 
     `next: str | Any | None`
     :   The type of the None singleton.
+
+<a id="UsersSearchData"></a>
 
 `UsersSearchData(**data: Any)`
 :   Search result data for users entity.

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/greenhouse/types.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/greenhouse/types.md
@@ -10,6 +10,8 @@ Type definitions for greenhouse connector.
 Classes
 -------
 
+<a id="AirbyteSearchParams"></a>
+
 `AirbyteSearchParams(*args, **kwargs)`
 :   Parameters for Airbyte cache search operations (generic, use entity-specific query types for better type hints).
 
@@ -31,6 +33,8 @@ Classes
     `query: dict[str, typing.Any]`
     :   The type of the None singleton.
 
+<a id="ApplicationAttachmentDownloadParams"></a>
+
 `ApplicationAttachmentDownloadParams(*args, **kwargs)`
 :   Parameters for application_attachment.download operation
 
@@ -48,6 +52,8 @@ Classes
 
     `range_header: str`
     :   The type of the None singleton.
+
+<a id="ApplicationsAndCondition"></a>
 
 `ApplicationsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -69,6 +75,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.greenhouse.types.ApplicationsEqCondition | airbyte_agent_sdk.connectors.greenhouse.types.ApplicationsNeqCondition | airbyte_agent_sdk.connectors.greenhouse.types.ApplicationsGtCondition | airbyte_agent_sdk.connectors.greenhouse.types.ApplicationsGteCondition | airbyte_agent_sdk.connectors.greenhouse.types.ApplicationsLtCondition | airbyte_agent_sdk.connectors.greenhouse.types.ApplicationsLteCondition | airbyte_agent_sdk.connectors.greenhouse.types.ApplicationsInCondition | airbyte_agent_sdk.connectors.greenhouse.types.ApplicationsLikeCondition | airbyte_agent_sdk.connectors.greenhouse.types.ApplicationsFuzzyCondition | airbyte_agent_sdk.connectors.greenhouse.types.ApplicationsKeywordCondition | airbyte_agent_sdk.connectors.greenhouse.types.ApplicationsContainsCondition | airbyte_agent_sdk.connectors.greenhouse.types.ApplicationsNotCondition | airbyte_agent_sdk.connectors.greenhouse.types.ApplicationsAndCondition | airbyte_agent_sdk.connectors.greenhouse.types.ApplicationsOrCondition | airbyte_agent_sdk.connectors.greenhouse.types.ApplicationsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="ApplicationsAnyCondition"></a>
+
 `ApplicationsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -88,6 +96,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.greenhouse.types.ApplicationsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="ApplicationsAnyValueFilter"></a>
 
 `ApplicationsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -158,6 +168,8 @@ Classes
     `status: Any`
     :   Status of the application.
 
+<a id="ApplicationsContainsCondition"></a>
+
 `ApplicationsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -169,6 +181,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.greenhouse.types.ApplicationsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="ApplicationsEqCondition"></a>
 
 `ApplicationsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -182,6 +196,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.greenhouse.types.ApplicationsSearchFilter`
     :   The type of the None singleton.
 
+<a id="ApplicationsFuzzyCondition"></a>
+
 `ApplicationsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -193,6 +209,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.greenhouse.types.ApplicationsStringFilter`
     :   The type of the None singleton.
+
+<a id="ApplicationsGetParams"></a>
 
 `ApplicationsGetParams(*args, **kwargs)`
 :   Parameters for applications.get operation
@@ -206,6 +224,8 @@ Classes
     `id: str`
     :   The type of the None singleton.
 
+<a id="ApplicationsGtCondition"></a>
+
 `ApplicationsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -218,6 +238,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.greenhouse.types.ApplicationsSearchFilter`
     :   The type of the None singleton.
 
+<a id="ApplicationsGteCondition"></a>
+
 `ApplicationsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -229,6 +251,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.greenhouse.types.ApplicationsSearchFilter`
     :   The type of the None singleton.
+
+<a id="ApplicationsInCondition"></a>
 
 `ApplicationsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -249,6 +273,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.greenhouse.types.ApplicationsInFilter`
     :   The type of the None singleton.
+
+<a id="ApplicationsInFilter"></a>
 
 `ApplicationsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -319,6 +345,8 @@ Classes
     `status: list[str]`
     :   Status of the application.
 
+<a id="ApplicationsKeywordCondition"></a>
+
 `ApplicationsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -331,6 +359,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.greenhouse.types.ApplicationsStringFilter`
     :   The type of the None singleton.
 
+<a id="ApplicationsLikeCondition"></a>
+
 `ApplicationsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -342,6 +372,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.greenhouse.types.ApplicationsStringFilter`
     :   The type of the None singleton.
+
+<a id="ApplicationsListParams"></a>
 
 `ApplicationsListParams(*args, **kwargs)`
 :   Parameters for applications.list operation
@@ -373,6 +405,8 @@ Classes
     `status: str`
     :   The type of the None singleton.
 
+<a id="ApplicationsLtCondition"></a>
+
 `ApplicationsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -384,6 +418,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.greenhouse.types.ApplicationsSearchFilter`
     :   The type of the None singleton.
+
+<a id="ApplicationsLteCondition"></a>
 
 `ApplicationsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -397,6 +433,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.greenhouse.types.ApplicationsSearchFilter`
     :   The type of the None singleton.
 
+<a id="ApplicationsNeqCondition"></a>
+
 `ApplicationsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -408,6 +446,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.greenhouse.types.ApplicationsSearchFilter`
     :   The type of the None singleton.
+
+<a id="ApplicationsNotCondition"></a>
 
 `ApplicationsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -429,6 +469,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.greenhouse.types.ApplicationsEqCondition | airbyte_agent_sdk.connectors.greenhouse.types.ApplicationsNeqCondition | airbyte_agent_sdk.connectors.greenhouse.types.ApplicationsGtCondition | airbyte_agent_sdk.connectors.greenhouse.types.ApplicationsGteCondition | airbyte_agent_sdk.connectors.greenhouse.types.ApplicationsLtCondition | airbyte_agent_sdk.connectors.greenhouse.types.ApplicationsLteCondition | airbyte_agent_sdk.connectors.greenhouse.types.ApplicationsInCondition | airbyte_agent_sdk.connectors.greenhouse.types.ApplicationsLikeCondition | airbyte_agent_sdk.connectors.greenhouse.types.ApplicationsFuzzyCondition | airbyte_agent_sdk.connectors.greenhouse.types.ApplicationsKeywordCondition | airbyte_agent_sdk.connectors.greenhouse.types.ApplicationsContainsCondition | airbyte_agent_sdk.connectors.greenhouse.types.ApplicationsNotCondition | airbyte_agent_sdk.connectors.greenhouse.types.ApplicationsAndCondition | airbyte_agent_sdk.connectors.greenhouse.types.ApplicationsOrCondition | airbyte_agent_sdk.connectors.greenhouse.types.ApplicationsAnyCondition`
     :   The type of the None singleton.
 
+<a id="ApplicationsOrCondition"></a>
+
 `ApplicationsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -448,6 +490,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.greenhouse.types.ApplicationsEqCondition | airbyte_agent_sdk.connectors.greenhouse.types.ApplicationsNeqCondition | airbyte_agent_sdk.connectors.greenhouse.types.ApplicationsGtCondition | airbyte_agent_sdk.connectors.greenhouse.types.ApplicationsGteCondition | airbyte_agent_sdk.connectors.greenhouse.types.ApplicationsLtCondition | airbyte_agent_sdk.connectors.greenhouse.types.ApplicationsLteCondition | airbyte_agent_sdk.connectors.greenhouse.types.ApplicationsInCondition | airbyte_agent_sdk.connectors.greenhouse.types.ApplicationsLikeCondition | airbyte_agent_sdk.connectors.greenhouse.types.ApplicationsFuzzyCondition | airbyte_agent_sdk.connectors.greenhouse.types.ApplicationsKeywordCondition | airbyte_agent_sdk.connectors.greenhouse.types.ApplicationsContainsCondition | airbyte_agent_sdk.connectors.greenhouse.types.ApplicationsNotCondition | airbyte_agent_sdk.connectors.greenhouse.types.ApplicationsAndCondition | airbyte_agent_sdk.connectors.greenhouse.types.ApplicationsOrCondition | airbyte_agent_sdk.connectors.greenhouse.types.ApplicationsAnyCondition]`
     :   The type of the None singleton.
+
+<a id="ApplicationsSearchFilter"></a>
 
 `ApplicationsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering applications search queries.
@@ -518,6 +562,8 @@ Classes
     `status: str | None`
     :   Status of the application.
 
+<a id="ApplicationsSearchQuery"></a>
+
 `ApplicationsSearchQuery(*args, **kwargs)`
 :   Search query for applications entity.
 
@@ -532,6 +578,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.greenhouse.types.ApplicationsSortFilter]`
     :   The type of the None singleton.
+
+<a id="ApplicationsSortFilter"></a>
 
 `ApplicationsSortFilter(*args, **kwargs)`
 :   Available fields for sorting applications search results.
@@ -602,6 +650,8 @@ Classes
     `status: Literal['asc', 'desc']`
     :   Status of the application.
 
+<a id="ApplicationsStringFilter"></a>
+
 `ApplicationsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -671,6 +721,8 @@ Classes
     `status: str`
     :   Status of the application.
 
+<a id="CandidateAttachmentDownloadParams"></a>
+
 `CandidateAttachmentDownloadParams(*args, **kwargs)`
 :   Parameters for candidate_attachment.download operation
 
@@ -688,6 +740,8 @@ Classes
 
     `range_header: str`
     :   The type of the None singleton.
+
+<a id="CandidatesAndCondition"></a>
 
 `CandidatesAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -709,6 +763,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.greenhouse.types.CandidatesEqCondition | airbyte_agent_sdk.connectors.greenhouse.types.CandidatesNeqCondition | airbyte_agent_sdk.connectors.greenhouse.types.CandidatesGtCondition | airbyte_agent_sdk.connectors.greenhouse.types.CandidatesGteCondition | airbyte_agent_sdk.connectors.greenhouse.types.CandidatesLtCondition | airbyte_agent_sdk.connectors.greenhouse.types.CandidatesLteCondition | airbyte_agent_sdk.connectors.greenhouse.types.CandidatesInCondition | airbyte_agent_sdk.connectors.greenhouse.types.CandidatesLikeCondition | airbyte_agent_sdk.connectors.greenhouse.types.CandidatesFuzzyCondition | airbyte_agent_sdk.connectors.greenhouse.types.CandidatesKeywordCondition | airbyte_agent_sdk.connectors.greenhouse.types.CandidatesContainsCondition | airbyte_agent_sdk.connectors.greenhouse.types.CandidatesNotCondition | airbyte_agent_sdk.connectors.greenhouse.types.CandidatesAndCondition | airbyte_agent_sdk.connectors.greenhouse.types.CandidatesOrCondition | airbyte_agent_sdk.connectors.greenhouse.types.CandidatesAnyCondition]`
     :   The type of the None singleton.
 
+<a id="CandidatesAnyCondition"></a>
+
 `CandidatesAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -728,6 +784,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.greenhouse.types.CandidatesAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="CandidatesAnyValueFilter"></a>
 
 `CandidatesAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -816,6 +874,8 @@ Classes
     `website_addresses: Any`
     :   List of candidate's website addresses
 
+<a id="CandidatesContainsCondition"></a>
+
 `CandidatesContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -827,6 +887,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.greenhouse.types.CandidatesAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="CandidatesEqCondition"></a>
 
 `CandidatesEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -840,6 +902,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.greenhouse.types.CandidatesSearchFilter`
     :   The type of the None singleton.
 
+<a id="CandidatesFuzzyCondition"></a>
+
 `CandidatesFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -851,6 +915,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.greenhouse.types.CandidatesStringFilter`
     :   The type of the None singleton.
+
+<a id="CandidatesGetParams"></a>
 
 `CandidatesGetParams(*args, **kwargs)`
 :   Parameters for candidates.get operation
@@ -864,6 +930,8 @@ Classes
     `id: str`
     :   The type of the None singleton.
 
+<a id="CandidatesGtCondition"></a>
+
 `CandidatesGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -876,6 +944,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.greenhouse.types.CandidatesSearchFilter`
     :   The type of the None singleton.
 
+<a id="CandidatesGteCondition"></a>
+
 `CandidatesGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -887,6 +957,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.greenhouse.types.CandidatesSearchFilter`
     :   The type of the None singleton.
+
+<a id="CandidatesInCondition"></a>
 
 `CandidatesInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -907,6 +979,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.greenhouse.types.CandidatesInFilter`
     :   The type of the None singleton.
+
+<a id="CandidatesInFilter"></a>
 
 `CandidatesInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -995,6 +1069,8 @@ Classes
     `website_addresses: list[list[typing.Any]]`
     :   List of candidate's website addresses
 
+<a id="CandidatesKeywordCondition"></a>
+
 `CandidatesKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -1007,6 +1083,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.greenhouse.types.CandidatesStringFilter`
     :   The type of the None singleton.
 
+<a id="CandidatesLikeCondition"></a>
+
 `CandidatesLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -1018,6 +1096,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.greenhouse.types.CandidatesStringFilter`
     :   The type of the None singleton.
+
+<a id="CandidatesListParams"></a>
 
 `CandidatesListParams(*args, **kwargs)`
 :   Parameters for candidates.list operation
@@ -1034,6 +1114,8 @@ Classes
     `per_page: int`
     :   The type of the None singleton.
 
+<a id="CandidatesLtCondition"></a>
+
 `CandidatesLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -1045,6 +1127,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.greenhouse.types.CandidatesSearchFilter`
     :   The type of the None singleton.
+
+<a id="CandidatesLteCondition"></a>
 
 `CandidatesLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -1058,6 +1142,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.greenhouse.types.CandidatesSearchFilter`
     :   The type of the None singleton.
 
+<a id="CandidatesNeqCondition"></a>
+
 `CandidatesNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -1069,6 +1155,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.greenhouse.types.CandidatesSearchFilter`
     :   The type of the None singleton.
+
+<a id="CandidatesNotCondition"></a>
 
 `CandidatesNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -1090,6 +1178,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.greenhouse.types.CandidatesEqCondition | airbyte_agent_sdk.connectors.greenhouse.types.CandidatesNeqCondition | airbyte_agent_sdk.connectors.greenhouse.types.CandidatesGtCondition | airbyte_agent_sdk.connectors.greenhouse.types.CandidatesGteCondition | airbyte_agent_sdk.connectors.greenhouse.types.CandidatesLtCondition | airbyte_agent_sdk.connectors.greenhouse.types.CandidatesLteCondition | airbyte_agent_sdk.connectors.greenhouse.types.CandidatesInCondition | airbyte_agent_sdk.connectors.greenhouse.types.CandidatesLikeCondition | airbyte_agent_sdk.connectors.greenhouse.types.CandidatesFuzzyCondition | airbyte_agent_sdk.connectors.greenhouse.types.CandidatesKeywordCondition | airbyte_agent_sdk.connectors.greenhouse.types.CandidatesContainsCondition | airbyte_agent_sdk.connectors.greenhouse.types.CandidatesNotCondition | airbyte_agent_sdk.connectors.greenhouse.types.CandidatesAndCondition | airbyte_agent_sdk.connectors.greenhouse.types.CandidatesOrCondition | airbyte_agent_sdk.connectors.greenhouse.types.CandidatesAnyCondition`
     :   The type of the None singleton.
 
+<a id="CandidatesOrCondition"></a>
+
 `CandidatesOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1109,6 +1199,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.greenhouse.types.CandidatesEqCondition | airbyte_agent_sdk.connectors.greenhouse.types.CandidatesNeqCondition | airbyte_agent_sdk.connectors.greenhouse.types.CandidatesGtCondition | airbyte_agent_sdk.connectors.greenhouse.types.CandidatesGteCondition | airbyte_agent_sdk.connectors.greenhouse.types.CandidatesLtCondition | airbyte_agent_sdk.connectors.greenhouse.types.CandidatesLteCondition | airbyte_agent_sdk.connectors.greenhouse.types.CandidatesInCondition | airbyte_agent_sdk.connectors.greenhouse.types.CandidatesLikeCondition | airbyte_agent_sdk.connectors.greenhouse.types.CandidatesFuzzyCondition | airbyte_agent_sdk.connectors.greenhouse.types.CandidatesKeywordCondition | airbyte_agent_sdk.connectors.greenhouse.types.CandidatesContainsCondition | airbyte_agent_sdk.connectors.greenhouse.types.CandidatesNotCondition | airbyte_agent_sdk.connectors.greenhouse.types.CandidatesAndCondition | airbyte_agent_sdk.connectors.greenhouse.types.CandidatesOrCondition | airbyte_agent_sdk.connectors.greenhouse.types.CandidatesAnyCondition]`
     :   The type of the None singleton.
+
+<a id="CandidatesSearchFilter"></a>
 
 `CandidatesSearchFilter(*args, **kwargs)`
 :   Available fields for filtering candidates search queries.
@@ -1197,6 +1289,8 @@ Classes
     `website_addresses: list[typing.Any] | None`
     :   List of candidate's website addresses
 
+<a id="CandidatesSearchQuery"></a>
+
 `CandidatesSearchQuery(*args, **kwargs)`
 :   Search query for candidates entity.
 
@@ -1211,6 +1305,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.greenhouse.types.CandidatesSortFilter]`
     :   The type of the None singleton.
+
+<a id="CandidatesSortFilter"></a>
 
 `CandidatesSortFilter(*args, **kwargs)`
 :   Available fields for sorting candidates search results.
@@ -1299,6 +1395,8 @@ Classes
     `website_addresses: Literal['asc', 'desc']`
     :   List of candidate's website addresses
 
+<a id="CandidatesStringFilter"></a>
+
 `CandidatesStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -1386,6 +1484,8 @@ Classes
     `website_addresses: str`
     :   List of candidate's website addresses
 
+<a id="DepartmentsAndCondition"></a>
+
 `DepartmentsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1406,6 +1506,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.greenhouse.types.DepartmentsEqCondition | airbyte_agent_sdk.connectors.greenhouse.types.DepartmentsNeqCondition | airbyte_agent_sdk.connectors.greenhouse.types.DepartmentsGtCondition | airbyte_agent_sdk.connectors.greenhouse.types.DepartmentsGteCondition | airbyte_agent_sdk.connectors.greenhouse.types.DepartmentsLtCondition | airbyte_agent_sdk.connectors.greenhouse.types.DepartmentsLteCondition | airbyte_agent_sdk.connectors.greenhouse.types.DepartmentsInCondition | airbyte_agent_sdk.connectors.greenhouse.types.DepartmentsLikeCondition | airbyte_agent_sdk.connectors.greenhouse.types.DepartmentsFuzzyCondition | airbyte_agent_sdk.connectors.greenhouse.types.DepartmentsKeywordCondition | airbyte_agent_sdk.connectors.greenhouse.types.DepartmentsContainsCondition | airbyte_agent_sdk.connectors.greenhouse.types.DepartmentsNotCondition | airbyte_agent_sdk.connectors.greenhouse.types.DepartmentsAndCondition | airbyte_agent_sdk.connectors.greenhouse.types.DepartmentsOrCondition | airbyte_agent_sdk.connectors.greenhouse.types.DepartmentsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="DepartmentsAnyCondition"></a>
+
 `DepartmentsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1425,6 +1527,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.greenhouse.types.DepartmentsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="DepartmentsAnyValueFilter"></a>
 
 `DepartmentsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -1456,6 +1560,8 @@ Classes
     `parent_id: Any`
     :   Unique ID of the parent department of this department.
 
+<a id="DepartmentsContainsCondition"></a>
+
 `DepartmentsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -1467,6 +1573,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.greenhouse.types.DepartmentsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="DepartmentsEqCondition"></a>
 
 `DepartmentsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -1480,6 +1588,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.greenhouse.types.DepartmentsSearchFilter`
     :   The type of the None singleton.
 
+<a id="DepartmentsFuzzyCondition"></a>
+
 `DepartmentsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -1491,6 +1601,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.greenhouse.types.DepartmentsStringFilter`
     :   The type of the None singleton.
+
+<a id="DepartmentsGetParams"></a>
 
 `DepartmentsGetParams(*args, **kwargs)`
 :   Parameters for departments.get operation
@@ -1504,6 +1616,8 @@ Classes
     `id: str`
     :   The type of the None singleton.
 
+<a id="DepartmentsGtCondition"></a>
+
 `DepartmentsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -1516,6 +1630,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.greenhouse.types.DepartmentsSearchFilter`
     :   The type of the None singleton.
 
+<a id="DepartmentsGteCondition"></a>
+
 `DepartmentsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -1527,6 +1643,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.greenhouse.types.DepartmentsSearchFilter`
     :   The type of the None singleton.
+
+<a id="DepartmentsInCondition"></a>
 
 `DepartmentsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -1547,6 +1665,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.greenhouse.types.DepartmentsInFilter`
     :   The type of the None singleton.
+
+<a id="DepartmentsInFilter"></a>
 
 `DepartmentsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -1578,6 +1698,8 @@ Classes
     `parent_id: list[int]`
     :   Unique ID of the parent department of this department.
 
+<a id="DepartmentsKeywordCondition"></a>
+
 `DepartmentsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -1590,6 +1712,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.greenhouse.types.DepartmentsStringFilter`
     :   The type of the None singleton.
 
+<a id="DepartmentsLikeCondition"></a>
+
 `DepartmentsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -1601,6 +1725,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.greenhouse.types.DepartmentsStringFilter`
     :   The type of the None singleton.
+
+<a id="DepartmentsListParams"></a>
 
 `DepartmentsListParams(*args, **kwargs)`
 :   Parameters for departments.list operation
@@ -1617,6 +1743,8 @@ Classes
     `per_page: int`
     :   The type of the None singleton.
 
+<a id="DepartmentsLtCondition"></a>
+
 `DepartmentsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -1628,6 +1756,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.greenhouse.types.DepartmentsSearchFilter`
     :   The type of the None singleton.
+
+<a id="DepartmentsLteCondition"></a>
 
 `DepartmentsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -1641,6 +1771,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.greenhouse.types.DepartmentsSearchFilter`
     :   The type of the None singleton.
 
+<a id="DepartmentsNeqCondition"></a>
+
 `DepartmentsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -1652,6 +1784,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.greenhouse.types.DepartmentsSearchFilter`
     :   The type of the None singleton.
+
+<a id="DepartmentsNotCondition"></a>
 
 `DepartmentsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -1673,6 +1807,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.greenhouse.types.DepartmentsEqCondition | airbyte_agent_sdk.connectors.greenhouse.types.DepartmentsNeqCondition | airbyte_agent_sdk.connectors.greenhouse.types.DepartmentsGtCondition | airbyte_agent_sdk.connectors.greenhouse.types.DepartmentsGteCondition | airbyte_agent_sdk.connectors.greenhouse.types.DepartmentsLtCondition | airbyte_agent_sdk.connectors.greenhouse.types.DepartmentsLteCondition | airbyte_agent_sdk.connectors.greenhouse.types.DepartmentsInCondition | airbyte_agent_sdk.connectors.greenhouse.types.DepartmentsLikeCondition | airbyte_agent_sdk.connectors.greenhouse.types.DepartmentsFuzzyCondition | airbyte_agent_sdk.connectors.greenhouse.types.DepartmentsKeywordCondition | airbyte_agent_sdk.connectors.greenhouse.types.DepartmentsContainsCondition | airbyte_agent_sdk.connectors.greenhouse.types.DepartmentsNotCondition | airbyte_agent_sdk.connectors.greenhouse.types.DepartmentsAndCondition | airbyte_agent_sdk.connectors.greenhouse.types.DepartmentsOrCondition | airbyte_agent_sdk.connectors.greenhouse.types.DepartmentsAnyCondition`
     :   The type of the None singleton.
 
+<a id="DepartmentsOrCondition"></a>
+
 `DepartmentsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1692,6 +1828,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.greenhouse.types.DepartmentsEqCondition | airbyte_agent_sdk.connectors.greenhouse.types.DepartmentsNeqCondition | airbyte_agent_sdk.connectors.greenhouse.types.DepartmentsGtCondition | airbyte_agent_sdk.connectors.greenhouse.types.DepartmentsGteCondition | airbyte_agent_sdk.connectors.greenhouse.types.DepartmentsLtCondition | airbyte_agent_sdk.connectors.greenhouse.types.DepartmentsLteCondition | airbyte_agent_sdk.connectors.greenhouse.types.DepartmentsInCondition | airbyte_agent_sdk.connectors.greenhouse.types.DepartmentsLikeCondition | airbyte_agent_sdk.connectors.greenhouse.types.DepartmentsFuzzyCondition | airbyte_agent_sdk.connectors.greenhouse.types.DepartmentsKeywordCondition | airbyte_agent_sdk.connectors.greenhouse.types.DepartmentsContainsCondition | airbyte_agent_sdk.connectors.greenhouse.types.DepartmentsNotCondition | airbyte_agent_sdk.connectors.greenhouse.types.DepartmentsAndCondition | airbyte_agent_sdk.connectors.greenhouse.types.DepartmentsOrCondition | airbyte_agent_sdk.connectors.greenhouse.types.DepartmentsAnyCondition]`
     :   The type of the None singleton.
+
+<a id="DepartmentsSearchFilter"></a>
 
 `DepartmentsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering departments search queries.
@@ -1723,6 +1861,8 @@ Classes
     `parent_id: int | None`
     :   Unique ID of the parent department of this department.
 
+<a id="DepartmentsSearchQuery"></a>
+
 `DepartmentsSearchQuery(*args, **kwargs)`
 :   Search query for departments entity.
 
@@ -1737,6 +1877,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.greenhouse.types.DepartmentsSortFilter]`
     :   The type of the None singleton.
+
+<a id="DepartmentsSortFilter"></a>
 
 `DepartmentsSortFilter(*args, **kwargs)`
 :   Available fields for sorting departments search results.
@@ -1768,6 +1910,8 @@ Classes
     `parent_id: Literal['asc', 'desc']`
     :   Unique ID of the parent department of this department.
 
+<a id="DepartmentsStringFilter"></a>
+
 `DepartmentsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -1798,6 +1942,8 @@ Classes
     `parent_id: str`
     :   Unique ID of the parent department of this department.
 
+<a id="JobPostsAndCondition"></a>
+
 `JobPostsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1818,6 +1964,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.greenhouse.types.JobPostsEqCondition | airbyte_agent_sdk.connectors.greenhouse.types.JobPostsNeqCondition | airbyte_agent_sdk.connectors.greenhouse.types.JobPostsGtCondition | airbyte_agent_sdk.connectors.greenhouse.types.JobPostsGteCondition | airbyte_agent_sdk.connectors.greenhouse.types.JobPostsLtCondition | airbyte_agent_sdk.connectors.greenhouse.types.JobPostsLteCondition | airbyte_agent_sdk.connectors.greenhouse.types.JobPostsInCondition | airbyte_agent_sdk.connectors.greenhouse.types.JobPostsLikeCondition | airbyte_agent_sdk.connectors.greenhouse.types.JobPostsFuzzyCondition | airbyte_agent_sdk.connectors.greenhouse.types.JobPostsKeywordCondition | airbyte_agent_sdk.connectors.greenhouse.types.JobPostsContainsCondition | airbyte_agent_sdk.connectors.greenhouse.types.JobPostsNotCondition | airbyte_agent_sdk.connectors.greenhouse.types.JobPostsAndCondition | airbyte_agent_sdk.connectors.greenhouse.types.JobPostsOrCondition | airbyte_agent_sdk.connectors.greenhouse.types.JobPostsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="JobPostsAnyCondition"></a>
+
 `JobPostsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1837,6 +1985,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.greenhouse.types.JobPostsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="JobPostsAnyValueFilter"></a>
 
 `JobPostsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -1892,6 +2042,8 @@ Classes
     `updated_at: Any`
     :   Date and time when the job post was last updated.
 
+<a id="JobPostsContainsCondition"></a>
+
 `JobPostsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -1903,6 +2055,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.greenhouse.types.JobPostsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="JobPostsEqCondition"></a>
 
 `JobPostsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -1916,6 +2070,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.greenhouse.types.JobPostsSearchFilter`
     :   The type of the None singleton.
 
+<a id="JobPostsFuzzyCondition"></a>
+
 `JobPostsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -1927,6 +2083,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.greenhouse.types.JobPostsStringFilter`
     :   The type of the None singleton.
+
+<a id="JobPostsGetParams"></a>
 
 `JobPostsGetParams(*args, **kwargs)`
 :   Parameters for job_posts.get operation
@@ -1940,6 +2098,8 @@ Classes
     `id: str`
     :   The type of the None singleton.
 
+<a id="JobPostsGtCondition"></a>
+
 `JobPostsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -1952,6 +2112,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.greenhouse.types.JobPostsSearchFilter`
     :   The type of the None singleton.
 
+<a id="JobPostsGteCondition"></a>
+
 `JobPostsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -1963,6 +2125,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.greenhouse.types.JobPostsSearchFilter`
     :   The type of the None singleton.
+
+<a id="JobPostsInCondition"></a>
 
 `JobPostsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -1983,6 +2147,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.greenhouse.types.JobPostsInFilter`
     :   The type of the None singleton.
+
+<a id="JobPostsInFilter"></a>
 
 `JobPostsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -2038,6 +2204,8 @@ Classes
     `updated_at: list[str]`
     :   Date and time when the job post was last updated.
 
+<a id="JobPostsKeywordCondition"></a>
+
 `JobPostsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -2050,6 +2218,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.greenhouse.types.JobPostsStringFilter`
     :   The type of the None singleton.
 
+<a id="JobPostsLikeCondition"></a>
+
 `JobPostsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -2061,6 +2231,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.greenhouse.types.JobPostsStringFilter`
     :   The type of the None singleton.
+
+<a id="JobPostsListParams"></a>
 
 `JobPostsListParams(*args, **kwargs)`
 :   Parameters for job_posts.list operation
@@ -2083,6 +2255,8 @@ Classes
     `per_page: int`
     :   The type of the None singleton.
 
+<a id="JobPostsLtCondition"></a>
+
 `JobPostsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -2094,6 +2268,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.greenhouse.types.JobPostsSearchFilter`
     :   The type of the None singleton.
+
+<a id="JobPostsLteCondition"></a>
 
 `JobPostsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -2107,6 +2283,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.greenhouse.types.JobPostsSearchFilter`
     :   The type of the None singleton.
 
+<a id="JobPostsNeqCondition"></a>
+
 `JobPostsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -2118,6 +2296,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.greenhouse.types.JobPostsSearchFilter`
     :   The type of the None singleton.
+
+<a id="JobPostsNotCondition"></a>
 
 `JobPostsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -2139,6 +2319,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.greenhouse.types.JobPostsEqCondition | airbyte_agent_sdk.connectors.greenhouse.types.JobPostsNeqCondition | airbyte_agent_sdk.connectors.greenhouse.types.JobPostsGtCondition | airbyte_agent_sdk.connectors.greenhouse.types.JobPostsGteCondition | airbyte_agent_sdk.connectors.greenhouse.types.JobPostsLtCondition | airbyte_agent_sdk.connectors.greenhouse.types.JobPostsLteCondition | airbyte_agent_sdk.connectors.greenhouse.types.JobPostsInCondition | airbyte_agent_sdk.connectors.greenhouse.types.JobPostsLikeCondition | airbyte_agent_sdk.connectors.greenhouse.types.JobPostsFuzzyCondition | airbyte_agent_sdk.connectors.greenhouse.types.JobPostsKeywordCondition | airbyte_agent_sdk.connectors.greenhouse.types.JobPostsContainsCondition | airbyte_agent_sdk.connectors.greenhouse.types.JobPostsNotCondition | airbyte_agent_sdk.connectors.greenhouse.types.JobPostsAndCondition | airbyte_agent_sdk.connectors.greenhouse.types.JobPostsOrCondition | airbyte_agent_sdk.connectors.greenhouse.types.JobPostsAnyCondition`
     :   The type of the None singleton.
 
+<a id="JobPostsOrCondition"></a>
+
 `JobPostsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -2158,6 +2340,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.greenhouse.types.JobPostsEqCondition | airbyte_agent_sdk.connectors.greenhouse.types.JobPostsNeqCondition | airbyte_agent_sdk.connectors.greenhouse.types.JobPostsGtCondition | airbyte_agent_sdk.connectors.greenhouse.types.JobPostsGteCondition | airbyte_agent_sdk.connectors.greenhouse.types.JobPostsLtCondition | airbyte_agent_sdk.connectors.greenhouse.types.JobPostsLteCondition | airbyte_agent_sdk.connectors.greenhouse.types.JobPostsInCondition | airbyte_agent_sdk.connectors.greenhouse.types.JobPostsLikeCondition | airbyte_agent_sdk.connectors.greenhouse.types.JobPostsFuzzyCondition | airbyte_agent_sdk.connectors.greenhouse.types.JobPostsKeywordCondition | airbyte_agent_sdk.connectors.greenhouse.types.JobPostsContainsCondition | airbyte_agent_sdk.connectors.greenhouse.types.JobPostsNotCondition | airbyte_agent_sdk.connectors.greenhouse.types.JobPostsAndCondition | airbyte_agent_sdk.connectors.greenhouse.types.JobPostsOrCondition | airbyte_agent_sdk.connectors.greenhouse.types.JobPostsAnyCondition]`
     :   The type of the None singleton.
+
+<a id="JobPostsSearchFilter"></a>
 
 `JobPostsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering job_posts search queries.
@@ -2213,6 +2397,8 @@ Classes
     `updated_at: str | None`
     :   Date and time when the job post was last updated.
 
+<a id="JobPostsSearchQuery"></a>
+
 `JobPostsSearchQuery(*args, **kwargs)`
 :   Search query for job_posts entity.
 
@@ -2227,6 +2413,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.greenhouse.types.JobPostsSortFilter]`
     :   The type of the None singleton.
+
+<a id="JobPostsSortFilter"></a>
 
 `JobPostsSortFilter(*args, **kwargs)`
 :   Available fields for sorting job_posts search results.
@@ -2282,6 +2470,8 @@ Classes
     `updated_at: Literal['asc', 'desc']`
     :   Date and time when the job post was last updated.
 
+<a id="JobPostsStringFilter"></a>
+
 `JobPostsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -2336,6 +2526,8 @@ Classes
     `updated_at: str`
     :   Date and time when the job post was last updated.
 
+<a id="JobsAndCondition"></a>
+
 `JobsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -2356,6 +2548,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.greenhouse.types.JobsEqCondition | airbyte_agent_sdk.connectors.greenhouse.types.JobsNeqCondition | airbyte_agent_sdk.connectors.greenhouse.types.JobsGtCondition | airbyte_agent_sdk.connectors.greenhouse.types.JobsGteCondition | airbyte_agent_sdk.connectors.greenhouse.types.JobsLtCondition | airbyte_agent_sdk.connectors.greenhouse.types.JobsLteCondition | airbyte_agent_sdk.connectors.greenhouse.types.JobsInCondition | airbyte_agent_sdk.connectors.greenhouse.types.JobsLikeCondition | airbyte_agent_sdk.connectors.greenhouse.types.JobsFuzzyCondition | airbyte_agent_sdk.connectors.greenhouse.types.JobsKeywordCondition | airbyte_agent_sdk.connectors.greenhouse.types.JobsContainsCondition | airbyte_agent_sdk.connectors.greenhouse.types.JobsNotCondition | airbyte_agent_sdk.connectors.greenhouse.types.JobsAndCondition | airbyte_agent_sdk.connectors.greenhouse.types.JobsOrCondition | airbyte_agent_sdk.connectors.greenhouse.types.JobsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="JobsAnyCondition"></a>
+
 `JobsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -2375,6 +2569,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.greenhouse.types.JobsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="JobsAnyValueFilter"></a>
 
 `JobsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -2439,6 +2635,8 @@ Classes
     `updated_at: Any`
     :   The date and time the job was last updated
 
+<a id="JobsContainsCondition"></a>
+
 `JobsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -2450,6 +2648,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.greenhouse.types.JobsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="JobsEqCondition"></a>
 
 `JobsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -2463,6 +2663,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.greenhouse.types.JobsSearchFilter`
     :   The type of the None singleton.
 
+<a id="JobsFuzzyCondition"></a>
+
 `JobsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -2474,6 +2676,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.greenhouse.types.JobsStringFilter`
     :   The type of the None singleton.
+
+<a id="JobsGetParams"></a>
 
 `JobsGetParams(*args, **kwargs)`
 :   Parameters for jobs.get operation
@@ -2487,6 +2691,8 @@ Classes
     `id: str`
     :   The type of the None singleton.
 
+<a id="JobsGtCondition"></a>
+
 `JobsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -2499,6 +2705,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.greenhouse.types.JobsSearchFilter`
     :   The type of the None singleton.
 
+<a id="JobsGteCondition"></a>
+
 `JobsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -2510,6 +2718,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.greenhouse.types.JobsSearchFilter`
     :   The type of the None singleton.
+
+<a id="JobsInCondition"></a>
 
 `JobsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -2530,6 +2740,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.greenhouse.types.JobsInFilter`
     :   The type of the None singleton.
+
+<a id="JobsInFilter"></a>
 
 `JobsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -2594,6 +2806,8 @@ Classes
     `updated_at: list[str]`
     :   The date and time the job was last updated
 
+<a id="JobsKeywordCondition"></a>
+
 `JobsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -2606,6 +2820,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.greenhouse.types.JobsStringFilter`
     :   The type of the None singleton.
 
+<a id="JobsLikeCondition"></a>
+
 `JobsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -2617,6 +2833,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.greenhouse.types.JobsStringFilter`
     :   The type of the None singleton.
+
+<a id="JobsListParams"></a>
 
 `JobsListParams(*args, **kwargs)`
 :   Parameters for jobs.list operation
@@ -2633,6 +2851,8 @@ Classes
     `per_page: int`
     :   The type of the None singleton.
 
+<a id="JobsLtCondition"></a>
+
 `JobsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -2644,6 +2864,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.greenhouse.types.JobsSearchFilter`
     :   The type of the None singleton.
+
+<a id="JobsLteCondition"></a>
 
 `JobsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -2657,6 +2879,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.greenhouse.types.JobsSearchFilter`
     :   The type of the None singleton.
 
+<a id="JobsNeqCondition"></a>
+
 `JobsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -2668,6 +2892,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.greenhouse.types.JobsSearchFilter`
     :   The type of the None singleton.
+
+<a id="JobsNotCondition"></a>
 
 `JobsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -2689,6 +2915,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.greenhouse.types.JobsEqCondition | airbyte_agent_sdk.connectors.greenhouse.types.JobsNeqCondition | airbyte_agent_sdk.connectors.greenhouse.types.JobsGtCondition | airbyte_agent_sdk.connectors.greenhouse.types.JobsGteCondition | airbyte_agent_sdk.connectors.greenhouse.types.JobsLtCondition | airbyte_agent_sdk.connectors.greenhouse.types.JobsLteCondition | airbyte_agent_sdk.connectors.greenhouse.types.JobsInCondition | airbyte_agent_sdk.connectors.greenhouse.types.JobsLikeCondition | airbyte_agent_sdk.connectors.greenhouse.types.JobsFuzzyCondition | airbyte_agent_sdk.connectors.greenhouse.types.JobsKeywordCondition | airbyte_agent_sdk.connectors.greenhouse.types.JobsContainsCondition | airbyte_agent_sdk.connectors.greenhouse.types.JobsNotCondition | airbyte_agent_sdk.connectors.greenhouse.types.JobsAndCondition | airbyte_agent_sdk.connectors.greenhouse.types.JobsOrCondition | airbyte_agent_sdk.connectors.greenhouse.types.JobsAnyCondition`
     :   The type of the None singleton.
 
+<a id="JobsOrCondition"></a>
+
 `JobsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -2708,6 +2936,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.greenhouse.types.JobsEqCondition | airbyte_agent_sdk.connectors.greenhouse.types.JobsNeqCondition | airbyte_agent_sdk.connectors.greenhouse.types.JobsGtCondition | airbyte_agent_sdk.connectors.greenhouse.types.JobsGteCondition | airbyte_agent_sdk.connectors.greenhouse.types.JobsLtCondition | airbyte_agent_sdk.connectors.greenhouse.types.JobsLteCondition | airbyte_agent_sdk.connectors.greenhouse.types.JobsInCondition | airbyte_agent_sdk.connectors.greenhouse.types.JobsLikeCondition | airbyte_agent_sdk.connectors.greenhouse.types.JobsFuzzyCondition | airbyte_agent_sdk.connectors.greenhouse.types.JobsKeywordCondition | airbyte_agent_sdk.connectors.greenhouse.types.JobsContainsCondition | airbyte_agent_sdk.connectors.greenhouse.types.JobsNotCondition | airbyte_agent_sdk.connectors.greenhouse.types.JobsAndCondition | airbyte_agent_sdk.connectors.greenhouse.types.JobsOrCondition | airbyte_agent_sdk.connectors.greenhouse.types.JobsAnyCondition]`
     :   The type of the None singleton.
+
+<a id="JobsSearchFilter"></a>
 
 `JobsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering jobs search queries.
@@ -2772,6 +3002,8 @@ Classes
     `updated_at: str | None`
     :   The date and time the job was last updated
 
+<a id="JobsSearchQuery"></a>
+
 `JobsSearchQuery(*args, **kwargs)`
 :   Search query for jobs entity.
 
@@ -2786,6 +3018,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.greenhouse.types.JobsSortFilter]`
     :   The type of the None singleton.
+
+<a id="JobsSortFilter"></a>
 
 `JobsSortFilter(*args, **kwargs)`
 :   Available fields for sorting jobs search results.
@@ -2850,6 +3084,8 @@ Classes
     `updated_at: Literal['asc', 'desc']`
     :   The date and time the job was last updated
 
+<a id="JobsStringFilter"></a>
+
 `JobsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -2913,6 +3149,8 @@ Classes
     `updated_at: str`
     :   The date and time the job was last updated
 
+<a id="OffersAndCondition"></a>
+
 `OffersAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -2933,6 +3171,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.greenhouse.types.OffersEqCondition | airbyte_agent_sdk.connectors.greenhouse.types.OffersNeqCondition | airbyte_agent_sdk.connectors.greenhouse.types.OffersGtCondition | airbyte_agent_sdk.connectors.greenhouse.types.OffersGteCondition | airbyte_agent_sdk.connectors.greenhouse.types.OffersLtCondition | airbyte_agent_sdk.connectors.greenhouse.types.OffersLteCondition | airbyte_agent_sdk.connectors.greenhouse.types.OffersInCondition | airbyte_agent_sdk.connectors.greenhouse.types.OffersLikeCondition | airbyte_agent_sdk.connectors.greenhouse.types.OffersFuzzyCondition | airbyte_agent_sdk.connectors.greenhouse.types.OffersKeywordCondition | airbyte_agent_sdk.connectors.greenhouse.types.OffersContainsCondition | airbyte_agent_sdk.connectors.greenhouse.types.OffersNotCondition | airbyte_agent_sdk.connectors.greenhouse.types.OffersAndCondition | airbyte_agent_sdk.connectors.greenhouse.types.OffersOrCondition | airbyte_agent_sdk.connectors.greenhouse.types.OffersAnyCondition]`
     :   The type of the None singleton.
 
+<a id="OffersAnyCondition"></a>
+
 `OffersAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -2952,6 +3192,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.greenhouse.types.OffersAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="OffersAnyValueFilter"></a>
 
 `OffersAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -3004,6 +3246,8 @@ Classes
     `version: Any`
     :   Version of the offer data
 
+<a id="OffersContainsCondition"></a>
+
 `OffersContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -3015,6 +3259,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.greenhouse.types.OffersAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="OffersEqCondition"></a>
 
 `OffersEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -3028,6 +3274,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.greenhouse.types.OffersSearchFilter`
     :   The type of the None singleton.
 
+<a id="OffersFuzzyCondition"></a>
+
 `OffersFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -3039,6 +3287,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.greenhouse.types.OffersStringFilter`
     :   The type of the None singleton.
+
+<a id="OffersGetParams"></a>
 
 `OffersGetParams(*args, **kwargs)`
 :   Parameters for offers.get operation
@@ -3052,6 +3302,8 @@ Classes
     `id: str`
     :   The type of the None singleton.
 
+<a id="OffersGtCondition"></a>
+
 `OffersGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -3064,6 +3316,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.greenhouse.types.OffersSearchFilter`
     :   The type of the None singleton.
 
+<a id="OffersGteCondition"></a>
+
 `OffersGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -3075,6 +3329,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.greenhouse.types.OffersSearchFilter`
     :   The type of the None singleton.
+
+<a id="OffersInCondition"></a>
 
 `OffersInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -3095,6 +3351,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.greenhouse.types.OffersInFilter`
     :   The type of the None singleton.
+
+<a id="OffersInFilter"></a>
 
 `OffersInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -3147,6 +3405,8 @@ Classes
     `version: list[int]`
     :   Version of the offer data
 
+<a id="OffersKeywordCondition"></a>
+
 `OffersKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -3159,6 +3419,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.greenhouse.types.OffersStringFilter`
     :   The type of the None singleton.
 
+<a id="OffersLikeCondition"></a>
+
 `OffersLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -3170,6 +3432,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.greenhouse.types.OffersStringFilter`
     :   The type of the None singleton.
+
+<a id="OffersListParams"></a>
 
 `OffersListParams(*args, **kwargs)`
 :   Parameters for offers.list operation
@@ -3195,6 +3459,8 @@ Classes
     `resolved_after: str`
     :   The type of the None singleton.
 
+<a id="OffersLtCondition"></a>
+
 `OffersLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -3206,6 +3472,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.greenhouse.types.OffersSearchFilter`
     :   The type of the None singleton.
+
+<a id="OffersLteCondition"></a>
 
 `OffersLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -3219,6 +3487,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.greenhouse.types.OffersSearchFilter`
     :   The type of the None singleton.
 
+<a id="OffersNeqCondition"></a>
+
 `OffersNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -3230,6 +3500,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.greenhouse.types.OffersSearchFilter`
     :   The type of the None singleton.
+
+<a id="OffersNotCondition"></a>
 
 `OffersNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -3251,6 +3523,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.greenhouse.types.OffersEqCondition | airbyte_agent_sdk.connectors.greenhouse.types.OffersNeqCondition | airbyte_agent_sdk.connectors.greenhouse.types.OffersGtCondition | airbyte_agent_sdk.connectors.greenhouse.types.OffersGteCondition | airbyte_agent_sdk.connectors.greenhouse.types.OffersLtCondition | airbyte_agent_sdk.connectors.greenhouse.types.OffersLteCondition | airbyte_agent_sdk.connectors.greenhouse.types.OffersInCondition | airbyte_agent_sdk.connectors.greenhouse.types.OffersLikeCondition | airbyte_agent_sdk.connectors.greenhouse.types.OffersFuzzyCondition | airbyte_agent_sdk.connectors.greenhouse.types.OffersKeywordCondition | airbyte_agent_sdk.connectors.greenhouse.types.OffersContainsCondition | airbyte_agent_sdk.connectors.greenhouse.types.OffersNotCondition | airbyte_agent_sdk.connectors.greenhouse.types.OffersAndCondition | airbyte_agent_sdk.connectors.greenhouse.types.OffersOrCondition | airbyte_agent_sdk.connectors.greenhouse.types.OffersAnyCondition`
     :   The type of the None singleton.
 
+<a id="OffersOrCondition"></a>
+
 `OffersOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -3270,6 +3544,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.greenhouse.types.OffersEqCondition | airbyte_agent_sdk.connectors.greenhouse.types.OffersNeqCondition | airbyte_agent_sdk.connectors.greenhouse.types.OffersGtCondition | airbyte_agent_sdk.connectors.greenhouse.types.OffersGteCondition | airbyte_agent_sdk.connectors.greenhouse.types.OffersLtCondition | airbyte_agent_sdk.connectors.greenhouse.types.OffersLteCondition | airbyte_agent_sdk.connectors.greenhouse.types.OffersInCondition | airbyte_agent_sdk.connectors.greenhouse.types.OffersLikeCondition | airbyte_agent_sdk.connectors.greenhouse.types.OffersFuzzyCondition | airbyte_agent_sdk.connectors.greenhouse.types.OffersKeywordCondition | airbyte_agent_sdk.connectors.greenhouse.types.OffersContainsCondition | airbyte_agent_sdk.connectors.greenhouse.types.OffersNotCondition | airbyte_agent_sdk.connectors.greenhouse.types.OffersAndCondition | airbyte_agent_sdk.connectors.greenhouse.types.OffersOrCondition | airbyte_agent_sdk.connectors.greenhouse.types.OffersAnyCondition]`
     :   The type of the None singleton.
+
+<a id="OffersSearchFilter"></a>
 
 `OffersSearchFilter(*args, **kwargs)`
 :   Available fields for filtering offers search queries.
@@ -3322,6 +3598,8 @@ Classes
     `version: int | None`
     :   Version of the offer data
 
+<a id="OffersSearchQuery"></a>
+
 `OffersSearchQuery(*args, **kwargs)`
 :   Search query for offers entity.
 
@@ -3336,6 +3614,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.greenhouse.types.OffersSortFilter]`
     :   The type of the None singleton.
+
+<a id="OffersSortFilter"></a>
 
 `OffersSortFilter(*args, **kwargs)`
 :   Available fields for sorting offers search results.
@@ -3388,6 +3668,8 @@ Classes
     `version: Literal['asc', 'desc']`
     :   Version of the offer data
 
+<a id="OffersStringFilter"></a>
+
 `OffersStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -3439,6 +3721,8 @@ Classes
     `version: str`
     :   Version of the offer data
 
+<a id="OfficesAndCondition"></a>
+
 `OfficesAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -3459,6 +3743,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.greenhouse.types.OfficesEqCondition | airbyte_agent_sdk.connectors.greenhouse.types.OfficesNeqCondition | airbyte_agent_sdk.connectors.greenhouse.types.OfficesGtCondition | airbyte_agent_sdk.connectors.greenhouse.types.OfficesGteCondition | airbyte_agent_sdk.connectors.greenhouse.types.OfficesLtCondition | airbyte_agent_sdk.connectors.greenhouse.types.OfficesLteCondition | airbyte_agent_sdk.connectors.greenhouse.types.OfficesInCondition | airbyte_agent_sdk.connectors.greenhouse.types.OfficesLikeCondition | airbyte_agent_sdk.connectors.greenhouse.types.OfficesFuzzyCondition | airbyte_agent_sdk.connectors.greenhouse.types.OfficesKeywordCondition | airbyte_agent_sdk.connectors.greenhouse.types.OfficesContainsCondition | airbyte_agent_sdk.connectors.greenhouse.types.OfficesNotCondition | airbyte_agent_sdk.connectors.greenhouse.types.OfficesAndCondition | airbyte_agent_sdk.connectors.greenhouse.types.OfficesOrCondition | airbyte_agent_sdk.connectors.greenhouse.types.OfficesAnyCondition]`
     :   The type of the None singleton.
 
+<a id="OfficesAnyCondition"></a>
+
 `OfficesAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -3478,6 +3764,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.greenhouse.types.OfficesAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="OfficesAnyValueFilter"></a>
 
 `OfficesAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -3515,6 +3803,8 @@ Classes
     `primary_contact_user_id: Any`
     :   User ID of the primary contact person for this office
 
+<a id="OfficesContainsCondition"></a>
+
 `OfficesContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -3526,6 +3816,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.greenhouse.types.OfficesAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="OfficesEqCondition"></a>
 
 `OfficesEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -3539,6 +3831,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.greenhouse.types.OfficesSearchFilter`
     :   The type of the None singleton.
 
+<a id="OfficesFuzzyCondition"></a>
+
 `OfficesFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -3550,6 +3844,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.greenhouse.types.OfficesStringFilter`
     :   The type of the None singleton.
+
+<a id="OfficesGetParams"></a>
 
 `OfficesGetParams(*args, **kwargs)`
 :   Parameters for offices.get operation
@@ -3563,6 +3859,8 @@ Classes
     `id: str`
     :   The type of the None singleton.
 
+<a id="OfficesGtCondition"></a>
+
 `OfficesGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -3575,6 +3873,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.greenhouse.types.OfficesSearchFilter`
     :   The type of the None singleton.
 
+<a id="OfficesGteCondition"></a>
+
 `OfficesGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -3586,6 +3886,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.greenhouse.types.OfficesSearchFilter`
     :   The type of the None singleton.
+
+<a id="OfficesInCondition"></a>
 
 `OfficesInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -3606,6 +3908,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.greenhouse.types.OfficesInFilter`
     :   The type of the None singleton.
+
+<a id="OfficesInFilter"></a>
 
 `OfficesInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -3643,6 +3947,8 @@ Classes
     `primary_contact_user_id: list[int]`
     :   User ID of the primary contact person for this office
 
+<a id="OfficesKeywordCondition"></a>
+
 `OfficesKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -3655,6 +3961,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.greenhouse.types.OfficesStringFilter`
     :   The type of the None singleton.
 
+<a id="OfficesLikeCondition"></a>
+
 `OfficesLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -3666,6 +3974,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.greenhouse.types.OfficesStringFilter`
     :   The type of the None singleton.
+
+<a id="OfficesListParams"></a>
 
 `OfficesListParams(*args, **kwargs)`
 :   Parameters for offices.list operation
@@ -3682,6 +3992,8 @@ Classes
     `per_page: int`
     :   The type of the None singleton.
 
+<a id="OfficesLtCondition"></a>
+
 `OfficesLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -3693,6 +4005,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.greenhouse.types.OfficesSearchFilter`
     :   The type of the None singleton.
+
+<a id="OfficesLteCondition"></a>
 
 `OfficesLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -3706,6 +4020,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.greenhouse.types.OfficesSearchFilter`
     :   The type of the None singleton.
 
+<a id="OfficesNeqCondition"></a>
+
 `OfficesNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -3717,6 +4033,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.greenhouse.types.OfficesSearchFilter`
     :   The type of the None singleton.
+
+<a id="OfficesNotCondition"></a>
 
 `OfficesNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -3738,6 +4056,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.greenhouse.types.OfficesEqCondition | airbyte_agent_sdk.connectors.greenhouse.types.OfficesNeqCondition | airbyte_agent_sdk.connectors.greenhouse.types.OfficesGtCondition | airbyte_agent_sdk.connectors.greenhouse.types.OfficesGteCondition | airbyte_agent_sdk.connectors.greenhouse.types.OfficesLtCondition | airbyte_agent_sdk.connectors.greenhouse.types.OfficesLteCondition | airbyte_agent_sdk.connectors.greenhouse.types.OfficesInCondition | airbyte_agent_sdk.connectors.greenhouse.types.OfficesLikeCondition | airbyte_agent_sdk.connectors.greenhouse.types.OfficesFuzzyCondition | airbyte_agent_sdk.connectors.greenhouse.types.OfficesKeywordCondition | airbyte_agent_sdk.connectors.greenhouse.types.OfficesContainsCondition | airbyte_agent_sdk.connectors.greenhouse.types.OfficesNotCondition | airbyte_agent_sdk.connectors.greenhouse.types.OfficesAndCondition | airbyte_agent_sdk.connectors.greenhouse.types.OfficesOrCondition | airbyte_agent_sdk.connectors.greenhouse.types.OfficesAnyCondition`
     :   The type of the None singleton.
 
+<a id="OfficesOrCondition"></a>
+
 `OfficesOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -3757,6 +4077,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.greenhouse.types.OfficesEqCondition | airbyte_agent_sdk.connectors.greenhouse.types.OfficesNeqCondition | airbyte_agent_sdk.connectors.greenhouse.types.OfficesGtCondition | airbyte_agent_sdk.connectors.greenhouse.types.OfficesGteCondition | airbyte_agent_sdk.connectors.greenhouse.types.OfficesLtCondition | airbyte_agent_sdk.connectors.greenhouse.types.OfficesLteCondition | airbyte_agent_sdk.connectors.greenhouse.types.OfficesInCondition | airbyte_agent_sdk.connectors.greenhouse.types.OfficesLikeCondition | airbyte_agent_sdk.connectors.greenhouse.types.OfficesFuzzyCondition | airbyte_agent_sdk.connectors.greenhouse.types.OfficesKeywordCondition | airbyte_agent_sdk.connectors.greenhouse.types.OfficesContainsCondition | airbyte_agent_sdk.connectors.greenhouse.types.OfficesNotCondition | airbyte_agent_sdk.connectors.greenhouse.types.OfficesAndCondition | airbyte_agent_sdk.connectors.greenhouse.types.OfficesOrCondition | airbyte_agent_sdk.connectors.greenhouse.types.OfficesAnyCondition]`
     :   The type of the None singleton.
+
+<a id="OfficesSearchFilter"></a>
 
 `OfficesSearchFilter(*args, **kwargs)`
 :   Available fields for filtering offices search queries.
@@ -3794,6 +4116,8 @@ Classes
     `primary_contact_user_id: int | None`
     :   User ID of the primary contact person for this office
 
+<a id="OfficesSearchQuery"></a>
+
 `OfficesSearchQuery(*args, **kwargs)`
 :   Search query for offices entity.
 
@@ -3808,6 +4132,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.greenhouse.types.OfficesSortFilter]`
     :   The type of the None singleton.
+
+<a id="OfficesSortFilter"></a>
 
 `OfficesSortFilter(*args, **kwargs)`
 :   Available fields for sorting offices search results.
@@ -3845,6 +4171,8 @@ Classes
     `primary_contact_user_id: Literal['asc', 'desc']`
     :   User ID of the primary contact person for this office
 
+<a id="OfficesStringFilter"></a>
+
 `OfficesStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -3881,6 +4209,8 @@ Classes
     `primary_contact_user_id: str`
     :   User ID of the primary contact person for this office
 
+<a id="ScheduledInterviewsGetParams"></a>
+
 `ScheduledInterviewsGetParams(*args, **kwargs)`
 :   Parameters for scheduled_interviews.get operation
 
@@ -3892,6 +4222,8 @@ Classes
 
     `id: str`
     :   The type of the None singleton.
+
+<a id="ScheduledInterviewsListParams"></a>
 
 `ScheduledInterviewsListParams(*args, **kwargs)`
 :   Parameters for scheduled_interviews.list operation
@@ -3926,6 +4258,8 @@ Classes
     `updated_before: str`
     :   The type of the None singleton.
 
+<a id="SourcesAndCondition"></a>
+
 `SourcesAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -3945,6 +4279,8 @@ Classes
 
     `and: list[airbyte_agent_sdk.connectors.greenhouse.types.SourcesEqCondition | airbyte_agent_sdk.connectors.greenhouse.types.SourcesNeqCondition | airbyte_agent_sdk.connectors.greenhouse.types.SourcesGtCondition | airbyte_agent_sdk.connectors.greenhouse.types.SourcesGteCondition | airbyte_agent_sdk.connectors.greenhouse.types.SourcesLtCondition | airbyte_agent_sdk.connectors.greenhouse.types.SourcesLteCondition | airbyte_agent_sdk.connectors.greenhouse.types.SourcesInCondition | airbyte_agent_sdk.connectors.greenhouse.types.SourcesLikeCondition | airbyte_agent_sdk.connectors.greenhouse.types.SourcesFuzzyCondition | airbyte_agent_sdk.connectors.greenhouse.types.SourcesKeywordCondition | airbyte_agent_sdk.connectors.greenhouse.types.SourcesContainsCondition | airbyte_agent_sdk.connectors.greenhouse.types.SourcesNotCondition | airbyte_agent_sdk.connectors.greenhouse.types.SourcesAndCondition | airbyte_agent_sdk.connectors.greenhouse.types.SourcesOrCondition | airbyte_agent_sdk.connectors.greenhouse.types.SourcesAnyCondition]`
     :   The type of the None singleton.
+
+<a id="SourcesAnyCondition"></a>
 
 `SourcesAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -3966,6 +4302,8 @@ Classes
     `any: airbyte_agent_sdk.connectors.greenhouse.types.SourcesAnyValueFilter`
     :   The type of the None singleton.
 
+<a id="SourcesAnyValueFilter"></a>
+
 `SourcesAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
 
@@ -3984,6 +4322,8 @@ Classes
     `type_: Any`
     :   Type of the data source
 
+<a id="SourcesContainsCondition"></a>
+
 `SourcesContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -3995,6 +4335,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.greenhouse.types.SourcesAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="SourcesEqCondition"></a>
 
 `SourcesEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -4008,6 +4350,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.greenhouse.types.SourcesSearchFilter`
     :   The type of the None singleton.
 
+<a id="SourcesFuzzyCondition"></a>
+
 `SourcesFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -4019,6 +4363,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.greenhouse.types.SourcesStringFilter`
     :   The type of the None singleton.
+
+<a id="SourcesGtCondition"></a>
 
 `SourcesGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
@@ -4032,6 +4378,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.greenhouse.types.SourcesSearchFilter`
     :   The type of the None singleton.
 
+<a id="SourcesGteCondition"></a>
+
 `SourcesGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -4043,6 +4391,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.greenhouse.types.SourcesSearchFilter`
     :   The type of the None singleton.
+
+<a id="SourcesInCondition"></a>
 
 `SourcesInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -4064,6 +4414,8 @@ Classes
     `in: airbyte_agent_sdk.connectors.greenhouse.types.SourcesInFilter`
     :   The type of the None singleton.
 
+<a id="SourcesInFilter"></a>
+
 `SourcesInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
 
@@ -4082,6 +4434,8 @@ Classes
     `type_: list[dict[str, typing.Any]]`
     :   Type of the data source
 
+<a id="SourcesKeywordCondition"></a>
+
 `SourcesKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -4094,6 +4448,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.greenhouse.types.SourcesStringFilter`
     :   The type of the None singleton.
 
+<a id="SourcesLikeCondition"></a>
+
 `SourcesLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -4105,6 +4461,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.greenhouse.types.SourcesStringFilter`
     :   The type of the None singleton.
+
+<a id="SourcesListParams"></a>
 
 `SourcesListParams(*args, **kwargs)`
 :   Parameters for sources.list operation
@@ -4121,6 +4479,8 @@ Classes
     `per_page: int`
     :   The type of the None singleton.
 
+<a id="SourcesLtCondition"></a>
+
 `SourcesLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -4132,6 +4492,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.greenhouse.types.SourcesSearchFilter`
     :   The type of the None singleton.
+
+<a id="SourcesLteCondition"></a>
 
 `SourcesLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -4145,6 +4507,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.greenhouse.types.SourcesSearchFilter`
     :   The type of the None singleton.
 
+<a id="SourcesNeqCondition"></a>
+
 `SourcesNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -4156,6 +4520,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.greenhouse.types.SourcesSearchFilter`
     :   The type of the None singleton.
+
+<a id="SourcesNotCondition"></a>
 
 `SourcesNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -4177,6 +4543,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.greenhouse.types.SourcesEqCondition | airbyte_agent_sdk.connectors.greenhouse.types.SourcesNeqCondition | airbyte_agent_sdk.connectors.greenhouse.types.SourcesGtCondition | airbyte_agent_sdk.connectors.greenhouse.types.SourcesGteCondition | airbyte_agent_sdk.connectors.greenhouse.types.SourcesLtCondition | airbyte_agent_sdk.connectors.greenhouse.types.SourcesLteCondition | airbyte_agent_sdk.connectors.greenhouse.types.SourcesInCondition | airbyte_agent_sdk.connectors.greenhouse.types.SourcesLikeCondition | airbyte_agent_sdk.connectors.greenhouse.types.SourcesFuzzyCondition | airbyte_agent_sdk.connectors.greenhouse.types.SourcesKeywordCondition | airbyte_agent_sdk.connectors.greenhouse.types.SourcesContainsCondition | airbyte_agent_sdk.connectors.greenhouse.types.SourcesNotCondition | airbyte_agent_sdk.connectors.greenhouse.types.SourcesAndCondition | airbyte_agent_sdk.connectors.greenhouse.types.SourcesOrCondition | airbyte_agent_sdk.connectors.greenhouse.types.SourcesAnyCondition`
     :   The type of the None singleton.
 
+<a id="SourcesOrCondition"></a>
+
 `SourcesOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -4197,6 +4565,8 @@ Classes
     `or: list[airbyte_agent_sdk.connectors.greenhouse.types.SourcesEqCondition | airbyte_agent_sdk.connectors.greenhouse.types.SourcesNeqCondition | airbyte_agent_sdk.connectors.greenhouse.types.SourcesGtCondition | airbyte_agent_sdk.connectors.greenhouse.types.SourcesGteCondition | airbyte_agent_sdk.connectors.greenhouse.types.SourcesLtCondition | airbyte_agent_sdk.connectors.greenhouse.types.SourcesLteCondition | airbyte_agent_sdk.connectors.greenhouse.types.SourcesInCondition | airbyte_agent_sdk.connectors.greenhouse.types.SourcesLikeCondition | airbyte_agent_sdk.connectors.greenhouse.types.SourcesFuzzyCondition | airbyte_agent_sdk.connectors.greenhouse.types.SourcesKeywordCondition | airbyte_agent_sdk.connectors.greenhouse.types.SourcesContainsCondition | airbyte_agent_sdk.connectors.greenhouse.types.SourcesNotCondition | airbyte_agent_sdk.connectors.greenhouse.types.SourcesAndCondition | airbyte_agent_sdk.connectors.greenhouse.types.SourcesOrCondition | airbyte_agent_sdk.connectors.greenhouse.types.SourcesAnyCondition]`
     :   The type of the None singleton.
 
+<a id="SourcesSearchFilter"></a>
+
 `SourcesSearchFilter(*args, **kwargs)`
 :   Available fields for filtering sources search queries.
 
@@ -4215,6 +4585,8 @@ Classes
     `type_: dict[str, typing.Any] | None`
     :   Type of the data source
 
+<a id="SourcesSearchQuery"></a>
+
 `SourcesSearchQuery(*args, **kwargs)`
 :   Search query for sources entity.
 
@@ -4229,6 +4601,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.greenhouse.types.SourcesSortFilter]`
     :   The type of the None singleton.
+
+<a id="SourcesSortFilter"></a>
 
 `SourcesSortFilter(*args, **kwargs)`
 :   Available fields for sorting sources search results.
@@ -4248,6 +4622,8 @@ Classes
     `type_: Literal['asc', 'desc']`
     :   Type of the data source
 
+<a id="SourcesStringFilter"></a>
+
 `SourcesStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -4265,6 +4641,8 @@ Classes
 
     `type_: str`
     :   Type of the data source
+
+<a id="UsersAndCondition"></a>
 
 `UsersAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -4286,6 +4664,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.greenhouse.types.UsersEqCondition | airbyte_agent_sdk.connectors.greenhouse.types.UsersNeqCondition | airbyte_agent_sdk.connectors.greenhouse.types.UsersGtCondition | airbyte_agent_sdk.connectors.greenhouse.types.UsersGteCondition | airbyte_agent_sdk.connectors.greenhouse.types.UsersLtCondition | airbyte_agent_sdk.connectors.greenhouse.types.UsersLteCondition | airbyte_agent_sdk.connectors.greenhouse.types.UsersInCondition | airbyte_agent_sdk.connectors.greenhouse.types.UsersLikeCondition | airbyte_agent_sdk.connectors.greenhouse.types.UsersFuzzyCondition | airbyte_agent_sdk.connectors.greenhouse.types.UsersKeywordCondition | airbyte_agent_sdk.connectors.greenhouse.types.UsersContainsCondition | airbyte_agent_sdk.connectors.greenhouse.types.UsersNotCondition | airbyte_agent_sdk.connectors.greenhouse.types.UsersAndCondition | airbyte_agent_sdk.connectors.greenhouse.types.UsersOrCondition | airbyte_agent_sdk.connectors.greenhouse.types.UsersAnyCondition]`
     :   The type of the None singleton.
 
+<a id="UsersAnyCondition"></a>
+
 `UsersAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -4305,6 +4685,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.greenhouse.types.UsersAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="UsersAnyValueFilter"></a>
 
 `UsersAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -4357,6 +4739,8 @@ Classes
     `updated_at: Any`
     :   The date and time when the user account was last updated.
 
+<a id="UsersContainsCondition"></a>
+
 `UsersContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -4368,6 +4752,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.greenhouse.types.UsersAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="UsersEqCondition"></a>
 
 `UsersEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -4381,6 +4767,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.greenhouse.types.UsersSearchFilter`
     :   The type of the None singleton.
 
+<a id="UsersFuzzyCondition"></a>
+
 `UsersFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -4392,6 +4780,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.greenhouse.types.UsersStringFilter`
     :   The type of the None singleton.
+
+<a id="UsersGetParams"></a>
 
 `UsersGetParams(*args, **kwargs)`
 :   Parameters for users.get operation
@@ -4405,6 +4795,8 @@ Classes
     `id: str`
     :   The type of the None singleton.
 
+<a id="UsersGtCondition"></a>
+
 `UsersGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -4417,6 +4809,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.greenhouse.types.UsersSearchFilter`
     :   The type of the None singleton.
 
+<a id="UsersGteCondition"></a>
+
 `UsersGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -4428,6 +4822,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.greenhouse.types.UsersSearchFilter`
     :   The type of the None singleton.
+
+<a id="UsersInCondition"></a>
 
 `UsersInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -4448,6 +4844,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.greenhouse.types.UsersInFilter`
     :   The type of the None singleton.
+
+<a id="UsersInFilter"></a>
 
 `UsersInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -4500,6 +4898,8 @@ Classes
     `updated_at: list[str]`
     :   The date and time when the user account was last updated.
 
+<a id="UsersKeywordCondition"></a>
+
 `UsersKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -4512,6 +4912,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.greenhouse.types.UsersStringFilter`
     :   The type of the None singleton.
 
+<a id="UsersLikeCondition"></a>
+
 `UsersLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -4523,6 +4925,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.greenhouse.types.UsersStringFilter`
     :   The type of the None singleton.
+
+<a id="UsersListParams"></a>
 
 `UsersListParams(*args, **kwargs)`
 :   Parameters for users.list operation
@@ -4551,6 +4955,8 @@ Classes
     `updated_before: str`
     :   The type of the None singleton.
 
+<a id="UsersLtCondition"></a>
+
 `UsersLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -4562,6 +4968,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.greenhouse.types.UsersSearchFilter`
     :   The type of the None singleton.
+
+<a id="UsersLteCondition"></a>
 
 `UsersLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -4575,6 +4983,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.greenhouse.types.UsersSearchFilter`
     :   The type of the None singleton.
 
+<a id="UsersNeqCondition"></a>
+
 `UsersNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -4586,6 +4996,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.greenhouse.types.UsersSearchFilter`
     :   The type of the None singleton.
+
+<a id="UsersNotCondition"></a>
 
 `UsersNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -4607,6 +5019,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.greenhouse.types.UsersEqCondition | airbyte_agent_sdk.connectors.greenhouse.types.UsersNeqCondition | airbyte_agent_sdk.connectors.greenhouse.types.UsersGtCondition | airbyte_agent_sdk.connectors.greenhouse.types.UsersGteCondition | airbyte_agent_sdk.connectors.greenhouse.types.UsersLtCondition | airbyte_agent_sdk.connectors.greenhouse.types.UsersLteCondition | airbyte_agent_sdk.connectors.greenhouse.types.UsersInCondition | airbyte_agent_sdk.connectors.greenhouse.types.UsersLikeCondition | airbyte_agent_sdk.connectors.greenhouse.types.UsersFuzzyCondition | airbyte_agent_sdk.connectors.greenhouse.types.UsersKeywordCondition | airbyte_agent_sdk.connectors.greenhouse.types.UsersContainsCondition | airbyte_agent_sdk.connectors.greenhouse.types.UsersNotCondition | airbyte_agent_sdk.connectors.greenhouse.types.UsersAndCondition | airbyte_agent_sdk.connectors.greenhouse.types.UsersOrCondition | airbyte_agent_sdk.connectors.greenhouse.types.UsersAnyCondition`
     :   The type of the None singleton.
 
+<a id="UsersOrCondition"></a>
+
 `UsersOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -4626,6 +5040,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.greenhouse.types.UsersEqCondition | airbyte_agent_sdk.connectors.greenhouse.types.UsersNeqCondition | airbyte_agent_sdk.connectors.greenhouse.types.UsersGtCondition | airbyte_agent_sdk.connectors.greenhouse.types.UsersGteCondition | airbyte_agent_sdk.connectors.greenhouse.types.UsersLtCondition | airbyte_agent_sdk.connectors.greenhouse.types.UsersLteCondition | airbyte_agent_sdk.connectors.greenhouse.types.UsersInCondition | airbyte_agent_sdk.connectors.greenhouse.types.UsersLikeCondition | airbyte_agent_sdk.connectors.greenhouse.types.UsersFuzzyCondition | airbyte_agent_sdk.connectors.greenhouse.types.UsersKeywordCondition | airbyte_agent_sdk.connectors.greenhouse.types.UsersContainsCondition | airbyte_agent_sdk.connectors.greenhouse.types.UsersNotCondition | airbyte_agent_sdk.connectors.greenhouse.types.UsersAndCondition | airbyte_agent_sdk.connectors.greenhouse.types.UsersOrCondition | airbyte_agent_sdk.connectors.greenhouse.types.UsersAnyCondition]`
     :   The type of the None singleton.
+
+<a id="UsersSearchFilter"></a>
 
 `UsersSearchFilter(*args, **kwargs)`
 :   Available fields for filtering users search queries.
@@ -4678,6 +5094,8 @@ Classes
     `updated_at: str | None`
     :   The date and time when the user account was last updated.
 
+<a id="UsersSearchQuery"></a>
+
 `UsersSearchQuery(*args, **kwargs)`
 :   Search query for users entity.
 
@@ -4692,6 +5110,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.greenhouse.types.UsersSortFilter]`
     :   The type of the None singleton.
+
+<a id="UsersSortFilter"></a>
 
 `UsersSortFilter(*args, **kwargs)`
 :   Available fields for sorting users search results.
@@ -4743,6 +5163,8 @@ Classes
 
     `updated_at: Literal['asc', 'desc']`
     :   The date and time when the user account was last updated.
+
+<a id="UsersStringFilter"></a>
 
 `UsersStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/harvest/connector.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/harvest/connector.md
@@ -10,6 +10,8 @@ Harvest connector.
 Classes
 -------
 
+<a id="ClientsQuery"></a>
+
 `ClientsQuery(connector: HarvestConnector)`
 :   Query class for Clients entity operations.
     
@@ -66,6 +68,8 @@ Classes
         Returns:
             ClientsListResult
 
+<a id="CompanyQuery"></a>
+
 `CompanyQuery(connector: HarvestConnector)`
 :   Query class for Company entity operations.
     
@@ -107,6 +111,8 @@ Classes
         
         Returns:
             Company
+
+<a id="ContactsQuery"></a>
 
 `ContactsQuery(connector: HarvestConnector)`
 :   Query class for Contacts entity operations.
@@ -165,6 +171,8 @@ Classes
         Returns:
             ContactsListResult
 
+<a id="EstimateItemCategoriesQuery"></a>
+
 `EstimateItemCategoriesQuery(connector: HarvestConnector)`
 :   Query class for EstimateItemCategories entity operations.
     
@@ -217,6 +225,8 @@ Classes
         
         Returns:
             EstimateItemCategoriesListResult
+
+<a id="EstimatesQuery"></a>
 
 `EstimatesQuery(connector: HarvestConnector)`
 :   Query class for Estimates entity operations.
@@ -277,6 +287,8 @@ Classes
         Returns:
             EstimatesListResult
 
+<a id="ExpenseCategoriesQuery"></a>
+
 `ExpenseCategoriesQuery(connector: HarvestConnector)`
 :   Query class for ExpenseCategories entity operations.
     
@@ -332,6 +344,8 @@ Classes
         
         Returns:
             ExpenseCategoriesListResult
+
+<a id="ExpensesQuery"></a>
 
 `ExpensesQuery(connector: HarvestConnector)`
 :   Query class for Expenses entity operations.
@@ -393,6 +407,8 @@ Classes
         
         Returns:
             ExpensesListResult
+
+<a id="HarvestConnector"></a>
 
 `HarvestConnector(auth_config: HarvestAuthConfig | AirbyteAuthConfig | BaseModel | None = None, on_token_refresh: Any | None = None)`
 :   Type-safe Harvest API connector.
@@ -650,6 +666,8 @@ Classes
             for entity in entities:
                 print(f"\{entity['entity_name']\}: \{entity['available_actions']\}")
 
+<a id="InvoiceItemCategoriesQuery"></a>
+
 `InvoiceItemCategoriesQuery(connector: HarvestConnector)`
 :   Query class for InvoiceItemCategories entity operations.
     
@@ -704,6 +722,8 @@ Classes
         
         Returns:
             InvoiceItemCategoriesListResult
+
+<a id="InvoicesQuery"></a>
 
 `InvoicesQuery(connector: HarvestConnector)`
 :   Query class for Invoices entity operations.
@@ -766,6 +786,8 @@ Classes
         Returns:
             InvoicesListResult
 
+<a id="ProjectsQuery"></a>
+
 `ProjectsQuery(connector: HarvestConnector)`
 :   Query class for Projects entity operations.
     
@@ -826,6 +848,8 @@ Classes
         Returns:
             ProjectsListResult
 
+<a id="RolesQuery"></a>
+
 `RolesQuery(connector: HarvestConnector)`
 :   Query class for Roles entity operations.
     
@@ -880,6 +904,8 @@ Classes
         Returns:
             RolesListResult
 
+<a id="TaskAssignmentsQuery"></a>
+
 `TaskAssignmentsQuery(connector: HarvestConnector)`
 :   Query class for TaskAssignments entity operations.
     
@@ -926,6 +952,8 @@ Classes
         
         Returns:
             TaskAssignmentsListResult
+
+<a id="TasksQuery"></a>
 
 `TasksQuery(connector: HarvestConnector)`
 :   Query class for Tasks entity operations.
@@ -982,6 +1010,8 @@ Classes
         
         Returns:
             TasksListResult
+
+<a id="TimeEntriesQuery"></a>
 
 `TimeEntriesQuery(connector: HarvestConnector)`
 :   Query class for TimeEntries entity operations.
@@ -1044,6 +1074,8 @@ Classes
         Returns:
             TimeEntriesListResult
 
+<a id="TimeProjectsQuery"></a>
+
 `TimeProjectsQuery(connector: HarvestConnector)`
 :   Query class for TimeProjects entity operations.
     
@@ -1093,6 +1125,8 @@ Classes
         Returns:
             TimeProjectsListResult
 
+<a id="TimeTasksQuery"></a>
+
 `TimeTasksQuery(connector: HarvestConnector)`
 :   Query class for TimeTasks entity operations.
     
@@ -1139,6 +1173,8 @@ Classes
         
         Returns:
             TimeTasksListResult
+
+<a id="UserAssignmentsQuery"></a>
 
 `UserAssignmentsQuery(connector: HarvestConnector)`
 :   Query class for UserAssignments entity operations.
@@ -1187,6 +1223,8 @@ Classes
         
         Returns:
             UserAssignmentsListResult
+
+<a id="UsersQuery"></a>
 
 `UsersQuery(connector: HarvestConnector)`
 :   Query class for Users entity operations.

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/harvest/index.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/harvest/index.md
@@ -19,6 +19,8 @@ Sub-modules
 Classes
 -------
 
+<a id="AirbyteAuthConfig"></a>
+
 `AirbyteAuthConfig(**data: Any)`
 :   Authentication configuration for Airbyte hosted mode execution.
     
@@ -87,6 +89,8 @@ Classes
     `workspace_name: str | None`
     :   The type of the None singleton.
 
+<a id="AirbyteSearchMeta"></a>
+
 `AirbyteSearchMeta(**data: Any)`
 :   Pagination metadata for search responses.
     
@@ -114,6 +118,8 @@ Classes
 
     `took_ms: int | None`
     :   Time taken to execute the search in milliseconds.
+
+<a id="AirbyteSearchResult"></a>
 
 `AirbyteSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -162,6 +168,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="ClientsSearchResult"></a>
+
 `ClientsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -177,6 +185,8 @@ Classes
     * airbyte_agent_sdk.connectors.harvest.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="CompanySearchResult"></a>
 
 `CompanySearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -194,6 +204,8 @@ Classes
     * pydantic.main.BaseModel
     * typing.Generic
 
+<a id="ContactsSearchResult"></a>
+
 `ContactsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -209,6 +221,8 @@ Classes
     * airbyte_agent_sdk.connectors.harvest.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="EstimateItemCategoriesSearchResult"></a>
 
 `EstimateItemCategoriesSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -226,6 +240,8 @@ Classes
     * pydantic.main.BaseModel
     * typing.Generic
 
+<a id="EstimatesSearchResult"></a>
+
 `EstimatesSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -241,6 +257,8 @@ Classes
     * airbyte_agent_sdk.connectors.harvest.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="ExpenseCategoriesSearchResult"></a>
 
 `ExpenseCategoriesSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -258,6 +276,8 @@ Classes
     * pydantic.main.BaseModel
     * typing.Generic
 
+<a id="ExpensesSearchResult"></a>
+
 `ExpensesSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -273,6 +293,8 @@ Classes
     * airbyte_agent_sdk.connectors.harvest.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="InvoiceItemCategoriesSearchResult"></a>
 
 `InvoiceItemCategoriesSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -290,6 +312,8 @@ Classes
     * pydantic.main.BaseModel
     * typing.Generic
 
+<a id="InvoicesSearchResult"></a>
+
 `InvoicesSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -305,6 +329,8 @@ Classes
     * airbyte_agent_sdk.connectors.harvest.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="ProjectsSearchResult"></a>
 
 `ProjectsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -322,6 +348,8 @@ Classes
     * pydantic.main.BaseModel
     * typing.Generic
 
+<a id="RolesSearchResult"></a>
+
 `RolesSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -337,6 +365,8 @@ Classes
     * airbyte_agent_sdk.connectors.harvest.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="TaskAssignmentsSearchResult"></a>
 
 `TaskAssignmentsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -354,6 +384,8 @@ Classes
     * pydantic.main.BaseModel
     * typing.Generic
 
+<a id="TasksSearchResult"></a>
+
 `TasksSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -369,6 +401,8 @@ Classes
     * airbyte_agent_sdk.connectors.harvest.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="TimeEntriesSearchResult"></a>
 
 `TimeEntriesSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -386,6 +420,8 @@ Classes
     * pydantic.main.BaseModel
     * typing.Generic
 
+<a id="TimeProjectsSearchResult"></a>
+
 `TimeProjectsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -401,6 +437,8 @@ Classes
     * airbyte_agent_sdk.connectors.harvest.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="TimeTasksSearchResult"></a>
 
 `TimeTasksSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -418,6 +456,8 @@ Classes
     * pydantic.main.BaseModel
     * typing.Generic
 
+<a id="UserAssignmentsSearchResult"></a>
+
 `UserAssignmentsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -434,6 +474,8 @@ Classes
     * pydantic.main.BaseModel
     * typing.Generic
 
+<a id="UsersSearchResult"></a>
+
 `UsersSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -449,6 +491,8 @@ Classes
     * airbyte_agent_sdk.connectors.harvest.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="ClientsSearchData"></a>
 
 `ClientsSearchData(**data: Any)`
 :   Search result data for clients entity.
@@ -490,6 +534,8 @@ Classes
     `updated_at: str | None`
     :   When the client record was last updated
 
+<a id="CompanySearchData"></a>
+
 `CompanySearchData(**data: Any)`
 :   Search result data for company entity.
     
@@ -529,6 +575,8 @@ Classes
 
     `weekly_capacity: int | None`
     :   Weekly capacity in seconds
+
+<a id="ContactsSearchData"></a>
 
 `ContactsSearchData(**data: Any)`
 :   Search result data for contacts entity.
@@ -573,6 +621,8 @@ Classes
     `updated_at: str | None`
     :   When last updated
 
+<a id="EstimateItemCategoriesSearchData"></a>
+
 `EstimateItemCategoriesSearchData(**data: Any)`
 :   Search result data for estimate_item_categories entity.
     
@@ -603,6 +653,8 @@ Classes
 
     `updated_at: str | None`
     :   When last updated
+
+<a id="EstimatesSearchData"></a>
 
 `EstimatesSearchData(**data: Any)`
 :   Search result data for estimates entity.
@@ -653,6 +705,8 @@ Classes
     `updated_at: str | None`
     :   When last updated
 
+<a id="ExpenseCategoriesSearchData"></a>
+
 `ExpenseCategoriesSearchData(**data: Any)`
 :   Search result data for expense_categories entity.
     
@@ -692,6 +746,8 @@ Classes
 
     `updated_at: str | None`
     :   When last updated
+
+<a id="ExpensesSearchData"></a>
 
 `ExpensesSearchData(**data: Any)`
 :   Search result data for expenses entity.
@@ -747,6 +803,8 @@ Classes
 
     `user: dict[str, typing.Any] | None`
     :   Associated user
+
+<a id="HarvestConnector"></a>
 
 `HarvestConnector(auth_config: HarvestAuthConfig | AirbyteAuthConfig | BaseModel | None = None, on_token_refresh: Any | None = None)`
 :   Type-safe Harvest API connector.
@@ -1004,6 +1062,8 @@ Classes
             for entity in entities:
                 print(f"\{entity['entity_name']\}: \{entity['available_actions']\}")
 
+<a id="HarvestReplicationConfig"></a>
+
 `HarvestReplicationConfig(**data: Any)`
 :   Replication Configuration - Settings for data replication from Harvest.
     
@@ -1025,6 +1085,8 @@ Classes
 
     `replication_start_date: str`
     :   UTC date and time in YYYY-MM-DDTHH:mm:ssZ format from which to start replicating data. Data before this date will not be replicated.
+
+<a id="InvoiceItemCategoriesSearchData"></a>
 
 `InvoiceItemCategoriesSearchData(**data: Any)`
 :   Search result data for invoice_item_categories entity.
@@ -1062,6 +1124,8 @@ Classes
 
     `use_as_service: bool | None`
     :   Whether used as service type
+
+<a id="InvoicesSearchData"></a>
 
 `InvoicesSearchData(**data: Any)`
 :   Search result data for invoices entity.
@@ -1118,6 +1182,8 @@ Classes
     `updated_at: str | None`
     :   When last updated
 
+<a id="ProjectsSearchData"></a>
+
 `ProjectsSearchData(**data: Any)`
 :   Search result data for projects entity.
     
@@ -1170,6 +1236,8 @@ Classes
     `updated_at: str | None`
     :   When last updated
 
+<a id="RolesSearchData"></a>
+
 `RolesSearchData(**data: Any)`
 :   Search result data for roles entity.
     
@@ -1203,6 +1271,8 @@ Classes
 
     `user_ids: list[typing.Any] | None`
     :   User IDs with this role
+
+<a id="TaskAssignmentsSearchData"></a>
 
 `TaskAssignmentsSearchData(**data: Any)`
 :   Search result data for task_assignments entity.
@@ -1247,6 +1317,8 @@ Classes
     `updated_at: str | None`
     :   When last updated
 
+<a id="TasksSearchData"></a>
+
 `TasksSearchData(**data: Any)`
 :   Search result data for tasks entity.
     
@@ -1286,6 +1358,8 @@ Classes
 
     `updated_at: str | None`
     :   When last updated
+
+<a id="TimeEntriesSearchData"></a>
 
 `TimeEntriesSearchData(**data: Any)`
 :   Search result data for time_entries entity.
@@ -1342,6 +1416,8 @@ Classes
     `user: dict[str, typing.Any] | None`
     :   Associated user
 
+<a id="TimeProjectsSearchData"></a>
+
 `TimeProjectsSearchData(**data: Any)`
 :   Search result data for time_projects entity.
     
@@ -1385,6 +1461,8 @@ Classes
     `total_hours: float | None`
     :   Total hours spent
 
+<a id="TimeTasksSearchData"></a>
+
 `TimeTasksSearchData(**data: Any)`
 :   Search result data for time_tasks entity.
     
@@ -1421,6 +1499,8 @@ Classes
 
     `total_hours: float | None`
     :   Total hours spent
+
+<a id="UserAssignmentsSearchData"></a>
 
 `UserAssignmentsSearchData(**data: Any)`
 :   Search result data for user_assignments entity.
@@ -1467,6 +1547,8 @@ Classes
 
     `user: dict[str, typing.Any] | None`
     :   Associated user
+
+<a id="UsersSearchData"></a>
 
 `UsersSearchData(**data: Any)`
 :   Search result data for users entity.

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/harvest/models.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/harvest/models.md
@@ -13,6 +13,8 @@ and response envelope types.
 Classes
 -------
 
+<a id="AirbyteSearchMeta"></a>
+
 `AirbyteSearchMeta(**data: Any)`
 :   Pagination metadata for search responses.
     
@@ -40,6 +42,8 @@ Classes
 
     `took_ms: int | None`
     :   Time taken to execute the search in milliseconds.
+
+<a id="AirbyteSearchResult"></a>
 
 `AirbyteSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -109,6 +113,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="ClientsSearchResult"></a>
+
 `ClientsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -145,6 +151,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="CompanySearchResult"></a>
 
 `CompanySearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -183,6 +191,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="ContactsSearchResult"></a>
+
 `ContactsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -219,6 +229,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="EstimateItemCategoriesSearchResult"></a>
 
 `EstimateItemCategoriesSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -257,6 +269,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="EstimatesSearchResult"></a>
+
 `EstimatesSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -293,6 +307,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="ExpenseCategoriesSearchResult"></a>
 
 `ExpenseCategoriesSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -331,6 +347,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="ExpensesSearchResult"></a>
+
 `ExpensesSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -367,6 +385,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="InvoiceItemCategoriesSearchResult"></a>
 
 `InvoiceItemCategoriesSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -405,6 +425,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="InvoicesSearchResult"></a>
+
 `InvoicesSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -441,6 +463,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="ProjectsSearchResult"></a>
 
 `ProjectsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -479,6 +503,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="RolesSearchResult"></a>
+
 `RolesSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -515,6 +541,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="TaskAssignmentsSearchResult"></a>
 
 `TaskAssignmentsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -553,6 +581,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="TasksSearchResult"></a>
+
 `TasksSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -589,6 +619,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="TimeEntriesSearchResult"></a>
 
 `TimeEntriesSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -627,6 +659,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="TimeProjectsSearchResult"></a>
+
 `TimeProjectsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -663,6 +697,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="TimeTasksSearchResult"></a>
 
 `TimeTasksSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -701,6 +737,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="UserAssignmentsSearchResult"></a>
+
 `UserAssignmentsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -738,6 +776,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="UsersSearchResult"></a>
+
 `UsersSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -753,6 +793,8 @@ Classes
     * airbyte_agent_sdk.connectors.harvest.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="Client"></a>
 
 `Client(**data: Any)`
 :   A Harvest client
@@ -797,6 +839,8 @@ Classes
     `updated_at: str | Any | None`
     :   The type of the None singleton.
 
+<a id="ClientsList"></a>
+
 `ClientsList(**data: Any)`
 :   Paginated list of clients
     
@@ -840,6 +884,8 @@ Classes
     `total_pages: int | Any`
     :   The type of the None singleton.
 
+<a id="ClientsListResultMeta"></a>
+
 `ClientsListResultMeta(**data: Any)`
 :   Metadata for clients.Action.LIST operation
     
@@ -861,6 +907,8 @@ Classes
 
     `next_link: str | Any | None`
     :   The type of the None singleton.
+
+<a id="ClientsSearchData"></a>
 
 `ClientsSearchData(**data: Any)`
 :   Search result data for clients entity.
@@ -901,6 +949,8 @@ Classes
 
     `updated_at: str | None`
     :   When the client record was last updated
+
+<a id="Company"></a>
 
 `Company(**data: Any)`
 :   The Harvest company/account information
@@ -993,6 +1043,8 @@ Classes
     `weekly_capacity: int | Any | None`
     :   The type of the None singleton.
 
+<a id="CompanySearchData"></a>
+
 `CompanySearchData(**data: Any)`
 :   Search result data for company entity.
     
@@ -1032,6 +1084,8 @@ Classes
 
     `weekly_capacity: int | None`
     :   Weekly capacity in seconds
+
+<a id="Contact"></a>
 
 `Contact(**data: Any)`
 :   A Harvest contact associated with a client
@@ -1085,6 +1139,8 @@ Classes
     `updated_at: str | Any | None`
     :   The type of the None singleton.
 
+<a id="ContactClient"></a>
+
 `ContactClient(**data: Any)`
 :   The client associated with this contact
     
@@ -1109,6 +1165,8 @@ Classes
 
     `name: str | Any | None`
     :   Client name
+
+<a id="ContactsList"></a>
 
 `ContactsList(**data: Any)`
 :   Paginated list of contacts
@@ -1153,6 +1211,8 @@ Classes
     `total_pages: int | Any`
     :   The type of the None singleton.
 
+<a id="ContactsListResultMeta"></a>
+
 `ContactsListResultMeta(**data: Any)`
 :   Metadata for contacts.Action.LIST operation
     
@@ -1174,6 +1234,8 @@ Classes
 
     `next_link: str | Any | None`
     :   The type of the None singleton.
+
+<a id="ContactsSearchData"></a>
 
 `ContactsSearchData(**data: Any)`
 :   Search result data for contacts entity.
@@ -1217,6 +1279,8 @@ Classes
 
     `updated_at: str | None`
     :   When last updated
+
+<a id="Estimate"></a>
 
 `Estimate(**data: Any)`
 :   A Harvest estimate
@@ -1309,6 +1373,8 @@ Classes
     `updated_at: str | Any | None`
     :   The type of the None singleton.
 
+<a id="EstimateItemCategoriesList"></a>
+
 `EstimateItemCategoriesList(**data: Any)`
 :   Paginated list of estimate item categories
     
@@ -1352,6 +1418,8 @@ Classes
     `total_pages: int | Any`
     :   The type of the None singleton.
 
+<a id="EstimateItemCategoriesListResultMeta"></a>
+
 `EstimateItemCategoriesListResultMeta(**data: Any)`
 :   Metadata for estimate_item_categories.Action.LIST operation
     
@@ -1373,6 +1441,8 @@ Classes
 
     `next_link: str | Any | None`
     :   The type of the None singleton.
+
+<a id="EstimateItemCategoriesSearchData"></a>
 
 `EstimateItemCategoriesSearchData(**data: Any)`
 :   Search result data for estimate_item_categories entity.
@@ -1405,6 +1475,8 @@ Classes
     `updated_at: str | None`
     :   When last updated
 
+<a id="EstimateItemCategory"></a>
+
 `EstimateItemCategory(**data: Any)`
 :   A Harvest estimate item category
     
@@ -1435,6 +1507,8 @@ Classes
 
     `updated_at: str | Any | None`
     :   The type of the None singleton.
+
+<a id="EstimatesList"></a>
 
 `EstimatesList(**data: Any)`
 :   Paginated list of estimates
@@ -1479,6 +1553,8 @@ Classes
     `total_pages: int | Any`
     :   The type of the None singleton.
 
+<a id="EstimatesListResultMeta"></a>
+
 `EstimatesListResultMeta(**data: Any)`
 :   Metadata for estimates.Action.LIST operation
     
@@ -1500,6 +1576,8 @@ Classes
 
     `next_link: str | Any | None`
     :   The type of the None singleton.
+
+<a id="EstimatesSearchData"></a>
 
 `EstimatesSearchData(**data: Any)`
 :   Search result data for estimates entity.
@@ -1549,6 +1627,8 @@ Classes
 
     `updated_at: str | None`
     :   When last updated
+
+<a id="Expense"></a>
 
 `Expense(**data: Any)`
 :   A Harvest expense
@@ -1632,6 +1712,8 @@ Classes
     `user_assignment: dict[str, typing.Any] | Any | None`
     :   The type of the None singleton.
 
+<a id="ExpenseCategoriesList"></a>
+
 `ExpenseCategoriesList(**data: Any)`
 :   Paginated list of expense categories
     
@@ -1675,6 +1757,8 @@ Classes
     `total_pages: int | Any`
     :   The type of the None singleton.
 
+<a id="ExpenseCategoriesListResultMeta"></a>
+
 `ExpenseCategoriesListResultMeta(**data: Any)`
 :   Metadata for expense_categories.Action.LIST operation
     
@@ -1696,6 +1780,8 @@ Classes
 
     `next_link: str | Any | None`
     :   The type of the None singleton.
+
+<a id="ExpenseCategoriesSearchData"></a>
 
 `ExpenseCategoriesSearchData(**data: Any)`
 :   Search result data for expense_categories entity.
@@ -1737,6 +1823,8 @@ Classes
     `updated_at: str | None`
     :   When last updated
 
+<a id="ExpenseCategory"></a>
+
 `ExpenseCategory(**data: Any)`
 :   A Harvest expense category
     
@@ -1776,6 +1864,8 @@ Classes
 
     `updated_at: str | Any | None`
     :   The type of the None singleton.
+
+<a id="ExpensesList"></a>
 
 `ExpensesList(**data: Any)`
 :   Paginated list of expenses
@@ -1820,6 +1910,8 @@ Classes
     `total_pages: int | Any`
     :   The type of the None singleton.
 
+<a id="ExpensesListResultMeta"></a>
+
 `ExpensesListResultMeta(**data: Any)`
 :   Metadata for expenses.Action.LIST operation
     
@@ -1841,6 +1933,8 @@ Classes
 
     `next_link: str | Any | None`
     :   The type of the None singleton.
+
+<a id="ExpensesSearchData"></a>
 
 `ExpensesSearchData(**data: Any)`
 :   Search result data for expenses entity.
@@ -1897,6 +1991,8 @@ Classes
     `user: dict[str, typing.Any] | None`
     :   Associated user
 
+<a id="HarvestCheckResult"></a>
+
 `HarvestCheckResult(**data: Any)`
 :   Result of a health check operation.
     
@@ -1930,6 +2026,8 @@ Classes
     `status: str`
     :   Health check status: 'healthy' or 'unhealthy'.
 
+<a id="HarvestExecuteResult"></a>
+
 `HarvestExecuteResult(**data: Any)`
 :   Response envelope with data only.
     
@@ -1958,6 +2056,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="HarvestExecuteResultWithMeta"></a>
 
 `HarvestExecuteResultWithMeta(**data: Any)`
 :   Response envelope with data and metadata.
@@ -2026,6 +2126,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="ClientsListResult"></a>
+
 `ClientsListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -2068,6 +2170,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="ContactsListResult"></a>
 
 `ContactsListResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -2112,6 +2216,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="EstimateItemCategoriesListResult"></a>
+
 `EstimateItemCategoriesListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -2154,6 +2260,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="EstimatesListResult"></a>
 
 `EstimatesListResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -2198,6 +2306,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="ExpenseCategoriesListResult"></a>
+
 `ExpenseCategoriesListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -2240,6 +2350,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="ExpensesListResult"></a>
 
 `ExpensesListResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -2284,6 +2396,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="InvoiceItemCategoriesListResult"></a>
+
 `InvoiceItemCategoriesListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -2326,6 +2440,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="InvoicesListResult"></a>
 
 `InvoicesListResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -2370,6 +2486,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="ProjectsListResult"></a>
+
 `ProjectsListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -2412,6 +2530,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="RolesListResult"></a>
 
 `RolesListResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -2456,6 +2576,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="TaskAssignmentsListResult"></a>
+
 `TaskAssignmentsListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -2498,6 +2620,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="TasksListResult"></a>
 
 `TasksListResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -2542,6 +2666,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="TimeEntriesListResult"></a>
+
 `TimeEntriesListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -2584,6 +2710,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="TimeProjectsListResult"></a>
 
 `TimeProjectsListResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -2628,6 +2756,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="TimeTasksListResult"></a>
+
 `TimeTasksListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -2670,6 +2800,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="UserAssignmentsListResult"></a>
 
 `UserAssignmentsListResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -2714,6 +2846,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="UsersListResult"></a>
+
 `UsersListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -2732,6 +2866,8 @@ Classes
     * airbyte_agent_sdk.connectors.harvest.models.HarvestExecuteResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="HarvestOauth20AuthConfig"></a>
 
 `HarvestOauth20AuthConfig(**data: Any)`
 :   OAuth 2.0
@@ -2764,6 +2900,8 @@ Classes
     `refresh_token: str`
     :   Your Harvest OAuth2 refresh token
 
+<a id="HarvestPersonalAccessTokenAuthConfig"></a>
+
 `HarvestPersonalAccessTokenAuthConfig(**data: Any)`
 :   Personal Access Token
     
@@ -2789,6 +2927,8 @@ Classes
     `token: str`
     :   Your Harvest personal access token
 
+<a id="HarvestReplicationConfig"></a>
+
 `HarvestReplicationConfig(**data: Any)`
 :   Replication Configuration - Settings for data replication from Harvest.
     
@@ -2810,6 +2950,8 @@ Classes
 
     `replication_start_date: str`
     :   UTC date and time in YYYY-MM-DDTHH:mm:ssZ format from which to start replicating data. Data before this date will not be replicated.
+
+<a id="Invoice"></a>
 
 `Invoice(**data: Any)`
 :   A Harvest invoice
@@ -2932,6 +3074,8 @@ Classes
     `updated_at: str | Any | None`
     :   The type of the None singleton.
 
+<a id="InvoiceItemCategoriesList"></a>
+
 `InvoiceItemCategoriesList(**data: Any)`
 :   Paginated list of invoice item categories
     
@@ -2975,6 +3119,8 @@ Classes
     `total_pages: int | Any`
     :   The type of the None singleton.
 
+<a id="InvoiceItemCategoriesListResultMeta"></a>
+
 `InvoiceItemCategoriesListResultMeta(**data: Any)`
 :   Metadata for invoice_item_categories.Action.LIST operation
     
@@ -2996,6 +3142,8 @@ Classes
 
     `next_link: str | Any | None`
     :   The type of the None singleton.
+
+<a id="InvoiceItemCategoriesSearchData"></a>
 
 `InvoiceItemCategoriesSearchData(**data: Any)`
 :   Search result data for invoice_item_categories entity.
@@ -3034,6 +3182,8 @@ Classes
     `use_as_service: bool | None`
     :   Whether used as service type
 
+<a id="InvoiceItemCategory"></a>
+
 `InvoiceItemCategory(**data: Any)`
 :   A Harvest invoice item category
     
@@ -3070,6 +3220,8 @@ Classes
 
     `use_as_service: bool | Any | None`
     :   The type of the None singleton.
+
+<a id="InvoicesList"></a>
 
 `InvoicesList(**data: Any)`
 :   Paginated list of invoices
@@ -3114,6 +3266,8 @@ Classes
     `total_pages: int | Any`
     :   The type of the None singleton.
 
+<a id="InvoicesListResultMeta"></a>
+
 `InvoicesListResultMeta(**data: Any)`
 :   Metadata for invoices.Action.LIST operation
     
@@ -3135,6 +3289,8 @@ Classes
 
     `next_link: str | Any | None`
     :   The type of the None singleton.
+
+<a id="InvoicesSearchData"></a>
 
 `InvoicesSearchData(**data: Any)`
 :   Search result data for invoices entity.
@@ -3191,6 +3347,8 @@ Classes
     `updated_at: str | None`
     :   When last updated
 
+<a id="PaginationLinks"></a>
+
 `PaginationLinks(**data: Any)`
 :   Pagination links for navigating result pages
     
@@ -3221,6 +3379,8 @@ Classes
 
     `previous: str | Any | None`
     :   The type of the None singleton.
+
+<a id="Project"></a>
 
 `Project(**data: Any)`
 :   A Harvest project
@@ -3313,6 +3473,8 @@ Classes
     `updated_at: str | Any | None`
     :   The type of the None singleton.
 
+<a id="ProjectClient"></a>
+
 `ProjectClient(**data: Any)`
 :   The client associated with the project
     
@@ -3340,6 +3502,8 @@ Classes
 
     `name: str | Any | None`
     :   Client name
+
+<a id="ProjectsList"></a>
 
 `ProjectsList(**data: Any)`
 :   Paginated list of projects
@@ -3384,6 +3548,8 @@ Classes
     `total_pages: int | Any`
     :   The type of the None singleton.
 
+<a id="ProjectsListResultMeta"></a>
+
 `ProjectsListResultMeta(**data: Any)`
 :   Metadata for projects.Action.LIST operation
     
@@ -3405,6 +3571,8 @@ Classes
 
     `next_link: str | Any | None`
     :   The type of the None singleton.
+
+<a id="ProjectsSearchData"></a>
 
 `ProjectsSearchData(**data: Any)`
 :   Search result data for projects entity.
@@ -3458,6 +3626,8 @@ Classes
     `updated_at: str | None`
     :   When last updated
 
+<a id="Role"></a>
+
 `Role(**data: Any)`
 :   A Harvest role
     
@@ -3491,6 +3661,8 @@ Classes
 
     `user_ids: list[int] | Any | None`
     :   The type of the None singleton.
+
+<a id="RolesList"></a>
 
 `RolesList(**data: Any)`
 :   Paginated list of roles
@@ -3535,6 +3707,8 @@ Classes
     `total_pages: int | Any`
     :   The type of the None singleton.
 
+<a id="RolesListResultMeta"></a>
+
 `RolesListResultMeta(**data: Any)`
 :   Metadata for roles.Action.LIST operation
     
@@ -3556,6 +3730,8 @@ Classes
 
     `next_link: str | Any | None`
     :   The type of the None singleton.
+
+<a id="RolesSearchData"></a>
 
 `RolesSearchData(**data: Any)`
 :   Search result data for roles entity.
@@ -3590,6 +3766,8 @@ Classes
 
     `user_ids: list[typing.Any] | None`
     :   User IDs with this role
+
+<a id="Task"></a>
 
 `Task(**data: Any)`
 :   A Harvest task
@@ -3633,6 +3811,8 @@ Classes
 
     `updated_at: str | Any | None`
     :   The type of the None singleton.
+
+<a id="TaskAssignment"></a>
 
 `TaskAssignment(**data: Any)`
 :   A Harvest task assignment linking a task to a project
@@ -3680,6 +3860,8 @@ Classes
     `updated_at: str | Any | None`
     :   The type of the None singleton.
 
+<a id="TaskAssignmentProject"></a>
+
 `TaskAssignmentProject(**data: Any)`
 :   The project associated with the assignment
     
@@ -3708,6 +3890,8 @@ Classes
     `name: str | Any | None`
     :   Project name
 
+<a id="TaskAssignmentTask"></a>
+
 `TaskAssignmentTask(**data: Any)`
 :   The task associated with the assignment
     
@@ -3732,6 +3916,8 @@ Classes
 
     `name: str | Any | None`
     :   Task name
+
+<a id="TaskAssignmentsList"></a>
 
 `TaskAssignmentsList(**data: Any)`
 :   Paginated list of task assignments
@@ -3776,6 +3962,8 @@ Classes
     `total_pages: int | Any`
     :   The type of the None singleton.
 
+<a id="TaskAssignmentsListResultMeta"></a>
+
 `TaskAssignmentsListResultMeta(**data: Any)`
 :   Metadata for task_assignments.Action.LIST operation
     
@@ -3797,6 +3985,8 @@ Classes
 
     `next_link: str | Any | None`
     :   The type of the None singleton.
+
+<a id="TaskAssignmentsSearchData"></a>
 
 `TaskAssignmentsSearchData(**data: Any)`
 :   Search result data for task_assignments entity.
@@ -3841,6 +4031,8 @@ Classes
     `updated_at: str | None`
     :   When last updated
 
+<a id="TasksList"></a>
+
 `TasksList(**data: Any)`
 :   Paginated list of tasks
     
@@ -3884,6 +4076,8 @@ Classes
     `total_pages: int | Any`
     :   The type of the None singleton.
 
+<a id="TasksListResultMeta"></a>
+
 `TasksListResultMeta(**data: Any)`
 :   Metadata for tasks.Action.LIST operation
     
@@ -3905,6 +4099,8 @@ Classes
 
     `next_link: str | Any | None`
     :   The type of the None singleton.
+
+<a id="TasksSearchData"></a>
 
 `TasksSearchData(**data: Any)`
 :   Search result data for tasks entity.
@@ -3945,6 +4141,8 @@ Classes
 
     `updated_at: str | None`
     :   When last updated
+
+<a id="TimeEntriesList"></a>
 
 `TimeEntriesList(**data: Any)`
 :   Paginated list of time entries
@@ -3989,6 +4187,8 @@ Classes
     `total_pages: int | Any`
     :   The type of the None singleton.
 
+<a id="TimeEntriesListResultMeta"></a>
+
 `TimeEntriesListResultMeta(**data: Any)`
 :   Metadata for time_entries.Action.LIST operation
     
@@ -4010,6 +4210,8 @@ Classes
 
     `next_link: str | Any | None`
     :   The type of the None singleton.
+
+<a id="TimeEntriesSearchData"></a>
 
 `TimeEntriesSearchData(**data: Any)`
 :   Search result data for time_entries entity.
@@ -4065,6 +4267,8 @@ Classes
 
     `user: dict[str, typing.Any] | None`
     :   Associated user
+
+<a id="TimeEntry"></a>
 
 `TimeEntry(**data: Any)`
 :   A Harvest time entry
@@ -4175,6 +4379,8 @@ Classes
     `user_assignment: dict[str, typing.Any] | Any | None`
     :   The type of the None singleton.
 
+<a id="TimeEntryClient"></a>
+
 `TimeEntryClient(**data: Any)`
 :   The client associated with the time entry
     
@@ -4199,6 +4405,8 @@ Classes
 
     `name: str | Any | None`
     :   Client name
+
+<a id="TimeEntryInvoice"></a>
 
 `TimeEntryInvoice(**data: Any)`
 :   The invoice associated with the time entry
@@ -4225,6 +4433,8 @@ Classes
     `number: str | Any | None`
     :   Invoice number
 
+<a id="TimeEntryProject"></a>
+
 `TimeEntryProject(**data: Any)`
 :   The project associated with the time entry
     
@@ -4249,6 +4459,8 @@ Classes
 
     `name: str | Any | None`
     :   Project name
+
+<a id="TimeEntryTask"></a>
 
 `TimeEntryTask(**data: Any)`
 :   The task associated with the time entry
@@ -4275,6 +4487,8 @@ Classes
     `name: str | Any | None`
     :   Task name
 
+<a id="TimeEntryUser"></a>
+
 `TimeEntryUser(**data: Any)`
 :   The user associated with the time entry
     
@@ -4299,6 +4513,8 @@ Classes
 
     `name: str | Any | None`
     :   User name
+
+<a id="TimeProject"></a>
 
 `TimeProject(**data: Any)`
 :   A time report entry grouped by project
@@ -4343,6 +4559,8 @@ Classes
     `total_hours: float | Any | None`
     :   The type of the None singleton.
 
+<a id="TimeProjectsList"></a>
+
 `TimeProjectsList(**data: Any)`
 :   Paginated list of time report entries by project
     
@@ -4386,6 +4604,8 @@ Classes
     `total_pages: int | Any`
     :   The type of the None singleton.
 
+<a id="TimeProjectsListResultMeta"></a>
+
 `TimeProjectsListResultMeta(**data: Any)`
 :   Metadata for time_projects.Action.LIST operation
     
@@ -4407,6 +4627,8 @@ Classes
 
     `next_link: str | Any | None`
     :   The type of the None singleton.
+
+<a id="TimeProjectsSearchData"></a>
 
 `TimeProjectsSearchData(**data: Any)`
 :   Search result data for time_projects entity.
@@ -4451,6 +4673,8 @@ Classes
     `total_hours: float | None`
     :   Total hours spent
 
+<a id="TimeTask"></a>
+
 `TimeTask(**data: Any)`
 :   A time report entry grouped by task
     
@@ -4487,6 +4711,8 @@ Classes
 
     `total_hours: float | Any | None`
     :   The type of the None singleton.
+
+<a id="TimeTasksList"></a>
 
 `TimeTasksList(**data: Any)`
 :   Paginated list of time report entries by task
@@ -4531,6 +4757,8 @@ Classes
     `total_pages: int | Any`
     :   The type of the None singleton.
 
+<a id="TimeTasksListResultMeta"></a>
+
 `TimeTasksListResultMeta(**data: Any)`
 :   Metadata for time_tasks.Action.LIST operation
     
@@ -4552,6 +4780,8 @@ Classes
 
     `next_link: str | Any | None`
     :   The type of the None singleton.
+
+<a id="TimeTasksSearchData"></a>
 
 `TimeTasksSearchData(**data: Any)`
 :   Search result data for time_tasks entity.
@@ -4589,6 +4819,8 @@ Classes
 
     `total_hours: float | None`
     :   Total hours spent
+
+<a id="User"></a>
 
 `User(**data: Any)`
 :   A Harvest user
@@ -4675,6 +4907,8 @@ Classes
     `weekly_capacity: int | Any | None`
     :   The type of the None singleton.
 
+<a id="UserAssignment"></a>
+
 `UserAssignment(**data: Any)`
 :   A Harvest user assignment linking a user to a project
     
@@ -4724,6 +4958,8 @@ Classes
     `user: airbyte_agent_sdk.connectors.harvest.models.UserAssignmentUser | Any | None`
     :   The type of the None singleton.
 
+<a id="UserAssignmentProject"></a>
+
 `UserAssignmentProject(**data: Any)`
 :   The project associated with the assignment
     
@@ -4752,6 +4988,8 @@ Classes
     `name: str | Any | None`
     :   Project name
 
+<a id="UserAssignmentUser"></a>
+
 `UserAssignmentUser(**data: Any)`
 :   The user associated with the assignment
     
@@ -4776,6 +5014,8 @@ Classes
 
     `name: str | Any | None`
     :   User name
+
+<a id="UserAssignmentsList"></a>
 
 `UserAssignmentsList(**data: Any)`
 :   Paginated list of user assignments
@@ -4820,6 +5060,8 @@ Classes
     `user_assignments: list[airbyte_agent_sdk.connectors.harvest.models.UserAssignment] | Any`
     :   The type of the None singleton.
 
+<a id="UserAssignmentsListResultMeta"></a>
+
 `UserAssignmentsListResultMeta(**data: Any)`
 :   Metadata for user_assignments.Action.LIST operation
     
@@ -4841,6 +5083,8 @@ Classes
 
     `next_link: str | Any | None`
     :   The type of the None singleton.
+
+<a id="UserAssignmentsSearchData"></a>
 
 `UserAssignmentsSearchData(**data: Any)`
 :   Search result data for user_assignments entity.
@@ -4888,6 +5132,8 @@ Classes
     `user: dict[str, typing.Any] | None`
     :   Associated user
 
+<a id="UsersList"></a>
+
 `UsersList(**data: Any)`
 :   Paginated list of users
     
@@ -4931,6 +5177,8 @@ Classes
     `users: list[airbyte_agent_sdk.connectors.harvest.models.User] | Any`
     :   The type of the None singleton.
 
+<a id="UsersListResultMeta"></a>
+
 `UsersListResultMeta(**data: Any)`
 :   Metadata for users.Action.LIST operation
     
@@ -4952,6 +5200,8 @@ Classes
 
     `next_link: str | Any | None`
     :   The type of the None singleton.
+
+<a id="UsersSearchData"></a>
 
 `UsersSearchData(**data: Any)`
 :   Search result data for users entity.

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/harvest/types.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/harvest/types.md
@@ -10,6 +10,8 @@ Type definitions for harvest connector.
 Classes
 -------
 
+<a id="AirbyteSearchParams"></a>
+
 `AirbyteSearchParams(*args, **kwargs)`
 :   Parameters for Airbyte cache search operations (generic, use entity-specific query types for better type hints).
 
@@ -31,6 +33,8 @@ Classes
     `query: dict[str, typing.Any]`
     :   The type of the None singleton.
 
+<a id="ClientsAndCondition"></a>
+
 `ClientsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -51,6 +55,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.harvest.types.ClientsEqCondition | airbyte_agent_sdk.connectors.harvest.types.ClientsNeqCondition | airbyte_agent_sdk.connectors.harvest.types.ClientsGtCondition | airbyte_agent_sdk.connectors.harvest.types.ClientsGteCondition | airbyte_agent_sdk.connectors.harvest.types.ClientsLtCondition | airbyte_agent_sdk.connectors.harvest.types.ClientsLteCondition | airbyte_agent_sdk.connectors.harvest.types.ClientsInCondition | airbyte_agent_sdk.connectors.harvest.types.ClientsLikeCondition | airbyte_agent_sdk.connectors.harvest.types.ClientsFuzzyCondition | airbyte_agent_sdk.connectors.harvest.types.ClientsKeywordCondition | airbyte_agent_sdk.connectors.harvest.types.ClientsContainsCondition | airbyte_agent_sdk.connectors.harvest.types.ClientsNotCondition | airbyte_agent_sdk.connectors.harvest.types.ClientsAndCondition | airbyte_agent_sdk.connectors.harvest.types.ClientsOrCondition | airbyte_agent_sdk.connectors.harvest.types.ClientsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="ClientsAnyCondition"></a>
+
 `ClientsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -70,6 +76,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.harvest.types.ClientsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="ClientsAnyValueFilter"></a>
 
 `ClientsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -101,6 +109,8 @@ Classes
     `updated_at: Any`
     :   When the client record was last updated
 
+<a id="ClientsContainsCondition"></a>
+
 `ClientsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -112,6 +122,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.harvest.types.ClientsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="ClientsEqCondition"></a>
 
 `ClientsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -125,6 +137,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.harvest.types.ClientsSearchFilter`
     :   The type of the None singleton.
 
+<a id="ClientsFuzzyCondition"></a>
+
 `ClientsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -136,6 +150,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.harvest.types.ClientsStringFilter`
     :   The type of the None singleton.
+
+<a id="ClientsGetParams"></a>
 
 `ClientsGetParams(*args, **kwargs)`
 :   Parameters for clients.get operation
@@ -149,6 +165,8 @@ Classes
     `id: str`
     :   The type of the None singleton.
 
+<a id="ClientsGtCondition"></a>
+
 `ClientsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -161,6 +179,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.harvest.types.ClientsSearchFilter`
     :   The type of the None singleton.
 
+<a id="ClientsGteCondition"></a>
+
 `ClientsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -172,6 +192,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.harvest.types.ClientsSearchFilter`
     :   The type of the None singleton.
+
+<a id="ClientsInCondition"></a>
 
 `ClientsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -192,6 +214,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.harvest.types.ClientsInFilter`
     :   The type of the None singleton.
+
+<a id="ClientsInFilter"></a>
 
 `ClientsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -223,6 +247,8 @@ Classes
     `updated_at: list[str]`
     :   When the client record was last updated
 
+<a id="ClientsKeywordCondition"></a>
+
 `ClientsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -234,6 +260,8 @@ Classes
 
     `keyword: airbyte_agent_sdk.connectors.harvest.types.ClientsStringFilter`
     :   The type of the None singleton.
+
+<a id="ClientsLikeCondition"></a>
 
 `ClientsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
@@ -247,6 +275,8 @@ Classes
     `like: airbyte_agent_sdk.connectors.harvest.types.ClientsStringFilter`
     :   The type of the None singleton.
 
+<a id="ClientsListParams"></a>
+
 `ClientsListParams(*args, **kwargs)`
 :   Parameters for clients.list operation
 
@@ -258,6 +288,8 @@ Classes
 
     `per_page: int`
     :   The type of the None singleton.
+
+<a id="ClientsLtCondition"></a>
 
 `ClientsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
@@ -271,6 +303,8 @@ Classes
     `lt: airbyte_agent_sdk.connectors.harvest.types.ClientsSearchFilter`
     :   The type of the None singleton.
 
+<a id="ClientsLteCondition"></a>
+
 `ClientsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
 
@@ -283,6 +317,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.harvest.types.ClientsSearchFilter`
     :   The type of the None singleton.
 
+<a id="ClientsNeqCondition"></a>
+
 `ClientsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -294,6 +330,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.harvest.types.ClientsSearchFilter`
     :   The type of the None singleton.
+
+<a id="ClientsNotCondition"></a>
 
 `ClientsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -315,6 +353,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.harvest.types.ClientsEqCondition | airbyte_agent_sdk.connectors.harvest.types.ClientsNeqCondition | airbyte_agent_sdk.connectors.harvest.types.ClientsGtCondition | airbyte_agent_sdk.connectors.harvest.types.ClientsGteCondition | airbyte_agent_sdk.connectors.harvest.types.ClientsLtCondition | airbyte_agent_sdk.connectors.harvest.types.ClientsLteCondition | airbyte_agent_sdk.connectors.harvest.types.ClientsInCondition | airbyte_agent_sdk.connectors.harvest.types.ClientsLikeCondition | airbyte_agent_sdk.connectors.harvest.types.ClientsFuzzyCondition | airbyte_agent_sdk.connectors.harvest.types.ClientsKeywordCondition | airbyte_agent_sdk.connectors.harvest.types.ClientsContainsCondition | airbyte_agent_sdk.connectors.harvest.types.ClientsNotCondition | airbyte_agent_sdk.connectors.harvest.types.ClientsAndCondition | airbyte_agent_sdk.connectors.harvest.types.ClientsOrCondition | airbyte_agent_sdk.connectors.harvest.types.ClientsAnyCondition`
     :   The type of the None singleton.
 
+<a id="ClientsOrCondition"></a>
+
 `ClientsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -334,6 +374,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.harvest.types.ClientsEqCondition | airbyte_agent_sdk.connectors.harvest.types.ClientsNeqCondition | airbyte_agent_sdk.connectors.harvest.types.ClientsGtCondition | airbyte_agent_sdk.connectors.harvest.types.ClientsGteCondition | airbyte_agent_sdk.connectors.harvest.types.ClientsLtCondition | airbyte_agent_sdk.connectors.harvest.types.ClientsLteCondition | airbyte_agent_sdk.connectors.harvest.types.ClientsInCondition | airbyte_agent_sdk.connectors.harvest.types.ClientsLikeCondition | airbyte_agent_sdk.connectors.harvest.types.ClientsFuzzyCondition | airbyte_agent_sdk.connectors.harvest.types.ClientsKeywordCondition | airbyte_agent_sdk.connectors.harvest.types.ClientsContainsCondition | airbyte_agent_sdk.connectors.harvest.types.ClientsNotCondition | airbyte_agent_sdk.connectors.harvest.types.ClientsAndCondition | airbyte_agent_sdk.connectors.harvest.types.ClientsOrCondition | airbyte_agent_sdk.connectors.harvest.types.ClientsAnyCondition]`
     :   The type of the None singleton.
+
+<a id="ClientsSearchFilter"></a>
 
 `ClientsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering clients search queries.
@@ -365,6 +407,8 @@ Classes
     `updated_at: str | None`
     :   When the client record was last updated
 
+<a id="ClientsSearchQuery"></a>
+
 `ClientsSearchQuery(*args, **kwargs)`
 :   Search query for clients entity.
 
@@ -379,6 +423,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.harvest.types.ClientsSortFilter]`
     :   The type of the None singleton.
+
+<a id="ClientsSortFilter"></a>
 
 `ClientsSortFilter(*args, **kwargs)`
 :   Available fields for sorting clients search results.
@@ -410,6 +456,8 @@ Classes
     `updated_at: Literal['asc', 'desc']`
     :   When the client record was last updated
 
+<a id="ClientsStringFilter"></a>
+
 `ClientsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -440,6 +488,8 @@ Classes
     `updated_at: str`
     :   When the client record was last updated
 
+<a id="CompanyAndCondition"></a>
+
 `CompanyAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -460,6 +510,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.harvest.types.CompanyEqCondition | airbyte_agent_sdk.connectors.harvest.types.CompanyNeqCondition | airbyte_agent_sdk.connectors.harvest.types.CompanyGtCondition | airbyte_agent_sdk.connectors.harvest.types.CompanyGteCondition | airbyte_agent_sdk.connectors.harvest.types.CompanyLtCondition | airbyte_agent_sdk.connectors.harvest.types.CompanyLteCondition | airbyte_agent_sdk.connectors.harvest.types.CompanyInCondition | airbyte_agent_sdk.connectors.harvest.types.CompanyLikeCondition | airbyte_agent_sdk.connectors.harvest.types.CompanyFuzzyCondition | airbyte_agent_sdk.connectors.harvest.types.CompanyKeywordCondition | airbyte_agent_sdk.connectors.harvest.types.CompanyContainsCondition | airbyte_agent_sdk.connectors.harvest.types.CompanyNotCondition | airbyte_agent_sdk.connectors.harvest.types.CompanyAndCondition | airbyte_agent_sdk.connectors.harvest.types.CompanyOrCondition | airbyte_agent_sdk.connectors.harvest.types.CompanyAnyCondition]`
     :   The type of the None singleton.
 
+<a id="CompanyAnyCondition"></a>
+
 `CompanyAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -479,6 +531,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.harvest.types.CompanyAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="CompanyAnyValueFilter"></a>
 
 `CompanyAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -510,6 +564,8 @@ Classes
     `weekly_capacity: Any`
     :   Weekly capacity in seconds
 
+<a id="CompanyContainsCondition"></a>
+
 `CompanyContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -521,6 +577,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.harvest.types.CompanyAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="CompanyEqCondition"></a>
 
 `CompanyEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -534,6 +592,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.harvest.types.CompanySearchFilter`
     :   The type of the None singleton.
 
+<a id="CompanyFuzzyCondition"></a>
+
 `CompanyFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -546,12 +606,16 @@ Classes
     `fuzzy: airbyte_agent_sdk.connectors.harvest.types.CompanyStringFilter`
     :   The type of the None singleton.
 
+<a id="CompanyGetParams"></a>
+
 `CompanyGetParams(*args, **kwargs)`
 :   Parameters for company.get operation
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="CompanyGtCondition"></a>
 
 `CompanyGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
@@ -565,6 +629,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.harvest.types.CompanySearchFilter`
     :   The type of the None singleton.
 
+<a id="CompanyGteCondition"></a>
+
 `CompanyGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -576,6 +642,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.harvest.types.CompanySearchFilter`
     :   The type of the None singleton.
+
+<a id="CompanyInCondition"></a>
 
 `CompanyInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -596,6 +664,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.harvest.types.CompanyInFilter`
     :   The type of the None singleton.
+
+<a id="CompanyInFilter"></a>
 
 `CompanyInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -627,6 +697,8 @@ Classes
     `weekly_capacity: list[int]`
     :   Weekly capacity in seconds
 
+<a id="CompanyKeywordCondition"></a>
+
 `CompanyKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -638,6 +710,8 @@ Classes
 
     `keyword: airbyte_agent_sdk.connectors.harvest.types.CompanyStringFilter`
     :   The type of the None singleton.
+
+<a id="CompanyLikeCondition"></a>
 
 `CompanyLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
@@ -651,6 +725,8 @@ Classes
     `like: airbyte_agent_sdk.connectors.harvest.types.CompanyStringFilter`
     :   The type of the None singleton.
 
+<a id="CompanyLtCondition"></a>
+
 `CompanyLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -662,6 +738,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.harvest.types.CompanySearchFilter`
     :   The type of the None singleton.
+
+<a id="CompanyLteCondition"></a>
 
 `CompanyLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -675,6 +753,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.harvest.types.CompanySearchFilter`
     :   The type of the None singleton.
 
+<a id="CompanyNeqCondition"></a>
+
 `CompanyNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -686,6 +766,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.harvest.types.CompanySearchFilter`
     :   The type of the None singleton.
+
+<a id="CompanyNotCondition"></a>
 
 `CompanyNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -707,6 +789,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.harvest.types.CompanyEqCondition | airbyte_agent_sdk.connectors.harvest.types.CompanyNeqCondition | airbyte_agent_sdk.connectors.harvest.types.CompanyGtCondition | airbyte_agent_sdk.connectors.harvest.types.CompanyGteCondition | airbyte_agent_sdk.connectors.harvest.types.CompanyLtCondition | airbyte_agent_sdk.connectors.harvest.types.CompanyLteCondition | airbyte_agent_sdk.connectors.harvest.types.CompanyInCondition | airbyte_agent_sdk.connectors.harvest.types.CompanyLikeCondition | airbyte_agent_sdk.connectors.harvest.types.CompanyFuzzyCondition | airbyte_agent_sdk.connectors.harvest.types.CompanyKeywordCondition | airbyte_agent_sdk.connectors.harvest.types.CompanyContainsCondition | airbyte_agent_sdk.connectors.harvest.types.CompanyNotCondition | airbyte_agent_sdk.connectors.harvest.types.CompanyAndCondition | airbyte_agent_sdk.connectors.harvest.types.CompanyOrCondition | airbyte_agent_sdk.connectors.harvest.types.CompanyAnyCondition`
     :   The type of the None singleton.
 
+<a id="CompanyOrCondition"></a>
+
 `CompanyOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -726,6 +810,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.harvest.types.CompanyEqCondition | airbyte_agent_sdk.connectors.harvest.types.CompanyNeqCondition | airbyte_agent_sdk.connectors.harvest.types.CompanyGtCondition | airbyte_agent_sdk.connectors.harvest.types.CompanyGteCondition | airbyte_agent_sdk.connectors.harvest.types.CompanyLtCondition | airbyte_agent_sdk.connectors.harvest.types.CompanyLteCondition | airbyte_agent_sdk.connectors.harvest.types.CompanyInCondition | airbyte_agent_sdk.connectors.harvest.types.CompanyLikeCondition | airbyte_agent_sdk.connectors.harvest.types.CompanyFuzzyCondition | airbyte_agent_sdk.connectors.harvest.types.CompanyKeywordCondition | airbyte_agent_sdk.connectors.harvest.types.CompanyContainsCondition | airbyte_agent_sdk.connectors.harvest.types.CompanyNotCondition | airbyte_agent_sdk.connectors.harvest.types.CompanyAndCondition | airbyte_agent_sdk.connectors.harvest.types.CompanyOrCondition | airbyte_agent_sdk.connectors.harvest.types.CompanyAnyCondition]`
     :   The type of the None singleton.
+
+<a id="CompanySearchFilter"></a>
 
 `CompanySearchFilter(*args, **kwargs)`
 :   Available fields for filtering company search queries.
@@ -757,6 +843,8 @@ Classes
     `weekly_capacity: int | None`
     :   Weekly capacity in seconds
 
+<a id="CompanySearchQuery"></a>
+
 `CompanySearchQuery(*args, **kwargs)`
 :   Search query for company entity.
 
@@ -771,6 +859,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.harvest.types.CompanySortFilter]`
     :   The type of the None singleton.
+
+<a id="CompanySortFilter"></a>
 
 `CompanySortFilter(*args, **kwargs)`
 :   Available fields for sorting company search results.
@@ -802,6 +892,8 @@ Classes
     `weekly_capacity: Literal['asc', 'desc']`
     :   Weekly capacity in seconds
 
+<a id="CompanyStringFilter"></a>
+
 `CompanyStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -832,6 +924,8 @@ Classes
     `weekly_capacity: str`
     :   Weekly capacity in seconds
 
+<a id="ContactsAndCondition"></a>
+
 `ContactsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -852,6 +946,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.harvest.types.ContactsEqCondition | airbyte_agent_sdk.connectors.harvest.types.ContactsNeqCondition | airbyte_agent_sdk.connectors.harvest.types.ContactsGtCondition | airbyte_agent_sdk.connectors.harvest.types.ContactsGteCondition | airbyte_agent_sdk.connectors.harvest.types.ContactsLtCondition | airbyte_agent_sdk.connectors.harvest.types.ContactsLteCondition | airbyte_agent_sdk.connectors.harvest.types.ContactsInCondition | airbyte_agent_sdk.connectors.harvest.types.ContactsLikeCondition | airbyte_agent_sdk.connectors.harvest.types.ContactsFuzzyCondition | airbyte_agent_sdk.connectors.harvest.types.ContactsKeywordCondition | airbyte_agent_sdk.connectors.harvest.types.ContactsContainsCondition | airbyte_agent_sdk.connectors.harvest.types.ContactsNotCondition | airbyte_agent_sdk.connectors.harvest.types.ContactsAndCondition | airbyte_agent_sdk.connectors.harvest.types.ContactsOrCondition | airbyte_agent_sdk.connectors.harvest.types.ContactsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="ContactsAnyCondition"></a>
+
 `ContactsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -871,6 +967,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.harvest.types.ContactsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="ContactsAnyValueFilter"></a>
 
 `ContactsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -905,6 +1003,8 @@ Classes
     `updated_at: Any`
     :   When last updated
 
+<a id="ContactsContainsCondition"></a>
+
 `ContactsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -916,6 +1016,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.harvest.types.ContactsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="ContactsEqCondition"></a>
 
 `ContactsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -929,6 +1031,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.harvest.types.ContactsSearchFilter`
     :   The type of the None singleton.
 
+<a id="ContactsFuzzyCondition"></a>
+
 `ContactsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -940,6 +1044,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.harvest.types.ContactsStringFilter`
     :   The type of the None singleton.
+
+<a id="ContactsGetParams"></a>
 
 `ContactsGetParams(*args, **kwargs)`
 :   Parameters for contacts.get operation
@@ -953,6 +1059,8 @@ Classes
     `id: str`
     :   The type of the None singleton.
 
+<a id="ContactsGtCondition"></a>
+
 `ContactsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -965,6 +1073,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.harvest.types.ContactsSearchFilter`
     :   The type of the None singleton.
 
+<a id="ContactsGteCondition"></a>
+
 `ContactsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -976,6 +1086,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.harvest.types.ContactsSearchFilter`
     :   The type of the None singleton.
+
+<a id="ContactsInCondition"></a>
 
 `ContactsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -996,6 +1108,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.harvest.types.ContactsInFilter`
     :   The type of the None singleton.
+
+<a id="ContactsInFilter"></a>
 
 `ContactsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -1030,6 +1144,8 @@ Classes
     `updated_at: list[str]`
     :   When last updated
 
+<a id="ContactsKeywordCondition"></a>
+
 `ContactsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -1041,6 +1157,8 @@ Classes
 
     `keyword: airbyte_agent_sdk.connectors.harvest.types.ContactsStringFilter`
     :   The type of the None singleton.
+
+<a id="ContactsLikeCondition"></a>
 
 `ContactsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
@@ -1054,6 +1172,8 @@ Classes
     `like: airbyte_agent_sdk.connectors.harvest.types.ContactsStringFilter`
     :   The type of the None singleton.
 
+<a id="ContactsListParams"></a>
+
 `ContactsListParams(*args, **kwargs)`
 :   Parameters for contacts.list operation
 
@@ -1065,6 +1185,8 @@ Classes
 
     `per_page: int`
     :   The type of the None singleton.
+
+<a id="ContactsLtCondition"></a>
 
 `ContactsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
@@ -1078,6 +1200,8 @@ Classes
     `lt: airbyte_agent_sdk.connectors.harvest.types.ContactsSearchFilter`
     :   The type of the None singleton.
 
+<a id="ContactsLteCondition"></a>
+
 `ContactsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
 
@@ -1090,6 +1214,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.harvest.types.ContactsSearchFilter`
     :   The type of the None singleton.
 
+<a id="ContactsNeqCondition"></a>
+
 `ContactsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -1101,6 +1227,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.harvest.types.ContactsSearchFilter`
     :   The type of the None singleton.
+
+<a id="ContactsNotCondition"></a>
 
 `ContactsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -1122,6 +1250,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.harvest.types.ContactsEqCondition | airbyte_agent_sdk.connectors.harvest.types.ContactsNeqCondition | airbyte_agent_sdk.connectors.harvest.types.ContactsGtCondition | airbyte_agent_sdk.connectors.harvest.types.ContactsGteCondition | airbyte_agent_sdk.connectors.harvest.types.ContactsLtCondition | airbyte_agent_sdk.connectors.harvest.types.ContactsLteCondition | airbyte_agent_sdk.connectors.harvest.types.ContactsInCondition | airbyte_agent_sdk.connectors.harvest.types.ContactsLikeCondition | airbyte_agent_sdk.connectors.harvest.types.ContactsFuzzyCondition | airbyte_agent_sdk.connectors.harvest.types.ContactsKeywordCondition | airbyte_agent_sdk.connectors.harvest.types.ContactsContainsCondition | airbyte_agent_sdk.connectors.harvest.types.ContactsNotCondition | airbyte_agent_sdk.connectors.harvest.types.ContactsAndCondition | airbyte_agent_sdk.connectors.harvest.types.ContactsOrCondition | airbyte_agent_sdk.connectors.harvest.types.ContactsAnyCondition`
     :   The type of the None singleton.
 
+<a id="ContactsOrCondition"></a>
+
 `ContactsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1141,6 +1271,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.harvest.types.ContactsEqCondition | airbyte_agent_sdk.connectors.harvest.types.ContactsNeqCondition | airbyte_agent_sdk.connectors.harvest.types.ContactsGtCondition | airbyte_agent_sdk.connectors.harvest.types.ContactsGteCondition | airbyte_agent_sdk.connectors.harvest.types.ContactsLtCondition | airbyte_agent_sdk.connectors.harvest.types.ContactsLteCondition | airbyte_agent_sdk.connectors.harvest.types.ContactsInCondition | airbyte_agent_sdk.connectors.harvest.types.ContactsLikeCondition | airbyte_agent_sdk.connectors.harvest.types.ContactsFuzzyCondition | airbyte_agent_sdk.connectors.harvest.types.ContactsKeywordCondition | airbyte_agent_sdk.connectors.harvest.types.ContactsContainsCondition | airbyte_agent_sdk.connectors.harvest.types.ContactsNotCondition | airbyte_agent_sdk.connectors.harvest.types.ContactsAndCondition | airbyte_agent_sdk.connectors.harvest.types.ContactsOrCondition | airbyte_agent_sdk.connectors.harvest.types.ContactsAnyCondition]`
     :   The type of the None singleton.
+
+<a id="ContactsSearchFilter"></a>
 
 `ContactsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering contacts search queries.
@@ -1175,6 +1307,8 @@ Classes
     `updated_at: str | None`
     :   When last updated
 
+<a id="ContactsSearchQuery"></a>
+
 `ContactsSearchQuery(*args, **kwargs)`
 :   Search query for contacts entity.
 
@@ -1189,6 +1323,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.harvest.types.ContactsSortFilter]`
     :   The type of the None singleton.
+
+<a id="ContactsSortFilter"></a>
 
 `ContactsSortFilter(*args, **kwargs)`
 :   Available fields for sorting contacts search results.
@@ -1223,6 +1359,8 @@ Classes
     `updated_at: Literal['asc', 'desc']`
     :   When last updated
 
+<a id="ContactsStringFilter"></a>
+
 `ContactsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -1256,6 +1394,8 @@ Classes
     `updated_at: str`
     :   When last updated
 
+<a id="EstimateItemCategoriesAndCondition"></a>
+
 `EstimateItemCategoriesAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1276,6 +1416,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.harvest.types.EstimateItemCategoriesEqCondition | airbyte_agent_sdk.connectors.harvest.types.EstimateItemCategoriesNeqCondition | airbyte_agent_sdk.connectors.harvest.types.EstimateItemCategoriesGtCondition | airbyte_agent_sdk.connectors.harvest.types.EstimateItemCategoriesGteCondition | airbyte_agent_sdk.connectors.harvest.types.EstimateItemCategoriesLtCondition | airbyte_agent_sdk.connectors.harvest.types.EstimateItemCategoriesLteCondition | airbyte_agent_sdk.connectors.harvest.types.EstimateItemCategoriesInCondition | airbyte_agent_sdk.connectors.harvest.types.EstimateItemCategoriesLikeCondition | airbyte_agent_sdk.connectors.harvest.types.EstimateItemCategoriesFuzzyCondition | airbyte_agent_sdk.connectors.harvest.types.EstimateItemCategoriesKeywordCondition | airbyte_agent_sdk.connectors.harvest.types.EstimateItemCategoriesContainsCondition | airbyte_agent_sdk.connectors.harvest.types.EstimateItemCategoriesNotCondition | airbyte_agent_sdk.connectors.harvest.types.EstimateItemCategoriesAndCondition | airbyte_agent_sdk.connectors.harvest.types.EstimateItemCategoriesOrCondition | airbyte_agent_sdk.connectors.harvest.types.EstimateItemCategoriesAnyCondition]`
     :   The type of the None singleton.
 
+<a id="EstimateItemCategoriesAnyCondition"></a>
+
 `EstimateItemCategoriesAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1295,6 +1437,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.harvest.types.EstimateItemCategoriesAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="EstimateItemCategoriesAnyValueFilter"></a>
 
 `EstimateItemCategoriesAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -1317,6 +1461,8 @@ Classes
     `updated_at: Any`
     :   When last updated
 
+<a id="EstimateItemCategoriesContainsCondition"></a>
+
 `EstimateItemCategoriesContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -1328,6 +1474,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.harvest.types.EstimateItemCategoriesAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="EstimateItemCategoriesEqCondition"></a>
 
 `EstimateItemCategoriesEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -1341,6 +1489,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.harvest.types.EstimateItemCategoriesSearchFilter`
     :   The type of the None singleton.
 
+<a id="EstimateItemCategoriesFuzzyCondition"></a>
+
 `EstimateItemCategoriesFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -1352,6 +1502,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.harvest.types.EstimateItemCategoriesStringFilter`
     :   The type of the None singleton.
+
+<a id="EstimateItemCategoriesGetParams"></a>
 
 `EstimateItemCategoriesGetParams(*args, **kwargs)`
 :   Parameters for estimate_item_categories.get operation
@@ -1365,6 +1517,8 @@ Classes
     `id: str`
     :   The type of the None singleton.
 
+<a id="EstimateItemCategoriesGtCondition"></a>
+
 `EstimateItemCategoriesGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -1377,6 +1531,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.harvest.types.EstimateItemCategoriesSearchFilter`
     :   The type of the None singleton.
 
+<a id="EstimateItemCategoriesGteCondition"></a>
+
 `EstimateItemCategoriesGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -1388,6 +1544,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.harvest.types.EstimateItemCategoriesSearchFilter`
     :   The type of the None singleton.
+
+<a id="EstimateItemCategoriesInCondition"></a>
 
 `EstimateItemCategoriesInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -1408,6 +1566,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.harvest.types.EstimateItemCategoriesInFilter`
     :   The type of the None singleton.
+
+<a id="EstimateItemCategoriesInFilter"></a>
 
 `EstimateItemCategoriesInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -1430,6 +1590,8 @@ Classes
     `updated_at: list[str]`
     :   When last updated
 
+<a id="EstimateItemCategoriesKeywordCondition"></a>
+
 `EstimateItemCategoriesKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -1441,6 +1603,8 @@ Classes
 
     `keyword: airbyte_agent_sdk.connectors.harvest.types.EstimateItemCategoriesStringFilter`
     :   The type of the None singleton.
+
+<a id="EstimateItemCategoriesLikeCondition"></a>
 
 `EstimateItemCategoriesLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
@@ -1454,6 +1618,8 @@ Classes
     `like: airbyte_agent_sdk.connectors.harvest.types.EstimateItemCategoriesStringFilter`
     :   The type of the None singleton.
 
+<a id="EstimateItemCategoriesListParams"></a>
+
 `EstimateItemCategoriesListParams(*args, **kwargs)`
 :   Parameters for estimate_item_categories.list operation
 
@@ -1465,6 +1631,8 @@ Classes
 
     `per_page: int`
     :   The type of the None singleton.
+
+<a id="EstimateItemCategoriesLtCondition"></a>
 
 `EstimateItemCategoriesLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
@@ -1478,6 +1646,8 @@ Classes
     `lt: airbyte_agent_sdk.connectors.harvest.types.EstimateItemCategoriesSearchFilter`
     :   The type of the None singleton.
 
+<a id="EstimateItemCategoriesLteCondition"></a>
+
 `EstimateItemCategoriesLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
 
@@ -1490,6 +1660,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.harvest.types.EstimateItemCategoriesSearchFilter`
     :   The type of the None singleton.
 
+<a id="EstimateItemCategoriesNeqCondition"></a>
+
 `EstimateItemCategoriesNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -1501,6 +1673,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.harvest.types.EstimateItemCategoriesSearchFilter`
     :   The type of the None singleton.
+
+<a id="EstimateItemCategoriesNotCondition"></a>
 
 `EstimateItemCategoriesNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -1522,6 +1696,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.harvest.types.EstimateItemCategoriesEqCondition | airbyte_agent_sdk.connectors.harvest.types.EstimateItemCategoriesNeqCondition | airbyte_agent_sdk.connectors.harvest.types.EstimateItemCategoriesGtCondition | airbyte_agent_sdk.connectors.harvest.types.EstimateItemCategoriesGteCondition | airbyte_agent_sdk.connectors.harvest.types.EstimateItemCategoriesLtCondition | airbyte_agent_sdk.connectors.harvest.types.EstimateItemCategoriesLteCondition | airbyte_agent_sdk.connectors.harvest.types.EstimateItemCategoriesInCondition | airbyte_agent_sdk.connectors.harvest.types.EstimateItemCategoriesLikeCondition | airbyte_agent_sdk.connectors.harvest.types.EstimateItemCategoriesFuzzyCondition | airbyte_agent_sdk.connectors.harvest.types.EstimateItemCategoriesKeywordCondition | airbyte_agent_sdk.connectors.harvest.types.EstimateItemCategoriesContainsCondition | airbyte_agent_sdk.connectors.harvest.types.EstimateItemCategoriesNotCondition | airbyte_agent_sdk.connectors.harvest.types.EstimateItemCategoriesAndCondition | airbyte_agent_sdk.connectors.harvest.types.EstimateItemCategoriesOrCondition | airbyte_agent_sdk.connectors.harvest.types.EstimateItemCategoriesAnyCondition`
     :   The type of the None singleton.
 
+<a id="EstimateItemCategoriesOrCondition"></a>
+
 `EstimateItemCategoriesOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1541,6 +1717,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.harvest.types.EstimateItemCategoriesEqCondition | airbyte_agent_sdk.connectors.harvest.types.EstimateItemCategoriesNeqCondition | airbyte_agent_sdk.connectors.harvest.types.EstimateItemCategoriesGtCondition | airbyte_agent_sdk.connectors.harvest.types.EstimateItemCategoriesGteCondition | airbyte_agent_sdk.connectors.harvest.types.EstimateItemCategoriesLtCondition | airbyte_agent_sdk.connectors.harvest.types.EstimateItemCategoriesLteCondition | airbyte_agent_sdk.connectors.harvest.types.EstimateItemCategoriesInCondition | airbyte_agent_sdk.connectors.harvest.types.EstimateItemCategoriesLikeCondition | airbyte_agent_sdk.connectors.harvest.types.EstimateItemCategoriesFuzzyCondition | airbyte_agent_sdk.connectors.harvest.types.EstimateItemCategoriesKeywordCondition | airbyte_agent_sdk.connectors.harvest.types.EstimateItemCategoriesContainsCondition | airbyte_agent_sdk.connectors.harvest.types.EstimateItemCategoriesNotCondition | airbyte_agent_sdk.connectors.harvest.types.EstimateItemCategoriesAndCondition | airbyte_agent_sdk.connectors.harvest.types.EstimateItemCategoriesOrCondition | airbyte_agent_sdk.connectors.harvest.types.EstimateItemCategoriesAnyCondition]`
     :   The type of the None singleton.
+
+<a id="EstimateItemCategoriesSearchFilter"></a>
 
 `EstimateItemCategoriesSearchFilter(*args, **kwargs)`
 :   Available fields for filtering estimate_item_categories search queries.
@@ -1563,6 +1741,8 @@ Classes
     `updated_at: str | None`
     :   When last updated
 
+<a id="EstimateItemCategoriesSearchQuery"></a>
+
 `EstimateItemCategoriesSearchQuery(*args, **kwargs)`
 :   Search query for estimate_item_categories entity.
 
@@ -1577,6 +1757,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.harvest.types.EstimateItemCategoriesSortFilter]`
     :   The type of the None singleton.
+
+<a id="EstimateItemCategoriesSortFilter"></a>
 
 `EstimateItemCategoriesSortFilter(*args, **kwargs)`
 :   Available fields for sorting estimate_item_categories search results.
@@ -1599,6 +1781,8 @@ Classes
     `updated_at: Literal['asc', 'desc']`
     :   When last updated
 
+<a id="EstimateItemCategoriesStringFilter"></a>
+
 `EstimateItemCategoriesStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -1620,6 +1804,8 @@ Classes
     `updated_at: str`
     :   When last updated
 
+<a id="EstimatesAndCondition"></a>
+
 `EstimatesAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1640,6 +1826,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.harvest.types.EstimatesEqCondition | airbyte_agent_sdk.connectors.harvest.types.EstimatesNeqCondition | airbyte_agent_sdk.connectors.harvest.types.EstimatesGtCondition | airbyte_agent_sdk.connectors.harvest.types.EstimatesGteCondition | airbyte_agent_sdk.connectors.harvest.types.EstimatesLtCondition | airbyte_agent_sdk.connectors.harvest.types.EstimatesLteCondition | airbyte_agent_sdk.connectors.harvest.types.EstimatesInCondition | airbyte_agent_sdk.connectors.harvest.types.EstimatesLikeCondition | airbyte_agent_sdk.connectors.harvest.types.EstimatesFuzzyCondition | airbyte_agent_sdk.connectors.harvest.types.EstimatesKeywordCondition | airbyte_agent_sdk.connectors.harvest.types.EstimatesContainsCondition | airbyte_agent_sdk.connectors.harvest.types.EstimatesNotCondition | airbyte_agent_sdk.connectors.harvest.types.EstimatesAndCondition | airbyte_agent_sdk.connectors.harvest.types.EstimatesOrCondition | airbyte_agent_sdk.connectors.harvest.types.EstimatesAnyCondition]`
     :   The type of the None singleton.
 
+<a id="EstimatesAnyCondition"></a>
+
 `EstimatesAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1659,6 +1847,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.harvest.types.EstimatesAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="EstimatesAnyValueFilter"></a>
 
 `EstimatesAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -1699,6 +1889,8 @@ Classes
     `updated_at: Any`
     :   When last updated
 
+<a id="EstimatesContainsCondition"></a>
+
 `EstimatesContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -1710,6 +1902,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.harvest.types.EstimatesAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="EstimatesEqCondition"></a>
 
 `EstimatesEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -1723,6 +1917,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.harvest.types.EstimatesSearchFilter`
     :   The type of the None singleton.
 
+<a id="EstimatesFuzzyCondition"></a>
+
 `EstimatesFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -1734,6 +1930,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.harvest.types.EstimatesStringFilter`
     :   The type of the None singleton.
+
+<a id="EstimatesGetParams"></a>
 
 `EstimatesGetParams(*args, **kwargs)`
 :   Parameters for estimates.get operation
@@ -1747,6 +1945,8 @@ Classes
     `id: str`
     :   The type of the None singleton.
 
+<a id="EstimatesGtCondition"></a>
+
 `EstimatesGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -1759,6 +1959,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.harvest.types.EstimatesSearchFilter`
     :   The type of the None singleton.
 
+<a id="EstimatesGteCondition"></a>
+
 `EstimatesGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -1770,6 +1972,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.harvest.types.EstimatesSearchFilter`
     :   The type of the None singleton.
+
+<a id="EstimatesInCondition"></a>
 
 `EstimatesInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -1790,6 +1994,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.harvest.types.EstimatesInFilter`
     :   The type of the None singleton.
+
+<a id="EstimatesInFilter"></a>
 
 `EstimatesInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -1830,6 +2036,8 @@ Classes
     `updated_at: list[str]`
     :   When last updated
 
+<a id="EstimatesKeywordCondition"></a>
+
 `EstimatesKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -1841,6 +2049,8 @@ Classes
 
     `keyword: airbyte_agent_sdk.connectors.harvest.types.EstimatesStringFilter`
     :   The type of the None singleton.
+
+<a id="EstimatesLikeCondition"></a>
 
 `EstimatesLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
@@ -1854,6 +2064,8 @@ Classes
     `like: airbyte_agent_sdk.connectors.harvest.types.EstimatesStringFilter`
     :   The type of the None singleton.
 
+<a id="EstimatesListParams"></a>
+
 `EstimatesListParams(*args, **kwargs)`
 :   Parameters for estimates.list operation
 
@@ -1865,6 +2077,8 @@ Classes
 
     `per_page: int`
     :   The type of the None singleton.
+
+<a id="EstimatesLtCondition"></a>
 
 `EstimatesLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
@@ -1878,6 +2092,8 @@ Classes
     `lt: airbyte_agent_sdk.connectors.harvest.types.EstimatesSearchFilter`
     :   The type of the None singleton.
 
+<a id="EstimatesLteCondition"></a>
+
 `EstimatesLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
 
@@ -1890,6 +2106,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.harvest.types.EstimatesSearchFilter`
     :   The type of the None singleton.
 
+<a id="EstimatesNeqCondition"></a>
+
 `EstimatesNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -1901,6 +2119,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.harvest.types.EstimatesSearchFilter`
     :   The type of the None singleton.
+
+<a id="EstimatesNotCondition"></a>
 
 `EstimatesNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -1922,6 +2142,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.harvest.types.EstimatesEqCondition | airbyte_agent_sdk.connectors.harvest.types.EstimatesNeqCondition | airbyte_agent_sdk.connectors.harvest.types.EstimatesGtCondition | airbyte_agent_sdk.connectors.harvest.types.EstimatesGteCondition | airbyte_agent_sdk.connectors.harvest.types.EstimatesLtCondition | airbyte_agent_sdk.connectors.harvest.types.EstimatesLteCondition | airbyte_agent_sdk.connectors.harvest.types.EstimatesInCondition | airbyte_agent_sdk.connectors.harvest.types.EstimatesLikeCondition | airbyte_agent_sdk.connectors.harvest.types.EstimatesFuzzyCondition | airbyte_agent_sdk.connectors.harvest.types.EstimatesKeywordCondition | airbyte_agent_sdk.connectors.harvest.types.EstimatesContainsCondition | airbyte_agent_sdk.connectors.harvest.types.EstimatesNotCondition | airbyte_agent_sdk.connectors.harvest.types.EstimatesAndCondition | airbyte_agent_sdk.connectors.harvest.types.EstimatesOrCondition | airbyte_agent_sdk.connectors.harvest.types.EstimatesAnyCondition`
     :   The type of the None singleton.
 
+<a id="EstimatesOrCondition"></a>
+
 `EstimatesOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1941,6 +2163,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.harvest.types.EstimatesEqCondition | airbyte_agent_sdk.connectors.harvest.types.EstimatesNeqCondition | airbyte_agent_sdk.connectors.harvest.types.EstimatesGtCondition | airbyte_agent_sdk.connectors.harvest.types.EstimatesGteCondition | airbyte_agent_sdk.connectors.harvest.types.EstimatesLtCondition | airbyte_agent_sdk.connectors.harvest.types.EstimatesLteCondition | airbyte_agent_sdk.connectors.harvest.types.EstimatesInCondition | airbyte_agent_sdk.connectors.harvest.types.EstimatesLikeCondition | airbyte_agent_sdk.connectors.harvest.types.EstimatesFuzzyCondition | airbyte_agent_sdk.connectors.harvest.types.EstimatesKeywordCondition | airbyte_agent_sdk.connectors.harvest.types.EstimatesContainsCondition | airbyte_agent_sdk.connectors.harvest.types.EstimatesNotCondition | airbyte_agent_sdk.connectors.harvest.types.EstimatesAndCondition | airbyte_agent_sdk.connectors.harvest.types.EstimatesOrCondition | airbyte_agent_sdk.connectors.harvest.types.EstimatesAnyCondition]`
     :   The type of the None singleton.
+
+<a id="EstimatesSearchFilter"></a>
 
 `EstimatesSearchFilter(*args, **kwargs)`
 :   Available fields for filtering estimates search queries.
@@ -1981,6 +2205,8 @@ Classes
     `updated_at: str | None`
     :   When last updated
 
+<a id="EstimatesSearchQuery"></a>
+
 `EstimatesSearchQuery(*args, **kwargs)`
 :   Search query for estimates entity.
 
@@ -1995,6 +2221,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.harvest.types.EstimatesSortFilter]`
     :   The type of the None singleton.
+
+<a id="EstimatesSortFilter"></a>
 
 `EstimatesSortFilter(*args, **kwargs)`
 :   Available fields for sorting estimates search results.
@@ -2035,6 +2263,8 @@ Classes
     `updated_at: Literal['asc', 'desc']`
     :   When last updated
 
+<a id="EstimatesStringFilter"></a>
+
 `EstimatesStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -2074,6 +2304,8 @@ Classes
     `updated_at: str`
     :   When last updated
 
+<a id="ExpenseCategoriesAndCondition"></a>
+
 `ExpenseCategoriesAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -2094,6 +2326,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.harvest.types.ExpenseCategoriesEqCondition | airbyte_agent_sdk.connectors.harvest.types.ExpenseCategoriesNeqCondition | airbyte_agent_sdk.connectors.harvest.types.ExpenseCategoriesGtCondition | airbyte_agent_sdk.connectors.harvest.types.ExpenseCategoriesGteCondition | airbyte_agent_sdk.connectors.harvest.types.ExpenseCategoriesLtCondition | airbyte_agent_sdk.connectors.harvest.types.ExpenseCategoriesLteCondition | airbyte_agent_sdk.connectors.harvest.types.ExpenseCategoriesInCondition | airbyte_agent_sdk.connectors.harvest.types.ExpenseCategoriesLikeCondition | airbyte_agent_sdk.connectors.harvest.types.ExpenseCategoriesFuzzyCondition | airbyte_agent_sdk.connectors.harvest.types.ExpenseCategoriesKeywordCondition | airbyte_agent_sdk.connectors.harvest.types.ExpenseCategoriesContainsCondition | airbyte_agent_sdk.connectors.harvest.types.ExpenseCategoriesNotCondition | airbyte_agent_sdk.connectors.harvest.types.ExpenseCategoriesAndCondition | airbyte_agent_sdk.connectors.harvest.types.ExpenseCategoriesOrCondition | airbyte_agent_sdk.connectors.harvest.types.ExpenseCategoriesAnyCondition]`
     :   The type of the None singleton.
 
+<a id="ExpenseCategoriesAnyCondition"></a>
+
 `ExpenseCategoriesAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -2113,6 +2347,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.harvest.types.ExpenseCategoriesAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="ExpenseCategoriesAnyValueFilter"></a>
 
 `ExpenseCategoriesAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -2144,6 +2380,8 @@ Classes
     `updated_at: Any`
     :   When last updated
 
+<a id="ExpenseCategoriesContainsCondition"></a>
+
 `ExpenseCategoriesContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -2155,6 +2393,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.harvest.types.ExpenseCategoriesAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="ExpenseCategoriesEqCondition"></a>
 
 `ExpenseCategoriesEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -2168,6 +2408,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.harvest.types.ExpenseCategoriesSearchFilter`
     :   The type of the None singleton.
 
+<a id="ExpenseCategoriesFuzzyCondition"></a>
+
 `ExpenseCategoriesFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -2179,6 +2421,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.harvest.types.ExpenseCategoriesStringFilter`
     :   The type of the None singleton.
+
+<a id="ExpenseCategoriesGetParams"></a>
 
 `ExpenseCategoriesGetParams(*args, **kwargs)`
 :   Parameters for expense_categories.get operation
@@ -2192,6 +2436,8 @@ Classes
     `id: str`
     :   The type of the None singleton.
 
+<a id="ExpenseCategoriesGtCondition"></a>
+
 `ExpenseCategoriesGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -2204,6 +2450,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.harvest.types.ExpenseCategoriesSearchFilter`
     :   The type of the None singleton.
 
+<a id="ExpenseCategoriesGteCondition"></a>
+
 `ExpenseCategoriesGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -2215,6 +2463,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.harvest.types.ExpenseCategoriesSearchFilter`
     :   The type of the None singleton.
+
+<a id="ExpenseCategoriesInCondition"></a>
 
 `ExpenseCategoriesInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -2235,6 +2485,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.harvest.types.ExpenseCategoriesInFilter`
     :   The type of the None singleton.
+
+<a id="ExpenseCategoriesInFilter"></a>
 
 `ExpenseCategoriesInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -2266,6 +2518,8 @@ Classes
     `updated_at: list[str]`
     :   When last updated
 
+<a id="ExpenseCategoriesKeywordCondition"></a>
+
 `ExpenseCategoriesKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -2277,6 +2531,8 @@ Classes
 
     `keyword: airbyte_agent_sdk.connectors.harvest.types.ExpenseCategoriesStringFilter`
     :   The type of the None singleton.
+
+<a id="ExpenseCategoriesLikeCondition"></a>
 
 `ExpenseCategoriesLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
@@ -2290,6 +2546,8 @@ Classes
     `like: airbyte_agent_sdk.connectors.harvest.types.ExpenseCategoriesStringFilter`
     :   The type of the None singleton.
 
+<a id="ExpenseCategoriesListParams"></a>
+
 `ExpenseCategoriesListParams(*args, **kwargs)`
 :   Parameters for expense_categories.list operation
 
@@ -2301,6 +2559,8 @@ Classes
 
     `per_page: int`
     :   The type of the None singleton.
+
+<a id="ExpenseCategoriesLtCondition"></a>
 
 `ExpenseCategoriesLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
@@ -2314,6 +2574,8 @@ Classes
     `lt: airbyte_agent_sdk.connectors.harvest.types.ExpenseCategoriesSearchFilter`
     :   The type of the None singleton.
 
+<a id="ExpenseCategoriesLteCondition"></a>
+
 `ExpenseCategoriesLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
 
@@ -2326,6 +2588,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.harvest.types.ExpenseCategoriesSearchFilter`
     :   The type of the None singleton.
 
+<a id="ExpenseCategoriesNeqCondition"></a>
+
 `ExpenseCategoriesNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -2337,6 +2601,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.harvest.types.ExpenseCategoriesSearchFilter`
     :   The type of the None singleton.
+
+<a id="ExpenseCategoriesNotCondition"></a>
 
 `ExpenseCategoriesNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -2358,6 +2624,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.harvest.types.ExpenseCategoriesEqCondition | airbyte_agent_sdk.connectors.harvest.types.ExpenseCategoriesNeqCondition | airbyte_agent_sdk.connectors.harvest.types.ExpenseCategoriesGtCondition | airbyte_agent_sdk.connectors.harvest.types.ExpenseCategoriesGteCondition | airbyte_agent_sdk.connectors.harvest.types.ExpenseCategoriesLtCondition | airbyte_agent_sdk.connectors.harvest.types.ExpenseCategoriesLteCondition | airbyte_agent_sdk.connectors.harvest.types.ExpenseCategoriesInCondition | airbyte_agent_sdk.connectors.harvest.types.ExpenseCategoriesLikeCondition | airbyte_agent_sdk.connectors.harvest.types.ExpenseCategoriesFuzzyCondition | airbyte_agent_sdk.connectors.harvest.types.ExpenseCategoriesKeywordCondition | airbyte_agent_sdk.connectors.harvest.types.ExpenseCategoriesContainsCondition | airbyte_agent_sdk.connectors.harvest.types.ExpenseCategoriesNotCondition | airbyte_agent_sdk.connectors.harvest.types.ExpenseCategoriesAndCondition | airbyte_agent_sdk.connectors.harvest.types.ExpenseCategoriesOrCondition | airbyte_agent_sdk.connectors.harvest.types.ExpenseCategoriesAnyCondition`
     :   The type of the None singleton.
 
+<a id="ExpenseCategoriesOrCondition"></a>
+
 `ExpenseCategoriesOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -2377,6 +2645,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.harvest.types.ExpenseCategoriesEqCondition | airbyte_agent_sdk.connectors.harvest.types.ExpenseCategoriesNeqCondition | airbyte_agent_sdk.connectors.harvest.types.ExpenseCategoriesGtCondition | airbyte_agent_sdk.connectors.harvest.types.ExpenseCategoriesGteCondition | airbyte_agent_sdk.connectors.harvest.types.ExpenseCategoriesLtCondition | airbyte_agent_sdk.connectors.harvest.types.ExpenseCategoriesLteCondition | airbyte_agent_sdk.connectors.harvest.types.ExpenseCategoriesInCondition | airbyte_agent_sdk.connectors.harvest.types.ExpenseCategoriesLikeCondition | airbyte_agent_sdk.connectors.harvest.types.ExpenseCategoriesFuzzyCondition | airbyte_agent_sdk.connectors.harvest.types.ExpenseCategoriesKeywordCondition | airbyte_agent_sdk.connectors.harvest.types.ExpenseCategoriesContainsCondition | airbyte_agent_sdk.connectors.harvest.types.ExpenseCategoriesNotCondition | airbyte_agent_sdk.connectors.harvest.types.ExpenseCategoriesAndCondition | airbyte_agent_sdk.connectors.harvest.types.ExpenseCategoriesOrCondition | airbyte_agent_sdk.connectors.harvest.types.ExpenseCategoriesAnyCondition]`
     :   The type of the None singleton.
+
+<a id="ExpenseCategoriesSearchFilter"></a>
 
 `ExpenseCategoriesSearchFilter(*args, **kwargs)`
 :   Available fields for filtering expense_categories search queries.
@@ -2408,6 +2678,8 @@ Classes
     `updated_at: str | None`
     :   When last updated
 
+<a id="ExpenseCategoriesSearchQuery"></a>
+
 `ExpenseCategoriesSearchQuery(*args, **kwargs)`
 :   Search query for expense_categories entity.
 
@@ -2422,6 +2694,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.harvest.types.ExpenseCategoriesSortFilter]`
     :   The type of the None singleton.
+
+<a id="ExpenseCategoriesSortFilter"></a>
 
 `ExpenseCategoriesSortFilter(*args, **kwargs)`
 :   Available fields for sorting expense_categories search results.
@@ -2453,6 +2727,8 @@ Classes
     `updated_at: Literal['asc', 'desc']`
     :   When last updated
 
+<a id="ExpenseCategoriesStringFilter"></a>
+
 `ExpenseCategoriesStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -2483,6 +2759,8 @@ Classes
     `updated_at: str`
     :   When last updated
 
+<a id="ExpensesAndCondition"></a>
+
 `ExpensesAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -2503,6 +2781,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.harvest.types.ExpensesEqCondition | airbyte_agent_sdk.connectors.harvest.types.ExpensesNeqCondition | airbyte_agent_sdk.connectors.harvest.types.ExpensesGtCondition | airbyte_agent_sdk.connectors.harvest.types.ExpensesGteCondition | airbyte_agent_sdk.connectors.harvest.types.ExpensesLtCondition | airbyte_agent_sdk.connectors.harvest.types.ExpensesLteCondition | airbyte_agent_sdk.connectors.harvest.types.ExpensesInCondition | airbyte_agent_sdk.connectors.harvest.types.ExpensesLikeCondition | airbyte_agent_sdk.connectors.harvest.types.ExpensesFuzzyCondition | airbyte_agent_sdk.connectors.harvest.types.ExpensesKeywordCondition | airbyte_agent_sdk.connectors.harvest.types.ExpensesContainsCondition | airbyte_agent_sdk.connectors.harvest.types.ExpensesNotCondition | airbyte_agent_sdk.connectors.harvest.types.ExpensesAndCondition | airbyte_agent_sdk.connectors.harvest.types.ExpensesOrCondition | airbyte_agent_sdk.connectors.harvest.types.ExpensesAnyCondition]`
     :   The type of the None singleton.
 
+<a id="ExpensesAnyCondition"></a>
+
 `ExpensesAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -2522,6 +2802,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.harvest.types.ExpensesAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="ExpensesAnyValueFilter"></a>
 
 `ExpensesAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -2568,6 +2850,8 @@ Classes
     `user: Any`
     :   Associated user
 
+<a id="ExpensesContainsCondition"></a>
+
 `ExpensesContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -2579,6 +2863,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.harvest.types.ExpensesAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="ExpensesEqCondition"></a>
 
 `ExpensesEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -2592,6 +2878,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.harvest.types.ExpensesSearchFilter`
     :   The type of the None singleton.
 
+<a id="ExpensesFuzzyCondition"></a>
+
 `ExpensesFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -2603,6 +2891,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.harvest.types.ExpensesStringFilter`
     :   The type of the None singleton.
+
+<a id="ExpensesGetParams"></a>
 
 `ExpensesGetParams(*args, **kwargs)`
 :   Parameters for expenses.get operation
@@ -2616,6 +2906,8 @@ Classes
     `id: str`
     :   The type of the None singleton.
 
+<a id="ExpensesGtCondition"></a>
+
 `ExpensesGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -2628,6 +2920,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.harvest.types.ExpensesSearchFilter`
     :   The type of the None singleton.
 
+<a id="ExpensesGteCondition"></a>
+
 `ExpensesGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -2639,6 +2933,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.harvest.types.ExpensesSearchFilter`
     :   The type of the None singleton.
+
+<a id="ExpensesInCondition"></a>
 
 `ExpensesInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -2659,6 +2955,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.harvest.types.ExpensesInFilter`
     :   The type of the None singleton.
+
+<a id="ExpensesInFilter"></a>
 
 `ExpensesInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -2705,6 +3003,8 @@ Classes
     `user: list[dict[str, typing.Any]]`
     :   Associated user
 
+<a id="ExpensesKeywordCondition"></a>
+
 `ExpensesKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -2716,6 +3016,8 @@ Classes
 
     `keyword: airbyte_agent_sdk.connectors.harvest.types.ExpensesStringFilter`
     :   The type of the None singleton.
+
+<a id="ExpensesLikeCondition"></a>
 
 `ExpensesLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
@@ -2729,6 +3031,8 @@ Classes
     `like: airbyte_agent_sdk.connectors.harvest.types.ExpensesStringFilter`
     :   The type of the None singleton.
 
+<a id="ExpensesListParams"></a>
+
 `ExpensesListParams(*args, **kwargs)`
 :   Parameters for expenses.list operation
 
@@ -2740,6 +3044,8 @@ Classes
 
     `per_page: int`
     :   The type of the None singleton.
+
+<a id="ExpensesLtCondition"></a>
 
 `ExpensesLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
@@ -2753,6 +3059,8 @@ Classes
     `lt: airbyte_agent_sdk.connectors.harvest.types.ExpensesSearchFilter`
     :   The type of the None singleton.
 
+<a id="ExpensesLteCondition"></a>
+
 `ExpensesLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
 
@@ -2765,6 +3073,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.harvest.types.ExpensesSearchFilter`
     :   The type of the None singleton.
 
+<a id="ExpensesNeqCondition"></a>
+
 `ExpensesNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -2776,6 +3086,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.harvest.types.ExpensesSearchFilter`
     :   The type of the None singleton.
+
+<a id="ExpensesNotCondition"></a>
 
 `ExpensesNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -2797,6 +3109,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.harvest.types.ExpensesEqCondition | airbyte_agent_sdk.connectors.harvest.types.ExpensesNeqCondition | airbyte_agent_sdk.connectors.harvest.types.ExpensesGtCondition | airbyte_agent_sdk.connectors.harvest.types.ExpensesGteCondition | airbyte_agent_sdk.connectors.harvest.types.ExpensesLtCondition | airbyte_agent_sdk.connectors.harvest.types.ExpensesLteCondition | airbyte_agent_sdk.connectors.harvest.types.ExpensesInCondition | airbyte_agent_sdk.connectors.harvest.types.ExpensesLikeCondition | airbyte_agent_sdk.connectors.harvest.types.ExpensesFuzzyCondition | airbyte_agent_sdk.connectors.harvest.types.ExpensesKeywordCondition | airbyte_agent_sdk.connectors.harvest.types.ExpensesContainsCondition | airbyte_agent_sdk.connectors.harvest.types.ExpensesNotCondition | airbyte_agent_sdk.connectors.harvest.types.ExpensesAndCondition | airbyte_agent_sdk.connectors.harvest.types.ExpensesOrCondition | airbyte_agent_sdk.connectors.harvest.types.ExpensesAnyCondition`
     :   The type of the None singleton.
 
+<a id="ExpensesOrCondition"></a>
+
 `ExpensesOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -2816,6 +3130,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.harvest.types.ExpensesEqCondition | airbyte_agent_sdk.connectors.harvest.types.ExpensesNeqCondition | airbyte_agent_sdk.connectors.harvest.types.ExpensesGtCondition | airbyte_agent_sdk.connectors.harvest.types.ExpensesGteCondition | airbyte_agent_sdk.connectors.harvest.types.ExpensesLtCondition | airbyte_agent_sdk.connectors.harvest.types.ExpensesLteCondition | airbyte_agent_sdk.connectors.harvest.types.ExpensesInCondition | airbyte_agent_sdk.connectors.harvest.types.ExpensesLikeCondition | airbyte_agent_sdk.connectors.harvest.types.ExpensesFuzzyCondition | airbyte_agent_sdk.connectors.harvest.types.ExpensesKeywordCondition | airbyte_agent_sdk.connectors.harvest.types.ExpensesContainsCondition | airbyte_agent_sdk.connectors.harvest.types.ExpensesNotCondition | airbyte_agent_sdk.connectors.harvest.types.ExpensesAndCondition | airbyte_agent_sdk.connectors.harvest.types.ExpensesOrCondition | airbyte_agent_sdk.connectors.harvest.types.ExpensesAnyCondition]`
     :   The type of the None singleton.
+
+<a id="ExpensesSearchFilter"></a>
 
 `ExpensesSearchFilter(*args, **kwargs)`
 :   Available fields for filtering expenses search queries.
@@ -2862,6 +3178,8 @@ Classes
     `user: dict[str, typing.Any] | None`
     :   Associated user
 
+<a id="ExpensesSearchQuery"></a>
+
 `ExpensesSearchQuery(*args, **kwargs)`
 :   Search query for expenses entity.
 
@@ -2876,6 +3194,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.harvest.types.ExpensesSortFilter]`
     :   The type of the None singleton.
+
+<a id="ExpensesSortFilter"></a>
 
 `ExpensesSortFilter(*args, **kwargs)`
 :   Available fields for sorting expenses search results.
@@ -2922,6 +3242,8 @@ Classes
     `user: Literal['asc', 'desc']`
     :   Associated user
 
+<a id="ExpensesStringFilter"></a>
+
 `ExpensesStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -2967,6 +3289,8 @@ Classes
     `user: str`
     :   Associated user
 
+<a id="InvoiceItemCategoriesAndCondition"></a>
+
 `InvoiceItemCategoriesAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -2987,6 +3311,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.harvest.types.InvoiceItemCategoriesEqCondition | airbyte_agent_sdk.connectors.harvest.types.InvoiceItemCategoriesNeqCondition | airbyte_agent_sdk.connectors.harvest.types.InvoiceItemCategoriesGtCondition | airbyte_agent_sdk.connectors.harvest.types.InvoiceItemCategoriesGteCondition | airbyte_agent_sdk.connectors.harvest.types.InvoiceItemCategoriesLtCondition | airbyte_agent_sdk.connectors.harvest.types.InvoiceItemCategoriesLteCondition | airbyte_agent_sdk.connectors.harvest.types.InvoiceItemCategoriesInCondition | airbyte_agent_sdk.connectors.harvest.types.InvoiceItemCategoriesLikeCondition | airbyte_agent_sdk.connectors.harvest.types.InvoiceItemCategoriesFuzzyCondition | airbyte_agent_sdk.connectors.harvest.types.InvoiceItemCategoriesKeywordCondition | airbyte_agent_sdk.connectors.harvest.types.InvoiceItemCategoriesContainsCondition | airbyte_agent_sdk.connectors.harvest.types.InvoiceItemCategoriesNotCondition | airbyte_agent_sdk.connectors.harvest.types.InvoiceItemCategoriesAndCondition | airbyte_agent_sdk.connectors.harvest.types.InvoiceItemCategoriesOrCondition | airbyte_agent_sdk.connectors.harvest.types.InvoiceItemCategoriesAnyCondition]`
     :   The type of the None singleton.
 
+<a id="InvoiceItemCategoriesAnyCondition"></a>
+
 `InvoiceItemCategoriesAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -3006,6 +3332,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.harvest.types.InvoiceItemCategoriesAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="InvoiceItemCategoriesAnyValueFilter"></a>
 
 `InvoiceItemCategoriesAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -3034,6 +3362,8 @@ Classes
     `use_as_service: Any`
     :   Whether used as service type
 
+<a id="InvoiceItemCategoriesContainsCondition"></a>
+
 `InvoiceItemCategoriesContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -3045,6 +3375,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.harvest.types.InvoiceItemCategoriesAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="InvoiceItemCategoriesEqCondition"></a>
 
 `InvoiceItemCategoriesEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -3058,6 +3390,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.harvest.types.InvoiceItemCategoriesSearchFilter`
     :   The type of the None singleton.
 
+<a id="InvoiceItemCategoriesFuzzyCondition"></a>
+
 `InvoiceItemCategoriesFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -3069,6 +3403,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.harvest.types.InvoiceItemCategoriesStringFilter`
     :   The type of the None singleton.
+
+<a id="InvoiceItemCategoriesGetParams"></a>
 
 `InvoiceItemCategoriesGetParams(*args, **kwargs)`
 :   Parameters for invoice_item_categories.get operation
@@ -3082,6 +3418,8 @@ Classes
     `id: str`
     :   The type of the None singleton.
 
+<a id="InvoiceItemCategoriesGtCondition"></a>
+
 `InvoiceItemCategoriesGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -3094,6 +3432,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.harvest.types.InvoiceItemCategoriesSearchFilter`
     :   The type of the None singleton.
 
+<a id="InvoiceItemCategoriesGteCondition"></a>
+
 `InvoiceItemCategoriesGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -3105,6 +3445,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.harvest.types.InvoiceItemCategoriesSearchFilter`
     :   The type of the None singleton.
+
+<a id="InvoiceItemCategoriesInCondition"></a>
 
 `InvoiceItemCategoriesInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -3125,6 +3467,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.harvest.types.InvoiceItemCategoriesInFilter`
     :   The type of the None singleton.
+
+<a id="InvoiceItemCategoriesInFilter"></a>
 
 `InvoiceItemCategoriesInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -3153,6 +3497,8 @@ Classes
     `use_as_service: list[bool]`
     :   Whether used as service type
 
+<a id="InvoiceItemCategoriesKeywordCondition"></a>
+
 `InvoiceItemCategoriesKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -3164,6 +3510,8 @@ Classes
 
     `keyword: airbyte_agent_sdk.connectors.harvest.types.InvoiceItemCategoriesStringFilter`
     :   The type of the None singleton.
+
+<a id="InvoiceItemCategoriesLikeCondition"></a>
 
 `InvoiceItemCategoriesLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
@@ -3177,6 +3525,8 @@ Classes
     `like: airbyte_agent_sdk.connectors.harvest.types.InvoiceItemCategoriesStringFilter`
     :   The type of the None singleton.
 
+<a id="InvoiceItemCategoriesListParams"></a>
+
 `InvoiceItemCategoriesListParams(*args, **kwargs)`
 :   Parameters for invoice_item_categories.list operation
 
@@ -3188,6 +3538,8 @@ Classes
 
     `per_page: int`
     :   The type of the None singleton.
+
+<a id="InvoiceItemCategoriesLtCondition"></a>
 
 `InvoiceItemCategoriesLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
@@ -3201,6 +3553,8 @@ Classes
     `lt: airbyte_agent_sdk.connectors.harvest.types.InvoiceItemCategoriesSearchFilter`
     :   The type of the None singleton.
 
+<a id="InvoiceItemCategoriesLteCondition"></a>
+
 `InvoiceItemCategoriesLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
 
@@ -3213,6 +3567,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.harvest.types.InvoiceItemCategoriesSearchFilter`
     :   The type of the None singleton.
 
+<a id="InvoiceItemCategoriesNeqCondition"></a>
+
 `InvoiceItemCategoriesNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -3224,6 +3580,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.harvest.types.InvoiceItemCategoriesSearchFilter`
     :   The type of the None singleton.
+
+<a id="InvoiceItemCategoriesNotCondition"></a>
 
 `InvoiceItemCategoriesNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -3245,6 +3603,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.harvest.types.InvoiceItemCategoriesEqCondition | airbyte_agent_sdk.connectors.harvest.types.InvoiceItemCategoriesNeqCondition | airbyte_agent_sdk.connectors.harvest.types.InvoiceItemCategoriesGtCondition | airbyte_agent_sdk.connectors.harvest.types.InvoiceItemCategoriesGteCondition | airbyte_agent_sdk.connectors.harvest.types.InvoiceItemCategoriesLtCondition | airbyte_agent_sdk.connectors.harvest.types.InvoiceItemCategoriesLteCondition | airbyte_agent_sdk.connectors.harvest.types.InvoiceItemCategoriesInCondition | airbyte_agent_sdk.connectors.harvest.types.InvoiceItemCategoriesLikeCondition | airbyte_agent_sdk.connectors.harvest.types.InvoiceItemCategoriesFuzzyCondition | airbyte_agent_sdk.connectors.harvest.types.InvoiceItemCategoriesKeywordCondition | airbyte_agent_sdk.connectors.harvest.types.InvoiceItemCategoriesContainsCondition | airbyte_agent_sdk.connectors.harvest.types.InvoiceItemCategoriesNotCondition | airbyte_agent_sdk.connectors.harvest.types.InvoiceItemCategoriesAndCondition | airbyte_agent_sdk.connectors.harvest.types.InvoiceItemCategoriesOrCondition | airbyte_agent_sdk.connectors.harvest.types.InvoiceItemCategoriesAnyCondition`
     :   The type of the None singleton.
 
+<a id="InvoiceItemCategoriesOrCondition"></a>
+
 `InvoiceItemCategoriesOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -3264,6 +3624,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.harvest.types.InvoiceItemCategoriesEqCondition | airbyte_agent_sdk.connectors.harvest.types.InvoiceItemCategoriesNeqCondition | airbyte_agent_sdk.connectors.harvest.types.InvoiceItemCategoriesGtCondition | airbyte_agent_sdk.connectors.harvest.types.InvoiceItemCategoriesGteCondition | airbyte_agent_sdk.connectors.harvest.types.InvoiceItemCategoriesLtCondition | airbyte_agent_sdk.connectors.harvest.types.InvoiceItemCategoriesLteCondition | airbyte_agent_sdk.connectors.harvest.types.InvoiceItemCategoriesInCondition | airbyte_agent_sdk.connectors.harvest.types.InvoiceItemCategoriesLikeCondition | airbyte_agent_sdk.connectors.harvest.types.InvoiceItemCategoriesFuzzyCondition | airbyte_agent_sdk.connectors.harvest.types.InvoiceItemCategoriesKeywordCondition | airbyte_agent_sdk.connectors.harvest.types.InvoiceItemCategoriesContainsCondition | airbyte_agent_sdk.connectors.harvest.types.InvoiceItemCategoriesNotCondition | airbyte_agent_sdk.connectors.harvest.types.InvoiceItemCategoriesAndCondition | airbyte_agent_sdk.connectors.harvest.types.InvoiceItemCategoriesOrCondition | airbyte_agent_sdk.connectors.harvest.types.InvoiceItemCategoriesAnyCondition]`
     :   The type of the None singleton.
+
+<a id="InvoiceItemCategoriesSearchFilter"></a>
 
 `InvoiceItemCategoriesSearchFilter(*args, **kwargs)`
 :   Available fields for filtering invoice_item_categories search queries.
@@ -3292,6 +3654,8 @@ Classes
     `use_as_service: bool | None`
     :   Whether used as service type
 
+<a id="InvoiceItemCategoriesSearchQuery"></a>
+
 `InvoiceItemCategoriesSearchQuery(*args, **kwargs)`
 :   Search query for invoice_item_categories entity.
 
@@ -3306,6 +3670,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.harvest.types.InvoiceItemCategoriesSortFilter]`
     :   The type of the None singleton.
+
+<a id="InvoiceItemCategoriesSortFilter"></a>
 
 `InvoiceItemCategoriesSortFilter(*args, **kwargs)`
 :   Available fields for sorting invoice_item_categories search results.
@@ -3334,6 +3700,8 @@ Classes
     `use_as_service: Literal['asc', 'desc']`
     :   Whether used as service type
 
+<a id="InvoiceItemCategoriesStringFilter"></a>
+
 `InvoiceItemCategoriesStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -3361,6 +3729,8 @@ Classes
     `use_as_service: str`
     :   Whether used as service type
 
+<a id="InvoicesAndCondition"></a>
+
 `InvoicesAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -3381,6 +3751,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.harvest.types.InvoicesEqCondition | airbyte_agent_sdk.connectors.harvest.types.InvoicesNeqCondition | airbyte_agent_sdk.connectors.harvest.types.InvoicesGtCondition | airbyte_agent_sdk.connectors.harvest.types.InvoicesGteCondition | airbyte_agent_sdk.connectors.harvest.types.InvoicesLtCondition | airbyte_agent_sdk.connectors.harvest.types.InvoicesLteCondition | airbyte_agent_sdk.connectors.harvest.types.InvoicesInCondition | airbyte_agent_sdk.connectors.harvest.types.InvoicesLikeCondition | airbyte_agent_sdk.connectors.harvest.types.InvoicesFuzzyCondition | airbyte_agent_sdk.connectors.harvest.types.InvoicesKeywordCondition | airbyte_agent_sdk.connectors.harvest.types.InvoicesContainsCondition | airbyte_agent_sdk.connectors.harvest.types.InvoicesNotCondition | airbyte_agent_sdk.connectors.harvest.types.InvoicesAndCondition | airbyte_agent_sdk.connectors.harvest.types.InvoicesOrCondition | airbyte_agent_sdk.connectors.harvest.types.InvoicesAnyCondition]`
     :   The type of the None singleton.
 
+<a id="InvoicesAnyCondition"></a>
+
 `InvoicesAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -3400,6 +3772,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.harvest.types.InvoicesAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="InvoicesAnyValueFilter"></a>
 
 `InvoicesAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -3446,6 +3820,8 @@ Classes
     `updated_at: Any`
     :   When last updated
 
+<a id="InvoicesContainsCondition"></a>
+
 `InvoicesContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -3457,6 +3833,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.harvest.types.InvoicesAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="InvoicesEqCondition"></a>
 
 `InvoicesEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -3470,6 +3848,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.harvest.types.InvoicesSearchFilter`
     :   The type of the None singleton.
 
+<a id="InvoicesFuzzyCondition"></a>
+
 `InvoicesFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -3481,6 +3861,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.harvest.types.InvoicesStringFilter`
     :   The type of the None singleton.
+
+<a id="InvoicesGetParams"></a>
 
 `InvoicesGetParams(*args, **kwargs)`
 :   Parameters for invoices.get operation
@@ -3494,6 +3876,8 @@ Classes
     `id: str`
     :   The type of the None singleton.
 
+<a id="InvoicesGtCondition"></a>
+
 `InvoicesGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -3506,6 +3890,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.harvest.types.InvoicesSearchFilter`
     :   The type of the None singleton.
 
+<a id="InvoicesGteCondition"></a>
+
 `InvoicesGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -3517,6 +3903,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.harvest.types.InvoicesSearchFilter`
     :   The type of the None singleton.
+
+<a id="InvoicesInCondition"></a>
 
 `InvoicesInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -3537,6 +3925,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.harvest.types.InvoicesInFilter`
     :   The type of the None singleton.
+
+<a id="InvoicesInFilter"></a>
 
 `InvoicesInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -3583,6 +3973,8 @@ Classes
     `updated_at: list[str]`
     :   When last updated
 
+<a id="InvoicesKeywordCondition"></a>
+
 `InvoicesKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -3594,6 +3986,8 @@ Classes
 
     `keyword: airbyte_agent_sdk.connectors.harvest.types.InvoicesStringFilter`
     :   The type of the None singleton.
+
+<a id="InvoicesLikeCondition"></a>
 
 `InvoicesLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
@@ -3607,6 +4001,8 @@ Classes
     `like: airbyte_agent_sdk.connectors.harvest.types.InvoicesStringFilter`
     :   The type of the None singleton.
 
+<a id="InvoicesListParams"></a>
+
 `InvoicesListParams(*args, **kwargs)`
 :   Parameters for invoices.list operation
 
@@ -3618,6 +4014,8 @@ Classes
 
     `per_page: int`
     :   The type of the None singleton.
+
+<a id="InvoicesLtCondition"></a>
 
 `InvoicesLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
@@ -3631,6 +4029,8 @@ Classes
     `lt: airbyte_agent_sdk.connectors.harvest.types.InvoicesSearchFilter`
     :   The type of the None singleton.
 
+<a id="InvoicesLteCondition"></a>
+
 `InvoicesLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
 
@@ -3643,6 +4043,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.harvest.types.InvoicesSearchFilter`
     :   The type of the None singleton.
 
+<a id="InvoicesNeqCondition"></a>
+
 `InvoicesNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -3654,6 +4056,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.harvest.types.InvoicesSearchFilter`
     :   The type of the None singleton.
+
+<a id="InvoicesNotCondition"></a>
 
 `InvoicesNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -3675,6 +4079,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.harvest.types.InvoicesEqCondition | airbyte_agent_sdk.connectors.harvest.types.InvoicesNeqCondition | airbyte_agent_sdk.connectors.harvest.types.InvoicesGtCondition | airbyte_agent_sdk.connectors.harvest.types.InvoicesGteCondition | airbyte_agent_sdk.connectors.harvest.types.InvoicesLtCondition | airbyte_agent_sdk.connectors.harvest.types.InvoicesLteCondition | airbyte_agent_sdk.connectors.harvest.types.InvoicesInCondition | airbyte_agent_sdk.connectors.harvest.types.InvoicesLikeCondition | airbyte_agent_sdk.connectors.harvest.types.InvoicesFuzzyCondition | airbyte_agent_sdk.connectors.harvest.types.InvoicesKeywordCondition | airbyte_agent_sdk.connectors.harvest.types.InvoicesContainsCondition | airbyte_agent_sdk.connectors.harvest.types.InvoicesNotCondition | airbyte_agent_sdk.connectors.harvest.types.InvoicesAndCondition | airbyte_agent_sdk.connectors.harvest.types.InvoicesOrCondition | airbyte_agent_sdk.connectors.harvest.types.InvoicesAnyCondition`
     :   The type of the None singleton.
 
+<a id="InvoicesOrCondition"></a>
+
 `InvoicesOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -3694,6 +4100,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.harvest.types.InvoicesEqCondition | airbyte_agent_sdk.connectors.harvest.types.InvoicesNeqCondition | airbyte_agent_sdk.connectors.harvest.types.InvoicesGtCondition | airbyte_agent_sdk.connectors.harvest.types.InvoicesGteCondition | airbyte_agent_sdk.connectors.harvest.types.InvoicesLtCondition | airbyte_agent_sdk.connectors.harvest.types.InvoicesLteCondition | airbyte_agent_sdk.connectors.harvest.types.InvoicesInCondition | airbyte_agent_sdk.connectors.harvest.types.InvoicesLikeCondition | airbyte_agent_sdk.connectors.harvest.types.InvoicesFuzzyCondition | airbyte_agent_sdk.connectors.harvest.types.InvoicesKeywordCondition | airbyte_agent_sdk.connectors.harvest.types.InvoicesContainsCondition | airbyte_agent_sdk.connectors.harvest.types.InvoicesNotCondition | airbyte_agent_sdk.connectors.harvest.types.InvoicesAndCondition | airbyte_agent_sdk.connectors.harvest.types.InvoicesOrCondition | airbyte_agent_sdk.connectors.harvest.types.InvoicesAnyCondition]`
     :   The type of the None singleton.
+
+<a id="InvoicesSearchFilter"></a>
 
 `InvoicesSearchFilter(*args, **kwargs)`
 :   Available fields for filtering invoices search queries.
@@ -3740,6 +4148,8 @@ Classes
     `updated_at: str | None`
     :   When last updated
 
+<a id="InvoicesSearchQuery"></a>
+
 `InvoicesSearchQuery(*args, **kwargs)`
 :   Search query for invoices entity.
 
@@ -3754,6 +4164,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.harvest.types.InvoicesSortFilter]`
     :   The type of the None singleton.
+
+<a id="InvoicesSortFilter"></a>
 
 `InvoicesSortFilter(*args, **kwargs)`
 :   Available fields for sorting invoices search results.
@@ -3800,6 +4212,8 @@ Classes
     `updated_at: Literal['asc', 'desc']`
     :   When last updated
 
+<a id="InvoicesStringFilter"></a>
+
 `InvoicesStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -3845,6 +4259,8 @@ Classes
     `updated_at: str`
     :   When last updated
 
+<a id="ProjectsAndCondition"></a>
+
 `ProjectsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -3865,6 +4281,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.harvest.types.ProjectsEqCondition | airbyte_agent_sdk.connectors.harvest.types.ProjectsNeqCondition | airbyte_agent_sdk.connectors.harvest.types.ProjectsGtCondition | airbyte_agent_sdk.connectors.harvest.types.ProjectsGteCondition | airbyte_agent_sdk.connectors.harvest.types.ProjectsLtCondition | airbyte_agent_sdk.connectors.harvest.types.ProjectsLteCondition | airbyte_agent_sdk.connectors.harvest.types.ProjectsInCondition | airbyte_agent_sdk.connectors.harvest.types.ProjectsLikeCondition | airbyte_agent_sdk.connectors.harvest.types.ProjectsFuzzyCondition | airbyte_agent_sdk.connectors.harvest.types.ProjectsKeywordCondition | airbyte_agent_sdk.connectors.harvest.types.ProjectsContainsCondition | airbyte_agent_sdk.connectors.harvest.types.ProjectsNotCondition | airbyte_agent_sdk.connectors.harvest.types.ProjectsAndCondition | airbyte_agent_sdk.connectors.harvest.types.ProjectsOrCondition | airbyte_agent_sdk.connectors.harvest.types.ProjectsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="ProjectsAnyCondition"></a>
+
 `ProjectsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -3884,6 +4302,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.harvest.types.ProjectsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="ProjectsAnyValueFilter"></a>
 
 `ProjectsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -3927,6 +4347,8 @@ Classes
     `updated_at: Any`
     :   When last updated
 
+<a id="ProjectsContainsCondition"></a>
+
 `ProjectsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -3938,6 +4360,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.harvest.types.ProjectsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="ProjectsEqCondition"></a>
 
 `ProjectsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -3951,6 +4375,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.harvest.types.ProjectsSearchFilter`
     :   The type of the None singleton.
 
+<a id="ProjectsFuzzyCondition"></a>
+
 `ProjectsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -3962,6 +4388,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.harvest.types.ProjectsStringFilter`
     :   The type of the None singleton.
+
+<a id="ProjectsGetParams"></a>
 
 `ProjectsGetParams(*args, **kwargs)`
 :   Parameters for projects.get operation
@@ -3975,6 +4403,8 @@ Classes
     `id: str`
     :   The type of the None singleton.
 
+<a id="ProjectsGtCondition"></a>
+
 `ProjectsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -3987,6 +4417,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.harvest.types.ProjectsSearchFilter`
     :   The type of the None singleton.
 
+<a id="ProjectsGteCondition"></a>
+
 `ProjectsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -3998,6 +4430,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.harvest.types.ProjectsSearchFilter`
     :   The type of the None singleton.
+
+<a id="ProjectsInCondition"></a>
 
 `ProjectsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -4018,6 +4452,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.harvest.types.ProjectsInFilter`
     :   The type of the None singleton.
+
+<a id="ProjectsInFilter"></a>
 
 `ProjectsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -4061,6 +4497,8 @@ Classes
     `updated_at: list[str]`
     :   When last updated
 
+<a id="ProjectsKeywordCondition"></a>
+
 `ProjectsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -4072,6 +4510,8 @@ Classes
 
     `keyword: airbyte_agent_sdk.connectors.harvest.types.ProjectsStringFilter`
     :   The type of the None singleton.
+
+<a id="ProjectsLikeCondition"></a>
 
 `ProjectsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
@@ -4085,6 +4525,8 @@ Classes
     `like: airbyte_agent_sdk.connectors.harvest.types.ProjectsStringFilter`
     :   The type of the None singleton.
 
+<a id="ProjectsListParams"></a>
+
 `ProjectsListParams(*args, **kwargs)`
 :   Parameters for projects.list operation
 
@@ -4096,6 +4538,8 @@ Classes
 
     `per_page: int`
     :   The type of the None singleton.
+
+<a id="ProjectsLtCondition"></a>
 
 `ProjectsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
@@ -4109,6 +4553,8 @@ Classes
     `lt: airbyte_agent_sdk.connectors.harvest.types.ProjectsSearchFilter`
     :   The type of the None singleton.
 
+<a id="ProjectsLteCondition"></a>
+
 `ProjectsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
 
@@ -4121,6 +4567,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.harvest.types.ProjectsSearchFilter`
     :   The type of the None singleton.
 
+<a id="ProjectsNeqCondition"></a>
+
 `ProjectsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -4132,6 +4580,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.harvest.types.ProjectsSearchFilter`
     :   The type of the None singleton.
+
+<a id="ProjectsNotCondition"></a>
 
 `ProjectsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -4153,6 +4603,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.harvest.types.ProjectsEqCondition | airbyte_agent_sdk.connectors.harvest.types.ProjectsNeqCondition | airbyte_agent_sdk.connectors.harvest.types.ProjectsGtCondition | airbyte_agent_sdk.connectors.harvest.types.ProjectsGteCondition | airbyte_agent_sdk.connectors.harvest.types.ProjectsLtCondition | airbyte_agent_sdk.connectors.harvest.types.ProjectsLteCondition | airbyte_agent_sdk.connectors.harvest.types.ProjectsInCondition | airbyte_agent_sdk.connectors.harvest.types.ProjectsLikeCondition | airbyte_agent_sdk.connectors.harvest.types.ProjectsFuzzyCondition | airbyte_agent_sdk.connectors.harvest.types.ProjectsKeywordCondition | airbyte_agent_sdk.connectors.harvest.types.ProjectsContainsCondition | airbyte_agent_sdk.connectors.harvest.types.ProjectsNotCondition | airbyte_agent_sdk.connectors.harvest.types.ProjectsAndCondition | airbyte_agent_sdk.connectors.harvest.types.ProjectsOrCondition | airbyte_agent_sdk.connectors.harvest.types.ProjectsAnyCondition`
     :   The type of the None singleton.
 
+<a id="ProjectsOrCondition"></a>
+
 `ProjectsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -4172,6 +4624,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.harvest.types.ProjectsEqCondition | airbyte_agent_sdk.connectors.harvest.types.ProjectsNeqCondition | airbyte_agent_sdk.connectors.harvest.types.ProjectsGtCondition | airbyte_agent_sdk.connectors.harvest.types.ProjectsGteCondition | airbyte_agent_sdk.connectors.harvest.types.ProjectsLtCondition | airbyte_agent_sdk.connectors.harvest.types.ProjectsLteCondition | airbyte_agent_sdk.connectors.harvest.types.ProjectsInCondition | airbyte_agent_sdk.connectors.harvest.types.ProjectsLikeCondition | airbyte_agent_sdk.connectors.harvest.types.ProjectsFuzzyCondition | airbyte_agent_sdk.connectors.harvest.types.ProjectsKeywordCondition | airbyte_agent_sdk.connectors.harvest.types.ProjectsContainsCondition | airbyte_agent_sdk.connectors.harvest.types.ProjectsNotCondition | airbyte_agent_sdk.connectors.harvest.types.ProjectsAndCondition | airbyte_agent_sdk.connectors.harvest.types.ProjectsOrCondition | airbyte_agent_sdk.connectors.harvest.types.ProjectsAnyCondition]`
     :   The type of the None singleton.
+
+<a id="ProjectsSearchFilter"></a>
 
 `ProjectsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering projects search queries.
@@ -4215,6 +4669,8 @@ Classes
     `updated_at: str | None`
     :   When last updated
 
+<a id="ProjectsSearchQuery"></a>
+
 `ProjectsSearchQuery(*args, **kwargs)`
 :   Search query for projects entity.
 
@@ -4229,6 +4685,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.harvest.types.ProjectsSortFilter]`
     :   The type of the None singleton.
+
+<a id="ProjectsSortFilter"></a>
 
 `ProjectsSortFilter(*args, **kwargs)`
 :   Available fields for sorting projects search results.
@@ -4272,6 +4730,8 @@ Classes
     `updated_at: Literal['asc', 'desc']`
     :   When last updated
 
+<a id="ProjectsStringFilter"></a>
+
 `ProjectsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -4314,6 +4774,8 @@ Classes
     `updated_at: str`
     :   When last updated
 
+<a id="RolesAndCondition"></a>
+
 `RolesAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -4334,6 +4796,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.harvest.types.RolesEqCondition | airbyte_agent_sdk.connectors.harvest.types.RolesNeqCondition | airbyte_agent_sdk.connectors.harvest.types.RolesGtCondition | airbyte_agent_sdk.connectors.harvest.types.RolesGteCondition | airbyte_agent_sdk.connectors.harvest.types.RolesLtCondition | airbyte_agent_sdk.connectors.harvest.types.RolesLteCondition | airbyte_agent_sdk.connectors.harvest.types.RolesInCondition | airbyte_agent_sdk.connectors.harvest.types.RolesLikeCondition | airbyte_agent_sdk.connectors.harvest.types.RolesFuzzyCondition | airbyte_agent_sdk.connectors.harvest.types.RolesKeywordCondition | airbyte_agent_sdk.connectors.harvest.types.RolesContainsCondition | airbyte_agent_sdk.connectors.harvest.types.RolesNotCondition | airbyte_agent_sdk.connectors.harvest.types.RolesAndCondition | airbyte_agent_sdk.connectors.harvest.types.RolesOrCondition | airbyte_agent_sdk.connectors.harvest.types.RolesAnyCondition]`
     :   The type of the None singleton.
 
+<a id="RolesAnyCondition"></a>
+
 `RolesAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -4353,6 +4817,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.harvest.types.RolesAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="RolesAnyValueFilter"></a>
 
 `RolesAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -4378,6 +4844,8 @@ Classes
     `user_ids: Any`
     :   User IDs with this role
 
+<a id="RolesContainsCondition"></a>
+
 `RolesContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -4389,6 +4857,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.harvest.types.RolesAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="RolesEqCondition"></a>
 
 `RolesEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -4402,6 +4872,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.harvest.types.RolesSearchFilter`
     :   The type of the None singleton.
 
+<a id="RolesFuzzyCondition"></a>
+
 `RolesFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -4413,6 +4885,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.harvest.types.RolesStringFilter`
     :   The type of the None singleton.
+
+<a id="RolesGetParams"></a>
 
 `RolesGetParams(*args, **kwargs)`
 :   Parameters for roles.get operation
@@ -4426,6 +4900,8 @@ Classes
     `id: str`
     :   The type of the None singleton.
 
+<a id="RolesGtCondition"></a>
+
 `RolesGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -4438,6 +4914,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.harvest.types.RolesSearchFilter`
     :   The type of the None singleton.
 
+<a id="RolesGteCondition"></a>
+
 `RolesGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -4449,6 +4927,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.harvest.types.RolesSearchFilter`
     :   The type of the None singleton.
+
+<a id="RolesInCondition"></a>
 
 `RolesInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -4469,6 +4949,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.harvest.types.RolesInFilter`
     :   The type of the None singleton.
+
+<a id="RolesInFilter"></a>
 
 `RolesInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -4494,6 +4976,8 @@ Classes
     `user_ids: list[list[typing.Any]]`
     :   User IDs with this role
 
+<a id="RolesKeywordCondition"></a>
+
 `RolesKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -4505,6 +4989,8 @@ Classes
 
     `keyword: airbyte_agent_sdk.connectors.harvest.types.RolesStringFilter`
     :   The type of the None singleton.
+
+<a id="RolesLikeCondition"></a>
 
 `RolesLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
@@ -4518,6 +5004,8 @@ Classes
     `like: airbyte_agent_sdk.connectors.harvest.types.RolesStringFilter`
     :   The type of the None singleton.
 
+<a id="RolesListParams"></a>
+
 `RolesListParams(*args, **kwargs)`
 :   Parameters for roles.list operation
 
@@ -4529,6 +5017,8 @@ Classes
 
     `per_page: int`
     :   The type of the None singleton.
+
+<a id="RolesLtCondition"></a>
 
 `RolesLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
@@ -4542,6 +5032,8 @@ Classes
     `lt: airbyte_agent_sdk.connectors.harvest.types.RolesSearchFilter`
     :   The type of the None singleton.
 
+<a id="RolesLteCondition"></a>
+
 `RolesLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
 
@@ -4554,6 +5046,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.harvest.types.RolesSearchFilter`
     :   The type of the None singleton.
 
+<a id="RolesNeqCondition"></a>
+
 `RolesNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -4565,6 +5059,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.harvest.types.RolesSearchFilter`
     :   The type of the None singleton.
+
+<a id="RolesNotCondition"></a>
 
 `RolesNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -4586,6 +5082,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.harvest.types.RolesEqCondition | airbyte_agent_sdk.connectors.harvest.types.RolesNeqCondition | airbyte_agent_sdk.connectors.harvest.types.RolesGtCondition | airbyte_agent_sdk.connectors.harvest.types.RolesGteCondition | airbyte_agent_sdk.connectors.harvest.types.RolesLtCondition | airbyte_agent_sdk.connectors.harvest.types.RolesLteCondition | airbyte_agent_sdk.connectors.harvest.types.RolesInCondition | airbyte_agent_sdk.connectors.harvest.types.RolesLikeCondition | airbyte_agent_sdk.connectors.harvest.types.RolesFuzzyCondition | airbyte_agent_sdk.connectors.harvest.types.RolesKeywordCondition | airbyte_agent_sdk.connectors.harvest.types.RolesContainsCondition | airbyte_agent_sdk.connectors.harvest.types.RolesNotCondition | airbyte_agent_sdk.connectors.harvest.types.RolesAndCondition | airbyte_agent_sdk.connectors.harvest.types.RolesOrCondition | airbyte_agent_sdk.connectors.harvest.types.RolesAnyCondition`
     :   The type of the None singleton.
 
+<a id="RolesOrCondition"></a>
+
 `RolesOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -4605,6 +5103,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.harvest.types.RolesEqCondition | airbyte_agent_sdk.connectors.harvest.types.RolesNeqCondition | airbyte_agent_sdk.connectors.harvest.types.RolesGtCondition | airbyte_agent_sdk.connectors.harvest.types.RolesGteCondition | airbyte_agent_sdk.connectors.harvest.types.RolesLtCondition | airbyte_agent_sdk.connectors.harvest.types.RolesLteCondition | airbyte_agent_sdk.connectors.harvest.types.RolesInCondition | airbyte_agent_sdk.connectors.harvest.types.RolesLikeCondition | airbyte_agent_sdk.connectors.harvest.types.RolesFuzzyCondition | airbyte_agent_sdk.connectors.harvest.types.RolesKeywordCondition | airbyte_agent_sdk.connectors.harvest.types.RolesContainsCondition | airbyte_agent_sdk.connectors.harvest.types.RolesNotCondition | airbyte_agent_sdk.connectors.harvest.types.RolesAndCondition | airbyte_agent_sdk.connectors.harvest.types.RolesOrCondition | airbyte_agent_sdk.connectors.harvest.types.RolesAnyCondition]`
     :   The type of the None singleton.
+
+<a id="RolesSearchFilter"></a>
 
 `RolesSearchFilter(*args, **kwargs)`
 :   Available fields for filtering roles search queries.
@@ -4630,6 +5130,8 @@ Classes
     `user_ids: list[typing.Any] | None`
     :   User IDs with this role
 
+<a id="RolesSearchQuery"></a>
+
 `RolesSearchQuery(*args, **kwargs)`
 :   Search query for roles entity.
 
@@ -4644,6 +5146,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.harvest.types.RolesSortFilter]`
     :   The type of the None singleton.
+
+<a id="RolesSortFilter"></a>
 
 `RolesSortFilter(*args, **kwargs)`
 :   Available fields for sorting roles search results.
@@ -4669,6 +5173,8 @@ Classes
     `user_ids: Literal['asc', 'desc']`
     :   User IDs with this role
 
+<a id="RolesStringFilter"></a>
+
 `RolesStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -4693,6 +5199,8 @@ Classes
     `user_ids: str`
     :   User IDs with this role
 
+<a id="TaskAssignmentsAndCondition"></a>
+
 `TaskAssignmentsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -4713,6 +5221,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.harvest.types.TaskAssignmentsEqCondition | airbyte_agent_sdk.connectors.harvest.types.TaskAssignmentsNeqCondition | airbyte_agent_sdk.connectors.harvest.types.TaskAssignmentsGtCondition | airbyte_agent_sdk.connectors.harvest.types.TaskAssignmentsGteCondition | airbyte_agent_sdk.connectors.harvest.types.TaskAssignmentsLtCondition | airbyte_agent_sdk.connectors.harvest.types.TaskAssignmentsLteCondition | airbyte_agent_sdk.connectors.harvest.types.TaskAssignmentsInCondition | airbyte_agent_sdk.connectors.harvest.types.TaskAssignmentsLikeCondition | airbyte_agent_sdk.connectors.harvest.types.TaskAssignmentsFuzzyCondition | airbyte_agent_sdk.connectors.harvest.types.TaskAssignmentsKeywordCondition | airbyte_agent_sdk.connectors.harvest.types.TaskAssignmentsContainsCondition | airbyte_agent_sdk.connectors.harvest.types.TaskAssignmentsNotCondition | airbyte_agent_sdk.connectors.harvest.types.TaskAssignmentsAndCondition | airbyte_agent_sdk.connectors.harvest.types.TaskAssignmentsOrCondition | airbyte_agent_sdk.connectors.harvest.types.TaskAssignmentsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="TaskAssignmentsAnyCondition"></a>
+
 `TaskAssignmentsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -4732,6 +5242,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.harvest.types.TaskAssignmentsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="TaskAssignmentsAnyValueFilter"></a>
 
 `TaskAssignmentsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -4766,6 +5278,8 @@ Classes
     `updated_at: Any`
     :   When last updated
 
+<a id="TaskAssignmentsContainsCondition"></a>
+
 `TaskAssignmentsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -4777,6 +5291,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.harvest.types.TaskAssignmentsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="TaskAssignmentsEqCondition"></a>
 
 `TaskAssignmentsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -4790,6 +5306,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.harvest.types.TaskAssignmentsSearchFilter`
     :   The type of the None singleton.
 
+<a id="TaskAssignmentsFuzzyCondition"></a>
+
 `TaskAssignmentsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -4801,6 +5319,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.harvest.types.TaskAssignmentsStringFilter`
     :   The type of the None singleton.
+
+<a id="TaskAssignmentsGtCondition"></a>
 
 `TaskAssignmentsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
@@ -4814,6 +5334,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.harvest.types.TaskAssignmentsSearchFilter`
     :   The type of the None singleton.
 
+<a id="TaskAssignmentsGteCondition"></a>
+
 `TaskAssignmentsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -4825,6 +5347,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.harvest.types.TaskAssignmentsSearchFilter`
     :   The type of the None singleton.
+
+<a id="TaskAssignmentsInCondition"></a>
 
 `TaskAssignmentsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -4845,6 +5369,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.harvest.types.TaskAssignmentsInFilter`
     :   The type of the None singleton.
+
+<a id="TaskAssignmentsInFilter"></a>
 
 `TaskAssignmentsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -4879,6 +5405,8 @@ Classes
     `updated_at: list[str]`
     :   When last updated
 
+<a id="TaskAssignmentsKeywordCondition"></a>
+
 `TaskAssignmentsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -4890,6 +5418,8 @@ Classes
 
     `keyword: airbyte_agent_sdk.connectors.harvest.types.TaskAssignmentsStringFilter`
     :   The type of the None singleton.
+
+<a id="TaskAssignmentsLikeCondition"></a>
 
 `TaskAssignmentsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
@@ -4903,6 +5433,8 @@ Classes
     `like: airbyte_agent_sdk.connectors.harvest.types.TaskAssignmentsStringFilter`
     :   The type of the None singleton.
 
+<a id="TaskAssignmentsListParams"></a>
+
 `TaskAssignmentsListParams(*args, **kwargs)`
 :   Parameters for task_assignments.list operation
 
@@ -4914,6 +5446,8 @@ Classes
 
     `per_page: int`
     :   The type of the None singleton.
+
+<a id="TaskAssignmentsLtCondition"></a>
 
 `TaskAssignmentsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
@@ -4927,6 +5461,8 @@ Classes
     `lt: airbyte_agent_sdk.connectors.harvest.types.TaskAssignmentsSearchFilter`
     :   The type of the None singleton.
 
+<a id="TaskAssignmentsLteCondition"></a>
+
 `TaskAssignmentsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
 
@@ -4939,6 +5475,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.harvest.types.TaskAssignmentsSearchFilter`
     :   The type of the None singleton.
 
+<a id="TaskAssignmentsNeqCondition"></a>
+
 `TaskAssignmentsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -4950,6 +5488,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.harvest.types.TaskAssignmentsSearchFilter`
     :   The type of the None singleton.
+
+<a id="TaskAssignmentsNotCondition"></a>
 
 `TaskAssignmentsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -4971,6 +5511,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.harvest.types.TaskAssignmentsEqCondition | airbyte_agent_sdk.connectors.harvest.types.TaskAssignmentsNeqCondition | airbyte_agent_sdk.connectors.harvest.types.TaskAssignmentsGtCondition | airbyte_agent_sdk.connectors.harvest.types.TaskAssignmentsGteCondition | airbyte_agent_sdk.connectors.harvest.types.TaskAssignmentsLtCondition | airbyte_agent_sdk.connectors.harvest.types.TaskAssignmentsLteCondition | airbyte_agent_sdk.connectors.harvest.types.TaskAssignmentsInCondition | airbyte_agent_sdk.connectors.harvest.types.TaskAssignmentsLikeCondition | airbyte_agent_sdk.connectors.harvest.types.TaskAssignmentsFuzzyCondition | airbyte_agent_sdk.connectors.harvest.types.TaskAssignmentsKeywordCondition | airbyte_agent_sdk.connectors.harvest.types.TaskAssignmentsContainsCondition | airbyte_agent_sdk.connectors.harvest.types.TaskAssignmentsNotCondition | airbyte_agent_sdk.connectors.harvest.types.TaskAssignmentsAndCondition | airbyte_agent_sdk.connectors.harvest.types.TaskAssignmentsOrCondition | airbyte_agent_sdk.connectors.harvest.types.TaskAssignmentsAnyCondition`
     :   The type of the None singleton.
 
+<a id="TaskAssignmentsOrCondition"></a>
+
 `TaskAssignmentsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -4990,6 +5532,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.harvest.types.TaskAssignmentsEqCondition | airbyte_agent_sdk.connectors.harvest.types.TaskAssignmentsNeqCondition | airbyte_agent_sdk.connectors.harvest.types.TaskAssignmentsGtCondition | airbyte_agent_sdk.connectors.harvest.types.TaskAssignmentsGteCondition | airbyte_agent_sdk.connectors.harvest.types.TaskAssignmentsLtCondition | airbyte_agent_sdk.connectors.harvest.types.TaskAssignmentsLteCondition | airbyte_agent_sdk.connectors.harvest.types.TaskAssignmentsInCondition | airbyte_agent_sdk.connectors.harvest.types.TaskAssignmentsLikeCondition | airbyte_agent_sdk.connectors.harvest.types.TaskAssignmentsFuzzyCondition | airbyte_agent_sdk.connectors.harvest.types.TaskAssignmentsKeywordCondition | airbyte_agent_sdk.connectors.harvest.types.TaskAssignmentsContainsCondition | airbyte_agent_sdk.connectors.harvest.types.TaskAssignmentsNotCondition | airbyte_agent_sdk.connectors.harvest.types.TaskAssignmentsAndCondition | airbyte_agent_sdk.connectors.harvest.types.TaskAssignmentsOrCondition | airbyte_agent_sdk.connectors.harvest.types.TaskAssignmentsAnyCondition]`
     :   The type of the None singleton.
+
+<a id="TaskAssignmentsSearchFilter"></a>
 
 `TaskAssignmentsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering task_assignments search queries.
@@ -5024,6 +5568,8 @@ Classes
     `updated_at: str | None`
     :   When last updated
 
+<a id="TaskAssignmentsSearchQuery"></a>
+
 `TaskAssignmentsSearchQuery(*args, **kwargs)`
 :   Search query for task_assignments entity.
 
@@ -5038,6 +5584,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.harvest.types.TaskAssignmentsSortFilter]`
     :   The type of the None singleton.
+
+<a id="TaskAssignmentsSortFilter"></a>
 
 `TaskAssignmentsSortFilter(*args, **kwargs)`
 :   Available fields for sorting task_assignments search results.
@@ -5072,6 +5620,8 @@ Classes
     `updated_at: Literal['asc', 'desc']`
     :   When last updated
 
+<a id="TaskAssignmentsStringFilter"></a>
+
 `TaskAssignmentsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -5105,6 +5655,8 @@ Classes
     `updated_at: str`
     :   When last updated
 
+<a id="TasksAndCondition"></a>
+
 `TasksAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -5125,6 +5677,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.harvest.types.TasksEqCondition | airbyte_agent_sdk.connectors.harvest.types.TasksNeqCondition | airbyte_agent_sdk.connectors.harvest.types.TasksGtCondition | airbyte_agent_sdk.connectors.harvest.types.TasksGteCondition | airbyte_agent_sdk.connectors.harvest.types.TasksLtCondition | airbyte_agent_sdk.connectors.harvest.types.TasksLteCondition | airbyte_agent_sdk.connectors.harvest.types.TasksInCondition | airbyte_agent_sdk.connectors.harvest.types.TasksLikeCondition | airbyte_agent_sdk.connectors.harvest.types.TasksFuzzyCondition | airbyte_agent_sdk.connectors.harvest.types.TasksKeywordCondition | airbyte_agent_sdk.connectors.harvest.types.TasksContainsCondition | airbyte_agent_sdk.connectors.harvest.types.TasksNotCondition | airbyte_agent_sdk.connectors.harvest.types.TasksAndCondition | airbyte_agent_sdk.connectors.harvest.types.TasksOrCondition | airbyte_agent_sdk.connectors.harvest.types.TasksAnyCondition]`
     :   The type of the None singleton.
 
+<a id="TasksAnyCondition"></a>
+
 `TasksAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -5144,6 +5698,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.harvest.types.TasksAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="TasksAnyValueFilter"></a>
 
 `TasksAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -5175,6 +5731,8 @@ Classes
     `updated_at: Any`
     :   When last updated
 
+<a id="TasksContainsCondition"></a>
+
 `TasksContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -5186,6 +5744,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.harvest.types.TasksAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="TasksEqCondition"></a>
 
 `TasksEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -5199,6 +5759,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.harvest.types.TasksSearchFilter`
     :   The type of the None singleton.
 
+<a id="TasksFuzzyCondition"></a>
+
 `TasksFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -5210,6 +5772,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.harvest.types.TasksStringFilter`
     :   The type of the None singleton.
+
+<a id="TasksGetParams"></a>
 
 `TasksGetParams(*args, **kwargs)`
 :   Parameters for tasks.get operation
@@ -5223,6 +5787,8 @@ Classes
     `id: str`
     :   The type of the None singleton.
 
+<a id="TasksGtCondition"></a>
+
 `TasksGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -5235,6 +5801,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.harvest.types.TasksSearchFilter`
     :   The type of the None singleton.
 
+<a id="TasksGteCondition"></a>
+
 `TasksGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -5246,6 +5814,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.harvest.types.TasksSearchFilter`
     :   The type of the None singleton.
+
+<a id="TasksInCondition"></a>
 
 `TasksInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -5266,6 +5836,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.harvest.types.TasksInFilter`
     :   The type of the None singleton.
+
+<a id="TasksInFilter"></a>
 
 `TasksInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -5297,6 +5869,8 @@ Classes
     `updated_at: list[str]`
     :   When last updated
 
+<a id="TasksKeywordCondition"></a>
+
 `TasksKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -5308,6 +5882,8 @@ Classes
 
     `keyword: airbyte_agent_sdk.connectors.harvest.types.TasksStringFilter`
     :   The type of the None singleton.
+
+<a id="TasksLikeCondition"></a>
 
 `TasksLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
@@ -5321,6 +5897,8 @@ Classes
     `like: airbyte_agent_sdk.connectors.harvest.types.TasksStringFilter`
     :   The type of the None singleton.
 
+<a id="TasksListParams"></a>
+
 `TasksListParams(*args, **kwargs)`
 :   Parameters for tasks.list operation
 
@@ -5332,6 +5910,8 @@ Classes
 
     `per_page: int`
     :   The type of the None singleton.
+
+<a id="TasksLtCondition"></a>
 
 `TasksLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
@@ -5345,6 +5925,8 @@ Classes
     `lt: airbyte_agent_sdk.connectors.harvest.types.TasksSearchFilter`
     :   The type of the None singleton.
 
+<a id="TasksLteCondition"></a>
+
 `TasksLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
 
@@ -5357,6 +5939,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.harvest.types.TasksSearchFilter`
     :   The type of the None singleton.
 
+<a id="TasksNeqCondition"></a>
+
 `TasksNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -5368,6 +5952,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.harvest.types.TasksSearchFilter`
     :   The type of the None singleton.
+
+<a id="TasksNotCondition"></a>
 
 `TasksNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -5389,6 +5975,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.harvest.types.TasksEqCondition | airbyte_agent_sdk.connectors.harvest.types.TasksNeqCondition | airbyte_agent_sdk.connectors.harvest.types.TasksGtCondition | airbyte_agent_sdk.connectors.harvest.types.TasksGteCondition | airbyte_agent_sdk.connectors.harvest.types.TasksLtCondition | airbyte_agent_sdk.connectors.harvest.types.TasksLteCondition | airbyte_agent_sdk.connectors.harvest.types.TasksInCondition | airbyte_agent_sdk.connectors.harvest.types.TasksLikeCondition | airbyte_agent_sdk.connectors.harvest.types.TasksFuzzyCondition | airbyte_agent_sdk.connectors.harvest.types.TasksKeywordCondition | airbyte_agent_sdk.connectors.harvest.types.TasksContainsCondition | airbyte_agent_sdk.connectors.harvest.types.TasksNotCondition | airbyte_agent_sdk.connectors.harvest.types.TasksAndCondition | airbyte_agent_sdk.connectors.harvest.types.TasksOrCondition | airbyte_agent_sdk.connectors.harvest.types.TasksAnyCondition`
     :   The type of the None singleton.
 
+<a id="TasksOrCondition"></a>
+
 `TasksOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -5408,6 +5996,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.harvest.types.TasksEqCondition | airbyte_agent_sdk.connectors.harvest.types.TasksNeqCondition | airbyte_agent_sdk.connectors.harvest.types.TasksGtCondition | airbyte_agent_sdk.connectors.harvest.types.TasksGteCondition | airbyte_agent_sdk.connectors.harvest.types.TasksLtCondition | airbyte_agent_sdk.connectors.harvest.types.TasksLteCondition | airbyte_agent_sdk.connectors.harvest.types.TasksInCondition | airbyte_agent_sdk.connectors.harvest.types.TasksLikeCondition | airbyte_agent_sdk.connectors.harvest.types.TasksFuzzyCondition | airbyte_agent_sdk.connectors.harvest.types.TasksKeywordCondition | airbyte_agent_sdk.connectors.harvest.types.TasksContainsCondition | airbyte_agent_sdk.connectors.harvest.types.TasksNotCondition | airbyte_agent_sdk.connectors.harvest.types.TasksAndCondition | airbyte_agent_sdk.connectors.harvest.types.TasksOrCondition | airbyte_agent_sdk.connectors.harvest.types.TasksAnyCondition]`
     :   The type of the None singleton.
+
+<a id="TasksSearchFilter"></a>
 
 `TasksSearchFilter(*args, **kwargs)`
 :   Available fields for filtering tasks search queries.
@@ -5439,6 +6029,8 @@ Classes
     `updated_at: str | None`
     :   When last updated
 
+<a id="TasksSearchQuery"></a>
+
 `TasksSearchQuery(*args, **kwargs)`
 :   Search query for tasks entity.
 
@@ -5453,6 +6045,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.harvest.types.TasksSortFilter]`
     :   The type of the None singleton.
+
+<a id="TasksSortFilter"></a>
 
 `TasksSortFilter(*args, **kwargs)`
 :   Available fields for sorting tasks search results.
@@ -5484,6 +6078,8 @@ Classes
     `updated_at: Literal['asc', 'desc']`
     :   When last updated
 
+<a id="TasksStringFilter"></a>
+
 `TasksStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -5514,6 +6110,8 @@ Classes
     `updated_at: str`
     :   When last updated
 
+<a id="TimeEntriesAndCondition"></a>
+
 `TimeEntriesAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -5534,6 +6132,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.harvest.types.TimeEntriesEqCondition | airbyte_agent_sdk.connectors.harvest.types.TimeEntriesNeqCondition | airbyte_agent_sdk.connectors.harvest.types.TimeEntriesGtCondition | airbyte_agent_sdk.connectors.harvest.types.TimeEntriesGteCondition | airbyte_agent_sdk.connectors.harvest.types.TimeEntriesLtCondition | airbyte_agent_sdk.connectors.harvest.types.TimeEntriesLteCondition | airbyte_agent_sdk.connectors.harvest.types.TimeEntriesInCondition | airbyte_agent_sdk.connectors.harvest.types.TimeEntriesLikeCondition | airbyte_agent_sdk.connectors.harvest.types.TimeEntriesFuzzyCondition | airbyte_agent_sdk.connectors.harvest.types.TimeEntriesKeywordCondition | airbyte_agent_sdk.connectors.harvest.types.TimeEntriesContainsCondition | airbyte_agent_sdk.connectors.harvest.types.TimeEntriesNotCondition | airbyte_agent_sdk.connectors.harvest.types.TimeEntriesAndCondition | airbyte_agent_sdk.connectors.harvest.types.TimeEntriesOrCondition | airbyte_agent_sdk.connectors.harvest.types.TimeEntriesAnyCondition]`
     :   The type of the None singleton.
 
+<a id="TimeEntriesAnyCondition"></a>
+
 `TimeEntriesAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -5553,6 +6153,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.harvest.types.TimeEntriesAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="TimeEntriesAnyValueFilter"></a>
 
 `TimeEntriesAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -5599,6 +6201,8 @@ Classes
     `user: Any`
     :   Associated user
 
+<a id="TimeEntriesContainsCondition"></a>
+
 `TimeEntriesContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -5610,6 +6214,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.harvest.types.TimeEntriesAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="TimeEntriesEqCondition"></a>
 
 `TimeEntriesEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -5623,6 +6229,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.harvest.types.TimeEntriesSearchFilter`
     :   The type of the None singleton.
 
+<a id="TimeEntriesFuzzyCondition"></a>
+
 `TimeEntriesFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -5634,6 +6242,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.harvest.types.TimeEntriesStringFilter`
     :   The type of the None singleton.
+
+<a id="TimeEntriesGetParams"></a>
 
 `TimeEntriesGetParams(*args, **kwargs)`
 :   Parameters for time_entries.get operation
@@ -5647,6 +6257,8 @@ Classes
     `id: str`
     :   The type of the None singleton.
 
+<a id="TimeEntriesGtCondition"></a>
+
 `TimeEntriesGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -5659,6 +6271,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.harvest.types.TimeEntriesSearchFilter`
     :   The type of the None singleton.
 
+<a id="TimeEntriesGteCondition"></a>
+
 `TimeEntriesGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -5670,6 +6284,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.harvest.types.TimeEntriesSearchFilter`
     :   The type of the None singleton.
+
+<a id="TimeEntriesInCondition"></a>
 
 `TimeEntriesInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -5690,6 +6306,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.harvest.types.TimeEntriesInFilter`
     :   The type of the None singleton.
+
+<a id="TimeEntriesInFilter"></a>
 
 `TimeEntriesInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -5736,6 +6354,8 @@ Classes
     `user: list[dict[str, typing.Any]]`
     :   Associated user
 
+<a id="TimeEntriesKeywordCondition"></a>
+
 `TimeEntriesKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -5747,6 +6367,8 @@ Classes
 
     `keyword: airbyte_agent_sdk.connectors.harvest.types.TimeEntriesStringFilter`
     :   The type of the None singleton.
+
+<a id="TimeEntriesLikeCondition"></a>
 
 `TimeEntriesLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
@@ -5760,6 +6382,8 @@ Classes
     `like: airbyte_agent_sdk.connectors.harvest.types.TimeEntriesStringFilter`
     :   The type of the None singleton.
 
+<a id="TimeEntriesListParams"></a>
+
 `TimeEntriesListParams(*args, **kwargs)`
 :   Parameters for time_entries.list operation
 
@@ -5771,6 +6395,8 @@ Classes
 
     `per_page: int`
     :   The type of the None singleton.
+
+<a id="TimeEntriesLtCondition"></a>
 
 `TimeEntriesLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
@@ -5784,6 +6410,8 @@ Classes
     `lt: airbyte_agent_sdk.connectors.harvest.types.TimeEntriesSearchFilter`
     :   The type of the None singleton.
 
+<a id="TimeEntriesLteCondition"></a>
+
 `TimeEntriesLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
 
@@ -5796,6 +6424,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.harvest.types.TimeEntriesSearchFilter`
     :   The type of the None singleton.
 
+<a id="TimeEntriesNeqCondition"></a>
+
 `TimeEntriesNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -5807,6 +6437,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.harvest.types.TimeEntriesSearchFilter`
     :   The type of the None singleton.
+
+<a id="TimeEntriesNotCondition"></a>
 
 `TimeEntriesNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -5828,6 +6460,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.harvest.types.TimeEntriesEqCondition | airbyte_agent_sdk.connectors.harvest.types.TimeEntriesNeqCondition | airbyte_agent_sdk.connectors.harvest.types.TimeEntriesGtCondition | airbyte_agent_sdk.connectors.harvest.types.TimeEntriesGteCondition | airbyte_agent_sdk.connectors.harvest.types.TimeEntriesLtCondition | airbyte_agent_sdk.connectors.harvest.types.TimeEntriesLteCondition | airbyte_agent_sdk.connectors.harvest.types.TimeEntriesInCondition | airbyte_agent_sdk.connectors.harvest.types.TimeEntriesLikeCondition | airbyte_agent_sdk.connectors.harvest.types.TimeEntriesFuzzyCondition | airbyte_agent_sdk.connectors.harvest.types.TimeEntriesKeywordCondition | airbyte_agent_sdk.connectors.harvest.types.TimeEntriesContainsCondition | airbyte_agent_sdk.connectors.harvest.types.TimeEntriesNotCondition | airbyte_agent_sdk.connectors.harvest.types.TimeEntriesAndCondition | airbyte_agent_sdk.connectors.harvest.types.TimeEntriesOrCondition | airbyte_agent_sdk.connectors.harvest.types.TimeEntriesAnyCondition`
     :   The type of the None singleton.
 
+<a id="TimeEntriesOrCondition"></a>
+
 `TimeEntriesOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -5847,6 +6481,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.harvest.types.TimeEntriesEqCondition | airbyte_agent_sdk.connectors.harvest.types.TimeEntriesNeqCondition | airbyte_agent_sdk.connectors.harvest.types.TimeEntriesGtCondition | airbyte_agent_sdk.connectors.harvest.types.TimeEntriesGteCondition | airbyte_agent_sdk.connectors.harvest.types.TimeEntriesLtCondition | airbyte_agent_sdk.connectors.harvest.types.TimeEntriesLteCondition | airbyte_agent_sdk.connectors.harvest.types.TimeEntriesInCondition | airbyte_agent_sdk.connectors.harvest.types.TimeEntriesLikeCondition | airbyte_agent_sdk.connectors.harvest.types.TimeEntriesFuzzyCondition | airbyte_agent_sdk.connectors.harvest.types.TimeEntriesKeywordCondition | airbyte_agent_sdk.connectors.harvest.types.TimeEntriesContainsCondition | airbyte_agent_sdk.connectors.harvest.types.TimeEntriesNotCondition | airbyte_agent_sdk.connectors.harvest.types.TimeEntriesAndCondition | airbyte_agent_sdk.connectors.harvest.types.TimeEntriesOrCondition | airbyte_agent_sdk.connectors.harvest.types.TimeEntriesAnyCondition]`
     :   The type of the None singleton.
+
+<a id="TimeEntriesSearchFilter"></a>
 
 `TimeEntriesSearchFilter(*args, **kwargs)`
 :   Available fields for filtering time_entries search queries.
@@ -5893,6 +6529,8 @@ Classes
     `user: dict[str, typing.Any] | None`
     :   Associated user
 
+<a id="TimeEntriesSearchQuery"></a>
+
 `TimeEntriesSearchQuery(*args, **kwargs)`
 :   Search query for time_entries entity.
 
@@ -5907,6 +6545,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.harvest.types.TimeEntriesSortFilter]`
     :   The type of the None singleton.
+
+<a id="TimeEntriesSortFilter"></a>
 
 `TimeEntriesSortFilter(*args, **kwargs)`
 :   Available fields for sorting time_entries search results.
@@ -5953,6 +6593,8 @@ Classes
     `user: Literal['asc', 'desc']`
     :   Associated user
 
+<a id="TimeEntriesStringFilter"></a>
+
 `TimeEntriesStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -5998,6 +6640,8 @@ Classes
     `user: str`
     :   Associated user
 
+<a id="TimeProjectsAndCondition"></a>
+
 `TimeProjectsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -6018,6 +6662,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.harvest.types.TimeProjectsEqCondition | airbyte_agent_sdk.connectors.harvest.types.TimeProjectsNeqCondition | airbyte_agent_sdk.connectors.harvest.types.TimeProjectsGtCondition | airbyte_agent_sdk.connectors.harvest.types.TimeProjectsGteCondition | airbyte_agent_sdk.connectors.harvest.types.TimeProjectsLtCondition | airbyte_agent_sdk.connectors.harvest.types.TimeProjectsLteCondition | airbyte_agent_sdk.connectors.harvest.types.TimeProjectsInCondition | airbyte_agent_sdk.connectors.harvest.types.TimeProjectsLikeCondition | airbyte_agent_sdk.connectors.harvest.types.TimeProjectsFuzzyCondition | airbyte_agent_sdk.connectors.harvest.types.TimeProjectsKeywordCondition | airbyte_agent_sdk.connectors.harvest.types.TimeProjectsContainsCondition | airbyte_agent_sdk.connectors.harvest.types.TimeProjectsNotCondition | airbyte_agent_sdk.connectors.harvest.types.TimeProjectsAndCondition | airbyte_agent_sdk.connectors.harvest.types.TimeProjectsOrCondition | airbyte_agent_sdk.connectors.harvest.types.TimeProjectsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="TimeProjectsAnyCondition"></a>
+
 `TimeProjectsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -6037,6 +6683,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.harvest.types.TimeProjectsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="TimeProjectsAnyValueFilter"></a>
 
 `TimeProjectsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -6071,6 +6719,8 @@ Classes
     `total_hours: Any`
     :   Total hours spent
 
+<a id="TimeProjectsContainsCondition"></a>
+
 `TimeProjectsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -6082,6 +6732,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.harvest.types.TimeProjectsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="TimeProjectsEqCondition"></a>
 
 `TimeProjectsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -6095,6 +6747,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.harvest.types.TimeProjectsSearchFilter`
     :   The type of the None singleton.
 
+<a id="TimeProjectsFuzzyCondition"></a>
+
 `TimeProjectsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -6106,6 +6760,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.harvest.types.TimeProjectsStringFilter`
     :   The type of the None singleton.
+
+<a id="TimeProjectsGtCondition"></a>
 
 `TimeProjectsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
@@ -6119,6 +6775,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.harvest.types.TimeProjectsSearchFilter`
     :   The type of the None singleton.
 
+<a id="TimeProjectsGteCondition"></a>
+
 `TimeProjectsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -6130,6 +6788,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.harvest.types.TimeProjectsSearchFilter`
     :   The type of the None singleton.
+
+<a id="TimeProjectsInCondition"></a>
 
 `TimeProjectsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -6150,6 +6810,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.harvest.types.TimeProjectsInFilter`
     :   The type of the None singleton.
+
+<a id="TimeProjectsInFilter"></a>
 
 `TimeProjectsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -6184,6 +6846,8 @@ Classes
     `total_hours: list[float]`
     :   Total hours spent
 
+<a id="TimeProjectsKeywordCondition"></a>
+
 `TimeProjectsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -6196,6 +6860,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.harvest.types.TimeProjectsStringFilter`
     :   The type of the None singleton.
 
+<a id="TimeProjectsLikeCondition"></a>
+
 `TimeProjectsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -6207,6 +6873,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.harvest.types.TimeProjectsStringFilter`
     :   The type of the None singleton.
+
+<a id="TimeProjectsListParams"></a>
 
 `TimeProjectsListParams(*args, **kwargs)`
 :   Parameters for time_projects.list operation
@@ -6226,6 +6894,8 @@ Classes
     `to: str`
     :   The type of the None singleton.
 
+<a id="TimeProjectsLtCondition"></a>
+
 `TimeProjectsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -6237,6 +6907,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.harvest.types.TimeProjectsSearchFilter`
     :   The type of the None singleton.
+
+<a id="TimeProjectsLteCondition"></a>
 
 `TimeProjectsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -6250,6 +6922,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.harvest.types.TimeProjectsSearchFilter`
     :   The type of the None singleton.
 
+<a id="TimeProjectsNeqCondition"></a>
+
 `TimeProjectsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -6261,6 +6935,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.harvest.types.TimeProjectsSearchFilter`
     :   The type of the None singleton.
+
+<a id="TimeProjectsNotCondition"></a>
 
 `TimeProjectsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -6282,6 +6958,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.harvest.types.TimeProjectsEqCondition | airbyte_agent_sdk.connectors.harvest.types.TimeProjectsNeqCondition | airbyte_agent_sdk.connectors.harvest.types.TimeProjectsGtCondition | airbyte_agent_sdk.connectors.harvest.types.TimeProjectsGteCondition | airbyte_agent_sdk.connectors.harvest.types.TimeProjectsLtCondition | airbyte_agent_sdk.connectors.harvest.types.TimeProjectsLteCondition | airbyte_agent_sdk.connectors.harvest.types.TimeProjectsInCondition | airbyte_agent_sdk.connectors.harvest.types.TimeProjectsLikeCondition | airbyte_agent_sdk.connectors.harvest.types.TimeProjectsFuzzyCondition | airbyte_agent_sdk.connectors.harvest.types.TimeProjectsKeywordCondition | airbyte_agent_sdk.connectors.harvest.types.TimeProjectsContainsCondition | airbyte_agent_sdk.connectors.harvest.types.TimeProjectsNotCondition | airbyte_agent_sdk.connectors.harvest.types.TimeProjectsAndCondition | airbyte_agent_sdk.connectors.harvest.types.TimeProjectsOrCondition | airbyte_agent_sdk.connectors.harvest.types.TimeProjectsAnyCondition`
     :   The type of the None singleton.
 
+<a id="TimeProjectsOrCondition"></a>
+
 `TimeProjectsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -6301,6 +6979,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.harvest.types.TimeProjectsEqCondition | airbyte_agent_sdk.connectors.harvest.types.TimeProjectsNeqCondition | airbyte_agent_sdk.connectors.harvest.types.TimeProjectsGtCondition | airbyte_agent_sdk.connectors.harvest.types.TimeProjectsGteCondition | airbyte_agent_sdk.connectors.harvest.types.TimeProjectsLtCondition | airbyte_agent_sdk.connectors.harvest.types.TimeProjectsLteCondition | airbyte_agent_sdk.connectors.harvest.types.TimeProjectsInCondition | airbyte_agent_sdk.connectors.harvest.types.TimeProjectsLikeCondition | airbyte_agent_sdk.connectors.harvest.types.TimeProjectsFuzzyCondition | airbyte_agent_sdk.connectors.harvest.types.TimeProjectsKeywordCondition | airbyte_agent_sdk.connectors.harvest.types.TimeProjectsContainsCondition | airbyte_agent_sdk.connectors.harvest.types.TimeProjectsNotCondition | airbyte_agent_sdk.connectors.harvest.types.TimeProjectsAndCondition | airbyte_agent_sdk.connectors.harvest.types.TimeProjectsOrCondition | airbyte_agent_sdk.connectors.harvest.types.TimeProjectsAnyCondition]`
     :   The type of the None singleton.
+
+<a id="TimeProjectsSearchFilter"></a>
 
 `TimeProjectsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering time_projects search queries.
@@ -6335,6 +7015,8 @@ Classes
     `total_hours: float | None`
     :   Total hours spent
 
+<a id="TimeProjectsSearchQuery"></a>
+
 `TimeProjectsSearchQuery(*args, **kwargs)`
 :   Search query for time_projects entity.
 
@@ -6349,6 +7031,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.harvest.types.TimeProjectsSortFilter]`
     :   The type of the None singleton.
+
+<a id="TimeProjectsSortFilter"></a>
 
 `TimeProjectsSortFilter(*args, **kwargs)`
 :   Available fields for sorting time_projects search results.
@@ -6383,6 +7067,8 @@ Classes
     `total_hours: Literal['asc', 'desc']`
     :   Total hours spent
 
+<a id="TimeProjectsStringFilter"></a>
+
 `TimeProjectsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -6416,6 +7102,8 @@ Classes
     `total_hours: str`
     :   Total hours spent
 
+<a id="TimeTasksAndCondition"></a>
+
 `TimeTasksAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -6436,6 +7124,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.harvest.types.TimeTasksEqCondition | airbyte_agent_sdk.connectors.harvest.types.TimeTasksNeqCondition | airbyte_agent_sdk.connectors.harvest.types.TimeTasksGtCondition | airbyte_agent_sdk.connectors.harvest.types.TimeTasksGteCondition | airbyte_agent_sdk.connectors.harvest.types.TimeTasksLtCondition | airbyte_agent_sdk.connectors.harvest.types.TimeTasksLteCondition | airbyte_agent_sdk.connectors.harvest.types.TimeTasksInCondition | airbyte_agent_sdk.connectors.harvest.types.TimeTasksLikeCondition | airbyte_agent_sdk.connectors.harvest.types.TimeTasksFuzzyCondition | airbyte_agent_sdk.connectors.harvest.types.TimeTasksKeywordCondition | airbyte_agent_sdk.connectors.harvest.types.TimeTasksContainsCondition | airbyte_agent_sdk.connectors.harvest.types.TimeTasksNotCondition | airbyte_agent_sdk.connectors.harvest.types.TimeTasksAndCondition | airbyte_agent_sdk.connectors.harvest.types.TimeTasksOrCondition | airbyte_agent_sdk.connectors.harvest.types.TimeTasksAnyCondition]`
     :   The type of the None singleton.
 
+<a id="TimeTasksAnyCondition"></a>
+
 `TimeTasksAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -6455,6 +7145,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.harvest.types.TimeTasksAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="TimeTasksAnyValueFilter"></a>
 
 `TimeTasksAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -6483,6 +7175,8 @@ Classes
     `total_hours: Any`
     :   Total hours spent
 
+<a id="TimeTasksContainsCondition"></a>
+
 `TimeTasksContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -6494,6 +7188,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.harvest.types.TimeTasksAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="TimeTasksEqCondition"></a>
 
 `TimeTasksEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -6507,6 +7203,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.harvest.types.TimeTasksSearchFilter`
     :   The type of the None singleton.
 
+<a id="TimeTasksFuzzyCondition"></a>
+
 `TimeTasksFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -6518,6 +7216,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.harvest.types.TimeTasksStringFilter`
     :   The type of the None singleton.
+
+<a id="TimeTasksGtCondition"></a>
 
 `TimeTasksGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
@@ -6531,6 +7231,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.harvest.types.TimeTasksSearchFilter`
     :   The type of the None singleton.
 
+<a id="TimeTasksGteCondition"></a>
+
 `TimeTasksGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -6542,6 +7244,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.harvest.types.TimeTasksSearchFilter`
     :   The type of the None singleton.
+
+<a id="TimeTasksInCondition"></a>
 
 `TimeTasksInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -6562,6 +7266,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.harvest.types.TimeTasksInFilter`
     :   The type of the None singleton.
+
+<a id="TimeTasksInFilter"></a>
 
 `TimeTasksInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -6590,6 +7296,8 @@ Classes
     `total_hours: list[float]`
     :   Total hours spent
 
+<a id="TimeTasksKeywordCondition"></a>
+
 `TimeTasksKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -6602,6 +7310,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.harvest.types.TimeTasksStringFilter`
     :   The type of the None singleton.
 
+<a id="TimeTasksLikeCondition"></a>
+
 `TimeTasksLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -6613,6 +7323,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.harvest.types.TimeTasksStringFilter`
     :   The type of the None singleton.
+
+<a id="TimeTasksListParams"></a>
 
 `TimeTasksListParams(*args, **kwargs)`
 :   Parameters for time_tasks.list operation
@@ -6632,6 +7344,8 @@ Classes
     `to: str`
     :   The type of the None singleton.
 
+<a id="TimeTasksLtCondition"></a>
+
 `TimeTasksLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -6643,6 +7357,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.harvest.types.TimeTasksSearchFilter`
     :   The type of the None singleton.
+
+<a id="TimeTasksLteCondition"></a>
 
 `TimeTasksLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -6656,6 +7372,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.harvest.types.TimeTasksSearchFilter`
     :   The type of the None singleton.
 
+<a id="TimeTasksNeqCondition"></a>
+
 `TimeTasksNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -6667,6 +7385,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.harvest.types.TimeTasksSearchFilter`
     :   The type of the None singleton.
+
+<a id="TimeTasksNotCondition"></a>
 
 `TimeTasksNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -6688,6 +7408,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.harvest.types.TimeTasksEqCondition | airbyte_agent_sdk.connectors.harvest.types.TimeTasksNeqCondition | airbyte_agent_sdk.connectors.harvest.types.TimeTasksGtCondition | airbyte_agent_sdk.connectors.harvest.types.TimeTasksGteCondition | airbyte_agent_sdk.connectors.harvest.types.TimeTasksLtCondition | airbyte_agent_sdk.connectors.harvest.types.TimeTasksLteCondition | airbyte_agent_sdk.connectors.harvest.types.TimeTasksInCondition | airbyte_agent_sdk.connectors.harvest.types.TimeTasksLikeCondition | airbyte_agent_sdk.connectors.harvest.types.TimeTasksFuzzyCondition | airbyte_agent_sdk.connectors.harvest.types.TimeTasksKeywordCondition | airbyte_agent_sdk.connectors.harvest.types.TimeTasksContainsCondition | airbyte_agent_sdk.connectors.harvest.types.TimeTasksNotCondition | airbyte_agent_sdk.connectors.harvest.types.TimeTasksAndCondition | airbyte_agent_sdk.connectors.harvest.types.TimeTasksOrCondition | airbyte_agent_sdk.connectors.harvest.types.TimeTasksAnyCondition`
     :   The type of the None singleton.
 
+<a id="TimeTasksOrCondition"></a>
+
 `TimeTasksOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -6707,6 +7429,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.harvest.types.TimeTasksEqCondition | airbyte_agent_sdk.connectors.harvest.types.TimeTasksNeqCondition | airbyte_agent_sdk.connectors.harvest.types.TimeTasksGtCondition | airbyte_agent_sdk.connectors.harvest.types.TimeTasksGteCondition | airbyte_agent_sdk.connectors.harvest.types.TimeTasksLtCondition | airbyte_agent_sdk.connectors.harvest.types.TimeTasksLteCondition | airbyte_agent_sdk.connectors.harvest.types.TimeTasksInCondition | airbyte_agent_sdk.connectors.harvest.types.TimeTasksLikeCondition | airbyte_agent_sdk.connectors.harvest.types.TimeTasksFuzzyCondition | airbyte_agent_sdk.connectors.harvest.types.TimeTasksKeywordCondition | airbyte_agent_sdk.connectors.harvest.types.TimeTasksContainsCondition | airbyte_agent_sdk.connectors.harvest.types.TimeTasksNotCondition | airbyte_agent_sdk.connectors.harvest.types.TimeTasksAndCondition | airbyte_agent_sdk.connectors.harvest.types.TimeTasksOrCondition | airbyte_agent_sdk.connectors.harvest.types.TimeTasksAnyCondition]`
     :   The type of the None singleton.
+
+<a id="TimeTasksSearchFilter"></a>
 
 `TimeTasksSearchFilter(*args, **kwargs)`
 :   Available fields for filtering time_tasks search queries.
@@ -6735,6 +7459,8 @@ Classes
     `total_hours: float | None`
     :   Total hours spent
 
+<a id="TimeTasksSearchQuery"></a>
+
 `TimeTasksSearchQuery(*args, **kwargs)`
 :   Search query for time_tasks entity.
 
@@ -6749,6 +7475,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.harvest.types.TimeTasksSortFilter]`
     :   The type of the None singleton.
+
+<a id="TimeTasksSortFilter"></a>
 
 `TimeTasksSortFilter(*args, **kwargs)`
 :   Available fields for sorting time_tasks search results.
@@ -6777,6 +7505,8 @@ Classes
     `total_hours: Literal['asc', 'desc']`
     :   Total hours spent
 
+<a id="TimeTasksStringFilter"></a>
+
 `TimeTasksStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -6804,6 +7534,8 @@ Classes
     `total_hours: str`
     :   Total hours spent
 
+<a id="UserAssignmentsAndCondition"></a>
+
 `UserAssignmentsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -6824,6 +7556,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.harvest.types.UserAssignmentsEqCondition | airbyte_agent_sdk.connectors.harvest.types.UserAssignmentsNeqCondition | airbyte_agent_sdk.connectors.harvest.types.UserAssignmentsGtCondition | airbyte_agent_sdk.connectors.harvest.types.UserAssignmentsGteCondition | airbyte_agent_sdk.connectors.harvest.types.UserAssignmentsLtCondition | airbyte_agent_sdk.connectors.harvest.types.UserAssignmentsLteCondition | airbyte_agent_sdk.connectors.harvest.types.UserAssignmentsInCondition | airbyte_agent_sdk.connectors.harvest.types.UserAssignmentsLikeCondition | airbyte_agent_sdk.connectors.harvest.types.UserAssignmentsFuzzyCondition | airbyte_agent_sdk.connectors.harvest.types.UserAssignmentsKeywordCondition | airbyte_agent_sdk.connectors.harvest.types.UserAssignmentsContainsCondition | airbyte_agent_sdk.connectors.harvest.types.UserAssignmentsNotCondition | airbyte_agent_sdk.connectors.harvest.types.UserAssignmentsAndCondition | airbyte_agent_sdk.connectors.harvest.types.UserAssignmentsOrCondition | airbyte_agent_sdk.connectors.harvest.types.UserAssignmentsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="UserAssignmentsAnyCondition"></a>
+
 `UserAssignmentsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -6843,6 +7577,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.harvest.types.UserAssignmentsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="UserAssignmentsAnyValueFilter"></a>
 
 `UserAssignmentsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -6880,6 +7616,8 @@ Classes
     `user: Any`
     :   Associated user
 
+<a id="UserAssignmentsContainsCondition"></a>
+
 `UserAssignmentsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -6891,6 +7629,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.harvest.types.UserAssignmentsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="UserAssignmentsEqCondition"></a>
 
 `UserAssignmentsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -6904,6 +7644,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.harvest.types.UserAssignmentsSearchFilter`
     :   The type of the None singleton.
 
+<a id="UserAssignmentsFuzzyCondition"></a>
+
 `UserAssignmentsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -6915,6 +7657,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.harvest.types.UserAssignmentsStringFilter`
     :   The type of the None singleton.
+
+<a id="UserAssignmentsGtCondition"></a>
 
 `UserAssignmentsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
@@ -6928,6 +7672,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.harvest.types.UserAssignmentsSearchFilter`
     :   The type of the None singleton.
 
+<a id="UserAssignmentsGteCondition"></a>
+
 `UserAssignmentsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -6939,6 +7685,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.harvest.types.UserAssignmentsSearchFilter`
     :   The type of the None singleton.
+
+<a id="UserAssignmentsInCondition"></a>
 
 `UserAssignmentsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -6959,6 +7707,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.harvest.types.UserAssignmentsInFilter`
     :   The type of the None singleton.
+
+<a id="UserAssignmentsInFilter"></a>
 
 `UserAssignmentsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -6996,6 +7746,8 @@ Classes
     `user: list[dict[str, typing.Any]]`
     :   Associated user
 
+<a id="UserAssignmentsKeywordCondition"></a>
+
 `UserAssignmentsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -7007,6 +7759,8 @@ Classes
 
     `keyword: airbyte_agent_sdk.connectors.harvest.types.UserAssignmentsStringFilter`
     :   The type of the None singleton.
+
+<a id="UserAssignmentsLikeCondition"></a>
 
 `UserAssignmentsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
@@ -7020,6 +7774,8 @@ Classes
     `like: airbyte_agent_sdk.connectors.harvest.types.UserAssignmentsStringFilter`
     :   The type of the None singleton.
 
+<a id="UserAssignmentsListParams"></a>
+
 `UserAssignmentsListParams(*args, **kwargs)`
 :   Parameters for user_assignments.list operation
 
@@ -7031,6 +7787,8 @@ Classes
 
     `per_page: int`
     :   The type of the None singleton.
+
+<a id="UserAssignmentsLtCondition"></a>
 
 `UserAssignmentsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
@@ -7044,6 +7802,8 @@ Classes
     `lt: airbyte_agent_sdk.connectors.harvest.types.UserAssignmentsSearchFilter`
     :   The type of the None singleton.
 
+<a id="UserAssignmentsLteCondition"></a>
+
 `UserAssignmentsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
 
@@ -7056,6 +7816,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.harvest.types.UserAssignmentsSearchFilter`
     :   The type of the None singleton.
 
+<a id="UserAssignmentsNeqCondition"></a>
+
 `UserAssignmentsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -7067,6 +7829,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.harvest.types.UserAssignmentsSearchFilter`
     :   The type of the None singleton.
+
+<a id="UserAssignmentsNotCondition"></a>
 
 `UserAssignmentsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -7088,6 +7852,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.harvest.types.UserAssignmentsEqCondition | airbyte_agent_sdk.connectors.harvest.types.UserAssignmentsNeqCondition | airbyte_agent_sdk.connectors.harvest.types.UserAssignmentsGtCondition | airbyte_agent_sdk.connectors.harvest.types.UserAssignmentsGteCondition | airbyte_agent_sdk.connectors.harvest.types.UserAssignmentsLtCondition | airbyte_agent_sdk.connectors.harvest.types.UserAssignmentsLteCondition | airbyte_agent_sdk.connectors.harvest.types.UserAssignmentsInCondition | airbyte_agent_sdk.connectors.harvest.types.UserAssignmentsLikeCondition | airbyte_agent_sdk.connectors.harvest.types.UserAssignmentsFuzzyCondition | airbyte_agent_sdk.connectors.harvest.types.UserAssignmentsKeywordCondition | airbyte_agent_sdk.connectors.harvest.types.UserAssignmentsContainsCondition | airbyte_agent_sdk.connectors.harvest.types.UserAssignmentsNotCondition | airbyte_agent_sdk.connectors.harvest.types.UserAssignmentsAndCondition | airbyte_agent_sdk.connectors.harvest.types.UserAssignmentsOrCondition | airbyte_agent_sdk.connectors.harvest.types.UserAssignmentsAnyCondition`
     :   The type of the None singleton.
 
+<a id="UserAssignmentsOrCondition"></a>
+
 `UserAssignmentsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -7107,6 +7873,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.harvest.types.UserAssignmentsEqCondition | airbyte_agent_sdk.connectors.harvest.types.UserAssignmentsNeqCondition | airbyte_agent_sdk.connectors.harvest.types.UserAssignmentsGtCondition | airbyte_agent_sdk.connectors.harvest.types.UserAssignmentsGteCondition | airbyte_agent_sdk.connectors.harvest.types.UserAssignmentsLtCondition | airbyte_agent_sdk.connectors.harvest.types.UserAssignmentsLteCondition | airbyte_agent_sdk.connectors.harvest.types.UserAssignmentsInCondition | airbyte_agent_sdk.connectors.harvest.types.UserAssignmentsLikeCondition | airbyte_agent_sdk.connectors.harvest.types.UserAssignmentsFuzzyCondition | airbyte_agent_sdk.connectors.harvest.types.UserAssignmentsKeywordCondition | airbyte_agent_sdk.connectors.harvest.types.UserAssignmentsContainsCondition | airbyte_agent_sdk.connectors.harvest.types.UserAssignmentsNotCondition | airbyte_agent_sdk.connectors.harvest.types.UserAssignmentsAndCondition | airbyte_agent_sdk.connectors.harvest.types.UserAssignmentsOrCondition | airbyte_agent_sdk.connectors.harvest.types.UserAssignmentsAnyCondition]`
     :   The type of the None singleton.
+
+<a id="UserAssignmentsSearchFilter"></a>
 
 `UserAssignmentsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering user_assignments search queries.
@@ -7144,6 +7912,8 @@ Classes
     `user: dict[str, typing.Any] | None`
     :   Associated user
 
+<a id="UserAssignmentsSearchQuery"></a>
+
 `UserAssignmentsSearchQuery(*args, **kwargs)`
 :   Search query for user_assignments entity.
 
@@ -7158,6 +7928,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.harvest.types.UserAssignmentsSortFilter]`
     :   The type of the None singleton.
+
+<a id="UserAssignmentsSortFilter"></a>
 
 `UserAssignmentsSortFilter(*args, **kwargs)`
 :   Available fields for sorting user_assignments search results.
@@ -7195,6 +7967,8 @@ Classes
     `user: Literal['asc', 'desc']`
     :   Associated user
 
+<a id="UserAssignmentsStringFilter"></a>
+
 `UserAssignmentsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -7231,6 +8005,8 @@ Classes
     `user: str`
     :   Associated user
 
+<a id="UsersAndCondition"></a>
+
 `UsersAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -7251,6 +8027,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.harvest.types.UsersEqCondition | airbyte_agent_sdk.connectors.harvest.types.UsersNeqCondition | airbyte_agent_sdk.connectors.harvest.types.UsersGtCondition | airbyte_agent_sdk.connectors.harvest.types.UsersGteCondition | airbyte_agent_sdk.connectors.harvest.types.UsersLtCondition | airbyte_agent_sdk.connectors.harvest.types.UsersLteCondition | airbyte_agent_sdk.connectors.harvest.types.UsersInCondition | airbyte_agent_sdk.connectors.harvest.types.UsersLikeCondition | airbyte_agent_sdk.connectors.harvest.types.UsersFuzzyCondition | airbyte_agent_sdk.connectors.harvest.types.UsersKeywordCondition | airbyte_agent_sdk.connectors.harvest.types.UsersContainsCondition | airbyte_agent_sdk.connectors.harvest.types.UsersNotCondition | airbyte_agent_sdk.connectors.harvest.types.UsersAndCondition | airbyte_agent_sdk.connectors.harvest.types.UsersOrCondition | airbyte_agent_sdk.connectors.harvest.types.UsersAnyCondition]`
     :   The type of the None singleton.
 
+<a id="UsersAnyCondition"></a>
+
 `UsersAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -7270,6 +8048,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.harvest.types.UsersAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="UsersAnyValueFilter"></a>
 
 `UsersAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -7325,6 +8105,8 @@ Classes
     `weekly_capacity: Any`
     :   Weekly capacity in seconds
 
+<a id="UsersContainsCondition"></a>
+
 `UsersContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -7336,6 +8118,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.harvest.types.UsersAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="UsersEqCondition"></a>
 
 `UsersEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -7349,6 +8133,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.harvest.types.UsersSearchFilter`
     :   The type of the None singleton.
 
+<a id="UsersFuzzyCondition"></a>
+
 `UsersFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -7360,6 +8146,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.harvest.types.UsersStringFilter`
     :   The type of the None singleton.
+
+<a id="UsersGetParams"></a>
 
 `UsersGetParams(*args, **kwargs)`
 :   Parameters for users.get operation
@@ -7373,6 +8161,8 @@ Classes
     `id: str`
     :   The type of the None singleton.
 
+<a id="UsersGtCondition"></a>
+
 `UsersGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -7385,6 +8175,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.harvest.types.UsersSearchFilter`
     :   The type of the None singleton.
 
+<a id="UsersGteCondition"></a>
+
 `UsersGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -7396,6 +8188,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.harvest.types.UsersSearchFilter`
     :   The type of the None singleton.
+
+<a id="UsersInCondition"></a>
 
 `UsersInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -7416,6 +8210,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.harvest.types.UsersInFilter`
     :   The type of the None singleton.
+
+<a id="UsersInFilter"></a>
 
 `UsersInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -7471,6 +8267,8 @@ Classes
     `weekly_capacity: list[int]`
     :   Weekly capacity in seconds
 
+<a id="UsersKeywordCondition"></a>
+
 `UsersKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -7482,6 +8280,8 @@ Classes
 
     `keyword: airbyte_agent_sdk.connectors.harvest.types.UsersStringFilter`
     :   The type of the None singleton.
+
+<a id="UsersLikeCondition"></a>
 
 `UsersLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
@@ -7495,6 +8295,8 @@ Classes
     `like: airbyte_agent_sdk.connectors.harvest.types.UsersStringFilter`
     :   The type of the None singleton.
 
+<a id="UsersListParams"></a>
+
 `UsersListParams(*args, **kwargs)`
 :   Parameters for users.list operation
 
@@ -7506,6 +8308,8 @@ Classes
 
     `per_page: int`
     :   The type of the None singleton.
+
+<a id="UsersLtCondition"></a>
 
 `UsersLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
@@ -7519,6 +8323,8 @@ Classes
     `lt: airbyte_agent_sdk.connectors.harvest.types.UsersSearchFilter`
     :   The type of the None singleton.
 
+<a id="UsersLteCondition"></a>
+
 `UsersLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
 
@@ -7531,6 +8337,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.harvest.types.UsersSearchFilter`
     :   The type of the None singleton.
 
+<a id="UsersNeqCondition"></a>
+
 `UsersNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -7542,6 +8350,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.harvest.types.UsersSearchFilter`
     :   The type of the None singleton.
+
+<a id="UsersNotCondition"></a>
 
 `UsersNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -7563,6 +8373,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.harvest.types.UsersEqCondition | airbyte_agent_sdk.connectors.harvest.types.UsersNeqCondition | airbyte_agent_sdk.connectors.harvest.types.UsersGtCondition | airbyte_agent_sdk.connectors.harvest.types.UsersGteCondition | airbyte_agent_sdk.connectors.harvest.types.UsersLtCondition | airbyte_agent_sdk.connectors.harvest.types.UsersLteCondition | airbyte_agent_sdk.connectors.harvest.types.UsersInCondition | airbyte_agent_sdk.connectors.harvest.types.UsersLikeCondition | airbyte_agent_sdk.connectors.harvest.types.UsersFuzzyCondition | airbyte_agent_sdk.connectors.harvest.types.UsersKeywordCondition | airbyte_agent_sdk.connectors.harvest.types.UsersContainsCondition | airbyte_agent_sdk.connectors.harvest.types.UsersNotCondition | airbyte_agent_sdk.connectors.harvest.types.UsersAndCondition | airbyte_agent_sdk.connectors.harvest.types.UsersOrCondition | airbyte_agent_sdk.connectors.harvest.types.UsersAnyCondition`
     :   The type of the None singleton.
 
+<a id="UsersOrCondition"></a>
+
 `UsersOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -7582,6 +8394,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.harvest.types.UsersEqCondition | airbyte_agent_sdk.connectors.harvest.types.UsersNeqCondition | airbyte_agent_sdk.connectors.harvest.types.UsersGtCondition | airbyte_agent_sdk.connectors.harvest.types.UsersGteCondition | airbyte_agent_sdk.connectors.harvest.types.UsersLtCondition | airbyte_agent_sdk.connectors.harvest.types.UsersLteCondition | airbyte_agent_sdk.connectors.harvest.types.UsersInCondition | airbyte_agent_sdk.connectors.harvest.types.UsersLikeCondition | airbyte_agent_sdk.connectors.harvest.types.UsersFuzzyCondition | airbyte_agent_sdk.connectors.harvest.types.UsersKeywordCondition | airbyte_agent_sdk.connectors.harvest.types.UsersContainsCondition | airbyte_agent_sdk.connectors.harvest.types.UsersNotCondition | airbyte_agent_sdk.connectors.harvest.types.UsersAndCondition | airbyte_agent_sdk.connectors.harvest.types.UsersOrCondition | airbyte_agent_sdk.connectors.harvest.types.UsersAnyCondition]`
     :   The type of the None singleton.
+
+<a id="UsersSearchFilter"></a>
 
 `UsersSearchFilter(*args, **kwargs)`
 :   Available fields for filtering users search queries.
@@ -7637,6 +8451,8 @@ Classes
     `weekly_capacity: int | None`
     :   Weekly capacity in seconds
 
+<a id="UsersSearchQuery"></a>
+
 `UsersSearchQuery(*args, **kwargs)`
 :   Search query for users entity.
 
@@ -7651,6 +8467,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.harvest.types.UsersSortFilter]`
     :   The type of the None singleton.
+
+<a id="UsersSortFilter"></a>
 
 `UsersSortFilter(*args, **kwargs)`
 :   Available fields for sorting users search results.
@@ -7705,6 +8523,8 @@ Classes
 
     `weekly_capacity: Literal['asc', 'desc']`
     :   Weekly capacity in seconds
+
+<a id="UsersStringFilter"></a>
 
 `UsersStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/hubspot/connector.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/hubspot/connector.md
@@ -10,6 +10,8 @@ Hubspot connector.
 Classes
 -------
 
+<a id="CompaniesQuery"></a>
+
 `CompaniesQuery(connector: HubspotConnector)`
 :   Query class for Companies entity operations.
     
@@ -90,6 +92,8 @@ Classes
         Returns:
             CompaniesListResult
 
+<a id="ContactsQuery"></a>
+
 `ContactsQuery(connector: HubspotConnector)`
 :   Query class for Contacts entity operations.
     
@@ -169,6 +173,8 @@ Classes
         
         Returns:
             ContactsListResult
+
+<a id="DealsQuery"></a>
 
 `DealsQuery(connector: HubspotConnector)`
 :   Query class for Deals entity operations.
@@ -251,6 +257,8 @@ Classes
         
         Returns:
             DealsListResult
+
+<a id="HubspotConnector"></a>
 
 `HubspotConnector(auth_config: HubspotAuthConfig | AirbyteAuthConfig | BaseModel | None = None, on_token_refresh: Any | None = None)`
 :   Type-safe Hubspot API connector.
@@ -528,6 +536,8 @@ Classes
             for entity in entities:
                 print(f"\{entity['entity_name']\}: \{entity['available_actions']\}")
 
+<a id="ObjectsQuery"></a>
+
 `ObjectsQuery(connector: HubspotConnector)`
 :   Query class for Objects entity operations.
     
@@ -567,6 +577,8 @@ Classes
         Returns:
             ObjectsListResult
 
+<a id="SchemasQuery"></a>
+
 `SchemasQuery(connector: HubspotConnector)`
 :   Query class for Schemas entity operations.
     
@@ -593,6 +605,8 @@ Classes
         
         Returns:
             SchemasListResult
+
+<a id="TicketsQuery"></a>
 
 `TicketsQuery(connector: HubspotConnector)`
 :   Query class for Tickets entity operations.

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/hubspot/index.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/hubspot/index.md
@@ -19,6 +19,8 @@ Sub-modules
 Classes
 -------
 
+<a id="AirbyteAuthConfig"></a>
+
 `AirbyteAuthConfig(**data: Any)`
 :   Authentication configuration for Airbyte hosted mode execution.
     
@@ -87,6 +89,8 @@ Classes
     `workspace_name: str | None`
     :   The type of the None singleton.
 
+<a id="AirbyteSearchMeta"></a>
+
 `AirbyteSearchMeta(**data: Any)`
 :   Pagination metadata for search responses.
     
@@ -114,6 +118,8 @@ Classes
 
     `took_ms: int | None`
     :   Time taken to execute the search in milliseconds.
+
+<a id="AirbyteSearchResult"></a>
 
 `AirbyteSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -147,6 +153,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="CompaniesSearchResult"></a>
+
 `CompaniesSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -162,6 +170,8 @@ Classes
     * airbyte_agent_sdk.connectors.hubspot.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="ContactsSearchResult"></a>
 
 `ContactsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -179,6 +189,8 @@ Classes
     * pydantic.main.BaseModel
     * typing.Generic
 
+<a id="DealsSearchResult"></a>
+
 `DealsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -194,6 +206,8 @@ Classes
     * airbyte_agent_sdk.connectors.hubspot.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="CompaniesSearchData"></a>
 
 `CompaniesSearchData(**data: Any)`
 :   Search result data for companies entity.
@@ -232,6 +246,8 @@ Classes
     `updated_at: str | None`
     :   Timestamp when the company record was last modified
 
+<a id="ContactsSearchData"></a>
+
 `ContactsSearchData(**data: Any)`
 :   Search result data for contacts entity.
     
@@ -268,6 +284,8 @@ Classes
 
     `updated_at: str | None`
     :   Timestamp indicating when the contact record was last modified.
+
+<a id="DealsSearchData"></a>
 
 `DealsSearchData(**data: Any)`
 :   Search result data for deals entity.
@@ -311,6 +329,8 @@ Classes
 
     `updated_at: str | None`
     :   Timestamp when the deal record was last modified
+
+<a id="HubspotConnector"></a>
 
 `HubspotConnector(auth_config: HubspotAuthConfig | AirbyteAuthConfig | BaseModel | None = None, on_token_refresh: Any | None = None)`
 :   Type-safe Hubspot API connector.
@@ -587,6 +607,8 @@ Classes
             entities = connector.list_entities()
             for entity in entities:
                 print(f"\{entity['entity_name']\}: \{entity['available_actions']\}")
+
+<a id="HubspotOAuthCredentials"></a>
 
 `HubspotOAuthCredentials(**data: Any)`
 :   HubSpot OAuth App Credentials - Provide your own HubSpot OAuth app credentials to override the default Airbyte-managed ones.

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/hubspot/models.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/hubspot/models.md
@@ -13,6 +13,8 @@ and response envelope types.
 Classes
 -------
 
+<a id="AirbyteSearchMeta"></a>
+
 `AirbyteSearchMeta(**data: Any)`
 :   Pagination metadata for search responses.
     
@@ -40,6 +42,8 @@ Classes
 
     `took_ms: int | None`
     :   Time taken to execute the search in milliseconds.
+
+<a id="AirbyteSearchResult"></a>
 
 `AirbyteSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -94,6 +98,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="CompaniesSearchResult"></a>
+
 `CompaniesSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -130,6 +136,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="ContactsSearchResult"></a>
 
 `ContactsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -168,6 +176,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="DealsSearchResult"></a>
+
 `DealsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -183,6 +193,8 @@ Classes
     * airbyte_agent_sdk.connectors.hubspot.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="CRMObject"></a>
 
 `CRMObject(**data: Any)`
 :   Generic HubSpot CRM object (for custom objects)
@@ -233,6 +245,8 @@ Classes
     `url: str | Any | None`
     :   The type of the None singleton.
 
+<a id="CRMObjectProperties"></a>
+
 `CRMObjectProperties(**data: Any)`
 :   Object properties
     
@@ -260,6 +274,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="CompaniesApiSearchResultMeta"></a>
 
 `CompaniesApiSearchResultMeta(**data: Any)`
 :   Metadata for companies.Action.API_SEARCH operation
@@ -289,6 +305,8 @@ Classes
     `total: int | Any`
     :   The type of the None singleton.
 
+<a id="CompaniesList"></a>
+
 `CompaniesList(**data: Any)`
 :   Paginated list of companies
     
@@ -317,6 +335,8 @@ Classes
     `total: int | Any`
     :   The type of the None singleton.
 
+<a id="CompaniesListResultMeta"></a>
+
 `CompaniesListResultMeta(**data: Any)`
 :   Metadata for companies.Action.LIST operation
     
@@ -341,6 +361,8 @@ Classes
 
     `next_link: str | Any`
     :   The type of the None singleton.
+
+<a id="CompaniesSearchData"></a>
 
 `CompaniesSearchData(**data: Any)`
 :   Search result data for companies entity.
@@ -378,6 +400,8 @@ Classes
 
     `updated_at: str | None`
     :   Timestamp when the company record was last modified
+
+<a id="Company"></a>
 
 `Company(**data: Any)`
 :   HubSpot company object
@@ -428,6 +452,8 @@ Classes
     `url: str | Any | None`
     :   The type of the None singleton.
 
+<a id="CompanyProperties"></a>
+
 `CompanyProperties(**data: Any)`
 :   Company properties
     
@@ -461,6 +487,8 @@ Classes
 
     `name: str | Any | None`
     :   The type of the None singleton.
+
+<a id="Contact"></a>
 
 `Contact(**data: Any)`
 :   HubSpot contact object
@@ -511,6 +539,8 @@ Classes
     `url: str | Any | None`
     :   The type of the None singleton.
 
+<a id="ContactProperties"></a>
+
 `ContactProperties(**data: Any)`
 :   Contact properties
     
@@ -548,6 +578,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="ContactsApiSearchResultMeta"></a>
+
 `ContactsApiSearchResultMeta(**data: Any)`
 :   Metadata for contacts.Action.API_SEARCH operation
     
@@ -575,6 +607,8 @@ Classes
 
     `total: int | Any`
     :   The type of the None singleton.
+
+<a id="ContactsList"></a>
 
 `ContactsList(**data: Any)`
 :   Paginated list of contacts
@@ -604,6 +638,8 @@ Classes
     `total: int | Any`
     :   The type of the None singleton.
 
+<a id="ContactsListResultMeta"></a>
+
 `ContactsListResultMeta(**data: Any)`
 :   Metadata for contacts.Action.LIST operation
     
@@ -628,6 +664,8 @@ Classes
 
     `next_link: str | Any`
     :   The type of the None singleton.
+
+<a id="ContactsSearchData"></a>
 
 `ContactsSearchData(**data: Any)`
 :   Search result data for contacts entity.
@@ -665,6 +703,8 @@ Classes
 
     `updated_at: str | None`
     :   Timestamp indicating when the contact record was last modified.
+
+<a id="Deal"></a>
 
 `Deal(**data: Any)`
 :   HubSpot deal object
@@ -715,6 +755,8 @@ Classes
     `url: str | Any | None`
     :   The type of the None singleton.
 
+<a id="DealProperties"></a>
+
 `DealProperties(**data: Any)`
 :   Deal properties
     
@@ -758,6 +800,8 @@ Classes
     `pipeline: str | Any | None`
     :   The type of the None singleton.
 
+<a id="DealsApiSearchResultMeta"></a>
+
 `DealsApiSearchResultMeta(**data: Any)`
 :   Metadata for deals.Action.API_SEARCH operation
     
@@ -785,6 +829,8 @@ Classes
 
     `total: int | Any`
     :   The type of the None singleton.
+
+<a id="DealsList"></a>
 
 `DealsList(**data: Any)`
 :   Paginated list of deals
@@ -814,6 +860,8 @@ Classes
     `total: int | Any`
     :   The type of the None singleton.
 
+<a id="DealsListResultMeta"></a>
+
 `DealsListResultMeta(**data: Any)`
 :   Metadata for deals.Action.LIST operation
     
@@ -838,6 +886,8 @@ Classes
 
     `next_link: str | Any`
     :   The type of the None singleton.
+
+<a id="DealsSearchData"></a>
 
 `DealsSearchData(**data: Any)`
 :   Search result data for deals entity.
@@ -882,6 +932,8 @@ Classes
     `updated_at: str | None`
     :   Timestamp when the deal record was last modified
 
+<a id="HubspotCheckResult"></a>
+
 `HubspotCheckResult(**data: Any)`
 :   Result of a health check operation.
     
@@ -915,6 +967,8 @@ Classes
     `status: str`
     :   Health check status: 'healthy' or 'unhealthy'.
 
+<a id="HubspotExecuteResult"></a>
+
 `HubspotExecuteResult(**data: Any)`
 :   Response envelope with data only.
     
@@ -944,6 +998,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="HubspotExecuteResultWithMeta"></a>
 
 `HubspotExecuteResultWithMeta(**data: Any)`
 :   Response envelope with data and metadata.
@@ -1004,6 +1060,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="ObjectsListResult"></a>
+
 `ObjectsListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -1046,6 +1104,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="CompaniesApiSearchResult"></a>
 
 `CompaniesApiSearchResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -1090,6 +1150,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="CompaniesListResult"></a>
+
 `CompaniesListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -1132,6 +1194,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="ContactsApiSearchResult"></a>
 
 `ContactsApiSearchResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -1176,6 +1240,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="ContactsListResult"></a>
+
 `ContactsListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -1218,6 +1284,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="DealsApiSearchResult"></a>
 
 `DealsApiSearchResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -1262,6 +1330,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="DealsListResult"></a>
+
 `DealsListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -1304,6 +1374,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="TicketsApiSearchResult"></a>
 
 `TicketsApiSearchResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -1348,6 +1420,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="TicketsListResult"></a>
+
 `TicketsListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -1390,6 +1464,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="SchemasListResult"></a>
+
 `SchemasListResult(**data: Any)`
 :   Response envelope with data only.
     
@@ -1407,6 +1483,8 @@ Classes
     * airbyte_agent_sdk.connectors.hubspot.models.HubspotExecuteResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="HubspotOAuthCredentials"></a>
 
 `HubspotOAuthCredentials(**data: Any)`
 :   HubSpot OAuth App Credentials - Provide your own HubSpot OAuth app credentials to override the default Airbyte-managed ones.
@@ -1432,6 +1510,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="HubspotOauth2AuthConfig"></a>
 
 `HubspotOauth2AuthConfig(**data: Any)`
 :   OAuth2
@@ -1464,6 +1544,8 @@ Classes
     `refresh_token: str`
     :   Your HubSpot OAuth2 Refresh Token
 
+<a id="HubspotPrivateAppAuthConfig"></a>
+
 `HubspotPrivateAppAuthConfig(**data: Any)`
 :   Private App
     
@@ -1485,6 +1567,8 @@ Classes
 
     `private_app_token: str`
     :   Access token from a HubSpot Private App
+
+<a id="ObjectsList"></a>
 
 `ObjectsList(**data: Any)`
 :   Paginated list of generic CRM objects
@@ -1511,6 +1595,8 @@ Classes
     `results: list[airbyte_agent_sdk.connectors.hubspot.models.CRMObject] | Any`
     :   The type of the None singleton.
 
+<a id="ObjectsListResultMeta"></a>
+
 `ObjectsListResultMeta(**data: Any)`
 :   Metadata for objects.Action.LIST operation
     
@@ -1536,6 +1622,8 @@ Classes
     `next_link: str | Any`
     :   The type of the None singleton.
 
+<a id="Paging"></a>
+
 `Paging(**data: Any)`
 :   Pagination information
     
@@ -1557,6 +1645,8 @@ Classes
 
     `next: airbyte_agent_sdk.connectors.hubspot.models.PagingNext | Any`
     :   The type of the None singleton.
+
+<a id="PagingNext"></a>
 
 `PagingNext(**data: Any)`
 :   Nested schema for Paging.next
@@ -1582,6 +1672,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="Schema"></a>
 
 `Schema(**data: Any)`
 :   Custom object schema definition
@@ -1662,6 +1754,8 @@ Classes
     `updated_by_user_id: int | Any`
     :   The type of the None singleton.
 
+<a id="SchemaAssociationsItem"></a>
+
 `SchemaAssociationsItem(**data: Any)`
 :   Nested schema for Schema.associations_item
     
@@ -1717,6 +1811,8 @@ Classes
     `updated_at: str | Any | None`
     :   The type of the None singleton.
 
+<a id="SchemaLabels"></a>
+
 `SchemaLabels(**data: Any)`
 :   Display labels
     
@@ -1741,6 +1837,8 @@ Classes
 
     `singular: str | Any`
     :   The type of the None singleton.
+
+<a id="SchemaPropertiesItem"></a>
 
 `SchemaPropertiesItem(**data: Any)`
 :   Nested schema for Schema.properties_item
@@ -1827,6 +1925,8 @@ Classes
     `updated_user_id: str | Any`
     :   The type of the None singleton.
 
+<a id="SchemaPropertiesItemModificationmetadata"></a>
+
 `SchemaPropertiesItemModificationmetadata(**data: Any)`
 :   Nested schema for SchemaPropertiesItem.modificationMetadata
     
@@ -1858,6 +1958,8 @@ Classes
     `read_only_value: bool | Any`
     :   The type of the None singleton.
 
+<a id="SchemasList"></a>
+
 `SchemasList(**data: Any)`
 :   List of custom object schemas
     
@@ -1879,6 +1981,8 @@ Classes
 
     `results: list[airbyte_agent_sdk.connectors.hubspot.models.Schema] | Any`
     :   The type of the None singleton.
+
+<a id="Ticket"></a>
 
 `Ticket(**data: Any)`
 :   HubSpot ticket object
@@ -1929,6 +2033,8 @@ Classes
     `url: str | Any | None`
     :   The type of the None singleton.
 
+<a id="TicketProperties"></a>
+
 `TicketProperties(**data: Any)`
 :   Ticket properties
     
@@ -1975,6 +2081,8 @@ Classes
     `subject: str | Any | None`
     :   The type of the None singleton.
 
+<a id="TicketsApiSearchResultMeta"></a>
+
 `TicketsApiSearchResultMeta(**data: Any)`
 :   Metadata for tickets.Action.API_SEARCH operation
     
@@ -2003,6 +2111,8 @@ Classes
     `total: int | Any`
     :   The type of the None singleton.
 
+<a id="TicketsList"></a>
+
 `TicketsList(**data: Any)`
 :   Paginated list of tickets
     
@@ -2030,6 +2140,8 @@ Classes
 
     `total: int | Any`
     :   The type of the None singleton.
+
+<a id="TicketsListResultMeta"></a>
 
 `TicketsListResultMeta(**data: Any)`
 :   Metadata for tickets.Action.LIST operation

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/hubspot/types.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/hubspot/types.md
@@ -10,6 +10,8 @@ Type definitions for hubspot connector.
 Classes
 -------
 
+<a id="AirbyteSearchParams"></a>
+
 `AirbyteSearchParams(*args, **kwargs)`
 :   Parameters for Airbyte cache search operations (generic, use entity-specific query types for better type hints).
 
@@ -31,6 +33,8 @@ Classes
     `query: dict[str, typing.Any]`
     :   The type of the None singleton.
 
+<a id="CompaniesAndCondition"></a>
+
 `CompaniesAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -51,6 +55,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.hubspot.types.CompaniesEqCondition | airbyte_agent_sdk.connectors.hubspot.types.CompaniesNeqCondition | airbyte_agent_sdk.connectors.hubspot.types.CompaniesGtCondition | airbyte_agent_sdk.connectors.hubspot.types.CompaniesGteCondition | airbyte_agent_sdk.connectors.hubspot.types.CompaniesLtCondition | airbyte_agent_sdk.connectors.hubspot.types.CompaniesLteCondition | airbyte_agent_sdk.connectors.hubspot.types.CompaniesInCondition | airbyte_agent_sdk.connectors.hubspot.types.CompaniesLikeCondition | airbyte_agent_sdk.connectors.hubspot.types.CompaniesFuzzyCondition | airbyte_agent_sdk.connectors.hubspot.types.CompaniesKeywordCondition | airbyte_agent_sdk.connectors.hubspot.types.CompaniesContainsCondition | airbyte_agent_sdk.connectors.hubspot.types.CompaniesNotCondition | airbyte_agent_sdk.connectors.hubspot.types.CompaniesAndCondition | airbyte_agent_sdk.connectors.hubspot.types.CompaniesOrCondition | airbyte_agent_sdk.connectors.hubspot.types.CompaniesAnyCondition]`
     :   The type of the None singleton.
 
+<a id="CompaniesAnyCondition"></a>
+
 `CompaniesAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -70,6 +76,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.hubspot.types.CompaniesAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="CompaniesAnyValueFilter"></a>
 
 `CompaniesAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -98,6 +106,8 @@ Classes
     `updated_at: Any`
     :   Timestamp when the company record was last modified
 
+<a id="CompaniesApiSearchParams"></a>
+
 `CompaniesApiSearchParams(*args, **kwargs)`
 :   Parameters for companies.api_search operation
 
@@ -125,6 +135,8 @@ Classes
     `sorts: list[airbyte_agent_sdk.connectors.hubspot.types.CompaniesApiSearchParamsSortsItem]`
     :   The type of the None singleton.
 
+<a id="CompaniesApiSearchParamsFiltergroupsItem"></a>
+
 `CompaniesApiSearchParamsFiltergroupsItem(*args, **kwargs)`
 :   Nested schema for CompaniesApiSearchParams.filterGroups_item
 
@@ -136,6 +148,8 @@ Classes
 
     `filters: list[airbyte_agent_sdk.connectors.hubspot.types.CompaniesApiSearchParamsFiltergroupsItemFiltersItem]`
     :   The type of the None singleton.
+
+<a id="CompaniesApiSearchParamsFiltergroupsItemFiltersItem"></a>
 
 `CompaniesApiSearchParamsFiltergroupsItemFiltersItem(*args, **kwargs)`
 :   Nested schema for CompaniesApiSearchParamsFiltergroupsItem.filters_item
@@ -160,6 +174,8 @@ Classes
     `values(self, /) ‑> list[str]`
     :   Return an object providing a view on the dict's values.
 
+<a id="CompaniesApiSearchParamsSortsItem"></a>
+
 `CompaniesApiSearchParamsSortsItem(*args, **kwargs)`
 :   Nested schema for CompaniesApiSearchParams.sorts_item
 
@@ -175,6 +191,8 @@ Classes
     `propertyName: str`
     :   The type of the None singleton.
 
+<a id="CompaniesContainsCondition"></a>
+
 `CompaniesContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -186,6 +204,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.hubspot.types.CompaniesAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="CompaniesEqCondition"></a>
 
 `CompaniesEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -199,6 +219,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.hubspot.types.CompaniesSearchFilter`
     :   The type of the None singleton.
 
+<a id="CompaniesFuzzyCondition"></a>
+
 `CompaniesFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -210,6 +232,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.hubspot.types.CompaniesStringFilter`
     :   The type of the None singleton.
+
+<a id="CompaniesGetParams"></a>
 
 `CompaniesGetParams(*args, **kwargs)`
 :   Parameters for companies.get operation
@@ -238,6 +262,8 @@ Classes
     `properties_with_history: str`
     :   The type of the None singleton.
 
+<a id="CompaniesGtCondition"></a>
+
 `CompaniesGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -250,6 +276,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.hubspot.types.CompaniesSearchFilter`
     :   The type of the None singleton.
 
+<a id="CompaniesGteCondition"></a>
+
 `CompaniesGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -261,6 +289,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.hubspot.types.CompaniesSearchFilter`
     :   The type of the None singleton.
+
+<a id="CompaniesInCondition"></a>
 
 `CompaniesInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -281,6 +311,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.hubspot.types.CompaniesInFilter`
     :   The type of the None singleton.
+
+<a id="CompaniesInFilter"></a>
 
 `CompaniesInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -309,6 +341,8 @@ Classes
     `updated_at: list[str]`
     :   Timestamp when the company record was last modified
 
+<a id="CompaniesKeywordCondition"></a>
+
 `CompaniesKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -321,6 +355,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.hubspot.types.CompaniesStringFilter`
     :   The type of the None singleton.
 
+<a id="CompaniesLikeCondition"></a>
+
 `CompaniesLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -332,6 +368,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.hubspot.types.CompaniesStringFilter`
     :   The type of the None singleton.
+
+<a id="CompaniesListParams"></a>
 
 `CompaniesListParams(*args, **kwargs)`
 :   Parameters for companies.list operation
@@ -360,6 +398,8 @@ Classes
     `properties_with_history: str`
     :   The type of the None singleton.
 
+<a id="CompaniesLtCondition"></a>
+
 `CompaniesLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -371,6 +411,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.hubspot.types.CompaniesSearchFilter`
     :   The type of the None singleton.
+
+<a id="CompaniesLteCondition"></a>
 
 `CompaniesLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -384,6 +426,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.hubspot.types.CompaniesSearchFilter`
     :   The type of the None singleton.
 
+<a id="CompaniesNeqCondition"></a>
+
 `CompaniesNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -395,6 +439,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.hubspot.types.CompaniesSearchFilter`
     :   The type of the None singleton.
+
+<a id="CompaniesNotCondition"></a>
 
 `CompaniesNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -416,6 +462,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.hubspot.types.CompaniesEqCondition | airbyte_agent_sdk.connectors.hubspot.types.CompaniesNeqCondition | airbyte_agent_sdk.connectors.hubspot.types.CompaniesGtCondition | airbyte_agent_sdk.connectors.hubspot.types.CompaniesGteCondition | airbyte_agent_sdk.connectors.hubspot.types.CompaniesLtCondition | airbyte_agent_sdk.connectors.hubspot.types.CompaniesLteCondition | airbyte_agent_sdk.connectors.hubspot.types.CompaniesInCondition | airbyte_agent_sdk.connectors.hubspot.types.CompaniesLikeCondition | airbyte_agent_sdk.connectors.hubspot.types.CompaniesFuzzyCondition | airbyte_agent_sdk.connectors.hubspot.types.CompaniesKeywordCondition | airbyte_agent_sdk.connectors.hubspot.types.CompaniesContainsCondition | airbyte_agent_sdk.connectors.hubspot.types.CompaniesNotCondition | airbyte_agent_sdk.connectors.hubspot.types.CompaniesAndCondition | airbyte_agent_sdk.connectors.hubspot.types.CompaniesOrCondition | airbyte_agent_sdk.connectors.hubspot.types.CompaniesAnyCondition`
     :   The type of the None singleton.
 
+<a id="CompaniesOrCondition"></a>
+
 `CompaniesOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -435,6 +483,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.hubspot.types.CompaniesEqCondition | airbyte_agent_sdk.connectors.hubspot.types.CompaniesNeqCondition | airbyte_agent_sdk.connectors.hubspot.types.CompaniesGtCondition | airbyte_agent_sdk.connectors.hubspot.types.CompaniesGteCondition | airbyte_agent_sdk.connectors.hubspot.types.CompaniesLtCondition | airbyte_agent_sdk.connectors.hubspot.types.CompaniesLteCondition | airbyte_agent_sdk.connectors.hubspot.types.CompaniesInCondition | airbyte_agent_sdk.connectors.hubspot.types.CompaniesLikeCondition | airbyte_agent_sdk.connectors.hubspot.types.CompaniesFuzzyCondition | airbyte_agent_sdk.connectors.hubspot.types.CompaniesKeywordCondition | airbyte_agent_sdk.connectors.hubspot.types.CompaniesContainsCondition | airbyte_agent_sdk.connectors.hubspot.types.CompaniesNotCondition | airbyte_agent_sdk.connectors.hubspot.types.CompaniesAndCondition | airbyte_agent_sdk.connectors.hubspot.types.CompaniesOrCondition | airbyte_agent_sdk.connectors.hubspot.types.CompaniesAnyCondition]`
     :   The type of the None singleton.
+
+<a id="CompaniesSearchFilter"></a>
 
 `CompaniesSearchFilter(*args, **kwargs)`
 :   Available fields for filtering companies search queries.
@@ -463,6 +513,8 @@ Classes
     `updated_at: str | None`
     :   Timestamp when the company record was last modified
 
+<a id="CompaniesSearchQuery"></a>
+
 `CompaniesSearchQuery(*args, **kwargs)`
 :   Search query for companies entity.
 
@@ -477,6 +529,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.hubspot.types.CompaniesSortFilter]`
     :   The type of the None singleton.
+
+<a id="CompaniesSortFilter"></a>
 
 `CompaniesSortFilter(*args, **kwargs)`
 :   Available fields for sorting companies search results.
@@ -505,6 +559,8 @@ Classes
     `updated_at: Literal['asc', 'desc']`
     :   Timestamp when the company record was last modified
 
+<a id="CompaniesStringFilter"></a>
+
 `CompaniesStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -532,6 +588,8 @@ Classes
     `updated_at: str`
     :   Timestamp when the company record was last modified
 
+<a id="ContactsAndCondition"></a>
+
 `ContactsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -552,6 +610,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.hubspot.types.ContactsEqCondition | airbyte_agent_sdk.connectors.hubspot.types.ContactsNeqCondition | airbyte_agent_sdk.connectors.hubspot.types.ContactsGtCondition | airbyte_agent_sdk.connectors.hubspot.types.ContactsGteCondition | airbyte_agent_sdk.connectors.hubspot.types.ContactsLtCondition | airbyte_agent_sdk.connectors.hubspot.types.ContactsLteCondition | airbyte_agent_sdk.connectors.hubspot.types.ContactsInCondition | airbyte_agent_sdk.connectors.hubspot.types.ContactsLikeCondition | airbyte_agent_sdk.connectors.hubspot.types.ContactsFuzzyCondition | airbyte_agent_sdk.connectors.hubspot.types.ContactsKeywordCondition | airbyte_agent_sdk.connectors.hubspot.types.ContactsContainsCondition | airbyte_agent_sdk.connectors.hubspot.types.ContactsNotCondition | airbyte_agent_sdk.connectors.hubspot.types.ContactsAndCondition | airbyte_agent_sdk.connectors.hubspot.types.ContactsOrCondition | airbyte_agent_sdk.connectors.hubspot.types.ContactsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="ContactsAnyCondition"></a>
+
 `ContactsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -571,6 +631,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.hubspot.types.ContactsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="ContactsAnyValueFilter"></a>
 
 `ContactsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -599,6 +661,8 @@ Classes
     `updated_at: Any`
     :   Timestamp indicating when the contact record was last modified.
 
+<a id="ContactsApiSearchParams"></a>
+
 `ContactsApiSearchParams(*args, **kwargs)`
 :   Parameters for contacts.api_search operation
 
@@ -626,6 +690,8 @@ Classes
     `sorts: list[airbyte_agent_sdk.connectors.hubspot.types.ContactsApiSearchParamsSortsItem]`
     :   The type of the None singleton.
 
+<a id="ContactsApiSearchParamsFiltergroupsItem"></a>
+
 `ContactsApiSearchParamsFiltergroupsItem(*args, **kwargs)`
 :   Nested schema for ContactsApiSearchParams.filterGroups_item
 
@@ -637,6 +703,8 @@ Classes
 
     `filters: list[airbyte_agent_sdk.connectors.hubspot.types.ContactsApiSearchParamsFiltergroupsItemFiltersItem]`
     :   The type of the None singleton.
+
+<a id="ContactsApiSearchParamsFiltergroupsItemFiltersItem"></a>
 
 `ContactsApiSearchParamsFiltergroupsItemFiltersItem(*args, **kwargs)`
 :   Nested schema for ContactsApiSearchParamsFiltergroupsItem.filters_item
@@ -661,6 +729,8 @@ Classes
     `values(self, /) ‑> list[str]`
     :   Return an object providing a view on the dict's values.
 
+<a id="ContactsApiSearchParamsSortsItem"></a>
+
 `ContactsApiSearchParamsSortsItem(*args, **kwargs)`
 :   Nested schema for ContactsApiSearchParams.sorts_item
 
@@ -676,6 +746,8 @@ Classes
     `propertyName: str`
     :   The type of the None singleton.
 
+<a id="ContactsContainsCondition"></a>
+
 `ContactsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -687,6 +759,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.hubspot.types.ContactsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="ContactsEqCondition"></a>
 
 `ContactsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -700,6 +774,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.hubspot.types.ContactsSearchFilter`
     :   The type of the None singleton.
 
+<a id="ContactsFuzzyCondition"></a>
+
 `ContactsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -711,6 +787,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.hubspot.types.ContactsStringFilter`
     :   The type of the None singleton.
+
+<a id="ContactsGetParams"></a>
 
 `ContactsGetParams(*args, **kwargs)`
 :   Parameters for contacts.get operation
@@ -739,6 +817,8 @@ Classes
     `properties_with_history: str`
     :   The type of the None singleton.
 
+<a id="ContactsGtCondition"></a>
+
 `ContactsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -751,6 +831,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.hubspot.types.ContactsSearchFilter`
     :   The type of the None singleton.
 
+<a id="ContactsGteCondition"></a>
+
 `ContactsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -762,6 +844,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.hubspot.types.ContactsSearchFilter`
     :   The type of the None singleton.
+
+<a id="ContactsInCondition"></a>
 
 `ContactsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -782,6 +866,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.hubspot.types.ContactsInFilter`
     :   The type of the None singleton.
+
+<a id="ContactsInFilter"></a>
 
 `ContactsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -810,6 +896,8 @@ Classes
     `updated_at: list[str]`
     :   Timestamp indicating when the contact record was last modified.
 
+<a id="ContactsKeywordCondition"></a>
+
 `ContactsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -822,6 +910,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.hubspot.types.ContactsStringFilter`
     :   The type of the None singleton.
 
+<a id="ContactsLikeCondition"></a>
+
 `ContactsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -833,6 +923,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.hubspot.types.ContactsStringFilter`
     :   The type of the None singleton.
+
+<a id="ContactsListParams"></a>
 
 `ContactsListParams(*args, **kwargs)`
 :   Parameters for contacts.list operation
@@ -861,6 +953,8 @@ Classes
     `properties_with_history: str`
     :   The type of the None singleton.
 
+<a id="ContactsLtCondition"></a>
+
 `ContactsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -872,6 +966,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.hubspot.types.ContactsSearchFilter`
     :   The type of the None singleton.
+
+<a id="ContactsLteCondition"></a>
 
 `ContactsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -885,6 +981,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.hubspot.types.ContactsSearchFilter`
     :   The type of the None singleton.
 
+<a id="ContactsNeqCondition"></a>
+
 `ContactsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -896,6 +994,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.hubspot.types.ContactsSearchFilter`
     :   The type of the None singleton.
+
+<a id="ContactsNotCondition"></a>
 
 `ContactsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -917,6 +1017,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.hubspot.types.ContactsEqCondition | airbyte_agent_sdk.connectors.hubspot.types.ContactsNeqCondition | airbyte_agent_sdk.connectors.hubspot.types.ContactsGtCondition | airbyte_agent_sdk.connectors.hubspot.types.ContactsGteCondition | airbyte_agent_sdk.connectors.hubspot.types.ContactsLtCondition | airbyte_agent_sdk.connectors.hubspot.types.ContactsLteCondition | airbyte_agent_sdk.connectors.hubspot.types.ContactsInCondition | airbyte_agent_sdk.connectors.hubspot.types.ContactsLikeCondition | airbyte_agent_sdk.connectors.hubspot.types.ContactsFuzzyCondition | airbyte_agent_sdk.connectors.hubspot.types.ContactsKeywordCondition | airbyte_agent_sdk.connectors.hubspot.types.ContactsContainsCondition | airbyte_agent_sdk.connectors.hubspot.types.ContactsNotCondition | airbyte_agent_sdk.connectors.hubspot.types.ContactsAndCondition | airbyte_agent_sdk.connectors.hubspot.types.ContactsOrCondition | airbyte_agent_sdk.connectors.hubspot.types.ContactsAnyCondition`
     :   The type of the None singleton.
 
+<a id="ContactsOrCondition"></a>
+
 `ContactsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -936,6 +1038,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.hubspot.types.ContactsEqCondition | airbyte_agent_sdk.connectors.hubspot.types.ContactsNeqCondition | airbyte_agent_sdk.connectors.hubspot.types.ContactsGtCondition | airbyte_agent_sdk.connectors.hubspot.types.ContactsGteCondition | airbyte_agent_sdk.connectors.hubspot.types.ContactsLtCondition | airbyte_agent_sdk.connectors.hubspot.types.ContactsLteCondition | airbyte_agent_sdk.connectors.hubspot.types.ContactsInCondition | airbyte_agent_sdk.connectors.hubspot.types.ContactsLikeCondition | airbyte_agent_sdk.connectors.hubspot.types.ContactsFuzzyCondition | airbyte_agent_sdk.connectors.hubspot.types.ContactsKeywordCondition | airbyte_agent_sdk.connectors.hubspot.types.ContactsContainsCondition | airbyte_agent_sdk.connectors.hubspot.types.ContactsNotCondition | airbyte_agent_sdk.connectors.hubspot.types.ContactsAndCondition | airbyte_agent_sdk.connectors.hubspot.types.ContactsOrCondition | airbyte_agent_sdk.connectors.hubspot.types.ContactsAnyCondition]`
     :   The type of the None singleton.
+
+<a id="ContactsSearchFilter"></a>
 
 `ContactsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering contacts search queries.
@@ -964,6 +1068,8 @@ Classes
     `updated_at: str | None`
     :   Timestamp indicating when the contact record was last modified.
 
+<a id="ContactsSearchQuery"></a>
+
 `ContactsSearchQuery(*args, **kwargs)`
 :   Search query for contacts entity.
 
@@ -978,6 +1084,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.hubspot.types.ContactsSortFilter]`
     :   The type of the None singleton.
+
+<a id="ContactsSortFilter"></a>
 
 `ContactsSortFilter(*args, **kwargs)`
 :   Available fields for sorting contacts search results.
@@ -1006,6 +1114,8 @@ Classes
     `updated_at: Literal['asc', 'desc']`
     :   Timestamp indicating when the contact record was last modified.
 
+<a id="ContactsStringFilter"></a>
+
 `ContactsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -1033,6 +1143,8 @@ Classes
     `updated_at: str`
     :   Timestamp indicating when the contact record was last modified.
 
+<a id="DealsAndCondition"></a>
+
 `DealsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1053,6 +1165,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.hubspot.types.DealsEqCondition | airbyte_agent_sdk.connectors.hubspot.types.DealsNeqCondition | airbyte_agent_sdk.connectors.hubspot.types.DealsGtCondition | airbyte_agent_sdk.connectors.hubspot.types.DealsGteCondition | airbyte_agent_sdk.connectors.hubspot.types.DealsLtCondition | airbyte_agent_sdk.connectors.hubspot.types.DealsLteCondition | airbyte_agent_sdk.connectors.hubspot.types.DealsInCondition | airbyte_agent_sdk.connectors.hubspot.types.DealsLikeCondition | airbyte_agent_sdk.connectors.hubspot.types.DealsFuzzyCondition | airbyte_agent_sdk.connectors.hubspot.types.DealsKeywordCondition | airbyte_agent_sdk.connectors.hubspot.types.DealsContainsCondition | airbyte_agent_sdk.connectors.hubspot.types.DealsNotCondition | airbyte_agent_sdk.connectors.hubspot.types.DealsAndCondition | airbyte_agent_sdk.connectors.hubspot.types.DealsOrCondition | airbyte_agent_sdk.connectors.hubspot.types.DealsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="DealsAnyCondition"></a>
+
 `DealsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1072,6 +1186,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.hubspot.types.DealsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="DealsAnyValueFilter"></a>
 
 `DealsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -1106,6 +1222,8 @@ Classes
     `updated_at: Any`
     :   Timestamp when the deal record was last modified
 
+<a id="DealsApiSearchParams"></a>
+
 `DealsApiSearchParams(*args, **kwargs)`
 :   Parameters for deals.api_search operation
 
@@ -1133,6 +1251,8 @@ Classes
     `sorts: list[airbyte_agent_sdk.connectors.hubspot.types.DealsApiSearchParamsSortsItem]`
     :   The type of the None singleton.
 
+<a id="DealsApiSearchParamsFiltergroupsItem"></a>
+
 `DealsApiSearchParamsFiltergroupsItem(*args, **kwargs)`
 :   Nested schema for DealsApiSearchParams.filterGroups_item
 
@@ -1144,6 +1264,8 @@ Classes
 
     `filters: list[airbyte_agent_sdk.connectors.hubspot.types.DealsApiSearchParamsFiltergroupsItemFiltersItem]`
     :   The type of the None singleton.
+
+<a id="DealsApiSearchParamsFiltergroupsItemFiltersItem"></a>
 
 `DealsApiSearchParamsFiltergroupsItemFiltersItem(*args, **kwargs)`
 :   Nested schema for DealsApiSearchParamsFiltergroupsItem.filters_item
@@ -1168,6 +1290,8 @@ Classes
     `values(self, /) ‑> list[str]`
     :   Return an object providing a view on the dict's values.
 
+<a id="DealsApiSearchParamsSortsItem"></a>
+
 `DealsApiSearchParamsSortsItem(*args, **kwargs)`
 :   Nested schema for DealsApiSearchParams.sorts_item
 
@@ -1183,6 +1307,8 @@ Classes
     `propertyName: str`
     :   The type of the None singleton.
 
+<a id="DealsContainsCondition"></a>
+
 `DealsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -1194,6 +1320,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.hubspot.types.DealsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="DealsEqCondition"></a>
 
 `DealsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -1207,6 +1335,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.hubspot.types.DealsSearchFilter`
     :   The type of the None singleton.
 
+<a id="DealsFuzzyCondition"></a>
+
 `DealsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -1218,6 +1348,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.hubspot.types.DealsStringFilter`
     :   The type of the None singleton.
+
+<a id="DealsGetParams"></a>
 
 `DealsGetParams(*args, **kwargs)`
 :   Parameters for deals.get operation
@@ -1246,6 +1378,8 @@ Classes
     `properties_with_history: str`
     :   The type of the None singleton.
 
+<a id="DealsGtCondition"></a>
+
 `DealsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -1258,6 +1392,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.hubspot.types.DealsSearchFilter`
     :   The type of the None singleton.
 
+<a id="DealsGteCondition"></a>
+
 `DealsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -1269,6 +1405,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.hubspot.types.DealsSearchFilter`
     :   The type of the None singleton.
+
+<a id="DealsInCondition"></a>
 
 `DealsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -1289,6 +1427,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.hubspot.types.DealsInFilter`
     :   The type of the None singleton.
+
+<a id="DealsInFilter"></a>
 
 `DealsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -1323,6 +1463,8 @@ Classes
     `updated_at: list[str]`
     :   Timestamp when the deal record was last modified
 
+<a id="DealsKeywordCondition"></a>
+
 `DealsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -1335,6 +1477,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.hubspot.types.DealsStringFilter`
     :   The type of the None singleton.
 
+<a id="DealsLikeCondition"></a>
+
 `DealsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -1346,6 +1490,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.hubspot.types.DealsStringFilter`
     :   The type of the None singleton.
+
+<a id="DealsListParams"></a>
 
 `DealsListParams(*args, **kwargs)`
 :   Parameters for deals.list operation
@@ -1374,6 +1520,8 @@ Classes
     `properties_with_history: str`
     :   The type of the None singleton.
 
+<a id="DealsLtCondition"></a>
+
 `DealsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -1385,6 +1533,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.hubspot.types.DealsSearchFilter`
     :   The type of the None singleton.
+
+<a id="DealsLteCondition"></a>
 
 `DealsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -1398,6 +1548,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.hubspot.types.DealsSearchFilter`
     :   The type of the None singleton.
 
+<a id="DealsNeqCondition"></a>
+
 `DealsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -1409,6 +1561,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.hubspot.types.DealsSearchFilter`
     :   The type of the None singleton.
+
+<a id="DealsNotCondition"></a>
 
 `DealsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -1430,6 +1584,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.hubspot.types.DealsEqCondition | airbyte_agent_sdk.connectors.hubspot.types.DealsNeqCondition | airbyte_agent_sdk.connectors.hubspot.types.DealsGtCondition | airbyte_agent_sdk.connectors.hubspot.types.DealsGteCondition | airbyte_agent_sdk.connectors.hubspot.types.DealsLtCondition | airbyte_agent_sdk.connectors.hubspot.types.DealsLteCondition | airbyte_agent_sdk.connectors.hubspot.types.DealsInCondition | airbyte_agent_sdk.connectors.hubspot.types.DealsLikeCondition | airbyte_agent_sdk.connectors.hubspot.types.DealsFuzzyCondition | airbyte_agent_sdk.connectors.hubspot.types.DealsKeywordCondition | airbyte_agent_sdk.connectors.hubspot.types.DealsContainsCondition | airbyte_agent_sdk.connectors.hubspot.types.DealsNotCondition | airbyte_agent_sdk.connectors.hubspot.types.DealsAndCondition | airbyte_agent_sdk.connectors.hubspot.types.DealsOrCondition | airbyte_agent_sdk.connectors.hubspot.types.DealsAnyCondition`
     :   The type of the None singleton.
 
+<a id="DealsOrCondition"></a>
+
 `DealsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1449,6 +1605,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.hubspot.types.DealsEqCondition | airbyte_agent_sdk.connectors.hubspot.types.DealsNeqCondition | airbyte_agent_sdk.connectors.hubspot.types.DealsGtCondition | airbyte_agent_sdk.connectors.hubspot.types.DealsGteCondition | airbyte_agent_sdk.connectors.hubspot.types.DealsLtCondition | airbyte_agent_sdk.connectors.hubspot.types.DealsLteCondition | airbyte_agent_sdk.connectors.hubspot.types.DealsInCondition | airbyte_agent_sdk.connectors.hubspot.types.DealsLikeCondition | airbyte_agent_sdk.connectors.hubspot.types.DealsFuzzyCondition | airbyte_agent_sdk.connectors.hubspot.types.DealsKeywordCondition | airbyte_agent_sdk.connectors.hubspot.types.DealsContainsCondition | airbyte_agent_sdk.connectors.hubspot.types.DealsNotCondition | airbyte_agent_sdk.connectors.hubspot.types.DealsAndCondition | airbyte_agent_sdk.connectors.hubspot.types.DealsOrCondition | airbyte_agent_sdk.connectors.hubspot.types.DealsAnyCondition]`
     :   The type of the None singleton.
+
+<a id="DealsSearchFilter"></a>
 
 `DealsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering deals search queries.
@@ -1483,6 +1641,8 @@ Classes
     `updated_at: str | None`
     :   Timestamp when the deal record was last modified
 
+<a id="DealsSearchQuery"></a>
+
 `DealsSearchQuery(*args, **kwargs)`
 :   Search query for deals entity.
 
@@ -1497,6 +1657,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.hubspot.types.DealsSortFilter]`
     :   The type of the None singleton.
+
+<a id="DealsSortFilter"></a>
 
 `DealsSortFilter(*args, **kwargs)`
 :   Available fields for sorting deals search results.
@@ -1531,6 +1693,8 @@ Classes
     `updated_at: Literal['asc', 'desc']`
     :   Timestamp when the deal record was last modified
 
+<a id="DealsStringFilter"></a>
+
 `DealsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -1564,6 +1728,8 @@ Classes
     `updated_at: str`
     :   Timestamp when the deal record was last modified
 
+<a id="ObjectsGetParams"></a>
+
 `ObjectsGetParams(*args, **kwargs)`
 :   Parameters for objects.get operation
 
@@ -1593,6 +1759,8 @@ Classes
 
     `properties_with_history: str`
     :   The type of the None singleton.
+
+<a id="ObjectsListParams"></a>
 
 `ObjectsListParams(*args, **kwargs)`
 :   Parameters for objects.list operation
@@ -1624,6 +1792,8 @@ Classes
     `properties_with_history: str`
     :   The type of the None singleton.
 
+<a id="SchemasGetParams"></a>
+
 `SchemasGetParams(*args, **kwargs)`
 :   Parameters for schemas.get operation
 
@@ -1636,6 +1806,8 @@ Classes
     `object_type: str`
     :   The type of the None singleton.
 
+<a id="SchemasListParams"></a>
+
 `SchemasListParams(*args, **kwargs)`
 :   Parameters for schemas.list operation
 
@@ -1647,6 +1819,8 @@ Classes
 
     `archived: bool`
     :   The type of the None singleton.
+
+<a id="TicketsApiSearchParams"></a>
 
 `TicketsApiSearchParams(*args, **kwargs)`
 :   Parameters for tickets.api_search operation
@@ -1675,6 +1849,8 @@ Classes
     `sorts: list[airbyte_agent_sdk.connectors.hubspot.types.TicketsApiSearchParamsSortsItem]`
     :   The type of the None singleton.
 
+<a id="TicketsApiSearchParamsFiltergroupsItem"></a>
+
 `TicketsApiSearchParamsFiltergroupsItem(*args, **kwargs)`
 :   Nested schema for TicketsApiSearchParams.filterGroups_item
 
@@ -1686,6 +1862,8 @@ Classes
 
     `filters: list[airbyte_agent_sdk.connectors.hubspot.types.TicketsApiSearchParamsFiltergroupsItemFiltersItem]`
     :   The type of the None singleton.
+
+<a id="TicketsApiSearchParamsFiltergroupsItemFiltersItem"></a>
 
 `TicketsApiSearchParamsFiltergroupsItemFiltersItem(*args, **kwargs)`
 :   Nested schema for TicketsApiSearchParamsFiltergroupsItem.filters_item
@@ -1710,6 +1888,8 @@ Classes
     `values(self, /) ‑> list[str]`
     :   Return an object providing a view on the dict's values.
 
+<a id="TicketsApiSearchParamsSortsItem"></a>
+
 `TicketsApiSearchParamsSortsItem(*args, **kwargs)`
 :   Nested schema for TicketsApiSearchParams.sorts_item
 
@@ -1724,6 +1904,8 @@ Classes
 
     `propertyName: str`
     :   The type of the None singleton.
+
+<a id="TicketsGetParams"></a>
 
 `TicketsGetParams(*args, **kwargs)`
 :   Parameters for tickets.get operation
@@ -1751,6 +1933,8 @@ Classes
 
     `ticket_id: str`
     :   The type of the None singleton.
+
+<a id="TicketsListParams"></a>
 
 `TicketsListParams(*args, **kwargs)`
 :   Parameters for tickets.list operation

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/incident_io/connector.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/incident_io/connector.md
@@ -10,6 +10,8 @@ Incident-Io connector.
 Classes
 -------
 
+<a id="AlertsQuery"></a>
+
 `AlertsQuery(connector: IncidentIoConnector)`
 :   Query class for Alerts entity operations.
     
@@ -70,6 +72,8 @@ Classes
         
         Returns:
             AlertsListResult
+
+<a id="CatalogTypesQuery"></a>
 
 `CatalogTypesQuery(connector: IncidentIoConnector)`
 :   Query class for CatalogTypes entity operations.
@@ -133,6 +137,8 @@ Classes
         Returns:
             CatalogTypesListResult
 
+<a id="CustomFieldsQuery"></a>
+
 `CustomFieldsQuery(connector: IncidentIoConnector)`
 :   Query class for CustomFields entity operations.
     
@@ -183,6 +189,8 @@ Classes
         
         Returns:
             CustomFieldsListResult
+
+<a id="EscalationsQuery"></a>
 
 `EscalationsQuery(connector: IncidentIoConnector)`
 :   Query class for Escalations entity operations.
@@ -244,6 +252,8 @@ Classes
         
         Returns:
             EscalationsListResult
+
+<a id="IncidentIoConnector"></a>
 
 `IncidentIoConnector(auth_config: IncidentIoAuthConfig | AirbyteAuthConfig | BaseModel | None = None, on_token_refresh: Any | None = None)`
 :   Type-safe Incident-Io API connector.
@@ -433,6 +443,8 @@ Classes
             for entity in entities:
                 print(f"\{entity['entity_name']\}: \{entity['available_actions']\}")
 
+<a id="IncidentRolesQuery"></a>
+
 `IncidentRolesQuery(connector: IncidentIoConnector)`
 :   Query class for IncidentRoles entity operations.
     
@@ -487,6 +499,8 @@ Classes
         Returns:
             IncidentRolesListResult
 
+<a id="IncidentStatusesQuery"></a>
+
 `IncidentStatusesQuery(connector: IncidentIoConnector)`
 :   Query class for IncidentStatuses entity operations.
     
@@ -539,6 +553,8 @@ Classes
         Returns:
             IncidentStatusesListResult
 
+<a id="IncidentTimestampsQuery"></a>
+
 `IncidentTimestampsQuery(connector: IncidentIoConnector)`
 :   Query class for IncidentTimestamps entity operations.
     
@@ -587,6 +603,8 @@ Classes
         Returns:
             IncidentTimestampsListResult
 
+<a id="IncidentUpdatesQuery"></a>
+
 `IncidentUpdatesQuery(connector: IncidentIoConnector)`
 :   Query class for IncidentUpdates entity operations.
     
@@ -633,6 +651,8 @@ Classes
         
         Returns:
             IncidentUpdatesListResult
+
+<a id="IncidentsQuery"></a>
 
 `IncidentsQuery(connector: IncidentIoConnector)`
 :   Query class for Incidents entity operations.
@@ -709,6 +729,8 @@ Classes
         Returns:
             IncidentsListResult
 
+<a id="SchedulesQuery"></a>
+
 `SchedulesQuery(connector: IncidentIoConnector)`
 :   Query class for Schedules entity operations.
     
@@ -767,6 +789,8 @@ Classes
         Returns:
             SchedulesListResult
 
+<a id="SeveritiesQuery"></a>
+
 `SeveritiesQuery(connector: IncidentIoConnector)`
 :   Query class for Severities entity operations.
     
@@ -817,6 +841,8 @@ Classes
         
         Returns:
             SeveritiesListResult
+
+<a id="UsersQuery"></a>
 
 `UsersQuery(connector: IncidentIoConnector)`
 :   Query class for Users entity operations.

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/incident_io/index.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/incident_io/index.md
@@ -19,6 +19,8 @@ Sub-modules
 Classes
 -------
 
+<a id="AirbyteAuthConfig"></a>
+
 `AirbyteAuthConfig(**data: Any)`
 :   Authentication configuration for Airbyte hosted mode execution.
     
@@ -87,6 +89,8 @@ Classes
     `workspace_name: str | None`
     :   The type of the None singleton.
 
+<a id="AirbyteSearchMeta"></a>
+
 `AirbyteSearchMeta(**data: Any)`
 :   Pagination metadata for search responses.
     
@@ -114,6 +118,8 @@ Classes
 
     `took_ms: int | None`
     :   Time taken to execute the search in milliseconds.
+
+<a id="AirbyteSearchResult"></a>
 
 `AirbyteSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -156,6 +162,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="AlertsSearchResult"></a>
+
 `AlertsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -171,6 +179,8 @@ Classes
     * airbyte_agent_sdk.connectors.incident_io.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="CatalogTypesSearchResult"></a>
 
 `CatalogTypesSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -188,6 +198,8 @@ Classes
     * pydantic.main.BaseModel
     * typing.Generic
 
+<a id="CustomFieldsSearchResult"></a>
+
 `CustomFieldsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -203,6 +215,8 @@ Classes
     * airbyte_agent_sdk.connectors.incident_io.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="EscalationsSearchResult"></a>
 
 `EscalationsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -220,6 +234,8 @@ Classes
     * pydantic.main.BaseModel
     * typing.Generic
 
+<a id="IncidentRolesSearchResult"></a>
+
 `IncidentRolesSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -235,6 +251,8 @@ Classes
     * airbyte_agent_sdk.connectors.incident_io.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="IncidentStatusesSearchResult"></a>
 
 `IncidentStatusesSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -252,6 +270,8 @@ Classes
     * pydantic.main.BaseModel
     * typing.Generic
 
+<a id="IncidentTimestampsSearchResult"></a>
+
 `IncidentTimestampsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -267,6 +287,8 @@ Classes
     * airbyte_agent_sdk.connectors.incident_io.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="IncidentUpdatesSearchResult"></a>
 
 `IncidentUpdatesSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -284,6 +306,8 @@ Classes
     * pydantic.main.BaseModel
     * typing.Generic
 
+<a id="IncidentsSearchResult"></a>
+
 `IncidentsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -299,6 +323,8 @@ Classes
     * airbyte_agent_sdk.connectors.incident_io.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="SchedulesSearchResult"></a>
 
 `SchedulesSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -316,6 +342,8 @@ Classes
     * pydantic.main.BaseModel
     * typing.Generic
 
+<a id="SeveritiesSearchResult"></a>
+
 `SeveritiesSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -332,6 +360,8 @@ Classes
     * pydantic.main.BaseModel
     * typing.Generic
 
+<a id="UsersSearchResult"></a>
+
 `UsersSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -347,6 +377,8 @@ Classes
     * airbyte_agent_sdk.connectors.incident_io.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="AlertsSearchData"></a>
 
 `AlertsSearchData(**data: Any)`
 :   Search result data for alerts entity.
@@ -399,6 +431,8 @@ Classes
 
     `updated_at: str | None`
     :   When the alert was last updated
+
+<a id="CatalogTypesSearchData"></a>
 
 `CatalogTypesSearchData(**data: Any)`
 :   Search result data for catalog_types entity.
@@ -470,6 +504,8 @@ Classes
     `updated_at: str | None`
     :   When the catalog type was last updated
 
+<a id="CustomFieldsSearchData"></a>
+
 `CustomFieldsSearchData(**data: Any)`
 :   Search result data for custom_fields entity.
     
@@ -506,6 +542,8 @@ Classes
 
     `updated_at: str | None`
     :   When the custom field was last updated
+
+<a id="EscalationsSearchData"></a>
 
 `EscalationsSearchData(**data: Any)`
 :   Search result data for escalations entity.
@@ -559,6 +597,8 @@ Classes
     `updated_at: str | None`
     :   When the escalation was last updated
 
+<a id="IncidentIoAuthConfig"></a>
+
 `IncidentIoAuthConfig(**data: Any)`
 :   API Key Authentication
     
@@ -580,6 +620,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="IncidentIoConnector"></a>
 
 `IncidentIoConnector(auth_config: IncidentIoAuthConfig | AirbyteAuthConfig | BaseModel | None = None, on_token_refresh: Any | None = None)`
 :   Type-safe Incident-Io API connector.
@@ -769,6 +811,8 @@ Classes
             for entity in entities:
                 print(f"\{entity['entity_name']\}: \{entity['available_actions']\}")
 
+<a id="IncidentRolesSearchData"></a>
+
 `IncidentRolesSearchData(**data: Any)`
 :   Search result data for incident_roles entity.
     
@@ -815,6 +859,8 @@ Classes
     `updated_at: str | None`
     :   When the role was last updated
 
+<a id="IncidentStatusesSearchData"></a>
+
 `IncidentStatusesSearchData(**data: Any)`
 :   Search result data for incident_statuses entity.
     
@@ -855,6 +901,8 @@ Classes
     `updated_at: str | None`
     :   When the status was last updated
 
+<a id="IncidentTimestampsSearchData"></a>
+
 `IncidentTimestampsSearchData(**data: Any)`
 :   Search result data for incident_timestamps entity.
     
@@ -882,6 +930,8 @@ Classes
 
     `rank: float | None`
     :   Rank for ordering
+
+<a id="IncidentUpdatesSearchData"></a>
 
 `IncidentUpdatesSearchData(**data: Any)`
 :   Search result data for incident_updates entity.
@@ -922,6 +972,8 @@ Classes
 
     `updater: dict[str, typing.Any] | None`
     :   Who made this update
+
+<a id="IncidentsSearchData"></a>
 
 `IncidentsSearchData(**data: Any)`
 :   Search result data for incidents entity.
@@ -1017,6 +1069,8 @@ Classes
     `workload_minutes_working: float | None`
     :   Minutes of workload classified as working
 
+<a id="SchedulesSearchData"></a>
+
 `SchedulesSearchData(**data: Any)`
 :   Search result data for schedules entity.
     
@@ -1060,6 +1114,8 @@ Classes
     `updated_at: str | None`
     :   When the schedule was last updated
 
+<a id="SeveritiesSearchData"></a>
+
 `SeveritiesSearchData(**data: Any)`
 :   Search result data for severities entity.
     
@@ -1096,6 +1152,8 @@ Classes
 
     `updated_at: str | None`
     :   When the severity was last updated
+
+<a id="UsersSearchData"></a>
 
 `UsersSearchData(**data: Any)`
 :   Search result data for users entity.

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/incident_io/models.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/incident_io/models.md
@@ -13,6 +13,8 @@ and response envelope types.
 Classes
 -------
 
+<a id="AirbyteSearchMeta"></a>
+
 `AirbyteSearchMeta(**data: Any)`
 :   Pagination metadata for search responses.
     
@@ -40,6 +42,8 @@ Classes
 
     `took_ms: int | None`
     :   Time taken to execute the search in milliseconds.
+
+<a id="AirbyteSearchResult"></a>
 
 `AirbyteSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -103,6 +107,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="AlertsSearchResult"></a>
+
 `AlertsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -139,6 +145,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="CatalogTypesSearchResult"></a>
 
 `CatalogTypesSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -177,6 +185,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="CustomFieldsSearchResult"></a>
+
 `CustomFieldsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -213,6 +223,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="EscalationsSearchResult"></a>
 
 `EscalationsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -251,6 +263,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="IncidentRolesSearchResult"></a>
+
 `IncidentRolesSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -287,6 +301,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="IncidentStatusesSearchResult"></a>
 
 `IncidentStatusesSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -325,6 +341,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="IncidentTimestampsSearchResult"></a>
+
 `IncidentTimestampsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -361,6 +379,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="IncidentUpdatesSearchResult"></a>
 
 `IncidentUpdatesSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -399,6 +419,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="IncidentsSearchResult"></a>
+
 `IncidentsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -435,6 +457,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="SchedulesSearchResult"></a>
 
 `SchedulesSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -473,6 +497,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="SeveritiesSearchResult"></a>
+
 `SeveritiesSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -510,6 +536,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="UsersSearchResult"></a>
+
 `UsersSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -525,6 +553,8 @@ Classes
     * airbyte_agent_sdk.connectors.incident_io.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="Alert"></a>
 
 `Alert(**data: Any)`
 :   An alert ingested from an alert source
@@ -578,6 +608,8 @@ Classes
     `updated_at: str | Any | None`
     :   The type of the None singleton.
 
+<a id="AlertAttributesItem"></a>
+
 `AlertAttributesItem(**data: Any)`
 :   Nested schema for Alert.attributes_item
     
@@ -602,6 +634,8 @@ Classes
 
     `value: airbyte_agent_sdk.connectors.incident_io.models.AlertAttributesItemValue | Any | None`
     :   The type of the None singleton.
+
+<a id="AlertAttributesItemAttribute"></a>
 
 `AlertAttributesItemAttribute(**data: Any)`
 :   Nested schema for AlertAttributesItem.attribute
@@ -634,6 +668,8 @@ Classes
     `type_: str | Any | None`
     :   The type of the None singleton.
 
+<a id="AlertAttributesItemValue"></a>
+
 `AlertAttributesItemValue(**data: Any)`
 :   Nested schema for AlertAttributesItem.value
     
@@ -661,6 +697,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="AlertAttributesItemValueCatalogEntry"></a>
 
 `AlertAttributesItemValueCatalogEntry(**data: Any)`
 :   Nested schema for AlertAttributesItemValue.catalog_entry
@@ -690,6 +728,8 @@ Classes
     `name: str | Any | None`
     :   The type of the None singleton.
 
+<a id="AlertsListResultMeta"></a>
+
 `AlertsListResultMeta(**data: Any)`
 :   Metadata for alerts.Action.LIST operation
     
@@ -711,6 +751,8 @@ Classes
 
     `next_cursor: str | Any | None`
     :   The type of the None singleton.
+
+<a id="AlertsSearchData"></a>
 
 `AlertsSearchData(**data: Any)`
 :   Search result data for alerts entity.
@@ -763,6 +805,8 @@ Classes
 
     `updated_at: str | None`
     :   When the alert was last updated
+
+<a id="CatalogType"></a>
 
 `CatalogType(**data: Any)`
 :   A catalog type defining a category of catalog entries
@@ -834,6 +878,8 @@ Classes
     `updated_at: str | Any | None`
     :   The type of the None singleton.
 
+<a id="CatalogTypeSchema"></a>
+
 `CatalogTypeSchema(**data: Any)`
 :   Schema definition for the catalog type
     
@@ -858,6 +904,8 @@ Classes
 
     `version: float | Any | None`
     :   The type of the None singleton.
+
+<a id="CatalogTypeSchemaAttributesItem"></a>
 
 `CatalogTypeSchemaAttributesItem(**data: Any)`
 :   Nested schema for CatalogTypeSchema.attributes_item
@@ -892,6 +940,8 @@ Classes
 
     `type_: str | Any | None`
     :   The type of the None singleton.
+
+<a id="CatalogTypesSearchData"></a>
 
 `CatalogTypesSearchData(**data: Any)`
 :   Search result data for catalog_types entity.
@@ -963,6 +1013,8 @@ Classes
     `updated_at: str | None`
     :   When the catalog type was last updated
 
+<a id="CustomField"></a>
+
 `CustomField(**data: Any)`
 :   A custom field definition for incidents
     
@@ -1003,6 +1055,8 @@ Classes
     `updated_at: str | Any | None`
     :   The type of the None singleton.
 
+<a id="CustomFieldsSearchData"></a>
+
 `CustomFieldsSearchData(**data: Any)`
 :   Search result data for custom_fields entity.
     
@@ -1039,6 +1093,8 @@ Classes
 
     `updated_at: str | None`
     :   When the custom field was last updated
+
+<a id="Escalation"></a>
 
 `Escalation(**data: Any)`
 :   An escalation that pages people via escalation paths
@@ -1092,6 +1148,8 @@ Classes
     `updated_at: str | Any | None`
     :   The type of the None singleton.
 
+<a id="EscalationCreator"></a>
+
 `EscalationCreator(**data: Any)`
 :   The creator of this escalation
     
@@ -1120,6 +1178,8 @@ Classes
     `workflow: airbyte_agent_sdk.connectors.incident_io.models.EscalationCreatorWorkflow | Any | None`
     :   The type of the None singleton.
 
+<a id="EscalationCreatorAlert"></a>
+
 `EscalationCreatorAlert(**data: Any)`
 :   Nested schema for EscalationCreator.alert
     
@@ -1144,6 +1204,8 @@ Classes
 
     `title: str | Any | None`
     :   The type of the None singleton.
+
+<a id="EscalationCreatorUser"></a>
 
 `EscalationCreatorUser(**data: Any)`
 :   Nested schema for EscalationCreator.user
@@ -1179,6 +1241,8 @@ Classes
     `slack_user_id: str | Any | None`
     :   The type of the None singleton.
 
+<a id="EscalationCreatorWorkflow"></a>
+
 `EscalationCreatorWorkflow(**data: Any)`
 :   Nested schema for EscalationCreator.workflow
     
@@ -1203,6 +1267,8 @@ Classes
 
     `name: str | Any | None`
     :   The type of the None singleton.
+
+<a id="EscalationEventsItem"></a>
 
 `EscalationEventsItem(**data: Any)`
 :   Nested schema for Escalation.events_item
@@ -1241,6 +1307,8 @@ Classes
     `users: list[airbyte_agent_sdk.connectors.incident_io.models.EscalationEventsItemUsersItem] | Any | None`
     :   The type of the None singleton.
 
+<a id="EscalationEventsItemChannelsItem"></a>
+
 `EscalationEventsItemChannelsItem(**data: Any)`
 :   Nested schema for EscalationEventsItem.channels_item
     
@@ -1271,6 +1339,8 @@ Classes
 
     `slack_team_id: str | Any | None`
     :   The type of the None singleton.
+
+<a id="EscalationEventsItemUsersItem"></a>
 
 `EscalationEventsItemUsersItem(**data: Any)`
 :   Nested schema for EscalationEventsItem.users_item
@@ -1306,6 +1376,8 @@ Classes
     `slack_user_id: str | Any | None`
     :   The type of the None singleton.
 
+<a id="EscalationPriority"></a>
+
 `EscalationPriority(**data: Any)`
 :   Priority of the escalation
     
@@ -1327,6 +1399,8 @@ Classes
 
     `name: str | Any | None`
     :   The type of the None singleton.
+
+<a id="EscalationRelatedAlertsItem"></a>
 
 `EscalationRelatedAlertsItem(**data: Any)`
 :   Nested schema for Escalation.related_alerts_item
@@ -1377,6 +1451,8 @@ Classes
     `updated_at: str | Any | None`
     :   The type of the None singleton.
 
+<a id="EscalationRelatedIncidentsItem"></a>
+
 `EscalationRelatedIncidentsItem(**data: Any)`
 :   Nested schema for Escalation.related_incidents_item
     
@@ -1417,6 +1493,8 @@ Classes
     `visibility: str | Any | None`
     :   The type of the None singleton.
 
+<a id="EscalationsListResultMeta"></a>
+
 `EscalationsListResultMeta(**data: Any)`
 :   Metadata for escalations.Action.LIST operation
     
@@ -1438,6 +1516,8 @@ Classes
 
     `next_cursor: str | Any | None`
     :   The type of the None singleton.
+
+<a id="EscalationsSearchData"></a>
 
 `EscalationsSearchData(**data: Any)`
 :   Search result data for escalations entity.
@@ -1490,6 +1570,8 @@ Classes
 
     `updated_at: str | None`
     :   When the escalation was last updated
+
+<a id="Incident"></a>
 
 `Incident(**data: Any)`
 :   An incident tracked in incident.io
@@ -1588,6 +1670,8 @@ Classes
     `workload_minutes_working: float | Any | None`
     :   The type of the None singleton.
 
+<a id="IncidentCreator"></a>
+
 `IncidentCreator(**data: Any)`
 :   The user who created the incident
     
@@ -1609,6 +1693,8 @@ Classes
 
     `user: airbyte_agent_sdk.connectors.incident_io.models.IncidentCreatorUser | Any | None`
     :   The type of the None singleton.
+
+<a id="IncidentCreatorUser"></a>
 
 `IncidentCreatorUser(**data: Any)`
 :   Nested schema for IncidentCreator.user
@@ -1644,6 +1730,8 @@ Classes
     `slack_user_id: str | Any | None`
     :   The type of the None singleton.
 
+<a id="IncidentCustomFieldEntriesItem"></a>
+
 `IncidentCustomFieldEntriesItem(**data: Any)`
 :   Nested schema for Incident.custom_field_entries_item
     
@@ -1668,6 +1756,8 @@ Classes
 
     `values: list[typing.Any] | Any | None`
     :   The type of the None singleton.
+
+<a id="IncidentCustomFieldEntriesItemCustomField"></a>
 
 `IncidentCustomFieldEntriesItemCustomField(**data: Any)`
 :   Nested schema for IncidentCustomFieldEntriesItem.custom_field
@@ -1703,6 +1793,8 @@ Classes
     `options: list[typing.Any] | Any | None`
     :   The type of the None singleton.
 
+<a id="IncidentDurationMetricsItem"></a>
+
 `IncidentDurationMetricsItem(**data: Any)`
 :   Nested schema for Incident.duration_metrics_item
     
@@ -1724,6 +1816,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="IncidentDurationMetricsItemDurationMetric"></a>
 
 `IncidentDurationMetricsItemDurationMetric(**data: Any)`
 :   Nested schema for IncidentDurationMetricsItem.duration_metric
@@ -1750,6 +1844,8 @@ Classes
     `name: str | Any | None`
     :   The type of the None singleton.
 
+<a id="IncidentIncidentRoleAssignmentsItem"></a>
+
 `IncidentIncidentRoleAssignmentsItem(**data: Any)`
 :   Nested schema for Incident.incident_role_assignments_item
     
@@ -1774,6 +1870,8 @@ Classes
 
     `role: airbyte_agent_sdk.connectors.incident_io.models.IncidentIncidentRoleAssignmentsItemRole | Any | None`
     :   The type of the None singleton.
+
+<a id="IncidentIncidentRoleAssignmentsItemAssignee"></a>
 
 `IncidentIncidentRoleAssignmentsItemAssignee(**data: Any)`
 :   Nested schema for IncidentIncidentRoleAssignmentsItem.assignee
@@ -1808,6 +1906,8 @@ Classes
 
     `slack_user_id: str | Any | None`
     :   The type of the None singleton.
+
+<a id="IncidentIncidentRoleAssignmentsItemRole"></a>
 
 `IncidentIncidentRoleAssignmentsItemRole(**data: Any)`
 :   Nested schema for IncidentIncidentRoleAssignmentsItem.role
@@ -1855,6 +1955,8 @@ Classes
     `updated_at: str | Any | None`
     :   The type of the None singleton.
 
+<a id="IncidentIncidentStatus"></a>
+
 `IncidentIncidentStatus(**data: Any)`
 :   Current status of the incident
     
@@ -1895,6 +1997,8 @@ Classes
     `updated_at: str | Any | None`
     :   The type of the None singleton.
 
+<a id="IncidentIncidentTimestampValuesItem"></a>
+
 `IncidentIncidentTimestampValuesItem(**data: Any)`
 :   Nested schema for Incident.incident_timestamp_values_item
     
@@ -1919,6 +2023,8 @@ Classes
 
     `value: airbyte_agent_sdk.connectors.incident_io.models.IncidentIncidentTimestampValuesItemValue | Any | None`
     :   The type of the None singleton.
+
+<a id="IncidentIncidentTimestampValuesItemIncidentTimestamp"></a>
 
 `IncidentIncidentTimestampValuesItemIncidentTimestamp(**data: Any)`
 :   Nested schema for IncidentIncidentTimestampValuesItem.incident_timestamp
@@ -1948,6 +2054,8 @@ Classes
     `rank: float | Any | None`
     :   The type of the None singleton.
 
+<a id="IncidentIncidentTimestampValuesItemValue"></a>
+
 `IncidentIncidentTimestampValuesItemValue(**data: Any)`
 :   Nested schema for IncidentIncidentTimestampValuesItem.value
     
@@ -1969,6 +2077,8 @@ Classes
 
     `value: str | Any | None`
     :   The type of the None singleton.
+
+<a id="IncidentIncidentType"></a>
 
 `IncidentIncidentType(**data: Any)`
 :   Type of the incident
@@ -2013,6 +2123,8 @@ Classes
     `updated_at: str | Any | None`
     :   The type of the None singleton.
 
+<a id="IncidentIoAuthConfig"></a>
+
 `IncidentIoAuthConfig(**data: Any)`
 :   API Key Authentication
     
@@ -2034,6 +2146,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="IncidentIoCheckResult"></a>
 
 `IncidentIoCheckResult(**data: Any)`
 :   Result of a health check operation.
@@ -2067,6 +2181,8 @@ Classes
 
     `status: str`
     :   Health check status: 'healthy' or 'unhealthy'.
+
+<a id="IncidentIoExecuteResult"></a>
 
 `IncidentIoExecuteResult(**data: Any)`
 :   Response envelope with data only.
@@ -2102,6 +2218,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="IncidentIoExecuteResultWithMeta"></a>
 
 `IncidentIoExecuteResultWithMeta(**data: Any)`
 :   Response envelope with data and metadata.
@@ -2159,6 +2277,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="AlertsListResult"></a>
+
 `AlertsListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -2201,6 +2321,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="EscalationsListResult"></a>
 
 `EscalationsListResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -2245,6 +2367,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="IncidentUpdatesListResult"></a>
+
 `IncidentUpdatesListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -2287,6 +2411,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="IncidentsListResult"></a>
 
 `IncidentsListResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -2331,6 +2457,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="SchedulesListResult"></a>
+
 `SchedulesListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -2374,6 +2502,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="UsersListResult"></a>
+
 `UsersListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -2416,6 +2546,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="CatalogTypesListResult"></a>
+
 `CatalogTypesListResult(**data: Any)`
 :   Response envelope with data only.
     
@@ -2456,6 +2588,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="CustomFieldsListResult"></a>
 
 `CustomFieldsListResult(**data: Any)`
 :   Response envelope with data only.
@@ -2498,6 +2632,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="IncidentRolesListResult"></a>
+
 `IncidentRolesListResult(**data: Any)`
 :   Response envelope with data only.
     
@@ -2538,6 +2674,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="IncidentStatusesListResult"></a>
 
 `IncidentStatusesListResult(**data: Any)`
 :   Response envelope with data only.
@@ -2580,6 +2718,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="IncidentTimestampsListResult"></a>
+
 `IncidentTimestampsListResult(**data: Any)`
 :   Response envelope with data only.
     
@@ -2621,6 +2761,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="SeveritiesListResult"></a>
+
 `SeveritiesListResult(**data: Any)`
 :   Response envelope with data only.
     
@@ -2638,6 +2780,8 @@ Classes
     * airbyte_agent_sdk.connectors.incident_io.models.IncidentIoExecuteResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="IncidentRole"></a>
 
 `IncidentRole(**data: Any)`
 :   A role that can be assigned during an incident
@@ -2685,6 +2829,8 @@ Classes
     `updated_at: str | Any | None`
     :   The type of the None singleton.
 
+<a id="IncidentRolesSearchData"></a>
+
 `IncidentRolesSearchData(**data: Any)`
 :   Search result data for incident_roles entity.
     
@@ -2731,6 +2877,8 @@ Classes
     `updated_at: str | None`
     :   When the role was last updated
 
+<a id="IncidentSeverity"></a>
+
 `IncidentSeverity(**data: Any)`
 :   Severity of the incident
     
@@ -2767,6 +2915,8 @@ Classes
 
     `updated_at: str | Any | None`
     :   The type of the None singleton.
+
+<a id="IncidentStatus"></a>
 
 `IncidentStatus(**data: Any)`
 :   A status that an incident can be in
@@ -2808,6 +2958,8 @@ Classes
     `updated_at: str | Any | None`
     :   The type of the None singleton.
 
+<a id="IncidentStatusesSearchData"></a>
+
 `IncidentStatusesSearchData(**data: Any)`
 :   Search result data for incident_statuses entity.
     
@@ -2848,6 +3000,8 @@ Classes
     `updated_at: str | None`
     :   When the status was last updated
 
+<a id="IncidentTimestamp"></a>
+
 `IncidentTimestamp(**data: Any)`
 :   A timestamp definition for incidents
     
@@ -2876,6 +3030,8 @@ Classes
     `rank: float | Any | None`
     :   The type of the None singleton.
 
+<a id="IncidentTimestampsSearchData"></a>
+
 `IncidentTimestampsSearchData(**data: Any)`
 :   Search result data for incident_timestamps entity.
     
@@ -2903,6 +3059,8 @@ Classes
 
     `rank: float | None`
     :   Rank for ordering
+
+<a id="IncidentUpdate"></a>
 
 `IncidentUpdate(**data: Any)`
 :   An update posted to an incident
@@ -2944,6 +3102,8 @@ Classes
     `updater: airbyte_agent_sdk.connectors.incident_io.models.IncidentUpdateUpdater | Any | None`
     :   The type of the None singleton.
 
+<a id="IncidentUpdateNewIncidentStatus"></a>
+
 `IncidentUpdateNewIncidentStatus(**data: Any)`
 :   New incident status set by this update
     
@@ -2984,6 +3144,8 @@ Classes
     `updated_at: str | Any | None`
     :   The type of the None singleton.
 
+<a id="IncidentUpdateNewSeverity"></a>
+
 `IncidentUpdateNewSeverity(**data: Any)`
 :   New severity set by this update
     
@@ -3021,6 +3183,8 @@ Classes
     `updated_at: str | Any | None`
     :   The type of the None singleton.
 
+<a id="IncidentUpdateUpdater"></a>
+
 `IncidentUpdateUpdater(**data: Any)`
 :   Who made this update
     
@@ -3042,6 +3206,8 @@ Classes
 
     `user: airbyte_agent_sdk.connectors.incident_io.models.IncidentUpdateUpdaterUser | Any | None`
     :   The type of the None singleton.
+
+<a id="IncidentUpdateUpdaterUser"></a>
 
 `IncidentUpdateUpdaterUser(**data: Any)`
 :   Nested schema for IncidentUpdateUpdater.user
@@ -3077,6 +3243,8 @@ Classes
     `slack_user_id: str | Any | None`
     :   The type of the None singleton.
 
+<a id="IncidentUpdatesListResultMeta"></a>
+
 `IncidentUpdatesListResultMeta(**data: Any)`
 :   Metadata for incident_updates.Action.LIST operation
     
@@ -3098,6 +3266,8 @@ Classes
 
     `next_cursor: str | Any | None`
     :   The type of the None singleton.
+
+<a id="IncidentUpdatesSearchData"></a>
 
 `IncidentUpdatesSearchData(**data: Any)`
 :   Search result data for incident_updates entity.
@@ -3139,6 +3309,8 @@ Classes
     `updater: dict[str, typing.Any] | None`
     :   Who made this update
 
+<a id="IncidentsListResultMeta"></a>
+
 `IncidentsListResultMeta(**data: Any)`
 :   Metadata for incidents.Action.LIST operation
     
@@ -3160,6 +3332,8 @@ Classes
 
     `next_cursor: str | Any | None`
     :   The type of the None singleton.
+
+<a id="IncidentsSearchData"></a>
 
 `IncidentsSearchData(**data: Any)`
 :   Search result data for incidents entity.
@@ -3255,6 +3429,8 @@ Classes
     `workload_minutes_working: float | None`
     :   Minutes of workload classified as working
 
+<a id="PaginationMeta"></a>
+
 `PaginationMeta(**data: Any)`
 :   Cursor-based pagination metadata
     
@@ -3279,6 +3455,8 @@ Classes
 
     `page_size: int | Any | None`
     :   The type of the None singleton.
+
+<a id="Schedule"></a>
 
 `Schedule(**data: Any)`
 :   An on-call schedule
@@ -3329,6 +3507,8 @@ Classes
     `updated_at: str | Any | None`
     :   The type of the None singleton.
 
+<a id="ScheduleConfig"></a>
+
 `ScheduleConfig(**data: Any)`
 :   Schedule configuration with rotations
     
@@ -3350,6 +3530,8 @@ Classes
 
     `rotations: list[airbyte_agent_sdk.connectors.incident_io.models.ScheduleConfigRotationsItem] | Any | None`
     :   The type of the None singleton.
+
+<a id="ScheduleConfigRotationsItem"></a>
 
 `ScheduleConfigRotationsItem(**data: Any)`
 :   Nested schema for ScheduleConfig.rotations_item
@@ -3385,6 +3567,8 @@ Classes
     `name: str | Any | None`
     :   The type of the None singleton.
 
+<a id="ScheduleConfigRotationsItemHandoversItem"></a>
+
 `ScheduleConfigRotationsItemHandoversItem(**data: Any)`
 :   Nested schema for ScheduleConfigRotationsItem.handovers_item
     
@@ -3410,6 +3594,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="ScheduleConfigRotationsItemLayersItem"></a>
+
 `ScheduleConfigRotationsItemLayersItem(**data: Any)`
 :   Nested schema for ScheduleConfigRotationsItem.layers_item
     
@@ -3434,6 +3620,8 @@ Classes
 
     `name: str | Any | None`
     :   The type of the None singleton.
+
+<a id="ScheduleCurrentShiftsItem"></a>
 
 `ScheduleCurrentShiftsItem(**data: Any)`
 :   Nested schema for Schedule.current_shifts_item
@@ -3466,6 +3654,8 @@ Classes
     `start_at: str | Any | None`
     :   The type of the None singleton.
 
+<a id="SchedulesListResultMeta"></a>
+
 `SchedulesListResultMeta(**data: Any)`
 :   Metadata for schedules.Action.LIST operation
     
@@ -3487,6 +3677,8 @@ Classes
 
     `next_cursor: str | Any | None`
     :   The type of the None singleton.
+
+<a id="SchedulesSearchData"></a>
 
 `SchedulesSearchData(**data: Any)`
 :   Search result data for schedules entity.
@@ -3531,6 +3723,8 @@ Classes
     `updated_at: str | None`
     :   When the schedule was last updated
 
+<a id="SeveritiesSearchData"></a>
+
 `SeveritiesSearchData(**data: Any)`
 :   Search result data for severities entity.
     
@@ -3568,6 +3762,8 @@ Classes
     `updated_at: str | None`
     :   When the severity was last updated
 
+<a id="Severity"></a>
+
 `Severity(**data: Any)`
 :   A severity level for incidents
     
@@ -3604,6 +3800,8 @@ Classes
 
     `updated_at: str | Any | None`
     :   The type of the None singleton.
+
+<a id="User"></a>
 
 `User(**data: Any)`
 :   A user in the incident.io organisation
@@ -3645,6 +3843,8 @@ Classes
     `slack_user_id: str | Any | None`
     :   The type of the None singleton.
 
+<a id="UserBaseRole"></a>
+
 `UserBaseRole(**data: Any)`
 :   Base role assigned to the user
     
@@ -3676,6 +3876,8 @@ Classes
     `slug: str | Any | None`
     :   The type of the None singleton.
 
+<a id="UsersListResultMeta"></a>
+
 `UsersListResultMeta(**data: Any)`
 :   Metadata for users.Action.LIST operation
     
@@ -3697,6 +3899,8 @@ Classes
 
     `next_cursor: str | Any | None`
     :   The type of the None singleton.
+
+<a id="UsersSearchData"></a>
 
 `UsersSearchData(**data: Any)`
 :   Search result data for users entity.

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/incident_io/types.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/incident_io/types.md
@@ -10,6 +10,8 @@ Type definitions for incident-io connector.
 Classes
 -------
 
+<a id="AirbyteSearchParams"></a>
+
 `AirbyteSearchParams(*args, **kwargs)`
 :   Parameters for Airbyte cache search operations (generic, use entity-specific query types for better type hints).
 
@@ -31,6 +33,8 @@ Classes
     `query: dict[str, typing.Any]`
     :   The type of the None singleton.
 
+<a id="AlertsAndCondition"></a>
+
 `AlertsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -51,6 +55,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.incident_io.types.AlertsEqCondition | airbyte_agent_sdk.connectors.incident_io.types.AlertsNeqCondition | airbyte_agent_sdk.connectors.incident_io.types.AlertsGtCondition | airbyte_agent_sdk.connectors.incident_io.types.AlertsGteCondition | airbyte_agent_sdk.connectors.incident_io.types.AlertsLtCondition | airbyte_agent_sdk.connectors.incident_io.types.AlertsLteCondition | airbyte_agent_sdk.connectors.incident_io.types.AlertsInCondition | airbyte_agent_sdk.connectors.incident_io.types.AlertsLikeCondition | airbyte_agent_sdk.connectors.incident_io.types.AlertsFuzzyCondition | airbyte_agent_sdk.connectors.incident_io.types.AlertsKeywordCondition | airbyte_agent_sdk.connectors.incident_io.types.AlertsContainsCondition | airbyte_agent_sdk.connectors.incident_io.types.AlertsNotCondition | airbyte_agent_sdk.connectors.incident_io.types.AlertsAndCondition | airbyte_agent_sdk.connectors.incident_io.types.AlertsOrCondition | airbyte_agent_sdk.connectors.incident_io.types.AlertsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="AlertsAnyCondition"></a>
+
 `AlertsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -70,6 +76,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.incident_io.types.AlertsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="AlertsAnyValueFilter"></a>
 
 `AlertsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -113,6 +121,8 @@ Classes
     `updated_at: Any`
     :   When the alert was last updated
 
+<a id="AlertsContainsCondition"></a>
+
 `AlertsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -124,6 +134,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.incident_io.types.AlertsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="AlertsEqCondition"></a>
 
 `AlertsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -137,6 +149,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.incident_io.types.AlertsSearchFilter`
     :   The type of the None singleton.
 
+<a id="AlertsFuzzyCondition"></a>
+
 `AlertsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -148,6 +162,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.incident_io.types.AlertsStringFilter`
     :   The type of the None singleton.
+
+<a id="AlertsGetParams"></a>
 
 `AlertsGetParams(*args, **kwargs)`
 :   Parameters for alerts.get operation
@@ -161,6 +177,8 @@ Classes
     `id: str`
     :   The type of the None singleton.
 
+<a id="AlertsGtCondition"></a>
+
 `AlertsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -173,6 +191,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.incident_io.types.AlertsSearchFilter`
     :   The type of the None singleton.
 
+<a id="AlertsGteCondition"></a>
+
 `AlertsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -184,6 +204,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.incident_io.types.AlertsSearchFilter`
     :   The type of the None singleton.
+
+<a id="AlertsInCondition"></a>
 
 `AlertsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -204,6 +226,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.incident_io.types.AlertsInFilter`
     :   The type of the None singleton.
+
+<a id="AlertsInFilter"></a>
 
 `AlertsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -247,6 +271,8 @@ Classes
     `updated_at: list[str]`
     :   When the alert was last updated
 
+<a id="AlertsKeywordCondition"></a>
+
 `AlertsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -259,6 +285,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.incident_io.types.AlertsStringFilter`
     :   The type of the None singleton.
 
+<a id="AlertsLikeCondition"></a>
+
 `AlertsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -270,6 +298,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.incident_io.types.AlertsStringFilter`
     :   The type of the None singleton.
+
+<a id="AlertsListParams"></a>
 
 `AlertsListParams(*args, **kwargs)`
 :   Parameters for alerts.list operation
@@ -286,6 +316,8 @@ Classes
     `page_size: int`
     :   The type of the None singleton.
 
+<a id="AlertsLtCondition"></a>
+
 `AlertsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -297,6 +329,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.incident_io.types.AlertsSearchFilter`
     :   The type of the None singleton.
+
+<a id="AlertsLteCondition"></a>
 
 `AlertsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -310,6 +344,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.incident_io.types.AlertsSearchFilter`
     :   The type of the None singleton.
 
+<a id="AlertsNeqCondition"></a>
+
 `AlertsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -321,6 +357,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.incident_io.types.AlertsSearchFilter`
     :   The type of the None singleton.
+
+<a id="AlertsNotCondition"></a>
 
 `AlertsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -342,6 +380,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.incident_io.types.AlertsEqCondition | airbyte_agent_sdk.connectors.incident_io.types.AlertsNeqCondition | airbyte_agent_sdk.connectors.incident_io.types.AlertsGtCondition | airbyte_agent_sdk.connectors.incident_io.types.AlertsGteCondition | airbyte_agent_sdk.connectors.incident_io.types.AlertsLtCondition | airbyte_agent_sdk.connectors.incident_io.types.AlertsLteCondition | airbyte_agent_sdk.connectors.incident_io.types.AlertsInCondition | airbyte_agent_sdk.connectors.incident_io.types.AlertsLikeCondition | airbyte_agent_sdk.connectors.incident_io.types.AlertsFuzzyCondition | airbyte_agent_sdk.connectors.incident_io.types.AlertsKeywordCondition | airbyte_agent_sdk.connectors.incident_io.types.AlertsContainsCondition | airbyte_agent_sdk.connectors.incident_io.types.AlertsNotCondition | airbyte_agent_sdk.connectors.incident_io.types.AlertsAndCondition | airbyte_agent_sdk.connectors.incident_io.types.AlertsOrCondition | airbyte_agent_sdk.connectors.incident_io.types.AlertsAnyCondition`
     :   The type of the None singleton.
 
+<a id="AlertsOrCondition"></a>
+
 `AlertsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -361,6 +401,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.incident_io.types.AlertsEqCondition | airbyte_agent_sdk.connectors.incident_io.types.AlertsNeqCondition | airbyte_agent_sdk.connectors.incident_io.types.AlertsGtCondition | airbyte_agent_sdk.connectors.incident_io.types.AlertsGteCondition | airbyte_agent_sdk.connectors.incident_io.types.AlertsLtCondition | airbyte_agent_sdk.connectors.incident_io.types.AlertsLteCondition | airbyte_agent_sdk.connectors.incident_io.types.AlertsInCondition | airbyte_agent_sdk.connectors.incident_io.types.AlertsLikeCondition | airbyte_agent_sdk.connectors.incident_io.types.AlertsFuzzyCondition | airbyte_agent_sdk.connectors.incident_io.types.AlertsKeywordCondition | airbyte_agent_sdk.connectors.incident_io.types.AlertsContainsCondition | airbyte_agent_sdk.connectors.incident_io.types.AlertsNotCondition | airbyte_agent_sdk.connectors.incident_io.types.AlertsAndCondition | airbyte_agent_sdk.connectors.incident_io.types.AlertsOrCondition | airbyte_agent_sdk.connectors.incident_io.types.AlertsAnyCondition]`
     :   The type of the None singleton.
+
+<a id="AlertsSearchFilter"></a>
 
 `AlertsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering alerts search queries.
@@ -404,6 +446,8 @@ Classes
     `updated_at: str | None`
     :   When the alert was last updated
 
+<a id="AlertsSearchQuery"></a>
+
 `AlertsSearchQuery(*args, **kwargs)`
 :   Search query for alerts entity.
 
@@ -418,6 +462,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.incident_io.types.AlertsSortFilter]`
     :   The type of the None singleton.
+
+<a id="AlertsSortFilter"></a>
 
 `AlertsSortFilter(*args, **kwargs)`
 :   Available fields for sorting alerts search results.
@@ -461,6 +507,8 @@ Classes
     `updated_at: Literal['asc', 'desc']`
     :   When the alert was last updated
 
+<a id="AlertsStringFilter"></a>
+
 `AlertsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -503,6 +551,8 @@ Classes
     `updated_at: str`
     :   When the alert was last updated
 
+<a id="CatalogTypesAndCondition"></a>
+
 `CatalogTypesAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -523,6 +573,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.incident_io.types.CatalogTypesEqCondition | airbyte_agent_sdk.connectors.incident_io.types.CatalogTypesNeqCondition | airbyte_agent_sdk.connectors.incident_io.types.CatalogTypesGtCondition | airbyte_agent_sdk.connectors.incident_io.types.CatalogTypesGteCondition | airbyte_agent_sdk.connectors.incident_io.types.CatalogTypesLtCondition | airbyte_agent_sdk.connectors.incident_io.types.CatalogTypesLteCondition | airbyte_agent_sdk.connectors.incident_io.types.CatalogTypesInCondition | airbyte_agent_sdk.connectors.incident_io.types.CatalogTypesLikeCondition | airbyte_agent_sdk.connectors.incident_io.types.CatalogTypesFuzzyCondition | airbyte_agent_sdk.connectors.incident_io.types.CatalogTypesKeywordCondition | airbyte_agent_sdk.connectors.incident_io.types.CatalogTypesContainsCondition | airbyte_agent_sdk.connectors.incident_io.types.CatalogTypesNotCondition | airbyte_agent_sdk.connectors.incident_io.types.CatalogTypesAndCondition | airbyte_agent_sdk.connectors.incident_io.types.CatalogTypesOrCondition | airbyte_agent_sdk.connectors.incident_io.types.CatalogTypesAnyCondition]`
     :   The type of the None singleton.
 
+<a id="CatalogTypesAnyCondition"></a>
+
 `CatalogTypesAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -542,6 +594,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.incident_io.types.CatalogTypesAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="CatalogTypesAnyValueFilter"></a>
 
 `CatalogTypesAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -603,6 +657,8 @@ Classes
     `updated_at: Any`
     :   When the catalog type was last updated
 
+<a id="CatalogTypesContainsCondition"></a>
+
 `CatalogTypesContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -614,6 +670,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.incident_io.types.CatalogTypesAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="CatalogTypesEqCondition"></a>
 
 `CatalogTypesEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -627,6 +685,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.incident_io.types.CatalogTypesSearchFilter`
     :   The type of the None singleton.
 
+<a id="CatalogTypesFuzzyCondition"></a>
+
 `CatalogTypesFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -638,6 +698,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.incident_io.types.CatalogTypesStringFilter`
     :   The type of the None singleton.
+
+<a id="CatalogTypesGetParams"></a>
 
 `CatalogTypesGetParams(*args, **kwargs)`
 :   Parameters for catalog_types.get operation
@@ -651,6 +713,8 @@ Classes
     `id: str`
     :   The type of the None singleton.
 
+<a id="CatalogTypesGtCondition"></a>
+
 `CatalogTypesGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -663,6 +727,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.incident_io.types.CatalogTypesSearchFilter`
     :   The type of the None singleton.
 
+<a id="CatalogTypesGteCondition"></a>
+
 `CatalogTypesGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -674,6 +740,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.incident_io.types.CatalogTypesSearchFilter`
     :   The type of the None singleton.
+
+<a id="CatalogTypesInCondition"></a>
 
 `CatalogTypesInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -694,6 +762,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.incident_io.types.CatalogTypesInFilter`
     :   The type of the None singleton.
+
+<a id="CatalogTypesInFilter"></a>
 
 `CatalogTypesInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -755,6 +825,8 @@ Classes
     `updated_at: list[str]`
     :   When the catalog type was last updated
 
+<a id="CatalogTypesKeywordCondition"></a>
+
 `CatalogTypesKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -766,6 +838,8 @@ Classes
 
     `keyword: airbyte_agent_sdk.connectors.incident_io.types.CatalogTypesStringFilter`
     :   The type of the None singleton.
+
+<a id="CatalogTypesLikeCondition"></a>
 
 `CatalogTypesLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
@@ -779,12 +853,16 @@ Classes
     `like: airbyte_agent_sdk.connectors.incident_io.types.CatalogTypesStringFilter`
     :   The type of the None singleton.
 
+<a id="CatalogTypesListParams"></a>
+
 `CatalogTypesListParams(*args, **kwargs)`
 :   Parameters for catalog_types.list operation
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="CatalogTypesLtCondition"></a>
 
 `CatalogTypesLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
@@ -798,6 +876,8 @@ Classes
     `lt: airbyte_agent_sdk.connectors.incident_io.types.CatalogTypesSearchFilter`
     :   The type of the None singleton.
 
+<a id="CatalogTypesLteCondition"></a>
+
 `CatalogTypesLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
 
@@ -810,6 +890,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.incident_io.types.CatalogTypesSearchFilter`
     :   The type of the None singleton.
 
+<a id="CatalogTypesNeqCondition"></a>
+
 `CatalogTypesNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -821,6 +903,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.incident_io.types.CatalogTypesSearchFilter`
     :   The type of the None singleton.
+
+<a id="CatalogTypesNotCondition"></a>
 
 `CatalogTypesNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -842,6 +926,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.incident_io.types.CatalogTypesEqCondition | airbyte_agent_sdk.connectors.incident_io.types.CatalogTypesNeqCondition | airbyte_agent_sdk.connectors.incident_io.types.CatalogTypesGtCondition | airbyte_agent_sdk.connectors.incident_io.types.CatalogTypesGteCondition | airbyte_agent_sdk.connectors.incident_io.types.CatalogTypesLtCondition | airbyte_agent_sdk.connectors.incident_io.types.CatalogTypesLteCondition | airbyte_agent_sdk.connectors.incident_io.types.CatalogTypesInCondition | airbyte_agent_sdk.connectors.incident_io.types.CatalogTypesLikeCondition | airbyte_agent_sdk.connectors.incident_io.types.CatalogTypesFuzzyCondition | airbyte_agent_sdk.connectors.incident_io.types.CatalogTypesKeywordCondition | airbyte_agent_sdk.connectors.incident_io.types.CatalogTypesContainsCondition | airbyte_agent_sdk.connectors.incident_io.types.CatalogTypesNotCondition | airbyte_agent_sdk.connectors.incident_io.types.CatalogTypesAndCondition | airbyte_agent_sdk.connectors.incident_io.types.CatalogTypesOrCondition | airbyte_agent_sdk.connectors.incident_io.types.CatalogTypesAnyCondition`
     :   The type of the None singleton.
 
+<a id="CatalogTypesOrCondition"></a>
+
 `CatalogTypesOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -861,6 +947,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.incident_io.types.CatalogTypesEqCondition | airbyte_agent_sdk.connectors.incident_io.types.CatalogTypesNeqCondition | airbyte_agent_sdk.connectors.incident_io.types.CatalogTypesGtCondition | airbyte_agent_sdk.connectors.incident_io.types.CatalogTypesGteCondition | airbyte_agent_sdk.connectors.incident_io.types.CatalogTypesLtCondition | airbyte_agent_sdk.connectors.incident_io.types.CatalogTypesLteCondition | airbyte_agent_sdk.connectors.incident_io.types.CatalogTypesInCondition | airbyte_agent_sdk.connectors.incident_io.types.CatalogTypesLikeCondition | airbyte_agent_sdk.connectors.incident_io.types.CatalogTypesFuzzyCondition | airbyte_agent_sdk.connectors.incident_io.types.CatalogTypesKeywordCondition | airbyte_agent_sdk.connectors.incident_io.types.CatalogTypesContainsCondition | airbyte_agent_sdk.connectors.incident_io.types.CatalogTypesNotCondition | airbyte_agent_sdk.connectors.incident_io.types.CatalogTypesAndCondition | airbyte_agent_sdk.connectors.incident_io.types.CatalogTypesOrCondition | airbyte_agent_sdk.connectors.incident_io.types.CatalogTypesAnyCondition]`
     :   The type of the None singleton.
+
+<a id="CatalogTypesSearchFilter"></a>
 
 `CatalogTypesSearchFilter(*args, **kwargs)`
 :   Available fields for filtering catalog_types search queries.
@@ -922,6 +1010,8 @@ Classes
     `updated_at: str | None`
     :   When the catalog type was last updated
 
+<a id="CatalogTypesSearchQuery"></a>
+
 `CatalogTypesSearchQuery(*args, **kwargs)`
 :   Search query for catalog_types entity.
 
@@ -936,6 +1026,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.incident_io.types.CatalogTypesSortFilter]`
     :   The type of the None singleton.
+
+<a id="CatalogTypesSortFilter"></a>
 
 `CatalogTypesSortFilter(*args, **kwargs)`
 :   Available fields for sorting catalog_types search results.
@@ -997,6 +1089,8 @@ Classes
     `updated_at: Literal['asc', 'desc']`
     :   When the catalog type was last updated
 
+<a id="CatalogTypesStringFilter"></a>
+
 `CatalogTypesStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -1057,6 +1151,8 @@ Classes
     `updated_at: str`
     :   When the catalog type was last updated
 
+<a id="CustomFieldsAndCondition"></a>
+
 `CustomFieldsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1077,6 +1173,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.incident_io.types.CustomFieldsEqCondition | airbyte_agent_sdk.connectors.incident_io.types.CustomFieldsNeqCondition | airbyte_agent_sdk.connectors.incident_io.types.CustomFieldsGtCondition | airbyte_agent_sdk.connectors.incident_io.types.CustomFieldsGteCondition | airbyte_agent_sdk.connectors.incident_io.types.CustomFieldsLtCondition | airbyte_agent_sdk.connectors.incident_io.types.CustomFieldsLteCondition | airbyte_agent_sdk.connectors.incident_io.types.CustomFieldsInCondition | airbyte_agent_sdk.connectors.incident_io.types.CustomFieldsLikeCondition | airbyte_agent_sdk.connectors.incident_io.types.CustomFieldsFuzzyCondition | airbyte_agent_sdk.connectors.incident_io.types.CustomFieldsKeywordCondition | airbyte_agent_sdk.connectors.incident_io.types.CustomFieldsContainsCondition | airbyte_agent_sdk.connectors.incident_io.types.CustomFieldsNotCondition | airbyte_agent_sdk.connectors.incident_io.types.CustomFieldsAndCondition | airbyte_agent_sdk.connectors.incident_io.types.CustomFieldsOrCondition | airbyte_agent_sdk.connectors.incident_io.types.CustomFieldsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="CustomFieldsAnyCondition"></a>
+
 `CustomFieldsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1096,6 +1194,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.incident_io.types.CustomFieldsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="CustomFieldsAnyValueFilter"></a>
 
 `CustomFieldsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -1124,6 +1224,8 @@ Classes
     `updated_at: Any`
     :   When the custom field was last updated
 
+<a id="CustomFieldsContainsCondition"></a>
+
 `CustomFieldsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -1135,6 +1237,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.incident_io.types.CustomFieldsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="CustomFieldsEqCondition"></a>
 
 `CustomFieldsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -1148,6 +1252,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.incident_io.types.CustomFieldsSearchFilter`
     :   The type of the None singleton.
 
+<a id="CustomFieldsFuzzyCondition"></a>
+
 `CustomFieldsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -1159,6 +1265,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.incident_io.types.CustomFieldsStringFilter`
     :   The type of the None singleton.
+
+<a id="CustomFieldsGetParams"></a>
 
 `CustomFieldsGetParams(*args, **kwargs)`
 :   Parameters for custom_fields.get operation
@@ -1172,6 +1280,8 @@ Classes
     `id: str`
     :   The type of the None singleton.
 
+<a id="CustomFieldsGtCondition"></a>
+
 `CustomFieldsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -1184,6 +1294,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.incident_io.types.CustomFieldsSearchFilter`
     :   The type of the None singleton.
 
+<a id="CustomFieldsGteCondition"></a>
+
 `CustomFieldsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -1195,6 +1307,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.incident_io.types.CustomFieldsSearchFilter`
     :   The type of the None singleton.
+
+<a id="CustomFieldsInCondition"></a>
 
 `CustomFieldsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -1215,6 +1329,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.incident_io.types.CustomFieldsInFilter`
     :   The type of the None singleton.
+
+<a id="CustomFieldsInFilter"></a>
 
 `CustomFieldsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -1243,6 +1359,8 @@ Classes
     `updated_at: list[str]`
     :   When the custom field was last updated
 
+<a id="CustomFieldsKeywordCondition"></a>
+
 `CustomFieldsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -1254,6 +1372,8 @@ Classes
 
     `keyword: airbyte_agent_sdk.connectors.incident_io.types.CustomFieldsStringFilter`
     :   The type of the None singleton.
+
+<a id="CustomFieldsLikeCondition"></a>
 
 `CustomFieldsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
@@ -1267,12 +1387,16 @@ Classes
     `like: airbyte_agent_sdk.connectors.incident_io.types.CustomFieldsStringFilter`
     :   The type of the None singleton.
 
+<a id="CustomFieldsListParams"></a>
+
 `CustomFieldsListParams(*args, **kwargs)`
 :   Parameters for custom_fields.list operation
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="CustomFieldsLtCondition"></a>
 
 `CustomFieldsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
@@ -1286,6 +1410,8 @@ Classes
     `lt: airbyte_agent_sdk.connectors.incident_io.types.CustomFieldsSearchFilter`
     :   The type of the None singleton.
 
+<a id="CustomFieldsLteCondition"></a>
+
 `CustomFieldsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
 
@@ -1298,6 +1424,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.incident_io.types.CustomFieldsSearchFilter`
     :   The type of the None singleton.
 
+<a id="CustomFieldsNeqCondition"></a>
+
 `CustomFieldsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -1309,6 +1437,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.incident_io.types.CustomFieldsSearchFilter`
     :   The type of the None singleton.
+
+<a id="CustomFieldsNotCondition"></a>
 
 `CustomFieldsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -1330,6 +1460,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.incident_io.types.CustomFieldsEqCondition | airbyte_agent_sdk.connectors.incident_io.types.CustomFieldsNeqCondition | airbyte_agent_sdk.connectors.incident_io.types.CustomFieldsGtCondition | airbyte_agent_sdk.connectors.incident_io.types.CustomFieldsGteCondition | airbyte_agent_sdk.connectors.incident_io.types.CustomFieldsLtCondition | airbyte_agent_sdk.connectors.incident_io.types.CustomFieldsLteCondition | airbyte_agent_sdk.connectors.incident_io.types.CustomFieldsInCondition | airbyte_agent_sdk.connectors.incident_io.types.CustomFieldsLikeCondition | airbyte_agent_sdk.connectors.incident_io.types.CustomFieldsFuzzyCondition | airbyte_agent_sdk.connectors.incident_io.types.CustomFieldsKeywordCondition | airbyte_agent_sdk.connectors.incident_io.types.CustomFieldsContainsCondition | airbyte_agent_sdk.connectors.incident_io.types.CustomFieldsNotCondition | airbyte_agent_sdk.connectors.incident_io.types.CustomFieldsAndCondition | airbyte_agent_sdk.connectors.incident_io.types.CustomFieldsOrCondition | airbyte_agent_sdk.connectors.incident_io.types.CustomFieldsAnyCondition`
     :   The type of the None singleton.
 
+<a id="CustomFieldsOrCondition"></a>
+
 `CustomFieldsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1349,6 +1481,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.incident_io.types.CustomFieldsEqCondition | airbyte_agent_sdk.connectors.incident_io.types.CustomFieldsNeqCondition | airbyte_agent_sdk.connectors.incident_io.types.CustomFieldsGtCondition | airbyte_agent_sdk.connectors.incident_io.types.CustomFieldsGteCondition | airbyte_agent_sdk.connectors.incident_io.types.CustomFieldsLtCondition | airbyte_agent_sdk.connectors.incident_io.types.CustomFieldsLteCondition | airbyte_agent_sdk.connectors.incident_io.types.CustomFieldsInCondition | airbyte_agent_sdk.connectors.incident_io.types.CustomFieldsLikeCondition | airbyte_agent_sdk.connectors.incident_io.types.CustomFieldsFuzzyCondition | airbyte_agent_sdk.connectors.incident_io.types.CustomFieldsKeywordCondition | airbyte_agent_sdk.connectors.incident_io.types.CustomFieldsContainsCondition | airbyte_agent_sdk.connectors.incident_io.types.CustomFieldsNotCondition | airbyte_agent_sdk.connectors.incident_io.types.CustomFieldsAndCondition | airbyte_agent_sdk.connectors.incident_io.types.CustomFieldsOrCondition | airbyte_agent_sdk.connectors.incident_io.types.CustomFieldsAnyCondition]`
     :   The type of the None singleton.
+
+<a id="CustomFieldsSearchFilter"></a>
 
 `CustomFieldsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering custom_fields search queries.
@@ -1377,6 +1511,8 @@ Classes
     `updated_at: str | None`
     :   When the custom field was last updated
 
+<a id="CustomFieldsSearchQuery"></a>
+
 `CustomFieldsSearchQuery(*args, **kwargs)`
 :   Search query for custom_fields entity.
 
@@ -1391,6 +1527,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.incident_io.types.CustomFieldsSortFilter]`
     :   The type of the None singleton.
+
+<a id="CustomFieldsSortFilter"></a>
 
 `CustomFieldsSortFilter(*args, **kwargs)`
 :   Available fields for sorting custom_fields search results.
@@ -1419,6 +1557,8 @@ Classes
     `updated_at: Literal['asc', 'desc']`
     :   When the custom field was last updated
 
+<a id="CustomFieldsStringFilter"></a>
+
 `CustomFieldsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -1446,6 +1586,8 @@ Classes
     `updated_at: str`
     :   When the custom field was last updated
 
+<a id="EscalationsAndCondition"></a>
+
 `EscalationsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1466,6 +1608,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.incident_io.types.EscalationsEqCondition | airbyte_agent_sdk.connectors.incident_io.types.EscalationsNeqCondition | airbyte_agent_sdk.connectors.incident_io.types.EscalationsGtCondition | airbyte_agent_sdk.connectors.incident_io.types.EscalationsGteCondition | airbyte_agent_sdk.connectors.incident_io.types.EscalationsLtCondition | airbyte_agent_sdk.connectors.incident_io.types.EscalationsLteCondition | airbyte_agent_sdk.connectors.incident_io.types.EscalationsInCondition | airbyte_agent_sdk.connectors.incident_io.types.EscalationsLikeCondition | airbyte_agent_sdk.connectors.incident_io.types.EscalationsFuzzyCondition | airbyte_agent_sdk.connectors.incident_io.types.EscalationsKeywordCondition | airbyte_agent_sdk.connectors.incident_io.types.EscalationsContainsCondition | airbyte_agent_sdk.connectors.incident_io.types.EscalationsNotCondition | airbyte_agent_sdk.connectors.incident_io.types.EscalationsAndCondition | airbyte_agent_sdk.connectors.incident_io.types.EscalationsOrCondition | airbyte_agent_sdk.connectors.incident_io.types.EscalationsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="EscalationsAnyCondition"></a>
+
 `EscalationsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1485,6 +1629,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.incident_io.types.EscalationsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="EscalationsAnyValueFilter"></a>
 
 `EscalationsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -1528,6 +1674,8 @@ Classes
     `updated_at: Any`
     :   When the escalation was last updated
 
+<a id="EscalationsContainsCondition"></a>
+
 `EscalationsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -1539,6 +1687,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.incident_io.types.EscalationsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="EscalationsEqCondition"></a>
 
 `EscalationsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -1552,6 +1702,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.incident_io.types.EscalationsSearchFilter`
     :   The type of the None singleton.
 
+<a id="EscalationsFuzzyCondition"></a>
+
 `EscalationsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -1563,6 +1715,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.incident_io.types.EscalationsStringFilter`
     :   The type of the None singleton.
+
+<a id="EscalationsGetParams"></a>
 
 `EscalationsGetParams(*args, **kwargs)`
 :   Parameters for escalations.get operation
@@ -1576,6 +1730,8 @@ Classes
     `id: str`
     :   The type of the None singleton.
 
+<a id="EscalationsGtCondition"></a>
+
 `EscalationsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -1588,6 +1744,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.incident_io.types.EscalationsSearchFilter`
     :   The type of the None singleton.
 
+<a id="EscalationsGteCondition"></a>
+
 `EscalationsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -1599,6 +1757,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.incident_io.types.EscalationsSearchFilter`
     :   The type of the None singleton.
+
+<a id="EscalationsInCondition"></a>
 
 `EscalationsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -1619,6 +1779,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.incident_io.types.EscalationsInFilter`
     :   The type of the None singleton.
+
+<a id="EscalationsInFilter"></a>
 
 `EscalationsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -1662,6 +1824,8 @@ Classes
     `updated_at: list[str]`
     :   When the escalation was last updated
 
+<a id="EscalationsKeywordCondition"></a>
+
 `EscalationsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -1674,6 +1838,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.incident_io.types.EscalationsStringFilter`
     :   The type of the None singleton.
 
+<a id="EscalationsLikeCondition"></a>
+
 `EscalationsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -1685,6 +1851,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.incident_io.types.EscalationsStringFilter`
     :   The type of the None singleton.
+
+<a id="EscalationsListParams"></a>
 
 `EscalationsListParams(*args, **kwargs)`
 :   Parameters for escalations.list operation
@@ -1701,6 +1869,8 @@ Classes
     `page_size: int`
     :   The type of the None singleton.
 
+<a id="EscalationsLtCondition"></a>
+
 `EscalationsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -1712,6 +1882,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.incident_io.types.EscalationsSearchFilter`
     :   The type of the None singleton.
+
+<a id="EscalationsLteCondition"></a>
 
 `EscalationsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -1725,6 +1897,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.incident_io.types.EscalationsSearchFilter`
     :   The type of the None singleton.
 
+<a id="EscalationsNeqCondition"></a>
+
 `EscalationsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -1736,6 +1910,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.incident_io.types.EscalationsSearchFilter`
     :   The type of the None singleton.
+
+<a id="EscalationsNotCondition"></a>
 
 `EscalationsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -1757,6 +1933,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.incident_io.types.EscalationsEqCondition | airbyte_agent_sdk.connectors.incident_io.types.EscalationsNeqCondition | airbyte_agent_sdk.connectors.incident_io.types.EscalationsGtCondition | airbyte_agent_sdk.connectors.incident_io.types.EscalationsGteCondition | airbyte_agent_sdk.connectors.incident_io.types.EscalationsLtCondition | airbyte_agent_sdk.connectors.incident_io.types.EscalationsLteCondition | airbyte_agent_sdk.connectors.incident_io.types.EscalationsInCondition | airbyte_agent_sdk.connectors.incident_io.types.EscalationsLikeCondition | airbyte_agent_sdk.connectors.incident_io.types.EscalationsFuzzyCondition | airbyte_agent_sdk.connectors.incident_io.types.EscalationsKeywordCondition | airbyte_agent_sdk.connectors.incident_io.types.EscalationsContainsCondition | airbyte_agent_sdk.connectors.incident_io.types.EscalationsNotCondition | airbyte_agent_sdk.connectors.incident_io.types.EscalationsAndCondition | airbyte_agent_sdk.connectors.incident_io.types.EscalationsOrCondition | airbyte_agent_sdk.connectors.incident_io.types.EscalationsAnyCondition`
     :   The type of the None singleton.
 
+<a id="EscalationsOrCondition"></a>
+
 `EscalationsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1776,6 +1954,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.incident_io.types.EscalationsEqCondition | airbyte_agent_sdk.connectors.incident_io.types.EscalationsNeqCondition | airbyte_agent_sdk.connectors.incident_io.types.EscalationsGtCondition | airbyte_agent_sdk.connectors.incident_io.types.EscalationsGteCondition | airbyte_agent_sdk.connectors.incident_io.types.EscalationsLtCondition | airbyte_agent_sdk.connectors.incident_io.types.EscalationsLteCondition | airbyte_agent_sdk.connectors.incident_io.types.EscalationsInCondition | airbyte_agent_sdk.connectors.incident_io.types.EscalationsLikeCondition | airbyte_agent_sdk.connectors.incident_io.types.EscalationsFuzzyCondition | airbyte_agent_sdk.connectors.incident_io.types.EscalationsKeywordCondition | airbyte_agent_sdk.connectors.incident_io.types.EscalationsContainsCondition | airbyte_agent_sdk.connectors.incident_io.types.EscalationsNotCondition | airbyte_agent_sdk.connectors.incident_io.types.EscalationsAndCondition | airbyte_agent_sdk.connectors.incident_io.types.EscalationsOrCondition | airbyte_agent_sdk.connectors.incident_io.types.EscalationsAnyCondition]`
     :   The type of the None singleton.
+
+<a id="EscalationsSearchFilter"></a>
 
 `EscalationsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering escalations search queries.
@@ -1819,6 +1999,8 @@ Classes
     `updated_at: str | None`
     :   When the escalation was last updated
 
+<a id="EscalationsSearchQuery"></a>
+
 `EscalationsSearchQuery(*args, **kwargs)`
 :   Search query for escalations entity.
 
@@ -1833,6 +2015,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.incident_io.types.EscalationsSortFilter]`
     :   The type of the None singleton.
+
+<a id="EscalationsSortFilter"></a>
 
 `EscalationsSortFilter(*args, **kwargs)`
 :   Available fields for sorting escalations search results.
@@ -1876,6 +2060,8 @@ Classes
     `updated_at: Literal['asc', 'desc']`
     :   When the escalation was last updated
 
+<a id="EscalationsStringFilter"></a>
+
 `EscalationsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -1918,6 +2104,8 @@ Classes
     `updated_at: str`
     :   When the escalation was last updated
 
+<a id="IncidentRolesAndCondition"></a>
+
 `IncidentRolesAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1938,6 +2126,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.incident_io.types.IncidentRolesEqCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentRolesNeqCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentRolesGtCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentRolesGteCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentRolesLtCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentRolesLteCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentRolesInCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentRolesLikeCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentRolesFuzzyCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentRolesKeywordCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentRolesContainsCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentRolesNotCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentRolesAndCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentRolesOrCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentRolesAnyCondition]`
     :   The type of the None singleton.
 
+<a id="IncidentRolesAnyCondition"></a>
+
 `IncidentRolesAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1957,6 +2147,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.incident_io.types.IncidentRolesAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="IncidentRolesAnyValueFilter"></a>
 
 `IncidentRolesAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -1994,6 +2186,8 @@ Classes
     `updated_at: Any`
     :   When the role was last updated
 
+<a id="IncidentRolesContainsCondition"></a>
+
 `IncidentRolesContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -2005,6 +2199,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.incident_io.types.IncidentRolesAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="IncidentRolesEqCondition"></a>
 
 `IncidentRolesEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -2018,6 +2214,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.incident_io.types.IncidentRolesSearchFilter`
     :   The type of the None singleton.
 
+<a id="IncidentRolesFuzzyCondition"></a>
+
 `IncidentRolesFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -2029,6 +2227,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.incident_io.types.IncidentRolesStringFilter`
     :   The type of the None singleton.
+
+<a id="IncidentRolesGetParams"></a>
 
 `IncidentRolesGetParams(*args, **kwargs)`
 :   Parameters for incident_roles.get operation
@@ -2042,6 +2242,8 @@ Classes
     `id: str`
     :   The type of the None singleton.
 
+<a id="IncidentRolesGtCondition"></a>
+
 `IncidentRolesGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -2054,6 +2256,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.incident_io.types.IncidentRolesSearchFilter`
     :   The type of the None singleton.
 
+<a id="IncidentRolesGteCondition"></a>
+
 `IncidentRolesGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -2065,6 +2269,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.incident_io.types.IncidentRolesSearchFilter`
     :   The type of the None singleton.
+
+<a id="IncidentRolesInCondition"></a>
 
 `IncidentRolesInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -2085,6 +2291,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.incident_io.types.IncidentRolesInFilter`
     :   The type of the None singleton.
+
+<a id="IncidentRolesInFilter"></a>
 
 `IncidentRolesInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -2122,6 +2330,8 @@ Classes
     `updated_at: list[str]`
     :   When the role was last updated
 
+<a id="IncidentRolesKeywordCondition"></a>
+
 `IncidentRolesKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -2133,6 +2343,8 @@ Classes
 
     `keyword: airbyte_agent_sdk.connectors.incident_io.types.IncidentRolesStringFilter`
     :   The type of the None singleton.
+
+<a id="IncidentRolesLikeCondition"></a>
 
 `IncidentRolesLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
@@ -2146,12 +2358,16 @@ Classes
     `like: airbyte_agent_sdk.connectors.incident_io.types.IncidentRolesStringFilter`
     :   The type of the None singleton.
 
+<a id="IncidentRolesListParams"></a>
+
 `IncidentRolesListParams(*args, **kwargs)`
 :   Parameters for incident_roles.list operation
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="IncidentRolesLtCondition"></a>
 
 `IncidentRolesLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
@@ -2165,6 +2381,8 @@ Classes
     `lt: airbyte_agent_sdk.connectors.incident_io.types.IncidentRolesSearchFilter`
     :   The type of the None singleton.
 
+<a id="IncidentRolesLteCondition"></a>
+
 `IncidentRolesLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
 
@@ -2177,6 +2395,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.incident_io.types.IncidentRolesSearchFilter`
     :   The type of the None singleton.
 
+<a id="IncidentRolesNeqCondition"></a>
+
 `IncidentRolesNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -2188,6 +2408,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.incident_io.types.IncidentRolesSearchFilter`
     :   The type of the None singleton.
+
+<a id="IncidentRolesNotCondition"></a>
 
 `IncidentRolesNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -2209,6 +2431,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.incident_io.types.IncidentRolesEqCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentRolesNeqCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentRolesGtCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentRolesGteCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentRolesLtCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentRolesLteCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentRolesInCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentRolesLikeCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentRolesFuzzyCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentRolesKeywordCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentRolesContainsCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentRolesNotCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentRolesAndCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentRolesOrCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentRolesAnyCondition`
     :   The type of the None singleton.
 
+<a id="IncidentRolesOrCondition"></a>
+
 `IncidentRolesOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -2228,6 +2452,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.incident_io.types.IncidentRolesEqCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentRolesNeqCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentRolesGtCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentRolesGteCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentRolesLtCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentRolesLteCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentRolesInCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentRolesLikeCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentRolesFuzzyCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentRolesKeywordCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentRolesContainsCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentRolesNotCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentRolesAndCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentRolesOrCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentRolesAnyCondition]`
     :   The type of the None singleton.
+
+<a id="IncidentRolesSearchFilter"></a>
 
 `IncidentRolesSearchFilter(*args, **kwargs)`
 :   Available fields for filtering incident_roles search queries.
@@ -2265,6 +2491,8 @@ Classes
     `updated_at: str | None`
     :   When the role was last updated
 
+<a id="IncidentRolesSearchQuery"></a>
+
 `IncidentRolesSearchQuery(*args, **kwargs)`
 :   Search query for incident_roles entity.
 
@@ -2279,6 +2507,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.incident_io.types.IncidentRolesSortFilter]`
     :   The type of the None singleton.
+
+<a id="IncidentRolesSortFilter"></a>
 
 `IncidentRolesSortFilter(*args, **kwargs)`
 :   Available fields for sorting incident_roles search results.
@@ -2316,6 +2546,8 @@ Classes
     `updated_at: Literal['asc', 'desc']`
     :   When the role was last updated
 
+<a id="IncidentRolesStringFilter"></a>
+
 `IncidentRolesStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -2352,6 +2584,8 @@ Classes
     `updated_at: str`
     :   When the role was last updated
 
+<a id="IncidentStatusesAndCondition"></a>
+
 `IncidentStatusesAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -2372,6 +2606,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.incident_io.types.IncidentStatusesEqCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentStatusesNeqCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentStatusesGtCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentStatusesGteCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentStatusesLtCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentStatusesLteCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentStatusesInCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentStatusesLikeCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentStatusesFuzzyCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentStatusesKeywordCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentStatusesContainsCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentStatusesNotCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentStatusesAndCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentStatusesOrCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentStatusesAnyCondition]`
     :   The type of the None singleton.
 
+<a id="IncidentStatusesAnyCondition"></a>
+
 `IncidentStatusesAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -2391,6 +2627,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.incident_io.types.IncidentStatusesAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="IncidentStatusesAnyValueFilter"></a>
 
 `IncidentStatusesAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -2422,6 +2660,8 @@ Classes
     `updated_at: Any`
     :   When the status was last updated
 
+<a id="IncidentStatusesContainsCondition"></a>
+
 `IncidentStatusesContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -2433,6 +2673,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.incident_io.types.IncidentStatusesAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="IncidentStatusesEqCondition"></a>
 
 `IncidentStatusesEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -2446,6 +2688,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.incident_io.types.IncidentStatusesSearchFilter`
     :   The type of the None singleton.
 
+<a id="IncidentStatusesFuzzyCondition"></a>
+
 `IncidentStatusesFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -2457,6 +2701,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.incident_io.types.IncidentStatusesStringFilter`
     :   The type of the None singleton.
+
+<a id="IncidentStatusesGetParams"></a>
 
 `IncidentStatusesGetParams(*args, **kwargs)`
 :   Parameters for incident_statuses.get operation
@@ -2470,6 +2716,8 @@ Classes
     `id: str`
     :   The type of the None singleton.
 
+<a id="IncidentStatusesGtCondition"></a>
+
 `IncidentStatusesGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -2482,6 +2730,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.incident_io.types.IncidentStatusesSearchFilter`
     :   The type of the None singleton.
 
+<a id="IncidentStatusesGteCondition"></a>
+
 `IncidentStatusesGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -2493,6 +2743,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.incident_io.types.IncidentStatusesSearchFilter`
     :   The type of the None singleton.
+
+<a id="IncidentStatusesInCondition"></a>
 
 `IncidentStatusesInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -2513,6 +2765,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.incident_io.types.IncidentStatusesInFilter`
     :   The type of the None singleton.
+
+<a id="IncidentStatusesInFilter"></a>
 
 `IncidentStatusesInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -2544,6 +2798,8 @@ Classes
     `updated_at: list[str]`
     :   When the status was last updated
 
+<a id="IncidentStatusesKeywordCondition"></a>
+
 `IncidentStatusesKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -2555,6 +2811,8 @@ Classes
 
     `keyword: airbyte_agent_sdk.connectors.incident_io.types.IncidentStatusesStringFilter`
     :   The type of the None singleton.
+
+<a id="IncidentStatusesLikeCondition"></a>
 
 `IncidentStatusesLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
@@ -2568,12 +2826,16 @@ Classes
     `like: airbyte_agent_sdk.connectors.incident_io.types.IncidentStatusesStringFilter`
     :   The type of the None singleton.
 
+<a id="IncidentStatusesListParams"></a>
+
 `IncidentStatusesListParams(*args, **kwargs)`
 :   Parameters for incident_statuses.list operation
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="IncidentStatusesLtCondition"></a>
 
 `IncidentStatusesLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
@@ -2587,6 +2849,8 @@ Classes
     `lt: airbyte_agent_sdk.connectors.incident_io.types.IncidentStatusesSearchFilter`
     :   The type of the None singleton.
 
+<a id="IncidentStatusesLteCondition"></a>
+
 `IncidentStatusesLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
 
@@ -2599,6 +2863,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.incident_io.types.IncidentStatusesSearchFilter`
     :   The type of the None singleton.
 
+<a id="IncidentStatusesNeqCondition"></a>
+
 `IncidentStatusesNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -2610,6 +2876,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.incident_io.types.IncidentStatusesSearchFilter`
     :   The type of the None singleton.
+
+<a id="IncidentStatusesNotCondition"></a>
 
 `IncidentStatusesNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -2631,6 +2899,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.incident_io.types.IncidentStatusesEqCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentStatusesNeqCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentStatusesGtCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentStatusesGteCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentStatusesLtCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentStatusesLteCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentStatusesInCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentStatusesLikeCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentStatusesFuzzyCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentStatusesKeywordCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentStatusesContainsCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentStatusesNotCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentStatusesAndCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentStatusesOrCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentStatusesAnyCondition`
     :   The type of the None singleton.
 
+<a id="IncidentStatusesOrCondition"></a>
+
 `IncidentStatusesOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -2650,6 +2920,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.incident_io.types.IncidentStatusesEqCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentStatusesNeqCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentStatusesGtCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentStatusesGteCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentStatusesLtCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentStatusesLteCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentStatusesInCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentStatusesLikeCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentStatusesFuzzyCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentStatusesKeywordCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentStatusesContainsCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentStatusesNotCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentStatusesAndCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentStatusesOrCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentStatusesAnyCondition]`
     :   The type of the None singleton.
+
+<a id="IncidentStatusesSearchFilter"></a>
 
 `IncidentStatusesSearchFilter(*args, **kwargs)`
 :   Available fields for filtering incident_statuses search queries.
@@ -2681,6 +2953,8 @@ Classes
     `updated_at: str | None`
     :   When the status was last updated
 
+<a id="IncidentStatusesSearchQuery"></a>
+
 `IncidentStatusesSearchQuery(*args, **kwargs)`
 :   Search query for incident_statuses entity.
 
@@ -2695,6 +2969,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.incident_io.types.IncidentStatusesSortFilter]`
     :   The type of the None singleton.
+
+<a id="IncidentStatusesSortFilter"></a>
 
 `IncidentStatusesSortFilter(*args, **kwargs)`
 :   Available fields for sorting incident_statuses search results.
@@ -2726,6 +3002,8 @@ Classes
     `updated_at: Literal['asc', 'desc']`
     :   When the status was last updated
 
+<a id="IncidentStatusesStringFilter"></a>
+
 `IncidentStatusesStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -2756,6 +3034,8 @@ Classes
     `updated_at: str`
     :   When the status was last updated
 
+<a id="IncidentTimestampsAndCondition"></a>
+
 `IncidentTimestampsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -2775,6 +3055,8 @@ Classes
 
     `and: list[airbyte_agent_sdk.connectors.incident_io.types.IncidentTimestampsEqCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentTimestampsNeqCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentTimestampsGtCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentTimestampsGteCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentTimestampsLtCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentTimestampsLteCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentTimestampsInCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentTimestampsLikeCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentTimestampsFuzzyCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentTimestampsKeywordCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentTimestampsContainsCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentTimestampsNotCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentTimestampsAndCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentTimestampsOrCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentTimestampsAnyCondition]`
     :   The type of the None singleton.
+
+<a id="IncidentTimestampsAnyCondition"></a>
 
 `IncidentTimestampsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -2796,6 +3078,8 @@ Classes
     `any: airbyte_agent_sdk.connectors.incident_io.types.IncidentTimestampsAnyValueFilter`
     :   The type of the None singleton.
 
+<a id="IncidentTimestampsAnyValueFilter"></a>
+
 `IncidentTimestampsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
 
@@ -2814,6 +3098,8 @@ Classes
     `rank: Any`
     :   Rank for ordering
 
+<a id="IncidentTimestampsContainsCondition"></a>
+
 `IncidentTimestampsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -2825,6 +3111,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.incident_io.types.IncidentTimestampsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="IncidentTimestampsEqCondition"></a>
 
 `IncidentTimestampsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -2838,6 +3126,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.incident_io.types.IncidentTimestampsSearchFilter`
     :   The type of the None singleton.
 
+<a id="IncidentTimestampsFuzzyCondition"></a>
+
 `IncidentTimestampsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -2849,6 +3139,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.incident_io.types.IncidentTimestampsStringFilter`
     :   The type of the None singleton.
+
+<a id="IncidentTimestampsGetParams"></a>
 
 `IncidentTimestampsGetParams(*args, **kwargs)`
 :   Parameters for incident_timestamps.get operation
@@ -2862,6 +3154,8 @@ Classes
     `id: str`
     :   The type of the None singleton.
 
+<a id="IncidentTimestampsGtCondition"></a>
+
 `IncidentTimestampsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -2874,6 +3168,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.incident_io.types.IncidentTimestampsSearchFilter`
     :   The type of the None singleton.
 
+<a id="IncidentTimestampsGteCondition"></a>
+
 `IncidentTimestampsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -2885,6 +3181,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.incident_io.types.IncidentTimestampsSearchFilter`
     :   The type of the None singleton.
+
+<a id="IncidentTimestampsInCondition"></a>
 
 `IncidentTimestampsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -2906,6 +3204,8 @@ Classes
     `in: airbyte_agent_sdk.connectors.incident_io.types.IncidentTimestampsInFilter`
     :   The type of the None singleton.
 
+<a id="IncidentTimestampsInFilter"></a>
+
 `IncidentTimestampsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
 
@@ -2924,6 +3224,8 @@ Classes
     `rank: list[float]`
     :   Rank for ordering
 
+<a id="IncidentTimestampsKeywordCondition"></a>
+
 `IncidentTimestampsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -2935,6 +3237,8 @@ Classes
 
     `keyword: airbyte_agent_sdk.connectors.incident_io.types.IncidentTimestampsStringFilter`
     :   The type of the None singleton.
+
+<a id="IncidentTimestampsLikeCondition"></a>
 
 `IncidentTimestampsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
@@ -2948,12 +3252,16 @@ Classes
     `like: airbyte_agent_sdk.connectors.incident_io.types.IncidentTimestampsStringFilter`
     :   The type of the None singleton.
 
+<a id="IncidentTimestampsListParams"></a>
+
 `IncidentTimestampsListParams(*args, **kwargs)`
 :   Parameters for incident_timestamps.list operation
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="IncidentTimestampsLtCondition"></a>
 
 `IncidentTimestampsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
@@ -2967,6 +3275,8 @@ Classes
     `lt: airbyte_agent_sdk.connectors.incident_io.types.IncidentTimestampsSearchFilter`
     :   The type of the None singleton.
 
+<a id="IncidentTimestampsLteCondition"></a>
+
 `IncidentTimestampsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
 
@@ -2979,6 +3289,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.incident_io.types.IncidentTimestampsSearchFilter`
     :   The type of the None singleton.
 
+<a id="IncidentTimestampsNeqCondition"></a>
+
 `IncidentTimestampsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -2990,6 +3302,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.incident_io.types.IncidentTimestampsSearchFilter`
     :   The type of the None singleton.
+
+<a id="IncidentTimestampsNotCondition"></a>
 
 `IncidentTimestampsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -3011,6 +3325,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.incident_io.types.IncidentTimestampsEqCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentTimestampsNeqCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentTimestampsGtCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentTimestampsGteCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentTimestampsLtCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentTimestampsLteCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentTimestampsInCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentTimestampsLikeCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentTimestampsFuzzyCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentTimestampsKeywordCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentTimestampsContainsCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentTimestampsNotCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentTimestampsAndCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentTimestampsOrCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentTimestampsAnyCondition`
     :   The type of the None singleton.
 
+<a id="IncidentTimestampsOrCondition"></a>
+
 `IncidentTimestampsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -3031,6 +3347,8 @@ Classes
     `or: list[airbyte_agent_sdk.connectors.incident_io.types.IncidentTimestampsEqCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentTimestampsNeqCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentTimestampsGtCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentTimestampsGteCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentTimestampsLtCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentTimestampsLteCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentTimestampsInCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentTimestampsLikeCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentTimestampsFuzzyCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentTimestampsKeywordCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentTimestampsContainsCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentTimestampsNotCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentTimestampsAndCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentTimestampsOrCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentTimestampsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="IncidentTimestampsSearchFilter"></a>
+
 `IncidentTimestampsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering incident_timestamps search queries.
 
@@ -3049,6 +3367,8 @@ Classes
     `rank: float | None`
     :   Rank for ordering
 
+<a id="IncidentTimestampsSearchQuery"></a>
+
 `IncidentTimestampsSearchQuery(*args, **kwargs)`
 :   Search query for incident_timestamps entity.
 
@@ -3063,6 +3383,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.incident_io.types.IncidentTimestampsSortFilter]`
     :   The type of the None singleton.
+
+<a id="IncidentTimestampsSortFilter"></a>
 
 `IncidentTimestampsSortFilter(*args, **kwargs)`
 :   Available fields for sorting incident_timestamps search results.
@@ -3082,6 +3404,8 @@ Classes
     `rank: Literal['asc', 'desc']`
     :   Rank for ordering
 
+<a id="IncidentTimestampsStringFilter"></a>
+
 `IncidentTimestampsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -3099,6 +3423,8 @@ Classes
 
     `rank: str`
     :   Rank for ordering
+
+<a id="IncidentUpdatesAndCondition"></a>
 
 `IncidentUpdatesAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -3120,6 +3446,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.incident_io.types.IncidentUpdatesEqCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentUpdatesNeqCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentUpdatesGtCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentUpdatesGteCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentUpdatesLtCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentUpdatesLteCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentUpdatesInCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentUpdatesLikeCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentUpdatesFuzzyCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentUpdatesKeywordCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentUpdatesContainsCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentUpdatesNotCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentUpdatesAndCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentUpdatesOrCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentUpdatesAnyCondition]`
     :   The type of the None singleton.
 
+<a id="IncidentUpdatesAnyCondition"></a>
+
 `IncidentUpdatesAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -3139,6 +3467,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.incident_io.types.IncidentUpdatesAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="IncidentUpdatesAnyValueFilter"></a>
 
 `IncidentUpdatesAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -3170,6 +3500,8 @@ Classes
     `updater: Any`
     :   Who made this update
 
+<a id="IncidentUpdatesContainsCondition"></a>
+
 `IncidentUpdatesContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -3181,6 +3513,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.incident_io.types.IncidentUpdatesAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="IncidentUpdatesEqCondition"></a>
 
 `IncidentUpdatesEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -3194,6 +3528,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.incident_io.types.IncidentUpdatesSearchFilter`
     :   The type of the None singleton.
 
+<a id="IncidentUpdatesFuzzyCondition"></a>
+
 `IncidentUpdatesFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -3205,6 +3541,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.incident_io.types.IncidentUpdatesStringFilter`
     :   The type of the None singleton.
+
+<a id="IncidentUpdatesGtCondition"></a>
 
 `IncidentUpdatesGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
@@ -3218,6 +3556,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.incident_io.types.IncidentUpdatesSearchFilter`
     :   The type of the None singleton.
 
+<a id="IncidentUpdatesGteCondition"></a>
+
 `IncidentUpdatesGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -3229,6 +3569,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.incident_io.types.IncidentUpdatesSearchFilter`
     :   The type of the None singleton.
+
+<a id="IncidentUpdatesInCondition"></a>
 
 `IncidentUpdatesInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -3249,6 +3591,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.incident_io.types.IncidentUpdatesInFilter`
     :   The type of the None singleton.
+
+<a id="IncidentUpdatesInFilter"></a>
 
 `IncidentUpdatesInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -3280,6 +3624,8 @@ Classes
     `updater: list[dict[str, typing.Any]]`
     :   Who made this update
 
+<a id="IncidentUpdatesKeywordCondition"></a>
+
 `IncidentUpdatesKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -3292,6 +3638,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.incident_io.types.IncidentUpdatesStringFilter`
     :   The type of the None singleton.
 
+<a id="IncidentUpdatesLikeCondition"></a>
+
 `IncidentUpdatesLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -3303,6 +3651,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.incident_io.types.IncidentUpdatesStringFilter`
     :   The type of the None singleton.
+
+<a id="IncidentUpdatesListParams"></a>
 
 `IncidentUpdatesListParams(*args, **kwargs)`
 :   Parameters for incident_updates.list operation
@@ -3319,6 +3669,8 @@ Classes
     `page_size: int`
     :   The type of the None singleton.
 
+<a id="IncidentUpdatesLtCondition"></a>
+
 `IncidentUpdatesLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -3330,6 +3682,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.incident_io.types.IncidentUpdatesSearchFilter`
     :   The type of the None singleton.
+
+<a id="IncidentUpdatesLteCondition"></a>
 
 `IncidentUpdatesLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -3343,6 +3697,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.incident_io.types.IncidentUpdatesSearchFilter`
     :   The type of the None singleton.
 
+<a id="IncidentUpdatesNeqCondition"></a>
+
 `IncidentUpdatesNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -3354,6 +3710,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.incident_io.types.IncidentUpdatesSearchFilter`
     :   The type of the None singleton.
+
+<a id="IncidentUpdatesNotCondition"></a>
 
 `IncidentUpdatesNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -3375,6 +3733,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.incident_io.types.IncidentUpdatesEqCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentUpdatesNeqCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentUpdatesGtCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentUpdatesGteCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentUpdatesLtCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentUpdatesLteCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentUpdatesInCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentUpdatesLikeCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentUpdatesFuzzyCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentUpdatesKeywordCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentUpdatesContainsCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentUpdatesNotCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentUpdatesAndCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentUpdatesOrCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentUpdatesAnyCondition`
     :   The type of the None singleton.
 
+<a id="IncidentUpdatesOrCondition"></a>
+
 `IncidentUpdatesOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -3394,6 +3754,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.incident_io.types.IncidentUpdatesEqCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentUpdatesNeqCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentUpdatesGtCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentUpdatesGteCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentUpdatesLtCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentUpdatesLteCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentUpdatesInCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentUpdatesLikeCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentUpdatesFuzzyCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentUpdatesKeywordCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentUpdatesContainsCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentUpdatesNotCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentUpdatesAndCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentUpdatesOrCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentUpdatesAnyCondition]`
     :   The type of the None singleton.
+
+<a id="IncidentUpdatesSearchFilter"></a>
 
 `IncidentUpdatesSearchFilter(*args, **kwargs)`
 :   Available fields for filtering incident_updates search queries.
@@ -3425,6 +3787,8 @@ Classes
     `updater: dict[str, typing.Any] | None`
     :   Who made this update
 
+<a id="IncidentUpdatesSearchQuery"></a>
+
 `IncidentUpdatesSearchQuery(*args, **kwargs)`
 :   Search query for incident_updates entity.
 
@@ -3439,6 +3803,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.incident_io.types.IncidentUpdatesSortFilter]`
     :   The type of the None singleton.
+
+<a id="IncidentUpdatesSortFilter"></a>
 
 `IncidentUpdatesSortFilter(*args, **kwargs)`
 :   Available fields for sorting incident_updates search results.
@@ -3470,6 +3836,8 @@ Classes
     `updater: Literal['asc', 'desc']`
     :   Who made this update
 
+<a id="IncidentUpdatesStringFilter"></a>
+
 `IncidentUpdatesStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -3500,6 +3868,8 @@ Classes
     `updater: str`
     :   Who made this update
 
+<a id="IncidentsAndCondition"></a>
+
 `IncidentsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -3520,6 +3890,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.incident_io.types.IncidentsEqCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentsNeqCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentsGtCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentsGteCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentsLtCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentsLteCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentsInCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentsLikeCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentsFuzzyCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentsKeywordCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentsContainsCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentsNotCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentsAndCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentsOrCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="IncidentsAnyCondition"></a>
+
 `IncidentsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -3539,6 +3911,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.incident_io.types.IncidentsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="IncidentsAnyValueFilter"></a>
 
 `IncidentsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -3624,6 +3998,8 @@ Classes
     `workload_minutes_working: Any`
     :   Minutes of workload classified as working
 
+<a id="IncidentsContainsCondition"></a>
+
 `IncidentsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -3635,6 +4011,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.incident_io.types.IncidentsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="IncidentsEqCondition"></a>
 
 `IncidentsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -3648,6 +4026,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.incident_io.types.IncidentsSearchFilter`
     :   The type of the None singleton.
 
+<a id="IncidentsFuzzyCondition"></a>
+
 `IncidentsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -3659,6 +4039,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.incident_io.types.IncidentsStringFilter`
     :   The type of the None singleton.
+
+<a id="IncidentsGetParams"></a>
 
 `IncidentsGetParams(*args, **kwargs)`
 :   Parameters for incidents.get operation
@@ -3672,6 +4054,8 @@ Classes
     `id: str`
     :   The type of the None singleton.
 
+<a id="IncidentsGtCondition"></a>
+
 `IncidentsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -3684,6 +4068,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.incident_io.types.IncidentsSearchFilter`
     :   The type of the None singleton.
 
+<a id="IncidentsGteCondition"></a>
+
 `IncidentsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -3695,6 +4081,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.incident_io.types.IncidentsSearchFilter`
     :   The type of the None singleton.
+
+<a id="IncidentsInCondition"></a>
 
 `IncidentsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -3715,6 +4103,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.incident_io.types.IncidentsInFilter`
     :   The type of the None singleton.
+
+<a id="IncidentsInFilter"></a>
 
 `IncidentsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -3800,6 +4190,8 @@ Classes
     `workload_minutes_working: list[float]`
     :   Minutes of workload classified as working
 
+<a id="IncidentsKeywordCondition"></a>
+
 `IncidentsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -3812,6 +4204,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.incident_io.types.IncidentsStringFilter`
     :   The type of the None singleton.
 
+<a id="IncidentsLikeCondition"></a>
+
 `IncidentsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -3823,6 +4217,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.incident_io.types.IncidentsStringFilter`
     :   The type of the None singleton.
+
+<a id="IncidentsListParams"></a>
 
 `IncidentsListParams(*args, **kwargs)`
 :   Parameters for incidents.list operation
@@ -3839,6 +4235,8 @@ Classes
     `page_size: int`
     :   The type of the None singleton.
 
+<a id="IncidentsLtCondition"></a>
+
 `IncidentsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -3850,6 +4248,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.incident_io.types.IncidentsSearchFilter`
     :   The type of the None singleton.
+
+<a id="IncidentsLteCondition"></a>
 
 `IncidentsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -3863,6 +4263,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.incident_io.types.IncidentsSearchFilter`
     :   The type of the None singleton.
 
+<a id="IncidentsNeqCondition"></a>
+
 `IncidentsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -3874,6 +4276,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.incident_io.types.IncidentsSearchFilter`
     :   The type of the None singleton.
+
+<a id="IncidentsNotCondition"></a>
 
 `IncidentsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -3895,6 +4299,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.incident_io.types.IncidentsEqCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentsNeqCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentsGtCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentsGteCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentsLtCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentsLteCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentsInCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentsLikeCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentsFuzzyCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentsKeywordCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentsContainsCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentsNotCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentsAndCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentsOrCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentsAnyCondition`
     :   The type of the None singleton.
 
+<a id="IncidentsOrCondition"></a>
+
 `IncidentsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -3914,6 +4320,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.incident_io.types.IncidentsEqCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentsNeqCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentsGtCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentsGteCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentsLtCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentsLteCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentsInCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentsLikeCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentsFuzzyCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentsKeywordCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentsContainsCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentsNotCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentsAndCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentsOrCondition | airbyte_agent_sdk.connectors.incident_io.types.IncidentsAnyCondition]`
     :   The type of the None singleton.
+
+<a id="IncidentsSearchFilter"></a>
 
 `IncidentsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering incidents search queries.
@@ -3999,6 +4407,8 @@ Classes
     `workload_minutes_working: float | None`
     :   Minutes of workload classified as working
 
+<a id="IncidentsSearchQuery"></a>
+
 `IncidentsSearchQuery(*args, **kwargs)`
 :   Search query for incidents entity.
 
@@ -4013,6 +4423,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.incident_io.types.IncidentsSortFilter]`
     :   The type of the None singleton.
+
+<a id="IncidentsSortFilter"></a>
 
 `IncidentsSortFilter(*args, **kwargs)`
 :   Available fields for sorting incidents search results.
@@ -4098,6 +4510,8 @@ Classes
     `workload_minutes_working: Literal['asc', 'desc']`
     :   Minutes of workload classified as working
 
+<a id="IncidentsStringFilter"></a>
+
 `IncidentsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -4182,6 +4596,8 @@ Classes
     `workload_minutes_working: str`
     :   Minutes of workload classified as working
 
+<a id="SchedulesAndCondition"></a>
+
 `SchedulesAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -4202,6 +4618,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.incident_io.types.SchedulesEqCondition | airbyte_agent_sdk.connectors.incident_io.types.SchedulesNeqCondition | airbyte_agent_sdk.connectors.incident_io.types.SchedulesGtCondition | airbyte_agent_sdk.connectors.incident_io.types.SchedulesGteCondition | airbyte_agent_sdk.connectors.incident_io.types.SchedulesLtCondition | airbyte_agent_sdk.connectors.incident_io.types.SchedulesLteCondition | airbyte_agent_sdk.connectors.incident_io.types.SchedulesInCondition | airbyte_agent_sdk.connectors.incident_io.types.SchedulesLikeCondition | airbyte_agent_sdk.connectors.incident_io.types.SchedulesFuzzyCondition | airbyte_agent_sdk.connectors.incident_io.types.SchedulesKeywordCondition | airbyte_agent_sdk.connectors.incident_io.types.SchedulesContainsCondition | airbyte_agent_sdk.connectors.incident_io.types.SchedulesNotCondition | airbyte_agent_sdk.connectors.incident_io.types.SchedulesAndCondition | airbyte_agent_sdk.connectors.incident_io.types.SchedulesOrCondition | airbyte_agent_sdk.connectors.incident_io.types.SchedulesAnyCondition]`
     :   The type of the None singleton.
 
+<a id="SchedulesAnyCondition"></a>
+
 `SchedulesAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -4221,6 +4639,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.incident_io.types.SchedulesAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="SchedulesAnyValueFilter"></a>
 
 `SchedulesAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -4255,6 +4675,8 @@ Classes
     `updated_at: Any`
     :   When the schedule was last updated
 
+<a id="SchedulesContainsCondition"></a>
+
 `SchedulesContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -4266,6 +4688,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.incident_io.types.SchedulesAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="SchedulesEqCondition"></a>
 
 `SchedulesEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -4279,6 +4703,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.incident_io.types.SchedulesSearchFilter`
     :   The type of the None singleton.
 
+<a id="SchedulesFuzzyCondition"></a>
+
 `SchedulesFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -4290,6 +4716,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.incident_io.types.SchedulesStringFilter`
     :   The type of the None singleton.
+
+<a id="SchedulesGetParams"></a>
 
 `SchedulesGetParams(*args, **kwargs)`
 :   Parameters for schedules.get operation
@@ -4303,6 +4731,8 @@ Classes
     `id: str`
     :   The type of the None singleton.
 
+<a id="SchedulesGtCondition"></a>
+
 `SchedulesGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -4315,6 +4745,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.incident_io.types.SchedulesSearchFilter`
     :   The type of the None singleton.
 
+<a id="SchedulesGteCondition"></a>
+
 `SchedulesGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -4326,6 +4758,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.incident_io.types.SchedulesSearchFilter`
     :   The type of the None singleton.
+
+<a id="SchedulesInCondition"></a>
 
 `SchedulesInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -4346,6 +4780,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.incident_io.types.SchedulesInFilter`
     :   The type of the None singleton.
+
+<a id="SchedulesInFilter"></a>
 
 `SchedulesInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -4380,6 +4816,8 @@ Classes
     `updated_at: list[str]`
     :   When the schedule was last updated
 
+<a id="SchedulesKeywordCondition"></a>
+
 `SchedulesKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -4392,6 +4830,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.incident_io.types.SchedulesStringFilter`
     :   The type of the None singleton.
 
+<a id="SchedulesLikeCondition"></a>
+
 `SchedulesLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -4403,6 +4843,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.incident_io.types.SchedulesStringFilter`
     :   The type of the None singleton.
+
+<a id="SchedulesListParams"></a>
 
 `SchedulesListParams(*args, **kwargs)`
 :   Parameters for schedules.list operation
@@ -4419,6 +4861,8 @@ Classes
     `page_size: int`
     :   The type of the None singleton.
 
+<a id="SchedulesLtCondition"></a>
+
 `SchedulesLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -4430,6 +4874,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.incident_io.types.SchedulesSearchFilter`
     :   The type of the None singleton.
+
+<a id="SchedulesLteCondition"></a>
 
 `SchedulesLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -4443,6 +4889,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.incident_io.types.SchedulesSearchFilter`
     :   The type of the None singleton.
 
+<a id="SchedulesNeqCondition"></a>
+
 `SchedulesNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -4454,6 +4902,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.incident_io.types.SchedulesSearchFilter`
     :   The type of the None singleton.
+
+<a id="SchedulesNotCondition"></a>
 
 `SchedulesNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -4475,6 +4925,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.incident_io.types.SchedulesEqCondition | airbyte_agent_sdk.connectors.incident_io.types.SchedulesNeqCondition | airbyte_agent_sdk.connectors.incident_io.types.SchedulesGtCondition | airbyte_agent_sdk.connectors.incident_io.types.SchedulesGteCondition | airbyte_agent_sdk.connectors.incident_io.types.SchedulesLtCondition | airbyte_agent_sdk.connectors.incident_io.types.SchedulesLteCondition | airbyte_agent_sdk.connectors.incident_io.types.SchedulesInCondition | airbyte_agent_sdk.connectors.incident_io.types.SchedulesLikeCondition | airbyte_agent_sdk.connectors.incident_io.types.SchedulesFuzzyCondition | airbyte_agent_sdk.connectors.incident_io.types.SchedulesKeywordCondition | airbyte_agent_sdk.connectors.incident_io.types.SchedulesContainsCondition | airbyte_agent_sdk.connectors.incident_io.types.SchedulesNotCondition | airbyte_agent_sdk.connectors.incident_io.types.SchedulesAndCondition | airbyte_agent_sdk.connectors.incident_io.types.SchedulesOrCondition | airbyte_agent_sdk.connectors.incident_io.types.SchedulesAnyCondition`
     :   The type of the None singleton.
 
+<a id="SchedulesOrCondition"></a>
+
 `SchedulesOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -4494,6 +4946,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.incident_io.types.SchedulesEqCondition | airbyte_agent_sdk.connectors.incident_io.types.SchedulesNeqCondition | airbyte_agent_sdk.connectors.incident_io.types.SchedulesGtCondition | airbyte_agent_sdk.connectors.incident_io.types.SchedulesGteCondition | airbyte_agent_sdk.connectors.incident_io.types.SchedulesLtCondition | airbyte_agent_sdk.connectors.incident_io.types.SchedulesLteCondition | airbyte_agent_sdk.connectors.incident_io.types.SchedulesInCondition | airbyte_agent_sdk.connectors.incident_io.types.SchedulesLikeCondition | airbyte_agent_sdk.connectors.incident_io.types.SchedulesFuzzyCondition | airbyte_agent_sdk.connectors.incident_io.types.SchedulesKeywordCondition | airbyte_agent_sdk.connectors.incident_io.types.SchedulesContainsCondition | airbyte_agent_sdk.connectors.incident_io.types.SchedulesNotCondition | airbyte_agent_sdk.connectors.incident_io.types.SchedulesAndCondition | airbyte_agent_sdk.connectors.incident_io.types.SchedulesOrCondition | airbyte_agent_sdk.connectors.incident_io.types.SchedulesAnyCondition]`
     :   The type of the None singleton.
+
+<a id="SchedulesSearchFilter"></a>
 
 `SchedulesSearchFilter(*args, **kwargs)`
 :   Available fields for filtering schedules search queries.
@@ -4528,6 +4982,8 @@ Classes
     `updated_at: str | None`
     :   When the schedule was last updated
 
+<a id="SchedulesSearchQuery"></a>
+
 `SchedulesSearchQuery(*args, **kwargs)`
 :   Search query for schedules entity.
 
@@ -4542,6 +4998,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.incident_io.types.SchedulesSortFilter]`
     :   The type of the None singleton.
+
+<a id="SchedulesSortFilter"></a>
 
 `SchedulesSortFilter(*args, **kwargs)`
 :   Available fields for sorting schedules search results.
@@ -4576,6 +5034,8 @@ Classes
     `updated_at: Literal['asc', 'desc']`
     :   When the schedule was last updated
 
+<a id="SchedulesStringFilter"></a>
+
 `SchedulesStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -4609,6 +5069,8 @@ Classes
     `updated_at: str`
     :   When the schedule was last updated
 
+<a id="SeveritiesAndCondition"></a>
+
 `SeveritiesAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -4629,6 +5091,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.incident_io.types.SeveritiesEqCondition | airbyte_agent_sdk.connectors.incident_io.types.SeveritiesNeqCondition | airbyte_agent_sdk.connectors.incident_io.types.SeveritiesGtCondition | airbyte_agent_sdk.connectors.incident_io.types.SeveritiesGteCondition | airbyte_agent_sdk.connectors.incident_io.types.SeveritiesLtCondition | airbyte_agent_sdk.connectors.incident_io.types.SeveritiesLteCondition | airbyte_agent_sdk.connectors.incident_io.types.SeveritiesInCondition | airbyte_agent_sdk.connectors.incident_io.types.SeveritiesLikeCondition | airbyte_agent_sdk.connectors.incident_io.types.SeveritiesFuzzyCondition | airbyte_agent_sdk.connectors.incident_io.types.SeveritiesKeywordCondition | airbyte_agent_sdk.connectors.incident_io.types.SeveritiesContainsCondition | airbyte_agent_sdk.connectors.incident_io.types.SeveritiesNotCondition | airbyte_agent_sdk.connectors.incident_io.types.SeveritiesAndCondition | airbyte_agent_sdk.connectors.incident_io.types.SeveritiesOrCondition | airbyte_agent_sdk.connectors.incident_io.types.SeveritiesAnyCondition]`
     :   The type of the None singleton.
 
+<a id="SeveritiesAnyCondition"></a>
+
 `SeveritiesAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -4648,6 +5112,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.incident_io.types.SeveritiesAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="SeveritiesAnyValueFilter"></a>
 
 `SeveritiesAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -4676,6 +5142,8 @@ Classes
     `updated_at: Any`
     :   When the severity was last updated
 
+<a id="SeveritiesContainsCondition"></a>
+
 `SeveritiesContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -4687,6 +5155,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.incident_io.types.SeveritiesAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="SeveritiesEqCondition"></a>
 
 `SeveritiesEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -4700,6 +5170,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.incident_io.types.SeveritiesSearchFilter`
     :   The type of the None singleton.
 
+<a id="SeveritiesFuzzyCondition"></a>
+
 `SeveritiesFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -4711,6 +5183,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.incident_io.types.SeveritiesStringFilter`
     :   The type of the None singleton.
+
+<a id="SeveritiesGetParams"></a>
 
 `SeveritiesGetParams(*args, **kwargs)`
 :   Parameters for severities.get operation
@@ -4724,6 +5198,8 @@ Classes
     `id: str`
     :   The type of the None singleton.
 
+<a id="SeveritiesGtCondition"></a>
+
 `SeveritiesGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -4736,6 +5212,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.incident_io.types.SeveritiesSearchFilter`
     :   The type of the None singleton.
 
+<a id="SeveritiesGteCondition"></a>
+
 `SeveritiesGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -4747,6 +5225,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.incident_io.types.SeveritiesSearchFilter`
     :   The type of the None singleton.
+
+<a id="SeveritiesInCondition"></a>
 
 `SeveritiesInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -4767,6 +5247,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.incident_io.types.SeveritiesInFilter`
     :   The type of the None singleton.
+
+<a id="SeveritiesInFilter"></a>
 
 `SeveritiesInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -4795,6 +5277,8 @@ Classes
     `updated_at: list[str]`
     :   When the severity was last updated
 
+<a id="SeveritiesKeywordCondition"></a>
+
 `SeveritiesKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -4806,6 +5290,8 @@ Classes
 
     `keyword: airbyte_agent_sdk.connectors.incident_io.types.SeveritiesStringFilter`
     :   The type of the None singleton.
+
+<a id="SeveritiesLikeCondition"></a>
 
 `SeveritiesLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
@@ -4819,12 +5305,16 @@ Classes
     `like: airbyte_agent_sdk.connectors.incident_io.types.SeveritiesStringFilter`
     :   The type of the None singleton.
 
+<a id="SeveritiesListParams"></a>
+
 `SeveritiesListParams(*args, **kwargs)`
 :   Parameters for severities.list operation
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="SeveritiesLtCondition"></a>
 
 `SeveritiesLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
@@ -4838,6 +5328,8 @@ Classes
     `lt: airbyte_agent_sdk.connectors.incident_io.types.SeveritiesSearchFilter`
     :   The type of the None singleton.
 
+<a id="SeveritiesLteCondition"></a>
+
 `SeveritiesLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
 
@@ -4850,6 +5342,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.incident_io.types.SeveritiesSearchFilter`
     :   The type of the None singleton.
 
+<a id="SeveritiesNeqCondition"></a>
+
 `SeveritiesNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -4861,6 +5355,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.incident_io.types.SeveritiesSearchFilter`
     :   The type of the None singleton.
+
+<a id="SeveritiesNotCondition"></a>
 
 `SeveritiesNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -4882,6 +5378,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.incident_io.types.SeveritiesEqCondition | airbyte_agent_sdk.connectors.incident_io.types.SeveritiesNeqCondition | airbyte_agent_sdk.connectors.incident_io.types.SeveritiesGtCondition | airbyte_agent_sdk.connectors.incident_io.types.SeveritiesGteCondition | airbyte_agent_sdk.connectors.incident_io.types.SeveritiesLtCondition | airbyte_agent_sdk.connectors.incident_io.types.SeveritiesLteCondition | airbyte_agent_sdk.connectors.incident_io.types.SeveritiesInCondition | airbyte_agent_sdk.connectors.incident_io.types.SeveritiesLikeCondition | airbyte_agent_sdk.connectors.incident_io.types.SeveritiesFuzzyCondition | airbyte_agent_sdk.connectors.incident_io.types.SeveritiesKeywordCondition | airbyte_agent_sdk.connectors.incident_io.types.SeveritiesContainsCondition | airbyte_agent_sdk.connectors.incident_io.types.SeveritiesNotCondition | airbyte_agent_sdk.connectors.incident_io.types.SeveritiesAndCondition | airbyte_agent_sdk.connectors.incident_io.types.SeveritiesOrCondition | airbyte_agent_sdk.connectors.incident_io.types.SeveritiesAnyCondition`
     :   The type of the None singleton.
 
+<a id="SeveritiesOrCondition"></a>
+
 `SeveritiesOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -4901,6 +5399,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.incident_io.types.SeveritiesEqCondition | airbyte_agent_sdk.connectors.incident_io.types.SeveritiesNeqCondition | airbyte_agent_sdk.connectors.incident_io.types.SeveritiesGtCondition | airbyte_agent_sdk.connectors.incident_io.types.SeveritiesGteCondition | airbyte_agent_sdk.connectors.incident_io.types.SeveritiesLtCondition | airbyte_agent_sdk.connectors.incident_io.types.SeveritiesLteCondition | airbyte_agent_sdk.connectors.incident_io.types.SeveritiesInCondition | airbyte_agent_sdk.connectors.incident_io.types.SeveritiesLikeCondition | airbyte_agent_sdk.connectors.incident_io.types.SeveritiesFuzzyCondition | airbyte_agent_sdk.connectors.incident_io.types.SeveritiesKeywordCondition | airbyte_agent_sdk.connectors.incident_io.types.SeveritiesContainsCondition | airbyte_agent_sdk.connectors.incident_io.types.SeveritiesNotCondition | airbyte_agent_sdk.connectors.incident_io.types.SeveritiesAndCondition | airbyte_agent_sdk.connectors.incident_io.types.SeveritiesOrCondition | airbyte_agent_sdk.connectors.incident_io.types.SeveritiesAnyCondition]`
     :   The type of the None singleton.
+
+<a id="SeveritiesSearchFilter"></a>
 
 `SeveritiesSearchFilter(*args, **kwargs)`
 :   Available fields for filtering severities search queries.
@@ -4929,6 +5429,8 @@ Classes
     `updated_at: str | None`
     :   When the severity was last updated
 
+<a id="SeveritiesSearchQuery"></a>
+
 `SeveritiesSearchQuery(*args, **kwargs)`
 :   Search query for severities entity.
 
@@ -4943,6 +5445,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.incident_io.types.SeveritiesSortFilter]`
     :   The type of the None singleton.
+
+<a id="SeveritiesSortFilter"></a>
 
 `SeveritiesSortFilter(*args, **kwargs)`
 :   Available fields for sorting severities search results.
@@ -4971,6 +5475,8 @@ Classes
     `updated_at: Literal['asc', 'desc']`
     :   When the severity was last updated
 
+<a id="SeveritiesStringFilter"></a>
+
 `SeveritiesStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -4998,6 +5504,8 @@ Classes
     `updated_at: str`
     :   When the severity was last updated
 
+<a id="UsersAndCondition"></a>
+
 `UsersAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -5018,6 +5526,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.incident_io.types.UsersEqCondition | airbyte_agent_sdk.connectors.incident_io.types.UsersNeqCondition | airbyte_agent_sdk.connectors.incident_io.types.UsersGtCondition | airbyte_agent_sdk.connectors.incident_io.types.UsersGteCondition | airbyte_agent_sdk.connectors.incident_io.types.UsersLtCondition | airbyte_agent_sdk.connectors.incident_io.types.UsersLteCondition | airbyte_agent_sdk.connectors.incident_io.types.UsersInCondition | airbyte_agent_sdk.connectors.incident_io.types.UsersLikeCondition | airbyte_agent_sdk.connectors.incident_io.types.UsersFuzzyCondition | airbyte_agent_sdk.connectors.incident_io.types.UsersKeywordCondition | airbyte_agent_sdk.connectors.incident_io.types.UsersContainsCondition | airbyte_agent_sdk.connectors.incident_io.types.UsersNotCondition | airbyte_agent_sdk.connectors.incident_io.types.UsersAndCondition | airbyte_agent_sdk.connectors.incident_io.types.UsersOrCondition | airbyte_agent_sdk.connectors.incident_io.types.UsersAnyCondition]`
     :   The type of the None singleton.
 
+<a id="UsersAnyCondition"></a>
+
 `UsersAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -5037,6 +5547,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.incident_io.types.UsersAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="UsersAnyValueFilter"></a>
 
 `UsersAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -5068,6 +5580,8 @@ Classes
     `slack_user_id: Any`
     :   Slack user ID
 
+<a id="UsersContainsCondition"></a>
+
 `UsersContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -5079,6 +5593,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.incident_io.types.UsersAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="UsersEqCondition"></a>
 
 `UsersEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -5092,6 +5608,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.incident_io.types.UsersSearchFilter`
     :   The type of the None singleton.
 
+<a id="UsersFuzzyCondition"></a>
+
 `UsersFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -5103,6 +5621,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.incident_io.types.UsersStringFilter`
     :   The type of the None singleton.
+
+<a id="UsersGetParams"></a>
 
 `UsersGetParams(*args, **kwargs)`
 :   Parameters for users.get operation
@@ -5116,6 +5636,8 @@ Classes
     `id: str`
     :   The type of the None singleton.
 
+<a id="UsersGtCondition"></a>
+
 `UsersGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -5128,6 +5650,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.incident_io.types.UsersSearchFilter`
     :   The type of the None singleton.
 
+<a id="UsersGteCondition"></a>
+
 `UsersGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -5139,6 +5663,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.incident_io.types.UsersSearchFilter`
     :   The type of the None singleton.
+
+<a id="UsersInCondition"></a>
 
 `UsersInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -5159,6 +5685,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.incident_io.types.UsersInFilter`
     :   The type of the None singleton.
+
+<a id="UsersInFilter"></a>
 
 `UsersInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -5190,6 +5718,8 @@ Classes
     `slack_user_id: list[str]`
     :   Slack user ID
 
+<a id="UsersKeywordCondition"></a>
+
 `UsersKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -5202,6 +5732,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.incident_io.types.UsersStringFilter`
     :   The type of the None singleton.
 
+<a id="UsersLikeCondition"></a>
+
 `UsersLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -5213,6 +5745,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.incident_io.types.UsersStringFilter`
     :   The type of the None singleton.
+
+<a id="UsersListParams"></a>
 
 `UsersListParams(*args, **kwargs)`
 :   Parameters for users.list operation
@@ -5229,6 +5763,8 @@ Classes
     `page_size: int`
     :   The type of the None singleton.
 
+<a id="UsersLtCondition"></a>
+
 `UsersLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -5240,6 +5776,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.incident_io.types.UsersSearchFilter`
     :   The type of the None singleton.
+
+<a id="UsersLteCondition"></a>
 
 `UsersLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -5253,6 +5791,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.incident_io.types.UsersSearchFilter`
     :   The type of the None singleton.
 
+<a id="UsersNeqCondition"></a>
+
 `UsersNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -5264,6 +5804,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.incident_io.types.UsersSearchFilter`
     :   The type of the None singleton.
+
+<a id="UsersNotCondition"></a>
 
 `UsersNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -5285,6 +5827,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.incident_io.types.UsersEqCondition | airbyte_agent_sdk.connectors.incident_io.types.UsersNeqCondition | airbyte_agent_sdk.connectors.incident_io.types.UsersGtCondition | airbyte_agent_sdk.connectors.incident_io.types.UsersGteCondition | airbyte_agent_sdk.connectors.incident_io.types.UsersLtCondition | airbyte_agent_sdk.connectors.incident_io.types.UsersLteCondition | airbyte_agent_sdk.connectors.incident_io.types.UsersInCondition | airbyte_agent_sdk.connectors.incident_io.types.UsersLikeCondition | airbyte_agent_sdk.connectors.incident_io.types.UsersFuzzyCondition | airbyte_agent_sdk.connectors.incident_io.types.UsersKeywordCondition | airbyte_agent_sdk.connectors.incident_io.types.UsersContainsCondition | airbyte_agent_sdk.connectors.incident_io.types.UsersNotCondition | airbyte_agent_sdk.connectors.incident_io.types.UsersAndCondition | airbyte_agent_sdk.connectors.incident_io.types.UsersOrCondition | airbyte_agent_sdk.connectors.incident_io.types.UsersAnyCondition`
     :   The type of the None singleton.
 
+<a id="UsersOrCondition"></a>
+
 `UsersOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -5304,6 +5848,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.incident_io.types.UsersEqCondition | airbyte_agent_sdk.connectors.incident_io.types.UsersNeqCondition | airbyte_agent_sdk.connectors.incident_io.types.UsersGtCondition | airbyte_agent_sdk.connectors.incident_io.types.UsersGteCondition | airbyte_agent_sdk.connectors.incident_io.types.UsersLtCondition | airbyte_agent_sdk.connectors.incident_io.types.UsersLteCondition | airbyte_agent_sdk.connectors.incident_io.types.UsersInCondition | airbyte_agent_sdk.connectors.incident_io.types.UsersLikeCondition | airbyte_agent_sdk.connectors.incident_io.types.UsersFuzzyCondition | airbyte_agent_sdk.connectors.incident_io.types.UsersKeywordCondition | airbyte_agent_sdk.connectors.incident_io.types.UsersContainsCondition | airbyte_agent_sdk.connectors.incident_io.types.UsersNotCondition | airbyte_agent_sdk.connectors.incident_io.types.UsersAndCondition | airbyte_agent_sdk.connectors.incident_io.types.UsersOrCondition | airbyte_agent_sdk.connectors.incident_io.types.UsersAnyCondition]`
     :   The type of the None singleton.
+
+<a id="UsersSearchFilter"></a>
 
 `UsersSearchFilter(*args, **kwargs)`
 :   Available fields for filtering users search queries.
@@ -5335,6 +5881,8 @@ Classes
     `slack_user_id: str | None`
     :   Slack user ID
 
+<a id="UsersSearchQuery"></a>
+
 `UsersSearchQuery(*args, **kwargs)`
 :   Search query for users entity.
 
@@ -5349,6 +5897,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.incident_io.types.UsersSortFilter]`
     :   The type of the None singleton.
+
+<a id="UsersSortFilter"></a>
 
 `UsersSortFilter(*args, **kwargs)`
 :   Available fields for sorting users search results.
@@ -5379,6 +5929,8 @@ Classes
 
     `slack_user_id: Literal['asc', 'desc']`
     :   Slack user ID
+
+<a id="UsersStringFilter"></a>
 
 `UsersStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/intercom/connector.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/intercom/connector.md
@@ -10,6 +10,8 @@ Intercom connector.
 Classes
 -------
 
+<a id="AdminsQuery"></a>
+
 `AdminsQuery(connector: IntercomConnector)`
 :   Query class for Admins entity operations.
     
@@ -32,6 +34,8 @@ Classes
         
         Returns:
             AdminsListResult
+
+<a id="CompaniesQuery"></a>
 
 `CompaniesQuery(connector: IntercomConnector)`
 :   Query class for Companies entity operations.
@@ -134,6 +138,8 @@ Classes
         
         Returns:
             Company
+
+<a id="ContactsQuery"></a>
 
 `ContactsQuery(connector: IntercomConnector)`
 :   Query class for Contacts entity operations.
@@ -280,6 +286,8 @@ Classes
         Returns:
             Contact
 
+<a id="ConversationsQuery"></a>
+
 `ConversationsQuery(connector: IntercomConnector)`
 :   Query class for Conversations entity operations.
     
@@ -362,6 +370,8 @@ Classes
         
         Returns:
             ConversationsListResult
+
+<a id="IntercomConnector"></a>
 
 `IntercomConnector(auth_config: IntercomAuthConfig | AirbyteAuthConfig | BaseModel | None = None, on_token_refresh: Any | None = None)`
 :   Type-safe Intercom API connector.
@@ -563,6 +573,8 @@ Classes
             for entity in entities:
                 print(f"\{entity['entity_name']\}: \{entity['available_actions']\}")
 
+<a id="InternalArticlesQuery"></a>
+
 `InternalArticlesQuery(connector: IntercomConnector)`
 :   Query class for InternalArticles entity operations.
     
@@ -583,6 +595,8 @@ Classes
         Returns:
             InternalArticle
 
+<a id="NotesQuery"></a>
+
 `NotesQuery(connector: IntercomConnector)`
 :   Query class for Notes entity operations.
     
@@ -601,6 +615,8 @@ Classes
         
         Returns:
             Note
+
+<a id="SegmentsQuery"></a>
 
 `SegmentsQuery(connector: IntercomConnector)`
 :   Query class for Segments entity operations.
@@ -628,6 +644,8 @@ Classes
         
         Returns:
             SegmentsListResult
+
+<a id="TagsQuery"></a>
 
 `TagsQuery(connector: IntercomConnector)`
 :   Query class for Tags entity operations.
@@ -661,6 +679,8 @@ Classes
         
         Returns:
             TagsListResult
+
+<a id="TeamsQuery"></a>
 
 `TeamsQuery(connector: IntercomConnector)`
 :   Query class for Teams entity operations.

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/intercom/index.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/intercom/index.md
@@ -19,6 +19,8 @@ Sub-modules
 Classes
 -------
 
+<a id="AirbyteAuthConfig"></a>
+
 `AirbyteAuthConfig(**data: Any)`
 :   Authentication configuration for Airbyte hosted mode execution.
     
@@ -87,6 +89,8 @@ Classes
     `workspace_name: str | None`
     :   The type of the None singleton.
 
+<a id="AirbyteSearchMeta"></a>
+
 `AirbyteSearchMeta(**data: Any)`
 :   Pagination metadata for search responses.
     
@@ -114,6 +118,8 @@ Classes
 
     `took_ms: int | None`
     :   Time taken to execute the search in milliseconds.
+
+<a id="AirbyteSearchResult"></a>
 
 `AirbyteSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -148,6 +154,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="CompaniesSearchResult"></a>
+
 `CompaniesSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -163,6 +171,8 @@ Classes
     * airbyte_agent_sdk.connectors.intercom.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="ContactsSearchResult"></a>
 
 `ContactsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -180,6 +190,8 @@ Classes
     * pydantic.main.BaseModel
     * typing.Generic
 
+<a id="ConversationsSearchResult"></a>
+
 `ConversationsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -196,6 +208,8 @@ Classes
     * pydantic.main.BaseModel
     * typing.Generic
 
+<a id="TeamsSearchResult"></a>
+
 `TeamsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -211,6 +225,8 @@ Classes
     * airbyte_agent_sdk.connectors.intercom.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="CompaniesSearchData"></a>
 
 `CompaniesSearchData(**data: Any)`
 :   Search result data for companies entity.
@@ -284,6 +300,8 @@ Classes
 
     `website: str | None`
     :   The website of the company
+
+<a id="ContactsSearchData"></a>
 
 `ContactsSearchData(**data: Any)`
 :   Search result data for contacts entity.
@@ -466,6 +484,8 @@ Classes
     `workspace_id: str | None`
     :   The unique identifier of the workspace associated with the contact.
 
+<a id="ConversationsSearchData"></a>
+
 `ConversationsSearchData(**data: Any)`
 :   Search result data for conversations entity.
     
@@ -584,6 +604,8 @@ Classes
     `waiting_since: int | None`
     :   Timestamp since waiting for a response
 
+<a id="IntercomAuthConfig"></a>
+
 `IntercomAuthConfig(**data: Any)`
 :   Access Token Authentication
     
@@ -605,6 +627,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="IntercomConnector"></a>
 
 `IntercomConnector(auth_config: IntercomAuthConfig | AirbyteAuthConfig | BaseModel | None = None, on_token_refresh: Any | None = None)`
 :   Type-safe Intercom API connector.
@@ -806,6 +830,8 @@ Classes
             for entity in entities:
                 print(f"\{entity['entity_name']\}: \{entity['available_actions']\}")
 
+<a id="IntercomReplicationConfig"></a>
+
 `IntercomReplicationConfig(**data: Any)`
 :   Replication Configuration - Settings for data replication from Intercom.
     
@@ -827,6 +853,8 @@ Classes
 
     `start_date: str`
     :   UTC date and time in the format YYYY-MM-DDTHH:mm:ssZ from which to start replicating data.
+
+<a id="TeamsSearchData"></a>
 
 `TeamsSearchData(**data: Any)`
 :   Search result data for teams entity.

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/intercom/models.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/intercom/models.md
@@ -13,6 +13,8 @@ and response envelope types.
 Classes
 -------
 
+<a id="Admin"></a>
+
 `Admin(**data: Any)`
 :   Admin object
     
@@ -65,6 +67,8 @@ Classes
     `type_: str | Any | None`
     :   The type of the None singleton.
 
+<a id="AdminPriorityLevel"></a>
+
 `AdminPriorityLevel(**data: Any)`
 :   Admin priority level settings
     
@@ -89,6 +93,8 @@ Classes
 
     `secondary_admin_ids: list[int] | Any`
     :   The type of the None singleton.
+
+<a id="AdminReference"></a>
 
 `AdminReference(**data: Any)`
 :   Admin reference
@@ -115,6 +121,8 @@ Classes
     `type_: str | Any | None`
     :   The type of the None singleton.
 
+<a id="AdminsList"></a>
+
 `AdminsList(**data: Any)`
 :   List of admins
     
@@ -139,6 +147,8 @@ Classes
 
     `type_: str | Any | None`
     :   The type of the None singleton.
+
+<a id="AirbyteSearchMeta"></a>
 
 `AirbyteSearchMeta(**data: Any)`
 :   Pagination metadata for search responses.
@@ -167,6 +177,8 @@ Classes
 
     `took_ms: int | None`
     :   Time taken to execute the search in milliseconds.
+
+<a id="AirbyteSearchResult"></a>
 
 `AirbyteSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -222,6 +234,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="CompaniesSearchResult"></a>
+
 `CompaniesSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -258,6 +272,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="ContactsSearchResult"></a>
 
 `ContactsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -296,6 +312,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="ConversationsSearchResult"></a>
+
 `ConversationsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -333,6 +351,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="TeamsSearchResult"></a>
+
 `TeamsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -348,6 +368,8 @@ Classes
     * airbyte_agent_sdk.connectors.intercom.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="Attachment"></a>
 
 `Attachment(**data: Any)`
 :   Message attachment
@@ -389,6 +411,8 @@ Classes
     `width: int | Any | None`
     :   The type of the None singleton.
 
+<a id="Author"></a>
+
 `Author(**data: Any)`
 :   Message author
     
@@ -420,6 +444,8 @@ Classes
     `type_: str | Any | None`
     :   The type of the None singleton.
 
+<a id="Avatar"></a>
+
 `Avatar(**data: Any)`
 :   Avatar image
     
@@ -444,6 +470,8 @@ Classes
 
     `type_: str | Any | None`
     :   The type of the None singleton.
+
+<a id="CompaniesList"></a>
 
 `CompaniesList(**data: Any)`
 :   Paginated list of companies
@@ -475,6 +503,8 @@ Classes
 
     `type_: str | Any | None`
     :   The type of the None singleton.
+
+<a id="CompaniesListPages"></a>
 
 `CompaniesListPages(**data: Any)`
 :   Pagination metadata
@@ -510,6 +540,8 @@ Classes
     `type_: str | Any | None`
     :   Type of pagination
 
+<a id="CompaniesListPagesNext"></a>
+
 `CompaniesListPagesNext(**data: Any)`
 :   Cursor for next page
     
@@ -535,6 +567,8 @@ Classes
     `starting_after: str | Any | None`
     :   Cursor for next page
 
+<a id="CompaniesListResultMeta"></a>
+
 `CompaniesListResultMeta(**data: Any)`
 :   Metadata for companies.Action.LIST operation
     
@@ -556,6 +590,8 @@ Classes
 
     `next_page: str | Any | None`
     :   The type of the None singleton.
+
+<a id="CompaniesSearchData"></a>
 
 `CompaniesSearchData(**data: Any)`
 :   Search result data for companies entity.
@@ -629,6 +665,8 @@ Classes
 
     `website: str | None`
     :   The website of the company
+
+<a id="Company"></a>
 
 `Company(**data: Any)`
 :   Company object
@@ -706,6 +744,8 @@ Classes
     `website: str | Any | None`
     :   The type of the None singleton.
 
+<a id="CompanyCreateParams"></a>
+
 `CompanyCreateParams(**data: Any)`
 :   CompanyCreateParams type definition
     
@@ -749,6 +789,8 @@ Classes
     `website: str | Any`
     :   The type of the None singleton.
 
+<a id="CompanyPlan"></a>
+
 `CompanyPlan(**data: Any)`
 :   Company plan
     
@@ -776,6 +818,8 @@ Classes
 
     `type_: str | Any | None`
     :   The type of the None singleton.
+
+<a id="CompanyReference"></a>
 
 `CompanyReference(**data: Any)`
 :   Company reference
@@ -805,6 +849,8 @@ Classes
     `url: str | Any | None`
     :   The type of the None singleton.
 
+<a id="CompanySegments"></a>
+
 `CompanySegments(**data: Any)`
 :   Segments for company
     
@@ -830,6 +876,8 @@ Classes
     `type_: str | Any | None`
     :   The type of the None singleton.
 
+<a id="CompanyTags"></a>
+
 `CompanyTags(**data: Any)`
 :   Tags on company
     
@@ -854,6 +902,8 @@ Classes
 
     `type_: str | Any | None`
     :   The type of the None singleton.
+
+<a id="CompanyUpdateParams"></a>
 
 `CompanyUpdateParams(**data: Any)`
 :   CompanyUpdateParams type definition
@@ -894,6 +944,8 @@ Classes
 
     `website: str | Any`
     :   The type of the None singleton.
+
+<a id="Contact"></a>
 
 `Contact(**data: Any)`
 :   Contact object representing a user or lead
@@ -1046,6 +1098,8 @@ Classes
     `workspace_id: str | Any | None`
     :   The type of the None singleton.
 
+<a id="ContactCompanies"></a>
+
 `ContactCompanies(**data: Any)`
 :   Companies associated with contact
     
@@ -1070,6 +1124,8 @@ Classes
 
     `type_: str | Any | None`
     :   The type of the None singleton.
+
+<a id="ContactCreateParams"></a>
 
 `ContactCreateParams(**data: Any)`
 :   ContactCreateParams type definition
@@ -1123,6 +1179,8 @@ Classes
     `unsubscribed_from_emails: bool | Any`
     :   The type of the None singleton.
 
+<a id="ContactNotes"></a>
+
 `ContactNotes(**data: Any)`
 :   Notes associated with contact
     
@@ -1147,6 +1205,8 @@ Classes
 
     `type_: str | Any | None`
     :   The type of the None singleton.
+
+<a id="ContactReference"></a>
 
 `ContactReference(**data: Any)`
 :   Contact reference
@@ -1173,6 +1233,8 @@ Classes
     `type_: str | Any | None`
     :   The type of the None singleton.
 
+<a id="ContactTags"></a>
+
 `ContactTags(**data: Any)`
 :   Tags associated with contact
     
@@ -1197,6 +1259,8 @@ Classes
 
     `type_: str | Any | None`
     :   The type of the None singleton.
+
+<a id="ContactUpdateParams"></a>
 
 `ContactUpdateParams(**data: Any)`
 :   ContactUpdateParams type definition
@@ -1250,6 +1314,8 @@ Classes
     `unsubscribed_from_emails: bool | Any`
     :   The type of the None singleton.
 
+<a id="ContactsList"></a>
+
 `ContactsList(**data: Any)`
 :   Paginated list of contacts
     
@@ -1280,6 +1346,8 @@ Classes
 
     `type_: str | Any | None`
     :   The type of the None singleton.
+
+<a id="ContactsListPages"></a>
 
 `ContactsListPages(**data: Any)`
 :   Pagination metadata
@@ -1315,6 +1383,8 @@ Classes
     `type_: str | Any | None`
     :   Type of pagination
 
+<a id="ContactsListPagesNext"></a>
+
 `ContactsListPagesNext(**data: Any)`
 :   Cursor for next page
     
@@ -1340,6 +1410,8 @@ Classes
     `starting_after: str | Any | None`
     :   Cursor for next page
 
+<a id="ContactsListResultMeta"></a>
+
 `ContactsListResultMeta(**data: Any)`
 :   Metadata for contacts.Action.LIST operation
     
@@ -1361,6 +1433,8 @@ Classes
 
     `next_page: str | Any | None`
     :   The type of the None singleton.
+
+<a id="ContactsSearchData"></a>
 
 `ContactsSearchData(**data: Any)`
 :   Search result data for contacts entity.
@@ -1543,6 +1617,8 @@ Classes
     `workspace_id: str | None`
     :   The unique identifier of the workspace associated with the contact.
 
+<a id="Conversation"></a>
+
 `Conversation(**data: Any)`
 :   Conversation object
     
@@ -1631,6 +1707,8 @@ Classes
     `waiting_since: int | Any | None`
     :   The type of the None singleton.
 
+<a id="ConversationContacts"></a>
+
 `ConversationContacts(**data: Any)`
 :   Contacts in conversation
     
@@ -1655,6 +1733,8 @@ Classes
 
     `type_: str | Any | None`
     :   The type of the None singleton.
+
+<a id="ConversationPart"></a>
 
 `ConversationPart(**data: Any)`
 :   Conversation part (message, note, action)
@@ -1711,6 +1791,8 @@ Classes
     `updated_at: int | Any | None`
     :   The type of the None singleton.
 
+<a id="ConversationPartsReference"></a>
+
 `ConversationPartsReference(**data: Any)`
 :   Reference to conversation parts
     
@@ -1738,6 +1820,8 @@ Classes
 
     `type_: str | Any | None`
     :   The type of the None singleton.
+
+<a id="ConversationRating"></a>
 
 `ConversationRating(**data: Any)`
 :   Conversation rating
@@ -1772,6 +1856,8 @@ Classes
 
     `teammate: Any`
     :   The type of the None singleton.
+
+<a id="ConversationSource"></a>
 
 `ConversationSource(**data: Any)`
 :   Conversation source
@@ -1818,6 +1904,8 @@ Classes
 
     `url: str | Any | None`
     :   The type of the None singleton.
+
+<a id="ConversationStatistics"></a>
 
 `ConversationStatistics(**data: Any)`
 :   Conversation statistics
@@ -1895,6 +1983,8 @@ Classes
     `type_: str | Any | None`
     :   The type of the None singleton.
 
+<a id="ConversationTags"></a>
+
 `ConversationTags(**data: Any)`
 :   Tags on conversation
     
@@ -1920,6 +2010,8 @@ Classes
     `type_: str | Any | None`
     :   The type of the None singleton.
 
+<a id="ConversationTeammates"></a>
+
 `ConversationTeammates(**data: Any)`
 :   Teammates in conversation
     
@@ -1944,6 +2036,8 @@ Classes
 
     `type_: str | Any | None`
     :   The type of the None singleton.
+
+<a id="ConversationsList"></a>
 
 `ConversationsList(**data: Any)`
 :   Paginated list of conversations
@@ -1975,6 +2069,8 @@ Classes
 
     `type_: str | Any | None`
     :   The type of the None singleton.
+
+<a id="ConversationsListPages"></a>
 
 `ConversationsListPages(**data: Any)`
 :   Pagination metadata
@@ -2010,6 +2106,8 @@ Classes
     `type_: str | Any | None`
     :   Type of pagination
 
+<a id="ConversationsListPagesNext"></a>
+
 `ConversationsListPagesNext(**data: Any)`
 :   Cursor for next page
     
@@ -2035,6 +2133,8 @@ Classes
     `starting_after: str | Any | None`
     :   Cursor for next page
 
+<a id="ConversationsListResultMeta"></a>
+
 `ConversationsListResultMeta(**data: Any)`
 :   Metadata for conversations.Action.LIST operation
     
@@ -2056,6 +2156,8 @@ Classes
 
     `next_page: str | Any | None`
     :   The type of the None singleton.
+
+<a id="ConversationsSearchData"></a>
 
 `ConversationsSearchData(**data: Any)`
 :   Search result data for conversations entity.
@@ -2175,6 +2277,8 @@ Classes
     `waiting_since: int | None`
     :   Timestamp since waiting for a response
 
+<a id="FirstContactReply"></a>
+
 `FirstContactReply(**data: Any)`
 :   First contact reply info
     
@@ -2203,6 +2307,8 @@ Classes
     `url: str | Any | None`
     :   The type of the None singleton.
 
+<a id="IntercomAuthConfig"></a>
+
 `IntercomAuthConfig(**data: Any)`
 :   Access Token Authentication
     
@@ -2224,6 +2330,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="IntercomCheckResult"></a>
 
 `IntercomCheckResult(**data: Any)`
 :   Result of a health check operation.
@@ -2258,6 +2366,8 @@ Classes
     `status: str`
     :   Health check status: 'healthy' or 'unhealthy'.
 
+<a id="IntercomExecuteResult"></a>
+
 `IntercomExecuteResult(**data: Any)`
 :   Response envelope with data only.
     
@@ -2290,6 +2400,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="IntercomExecuteResultWithMeta"></a>
 
 `IntercomExecuteResultWithMeta(**data: Any)`
 :   Response envelope with data and metadata.
@@ -2344,6 +2456,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="CompaniesListResult"></a>
+
 `CompaniesListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -2386,6 +2500,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="ContactsListResult"></a>
 
 `ContactsListResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -2430,6 +2546,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="ConversationsListResult"></a>
+
 `ConversationsListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -2472,6 +2590,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="AdminsListResult"></a>
+
 `AdminsListResult(**data: Any)`
 :   Response envelope with data only.
     
@@ -2512,6 +2632,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="SegmentsListResult"></a>
 
 `SegmentsListResult(**data: Any)`
 :   Response envelope with data only.
@@ -2554,6 +2676,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="TagsListResult"></a>
+
 `TagsListResult(**data: Any)`
 :   Response envelope with data only.
     
@@ -2595,6 +2719,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="TeamsListResult"></a>
+
 `TeamsListResult(**data: Any)`
 :   Response envelope with data only.
     
@@ -2612,6 +2738,8 @@ Classes
     * airbyte_agent_sdk.connectors.intercom.models.IntercomExecuteResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="IntercomReplicationConfig"></a>
 
 `IntercomReplicationConfig(**data: Any)`
 :   Replication Configuration - Settings for data replication from Intercom.
@@ -2634,6 +2762,8 @@ Classes
 
     `start_date: str`
     :   UTC date and time in the format YYYY-MM-DDTHH:mm:ssZ from which to start replicating data.
+
+<a id="InternalArticle"></a>
 
 `InternalArticle(**data: Any)`
 :   Internal article object
@@ -2678,6 +2808,8 @@ Classes
     `updated_at: int | Any | None`
     :   The type of the None singleton.
 
+<a id="InternalArticleCreateParams"></a>
+
 `InternalArticleCreateParams(**data: Any)`
 :   InternalArticleCreateParams type definition
     
@@ -2708,6 +2840,8 @@ Classes
 
     `title: str | Any`
     :   The type of the None singleton.
+
+<a id="Location"></a>
 
 `Location(**data: Any)`
 :   Location information
@@ -2746,6 +2880,8 @@ Classes
     `type_: str | Any | None`
     :   The type of the None singleton.
 
+<a id="Note"></a>
+
 `Note(**data: Any)`
 :   Note object on a contact
     
@@ -2783,6 +2919,8 @@ Classes
     `type_: str | Any | None`
     :   The type of the None singleton.
 
+<a id="NoteCreateParams"></a>
+
 `NoteCreateParams(**data: Any)`
 :   NoteCreateParams type definition
     
@@ -2807,6 +2945,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="NoteReference"></a>
 
 `NoteReference(**data: Any)`
 :   Note reference
@@ -2835,6 +2975,8 @@ Classes
 
     `url: str | Any | None`
     :   The type of the None singleton.
+
+<a id="Pages"></a>
 
 `Pages(**data: Any)`
 :   Pagination metadata
@@ -2870,6 +3012,8 @@ Classes
     `type_: str | Any | None`
     :   The type of the None singleton.
 
+<a id="PagesNext"></a>
+
 `PagesNext(**data: Any)`
 :   Cursor for next page
     
@@ -2894,6 +3038,8 @@ Classes
 
     `starting_after: str | Any | None`
     :   Cursor for next page
+
+<a id="Segment"></a>
 
 `Segment(**data: Any)`
 :   Segment object
@@ -2935,6 +3081,8 @@ Classes
     `updated_at: int | Any | None`
     :   The type of the None singleton.
 
+<a id="SegmentsList"></a>
+
 `SegmentsList(**data: Any)`
 :   List of segments
     
@@ -2959,6 +3107,8 @@ Classes
 
     `type_: str | Any | None`
     :   The type of the None singleton.
+
+<a id="SlaApplied"></a>
 
 `SlaApplied(**data: Any)`
 :   SLA applied to conversation
@@ -2988,6 +3138,8 @@ Classes
     `type_: str | Any | None`
     :   The type of the None singleton.
 
+<a id="SocialProfile"></a>
+
 `SocialProfile(**data: Any)`
 :   Social profile
     
@@ -3016,6 +3168,8 @@ Classes
     `url: str | Any | None`
     :   The type of the None singleton.
 
+<a id="SocialProfiles"></a>
+
 `SocialProfiles(**data: Any)`
 :   Social profiles
     
@@ -3040,6 +3194,8 @@ Classes
 
     `type_: str | Any | None`
     :   The type of the None singleton.
+
+<a id="Tag"></a>
 
 `Tag(**data: Any)`
 :   Tag object
@@ -3075,6 +3231,8 @@ Classes
     `type_: str | Any | None`
     :   The type of the None singleton.
 
+<a id="TagCreateParams"></a>
+
 `TagCreateParams(**data: Any)`
 :   TagCreateParams type definition
     
@@ -3096,6 +3254,8 @@ Classes
 
     `name: str | Any`
     :   The type of the None singleton.
+
+<a id="TagReference"></a>
 
 `TagReference(**data: Any)`
 :   Tag reference
@@ -3125,6 +3285,8 @@ Classes
     `url: str | Any | None`
     :   The type of the None singleton.
 
+<a id="TagsList"></a>
+
 `TagsList(**data: Any)`
 :   List of tags
     
@@ -3149,6 +3311,8 @@ Classes
 
     `type_: str | Any | None`
     :   The type of the None singleton.
+
+<a id="Team"></a>
 
 `Team(**data: Any)`
 :   Team object
@@ -3184,6 +3348,8 @@ Classes
     `type_: str | Any | None`
     :   The type of the None singleton.
 
+<a id="TeamsList"></a>
+
 `TeamsList(**data: Any)`
 :   List of teams
     
@@ -3208,6 +3374,8 @@ Classes
 
     `type_: str | Any | None`
     :   The type of the None singleton.
+
+<a id="TeamsSearchData"></a>
 
 `TeamsSearchData(**data: Any)`
 :   Search result data for teams entity.

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/intercom/types.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/intercom/types.md
@@ -10,6 +10,8 @@ Type definitions for intercom connector.
 Classes
 -------
 
+<a id="AdminsGetParams"></a>
+
 `AdminsGetParams(*args, **kwargs)`
 :   Parameters for admins.get operation
 
@@ -22,12 +24,16 @@ Classes
     `id: str`
     :   The type of the None singleton.
 
+<a id="AdminsListParams"></a>
+
 `AdminsListParams(*args, **kwargs)`
 :   Parameters for admins.list operation
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="AirbyteSearchParams"></a>
 
 `AirbyteSearchParams(*args, **kwargs)`
 :   Parameters for Airbyte cache search operations (generic, use entity-specific query types for better type hints).
@@ -50,6 +56,8 @@ Classes
     `query: dict[str, typing.Any]`
     :   The type of the None singleton.
 
+<a id="CompaniesAndCondition"></a>
+
 `CompaniesAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -70,6 +78,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.intercom.types.CompaniesEqCondition | airbyte_agent_sdk.connectors.intercom.types.CompaniesNeqCondition | airbyte_agent_sdk.connectors.intercom.types.CompaniesGtCondition | airbyte_agent_sdk.connectors.intercom.types.CompaniesGteCondition | airbyte_agent_sdk.connectors.intercom.types.CompaniesLtCondition | airbyte_agent_sdk.connectors.intercom.types.CompaniesLteCondition | airbyte_agent_sdk.connectors.intercom.types.CompaniesInCondition | airbyte_agent_sdk.connectors.intercom.types.CompaniesLikeCondition | airbyte_agent_sdk.connectors.intercom.types.CompaniesFuzzyCondition | airbyte_agent_sdk.connectors.intercom.types.CompaniesKeywordCondition | airbyte_agent_sdk.connectors.intercom.types.CompaniesContainsCondition | airbyte_agent_sdk.connectors.intercom.types.CompaniesNotCondition | airbyte_agent_sdk.connectors.intercom.types.CompaniesAndCondition | airbyte_agent_sdk.connectors.intercom.types.CompaniesOrCondition | airbyte_agent_sdk.connectors.intercom.types.CompaniesAnyCondition]`
     :   The type of the None singleton.
 
+<a id="CompaniesAnyCondition"></a>
+
 `CompaniesAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -89,6 +99,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.intercom.types.CompaniesAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="CompaniesAnyValueFilter"></a>
 
 `CompaniesAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -153,6 +165,8 @@ Classes
     `website: Any`
     :   The website of the company
 
+<a id="CompaniesContainsCondition"></a>
+
 `CompaniesContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -164,6 +178,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.intercom.types.CompaniesAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="CompaniesCreateParams"></a>
 
 `CompaniesCreateParams(*args, **kwargs)`
 :   Parameters for companies.create operation
@@ -198,6 +214,8 @@ Classes
     `website: str`
     :   The type of the None singleton.
 
+<a id="CompaniesEqCondition"></a>
+
 `CompaniesEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
 
@@ -209,6 +227,8 @@ Classes
 
     `eq: airbyte_agent_sdk.connectors.intercom.types.CompaniesSearchFilter`
     :   The type of the None singleton.
+
+<a id="CompaniesFuzzyCondition"></a>
 
 `CompaniesFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
@@ -222,6 +242,8 @@ Classes
     `fuzzy: airbyte_agent_sdk.connectors.intercom.types.CompaniesStringFilter`
     :   The type of the None singleton.
 
+<a id="CompaniesGetParams"></a>
+
 `CompaniesGetParams(*args, **kwargs)`
 :   Parameters for companies.get operation
 
@@ -233,6 +255,8 @@ Classes
 
     `id: str`
     :   The type of the None singleton.
+
+<a id="CompaniesGtCondition"></a>
 
 `CompaniesGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
@@ -246,6 +270,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.intercom.types.CompaniesSearchFilter`
     :   The type of the None singleton.
 
+<a id="CompaniesGteCondition"></a>
+
 `CompaniesGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -257,6 +283,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.intercom.types.CompaniesSearchFilter`
     :   The type of the None singleton.
+
+<a id="CompaniesInCondition"></a>
 
 `CompaniesInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -277,6 +305,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.intercom.types.CompaniesInFilter`
     :   The type of the None singleton.
+
+<a id="CompaniesInFilter"></a>
 
 `CompaniesInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -341,6 +371,8 @@ Classes
     `website: list[str]`
     :   The website of the company
 
+<a id="CompaniesKeywordCondition"></a>
+
 `CompaniesKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -353,6 +385,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.intercom.types.CompaniesStringFilter`
     :   The type of the None singleton.
 
+<a id="CompaniesLikeCondition"></a>
+
 `CompaniesLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -364,6 +398,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.intercom.types.CompaniesStringFilter`
     :   The type of the None singleton.
+
+<a id="CompaniesListParams"></a>
 
 `CompaniesListParams(*args, **kwargs)`
 :   Parameters for companies.list operation
@@ -380,6 +416,8 @@ Classes
     `starting_after: str`
     :   The type of the None singleton.
 
+<a id="CompaniesLtCondition"></a>
+
 `CompaniesLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -391,6 +429,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.intercom.types.CompaniesSearchFilter`
     :   The type of the None singleton.
+
+<a id="CompaniesLteCondition"></a>
 
 `CompaniesLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -404,6 +444,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.intercom.types.CompaniesSearchFilter`
     :   The type of the None singleton.
 
+<a id="CompaniesNeqCondition"></a>
+
 `CompaniesNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -415,6 +457,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.intercom.types.CompaniesSearchFilter`
     :   The type of the None singleton.
+
+<a id="CompaniesNotCondition"></a>
 
 `CompaniesNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -436,6 +480,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.intercom.types.CompaniesEqCondition | airbyte_agent_sdk.connectors.intercom.types.CompaniesNeqCondition | airbyte_agent_sdk.connectors.intercom.types.CompaniesGtCondition | airbyte_agent_sdk.connectors.intercom.types.CompaniesGteCondition | airbyte_agent_sdk.connectors.intercom.types.CompaniesLtCondition | airbyte_agent_sdk.connectors.intercom.types.CompaniesLteCondition | airbyte_agent_sdk.connectors.intercom.types.CompaniesInCondition | airbyte_agent_sdk.connectors.intercom.types.CompaniesLikeCondition | airbyte_agent_sdk.connectors.intercom.types.CompaniesFuzzyCondition | airbyte_agent_sdk.connectors.intercom.types.CompaniesKeywordCondition | airbyte_agent_sdk.connectors.intercom.types.CompaniesContainsCondition | airbyte_agent_sdk.connectors.intercom.types.CompaniesNotCondition | airbyte_agent_sdk.connectors.intercom.types.CompaniesAndCondition | airbyte_agent_sdk.connectors.intercom.types.CompaniesOrCondition | airbyte_agent_sdk.connectors.intercom.types.CompaniesAnyCondition`
     :   The type of the None singleton.
 
+<a id="CompaniesOrCondition"></a>
+
 `CompaniesOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -455,6 +501,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.intercom.types.CompaniesEqCondition | airbyte_agent_sdk.connectors.intercom.types.CompaniesNeqCondition | airbyte_agent_sdk.connectors.intercom.types.CompaniesGtCondition | airbyte_agent_sdk.connectors.intercom.types.CompaniesGteCondition | airbyte_agent_sdk.connectors.intercom.types.CompaniesLtCondition | airbyte_agent_sdk.connectors.intercom.types.CompaniesLteCondition | airbyte_agent_sdk.connectors.intercom.types.CompaniesInCondition | airbyte_agent_sdk.connectors.intercom.types.CompaniesLikeCondition | airbyte_agent_sdk.connectors.intercom.types.CompaniesFuzzyCondition | airbyte_agent_sdk.connectors.intercom.types.CompaniesKeywordCondition | airbyte_agent_sdk.connectors.intercom.types.CompaniesContainsCondition | airbyte_agent_sdk.connectors.intercom.types.CompaniesNotCondition | airbyte_agent_sdk.connectors.intercom.types.CompaniesAndCondition | airbyte_agent_sdk.connectors.intercom.types.CompaniesOrCondition | airbyte_agent_sdk.connectors.intercom.types.CompaniesAnyCondition]`
     :   The type of the None singleton.
+
+<a id="CompaniesSearchFilter"></a>
 
 `CompaniesSearchFilter(*args, **kwargs)`
 :   Available fields for filtering companies search queries.
@@ -519,6 +567,8 @@ Classes
     `website: str | None`
     :   The website of the company
 
+<a id="CompaniesSearchQuery"></a>
+
 `CompaniesSearchQuery(*args, **kwargs)`
 :   Search query for companies entity.
 
@@ -533,6 +583,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.intercom.types.CompaniesSortFilter]`
     :   The type of the None singleton.
+
+<a id="CompaniesSortFilter"></a>
 
 `CompaniesSortFilter(*args, **kwargs)`
 :   Available fields for sorting companies search results.
@@ -597,6 +649,8 @@ Classes
     `website: Literal['asc', 'desc']`
     :   The website of the company
 
+<a id="CompaniesStringFilter"></a>
+
 `CompaniesStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -660,6 +714,8 @@ Classes
     `website: str`
     :   The website of the company
 
+<a id="CompaniesUpdateParams"></a>
+
 `CompaniesUpdateParams(*args, **kwargs)`
 :   Parameters for companies.update operation
 
@@ -693,6 +749,8 @@ Classes
     `website: str`
     :   The type of the None singleton.
 
+<a id="ContactsAndCondition"></a>
+
 `ContactsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -713,6 +771,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.intercom.types.ContactsEqCondition | airbyte_agent_sdk.connectors.intercom.types.ContactsNeqCondition | airbyte_agent_sdk.connectors.intercom.types.ContactsGtCondition | airbyte_agent_sdk.connectors.intercom.types.ContactsGteCondition | airbyte_agent_sdk.connectors.intercom.types.ContactsLtCondition | airbyte_agent_sdk.connectors.intercom.types.ContactsLteCondition | airbyte_agent_sdk.connectors.intercom.types.ContactsInCondition | airbyte_agent_sdk.connectors.intercom.types.ContactsLikeCondition | airbyte_agent_sdk.connectors.intercom.types.ContactsFuzzyCondition | airbyte_agent_sdk.connectors.intercom.types.ContactsKeywordCondition | airbyte_agent_sdk.connectors.intercom.types.ContactsContainsCondition | airbyte_agent_sdk.connectors.intercom.types.ContactsNotCondition | airbyte_agent_sdk.connectors.intercom.types.ContactsAndCondition | airbyte_agent_sdk.connectors.intercom.types.ContactsOrCondition | airbyte_agent_sdk.connectors.intercom.types.ContactsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="ContactsAnyCondition"></a>
+
 `ContactsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -732,6 +792,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.intercom.types.ContactsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="ContactsAnyValueFilter"></a>
 
 `ContactsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -904,6 +966,8 @@ Classes
     `workspace_id: Any`
     :   The unique identifier of the workspace associated with the contact.
 
+<a id="ContactsContainsCondition"></a>
+
 `ContactsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -915,6 +979,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.intercom.types.ContactsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="ContactsCreateParams"></a>
 
 `ContactsCreateParams(*args, **kwargs)`
 :   Parameters for contacts.create operation
@@ -958,6 +1024,8 @@ Classes
     `unsubscribed_from_emails: bool`
     :   The type of the None singleton.
 
+<a id="ContactsEqCondition"></a>
+
 `ContactsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
 
@@ -969,6 +1037,8 @@ Classes
 
     `eq: airbyte_agent_sdk.connectors.intercom.types.ContactsSearchFilter`
     :   The type of the None singleton.
+
+<a id="ContactsFuzzyCondition"></a>
 
 `ContactsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
@@ -982,6 +1052,8 @@ Classes
     `fuzzy: airbyte_agent_sdk.connectors.intercom.types.ContactsStringFilter`
     :   The type of the None singleton.
 
+<a id="ContactsGetParams"></a>
+
 `ContactsGetParams(*args, **kwargs)`
 :   Parameters for contacts.get operation
 
@@ -993,6 +1065,8 @@ Classes
 
     `id: str`
     :   The type of the None singleton.
+
+<a id="ContactsGtCondition"></a>
 
 `ContactsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
@@ -1006,6 +1080,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.intercom.types.ContactsSearchFilter`
     :   The type of the None singleton.
 
+<a id="ContactsGteCondition"></a>
+
 `ContactsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -1017,6 +1093,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.intercom.types.ContactsSearchFilter`
     :   The type of the None singleton.
+
+<a id="ContactsInCondition"></a>
 
 `ContactsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -1037,6 +1115,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.intercom.types.ContactsInFilter`
     :   The type of the None singleton.
+
+<a id="ContactsInFilter"></a>
 
 `ContactsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -1209,6 +1289,8 @@ Classes
     `workspace_id: list[str]`
     :   The unique identifier of the workspace associated with the contact.
 
+<a id="ContactsKeywordCondition"></a>
+
 `ContactsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -1221,6 +1303,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.intercom.types.ContactsStringFilter`
     :   The type of the None singleton.
 
+<a id="ContactsLikeCondition"></a>
+
 `ContactsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -1232,6 +1316,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.intercom.types.ContactsStringFilter`
     :   The type of the None singleton.
+
+<a id="ContactsListParams"></a>
 
 `ContactsListParams(*args, **kwargs)`
 :   Parameters for contacts.list operation
@@ -1248,6 +1334,8 @@ Classes
     `starting_after: str`
     :   The type of the None singleton.
 
+<a id="ContactsLtCondition"></a>
+
 `ContactsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -1259,6 +1347,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.intercom.types.ContactsSearchFilter`
     :   The type of the None singleton.
+
+<a id="ContactsLteCondition"></a>
 
 `ContactsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -1272,6 +1362,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.intercom.types.ContactsSearchFilter`
     :   The type of the None singleton.
 
+<a id="ContactsNeqCondition"></a>
+
 `ContactsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -1283,6 +1375,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.intercom.types.ContactsSearchFilter`
     :   The type of the None singleton.
+
+<a id="ContactsNotCondition"></a>
 
 `ContactsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -1304,6 +1398,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.intercom.types.ContactsEqCondition | airbyte_agent_sdk.connectors.intercom.types.ContactsNeqCondition | airbyte_agent_sdk.connectors.intercom.types.ContactsGtCondition | airbyte_agent_sdk.connectors.intercom.types.ContactsGteCondition | airbyte_agent_sdk.connectors.intercom.types.ContactsLtCondition | airbyte_agent_sdk.connectors.intercom.types.ContactsLteCondition | airbyte_agent_sdk.connectors.intercom.types.ContactsInCondition | airbyte_agent_sdk.connectors.intercom.types.ContactsLikeCondition | airbyte_agent_sdk.connectors.intercom.types.ContactsFuzzyCondition | airbyte_agent_sdk.connectors.intercom.types.ContactsKeywordCondition | airbyte_agent_sdk.connectors.intercom.types.ContactsContainsCondition | airbyte_agent_sdk.connectors.intercom.types.ContactsNotCondition | airbyte_agent_sdk.connectors.intercom.types.ContactsAndCondition | airbyte_agent_sdk.connectors.intercom.types.ContactsOrCondition | airbyte_agent_sdk.connectors.intercom.types.ContactsAnyCondition`
     :   The type of the None singleton.
 
+<a id="ContactsOrCondition"></a>
+
 `ContactsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1323,6 +1419,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.intercom.types.ContactsEqCondition | airbyte_agent_sdk.connectors.intercom.types.ContactsNeqCondition | airbyte_agent_sdk.connectors.intercom.types.ContactsGtCondition | airbyte_agent_sdk.connectors.intercom.types.ContactsGteCondition | airbyte_agent_sdk.connectors.intercom.types.ContactsLtCondition | airbyte_agent_sdk.connectors.intercom.types.ContactsLteCondition | airbyte_agent_sdk.connectors.intercom.types.ContactsInCondition | airbyte_agent_sdk.connectors.intercom.types.ContactsLikeCondition | airbyte_agent_sdk.connectors.intercom.types.ContactsFuzzyCondition | airbyte_agent_sdk.connectors.intercom.types.ContactsKeywordCondition | airbyte_agent_sdk.connectors.intercom.types.ContactsContainsCondition | airbyte_agent_sdk.connectors.intercom.types.ContactsNotCondition | airbyte_agent_sdk.connectors.intercom.types.ContactsAndCondition | airbyte_agent_sdk.connectors.intercom.types.ContactsOrCondition | airbyte_agent_sdk.connectors.intercom.types.ContactsAnyCondition]`
     :   The type of the None singleton.
+
+<a id="ContactsSearchFilter"></a>
 
 `ContactsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering contacts search queries.
@@ -1495,6 +1593,8 @@ Classes
     `workspace_id: str | None`
     :   The unique identifier of the workspace associated with the contact.
 
+<a id="ContactsSearchQuery"></a>
+
 `ContactsSearchQuery(*args, **kwargs)`
 :   Search query for contacts entity.
 
@@ -1509,6 +1609,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.intercom.types.ContactsSortFilter]`
     :   The type of the None singleton.
+
+<a id="ContactsSortFilter"></a>
 
 `ContactsSortFilter(*args, **kwargs)`
 :   Available fields for sorting contacts search results.
@@ -1681,6 +1783,8 @@ Classes
     `workspace_id: Literal['asc', 'desc']`
     :   The unique identifier of the workspace associated with the contact.
 
+<a id="ContactsStringFilter"></a>
+
 `ContactsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -1852,6 +1956,8 @@ Classes
     `workspace_id: str`
     :   The unique identifier of the workspace associated with the contact.
 
+<a id="ContactsUpdateParams"></a>
+
 `ContactsUpdateParams(*args, **kwargs)`
 :   Parameters for contacts.update operation
 
@@ -1897,6 +2003,8 @@ Classes
     `unsubscribed_from_emails: bool`
     :   The type of the None singleton.
 
+<a id="ConversationsAndCondition"></a>
+
 `ConversationsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1917,6 +2025,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.intercom.types.ConversationsEqCondition | airbyte_agent_sdk.connectors.intercom.types.ConversationsNeqCondition | airbyte_agent_sdk.connectors.intercom.types.ConversationsGtCondition | airbyte_agent_sdk.connectors.intercom.types.ConversationsGteCondition | airbyte_agent_sdk.connectors.intercom.types.ConversationsLtCondition | airbyte_agent_sdk.connectors.intercom.types.ConversationsLteCondition | airbyte_agent_sdk.connectors.intercom.types.ConversationsInCondition | airbyte_agent_sdk.connectors.intercom.types.ConversationsLikeCondition | airbyte_agent_sdk.connectors.intercom.types.ConversationsFuzzyCondition | airbyte_agent_sdk.connectors.intercom.types.ConversationsKeywordCondition | airbyte_agent_sdk.connectors.intercom.types.ConversationsContainsCondition | airbyte_agent_sdk.connectors.intercom.types.ConversationsNotCondition | airbyte_agent_sdk.connectors.intercom.types.ConversationsAndCondition | airbyte_agent_sdk.connectors.intercom.types.ConversationsOrCondition | airbyte_agent_sdk.connectors.intercom.types.ConversationsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="ConversationsAnyCondition"></a>
+
 `ConversationsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1936,6 +2046,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.intercom.types.ConversationsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="ConversationsAnyValueFilter"></a>
 
 `ConversationsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -2045,6 +2157,8 @@ Classes
     `waiting_since: Any`
     :   Timestamp since waiting for a response
 
+<a id="ConversationsContainsCondition"></a>
+
 `ConversationsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -2056,6 +2170,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.intercom.types.ConversationsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="ConversationsEqCondition"></a>
 
 `ConversationsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -2069,6 +2185,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.intercom.types.ConversationsSearchFilter`
     :   The type of the None singleton.
 
+<a id="ConversationsFuzzyCondition"></a>
+
 `ConversationsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -2080,6 +2198,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.intercom.types.ConversationsStringFilter`
     :   The type of the None singleton.
+
+<a id="ConversationsGetParams"></a>
 
 `ConversationsGetParams(*args, **kwargs)`
 :   Parameters for conversations.get operation
@@ -2093,6 +2213,8 @@ Classes
     `id: str`
     :   The type of the None singleton.
 
+<a id="ConversationsGtCondition"></a>
+
 `ConversationsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -2105,6 +2227,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.intercom.types.ConversationsSearchFilter`
     :   The type of the None singleton.
 
+<a id="ConversationsGteCondition"></a>
+
 `ConversationsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -2116,6 +2240,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.intercom.types.ConversationsSearchFilter`
     :   The type of the None singleton.
+
+<a id="ConversationsInCondition"></a>
 
 `ConversationsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -2136,6 +2262,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.intercom.types.ConversationsInFilter`
     :   The type of the None singleton.
+
+<a id="ConversationsInFilter"></a>
 
 `ConversationsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -2245,6 +2373,8 @@ Classes
     `waiting_since: list[int]`
     :   Timestamp since waiting for a response
 
+<a id="ConversationsKeywordCondition"></a>
+
 `ConversationsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -2257,6 +2387,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.intercom.types.ConversationsStringFilter`
     :   The type of the None singleton.
 
+<a id="ConversationsLikeCondition"></a>
+
 `ConversationsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -2268,6 +2400,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.intercom.types.ConversationsStringFilter`
     :   The type of the None singleton.
+
+<a id="ConversationsListParams"></a>
 
 `ConversationsListParams(*args, **kwargs)`
 :   Parameters for conversations.list operation
@@ -2284,6 +2418,8 @@ Classes
     `starting_after: str`
     :   The type of the None singleton.
 
+<a id="ConversationsLtCondition"></a>
+
 `ConversationsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -2295,6 +2431,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.intercom.types.ConversationsSearchFilter`
     :   The type of the None singleton.
+
+<a id="ConversationsLteCondition"></a>
 
 `ConversationsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -2308,6 +2446,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.intercom.types.ConversationsSearchFilter`
     :   The type of the None singleton.
 
+<a id="ConversationsNeqCondition"></a>
+
 `ConversationsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -2319,6 +2459,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.intercom.types.ConversationsSearchFilter`
     :   The type of the None singleton.
+
+<a id="ConversationsNotCondition"></a>
 
 `ConversationsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -2340,6 +2482,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.intercom.types.ConversationsEqCondition | airbyte_agent_sdk.connectors.intercom.types.ConversationsNeqCondition | airbyte_agent_sdk.connectors.intercom.types.ConversationsGtCondition | airbyte_agent_sdk.connectors.intercom.types.ConversationsGteCondition | airbyte_agent_sdk.connectors.intercom.types.ConversationsLtCondition | airbyte_agent_sdk.connectors.intercom.types.ConversationsLteCondition | airbyte_agent_sdk.connectors.intercom.types.ConversationsInCondition | airbyte_agent_sdk.connectors.intercom.types.ConversationsLikeCondition | airbyte_agent_sdk.connectors.intercom.types.ConversationsFuzzyCondition | airbyte_agent_sdk.connectors.intercom.types.ConversationsKeywordCondition | airbyte_agent_sdk.connectors.intercom.types.ConversationsContainsCondition | airbyte_agent_sdk.connectors.intercom.types.ConversationsNotCondition | airbyte_agent_sdk.connectors.intercom.types.ConversationsAndCondition | airbyte_agent_sdk.connectors.intercom.types.ConversationsOrCondition | airbyte_agent_sdk.connectors.intercom.types.ConversationsAnyCondition`
     :   The type of the None singleton.
 
+<a id="ConversationsOrCondition"></a>
+
 `ConversationsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -2359,6 +2503,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.intercom.types.ConversationsEqCondition | airbyte_agent_sdk.connectors.intercom.types.ConversationsNeqCondition | airbyte_agent_sdk.connectors.intercom.types.ConversationsGtCondition | airbyte_agent_sdk.connectors.intercom.types.ConversationsGteCondition | airbyte_agent_sdk.connectors.intercom.types.ConversationsLtCondition | airbyte_agent_sdk.connectors.intercom.types.ConversationsLteCondition | airbyte_agent_sdk.connectors.intercom.types.ConversationsInCondition | airbyte_agent_sdk.connectors.intercom.types.ConversationsLikeCondition | airbyte_agent_sdk.connectors.intercom.types.ConversationsFuzzyCondition | airbyte_agent_sdk.connectors.intercom.types.ConversationsKeywordCondition | airbyte_agent_sdk.connectors.intercom.types.ConversationsContainsCondition | airbyte_agent_sdk.connectors.intercom.types.ConversationsNotCondition | airbyte_agent_sdk.connectors.intercom.types.ConversationsAndCondition | airbyte_agent_sdk.connectors.intercom.types.ConversationsOrCondition | airbyte_agent_sdk.connectors.intercom.types.ConversationsAnyCondition]`
     :   The type of the None singleton.
+
+<a id="ConversationsSearchFilter"></a>
 
 `ConversationsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering conversations search queries.
@@ -2468,6 +2614,8 @@ Classes
     `waiting_since: int | None`
     :   Timestamp since waiting for a response
 
+<a id="ConversationsSearchQuery"></a>
+
 `ConversationsSearchQuery(*args, **kwargs)`
 :   Search query for conversations entity.
 
@@ -2482,6 +2630,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.intercom.types.ConversationsSortFilter]`
     :   The type of the None singleton.
+
+<a id="ConversationsSortFilter"></a>
 
 `ConversationsSortFilter(*args, **kwargs)`
 :   Available fields for sorting conversations search results.
@@ -2591,6 +2741,8 @@ Classes
     `waiting_since: Literal['asc', 'desc']`
     :   Timestamp since waiting for a response
 
+<a id="ConversationsStringFilter"></a>
+
 `ConversationsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -2699,6 +2851,8 @@ Classes
     `waiting_since: str`
     :   Timestamp since waiting for a response
 
+<a id="InternalArticlesCreateParams"></a>
+
 `InternalArticlesCreateParams(*args, **kwargs)`
 :   Parameters for internal_articles.create operation
 
@@ -2720,6 +2874,8 @@ Classes
     `title: str`
     :   The type of the None singleton.
 
+<a id="NotesCreateParams"></a>
+
 `NotesCreateParams(*args, **kwargs)`
 :   Parameters for notes.create operation
 
@@ -2738,6 +2894,8 @@ Classes
     `contact_id: str`
     :   The type of the None singleton.
 
+<a id="SegmentsGetParams"></a>
+
 `SegmentsGetParams(*args, **kwargs)`
 :   Parameters for segments.get operation
 
@@ -2749,6 +2907,8 @@ Classes
 
     `id: str`
     :   The type of the None singleton.
+
+<a id="SegmentsListParams"></a>
 
 `SegmentsListParams(*args, **kwargs)`
 :   Parameters for segments.list operation
@@ -2762,6 +2922,8 @@ Classes
     `include_count: bool`
     :   The type of the None singleton.
 
+<a id="TagsCreateParams"></a>
+
 `TagsCreateParams(*args, **kwargs)`
 :   Parameters for tags.create operation
 
@@ -2773,6 +2935,8 @@ Classes
 
     `name: str`
     :   The type of the None singleton.
+
+<a id="TagsGetParams"></a>
 
 `TagsGetParams(*args, **kwargs)`
 :   Parameters for tags.get operation
@@ -2786,12 +2950,16 @@ Classes
     `id: str`
     :   The type of the None singleton.
 
+<a id="TagsListParams"></a>
+
 `TagsListParams(*args, **kwargs)`
 :   Parameters for tags.list operation
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="TeamsAndCondition"></a>
 
 `TeamsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -2813,6 +2981,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.intercom.types.TeamsEqCondition | airbyte_agent_sdk.connectors.intercom.types.TeamsNeqCondition | airbyte_agent_sdk.connectors.intercom.types.TeamsGtCondition | airbyte_agent_sdk.connectors.intercom.types.TeamsGteCondition | airbyte_agent_sdk.connectors.intercom.types.TeamsLtCondition | airbyte_agent_sdk.connectors.intercom.types.TeamsLteCondition | airbyte_agent_sdk.connectors.intercom.types.TeamsInCondition | airbyte_agent_sdk.connectors.intercom.types.TeamsLikeCondition | airbyte_agent_sdk.connectors.intercom.types.TeamsFuzzyCondition | airbyte_agent_sdk.connectors.intercom.types.TeamsKeywordCondition | airbyte_agent_sdk.connectors.intercom.types.TeamsContainsCondition | airbyte_agent_sdk.connectors.intercom.types.TeamsNotCondition | airbyte_agent_sdk.connectors.intercom.types.TeamsAndCondition | airbyte_agent_sdk.connectors.intercom.types.TeamsOrCondition | airbyte_agent_sdk.connectors.intercom.types.TeamsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="TeamsAnyCondition"></a>
+
 `TeamsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -2832,6 +3002,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.intercom.types.TeamsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="TeamsAnyValueFilter"></a>
 
 `TeamsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -2854,6 +3026,8 @@ Classes
     `type_: Any`
     :   Type of team (e.g., 'internal', 'external').
 
+<a id="TeamsContainsCondition"></a>
+
 `TeamsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -2865,6 +3039,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.intercom.types.TeamsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="TeamsEqCondition"></a>
 
 `TeamsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -2878,6 +3054,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.intercom.types.TeamsSearchFilter`
     :   The type of the None singleton.
 
+<a id="TeamsFuzzyCondition"></a>
+
 `TeamsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -2889,6 +3067,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.intercom.types.TeamsStringFilter`
     :   The type of the None singleton.
+
+<a id="TeamsGetParams"></a>
 
 `TeamsGetParams(*args, **kwargs)`
 :   Parameters for teams.get operation
@@ -2902,6 +3082,8 @@ Classes
     `id: str`
     :   The type of the None singleton.
 
+<a id="TeamsGtCondition"></a>
+
 `TeamsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -2914,6 +3096,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.intercom.types.TeamsSearchFilter`
     :   The type of the None singleton.
 
+<a id="TeamsGteCondition"></a>
+
 `TeamsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -2925,6 +3109,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.intercom.types.TeamsSearchFilter`
     :   The type of the None singleton.
+
+<a id="TeamsInCondition"></a>
 
 `TeamsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -2945,6 +3131,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.intercom.types.TeamsInFilter`
     :   The type of the None singleton.
+
+<a id="TeamsInFilter"></a>
 
 `TeamsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -2967,6 +3155,8 @@ Classes
     `type_: list[str]`
     :   Type of team (e.g., 'internal', 'external').
 
+<a id="TeamsKeywordCondition"></a>
+
 `TeamsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -2978,6 +3168,8 @@ Classes
 
     `keyword: airbyte_agent_sdk.connectors.intercom.types.TeamsStringFilter`
     :   The type of the None singleton.
+
+<a id="TeamsLikeCondition"></a>
 
 `TeamsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
@@ -2991,12 +3183,16 @@ Classes
     `like: airbyte_agent_sdk.connectors.intercom.types.TeamsStringFilter`
     :   The type of the None singleton.
 
+<a id="TeamsListParams"></a>
+
 `TeamsListParams(*args, **kwargs)`
 :   Parameters for teams.list operation
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="TeamsLtCondition"></a>
 
 `TeamsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
@@ -3010,6 +3206,8 @@ Classes
     `lt: airbyte_agent_sdk.connectors.intercom.types.TeamsSearchFilter`
     :   The type of the None singleton.
 
+<a id="TeamsLteCondition"></a>
+
 `TeamsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
 
@@ -3022,6 +3220,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.intercom.types.TeamsSearchFilter`
     :   The type of the None singleton.
 
+<a id="TeamsNeqCondition"></a>
+
 `TeamsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -3033,6 +3233,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.intercom.types.TeamsSearchFilter`
     :   The type of the None singleton.
+
+<a id="TeamsNotCondition"></a>
 
 `TeamsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -3054,6 +3256,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.intercom.types.TeamsEqCondition | airbyte_agent_sdk.connectors.intercom.types.TeamsNeqCondition | airbyte_agent_sdk.connectors.intercom.types.TeamsGtCondition | airbyte_agent_sdk.connectors.intercom.types.TeamsGteCondition | airbyte_agent_sdk.connectors.intercom.types.TeamsLtCondition | airbyte_agent_sdk.connectors.intercom.types.TeamsLteCondition | airbyte_agent_sdk.connectors.intercom.types.TeamsInCondition | airbyte_agent_sdk.connectors.intercom.types.TeamsLikeCondition | airbyte_agent_sdk.connectors.intercom.types.TeamsFuzzyCondition | airbyte_agent_sdk.connectors.intercom.types.TeamsKeywordCondition | airbyte_agent_sdk.connectors.intercom.types.TeamsContainsCondition | airbyte_agent_sdk.connectors.intercom.types.TeamsNotCondition | airbyte_agent_sdk.connectors.intercom.types.TeamsAndCondition | airbyte_agent_sdk.connectors.intercom.types.TeamsOrCondition | airbyte_agent_sdk.connectors.intercom.types.TeamsAnyCondition`
     :   The type of the None singleton.
 
+<a id="TeamsOrCondition"></a>
+
 `TeamsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -3073,6 +3277,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.intercom.types.TeamsEqCondition | airbyte_agent_sdk.connectors.intercom.types.TeamsNeqCondition | airbyte_agent_sdk.connectors.intercom.types.TeamsGtCondition | airbyte_agent_sdk.connectors.intercom.types.TeamsGteCondition | airbyte_agent_sdk.connectors.intercom.types.TeamsLtCondition | airbyte_agent_sdk.connectors.intercom.types.TeamsLteCondition | airbyte_agent_sdk.connectors.intercom.types.TeamsInCondition | airbyte_agent_sdk.connectors.intercom.types.TeamsLikeCondition | airbyte_agent_sdk.connectors.intercom.types.TeamsFuzzyCondition | airbyte_agent_sdk.connectors.intercom.types.TeamsKeywordCondition | airbyte_agent_sdk.connectors.intercom.types.TeamsContainsCondition | airbyte_agent_sdk.connectors.intercom.types.TeamsNotCondition | airbyte_agent_sdk.connectors.intercom.types.TeamsAndCondition | airbyte_agent_sdk.connectors.intercom.types.TeamsOrCondition | airbyte_agent_sdk.connectors.intercom.types.TeamsAnyCondition]`
     :   The type of the None singleton.
+
+<a id="TeamsSearchFilter"></a>
 
 `TeamsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering teams search queries.
@@ -3095,6 +3301,8 @@ Classes
     `type_: str | None`
     :   Type of team (e.g., 'internal', 'external').
 
+<a id="TeamsSearchQuery"></a>
+
 `TeamsSearchQuery(*args, **kwargs)`
 :   Search query for teams entity.
 
@@ -3109,6 +3317,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.intercom.types.TeamsSortFilter]`
     :   The type of the None singleton.
+
+<a id="TeamsSortFilter"></a>
 
 `TeamsSortFilter(*args, **kwargs)`
 :   Available fields for sorting teams search results.
@@ -3130,6 +3340,8 @@ Classes
 
     `type_: Literal['asc', 'desc']`
     :   Type of team (e.g., 'internal', 'external').
+
+<a id="TeamsStringFilter"></a>
 
 `TeamsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/jira/connector.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/jira/connector.md
@@ -10,6 +10,8 @@ Jira connector.
 Classes
 -------
 
+<a id="IssueCommentsQuery"></a>
+
 `IssueCommentsQuery(connector: JiraConnector)`
 :   Query class for IssueComments entity operations.
     
@@ -117,6 +119,8 @@ Classes
         Returns:
             IssueComment
 
+<a id="IssueFieldsQuery"></a>
+
 `IssueFieldsQuery(connector: JiraConnector)`
 :   Query class for IssueFields entity operations.
     
@@ -178,6 +182,8 @@ Classes
         
         Returns:
             IssueFieldsListResult
+
+<a id="IssueWorklogsQuery"></a>
 
 `IssueWorklogsQuery(connector: JiraConnector)`
 :   Query class for IssueWorklogs entity operations.
@@ -246,6 +252,8 @@ Classes
         Returns:
             IssueWorklogsListResult
 
+<a id="IssuesAssigneeQuery"></a>
+
 `IssuesAssigneeQuery(connector: JiraConnector)`
 :   Query class for IssuesAssignee entity operations.
     
@@ -263,6 +271,8 @@ Classes
         
         Returns:
             dict[str, Any]
+
+<a id="IssuesQuery"></a>
 
 `IssuesQuery(connector: JiraConnector)`
 :   Query class for Issues entity operations.
@@ -388,6 +398,8 @@ Classes
         
         Returns:
             Issue
+
+<a id="JiraConnector"></a>
 
 `JiraConnector(auth_config: JiraAuthConfig | AirbyteAuthConfig | BaseModel | None = None, on_token_refresh: Any | None = None, subdomain: str | None = None)`
 :   Type-safe Jira API connector.
@@ -577,6 +589,8 @@ Classes
             for entity in entities:
                 print(f"\{entity['entity_name']\}: \{entity['available_actions']\}")
 
+<a id="ProjectsQuery"></a>
+
 `ProjectsQuery(connector: JiraConnector)`
 :   Query class for Projects entity operations.
     
@@ -671,6 +685,8 @@ Classes
         
         Returns:
             Project
+
+<a id="UsersQuery"></a>
 
 `UsersQuery(connector: JiraConnector)`
 :   Query class for Users entity operations.

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/jira/index.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/jira/index.md
@@ -19,6 +19,8 @@ Sub-modules
 Classes
 -------
 
+<a id="AirbyteAuthConfig"></a>
+
 `AirbyteAuthConfig(**data: Any)`
 :   Authentication configuration for Airbyte hosted mode execution.
     
@@ -87,6 +89,8 @@ Classes
     `workspace_name: str | None`
     :   The type of the None singleton.
 
+<a id="AirbyteSearchMeta"></a>
+
 `AirbyteSearchMeta(**data: Any)`
 :   Pagination metadata for search responses.
     
@@ -114,6 +118,8 @@ Classes
 
     `took_ms: int | None`
     :   Time taken to execute the search in milliseconds.
+
+<a id="AirbyteSearchResult"></a>
 
 `AirbyteSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -150,6 +156,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="IssueCommentsSearchResult"></a>
+
 `IssueCommentsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -165,6 +173,8 @@ Classes
     * airbyte_agent_sdk.connectors.jira.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="IssueFieldsSearchResult"></a>
 
 `IssueFieldsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -182,6 +192,8 @@ Classes
     * pydantic.main.BaseModel
     * typing.Generic
 
+<a id="IssueWorklogsSearchResult"></a>
+
 `IssueWorklogsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -197,6 +209,8 @@ Classes
     * airbyte_agent_sdk.connectors.jira.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="IssuesSearchResult"></a>
 
 `IssuesSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -214,6 +228,8 @@ Classes
     * pydantic.main.BaseModel
     * typing.Generic
 
+<a id="ProjectsSearchResult"></a>
+
 `ProjectsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -230,6 +246,8 @@ Classes
     * pydantic.main.BaseModel
     * typing.Generic
 
+<a id="UsersSearchResult"></a>
+
 `UsersSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -245,6 +263,8 @@ Classes
     * airbyte_agent_sdk.connectors.jira.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="IssueCommentsSearchData"></a>
 
 `IssueCommentsSearchData(**data: Any)`
 :   Search result data for issue_comments entity.
@@ -301,6 +321,8 @@ Classes
     `visibility: dict[str, typing.Any] | None`
     :   The group or role to which this item is visible
 
+<a id="IssueFieldsSearchData"></a>
+
 `IssueFieldsSearchData(**data: Any)`
 :   Search result data for issue_fields entity.
     
@@ -352,6 +374,8 @@ Classes
 
     `untranslated_name: str | None`
     :   The untranslated name of the field
+
+<a id="IssueWorklogsSearchData"></a>
 
 `IssueWorklogsSearchData(**data: Any)`
 :   Search result data for issue_worklogs entity.
@@ -410,6 +434,8 @@ Classes
 
     `visibility: dict[str, typing.Any] | None`
     :   Details about any restrictions in the visibility of the worklog
+
+<a id="IssuesSearchData"></a>
 
 `IssuesSearchData(**data: Any)`
 :   Search result data for issues entity.
@@ -487,6 +513,8 @@ Classes
     `versioned_representations: dict[str, typing.Any]`
     :   The versions of each field on the issue
 
+<a id="JiraAuthConfig"></a>
+
 `JiraAuthConfig(**data: Any)`
 :   Jira API Token Authentication - Authenticate using your Atlassian account email and API token
     
@@ -511,6 +539,8 @@ Classes
 
     `username: str`
     :   Your Atlassian account email address
+
+<a id="JiraConnector"></a>
 
 `JiraConnector(auth_config: JiraAuthConfig | AirbyteAuthConfig | BaseModel | None = None, on_token_refresh: Any | None = None, subdomain: str | None = None)`
 :   Type-safe Jira API connector.
@@ -700,6 +730,8 @@ Classes
             for entity in entities:
                 print(f"\{entity['entity_name']\}: \{entity['available_actions']\}")
 
+<a id="ProjectsSearchData"></a>
+
 `ProjectsSearchData(**data: Any)`
 :   Search result data for projects entity.
     
@@ -820,6 +852,8 @@ Classes
 
     `versions: list[typing.Any]`
     :   The versions defined in the project
+
+<a id="UsersSearchData"></a>
 
 `UsersSearchData(**data: Any)`
 :   Search result data for users entity.

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/jira/models.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/jira/models.md
@@ -13,6 +13,8 @@ and response envelope types.
 Classes
 -------
 
+<a id="AirbyteSearchMeta"></a>
+
 `AirbyteSearchMeta(**data: Any)`
 :   Pagination metadata for search responses.
     
@@ -40,6 +42,8 @@ Classes
 
     `took_ms: int | None`
     :   Time taken to execute the search in milliseconds.
+
+<a id="AirbyteSearchResult"></a>
 
 `AirbyteSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -97,6 +101,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="IssueCommentsSearchResult"></a>
+
 `IssueCommentsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -133,6 +139,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="IssueFieldsSearchResult"></a>
 
 `IssueFieldsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -171,6 +179,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="IssueWorklogsSearchResult"></a>
+
 `IssueWorklogsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -207,6 +217,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="IssuesSearchResult"></a>
 
 `IssuesSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -245,6 +257,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="ProjectsSearchResult"></a>
+
 `ProjectsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -282,6 +296,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="UsersSearchResult"></a>
+
 `UsersSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -297,6 +313,8 @@ Classes
     * airbyte_agent_sdk.connectors.jira.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="CommentCreateParams"></a>
 
 `CommentCreateParams(**data: Any)`
 :   Parameters for creating a comment on an issue
@@ -326,6 +344,8 @@ Classes
     `visibility: airbyte_agent_sdk.connectors.jira.models.CommentCreateParamsVisibility | Any`
     :   The type of the None singleton.
 
+<a id="CommentCreateParamsBody"></a>
+
 `CommentCreateParamsBody(**data: Any)`
 :   Comment content in Atlassian Document Format (ADF)
     
@@ -354,6 +374,8 @@ Classes
     `version: int | Any`
     :   ADF version
 
+<a id="CommentCreateParamsBodyContentItem"></a>
+
 `CommentCreateParamsBodyContentItem(**data: Any)`
 :   Nested schema for CommentCreateParamsBody.content_item
     
@@ -379,6 +401,8 @@ Classes
     `type_: str | Any`
     :   Block type (e.g., 'paragraph')
 
+<a id="CommentCreateParamsBodyContentItemContentItem"></a>
+
 `CommentCreateParamsBodyContentItemContentItem(**data: Any)`
 :   Nested schema for CommentCreateParamsBodyContentItem.content_item
     
@@ -403,6 +427,8 @@ Classes
 
     `type_: str | Any`
     :   Content type (e.g., 'text')
+
+<a id="CommentCreateParamsVisibility"></a>
 
 `CommentCreateParamsVisibility(**data: Any)`
 :   Restrict comment visibility to a group or role
@@ -432,6 +458,8 @@ Classes
     `value: str | Any`
     :   The name of the group or role
 
+<a id="CommentUpdateParams"></a>
+
 `CommentUpdateParams(**data: Any)`
 :   Parameters for updating a comment. Only fields included are updated.
     
@@ -456,6 +484,8 @@ Classes
 
     `visibility: airbyte_agent_sdk.connectors.jira.models.CommentUpdateParamsVisibility | Any`
     :   The type of the None singleton.
+
+<a id="CommentUpdateParamsBody"></a>
 
 `CommentUpdateParamsBody(**data: Any)`
 :   Updated comment content in Atlassian Document Format (ADF)
@@ -485,6 +515,8 @@ Classes
     `version: int | Any`
     :   ADF version
 
+<a id="CommentUpdateParamsBodyContentItem"></a>
+
 `CommentUpdateParamsBodyContentItem(**data: Any)`
 :   Nested schema for CommentUpdateParamsBody.content_item
     
@@ -510,6 +542,8 @@ Classes
     `type_: str | Any`
     :   Block type (e.g., 'paragraph')
 
+<a id="CommentUpdateParamsBodyContentItemContentItem"></a>
+
 `CommentUpdateParamsBodyContentItemContentItem(**data: Any)`
 :   Nested schema for CommentUpdateParamsBodyContentItem.content_item
     
@@ -534,6 +568,8 @@ Classes
 
     `type_: str | Any`
     :   Content type (e.g., 'text')
+
+<a id="CommentUpdateParamsVisibility"></a>
 
 `CommentUpdateParamsVisibility(**data: Any)`
 :   Restrict comment visibility to a group or role
@@ -563,6 +599,8 @@ Classes
     `value: str | Any`
     :   The name of the group or role
 
+<a id="EmptyResponse"></a>
+
 `EmptyResponse(**data: Any)`
 :   Empty response object (returned for 204 No Content responses)
     
@@ -581,6 +619,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="Issue"></a>
 
 `Issue(**data: Any)`
 :   Jira issue object
@@ -616,6 +656,8 @@ Classes
     `self: str | Any`
     :   The type of the None singleton.
 
+<a id="IssueAssigneeParams"></a>
+
 `IssueAssigneeParams(**data: Any)`
 :   Parameters for assigning an issue to a user
     
@@ -637,6 +679,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="IssueComment"></a>
 
 `IssueComment(**data: Any)`
 :   Jira issue comment object
@@ -690,6 +734,8 @@ Classes
     `visibility: airbyte_agent_sdk.connectors.jira.models.IssueCommentVisibility | Any | None`
     :   The type of the None singleton.
 
+<a id="IssueCommentAuthor"></a>
+
 `IssueCommentAuthor(**data: Any)`
 :   Comment author user information
     
@@ -733,6 +779,8 @@ Classes
     `time_zone: str | Any`
     :   The type of the None singleton.
 
+<a id="IssueCommentAuthorAvatarurls"></a>
+
 `IssueCommentAuthorAvatarurls(**data: Any)`
 :   URLs for user avatars in different sizes
     
@@ -764,6 +812,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="IssueCommentBody"></a>
+
 `IssueCommentBody(**data: Any)`
 :   Comment content in ADF (Atlassian Document Format)
     
@@ -792,6 +842,8 @@ Classes
     `version: int | Any`
     :   ADF version
 
+<a id="IssueCommentBodyContentItem"></a>
+
 `IssueCommentBodyContentItem(**data: Any)`
 :   Nested schema for IssueCommentBody.content_item
     
@@ -817,6 +869,8 @@ Classes
     `type_: str | Any`
     :   Block type (e.g., 'paragraph')
 
+<a id="IssueCommentBodyContentItemContentItem"></a>
+
 `IssueCommentBodyContentItemContentItem(**data: Any)`
 :   Nested schema for IssueCommentBodyContentItem.content_item
     
@@ -841,6 +895,8 @@ Classes
 
     `type_: str | Any`
     :   Content type (e.g., 'text')
+
+<a id="IssueCommentUpdateauthor"></a>
 
 `IssueCommentUpdateauthor(**data: Any)`
 :   User who last updated the comment
@@ -885,6 +941,8 @@ Classes
     `time_zone: str | Any`
     :   The type of the None singleton.
 
+<a id="IssueCommentUpdateauthorAvatarurls"></a>
+
 `IssueCommentUpdateauthorAvatarurls(**data: Any)`
 :   URLs for user avatars in different sizes
     
@@ -916,6 +974,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="IssueCommentVisibility"></a>
+
 `IssueCommentVisibility(**data: Any)`
 :   Visibility restrictions for the comment
     
@@ -943,6 +1003,8 @@ Classes
 
     `value: str | Any`
     :   The type of the None singleton.
+
+<a id="IssueCommentsList"></a>
 
 `IssueCommentsList(**data: Any)`
 :   Paginated list of issue comments
@@ -975,6 +1037,8 @@ Classes
     `total: int | Any`
     :   The type of the None singleton.
 
+<a id="IssueCommentsListResultMeta"></a>
+
 `IssueCommentsListResultMeta(**data: Any)`
 :   Metadata for issue_comments.Action.LIST operation
     
@@ -1002,6 +1066,8 @@ Classes
 
     `total: int | Any`
     :   The type of the None singleton.
+
+<a id="IssueCommentsSearchData"></a>
 
 `IssueCommentsSearchData(**data: Any)`
 :   Search result data for issue_comments entity.
@@ -1058,6 +1124,8 @@ Classes
     `visibility: dict[str, typing.Any] | None`
     :   The group or role to which this item is visible
 
+<a id="IssueCreateParams"></a>
+
 `IssueCreateParams(**data: Any)`
 :   Parameters for creating a new issue
     
@@ -1082,6 +1150,8 @@ Classes
 
     `update: dict[str, typing.Any] | Any`
     :   The type of the None singleton.
+
+<a id="IssueCreateParamsFields"></a>
 
 `IssueCreateParamsFields(**data: Any)`
 :   The issue fields to set
@@ -1126,6 +1196,8 @@ Classes
     `summary: str | Any`
     :   A brief summary of the issue (title)
 
+<a id="IssueCreateParamsFieldsAssignee"></a>
+
 `IssueCreateParamsFieldsAssignee(**data: Any)`
 :   The user to assign the issue to
     
@@ -1147,6 +1219,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="IssueCreateParamsFieldsDescription"></a>
 
 `IssueCreateParamsFieldsDescription(**data: Any)`
 :   Issue description in Atlassian Document Format (ADF)
@@ -1176,6 +1250,8 @@ Classes
     `version: int | Any`
     :   ADF version
 
+<a id="IssueCreateParamsFieldsDescriptionContentItem"></a>
+
 `IssueCreateParamsFieldsDescriptionContentItem(**data: Any)`
 :   Nested schema for IssueCreateParamsFieldsDescription.content_item
     
@@ -1200,6 +1276,8 @@ Classes
 
     `type_: str | Any`
     :   Block type (e.g., 'paragraph')
+
+<a id="IssueCreateParamsFieldsDescriptionContentItemContentItem"></a>
 
 `IssueCreateParamsFieldsDescriptionContentItemContentItem(**data: Any)`
 :   Nested schema for IssueCreateParamsFieldsDescriptionContentItem.content_item
@@ -1226,6 +1304,8 @@ Classes
     `type_: str | Any`
     :   Content type (e.g., 'text')
 
+<a id="IssueCreateParamsFieldsIssuetype"></a>
+
 `IssueCreateParamsFieldsIssuetype(**data: Any)`
 :   The type of issue (e.g., Bug, Task, Story)
     
@@ -1251,6 +1331,8 @@ Classes
     `name: str | Any`
     :   Issue type name (e.g., 'Bug', 'Task', 'Story')
 
+<a id="IssueCreateParamsFieldsParent"></a>
+
 `IssueCreateParamsFieldsParent(**data: Any)`
 :   Parent issue for subtasks
     
@@ -1272,6 +1354,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="IssueCreateParamsFieldsPriority"></a>
 
 `IssueCreateParamsFieldsPriority(**data: Any)`
 :   Issue priority
@@ -1298,6 +1382,8 @@ Classes
     `name: str | Any`
     :   Priority name (e.g., 'Highest', 'High', 'Medium', 'Low', 'Lowest')
 
+<a id="IssueCreateParamsFieldsProject"></a>
+
 `IssueCreateParamsFieldsProject(**data: Any)`
 :   The project to create the issue in
     
@@ -1322,6 +1408,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="IssueCreateResponse"></a>
 
 `IssueCreateResponse(**data: Any)`
 :   Response from creating an issue
@@ -1350,6 +1438,8 @@ Classes
 
     `self: str | Any`
     :   The type of the None singleton.
+
+<a id="IssueField"></a>
 
 `IssueField(**data: Any)`
 :   Jira issue field object (custom or system field)
@@ -1421,6 +1511,8 @@ Classes
     `untranslated_name: str | Any | None`
     :   The type of the None singleton.
 
+<a id="IssueFieldSchema"></a>
+
 `IssueFieldSchema(**data: Any)`
 :   Schema information for the field
     
@@ -1458,6 +1550,8 @@ Classes
     `type_: str | Any`
     :   Field type (e.g., string, number, array)
 
+<a id="IssueFieldSearchResults"></a>
+
 `IssueFieldSearchResults(**data: Any)`
 :   Paginated search results for issue fields
     
@@ -1491,6 +1585,8 @@ Classes
 
     `values: list[airbyte_agent_sdk.connectors.jira.models.IssueField] | Any`
     :   The type of the None singleton.
+
+<a id="IssueFields"></a>
 
 `IssueFields(**data: Any)`
 :   Issue fields (actual fields depend on 'fields' parameter in request)
@@ -1538,6 +1634,8 @@ Classes
     `updated: str | Any`
     :   Issue last update timestamp
 
+<a id="IssueFieldsAssignee"></a>
+
 `IssueFieldsAssignee(**data: Any)`
 :   Issue assignee user information (null if unassigned)
     
@@ -1581,6 +1679,8 @@ Classes
     `time_zone: str | Any`
     :   The type of the None singleton.
 
+<a id="IssueFieldsAssigneeAvatarurls"></a>
+
 `IssueFieldsAssigneeAvatarurls(**data: Any)`
 :   URLs for user avatars in different sizes
     
@@ -1611,6 +1711,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="IssueFieldsIssuetype"></a>
 
 `IssueFieldsIssuetype(**data: Any)`
 :   Issue type information
@@ -1655,6 +1757,8 @@ Classes
     `subtask: bool | Any`
     :   The type of the None singleton.
 
+<a id="IssueFieldsPriority"></a>
+
 `IssueFieldsPriority(**data: Any)`
 :   Issue priority information
     
@@ -1685,6 +1789,8 @@ Classes
 
     `self: str | Any`
     :   The type of the None singleton.
+
+<a id="IssueFieldsProject"></a>
 
 `IssueFieldsProject(**data: Any)`
 :   Project information
@@ -1729,6 +1835,8 @@ Classes
     `simplified: bool | Any`
     :   The type of the None singleton.
 
+<a id="IssueFieldsProjectAvatarurls"></a>
+
 `IssueFieldsProjectAvatarurls(**data: Any)`
 :   URLs for user avatars in different sizes
     
@@ -1760,6 +1868,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="IssueFieldsProjectProjectcategory"></a>
+
 `IssueFieldsProjectProjectcategory(**data: Any)`
 :   Nested schema for IssueFieldsProject.projectCategory
     
@@ -1790,6 +1900,8 @@ Classes
 
     `self: str | Any`
     :   The type of the None singleton.
+
+<a id="IssueFieldsReporter"></a>
 
 `IssueFieldsReporter(**data: Any)`
 :   Issue reporter user information
@@ -1834,6 +1946,8 @@ Classes
     `time_zone: str | Any`
     :   The type of the None singleton.
 
+<a id="IssueFieldsReporterAvatarurls"></a>
+
 `IssueFieldsReporterAvatarurls(**data: Any)`
 :   URLs for user avatars in different sizes
     
@@ -1864,6 +1978,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="IssueFieldsSearchData"></a>
 
 `IssueFieldsSearchData(**data: Any)`
 :   Search result data for issue_fields entity.
@@ -1917,6 +2033,8 @@ Classes
     `untranslated_name: str | None`
     :   The untranslated name of the field
 
+<a id="IssueFieldsStatus"></a>
+
 `IssueFieldsStatus(**data: Any)`
 :   Issue status information
     
@@ -1954,6 +2072,8 @@ Classes
     `status_category: airbyte_agent_sdk.connectors.jira.models.IssueFieldsStatusStatuscategory | Any`
     :   The type of the None singleton.
 
+<a id="IssueFieldsStatusStatuscategory"></a>
+
 `IssueFieldsStatusStatuscategory(**data: Any)`
 :   Nested schema for IssueFieldsStatus.statusCategory
     
@@ -1988,6 +2108,8 @@ Classes
     `self: str | Any`
     :   The type of the None singleton.
 
+<a id="IssueUpdateParams"></a>
+
 `IssueUpdateParams(**data: Any)`
 :   Parameters for updating an issue. Only fields included are updated.
     
@@ -2015,6 +2137,8 @@ Classes
 
     `update: dict[str, typing.Any] | Any`
     :   The type of the None singleton.
+
+<a id="IssueUpdateParamsFields"></a>
 
 `IssueUpdateParamsFields(**data: Any)`
 :   The issue fields to update
@@ -2050,6 +2174,8 @@ Classes
     `summary: str | Any`
     :   A brief summary of the issue (title)
 
+<a id="IssueUpdateParamsFieldsAssignee"></a>
+
 `IssueUpdateParamsFieldsAssignee(**data: Any)`
 :   The user to assign the issue to
     
@@ -2071,6 +2197,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="IssueUpdateParamsFieldsDescription"></a>
 
 `IssueUpdateParamsFieldsDescription(**data: Any)`
 :   Issue description in Atlassian Document Format (ADF)
@@ -2100,6 +2228,8 @@ Classes
     `version: int | Any`
     :   ADF version
 
+<a id="IssueUpdateParamsFieldsDescriptionContentItem"></a>
+
 `IssueUpdateParamsFieldsDescriptionContentItem(**data: Any)`
 :   Nested schema for IssueUpdateParamsFieldsDescription.content_item
     
@@ -2124,6 +2254,8 @@ Classes
 
     `type_: str | Any`
     :   Block type (e.g., 'paragraph')
+
+<a id="IssueUpdateParamsFieldsDescriptionContentItemContentItem"></a>
 
 `IssueUpdateParamsFieldsDescriptionContentItemContentItem(**data: Any)`
 :   Nested schema for IssueUpdateParamsFieldsDescriptionContentItem.content_item
@@ -2150,6 +2282,8 @@ Classes
     `type_: str | Any`
     :   Content type (e.g., 'text')
 
+<a id="IssueUpdateParamsFieldsPriority"></a>
+
 `IssueUpdateParamsFieldsPriority(**data: Any)`
 :   Issue priority
     
@@ -2175,6 +2309,8 @@ Classes
     `name: str | Any`
     :   Priority name (e.g., 'Highest', 'High', 'Medium', 'Low', 'Lowest')
 
+<a id="IssueUpdateParamsTransition"></a>
+
 `IssueUpdateParamsTransition(**data: Any)`
 :   Transition the issue to a new status
     
@@ -2196,6 +2332,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="IssueWorklogsListResultMeta"></a>
 
 `IssueWorklogsListResultMeta(**data: Any)`
 :   Metadata for issue_worklogs.Action.LIST operation
@@ -2224,6 +2362,8 @@ Classes
 
     `total: int | Any`
     :   The type of the None singleton.
+
+<a id="IssueWorklogsSearchData"></a>
 
 `IssueWorklogsSearchData(**data: Any)`
 :   Search result data for issue_worklogs entity.
@@ -2283,6 +2423,8 @@ Classes
     `visibility: dict[str, typing.Any] | None`
     :   Details about any restrictions in the visibility of the worklog
 
+<a id="IssuesApiSearchResultMeta"></a>
+
 `IssuesApiSearchResultMeta(**data: Any)`
 :   Metadata for issues.Action.API_SEARCH operation
     
@@ -2310,6 +2452,8 @@ Classes
 
     `total: int | Any`
     :   The type of the None singleton.
+
+<a id="IssuesList"></a>
 
 `IssuesList(**data: Any)`
 :   Paginated list of issues from JQL search
@@ -2347,6 +2491,8 @@ Classes
 
     `total: int | Any`
     :   The type of the None singleton.
+
+<a id="IssuesSearchData"></a>
 
 `IssuesSearchData(**data: Any)`
 :   Search result data for issues entity.
@@ -2424,6 +2570,8 @@ Classes
     `versioned_representations: dict[str, typing.Any]`
     :   The versions of each field on the issue
 
+<a id="JiraAuthConfig"></a>
+
 `JiraAuthConfig(**data: Any)`
 :   Jira API Token Authentication - Authenticate using your Atlassian account email and API token
     
@@ -2448,6 +2596,8 @@ Classes
 
     `username: str`
     :   Your Atlassian account email address
+
+<a id="JiraCheckResult"></a>
 
 `JiraCheckResult(**data: Any)`
 :   Result of a health check operation.
@@ -2482,6 +2632,8 @@ Classes
     `status: str`
     :   Health check status: 'healthy' or 'unhealthy'.
 
+<a id="JiraExecuteResult"></a>
+
 `JiraExecuteResult(**data: Any)`
 :   Response envelope with data only.
     
@@ -2513,6 +2665,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="JiraExecuteResultWithMeta"></a>
 
 `JiraExecuteResultWithMeta(**data: Any)`
 :   Response envelope with data and metadata.
@@ -2568,6 +2722,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="IssueCommentsListResult"></a>
+
 `IssueCommentsListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -2610,6 +2766,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="IssuesApiSearchResult"></a>
 
 `IssuesApiSearchResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -2654,6 +2812,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="ProjectsApiSearchResult"></a>
+
 `ProjectsApiSearchResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -2697,6 +2857,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="IssueWorklogsListResult"></a>
+
 `IssueWorklogsListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -2739,6 +2901,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="IssueFieldsApiSearchResult"></a>
+
 `IssueFieldsApiSearchResult(**data: Any)`
 :   Response envelope with data only.
     
@@ -2779,6 +2943,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="IssueFieldsListResult"></a>
 
 `IssueFieldsListResult(**data: Any)`
 :   Response envelope with data only.
@@ -2821,6 +2987,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="UsersListResult"></a>
+
 `UsersListResult(**data: Any)`
 :   Response envelope with data only.
     
@@ -2844,6 +3012,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="UsersApiSearchResult"></a>
+
 `UsersApiSearchResult(**data: Any)`
 :   Response envelope with data only.
     
@@ -2861,6 +3031,8 @@ Classes
     * airbyte_agent_sdk.connectors.jira.models.JiraExecuteResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="Project"></a>
 
 `Project(**data: Any)`
 :   Jira project object
@@ -2947,6 +3119,8 @@ Classes
     `versions: list[airbyte_agent_sdk.connectors.jira.models.ProjectVersionsItem] | Any | None`
     :   The type of the None singleton.
 
+<a id="ProjectAvatarurls"></a>
+
 `ProjectAvatarurls(**data: Any)`
 :   URLs for project avatars in different sizes
     
@@ -2977,6 +3151,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="ProjectComponentsItem"></a>
 
 `ProjectComponentsItem(**data: Any)`
 :   Nested schema for Project.components_item
@@ -3011,6 +3187,8 @@ Classes
 
     `self: str | Any`
     :   The type of the None singleton.
+
+<a id="ProjectIssuetypesItem"></a>
 
 `ProjectIssuetypesItem(**data: Any)`
 :   Nested schema for Project.issueTypes_item
@@ -3055,6 +3233,8 @@ Classes
     `subtask: bool | Any`
     :   The type of the None singleton.
 
+<a id="ProjectLead"></a>
+
 `ProjectLead(**data: Any)`
 :   Project lead user (available with expand=lead)
     
@@ -3092,6 +3272,8 @@ Classes
     `self: str | Any`
     :   The type of the None singleton.
 
+<a id="ProjectLeadAvatarurls"></a>
+
 `ProjectLeadAvatarurls(**data: Any)`
 :   URLs for user avatars in different sizes
     
@@ -3123,6 +3305,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="ProjectProjectcategory"></a>
+
 `ProjectProjectcategory(**data: Any)`
 :   Project category information
     
@@ -3153,6 +3337,8 @@ Classes
 
     `self: str | Any`
     :   The type of the None singleton.
+
+<a id="ProjectVersionsItem"></a>
 
 `ProjectVersionsItem(**data: Any)`
 :   Nested schema for Project.versions_item
@@ -3209,6 +3395,8 @@ Classes
     `user_start_date: str | Any | None`
     :   The type of the None singleton.
 
+<a id="ProjectsApiSearchResultMeta"></a>
+
 `ProjectsApiSearchResultMeta(**data: Any)`
 :   Metadata for projects.Action.API_SEARCH operation
     
@@ -3233,6 +3421,8 @@ Classes
 
     `total: int | Any`
     :   The type of the None singleton.
+
+<a id="ProjectsList"></a>
 
 `ProjectsList(**data: Any)`
 :   Paginated list of projects from search results
@@ -3273,6 +3463,8 @@ Classes
 
     `values: list[airbyte_agent_sdk.connectors.jira.models.Project] | Any`
     :   The type of the None singleton.
+
+<a id="ProjectsSearchData"></a>
 
 `ProjectsSearchData(**data: Any)`
 :   Search result data for projects entity.
@@ -3395,6 +3587,8 @@ Classes
     `versions: list[typing.Any]`
     :   The versions defined in the project
 
+<a id="User"></a>
+
 `User(**data: Any)`
 :   Jira user object
     
@@ -3450,6 +3644,8 @@ Classes
     `time_zone: str | Any | None`
     :   The type of the None singleton.
 
+<a id="UserApplicationroles"></a>
+
 `UserApplicationroles(**data: Any)`
 :   User application roles (available with expand=applicationRoles)
     
@@ -3474,6 +3670,8 @@ Classes
 
     `size: int | Any`
     :   Number of application roles
+
+<a id="UserApplicationrolesItemsItem"></a>
 
 `UserApplicationrolesItemsItem(**data: Any)`
 :   Nested schema for UserApplicationroles.items_item
@@ -3536,6 +3734,8 @@ Classes
     `user_count_description: str | Any`
     :   The type of the None singleton.
 
+<a id="UserApplicationrolesItemsItemDefaultgroupsdetailsItem"></a>
+
 `UserApplicationrolesItemsItemDefaultgroupsdetailsItem(**data: Any)`
 :   Nested schema for UserApplicationrolesItemsItem.defaultGroupsDetails_item
     
@@ -3564,6 +3764,8 @@ Classes
     `self: str | Any`
     :   The type of the None singleton.
 
+<a id="UserApplicationrolesItemsItemGroupdetailsItem"></a>
+
 `UserApplicationrolesItemsItemGroupdetailsItem(**data: Any)`
 :   Nested schema for UserApplicationrolesItemsItem.groupDetails_item
     
@@ -3591,6 +3793,8 @@ Classes
 
     `self: str | Any`
     :   The type of the None singleton.
+
+<a id="UserAvatarurls"></a>
 
 `UserAvatarurls(**data: Any)`
 :   URLs for user avatars in different sizes
@@ -3623,6 +3827,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="UserGroups"></a>
+
 `UserGroups(**data: Any)`
 :   User groups (available with expand=groups)
     
@@ -3647,6 +3853,8 @@ Classes
 
     `size: int | Any`
     :   Number of groups
+
+<a id="UserGroupsItemsItem"></a>
 
 `UserGroupsItemsItem(**data: Any)`
 :   Nested schema for UserGroups.items_item
@@ -3675,6 +3883,8 @@ Classes
 
     `self: str | Any`
     :   The type of the None singleton.
+
+<a id="UsersSearchData"></a>
 
 `UsersSearchData(**data: Any)`
 :   Search result data for users entity.
@@ -3737,6 +3947,8 @@ Classes
     `time_zone: str | None`
     :   The time zone specified in the user's profile
 
+<a id="Worklog"></a>
+
 `Worklog(**data: Any)`
 :   Jira worklog object
     
@@ -3795,6 +4007,8 @@ Classes
     `visibility: airbyte_agent_sdk.connectors.jira.models.WorklogVisibility | Any | None`
     :   The type of the None singleton.
 
+<a id="WorklogAuthor"></a>
+
 `WorklogAuthor(**data: Any)`
 :   Worklog author user information
     
@@ -3838,6 +4052,8 @@ Classes
     `time_zone: str | Any`
     :   The type of the None singleton.
 
+<a id="WorklogAuthorAvatarurls"></a>
+
 `WorklogAuthorAvatarurls(**data: Any)`
 :   URLs for user avatars in different sizes
     
@@ -3869,6 +4085,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="WorklogComment"></a>
+
 `WorklogComment(**data: Any)`
 :   Comment associated with the worklog (ADF format)
     
@@ -3897,6 +4115,8 @@ Classes
     `version: int | Any`
     :   ADF version
 
+<a id="WorklogCommentContentItem"></a>
+
 `WorklogCommentContentItem(**data: Any)`
 :   Nested schema for WorklogComment.content_item
     
@@ -3922,6 +4142,8 @@ Classes
     `type_: str | Any`
     :   Block type (e.g., 'paragraph')
 
+<a id="WorklogCommentContentItemContentItem"></a>
+
 `WorklogCommentContentItemContentItem(**data: Any)`
 :   Nested schema for WorklogCommentContentItem.content_item
     
@@ -3946,6 +4168,8 @@ Classes
 
     `type_: str | Any`
     :   Content type (e.g., 'text')
+
+<a id="WorklogUpdateauthor"></a>
 
 `WorklogUpdateauthor(**data: Any)`
 :   User who last updated the worklog
@@ -3990,6 +4214,8 @@ Classes
     `time_zone: str | Any`
     :   The type of the None singleton.
 
+<a id="WorklogUpdateauthorAvatarurls"></a>
+
 `WorklogUpdateauthorAvatarurls(**data: Any)`
 :   URLs for user avatars in different sizes
     
@@ -4021,6 +4247,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="WorklogVisibility"></a>
+
 `WorklogVisibility(**data: Any)`
 :   Visibility restrictions for the worklog
     
@@ -4048,6 +4276,8 @@ Classes
 
     `value: str | Any`
     :   The type of the None singleton.
+
+<a id="WorklogsList"></a>
 
 `WorklogsList(**data: Any)`
 :   Paginated list of issue worklogs

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/jira/types.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/jira/types.md
@@ -10,6 +10,8 @@ Type definitions for jira connector.
 Classes
 -------
 
+<a id="AirbyteSearchParams"></a>
+
 `AirbyteSearchParams(*args, **kwargs)`
 :   Parameters for Airbyte cache search operations (generic, use entity-specific query types for better type hints).
 
@@ -31,6 +33,8 @@ Classes
     `query: dict[str, typing.Any]`
     :   The type of the None singleton.
 
+<a id="IssueCommentsAndCondition"></a>
+
 `IssueCommentsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -51,6 +55,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.jira.types.IssueCommentsEqCondition | airbyte_agent_sdk.connectors.jira.types.IssueCommentsNeqCondition | airbyte_agent_sdk.connectors.jira.types.IssueCommentsGtCondition | airbyte_agent_sdk.connectors.jira.types.IssueCommentsGteCondition | airbyte_agent_sdk.connectors.jira.types.IssueCommentsLtCondition | airbyte_agent_sdk.connectors.jira.types.IssueCommentsLteCondition | airbyte_agent_sdk.connectors.jira.types.IssueCommentsInCondition | airbyte_agent_sdk.connectors.jira.types.IssueCommentsLikeCondition | airbyte_agent_sdk.connectors.jira.types.IssueCommentsFuzzyCondition | airbyte_agent_sdk.connectors.jira.types.IssueCommentsKeywordCondition | airbyte_agent_sdk.connectors.jira.types.IssueCommentsContainsCondition | airbyte_agent_sdk.connectors.jira.types.IssueCommentsNotCondition | airbyte_agent_sdk.connectors.jira.types.IssueCommentsAndCondition | airbyte_agent_sdk.connectors.jira.types.IssueCommentsOrCondition | airbyte_agent_sdk.connectors.jira.types.IssueCommentsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="IssueCommentsAnyCondition"></a>
+
 `IssueCommentsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -70,6 +76,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.jira.types.IssueCommentsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="IssueCommentsAnyValueFilter"></a>
 
 `IssueCommentsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -116,6 +124,8 @@ Classes
     `visibility: Any`
     :   The group or role to which this item is visible
 
+<a id="IssueCommentsContainsCondition"></a>
+
 `IssueCommentsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -127,6 +137,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.jira.types.IssueCommentsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="IssueCommentsCreateParams"></a>
 
 `IssueCommentsCreateParams(*args, **kwargs)`
 :   Parameters for issue_comments.create operation
@@ -152,6 +164,8 @@ Classes
     `visibility: airbyte_agent_sdk.connectors.jira.types.IssueCommentsCreateParamsVisibility`
     :   The type of the None singleton.
 
+<a id="IssueCommentsCreateParamsBody"></a>
+
 `IssueCommentsCreateParamsBody(*args, **kwargs)`
 :   Comment content in Atlassian Document Format (ADF)
 
@@ -170,6 +184,8 @@ Classes
     `version: int`
     :   The type of the None singleton.
 
+<a id="IssueCommentsCreateParamsBodyContentItem"></a>
+
 `IssueCommentsCreateParamsBodyContentItem(*args, **kwargs)`
 :   Nested schema for IssueCommentsCreateParamsBody.content_item
 
@@ -185,6 +201,8 @@ Classes
     `type: str`
     :   The type of the None singleton.
 
+<a id="IssueCommentsCreateParamsBodyContentItemContentItem"></a>
+
 `IssueCommentsCreateParamsBodyContentItemContentItem(*args, **kwargs)`
 :   Nested schema for IssueCommentsCreateParamsBodyContentItem.content_item
 
@@ -199,6 +217,8 @@ Classes
 
     `type: str`
     :   The type of the None singleton.
+
+<a id="IssueCommentsCreateParamsVisibility"></a>
 
 `IssueCommentsCreateParamsVisibility(*args, **kwargs)`
 :   Restrict comment visibility to a group or role
@@ -218,6 +238,8 @@ Classes
     `value: str`
     :   The type of the None singleton.
 
+<a id="IssueCommentsDeleteParams"></a>
+
 `IssueCommentsDeleteParams(*args, **kwargs)`
 :   Parameters for issue_comments.delete operation
 
@@ -233,6 +255,8 @@ Classes
     `issue_id_or_key: str`
     :   The type of the None singleton.
 
+<a id="IssueCommentsEqCondition"></a>
+
 `IssueCommentsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
 
@@ -245,6 +269,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.jira.types.IssueCommentsSearchFilter`
     :   The type of the None singleton.
 
+<a id="IssueCommentsFuzzyCondition"></a>
+
 `IssueCommentsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -256,6 +282,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.jira.types.IssueCommentsStringFilter`
     :   The type of the None singleton.
+
+<a id="IssueCommentsGetParams"></a>
 
 `IssueCommentsGetParams(*args, **kwargs)`
 :   Parameters for issue_comments.get operation
@@ -275,6 +303,8 @@ Classes
     `issue_id_or_key: str`
     :   The type of the None singleton.
 
+<a id="IssueCommentsGtCondition"></a>
+
 `IssueCommentsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -287,6 +317,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.jira.types.IssueCommentsSearchFilter`
     :   The type of the None singleton.
 
+<a id="IssueCommentsGteCondition"></a>
+
 `IssueCommentsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -298,6 +330,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.jira.types.IssueCommentsSearchFilter`
     :   The type of the None singleton.
+
+<a id="IssueCommentsInCondition"></a>
 
 `IssueCommentsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -318,6 +352,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.jira.types.IssueCommentsInFilter`
     :   The type of the None singleton.
+
+<a id="IssueCommentsInFilter"></a>
 
 `IssueCommentsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -364,6 +400,8 @@ Classes
     `visibility: list[dict[str, typing.Any]]`
     :   The group or role to which this item is visible
 
+<a id="IssueCommentsKeywordCondition"></a>
+
 `IssueCommentsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -376,6 +414,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.jira.types.IssueCommentsStringFilter`
     :   The type of the None singleton.
 
+<a id="IssueCommentsLikeCondition"></a>
+
 `IssueCommentsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -387,6 +427,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.jira.types.IssueCommentsStringFilter`
     :   The type of the None singleton.
+
+<a id="IssueCommentsListParams"></a>
 
 `IssueCommentsListParams(*args, **kwargs)`
 :   Parameters for issue_comments.list operation
@@ -412,6 +454,8 @@ Classes
     `start_at: int`
     :   The type of the None singleton.
 
+<a id="IssueCommentsLtCondition"></a>
+
 `IssueCommentsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -423,6 +467,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.jira.types.IssueCommentsSearchFilter`
     :   The type of the None singleton.
+
+<a id="IssueCommentsLteCondition"></a>
 
 `IssueCommentsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -436,6 +482,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.jira.types.IssueCommentsSearchFilter`
     :   The type of the None singleton.
 
+<a id="IssueCommentsNeqCondition"></a>
+
 `IssueCommentsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -447,6 +495,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.jira.types.IssueCommentsSearchFilter`
     :   The type of the None singleton.
+
+<a id="IssueCommentsNotCondition"></a>
 
 `IssueCommentsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -468,6 +518,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.jira.types.IssueCommentsEqCondition | airbyte_agent_sdk.connectors.jira.types.IssueCommentsNeqCondition | airbyte_agent_sdk.connectors.jira.types.IssueCommentsGtCondition | airbyte_agent_sdk.connectors.jira.types.IssueCommentsGteCondition | airbyte_agent_sdk.connectors.jira.types.IssueCommentsLtCondition | airbyte_agent_sdk.connectors.jira.types.IssueCommentsLteCondition | airbyte_agent_sdk.connectors.jira.types.IssueCommentsInCondition | airbyte_agent_sdk.connectors.jira.types.IssueCommentsLikeCondition | airbyte_agent_sdk.connectors.jira.types.IssueCommentsFuzzyCondition | airbyte_agent_sdk.connectors.jira.types.IssueCommentsKeywordCondition | airbyte_agent_sdk.connectors.jira.types.IssueCommentsContainsCondition | airbyte_agent_sdk.connectors.jira.types.IssueCommentsNotCondition | airbyte_agent_sdk.connectors.jira.types.IssueCommentsAndCondition | airbyte_agent_sdk.connectors.jira.types.IssueCommentsOrCondition | airbyte_agent_sdk.connectors.jira.types.IssueCommentsAnyCondition`
     :   The type of the None singleton.
 
+<a id="IssueCommentsOrCondition"></a>
+
 `IssueCommentsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -487,6 +539,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.jira.types.IssueCommentsEqCondition | airbyte_agent_sdk.connectors.jira.types.IssueCommentsNeqCondition | airbyte_agent_sdk.connectors.jira.types.IssueCommentsGtCondition | airbyte_agent_sdk.connectors.jira.types.IssueCommentsGteCondition | airbyte_agent_sdk.connectors.jira.types.IssueCommentsLtCondition | airbyte_agent_sdk.connectors.jira.types.IssueCommentsLteCondition | airbyte_agent_sdk.connectors.jira.types.IssueCommentsInCondition | airbyte_agent_sdk.connectors.jira.types.IssueCommentsLikeCondition | airbyte_agent_sdk.connectors.jira.types.IssueCommentsFuzzyCondition | airbyte_agent_sdk.connectors.jira.types.IssueCommentsKeywordCondition | airbyte_agent_sdk.connectors.jira.types.IssueCommentsContainsCondition | airbyte_agent_sdk.connectors.jira.types.IssueCommentsNotCondition | airbyte_agent_sdk.connectors.jira.types.IssueCommentsAndCondition | airbyte_agent_sdk.connectors.jira.types.IssueCommentsOrCondition | airbyte_agent_sdk.connectors.jira.types.IssueCommentsAnyCondition]`
     :   The type of the None singleton.
+
+<a id="IssueCommentsSearchFilter"></a>
 
 `IssueCommentsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering issue_comments search queries.
@@ -533,6 +587,8 @@ Classes
     `visibility: dict[str, typing.Any] | None`
     :   The group or role to which this item is visible
 
+<a id="IssueCommentsSearchQuery"></a>
+
 `IssueCommentsSearchQuery(*args, **kwargs)`
 :   Search query for issue_comments entity.
 
@@ -547,6 +603,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.jira.types.IssueCommentsSortFilter]`
     :   The type of the None singleton.
+
+<a id="IssueCommentsSortFilter"></a>
 
 `IssueCommentsSortFilter(*args, **kwargs)`
 :   Available fields for sorting issue_comments search results.
@@ -593,6 +651,8 @@ Classes
     `visibility: Literal['asc', 'desc']`
     :   The group or role to which this item is visible
 
+<a id="IssueCommentsStringFilter"></a>
+
 `IssueCommentsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -638,6 +698,8 @@ Classes
     `visibility: str`
     :   The group or role to which this item is visible
 
+<a id="IssueCommentsUpdateParams"></a>
+
 `IssueCommentsUpdateParams(*args, **kwargs)`
 :   Parameters for issue_comments.update operation
 
@@ -665,6 +727,8 @@ Classes
     `visibility: airbyte_agent_sdk.connectors.jira.types.IssueCommentsUpdateParamsVisibility`
     :   The type of the None singleton.
 
+<a id="IssueCommentsUpdateParamsBody"></a>
+
 `IssueCommentsUpdateParamsBody(*args, **kwargs)`
 :   Updated comment content in Atlassian Document Format (ADF)
 
@@ -683,6 +747,8 @@ Classes
     `version: int`
     :   The type of the None singleton.
 
+<a id="IssueCommentsUpdateParamsBodyContentItem"></a>
+
 `IssueCommentsUpdateParamsBodyContentItem(*args, **kwargs)`
 :   Nested schema for IssueCommentsUpdateParamsBody.content_item
 
@@ -698,6 +764,8 @@ Classes
     `type: str`
     :   The type of the None singleton.
 
+<a id="IssueCommentsUpdateParamsBodyContentItemContentItem"></a>
+
 `IssueCommentsUpdateParamsBodyContentItemContentItem(*args, **kwargs)`
 :   Nested schema for IssueCommentsUpdateParamsBodyContentItem.content_item
 
@@ -712,6 +780,8 @@ Classes
 
     `type: str`
     :   The type of the None singleton.
+
+<a id="IssueCommentsUpdateParamsVisibility"></a>
 
 `IssueCommentsUpdateParamsVisibility(*args, **kwargs)`
 :   Restrict comment visibility to a group or role
@@ -730,6 +800,8 @@ Classes
 
     `value: str`
     :   The type of the None singleton.
+
+<a id="IssueFieldsAndCondition"></a>
 
 `IssueFieldsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -751,6 +823,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.jira.types.IssueFieldsEqCondition | airbyte_agent_sdk.connectors.jira.types.IssueFieldsNeqCondition | airbyte_agent_sdk.connectors.jira.types.IssueFieldsGtCondition | airbyte_agent_sdk.connectors.jira.types.IssueFieldsGteCondition | airbyte_agent_sdk.connectors.jira.types.IssueFieldsLtCondition | airbyte_agent_sdk.connectors.jira.types.IssueFieldsLteCondition | airbyte_agent_sdk.connectors.jira.types.IssueFieldsInCondition | airbyte_agent_sdk.connectors.jira.types.IssueFieldsLikeCondition | airbyte_agent_sdk.connectors.jira.types.IssueFieldsFuzzyCondition | airbyte_agent_sdk.connectors.jira.types.IssueFieldsKeywordCondition | airbyte_agent_sdk.connectors.jira.types.IssueFieldsContainsCondition | airbyte_agent_sdk.connectors.jira.types.IssueFieldsNotCondition | airbyte_agent_sdk.connectors.jira.types.IssueFieldsAndCondition | airbyte_agent_sdk.connectors.jira.types.IssueFieldsOrCondition | airbyte_agent_sdk.connectors.jira.types.IssueFieldsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="IssueFieldsAnyCondition"></a>
+
 `IssueFieldsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -770,6 +844,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.jira.types.IssueFieldsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="IssueFieldsAnyValueFilter"></a>
 
 `IssueFieldsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -813,6 +889,8 @@ Classes
     `untranslated_name: Any`
     :   The untranslated name of the field
 
+<a id="IssueFieldsApiSearchParams"></a>
+
 `IssueFieldsApiSearchParams(*args, **kwargs)`
 :   Parameters for issue_fields.api_search operation
 
@@ -843,6 +921,8 @@ Classes
     `type: list[str]`
     :   The type of the None singleton.
 
+<a id="IssueFieldsContainsCondition"></a>
+
 `IssueFieldsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -854,6 +934,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.jira.types.IssueFieldsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="IssueFieldsEqCondition"></a>
 
 `IssueFieldsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -867,6 +949,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.jira.types.IssueFieldsSearchFilter`
     :   The type of the None singleton.
 
+<a id="IssueFieldsFuzzyCondition"></a>
+
 `IssueFieldsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -878,6 +962,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.jira.types.IssueFieldsStringFilter`
     :   The type of the None singleton.
+
+<a id="IssueFieldsGtCondition"></a>
 
 `IssueFieldsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
@@ -891,6 +977,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.jira.types.IssueFieldsSearchFilter`
     :   The type of the None singleton.
 
+<a id="IssueFieldsGteCondition"></a>
+
 `IssueFieldsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -902,6 +990,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.jira.types.IssueFieldsSearchFilter`
     :   The type of the None singleton.
+
+<a id="IssueFieldsInCondition"></a>
 
 `IssueFieldsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -922,6 +1012,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.jira.types.IssueFieldsInFilter`
     :   The type of the None singleton.
+
+<a id="IssueFieldsInFilter"></a>
 
 `IssueFieldsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -965,6 +1057,8 @@ Classes
     `untranslated_name: list[str]`
     :   The untranslated name of the field
 
+<a id="IssueFieldsKeywordCondition"></a>
+
 `IssueFieldsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -976,6 +1070,8 @@ Classes
 
     `keyword: airbyte_agent_sdk.connectors.jira.types.IssueFieldsStringFilter`
     :   The type of the None singleton.
+
+<a id="IssueFieldsLikeCondition"></a>
 
 `IssueFieldsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
@@ -989,12 +1085,16 @@ Classes
     `like: airbyte_agent_sdk.connectors.jira.types.IssueFieldsStringFilter`
     :   The type of the None singleton.
 
+<a id="IssueFieldsListParams"></a>
+
 `IssueFieldsListParams(*args, **kwargs)`
 :   Parameters for issue_fields.list operation
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="IssueFieldsLtCondition"></a>
 
 `IssueFieldsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
@@ -1008,6 +1108,8 @@ Classes
     `lt: airbyte_agent_sdk.connectors.jira.types.IssueFieldsSearchFilter`
     :   The type of the None singleton.
 
+<a id="IssueFieldsLteCondition"></a>
+
 `IssueFieldsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
 
@@ -1020,6 +1122,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.jira.types.IssueFieldsSearchFilter`
     :   The type of the None singleton.
 
+<a id="IssueFieldsNeqCondition"></a>
+
 `IssueFieldsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -1031,6 +1135,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.jira.types.IssueFieldsSearchFilter`
     :   The type of the None singleton.
+
+<a id="IssueFieldsNotCondition"></a>
 
 `IssueFieldsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -1052,6 +1158,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.jira.types.IssueFieldsEqCondition | airbyte_agent_sdk.connectors.jira.types.IssueFieldsNeqCondition | airbyte_agent_sdk.connectors.jira.types.IssueFieldsGtCondition | airbyte_agent_sdk.connectors.jira.types.IssueFieldsGteCondition | airbyte_agent_sdk.connectors.jira.types.IssueFieldsLtCondition | airbyte_agent_sdk.connectors.jira.types.IssueFieldsLteCondition | airbyte_agent_sdk.connectors.jira.types.IssueFieldsInCondition | airbyte_agent_sdk.connectors.jira.types.IssueFieldsLikeCondition | airbyte_agent_sdk.connectors.jira.types.IssueFieldsFuzzyCondition | airbyte_agent_sdk.connectors.jira.types.IssueFieldsKeywordCondition | airbyte_agent_sdk.connectors.jira.types.IssueFieldsContainsCondition | airbyte_agent_sdk.connectors.jira.types.IssueFieldsNotCondition | airbyte_agent_sdk.connectors.jira.types.IssueFieldsAndCondition | airbyte_agent_sdk.connectors.jira.types.IssueFieldsOrCondition | airbyte_agent_sdk.connectors.jira.types.IssueFieldsAnyCondition`
     :   The type of the None singleton.
 
+<a id="IssueFieldsOrCondition"></a>
+
 `IssueFieldsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1071,6 +1179,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.jira.types.IssueFieldsEqCondition | airbyte_agent_sdk.connectors.jira.types.IssueFieldsNeqCondition | airbyte_agent_sdk.connectors.jira.types.IssueFieldsGtCondition | airbyte_agent_sdk.connectors.jira.types.IssueFieldsGteCondition | airbyte_agent_sdk.connectors.jira.types.IssueFieldsLtCondition | airbyte_agent_sdk.connectors.jira.types.IssueFieldsLteCondition | airbyte_agent_sdk.connectors.jira.types.IssueFieldsInCondition | airbyte_agent_sdk.connectors.jira.types.IssueFieldsLikeCondition | airbyte_agent_sdk.connectors.jira.types.IssueFieldsFuzzyCondition | airbyte_agent_sdk.connectors.jira.types.IssueFieldsKeywordCondition | airbyte_agent_sdk.connectors.jira.types.IssueFieldsContainsCondition | airbyte_agent_sdk.connectors.jira.types.IssueFieldsNotCondition | airbyte_agent_sdk.connectors.jira.types.IssueFieldsAndCondition | airbyte_agent_sdk.connectors.jira.types.IssueFieldsOrCondition | airbyte_agent_sdk.connectors.jira.types.IssueFieldsAnyCondition]`
     :   The type of the None singleton.
+
+<a id="IssueFieldsSearchFilter"></a>
 
 `IssueFieldsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering issue_fields search queries.
@@ -1114,6 +1224,8 @@ Classes
     `untranslated_name: str | None`
     :   The untranslated name of the field
 
+<a id="IssueFieldsSearchQuery"></a>
+
 `IssueFieldsSearchQuery(*args, **kwargs)`
 :   Search query for issue_fields entity.
 
@@ -1128,6 +1240,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.jira.types.IssueFieldsSortFilter]`
     :   The type of the None singleton.
+
+<a id="IssueFieldsSortFilter"></a>
 
 `IssueFieldsSortFilter(*args, **kwargs)`
 :   Available fields for sorting issue_fields search results.
@@ -1171,6 +1285,8 @@ Classes
     `untranslated_name: Literal['asc', 'desc']`
     :   The untranslated name of the field
 
+<a id="IssueFieldsStringFilter"></a>
+
 `IssueFieldsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -1213,6 +1329,8 @@ Classes
     `untranslated_name: str`
     :   The untranslated name of the field
 
+<a id="IssueWorklogsAndCondition"></a>
+
 `IssueWorklogsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1233,6 +1351,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.jira.types.IssueWorklogsEqCondition | airbyte_agent_sdk.connectors.jira.types.IssueWorklogsNeqCondition | airbyte_agent_sdk.connectors.jira.types.IssueWorklogsGtCondition | airbyte_agent_sdk.connectors.jira.types.IssueWorklogsGteCondition | airbyte_agent_sdk.connectors.jira.types.IssueWorklogsLtCondition | airbyte_agent_sdk.connectors.jira.types.IssueWorklogsLteCondition | airbyte_agent_sdk.connectors.jira.types.IssueWorklogsInCondition | airbyte_agent_sdk.connectors.jira.types.IssueWorklogsLikeCondition | airbyte_agent_sdk.connectors.jira.types.IssueWorklogsFuzzyCondition | airbyte_agent_sdk.connectors.jira.types.IssueWorklogsKeywordCondition | airbyte_agent_sdk.connectors.jira.types.IssueWorklogsContainsCondition | airbyte_agent_sdk.connectors.jira.types.IssueWorklogsNotCondition | airbyte_agent_sdk.connectors.jira.types.IssueWorklogsAndCondition | airbyte_agent_sdk.connectors.jira.types.IssueWorklogsOrCondition | airbyte_agent_sdk.connectors.jira.types.IssueWorklogsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="IssueWorklogsAnyCondition"></a>
+
 `IssueWorklogsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1252,6 +1372,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.jira.types.IssueWorklogsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="IssueWorklogsAnyValueFilter"></a>
 
 `IssueWorklogsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -1301,6 +1423,8 @@ Classes
     `visibility: Any`
     :   Details about any restrictions in the visibility of the worklog
 
+<a id="IssueWorklogsContainsCondition"></a>
+
 `IssueWorklogsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -1312,6 +1436,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.jira.types.IssueWorklogsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="IssueWorklogsEqCondition"></a>
 
 `IssueWorklogsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -1325,6 +1451,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.jira.types.IssueWorklogsSearchFilter`
     :   The type of the None singleton.
 
+<a id="IssueWorklogsFuzzyCondition"></a>
+
 `IssueWorklogsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -1336,6 +1464,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.jira.types.IssueWorklogsStringFilter`
     :   The type of the None singleton.
+
+<a id="IssueWorklogsGetParams"></a>
 
 `IssueWorklogsGetParams(*args, **kwargs)`
 :   Parameters for issue_worklogs.get operation
@@ -1355,6 +1485,8 @@ Classes
     `worklog_id: str`
     :   The type of the None singleton.
 
+<a id="IssueWorklogsGtCondition"></a>
+
 `IssueWorklogsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -1367,6 +1499,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.jira.types.IssueWorklogsSearchFilter`
     :   The type of the None singleton.
 
+<a id="IssueWorklogsGteCondition"></a>
+
 `IssueWorklogsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -1378,6 +1512,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.jira.types.IssueWorklogsSearchFilter`
     :   The type of the None singleton.
+
+<a id="IssueWorklogsInCondition"></a>
 
 `IssueWorklogsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -1398,6 +1534,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.jira.types.IssueWorklogsInFilter`
     :   The type of the None singleton.
+
+<a id="IssueWorklogsInFilter"></a>
 
 `IssueWorklogsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -1447,6 +1585,8 @@ Classes
     `visibility: list[dict[str, typing.Any]]`
     :   Details about any restrictions in the visibility of the worklog
 
+<a id="IssueWorklogsKeywordCondition"></a>
+
 `IssueWorklogsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -1459,6 +1599,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.jira.types.IssueWorklogsStringFilter`
     :   The type of the None singleton.
 
+<a id="IssueWorklogsLikeCondition"></a>
+
 `IssueWorklogsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -1470,6 +1612,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.jira.types.IssueWorklogsStringFilter`
     :   The type of the None singleton.
+
+<a id="IssueWorklogsListParams"></a>
 
 `IssueWorklogsListParams(*args, **kwargs)`
 :   Parameters for issue_worklogs.list operation
@@ -1492,6 +1636,8 @@ Classes
     `start_at: int`
     :   The type of the None singleton.
 
+<a id="IssueWorklogsLtCondition"></a>
+
 `IssueWorklogsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -1503,6 +1649,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.jira.types.IssueWorklogsSearchFilter`
     :   The type of the None singleton.
+
+<a id="IssueWorklogsLteCondition"></a>
 
 `IssueWorklogsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -1516,6 +1664,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.jira.types.IssueWorklogsSearchFilter`
     :   The type of the None singleton.
 
+<a id="IssueWorklogsNeqCondition"></a>
+
 `IssueWorklogsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -1527,6 +1677,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.jira.types.IssueWorklogsSearchFilter`
     :   The type of the None singleton.
+
+<a id="IssueWorklogsNotCondition"></a>
 
 `IssueWorklogsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -1548,6 +1700,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.jira.types.IssueWorklogsEqCondition | airbyte_agent_sdk.connectors.jira.types.IssueWorklogsNeqCondition | airbyte_agent_sdk.connectors.jira.types.IssueWorklogsGtCondition | airbyte_agent_sdk.connectors.jira.types.IssueWorklogsGteCondition | airbyte_agent_sdk.connectors.jira.types.IssueWorklogsLtCondition | airbyte_agent_sdk.connectors.jira.types.IssueWorklogsLteCondition | airbyte_agent_sdk.connectors.jira.types.IssueWorklogsInCondition | airbyte_agent_sdk.connectors.jira.types.IssueWorklogsLikeCondition | airbyte_agent_sdk.connectors.jira.types.IssueWorklogsFuzzyCondition | airbyte_agent_sdk.connectors.jira.types.IssueWorklogsKeywordCondition | airbyte_agent_sdk.connectors.jira.types.IssueWorklogsContainsCondition | airbyte_agent_sdk.connectors.jira.types.IssueWorklogsNotCondition | airbyte_agent_sdk.connectors.jira.types.IssueWorklogsAndCondition | airbyte_agent_sdk.connectors.jira.types.IssueWorklogsOrCondition | airbyte_agent_sdk.connectors.jira.types.IssueWorklogsAnyCondition`
     :   The type of the None singleton.
 
+<a id="IssueWorklogsOrCondition"></a>
+
 `IssueWorklogsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1567,6 +1721,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.jira.types.IssueWorklogsEqCondition | airbyte_agent_sdk.connectors.jira.types.IssueWorklogsNeqCondition | airbyte_agent_sdk.connectors.jira.types.IssueWorklogsGtCondition | airbyte_agent_sdk.connectors.jira.types.IssueWorklogsGteCondition | airbyte_agent_sdk.connectors.jira.types.IssueWorklogsLtCondition | airbyte_agent_sdk.connectors.jira.types.IssueWorklogsLteCondition | airbyte_agent_sdk.connectors.jira.types.IssueWorklogsInCondition | airbyte_agent_sdk.connectors.jira.types.IssueWorklogsLikeCondition | airbyte_agent_sdk.connectors.jira.types.IssueWorklogsFuzzyCondition | airbyte_agent_sdk.connectors.jira.types.IssueWorklogsKeywordCondition | airbyte_agent_sdk.connectors.jira.types.IssueWorklogsContainsCondition | airbyte_agent_sdk.connectors.jira.types.IssueWorklogsNotCondition | airbyte_agent_sdk.connectors.jira.types.IssueWorklogsAndCondition | airbyte_agent_sdk.connectors.jira.types.IssueWorklogsOrCondition | airbyte_agent_sdk.connectors.jira.types.IssueWorklogsAnyCondition]`
     :   The type of the None singleton.
+
+<a id="IssueWorklogsSearchFilter"></a>
 
 `IssueWorklogsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering issue_worklogs search queries.
@@ -1616,6 +1772,8 @@ Classes
     `visibility: dict[str, typing.Any] | None`
     :   Details about any restrictions in the visibility of the worklog
 
+<a id="IssueWorklogsSearchQuery"></a>
+
 `IssueWorklogsSearchQuery(*args, **kwargs)`
 :   Search query for issue_worklogs entity.
 
@@ -1630,6 +1788,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.jira.types.IssueWorklogsSortFilter]`
     :   The type of the None singleton.
+
+<a id="IssueWorklogsSortFilter"></a>
 
 `IssueWorklogsSortFilter(*args, **kwargs)`
 :   Available fields for sorting issue_worklogs search results.
@@ -1679,6 +1839,8 @@ Classes
     `visibility: Literal['asc', 'desc']`
     :   Details about any restrictions in the visibility of the worklog
 
+<a id="IssueWorklogsStringFilter"></a>
+
 `IssueWorklogsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -1727,6 +1889,8 @@ Classes
     `visibility: str`
     :   Details about any restrictions in the visibility of the worklog
 
+<a id="IssuesAndCondition"></a>
+
 `IssuesAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1747,6 +1911,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.jira.types.IssuesEqCondition | airbyte_agent_sdk.connectors.jira.types.IssuesNeqCondition | airbyte_agent_sdk.connectors.jira.types.IssuesGtCondition | airbyte_agent_sdk.connectors.jira.types.IssuesGteCondition | airbyte_agent_sdk.connectors.jira.types.IssuesLtCondition | airbyte_agent_sdk.connectors.jira.types.IssuesLteCondition | airbyte_agent_sdk.connectors.jira.types.IssuesInCondition | airbyte_agent_sdk.connectors.jira.types.IssuesLikeCondition | airbyte_agent_sdk.connectors.jira.types.IssuesFuzzyCondition | airbyte_agent_sdk.connectors.jira.types.IssuesKeywordCondition | airbyte_agent_sdk.connectors.jira.types.IssuesContainsCondition | airbyte_agent_sdk.connectors.jira.types.IssuesNotCondition | airbyte_agent_sdk.connectors.jira.types.IssuesAndCondition | airbyte_agent_sdk.connectors.jira.types.IssuesOrCondition | airbyte_agent_sdk.connectors.jira.types.IssuesAnyCondition]`
     :   The type of the None singleton.
 
+<a id="IssuesAnyCondition"></a>
+
 `IssuesAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1766,6 +1932,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.jira.types.IssuesAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="IssuesAnyValueFilter"></a>
 
 `IssuesAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -1833,6 +2001,8 @@ Classes
     `versioned_representations: Any`
     :   The versions of each field on the issue
 
+<a id="IssuesApiSearchParams"></a>
+
 `IssuesApiSearchParams(*args, **kwargs)`
 :   Parameters for issues.api_search operation
 
@@ -1866,6 +2036,8 @@ Classes
     `properties: str`
     :   The type of the None singleton.
 
+<a id="IssuesAssigneeUpdateParams"></a>
+
 `IssuesAssigneeUpdateParams(*args, **kwargs)`
 :   Parameters for issues_assignee.update operation
 
@@ -1881,6 +2053,8 @@ Classes
     `issue_id_or_key: str`
     :   The type of the None singleton.
 
+<a id="IssuesContainsCondition"></a>
+
 `IssuesContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -1892,6 +2066,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.jira.types.IssuesAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="IssuesCreateParams"></a>
 
 `IssuesCreateParams(*args, **kwargs)`
 :   Parameters for issues.create operation
@@ -1915,6 +2091,8 @@ Classes
         If E is present and has a .keys() method, then does:  for k in E.keys(): D[k] = E[k]
         If E is present and lacks a .keys() method, then does:  for k, v in E: D[k] = v
         In either case, this is followed by: for k in F:  D[k] = F[k]
+
+<a id="IssuesCreateParamsFields"></a>
 
 `IssuesCreateParamsFields(*args, **kwargs)`
 :   The issue fields to set
@@ -1949,6 +2127,8 @@ Classes
     `summary: str`
     :   The type of the None singleton.
 
+<a id="IssuesCreateParamsFieldsAssignee"></a>
+
 `IssuesCreateParamsFieldsAssignee(*args, **kwargs)`
 :   The user to assign the issue to
 
@@ -1960,6 +2140,8 @@ Classes
 
     `accountId: str`
     :   The type of the None singleton.
+
+<a id="IssuesCreateParamsFieldsDescription"></a>
 
 `IssuesCreateParamsFieldsDescription(*args, **kwargs)`
 :   Issue description in Atlassian Document Format (ADF)
@@ -1979,6 +2161,8 @@ Classes
     `version: int`
     :   The type of the None singleton.
 
+<a id="IssuesCreateParamsFieldsDescriptionContentItem"></a>
+
 `IssuesCreateParamsFieldsDescriptionContentItem(*args, **kwargs)`
 :   Nested schema for IssuesCreateParamsFieldsDescription.content_item
 
@@ -1993,6 +2177,8 @@ Classes
 
     `type: str`
     :   The type of the None singleton.
+
+<a id="IssuesCreateParamsFieldsDescriptionContentItemContentItem"></a>
 
 `IssuesCreateParamsFieldsDescriptionContentItemContentItem(*args, **kwargs)`
 :   Nested schema for IssuesCreateParamsFieldsDescriptionContentItem.content_item
@@ -2009,6 +2195,8 @@ Classes
     `type: str`
     :   The type of the None singleton.
 
+<a id="IssuesCreateParamsFieldsIssuetype"></a>
+
 `IssuesCreateParamsFieldsIssuetype(*args, **kwargs)`
 :   The type of issue (e.g., Bug, Task, Story)
 
@@ -2024,6 +2212,8 @@ Classes
     `name: str`
     :   The type of the None singleton.
 
+<a id="IssuesCreateParamsFieldsParent"></a>
+
 `IssuesCreateParamsFieldsParent(*args, **kwargs)`
 :   Parent issue for subtasks
 
@@ -2035,6 +2225,8 @@ Classes
 
     `key: str`
     :   The type of the None singleton.
+
+<a id="IssuesCreateParamsFieldsPriority"></a>
 
 `IssuesCreateParamsFieldsPriority(*args, **kwargs)`
 :   Issue priority
@@ -2051,6 +2243,8 @@ Classes
     `name: str`
     :   The type of the None singleton.
 
+<a id="IssuesCreateParamsFieldsProject"></a>
+
 `IssuesCreateParamsFieldsProject(*args, **kwargs)`
 :   The project to create the issue in
 
@@ -2065,6 +2259,8 @@ Classes
 
     `key: str`
     :   The type of the None singleton.
+
+<a id="IssuesDeleteParams"></a>
 
 `IssuesDeleteParams(*args, **kwargs)`
 :   Parameters for issues.delete operation
@@ -2081,6 +2277,8 @@ Classes
     `issue_id_or_key: str`
     :   The type of the None singleton.
 
+<a id="IssuesEqCondition"></a>
+
 `IssuesEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
 
@@ -2093,6 +2291,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.jira.types.IssuesSearchFilter`
     :   The type of the None singleton.
 
+<a id="IssuesFuzzyCondition"></a>
+
 `IssuesFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -2104,6 +2304,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.jira.types.IssuesStringFilter`
     :   The type of the None singleton.
+
+<a id="IssuesGetParams"></a>
 
 `IssuesGetParams(*args, **kwargs)`
 :   Parameters for issues.get operation
@@ -2135,6 +2337,8 @@ Classes
     `update_history: bool`
     :   The type of the None singleton.
 
+<a id="IssuesGtCondition"></a>
+
 `IssuesGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -2147,6 +2351,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.jira.types.IssuesSearchFilter`
     :   The type of the None singleton.
 
+<a id="IssuesGteCondition"></a>
+
 `IssuesGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -2158,6 +2364,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.jira.types.IssuesSearchFilter`
     :   The type of the None singleton.
+
+<a id="IssuesInCondition"></a>
 
 `IssuesInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -2178,6 +2386,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.jira.types.IssuesInFilter`
     :   The type of the None singleton.
+
+<a id="IssuesInFilter"></a>
 
 `IssuesInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -2245,6 +2455,8 @@ Classes
     `versioned_representations: list[dict[str, typing.Any]]`
     :   The versions of each field on the issue
 
+<a id="IssuesKeywordCondition"></a>
+
 `IssuesKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -2256,6 +2468,8 @@ Classes
 
     `keyword: airbyte_agent_sdk.connectors.jira.types.IssuesStringFilter`
     :   The type of the None singleton.
+
+<a id="IssuesLikeCondition"></a>
 
 `IssuesLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
@@ -2269,6 +2483,8 @@ Classes
     `like: airbyte_agent_sdk.connectors.jira.types.IssuesStringFilter`
     :   The type of the None singleton.
 
+<a id="IssuesLtCondition"></a>
+
 `IssuesLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -2280,6 +2496,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.jira.types.IssuesSearchFilter`
     :   The type of the None singleton.
+
+<a id="IssuesLteCondition"></a>
 
 `IssuesLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -2293,6 +2511,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.jira.types.IssuesSearchFilter`
     :   The type of the None singleton.
 
+<a id="IssuesNeqCondition"></a>
+
 `IssuesNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -2304,6 +2524,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.jira.types.IssuesSearchFilter`
     :   The type of the None singleton.
+
+<a id="IssuesNotCondition"></a>
 
 `IssuesNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -2325,6 +2547,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.jira.types.IssuesEqCondition | airbyte_agent_sdk.connectors.jira.types.IssuesNeqCondition | airbyte_agent_sdk.connectors.jira.types.IssuesGtCondition | airbyte_agent_sdk.connectors.jira.types.IssuesGteCondition | airbyte_agent_sdk.connectors.jira.types.IssuesLtCondition | airbyte_agent_sdk.connectors.jira.types.IssuesLteCondition | airbyte_agent_sdk.connectors.jira.types.IssuesInCondition | airbyte_agent_sdk.connectors.jira.types.IssuesLikeCondition | airbyte_agent_sdk.connectors.jira.types.IssuesFuzzyCondition | airbyte_agent_sdk.connectors.jira.types.IssuesKeywordCondition | airbyte_agent_sdk.connectors.jira.types.IssuesContainsCondition | airbyte_agent_sdk.connectors.jira.types.IssuesNotCondition | airbyte_agent_sdk.connectors.jira.types.IssuesAndCondition | airbyte_agent_sdk.connectors.jira.types.IssuesOrCondition | airbyte_agent_sdk.connectors.jira.types.IssuesAnyCondition`
     :   The type of the None singleton.
 
+<a id="IssuesOrCondition"></a>
+
 `IssuesOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -2344,6 +2568,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.jira.types.IssuesEqCondition | airbyte_agent_sdk.connectors.jira.types.IssuesNeqCondition | airbyte_agent_sdk.connectors.jira.types.IssuesGtCondition | airbyte_agent_sdk.connectors.jira.types.IssuesGteCondition | airbyte_agent_sdk.connectors.jira.types.IssuesLtCondition | airbyte_agent_sdk.connectors.jira.types.IssuesLteCondition | airbyte_agent_sdk.connectors.jira.types.IssuesInCondition | airbyte_agent_sdk.connectors.jira.types.IssuesLikeCondition | airbyte_agent_sdk.connectors.jira.types.IssuesFuzzyCondition | airbyte_agent_sdk.connectors.jira.types.IssuesKeywordCondition | airbyte_agent_sdk.connectors.jira.types.IssuesContainsCondition | airbyte_agent_sdk.connectors.jira.types.IssuesNotCondition | airbyte_agent_sdk.connectors.jira.types.IssuesAndCondition | airbyte_agent_sdk.connectors.jira.types.IssuesOrCondition | airbyte_agent_sdk.connectors.jira.types.IssuesAnyCondition]`
     :   The type of the None singleton.
+
+<a id="IssuesSearchFilter"></a>
 
 `IssuesSearchFilter(*args, **kwargs)`
 :   Available fields for filtering issues search queries.
@@ -2411,6 +2637,8 @@ Classes
     `versioned_representations: dict[str, typing.Any]`
     :   The versions of each field on the issue
 
+<a id="IssuesSearchQuery"></a>
+
 `IssuesSearchQuery(*args, **kwargs)`
 :   Search query for issues entity.
 
@@ -2425,6 +2653,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.jira.types.IssuesSortFilter]`
     :   The type of the None singleton.
+
+<a id="IssuesSortFilter"></a>
 
 `IssuesSortFilter(*args, **kwargs)`
 :   Available fields for sorting issues search results.
@@ -2492,6 +2722,8 @@ Classes
     `versioned_representations: Literal['asc', 'desc']`
     :   The versions of each field on the issue
 
+<a id="IssuesStringFilter"></a>
+
 `IssuesStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -2558,6 +2790,8 @@ Classes
     `versioned_representations: str`
     :   The versions of each field on the issue
 
+<a id="IssuesUpdateParams"></a>
+
 `IssuesUpdateParams(*args, **kwargs)`
 :   Parameters for issues.update operation
 
@@ -2599,6 +2833,8 @@ Classes
         If E is present and lacks a .keys() method, then does:  for k, v in E: D[k] = v
         In either case, this is followed by: for k in F:  D[k] = F[k]
 
+<a id="IssuesUpdateParamsFields"></a>
+
 `IssuesUpdateParamsFields(*args, **kwargs)`
 :   The issue fields to update
 
@@ -2623,6 +2859,8 @@ Classes
     `summary: str`
     :   The type of the None singleton.
 
+<a id="IssuesUpdateParamsFieldsAssignee"></a>
+
 `IssuesUpdateParamsFieldsAssignee(*args, **kwargs)`
 :   The user to assign the issue to
 
@@ -2634,6 +2872,8 @@ Classes
 
     `accountId: str`
     :   The type of the None singleton.
+
+<a id="IssuesUpdateParamsFieldsDescription"></a>
 
 `IssuesUpdateParamsFieldsDescription(*args, **kwargs)`
 :   Issue description in Atlassian Document Format (ADF)
@@ -2653,6 +2893,8 @@ Classes
     `version: int`
     :   The type of the None singleton.
 
+<a id="IssuesUpdateParamsFieldsDescriptionContentItem"></a>
+
 `IssuesUpdateParamsFieldsDescriptionContentItem(*args, **kwargs)`
 :   Nested schema for IssuesUpdateParamsFieldsDescription.content_item
 
@@ -2667,6 +2909,8 @@ Classes
 
     `type: str`
     :   The type of the None singleton.
+
+<a id="IssuesUpdateParamsFieldsDescriptionContentItemContentItem"></a>
 
 `IssuesUpdateParamsFieldsDescriptionContentItemContentItem(*args, **kwargs)`
 :   Nested schema for IssuesUpdateParamsFieldsDescriptionContentItem.content_item
@@ -2683,6 +2927,8 @@ Classes
     `type: str`
     :   The type of the None singleton.
 
+<a id="IssuesUpdateParamsFieldsPriority"></a>
+
 `IssuesUpdateParamsFieldsPriority(*args, **kwargs)`
 :   Issue priority
 
@@ -2698,6 +2944,8 @@ Classes
     `name: str`
     :   The type of the None singleton.
 
+<a id="IssuesUpdateParamsTransition"></a>
+
 `IssuesUpdateParamsTransition(*args, **kwargs)`
 :   Transition the issue to a new status
 
@@ -2709,6 +2957,8 @@ Classes
 
     `id: str`
     :   The type of the None singleton.
+
+<a id="ProjectsAndCondition"></a>
 
 `ProjectsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -2730,6 +2980,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.jira.types.ProjectsEqCondition | airbyte_agent_sdk.connectors.jira.types.ProjectsNeqCondition | airbyte_agent_sdk.connectors.jira.types.ProjectsGtCondition | airbyte_agent_sdk.connectors.jira.types.ProjectsGteCondition | airbyte_agent_sdk.connectors.jira.types.ProjectsLtCondition | airbyte_agent_sdk.connectors.jira.types.ProjectsLteCondition | airbyte_agent_sdk.connectors.jira.types.ProjectsInCondition | airbyte_agent_sdk.connectors.jira.types.ProjectsLikeCondition | airbyte_agent_sdk.connectors.jira.types.ProjectsFuzzyCondition | airbyte_agent_sdk.connectors.jira.types.ProjectsKeywordCondition | airbyte_agent_sdk.connectors.jira.types.ProjectsContainsCondition | airbyte_agent_sdk.connectors.jira.types.ProjectsNotCondition | airbyte_agent_sdk.connectors.jira.types.ProjectsAndCondition | airbyte_agent_sdk.connectors.jira.types.ProjectsOrCondition | airbyte_agent_sdk.connectors.jira.types.ProjectsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="ProjectsAnyCondition"></a>
+
 `ProjectsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -2749,6 +3001,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.jira.types.ProjectsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="ProjectsAnyValueFilter"></a>
 
 `ProjectsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -2861,6 +3115,8 @@ Classes
     `versions: Any`
     :   The versions defined in the project
 
+<a id="ProjectsApiSearchParams"></a>
+
 `ProjectsApiSearchParams(*args, **kwargs)`
 :   Parameters for projects.api_search operation
 
@@ -2905,6 +3161,8 @@ Classes
     `keys(self, /) ‑> list[str]`
     :   Return a set-like object providing a view on the dict's keys.
 
+<a id="ProjectsContainsCondition"></a>
+
 `ProjectsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -2916,6 +3174,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.jira.types.ProjectsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="ProjectsEqCondition"></a>
 
 `ProjectsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -2929,6 +3189,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.jira.types.ProjectsSearchFilter`
     :   The type of the None singleton.
 
+<a id="ProjectsFuzzyCondition"></a>
+
 `ProjectsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -2940,6 +3202,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.jira.types.ProjectsStringFilter`
     :   The type of the None singleton.
+
+<a id="ProjectsGetParams"></a>
 
 `ProjectsGetParams(*args, **kwargs)`
 :   Parameters for projects.get operation
@@ -2959,6 +3223,8 @@ Classes
     `properties: str`
     :   The type of the None singleton.
 
+<a id="ProjectsGtCondition"></a>
+
 `ProjectsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -2971,6 +3237,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.jira.types.ProjectsSearchFilter`
     :   The type of the None singleton.
 
+<a id="ProjectsGteCondition"></a>
+
 `ProjectsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -2982,6 +3250,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.jira.types.ProjectsSearchFilter`
     :   The type of the None singleton.
+
+<a id="ProjectsInCondition"></a>
 
 `ProjectsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -3002,6 +3272,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.jira.types.ProjectsInFilter`
     :   The type of the None singleton.
+
+<a id="ProjectsInFilter"></a>
 
 `ProjectsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -3114,6 +3386,8 @@ Classes
     `versions: list[list[typing.Any]]`
     :   The versions defined in the project
 
+<a id="ProjectsKeywordCondition"></a>
+
 `ProjectsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -3125,6 +3399,8 @@ Classes
 
     `keyword: airbyte_agent_sdk.connectors.jira.types.ProjectsStringFilter`
     :   The type of the None singleton.
+
+<a id="ProjectsLikeCondition"></a>
 
 `ProjectsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
@@ -3138,6 +3414,8 @@ Classes
     `like: airbyte_agent_sdk.connectors.jira.types.ProjectsStringFilter`
     :   The type of the None singleton.
 
+<a id="ProjectsLtCondition"></a>
+
 `ProjectsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -3149,6 +3427,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.jira.types.ProjectsSearchFilter`
     :   The type of the None singleton.
+
+<a id="ProjectsLteCondition"></a>
 
 `ProjectsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -3162,6 +3442,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.jira.types.ProjectsSearchFilter`
     :   The type of the None singleton.
 
+<a id="ProjectsNeqCondition"></a>
+
 `ProjectsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -3173,6 +3455,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.jira.types.ProjectsSearchFilter`
     :   The type of the None singleton.
+
+<a id="ProjectsNotCondition"></a>
 
 `ProjectsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -3194,6 +3478,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.jira.types.ProjectsEqCondition | airbyte_agent_sdk.connectors.jira.types.ProjectsNeqCondition | airbyte_agent_sdk.connectors.jira.types.ProjectsGtCondition | airbyte_agent_sdk.connectors.jira.types.ProjectsGteCondition | airbyte_agent_sdk.connectors.jira.types.ProjectsLtCondition | airbyte_agent_sdk.connectors.jira.types.ProjectsLteCondition | airbyte_agent_sdk.connectors.jira.types.ProjectsInCondition | airbyte_agent_sdk.connectors.jira.types.ProjectsLikeCondition | airbyte_agent_sdk.connectors.jira.types.ProjectsFuzzyCondition | airbyte_agent_sdk.connectors.jira.types.ProjectsKeywordCondition | airbyte_agent_sdk.connectors.jira.types.ProjectsContainsCondition | airbyte_agent_sdk.connectors.jira.types.ProjectsNotCondition | airbyte_agent_sdk.connectors.jira.types.ProjectsAndCondition | airbyte_agent_sdk.connectors.jira.types.ProjectsOrCondition | airbyte_agent_sdk.connectors.jira.types.ProjectsAnyCondition`
     :   The type of the None singleton.
 
+<a id="ProjectsOrCondition"></a>
+
 `ProjectsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -3213,6 +3499,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.jira.types.ProjectsEqCondition | airbyte_agent_sdk.connectors.jira.types.ProjectsNeqCondition | airbyte_agent_sdk.connectors.jira.types.ProjectsGtCondition | airbyte_agent_sdk.connectors.jira.types.ProjectsGteCondition | airbyte_agent_sdk.connectors.jira.types.ProjectsLtCondition | airbyte_agent_sdk.connectors.jira.types.ProjectsLteCondition | airbyte_agent_sdk.connectors.jira.types.ProjectsInCondition | airbyte_agent_sdk.connectors.jira.types.ProjectsLikeCondition | airbyte_agent_sdk.connectors.jira.types.ProjectsFuzzyCondition | airbyte_agent_sdk.connectors.jira.types.ProjectsKeywordCondition | airbyte_agent_sdk.connectors.jira.types.ProjectsContainsCondition | airbyte_agent_sdk.connectors.jira.types.ProjectsNotCondition | airbyte_agent_sdk.connectors.jira.types.ProjectsAndCondition | airbyte_agent_sdk.connectors.jira.types.ProjectsOrCondition | airbyte_agent_sdk.connectors.jira.types.ProjectsAnyCondition]`
     :   The type of the None singleton.
+
+<a id="ProjectsSearchFilter"></a>
 
 `ProjectsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering projects search queries.
@@ -3325,6 +3613,8 @@ Classes
     `versions: list[typing.Any]`
     :   The versions defined in the project
 
+<a id="ProjectsSearchQuery"></a>
+
 `ProjectsSearchQuery(*args, **kwargs)`
 :   Search query for projects entity.
 
@@ -3339,6 +3629,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.jira.types.ProjectsSortFilter]`
     :   The type of the None singleton.
+
+<a id="ProjectsSortFilter"></a>
 
 `ProjectsSortFilter(*args, **kwargs)`
 :   Available fields for sorting projects search results.
@@ -3451,6 +3743,8 @@ Classes
     `versions: Literal['asc', 'desc']`
     :   The versions defined in the project
 
+<a id="ProjectsStringFilter"></a>
+
 `ProjectsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -3562,6 +3856,8 @@ Classes
     `versions: str`
     :   The versions defined in the project
 
+<a id="UsersAndCondition"></a>
+
 `UsersAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -3582,6 +3878,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.jira.types.UsersEqCondition | airbyte_agent_sdk.connectors.jira.types.UsersNeqCondition | airbyte_agent_sdk.connectors.jira.types.UsersGtCondition | airbyte_agent_sdk.connectors.jira.types.UsersGteCondition | airbyte_agent_sdk.connectors.jira.types.UsersLtCondition | airbyte_agent_sdk.connectors.jira.types.UsersLteCondition | airbyte_agent_sdk.connectors.jira.types.UsersInCondition | airbyte_agent_sdk.connectors.jira.types.UsersLikeCondition | airbyte_agent_sdk.connectors.jira.types.UsersFuzzyCondition | airbyte_agent_sdk.connectors.jira.types.UsersKeywordCondition | airbyte_agent_sdk.connectors.jira.types.UsersContainsCondition | airbyte_agent_sdk.connectors.jira.types.UsersNotCondition | airbyte_agent_sdk.connectors.jira.types.UsersAndCondition | airbyte_agent_sdk.connectors.jira.types.UsersOrCondition | airbyte_agent_sdk.connectors.jira.types.UsersAnyCondition]`
     :   The type of the None singleton.
 
+<a id="UsersAnyCondition"></a>
+
 `UsersAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -3601,6 +3899,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.jira.types.UsersAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="UsersAnyValueFilter"></a>
 
 `UsersAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -3653,6 +3953,8 @@ Classes
     `time_zone: Any`
     :   The time zone specified in the user's profile
 
+<a id="UsersApiSearchParams"></a>
+
 `UsersApiSearchParams(*args, **kwargs)`
 :   Parameters for users.api_search operation
 
@@ -3677,6 +3979,8 @@ Classes
     `start_at: int`
     :   The type of the None singleton.
 
+<a id="UsersContainsCondition"></a>
+
 `UsersContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -3688,6 +3992,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.jira.types.UsersAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="UsersEqCondition"></a>
 
 `UsersEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -3701,6 +4007,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.jira.types.UsersSearchFilter`
     :   The type of the None singleton.
 
+<a id="UsersFuzzyCondition"></a>
+
 `UsersFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -3712,6 +4020,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.jira.types.UsersStringFilter`
     :   The type of the None singleton.
+
+<a id="UsersGetParams"></a>
 
 `UsersGetParams(*args, **kwargs)`
 :   Parameters for users.get operation
@@ -3728,6 +4038,8 @@ Classes
     `expand: str`
     :   The type of the None singleton.
 
+<a id="UsersGtCondition"></a>
+
 `UsersGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -3740,6 +4052,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.jira.types.UsersSearchFilter`
     :   The type of the None singleton.
 
+<a id="UsersGteCondition"></a>
+
 `UsersGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -3751,6 +4065,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.jira.types.UsersSearchFilter`
     :   The type of the None singleton.
+
+<a id="UsersInCondition"></a>
 
 `UsersInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -3771,6 +4087,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.jira.types.UsersInFilter`
     :   The type of the None singleton.
+
+<a id="UsersInFilter"></a>
 
 `UsersInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -3823,6 +4141,8 @@ Classes
     `time_zone: list[str]`
     :   The time zone specified in the user's profile
 
+<a id="UsersKeywordCondition"></a>
+
 `UsersKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -3835,6 +4155,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.jira.types.UsersStringFilter`
     :   The type of the None singleton.
 
+<a id="UsersLikeCondition"></a>
+
 `UsersLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -3846,6 +4168,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.jira.types.UsersStringFilter`
     :   The type of the None singleton.
+
+<a id="UsersListParams"></a>
 
 `UsersListParams(*args, **kwargs)`
 :   Parameters for users.list operation
@@ -3862,6 +4186,8 @@ Classes
     `start_at: int`
     :   The type of the None singleton.
 
+<a id="UsersLtCondition"></a>
+
 `UsersLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -3873,6 +4199,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.jira.types.UsersSearchFilter`
     :   The type of the None singleton.
+
+<a id="UsersLteCondition"></a>
 
 `UsersLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -3886,6 +4214,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.jira.types.UsersSearchFilter`
     :   The type of the None singleton.
 
+<a id="UsersNeqCondition"></a>
+
 `UsersNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -3897,6 +4227,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.jira.types.UsersSearchFilter`
     :   The type of the None singleton.
+
+<a id="UsersNotCondition"></a>
 
 `UsersNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -3918,6 +4250,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.jira.types.UsersEqCondition | airbyte_agent_sdk.connectors.jira.types.UsersNeqCondition | airbyte_agent_sdk.connectors.jira.types.UsersGtCondition | airbyte_agent_sdk.connectors.jira.types.UsersGteCondition | airbyte_agent_sdk.connectors.jira.types.UsersLtCondition | airbyte_agent_sdk.connectors.jira.types.UsersLteCondition | airbyte_agent_sdk.connectors.jira.types.UsersInCondition | airbyte_agent_sdk.connectors.jira.types.UsersLikeCondition | airbyte_agent_sdk.connectors.jira.types.UsersFuzzyCondition | airbyte_agent_sdk.connectors.jira.types.UsersKeywordCondition | airbyte_agent_sdk.connectors.jira.types.UsersContainsCondition | airbyte_agent_sdk.connectors.jira.types.UsersNotCondition | airbyte_agent_sdk.connectors.jira.types.UsersAndCondition | airbyte_agent_sdk.connectors.jira.types.UsersOrCondition | airbyte_agent_sdk.connectors.jira.types.UsersAnyCondition`
     :   The type of the None singleton.
 
+<a id="UsersOrCondition"></a>
+
 `UsersOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -3937,6 +4271,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.jira.types.UsersEqCondition | airbyte_agent_sdk.connectors.jira.types.UsersNeqCondition | airbyte_agent_sdk.connectors.jira.types.UsersGtCondition | airbyte_agent_sdk.connectors.jira.types.UsersGteCondition | airbyte_agent_sdk.connectors.jira.types.UsersLtCondition | airbyte_agent_sdk.connectors.jira.types.UsersLteCondition | airbyte_agent_sdk.connectors.jira.types.UsersInCondition | airbyte_agent_sdk.connectors.jira.types.UsersLikeCondition | airbyte_agent_sdk.connectors.jira.types.UsersFuzzyCondition | airbyte_agent_sdk.connectors.jira.types.UsersKeywordCondition | airbyte_agent_sdk.connectors.jira.types.UsersContainsCondition | airbyte_agent_sdk.connectors.jira.types.UsersNotCondition | airbyte_agent_sdk.connectors.jira.types.UsersAndCondition | airbyte_agent_sdk.connectors.jira.types.UsersOrCondition | airbyte_agent_sdk.connectors.jira.types.UsersAnyCondition]`
     :   The type of the None singleton.
+
+<a id="UsersSearchFilter"></a>
 
 `UsersSearchFilter(*args, **kwargs)`
 :   Available fields for filtering users search queries.
@@ -3989,6 +4325,8 @@ Classes
     `time_zone: str | None`
     :   The time zone specified in the user's profile
 
+<a id="UsersSearchQuery"></a>
+
 `UsersSearchQuery(*args, **kwargs)`
 :   Search query for users entity.
 
@@ -4003,6 +4341,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.jira.types.UsersSortFilter]`
     :   The type of the None singleton.
+
+<a id="UsersSortFilter"></a>
 
 `UsersSortFilter(*args, **kwargs)`
 :   Available fields for sorting users search results.
@@ -4054,6 +4394,8 @@ Classes
 
     `time_zone: Literal['asc', 'desc']`
     :   The time zone specified in the user's profile
+
+<a id="UsersStringFilter"></a>
 
 `UsersStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/klaviyo/connector.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/klaviyo/connector.md
@@ -10,6 +10,8 @@ Klaviyo connector.
 Classes
 -------
 
+<a id="CampaignsQuery"></a>
+
 `CampaignsQuery(connector: KlaviyoConnector)`
 :   Query class for Campaigns entity operations.
     
@@ -67,6 +69,8 @@ Classes
         Returns:
             CampaignsListResult
 
+<a id="EmailTemplatesQuery"></a>
+
 `EmailTemplatesQuery(connector: KlaviyoConnector)`
 :   Query class for EmailTemplates entity operations.
     
@@ -122,6 +126,8 @@ Classes
         Returns:
             EmailTemplatesListResult
 
+<a id="EventsQuery"></a>
+
 `EventsQuery(connector: KlaviyoConnector)`
 :   Query class for Events entity operations.
     
@@ -168,6 +174,8 @@ Classes
         
         Returns:
             EventsListResult
+
+<a id="FlowsQuery"></a>
 
 `FlowsQuery(connector: KlaviyoConnector)`
 :   Query class for Flows entity operations.
@@ -224,6 +232,8 @@ Classes
         
         Returns:
             FlowsListResult
+
+<a id="KlaviyoConnector"></a>
 
 `KlaviyoConnector(auth_config: KlaviyoAuthConfig | AirbyteAuthConfig | BaseModel | None = None, on_token_refresh: Any | None = None)`
 :   Type-safe Klaviyo API connector.
@@ -413,6 +423,8 @@ Classes
             for entity in entities:
                 print(f"\{entity['entity_name']\}: \{entity['available_actions']\}")
 
+<a id="ListsQuery"></a>
+
 `ListsQuery(connector: KlaviyoConnector)`
 :   Query class for Lists entity operations.
     
@@ -469,6 +481,8 @@ Classes
         Returns:
             ListsListResult
 
+<a id="MetricsQuery"></a>
+
 `MetricsQuery(connector: KlaviyoConnector)`
 :   Query class for Metrics entity operations.
     
@@ -524,6 +538,8 @@ Classes
         
         Returns:
             MetricsListResult
+
+<a id="ProfilesQuery"></a>
 
 `ProfilesQuery(connector: KlaviyoConnector)`
 :   Query class for Profiles entity operations.

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/klaviyo/index.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/klaviyo/index.md
@@ -19,6 +19,8 @@ Sub-modules
 Classes
 -------
 
+<a id="AirbyteAuthConfig"></a>
+
 `AirbyteAuthConfig(**data: Any)`
 :   Authentication configuration for Airbyte hosted mode execution.
     
@@ -87,6 +89,8 @@ Classes
     `workspace_name: str | None`
     :   The type of the None singleton.
 
+<a id="AirbyteSearchMeta"></a>
+
 `AirbyteSearchMeta(**data: Any)`
 :   Pagination metadata for search responses.
     
@@ -114,6 +118,8 @@ Classes
 
     `took_ms: int | None`
     :   Time taken to execute the search in milliseconds.
+
+<a id="AirbyteSearchResult"></a>
 
 `AirbyteSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -151,6 +157,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="CampaignsSearchResult"></a>
+
 `CampaignsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -166,6 +174,8 @@ Classes
     * airbyte_agent_sdk.connectors.klaviyo.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="EmailTemplatesSearchResult"></a>
 
 `EmailTemplatesSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -183,6 +193,8 @@ Classes
     * pydantic.main.BaseModel
     * typing.Generic
 
+<a id="EventsSearchResult"></a>
+
 `EventsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -198,6 +210,8 @@ Classes
     * airbyte_agent_sdk.connectors.klaviyo.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="FlowsSearchResult"></a>
 
 `FlowsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -215,6 +229,8 @@ Classes
     * pydantic.main.BaseModel
     * typing.Generic
 
+<a id="ListsSearchResult"></a>
+
 `ListsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -230,6 +246,8 @@ Classes
     * airbyte_agent_sdk.connectors.klaviyo.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="MetricsSearchResult"></a>
 
 `MetricsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -247,6 +265,8 @@ Classes
     * pydantic.main.BaseModel
     * typing.Generic
 
+<a id="ProfilesSearchResult"></a>
+
 `ProfilesSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -262,6 +282,8 @@ Classes
     * airbyte_agent_sdk.connectors.klaviyo.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="CampaignsSearchData"></a>
 
 `CampaignsSearchData(**data: Any)`
 :   Search result data for campaigns entity.
@@ -300,6 +322,8 @@ Classes
     `updated_at: str | None`
     :   The type of the None singleton.
 
+<a id="EmailTemplatesSearchData"></a>
+
 `EmailTemplatesSearchData(**data: Any)`
 :   Search result data for email_templates entity.
     
@@ -333,6 +357,8 @@ Classes
 
     `updated: str | None`
     :   The type of the None singleton.
+
+<a id="EventsSearchData"></a>
 
 `EventsSearchData(**data: Any)`
 :   Search result data for events entity.
@@ -371,6 +397,8 @@ Classes
     `type_: str | None`
     :   The type of the None singleton.
 
+<a id="FlowsSearchData"></a>
+
 `FlowsSearchData(**data: Any)`
 :   Search result data for flows entity.
     
@@ -408,6 +436,8 @@ Classes
     `updated: str | None`
     :   The type of the None singleton.
 
+<a id="KlaviyoAuthConfig"></a>
+
 `KlaviyoAuthConfig(**data: Any)`
 :   Authentication
     
@@ -429,6 +459,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="KlaviyoConnector"></a>
 
 `KlaviyoConnector(auth_config: KlaviyoAuthConfig | AirbyteAuthConfig | BaseModel | None = None, on_token_refresh: Any | None = None)`
 :   Type-safe Klaviyo API connector.
@@ -618,6 +650,8 @@ Classes
             for entity in entities:
                 print(f"\{entity['entity_name']\}: \{entity['available_actions']\}")
 
+<a id="ListsSearchData"></a>
+
 `ListsSearchData(**data: Any)`
 :   Search result data for lists entity.
     
@@ -655,6 +689,8 @@ Classes
     `updated: str | None`
     :   The type of the None singleton.
 
+<a id="MetricsSearchData"></a>
+
 `MetricsSearchData(**data: Any)`
 :   Search result data for metrics entity.
     
@@ -691,6 +727,8 @@ Classes
 
     `updated: str | None`
     :   The type of the None singleton.
+
+<a id="ProfilesSearchData"></a>
 
 `ProfilesSearchData(**data: Any)`
 :   Search result data for profiles entity.

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/klaviyo/models.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/klaviyo/models.md
@@ -13,6 +13,8 @@ and response envelope types.
 Classes
 -------
 
+<a id="AirbyteSearchMeta"></a>
+
 `AirbyteSearchMeta(**data: Any)`
 :   Pagination metadata for search responses.
     
@@ -40,6 +42,8 @@ Classes
 
     `took_ms: int | None`
     :   Time taken to execute the search in milliseconds.
+
+<a id="AirbyteSearchResult"></a>
 
 `AirbyteSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -98,6 +102,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="CampaignsSearchResult"></a>
+
 `CampaignsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -134,6 +140,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="EmailTemplatesSearchResult"></a>
 
 `EmailTemplatesSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -172,6 +180,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="EventsSearchResult"></a>
+
 `EventsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -208,6 +218,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="FlowsSearchResult"></a>
 
 `FlowsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -246,6 +258,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="ListsSearchResult"></a>
+
 `ListsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -282,6 +296,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="MetricsSearchResult"></a>
 
 `MetricsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -320,6 +336,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="ProfilesSearchResult"></a>
+
 `ProfilesSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -335,6 +353,8 @@ Classes
     * airbyte_agent_sdk.connectors.klaviyo.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="Campaign"></a>
 
 `Campaign(**data: Any)`
 :   A Klaviyo campaign
@@ -366,6 +386,8 @@ Classes
 
     `type_: str | Any | None`
     :   The type of the None singleton.
+
+<a id="CampaignAttributes"></a>
 
 `CampaignAttributes(**data: Any)`
 :   Campaign attributes
@@ -419,6 +441,8 @@ Classes
     `updated_at: str | Any | None`
     :   Last update timestamp
 
+<a id="CampaignLinks"></a>
+
 `CampaignLinks(**data: Any)`
 :   Related links
     
@@ -440,6 +464,8 @@ Classes
 
     `self: str | Any | None`
     :   The type of the None singleton.
+
+<a id="CampaignsList"></a>
 
 `CampaignsList(**data: Any)`
 :   Paginated list of campaigns
@@ -465,6 +491,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="CampaignsListLinks"></a>
 
 `CampaignsListLinks(**data: Any)`
 :   Nested schema for CampaignsList.links
@@ -494,6 +522,8 @@ Classes
     `self: str | Any | None`
     :   The type of the None singleton.
 
+<a id="CampaignsListResultMeta"></a>
+
 `CampaignsListResultMeta(**data: Any)`
 :   Metadata for campaigns.Action.LIST operation
     
@@ -515,6 +545,8 @@ Classes
 
     `next: str | Any | None`
     :   The type of the None singleton.
+
+<a id="CampaignsSearchData"></a>
 
 `CampaignsSearchData(**data: Any)`
 :   Search result data for campaigns entity.
@@ -553,6 +585,8 @@ Classes
     `updated_at: str | None`
     :   The type of the None singleton.
 
+<a id="EmailTemplatesListResultMeta"></a>
+
 `EmailTemplatesListResultMeta(**data: Any)`
 :   Metadata for email_templates.Action.LIST operation
     
@@ -574,6 +608,8 @@ Classes
 
     `next: str | Any | None`
     :   The type of the None singleton.
+
+<a id="EmailTemplatesSearchData"></a>
 
 `EmailTemplatesSearchData(**data: Any)`
 :   Search result data for email_templates entity.
@@ -609,6 +645,8 @@ Classes
     `updated: str | None`
     :   The type of the None singleton.
 
+<a id="Event"></a>
+
 `Event(**data: Any)`
 :   A Klaviyo event representing an action taken by a profile
     
@@ -643,6 +681,8 @@ Classes
     `type_: str | Any | None`
     :   The type of the None singleton.
 
+<a id="EventAttributes"></a>
+
 `EventAttributes(**data: Any)`
 :   Event attributes
     
@@ -674,6 +714,8 @@ Classes
     `uuid: str | Any | None`
     :   Event UUID
 
+<a id="EventLinks"></a>
+
 `EventLinks(**data: Any)`
 :   Related links
     
@@ -695,6 +737,8 @@ Classes
 
     `self: str | Any | None`
     :   The type of the None singleton.
+
+<a id="EventRelationships"></a>
 
 `EventRelationships(**data: Any)`
 :   Related resources
@@ -721,6 +765,8 @@ Classes
     `profile: airbyte_agent_sdk.connectors.klaviyo.models.EventRelationshipsProfile | Any | None`
     :   The type of the None singleton.
 
+<a id="EventRelationshipsMetric"></a>
+
 `EventRelationshipsMetric(**data: Any)`
 :   Nested schema for EventRelationships.metric
     
@@ -742,6 +788,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="EventRelationshipsMetricData"></a>
 
 `EventRelationshipsMetricData(**data: Any)`
 :   Nested schema for EventRelationshipsMetric.data
@@ -768,6 +816,8 @@ Classes
     `type_: str | Any | None`
     :   The type of the None singleton.
 
+<a id="EventRelationshipsProfile"></a>
+
 `EventRelationshipsProfile(**data: Any)`
 :   Nested schema for EventRelationships.profile
     
@@ -789,6 +839,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="EventRelationshipsProfileData"></a>
 
 `EventRelationshipsProfileData(**data: Any)`
 :   Nested schema for EventRelationshipsProfile.data
@@ -815,6 +867,8 @@ Classes
     `type_: str | Any | None`
     :   The type of the None singleton.
 
+<a id="EventsList"></a>
+
 `EventsList(**data: Any)`
 :   Paginated list of events
     
@@ -839,6 +893,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="EventsListLinks"></a>
 
 `EventsListLinks(**data: Any)`
 :   Nested schema for EventsList.links
@@ -868,6 +924,8 @@ Classes
     `self: str | Any | None`
     :   The type of the None singleton.
 
+<a id="EventsListResultMeta"></a>
+
 `EventsListResultMeta(**data: Any)`
 :   Metadata for events.Action.LIST operation
     
@@ -889,6 +947,8 @@ Classes
 
     `next: str | Any | None`
     :   The type of the None singleton.
+
+<a id="EventsSearchData"></a>
 
 `EventsSearchData(**data: Any)`
 :   Search result data for events entity.
@@ -927,6 +987,8 @@ Classes
     `type_: str | None`
     :   The type of the None singleton.
 
+<a id="Flow"></a>
+
 `Flow(**data: Any)`
 :   A Klaviyo flow (automated sequence)
     
@@ -957,6 +1019,8 @@ Classes
 
     `type_: str | Any | None`
     :   The type of the None singleton.
+
+<a id="FlowAttributes"></a>
 
 `FlowAttributes(**data: Any)`
 :   Flow attributes
@@ -995,6 +1059,8 @@ Classes
     `updated: str | Any | None`
     :   Last update timestamp
 
+<a id="FlowLinks"></a>
+
 `FlowLinks(**data: Any)`
 :   Related links
     
@@ -1016,6 +1082,8 @@ Classes
 
     `self: str | Any | None`
     :   The type of the None singleton.
+
+<a id="FlowsList"></a>
 
 `FlowsList(**data: Any)`
 :   Paginated list of flows
@@ -1041,6 +1109,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="FlowsListLinks"></a>
 
 `FlowsListLinks(**data: Any)`
 :   Nested schema for FlowsList.links
@@ -1070,6 +1140,8 @@ Classes
     `self: str | Any | None`
     :   The type of the None singleton.
 
+<a id="FlowsListResultMeta"></a>
+
 `FlowsListResultMeta(**data: Any)`
 :   Metadata for flows.Action.LIST operation
     
@@ -1091,6 +1163,8 @@ Classes
 
     `next: str | Any | None`
     :   The type of the None singleton.
+
+<a id="FlowsSearchData"></a>
 
 `FlowsSearchData(**data: Any)`
 :   Search result data for flows entity.
@@ -1129,6 +1203,8 @@ Classes
     `updated: str | None`
     :   The type of the None singleton.
 
+<a id="KlaviyoAuthConfig"></a>
+
 `KlaviyoAuthConfig(**data: Any)`
 :   Authentication
     
@@ -1150,6 +1226,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="KlaviyoCheckResult"></a>
 
 `KlaviyoCheckResult(**data: Any)`
 :   Result of a health check operation.
@@ -1184,6 +1262,8 @@ Classes
     `status: str`
     :   Health check status: 'healthy' or 'unhealthy'.
 
+<a id="KlaviyoExecuteResult"></a>
+
 `KlaviyoExecuteResult(**data: Any)`
 :   Response envelope with data only.
     
@@ -1212,6 +1292,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="KlaviyoExecuteResultWithMeta"></a>
 
 `KlaviyoExecuteResultWithMeta(**data: Any)`
 :   Response envelope with data and metadata.
@@ -1270,6 +1352,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="CampaignsListResult"></a>
+
 `CampaignsListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -1312,6 +1396,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="EventsListResult"></a>
 
 `EventsListResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -1356,6 +1442,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="FlowsListResult"></a>
+
 `FlowsListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -1398,6 +1486,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="ListsListResult"></a>
 
 `ListsListResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -1442,6 +1532,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="MetricsListResult"></a>
+
 `MetricsListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -1484,6 +1576,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="ProfilesListResult"></a>
 
 `ProfilesListResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -1528,6 +1622,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="EmailTemplatesListResult"></a>
+
 `EmailTemplatesListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -1546,6 +1642,8 @@ Classes
     * airbyte_agent_sdk.connectors.klaviyo.models.KlaviyoExecuteResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="List"></a>
 
 `List(**data: Any)`
 :   A Klaviyo list for organizing profiles
@@ -1578,6 +1676,8 @@ Classes
     `type_: str | Any | None`
     :   The type of the None singleton.
 
+<a id="ListAttributes"></a>
+
 `ListAttributes(**data: Any)`
 :   List attributes
     
@@ -1609,6 +1709,8 @@ Classes
     `updated: str | Any | None`
     :   Last update timestamp
 
+<a id="ListLinks"></a>
+
 `ListLinks(**data: Any)`
 :   Related links
     
@@ -1630,6 +1732,8 @@ Classes
 
     `self: str | Any | None`
     :   The type of the None singleton.
+
+<a id="ListsList"></a>
 
 `ListsList(**data: Any)`
 :   Paginated list of lists
@@ -1655,6 +1759,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="ListsListLinks"></a>
 
 `ListsListLinks(**data: Any)`
 :   Nested schema for ListsList.links
@@ -1684,6 +1790,8 @@ Classes
     `self: str | Any | None`
     :   The type of the None singleton.
 
+<a id="ListsListResultMeta"></a>
+
 `ListsListResultMeta(**data: Any)`
 :   Metadata for lists.Action.LIST operation
     
@@ -1705,6 +1813,8 @@ Classes
 
     `next: str | Any | None`
     :   The type of the None singleton.
+
+<a id="ListsSearchData"></a>
 
 `ListsSearchData(**data: Any)`
 :   Search result data for lists entity.
@@ -1743,6 +1853,8 @@ Classes
     `updated: str | None`
     :   The type of the None singleton.
 
+<a id="Metric"></a>
+
 `Metric(**data: Any)`
 :   A Klaviyo metric (event type)
     
@@ -1773,6 +1885,8 @@ Classes
 
     `type_: str | Any | None`
     :   The type of the None singleton.
+
+<a id="MetricAttributes"></a>
 
 `MetricAttributes(**data: Any)`
 :   Metric attributes
@@ -1805,6 +1919,8 @@ Classes
     `updated: str | Any | None`
     :   Last update timestamp
 
+<a id="MetricAttributesIntegration"></a>
+
 `MetricAttributesIntegration(**data: Any)`
 :   Integration information
     
@@ -1833,6 +1949,8 @@ Classes
     `name: str | Any | None`
     :   The type of the None singleton.
 
+<a id="MetricLinks"></a>
+
 `MetricLinks(**data: Any)`
 :   Related links
     
@@ -1854,6 +1972,8 @@ Classes
 
     `self: str | Any | None`
     :   The type of the None singleton.
+
+<a id="MetricsList"></a>
 
 `MetricsList(**data: Any)`
 :   Paginated list of metrics
@@ -1879,6 +1999,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="MetricsListLinks"></a>
 
 `MetricsListLinks(**data: Any)`
 :   Nested schema for MetricsList.links
@@ -1908,6 +2030,8 @@ Classes
     `self: str | Any | None`
     :   The type of the None singleton.
 
+<a id="MetricsListResultMeta"></a>
+
 `MetricsListResultMeta(**data: Any)`
 :   Metadata for metrics.Action.LIST operation
     
@@ -1929,6 +2053,8 @@ Classes
 
     `next: str | Any | None`
     :   The type of the None singleton.
+
+<a id="MetricsSearchData"></a>
 
 `MetricsSearchData(**data: Any)`
 :   Search result data for metrics entity.
@@ -1967,6 +2093,8 @@ Classes
     `updated: str | None`
     :   The type of the None singleton.
 
+<a id="Profile"></a>
+
 `Profile(**data: Any)`
 :   A Klaviyo profile representing a contact
     
@@ -1997,6 +2125,8 @@ Classes
 
     `type_: str | Any | None`
     :   The type of the None singleton.
+
+<a id="ProfileAttributes"></a>
 
 `ProfileAttributes(**data: Any)`
 :   Profile attributes
@@ -2053,6 +2183,8 @@ Classes
     `updated: str | Any | None`
     :   Last update timestamp
 
+<a id="ProfileAttributesLocation"></a>
+
 `ProfileAttributesLocation(**data: Any)`
 :   Location information
     
@@ -2099,6 +2231,8 @@ Classes
     `zip: str | Any | None`
     :   The type of the None singleton.
 
+<a id="ProfileLinks"></a>
+
 `ProfileLinks(**data: Any)`
 :   Related links
     
@@ -2120,6 +2254,8 @@ Classes
 
     `self: str | Any | None`
     :   The type of the None singleton.
+
+<a id="ProfilesList"></a>
 
 `ProfilesList(**data: Any)`
 :   Paginated list of profiles
@@ -2145,6 +2281,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="ProfilesListLinks"></a>
 
 `ProfilesListLinks(**data: Any)`
 :   Nested schema for ProfilesList.links
@@ -2174,6 +2312,8 @@ Classes
     `self: str | Any | None`
     :   The type of the None singleton.
 
+<a id="ProfilesListResultMeta"></a>
+
 `ProfilesListResultMeta(**data: Any)`
 :   Metadata for profiles.Action.LIST operation
     
@@ -2195,6 +2335,8 @@ Classes
 
     `next: str | Any | None`
     :   The type of the None singleton.
+
+<a id="ProfilesSearchData"></a>
 
 `ProfilesSearchData(**data: Any)`
 :   Search result data for profiles entity.
@@ -2236,6 +2378,8 @@ Classes
     `updated: str | None`
     :   The type of the None singleton.
 
+<a id="Template"></a>
+
 `Template(**data: Any)`
 :   A Klaviyo email template
     
@@ -2266,6 +2410,8 @@ Classes
 
     `type_: str | Any | None`
     :   The type of the None singleton.
+
+<a id="TemplateAttributes"></a>
 
 `TemplateAttributes(**data: Any)`
 :   Template attributes
@@ -2304,6 +2450,8 @@ Classes
     `updated: str | Any | None`
     :   Last update timestamp
 
+<a id="TemplateLinks"></a>
+
 `TemplateLinks(**data: Any)`
 :   Related links
     
@@ -2325,6 +2473,8 @@ Classes
 
     `self: str | Any | None`
     :   The type of the None singleton.
+
+<a id="TemplatesList"></a>
 
 `TemplatesList(**data: Any)`
 :   Paginated list of templates
@@ -2350,6 +2500,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="TemplatesListLinks"></a>
 
 `TemplatesListLinks(**data: Any)`
 :   Nested schema for TemplatesList.links

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/klaviyo/types.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/klaviyo/types.md
@@ -10,6 +10,8 @@ Type definitions for klaviyo connector.
 Classes
 -------
 
+<a id="AirbyteSearchParams"></a>
+
 `AirbyteSearchParams(*args, **kwargs)`
 :   Parameters for Airbyte cache search operations (generic, use entity-specific query types for better type hints).
 
@@ -31,6 +33,8 @@ Classes
     `query: dict[str, typing.Any]`
     :   The type of the None singleton.
 
+<a id="CampaignsAndCondition"></a>
+
 `CampaignsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -51,6 +55,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.klaviyo.types.CampaignsEqCondition | airbyte_agent_sdk.connectors.klaviyo.types.CampaignsNeqCondition | airbyte_agent_sdk.connectors.klaviyo.types.CampaignsGtCondition | airbyte_agent_sdk.connectors.klaviyo.types.CampaignsGteCondition | airbyte_agent_sdk.connectors.klaviyo.types.CampaignsLtCondition | airbyte_agent_sdk.connectors.klaviyo.types.CampaignsLteCondition | airbyte_agent_sdk.connectors.klaviyo.types.CampaignsInCondition | airbyte_agent_sdk.connectors.klaviyo.types.CampaignsLikeCondition | airbyte_agent_sdk.connectors.klaviyo.types.CampaignsFuzzyCondition | airbyte_agent_sdk.connectors.klaviyo.types.CampaignsKeywordCondition | airbyte_agent_sdk.connectors.klaviyo.types.CampaignsContainsCondition | airbyte_agent_sdk.connectors.klaviyo.types.CampaignsNotCondition | airbyte_agent_sdk.connectors.klaviyo.types.CampaignsAndCondition | airbyte_agent_sdk.connectors.klaviyo.types.CampaignsOrCondition | airbyte_agent_sdk.connectors.klaviyo.types.CampaignsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="CampaignsAnyCondition"></a>
+
 `CampaignsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -70,6 +76,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.klaviyo.types.CampaignsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="CampaignsAnyValueFilter"></a>
 
 `CampaignsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -98,6 +106,8 @@ Classes
     `updated_at: Any`
     :   The type of the None singleton.
 
+<a id="CampaignsContainsCondition"></a>
+
 `CampaignsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -109,6 +119,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.klaviyo.types.CampaignsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="CampaignsEqCondition"></a>
 
 `CampaignsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -122,6 +134,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.klaviyo.types.CampaignsSearchFilter`
     :   The type of the None singleton.
 
+<a id="CampaignsFuzzyCondition"></a>
+
 `CampaignsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -133,6 +147,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.klaviyo.types.CampaignsStringFilter`
     :   The type of the None singleton.
+
+<a id="CampaignsGetParams"></a>
 
 `CampaignsGetParams(*args, **kwargs)`
 :   Parameters for campaigns.get operation
@@ -146,6 +162,8 @@ Classes
     `id: str`
     :   The type of the None singleton.
 
+<a id="CampaignsGtCondition"></a>
+
 `CampaignsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -158,6 +176,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.klaviyo.types.CampaignsSearchFilter`
     :   The type of the None singleton.
 
+<a id="CampaignsGteCondition"></a>
+
 `CampaignsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -169,6 +189,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.klaviyo.types.CampaignsSearchFilter`
     :   The type of the None singleton.
+
+<a id="CampaignsInCondition"></a>
 
 `CampaignsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -189,6 +211,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.klaviyo.types.CampaignsInFilter`
     :   The type of the None singleton.
+
+<a id="CampaignsInFilter"></a>
 
 `CampaignsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -217,6 +241,8 @@ Classes
     `updated_at: list[str]`
     :   The type of the None singleton.
 
+<a id="CampaignsKeywordCondition"></a>
+
 `CampaignsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -229,6 +255,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.klaviyo.types.CampaignsStringFilter`
     :   The type of the None singleton.
 
+<a id="CampaignsLikeCondition"></a>
+
 `CampaignsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -240,6 +268,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.klaviyo.types.CampaignsStringFilter`
     :   The type of the None singleton.
+
+<a id="CampaignsListParams"></a>
 
 `CampaignsListParams(*args, **kwargs)`
 :   Parameters for campaigns.list operation
@@ -259,6 +289,8 @@ Classes
     `page_size: int`
     :   The type of the None singleton.
 
+<a id="CampaignsLtCondition"></a>
+
 `CampaignsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -270,6 +302,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.klaviyo.types.CampaignsSearchFilter`
     :   The type of the None singleton.
+
+<a id="CampaignsLteCondition"></a>
 
 `CampaignsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -283,6 +317,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.klaviyo.types.CampaignsSearchFilter`
     :   The type of the None singleton.
 
+<a id="CampaignsNeqCondition"></a>
+
 `CampaignsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -294,6 +330,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.klaviyo.types.CampaignsSearchFilter`
     :   The type of the None singleton.
+
+<a id="CampaignsNotCondition"></a>
 
 `CampaignsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -315,6 +353,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.klaviyo.types.CampaignsEqCondition | airbyte_agent_sdk.connectors.klaviyo.types.CampaignsNeqCondition | airbyte_agent_sdk.connectors.klaviyo.types.CampaignsGtCondition | airbyte_agent_sdk.connectors.klaviyo.types.CampaignsGteCondition | airbyte_agent_sdk.connectors.klaviyo.types.CampaignsLtCondition | airbyte_agent_sdk.connectors.klaviyo.types.CampaignsLteCondition | airbyte_agent_sdk.connectors.klaviyo.types.CampaignsInCondition | airbyte_agent_sdk.connectors.klaviyo.types.CampaignsLikeCondition | airbyte_agent_sdk.connectors.klaviyo.types.CampaignsFuzzyCondition | airbyte_agent_sdk.connectors.klaviyo.types.CampaignsKeywordCondition | airbyte_agent_sdk.connectors.klaviyo.types.CampaignsContainsCondition | airbyte_agent_sdk.connectors.klaviyo.types.CampaignsNotCondition | airbyte_agent_sdk.connectors.klaviyo.types.CampaignsAndCondition | airbyte_agent_sdk.connectors.klaviyo.types.CampaignsOrCondition | airbyte_agent_sdk.connectors.klaviyo.types.CampaignsAnyCondition`
     :   The type of the None singleton.
 
+<a id="CampaignsOrCondition"></a>
+
 `CampaignsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -334,6 +374,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.klaviyo.types.CampaignsEqCondition | airbyte_agent_sdk.connectors.klaviyo.types.CampaignsNeqCondition | airbyte_agent_sdk.connectors.klaviyo.types.CampaignsGtCondition | airbyte_agent_sdk.connectors.klaviyo.types.CampaignsGteCondition | airbyte_agent_sdk.connectors.klaviyo.types.CampaignsLtCondition | airbyte_agent_sdk.connectors.klaviyo.types.CampaignsLteCondition | airbyte_agent_sdk.connectors.klaviyo.types.CampaignsInCondition | airbyte_agent_sdk.connectors.klaviyo.types.CampaignsLikeCondition | airbyte_agent_sdk.connectors.klaviyo.types.CampaignsFuzzyCondition | airbyte_agent_sdk.connectors.klaviyo.types.CampaignsKeywordCondition | airbyte_agent_sdk.connectors.klaviyo.types.CampaignsContainsCondition | airbyte_agent_sdk.connectors.klaviyo.types.CampaignsNotCondition | airbyte_agent_sdk.connectors.klaviyo.types.CampaignsAndCondition | airbyte_agent_sdk.connectors.klaviyo.types.CampaignsOrCondition | airbyte_agent_sdk.connectors.klaviyo.types.CampaignsAnyCondition]`
     :   The type of the None singleton.
+
+<a id="CampaignsSearchFilter"></a>
 
 `CampaignsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering campaigns search queries.
@@ -362,6 +404,8 @@ Classes
     `updated_at: str | None`
     :   The type of the None singleton.
 
+<a id="CampaignsSearchQuery"></a>
+
 `CampaignsSearchQuery(*args, **kwargs)`
 :   Search query for campaigns entity.
 
@@ -376,6 +420,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.klaviyo.types.CampaignsSortFilter]`
     :   The type of the None singleton.
+
+<a id="CampaignsSortFilter"></a>
 
 `CampaignsSortFilter(*args, **kwargs)`
 :   Available fields for sorting campaigns search results.
@@ -404,6 +450,8 @@ Classes
     `updated_at: Literal['asc', 'desc']`
     :   The type of the None singleton.
 
+<a id="CampaignsStringFilter"></a>
+
 `CampaignsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -431,6 +479,8 @@ Classes
     `updated_at: str`
     :   The type of the None singleton.
 
+<a id="EmailTemplatesAndCondition"></a>
+
 `EmailTemplatesAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -451,6 +501,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.klaviyo.types.EmailTemplatesEqCondition | airbyte_agent_sdk.connectors.klaviyo.types.EmailTemplatesNeqCondition | airbyte_agent_sdk.connectors.klaviyo.types.EmailTemplatesGtCondition | airbyte_agent_sdk.connectors.klaviyo.types.EmailTemplatesGteCondition | airbyte_agent_sdk.connectors.klaviyo.types.EmailTemplatesLtCondition | airbyte_agent_sdk.connectors.klaviyo.types.EmailTemplatesLteCondition | airbyte_agent_sdk.connectors.klaviyo.types.EmailTemplatesInCondition | airbyte_agent_sdk.connectors.klaviyo.types.EmailTemplatesLikeCondition | airbyte_agent_sdk.connectors.klaviyo.types.EmailTemplatesFuzzyCondition | airbyte_agent_sdk.connectors.klaviyo.types.EmailTemplatesKeywordCondition | airbyte_agent_sdk.connectors.klaviyo.types.EmailTemplatesContainsCondition | airbyte_agent_sdk.connectors.klaviyo.types.EmailTemplatesNotCondition | airbyte_agent_sdk.connectors.klaviyo.types.EmailTemplatesAndCondition | airbyte_agent_sdk.connectors.klaviyo.types.EmailTemplatesOrCondition | airbyte_agent_sdk.connectors.klaviyo.types.EmailTemplatesAnyCondition]`
     :   The type of the None singleton.
 
+<a id="EmailTemplatesAnyCondition"></a>
+
 `EmailTemplatesAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -470,6 +522,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.klaviyo.types.EmailTemplatesAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="EmailTemplatesAnyValueFilter"></a>
 
 `EmailTemplatesAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -495,6 +549,8 @@ Classes
     `updated: Any`
     :   The type of the None singleton.
 
+<a id="EmailTemplatesContainsCondition"></a>
+
 `EmailTemplatesContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -506,6 +562,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.klaviyo.types.EmailTemplatesAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="EmailTemplatesEqCondition"></a>
 
 `EmailTemplatesEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -519,6 +577,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.klaviyo.types.EmailTemplatesSearchFilter`
     :   The type of the None singleton.
 
+<a id="EmailTemplatesFuzzyCondition"></a>
+
 `EmailTemplatesFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -530,6 +590,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.klaviyo.types.EmailTemplatesStringFilter`
     :   The type of the None singleton.
+
+<a id="EmailTemplatesGetParams"></a>
 
 `EmailTemplatesGetParams(*args, **kwargs)`
 :   Parameters for email_templates.get operation
@@ -543,6 +605,8 @@ Classes
     `id: str`
     :   The type of the None singleton.
 
+<a id="EmailTemplatesGtCondition"></a>
+
 `EmailTemplatesGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -555,6 +619,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.klaviyo.types.EmailTemplatesSearchFilter`
     :   The type of the None singleton.
 
+<a id="EmailTemplatesGteCondition"></a>
+
 `EmailTemplatesGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -566,6 +632,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.klaviyo.types.EmailTemplatesSearchFilter`
     :   The type of the None singleton.
+
+<a id="EmailTemplatesInCondition"></a>
 
 `EmailTemplatesInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -586,6 +654,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.klaviyo.types.EmailTemplatesInFilter`
     :   The type of the None singleton.
+
+<a id="EmailTemplatesInFilter"></a>
 
 `EmailTemplatesInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -611,6 +681,8 @@ Classes
     `updated: list[str]`
     :   The type of the None singleton.
 
+<a id="EmailTemplatesKeywordCondition"></a>
+
 `EmailTemplatesKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -623,6 +695,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.klaviyo.types.EmailTemplatesStringFilter`
     :   The type of the None singleton.
 
+<a id="EmailTemplatesLikeCondition"></a>
+
 `EmailTemplatesLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -634,6 +708,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.klaviyo.types.EmailTemplatesStringFilter`
     :   The type of the None singleton.
+
+<a id="EmailTemplatesListParams"></a>
 
 `EmailTemplatesListParams(*args, **kwargs)`
 :   Parameters for email_templates.list operation
@@ -650,6 +726,8 @@ Classes
     `page_size: int`
     :   The type of the None singleton.
 
+<a id="EmailTemplatesLtCondition"></a>
+
 `EmailTemplatesLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -661,6 +739,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.klaviyo.types.EmailTemplatesSearchFilter`
     :   The type of the None singleton.
+
+<a id="EmailTemplatesLteCondition"></a>
 
 `EmailTemplatesLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -674,6 +754,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.klaviyo.types.EmailTemplatesSearchFilter`
     :   The type of the None singleton.
 
+<a id="EmailTemplatesNeqCondition"></a>
+
 `EmailTemplatesNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -685,6 +767,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.klaviyo.types.EmailTemplatesSearchFilter`
     :   The type of the None singleton.
+
+<a id="EmailTemplatesNotCondition"></a>
 
 `EmailTemplatesNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -706,6 +790,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.klaviyo.types.EmailTemplatesEqCondition | airbyte_agent_sdk.connectors.klaviyo.types.EmailTemplatesNeqCondition | airbyte_agent_sdk.connectors.klaviyo.types.EmailTemplatesGtCondition | airbyte_agent_sdk.connectors.klaviyo.types.EmailTemplatesGteCondition | airbyte_agent_sdk.connectors.klaviyo.types.EmailTemplatesLtCondition | airbyte_agent_sdk.connectors.klaviyo.types.EmailTemplatesLteCondition | airbyte_agent_sdk.connectors.klaviyo.types.EmailTemplatesInCondition | airbyte_agent_sdk.connectors.klaviyo.types.EmailTemplatesLikeCondition | airbyte_agent_sdk.connectors.klaviyo.types.EmailTemplatesFuzzyCondition | airbyte_agent_sdk.connectors.klaviyo.types.EmailTemplatesKeywordCondition | airbyte_agent_sdk.connectors.klaviyo.types.EmailTemplatesContainsCondition | airbyte_agent_sdk.connectors.klaviyo.types.EmailTemplatesNotCondition | airbyte_agent_sdk.connectors.klaviyo.types.EmailTemplatesAndCondition | airbyte_agent_sdk.connectors.klaviyo.types.EmailTemplatesOrCondition | airbyte_agent_sdk.connectors.klaviyo.types.EmailTemplatesAnyCondition`
     :   The type of the None singleton.
 
+<a id="EmailTemplatesOrCondition"></a>
+
 `EmailTemplatesOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -725,6 +811,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.klaviyo.types.EmailTemplatesEqCondition | airbyte_agent_sdk.connectors.klaviyo.types.EmailTemplatesNeqCondition | airbyte_agent_sdk.connectors.klaviyo.types.EmailTemplatesGtCondition | airbyte_agent_sdk.connectors.klaviyo.types.EmailTemplatesGteCondition | airbyte_agent_sdk.connectors.klaviyo.types.EmailTemplatesLtCondition | airbyte_agent_sdk.connectors.klaviyo.types.EmailTemplatesLteCondition | airbyte_agent_sdk.connectors.klaviyo.types.EmailTemplatesInCondition | airbyte_agent_sdk.connectors.klaviyo.types.EmailTemplatesLikeCondition | airbyte_agent_sdk.connectors.klaviyo.types.EmailTemplatesFuzzyCondition | airbyte_agent_sdk.connectors.klaviyo.types.EmailTemplatesKeywordCondition | airbyte_agent_sdk.connectors.klaviyo.types.EmailTemplatesContainsCondition | airbyte_agent_sdk.connectors.klaviyo.types.EmailTemplatesNotCondition | airbyte_agent_sdk.connectors.klaviyo.types.EmailTemplatesAndCondition | airbyte_agent_sdk.connectors.klaviyo.types.EmailTemplatesOrCondition | airbyte_agent_sdk.connectors.klaviyo.types.EmailTemplatesAnyCondition]`
     :   The type of the None singleton.
+
+<a id="EmailTemplatesSearchFilter"></a>
 
 `EmailTemplatesSearchFilter(*args, **kwargs)`
 :   Available fields for filtering email_templates search queries.
@@ -750,6 +838,8 @@ Classes
     `updated: str | None`
     :   The type of the None singleton.
 
+<a id="EmailTemplatesSearchQuery"></a>
+
 `EmailTemplatesSearchQuery(*args, **kwargs)`
 :   Search query for email_templates entity.
 
@@ -764,6 +854,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.klaviyo.types.EmailTemplatesSortFilter]`
     :   The type of the None singleton.
+
+<a id="EmailTemplatesSortFilter"></a>
 
 `EmailTemplatesSortFilter(*args, **kwargs)`
 :   Available fields for sorting email_templates search results.
@@ -789,6 +881,8 @@ Classes
     `updated: Literal['asc', 'desc']`
     :   The type of the None singleton.
 
+<a id="EmailTemplatesStringFilter"></a>
+
 `EmailTemplatesStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -813,6 +907,8 @@ Classes
     `updated: str`
     :   The type of the None singleton.
 
+<a id="EventsAndCondition"></a>
+
 `EventsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -833,6 +929,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.klaviyo.types.EventsEqCondition | airbyte_agent_sdk.connectors.klaviyo.types.EventsNeqCondition | airbyte_agent_sdk.connectors.klaviyo.types.EventsGtCondition | airbyte_agent_sdk.connectors.klaviyo.types.EventsGteCondition | airbyte_agent_sdk.connectors.klaviyo.types.EventsLtCondition | airbyte_agent_sdk.connectors.klaviyo.types.EventsLteCondition | airbyte_agent_sdk.connectors.klaviyo.types.EventsInCondition | airbyte_agent_sdk.connectors.klaviyo.types.EventsLikeCondition | airbyte_agent_sdk.connectors.klaviyo.types.EventsFuzzyCondition | airbyte_agent_sdk.connectors.klaviyo.types.EventsKeywordCondition | airbyte_agent_sdk.connectors.klaviyo.types.EventsContainsCondition | airbyte_agent_sdk.connectors.klaviyo.types.EventsNotCondition | airbyte_agent_sdk.connectors.klaviyo.types.EventsAndCondition | airbyte_agent_sdk.connectors.klaviyo.types.EventsOrCondition | airbyte_agent_sdk.connectors.klaviyo.types.EventsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="EventsAnyCondition"></a>
+
 `EventsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -852,6 +950,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.klaviyo.types.EventsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="EventsAnyValueFilter"></a>
 
 `EventsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -880,6 +980,8 @@ Classes
     `type_: Any`
     :   The type of the None singleton.
 
+<a id="EventsContainsCondition"></a>
+
 `EventsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -891,6 +993,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.klaviyo.types.EventsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="EventsEqCondition"></a>
 
 `EventsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -904,6 +1008,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.klaviyo.types.EventsSearchFilter`
     :   The type of the None singleton.
 
+<a id="EventsFuzzyCondition"></a>
+
 `EventsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -915,6 +1021,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.klaviyo.types.EventsStringFilter`
     :   The type of the None singleton.
+
+<a id="EventsGtCondition"></a>
 
 `EventsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
@@ -928,6 +1036,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.klaviyo.types.EventsSearchFilter`
     :   The type of the None singleton.
 
+<a id="EventsGteCondition"></a>
+
 `EventsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -939,6 +1049,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.klaviyo.types.EventsSearchFilter`
     :   The type of the None singleton.
+
+<a id="EventsInCondition"></a>
 
 `EventsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -959,6 +1071,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.klaviyo.types.EventsInFilter`
     :   The type of the None singleton.
+
+<a id="EventsInFilter"></a>
 
 `EventsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -987,6 +1101,8 @@ Classes
     `type_: list[str]`
     :   The type of the None singleton.
 
+<a id="EventsKeywordCondition"></a>
+
 `EventsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -999,6 +1115,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.klaviyo.types.EventsStringFilter`
     :   The type of the None singleton.
 
+<a id="EventsLikeCondition"></a>
+
 `EventsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -1010,6 +1128,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.klaviyo.types.EventsStringFilter`
     :   The type of the None singleton.
+
+<a id="EventsListParams"></a>
 
 `EventsListParams(*args, **kwargs)`
 :   Parameters for events.list operation
@@ -1029,6 +1149,8 @@ Classes
     `sort: str`
     :   The type of the None singleton.
 
+<a id="EventsLtCondition"></a>
+
 `EventsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -1040,6 +1162,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.klaviyo.types.EventsSearchFilter`
     :   The type of the None singleton.
+
+<a id="EventsLteCondition"></a>
 
 `EventsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -1053,6 +1177,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.klaviyo.types.EventsSearchFilter`
     :   The type of the None singleton.
 
+<a id="EventsNeqCondition"></a>
+
 `EventsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -1064,6 +1190,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.klaviyo.types.EventsSearchFilter`
     :   The type of the None singleton.
+
+<a id="EventsNotCondition"></a>
 
 `EventsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -1085,6 +1213,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.klaviyo.types.EventsEqCondition | airbyte_agent_sdk.connectors.klaviyo.types.EventsNeqCondition | airbyte_agent_sdk.connectors.klaviyo.types.EventsGtCondition | airbyte_agent_sdk.connectors.klaviyo.types.EventsGteCondition | airbyte_agent_sdk.connectors.klaviyo.types.EventsLtCondition | airbyte_agent_sdk.connectors.klaviyo.types.EventsLteCondition | airbyte_agent_sdk.connectors.klaviyo.types.EventsInCondition | airbyte_agent_sdk.connectors.klaviyo.types.EventsLikeCondition | airbyte_agent_sdk.connectors.klaviyo.types.EventsFuzzyCondition | airbyte_agent_sdk.connectors.klaviyo.types.EventsKeywordCondition | airbyte_agent_sdk.connectors.klaviyo.types.EventsContainsCondition | airbyte_agent_sdk.connectors.klaviyo.types.EventsNotCondition | airbyte_agent_sdk.connectors.klaviyo.types.EventsAndCondition | airbyte_agent_sdk.connectors.klaviyo.types.EventsOrCondition | airbyte_agent_sdk.connectors.klaviyo.types.EventsAnyCondition`
     :   The type of the None singleton.
 
+<a id="EventsOrCondition"></a>
+
 `EventsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1104,6 +1234,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.klaviyo.types.EventsEqCondition | airbyte_agent_sdk.connectors.klaviyo.types.EventsNeqCondition | airbyte_agent_sdk.connectors.klaviyo.types.EventsGtCondition | airbyte_agent_sdk.connectors.klaviyo.types.EventsGteCondition | airbyte_agent_sdk.connectors.klaviyo.types.EventsLtCondition | airbyte_agent_sdk.connectors.klaviyo.types.EventsLteCondition | airbyte_agent_sdk.connectors.klaviyo.types.EventsInCondition | airbyte_agent_sdk.connectors.klaviyo.types.EventsLikeCondition | airbyte_agent_sdk.connectors.klaviyo.types.EventsFuzzyCondition | airbyte_agent_sdk.connectors.klaviyo.types.EventsKeywordCondition | airbyte_agent_sdk.connectors.klaviyo.types.EventsContainsCondition | airbyte_agent_sdk.connectors.klaviyo.types.EventsNotCondition | airbyte_agent_sdk.connectors.klaviyo.types.EventsAndCondition | airbyte_agent_sdk.connectors.klaviyo.types.EventsOrCondition | airbyte_agent_sdk.connectors.klaviyo.types.EventsAnyCondition]`
     :   The type of the None singleton.
+
+<a id="EventsSearchFilter"></a>
 
 `EventsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering events search queries.
@@ -1132,6 +1264,8 @@ Classes
     `type_: str | None`
     :   The type of the None singleton.
 
+<a id="EventsSearchQuery"></a>
+
 `EventsSearchQuery(*args, **kwargs)`
 :   Search query for events entity.
 
@@ -1146,6 +1280,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.klaviyo.types.EventsSortFilter]`
     :   The type of the None singleton.
+
+<a id="EventsSortFilter"></a>
 
 `EventsSortFilter(*args, **kwargs)`
 :   Available fields for sorting events search results.
@@ -1174,6 +1310,8 @@ Classes
     `type_: Literal['asc', 'desc']`
     :   The type of the None singleton.
 
+<a id="EventsStringFilter"></a>
+
 `EventsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -1201,6 +1339,8 @@ Classes
     `type_: str`
     :   The type of the None singleton.
 
+<a id="FlowsAndCondition"></a>
+
 `FlowsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1221,6 +1361,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.klaviyo.types.FlowsEqCondition | airbyte_agent_sdk.connectors.klaviyo.types.FlowsNeqCondition | airbyte_agent_sdk.connectors.klaviyo.types.FlowsGtCondition | airbyte_agent_sdk.connectors.klaviyo.types.FlowsGteCondition | airbyte_agent_sdk.connectors.klaviyo.types.FlowsLtCondition | airbyte_agent_sdk.connectors.klaviyo.types.FlowsLteCondition | airbyte_agent_sdk.connectors.klaviyo.types.FlowsInCondition | airbyte_agent_sdk.connectors.klaviyo.types.FlowsLikeCondition | airbyte_agent_sdk.connectors.klaviyo.types.FlowsFuzzyCondition | airbyte_agent_sdk.connectors.klaviyo.types.FlowsKeywordCondition | airbyte_agent_sdk.connectors.klaviyo.types.FlowsContainsCondition | airbyte_agent_sdk.connectors.klaviyo.types.FlowsNotCondition | airbyte_agent_sdk.connectors.klaviyo.types.FlowsAndCondition | airbyte_agent_sdk.connectors.klaviyo.types.FlowsOrCondition | airbyte_agent_sdk.connectors.klaviyo.types.FlowsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="FlowsAnyCondition"></a>
+
 `FlowsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1240,6 +1382,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.klaviyo.types.FlowsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="FlowsAnyValueFilter"></a>
 
 `FlowsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -1268,6 +1412,8 @@ Classes
     `updated: Any`
     :   The type of the None singleton.
 
+<a id="FlowsContainsCondition"></a>
+
 `FlowsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -1279,6 +1425,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.klaviyo.types.FlowsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="FlowsEqCondition"></a>
 
 `FlowsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -1292,6 +1440,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.klaviyo.types.FlowsSearchFilter`
     :   The type of the None singleton.
 
+<a id="FlowsFuzzyCondition"></a>
+
 `FlowsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -1303,6 +1453,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.klaviyo.types.FlowsStringFilter`
     :   The type of the None singleton.
+
+<a id="FlowsGetParams"></a>
 
 `FlowsGetParams(*args, **kwargs)`
 :   Parameters for flows.get operation
@@ -1316,6 +1468,8 @@ Classes
     `id: str`
     :   The type of the None singleton.
 
+<a id="FlowsGtCondition"></a>
+
 `FlowsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -1328,6 +1482,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.klaviyo.types.FlowsSearchFilter`
     :   The type of the None singleton.
 
+<a id="FlowsGteCondition"></a>
+
 `FlowsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -1339,6 +1495,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.klaviyo.types.FlowsSearchFilter`
     :   The type of the None singleton.
+
+<a id="FlowsInCondition"></a>
 
 `FlowsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -1359,6 +1517,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.klaviyo.types.FlowsInFilter`
     :   The type of the None singleton.
+
+<a id="FlowsInFilter"></a>
 
 `FlowsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -1387,6 +1547,8 @@ Classes
     `updated: list[str]`
     :   The type of the None singleton.
 
+<a id="FlowsKeywordCondition"></a>
+
 `FlowsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -1399,6 +1561,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.klaviyo.types.FlowsStringFilter`
     :   The type of the None singleton.
 
+<a id="FlowsLikeCondition"></a>
+
 `FlowsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -1410,6 +1574,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.klaviyo.types.FlowsStringFilter`
     :   The type of the None singleton.
+
+<a id="FlowsListParams"></a>
 
 `FlowsListParams(*args, **kwargs)`
 :   Parameters for flows.list operation
@@ -1426,6 +1592,8 @@ Classes
     `page_size: int`
     :   The type of the None singleton.
 
+<a id="FlowsLtCondition"></a>
+
 `FlowsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -1437,6 +1605,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.klaviyo.types.FlowsSearchFilter`
     :   The type of the None singleton.
+
+<a id="FlowsLteCondition"></a>
 
 `FlowsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -1450,6 +1620,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.klaviyo.types.FlowsSearchFilter`
     :   The type of the None singleton.
 
+<a id="FlowsNeqCondition"></a>
+
 `FlowsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -1461,6 +1633,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.klaviyo.types.FlowsSearchFilter`
     :   The type of the None singleton.
+
+<a id="FlowsNotCondition"></a>
 
 `FlowsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -1482,6 +1656,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.klaviyo.types.FlowsEqCondition | airbyte_agent_sdk.connectors.klaviyo.types.FlowsNeqCondition | airbyte_agent_sdk.connectors.klaviyo.types.FlowsGtCondition | airbyte_agent_sdk.connectors.klaviyo.types.FlowsGteCondition | airbyte_agent_sdk.connectors.klaviyo.types.FlowsLtCondition | airbyte_agent_sdk.connectors.klaviyo.types.FlowsLteCondition | airbyte_agent_sdk.connectors.klaviyo.types.FlowsInCondition | airbyte_agent_sdk.connectors.klaviyo.types.FlowsLikeCondition | airbyte_agent_sdk.connectors.klaviyo.types.FlowsFuzzyCondition | airbyte_agent_sdk.connectors.klaviyo.types.FlowsKeywordCondition | airbyte_agent_sdk.connectors.klaviyo.types.FlowsContainsCondition | airbyte_agent_sdk.connectors.klaviyo.types.FlowsNotCondition | airbyte_agent_sdk.connectors.klaviyo.types.FlowsAndCondition | airbyte_agent_sdk.connectors.klaviyo.types.FlowsOrCondition | airbyte_agent_sdk.connectors.klaviyo.types.FlowsAnyCondition`
     :   The type of the None singleton.
 
+<a id="FlowsOrCondition"></a>
+
 `FlowsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1501,6 +1677,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.klaviyo.types.FlowsEqCondition | airbyte_agent_sdk.connectors.klaviyo.types.FlowsNeqCondition | airbyte_agent_sdk.connectors.klaviyo.types.FlowsGtCondition | airbyte_agent_sdk.connectors.klaviyo.types.FlowsGteCondition | airbyte_agent_sdk.connectors.klaviyo.types.FlowsLtCondition | airbyte_agent_sdk.connectors.klaviyo.types.FlowsLteCondition | airbyte_agent_sdk.connectors.klaviyo.types.FlowsInCondition | airbyte_agent_sdk.connectors.klaviyo.types.FlowsLikeCondition | airbyte_agent_sdk.connectors.klaviyo.types.FlowsFuzzyCondition | airbyte_agent_sdk.connectors.klaviyo.types.FlowsKeywordCondition | airbyte_agent_sdk.connectors.klaviyo.types.FlowsContainsCondition | airbyte_agent_sdk.connectors.klaviyo.types.FlowsNotCondition | airbyte_agent_sdk.connectors.klaviyo.types.FlowsAndCondition | airbyte_agent_sdk.connectors.klaviyo.types.FlowsOrCondition | airbyte_agent_sdk.connectors.klaviyo.types.FlowsAnyCondition]`
     :   The type of the None singleton.
+
+<a id="FlowsSearchFilter"></a>
 
 `FlowsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering flows search queries.
@@ -1529,6 +1707,8 @@ Classes
     `updated: str | None`
     :   The type of the None singleton.
 
+<a id="FlowsSearchQuery"></a>
+
 `FlowsSearchQuery(*args, **kwargs)`
 :   Search query for flows entity.
 
@@ -1543,6 +1723,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.klaviyo.types.FlowsSortFilter]`
     :   The type of the None singleton.
+
+<a id="FlowsSortFilter"></a>
 
 `FlowsSortFilter(*args, **kwargs)`
 :   Available fields for sorting flows search results.
@@ -1571,6 +1753,8 @@ Classes
     `updated: Literal['asc', 'desc']`
     :   The type of the None singleton.
 
+<a id="FlowsStringFilter"></a>
+
 `FlowsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -1598,6 +1782,8 @@ Classes
     `updated: str`
     :   The type of the None singleton.
 
+<a id="ListsAndCondition"></a>
+
 `ListsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1618,6 +1804,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.klaviyo.types.ListsEqCondition | airbyte_agent_sdk.connectors.klaviyo.types.ListsNeqCondition | airbyte_agent_sdk.connectors.klaviyo.types.ListsGtCondition | airbyte_agent_sdk.connectors.klaviyo.types.ListsGteCondition | airbyte_agent_sdk.connectors.klaviyo.types.ListsLtCondition | airbyte_agent_sdk.connectors.klaviyo.types.ListsLteCondition | airbyte_agent_sdk.connectors.klaviyo.types.ListsInCondition | airbyte_agent_sdk.connectors.klaviyo.types.ListsLikeCondition | airbyte_agent_sdk.connectors.klaviyo.types.ListsFuzzyCondition | airbyte_agent_sdk.connectors.klaviyo.types.ListsKeywordCondition | airbyte_agent_sdk.connectors.klaviyo.types.ListsContainsCondition | airbyte_agent_sdk.connectors.klaviyo.types.ListsNotCondition | airbyte_agent_sdk.connectors.klaviyo.types.ListsAndCondition | airbyte_agent_sdk.connectors.klaviyo.types.ListsOrCondition | airbyte_agent_sdk.connectors.klaviyo.types.ListsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="ListsAnyCondition"></a>
+
 `ListsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1637,6 +1825,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.klaviyo.types.ListsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="ListsAnyValueFilter"></a>
 
 `ListsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -1665,6 +1855,8 @@ Classes
     `updated: Any`
     :   The type of the None singleton.
 
+<a id="ListsContainsCondition"></a>
+
 `ListsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -1676,6 +1868,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.klaviyo.types.ListsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="ListsEqCondition"></a>
 
 `ListsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -1689,6 +1883,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.klaviyo.types.ListsSearchFilter`
     :   The type of the None singleton.
 
+<a id="ListsFuzzyCondition"></a>
+
 `ListsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -1700,6 +1896,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.klaviyo.types.ListsStringFilter`
     :   The type of the None singleton.
+
+<a id="ListsGetParams"></a>
 
 `ListsGetParams(*args, **kwargs)`
 :   Parameters for lists.get operation
@@ -1713,6 +1911,8 @@ Classes
     `id: str`
     :   The type of the None singleton.
 
+<a id="ListsGtCondition"></a>
+
 `ListsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -1725,6 +1925,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.klaviyo.types.ListsSearchFilter`
     :   The type of the None singleton.
 
+<a id="ListsGteCondition"></a>
+
 `ListsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -1736,6 +1938,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.klaviyo.types.ListsSearchFilter`
     :   The type of the None singleton.
+
+<a id="ListsInCondition"></a>
 
 `ListsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -1756,6 +1960,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.klaviyo.types.ListsInFilter`
     :   The type of the None singleton.
+
+<a id="ListsInFilter"></a>
 
 `ListsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -1784,6 +1990,8 @@ Classes
     `updated: list[str]`
     :   The type of the None singleton.
 
+<a id="ListsKeywordCondition"></a>
+
 `ListsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -1796,6 +2004,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.klaviyo.types.ListsStringFilter`
     :   The type of the None singleton.
 
+<a id="ListsLikeCondition"></a>
+
 `ListsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -1807,6 +2017,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.klaviyo.types.ListsStringFilter`
     :   The type of the None singleton.
+
+<a id="ListsListParams"></a>
 
 `ListsListParams(*args, **kwargs)`
 :   Parameters for lists.list operation
@@ -1823,6 +2035,8 @@ Classes
     `page_size: int`
     :   The type of the None singleton.
 
+<a id="ListsLtCondition"></a>
+
 `ListsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -1834,6 +2048,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.klaviyo.types.ListsSearchFilter`
     :   The type of the None singleton.
+
+<a id="ListsLteCondition"></a>
 
 `ListsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -1847,6 +2063,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.klaviyo.types.ListsSearchFilter`
     :   The type of the None singleton.
 
+<a id="ListsNeqCondition"></a>
+
 `ListsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -1858,6 +2076,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.klaviyo.types.ListsSearchFilter`
     :   The type of the None singleton.
+
+<a id="ListsNotCondition"></a>
 
 `ListsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -1879,6 +2099,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.klaviyo.types.ListsEqCondition | airbyte_agent_sdk.connectors.klaviyo.types.ListsNeqCondition | airbyte_agent_sdk.connectors.klaviyo.types.ListsGtCondition | airbyte_agent_sdk.connectors.klaviyo.types.ListsGteCondition | airbyte_agent_sdk.connectors.klaviyo.types.ListsLtCondition | airbyte_agent_sdk.connectors.klaviyo.types.ListsLteCondition | airbyte_agent_sdk.connectors.klaviyo.types.ListsInCondition | airbyte_agent_sdk.connectors.klaviyo.types.ListsLikeCondition | airbyte_agent_sdk.connectors.klaviyo.types.ListsFuzzyCondition | airbyte_agent_sdk.connectors.klaviyo.types.ListsKeywordCondition | airbyte_agent_sdk.connectors.klaviyo.types.ListsContainsCondition | airbyte_agent_sdk.connectors.klaviyo.types.ListsNotCondition | airbyte_agent_sdk.connectors.klaviyo.types.ListsAndCondition | airbyte_agent_sdk.connectors.klaviyo.types.ListsOrCondition | airbyte_agent_sdk.connectors.klaviyo.types.ListsAnyCondition`
     :   The type of the None singleton.
 
+<a id="ListsOrCondition"></a>
+
 `ListsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1898,6 +2120,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.klaviyo.types.ListsEqCondition | airbyte_agent_sdk.connectors.klaviyo.types.ListsNeqCondition | airbyte_agent_sdk.connectors.klaviyo.types.ListsGtCondition | airbyte_agent_sdk.connectors.klaviyo.types.ListsGteCondition | airbyte_agent_sdk.connectors.klaviyo.types.ListsLtCondition | airbyte_agent_sdk.connectors.klaviyo.types.ListsLteCondition | airbyte_agent_sdk.connectors.klaviyo.types.ListsInCondition | airbyte_agent_sdk.connectors.klaviyo.types.ListsLikeCondition | airbyte_agent_sdk.connectors.klaviyo.types.ListsFuzzyCondition | airbyte_agent_sdk.connectors.klaviyo.types.ListsKeywordCondition | airbyte_agent_sdk.connectors.klaviyo.types.ListsContainsCondition | airbyte_agent_sdk.connectors.klaviyo.types.ListsNotCondition | airbyte_agent_sdk.connectors.klaviyo.types.ListsAndCondition | airbyte_agent_sdk.connectors.klaviyo.types.ListsOrCondition | airbyte_agent_sdk.connectors.klaviyo.types.ListsAnyCondition]`
     :   The type of the None singleton.
+
+<a id="ListsSearchFilter"></a>
 
 `ListsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering lists search queries.
@@ -1926,6 +2150,8 @@ Classes
     `updated: str | None`
     :   The type of the None singleton.
 
+<a id="ListsSearchQuery"></a>
+
 `ListsSearchQuery(*args, **kwargs)`
 :   Search query for lists entity.
 
@@ -1940,6 +2166,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.klaviyo.types.ListsSortFilter]`
     :   The type of the None singleton.
+
+<a id="ListsSortFilter"></a>
 
 `ListsSortFilter(*args, **kwargs)`
 :   Available fields for sorting lists search results.
@@ -1968,6 +2196,8 @@ Classes
     `updated: Literal['asc', 'desc']`
     :   The type of the None singleton.
 
+<a id="ListsStringFilter"></a>
+
 `ListsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -1995,6 +2225,8 @@ Classes
     `updated: str`
     :   The type of the None singleton.
 
+<a id="MetricsAndCondition"></a>
+
 `MetricsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -2015,6 +2247,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.klaviyo.types.MetricsEqCondition | airbyte_agent_sdk.connectors.klaviyo.types.MetricsNeqCondition | airbyte_agent_sdk.connectors.klaviyo.types.MetricsGtCondition | airbyte_agent_sdk.connectors.klaviyo.types.MetricsGteCondition | airbyte_agent_sdk.connectors.klaviyo.types.MetricsLtCondition | airbyte_agent_sdk.connectors.klaviyo.types.MetricsLteCondition | airbyte_agent_sdk.connectors.klaviyo.types.MetricsInCondition | airbyte_agent_sdk.connectors.klaviyo.types.MetricsLikeCondition | airbyte_agent_sdk.connectors.klaviyo.types.MetricsFuzzyCondition | airbyte_agent_sdk.connectors.klaviyo.types.MetricsKeywordCondition | airbyte_agent_sdk.connectors.klaviyo.types.MetricsContainsCondition | airbyte_agent_sdk.connectors.klaviyo.types.MetricsNotCondition | airbyte_agent_sdk.connectors.klaviyo.types.MetricsAndCondition | airbyte_agent_sdk.connectors.klaviyo.types.MetricsOrCondition | airbyte_agent_sdk.connectors.klaviyo.types.MetricsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="MetricsAnyCondition"></a>
+
 `MetricsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -2034,6 +2268,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.klaviyo.types.MetricsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="MetricsAnyValueFilter"></a>
 
 `MetricsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -2062,6 +2298,8 @@ Classes
     `updated: Any`
     :   The type of the None singleton.
 
+<a id="MetricsContainsCondition"></a>
+
 `MetricsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -2073,6 +2311,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.klaviyo.types.MetricsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="MetricsEqCondition"></a>
 
 `MetricsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -2086,6 +2326,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.klaviyo.types.MetricsSearchFilter`
     :   The type of the None singleton.
 
+<a id="MetricsFuzzyCondition"></a>
+
 `MetricsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -2097,6 +2339,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.klaviyo.types.MetricsStringFilter`
     :   The type of the None singleton.
+
+<a id="MetricsGetParams"></a>
 
 `MetricsGetParams(*args, **kwargs)`
 :   Parameters for metrics.get operation
@@ -2110,6 +2354,8 @@ Classes
     `id: str`
     :   The type of the None singleton.
 
+<a id="MetricsGtCondition"></a>
+
 `MetricsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -2122,6 +2368,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.klaviyo.types.MetricsSearchFilter`
     :   The type of the None singleton.
 
+<a id="MetricsGteCondition"></a>
+
 `MetricsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -2133,6 +2381,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.klaviyo.types.MetricsSearchFilter`
     :   The type of the None singleton.
+
+<a id="MetricsInCondition"></a>
 
 `MetricsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -2153,6 +2403,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.klaviyo.types.MetricsInFilter`
     :   The type of the None singleton.
+
+<a id="MetricsInFilter"></a>
 
 `MetricsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -2181,6 +2433,8 @@ Classes
     `updated: list[str]`
     :   The type of the None singleton.
 
+<a id="MetricsKeywordCondition"></a>
+
 `MetricsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -2193,6 +2447,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.klaviyo.types.MetricsStringFilter`
     :   The type of the None singleton.
 
+<a id="MetricsLikeCondition"></a>
+
 `MetricsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -2204,6 +2460,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.klaviyo.types.MetricsStringFilter`
     :   The type of the None singleton.
+
+<a id="MetricsListParams"></a>
 
 `MetricsListParams(*args, **kwargs)`
 :   Parameters for metrics.list operation
@@ -2220,6 +2478,8 @@ Classes
     `page_size: int`
     :   The type of the None singleton.
 
+<a id="MetricsLtCondition"></a>
+
 `MetricsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -2231,6 +2491,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.klaviyo.types.MetricsSearchFilter`
     :   The type of the None singleton.
+
+<a id="MetricsLteCondition"></a>
 
 `MetricsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -2244,6 +2506,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.klaviyo.types.MetricsSearchFilter`
     :   The type of the None singleton.
 
+<a id="MetricsNeqCondition"></a>
+
 `MetricsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -2255,6 +2519,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.klaviyo.types.MetricsSearchFilter`
     :   The type of the None singleton.
+
+<a id="MetricsNotCondition"></a>
 
 `MetricsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -2276,6 +2542,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.klaviyo.types.MetricsEqCondition | airbyte_agent_sdk.connectors.klaviyo.types.MetricsNeqCondition | airbyte_agent_sdk.connectors.klaviyo.types.MetricsGtCondition | airbyte_agent_sdk.connectors.klaviyo.types.MetricsGteCondition | airbyte_agent_sdk.connectors.klaviyo.types.MetricsLtCondition | airbyte_agent_sdk.connectors.klaviyo.types.MetricsLteCondition | airbyte_agent_sdk.connectors.klaviyo.types.MetricsInCondition | airbyte_agent_sdk.connectors.klaviyo.types.MetricsLikeCondition | airbyte_agent_sdk.connectors.klaviyo.types.MetricsFuzzyCondition | airbyte_agent_sdk.connectors.klaviyo.types.MetricsKeywordCondition | airbyte_agent_sdk.connectors.klaviyo.types.MetricsContainsCondition | airbyte_agent_sdk.connectors.klaviyo.types.MetricsNotCondition | airbyte_agent_sdk.connectors.klaviyo.types.MetricsAndCondition | airbyte_agent_sdk.connectors.klaviyo.types.MetricsOrCondition | airbyte_agent_sdk.connectors.klaviyo.types.MetricsAnyCondition`
     :   The type of the None singleton.
 
+<a id="MetricsOrCondition"></a>
+
 `MetricsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -2295,6 +2563,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.klaviyo.types.MetricsEqCondition | airbyte_agent_sdk.connectors.klaviyo.types.MetricsNeqCondition | airbyte_agent_sdk.connectors.klaviyo.types.MetricsGtCondition | airbyte_agent_sdk.connectors.klaviyo.types.MetricsGteCondition | airbyte_agent_sdk.connectors.klaviyo.types.MetricsLtCondition | airbyte_agent_sdk.connectors.klaviyo.types.MetricsLteCondition | airbyte_agent_sdk.connectors.klaviyo.types.MetricsInCondition | airbyte_agent_sdk.connectors.klaviyo.types.MetricsLikeCondition | airbyte_agent_sdk.connectors.klaviyo.types.MetricsFuzzyCondition | airbyte_agent_sdk.connectors.klaviyo.types.MetricsKeywordCondition | airbyte_agent_sdk.connectors.klaviyo.types.MetricsContainsCondition | airbyte_agent_sdk.connectors.klaviyo.types.MetricsNotCondition | airbyte_agent_sdk.connectors.klaviyo.types.MetricsAndCondition | airbyte_agent_sdk.connectors.klaviyo.types.MetricsOrCondition | airbyte_agent_sdk.connectors.klaviyo.types.MetricsAnyCondition]`
     :   The type of the None singleton.
+
+<a id="MetricsSearchFilter"></a>
 
 `MetricsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering metrics search queries.
@@ -2323,6 +2593,8 @@ Classes
     `updated: str | None`
     :   The type of the None singleton.
 
+<a id="MetricsSearchQuery"></a>
+
 `MetricsSearchQuery(*args, **kwargs)`
 :   Search query for metrics entity.
 
@@ -2337,6 +2609,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.klaviyo.types.MetricsSortFilter]`
     :   The type of the None singleton.
+
+<a id="MetricsSortFilter"></a>
 
 `MetricsSortFilter(*args, **kwargs)`
 :   Available fields for sorting metrics search results.
@@ -2365,6 +2639,8 @@ Classes
     `updated: Literal['asc', 'desc']`
     :   The type of the None singleton.
 
+<a id="MetricsStringFilter"></a>
+
 `MetricsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -2392,6 +2668,8 @@ Classes
     `updated: str`
     :   The type of the None singleton.
 
+<a id="ProfilesAndCondition"></a>
+
 `ProfilesAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -2412,6 +2690,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.klaviyo.types.ProfilesEqCondition | airbyte_agent_sdk.connectors.klaviyo.types.ProfilesNeqCondition | airbyte_agent_sdk.connectors.klaviyo.types.ProfilesGtCondition | airbyte_agent_sdk.connectors.klaviyo.types.ProfilesGteCondition | airbyte_agent_sdk.connectors.klaviyo.types.ProfilesLtCondition | airbyte_agent_sdk.connectors.klaviyo.types.ProfilesLteCondition | airbyte_agent_sdk.connectors.klaviyo.types.ProfilesInCondition | airbyte_agent_sdk.connectors.klaviyo.types.ProfilesLikeCondition | airbyte_agent_sdk.connectors.klaviyo.types.ProfilesFuzzyCondition | airbyte_agent_sdk.connectors.klaviyo.types.ProfilesKeywordCondition | airbyte_agent_sdk.connectors.klaviyo.types.ProfilesContainsCondition | airbyte_agent_sdk.connectors.klaviyo.types.ProfilesNotCondition | airbyte_agent_sdk.connectors.klaviyo.types.ProfilesAndCondition | airbyte_agent_sdk.connectors.klaviyo.types.ProfilesOrCondition | airbyte_agent_sdk.connectors.klaviyo.types.ProfilesAnyCondition]`
     :   The type of the None singleton.
 
+<a id="ProfilesAnyCondition"></a>
+
 `ProfilesAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -2431,6 +2711,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.klaviyo.types.ProfilesAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="ProfilesAnyValueFilter"></a>
 
 `ProfilesAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -2462,6 +2744,8 @@ Classes
     `updated: Any`
     :   The type of the None singleton.
 
+<a id="ProfilesContainsCondition"></a>
+
 `ProfilesContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -2473,6 +2757,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.klaviyo.types.ProfilesAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="ProfilesEqCondition"></a>
 
 `ProfilesEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -2486,6 +2772,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.klaviyo.types.ProfilesSearchFilter`
     :   The type of the None singleton.
 
+<a id="ProfilesFuzzyCondition"></a>
+
 `ProfilesFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -2497,6 +2785,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.klaviyo.types.ProfilesStringFilter`
     :   The type of the None singleton.
+
+<a id="ProfilesGetParams"></a>
 
 `ProfilesGetParams(*args, **kwargs)`
 :   Parameters for profiles.get operation
@@ -2510,6 +2800,8 @@ Classes
     `id: str`
     :   The type of the None singleton.
 
+<a id="ProfilesGtCondition"></a>
+
 `ProfilesGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -2522,6 +2814,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.klaviyo.types.ProfilesSearchFilter`
     :   The type of the None singleton.
 
+<a id="ProfilesGteCondition"></a>
+
 `ProfilesGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -2533,6 +2827,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.klaviyo.types.ProfilesSearchFilter`
     :   The type of the None singleton.
+
+<a id="ProfilesInCondition"></a>
 
 `ProfilesInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -2553,6 +2849,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.klaviyo.types.ProfilesInFilter`
     :   The type of the None singleton.
+
+<a id="ProfilesInFilter"></a>
 
 `ProfilesInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -2584,6 +2882,8 @@ Classes
     `updated: list[str]`
     :   The type of the None singleton.
 
+<a id="ProfilesKeywordCondition"></a>
+
 `ProfilesKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -2596,6 +2896,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.klaviyo.types.ProfilesStringFilter`
     :   The type of the None singleton.
 
+<a id="ProfilesLikeCondition"></a>
+
 `ProfilesLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -2607,6 +2909,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.klaviyo.types.ProfilesStringFilter`
     :   The type of the None singleton.
+
+<a id="ProfilesListParams"></a>
 
 `ProfilesListParams(*args, **kwargs)`
 :   Parameters for profiles.list operation
@@ -2623,6 +2927,8 @@ Classes
     `page_size: int`
     :   The type of the None singleton.
 
+<a id="ProfilesLtCondition"></a>
+
 `ProfilesLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -2634,6 +2940,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.klaviyo.types.ProfilesSearchFilter`
     :   The type of the None singleton.
+
+<a id="ProfilesLteCondition"></a>
 
 `ProfilesLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -2647,6 +2955,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.klaviyo.types.ProfilesSearchFilter`
     :   The type of the None singleton.
 
+<a id="ProfilesNeqCondition"></a>
+
 `ProfilesNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -2658,6 +2968,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.klaviyo.types.ProfilesSearchFilter`
     :   The type of the None singleton.
+
+<a id="ProfilesNotCondition"></a>
 
 `ProfilesNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -2679,6 +2991,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.klaviyo.types.ProfilesEqCondition | airbyte_agent_sdk.connectors.klaviyo.types.ProfilesNeqCondition | airbyte_agent_sdk.connectors.klaviyo.types.ProfilesGtCondition | airbyte_agent_sdk.connectors.klaviyo.types.ProfilesGteCondition | airbyte_agent_sdk.connectors.klaviyo.types.ProfilesLtCondition | airbyte_agent_sdk.connectors.klaviyo.types.ProfilesLteCondition | airbyte_agent_sdk.connectors.klaviyo.types.ProfilesInCondition | airbyte_agent_sdk.connectors.klaviyo.types.ProfilesLikeCondition | airbyte_agent_sdk.connectors.klaviyo.types.ProfilesFuzzyCondition | airbyte_agent_sdk.connectors.klaviyo.types.ProfilesKeywordCondition | airbyte_agent_sdk.connectors.klaviyo.types.ProfilesContainsCondition | airbyte_agent_sdk.connectors.klaviyo.types.ProfilesNotCondition | airbyte_agent_sdk.connectors.klaviyo.types.ProfilesAndCondition | airbyte_agent_sdk.connectors.klaviyo.types.ProfilesOrCondition | airbyte_agent_sdk.connectors.klaviyo.types.ProfilesAnyCondition`
     :   The type of the None singleton.
 
+<a id="ProfilesOrCondition"></a>
+
 `ProfilesOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -2698,6 +3012,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.klaviyo.types.ProfilesEqCondition | airbyte_agent_sdk.connectors.klaviyo.types.ProfilesNeqCondition | airbyte_agent_sdk.connectors.klaviyo.types.ProfilesGtCondition | airbyte_agent_sdk.connectors.klaviyo.types.ProfilesGteCondition | airbyte_agent_sdk.connectors.klaviyo.types.ProfilesLtCondition | airbyte_agent_sdk.connectors.klaviyo.types.ProfilesLteCondition | airbyte_agent_sdk.connectors.klaviyo.types.ProfilesInCondition | airbyte_agent_sdk.connectors.klaviyo.types.ProfilesLikeCondition | airbyte_agent_sdk.connectors.klaviyo.types.ProfilesFuzzyCondition | airbyte_agent_sdk.connectors.klaviyo.types.ProfilesKeywordCondition | airbyte_agent_sdk.connectors.klaviyo.types.ProfilesContainsCondition | airbyte_agent_sdk.connectors.klaviyo.types.ProfilesNotCondition | airbyte_agent_sdk.connectors.klaviyo.types.ProfilesAndCondition | airbyte_agent_sdk.connectors.klaviyo.types.ProfilesOrCondition | airbyte_agent_sdk.connectors.klaviyo.types.ProfilesAnyCondition]`
     :   The type of the None singleton.
+
+<a id="ProfilesSearchFilter"></a>
 
 `ProfilesSearchFilter(*args, **kwargs)`
 :   Available fields for filtering profiles search queries.
@@ -2729,6 +3045,8 @@ Classes
     `updated: str | None`
     :   The type of the None singleton.
 
+<a id="ProfilesSearchQuery"></a>
+
 `ProfilesSearchQuery(*args, **kwargs)`
 :   Search query for profiles entity.
 
@@ -2743,6 +3061,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.klaviyo.types.ProfilesSortFilter]`
     :   The type of the None singleton.
+
+<a id="ProfilesSortFilter"></a>
 
 `ProfilesSortFilter(*args, **kwargs)`
 :   Available fields for sorting profiles search results.
@@ -2773,6 +3093,8 @@ Classes
 
     `updated: Literal['asc', 'desc']`
     :   The type of the None singleton.
+
+<a id="ProfilesStringFilter"></a>
 
 `ProfilesStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/linear/connector.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/linear/connector.md
@@ -10,6 +10,8 @@ Linear connector.
 Classes
 -------
 
+<a id="CommentsQuery"></a>
+
 `CommentsQuery(connector: LinearConnector)`
 :   Query class for Comments entity operations.
     
@@ -97,6 +99,8 @@ Classes
         
         Returns:
             CommentMutationPayload
+
+<a id="IssuesQuery"></a>
 
 `IssuesQuery(connector: LinearConnector)`
 :   Query class for Issues entity operations.
@@ -234,6 +238,8 @@ Classes
         
                 Returns:
                     IssueMutationPayload
+
+<a id="LinearConnector"></a>
 
 `LinearConnector(auth_config: LinearAuthConfig | AirbyteAuthConfig | BaseModel | None = None, on_token_refresh: Any | None = None)`
 :   Type-safe Linear API connector.
@@ -423,6 +429,8 @@ Classes
             for entity in entities:
                 print(f"\{entity['entity_name']\}: \{entity['available_actions']\}")
 
+<a id="ProjectsQuery"></a>
+
 `ProjectsQuery(connector: LinearConnector)`
 :   Query class for Projects entity operations.
     
@@ -547,6 +555,8 @@ Classes
                 Returns:
                     ProjectMutationPayload
 
+<a id="TeamsQuery"></a>
+
 `TeamsQuery(connector: LinearConnector)`
 :   Query class for Teams entity operations.
     
@@ -637,6 +647,8 @@ Classes
         Returns:
             TeamsListResult
 
+<a id="UsersQuery"></a>
+
 `UsersQuery(connector: LinearConnector)`
 :   Query class for Users entity operations.
     
@@ -706,6 +718,8 @@ Classes
         
         Returns:
             UsersListResult
+
+<a id="WorkflowStatesQuery"></a>
 
 `WorkflowStatesQuery(connector: LinearConnector)`
 :   Query class for WorkflowStates entity operations.

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/linear/index.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/linear/index.md
@@ -19,6 +19,8 @@ Sub-modules
 Classes
 -------
 
+<a id="AirbyteAuthConfig"></a>
+
 `AirbyteAuthConfig(**data: Any)`
 :   Authentication configuration for Airbyte hosted mode execution.
     
@@ -87,6 +89,8 @@ Classes
     `workspace_name: str | None`
     :   The type of the None singleton.
 
+<a id="AirbyteSearchMeta"></a>
+
 `AirbyteSearchMeta(**data: Any)`
 :   Pagination metadata for search responses.
     
@@ -114,6 +118,8 @@ Classes
 
     `took_ms: int | None`
     :   Time taken to execute the search in milliseconds.
+
+<a id="AirbyteSearchResult"></a>
 
 `AirbyteSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -150,6 +156,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="CommentsSearchResult"></a>
+
 `CommentsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -165,6 +173,8 @@ Classes
     * airbyte_agent_sdk.connectors.linear.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="IssuesSearchResult"></a>
 
 `IssuesSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -182,6 +192,8 @@ Classes
     * pydantic.main.BaseModel
     * typing.Generic
 
+<a id="ProjectsSearchResult"></a>
+
 `ProjectsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -197,6 +209,8 @@ Classes
     * airbyte_agent_sdk.connectors.linear.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="TeamsSearchResult"></a>
 
 `TeamsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -214,6 +228,8 @@ Classes
     * pydantic.main.BaseModel
     * typing.Generic
 
+<a id="UsersSearchResult"></a>
+
 `UsersSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -230,6 +246,8 @@ Classes
     * pydantic.main.BaseModel
     * typing.Generic
 
+<a id="WorkflowStatesSearchResult"></a>
+
 `WorkflowStatesSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -245,6 +263,8 @@ Classes
     * airbyte_agent_sdk.connectors.linear.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="CommentsSearchData"></a>
 
 `CommentsSearchData(**data: Any)`
 :   Search result data for comments entity.
@@ -309,6 +329,8 @@ Classes
 
     `user_id: str | None`
     :   The type of the None singleton.
+
+<a id="IssuesSearchData"></a>
 
 `IssuesSearchData(**data: Any)`
 :   Search result data for issues entity.
@@ -488,6 +510,8 @@ Classes
     `url: str | None`
     :   The type of the None singleton.
 
+<a id="LinearAuthConfig"></a>
+
 `LinearAuthConfig(**data: Any)`
 :   Linear API Key Authentication - Authenticate using your Linear API key
     
@@ -509,6 +533,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="LinearConnector"></a>
 
 `LinearConnector(auth_config: LinearAuthConfig | AirbyteAuthConfig | BaseModel | None = None, on_token_refresh: Any | None = None)`
 :   Type-safe Linear API connector.
@@ -698,6 +724,8 @@ Classes
             for entity in entities:
                 print(f"\{entity['entity_name']\}: \{entity['available_actions']\}")
 
+<a id="ProjectsSearchData"></a>
+
 `ProjectsSearchData(**data: Any)`
 :   Search result data for projects entity.
     
@@ -836,6 +864,8 @@ Classes
 
     `url: str | None`
     :   The type of the None singleton.
+
+<a id="TeamsSearchData"></a>
 
 `TeamsSearchData(**data: Any)`
 :   Search result data for teams entity.
@@ -976,6 +1006,8 @@ Classes
     `updated_at: str | None`
     :   The type of the None singleton.
 
+<a id="UsersSearchData"></a>
+
 `UsersSearchData(**data: Any)`
 :   Search result data for users entity.
     
@@ -1054,6 +1086,8 @@ Classes
 
     `url: str | None`
     :   The type of the None singleton.
+
+<a id="WorkflowStatesSearchData"></a>
 
 `WorkflowStatesSearchData(**data: Any)`
 :   Search result data for workflow_states entity.

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/linear/models.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/linear/models.md
@@ -13,6 +13,8 @@ and response envelope types.
 Classes
 -------
 
+<a id="AirbyteSearchMeta"></a>
+
 `AirbyteSearchMeta(**data: Any)`
 :   Pagination metadata for search responses.
     
@@ -40,6 +42,8 @@ Classes
 
     `took_ms: int | None`
     :   Time taken to execute the search in milliseconds.
+
+<a id="AirbyteSearchResult"></a>
 
 `AirbyteSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -97,6 +101,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="CommentsSearchResult"></a>
+
 `CommentsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -133,6 +139,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="IssuesSearchResult"></a>
 
 `IssuesSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -171,6 +179,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="ProjectsSearchResult"></a>
+
 `ProjectsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -207,6 +217,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="TeamsSearchResult"></a>
 
 `TeamsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -245,6 +257,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="UsersSearchResult"></a>
+
 `UsersSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -282,6 +296,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="WorkflowStatesSearchResult"></a>
+
 `WorkflowStatesSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -297,6 +313,8 @@ Classes
     * airbyte_agent_sdk.connectors.linear.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="Comment"></a>
 
 `Comment(**data: Any)`
 :   Linear comment object
@@ -335,6 +353,8 @@ Classes
     `user: Any`
     :   The type of the None singleton.
 
+<a id="CommentCreateParams"></a>
+
 `CommentCreateParams(**data: Any)`
 :   Parameters for creating a comment
     
@@ -360,6 +380,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="CommentCreateResponse"></a>
+
 `CommentCreateResponse(**data: Any)`
 :   GraphQL response for comment creation
     
@@ -382,6 +404,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="CommentCreateResponseData"></a>
+
 `CommentCreateResponseData(**data: Any)`
 :   Nested schema for CommentCreateResponse.data
     
@@ -403,6 +427,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="CommentMutationPayload"></a>
 
 `CommentMutationPayload(**data: Any)`
 :   Comment mutation result
@@ -429,6 +455,8 @@ Classes
     `success: bool | Any`
     :   The type of the None singleton.
 
+<a id="CommentResponse"></a>
+
 `CommentResponse(**data: Any)`
 :   GraphQL response for single comment
     
@@ -451,6 +479,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="CommentResponseData"></a>
+
 `CommentResponseData(**data: Any)`
 :   Nested schema for CommentResponse.data
     
@@ -472,6 +502,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="CommentUpdateParams"></a>
 
 `CommentUpdateParams(**data: Any)`
 :   Parameters for updating a comment
@@ -498,6 +530,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="CommentUpdateResponse"></a>
+
 `CommentUpdateResponse(**data: Any)`
 :   GraphQL response for comment update
     
@@ -519,6 +553,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="CommentUpdateResponseData"></a>
 
 `CommentUpdateResponseData(**data: Any)`
 :   Nested schema for CommentUpdateResponse.data
@@ -542,6 +578,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="CommentsListResponse"></a>
+
 `CommentsListResponse(**data: Any)`
 :   GraphQL response for comments list
     
@@ -563,6 +601,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="CommentsListResponseData"></a>
 
 `CommentsListResponseData(**data: Any)`
 :   Nested schema for CommentsListResponse.data
@@ -586,6 +626,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="CommentsListResponseDataIssue"></a>
+
 `CommentsListResponseDataIssue(**data: Any)`
 :   Nested schema for CommentsListResponseData.issue
     
@@ -607,6 +649,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="CommentsListResponseDataIssueComments"></a>
 
 `CommentsListResponseDataIssueComments(**data: Any)`
 :   Nested schema for CommentsListResponseDataIssue.comments
@@ -633,6 +677,8 @@ Classes
     `page_info: airbyte_agent_sdk.connectors.linear.models.CommentsListResponseDataIssueCommentsPageinfo | Any`
     :   Pagination information
 
+<a id="CommentsListResponseDataIssueCommentsPageinfo"></a>
+
 `CommentsListResponseDataIssueCommentsPageinfo(**data: Any)`
 :   Pagination information
     
@@ -658,6 +704,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="CommentsListResultMeta"></a>
+
 `CommentsListResultMeta(**data: Any)`
 :   Metadata for comments.Action.LIST operation
     
@@ -682,6 +730,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="CommentsSearchData"></a>
 
 `CommentsSearchData(**data: Any)`
 :   Search result data for comments entity.
@@ -747,6 +797,8 @@ Classes
     `user_id: str | None`
     :   The type of the None singleton.
 
+<a id="Issue"></a>
+
 `Issue(**data: Any)`
 :   Linear issue object
     
@@ -796,6 +848,8 @@ Classes
     `updated_at: str | Any`
     :   The type of the None singleton.
 
+<a id="IssueCreateParams"></a>
+
 `IssueCreateParams(**data: Any)`
 :   Parameters for creating an issue
     
@@ -833,6 +887,8 @@ Classes
     `title: str | Any`
     :   The type of the None singleton.
 
+<a id="IssueCreateResponse"></a>
+
 `IssueCreateResponse(**data: Any)`
 :   GraphQL response for issue creation
     
@@ -855,6 +911,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="IssueCreateResponseData"></a>
+
 `IssueCreateResponseData(**data: Any)`
 :   Nested schema for IssueCreateResponse.data
     
@@ -876,6 +934,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="IssueMutationPayload"></a>
 
 `IssueMutationPayload(**data: Any)`
 :   Issue mutation result
@@ -902,6 +962,8 @@ Classes
     `success: bool | Any`
     :   The type of the None singleton.
 
+<a id="IssueResponse"></a>
+
 `IssueResponse(**data: Any)`
 :   GraphQL response for single issue
     
@@ -924,6 +986,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="IssueResponseData"></a>
+
 `IssueResponseData(**data: Any)`
 :   Nested schema for IssueResponse.data
     
@@ -945,6 +1009,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="IssueUpdateParams"></a>
 
 `IssueUpdateParams(**data: Any)`
 :   Parameters for updating an issue. All fields except id are optional for partial updates.
@@ -989,6 +1055,8 @@ Classes
     `title: str | Any`
     :   The type of the None singleton.
 
+<a id="IssueUpdateResponse"></a>
+
 `IssueUpdateResponse(**data: Any)`
 :   GraphQL response for issue update
     
@@ -1011,6 +1079,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="IssueUpdateResponseData"></a>
+
 `IssueUpdateResponseData(**data: Any)`
 :   Nested schema for IssueUpdateResponse.data
     
@@ -1032,6 +1102,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="IssueWithState"></a>
 
 `IssueWithState(**data: Any)`
 :   Issue object with state ID and assignee ID included
@@ -1079,6 +1151,8 @@ Classes
     `updated_at: str | Any`
     :   The type of the None singleton.
 
+<a id="IssuesListResponse"></a>
+
 `IssuesListResponse(**data: Any)`
 :   GraphQL response for issues list
     
@@ -1101,6 +1175,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="IssuesListResponseData"></a>
+
 `IssuesListResponseData(**data: Any)`
 :   Nested schema for IssuesListResponse.data
     
@@ -1122,6 +1198,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="IssuesListResponseDataIssues"></a>
 
 `IssuesListResponseDataIssues(**data: Any)`
 :   Nested schema for IssuesListResponseData.issues
@@ -1148,6 +1226,8 @@ Classes
     `page_info: airbyte_agent_sdk.connectors.linear.models.IssuesListResponseDataIssuesPageinfo | Any`
     :   Pagination information
 
+<a id="IssuesListResponseDataIssuesPageinfo"></a>
+
 `IssuesListResponseDataIssuesPageinfo(**data: Any)`
 :   Pagination information
     
@@ -1173,6 +1253,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="IssuesListResultMeta"></a>
+
 `IssuesListResultMeta(**data: Any)`
 :   Metadata for issues.Action.LIST operation
     
@@ -1197,6 +1279,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="IssuesSearchData"></a>
 
 `IssuesSearchData(**data: Any)`
 :   Search result data for issues entity.
@@ -1376,6 +1460,8 @@ Classes
     `url: str | None`
     :   The type of the None singleton.
 
+<a id="LinearAuthConfig"></a>
+
 `LinearAuthConfig(**data: Any)`
 :   Linear API Key Authentication - Authenticate using your Linear API key
     
@@ -1397,6 +1483,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="LinearCheckResult"></a>
 
 `LinearCheckResult(**data: Any)`
 :   Result of a health check operation.
@@ -1431,6 +1519,8 @@ Classes
     `status: str`
     :   Health check status: 'healthy' or 'unhealthy'.
 
+<a id="LinearExecuteResult"></a>
+
 `LinearExecuteResult(**data: Any)`
 :   Response envelope with data only.
     
@@ -1459,6 +1549,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="LinearExecuteResultWithMeta"></a>
 
 `LinearExecuteResultWithMeta(**data: Any)`
 :   Response envelope with data and metadata.
@@ -1516,6 +1608,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="CommentsListResult"></a>
+
 `CommentsListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -1558,6 +1652,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="IssuesListResult"></a>
 
 `IssuesListResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -1602,6 +1698,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="ProjectsListResult"></a>
+
 `ProjectsListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -1644,6 +1742,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="TeamsListResult"></a>
 
 `TeamsListResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -1688,6 +1788,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="UsersListResult"></a>
+
 `UsersListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -1731,6 +1833,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="WorkflowStatesListResult"></a>
+
 `WorkflowStatesListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -1749,6 +1853,8 @@ Classes
     * airbyte_agent_sdk.connectors.linear.models.LinearExecuteResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="Project"></a>
 
 `Project(**data: Any)`
 :   Linear project object
@@ -1796,6 +1902,8 @@ Classes
     `updated_at: str | Any`
     :   The type of the None singleton.
 
+<a id="ProjectCreateParams"></a>
+
 `ProjectCreateParams(**data: Any)`
 :   Parameters for creating a project
     
@@ -1836,6 +1944,8 @@ Classes
     `team_ids: list[str] | Any`
     :   The type of the None singleton.
 
+<a id="ProjectCreateResponse"></a>
+
 `ProjectCreateResponse(**data: Any)`
 :   GraphQL response for project creation
     
@@ -1858,6 +1968,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="ProjectCreateResponseData"></a>
+
 `ProjectCreateResponseData(**data: Any)`
 :   Nested schema for ProjectCreateResponse.data
     
@@ -1879,6 +1991,8 @@ Classes
 
     `project_create: airbyte_agent_sdk.connectors.linear.models.ProjectMutationPayload | Any`
     :   The type of the None singleton.
+
+<a id="ProjectMutationPayload"></a>
 
 `ProjectMutationPayload(**data: Any)`
 :   Project mutation result
@@ -1905,6 +2019,8 @@ Classes
     `success: bool | Any`
     :   The type of the None singleton.
 
+<a id="ProjectResponse"></a>
+
 `ProjectResponse(**data: Any)`
 :   GraphQL response for single project
     
@@ -1927,6 +2043,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="ProjectResponseData"></a>
+
 `ProjectResponseData(**data: Any)`
 :   Nested schema for ProjectResponse.data
     
@@ -1948,6 +2066,8 @@ Classes
 
     `project: airbyte_agent_sdk.connectors.linear.models.Project | Any`
     :   The type of the None singleton.
+
+<a id="ProjectUpdateParams"></a>
 
 `ProjectUpdateParams(**data: Any)`
 :   Parameters for updating a project. All fields except id are optional for partial updates.
@@ -1990,6 +2110,8 @@ Classes
     `target_date: str | Any`
     :   The type of the None singleton.
 
+<a id="ProjectUpdateResponse"></a>
+
 `ProjectUpdateResponse(**data: Any)`
 :   GraphQL response for project update
     
@@ -2011,6 +2133,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="ProjectUpdateResponseData"></a>
 
 `ProjectUpdateResponseData(**data: Any)`
 :   Nested schema for ProjectUpdateResponse.data
@@ -2034,6 +2158,8 @@ Classes
     `project_update: airbyte_agent_sdk.connectors.linear.models.ProjectMutationPayload | Any`
     :   The type of the None singleton.
 
+<a id="ProjectsListResponse"></a>
+
 `ProjectsListResponse(**data: Any)`
 :   GraphQL response for projects list
     
@@ -2056,6 +2182,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="ProjectsListResponseData"></a>
+
 `ProjectsListResponseData(**data: Any)`
 :   Nested schema for ProjectsListResponse.data
     
@@ -2077,6 +2205,8 @@ Classes
 
     `projects: airbyte_agent_sdk.connectors.linear.models.ProjectsListResponseDataProjects | Any`
     :   The type of the None singleton.
+
+<a id="ProjectsListResponseDataProjects"></a>
 
 `ProjectsListResponseDataProjects(**data: Any)`
 :   Nested schema for ProjectsListResponseData.projects
@@ -2103,6 +2233,8 @@ Classes
     `page_info: airbyte_agent_sdk.connectors.linear.models.ProjectsListResponseDataProjectsPageinfo | Any`
     :   Pagination information
 
+<a id="ProjectsListResponseDataProjectsPageinfo"></a>
+
 `ProjectsListResponseDataProjectsPageinfo(**data: Any)`
 :   Pagination information
     
@@ -2128,6 +2260,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="ProjectsListResultMeta"></a>
+
 `ProjectsListResultMeta(**data: Any)`
 :   Metadata for projects.Action.LIST operation
     
@@ -2152,6 +2286,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="ProjectsSearchData"></a>
 
 `ProjectsSearchData(**data: Any)`
 :   Search result data for projects entity.
@@ -2292,6 +2428,8 @@ Classes
     `url: str | None`
     :   The type of the None singleton.
 
+<a id="Team"></a>
+
 `Team(**data: Any)`
 :   Linear team object
     
@@ -2332,6 +2470,8 @@ Classes
     `updated_at: str | Any`
     :   The type of the None singleton.
 
+<a id="TeamResponse"></a>
+
 `TeamResponse(**data: Any)`
 :   GraphQL response for single team
     
@@ -2353,6 +2493,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="TeamResponseData"></a>
 
 `TeamResponseData(**data: Any)`
 :   Nested schema for TeamResponse.data
@@ -2376,6 +2518,8 @@ Classes
     `team: airbyte_agent_sdk.connectors.linear.models.Team | Any`
     :   The type of the None singleton.
 
+<a id="TeamsListResponse"></a>
+
 `TeamsListResponse(**data: Any)`
 :   GraphQL response for teams list
     
@@ -2398,6 +2542,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="TeamsListResponseData"></a>
+
 `TeamsListResponseData(**data: Any)`
 :   Nested schema for TeamsListResponse.data
     
@@ -2419,6 +2565,8 @@ Classes
 
     `teams: airbyte_agent_sdk.connectors.linear.models.TeamsListResponseDataTeams | Any`
     :   The type of the None singleton.
+
+<a id="TeamsListResponseDataTeams"></a>
 
 `TeamsListResponseDataTeams(**data: Any)`
 :   Nested schema for TeamsListResponseData.teams
@@ -2445,6 +2593,8 @@ Classes
     `page_info: airbyte_agent_sdk.connectors.linear.models.TeamsListResponseDataTeamsPageinfo | Any`
     :   Pagination information
 
+<a id="TeamsListResponseDataTeamsPageinfo"></a>
+
 `TeamsListResponseDataTeamsPageinfo(**data: Any)`
 :   Pagination information
     
@@ -2470,6 +2620,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="TeamsListResultMeta"></a>
+
 `TeamsListResultMeta(**data: Any)`
 :   Metadata for teams.Action.LIST operation
     
@@ -2494,6 +2646,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="TeamsSearchData"></a>
 
 `TeamsSearchData(**data: Any)`
 :   Search result data for teams entity.
@@ -2634,6 +2788,8 @@ Classes
     `updated_at: str | None`
     :   The type of the None singleton.
 
+<a id="User"></a>
+
 `User(**data: Any)`
 :   Linear user object
     
@@ -2677,6 +2833,8 @@ Classes
     `updated_at: str | Any`
     :   The type of the None singleton.
 
+<a id="UserResponse"></a>
+
 `UserResponse(**data: Any)`
 :   GraphQL response for single user
     
@@ -2698,6 +2856,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="UserResponseData"></a>
 
 `UserResponseData(**data: Any)`
 :   Nested schema for UserResponse.data
@@ -2721,6 +2881,8 @@ Classes
     `user: airbyte_agent_sdk.connectors.linear.models.User | Any`
     :   The type of the None singleton.
 
+<a id="UsersListResponse"></a>
+
 `UsersListResponse(**data: Any)`
 :   GraphQL response for users list
     
@@ -2743,6 +2905,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="UsersListResponseData"></a>
+
 `UsersListResponseData(**data: Any)`
 :   Nested schema for UsersListResponse.data
     
@@ -2764,6 +2928,8 @@ Classes
 
     `users: airbyte_agent_sdk.connectors.linear.models.UsersListResponseDataUsers | Any`
     :   The type of the None singleton.
+
+<a id="UsersListResponseDataUsers"></a>
 
 `UsersListResponseDataUsers(**data: Any)`
 :   Nested schema for UsersListResponseData.users
@@ -2790,6 +2956,8 @@ Classes
     `page_info: airbyte_agent_sdk.connectors.linear.models.UsersListResponseDataUsersPageinfo | Any`
     :   Pagination information
 
+<a id="UsersListResponseDataUsersPageinfo"></a>
+
 `UsersListResponseDataUsersPageinfo(**data: Any)`
 :   Pagination information
     
@@ -2815,6 +2983,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="UsersListResultMeta"></a>
+
 `UsersListResultMeta(**data: Any)`
 :   Metadata for users.Action.LIST operation
     
@@ -2839,6 +3009,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="UsersSearchData"></a>
 
 `UsersSearchData(**data: Any)`
 :   Search result data for users entity.
@@ -2919,6 +3091,8 @@ Classes
     `url: str | None`
     :   The type of the None singleton.
 
+<a id="WorkflowState"></a>
+
 `WorkflowState(**data: Any)`
 :   Linear workflow state object representing a status in a team's workflow
     
@@ -2962,6 +3136,8 @@ Classes
     `updated_at: str | Any`
     :   The type of the None singleton.
 
+<a id="WorkflowStatesListResponse"></a>
+
 `WorkflowStatesListResponse(**data: Any)`
 :   GraphQL response for workflow states list
     
@@ -2984,6 +3160,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="WorkflowStatesListResponseData"></a>
+
 `WorkflowStatesListResponseData(**data: Any)`
 :   Nested schema for WorkflowStatesListResponse.data
     
@@ -3005,6 +3183,8 @@ Classes
 
     `workflow_states: airbyte_agent_sdk.connectors.linear.models.WorkflowStatesListResponseDataWorkflowstates | Any`
     :   The type of the None singleton.
+
+<a id="WorkflowStatesListResponseDataWorkflowstates"></a>
 
 `WorkflowStatesListResponseDataWorkflowstates(**data: Any)`
 :   Nested schema for WorkflowStatesListResponseData.workflowStates
@@ -3031,6 +3211,8 @@ Classes
     `page_info: airbyte_agent_sdk.connectors.linear.models.WorkflowStatesListResponseDataWorkflowstatesPageinfo | Any`
     :   Pagination information
 
+<a id="WorkflowStatesListResponseDataWorkflowstatesPageinfo"></a>
+
 `WorkflowStatesListResponseDataWorkflowstatesPageinfo(**data: Any)`
 :   Pagination information
     
@@ -3056,6 +3238,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="WorkflowStatesListResultMeta"></a>
+
 `WorkflowStatesListResultMeta(**data: Any)`
 :   Metadata for workflow_states.Action.LIST operation
     
@@ -3080,6 +3264,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="WorkflowStatesSearchData"></a>
 
 `WorkflowStatesSearchData(**data: Any)`
 :   Search result data for workflow_states entity.

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/linear/types.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/linear/types.md
@@ -10,6 +10,8 @@ Type definitions for linear connector.
 Classes
 -------
 
+<a id="AirbyteSearchParams"></a>
+
 `AirbyteSearchParams(*args, **kwargs)`
 :   Parameters for Airbyte cache search operations (generic, use entity-specific query types for better type hints).
 
@@ -31,6 +33,8 @@ Classes
     `query: dict[str, typing.Any]`
     :   The type of the None singleton.
 
+<a id="CommentsAndCondition"></a>
+
 `CommentsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -51,6 +55,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.linear.types.CommentsEqCondition | airbyte_agent_sdk.connectors.linear.types.CommentsNeqCondition | airbyte_agent_sdk.connectors.linear.types.CommentsGtCondition | airbyte_agent_sdk.connectors.linear.types.CommentsGteCondition | airbyte_agent_sdk.connectors.linear.types.CommentsLtCondition | airbyte_agent_sdk.connectors.linear.types.CommentsLteCondition | airbyte_agent_sdk.connectors.linear.types.CommentsInCondition | airbyte_agent_sdk.connectors.linear.types.CommentsLikeCondition | airbyte_agent_sdk.connectors.linear.types.CommentsFuzzyCondition | airbyte_agent_sdk.connectors.linear.types.CommentsKeywordCondition | airbyte_agent_sdk.connectors.linear.types.CommentsContainsCondition | airbyte_agent_sdk.connectors.linear.types.CommentsNotCondition | airbyte_agent_sdk.connectors.linear.types.CommentsAndCondition | airbyte_agent_sdk.connectors.linear.types.CommentsOrCondition | airbyte_agent_sdk.connectors.linear.types.CommentsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="CommentsAnyCondition"></a>
+
 `CommentsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -70,6 +76,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.linear.types.CommentsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="CommentsAnyValueFilter"></a>
 
 `CommentsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -125,6 +133,8 @@ Classes
     `user_id: Any`
     :   The type of the None singleton.
 
+<a id="CommentsContainsCondition"></a>
+
 `CommentsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -136,6 +146,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.linear.types.CommentsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="CommentsCreateParams"></a>
 
 `CommentsCreateParams(*args, **kwargs)`
 :   Parameters for comments.create operation
@@ -152,6 +164,8 @@ Classes
     `issue_id: str`
     :   The type of the None singleton.
 
+<a id="CommentsEqCondition"></a>
+
 `CommentsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
 
@@ -163,6 +177,8 @@ Classes
 
     `eq: airbyte_agent_sdk.connectors.linear.types.CommentsSearchFilter`
     :   The type of the None singleton.
+
+<a id="CommentsFuzzyCondition"></a>
 
 `CommentsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
@@ -176,6 +192,8 @@ Classes
     `fuzzy: airbyte_agent_sdk.connectors.linear.types.CommentsStringFilter`
     :   The type of the None singleton.
 
+<a id="CommentsGetParams"></a>
+
 `CommentsGetParams(*args, **kwargs)`
 :   Parameters for comments.get operation
 
@@ -187,6 +205,8 @@ Classes
 
     `id: str`
     :   The type of the None singleton.
+
+<a id="CommentsGtCondition"></a>
 
 `CommentsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
@@ -200,6 +220,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.linear.types.CommentsSearchFilter`
     :   The type of the None singleton.
 
+<a id="CommentsGteCondition"></a>
+
 `CommentsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -211,6 +233,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.linear.types.CommentsSearchFilter`
     :   The type of the None singleton.
+
+<a id="CommentsInCondition"></a>
 
 `CommentsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -231,6 +255,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.linear.types.CommentsInFilter`
     :   The type of the None singleton.
+
+<a id="CommentsInFilter"></a>
 
 `CommentsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -286,6 +312,8 @@ Classes
     `user_id: list[str]`
     :   The type of the None singleton.
 
+<a id="CommentsKeywordCondition"></a>
+
 `CommentsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -298,6 +326,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.linear.types.CommentsStringFilter`
     :   The type of the None singleton.
 
+<a id="CommentsLikeCondition"></a>
+
 `CommentsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -309,6 +339,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.linear.types.CommentsStringFilter`
     :   The type of the None singleton.
+
+<a id="CommentsListParams"></a>
 
 `CommentsListParams(*args, **kwargs)`
 :   Parameters for comments.list operation
@@ -328,6 +360,8 @@ Classes
     `issue_id: str`
     :   The type of the None singleton.
 
+<a id="CommentsLtCondition"></a>
+
 `CommentsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -339,6 +373,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.linear.types.CommentsSearchFilter`
     :   The type of the None singleton.
+
+<a id="CommentsLteCondition"></a>
 
 `CommentsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -352,6 +388,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.linear.types.CommentsSearchFilter`
     :   The type of the None singleton.
 
+<a id="CommentsNeqCondition"></a>
+
 `CommentsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -363,6 +401,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.linear.types.CommentsSearchFilter`
     :   The type of the None singleton.
+
+<a id="CommentsNotCondition"></a>
 
 `CommentsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -384,6 +424,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.linear.types.CommentsEqCondition | airbyte_agent_sdk.connectors.linear.types.CommentsNeqCondition | airbyte_agent_sdk.connectors.linear.types.CommentsGtCondition | airbyte_agent_sdk.connectors.linear.types.CommentsGteCondition | airbyte_agent_sdk.connectors.linear.types.CommentsLtCondition | airbyte_agent_sdk.connectors.linear.types.CommentsLteCondition | airbyte_agent_sdk.connectors.linear.types.CommentsInCondition | airbyte_agent_sdk.connectors.linear.types.CommentsLikeCondition | airbyte_agent_sdk.connectors.linear.types.CommentsFuzzyCondition | airbyte_agent_sdk.connectors.linear.types.CommentsKeywordCondition | airbyte_agent_sdk.connectors.linear.types.CommentsContainsCondition | airbyte_agent_sdk.connectors.linear.types.CommentsNotCondition | airbyte_agent_sdk.connectors.linear.types.CommentsAndCondition | airbyte_agent_sdk.connectors.linear.types.CommentsOrCondition | airbyte_agent_sdk.connectors.linear.types.CommentsAnyCondition`
     :   The type of the None singleton.
 
+<a id="CommentsOrCondition"></a>
+
 `CommentsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -403,6 +445,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.linear.types.CommentsEqCondition | airbyte_agent_sdk.connectors.linear.types.CommentsNeqCondition | airbyte_agent_sdk.connectors.linear.types.CommentsGtCondition | airbyte_agent_sdk.connectors.linear.types.CommentsGteCondition | airbyte_agent_sdk.connectors.linear.types.CommentsLtCondition | airbyte_agent_sdk.connectors.linear.types.CommentsLteCondition | airbyte_agent_sdk.connectors.linear.types.CommentsInCondition | airbyte_agent_sdk.connectors.linear.types.CommentsLikeCondition | airbyte_agent_sdk.connectors.linear.types.CommentsFuzzyCondition | airbyte_agent_sdk.connectors.linear.types.CommentsKeywordCondition | airbyte_agent_sdk.connectors.linear.types.CommentsContainsCondition | airbyte_agent_sdk.connectors.linear.types.CommentsNotCondition | airbyte_agent_sdk.connectors.linear.types.CommentsAndCondition | airbyte_agent_sdk.connectors.linear.types.CommentsOrCondition | airbyte_agent_sdk.connectors.linear.types.CommentsAnyCondition]`
     :   The type of the None singleton.
+
+<a id="CommentsSearchFilter"></a>
 
 `CommentsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering comments search queries.
@@ -458,6 +502,8 @@ Classes
     `user_id: str | None`
     :   The type of the None singleton.
 
+<a id="CommentsSearchQuery"></a>
+
 `CommentsSearchQuery(*args, **kwargs)`
 :   Search query for comments entity.
 
@@ -472,6 +518,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.linear.types.CommentsSortFilter]`
     :   The type of the None singleton.
+
+<a id="CommentsSortFilter"></a>
 
 `CommentsSortFilter(*args, **kwargs)`
 :   Available fields for sorting comments search results.
@@ -527,6 +575,8 @@ Classes
     `user_id: Literal['asc', 'desc']`
     :   The type of the None singleton.
 
+<a id="CommentsStringFilter"></a>
+
 `CommentsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -581,6 +631,8 @@ Classes
     `user_id: str`
     :   The type of the None singleton.
 
+<a id="CommentsUpdateParams"></a>
+
 `CommentsUpdateParams(*args, **kwargs)`
 :   Parameters for comments.update operation
 
@@ -595,6 +647,8 @@ Classes
 
     `id: str`
     :   The type of the None singleton.
+
+<a id="IssuesAndCondition"></a>
 
 `IssuesAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -616,6 +670,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.linear.types.IssuesEqCondition | airbyte_agent_sdk.connectors.linear.types.IssuesNeqCondition | airbyte_agent_sdk.connectors.linear.types.IssuesGtCondition | airbyte_agent_sdk.connectors.linear.types.IssuesGteCondition | airbyte_agent_sdk.connectors.linear.types.IssuesLtCondition | airbyte_agent_sdk.connectors.linear.types.IssuesLteCondition | airbyte_agent_sdk.connectors.linear.types.IssuesInCondition | airbyte_agent_sdk.connectors.linear.types.IssuesLikeCondition | airbyte_agent_sdk.connectors.linear.types.IssuesFuzzyCondition | airbyte_agent_sdk.connectors.linear.types.IssuesKeywordCondition | airbyte_agent_sdk.connectors.linear.types.IssuesContainsCondition | airbyte_agent_sdk.connectors.linear.types.IssuesNotCondition | airbyte_agent_sdk.connectors.linear.types.IssuesAndCondition | airbyte_agent_sdk.connectors.linear.types.IssuesOrCondition | airbyte_agent_sdk.connectors.linear.types.IssuesAnyCondition]`
     :   The type of the None singleton.
 
+<a id="IssuesAnyCondition"></a>
+
 `IssuesAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -635,6 +691,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.linear.types.IssuesAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="IssuesAnyValueFilter"></a>
 
 `IssuesAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -804,6 +862,8 @@ Classes
     `url: Any`
     :   The type of the None singleton.
 
+<a id="IssuesContainsCondition"></a>
+
 `IssuesContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -815,6 +875,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.linear.types.IssuesAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="IssuesCreateParams"></a>
 
 `IssuesCreateParams(*args, **kwargs)`
 :   Parameters for issues.create operation
@@ -843,6 +905,8 @@ Classes
     `title: str`
     :   The type of the None singleton.
 
+<a id="IssuesEqCondition"></a>
+
 `IssuesEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
 
@@ -854,6 +918,8 @@ Classes
 
     `eq: airbyte_agent_sdk.connectors.linear.types.IssuesSearchFilter`
     :   The type of the None singleton.
+
+<a id="IssuesFuzzyCondition"></a>
 
 `IssuesFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
@@ -867,6 +933,8 @@ Classes
     `fuzzy: airbyte_agent_sdk.connectors.linear.types.IssuesStringFilter`
     :   The type of the None singleton.
 
+<a id="IssuesGetParams"></a>
+
 `IssuesGetParams(*args, **kwargs)`
 :   Parameters for issues.get operation
 
@@ -878,6 +946,8 @@ Classes
 
     `id: str`
     :   The type of the None singleton.
+
+<a id="IssuesGtCondition"></a>
 
 `IssuesGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
@@ -891,6 +961,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.linear.types.IssuesSearchFilter`
     :   The type of the None singleton.
 
+<a id="IssuesGteCondition"></a>
+
 `IssuesGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -902,6 +974,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.linear.types.IssuesSearchFilter`
     :   The type of the None singleton.
+
+<a id="IssuesInCondition"></a>
 
 `IssuesInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -922,6 +996,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.linear.types.IssuesInFilter`
     :   The type of the None singleton.
+
+<a id="IssuesInFilter"></a>
 
 `IssuesInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -1091,6 +1167,8 @@ Classes
     `url: list[str]`
     :   The type of the None singleton.
 
+<a id="IssuesKeywordCondition"></a>
+
 `IssuesKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -1103,6 +1181,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.linear.types.IssuesStringFilter`
     :   The type of the None singleton.
 
+<a id="IssuesLikeCondition"></a>
+
 `IssuesLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -1114,6 +1194,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.linear.types.IssuesStringFilter`
     :   The type of the None singleton.
+
+<a id="IssuesListParams"></a>
 
 `IssuesListParams(*args, **kwargs)`
 :   Parameters for issues.list operation
@@ -1130,6 +1212,8 @@ Classes
     `first: int`
     :   The type of the None singleton.
 
+<a id="IssuesLtCondition"></a>
+
 `IssuesLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -1141,6 +1225,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.linear.types.IssuesSearchFilter`
     :   The type of the None singleton.
+
+<a id="IssuesLteCondition"></a>
 
 `IssuesLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -1154,6 +1240,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.linear.types.IssuesSearchFilter`
     :   The type of the None singleton.
 
+<a id="IssuesNeqCondition"></a>
+
 `IssuesNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -1165,6 +1253,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.linear.types.IssuesSearchFilter`
     :   The type of the None singleton.
+
+<a id="IssuesNotCondition"></a>
 
 `IssuesNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -1186,6 +1276,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.linear.types.IssuesEqCondition | airbyte_agent_sdk.connectors.linear.types.IssuesNeqCondition | airbyte_agent_sdk.connectors.linear.types.IssuesGtCondition | airbyte_agent_sdk.connectors.linear.types.IssuesGteCondition | airbyte_agent_sdk.connectors.linear.types.IssuesLtCondition | airbyte_agent_sdk.connectors.linear.types.IssuesLteCondition | airbyte_agent_sdk.connectors.linear.types.IssuesInCondition | airbyte_agent_sdk.connectors.linear.types.IssuesLikeCondition | airbyte_agent_sdk.connectors.linear.types.IssuesFuzzyCondition | airbyte_agent_sdk.connectors.linear.types.IssuesKeywordCondition | airbyte_agent_sdk.connectors.linear.types.IssuesContainsCondition | airbyte_agent_sdk.connectors.linear.types.IssuesNotCondition | airbyte_agent_sdk.connectors.linear.types.IssuesAndCondition | airbyte_agent_sdk.connectors.linear.types.IssuesOrCondition | airbyte_agent_sdk.connectors.linear.types.IssuesAnyCondition`
     :   The type of the None singleton.
 
+<a id="IssuesOrCondition"></a>
+
 `IssuesOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1205,6 +1297,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.linear.types.IssuesEqCondition | airbyte_agent_sdk.connectors.linear.types.IssuesNeqCondition | airbyte_agent_sdk.connectors.linear.types.IssuesGtCondition | airbyte_agent_sdk.connectors.linear.types.IssuesGteCondition | airbyte_agent_sdk.connectors.linear.types.IssuesLtCondition | airbyte_agent_sdk.connectors.linear.types.IssuesLteCondition | airbyte_agent_sdk.connectors.linear.types.IssuesInCondition | airbyte_agent_sdk.connectors.linear.types.IssuesLikeCondition | airbyte_agent_sdk.connectors.linear.types.IssuesFuzzyCondition | airbyte_agent_sdk.connectors.linear.types.IssuesKeywordCondition | airbyte_agent_sdk.connectors.linear.types.IssuesContainsCondition | airbyte_agent_sdk.connectors.linear.types.IssuesNotCondition | airbyte_agent_sdk.connectors.linear.types.IssuesAndCondition | airbyte_agent_sdk.connectors.linear.types.IssuesOrCondition | airbyte_agent_sdk.connectors.linear.types.IssuesAnyCondition]`
     :   The type of the None singleton.
+
+<a id="IssuesSearchFilter"></a>
 
 `IssuesSearchFilter(*args, **kwargs)`
 :   Available fields for filtering issues search queries.
@@ -1374,6 +1468,8 @@ Classes
     `url: str | None`
     :   The type of the None singleton.
 
+<a id="IssuesSearchQuery"></a>
+
 `IssuesSearchQuery(*args, **kwargs)`
 :   Search query for issues entity.
 
@@ -1388,6 +1484,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.linear.types.IssuesSortFilter]`
     :   The type of the None singleton.
+
+<a id="IssuesSortFilter"></a>
 
 `IssuesSortFilter(*args, **kwargs)`
 :   Available fields for sorting issues search results.
@@ -1557,6 +1655,8 @@ Classes
     `url: Literal['asc', 'desc']`
     :   The type of the None singleton.
 
+<a id="IssuesStringFilter"></a>
+
 `IssuesStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -1725,6 +1825,8 @@ Classes
     `url: str`
     :   The type of the None singleton.
 
+<a id="IssuesUpdateParams"></a>
+
 `IssuesUpdateParams(*args, **kwargs)`
 :   Parameters for issues.update operation
 
@@ -1755,6 +1857,8 @@ Classes
     `title: str`
     :   The type of the None singleton.
 
+<a id="ProjectsAndCondition"></a>
+
 `ProjectsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1775,6 +1879,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.linear.types.ProjectsEqCondition | airbyte_agent_sdk.connectors.linear.types.ProjectsNeqCondition | airbyte_agent_sdk.connectors.linear.types.ProjectsGtCondition | airbyte_agent_sdk.connectors.linear.types.ProjectsGteCondition | airbyte_agent_sdk.connectors.linear.types.ProjectsLtCondition | airbyte_agent_sdk.connectors.linear.types.ProjectsLteCondition | airbyte_agent_sdk.connectors.linear.types.ProjectsInCondition | airbyte_agent_sdk.connectors.linear.types.ProjectsLikeCondition | airbyte_agent_sdk.connectors.linear.types.ProjectsFuzzyCondition | airbyte_agent_sdk.connectors.linear.types.ProjectsKeywordCondition | airbyte_agent_sdk.connectors.linear.types.ProjectsContainsCondition | airbyte_agent_sdk.connectors.linear.types.ProjectsNotCondition | airbyte_agent_sdk.connectors.linear.types.ProjectsAndCondition | airbyte_agent_sdk.connectors.linear.types.ProjectsOrCondition | airbyte_agent_sdk.connectors.linear.types.ProjectsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="ProjectsAnyCondition"></a>
+
 `ProjectsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1794,6 +1900,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.linear.types.ProjectsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="ProjectsAnyValueFilter"></a>
 
 `ProjectsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -1924,6 +2032,8 @@ Classes
     `url: Any`
     :   The type of the None singleton.
 
+<a id="ProjectsContainsCondition"></a>
+
 `ProjectsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -1935,6 +2045,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.linear.types.ProjectsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="ProjectsCreateParams"></a>
 
 `ProjectsCreateParams(*args, **kwargs)`
 :   Parameters for projects.create operation
@@ -1966,6 +2078,8 @@ Classes
     `team_ids: list[str]`
     :   The type of the None singleton.
 
+<a id="ProjectsEqCondition"></a>
+
 `ProjectsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
 
@@ -1977,6 +2091,8 @@ Classes
 
     `eq: airbyte_agent_sdk.connectors.linear.types.ProjectsSearchFilter`
     :   The type of the None singleton.
+
+<a id="ProjectsFuzzyCondition"></a>
 
 `ProjectsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
@@ -1990,6 +2106,8 @@ Classes
     `fuzzy: airbyte_agent_sdk.connectors.linear.types.ProjectsStringFilter`
     :   The type of the None singleton.
 
+<a id="ProjectsGetParams"></a>
+
 `ProjectsGetParams(*args, **kwargs)`
 :   Parameters for projects.get operation
 
@@ -2001,6 +2119,8 @@ Classes
 
     `id: str`
     :   The type of the None singleton.
+
+<a id="ProjectsGtCondition"></a>
 
 `ProjectsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
@@ -2014,6 +2134,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.linear.types.ProjectsSearchFilter`
     :   The type of the None singleton.
 
+<a id="ProjectsGteCondition"></a>
+
 `ProjectsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -2025,6 +2147,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.linear.types.ProjectsSearchFilter`
     :   The type of the None singleton.
+
+<a id="ProjectsInCondition"></a>
 
 `ProjectsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -2045,6 +2169,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.linear.types.ProjectsInFilter`
     :   The type of the None singleton.
+
+<a id="ProjectsInFilter"></a>
 
 `ProjectsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -2175,6 +2301,8 @@ Classes
     `url: list[str]`
     :   The type of the None singleton.
 
+<a id="ProjectsKeywordCondition"></a>
+
 `ProjectsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -2187,6 +2315,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.linear.types.ProjectsStringFilter`
     :   The type of the None singleton.
 
+<a id="ProjectsLikeCondition"></a>
+
 `ProjectsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -2198,6 +2328,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.linear.types.ProjectsStringFilter`
     :   The type of the None singleton.
+
+<a id="ProjectsListParams"></a>
 
 `ProjectsListParams(*args, **kwargs)`
 :   Parameters for projects.list operation
@@ -2214,6 +2346,8 @@ Classes
     `first: int`
     :   The type of the None singleton.
 
+<a id="ProjectsLtCondition"></a>
+
 `ProjectsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -2225,6 +2359,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.linear.types.ProjectsSearchFilter`
     :   The type of the None singleton.
+
+<a id="ProjectsLteCondition"></a>
 
 `ProjectsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -2238,6 +2374,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.linear.types.ProjectsSearchFilter`
     :   The type of the None singleton.
 
+<a id="ProjectsNeqCondition"></a>
+
 `ProjectsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -2249,6 +2387,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.linear.types.ProjectsSearchFilter`
     :   The type of the None singleton.
+
+<a id="ProjectsNotCondition"></a>
 
 `ProjectsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -2270,6 +2410,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.linear.types.ProjectsEqCondition | airbyte_agent_sdk.connectors.linear.types.ProjectsNeqCondition | airbyte_agent_sdk.connectors.linear.types.ProjectsGtCondition | airbyte_agent_sdk.connectors.linear.types.ProjectsGteCondition | airbyte_agent_sdk.connectors.linear.types.ProjectsLtCondition | airbyte_agent_sdk.connectors.linear.types.ProjectsLteCondition | airbyte_agent_sdk.connectors.linear.types.ProjectsInCondition | airbyte_agent_sdk.connectors.linear.types.ProjectsLikeCondition | airbyte_agent_sdk.connectors.linear.types.ProjectsFuzzyCondition | airbyte_agent_sdk.connectors.linear.types.ProjectsKeywordCondition | airbyte_agent_sdk.connectors.linear.types.ProjectsContainsCondition | airbyte_agent_sdk.connectors.linear.types.ProjectsNotCondition | airbyte_agent_sdk.connectors.linear.types.ProjectsAndCondition | airbyte_agent_sdk.connectors.linear.types.ProjectsOrCondition | airbyte_agent_sdk.connectors.linear.types.ProjectsAnyCondition`
     :   The type of the None singleton.
 
+<a id="ProjectsOrCondition"></a>
+
 `ProjectsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -2289,6 +2431,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.linear.types.ProjectsEqCondition | airbyte_agent_sdk.connectors.linear.types.ProjectsNeqCondition | airbyte_agent_sdk.connectors.linear.types.ProjectsGtCondition | airbyte_agent_sdk.connectors.linear.types.ProjectsGteCondition | airbyte_agent_sdk.connectors.linear.types.ProjectsLtCondition | airbyte_agent_sdk.connectors.linear.types.ProjectsLteCondition | airbyte_agent_sdk.connectors.linear.types.ProjectsInCondition | airbyte_agent_sdk.connectors.linear.types.ProjectsLikeCondition | airbyte_agent_sdk.connectors.linear.types.ProjectsFuzzyCondition | airbyte_agent_sdk.connectors.linear.types.ProjectsKeywordCondition | airbyte_agent_sdk.connectors.linear.types.ProjectsContainsCondition | airbyte_agent_sdk.connectors.linear.types.ProjectsNotCondition | airbyte_agent_sdk.connectors.linear.types.ProjectsAndCondition | airbyte_agent_sdk.connectors.linear.types.ProjectsOrCondition | airbyte_agent_sdk.connectors.linear.types.ProjectsAnyCondition]`
     :   The type of the None singleton.
+
+<a id="ProjectsSearchFilter"></a>
 
 `ProjectsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering projects search queries.
@@ -2419,6 +2563,8 @@ Classes
     `url: str | None`
     :   The type of the None singleton.
 
+<a id="ProjectsSearchQuery"></a>
+
 `ProjectsSearchQuery(*args, **kwargs)`
 :   Search query for projects entity.
 
@@ -2433,6 +2579,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.linear.types.ProjectsSortFilter]`
     :   The type of the None singleton.
+
+<a id="ProjectsSortFilter"></a>
 
 `ProjectsSortFilter(*args, **kwargs)`
 :   Available fields for sorting projects search results.
@@ -2563,6 +2711,8 @@ Classes
     `url: Literal['asc', 'desc']`
     :   The type of the None singleton.
 
+<a id="ProjectsStringFilter"></a>
+
 `ProjectsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -2692,6 +2842,8 @@ Classes
     `url: str`
     :   The type of the None singleton.
 
+<a id="ProjectsUpdateParams"></a>
+
 `ProjectsUpdateParams(*args, **kwargs)`
 :   Parameters for projects.update operation
 
@@ -2722,6 +2874,8 @@ Classes
     `target_date: str`
     :   The type of the None singleton.
 
+<a id="TeamsAndCondition"></a>
+
 `TeamsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -2742,6 +2896,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.linear.types.TeamsEqCondition | airbyte_agent_sdk.connectors.linear.types.TeamsNeqCondition | airbyte_agent_sdk.connectors.linear.types.TeamsGtCondition | airbyte_agent_sdk.connectors.linear.types.TeamsGteCondition | airbyte_agent_sdk.connectors.linear.types.TeamsLtCondition | airbyte_agent_sdk.connectors.linear.types.TeamsLteCondition | airbyte_agent_sdk.connectors.linear.types.TeamsInCondition | airbyte_agent_sdk.connectors.linear.types.TeamsLikeCondition | airbyte_agent_sdk.connectors.linear.types.TeamsFuzzyCondition | airbyte_agent_sdk.connectors.linear.types.TeamsKeywordCondition | airbyte_agent_sdk.connectors.linear.types.TeamsContainsCondition | airbyte_agent_sdk.connectors.linear.types.TeamsNotCondition | airbyte_agent_sdk.connectors.linear.types.TeamsAndCondition | airbyte_agent_sdk.connectors.linear.types.TeamsOrCondition | airbyte_agent_sdk.connectors.linear.types.TeamsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="TeamsAnyCondition"></a>
+
 `TeamsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -2761,6 +2917,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.linear.types.TeamsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="TeamsAnyValueFilter"></a>
 
 `TeamsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -2891,6 +3049,8 @@ Classes
     `updated_at: Any`
     :   The type of the None singleton.
 
+<a id="TeamsContainsCondition"></a>
+
 `TeamsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -2902,6 +3062,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.linear.types.TeamsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="TeamsEqCondition"></a>
 
 `TeamsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -2915,6 +3077,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.linear.types.TeamsSearchFilter`
     :   The type of the None singleton.
 
+<a id="TeamsFuzzyCondition"></a>
+
 `TeamsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -2926,6 +3090,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.linear.types.TeamsStringFilter`
     :   The type of the None singleton.
+
+<a id="TeamsGetParams"></a>
 
 `TeamsGetParams(*args, **kwargs)`
 :   Parameters for teams.get operation
@@ -2939,6 +3105,8 @@ Classes
     `id: str`
     :   The type of the None singleton.
 
+<a id="TeamsGtCondition"></a>
+
 `TeamsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -2951,6 +3119,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.linear.types.TeamsSearchFilter`
     :   The type of the None singleton.
 
+<a id="TeamsGteCondition"></a>
+
 `TeamsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -2962,6 +3132,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.linear.types.TeamsSearchFilter`
     :   The type of the None singleton.
+
+<a id="TeamsInCondition"></a>
 
 `TeamsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -2982,6 +3154,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.linear.types.TeamsInFilter`
     :   The type of the None singleton.
+
+<a id="TeamsInFilter"></a>
 
 `TeamsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -3112,6 +3286,8 @@ Classes
     `updated_at: list[str]`
     :   The type of the None singleton.
 
+<a id="TeamsKeywordCondition"></a>
+
 `TeamsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -3124,6 +3300,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.linear.types.TeamsStringFilter`
     :   The type of the None singleton.
 
+<a id="TeamsLikeCondition"></a>
+
 `TeamsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -3135,6 +3313,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.linear.types.TeamsStringFilter`
     :   The type of the None singleton.
+
+<a id="TeamsListParams"></a>
 
 `TeamsListParams(*args, **kwargs)`
 :   Parameters for teams.list operation
@@ -3151,6 +3331,8 @@ Classes
     `first: int`
     :   The type of the None singleton.
 
+<a id="TeamsLtCondition"></a>
+
 `TeamsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -3162,6 +3344,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.linear.types.TeamsSearchFilter`
     :   The type of the None singleton.
+
+<a id="TeamsLteCondition"></a>
 
 `TeamsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -3175,6 +3359,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.linear.types.TeamsSearchFilter`
     :   The type of the None singleton.
 
+<a id="TeamsNeqCondition"></a>
+
 `TeamsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -3186,6 +3372,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.linear.types.TeamsSearchFilter`
     :   The type of the None singleton.
+
+<a id="TeamsNotCondition"></a>
 
 `TeamsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -3207,6 +3395,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.linear.types.TeamsEqCondition | airbyte_agent_sdk.connectors.linear.types.TeamsNeqCondition | airbyte_agent_sdk.connectors.linear.types.TeamsGtCondition | airbyte_agent_sdk.connectors.linear.types.TeamsGteCondition | airbyte_agent_sdk.connectors.linear.types.TeamsLtCondition | airbyte_agent_sdk.connectors.linear.types.TeamsLteCondition | airbyte_agent_sdk.connectors.linear.types.TeamsInCondition | airbyte_agent_sdk.connectors.linear.types.TeamsLikeCondition | airbyte_agent_sdk.connectors.linear.types.TeamsFuzzyCondition | airbyte_agent_sdk.connectors.linear.types.TeamsKeywordCondition | airbyte_agent_sdk.connectors.linear.types.TeamsContainsCondition | airbyte_agent_sdk.connectors.linear.types.TeamsNotCondition | airbyte_agent_sdk.connectors.linear.types.TeamsAndCondition | airbyte_agent_sdk.connectors.linear.types.TeamsOrCondition | airbyte_agent_sdk.connectors.linear.types.TeamsAnyCondition`
     :   The type of the None singleton.
 
+<a id="TeamsOrCondition"></a>
+
 `TeamsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -3226,6 +3416,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.linear.types.TeamsEqCondition | airbyte_agent_sdk.connectors.linear.types.TeamsNeqCondition | airbyte_agent_sdk.connectors.linear.types.TeamsGtCondition | airbyte_agent_sdk.connectors.linear.types.TeamsGteCondition | airbyte_agent_sdk.connectors.linear.types.TeamsLtCondition | airbyte_agent_sdk.connectors.linear.types.TeamsLteCondition | airbyte_agent_sdk.connectors.linear.types.TeamsInCondition | airbyte_agent_sdk.connectors.linear.types.TeamsLikeCondition | airbyte_agent_sdk.connectors.linear.types.TeamsFuzzyCondition | airbyte_agent_sdk.connectors.linear.types.TeamsKeywordCondition | airbyte_agent_sdk.connectors.linear.types.TeamsContainsCondition | airbyte_agent_sdk.connectors.linear.types.TeamsNotCondition | airbyte_agent_sdk.connectors.linear.types.TeamsAndCondition | airbyte_agent_sdk.connectors.linear.types.TeamsOrCondition | airbyte_agent_sdk.connectors.linear.types.TeamsAnyCondition]`
     :   The type of the None singleton.
+
+<a id="TeamsSearchFilter"></a>
 
 `TeamsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering teams search queries.
@@ -3356,6 +3548,8 @@ Classes
     `updated_at: str | None`
     :   The type of the None singleton.
 
+<a id="TeamsSearchQuery"></a>
+
 `TeamsSearchQuery(*args, **kwargs)`
 :   Search query for teams entity.
 
@@ -3370,6 +3564,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.linear.types.TeamsSortFilter]`
     :   The type of the None singleton.
+
+<a id="TeamsSortFilter"></a>
 
 `TeamsSortFilter(*args, **kwargs)`
 :   Available fields for sorting teams search results.
@@ -3500,6 +3696,8 @@ Classes
     `updated_at: Literal['asc', 'desc']`
     :   The type of the None singleton.
 
+<a id="TeamsStringFilter"></a>
+
 `TeamsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -3629,6 +3827,8 @@ Classes
     `updated_at: str`
     :   The type of the None singleton.
 
+<a id="UsersAndCondition"></a>
+
 `UsersAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -3649,6 +3849,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.linear.types.UsersEqCondition | airbyte_agent_sdk.connectors.linear.types.UsersNeqCondition | airbyte_agent_sdk.connectors.linear.types.UsersGtCondition | airbyte_agent_sdk.connectors.linear.types.UsersGteCondition | airbyte_agent_sdk.connectors.linear.types.UsersLtCondition | airbyte_agent_sdk.connectors.linear.types.UsersLteCondition | airbyte_agent_sdk.connectors.linear.types.UsersInCondition | airbyte_agent_sdk.connectors.linear.types.UsersLikeCondition | airbyte_agent_sdk.connectors.linear.types.UsersFuzzyCondition | airbyte_agent_sdk.connectors.linear.types.UsersKeywordCondition | airbyte_agent_sdk.connectors.linear.types.UsersContainsCondition | airbyte_agent_sdk.connectors.linear.types.UsersNotCondition | airbyte_agent_sdk.connectors.linear.types.UsersAndCondition | airbyte_agent_sdk.connectors.linear.types.UsersOrCondition | airbyte_agent_sdk.connectors.linear.types.UsersAnyCondition]`
     :   The type of the None singleton.
 
+<a id="UsersAnyCondition"></a>
+
 `UsersAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -3668,6 +3870,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.linear.types.UsersAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="UsersAnyValueFilter"></a>
 
 `UsersAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -3738,6 +3942,8 @@ Classes
     `url: Any`
     :   The type of the None singleton.
 
+<a id="UsersContainsCondition"></a>
+
 `UsersContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -3749,6 +3955,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.linear.types.UsersAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="UsersEqCondition"></a>
 
 `UsersEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -3762,6 +3970,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.linear.types.UsersSearchFilter`
     :   The type of the None singleton.
 
+<a id="UsersFuzzyCondition"></a>
+
 `UsersFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -3773,6 +3983,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.linear.types.UsersStringFilter`
     :   The type of the None singleton.
+
+<a id="UsersGetParams"></a>
 
 `UsersGetParams(*args, **kwargs)`
 :   Parameters for users.get operation
@@ -3786,6 +3998,8 @@ Classes
     `id: str`
     :   The type of the None singleton.
 
+<a id="UsersGtCondition"></a>
+
 `UsersGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -3798,6 +4012,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.linear.types.UsersSearchFilter`
     :   The type of the None singleton.
 
+<a id="UsersGteCondition"></a>
+
 `UsersGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -3809,6 +4025,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.linear.types.UsersSearchFilter`
     :   The type of the None singleton.
+
+<a id="UsersInCondition"></a>
 
 `UsersInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -3829,6 +4047,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.linear.types.UsersInFilter`
     :   The type of the None singleton.
+
+<a id="UsersInFilter"></a>
 
 `UsersInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -3899,6 +4119,8 @@ Classes
     `url: list[str]`
     :   The type of the None singleton.
 
+<a id="UsersKeywordCondition"></a>
+
 `UsersKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -3911,6 +4133,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.linear.types.UsersStringFilter`
     :   The type of the None singleton.
 
+<a id="UsersLikeCondition"></a>
+
 `UsersLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -3922,6 +4146,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.linear.types.UsersStringFilter`
     :   The type of the None singleton.
+
+<a id="UsersListParams"></a>
 
 `UsersListParams(*args, **kwargs)`
 :   Parameters for users.list operation
@@ -3938,6 +4164,8 @@ Classes
     `first: int`
     :   The type of the None singleton.
 
+<a id="UsersLtCondition"></a>
+
 `UsersLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -3949,6 +4177,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.linear.types.UsersSearchFilter`
     :   The type of the None singleton.
+
+<a id="UsersLteCondition"></a>
 
 `UsersLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -3962,6 +4192,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.linear.types.UsersSearchFilter`
     :   The type of the None singleton.
 
+<a id="UsersNeqCondition"></a>
+
 `UsersNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -3973,6 +4205,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.linear.types.UsersSearchFilter`
     :   The type of the None singleton.
+
+<a id="UsersNotCondition"></a>
 
 `UsersNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -3994,6 +4228,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.linear.types.UsersEqCondition | airbyte_agent_sdk.connectors.linear.types.UsersNeqCondition | airbyte_agent_sdk.connectors.linear.types.UsersGtCondition | airbyte_agent_sdk.connectors.linear.types.UsersGteCondition | airbyte_agent_sdk.connectors.linear.types.UsersLtCondition | airbyte_agent_sdk.connectors.linear.types.UsersLteCondition | airbyte_agent_sdk.connectors.linear.types.UsersInCondition | airbyte_agent_sdk.connectors.linear.types.UsersLikeCondition | airbyte_agent_sdk.connectors.linear.types.UsersFuzzyCondition | airbyte_agent_sdk.connectors.linear.types.UsersKeywordCondition | airbyte_agent_sdk.connectors.linear.types.UsersContainsCondition | airbyte_agent_sdk.connectors.linear.types.UsersNotCondition | airbyte_agent_sdk.connectors.linear.types.UsersAndCondition | airbyte_agent_sdk.connectors.linear.types.UsersOrCondition | airbyte_agent_sdk.connectors.linear.types.UsersAnyCondition`
     :   The type of the None singleton.
 
+<a id="UsersOrCondition"></a>
+
 `UsersOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -4013,6 +4249,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.linear.types.UsersEqCondition | airbyte_agent_sdk.connectors.linear.types.UsersNeqCondition | airbyte_agent_sdk.connectors.linear.types.UsersGtCondition | airbyte_agent_sdk.connectors.linear.types.UsersGteCondition | airbyte_agent_sdk.connectors.linear.types.UsersLtCondition | airbyte_agent_sdk.connectors.linear.types.UsersLteCondition | airbyte_agent_sdk.connectors.linear.types.UsersInCondition | airbyte_agent_sdk.connectors.linear.types.UsersLikeCondition | airbyte_agent_sdk.connectors.linear.types.UsersFuzzyCondition | airbyte_agent_sdk.connectors.linear.types.UsersKeywordCondition | airbyte_agent_sdk.connectors.linear.types.UsersContainsCondition | airbyte_agent_sdk.connectors.linear.types.UsersNotCondition | airbyte_agent_sdk.connectors.linear.types.UsersAndCondition | airbyte_agent_sdk.connectors.linear.types.UsersOrCondition | airbyte_agent_sdk.connectors.linear.types.UsersAnyCondition]`
     :   The type of the None singleton.
+
+<a id="UsersSearchFilter"></a>
 
 `UsersSearchFilter(*args, **kwargs)`
 :   Available fields for filtering users search queries.
@@ -4083,6 +4321,8 @@ Classes
     `url: str | None`
     :   The type of the None singleton.
 
+<a id="UsersSearchQuery"></a>
+
 `UsersSearchQuery(*args, **kwargs)`
 :   Search query for users entity.
 
@@ -4097,6 +4337,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.linear.types.UsersSortFilter]`
     :   The type of the None singleton.
+
+<a id="UsersSortFilter"></a>
 
 `UsersSortFilter(*args, **kwargs)`
 :   Available fields for sorting users search results.
@@ -4167,6 +4409,8 @@ Classes
     `url: Literal['asc', 'desc']`
     :   The type of the None singleton.
 
+<a id="UsersStringFilter"></a>
+
 `UsersStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -4236,6 +4480,8 @@ Classes
     `url: str`
     :   The type of the None singleton.
 
+<a id="WorkflowStatesAndCondition"></a>
+
 `WorkflowStatesAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -4256,6 +4502,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.linear.types.WorkflowStatesEqCondition | airbyte_agent_sdk.connectors.linear.types.WorkflowStatesNeqCondition | airbyte_agent_sdk.connectors.linear.types.WorkflowStatesGtCondition | airbyte_agent_sdk.connectors.linear.types.WorkflowStatesGteCondition | airbyte_agent_sdk.connectors.linear.types.WorkflowStatesLtCondition | airbyte_agent_sdk.connectors.linear.types.WorkflowStatesLteCondition | airbyte_agent_sdk.connectors.linear.types.WorkflowStatesInCondition | airbyte_agent_sdk.connectors.linear.types.WorkflowStatesLikeCondition | airbyte_agent_sdk.connectors.linear.types.WorkflowStatesFuzzyCondition | airbyte_agent_sdk.connectors.linear.types.WorkflowStatesKeywordCondition | airbyte_agent_sdk.connectors.linear.types.WorkflowStatesContainsCondition | airbyte_agent_sdk.connectors.linear.types.WorkflowStatesNotCondition | airbyte_agent_sdk.connectors.linear.types.WorkflowStatesAndCondition | airbyte_agent_sdk.connectors.linear.types.WorkflowStatesOrCondition | airbyte_agent_sdk.connectors.linear.types.WorkflowStatesAnyCondition]`
     :   The type of the None singleton.
 
+<a id="WorkflowStatesAnyCondition"></a>
+
 `WorkflowStatesAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -4275,6 +4523,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.linear.types.WorkflowStatesAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="WorkflowStatesAnyValueFilter"></a>
 
 `WorkflowStatesAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -4318,6 +4568,8 @@ Classes
     `updated_at: Any`
     :   The type of the None singleton.
 
+<a id="WorkflowStatesContainsCondition"></a>
+
 `WorkflowStatesContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -4329,6 +4581,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.linear.types.WorkflowStatesAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="WorkflowStatesEqCondition"></a>
 
 `WorkflowStatesEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -4342,6 +4596,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.linear.types.WorkflowStatesSearchFilter`
     :   The type of the None singleton.
 
+<a id="WorkflowStatesFuzzyCondition"></a>
+
 `WorkflowStatesFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -4353,6 +4609,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.linear.types.WorkflowStatesStringFilter`
     :   The type of the None singleton.
+
+<a id="WorkflowStatesGtCondition"></a>
 
 `WorkflowStatesGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
@@ -4366,6 +4624,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.linear.types.WorkflowStatesSearchFilter`
     :   The type of the None singleton.
 
+<a id="WorkflowStatesGteCondition"></a>
+
 `WorkflowStatesGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -4377,6 +4637,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.linear.types.WorkflowStatesSearchFilter`
     :   The type of the None singleton.
+
+<a id="WorkflowStatesInCondition"></a>
 
 `WorkflowStatesInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -4397,6 +4659,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.linear.types.WorkflowStatesInFilter`
     :   The type of the None singleton.
+
+<a id="WorkflowStatesInFilter"></a>
 
 `WorkflowStatesInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -4440,6 +4704,8 @@ Classes
     `updated_at: list[str]`
     :   The type of the None singleton.
 
+<a id="WorkflowStatesKeywordCondition"></a>
+
 `WorkflowStatesKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -4452,6 +4718,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.linear.types.WorkflowStatesStringFilter`
     :   The type of the None singleton.
 
+<a id="WorkflowStatesLikeCondition"></a>
+
 `WorkflowStatesLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -4463,6 +4731,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.linear.types.WorkflowStatesStringFilter`
     :   The type of the None singleton.
+
+<a id="WorkflowStatesListParams"></a>
 
 `WorkflowStatesListParams(*args, **kwargs)`
 :   Parameters for workflow_states.list operation
@@ -4479,6 +4749,8 @@ Classes
     `first: int`
     :   The type of the None singleton.
 
+<a id="WorkflowStatesLtCondition"></a>
+
 `WorkflowStatesLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -4490,6 +4762,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.linear.types.WorkflowStatesSearchFilter`
     :   The type of the None singleton.
+
+<a id="WorkflowStatesLteCondition"></a>
 
 `WorkflowStatesLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -4503,6 +4777,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.linear.types.WorkflowStatesSearchFilter`
     :   The type of the None singleton.
 
+<a id="WorkflowStatesNeqCondition"></a>
+
 `WorkflowStatesNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -4514,6 +4790,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.linear.types.WorkflowStatesSearchFilter`
     :   The type of the None singleton.
+
+<a id="WorkflowStatesNotCondition"></a>
 
 `WorkflowStatesNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -4535,6 +4813,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.linear.types.WorkflowStatesEqCondition | airbyte_agent_sdk.connectors.linear.types.WorkflowStatesNeqCondition | airbyte_agent_sdk.connectors.linear.types.WorkflowStatesGtCondition | airbyte_agent_sdk.connectors.linear.types.WorkflowStatesGteCondition | airbyte_agent_sdk.connectors.linear.types.WorkflowStatesLtCondition | airbyte_agent_sdk.connectors.linear.types.WorkflowStatesLteCondition | airbyte_agent_sdk.connectors.linear.types.WorkflowStatesInCondition | airbyte_agent_sdk.connectors.linear.types.WorkflowStatesLikeCondition | airbyte_agent_sdk.connectors.linear.types.WorkflowStatesFuzzyCondition | airbyte_agent_sdk.connectors.linear.types.WorkflowStatesKeywordCondition | airbyte_agent_sdk.connectors.linear.types.WorkflowStatesContainsCondition | airbyte_agent_sdk.connectors.linear.types.WorkflowStatesNotCondition | airbyte_agent_sdk.connectors.linear.types.WorkflowStatesAndCondition | airbyte_agent_sdk.connectors.linear.types.WorkflowStatesOrCondition | airbyte_agent_sdk.connectors.linear.types.WorkflowStatesAnyCondition`
     :   The type of the None singleton.
 
+<a id="WorkflowStatesOrCondition"></a>
+
 `WorkflowStatesOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -4554,6 +4834,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.linear.types.WorkflowStatesEqCondition | airbyte_agent_sdk.connectors.linear.types.WorkflowStatesNeqCondition | airbyte_agent_sdk.connectors.linear.types.WorkflowStatesGtCondition | airbyte_agent_sdk.connectors.linear.types.WorkflowStatesGteCondition | airbyte_agent_sdk.connectors.linear.types.WorkflowStatesLtCondition | airbyte_agent_sdk.connectors.linear.types.WorkflowStatesLteCondition | airbyte_agent_sdk.connectors.linear.types.WorkflowStatesInCondition | airbyte_agent_sdk.connectors.linear.types.WorkflowStatesLikeCondition | airbyte_agent_sdk.connectors.linear.types.WorkflowStatesFuzzyCondition | airbyte_agent_sdk.connectors.linear.types.WorkflowStatesKeywordCondition | airbyte_agent_sdk.connectors.linear.types.WorkflowStatesContainsCondition | airbyte_agent_sdk.connectors.linear.types.WorkflowStatesNotCondition | airbyte_agent_sdk.connectors.linear.types.WorkflowStatesAndCondition | airbyte_agent_sdk.connectors.linear.types.WorkflowStatesOrCondition | airbyte_agent_sdk.connectors.linear.types.WorkflowStatesAnyCondition]`
     :   The type of the None singleton.
+
+<a id="WorkflowStatesSearchFilter"></a>
 
 `WorkflowStatesSearchFilter(*args, **kwargs)`
 :   Available fields for filtering workflow_states search queries.
@@ -4597,6 +4879,8 @@ Classes
     `updated_at: str | None`
     :   The type of the None singleton.
 
+<a id="WorkflowStatesSearchQuery"></a>
+
 `WorkflowStatesSearchQuery(*args, **kwargs)`
 :   Search query for workflow_states entity.
 
@@ -4611,6 +4895,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.linear.types.WorkflowStatesSortFilter]`
     :   The type of the None singleton.
+
+<a id="WorkflowStatesSortFilter"></a>
 
 `WorkflowStatesSortFilter(*args, **kwargs)`
 :   Available fields for sorting workflow_states search results.
@@ -4653,6 +4939,8 @@ Classes
 
     `updated_at: Literal['asc', 'desc']`
     :   The type of the None singleton.
+
+<a id="WorkflowStatesStringFilter"></a>
 
 `WorkflowStatesStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/linkedin_ads/connector.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/linkedin_ads/connector.md
@@ -10,6 +10,8 @@ Linkedin-Ads connector.
 Classes
 -------
 
+<a id="AccountUsersQuery"></a>
+
 `AccountUsersQuery(connector: LinkedinAdsConnector)`
 :   Query class for AccountUsers entity operations.
     
@@ -54,6 +56,8 @@ Classes
         
         Returns:
             AccountUsersListResult
+
+<a id="AccountsQuery"></a>
 
 `AccountsQuery(connector: LinkedinAdsConnector)`
 :   Query class for Accounts entity operations.
@@ -119,6 +123,8 @@ Classes
         
         Returns:
             AccountsListResult
+
+<a id="AdCampaignAnalyticsQuery"></a>
 
 `AdCampaignAnalyticsQuery(connector: LinkedinAdsConnector)`
 :   Query class for AdCampaignAnalytics entity operations.
@@ -204,6 +210,8 @@ Classes
         Returns:
             AdCampaignAnalyticsListResult
 
+<a id="AdCreativeAnalyticsQuery"></a>
+
 `AdCreativeAnalyticsQuery(connector: LinkedinAdsConnector)`
 :   Query class for AdCreativeAnalytics entity operations.
     
@@ -288,6 +296,8 @@ Classes
         Returns:
             AdCreativeAnalyticsListResult
 
+<a id="CampaignGroupsQuery"></a>
+
 `CampaignGroupsQuery(connector: LinkedinAdsConnector)`
 :   Query class for CampaignGroups entity operations.
     
@@ -350,6 +360,8 @@ Classes
         
         Returns:
             CampaignGroupsListResult
+
+<a id="CampaignsQuery"></a>
 
 `CampaignsQuery(connector: LinkedinAdsConnector)`
 :   Query class for Campaigns entity operations.
@@ -428,6 +440,8 @@ Classes
         Returns:
             CampaignsListResult
 
+<a id="ConversionsQuery"></a>
+
 `ConversionsQuery(connector: LinkedinAdsConnector)`
 :   Query class for Conversions entity operations.
     
@@ -494,6 +508,8 @@ Classes
         Returns:
             ConversionsListResult
 
+<a id="CreativesQuery"></a>
+
 `CreativesQuery(connector: LinkedinAdsConnector)`
 :   Query class for Creatives entity operations.
     
@@ -559,6 +575,8 @@ Classes
         
         Returns:
             CreativesListResult
+
+<a id="LinkedinAdsConnector"></a>
 
 `LinkedinAdsConnector(auth_config: LinkedinAdsAuthConfig | AirbyteAuthConfig | BaseModel | None = None, on_token_refresh: Any | None = None)`
 :   Type-safe Linkedin-Ads API connector.

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/linkedin_ads/index.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/linkedin_ads/index.md
@@ -19,6 +19,8 @@ Sub-modules
 Classes
 -------
 
+<a id="AccountUsersSearchData"></a>
+
 `AccountUsersSearchData(**data: Any)`
 :   Search result data for account_users entity.
     
@@ -46,6 +48,8 @@ Classes
 
     `user: str | None`
     :   User URN
+
+<a id="AccountsSearchData"></a>
 
 `AccountsSearchData(**data: Any)`
 :   Search result data for accounts entity.
@@ -107,6 +111,8 @@ Classes
 
     `version: dict[str, typing.Any] | None`
     :   Version information
+
+<a id="AdCampaignAnalyticsSearchData"></a>
 
 `AdCampaignAnalyticsSearchData(**data: Any)`
 :   Search result data for ad_campaign_analytics entity.
@@ -244,6 +250,8 @@ Classes
     `video_views: float | None`
     :   Number of video views
 
+<a id="AdCreativeAnalyticsSearchData"></a>
+
 `AdCreativeAnalyticsSearchData(**data: Any)`
 :   Search result data for ad_creative_analytics entity.
     
@@ -380,6 +388,8 @@ Classes
     `video_views: float | None`
     :   Number of video views
 
+<a id="AirbyteAuthConfig"></a>
+
 `AirbyteAuthConfig(**data: Any)`
 :   Authentication configuration for Airbyte hosted mode execution.
     
@@ -448,6 +458,8 @@ Classes
     `workspace_name: str | None`
     :   The type of the None singleton.
 
+<a id="AirbyteSearchMeta"></a>
+
 `AirbyteSearchMeta(**data: Any)`
 :   Pagination metadata for search responses.
     
@@ -475,6 +487,8 @@ Classes
 
     `took_ms: int | None`
     :   Time taken to execute the search in milliseconds.
+
+<a id="AirbyteSearchResult"></a>
 
 `AirbyteSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -513,6 +527,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="AccountUsersSearchResult"></a>
+
 `AccountUsersSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -528,6 +544,8 @@ Classes
     * airbyte_agent_sdk.connectors.linkedin_ads.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="AccountsSearchResult"></a>
 
 `AccountsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -545,6 +563,8 @@ Classes
     * pydantic.main.BaseModel
     * typing.Generic
 
+<a id="AdCampaignAnalyticsSearchResult"></a>
+
 `AdCampaignAnalyticsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -560,6 +580,8 @@ Classes
     * airbyte_agent_sdk.connectors.linkedin_ads.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="AdCreativeAnalyticsSearchResult"></a>
 
 `AdCreativeAnalyticsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -577,6 +599,8 @@ Classes
     * pydantic.main.BaseModel
     * typing.Generic
 
+<a id="CampaignGroupsSearchResult"></a>
+
 `CampaignGroupsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -592,6 +616,8 @@ Classes
     * airbyte_agent_sdk.connectors.linkedin_ads.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="CampaignsSearchResult"></a>
 
 `CampaignsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -609,6 +635,8 @@ Classes
     * pydantic.main.BaseModel
     * typing.Generic
 
+<a id="ConversionsSearchResult"></a>
+
 `ConversionsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -625,6 +653,8 @@ Classes
     * pydantic.main.BaseModel
     * typing.Generic
 
+<a id="CreativesSearchResult"></a>
+
 `CreativesSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -640,6 +670,8 @@ Classes
     * airbyte_agent_sdk.connectors.linkedin_ads.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="CampaignGroupsSearchData"></a>
 
 `CampaignGroupsSearchData(**data: Any)`
 :   Search result data for campaign_groups entity.
@@ -689,6 +721,8 @@ Classes
 
     `total_budget: dict[str, typing.Any] | None`
     :   Total budget for the campaign group
+
+<a id="CampaignsSearchData"></a>
 
 `CampaignsSearchData(**data: Any)`
 :   Search result data for campaigns entity.
@@ -781,6 +815,8 @@ Classes
     `version: dict[str, typing.Any] | None`
     :   Version information
 
+<a id="ConversionsSearchData"></a>
+
 `ConversionsSearchData(**data: Any)`
 :   Search result data for conversions entity.
     
@@ -842,6 +878,8 @@ Classes
     `view_through_attribution_window_size: int | None`
     :   View-through attribution window size in days
 
+<a id="CreativesSearchData"></a>
+
 `CreativesSearchData(**data: Any)`
 :   Search result data for creatives entity.
     
@@ -900,6 +938,8 @@ Classes
     `serving_hold_reasons: list[typing.Any] | None`
     :   Reasons for holding creative from serving
 
+<a id="LinkedinAdsAuthConfig"></a>
+
 `LinkedinAdsAuthConfig(**data: Any)`
 :   OAuth 2.0 Authentication
     
@@ -927,6 +967,8 @@ Classes
 
     `refresh_token: str`
     :   OAuth 2.0 refresh token for automatic renewal
+
+<a id="LinkedinAdsConnector"></a>
 
 `LinkedinAdsConnector(auth_config: LinkedinAdsAuthConfig | AirbyteAuthConfig | BaseModel | None = None, on_token_refresh: Any | None = None)`
 :   Type-safe Linkedin-Ads API connector.
@@ -1183,6 +1225,8 @@ Classes
             entities = connector.list_entities()
             for entity in entities:
                 print(f"\{entity['entity_name']\}: \{entity['available_actions']\}")
+
+<a id="LinkedinAdsReplicationConfig"></a>
 
 `LinkedinAdsReplicationConfig(**data: Any)`
 :   Replication Configuration - Settings for data replication from LinkedIn Ads.

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/linkedin_ads/models.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/linkedin_ads/models.md
@@ -13,6 +13,8 @@ and response envelope types.
 Classes
 -------
 
+<a id="Account"></a>
+
 `Account(**data: Any)`
 :   LinkedIn ad account object
     
@@ -77,6 +79,8 @@ Classes
     `version: airbyte_agent_sdk.connectors.linkedin_ads.models.AccountVersion | Any | None`
     :   The type of the None singleton.
 
+<a id="AccountChangeauditstamps"></a>
+
 `AccountChangeauditstamps(**data: Any)`
 :   Creation and last modification audit stamps
     
@@ -101,6 +105,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="AccountChangeauditstampsCreated"></a>
 
 `AccountChangeauditstampsCreated(**data: Any)`
 :   Nested schema for AccountChangeauditstamps.created
@@ -127,6 +133,8 @@ Classes
     `time: int | Any | None`
     :   The type of the None singleton.
 
+<a id="AccountChangeauditstampsLastmodified"></a>
+
 `AccountChangeauditstampsLastmodified(**data: Any)`
 :   Nested schema for AccountChangeauditstamps.lastModified
     
@@ -151,6 +159,8 @@ Classes
 
     `time: int | Any | None`
     :   The type of the None singleton.
+
+<a id="AccountUser"></a>
 
 `AccountUser(**data: Any)`
 :   LinkedIn ad account user object
@@ -183,6 +193,8 @@ Classes
     `user: str | Any | None`
     :   The type of the None singleton.
 
+<a id="AccountUserChangeauditstamps"></a>
+
 `AccountUserChangeauditstamps(**data: Any)`
 :   Creation and last modification audit stamps
     
@@ -207,6 +219,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="AccountUserChangeauditstampsCreated"></a>
 
 `AccountUserChangeauditstampsCreated(**data: Any)`
 :   Nested schema for AccountUserChangeauditstamps.created
@@ -233,6 +247,8 @@ Classes
     `time: int | Any | None`
     :   The type of the None singleton.
 
+<a id="AccountUserChangeauditstampsLastmodified"></a>
+
 `AccountUserChangeauditstampsLastmodified(**data: Any)`
 :   Nested schema for AccountUserChangeauditstamps.lastModified
     
@@ -257,6 +273,8 @@ Classes
 
     `time: int | Any | None`
     :   The type of the None singleton.
+
+<a id="AccountUsersList"></a>
 
 `AccountUsersList(**data: Any)`
 :   Paginated list of account users
@@ -283,6 +301,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="AccountUsersListMetadata"></a>
+
 `AccountUsersListMetadata(**data: Any)`
 :   Nested schema for AccountUsersList.metadata
     
@@ -305,6 +325,8 @@ Classes
     `next_page_token: str | Any`
     :   The type of the None singleton.
 
+<a id="AccountUsersListResultMeta"></a>
+
 `AccountUsersListResultMeta(**data: Any)`
 :   Metadata for account_users.Action.LIST operation
     
@@ -326,6 +348,8 @@ Classes
 
     `next_page_token: str | Any`
     :   The type of the None singleton.
+
+<a id="AccountUsersSearchData"></a>
 
 `AccountUsersSearchData(**data: Any)`
 :   Search result data for account_users entity.
@@ -355,6 +379,8 @@ Classes
     `user: str | None`
     :   User URN
 
+<a id="AccountVersion"></a>
+
 `AccountVersion(**data: Any)`
 :   Version information
     
@@ -376,6 +402,8 @@ Classes
 
     `version_tag: str | Any | None`
     :   The type of the None singleton.
+
+<a id="AccountsList"></a>
 
 `AccountsList(**data: Any)`
 :   Paginated list of ad accounts
@@ -402,6 +430,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="AccountsListMetadata"></a>
+
 `AccountsListMetadata(**data: Any)`
 :   Nested schema for AccountsList.metadata
     
@@ -424,6 +454,8 @@ Classes
     `next_page_token: str | Any`
     :   The type of the None singleton.
 
+<a id="AccountsListResultMeta"></a>
+
 `AccountsListResultMeta(**data: Any)`
 :   Metadata for accounts.Action.LIST operation
     
@@ -445,6 +477,8 @@ Classes
 
     `next_page_token: str | Any`
     :   The type of the None singleton.
+
+<a id="AccountsSearchData"></a>
 
 `AccountsSearchData(**data: Any)`
 :   Search result data for accounts entity.
@@ -506,6 +540,8 @@ Classes
 
     `version: dict[str, typing.Any] | None`
     :   Version information
+
+<a id="AdAnalyticsRecord"></a>
 
 `AdAnalyticsRecord(**data: Any)`
 :   Ad analytics data record with performance metrics
@@ -691,6 +727,8 @@ Classes
     `video_views: int | Any | None`
     :   The type of the None singleton.
 
+<a id="AdAnalyticsRecordDaterange"></a>
+
 `AdAnalyticsRecordDaterange(**data: Any)`
 :   Date range for this analytics record
     
@@ -715,6 +753,8 @@ Classes
 
     `start: airbyte_agent_sdk.connectors.linkedin_ads.models.AdAnalyticsRecordDaterangeStart | Any`
     :   The type of the None singleton.
+
+<a id="AdAnalyticsRecordDaterangeEnd"></a>
 
 `AdAnalyticsRecordDaterangeEnd(**data: Any)`
 :   Nested schema for AdAnalyticsRecordDaterange.end
@@ -744,6 +784,8 @@ Classes
     `year: int | Any`
     :   The type of the None singleton.
 
+<a id="AdAnalyticsRecordDaterangeStart"></a>
+
 `AdAnalyticsRecordDaterangeStart(**data: Any)`
 :   Nested schema for AdAnalyticsRecordDaterange.start
     
@@ -772,6 +814,8 @@ Classes
     `year: int | Any`
     :   The type of the None singleton.
 
+<a id="AdAnalyticsResponse"></a>
+
 `AdAnalyticsResponse(**data: Any)`
 :   Ad analytics API response
     
@@ -797,6 +841,8 @@ Classes
     `paging: airbyte_agent_sdk.connectors.linkedin_ads.models.AdAnalyticsResponsePaging | Any`
     :   The type of the None singleton.
 
+<a id="AdAnalyticsResponsePaging"></a>
+
 `AdAnalyticsResponsePaging(**data: Any)`
 :   Nested schema for AdAnalyticsResponse.paging
     
@@ -821,6 +867,8 @@ Classes
 
     `start: int | Any`
     :   The type of the None singleton.
+
+<a id="AdCampaignAnalyticsSearchData"></a>
 
 `AdCampaignAnalyticsSearchData(**data: Any)`
 :   Search result data for ad_campaign_analytics entity.
@@ -958,6 +1006,8 @@ Classes
     `video_views: float | None`
     :   Number of video views
 
+<a id="AdCreativeAnalyticsSearchData"></a>
+
 `AdCreativeAnalyticsSearchData(**data: Any)`
 :   Search result data for ad_creative_analytics entity.
     
@@ -1094,6 +1144,8 @@ Classes
     `video_views: float | None`
     :   Number of video views
 
+<a id="AirbyteSearchMeta"></a>
+
 `AirbyteSearchMeta(**data: Any)`
 :   Pagination metadata for search responses.
     
@@ -1121,6 +1173,8 @@ Classes
 
     `took_ms: int | None`
     :   Time taken to execute the search in milliseconds.
+
+<a id="AirbyteSearchResult"></a>
 
 `AirbyteSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -1180,6 +1234,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="AccountUsersSearchResult"></a>
+
 `AccountUsersSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -1216,6 +1272,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="AccountsSearchResult"></a>
 
 `AccountsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -1254,6 +1312,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="AdCampaignAnalyticsSearchResult"></a>
+
 `AdCampaignAnalyticsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -1290,6 +1350,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="AdCreativeAnalyticsSearchResult"></a>
 
 `AdCreativeAnalyticsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -1328,6 +1390,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="CampaignGroupsSearchResult"></a>
+
 `CampaignGroupsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -1364,6 +1428,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="CampaignsSearchResult"></a>
 
 `CampaignsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -1402,6 +1468,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="ConversionsSearchResult"></a>
+
 `ConversionsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -1439,6 +1507,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="CreativesSearchResult"></a>
+
 `CreativesSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -1454,6 +1524,8 @@ Classes
     * airbyte_agent_sdk.connectors.linkedin_ads.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="Campaign"></a>
 
 `Campaign(**data: Any)`
 :   LinkedIn ad campaign object
@@ -1561,6 +1633,8 @@ Classes
     `version: airbyte_agent_sdk.connectors.linkedin_ads.models.CampaignVersion | Any | None`
     :   The type of the None singleton.
 
+<a id="CampaignChangeauditstamps"></a>
+
 `CampaignChangeauditstamps(**data: Any)`
 :   Creation and last modification audit stamps
     
@@ -1585,6 +1659,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="CampaignChangeauditstampsCreated"></a>
 
 `CampaignChangeauditstampsCreated(**data: Any)`
 :   Nested schema for CampaignChangeauditstamps.created
@@ -1611,6 +1687,8 @@ Classes
     `time: int | Any | None`
     :   The type of the None singleton.
 
+<a id="CampaignChangeauditstampsLastmodified"></a>
+
 `CampaignChangeauditstampsLastmodified(**data: Any)`
 :   Nested schema for CampaignChangeauditstamps.lastModified
     
@@ -1636,6 +1714,8 @@ Classes
     `time: int | Any | None`
     :   The type of the None singleton.
 
+<a id="CampaignDailybudget"></a>
+
 `CampaignDailybudget(**data: Any)`
 :   Daily budget configuration
     
@@ -1660,6 +1740,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="CampaignGroup"></a>
 
 `CampaignGroup(**data: Any)`
 :   LinkedIn ad campaign group object
@@ -1713,6 +1795,8 @@ Classes
     `total_budget: airbyte_agent_sdk.connectors.linkedin_ads.models.CampaignGroupTotalbudget | Any | None`
     :   The type of the None singleton.
 
+<a id="CampaignGroupChangeauditstamps"></a>
+
 `CampaignGroupChangeauditstamps(**data: Any)`
 :   Creation and last modification audit stamps
     
@@ -1737,6 +1821,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="CampaignGroupChangeauditstampsCreated"></a>
 
 `CampaignGroupChangeauditstampsCreated(**data: Any)`
 :   Nested schema for CampaignGroupChangeauditstamps.created
@@ -1763,6 +1849,8 @@ Classes
     `time: int | Any | None`
     :   The type of the None singleton.
 
+<a id="CampaignGroupChangeauditstampsLastmodified"></a>
+
 `CampaignGroupChangeauditstampsLastmodified(**data: Any)`
 :   Nested schema for CampaignGroupChangeauditstamps.lastModified
     
@@ -1787,6 +1875,8 @@ Classes
 
     `time: int | Any | None`
     :   The type of the None singleton.
+
+<a id="CampaignGroupRunschedule"></a>
 
 `CampaignGroupRunschedule(**data: Any)`
 :   Campaign group run schedule
@@ -1813,6 +1903,8 @@ Classes
     `start: int | Any | None`
     :   The type of the None singleton.
 
+<a id="CampaignGroupTotalbudget"></a>
+
 `CampaignGroupTotalbudget(**data: Any)`
 :   Total budget for the campaign group
     
@@ -1837,6 +1929,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="CampaignGroupsList"></a>
 
 `CampaignGroupsList(**data: Any)`
 :   Paginated list of campaign groups
@@ -1863,6 +1957,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="CampaignGroupsListMetadata"></a>
+
 `CampaignGroupsListMetadata(**data: Any)`
 :   Nested schema for CampaignGroupsList.metadata
     
@@ -1885,6 +1981,8 @@ Classes
     `next_page_token: str | Any`
     :   The type of the None singleton.
 
+<a id="CampaignGroupsListResultMeta"></a>
+
 `CampaignGroupsListResultMeta(**data: Any)`
 :   Metadata for campaign_groups.Action.LIST operation
     
@@ -1906,6 +2004,8 @@ Classes
 
     `next_page_token: str | Any`
     :   The type of the None singleton.
+
+<a id="CampaignGroupsSearchData"></a>
 
 `CampaignGroupsSearchData(**data: Any)`
 :   Search result data for campaign_groups entity.
@@ -1956,6 +2056,8 @@ Classes
     `total_budget: dict[str, typing.Any] | None`
     :   Total budget for the campaign group
 
+<a id="CampaignLocale"></a>
+
 `CampaignLocale(**data: Any)`
 :   Campaign locale settings
     
@@ -1980,6 +2082,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="CampaignRunschedule"></a>
 
 `CampaignRunschedule(**data: Any)`
 :   Campaign run schedule
@@ -2006,6 +2110,8 @@ Classes
     `start: int | Any | None`
     :   The type of the None singleton.
 
+<a id="CampaignTotalbudget"></a>
+
 `CampaignTotalbudget(**data: Any)`
 :   Total budget configuration
     
@@ -2030,6 +2136,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="CampaignUnitcost"></a>
 
 `CampaignUnitcost(**data: Any)`
 :   Cost per unit (bid amount)
@@ -2056,6 +2164,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="CampaignVersion"></a>
+
 `CampaignVersion(**data: Any)`
 :   Version information
     
@@ -2077,6 +2187,8 @@ Classes
 
     `version_tag: str | Any | None`
     :   The type of the None singleton.
+
+<a id="CampaignsList"></a>
 
 `CampaignsList(**data: Any)`
 :   Paginated list of campaigns
@@ -2103,6 +2215,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="CampaignsListMetadata"></a>
+
 `CampaignsListMetadata(**data: Any)`
 :   Nested schema for CampaignsList.metadata
     
@@ -2125,6 +2239,8 @@ Classes
     `next_page_token: str | Any`
     :   The type of the None singleton.
 
+<a id="CampaignsListResultMeta"></a>
+
 `CampaignsListResultMeta(**data: Any)`
 :   Metadata for campaigns.Action.LIST operation
     
@@ -2146,6 +2262,8 @@ Classes
 
     `next_page_token: str | Any`
     :   The type of the None singleton.
+
+<a id="CampaignsSearchData"></a>
 
 `CampaignsSearchData(**data: Any)`
 :   Search result data for campaigns entity.
@@ -2238,6 +2356,8 @@ Classes
     `version: dict[str, typing.Any] | None`
     :   Version information
 
+<a id="Conversion"></a>
+
 `Conversion(**data: Any)`
 :   LinkedIn ad conversion tracking rule
     
@@ -2317,6 +2437,8 @@ Classes
     `view_through_attribution_window_size: int | Any | None`
     :   The type of the None singleton.
 
+<a id="ConversionValue"></a>
+
 `ConversionValue(**data: Any)`
 :   Conversion value
     
@@ -2342,6 +2464,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="ConversionsList"></a>
+
 `ConversionsList(**data: Any)`
 :   Paginated list of conversions
     
@@ -2366,6 +2490,8 @@ Classes
 
     `paging: airbyte_agent_sdk.connectors.linkedin_ads.models.ConversionsListPaging | Any`
     :   The type of the None singleton.
+
+<a id="ConversionsListPaging"></a>
 
 `ConversionsListPaging(**data: Any)`
 :   Nested schema for ConversionsList.paging
@@ -2395,6 +2521,8 @@ Classes
     `total: int | Any`
     :   The type of the None singleton.
 
+<a id="ConversionsListResultMeta"></a>
+
 `ConversionsListResultMeta(**data: Any)`
 :   Metadata for conversions.Action.LIST operation
     
@@ -2416,6 +2544,8 @@ Classes
 
     `total: int | Any`
     :   The type of the None singleton.
+
+<a id="ConversionsSearchData"></a>
 
 `ConversionsSearchData(**data: Any)`
 :   Search result data for conversions entity.
@@ -2477,6 +2607,8 @@ Classes
 
     `view_through_attribution_window_size: int | None`
     :   View-through attribution window size in days
+
+<a id="Creative"></a>
 
 `Creative(**data: Any)`
 :   LinkedIn ad creative object
@@ -2542,6 +2674,8 @@ Classes
     `serving_hold_reasons: list[str] | Any | None`
     :   The type of the None singleton.
 
+<a id="CreativeLeadgencalltoaction"></a>
+
 `CreativeLeadgencalltoaction(**data: Any)`
 :   Lead generation call to action
     
@@ -2566,6 +2700,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="CreativeReview"></a>
 
 `CreativeReview(**data: Any)`
 :   Review status and rejection reasons
@@ -2592,6 +2728,8 @@ Classes
     `status: str | Any | None`
     :   The type of the None singleton.
 
+<a id="CreativesList"></a>
+
 `CreativesList(**data: Any)`
 :   Paginated list of creatives
     
@@ -2617,6 +2755,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="CreativesListMetadata"></a>
+
 `CreativesListMetadata(**data: Any)`
 :   Nested schema for CreativesList.metadata
     
@@ -2639,6 +2779,8 @@ Classes
     `next_page_token: str | Any`
     :   The type of the None singleton.
 
+<a id="CreativesListResultMeta"></a>
+
 `CreativesListResultMeta(**data: Any)`
 :   Metadata for creatives.Action.LIST operation
     
@@ -2660,6 +2802,8 @@ Classes
 
     `next_page_token: str | Any`
     :   The type of the None singleton.
+
+<a id="CreativesSearchData"></a>
 
 `CreativesSearchData(**data: Any)`
 :   Search result data for creatives entity.
@@ -2719,6 +2863,8 @@ Classes
     `serving_hold_reasons: list[typing.Any] | None`
     :   Reasons for holding creative from serving
 
+<a id="LinkedinAdsAuthConfig"></a>
+
 `LinkedinAdsAuthConfig(**data: Any)`
 :   OAuth 2.0 Authentication
     
@@ -2746,6 +2892,8 @@ Classes
 
     `refresh_token: str`
     :   OAuth 2.0 refresh token for automatic renewal
+
+<a id="LinkedinAdsCheckResult"></a>
 
 `LinkedinAdsCheckResult(**data: Any)`
 :   Result of a health check operation.
@@ -2780,6 +2928,8 @@ Classes
     `status: str`
     :   Health check status: 'healthy' or 'unhealthy'.
 
+<a id="LinkedinAdsExecuteResult"></a>
+
 `LinkedinAdsExecuteResult(**data: Any)`
 :   Response envelope with data only.
     
@@ -2809,6 +2959,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="LinkedinAdsExecuteResultWithMeta"></a>
 
 `LinkedinAdsExecuteResultWithMeta(**data: Any)`
 :   Response envelope with data and metadata.
@@ -2866,6 +3018,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="AccountUsersListResult"></a>
+
 `AccountUsersListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -2908,6 +3062,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="AccountsListResult"></a>
 
 `AccountsListResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -2952,6 +3108,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="CampaignGroupsListResult"></a>
+
 `CampaignGroupsListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -2994,6 +3152,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="CampaignsListResult"></a>
 
 `CampaignsListResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -3038,6 +3198,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="ConversionsListResult"></a>
+
 `ConversionsListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -3081,6 +3243,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="CreativesListResult"></a>
+
 `CreativesListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -3123,6 +3287,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="AdCampaignAnalyticsListResult"></a>
+
 `AdCampaignAnalyticsListResult(**data: Any)`
 :   Response envelope with data only.
     
@@ -3146,6 +3312,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="AdCreativeAnalyticsListResult"></a>
+
 `AdCreativeAnalyticsListResult(**data: Any)`
 :   Response envelope with data only.
     
@@ -3163,6 +3331,8 @@ Classes
     * airbyte_agent_sdk.connectors.linkedin_ads.models.LinkedinAdsExecuteResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="LinkedinAdsReplicationConfig"></a>
 
 `LinkedinAdsReplicationConfig(**data: Any)`
 :   Replication Configuration - Settings for data replication from LinkedIn Ads.

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/linkedin_ads/types.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/linkedin_ads/types.md
@@ -10,6 +10,8 @@ Type definitions for linkedin-ads connector.
 Classes
 -------
 
+<a id="AccountUsersAndCondition"></a>
+
 `AccountUsersAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -29,6 +31,8 @@ Classes
 
     `and: list[airbyte_agent_sdk.connectors.linkedin_ads.types.AccountUsersEqCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.AccountUsersNeqCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.AccountUsersGtCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.AccountUsersGteCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.AccountUsersLtCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.AccountUsersLteCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.AccountUsersInCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.AccountUsersLikeCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.AccountUsersFuzzyCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.AccountUsersKeywordCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.AccountUsersContainsCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.AccountUsersNotCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.AccountUsersAndCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.AccountUsersOrCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.AccountUsersAnyCondition]`
     :   The type of the None singleton.
+
+<a id="AccountUsersAnyCondition"></a>
 
 `AccountUsersAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -50,6 +54,8 @@ Classes
     `any: airbyte_agent_sdk.connectors.linkedin_ads.types.AccountUsersAnyValueFilter`
     :   The type of the None singleton.
 
+<a id="AccountUsersAnyValueFilter"></a>
+
 `AccountUsersAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
 
@@ -68,6 +74,8 @@ Classes
     `user: Any`
     :   User URN
 
+<a id="AccountUsersContainsCondition"></a>
+
 `AccountUsersContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -79,6 +87,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.linkedin_ads.types.AccountUsersAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="AccountUsersEqCondition"></a>
 
 `AccountUsersEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -92,6 +102,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.linkedin_ads.types.AccountUsersSearchFilter`
     :   The type of the None singleton.
 
+<a id="AccountUsersFuzzyCondition"></a>
+
 `AccountUsersFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -103,6 +115,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.linkedin_ads.types.AccountUsersStringFilter`
     :   The type of the None singleton.
+
+<a id="AccountUsersGtCondition"></a>
 
 `AccountUsersGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
@@ -116,6 +130,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.linkedin_ads.types.AccountUsersSearchFilter`
     :   The type of the None singleton.
 
+<a id="AccountUsersGteCondition"></a>
+
 `AccountUsersGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -127,6 +143,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.linkedin_ads.types.AccountUsersSearchFilter`
     :   The type of the None singleton.
+
+<a id="AccountUsersInCondition"></a>
 
 `AccountUsersInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -148,6 +166,8 @@ Classes
     `in: airbyte_agent_sdk.connectors.linkedin_ads.types.AccountUsersInFilter`
     :   The type of the None singleton.
 
+<a id="AccountUsersInFilter"></a>
+
 `AccountUsersInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
 
@@ -166,6 +186,8 @@ Classes
     `user: list[str]`
     :   User URN
 
+<a id="AccountUsersKeywordCondition"></a>
+
 `AccountUsersKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -178,6 +200,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.linkedin_ads.types.AccountUsersStringFilter`
     :   The type of the None singleton.
 
+<a id="AccountUsersLikeCondition"></a>
+
 `AccountUsersLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -189,6 +213,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.linkedin_ads.types.AccountUsersStringFilter`
     :   The type of the None singleton.
+
+<a id="AccountUsersListParams"></a>
 
 `AccountUsersListParams(*args, **kwargs)`
 :   Parameters for account_users.list operation
@@ -211,6 +237,8 @@ Classes
     `start: int`
     :   The type of the None singleton.
 
+<a id="AccountUsersLtCondition"></a>
+
 `AccountUsersLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -222,6 +250,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.linkedin_ads.types.AccountUsersSearchFilter`
     :   The type of the None singleton.
+
+<a id="AccountUsersLteCondition"></a>
 
 `AccountUsersLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -235,6 +265,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.linkedin_ads.types.AccountUsersSearchFilter`
     :   The type of the None singleton.
 
+<a id="AccountUsersNeqCondition"></a>
+
 `AccountUsersNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -246,6 +278,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.linkedin_ads.types.AccountUsersSearchFilter`
     :   The type of the None singleton.
+
+<a id="AccountUsersNotCondition"></a>
 
 `AccountUsersNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -267,6 +301,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.linkedin_ads.types.AccountUsersEqCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.AccountUsersNeqCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.AccountUsersGtCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.AccountUsersGteCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.AccountUsersLtCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.AccountUsersLteCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.AccountUsersInCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.AccountUsersLikeCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.AccountUsersFuzzyCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.AccountUsersKeywordCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.AccountUsersContainsCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.AccountUsersNotCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.AccountUsersAndCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.AccountUsersOrCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.AccountUsersAnyCondition`
     :   The type of the None singleton.
 
+<a id="AccountUsersOrCondition"></a>
+
 `AccountUsersOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -287,6 +323,8 @@ Classes
     `or: list[airbyte_agent_sdk.connectors.linkedin_ads.types.AccountUsersEqCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.AccountUsersNeqCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.AccountUsersGtCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.AccountUsersGteCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.AccountUsersLtCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.AccountUsersLteCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.AccountUsersInCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.AccountUsersLikeCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.AccountUsersFuzzyCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.AccountUsersKeywordCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.AccountUsersContainsCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.AccountUsersNotCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.AccountUsersAndCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.AccountUsersOrCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.AccountUsersAnyCondition]`
     :   The type of the None singleton.
 
+<a id="AccountUsersSearchFilter"></a>
+
 `AccountUsersSearchFilter(*args, **kwargs)`
 :   Available fields for filtering account_users search queries.
 
@@ -305,6 +343,8 @@ Classes
     `user: str | None`
     :   User URN
 
+<a id="AccountUsersSearchQuery"></a>
+
 `AccountUsersSearchQuery(*args, **kwargs)`
 :   Search query for account_users entity.
 
@@ -319,6 +359,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.linkedin_ads.types.AccountUsersSortFilter]`
     :   The type of the None singleton.
+
+<a id="AccountUsersSortFilter"></a>
 
 `AccountUsersSortFilter(*args, **kwargs)`
 :   Available fields for sorting account_users search results.
@@ -338,6 +380,8 @@ Classes
     `user: Literal['asc', 'desc']`
     :   User URN
 
+<a id="AccountUsersStringFilter"></a>
+
 `AccountUsersStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -355,6 +399,8 @@ Classes
 
     `user: str`
     :   User URN
+
+<a id="AccountsAndCondition"></a>
 
 `AccountsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -376,6 +422,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.linkedin_ads.types.AccountsEqCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.AccountsNeqCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.AccountsGtCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.AccountsGteCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.AccountsLtCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.AccountsLteCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.AccountsInCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.AccountsLikeCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.AccountsFuzzyCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.AccountsKeywordCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.AccountsContainsCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.AccountsNotCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.AccountsAndCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.AccountsOrCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.AccountsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="AccountsAnyCondition"></a>
+
 `AccountsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -395,6 +443,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.linkedin_ads.types.AccountsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="AccountsAnyValueFilter"></a>
 
 `AccountsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -447,6 +497,8 @@ Classes
     `version: Any`
     :   Version information
 
+<a id="AccountsContainsCondition"></a>
+
 `AccountsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -458,6 +510,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.linkedin_ads.types.AccountsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="AccountsEqCondition"></a>
 
 `AccountsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -471,6 +525,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.linkedin_ads.types.AccountsSearchFilter`
     :   The type of the None singleton.
 
+<a id="AccountsFuzzyCondition"></a>
+
 `AccountsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -482,6 +538,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.linkedin_ads.types.AccountsStringFilter`
     :   The type of the None singleton.
+
+<a id="AccountsGetParams"></a>
 
 `AccountsGetParams(*args, **kwargs)`
 :   Parameters for accounts.get operation
@@ -495,6 +553,8 @@ Classes
     `id: str`
     :   The type of the None singleton.
 
+<a id="AccountsGtCondition"></a>
+
 `AccountsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -507,6 +567,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.linkedin_ads.types.AccountsSearchFilter`
     :   The type of the None singleton.
 
+<a id="AccountsGteCondition"></a>
+
 `AccountsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -518,6 +580,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.linkedin_ads.types.AccountsSearchFilter`
     :   The type of the None singleton.
+
+<a id="AccountsInCondition"></a>
 
 `AccountsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -538,6 +602,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.linkedin_ads.types.AccountsInFilter`
     :   The type of the None singleton.
+
+<a id="AccountsInFilter"></a>
 
 `AccountsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -590,6 +656,8 @@ Classes
     `version: list[dict[str, typing.Any]]`
     :   Version information
 
+<a id="AccountsKeywordCondition"></a>
+
 `AccountsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -602,6 +670,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.linkedin_ads.types.AccountsStringFilter`
     :   The type of the None singleton.
 
+<a id="AccountsLikeCondition"></a>
+
 `AccountsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -613,6 +683,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.linkedin_ads.types.AccountsStringFilter`
     :   The type of the None singleton.
+
+<a id="AccountsListParams"></a>
 
 `AccountsListParams(*args, **kwargs)`
 :   Parameters for accounts.list operation
@@ -632,6 +704,8 @@ Classes
     `q: str`
     :   The type of the None singleton.
 
+<a id="AccountsLtCondition"></a>
+
 `AccountsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -643,6 +717,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.linkedin_ads.types.AccountsSearchFilter`
     :   The type of the None singleton.
+
+<a id="AccountsLteCondition"></a>
 
 `AccountsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -656,6 +732,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.linkedin_ads.types.AccountsSearchFilter`
     :   The type of the None singleton.
 
+<a id="AccountsNeqCondition"></a>
+
 `AccountsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -667,6 +745,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.linkedin_ads.types.AccountsSearchFilter`
     :   The type of the None singleton.
+
+<a id="AccountsNotCondition"></a>
 
 `AccountsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -688,6 +768,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.linkedin_ads.types.AccountsEqCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.AccountsNeqCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.AccountsGtCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.AccountsGteCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.AccountsLtCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.AccountsLteCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.AccountsInCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.AccountsLikeCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.AccountsFuzzyCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.AccountsKeywordCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.AccountsContainsCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.AccountsNotCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.AccountsAndCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.AccountsOrCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.AccountsAnyCondition`
     :   The type of the None singleton.
 
+<a id="AccountsOrCondition"></a>
+
 `AccountsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -707,6 +789,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.linkedin_ads.types.AccountsEqCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.AccountsNeqCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.AccountsGtCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.AccountsGteCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.AccountsLtCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.AccountsLteCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.AccountsInCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.AccountsLikeCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.AccountsFuzzyCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.AccountsKeywordCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.AccountsContainsCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.AccountsNotCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.AccountsAndCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.AccountsOrCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.AccountsAnyCondition]`
     :   The type of the None singleton.
+
+<a id="AccountsSearchFilter"></a>
 
 `AccountsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering accounts search queries.
@@ -759,6 +843,8 @@ Classes
     `version: dict[str, typing.Any] | None`
     :   Version information
 
+<a id="AccountsSearchQuery"></a>
+
 `AccountsSearchQuery(*args, **kwargs)`
 :   Search query for accounts entity.
 
@@ -773,6 +859,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.linkedin_ads.types.AccountsSortFilter]`
     :   The type of the None singleton.
+
+<a id="AccountsSortFilter"></a>
 
 `AccountsSortFilter(*args, **kwargs)`
 :   Available fields for sorting accounts search results.
@@ -825,6 +913,8 @@ Classes
     `version: Literal['asc', 'desc']`
     :   Version information
 
+<a id="AccountsStringFilter"></a>
+
 `AccountsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -876,6 +966,8 @@ Classes
     `version: str`
     :   Version information
 
+<a id="AdCampaignAnalyticsAndCondition"></a>
+
 `AdCampaignAnalyticsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -896,6 +988,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.linkedin_ads.types.AdCampaignAnalyticsEqCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.AdCampaignAnalyticsNeqCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.AdCampaignAnalyticsGtCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.AdCampaignAnalyticsGteCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.AdCampaignAnalyticsLtCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.AdCampaignAnalyticsLteCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.AdCampaignAnalyticsInCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.AdCampaignAnalyticsLikeCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.AdCampaignAnalyticsFuzzyCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.AdCampaignAnalyticsKeywordCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.AdCampaignAnalyticsContainsCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.AdCampaignAnalyticsNotCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.AdCampaignAnalyticsAndCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.AdCampaignAnalyticsOrCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.AdCampaignAnalyticsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="AdCampaignAnalyticsAnyCondition"></a>
+
 `AdCampaignAnalyticsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -915,6 +1009,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.linkedin_ads.types.AdCampaignAnalyticsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="AdCampaignAnalyticsAnyValueFilter"></a>
 
 `AdCampaignAnalyticsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -1042,6 +1138,8 @@ Classes
     `video_views: Any`
     :   Number of video views
 
+<a id="AdCampaignAnalyticsContainsCondition"></a>
+
 `AdCampaignAnalyticsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -1053,6 +1151,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.linkedin_ads.types.AdCampaignAnalyticsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="AdCampaignAnalyticsEqCondition"></a>
 
 `AdCampaignAnalyticsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -1066,6 +1166,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.linkedin_ads.types.AdCampaignAnalyticsSearchFilter`
     :   The type of the None singleton.
 
+<a id="AdCampaignAnalyticsFuzzyCondition"></a>
+
 `AdCampaignAnalyticsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -1077,6 +1179,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.linkedin_ads.types.AdCampaignAnalyticsStringFilter`
     :   The type of the None singleton.
+
+<a id="AdCampaignAnalyticsGtCondition"></a>
 
 `AdCampaignAnalyticsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
@@ -1090,6 +1194,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.linkedin_ads.types.AdCampaignAnalyticsSearchFilter`
     :   The type of the None singleton.
 
+<a id="AdCampaignAnalyticsGteCondition"></a>
+
 `AdCampaignAnalyticsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -1101,6 +1207,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.linkedin_ads.types.AdCampaignAnalyticsSearchFilter`
     :   The type of the None singleton.
+
+<a id="AdCampaignAnalyticsInCondition"></a>
 
 `AdCampaignAnalyticsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -1121,6 +1229,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.linkedin_ads.types.AdCampaignAnalyticsInFilter`
     :   The type of the None singleton.
+
+<a id="AdCampaignAnalyticsInFilter"></a>
 
 `AdCampaignAnalyticsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -1248,6 +1358,8 @@ Classes
     `video_views: list[float]`
     :   Number of video views
 
+<a id="AdCampaignAnalyticsKeywordCondition"></a>
+
 `AdCampaignAnalyticsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -1260,6 +1372,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.linkedin_ads.types.AdCampaignAnalyticsStringFilter`
     :   The type of the None singleton.
 
+<a id="AdCampaignAnalyticsLikeCondition"></a>
+
 `AdCampaignAnalyticsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -1271,6 +1385,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.linkedin_ads.types.AdCampaignAnalyticsStringFilter`
     :   The type of the None singleton.
+
+<a id="AdCampaignAnalyticsListParams"></a>
 
 `AdCampaignAnalyticsListParams(*args, **kwargs)`
 :   Parameters for ad_campaign_analytics.list operation
@@ -1299,6 +1415,8 @@ Classes
     `time_granularity: str`
     :   The type of the None singleton.
 
+<a id="AdCampaignAnalyticsLtCondition"></a>
+
 `AdCampaignAnalyticsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -1310,6 +1428,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.linkedin_ads.types.AdCampaignAnalyticsSearchFilter`
     :   The type of the None singleton.
+
+<a id="AdCampaignAnalyticsLteCondition"></a>
 
 `AdCampaignAnalyticsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -1323,6 +1443,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.linkedin_ads.types.AdCampaignAnalyticsSearchFilter`
     :   The type of the None singleton.
 
+<a id="AdCampaignAnalyticsNeqCondition"></a>
+
 `AdCampaignAnalyticsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -1334,6 +1456,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.linkedin_ads.types.AdCampaignAnalyticsSearchFilter`
     :   The type of the None singleton.
+
+<a id="AdCampaignAnalyticsNotCondition"></a>
 
 `AdCampaignAnalyticsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -1355,6 +1479,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.linkedin_ads.types.AdCampaignAnalyticsEqCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.AdCampaignAnalyticsNeqCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.AdCampaignAnalyticsGtCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.AdCampaignAnalyticsGteCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.AdCampaignAnalyticsLtCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.AdCampaignAnalyticsLteCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.AdCampaignAnalyticsInCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.AdCampaignAnalyticsLikeCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.AdCampaignAnalyticsFuzzyCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.AdCampaignAnalyticsKeywordCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.AdCampaignAnalyticsContainsCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.AdCampaignAnalyticsNotCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.AdCampaignAnalyticsAndCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.AdCampaignAnalyticsOrCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.AdCampaignAnalyticsAnyCondition`
     :   The type of the None singleton.
 
+<a id="AdCampaignAnalyticsOrCondition"></a>
+
 `AdCampaignAnalyticsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1374,6 +1500,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.linkedin_ads.types.AdCampaignAnalyticsEqCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.AdCampaignAnalyticsNeqCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.AdCampaignAnalyticsGtCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.AdCampaignAnalyticsGteCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.AdCampaignAnalyticsLtCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.AdCampaignAnalyticsLteCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.AdCampaignAnalyticsInCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.AdCampaignAnalyticsLikeCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.AdCampaignAnalyticsFuzzyCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.AdCampaignAnalyticsKeywordCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.AdCampaignAnalyticsContainsCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.AdCampaignAnalyticsNotCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.AdCampaignAnalyticsAndCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.AdCampaignAnalyticsOrCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.AdCampaignAnalyticsAnyCondition]`
     :   The type of the None singleton.
+
+<a id="AdCampaignAnalyticsSearchFilter"></a>
 
 `AdCampaignAnalyticsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering ad_campaign_analytics search queries.
@@ -1501,6 +1629,8 @@ Classes
     `video_views: float | None`
     :   Number of video views
 
+<a id="AdCampaignAnalyticsSearchQuery"></a>
+
 `AdCampaignAnalyticsSearchQuery(*args, **kwargs)`
 :   Search query for ad_campaign_analytics entity.
 
@@ -1515,6 +1645,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.linkedin_ads.types.AdCampaignAnalyticsSortFilter]`
     :   The type of the None singleton.
+
+<a id="AdCampaignAnalyticsSortFilter"></a>
 
 `AdCampaignAnalyticsSortFilter(*args, **kwargs)`
 :   Available fields for sorting ad_campaign_analytics search results.
@@ -1642,6 +1774,8 @@ Classes
     `video_views: Literal['asc', 'desc']`
     :   Number of video views
 
+<a id="AdCampaignAnalyticsStringFilter"></a>
+
 `AdCampaignAnalyticsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -1768,6 +1902,8 @@ Classes
     `video_views: str`
     :   Number of video views
 
+<a id="AdCreativeAnalyticsAndCondition"></a>
+
 `AdCreativeAnalyticsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1788,6 +1924,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.linkedin_ads.types.AdCreativeAnalyticsEqCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.AdCreativeAnalyticsNeqCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.AdCreativeAnalyticsGtCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.AdCreativeAnalyticsGteCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.AdCreativeAnalyticsLtCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.AdCreativeAnalyticsLteCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.AdCreativeAnalyticsInCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.AdCreativeAnalyticsLikeCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.AdCreativeAnalyticsFuzzyCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.AdCreativeAnalyticsKeywordCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.AdCreativeAnalyticsContainsCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.AdCreativeAnalyticsNotCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.AdCreativeAnalyticsAndCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.AdCreativeAnalyticsOrCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.AdCreativeAnalyticsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="AdCreativeAnalyticsAnyCondition"></a>
+
 `AdCreativeAnalyticsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1807,6 +1945,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.linkedin_ads.types.AdCreativeAnalyticsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="AdCreativeAnalyticsAnyValueFilter"></a>
 
 `AdCreativeAnalyticsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -1934,6 +2074,8 @@ Classes
     `video_views: Any`
     :   Number of video views
 
+<a id="AdCreativeAnalyticsContainsCondition"></a>
+
 `AdCreativeAnalyticsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -1945,6 +2087,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.linkedin_ads.types.AdCreativeAnalyticsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="AdCreativeAnalyticsEqCondition"></a>
 
 `AdCreativeAnalyticsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -1958,6 +2102,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.linkedin_ads.types.AdCreativeAnalyticsSearchFilter`
     :   The type of the None singleton.
 
+<a id="AdCreativeAnalyticsFuzzyCondition"></a>
+
 `AdCreativeAnalyticsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -1969,6 +2115,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.linkedin_ads.types.AdCreativeAnalyticsStringFilter`
     :   The type of the None singleton.
+
+<a id="AdCreativeAnalyticsGtCondition"></a>
 
 `AdCreativeAnalyticsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
@@ -1982,6 +2130,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.linkedin_ads.types.AdCreativeAnalyticsSearchFilter`
     :   The type of the None singleton.
 
+<a id="AdCreativeAnalyticsGteCondition"></a>
+
 `AdCreativeAnalyticsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -1993,6 +2143,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.linkedin_ads.types.AdCreativeAnalyticsSearchFilter`
     :   The type of the None singleton.
+
+<a id="AdCreativeAnalyticsInCondition"></a>
 
 `AdCreativeAnalyticsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -2013,6 +2165,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.linkedin_ads.types.AdCreativeAnalyticsInFilter`
     :   The type of the None singleton.
+
+<a id="AdCreativeAnalyticsInFilter"></a>
 
 `AdCreativeAnalyticsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -2140,6 +2294,8 @@ Classes
     `video_views: list[float]`
     :   Number of video views
 
+<a id="AdCreativeAnalyticsKeywordCondition"></a>
+
 `AdCreativeAnalyticsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -2152,6 +2308,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.linkedin_ads.types.AdCreativeAnalyticsStringFilter`
     :   The type of the None singleton.
 
+<a id="AdCreativeAnalyticsLikeCondition"></a>
+
 `AdCreativeAnalyticsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -2163,6 +2321,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.linkedin_ads.types.AdCreativeAnalyticsStringFilter`
     :   The type of the None singleton.
+
+<a id="AdCreativeAnalyticsListParams"></a>
 
 `AdCreativeAnalyticsListParams(*args, **kwargs)`
 :   Parameters for ad_creative_analytics.list operation
@@ -2191,6 +2351,8 @@ Classes
     `time_granularity: str`
     :   The type of the None singleton.
 
+<a id="AdCreativeAnalyticsLtCondition"></a>
+
 `AdCreativeAnalyticsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -2202,6 +2364,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.linkedin_ads.types.AdCreativeAnalyticsSearchFilter`
     :   The type of the None singleton.
+
+<a id="AdCreativeAnalyticsLteCondition"></a>
 
 `AdCreativeAnalyticsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -2215,6 +2379,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.linkedin_ads.types.AdCreativeAnalyticsSearchFilter`
     :   The type of the None singleton.
 
+<a id="AdCreativeAnalyticsNeqCondition"></a>
+
 `AdCreativeAnalyticsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -2226,6 +2392,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.linkedin_ads.types.AdCreativeAnalyticsSearchFilter`
     :   The type of the None singleton.
+
+<a id="AdCreativeAnalyticsNotCondition"></a>
 
 `AdCreativeAnalyticsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -2247,6 +2415,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.linkedin_ads.types.AdCreativeAnalyticsEqCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.AdCreativeAnalyticsNeqCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.AdCreativeAnalyticsGtCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.AdCreativeAnalyticsGteCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.AdCreativeAnalyticsLtCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.AdCreativeAnalyticsLteCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.AdCreativeAnalyticsInCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.AdCreativeAnalyticsLikeCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.AdCreativeAnalyticsFuzzyCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.AdCreativeAnalyticsKeywordCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.AdCreativeAnalyticsContainsCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.AdCreativeAnalyticsNotCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.AdCreativeAnalyticsAndCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.AdCreativeAnalyticsOrCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.AdCreativeAnalyticsAnyCondition`
     :   The type of the None singleton.
 
+<a id="AdCreativeAnalyticsOrCondition"></a>
+
 `AdCreativeAnalyticsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -2266,6 +2436,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.linkedin_ads.types.AdCreativeAnalyticsEqCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.AdCreativeAnalyticsNeqCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.AdCreativeAnalyticsGtCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.AdCreativeAnalyticsGteCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.AdCreativeAnalyticsLtCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.AdCreativeAnalyticsLteCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.AdCreativeAnalyticsInCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.AdCreativeAnalyticsLikeCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.AdCreativeAnalyticsFuzzyCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.AdCreativeAnalyticsKeywordCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.AdCreativeAnalyticsContainsCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.AdCreativeAnalyticsNotCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.AdCreativeAnalyticsAndCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.AdCreativeAnalyticsOrCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.AdCreativeAnalyticsAnyCondition]`
     :   The type of the None singleton.
+
+<a id="AdCreativeAnalyticsSearchFilter"></a>
 
 `AdCreativeAnalyticsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering ad_creative_analytics search queries.
@@ -2393,6 +2565,8 @@ Classes
     `video_views: float | None`
     :   Number of video views
 
+<a id="AdCreativeAnalyticsSearchQuery"></a>
+
 `AdCreativeAnalyticsSearchQuery(*args, **kwargs)`
 :   Search query for ad_creative_analytics entity.
 
@@ -2407,6 +2581,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.linkedin_ads.types.AdCreativeAnalyticsSortFilter]`
     :   The type of the None singleton.
+
+<a id="AdCreativeAnalyticsSortFilter"></a>
 
 `AdCreativeAnalyticsSortFilter(*args, **kwargs)`
 :   Available fields for sorting ad_creative_analytics search results.
@@ -2534,6 +2710,8 @@ Classes
     `video_views: Literal['asc', 'desc']`
     :   Number of video views
 
+<a id="AdCreativeAnalyticsStringFilter"></a>
+
 `AdCreativeAnalyticsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -2660,6 +2838,8 @@ Classes
     `video_views: str`
     :   Number of video views
 
+<a id="AirbyteSearchParams"></a>
+
 `AirbyteSearchParams(*args, **kwargs)`
 :   Parameters for Airbyte cache search operations (generic, use entity-specific query types for better type hints).
 
@@ -2681,6 +2861,8 @@ Classes
     `query: dict[str, typing.Any]`
     :   The type of the None singleton.
 
+<a id="CampaignGroupsAndCondition"></a>
+
 `CampaignGroupsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -2701,6 +2883,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.linkedin_ads.types.CampaignGroupsEqCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.CampaignGroupsNeqCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.CampaignGroupsGtCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.CampaignGroupsGteCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.CampaignGroupsLtCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.CampaignGroupsLteCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.CampaignGroupsInCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.CampaignGroupsLikeCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.CampaignGroupsFuzzyCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.CampaignGroupsKeywordCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.CampaignGroupsContainsCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.CampaignGroupsNotCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.CampaignGroupsAndCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.CampaignGroupsOrCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.CampaignGroupsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="CampaignGroupsAnyCondition"></a>
+
 `CampaignGroupsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -2720,6 +2904,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.linkedin_ads.types.CampaignGroupsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="CampaignGroupsAnyValueFilter"></a>
 
 `CampaignGroupsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -2760,6 +2946,8 @@ Classes
     `total_budget: Any`
     :   Total budget for the campaign group
 
+<a id="CampaignGroupsContainsCondition"></a>
+
 `CampaignGroupsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -2771,6 +2959,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.linkedin_ads.types.CampaignGroupsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="CampaignGroupsEqCondition"></a>
 
 `CampaignGroupsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -2784,6 +2974,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.linkedin_ads.types.CampaignGroupsSearchFilter`
     :   The type of the None singleton.
 
+<a id="CampaignGroupsFuzzyCondition"></a>
+
 `CampaignGroupsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -2795,6 +2987,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.linkedin_ads.types.CampaignGroupsStringFilter`
     :   The type of the None singleton.
+
+<a id="CampaignGroupsGetParams"></a>
 
 `CampaignGroupsGetParams(*args, **kwargs)`
 :   Parameters for campaign_groups.get operation
@@ -2811,6 +3005,8 @@ Classes
     `id: str`
     :   The type of the None singleton.
 
+<a id="CampaignGroupsGtCondition"></a>
+
 `CampaignGroupsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -2823,6 +3019,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.linkedin_ads.types.CampaignGroupsSearchFilter`
     :   The type of the None singleton.
 
+<a id="CampaignGroupsGteCondition"></a>
+
 `CampaignGroupsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -2834,6 +3032,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.linkedin_ads.types.CampaignGroupsSearchFilter`
     :   The type of the None singleton.
+
+<a id="CampaignGroupsInCondition"></a>
 
 `CampaignGroupsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -2854,6 +3054,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.linkedin_ads.types.CampaignGroupsInFilter`
     :   The type of the None singleton.
+
+<a id="CampaignGroupsInFilter"></a>
 
 `CampaignGroupsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -2894,6 +3096,8 @@ Classes
     `total_budget: list[dict[str, typing.Any]]`
     :   Total budget for the campaign group
 
+<a id="CampaignGroupsKeywordCondition"></a>
+
 `CampaignGroupsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -2906,6 +3110,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.linkedin_ads.types.CampaignGroupsStringFilter`
     :   The type of the None singleton.
 
+<a id="CampaignGroupsLikeCondition"></a>
+
 `CampaignGroupsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -2917,6 +3123,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.linkedin_ads.types.CampaignGroupsStringFilter`
     :   The type of the None singleton.
+
+<a id="CampaignGroupsListParams"></a>
 
 `CampaignGroupsListParams(*args, **kwargs)`
 :   Parameters for campaign_groups.list operation
@@ -2939,6 +3147,8 @@ Classes
     `q: str`
     :   The type of the None singleton.
 
+<a id="CampaignGroupsLtCondition"></a>
+
 `CampaignGroupsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -2950,6 +3160,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.linkedin_ads.types.CampaignGroupsSearchFilter`
     :   The type of the None singleton.
+
+<a id="CampaignGroupsLteCondition"></a>
 
 `CampaignGroupsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -2963,6 +3175,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.linkedin_ads.types.CampaignGroupsSearchFilter`
     :   The type of the None singleton.
 
+<a id="CampaignGroupsNeqCondition"></a>
+
 `CampaignGroupsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -2974,6 +3188,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.linkedin_ads.types.CampaignGroupsSearchFilter`
     :   The type of the None singleton.
+
+<a id="CampaignGroupsNotCondition"></a>
 
 `CampaignGroupsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -2995,6 +3211,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.linkedin_ads.types.CampaignGroupsEqCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.CampaignGroupsNeqCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.CampaignGroupsGtCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.CampaignGroupsGteCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.CampaignGroupsLtCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.CampaignGroupsLteCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.CampaignGroupsInCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.CampaignGroupsLikeCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.CampaignGroupsFuzzyCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.CampaignGroupsKeywordCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.CampaignGroupsContainsCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.CampaignGroupsNotCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.CampaignGroupsAndCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.CampaignGroupsOrCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.CampaignGroupsAnyCondition`
     :   The type of the None singleton.
 
+<a id="CampaignGroupsOrCondition"></a>
+
 `CampaignGroupsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -3014,6 +3232,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.linkedin_ads.types.CampaignGroupsEqCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.CampaignGroupsNeqCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.CampaignGroupsGtCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.CampaignGroupsGteCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.CampaignGroupsLtCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.CampaignGroupsLteCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.CampaignGroupsInCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.CampaignGroupsLikeCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.CampaignGroupsFuzzyCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.CampaignGroupsKeywordCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.CampaignGroupsContainsCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.CampaignGroupsNotCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.CampaignGroupsAndCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.CampaignGroupsOrCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.CampaignGroupsAnyCondition]`
     :   The type of the None singleton.
+
+<a id="CampaignGroupsSearchFilter"></a>
 
 `CampaignGroupsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering campaign_groups search queries.
@@ -3054,6 +3274,8 @@ Classes
     `total_budget: dict[str, typing.Any] | None`
     :   Total budget for the campaign group
 
+<a id="CampaignGroupsSearchQuery"></a>
+
 `CampaignGroupsSearchQuery(*args, **kwargs)`
 :   Search query for campaign_groups entity.
 
@@ -3068,6 +3290,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.linkedin_ads.types.CampaignGroupsSortFilter]`
     :   The type of the None singleton.
+
+<a id="CampaignGroupsSortFilter"></a>
 
 `CampaignGroupsSortFilter(*args, **kwargs)`
 :   Available fields for sorting campaign_groups search results.
@@ -3108,6 +3332,8 @@ Classes
     `total_budget: Literal['asc', 'desc']`
     :   Total budget for the campaign group
 
+<a id="CampaignGroupsStringFilter"></a>
+
 `CampaignGroupsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -3147,6 +3373,8 @@ Classes
     `total_budget: str`
     :   Total budget for the campaign group
 
+<a id="CampaignsAndCondition"></a>
+
 `CampaignsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -3167,6 +3395,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.linkedin_ads.types.CampaignsEqCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.CampaignsNeqCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.CampaignsGtCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.CampaignsGteCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.CampaignsLtCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.CampaignsLteCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.CampaignsInCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.CampaignsLikeCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.CampaignsFuzzyCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.CampaignsKeywordCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.CampaignsContainsCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.CampaignsNotCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.CampaignsAndCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.CampaignsOrCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.CampaignsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="CampaignsAnyCondition"></a>
+
 `CampaignsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -3186,6 +3416,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.linkedin_ads.types.CampaignsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="CampaignsAnyValueFilter"></a>
 
 `CampaignsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -3268,6 +3500,8 @@ Classes
     `version: Any`
     :   Version information
 
+<a id="CampaignsContainsCondition"></a>
+
 `CampaignsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -3279,6 +3513,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.linkedin_ads.types.CampaignsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="CampaignsEqCondition"></a>
 
 `CampaignsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -3292,6 +3528,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.linkedin_ads.types.CampaignsSearchFilter`
     :   The type of the None singleton.
 
+<a id="CampaignsFuzzyCondition"></a>
+
 `CampaignsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -3303,6 +3541,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.linkedin_ads.types.CampaignsStringFilter`
     :   The type of the None singleton.
+
+<a id="CampaignsGetParams"></a>
 
 `CampaignsGetParams(*args, **kwargs)`
 :   Parameters for campaigns.get operation
@@ -3319,6 +3559,8 @@ Classes
     `id: str`
     :   The type of the None singleton.
 
+<a id="CampaignsGtCondition"></a>
+
 `CampaignsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -3331,6 +3573,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.linkedin_ads.types.CampaignsSearchFilter`
     :   The type of the None singleton.
 
+<a id="CampaignsGteCondition"></a>
+
 `CampaignsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -3342,6 +3586,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.linkedin_ads.types.CampaignsSearchFilter`
     :   The type of the None singleton.
+
+<a id="CampaignsInCondition"></a>
 
 `CampaignsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -3362,6 +3608,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.linkedin_ads.types.CampaignsInFilter`
     :   The type of the None singleton.
+
+<a id="CampaignsInFilter"></a>
 
 `CampaignsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -3444,6 +3692,8 @@ Classes
     `version: list[dict[str, typing.Any]]`
     :   Version information
 
+<a id="CampaignsKeywordCondition"></a>
+
 `CampaignsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -3456,6 +3706,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.linkedin_ads.types.CampaignsStringFilter`
     :   The type of the None singleton.
 
+<a id="CampaignsLikeCondition"></a>
+
 `CampaignsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -3467,6 +3719,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.linkedin_ads.types.CampaignsStringFilter`
     :   The type of the None singleton.
+
+<a id="CampaignsListParams"></a>
 
 `CampaignsListParams(*args, **kwargs)`
 :   Parameters for campaigns.list operation
@@ -3489,6 +3743,8 @@ Classes
     `q: str`
     :   The type of the None singleton.
 
+<a id="CampaignsLtCondition"></a>
+
 `CampaignsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -3500,6 +3756,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.linkedin_ads.types.CampaignsSearchFilter`
     :   The type of the None singleton.
+
+<a id="CampaignsLteCondition"></a>
 
 `CampaignsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -3513,6 +3771,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.linkedin_ads.types.CampaignsSearchFilter`
     :   The type of the None singleton.
 
+<a id="CampaignsNeqCondition"></a>
+
 `CampaignsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -3524,6 +3784,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.linkedin_ads.types.CampaignsSearchFilter`
     :   The type of the None singleton.
+
+<a id="CampaignsNotCondition"></a>
 
 `CampaignsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -3545,6 +3807,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.linkedin_ads.types.CampaignsEqCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.CampaignsNeqCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.CampaignsGtCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.CampaignsGteCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.CampaignsLtCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.CampaignsLteCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.CampaignsInCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.CampaignsLikeCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.CampaignsFuzzyCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.CampaignsKeywordCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.CampaignsContainsCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.CampaignsNotCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.CampaignsAndCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.CampaignsOrCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.CampaignsAnyCondition`
     :   The type of the None singleton.
 
+<a id="CampaignsOrCondition"></a>
+
 `CampaignsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -3564,6 +3828,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.linkedin_ads.types.CampaignsEqCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.CampaignsNeqCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.CampaignsGtCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.CampaignsGteCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.CampaignsLtCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.CampaignsLteCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.CampaignsInCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.CampaignsLikeCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.CampaignsFuzzyCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.CampaignsKeywordCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.CampaignsContainsCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.CampaignsNotCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.CampaignsAndCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.CampaignsOrCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.CampaignsAnyCondition]`
     :   The type of the None singleton.
+
+<a id="CampaignsSearchFilter"></a>
 
 `CampaignsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering campaigns search queries.
@@ -3646,6 +3912,8 @@ Classes
     `version: dict[str, typing.Any] | None`
     :   Version information
 
+<a id="CampaignsSearchQuery"></a>
+
 `CampaignsSearchQuery(*args, **kwargs)`
 :   Search query for campaigns entity.
 
@@ -3660,6 +3928,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.linkedin_ads.types.CampaignsSortFilter]`
     :   The type of the None singleton.
+
+<a id="CampaignsSortFilter"></a>
 
 `CampaignsSortFilter(*args, **kwargs)`
 :   Available fields for sorting campaigns search results.
@@ -3742,6 +4012,8 @@ Classes
     `version: Literal['asc', 'desc']`
     :   Version information
 
+<a id="CampaignsStringFilter"></a>
+
 `CampaignsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -3823,6 +4095,8 @@ Classes
     `version: str`
     :   Version information
 
+<a id="ConversionsAndCondition"></a>
+
 `ConversionsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -3843,6 +4117,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.linkedin_ads.types.ConversionsEqCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.ConversionsNeqCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.ConversionsGtCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.ConversionsGteCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.ConversionsLtCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.ConversionsLteCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.ConversionsInCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.ConversionsLikeCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.ConversionsFuzzyCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.ConversionsKeywordCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.ConversionsContainsCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.ConversionsNotCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.ConversionsAndCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.ConversionsOrCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.ConversionsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="ConversionsAnyCondition"></a>
+
 `ConversionsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -3862,6 +4138,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.linkedin_ads.types.ConversionsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="ConversionsAnyValueFilter"></a>
 
 `ConversionsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -3914,6 +4192,8 @@ Classes
     `view_through_attribution_window_size: Any`
     :   View-through attribution window size in days
 
+<a id="ConversionsContainsCondition"></a>
+
 `ConversionsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -3925,6 +4205,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.linkedin_ads.types.ConversionsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="ConversionsEqCondition"></a>
 
 `ConversionsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -3938,6 +4220,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.linkedin_ads.types.ConversionsSearchFilter`
     :   The type of the None singleton.
 
+<a id="ConversionsFuzzyCondition"></a>
+
 `ConversionsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -3949,6 +4233,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.linkedin_ads.types.ConversionsStringFilter`
     :   The type of the None singleton.
+
+<a id="ConversionsGetParams"></a>
 
 `ConversionsGetParams(*args, **kwargs)`
 :   Parameters for conversions.get operation
@@ -3962,6 +4248,8 @@ Classes
     `id: str`
     :   The type of the None singleton.
 
+<a id="ConversionsGtCondition"></a>
+
 `ConversionsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -3974,6 +4262,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.linkedin_ads.types.ConversionsSearchFilter`
     :   The type of the None singleton.
 
+<a id="ConversionsGteCondition"></a>
+
 `ConversionsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -3985,6 +4275,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.linkedin_ads.types.ConversionsSearchFilter`
     :   The type of the None singleton.
+
+<a id="ConversionsInCondition"></a>
 
 `ConversionsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -4005,6 +4297,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.linkedin_ads.types.ConversionsInFilter`
     :   The type of the None singleton.
+
+<a id="ConversionsInFilter"></a>
 
 `ConversionsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -4057,6 +4351,8 @@ Classes
     `view_through_attribution_window_size: list[int]`
     :   View-through attribution window size in days
 
+<a id="ConversionsKeywordCondition"></a>
+
 `ConversionsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -4069,6 +4365,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.linkedin_ads.types.ConversionsStringFilter`
     :   The type of the None singleton.
 
+<a id="ConversionsLikeCondition"></a>
+
 `ConversionsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -4080,6 +4378,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.linkedin_ads.types.ConversionsStringFilter`
     :   The type of the None singleton.
+
+<a id="ConversionsListParams"></a>
 
 `ConversionsListParams(*args, **kwargs)`
 :   Parameters for conversions.list operation
@@ -4102,6 +4402,8 @@ Classes
     `start: int`
     :   The type of the None singleton.
 
+<a id="ConversionsLtCondition"></a>
+
 `ConversionsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -4113,6 +4415,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.linkedin_ads.types.ConversionsSearchFilter`
     :   The type of the None singleton.
+
+<a id="ConversionsLteCondition"></a>
 
 `ConversionsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -4126,6 +4430,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.linkedin_ads.types.ConversionsSearchFilter`
     :   The type of the None singleton.
 
+<a id="ConversionsNeqCondition"></a>
+
 `ConversionsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -4137,6 +4443,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.linkedin_ads.types.ConversionsSearchFilter`
     :   The type of the None singleton.
+
+<a id="ConversionsNotCondition"></a>
 
 `ConversionsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -4158,6 +4466,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.linkedin_ads.types.ConversionsEqCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.ConversionsNeqCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.ConversionsGtCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.ConversionsGteCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.ConversionsLtCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.ConversionsLteCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.ConversionsInCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.ConversionsLikeCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.ConversionsFuzzyCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.ConversionsKeywordCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.ConversionsContainsCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.ConversionsNotCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.ConversionsAndCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.ConversionsOrCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.ConversionsAnyCondition`
     :   The type of the None singleton.
 
+<a id="ConversionsOrCondition"></a>
+
 `ConversionsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -4177,6 +4487,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.linkedin_ads.types.ConversionsEqCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.ConversionsNeqCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.ConversionsGtCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.ConversionsGteCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.ConversionsLtCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.ConversionsLteCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.ConversionsInCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.ConversionsLikeCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.ConversionsFuzzyCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.ConversionsKeywordCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.ConversionsContainsCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.ConversionsNotCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.ConversionsAndCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.ConversionsOrCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.ConversionsAnyCondition]`
     :   The type of the None singleton.
+
+<a id="ConversionsSearchFilter"></a>
 
 `ConversionsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering conversions search queries.
@@ -4229,6 +4541,8 @@ Classes
     `view_through_attribution_window_size: int | None`
     :   View-through attribution window size in days
 
+<a id="ConversionsSearchQuery"></a>
+
 `ConversionsSearchQuery(*args, **kwargs)`
 :   Search query for conversions entity.
 
@@ -4243,6 +4557,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.linkedin_ads.types.ConversionsSortFilter]`
     :   The type of the None singleton.
+
+<a id="ConversionsSortFilter"></a>
 
 `ConversionsSortFilter(*args, **kwargs)`
 :   Available fields for sorting conversions search results.
@@ -4295,6 +4611,8 @@ Classes
     `view_through_attribution_window_size: Literal['asc', 'desc']`
     :   View-through attribution window size in days
 
+<a id="ConversionsStringFilter"></a>
+
 `ConversionsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -4346,6 +4664,8 @@ Classes
     `view_through_attribution_window_size: str`
     :   View-through attribution window size in days
 
+<a id="CreativesAndCondition"></a>
+
 `CreativesAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -4366,6 +4686,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.linkedin_ads.types.CreativesEqCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.CreativesNeqCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.CreativesGtCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.CreativesGteCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.CreativesLtCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.CreativesLteCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.CreativesInCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.CreativesLikeCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.CreativesFuzzyCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.CreativesKeywordCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.CreativesContainsCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.CreativesNotCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.CreativesAndCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.CreativesOrCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.CreativesAnyCondition]`
     :   The type of the None singleton.
 
+<a id="CreativesAnyCondition"></a>
+
 `CreativesAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -4385,6 +4707,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.linkedin_ads.types.CreativesAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="CreativesAnyValueFilter"></a>
 
 `CreativesAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -4434,6 +4758,8 @@ Classes
     `serving_hold_reasons: Any`
     :   Reasons for holding creative from serving
 
+<a id="CreativesContainsCondition"></a>
+
 `CreativesContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -4445,6 +4771,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.linkedin_ads.types.CreativesAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="CreativesEqCondition"></a>
 
 `CreativesEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -4458,6 +4786,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.linkedin_ads.types.CreativesSearchFilter`
     :   The type of the None singleton.
 
+<a id="CreativesFuzzyCondition"></a>
+
 `CreativesFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -4469,6 +4799,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.linkedin_ads.types.CreativesStringFilter`
     :   The type of the None singleton.
+
+<a id="CreativesGetParams"></a>
 
 `CreativesGetParams(*args, **kwargs)`
 :   Parameters for creatives.get operation
@@ -4485,6 +4817,8 @@ Classes
     `id: str`
     :   The type of the None singleton.
 
+<a id="CreativesGtCondition"></a>
+
 `CreativesGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -4497,6 +4831,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.linkedin_ads.types.CreativesSearchFilter`
     :   The type of the None singleton.
 
+<a id="CreativesGteCondition"></a>
+
 `CreativesGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -4508,6 +4844,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.linkedin_ads.types.CreativesSearchFilter`
     :   The type of the None singleton.
+
+<a id="CreativesInCondition"></a>
 
 `CreativesInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -4528,6 +4866,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.linkedin_ads.types.CreativesInFilter`
     :   The type of the None singleton.
+
+<a id="CreativesInFilter"></a>
 
 `CreativesInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -4577,6 +4917,8 @@ Classes
     `serving_hold_reasons: list[list[typing.Any]]`
     :   Reasons for holding creative from serving
 
+<a id="CreativesKeywordCondition"></a>
+
 `CreativesKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -4589,6 +4931,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.linkedin_ads.types.CreativesStringFilter`
     :   The type of the None singleton.
 
+<a id="CreativesLikeCondition"></a>
+
 `CreativesLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -4600,6 +4944,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.linkedin_ads.types.CreativesStringFilter`
     :   The type of the None singleton.
+
+<a id="CreativesListParams"></a>
 
 `CreativesListParams(*args, **kwargs)`
 :   Parameters for creatives.list operation
@@ -4622,6 +4968,8 @@ Classes
     `q: str`
     :   The type of the None singleton.
 
+<a id="CreativesLtCondition"></a>
+
 `CreativesLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -4633,6 +4981,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.linkedin_ads.types.CreativesSearchFilter`
     :   The type of the None singleton.
+
+<a id="CreativesLteCondition"></a>
 
 `CreativesLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -4646,6 +4996,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.linkedin_ads.types.CreativesSearchFilter`
     :   The type of the None singleton.
 
+<a id="CreativesNeqCondition"></a>
+
 `CreativesNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -4657,6 +5009,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.linkedin_ads.types.CreativesSearchFilter`
     :   The type of the None singleton.
+
+<a id="CreativesNotCondition"></a>
 
 `CreativesNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -4678,6 +5032,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.linkedin_ads.types.CreativesEqCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.CreativesNeqCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.CreativesGtCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.CreativesGteCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.CreativesLtCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.CreativesLteCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.CreativesInCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.CreativesLikeCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.CreativesFuzzyCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.CreativesKeywordCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.CreativesContainsCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.CreativesNotCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.CreativesAndCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.CreativesOrCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.CreativesAnyCondition`
     :   The type of the None singleton.
 
+<a id="CreativesOrCondition"></a>
+
 `CreativesOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -4697,6 +5053,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.linkedin_ads.types.CreativesEqCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.CreativesNeqCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.CreativesGtCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.CreativesGteCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.CreativesLtCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.CreativesLteCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.CreativesInCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.CreativesLikeCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.CreativesFuzzyCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.CreativesKeywordCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.CreativesContainsCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.CreativesNotCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.CreativesAndCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.CreativesOrCondition | airbyte_agent_sdk.connectors.linkedin_ads.types.CreativesAnyCondition]`
     :   The type of the None singleton.
+
+<a id="CreativesSearchFilter"></a>
 
 `CreativesSearchFilter(*args, **kwargs)`
 :   Available fields for filtering creatives search queries.
@@ -4746,6 +5104,8 @@ Classes
     `serving_hold_reasons: list[typing.Any] | None`
     :   Reasons for holding creative from serving
 
+<a id="CreativesSearchQuery"></a>
+
 `CreativesSearchQuery(*args, **kwargs)`
 :   Search query for creatives entity.
 
@@ -4760,6 +5120,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.linkedin_ads.types.CreativesSortFilter]`
     :   The type of the None singleton.
+
+<a id="CreativesSortFilter"></a>
 
 `CreativesSortFilter(*args, **kwargs)`
 :   Available fields for sorting creatives search results.
@@ -4808,6 +5170,8 @@ Classes
 
     `serving_hold_reasons: Literal['asc', 'desc']`
     :   Reasons for holding creative from serving
+
+<a id="CreativesStringFilter"></a>
 
 `CreativesStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/mailchimp/connector.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/mailchimp/connector.md
@@ -10,6 +10,8 @@ Mailchimp connector.
 Classes
 -------
 
+<a id="AutomationsQuery"></a>
+
 `AutomationsQuery(connector: MailchimpConnector)`
 :   Query class for Automations entity operations.
     
@@ -32,6 +34,8 @@ Classes
         
         Returns:
             AutomationsListResult
+
+<a id="CampaignsQuery"></a>
 
 `CampaignsQuery(connector: MailchimpConnector)`
 :   Query class for Campaigns entity operations.
@@ -115,6 +119,8 @@ Classes
         Returns:
             CampaignsListResult
 
+<a id="EmailActivityQuery"></a>
+
 `EmailActivityQuery(connector: MailchimpConnector)`
 :   Query class for EmailActivity entity operations.
     
@@ -167,6 +173,8 @@ Classes
         Returns:
             EmailActivityListResult
 
+<a id="InterestCategoriesQuery"></a>
+
 `InterestCategoriesQuery(connector: MailchimpConnector)`
 :   Query class for InterestCategories entity operations.
     
@@ -196,6 +204,8 @@ Classes
         
         Returns:
             InterestCategoriesListResult
+
+<a id="InterestsQuery"></a>
 
 `InterestsQuery(connector: MailchimpConnector)`
 :   Query class for Interests entity operations.
@@ -228,6 +238,8 @@ Classes
         
         Returns:
             InterestsListResult
+
+<a id="ListMembersQuery"></a>
 
 `ListMembersQuery(connector: MailchimpConnector)`
 :   Query class for ListMembers entity operations.
@@ -271,6 +283,8 @@ Classes
         
         Returns:
             ListMembersListResult
+
+<a id="ListsQuery"></a>
 
 `ListsQuery(connector: MailchimpConnector)`
 :   Query class for Lists entity operations.
@@ -349,6 +363,8 @@ Classes
         
         Returns:
             ListsListResult
+
+<a id="MailchimpConnector"></a>
 
 `MailchimpConnector(auth_config: MailchimpAuthConfig | AirbyteAuthConfig | BaseModel | None = None, on_token_refresh: Any | None = None, data_center: str | None = None)`
 :   Type-safe Mailchimp API connector.
@@ -538,6 +554,8 @@ Classes
             for entity in entities:
                 print(f"\{entity['entity_name']\}: \{entity['available_actions']\}")
 
+<a id="ReportsQuery"></a>
+
 `ReportsQuery(connector: MailchimpConnector)`
 :   Query class for Reports entity operations.
     
@@ -617,6 +635,8 @@ Classes
         Returns:
             ReportsListResult
 
+<a id="SegmentMembersQuery"></a>
+
 `SegmentMembersQuery(connector: MailchimpConnector)`
 :   Query class for SegmentMembers entity operations.
     
@@ -636,6 +656,8 @@ Classes
         
         Returns:
             SegmentMembersListResult
+
+<a id="SegmentsQuery"></a>
 
 `SegmentsQuery(connector: MailchimpConnector)`
 :   Query class for Segments entity operations.
@@ -672,6 +694,8 @@ Classes
         Returns:
             SegmentsListResult
 
+<a id="TagsQuery"></a>
+
 `TagsQuery(connector: MailchimpConnector)`
 :   Query class for Tags entity operations.
     
@@ -689,6 +713,8 @@ Classes
         
         Returns:
             TagsListResult
+
+<a id="UnsubscribesQuery"></a>
 
 `UnsubscribesQuery(connector: MailchimpConnector)`
 :   Query class for Unsubscribes entity operations.

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/mailchimp/index.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/mailchimp/index.md
@@ -19,6 +19,8 @@ Sub-modules
 Classes
 -------
 
+<a id="AirbyteAuthConfig"></a>
+
 `AirbyteAuthConfig(**data: Any)`
 :   Authentication configuration for Airbyte hosted mode execution.
     
@@ -87,6 +89,8 @@ Classes
     `workspace_name: str | None`
     :   The type of the None singleton.
 
+<a id="AirbyteSearchMeta"></a>
+
 `AirbyteSearchMeta(**data: Any)`
 :   Pagination metadata for search responses.
     
@@ -114,6 +118,8 @@ Classes
 
     `took_ms: int | None`
     :   Time taken to execute the search in milliseconds.
+
+<a id="AirbyteSearchResult"></a>
 
 `AirbyteSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -148,6 +154,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="CampaignsSearchResult"></a>
+
 `CampaignsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -163,6 +171,8 @@ Classes
     * airbyte_agent_sdk.connectors.mailchimp.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="EmailActivitySearchResult"></a>
 
 `EmailActivitySearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -180,6 +190,8 @@ Classes
     * pydantic.main.BaseModel
     * typing.Generic
 
+<a id="ListsSearchResult"></a>
+
 `ListsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -196,6 +208,8 @@ Classes
     * pydantic.main.BaseModel
     * typing.Generic
 
+<a id="ReportsSearchResult"></a>
+
 `ReportsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -211,6 +225,8 @@ Classes
     * airbyte_agent_sdk.connectors.mailchimp.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="CampaignsSearchData"></a>
 
 `CampaignsSearchData(**data: Any)`
 :   Search result data for campaigns entity.
@@ -297,6 +313,8 @@ Classes
     `web_id: int | None`
     :   The ID used in the Mailchimp web application. View this campaign in your Mailchimp account at `ht...
 
+<a id="EmailActivitySearchData"></a>
+
 `EmailActivitySearchData(**data: Any)`
 :   Search result data for email_activity entity.
     
@@ -345,6 +363,8 @@ Classes
 
     `url: str | None`
     :   If the action is a 'click', the URL on which the member clicked.
+
+<a id="ListsSearchData"></a>
 
 `ListsSearchData(**data: Any)`
 :   Search result data for lists entity.
@@ -428,6 +448,8 @@ Classes
     `web_id: int | None`
     :   The ID used in the Mailchimp web application. View this list in your Mailchimp account at `https:...
 
+<a id="MailchimpAuthConfig"></a>
+
 `MailchimpAuthConfig(**data: Any)`
 :   API Key Authentication
     
@@ -449,6 +471,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="MailchimpConnector"></a>
 
 `MailchimpConnector(auth_config: MailchimpAuthConfig | AirbyteAuthConfig | BaseModel | None = None, on_token_refresh: Any | None = None, data_center: str | None = None)`
 :   Type-safe Mailchimp API connector.
@@ -637,6 +661,8 @@ Classes
             entities = connector.list_entities()
             for entity in entities:
                 print(f"\{entity['entity_name']\}: \{entity['available_actions']\}")
+
+<a id="ReportsSearchData"></a>
 
 `ReportsSearchData(**data: Any)`
 :   Search result data for reports entity.

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/mailchimp/models.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/mailchimp/models.md
@@ -13,6 +13,8 @@ and response envelope types.
 Classes
 -------
 
+<a id="AirbyteSearchMeta"></a>
+
 `AirbyteSearchMeta(**data: Any)`
 :   Pagination metadata for search responses.
     
@@ -40,6 +42,8 @@ Classes
 
     `took_ms: int | None`
     :   Time taken to execute the search in milliseconds.
+
+<a id="AirbyteSearchResult"></a>
 
 `AirbyteSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -95,6 +99,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="CampaignsSearchResult"></a>
+
 `CampaignsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -131,6 +137,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="EmailActivitySearchResult"></a>
 
 `EmailActivitySearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -169,6 +177,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="ListsSearchResult"></a>
+
 `ListsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -206,6 +216,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="ReportsSearchResult"></a>
+
 `ReportsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -221,6 +233,8 @@ Classes
     * airbyte_agent_sdk.connectors.mailchimp.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="Automation"></a>
 
 `Automation(**data: Any)`
 :   A summary of an individual Automation workflow's settings and content
@@ -268,6 +282,8 @@ Classes
     `tracking: airbyte_agent_sdk.connectors.mailchimp.models.AutomationTracking | Any | None`
     :   The type of the None singleton.
 
+<a id="AutomationRecipients"></a>
+
 `AutomationRecipients(**data: Any)`
 :   List settings for the Automation
     
@@ -302,6 +318,8 @@ Classes
     `store_id: str | Any | None`
     :   The id of the store
 
+<a id="AutomationRecipientsSegmentOpts"></a>
+
 `AutomationRecipientsSegmentOpts(**data: Any)`
 :   An object representing all segmentation options
     
@@ -329,6 +347,8 @@ Classes
 
     `saved_segment_id: int | Any | None`
     :   The id for an existing saved segment
+
+<a id="AutomationReportSummary"></a>
 
 `AutomationReportSummary(**data: Any)`
 :   A summary of opens and clicks for sent campaigns
@@ -366,6 +386,8 @@ Classes
 
     `unique_opens: int | Any | None`
     :   The number of unique opens
+
+<a id="AutomationSettings"></a>
 
 `AutomationSettings(**data: Any)`
 :   The settings for the Automation workflow
@@ -410,6 +432,8 @@ Classes
     `use_conversation: bool | Any | None`
     :   Whether to use Mailchimp Conversation feature
 
+<a id="AutomationTracking"></a>
+
 `AutomationTracking(**data: Any)`
 :   The tracking options for the Automation
     
@@ -450,6 +474,8 @@ Classes
     `text_clicks: bool | Any | None`
     :   Whether to track clicks in the plain-text version
 
+<a id="AutomationsList"></a>
+
 `AutomationsList(**data: Any)`
 :   A summary of the Automations for an account
     
@@ -478,6 +504,8 @@ Classes
     `total_items: int | Any`
     :   The type of the None singleton.
 
+<a id="AutomationsListResultMeta"></a>
+
 `AutomationsListResultMeta(**data: Any)`
 :   Metadata for automations.Action.LIST operation
     
@@ -499,6 +527,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="Campaign"></a>
 
 `Campaign(**data: Any)`
 :   A summary of an individual campaign's settings and content
@@ -573,6 +603,8 @@ Classes
     `web_id: int | Any | None`
     :   The type of the None singleton.
 
+<a id="CampaignDeliveryStatus"></a>
+
 `CampaignDeliveryStatus(**data: Any)`
 :   Updates on campaigns in the process of sending
     
@@ -607,6 +639,8 @@ Classes
     `status: str | Any | None`
     :   The current state of a campaign delivery
 
+<a id="CampaignRecipients"></a>
+
 `CampaignRecipients(**data: Any)`
 :   List settings for the campaign
     
@@ -640,6 +674,8 @@ Classes
 
     `segment_text: str | Any | None`
     :   A description of the segment used for the campaign
+
+<a id="CampaignReportSummary"></a>
 
 `CampaignReportSummary(**data: Any)`
 :   For sent campaigns, a summary of opens, clicks, and e-commerce data
@@ -681,6 +717,8 @@ Classes
     `unique_opens: int | Any | None`
     :   The number of unique opens
 
+<a id="CampaignReportSummaryEcommerce"></a>
+
 `CampaignReportSummaryEcommerce(**data: Any)`
 :   E-Commerce stats for a campaign
     
@@ -708,6 +746,8 @@ Classes
 
     `total_spent: float | Any | None`
     :   The total spent for a campaign
+
+<a id="CampaignSettings"></a>
 
 `CampaignSettings(**data: Any)`
 :   The settings for your campaign
@@ -776,6 +816,8 @@ Classes
     `use_conversation: bool | Any | None`
     :   Use Mailchimp Conversation feature to manage out-of-office replies
 
+<a id="CampaignTracking"></a>
+
 `CampaignTracking(**data: Any)`
 :   The tracking options for a campaign
     
@@ -816,6 +858,8 @@ Classes
     `text_clicks: bool | Any | None`
     :   Whether to track clicks in the plain-text version of the campaign
 
+<a id="CampaignsList"></a>
+
 `CampaignsList(**data: Any)`
 :   A collection of campaigns
     
@@ -844,6 +888,8 @@ Classes
     `total_items: int | Any`
     :   The type of the None singleton.
 
+<a id="CampaignsListResultMeta"></a>
+
 `CampaignsListResultMeta(**data: Any)`
 :   Metadata for campaigns.Action.LIST operation
     
@@ -865,6 +911,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="CampaignsSearchData"></a>
 
 `CampaignsSearchData(**data: Any)`
 :   Search result data for campaigns entity.
@@ -951,6 +999,8 @@ Classes
     `web_id: int | None`
     :   The ID used in the Mailchimp web application. View this campaign in your Mailchimp account at `ht...
 
+<a id="EmailActivity"></a>
+
 `EmailActivity(**data: Any)`
 :   A summary of the email activity for a campaign
     
@@ -988,6 +1038,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="EmailActivityActivityItem"></a>
+
 `EmailActivityActivityItem(**data: Any)`
 :   Nested schema for EmailActivity.activity_item
     
@@ -1022,6 +1074,8 @@ Classes
     `url: str | Any | None`
     :   If the action is a click, the URL on which the member clicked
 
+<a id="EmailActivityList"></a>
+
 `EmailActivityList(**data: Any)`
 :   A list of member's subscriber activity in a specific campaign
     
@@ -1053,6 +1107,8 @@ Classes
     `total_items: int | Any`
     :   The type of the None singleton.
 
+<a id="EmailActivityListResultMeta"></a>
+
 `EmailActivityListResultMeta(**data: Any)`
 :   Metadata for email_activity.Action.LIST operation
     
@@ -1074,6 +1130,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="EmailActivitySearchData"></a>
 
 `EmailActivitySearchData(**data: Any)`
 :   Search result data for email_activity entity.
@@ -1124,6 +1182,8 @@ Classes
     `url: str | None`
     :   If the action is a 'click', the URL on which the member clicked.
 
+<a id="Interest"></a>
+
 `Interest(**data: Any)`
 :   Assign subscribers to interests to group them together
     
@@ -1161,6 +1221,8 @@ Classes
     `subscriber_count: str | Any | None`
     :   The type of the None singleton.
 
+<a id="InterestCategoriesList"></a>
+
 `InterestCategoriesList(**data: Any)`
 :   Information about this list's interest categories
     
@@ -1192,6 +1254,8 @@ Classes
     `total_items: int | Any`
     :   The type of the None singleton.
 
+<a id="InterestCategoriesListResultMeta"></a>
+
 `InterestCategoriesListResultMeta(**data: Any)`
 :   Metadata for interest_categories.Action.LIST operation
     
@@ -1213,6 +1277,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="InterestCategory"></a>
 
 `InterestCategory(**data: Any)`
 :   Interest categories organize interests, which are used to group subscribers based on their preferences
@@ -1248,6 +1314,8 @@ Classes
     `type_: str | Any | None`
     :   The type of the None singleton.
 
+<a id="InterestsList"></a>
+
 `InterestsList(**data: Any)`
 :   A list of interests for a specific list
     
@@ -1282,6 +1350,8 @@ Classes
     `total_items: int | Any`
     :   The type of the None singleton.
 
+<a id="InterestsListResultMeta"></a>
+
 `InterestsListResultMeta(**data: Any)`
 :   Metadata for interests.Action.LIST operation
     
@@ -1303,6 +1373,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="Link"></a>
 
 `Link(**data: Any)`
 :   A HAL-style link relating the current resource to another.
@@ -1337,6 +1409,8 @@ Classes
 
     `target_schema: str | Any | None`
     :   The type of the None singleton.
+
+<a id="List"></a>
 
 `List(**data: Any)`
 :   Information about a specific list
@@ -1417,6 +1491,8 @@ Classes
     `web_id: int | Any | None`
     :   The type of the None singleton.
 
+<a id="ListCampaignDefaults"></a>
+
 `ListCampaignDefaults(**data: Any)`
 :   Default values for campaigns created for this list
     
@@ -1447,6 +1523,8 @@ Classes
 
     `subject: str | Any | None`
     :   The default subject line for campaigns sent to this list
+
+<a id="ListContact"></a>
 
 `ListContact(**data: Any)`
 :   Contact information displayed in campaign footers to comply with international spam laws
@@ -1490,6 +1568,8 @@ Classes
 
     `zip: str | Any | None`
     :   The postal or zip code for the list contact
+
+<a id="ListMember"></a>
 
 `ListMember(**data: Any)`
 :   Individuals who are currently or have been previously subscribed to this list
@@ -1591,6 +1671,8 @@ Classes
     `web_id: int | Any | None`
     :   The type of the None singleton.
 
+<a id="ListMemberLocation"></a>
+
 `ListMemberLocation(**data: Any)`
 :   Subscriber location information
     
@@ -1631,6 +1713,8 @@ Classes
     `timezone: str | Any | None`
     :   The timezone for the location
 
+<a id="ListMemberStats"></a>
+
 `ListMemberStats(**data: Any)`
 :   Open and click rates for this subscriber
     
@@ -1658,6 +1742,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="ListMemberStatsEcommerceData"></a>
 
 `ListMemberStatsEcommerceData(**data: Any)`
 :   Ecommerce stats for the list member if the list is attached to a store
@@ -1687,6 +1773,8 @@ Classes
     `total_revenue: float | Any | None`
     :   The total revenue the list member has brought in
 
+<a id="ListMemberTagsItem"></a>
+
 `ListMemberTagsItem(**data: Any)`
 :   Nested schema for ListMember.tags_item
     
@@ -1711,6 +1799,8 @@ Classes
 
     `name: str | Any | None`
     :   The name of the tag
+
+<a id="ListMembersList"></a>
 
 `ListMembersList(**data: Any)`
 :   Manage members of a specific Mailchimp list
@@ -1743,6 +1833,8 @@ Classes
     `total_items: int | Any`
     :   The type of the None singleton.
 
+<a id="ListMembersListResultMeta"></a>
+
 `ListMembersListResultMeta(**data: Any)`
 :   Metadata for list_members.Action.LIST operation
     
@@ -1764,6 +1856,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="ListStats"></a>
 
 `ListStats(**data: Any)`
 :   Stats for the list
@@ -1835,6 +1929,8 @@ Classes
     `unsubscribe_count_since_send: int | Any | None`
     :   The number of members who have unsubscribed since the last campaign was sent
 
+<a id="ListsList"></a>
+
 `ListsList(**data: Any)`
 :   A collection of subscriber lists for this account
     
@@ -1863,6 +1959,8 @@ Classes
     `total_items: int | Any`
     :   The type of the None singleton.
 
+<a id="ListsListResultMeta"></a>
+
 `ListsListResultMeta(**data: Any)`
 :   Metadata for lists.Action.LIST operation
     
@@ -1884,6 +1982,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="ListsSearchData"></a>
 
 `ListsSearchData(**data: Any)`
 :   Search result data for lists entity.
@@ -1967,6 +2067,8 @@ Classes
     `web_id: int | None`
     :   The ID used in the Mailchimp web application. View this list in your Mailchimp account at `https:...
 
+<a id="MailchimpAuthConfig"></a>
+
 `MailchimpAuthConfig(**data: Any)`
 :   API Key Authentication
     
@@ -1988,6 +2090,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="MailchimpCheckResult"></a>
 
 `MailchimpCheckResult(**data: Any)`
 :   Result of a health check operation.
@@ -2022,6 +2126,8 @@ Classes
     `status: str`
     :   Health check status: 'healthy' or 'unhealthy'.
 
+<a id="MailchimpExecuteResult"></a>
+
 `MailchimpExecuteResult(**data: Any)`
 :   Response envelope with data only.
     
@@ -2050,6 +2156,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="MailchimpExecuteResultWithMeta"></a>
 
 `MailchimpExecuteResultWithMeta(**data: Any)`
 :   Response envelope with data and metadata.
@@ -2113,6 +2221,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="AutomationsListResult"></a>
+
 `AutomationsListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -2155,6 +2265,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="CampaignsListResult"></a>
 
 `CampaignsListResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -2199,6 +2311,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="EmailActivityListResult"></a>
+
 `EmailActivityListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -2241,6 +2355,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="InterestCategoriesListResult"></a>
 
 `InterestCategoriesListResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -2285,6 +2401,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="InterestsListResult"></a>
+
 `InterestsListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -2327,6 +2445,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="ListMembersListResult"></a>
 
 `ListMembersListResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -2371,6 +2491,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="ListsListResult"></a>
+
 `ListsListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -2413,6 +2535,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="ReportsListResult"></a>
 
 `ReportsListResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -2457,6 +2581,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="SegmentMembersListResult"></a>
+
 `SegmentMembersListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -2499,6 +2625,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="SegmentsListResult"></a>
 
 `SegmentsListResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -2543,6 +2671,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="TagsListResult"></a>
+
 `TagsListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -2586,6 +2716,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="UnsubscribesListResult"></a>
+
 `UnsubscribesListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -2604,6 +2736,8 @@ Classes
     * airbyte_agent_sdk.connectors.mailchimp.models.MailchimpExecuteResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="Report"></a>
 
 `Report(**data: Any)`
 :   Report details about a sent campaign
@@ -2690,6 +2824,8 @@ Classes
     `unsubscribed: int | Any | None`
     :   The type of the None singleton.
 
+<a id="ReportBounces"></a>
+
 `ReportBounces(**data: Any)`
 :   An object describing the bounce summary for the campaign
     
@@ -2717,6 +2853,8 @@ Classes
 
     `syntax_errors: int | Any | None`
     :   The total number of addresses that were syntax-related bounces
+
+<a id="ReportClicks"></a>
 
 `ReportClicks(**data: Any)`
 :   An object describing the click activity for the campaign
@@ -2752,6 +2890,8 @@ Classes
     `unique_subscriber_clicks: int | Any | None`
     :   The total number of subscribers who clicked on a campaign
 
+<a id="ReportDeliveryStatus"></a>
+
 `ReportDeliveryStatus(**data: Any)`
 :   Updates on campaigns in the process of sending
     
@@ -2773,6 +2913,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="ReportEcommerce"></a>
 
 `ReportEcommerce(**data: Any)`
 :   E-Commerce stats for a campaign
@@ -2802,6 +2944,8 @@ Classes
     `total_spent: float | Any | None`
     :   The total spent for a campaign
 
+<a id="ReportFacebookLikes"></a>
+
 `ReportFacebookLikes(**data: Any)`
 :   An object describing campaign engagement on Facebook
     
@@ -2830,6 +2974,8 @@ Classes
     `unique_likes: int | Any | None`
     :   The number of unique likes
 
+<a id="ReportForwards"></a>
+
 `ReportForwards(**data: Any)`
 :   An object describing the forwards and forward activity for the campaign
     
@@ -2854,6 +3000,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="ReportIndustryStats"></a>
 
 `ReportIndustryStats(**data: Any)`
 :   The average campaign statistics for your industry
@@ -2895,6 +3043,8 @@ Classes
     `unsub_rate: float | Any | None`
     :   The industry unsubscribe rate
 
+<a id="ReportListStats"></a>
+
 `ReportListStats(**data: Any)`
 :   The average campaign statistics for your list
     
@@ -2925,6 +3075,8 @@ Classes
 
     `unsub_rate: float | Any | None`
     :   The average number of unsubscriptions per month for the list
+
+<a id="ReportOpens"></a>
 
 `ReportOpens(**data: Any)`
 :   An object describing the open activity for the campaign
@@ -2957,6 +3109,8 @@ Classes
     `unique_opens: int | Any | None`
     :   The total number of unique opens
 
+<a id="ReportsList"></a>
+
 `ReportsList(**data: Any)`
 :   A list of reports containing campaigns marked as Sent
     
@@ -2985,6 +3139,8 @@ Classes
     `total_items: int | Any`
     :   The type of the None singleton.
 
+<a id="ReportsListResultMeta"></a>
+
 `ReportsListResultMeta(**data: Any)`
 :   Metadata for reports.Action.LIST operation
     
@@ -3006,6 +3162,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="ReportsSearchData"></a>
 
 `ReportsSearchData(**data: Any)`
 :   Search result data for reports entity.
@@ -3104,6 +3262,8 @@ Classes
     `unsubscribed: int | None`
     :   The total number of unsubscribed members for this campaign.
 
+<a id="Segment"></a>
+
 `Segment(**data: Any)`
 :   Information about a specific segment
     
@@ -3146,6 +3306,8 @@ Classes
 
     `updated_at: str | Any | None`
     :   The type of the None singleton.
+
+<a id="SegmentMember"></a>
 
 `SegmentMember(**data: Any)`
 :   Individuals who are currently or have been previously subscribed to this list
@@ -3223,6 +3385,8 @@ Classes
     `vip: bool | Any | None`
     :   The type of the None singleton.
 
+<a id="SegmentMemberLocation"></a>
+
 `SegmentMemberLocation(**data: Any)`
 :   Subscriber location information
     
@@ -3263,6 +3427,8 @@ Classes
     `timezone: str | Any | None`
     :   The timezone for the location
 
+<a id="SegmentMemberStats"></a>
+
 `SegmentMemberStats(**data: Any)`
 :   Open and click rates for this subscriber
     
@@ -3287,6 +3453,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="SegmentMembersList"></a>
 
 `SegmentMembersList(**data: Any)`
 :   View members in a specific list segment
@@ -3316,6 +3484,8 @@ Classes
     `total_items: int | Any`
     :   The type of the None singleton.
 
+<a id="SegmentMembersListResultMeta"></a>
+
 `SegmentMembersListResultMeta(**data: Any)`
 :   Metadata for segment_members.Action.LIST operation
     
@@ -3337,6 +3507,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="SegmentOptions"></a>
 
 `SegmentOptions(**data: Any)`
 :   The conditions of the segment
@@ -3362,6 +3534,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="SegmentsList"></a>
 
 `SegmentsList(**data: Any)`
 :   A list of available segments
@@ -3394,6 +3568,8 @@ Classes
     `total_items: int | Any`
     :   The type of the None singleton.
 
+<a id="SegmentsListResultMeta"></a>
+
 `SegmentsListResultMeta(**data: Any)`
 :   Metadata for segments.Action.LIST operation
     
@@ -3415,6 +3591,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="Tag"></a>
 
 `Tag(**data: Any)`
 :   A tag that can be assigned to a list member
@@ -3440,6 +3618,8 @@ Classes
 
     `name: str | Any | None`
     :   The type of the None singleton.
+
+<a id="TagsList"></a>
 
 `TagsList(**data: Any)`
 :   A list of tags assigned to a list
@@ -3469,6 +3649,8 @@ Classes
     `total_items: int | Any`
     :   The type of the None singleton.
 
+<a id="TagsListResultMeta"></a>
+
 `TagsListResultMeta(**data: Any)`
 :   Metadata for tags.Action.LIST operation
     
@@ -3490,6 +3672,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="Unsubscribe"></a>
 
 `Unsubscribe(**data: Any)`
 :   A member who unsubscribed from a specific campaign
@@ -3537,6 +3721,8 @@ Classes
     `vip: bool | Any | None`
     :   The type of the None singleton.
 
+<a id="UnsubscribesList"></a>
+
 `UnsubscribesList(**data: Any)`
 :   A list of members who have unsubscribed from a specific campaign
     
@@ -3567,6 +3753,8 @@ Classes
 
     `unsubscribes: list[airbyte_agent_sdk.connectors.mailchimp.models.Unsubscribe] | Any`
     :   The type of the None singleton.
+
+<a id="UnsubscribesListResultMeta"></a>
 
 `UnsubscribesListResultMeta(**data: Any)`
 :   Metadata for unsubscribes.Action.LIST operation

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/mailchimp/types.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/mailchimp/types.md
@@ -10,6 +10,8 @@ Type definitions for mailchimp connector.
 Classes
 -------
 
+<a id="AirbyteSearchParams"></a>
+
 `AirbyteSearchParams(*args, **kwargs)`
 :   Parameters for Airbyte cache search operations (generic, use entity-specific query types for better type hints).
 
@@ -30,6 +32,8 @@ Classes
 
     `query: dict[str, typing.Any]`
     :   The type of the None singleton.
+
+<a id="AutomationsListParams"></a>
 
 `AutomationsListParams(*args, **kwargs)`
 :   Parameters for automations.list operation
@@ -61,6 +65,8 @@ Classes
     `status: str`
     :   The type of the None singleton.
 
+<a id="CampaignsAndCondition"></a>
+
 `CampaignsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -81,6 +87,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.mailchimp.types.CampaignsEqCondition | airbyte_agent_sdk.connectors.mailchimp.types.CampaignsNeqCondition | airbyte_agent_sdk.connectors.mailchimp.types.CampaignsGtCondition | airbyte_agent_sdk.connectors.mailchimp.types.CampaignsGteCondition | airbyte_agent_sdk.connectors.mailchimp.types.CampaignsLtCondition | airbyte_agent_sdk.connectors.mailchimp.types.CampaignsLteCondition | airbyte_agent_sdk.connectors.mailchimp.types.CampaignsInCondition | airbyte_agent_sdk.connectors.mailchimp.types.CampaignsLikeCondition | airbyte_agent_sdk.connectors.mailchimp.types.CampaignsFuzzyCondition | airbyte_agent_sdk.connectors.mailchimp.types.CampaignsKeywordCondition | airbyte_agent_sdk.connectors.mailchimp.types.CampaignsContainsCondition | airbyte_agent_sdk.connectors.mailchimp.types.CampaignsNotCondition | airbyte_agent_sdk.connectors.mailchimp.types.CampaignsAndCondition | airbyte_agent_sdk.connectors.mailchimp.types.CampaignsOrCondition | airbyte_agent_sdk.connectors.mailchimp.types.CampaignsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="CampaignsAnyCondition"></a>
+
 `CampaignsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -100,6 +108,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.mailchimp.types.CampaignsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="CampaignsAnyValueFilter"></a>
 
 `CampaignsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -176,6 +186,8 @@ Classes
     `web_id: Any`
     :   The ID used in the Mailchimp web application. View this campaign in your Mailchimp account at `ht...
 
+<a id="CampaignsContainsCondition"></a>
+
 `CampaignsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -187,6 +199,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.mailchimp.types.CampaignsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="CampaignsEqCondition"></a>
 
 `CampaignsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -200,6 +214,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.mailchimp.types.CampaignsSearchFilter`
     :   The type of the None singleton.
 
+<a id="CampaignsFuzzyCondition"></a>
+
 `CampaignsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -211,6 +227,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.mailchimp.types.CampaignsStringFilter`
     :   The type of the None singleton.
+
+<a id="CampaignsGetParams"></a>
 
 `CampaignsGetParams(*args, **kwargs)`
 :   Parameters for campaigns.get operation
@@ -224,6 +242,8 @@ Classes
     `campaign_id: str`
     :   The type of the None singleton.
 
+<a id="CampaignsGtCondition"></a>
+
 `CampaignsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -236,6 +256,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.mailchimp.types.CampaignsSearchFilter`
     :   The type of the None singleton.
 
+<a id="CampaignsGteCondition"></a>
+
 `CampaignsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -247,6 +269,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.mailchimp.types.CampaignsSearchFilter`
     :   The type of the None singleton.
+
+<a id="CampaignsInCondition"></a>
 
 `CampaignsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -267,6 +291,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.mailchimp.types.CampaignsInFilter`
     :   The type of the None singleton.
+
+<a id="CampaignsInFilter"></a>
 
 `CampaignsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -343,6 +369,8 @@ Classes
     `web_id: list[int]`
     :   The ID used in the Mailchimp web application. View this campaign in your Mailchimp account at `ht...
 
+<a id="CampaignsKeywordCondition"></a>
+
 `CampaignsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -355,6 +383,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.mailchimp.types.CampaignsStringFilter`
     :   The type of the None singleton.
 
+<a id="CampaignsLikeCondition"></a>
+
 `CampaignsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -366,6 +396,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.mailchimp.types.CampaignsStringFilter`
     :   The type of the None singleton.
+
+<a id="CampaignsListParams"></a>
 
 `CampaignsListParams(*args, **kwargs)`
 :   Parameters for campaigns.list operation
@@ -412,6 +444,8 @@ Classes
     `type: str`
     :   The type of the None singleton.
 
+<a id="CampaignsLtCondition"></a>
+
 `CampaignsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -423,6 +457,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.mailchimp.types.CampaignsSearchFilter`
     :   The type of the None singleton.
+
+<a id="CampaignsLteCondition"></a>
 
 `CampaignsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -436,6 +472,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.mailchimp.types.CampaignsSearchFilter`
     :   The type of the None singleton.
 
+<a id="CampaignsNeqCondition"></a>
+
 `CampaignsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -447,6 +485,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.mailchimp.types.CampaignsSearchFilter`
     :   The type of the None singleton.
+
+<a id="CampaignsNotCondition"></a>
 
 `CampaignsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -468,6 +508,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.mailchimp.types.CampaignsEqCondition | airbyte_agent_sdk.connectors.mailchimp.types.CampaignsNeqCondition | airbyte_agent_sdk.connectors.mailchimp.types.CampaignsGtCondition | airbyte_agent_sdk.connectors.mailchimp.types.CampaignsGteCondition | airbyte_agent_sdk.connectors.mailchimp.types.CampaignsLtCondition | airbyte_agent_sdk.connectors.mailchimp.types.CampaignsLteCondition | airbyte_agent_sdk.connectors.mailchimp.types.CampaignsInCondition | airbyte_agent_sdk.connectors.mailchimp.types.CampaignsLikeCondition | airbyte_agent_sdk.connectors.mailchimp.types.CampaignsFuzzyCondition | airbyte_agent_sdk.connectors.mailchimp.types.CampaignsKeywordCondition | airbyte_agent_sdk.connectors.mailchimp.types.CampaignsContainsCondition | airbyte_agent_sdk.connectors.mailchimp.types.CampaignsNotCondition | airbyte_agent_sdk.connectors.mailchimp.types.CampaignsAndCondition | airbyte_agent_sdk.connectors.mailchimp.types.CampaignsOrCondition | airbyte_agent_sdk.connectors.mailchimp.types.CampaignsAnyCondition`
     :   The type of the None singleton.
 
+<a id="CampaignsOrCondition"></a>
+
 `CampaignsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -487,6 +529,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.mailchimp.types.CampaignsEqCondition | airbyte_agent_sdk.connectors.mailchimp.types.CampaignsNeqCondition | airbyte_agent_sdk.connectors.mailchimp.types.CampaignsGtCondition | airbyte_agent_sdk.connectors.mailchimp.types.CampaignsGteCondition | airbyte_agent_sdk.connectors.mailchimp.types.CampaignsLtCondition | airbyte_agent_sdk.connectors.mailchimp.types.CampaignsLteCondition | airbyte_agent_sdk.connectors.mailchimp.types.CampaignsInCondition | airbyte_agent_sdk.connectors.mailchimp.types.CampaignsLikeCondition | airbyte_agent_sdk.connectors.mailchimp.types.CampaignsFuzzyCondition | airbyte_agent_sdk.connectors.mailchimp.types.CampaignsKeywordCondition | airbyte_agent_sdk.connectors.mailchimp.types.CampaignsContainsCondition | airbyte_agent_sdk.connectors.mailchimp.types.CampaignsNotCondition | airbyte_agent_sdk.connectors.mailchimp.types.CampaignsAndCondition | airbyte_agent_sdk.connectors.mailchimp.types.CampaignsOrCondition | airbyte_agent_sdk.connectors.mailchimp.types.CampaignsAnyCondition]`
     :   The type of the None singleton.
+
+<a id="CampaignsSearchFilter"></a>
 
 `CampaignsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering campaigns search queries.
@@ -563,6 +607,8 @@ Classes
     `web_id: int | None`
     :   The ID used in the Mailchimp web application. View this campaign in your Mailchimp account at `ht...
 
+<a id="CampaignsSearchQuery"></a>
+
 `CampaignsSearchQuery(*args, **kwargs)`
 :   Search query for campaigns entity.
 
@@ -577,6 +623,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.mailchimp.types.CampaignsSortFilter]`
     :   The type of the None singleton.
+
+<a id="CampaignsSortFilter"></a>
 
 `CampaignsSortFilter(*args, **kwargs)`
 :   Available fields for sorting campaigns search results.
@@ -653,6 +701,8 @@ Classes
     `web_id: Literal['asc', 'desc']`
     :   The ID used in the Mailchimp web application. View this campaign in your Mailchimp account at `ht...
 
+<a id="CampaignsStringFilter"></a>
+
 `CampaignsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -728,6 +778,8 @@ Classes
     `web_id: str`
     :   The ID used in the Mailchimp web application. View this campaign in your Mailchimp account at `ht...
 
+<a id="EmailActivityAndCondition"></a>
+
 `EmailActivityAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -748,6 +800,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.mailchimp.types.EmailActivityEqCondition | airbyte_agent_sdk.connectors.mailchimp.types.EmailActivityNeqCondition | airbyte_agent_sdk.connectors.mailchimp.types.EmailActivityGtCondition | airbyte_agent_sdk.connectors.mailchimp.types.EmailActivityGteCondition | airbyte_agent_sdk.connectors.mailchimp.types.EmailActivityLtCondition | airbyte_agent_sdk.connectors.mailchimp.types.EmailActivityLteCondition | airbyte_agent_sdk.connectors.mailchimp.types.EmailActivityInCondition | airbyte_agent_sdk.connectors.mailchimp.types.EmailActivityLikeCondition | airbyte_agent_sdk.connectors.mailchimp.types.EmailActivityFuzzyCondition | airbyte_agent_sdk.connectors.mailchimp.types.EmailActivityKeywordCondition | airbyte_agent_sdk.connectors.mailchimp.types.EmailActivityContainsCondition | airbyte_agent_sdk.connectors.mailchimp.types.EmailActivityNotCondition | airbyte_agent_sdk.connectors.mailchimp.types.EmailActivityAndCondition | airbyte_agent_sdk.connectors.mailchimp.types.EmailActivityOrCondition | airbyte_agent_sdk.connectors.mailchimp.types.EmailActivityAnyCondition]`
     :   The type of the None singleton.
 
+<a id="EmailActivityAnyCondition"></a>
+
 `EmailActivityAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -767,6 +821,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.mailchimp.types.EmailActivityAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="EmailActivityAnyValueFilter"></a>
 
 `EmailActivityAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -807,6 +863,8 @@ Classes
     `url: Any`
     :   If the action is a 'click', the URL on which the member clicked.
 
+<a id="EmailActivityContainsCondition"></a>
+
 `EmailActivityContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -818,6 +876,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.mailchimp.types.EmailActivityAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="EmailActivityEqCondition"></a>
 
 `EmailActivityEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -831,6 +891,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.mailchimp.types.EmailActivitySearchFilter`
     :   The type of the None singleton.
 
+<a id="EmailActivityFuzzyCondition"></a>
+
 `EmailActivityFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -842,6 +904,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.mailchimp.types.EmailActivityStringFilter`
     :   The type of the None singleton.
+
+<a id="EmailActivityGtCondition"></a>
 
 `EmailActivityGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
@@ -855,6 +919,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.mailchimp.types.EmailActivitySearchFilter`
     :   The type of the None singleton.
 
+<a id="EmailActivityGteCondition"></a>
+
 `EmailActivityGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -866,6 +932,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.mailchimp.types.EmailActivitySearchFilter`
     :   The type of the None singleton.
+
+<a id="EmailActivityInCondition"></a>
 
 `EmailActivityInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -886,6 +954,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.mailchimp.types.EmailActivityInFilter`
     :   The type of the None singleton.
+
+<a id="EmailActivityInFilter"></a>
 
 `EmailActivityInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -926,6 +996,8 @@ Classes
     `url: list[str]`
     :   If the action is a 'click', the URL on which the member clicked.
 
+<a id="EmailActivityKeywordCondition"></a>
+
 `EmailActivityKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -938,6 +1010,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.mailchimp.types.EmailActivityStringFilter`
     :   The type of the None singleton.
 
+<a id="EmailActivityLikeCondition"></a>
+
 `EmailActivityLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -949,6 +1023,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.mailchimp.types.EmailActivityStringFilter`
     :   The type of the None singleton.
+
+<a id="EmailActivityListParams"></a>
 
 `EmailActivityListParams(*args, **kwargs)`
 :   Parameters for email_activity.list operation
@@ -971,6 +1047,8 @@ Classes
     `since: str`
     :   The type of the None singleton.
 
+<a id="EmailActivityLtCondition"></a>
+
 `EmailActivityLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -982,6 +1060,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.mailchimp.types.EmailActivitySearchFilter`
     :   The type of the None singleton.
+
+<a id="EmailActivityLteCondition"></a>
 
 `EmailActivityLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -995,6 +1075,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.mailchimp.types.EmailActivitySearchFilter`
     :   The type of the None singleton.
 
+<a id="EmailActivityNeqCondition"></a>
+
 `EmailActivityNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -1006,6 +1088,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.mailchimp.types.EmailActivitySearchFilter`
     :   The type of the None singleton.
+
+<a id="EmailActivityNotCondition"></a>
 
 `EmailActivityNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -1027,6 +1111,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.mailchimp.types.EmailActivityEqCondition | airbyte_agent_sdk.connectors.mailchimp.types.EmailActivityNeqCondition | airbyte_agent_sdk.connectors.mailchimp.types.EmailActivityGtCondition | airbyte_agent_sdk.connectors.mailchimp.types.EmailActivityGteCondition | airbyte_agent_sdk.connectors.mailchimp.types.EmailActivityLtCondition | airbyte_agent_sdk.connectors.mailchimp.types.EmailActivityLteCondition | airbyte_agent_sdk.connectors.mailchimp.types.EmailActivityInCondition | airbyte_agent_sdk.connectors.mailchimp.types.EmailActivityLikeCondition | airbyte_agent_sdk.connectors.mailchimp.types.EmailActivityFuzzyCondition | airbyte_agent_sdk.connectors.mailchimp.types.EmailActivityKeywordCondition | airbyte_agent_sdk.connectors.mailchimp.types.EmailActivityContainsCondition | airbyte_agent_sdk.connectors.mailchimp.types.EmailActivityNotCondition | airbyte_agent_sdk.connectors.mailchimp.types.EmailActivityAndCondition | airbyte_agent_sdk.connectors.mailchimp.types.EmailActivityOrCondition | airbyte_agent_sdk.connectors.mailchimp.types.EmailActivityAnyCondition`
     :   The type of the None singleton.
 
+<a id="EmailActivityOrCondition"></a>
+
 `EmailActivityOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1046,6 +1132,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.mailchimp.types.EmailActivityEqCondition | airbyte_agent_sdk.connectors.mailchimp.types.EmailActivityNeqCondition | airbyte_agent_sdk.connectors.mailchimp.types.EmailActivityGtCondition | airbyte_agent_sdk.connectors.mailchimp.types.EmailActivityGteCondition | airbyte_agent_sdk.connectors.mailchimp.types.EmailActivityLtCondition | airbyte_agent_sdk.connectors.mailchimp.types.EmailActivityLteCondition | airbyte_agent_sdk.connectors.mailchimp.types.EmailActivityInCondition | airbyte_agent_sdk.connectors.mailchimp.types.EmailActivityLikeCondition | airbyte_agent_sdk.connectors.mailchimp.types.EmailActivityFuzzyCondition | airbyte_agent_sdk.connectors.mailchimp.types.EmailActivityKeywordCondition | airbyte_agent_sdk.connectors.mailchimp.types.EmailActivityContainsCondition | airbyte_agent_sdk.connectors.mailchimp.types.EmailActivityNotCondition | airbyte_agent_sdk.connectors.mailchimp.types.EmailActivityAndCondition | airbyte_agent_sdk.connectors.mailchimp.types.EmailActivityOrCondition | airbyte_agent_sdk.connectors.mailchimp.types.EmailActivityAnyCondition]`
     :   The type of the None singleton.
+
+<a id="EmailActivitySearchFilter"></a>
 
 `EmailActivitySearchFilter(*args, **kwargs)`
 :   Available fields for filtering email_activity search queries.
@@ -1086,6 +1174,8 @@ Classes
     `url: str | None`
     :   If the action is a 'click', the URL on which the member clicked.
 
+<a id="EmailActivitySearchQuery"></a>
+
 `EmailActivitySearchQuery(*args, **kwargs)`
 :   Search query for email_activity entity.
 
@@ -1100,6 +1190,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.mailchimp.types.EmailActivitySortFilter]`
     :   The type of the None singleton.
+
+<a id="EmailActivitySortFilter"></a>
 
 `EmailActivitySortFilter(*args, **kwargs)`
 :   Available fields for sorting email_activity search results.
@@ -1140,6 +1232,8 @@ Classes
     `url: Literal['asc', 'desc']`
     :   If the action is a 'click', the URL on which the member clicked.
 
+<a id="EmailActivityStringFilter"></a>
+
 `EmailActivityStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -1179,6 +1273,8 @@ Classes
     `url: str`
     :   If the action is a 'click', the URL on which the member clicked.
 
+<a id="InterestCategoriesGetParams"></a>
+
 `InterestCategoriesGetParams(*args, **kwargs)`
 :   Parameters for interest_categories.get operation
 
@@ -1193,6 +1289,8 @@ Classes
 
     `list_id: str`
     :   The type of the None singleton.
+
+<a id="InterestCategoriesListParams"></a>
 
 `InterestCategoriesListParams(*args, **kwargs)`
 :   Parameters for interest_categories.list operation
@@ -1212,6 +1310,8 @@ Classes
     `offset: int`
     :   The type of the None singleton.
 
+<a id="InterestsGetParams"></a>
+
 `InterestsGetParams(*args, **kwargs)`
 :   Parameters for interests.get operation
 
@@ -1229,6 +1329,8 @@ Classes
 
     `list_id: str`
     :   The type of the None singleton.
+
+<a id="InterestsListParams"></a>
 
 `InterestsListParams(*args, **kwargs)`
 :   Parameters for interests.list operation
@@ -1251,6 +1353,8 @@ Classes
     `offset: int`
     :   The type of the None singleton.
 
+<a id="ListMembersGetParams"></a>
+
 `ListMembersGetParams(*args, **kwargs)`
 :   Parameters for list_members.get operation
 
@@ -1265,6 +1369,8 @@ Classes
 
     `subscriber_hash: str`
     :   The type of the None singleton.
+
+<a id="ListMembersListParams"></a>
 
 `ListMembersListParams(*args, **kwargs)`
 :   Parameters for list_members.list operation
@@ -1323,6 +1429,8 @@ Classes
     `vip_only: bool`
     :   The type of the None singleton.
 
+<a id="ListsAndCondition"></a>
+
 `ListsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1343,6 +1451,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.mailchimp.types.ListsEqCondition | airbyte_agent_sdk.connectors.mailchimp.types.ListsNeqCondition | airbyte_agent_sdk.connectors.mailchimp.types.ListsGtCondition | airbyte_agent_sdk.connectors.mailchimp.types.ListsGteCondition | airbyte_agent_sdk.connectors.mailchimp.types.ListsLtCondition | airbyte_agent_sdk.connectors.mailchimp.types.ListsLteCondition | airbyte_agent_sdk.connectors.mailchimp.types.ListsInCondition | airbyte_agent_sdk.connectors.mailchimp.types.ListsLikeCondition | airbyte_agent_sdk.connectors.mailchimp.types.ListsFuzzyCondition | airbyte_agent_sdk.connectors.mailchimp.types.ListsKeywordCondition | airbyte_agent_sdk.connectors.mailchimp.types.ListsContainsCondition | airbyte_agent_sdk.connectors.mailchimp.types.ListsNotCondition | airbyte_agent_sdk.connectors.mailchimp.types.ListsAndCondition | airbyte_agent_sdk.connectors.mailchimp.types.ListsOrCondition | airbyte_agent_sdk.connectors.mailchimp.types.ListsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="ListsAnyCondition"></a>
+
 `ListsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1362,6 +1472,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.mailchimp.types.ListsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="ListsAnyValueFilter"></a>
 
 `ListsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -1435,6 +1547,8 @@ Classes
     `web_id: Any`
     :   The ID used in the Mailchimp web application. View this list in your Mailchimp account at `https:...
 
+<a id="ListsContainsCondition"></a>
+
 `ListsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -1446,6 +1560,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.mailchimp.types.ListsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="ListsEqCondition"></a>
 
 `ListsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -1459,6 +1575,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.mailchimp.types.ListsSearchFilter`
     :   The type of the None singleton.
 
+<a id="ListsFuzzyCondition"></a>
+
 `ListsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -1470,6 +1588,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.mailchimp.types.ListsStringFilter`
     :   The type of the None singleton.
+
+<a id="ListsGetParams"></a>
 
 `ListsGetParams(*args, **kwargs)`
 :   Parameters for lists.get operation
@@ -1483,6 +1603,8 @@ Classes
     `list_id: str`
     :   The type of the None singleton.
 
+<a id="ListsGtCondition"></a>
+
 `ListsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -1495,6 +1617,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.mailchimp.types.ListsSearchFilter`
     :   The type of the None singleton.
 
+<a id="ListsGteCondition"></a>
+
 `ListsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -1506,6 +1630,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.mailchimp.types.ListsSearchFilter`
     :   The type of the None singleton.
+
+<a id="ListsInCondition"></a>
 
 `ListsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -1526,6 +1652,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.mailchimp.types.ListsInFilter`
     :   The type of the None singleton.
+
+<a id="ListsInFilter"></a>
 
 `ListsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -1599,6 +1727,8 @@ Classes
     `web_id: list[int]`
     :   The ID used in the Mailchimp web application. View this list in your Mailchimp account at `https:...
 
+<a id="ListsKeywordCondition"></a>
+
 `ListsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -1611,6 +1741,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.mailchimp.types.ListsStringFilter`
     :   The type of the None singleton.
 
+<a id="ListsLikeCondition"></a>
+
 `ListsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -1622,6 +1754,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.mailchimp.types.ListsStringFilter`
     :   The type of the None singleton.
+
+<a id="ListsListParams"></a>
 
 `ListsListParams(*args, **kwargs)`
 :   Parameters for lists.list operation
@@ -1659,6 +1793,8 @@ Classes
     `sort_field: str`
     :   The type of the None singleton.
 
+<a id="ListsLtCondition"></a>
+
 `ListsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -1670,6 +1806,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.mailchimp.types.ListsSearchFilter`
     :   The type of the None singleton.
+
+<a id="ListsLteCondition"></a>
 
 `ListsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -1683,6 +1821,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.mailchimp.types.ListsSearchFilter`
     :   The type of the None singleton.
 
+<a id="ListsNeqCondition"></a>
+
 `ListsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -1694,6 +1834,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.mailchimp.types.ListsSearchFilter`
     :   The type of the None singleton.
+
+<a id="ListsNotCondition"></a>
 
 `ListsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -1715,6 +1857,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.mailchimp.types.ListsEqCondition | airbyte_agent_sdk.connectors.mailchimp.types.ListsNeqCondition | airbyte_agent_sdk.connectors.mailchimp.types.ListsGtCondition | airbyte_agent_sdk.connectors.mailchimp.types.ListsGteCondition | airbyte_agent_sdk.connectors.mailchimp.types.ListsLtCondition | airbyte_agent_sdk.connectors.mailchimp.types.ListsLteCondition | airbyte_agent_sdk.connectors.mailchimp.types.ListsInCondition | airbyte_agent_sdk.connectors.mailchimp.types.ListsLikeCondition | airbyte_agent_sdk.connectors.mailchimp.types.ListsFuzzyCondition | airbyte_agent_sdk.connectors.mailchimp.types.ListsKeywordCondition | airbyte_agent_sdk.connectors.mailchimp.types.ListsContainsCondition | airbyte_agent_sdk.connectors.mailchimp.types.ListsNotCondition | airbyte_agent_sdk.connectors.mailchimp.types.ListsAndCondition | airbyte_agent_sdk.connectors.mailchimp.types.ListsOrCondition | airbyte_agent_sdk.connectors.mailchimp.types.ListsAnyCondition`
     :   The type of the None singleton.
 
+<a id="ListsOrCondition"></a>
+
 `ListsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1734,6 +1878,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.mailchimp.types.ListsEqCondition | airbyte_agent_sdk.connectors.mailchimp.types.ListsNeqCondition | airbyte_agent_sdk.connectors.mailchimp.types.ListsGtCondition | airbyte_agent_sdk.connectors.mailchimp.types.ListsGteCondition | airbyte_agent_sdk.connectors.mailchimp.types.ListsLtCondition | airbyte_agent_sdk.connectors.mailchimp.types.ListsLteCondition | airbyte_agent_sdk.connectors.mailchimp.types.ListsInCondition | airbyte_agent_sdk.connectors.mailchimp.types.ListsLikeCondition | airbyte_agent_sdk.connectors.mailchimp.types.ListsFuzzyCondition | airbyte_agent_sdk.connectors.mailchimp.types.ListsKeywordCondition | airbyte_agent_sdk.connectors.mailchimp.types.ListsContainsCondition | airbyte_agent_sdk.connectors.mailchimp.types.ListsNotCondition | airbyte_agent_sdk.connectors.mailchimp.types.ListsAndCondition | airbyte_agent_sdk.connectors.mailchimp.types.ListsOrCondition | airbyte_agent_sdk.connectors.mailchimp.types.ListsAnyCondition]`
     :   The type of the None singleton.
+
+<a id="ListsSearchFilter"></a>
 
 `ListsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering lists search queries.
@@ -1807,6 +1953,8 @@ Classes
     `web_id: int | None`
     :   The ID used in the Mailchimp web application. View this list in your Mailchimp account at `https:...
 
+<a id="ListsSearchQuery"></a>
+
 `ListsSearchQuery(*args, **kwargs)`
 :   Search query for lists entity.
 
@@ -1821,6 +1969,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.mailchimp.types.ListsSortFilter]`
     :   The type of the None singleton.
+
+<a id="ListsSortFilter"></a>
 
 `ListsSortFilter(*args, **kwargs)`
 :   Available fields for sorting lists search results.
@@ -1894,6 +2044,8 @@ Classes
     `web_id: Literal['asc', 'desc']`
     :   The ID used in the Mailchimp web application. View this list in your Mailchimp account at `https:...
 
+<a id="ListsStringFilter"></a>
+
 `ListsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -1966,6 +2118,8 @@ Classes
     `web_id: str`
     :   The ID used in the Mailchimp web application. View this list in your Mailchimp account at `https:...
 
+<a id="ReportsAndCondition"></a>
+
 `ReportsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1986,6 +2140,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.mailchimp.types.ReportsEqCondition | airbyte_agent_sdk.connectors.mailchimp.types.ReportsNeqCondition | airbyte_agent_sdk.connectors.mailchimp.types.ReportsGtCondition | airbyte_agent_sdk.connectors.mailchimp.types.ReportsGteCondition | airbyte_agent_sdk.connectors.mailchimp.types.ReportsLtCondition | airbyte_agent_sdk.connectors.mailchimp.types.ReportsLteCondition | airbyte_agent_sdk.connectors.mailchimp.types.ReportsInCondition | airbyte_agent_sdk.connectors.mailchimp.types.ReportsLikeCondition | airbyte_agent_sdk.connectors.mailchimp.types.ReportsFuzzyCondition | airbyte_agent_sdk.connectors.mailchimp.types.ReportsKeywordCondition | airbyte_agent_sdk.connectors.mailchimp.types.ReportsContainsCondition | airbyte_agent_sdk.connectors.mailchimp.types.ReportsNotCondition | airbyte_agent_sdk.connectors.mailchimp.types.ReportsAndCondition | airbyte_agent_sdk.connectors.mailchimp.types.ReportsOrCondition | airbyte_agent_sdk.connectors.mailchimp.types.ReportsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="ReportsAnyCondition"></a>
+
 `ReportsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -2005,6 +2161,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.mailchimp.types.ReportsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="ReportsAnyValueFilter"></a>
 
 `ReportsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -2093,6 +2251,8 @@ Classes
     `unsubscribed: Any`
     :   The total number of unsubscribed members for this campaign.
 
+<a id="ReportsContainsCondition"></a>
+
 `ReportsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -2104,6 +2264,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.mailchimp.types.ReportsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="ReportsEqCondition"></a>
 
 `ReportsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -2117,6 +2279,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.mailchimp.types.ReportsSearchFilter`
     :   The type of the None singleton.
 
+<a id="ReportsFuzzyCondition"></a>
+
 `ReportsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -2128,6 +2292,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.mailchimp.types.ReportsStringFilter`
     :   The type of the None singleton.
+
+<a id="ReportsGetParams"></a>
 
 `ReportsGetParams(*args, **kwargs)`
 :   Parameters for reports.get operation
@@ -2141,6 +2307,8 @@ Classes
     `campaign_id: str`
     :   The type of the None singleton.
 
+<a id="ReportsGtCondition"></a>
+
 `ReportsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -2153,6 +2321,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.mailchimp.types.ReportsSearchFilter`
     :   The type of the None singleton.
 
+<a id="ReportsGteCondition"></a>
+
 `ReportsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -2164,6 +2334,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.mailchimp.types.ReportsSearchFilter`
     :   The type of the None singleton.
+
+<a id="ReportsInCondition"></a>
 
 `ReportsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -2184,6 +2356,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.mailchimp.types.ReportsInFilter`
     :   The type of the None singleton.
+
+<a id="ReportsInFilter"></a>
 
 `ReportsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -2272,6 +2446,8 @@ Classes
     `unsubscribed: list[int]`
     :   The total number of unsubscribed members for this campaign.
 
+<a id="ReportsKeywordCondition"></a>
+
 `ReportsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -2284,6 +2460,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.mailchimp.types.ReportsStringFilter`
     :   The type of the None singleton.
 
+<a id="ReportsLikeCondition"></a>
+
 `ReportsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -2295,6 +2473,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.mailchimp.types.ReportsStringFilter`
     :   The type of the None singleton.
+
+<a id="ReportsListParams"></a>
 
 `ReportsListParams(*args, **kwargs)`
 :   Parameters for reports.list operation
@@ -2320,6 +2500,8 @@ Classes
     `type: str`
     :   The type of the None singleton.
 
+<a id="ReportsLtCondition"></a>
+
 `ReportsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -2331,6 +2513,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.mailchimp.types.ReportsSearchFilter`
     :   The type of the None singleton.
+
+<a id="ReportsLteCondition"></a>
 
 `ReportsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -2344,6 +2528,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.mailchimp.types.ReportsSearchFilter`
     :   The type of the None singleton.
 
+<a id="ReportsNeqCondition"></a>
+
 `ReportsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -2355,6 +2541,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.mailchimp.types.ReportsSearchFilter`
     :   The type of the None singleton.
+
+<a id="ReportsNotCondition"></a>
 
 `ReportsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -2376,6 +2564,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.mailchimp.types.ReportsEqCondition | airbyte_agent_sdk.connectors.mailchimp.types.ReportsNeqCondition | airbyte_agent_sdk.connectors.mailchimp.types.ReportsGtCondition | airbyte_agent_sdk.connectors.mailchimp.types.ReportsGteCondition | airbyte_agent_sdk.connectors.mailchimp.types.ReportsLtCondition | airbyte_agent_sdk.connectors.mailchimp.types.ReportsLteCondition | airbyte_agent_sdk.connectors.mailchimp.types.ReportsInCondition | airbyte_agent_sdk.connectors.mailchimp.types.ReportsLikeCondition | airbyte_agent_sdk.connectors.mailchimp.types.ReportsFuzzyCondition | airbyte_agent_sdk.connectors.mailchimp.types.ReportsKeywordCondition | airbyte_agent_sdk.connectors.mailchimp.types.ReportsContainsCondition | airbyte_agent_sdk.connectors.mailchimp.types.ReportsNotCondition | airbyte_agent_sdk.connectors.mailchimp.types.ReportsAndCondition | airbyte_agent_sdk.connectors.mailchimp.types.ReportsOrCondition | airbyte_agent_sdk.connectors.mailchimp.types.ReportsAnyCondition`
     :   The type of the None singleton.
 
+<a id="ReportsOrCondition"></a>
+
 `ReportsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -2395,6 +2585,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.mailchimp.types.ReportsEqCondition | airbyte_agent_sdk.connectors.mailchimp.types.ReportsNeqCondition | airbyte_agent_sdk.connectors.mailchimp.types.ReportsGtCondition | airbyte_agent_sdk.connectors.mailchimp.types.ReportsGteCondition | airbyte_agent_sdk.connectors.mailchimp.types.ReportsLtCondition | airbyte_agent_sdk.connectors.mailchimp.types.ReportsLteCondition | airbyte_agent_sdk.connectors.mailchimp.types.ReportsInCondition | airbyte_agent_sdk.connectors.mailchimp.types.ReportsLikeCondition | airbyte_agent_sdk.connectors.mailchimp.types.ReportsFuzzyCondition | airbyte_agent_sdk.connectors.mailchimp.types.ReportsKeywordCondition | airbyte_agent_sdk.connectors.mailchimp.types.ReportsContainsCondition | airbyte_agent_sdk.connectors.mailchimp.types.ReportsNotCondition | airbyte_agent_sdk.connectors.mailchimp.types.ReportsAndCondition | airbyte_agent_sdk.connectors.mailchimp.types.ReportsOrCondition | airbyte_agent_sdk.connectors.mailchimp.types.ReportsAnyCondition]`
     :   The type of the None singleton.
+
+<a id="ReportsSearchFilter"></a>
 
 `ReportsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering reports search queries.
@@ -2483,6 +2675,8 @@ Classes
     `unsubscribed: int | None`
     :   The total number of unsubscribed members for this campaign.
 
+<a id="ReportsSearchQuery"></a>
+
 `ReportsSearchQuery(*args, **kwargs)`
 :   Search query for reports entity.
 
@@ -2497,6 +2691,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.mailchimp.types.ReportsSortFilter]`
     :   The type of the None singleton.
+
+<a id="ReportsSortFilter"></a>
 
 `ReportsSortFilter(*args, **kwargs)`
 :   Available fields for sorting reports search results.
@@ -2585,6 +2781,8 @@ Classes
     `unsubscribed: Literal['asc', 'desc']`
     :   The total number of unsubscribed members for this campaign.
 
+<a id="ReportsStringFilter"></a>
+
 `ReportsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -2672,6 +2870,8 @@ Classes
     `unsubscribed: str`
     :   The total number of unsubscribed members for this campaign.
 
+<a id="SegmentMembersListParams"></a>
+
 `SegmentMembersListParams(*args, **kwargs)`
 :   Parameters for segment_members.list operation
 
@@ -2693,6 +2893,8 @@ Classes
     `segment_id: str`
     :   The type of the None singleton.
 
+<a id="SegmentsGetParams"></a>
+
 `SegmentsGetParams(*args, **kwargs)`
 :   Parameters for segments.get operation
 
@@ -2707,6 +2909,8 @@ Classes
 
     `segment_id: str`
     :   The type of the None singleton.
+
+<a id="SegmentsListParams"></a>
 
 `SegmentsListParams(*args, **kwargs)`
 :   Parameters for segments.list operation
@@ -2741,6 +2945,8 @@ Classes
     `type: str`
     :   The type of the None singleton.
 
+<a id="TagsListParams"></a>
+
 `TagsListParams(*args, **kwargs)`
 :   Parameters for tags.list operation
 
@@ -2755,6 +2961,8 @@ Classes
 
     `name: str`
     :   The type of the None singleton.
+
+<a id="UnsubscribesListParams"></a>
 
 `UnsubscribesListParams(*args, **kwargs)`
 :   Parameters for unsubscribes.list operation

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/monday/connector.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/monday/connector.md
@@ -10,6 +10,8 @@ Monday connector.
 Classes
 -------
 
+<a id="ActivityLogsQuery"></a>
+
 `ActivityLogsQuery(connector: MondayConnector)`
 :   Query class for ActivityLogs entity operations.
     
@@ -57,6 +59,8 @@ Classes
         
         Returns:
             ActivityLogsListResult
+
+<a id="BoardsQuery"></a>
 
 `BoardsQuery(connector: MondayConnector)`
 :   Query class for Boards entity operations.
@@ -123,6 +127,8 @@ Classes
         Returns:
             BoardsListResult
 
+<a id="ItemsQuery"></a>
+
 `ItemsQuery(connector: MondayConnector)`
 :   Query class for Items entity operations.
     
@@ -185,6 +191,8 @@ Classes
         
         Returns:
             ItemsListResult
+
+<a id="MondayConnector"></a>
 
 `MondayConnector(auth_config: MondayAuthConfig | AirbyteAuthConfig | BaseModel | None = None, on_token_refresh: Any | None = None)`
 :   Type-safe Monday API connector.
@@ -428,6 +436,8 @@ Classes
             for entity in entities:
                 print(f"\{entity['entity_name']\}: \{entity['available_actions']\}")
 
+<a id="TagsQuery"></a>
+
 `TagsQuery(connector: MondayConnector)`
 :   Query class for Tags entity operations.
     
@@ -465,6 +475,8 @@ Classes
         
         Returns:
             TagsListResult
+
+<a id="TeamsQuery"></a>
 
 `TeamsQuery(connector: MondayConnector)`
 :   Query class for Teams entity operations.
@@ -514,6 +526,8 @@ Classes
         
         Returns:
             TeamsListResult
+
+<a id="UpdatesQuery"></a>
 
 `UpdatesQuery(connector: MondayConnector)`
 :   Query class for Updates entity operations.
@@ -573,6 +587,8 @@ Classes
         
         Returns:
             UpdatesListResult
+
+<a id="UsersQuery"></a>
 
 `UsersQuery(connector: MondayConnector)`
 :   Query class for Users entity operations.
@@ -643,6 +659,8 @@ Classes
         
         Returns:
             UsersListResult
+
+<a id="WorkspacesQuery"></a>
 
 `WorkspacesQuery(connector: MondayConnector)`
 :   Query class for Workspaces entity operations.

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/monday/index.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/monday/index.md
@@ -19,6 +19,8 @@ Sub-modules
 Classes
 -------
 
+<a id="ActivityLogsSearchData"></a>
+
 `ActivityLogsSearchData(**data: Any)`
 :   Search result data for activity_logs entity.
     
@@ -64,6 +66,8 @@ Classes
 
     `user_id: str | None`
     :   ID of the user who performed the action
+
+<a id="AirbyteAuthConfig"></a>
 
 `AirbyteAuthConfig(**data: Any)`
 :   Authentication configuration for Airbyte hosted mode execution.
@@ -133,6 +137,8 @@ Classes
     `workspace_name: str | None`
     :   The type of the None singleton.
 
+<a id="AirbyteSearchMeta"></a>
+
 `AirbyteSearchMeta(**data: Any)`
 :   Pagination metadata for search responses.
     
@@ -160,6 +166,8 @@ Classes
 
     `took_ms: int | None`
     :   Time taken to execute the search in milliseconds.
+
+<a id="AirbyteSearchResult"></a>
 
 `AirbyteSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -198,6 +206,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="ActivityLogsSearchResult"></a>
+
 `ActivityLogsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -213,6 +223,8 @@ Classes
     * airbyte_agent_sdk.connectors.monday.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="BoardsSearchResult"></a>
 
 `BoardsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -230,6 +242,8 @@ Classes
     * pydantic.main.BaseModel
     * typing.Generic
 
+<a id="ItemsSearchResult"></a>
+
 `ItemsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -245,6 +259,8 @@ Classes
     * airbyte_agent_sdk.connectors.monday.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="TagsSearchResult"></a>
 
 `TagsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -262,6 +278,8 @@ Classes
     * pydantic.main.BaseModel
     * typing.Generic
 
+<a id="TeamsSearchResult"></a>
+
 `TeamsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -277,6 +295,8 @@ Classes
     * airbyte_agent_sdk.connectors.monday.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="UpdatesSearchResult"></a>
 
 `UpdatesSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -294,6 +314,8 @@ Classes
     * pydantic.main.BaseModel
     * typing.Generic
 
+<a id="UsersSearchResult"></a>
+
 `UsersSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -310,6 +332,8 @@ Classes
     * pydantic.main.BaseModel
     * typing.Generic
 
+<a id="WorkspacesSearchResult"></a>
+
 `WorkspacesSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -325,6 +349,8 @@ Classes
     * airbyte_agent_sdk.connectors.monday.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="BoardsSearchData"></a>
 
 `BoardsSearchData(**data: Any)`
 :   Search result data for boards entity.
@@ -405,6 +431,8 @@ Classes
     `workspace: dict[str, typing.Any] | None`
     :   Workspace the board belongs to
 
+<a id="ItemsSearchData"></a>
+
 `ItemsSearchData(**data: Any)`
 :   Search result data for items entity.
     
@@ -465,6 +493,8 @@ Classes
 
     `updates: list[typing.Any] | None`
     :   Item updates
+
+<a id="MondayConnector"></a>
 
 `MondayConnector(auth_config: MondayAuthConfig | AirbyteAuthConfig | BaseModel | None = None, on_token_refresh: Any | None = None)`
 :   Type-safe Monday API connector.
@@ -708,6 +738,8 @@ Classes
             for entity in entities:
                 print(f"\{entity['entity_name']\}: \{entity['available_actions']\}")
 
+<a id="TagsSearchData"></a>
+
 `TagsSearchData(**data: Any)`
 :   Search result data for tags entity.
     
@@ -735,6 +767,8 @@ Classes
 
     `name: str | None`
     :   Tag name
+
+<a id="TeamsSearchData"></a>
 
 `TeamsSearchData(**data: Any)`
 :   Search result data for teams entity.
@@ -766,6 +800,8 @@ Classes
 
     `users: list[typing.Any] | None`
     :   Team members
+
+<a id="UpdatesSearchData"></a>
 
 `UpdatesSearchData(**data: Any)`
 :   Search result data for updates entity.
@@ -812,6 +848,8 @@ Classes
 
     `updated_at: str | None`
     :   When the update was last modified
+
+<a id="UsersSearchData"></a>
 
 `UsersSearchData(**data: Any)`
 :   Search result data for users entity.
@@ -906,6 +944,8 @@ Classes
 
     `utc_hours_diff: int | None`
     :   UTC hours difference for the user's timezone
+
+<a id="WorkspacesSearchData"></a>
 
 `WorkspacesSearchData(**data: Any)`
 :   Search result data for workspaces entity.

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/monday/models.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/monday/models.md
@@ -13,6 +13,8 @@ and response envelope types.
 Classes
 -------
 
+<a id="ActivityLog"></a>
+
 `ActivityLog(**data: Any)`
 :   Monday.com activity log entry
     
@@ -49,6 +51,8 @@ Classes
 
     `user_id: str | Any | None`
     :   The type of the None singleton.
+
+<a id="ActivityLogsSearchData"></a>
 
 `ActivityLogsSearchData(**data: Any)`
 :   Search result data for activity_logs entity.
@@ -96,6 +100,8 @@ Classes
     `user_id: str | None`
     :   ID of the user who performed the action
 
+<a id="AirbyteSearchMeta"></a>
+
 `AirbyteSearchMeta(**data: Any)`
 :   Pagination metadata for search responses.
     
@@ -123,6 +129,8 @@ Classes
 
     `took_ms: int | None`
     :   Time taken to execute the search in milliseconds.
+
+<a id="AirbyteSearchResult"></a>
 
 `AirbyteSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -182,6 +190,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="ActivityLogsSearchResult"></a>
+
 `ActivityLogsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -218,6 +228,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="BoardsSearchResult"></a>
 
 `BoardsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -256,6 +268,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="ItemsSearchResult"></a>
+
 `ItemsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -292,6 +306,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="TagsSearchResult"></a>
 
 `TagsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -330,6 +346,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="TeamsSearchResult"></a>
+
 `TeamsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -366,6 +384,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="UpdatesSearchResult"></a>
 
 `UpdatesSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -404,6 +424,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="UsersSearchResult"></a>
+
 `UsersSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -441,6 +463,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="WorkspacesSearchResult"></a>
+
 `WorkspacesSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -456,6 +480,8 @@ Classes
     * airbyte_agent_sdk.connectors.monday.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="Board"></a>
 
 `Board(**data: Any)`
 :   Monday.com board object
@@ -527,6 +553,8 @@ Classes
     `workspace: airbyte_agent_sdk.connectors.monday.models.BoardWorkspace | Any | None`
     :   The type of the None singleton.
 
+<a id="BoardColumnsItem"></a>
+
 `BoardColumnsItem(**data: Any)`
 :   Nested schema for Board.columns_item
     
@@ -567,6 +595,8 @@ Classes
     `width: int | Any | None`
     :   The type of the None singleton.
 
+<a id="BoardCreator"></a>
+
 `BoardCreator(**data: Any)`
 :   Board creator
     
@@ -588,6 +618,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="BoardGroupsItem"></a>
 
 `BoardGroupsItem(**data: Any)`
 :   Nested schema for Board.groups_item
@@ -626,6 +658,8 @@ Classes
     `title: str | Any | None`
     :   The type of the None singleton.
 
+<a id="BoardOwnersItem"></a>
+
 `BoardOwnersItem(**data: Any)`
 :   Nested schema for Board.owners_item
     
@@ -647,6 +681,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="BoardSubscribersItem"></a>
 
 `BoardSubscribersItem(**data: Any)`
 :   Nested schema for Board.subscribers_item
@@ -670,6 +706,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="BoardTagsItem"></a>
+
 `BoardTagsItem(**data: Any)`
 :   Nested schema for Board.tags_item
     
@@ -692,6 +730,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="BoardTopGroup"></a>
+
 `BoardTopGroup(**data: Any)`
 :   Top group on the board
     
@@ -713,6 +753,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="BoardViewsItem"></a>
 
 `BoardViewsItem(**data: Any)`
 :   Nested schema for Board.views_item
@@ -748,6 +790,8 @@ Classes
     `view_specific_data_str: str | Any | None`
     :   The type of the None singleton.
 
+<a id="BoardWorkspace"></a>
+
 `BoardWorkspace(**data: Any)`
 :   Workspace the board belongs to
     
@@ -778,6 +822,8 @@ Classes
 
     `name: str | Any | None`
     :   The type of the None singleton.
+
+<a id="BoardsSearchData"></a>
 
 `BoardsSearchData(**data: Any)`
 :   Search result data for boards entity.
@@ -858,6 +904,8 @@ Classes
     `workspace: dict[str, typing.Any] | None`
     :   Workspace the board belongs to
 
+<a id="Item"></a>
+
 `Item(**data: Any)`
 :   Monday.com item object
     
@@ -910,6 +958,8 @@ Classes
     `updated_at: str | Any | None`
     :   The type of the None singleton.
 
+<a id="ItemBoard"></a>
+
 `ItemBoard(**data: Any)`
 :   Board the item belongs to
     
@@ -934,6 +984,8 @@ Classes
 
     `name: str | Any | None`
     :   The type of the None singleton.
+
+<a id="ItemColumnValuesItem"></a>
 
 `ItemColumnValuesItem(**data: Any)`
 :   Nested schema for Item.column_values_item
@@ -966,6 +1018,8 @@ Classes
     `value: str | Any | None`
     :   The type of the None singleton.
 
+<a id="ItemGroup"></a>
+
 `ItemGroup(**data: Any)`
 :   Group the item belongs to
     
@@ -987,6 +1041,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="ItemParentItem"></a>
 
 `ItemParentItem(**data: Any)`
 :   Parent item (for subitems)
@@ -1010,6 +1066,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="ItemSubscribersItem"></a>
+
 `ItemSubscribersItem(**data: Any)`
 :   Nested schema for Item.subscribers_item
     
@@ -1031,6 +1089,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="ItemsSearchData"></a>
 
 `ItemsSearchData(**data: Any)`
 :   Search result data for items entity.
@@ -1093,6 +1153,8 @@ Classes
     `updates: list[typing.Any] | None`
     :   Item updates
 
+<a id="MondayApiTokenAuthenticationAuthConfig"></a>
+
 `MondayApiTokenAuthenticationAuthConfig(**data: Any)`
 :   API Token Authentication
     
@@ -1114,6 +1176,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="MondayCheckResult"></a>
 
 `MondayCheckResult(**data: Any)`
 :   Result of a health check operation.
@@ -1147,6 +1211,8 @@ Classes
 
     `status: str`
     :   Health check status: 'healthy' or 'unhealthy'.
+
+<a id="MondayExecuteResult"></a>
 
 `MondayExecuteResult(**data: Any)`
 :   Response envelope with data only.
@@ -1184,6 +1250,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="MondayExecuteResultWithMeta"></a>
 
 `MondayExecuteResultWithMeta(**data: Any)`
 :   Response envelope with data and metadata.
@@ -1231,6 +1299,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="ActivityLogsListResult"></a>
+
 `ActivityLogsListResult(**data: Any)`
 :   Response envelope with data only.
     
@@ -1271,6 +1341,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="BoardsListResult"></a>
 
 `BoardsListResult(**data: Any)`
 :   Response envelope with data only.
@@ -1313,6 +1385,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="ItemsListResult"></a>
+
 `ItemsListResult(**data: Any)`
 :   Response envelope with data only.
     
@@ -1353,6 +1427,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="TagsListResult"></a>
 
 `TagsListResult(**data: Any)`
 :   Response envelope with data only.
@@ -1395,6 +1471,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="TeamsListResult"></a>
+
 `TeamsListResult(**data: Any)`
 :   Response envelope with data only.
     
@@ -1435,6 +1513,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="UpdatesListResult"></a>
 
 `UpdatesListResult(**data: Any)`
 :   Response envelope with data only.
@@ -1477,6 +1557,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="UsersListResult"></a>
+
 `UsersListResult(**data: Any)`
 :   Response envelope with data only.
     
@@ -1518,6 +1600,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="WorkspacesListResult"></a>
+
 `WorkspacesListResult(**data: Any)`
 :   Response envelope with data only.
     
@@ -1535,6 +1619,8 @@ Classes
     * airbyte_agent_sdk.connectors.monday.models.MondayExecuteResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="MondayOauth20AuthenticationAuthConfig"></a>
 
 `MondayOauth20AuthenticationAuthConfig(**data: Any)`
 :   OAuth 2.0 Authentication
@@ -1564,6 +1650,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="Tag"></a>
+
 `Tag(**data: Any)`
 :   Monday.com tag object
     
@@ -1592,6 +1680,8 @@ Classes
     `name: str | Any | None`
     :   The type of the None singleton.
 
+<a id="TagsSearchData"></a>
+
 `TagsSearchData(**data: Any)`
 :   Search result data for tags entity.
     
@@ -1619,6 +1709,8 @@ Classes
 
     `name: str | None`
     :   Tag name
+
+<a id="Team"></a>
 
 `Team(**data: Any)`
 :   Monday.com team object
@@ -1651,6 +1743,8 @@ Classes
     `users: list[airbyte_agent_sdk.connectors.monday.models.TeamUsersItem | None] | Any | None`
     :   The type of the None singleton.
 
+<a id="TeamUsersItem"></a>
+
 `TeamUsersItem(**data: Any)`
 :   Nested schema for Team.users_item
     
@@ -1672,6 +1766,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="TeamsSearchData"></a>
 
 `TeamsSearchData(**data: Any)`
 :   Search result data for teams entity.
@@ -1703,6 +1799,8 @@ Classes
 
     `users: list[typing.Any] | None`
     :   Team members
+
+<a id="Update"></a>
 
 `Update(**data: Any)`
 :   Monday.com update (comment/post) object
@@ -1749,6 +1847,8 @@ Classes
 
     `updated_at: str | Any | None`
     :   The type of the None singleton.
+
+<a id="UpdateAssetsItem"></a>
 
 `UpdateAssetsItem(**data: Any)`
 :   Nested schema for Update.assets_item
@@ -1799,6 +1899,8 @@ Classes
     `url_thumbnail: str | Any | None`
     :   The type of the None singleton.
 
+<a id="UpdateAssetsItemUploadedBy"></a>
+
 `UpdateAssetsItemUploadedBy(**data: Any)`
 :   Nested schema for UpdateAssetsItem.uploaded_by
     
@@ -1820,6 +1922,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="UpdateRepliesItem"></a>
 
 `UpdateRepliesItem(**data: Any)`
 :   Nested schema for Update.replies_item
@@ -1857,6 +1961,8 @@ Classes
 
     `updated_at: str | Any | None`
     :   The type of the None singleton.
+
+<a id="UpdatesSearchData"></a>
 
 `UpdatesSearchData(**data: Any)`
 :   Search result data for updates entity.
@@ -1903,6 +2009,8 @@ Classes
 
     `updated_at: str | None`
     :   When the update was last modified
+
+<a id="User"></a>
 
 `User(**data: Any)`
 :   Monday.com user object
@@ -1998,6 +2106,8 @@ Classes
     `utc_hours_diff: int | Any | None`
     :   The type of the None singleton.
 
+<a id="UsersSearchData"></a>
+
 `UsersSearchData(**data: Any)`
 :   Search result data for users entity.
     
@@ -2092,6 +2202,8 @@ Classes
     `utc_hours_diff: int | None`
     :   UTC hours difference for the user's timezone
 
+<a id="Workspace"></a>
+
 `Workspace(**data: Any)`
 :   Monday.com workspace object
     
@@ -2147,6 +2259,8 @@ Classes
     `users_subscribers: list[airbyte_agent_sdk.connectors.monday.models.WorkspaceUsersSubscribersItem | None] | Any | None`
     :   The type of the None singleton.
 
+<a id="WorkspaceAccountProduct"></a>
+
 `WorkspaceAccountProduct(**data: Any)`
 :   Account product info
     
@@ -2172,6 +2286,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="WorkspaceOwnersSubscribersItem"></a>
+
 `WorkspaceOwnersSubscribersItem(**data: Any)`
 :   Nested schema for Workspace.owners_subscribers_item
     
@@ -2194,6 +2310,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="WorkspaceSettings"></a>
+
 `WorkspaceSettings(**data: Any)`
 :   Workspace settings
     
@@ -2215,6 +2333,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="WorkspaceSettingsIcon"></a>
 
 `WorkspaceSettingsIcon(**data: Any)`
 :   Nested schema for WorkspaceSettings.icon
@@ -2241,6 +2361,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="WorkspaceTeamOwnersSubscribersItem"></a>
+
 `WorkspaceTeamOwnersSubscribersItem(**data: Any)`
 :   Nested schema for Workspace.team_owners_subscribers_item
     
@@ -2265,6 +2387,8 @@ Classes
 
     `name: str | Any | None`
     :   The type of the None singleton.
+
+<a id="WorkspaceTeamsSubscribersItem"></a>
 
 `WorkspaceTeamsSubscribersItem(**data: Any)`
 :   Nested schema for Workspace.teams_subscribers_item
@@ -2291,6 +2415,8 @@ Classes
     `name: str | Any | None`
     :   The type of the None singleton.
 
+<a id="WorkspaceUsersSubscribersItem"></a>
+
 `WorkspaceUsersSubscribersItem(**data: Any)`
 :   Nested schema for Workspace.users_subscribers_item
     
@@ -2312,6 +2438,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="WorkspacesSearchData"></a>
 
 `WorkspacesSearchData(**data: Any)`
 :   Search result data for workspaces entity.

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/monday/types.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/monday/types.md
@@ -10,6 +10,8 @@ Type definitions for monday connector.
 Classes
 -------
 
+<a id="ActivityLogsAndCondition"></a>
+
 `ActivityLogsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -30,6 +32,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.monday.types.ActivityLogsEqCondition | airbyte_agent_sdk.connectors.monday.types.ActivityLogsNeqCondition | airbyte_agent_sdk.connectors.monday.types.ActivityLogsGtCondition | airbyte_agent_sdk.connectors.monday.types.ActivityLogsGteCondition | airbyte_agent_sdk.connectors.monday.types.ActivityLogsLtCondition | airbyte_agent_sdk.connectors.monday.types.ActivityLogsLteCondition | airbyte_agent_sdk.connectors.monday.types.ActivityLogsInCondition | airbyte_agent_sdk.connectors.monday.types.ActivityLogsLikeCondition | airbyte_agent_sdk.connectors.monday.types.ActivityLogsFuzzyCondition | airbyte_agent_sdk.connectors.monday.types.ActivityLogsKeywordCondition | airbyte_agent_sdk.connectors.monday.types.ActivityLogsContainsCondition | airbyte_agent_sdk.connectors.monday.types.ActivityLogsNotCondition | airbyte_agent_sdk.connectors.monday.types.ActivityLogsAndCondition | airbyte_agent_sdk.connectors.monday.types.ActivityLogsOrCondition | airbyte_agent_sdk.connectors.monday.types.ActivityLogsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="ActivityLogsAnyCondition"></a>
+
 `ActivityLogsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -49,6 +53,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.monday.types.ActivityLogsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="ActivityLogsAnyValueFilter"></a>
 
 `ActivityLogsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -86,6 +92,8 @@ Classes
     `user_id: Any`
     :   ID of the user who performed the action
 
+<a id="ActivityLogsContainsCondition"></a>
+
 `ActivityLogsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -97,6 +105,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.monday.types.ActivityLogsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="ActivityLogsEqCondition"></a>
 
 `ActivityLogsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -110,6 +120,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.monday.types.ActivityLogsSearchFilter`
     :   The type of the None singleton.
 
+<a id="ActivityLogsFuzzyCondition"></a>
+
 `ActivityLogsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -121,6 +133,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.monday.types.ActivityLogsStringFilter`
     :   The type of the None singleton.
+
+<a id="ActivityLogsGtCondition"></a>
 
 `ActivityLogsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
@@ -134,6 +148,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.monday.types.ActivityLogsSearchFilter`
     :   The type of the None singleton.
 
+<a id="ActivityLogsGteCondition"></a>
+
 `ActivityLogsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -145,6 +161,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.monday.types.ActivityLogsSearchFilter`
     :   The type of the None singleton.
+
+<a id="ActivityLogsInCondition"></a>
 
 `ActivityLogsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -165,6 +183,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.monday.types.ActivityLogsInFilter`
     :   The type of the None singleton.
+
+<a id="ActivityLogsInFilter"></a>
 
 `ActivityLogsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -202,6 +222,8 @@ Classes
     `user_id: list[str]`
     :   ID of the user who performed the action
 
+<a id="ActivityLogsKeywordCondition"></a>
+
 `ActivityLogsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -213,6 +235,8 @@ Classes
 
     `keyword: airbyte_agent_sdk.connectors.monday.types.ActivityLogsStringFilter`
     :   The type of the None singleton.
+
+<a id="ActivityLogsLikeCondition"></a>
 
 `ActivityLogsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
@@ -226,6 +250,8 @@ Classes
     `like: airbyte_agent_sdk.connectors.monday.types.ActivityLogsStringFilter`
     :   The type of the None singleton.
 
+<a id="ActivityLogsListParams"></a>
+
 `ActivityLogsListParams(*args, **kwargs)`
 :   Parameters for activity_logs.list operation
 
@@ -237,6 +263,8 @@ Classes
 
     `board_id: str`
     :   The type of the None singleton.
+
+<a id="ActivityLogsLtCondition"></a>
 
 `ActivityLogsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
@@ -250,6 +278,8 @@ Classes
     `lt: airbyte_agent_sdk.connectors.monday.types.ActivityLogsSearchFilter`
     :   The type of the None singleton.
 
+<a id="ActivityLogsLteCondition"></a>
+
 `ActivityLogsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
 
@@ -262,6 +292,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.monday.types.ActivityLogsSearchFilter`
     :   The type of the None singleton.
 
+<a id="ActivityLogsNeqCondition"></a>
+
 `ActivityLogsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -273,6 +305,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.monday.types.ActivityLogsSearchFilter`
     :   The type of the None singleton.
+
+<a id="ActivityLogsNotCondition"></a>
 
 `ActivityLogsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -294,6 +328,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.monday.types.ActivityLogsEqCondition | airbyte_agent_sdk.connectors.monday.types.ActivityLogsNeqCondition | airbyte_agent_sdk.connectors.monday.types.ActivityLogsGtCondition | airbyte_agent_sdk.connectors.monday.types.ActivityLogsGteCondition | airbyte_agent_sdk.connectors.monday.types.ActivityLogsLtCondition | airbyte_agent_sdk.connectors.monday.types.ActivityLogsLteCondition | airbyte_agent_sdk.connectors.monday.types.ActivityLogsInCondition | airbyte_agent_sdk.connectors.monday.types.ActivityLogsLikeCondition | airbyte_agent_sdk.connectors.monday.types.ActivityLogsFuzzyCondition | airbyte_agent_sdk.connectors.monday.types.ActivityLogsKeywordCondition | airbyte_agent_sdk.connectors.monday.types.ActivityLogsContainsCondition | airbyte_agent_sdk.connectors.monday.types.ActivityLogsNotCondition | airbyte_agent_sdk.connectors.monday.types.ActivityLogsAndCondition | airbyte_agent_sdk.connectors.monday.types.ActivityLogsOrCondition | airbyte_agent_sdk.connectors.monday.types.ActivityLogsAnyCondition`
     :   The type of the None singleton.
 
+<a id="ActivityLogsOrCondition"></a>
+
 `ActivityLogsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -313,6 +349,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.monday.types.ActivityLogsEqCondition | airbyte_agent_sdk.connectors.monday.types.ActivityLogsNeqCondition | airbyte_agent_sdk.connectors.monday.types.ActivityLogsGtCondition | airbyte_agent_sdk.connectors.monday.types.ActivityLogsGteCondition | airbyte_agent_sdk.connectors.monday.types.ActivityLogsLtCondition | airbyte_agent_sdk.connectors.monday.types.ActivityLogsLteCondition | airbyte_agent_sdk.connectors.monday.types.ActivityLogsInCondition | airbyte_agent_sdk.connectors.monday.types.ActivityLogsLikeCondition | airbyte_agent_sdk.connectors.monday.types.ActivityLogsFuzzyCondition | airbyte_agent_sdk.connectors.monday.types.ActivityLogsKeywordCondition | airbyte_agent_sdk.connectors.monday.types.ActivityLogsContainsCondition | airbyte_agent_sdk.connectors.monday.types.ActivityLogsNotCondition | airbyte_agent_sdk.connectors.monday.types.ActivityLogsAndCondition | airbyte_agent_sdk.connectors.monday.types.ActivityLogsOrCondition | airbyte_agent_sdk.connectors.monday.types.ActivityLogsAnyCondition]`
     :   The type of the None singleton.
+
+<a id="ActivityLogsSearchFilter"></a>
 
 `ActivityLogsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering activity_logs search queries.
@@ -350,6 +388,8 @@ Classes
     `user_id: str | None`
     :   ID of the user who performed the action
 
+<a id="ActivityLogsSearchQuery"></a>
+
 `ActivityLogsSearchQuery(*args, **kwargs)`
 :   Search query for activity_logs entity.
 
@@ -364,6 +404,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.monday.types.ActivityLogsSortFilter]`
     :   The type of the None singleton.
+
+<a id="ActivityLogsSortFilter"></a>
 
 `ActivityLogsSortFilter(*args, **kwargs)`
 :   Available fields for sorting activity_logs search results.
@@ -401,6 +443,8 @@ Classes
     `user_id: Literal['asc', 'desc']`
     :   ID of the user who performed the action
 
+<a id="ActivityLogsStringFilter"></a>
+
 `ActivityLogsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -437,6 +481,8 @@ Classes
     `user_id: str`
     :   ID of the user who performed the action
 
+<a id="AirbyteSearchParams"></a>
+
 `AirbyteSearchParams(*args, **kwargs)`
 :   Parameters for Airbyte cache search operations (generic, use entity-specific query types for better type hints).
 
@@ -458,6 +504,8 @@ Classes
     `query: dict[str, typing.Any]`
     :   The type of the None singleton.
 
+<a id="BoardsAndCondition"></a>
+
 `BoardsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -478,6 +526,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.monday.types.BoardsEqCondition | airbyte_agent_sdk.connectors.monday.types.BoardsNeqCondition | airbyte_agent_sdk.connectors.monday.types.BoardsGtCondition | airbyte_agent_sdk.connectors.monday.types.BoardsGteCondition | airbyte_agent_sdk.connectors.monday.types.BoardsLtCondition | airbyte_agent_sdk.connectors.monday.types.BoardsLteCondition | airbyte_agent_sdk.connectors.monday.types.BoardsInCondition | airbyte_agent_sdk.connectors.monday.types.BoardsLikeCondition | airbyte_agent_sdk.connectors.monday.types.BoardsFuzzyCondition | airbyte_agent_sdk.connectors.monday.types.BoardsKeywordCondition | airbyte_agent_sdk.connectors.monday.types.BoardsContainsCondition | airbyte_agent_sdk.connectors.monday.types.BoardsNotCondition | airbyte_agent_sdk.connectors.monday.types.BoardsAndCondition | airbyte_agent_sdk.connectors.monday.types.BoardsOrCondition | airbyte_agent_sdk.connectors.monday.types.BoardsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="BoardsAnyCondition"></a>
+
 `BoardsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -497,6 +547,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.monday.types.BoardsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="BoardsAnyValueFilter"></a>
 
 `BoardsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -567,6 +619,8 @@ Classes
     `workspace: Any`
     :   Workspace the board belongs to
 
+<a id="BoardsContainsCondition"></a>
+
 `BoardsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -578,6 +632,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.monday.types.BoardsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="BoardsEqCondition"></a>
 
 `BoardsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -591,6 +647,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.monday.types.BoardsSearchFilter`
     :   The type of the None singleton.
 
+<a id="BoardsFuzzyCondition"></a>
+
 `BoardsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -602,6 +660,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.monday.types.BoardsStringFilter`
     :   The type of the None singleton.
+
+<a id="BoardsGetParams"></a>
 
 `BoardsGetParams(*args, **kwargs)`
 :   Parameters for boards.get operation
@@ -615,6 +675,8 @@ Classes
     `id: str`
     :   The type of the None singleton.
 
+<a id="BoardsGtCondition"></a>
+
 `BoardsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -627,6 +689,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.monday.types.BoardsSearchFilter`
     :   The type of the None singleton.
 
+<a id="BoardsGteCondition"></a>
+
 `BoardsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -638,6 +702,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.monday.types.BoardsSearchFilter`
     :   The type of the None singleton.
+
+<a id="BoardsInCondition"></a>
 
 `BoardsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -658,6 +724,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.monday.types.BoardsInFilter`
     :   The type of the None singleton.
+
+<a id="BoardsInFilter"></a>
 
 `BoardsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -728,6 +796,8 @@ Classes
     `workspace: list[dict[str, typing.Any]]`
     :   Workspace the board belongs to
 
+<a id="BoardsKeywordCondition"></a>
+
 `BoardsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -739,6 +809,8 @@ Classes
 
     `keyword: airbyte_agent_sdk.connectors.monday.types.BoardsStringFilter`
     :   The type of the None singleton.
+
+<a id="BoardsLikeCondition"></a>
 
 `BoardsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
@@ -752,12 +824,16 @@ Classes
     `like: airbyte_agent_sdk.connectors.monday.types.BoardsStringFilter`
     :   The type of the None singleton.
 
+<a id="BoardsListParams"></a>
+
 `BoardsListParams(*args, **kwargs)`
 :   Parameters for boards.list operation
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="BoardsLtCondition"></a>
 
 `BoardsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
@@ -771,6 +847,8 @@ Classes
     `lt: airbyte_agent_sdk.connectors.monday.types.BoardsSearchFilter`
     :   The type of the None singleton.
 
+<a id="BoardsLteCondition"></a>
+
 `BoardsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
 
@@ -783,6 +861,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.monday.types.BoardsSearchFilter`
     :   The type of the None singleton.
 
+<a id="BoardsNeqCondition"></a>
+
 `BoardsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -794,6 +874,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.monday.types.BoardsSearchFilter`
     :   The type of the None singleton.
+
+<a id="BoardsNotCondition"></a>
 
 `BoardsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -815,6 +897,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.monday.types.BoardsEqCondition | airbyte_agent_sdk.connectors.monday.types.BoardsNeqCondition | airbyte_agent_sdk.connectors.monday.types.BoardsGtCondition | airbyte_agent_sdk.connectors.monday.types.BoardsGteCondition | airbyte_agent_sdk.connectors.monday.types.BoardsLtCondition | airbyte_agent_sdk.connectors.monday.types.BoardsLteCondition | airbyte_agent_sdk.connectors.monday.types.BoardsInCondition | airbyte_agent_sdk.connectors.monday.types.BoardsLikeCondition | airbyte_agent_sdk.connectors.monday.types.BoardsFuzzyCondition | airbyte_agent_sdk.connectors.monday.types.BoardsKeywordCondition | airbyte_agent_sdk.connectors.monday.types.BoardsContainsCondition | airbyte_agent_sdk.connectors.monday.types.BoardsNotCondition | airbyte_agent_sdk.connectors.monday.types.BoardsAndCondition | airbyte_agent_sdk.connectors.monday.types.BoardsOrCondition | airbyte_agent_sdk.connectors.monday.types.BoardsAnyCondition`
     :   The type of the None singleton.
 
+<a id="BoardsOrCondition"></a>
+
 `BoardsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -834,6 +918,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.monday.types.BoardsEqCondition | airbyte_agent_sdk.connectors.monday.types.BoardsNeqCondition | airbyte_agent_sdk.connectors.monday.types.BoardsGtCondition | airbyte_agent_sdk.connectors.monday.types.BoardsGteCondition | airbyte_agent_sdk.connectors.monday.types.BoardsLtCondition | airbyte_agent_sdk.connectors.monday.types.BoardsLteCondition | airbyte_agent_sdk.connectors.monday.types.BoardsInCondition | airbyte_agent_sdk.connectors.monday.types.BoardsLikeCondition | airbyte_agent_sdk.connectors.monday.types.BoardsFuzzyCondition | airbyte_agent_sdk.connectors.monday.types.BoardsKeywordCondition | airbyte_agent_sdk.connectors.monday.types.BoardsContainsCondition | airbyte_agent_sdk.connectors.monday.types.BoardsNotCondition | airbyte_agent_sdk.connectors.monday.types.BoardsAndCondition | airbyte_agent_sdk.connectors.monday.types.BoardsOrCondition | airbyte_agent_sdk.connectors.monday.types.BoardsAnyCondition]`
     :   The type of the None singleton.
+
+<a id="BoardsSearchFilter"></a>
 
 `BoardsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering boards search queries.
@@ -904,6 +990,8 @@ Classes
     `workspace: dict[str, typing.Any] | None`
     :   Workspace the board belongs to
 
+<a id="BoardsSearchQuery"></a>
+
 `BoardsSearchQuery(*args, **kwargs)`
 :   Search query for boards entity.
 
@@ -918,6 +1006,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.monday.types.BoardsSortFilter]`
     :   The type of the None singleton.
+
+<a id="BoardsSortFilter"></a>
 
 `BoardsSortFilter(*args, **kwargs)`
 :   Available fields for sorting boards search results.
@@ -988,6 +1078,8 @@ Classes
     `workspace: Literal['asc', 'desc']`
     :   Workspace the board belongs to
 
+<a id="BoardsStringFilter"></a>
+
 `BoardsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -1057,6 +1149,8 @@ Classes
     `workspace: str`
     :   Workspace the board belongs to
 
+<a id="ItemsAndCondition"></a>
+
 `ItemsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1077,6 +1171,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.monday.types.ItemsEqCondition | airbyte_agent_sdk.connectors.monday.types.ItemsNeqCondition | airbyte_agent_sdk.connectors.monday.types.ItemsGtCondition | airbyte_agent_sdk.connectors.monday.types.ItemsGteCondition | airbyte_agent_sdk.connectors.monday.types.ItemsLtCondition | airbyte_agent_sdk.connectors.monday.types.ItemsLteCondition | airbyte_agent_sdk.connectors.monday.types.ItemsInCondition | airbyte_agent_sdk.connectors.monday.types.ItemsLikeCondition | airbyte_agent_sdk.connectors.monday.types.ItemsFuzzyCondition | airbyte_agent_sdk.connectors.monday.types.ItemsKeywordCondition | airbyte_agent_sdk.connectors.monday.types.ItemsContainsCondition | airbyte_agent_sdk.connectors.monday.types.ItemsNotCondition | airbyte_agent_sdk.connectors.monday.types.ItemsAndCondition | airbyte_agent_sdk.connectors.monday.types.ItemsOrCondition | airbyte_agent_sdk.connectors.monday.types.ItemsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="ItemsAnyCondition"></a>
+
 `ItemsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1096,6 +1192,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.monday.types.ItemsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="ItemsAnyValueFilter"></a>
 
 `ItemsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -1148,6 +1246,8 @@ Classes
     `updates: Any`
     :   Item updates
 
+<a id="ItemsContainsCondition"></a>
+
 `ItemsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -1159,6 +1259,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.monday.types.ItemsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="ItemsEqCondition"></a>
 
 `ItemsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -1172,6 +1274,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.monday.types.ItemsSearchFilter`
     :   The type of the None singleton.
 
+<a id="ItemsFuzzyCondition"></a>
+
 `ItemsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -1183,6 +1287,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.monday.types.ItemsStringFilter`
     :   The type of the None singleton.
+
+<a id="ItemsGetParams"></a>
 
 `ItemsGetParams(*args, **kwargs)`
 :   Parameters for items.get operation
@@ -1196,6 +1302,8 @@ Classes
     `id: str`
     :   The type of the None singleton.
 
+<a id="ItemsGtCondition"></a>
+
 `ItemsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -1208,6 +1316,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.monday.types.ItemsSearchFilter`
     :   The type of the None singleton.
 
+<a id="ItemsGteCondition"></a>
+
 `ItemsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -1219,6 +1329,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.monday.types.ItemsSearchFilter`
     :   The type of the None singleton.
+
+<a id="ItemsInCondition"></a>
 
 `ItemsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -1239,6 +1351,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.monday.types.ItemsInFilter`
     :   The type of the None singleton.
+
+<a id="ItemsInFilter"></a>
 
 `ItemsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -1291,6 +1405,8 @@ Classes
     `updates: list[list[typing.Any]]`
     :   Item updates
 
+<a id="ItemsKeywordCondition"></a>
+
 `ItemsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -1302,6 +1418,8 @@ Classes
 
     `keyword: airbyte_agent_sdk.connectors.monday.types.ItemsStringFilter`
     :   The type of the None singleton.
+
+<a id="ItemsLikeCondition"></a>
 
 `ItemsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
@@ -1315,6 +1433,8 @@ Classes
     `like: airbyte_agent_sdk.connectors.monday.types.ItemsStringFilter`
     :   The type of the None singleton.
 
+<a id="ItemsListParams"></a>
+
 `ItemsListParams(*args, **kwargs)`
 :   Parameters for items.list operation
 
@@ -1326,6 +1446,8 @@ Classes
 
     `board_id: str`
     :   The type of the None singleton.
+
+<a id="ItemsLtCondition"></a>
 
 `ItemsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
@@ -1339,6 +1461,8 @@ Classes
     `lt: airbyte_agent_sdk.connectors.monday.types.ItemsSearchFilter`
     :   The type of the None singleton.
 
+<a id="ItemsLteCondition"></a>
+
 `ItemsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
 
@@ -1351,6 +1475,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.monday.types.ItemsSearchFilter`
     :   The type of the None singleton.
 
+<a id="ItemsNeqCondition"></a>
+
 `ItemsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -1362,6 +1488,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.monday.types.ItemsSearchFilter`
     :   The type of the None singleton.
+
+<a id="ItemsNotCondition"></a>
 
 `ItemsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -1383,6 +1511,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.monday.types.ItemsEqCondition | airbyte_agent_sdk.connectors.monday.types.ItemsNeqCondition | airbyte_agent_sdk.connectors.monday.types.ItemsGtCondition | airbyte_agent_sdk.connectors.monday.types.ItemsGteCondition | airbyte_agent_sdk.connectors.monday.types.ItemsLtCondition | airbyte_agent_sdk.connectors.monday.types.ItemsLteCondition | airbyte_agent_sdk.connectors.monday.types.ItemsInCondition | airbyte_agent_sdk.connectors.monday.types.ItemsLikeCondition | airbyte_agent_sdk.connectors.monday.types.ItemsFuzzyCondition | airbyte_agent_sdk.connectors.monday.types.ItemsKeywordCondition | airbyte_agent_sdk.connectors.monday.types.ItemsContainsCondition | airbyte_agent_sdk.connectors.monday.types.ItemsNotCondition | airbyte_agent_sdk.connectors.monday.types.ItemsAndCondition | airbyte_agent_sdk.connectors.monday.types.ItemsOrCondition | airbyte_agent_sdk.connectors.monday.types.ItemsAnyCondition`
     :   The type of the None singleton.
 
+<a id="ItemsOrCondition"></a>
+
 `ItemsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1402,6 +1532,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.monday.types.ItemsEqCondition | airbyte_agent_sdk.connectors.monday.types.ItemsNeqCondition | airbyte_agent_sdk.connectors.monday.types.ItemsGtCondition | airbyte_agent_sdk.connectors.monday.types.ItemsGteCondition | airbyte_agent_sdk.connectors.monday.types.ItemsLtCondition | airbyte_agent_sdk.connectors.monday.types.ItemsLteCondition | airbyte_agent_sdk.connectors.monday.types.ItemsInCondition | airbyte_agent_sdk.connectors.monday.types.ItemsLikeCondition | airbyte_agent_sdk.connectors.monday.types.ItemsFuzzyCondition | airbyte_agent_sdk.connectors.monday.types.ItemsKeywordCondition | airbyte_agent_sdk.connectors.monday.types.ItemsContainsCondition | airbyte_agent_sdk.connectors.monday.types.ItemsNotCondition | airbyte_agent_sdk.connectors.monday.types.ItemsAndCondition | airbyte_agent_sdk.connectors.monday.types.ItemsOrCondition | airbyte_agent_sdk.connectors.monday.types.ItemsAnyCondition]`
     :   The type of the None singleton.
+
+<a id="ItemsSearchFilter"></a>
 
 `ItemsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering items search queries.
@@ -1454,6 +1586,8 @@ Classes
     `updates: list[typing.Any] | None`
     :   Item updates
 
+<a id="ItemsSearchQuery"></a>
+
 `ItemsSearchQuery(*args, **kwargs)`
 :   Search query for items entity.
 
@@ -1468,6 +1602,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.monday.types.ItemsSortFilter]`
     :   The type of the None singleton.
+
+<a id="ItemsSortFilter"></a>
 
 `ItemsSortFilter(*args, **kwargs)`
 :   Available fields for sorting items search results.
@@ -1520,6 +1656,8 @@ Classes
     `updates: Literal['asc', 'desc']`
     :   Item updates
 
+<a id="ItemsStringFilter"></a>
+
 `ItemsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -1571,6 +1709,8 @@ Classes
     `updates: str`
     :   Item updates
 
+<a id="TagsAndCondition"></a>
+
 `TagsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1590,6 +1730,8 @@ Classes
 
     `and: list[airbyte_agent_sdk.connectors.monday.types.TagsEqCondition | airbyte_agent_sdk.connectors.monday.types.TagsNeqCondition | airbyte_agent_sdk.connectors.monday.types.TagsGtCondition | airbyte_agent_sdk.connectors.monday.types.TagsGteCondition | airbyte_agent_sdk.connectors.monday.types.TagsLtCondition | airbyte_agent_sdk.connectors.monday.types.TagsLteCondition | airbyte_agent_sdk.connectors.monday.types.TagsInCondition | airbyte_agent_sdk.connectors.monday.types.TagsLikeCondition | airbyte_agent_sdk.connectors.monday.types.TagsFuzzyCondition | airbyte_agent_sdk.connectors.monday.types.TagsKeywordCondition | airbyte_agent_sdk.connectors.monday.types.TagsContainsCondition | airbyte_agent_sdk.connectors.monday.types.TagsNotCondition | airbyte_agent_sdk.connectors.monday.types.TagsAndCondition | airbyte_agent_sdk.connectors.monday.types.TagsOrCondition | airbyte_agent_sdk.connectors.monday.types.TagsAnyCondition]`
     :   The type of the None singleton.
+
+<a id="TagsAnyCondition"></a>
 
 `TagsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -1611,6 +1753,8 @@ Classes
     `any: airbyte_agent_sdk.connectors.monday.types.TagsAnyValueFilter`
     :   The type of the None singleton.
 
+<a id="TagsAnyValueFilter"></a>
+
 `TagsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
 
@@ -1629,6 +1773,8 @@ Classes
     `name: Any`
     :   Tag name
 
+<a id="TagsContainsCondition"></a>
+
 `TagsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -1640,6 +1786,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.monday.types.TagsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="TagsEqCondition"></a>
 
 `TagsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -1653,6 +1801,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.monday.types.TagsSearchFilter`
     :   The type of the None singleton.
 
+<a id="TagsFuzzyCondition"></a>
+
 `TagsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -1664,6 +1814,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.monday.types.TagsStringFilter`
     :   The type of the None singleton.
+
+<a id="TagsGtCondition"></a>
 
 `TagsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
@@ -1677,6 +1829,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.monday.types.TagsSearchFilter`
     :   The type of the None singleton.
 
+<a id="TagsGteCondition"></a>
+
 `TagsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -1688,6 +1842,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.monday.types.TagsSearchFilter`
     :   The type of the None singleton.
+
+<a id="TagsInCondition"></a>
 
 `TagsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -1709,6 +1865,8 @@ Classes
     `in: airbyte_agent_sdk.connectors.monday.types.TagsInFilter`
     :   The type of the None singleton.
 
+<a id="TagsInFilter"></a>
+
 `TagsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
 
@@ -1727,6 +1885,8 @@ Classes
     `name: list[str]`
     :   Tag name
 
+<a id="TagsKeywordCondition"></a>
+
 `TagsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -1738,6 +1898,8 @@ Classes
 
     `keyword: airbyte_agent_sdk.connectors.monday.types.TagsStringFilter`
     :   The type of the None singleton.
+
+<a id="TagsLikeCondition"></a>
 
 `TagsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
@@ -1751,12 +1913,16 @@ Classes
     `like: airbyte_agent_sdk.connectors.monday.types.TagsStringFilter`
     :   The type of the None singleton.
 
+<a id="TagsListParams"></a>
+
 `TagsListParams(*args, **kwargs)`
 :   Parameters for tags.list operation
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="TagsLtCondition"></a>
 
 `TagsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
@@ -1770,6 +1936,8 @@ Classes
     `lt: airbyte_agent_sdk.connectors.monday.types.TagsSearchFilter`
     :   The type of the None singleton.
 
+<a id="TagsLteCondition"></a>
+
 `TagsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
 
@@ -1782,6 +1950,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.monday.types.TagsSearchFilter`
     :   The type of the None singleton.
 
+<a id="TagsNeqCondition"></a>
+
 `TagsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -1793,6 +1963,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.monday.types.TagsSearchFilter`
     :   The type of the None singleton.
+
+<a id="TagsNotCondition"></a>
 
 `TagsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -1814,6 +1986,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.monday.types.TagsEqCondition | airbyte_agent_sdk.connectors.monday.types.TagsNeqCondition | airbyte_agent_sdk.connectors.monday.types.TagsGtCondition | airbyte_agent_sdk.connectors.monday.types.TagsGteCondition | airbyte_agent_sdk.connectors.monday.types.TagsLtCondition | airbyte_agent_sdk.connectors.monday.types.TagsLteCondition | airbyte_agent_sdk.connectors.monday.types.TagsInCondition | airbyte_agent_sdk.connectors.monday.types.TagsLikeCondition | airbyte_agent_sdk.connectors.monday.types.TagsFuzzyCondition | airbyte_agent_sdk.connectors.monday.types.TagsKeywordCondition | airbyte_agent_sdk.connectors.monday.types.TagsContainsCondition | airbyte_agent_sdk.connectors.monday.types.TagsNotCondition | airbyte_agent_sdk.connectors.monday.types.TagsAndCondition | airbyte_agent_sdk.connectors.monday.types.TagsOrCondition | airbyte_agent_sdk.connectors.monday.types.TagsAnyCondition`
     :   The type of the None singleton.
 
+<a id="TagsOrCondition"></a>
+
 `TagsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1834,6 +2008,8 @@ Classes
     `or: list[airbyte_agent_sdk.connectors.monday.types.TagsEqCondition | airbyte_agent_sdk.connectors.monday.types.TagsNeqCondition | airbyte_agent_sdk.connectors.monday.types.TagsGtCondition | airbyte_agent_sdk.connectors.monday.types.TagsGteCondition | airbyte_agent_sdk.connectors.monday.types.TagsLtCondition | airbyte_agent_sdk.connectors.monday.types.TagsLteCondition | airbyte_agent_sdk.connectors.monday.types.TagsInCondition | airbyte_agent_sdk.connectors.monday.types.TagsLikeCondition | airbyte_agent_sdk.connectors.monday.types.TagsFuzzyCondition | airbyte_agent_sdk.connectors.monday.types.TagsKeywordCondition | airbyte_agent_sdk.connectors.monday.types.TagsContainsCondition | airbyte_agent_sdk.connectors.monday.types.TagsNotCondition | airbyte_agent_sdk.connectors.monday.types.TagsAndCondition | airbyte_agent_sdk.connectors.monday.types.TagsOrCondition | airbyte_agent_sdk.connectors.monday.types.TagsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="TagsSearchFilter"></a>
+
 `TagsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering tags search queries.
 
@@ -1852,6 +2028,8 @@ Classes
     `name: str | None`
     :   Tag name
 
+<a id="TagsSearchQuery"></a>
+
 `TagsSearchQuery(*args, **kwargs)`
 :   Search query for tags entity.
 
@@ -1866,6 +2044,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.monday.types.TagsSortFilter]`
     :   The type of the None singleton.
+
+<a id="TagsSortFilter"></a>
 
 `TagsSortFilter(*args, **kwargs)`
 :   Available fields for sorting tags search results.
@@ -1885,6 +2065,8 @@ Classes
     `name: Literal['asc', 'desc']`
     :   Tag name
 
+<a id="TagsStringFilter"></a>
+
 `TagsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -1902,6 +2084,8 @@ Classes
 
     `name: str`
     :   Tag name
+
+<a id="TeamsAndCondition"></a>
 
 `TeamsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -1923,6 +2107,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.monday.types.TeamsEqCondition | airbyte_agent_sdk.connectors.monday.types.TeamsNeqCondition | airbyte_agent_sdk.connectors.monday.types.TeamsGtCondition | airbyte_agent_sdk.connectors.monday.types.TeamsGteCondition | airbyte_agent_sdk.connectors.monday.types.TeamsLtCondition | airbyte_agent_sdk.connectors.monday.types.TeamsLteCondition | airbyte_agent_sdk.connectors.monday.types.TeamsInCondition | airbyte_agent_sdk.connectors.monday.types.TeamsLikeCondition | airbyte_agent_sdk.connectors.monday.types.TeamsFuzzyCondition | airbyte_agent_sdk.connectors.monday.types.TeamsKeywordCondition | airbyte_agent_sdk.connectors.monday.types.TeamsContainsCondition | airbyte_agent_sdk.connectors.monday.types.TeamsNotCondition | airbyte_agent_sdk.connectors.monday.types.TeamsAndCondition | airbyte_agent_sdk.connectors.monday.types.TeamsOrCondition | airbyte_agent_sdk.connectors.monday.types.TeamsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="TeamsAnyCondition"></a>
+
 `TeamsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1942,6 +2128,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.monday.types.TeamsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="TeamsAnyValueFilter"></a>
 
 `TeamsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -1964,6 +2152,8 @@ Classes
     `users: Any`
     :   Team members
 
+<a id="TeamsContainsCondition"></a>
+
 `TeamsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -1975,6 +2165,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.monday.types.TeamsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="TeamsEqCondition"></a>
 
 `TeamsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -1988,6 +2180,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.monday.types.TeamsSearchFilter`
     :   The type of the None singleton.
 
+<a id="TeamsFuzzyCondition"></a>
+
 `TeamsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -1999,6 +2193,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.monday.types.TeamsStringFilter`
     :   The type of the None singleton.
+
+<a id="TeamsGetParams"></a>
 
 `TeamsGetParams(*args, **kwargs)`
 :   Parameters for teams.get operation
@@ -2012,6 +2208,8 @@ Classes
     `id: str`
     :   The type of the None singleton.
 
+<a id="TeamsGtCondition"></a>
+
 `TeamsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -2024,6 +2222,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.monday.types.TeamsSearchFilter`
     :   The type of the None singleton.
 
+<a id="TeamsGteCondition"></a>
+
 `TeamsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -2035,6 +2235,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.monday.types.TeamsSearchFilter`
     :   The type of the None singleton.
+
+<a id="TeamsInCondition"></a>
 
 `TeamsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -2055,6 +2257,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.monday.types.TeamsInFilter`
     :   The type of the None singleton.
+
+<a id="TeamsInFilter"></a>
 
 `TeamsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -2077,6 +2281,8 @@ Classes
     `users: list[list[typing.Any]]`
     :   Team members
 
+<a id="TeamsKeywordCondition"></a>
+
 `TeamsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -2088,6 +2294,8 @@ Classes
 
     `keyword: airbyte_agent_sdk.connectors.monday.types.TeamsStringFilter`
     :   The type of the None singleton.
+
+<a id="TeamsLikeCondition"></a>
 
 `TeamsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
@@ -2101,12 +2309,16 @@ Classes
     `like: airbyte_agent_sdk.connectors.monday.types.TeamsStringFilter`
     :   The type of the None singleton.
 
+<a id="TeamsListParams"></a>
+
 `TeamsListParams(*args, **kwargs)`
 :   Parameters for teams.list operation
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="TeamsLtCondition"></a>
 
 `TeamsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
@@ -2120,6 +2332,8 @@ Classes
     `lt: airbyte_agent_sdk.connectors.monday.types.TeamsSearchFilter`
     :   The type of the None singleton.
 
+<a id="TeamsLteCondition"></a>
+
 `TeamsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
 
@@ -2132,6 +2346,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.monday.types.TeamsSearchFilter`
     :   The type of the None singleton.
 
+<a id="TeamsNeqCondition"></a>
+
 `TeamsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -2143,6 +2359,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.monday.types.TeamsSearchFilter`
     :   The type of the None singleton.
+
+<a id="TeamsNotCondition"></a>
 
 `TeamsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -2164,6 +2382,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.monday.types.TeamsEqCondition | airbyte_agent_sdk.connectors.monday.types.TeamsNeqCondition | airbyte_agent_sdk.connectors.monday.types.TeamsGtCondition | airbyte_agent_sdk.connectors.monday.types.TeamsGteCondition | airbyte_agent_sdk.connectors.monday.types.TeamsLtCondition | airbyte_agent_sdk.connectors.monday.types.TeamsLteCondition | airbyte_agent_sdk.connectors.monday.types.TeamsInCondition | airbyte_agent_sdk.connectors.monday.types.TeamsLikeCondition | airbyte_agent_sdk.connectors.monday.types.TeamsFuzzyCondition | airbyte_agent_sdk.connectors.monday.types.TeamsKeywordCondition | airbyte_agent_sdk.connectors.monday.types.TeamsContainsCondition | airbyte_agent_sdk.connectors.monday.types.TeamsNotCondition | airbyte_agent_sdk.connectors.monday.types.TeamsAndCondition | airbyte_agent_sdk.connectors.monday.types.TeamsOrCondition | airbyte_agent_sdk.connectors.monday.types.TeamsAnyCondition`
     :   The type of the None singleton.
 
+<a id="TeamsOrCondition"></a>
+
 `TeamsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -2183,6 +2403,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.monday.types.TeamsEqCondition | airbyte_agent_sdk.connectors.monday.types.TeamsNeqCondition | airbyte_agent_sdk.connectors.monday.types.TeamsGtCondition | airbyte_agent_sdk.connectors.monday.types.TeamsGteCondition | airbyte_agent_sdk.connectors.monday.types.TeamsLtCondition | airbyte_agent_sdk.connectors.monday.types.TeamsLteCondition | airbyte_agent_sdk.connectors.monday.types.TeamsInCondition | airbyte_agent_sdk.connectors.monday.types.TeamsLikeCondition | airbyte_agent_sdk.connectors.monday.types.TeamsFuzzyCondition | airbyte_agent_sdk.connectors.monday.types.TeamsKeywordCondition | airbyte_agent_sdk.connectors.monday.types.TeamsContainsCondition | airbyte_agent_sdk.connectors.monday.types.TeamsNotCondition | airbyte_agent_sdk.connectors.monday.types.TeamsAndCondition | airbyte_agent_sdk.connectors.monday.types.TeamsOrCondition | airbyte_agent_sdk.connectors.monday.types.TeamsAnyCondition]`
     :   The type of the None singleton.
+
+<a id="TeamsSearchFilter"></a>
 
 `TeamsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering teams search queries.
@@ -2205,6 +2427,8 @@ Classes
     `users: list[typing.Any] | None`
     :   Team members
 
+<a id="TeamsSearchQuery"></a>
+
 `TeamsSearchQuery(*args, **kwargs)`
 :   Search query for teams entity.
 
@@ -2219,6 +2443,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.monday.types.TeamsSortFilter]`
     :   The type of the None singleton.
+
+<a id="TeamsSortFilter"></a>
 
 `TeamsSortFilter(*args, **kwargs)`
 :   Available fields for sorting teams search results.
@@ -2241,6 +2467,8 @@ Classes
     `users: Literal['asc', 'desc']`
     :   Team members
 
+<a id="TeamsStringFilter"></a>
+
 `TeamsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -2262,6 +2490,8 @@ Classes
     `users: str`
     :   Team members
 
+<a id="UpdatesAndCondition"></a>
+
 `UpdatesAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -2282,6 +2512,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.monday.types.UpdatesEqCondition | airbyte_agent_sdk.connectors.monday.types.UpdatesNeqCondition | airbyte_agent_sdk.connectors.monday.types.UpdatesGtCondition | airbyte_agent_sdk.connectors.monday.types.UpdatesGteCondition | airbyte_agent_sdk.connectors.monday.types.UpdatesLtCondition | airbyte_agent_sdk.connectors.monday.types.UpdatesLteCondition | airbyte_agent_sdk.connectors.monday.types.UpdatesInCondition | airbyte_agent_sdk.connectors.monday.types.UpdatesLikeCondition | airbyte_agent_sdk.connectors.monday.types.UpdatesFuzzyCondition | airbyte_agent_sdk.connectors.monday.types.UpdatesKeywordCondition | airbyte_agent_sdk.connectors.monday.types.UpdatesContainsCondition | airbyte_agent_sdk.connectors.monday.types.UpdatesNotCondition | airbyte_agent_sdk.connectors.monday.types.UpdatesAndCondition | airbyte_agent_sdk.connectors.monday.types.UpdatesOrCondition | airbyte_agent_sdk.connectors.monday.types.UpdatesAnyCondition]`
     :   The type of the None singleton.
 
+<a id="UpdatesAnyCondition"></a>
+
 `UpdatesAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -2301,6 +2533,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.monday.types.UpdatesAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="UpdatesAnyValueFilter"></a>
 
 `UpdatesAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -2338,6 +2572,8 @@ Classes
     `updated_at: Any`
     :   When the update was last modified
 
+<a id="UpdatesContainsCondition"></a>
+
 `UpdatesContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -2349,6 +2585,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.monday.types.UpdatesAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="UpdatesEqCondition"></a>
 
 `UpdatesEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -2362,6 +2600,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.monday.types.UpdatesSearchFilter`
     :   The type of the None singleton.
 
+<a id="UpdatesFuzzyCondition"></a>
+
 `UpdatesFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -2373,6 +2613,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.monday.types.UpdatesStringFilter`
     :   The type of the None singleton.
+
+<a id="UpdatesGetParams"></a>
 
 `UpdatesGetParams(*args, **kwargs)`
 :   Parameters for updates.get operation
@@ -2386,6 +2628,8 @@ Classes
     `id: str`
     :   The type of the None singleton.
 
+<a id="UpdatesGtCondition"></a>
+
 `UpdatesGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -2398,6 +2642,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.monday.types.UpdatesSearchFilter`
     :   The type of the None singleton.
 
+<a id="UpdatesGteCondition"></a>
+
 `UpdatesGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -2409,6 +2655,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.monday.types.UpdatesSearchFilter`
     :   The type of the None singleton.
+
+<a id="UpdatesInCondition"></a>
 
 `UpdatesInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -2429,6 +2677,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.monday.types.UpdatesInFilter`
     :   The type of the None singleton.
+
+<a id="UpdatesInFilter"></a>
 
 `UpdatesInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -2466,6 +2716,8 @@ Classes
     `updated_at: list[str]`
     :   When the update was last modified
 
+<a id="UpdatesKeywordCondition"></a>
+
 `UpdatesKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -2478,6 +2730,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.monday.types.UpdatesStringFilter`
     :   The type of the None singleton.
 
+<a id="UpdatesLikeCondition"></a>
+
 `UpdatesLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -2489,6 +2743,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.monday.types.UpdatesStringFilter`
     :   The type of the None singleton.
+
+<a id="UpdatesListParams"></a>
 
 `UpdatesListParams(*args, **kwargs)`
 :   Parameters for updates.list operation
@@ -2505,6 +2761,8 @@ Classes
     `page: int`
     :   The type of the None singleton.
 
+<a id="UpdatesLtCondition"></a>
+
 `UpdatesLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -2516,6 +2774,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.monday.types.UpdatesSearchFilter`
     :   The type of the None singleton.
+
+<a id="UpdatesLteCondition"></a>
 
 `UpdatesLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -2529,6 +2789,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.monday.types.UpdatesSearchFilter`
     :   The type of the None singleton.
 
+<a id="UpdatesNeqCondition"></a>
+
 `UpdatesNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -2540,6 +2802,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.monday.types.UpdatesSearchFilter`
     :   The type of the None singleton.
+
+<a id="UpdatesNotCondition"></a>
 
 `UpdatesNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -2561,6 +2825,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.monday.types.UpdatesEqCondition | airbyte_agent_sdk.connectors.monday.types.UpdatesNeqCondition | airbyte_agent_sdk.connectors.monday.types.UpdatesGtCondition | airbyte_agent_sdk.connectors.monday.types.UpdatesGteCondition | airbyte_agent_sdk.connectors.monday.types.UpdatesLtCondition | airbyte_agent_sdk.connectors.monday.types.UpdatesLteCondition | airbyte_agent_sdk.connectors.monday.types.UpdatesInCondition | airbyte_agent_sdk.connectors.monday.types.UpdatesLikeCondition | airbyte_agent_sdk.connectors.monday.types.UpdatesFuzzyCondition | airbyte_agent_sdk.connectors.monday.types.UpdatesKeywordCondition | airbyte_agent_sdk.connectors.monday.types.UpdatesContainsCondition | airbyte_agent_sdk.connectors.monday.types.UpdatesNotCondition | airbyte_agent_sdk.connectors.monday.types.UpdatesAndCondition | airbyte_agent_sdk.connectors.monday.types.UpdatesOrCondition | airbyte_agent_sdk.connectors.monday.types.UpdatesAnyCondition`
     :   The type of the None singleton.
 
+<a id="UpdatesOrCondition"></a>
+
 `UpdatesOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -2580,6 +2846,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.monday.types.UpdatesEqCondition | airbyte_agent_sdk.connectors.monday.types.UpdatesNeqCondition | airbyte_agent_sdk.connectors.monday.types.UpdatesGtCondition | airbyte_agent_sdk.connectors.monday.types.UpdatesGteCondition | airbyte_agent_sdk.connectors.monday.types.UpdatesLtCondition | airbyte_agent_sdk.connectors.monday.types.UpdatesLteCondition | airbyte_agent_sdk.connectors.monday.types.UpdatesInCondition | airbyte_agent_sdk.connectors.monday.types.UpdatesLikeCondition | airbyte_agent_sdk.connectors.monday.types.UpdatesFuzzyCondition | airbyte_agent_sdk.connectors.monday.types.UpdatesKeywordCondition | airbyte_agent_sdk.connectors.monday.types.UpdatesContainsCondition | airbyte_agent_sdk.connectors.monday.types.UpdatesNotCondition | airbyte_agent_sdk.connectors.monday.types.UpdatesAndCondition | airbyte_agent_sdk.connectors.monday.types.UpdatesOrCondition | airbyte_agent_sdk.connectors.monday.types.UpdatesAnyCondition]`
     :   The type of the None singleton.
+
+<a id="UpdatesSearchFilter"></a>
 
 `UpdatesSearchFilter(*args, **kwargs)`
 :   Available fields for filtering updates search queries.
@@ -2617,6 +2885,8 @@ Classes
     `updated_at: str | None`
     :   When the update was last modified
 
+<a id="UpdatesSearchQuery"></a>
+
 `UpdatesSearchQuery(*args, **kwargs)`
 :   Search query for updates entity.
 
@@ -2631,6 +2901,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.monday.types.UpdatesSortFilter]`
     :   The type of the None singleton.
+
+<a id="UpdatesSortFilter"></a>
 
 `UpdatesSortFilter(*args, **kwargs)`
 :   Available fields for sorting updates search results.
@@ -2668,6 +2940,8 @@ Classes
     `updated_at: Literal['asc', 'desc']`
     :   When the update was last modified
 
+<a id="UpdatesStringFilter"></a>
+
 `UpdatesStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -2704,6 +2978,8 @@ Classes
     `updated_at: str`
     :   When the update was last modified
 
+<a id="UsersAndCondition"></a>
+
 `UsersAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -2724,6 +3000,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.monday.types.UsersEqCondition | airbyte_agent_sdk.connectors.monday.types.UsersNeqCondition | airbyte_agent_sdk.connectors.monday.types.UsersGtCondition | airbyte_agent_sdk.connectors.monday.types.UsersGteCondition | airbyte_agent_sdk.connectors.monday.types.UsersLtCondition | airbyte_agent_sdk.connectors.monday.types.UsersLteCondition | airbyte_agent_sdk.connectors.monday.types.UsersInCondition | airbyte_agent_sdk.connectors.monday.types.UsersLikeCondition | airbyte_agent_sdk.connectors.monday.types.UsersFuzzyCondition | airbyte_agent_sdk.connectors.monday.types.UsersKeywordCondition | airbyte_agent_sdk.connectors.monday.types.UsersContainsCondition | airbyte_agent_sdk.connectors.monday.types.UsersNotCondition | airbyte_agent_sdk.connectors.monday.types.UsersAndCondition | airbyte_agent_sdk.connectors.monday.types.UsersOrCondition | airbyte_agent_sdk.connectors.monday.types.UsersAnyCondition]`
     :   The type of the None singleton.
 
+<a id="UsersAnyCondition"></a>
+
 `UsersAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -2743,6 +3021,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.monday.types.UsersAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="UsersAnyValueFilter"></a>
 
 `UsersAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -2828,6 +3108,8 @@ Classes
     `utc_hours_diff: Any`
     :   UTC hours difference for the user's timezone
 
+<a id="UsersContainsCondition"></a>
+
 `UsersContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -2839,6 +3121,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.monday.types.UsersAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="UsersEqCondition"></a>
 
 `UsersEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -2852,6 +3136,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.monday.types.UsersSearchFilter`
     :   The type of the None singleton.
 
+<a id="UsersFuzzyCondition"></a>
+
 `UsersFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -2863,6 +3149,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.monday.types.UsersStringFilter`
     :   The type of the None singleton.
+
+<a id="UsersGetParams"></a>
 
 `UsersGetParams(*args, **kwargs)`
 :   Parameters for users.get operation
@@ -2876,6 +3164,8 @@ Classes
     `id: str`
     :   The type of the None singleton.
 
+<a id="UsersGtCondition"></a>
+
 `UsersGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -2888,6 +3178,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.monday.types.UsersSearchFilter`
     :   The type of the None singleton.
 
+<a id="UsersGteCondition"></a>
+
 `UsersGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -2899,6 +3191,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.monday.types.UsersSearchFilter`
     :   The type of the None singleton.
+
+<a id="UsersInCondition"></a>
 
 `UsersInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -2919,6 +3213,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.monday.types.UsersInFilter`
     :   The type of the None singleton.
+
+<a id="UsersInFilter"></a>
 
 `UsersInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -3004,6 +3300,8 @@ Classes
     `utc_hours_diff: list[int]`
     :   UTC hours difference for the user's timezone
 
+<a id="UsersKeywordCondition"></a>
+
 `UsersKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -3015,6 +3313,8 @@ Classes
 
     `keyword: airbyte_agent_sdk.connectors.monday.types.UsersStringFilter`
     :   The type of the None singleton.
+
+<a id="UsersLikeCondition"></a>
 
 `UsersLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
@@ -3028,12 +3328,16 @@ Classes
     `like: airbyte_agent_sdk.connectors.monday.types.UsersStringFilter`
     :   The type of the None singleton.
 
+<a id="UsersListParams"></a>
+
 `UsersListParams(*args, **kwargs)`
 :   Parameters for users.list operation
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="UsersLtCondition"></a>
 
 `UsersLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
@@ -3047,6 +3351,8 @@ Classes
     `lt: airbyte_agent_sdk.connectors.monday.types.UsersSearchFilter`
     :   The type of the None singleton.
 
+<a id="UsersLteCondition"></a>
+
 `UsersLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
 
@@ -3059,6 +3365,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.monday.types.UsersSearchFilter`
     :   The type of the None singleton.
 
+<a id="UsersNeqCondition"></a>
+
 `UsersNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -3070,6 +3378,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.monday.types.UsersSearchFilter`
     :   The type of the None singleton.
+
+<a id="UsersNotCondition"></a>
 
 `UsersNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -3091,6 +3401,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.monday.types.UsersEqCondition | airbyte_agent_sdk.connectors.monday.types.UsersNeqCondition | airbyte_agent_sdk.connectors.monday.types.UsersGtCondition | airbyte_agent_sdk.connectors.monday.types.UsersGteCondition | airbyte_agent_sdk.connectors.monday.types.UsersLtCondition | airbyte_agent_sdk.connectors.monday.types.UsersLteCondition | airbyte_agent_sdk.connectors.monday.types.UsersInCondition | airbyte_agent_sdk.connectors.monday.types.UsersLikeCondition | airbyte_agent_sdk.connectors.monday.types.UsersFuzzyCondition | airbyte_agent_sdk.connectors.monday.types.UsersKeywordCondition | airbyte_agent_sdk.connectors.monday.types.UsersContainsCondition | airbyte_agent_sdk.connectors.monday.types.UsersNotCondition | airbyte_agent_sdk.connectors.monday.types.UsersAndCondition | airbyte_agent_sdk.connectors.monday.types.UsersOrCondition | airbyte_agent_sdk.connectors.monday.types.UsersAnyCondition`
     :   The type of the None singleton.
 
+<a id="UsersOrCondition"></a>
+
 `UsersOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -3110,6 +3422,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.monday.types.UsersEqCondition | airbyte_agent_sdk.connectors.monday.types.UsersNeqCondition | airbyte_agent_sdk.connectors.monday.types.UsersGtCondition | airbyte_agent_sdk.connectors.monday.types.UsersGteCondition | airbyte_agent_sdk.connectors.monday.types.UsersLtCondition | airbyte_agent_sdk.connectors.monday.types.UsersLteCondition | airbyte_agent_sdk.connectors.monday.types.UsersInCondition | airbyte_agent_sdk.connectors.monday.types.UsersLikeCondition | airbyte_agent_sdk.connectors.monday.types.UsersFuzzyCondition | airbyte_agent_sdk.connectors.monday.types.UsersKeywordCondition | airbyte_agent_sdk.connectors.monday.types.UsersContainsCondition | airbyte_agent_sdk.connectors.monday.types.UsersNotCondition | airbyte_agent_sdk.connectors.monday.types.UsersAndCondition | airbyte_agent_sdk.connectors.monday.types.UsersOrCondition | airbyte_agent_sdk.connectors.monday.types.UsersAnyCondition]`
     :   The type of the None singleton.
+
+<a id="UsersSearchFilter"></a>
 
 `UsersSearchFilter(*args, **kwargs)`
 :   Available fields for filtering users search queries.
@@ -3195,6 +3509,8 @@ Classes
     `utc_hours_diff: int | None`
     :   UTC hours difference for the user's timezone
 
+<a id="UsersSearchQuery"></a>
+
 `UsersSearchQuery(*args, **kwargs)`
 :   Search query for users entity.
 
@@ -3209,6 +3525,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.monday.types.UsersSortFilter]`
     :   The type of the None singleton.
+
+<a id="UsersSortFilter"></a>
 
 `UsersSortFilter(*args, **kwargs)`
 :   Available fields for sorting users search results.
@@ -3294,6 +3612,8 @@ Classes
     `utc_hours_diff: Literal['asc', 'desc']`
     :   UTC hours difference for the user's timezone
 
+<a id="UsersStringFilter"></a>
+
 `UsersStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -3378,6 +3698,8 @@ Classes
     `utc_hours_diff: str`
     :   UTC hours difference for the user's timezone
 
+<a id="WorkspacesAndCondition"></a>
+
 `WorkspacesAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -3398,6 +3720,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.monday.types.WorkspacesEqCondition | airbyte_agent_sdk.connectors.monday.types.WorkspacesNeqCondition | airbyte_agent_sdk.connectors.monday.types.WorkspacesGtCondition | airbyte_agent_sdk.connectors.monday.types.WorkspacesGteCondition | airbyte_agent_sdk.connectors.monday.types.WorkspacesLtCondition | airbyte_agent_sdk.connectors.monday.types.WorkspacesLteCondition | airbyte_agent_sdk.connectors.monday.types.WorkspacesInCondition | airbyte_agent_sdk.connectors.monday.types.WorkspacesLikeCondition | airbyte_agent_sdk.connectors.monday.types.WorkspacesFuzzyCondition | airbyte_agent_sdk.connectors.monday.types.WorkspacesKeywordCondition | airbyte_agent_sdk.connectors.monday.types.WorkspacesContainsCondition | airbyte_agent_sdk.connectors.monday.types.WorkspacesNotCondition | airbyte_agent_sdk.connectors.monday.types.WorkspacesAndCondition | airbyte_agent_sdk.connectors.monday.types.WorkspacesOrCondition | airbyte_agent_sdk.connectors.monday.types.WorkspacesAnyCondition]`
     :   The type of the None singleton.
 
+<a id="WorkspacesAnyCondition"></a>
+
 `WorkspacesAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -3417,6 +3741,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.monday.types.WorkspacesAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="WorkspacesAnyValueFilter"></a>
 
 `WorkspacesAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -3463,6 +3789,8 @@ Classes
     `users_subscribers: Any`
     :   User subscribers
 
+<a id="WorkspacesContainsCondition"></a>
+
 `WorkspacesContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -3474,6 +3802,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.monday.types.WorkspacesAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="WorkspacesEqCondition"></a>
 
 `WorkspacesEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -3487,6 +3817,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.monday.types.WorkspacesSearchFilter`
     :   The type of the None singleton.
 
+<a id="WorkspacesFuzzyCondition"></a>
+
 `WorkspacesFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -3498,6 +3830,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.monday.types.WorkspacesStringFilter`
     :   The type of the None singleton.
+
+<a id="WorkspacesGetParams"></a>
 
 `WorkspacesGetParams(*args, **kwargs)`
 :   Parameters for workspaces.get operation
@@ -3511,6 +3845,8 @@ Classes
     `id: str`
     :   The type of the None singleton.
 
+<a id="WorkspacesGtCondition"></a>
+
 `WorkspacesGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -3523,6 +3859,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.monday.types.WorkspacesSearchFilter`
     :   The type of the None singleton.
 
+<a id="WorkspacesGteCondition"></a>
+
 `WorkspacesGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -3534,6 +3872,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.monday.types.WorkspacesSearchFilter`
     :   The type of the None singleton.
+
+<a id="WorkspacesInCondition"></a>
 
 `WorkspacesInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -3554,6 +3894,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.monday.types.WorkspacesInFilter`
     :   The type of the None singleton.
+
+<a id="WorkspacesInFilter"></a>
 
 `WorkspacesInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -3600,6 +3942,8 @@ Classes
     `users_subscribers: list[list[typing.Any]]`
     :   User subscribers
 
+<a id="WorkspacesKeywordCondition"></a>
+
 `WorkspacesKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -3611,6 +3955,8 @@ Classes
 
     `keyword: airbyte_agent_sdk.connectors.monday.types.WorkspacesStringFilter`
     :   The type of the None singleton.
+
+<a id="WorkspacesLikeCondition"></a>
 
 `WorkspacesLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
@@ -3624,12 +3970,16 @@ Classes
     `like: airbyte_agent_sdk.connectors.monday.types.WorkspacesStringFilter`
     :   The type of the None singleton.
 
+<a id="WorkspacesListParams"></a>
+
 `WorkspacesListParams(*args, **kwargs)`
 :   Parameters for workspaces.list operation
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="WorkspacesLtCondition"></a>
 
 `WorkspacesLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
@@ -3643,6 +3993,8 @@ Classes
     `lt: airbyte_agent_sdk.connectors.monday.types.WorkspacesSearchFilter`
     :   The type of the None singleton.
 
+<a id="WorkspacesLteCondition"></a>
+
 `WorkspacesLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
 
@@ -3655,6 +4007,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.monday.types.WorkspacesSearchFilter`
     :   The type of the None singleton.
 
+<a id="WorkspacesNeqCondition"></a>
+
 `WorkspacesNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -3666,6 +4020,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.monday.types.WorkspacesSearchFilter`
     :   The type of the None singleton.
+
+<a id="WorkspacesNotCondition"></a>
 
 `WorkspacesNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -3687,6 +4043,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.monday.types.WorkspacesEqCondition | airbyte_agent_sdk.connectors.monday.types.WorkspacesNeqCondition | airbyte_agent_sdk.connectors.monday.types.WorkspacesGtCondition | airbyte_agent_sdk.connectors.monday.types.WorkspacesGteCondition | airbyte_agent_sdk.connectors.monday.types.WorkspacesLtCondition | airbyte_agent_sdk.connectors.monday.types.WorkspacesLteCondition | airbyte_agent_sdk.connectors.monday.types.WorkspacesInCondition | airbyte_agent_sdk.connectors.monday.types.WorkspacesLikeCondition | airbyte_agent_sdk.connectors.monday.types.WorkspacesFuzzyCondition | airbyte_agent_sdk.connectors.monday.types.WorkspacesKeywordCondition | airbyte_agent_sdk.connectors.monday.types.WorkspacesContainsCondition | airbyte_agent_sdk.connectors.monday.types.WorkspacesNotCondition | airbyte_agent_sdk.connectors.monday.types.WorkspacesAndCondition | airbyte_agent_sdk.connectors.monday.types.WorkspacesOrCondition | airbyte_agent_sdk.connectors.monday.types.WorkspacesAnyCondition`
     :   The type of the None singleton.
 
+<a id="WorkspacesOrCondition"></a>
+
 `WorkspacesOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -3706,6 +4064,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.monday.types.WorkspacesEqCondition | airbyte_agent_sdk.connectors.monday.types.WorkspacesNeqCondition | airbyte_agent_sdk.connectors.monday.types.WorkspacesGtCondition | airbyte_agent_sdk.connectors.monday.types.WorkspacesGteCondition | airbyte_agent_sdk.connectors.monday.types.WorkspacesLtCondition | airbyte_agent_sdk.connectors.monday.types.WorkspacesLteCondition | airbyte_agent_sdk.connectors.monday.types.WorkspacesInCondition | airbyte_agent_sdk.connectors.monday.types.WorkspacesLikeCondition | airbyte_agent_sdk.connectors.monday.types.WorkspacesFuzzyCondition | airbyte_agent_sdk.connectors.monday.types.WorkspacesKeywordCondition | airbyte_agent_sdk.connectors.monday.types.WorkspacesContainsCondition | airbyte_agent_sdk.connectors.monday.types.WorkspacesNotCondition | airbyte_agent_sdk.connectors.monday.types.WorkspacesAndCondition | airbyte_agent_sdk.connectors.monday.types.WorkspacesOrCondition | airbyte_agent_sdk.connectors.monday.types.WorkspacesAnyCondition]`
     :   The type of the None singleton.
+
+<a id="WorkspacesSearchFilter"></a>
 
 `WorkspacesSearchFilter(*args, **kwargs)`
 :   Available fields for filtering workspaces search queries.
@@ -3752,6 +4112,8 @@ Classes
     `users_subscribers: list[typing.Any] | None`
     :   User subscribers
 
+<a id="WorkspacesSearchQuery"></a>
+
 `WorkspacesSearchQuery(*args, **kwargs)`
 :   Search query for workspaces entity.
 
@@ -3766,6 +4128,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.monday.types.WorkspacesSortFilter]`
     :   The type of the None singleton.
+
+<a id="WorkspacesSortFilter"></a>
 
 `WorkspacesSortFilter(*args, **kwargs)`
 :   Available fields for sorting workspaces search results.
@@ -3811,6 +4175,8 @@ Classes
 
     `users_subscribers: Literal['asc', 'desc']`
     :   User subscribers
+
+<a id="WorkspacesStringFilter"></a>
 
 `WorkspacesStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/notion/connector.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/notion/connector.md
@@ -10,6 +10,8 @@ Notion connector.
 Classes
 -------
 
+<a id="BlocksQuery"></a>
+
 `BlocksQuery(connector: NotionConnector)`
 :   Query class for Blocks entity operations.
     
@@ -103,6 +105,8 @@ Classes
         Returns:
             BlocksListResult
 
+<a id="CommentsQuery"></a>
+
 `CommentsQuery(connector: NotionConnector)`
 :   Query class for Comments entity operations.
     
@@ -121,6 +125,8 @@ Classes
         
         Returns:
             CommentsListResult
+
+<a id="DataSourcesQuery"></a>
 
 `DataSourcesQuery(connector: NotionConnector)`
 :   Query class for DataSources entity operations.
@@ -190,6 +196,8 @@ Classes
         
         Returns:
             DataSourcesListResult
+
+<a id="NotionConnector"></a>
 
 `NotionConnector(auth_config: NotionAuthConfig | AirbyteAuthConfig | BaseModel | None = None, on_token_refresh: Any | None = None)`
 :   Type-safe Notion API connector.
@@ -467,6 +475,8 @@ Classes
             for entity in entities:
                 print(f"\{entity['entity_name']\}: \{entity['available_actions']\}")
 
+<a id="PagesQuery"></a>
+
 `PagesQuery(connector: NotionConnector)`
 :   Query class for Pages entity operations.
     
@@ -532,6 +542,8 @@ Classes
         
         Returns:
             PagesListResult
+
+<a id="UsersQuery"></a>
 
 `UsersQuery(connector: NotionConnector)`
 :   Query class for Users entity operations.

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/notion/index.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/notion/index.md
@@ -19,6 +19,8 @@ Sub-modules
 Classes
 -------
 
+<a id="AirbyteAuthConfig"></a>
+
 `AirbyteAuthConfig(**data: Any)`
 :   Authentication configuration for Airbyte hosted mode execution.
     
@@ -87,6 +89,8 @@ Classes
     `workspace_name: str | None`
     :   The type of the None singleton.
 
+<a id="AirbyteSearchMeta"></a>
+
 `AirbyteSearchMeta(**data: Any)`
 :   Pagination metadata for search responses.
     
@@ -114,6 +118,8 @@ Classes
 
     `took_ms: int | None`
     :   Time taken to execute the search in milliseconds.
+
+<a id="AirbyteSearchResult"></a>
 
 `AirbyteSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -148,6 +154,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="BlocksSearchResult"></a>
+
 `BlocksSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -163,6 +171,8 @@ Classes
     * airbyte_agent_sdk.connectors.notion.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="DataSourcesSearchResult"></a>
 
 `DataSourcesSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -180,6 +190,8 @@ Classes
     * pydantic.main.BaseModel
     * typing.Generic
 
+<a id="PagesSearchResult"></a>
+
 `PagesSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -196,6 +208,8 @@ Classes
     * pydantic.main.BaseModel
     * typing.Generic
 
+<a id="UsersSearchResult"></a>
+
 `UsersSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -211,6 +225,8 @@ Classes
     * airbyte_agent_sdk.connectors.notion.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="BlocksSearchData"></a>
 
 `BlocksSearchData(**data: Any)`
 :   Search result data for blocks entity.
@@ -357,6 +373,8 @@ Classes
     `video: dict[str, typing.Any] | None`
     :   Represents a video block.
 
+<a id="DataSourcesSearchData"></a>
+
 `DataSourcesSearchData(**data: Any)`
 :   Search result data for data_sources entity.
     
@@ -426,6 +444,8 @@ Classes
 
     `url: str | None`
     :   URL or reference to access the data source.
+
+<a id="NotionConnector"></a>
 
 `NotionConnector(auth_config: NotionAuthConfig | AirbyteAuthConfig | BaseModel | None = None, on_token_refresh: Any | None = None)`
 :   Type-safe Notion API connector.
@@ -703,6 +723,8 @@ Classes
             for entity in entities:
                 print(f"\{entity['entity_name']\}: \{entity['available_actions']\}")
 
+<a id="NotionOAuthCredentials"></a>
+
 `NotionOAuthCredentials(**data: Any)`
 :   Notion OAuth App Credentials - Provide your own Notion OAuth app credentials to override the default Airbyte-managed ones.
     
@@ -727,6 +749,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="PagesSearchData"></a>
 
 `PagesSearchData(**data: Any)`
 :   Search result data for pages entity.
@@ -788,6 +812,8 @@ Classes
 
     `url: str | None`
     :   URL of the page within the service.
+
+<a id="UsersSearchData"></a>
 
 `UsersSearchData(**data: Any)`
 :   Search result data for users entity.

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/notion/models.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/notion/models.md
@@ -13,6 +13,8 @@ and response envelope types.
 Classes
 -------
 
+<a id="AirbyteSearchMeta"></a>
+
 `AirbyteSearchMeta(**data: Any)`
 :   Pagination metadata for search responses.
     
@@ -40,6 +42,8 @@ Classes
 
     `took_ms: int | None`
     :   Time taken to execute the search in milliseconds.
+
+<a id="AirbyteSearchResult"></a>
 
 `AirbyteSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -95,6 +99,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="BlocksSearchResult"></a>
+
 `BlocksSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -131,6 +137,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="DataSourcesSearchResult"></a>
 
 `DataSourcesSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -169,6 +177,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="PagesSearchResult"></a>
+
 `PagesSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -206,6 +216,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="UsersSearchResult"></a>
+
 `UsersSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -221,6 +233,8 @@ Classes
     * airbyte_agent_sdk.connectors.notion.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="Block"></a>
 
 `Block(**data: Any)`
 :   A Notion block object
@@ -373,6 +387,8 @@ Classes
     `video: dict[str, typing.Any] | Any | None`
     :   The type of the None singleton.
 
+<a id="BlockBookmark"></a>
+
 `BlockBookmark(**data: Any)`
 :   Bookmark block
     
@@ -398,6 +414,8 @@ Classes
     `url: str | Any | None`
     :   The type of the None singleton.
 
+<a id="BlockBulletedListItem"></a>
+
 `BlockBulletedListItem(**data: Any)`
 :   Bulleted list item content
     
@@ -422,6 +440,8 @@ Classes
 
     `rich_text: list[airbyte_agent_sdk.connectors.notion.models.RichText] | Any | None`
     :   The type of the None singleton.
+
+<a id="BlockCallout"></a>
 
 `BlockCallout(**data: Any)`
 :   Callout block content
@@ -451,6 +471,8 @@ Classes
     `rich_text: list[airbyte_agent_sdk.connectors.notion.models.RichText] | Any | None`
     :   The type of the None singleton.
 
+<a id="BlockChildDatabase"></a>
+
 `BlockChildDatabase(**data: Any)`
 :   Child database block
     
@@ -473,6 +495,8 @@ Classes
     `title: str | Any | None`
     :   The type of the None singleton.
 
+<a id="BlockChildPage"></a>
+
 `BlockChildPage(**data: Any)`
 :   Child page block
     
@@ -494,6 +518,8 @@ Classes
 
     `title: str | Any | None`
     :   The type of the None singleton.
+
+<a id="BlockCode"></a>
 
 `BlockCode(**data: Any)`
 :   Code block content
@@ -523,6 +549,8 @@ Classes
     `rich_text: list[airbyte_agent_sdk.connectors.notion.models.RichText] | Any | None`
     :   The type of the None singleton.
 
+<a id="BlockColumn"></a>
+
 `BlockColumn(**data: Any)`
 :   Column block
     
@@ -544,6 +572,8 @@ Classes
 
     `width_ratio: float | Any | None`
     :   The type of the None singleton.
+
+<a id="BlockCreatedBy"></a>
 
 `BlockCreatedBy(**data: Any)`
 :   User who created the block
@@ -570,6 +600,8 @@ Classes
     `object_: str | Any | None`
     :   The type of the None singleton.
 
+<a id="BlockEmbed"></a>
+
 `BlockEmbed(**data: Any)`
 :   Embed block
     
@@ -592,6 +624,8 @@ Classes
     `url: str | Any | None`
     :   The type of the None singleton.
 
+<a id="BlockEquation"></a>
+
 `BlockEquation(**data: Any)`
 :   Equation block
     
@@ -613,6 +647,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="BlockHeading1"></a>
 
 `BlockHeading1(**data: Any)`
 :   Heading 1 block content
@@ -642,6 +678,8 @@ Classes
     `rich_text: list[airbyte_agent_sdk.connectors.notion.models.RichText] | Any | None`
     :   The type of the None singleton.
 
+<a id="BlockHeading2"></a>
+
 `BlockHeading2(**data: Any)`
 :   Heading 2 block content
     
@@ -669,6 +707,8 @@ Classes
 
     `rich_text: list[airbyte_agent_sdk.connectors.notion.models.RichText] | Any | None`
     :   The type of the None singleton.
+
+<a id="BlockHeading3"></a>
 
 `BlockHeading3(**data: Any)`
 :   Heading 3 block content
@@ -698,6 +738,8 @@ Classes
     `rich_text: list[airbyte_agent_sdk.connectors.notion.models.RichText] | Any | None`
     :   The type of the None singleton.
 
+<a id="BlockLastEditedBy"></a>
+
 `BlockLastEditedBy(**data: Any)`
 :   User who last edited the block
     
@@ -723,6 +765,8 @@ Classes
     `object_: str | Any | None`
     :   The type of the None singleton.
 
+<a id="BlockLinkPreview"></a>
+
 `BlockLinkPreview(**data: Any)`
 :   Link preview block
     
@@ -744,6 +788,8 @@ Classes
 
     `url: str | Any | None`
     :   The type of the None singleton.
+
+<a id="BlockNumberedListItem"></a>
 
 `BlockNumberedListItem(**data: Any)`
 :   Numbered list item content
@@ -770,6 +816,8 @@ Classes
     `rich_text: list[airbyte_agent_sdk.connectors.notion.models.RichText] | Any | None`
     :   The type of the None singleton.
 
+<a id="BlockParagraph"></a>
+
 `BlockParagraph(**data: Any)`
 :   Paragraph block content
     
@@ -795,6 +843,8 @@ Classes
     `rich_text: list[airbyte_agent_sdk.connectors.notion.models.RichText] | Any | None`
     :   The type of the None singleton.
 
+<a id="BlockQuote"></a>
+
 `BlockQuote(**data: Any)`
 :   Quote block content
     
@@ -819,6 +869,8 @@ Classes
 
     `rich_text: list[airbyte_agent_sdk.connectors.notion.models.RichText] | Any | None`
     :   The type of the None singleton.
+
+<a id="BlockTable"></a>
 
 `BlockTable(**data: Any)`
 :   Table block
@@ -848,6 +900,8 @@ Classes
     `table_width: int | Any | None`
     :   The type of the None singleton.
 
+<a id="BlockTableOfContents"></a>
+
 `BlockTableOfContents(**data: Any)`
 :   Table of contents block
     
@@ -870,6 +924,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="BlockTableRow"></a>
+
 `BlockTableRow(**data: Any)`
 :   Table row block
     
@@ -891,6 +947,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="BlockToDo"></a>
 
 `BlockToDo(**data: Any)`
 :   To-do block content
@@ -920,6 +978,8 @@ Classes
     `rich_text: list[airbyte_agent_sdk.connectors.notion.models.RichText] | Any | None`
     :   The type of the None singleton.
 
+<a id="BlockToggle"></a>
+
 `BlockToggle(**data: Any)`
 :   Toggle block content
     
@@ -944,6 +1004,8 @@ Classes
 
     `rich_text: list[airbyte_agent_sdk.connectors.notion.models.RichText] | Any | None`
     :   The type of the None singleton.
+
+<a id="BlocksListResponse"></a>
 
 `BlocksListResponse(**data: Any)`
 :   Paginated list of blocks
@@ -985,6 +1047,8 @@ Classes
     `type_: str | Any | None`
     :   The type of the None singleton.
 
+<a id="BlocksListResultMeta"></a>
+
 `BlocksListResultMeta(**data: Any)`
 :   Metadata for blocks.Action.LIST operation
     
@@ -1009,6 +1073,8 @@ Classes
 
     `next_cursor: str | Any | None`
     :   The type of the None singleton.
+
+<a id="BlocksSearchData"></a>
 
 `BlocksSearchData(**data: Any)`
 :   Search result data for blocks entity.
@@ -1155,6 +1221,8 @@ Classes
     `video: dict[str, typing.Any] | None`
     :   Represents a video block.
 
+<a id="Comment"></a>
+
 `Comment(**data: Any)`
 :   A Notion comment object
     
@@ -1198,6 +1266,8 @@ Classes
     `rich_text: list[airbyte_agent_sdk.connectors.notion.models.RichText] | Any | None`
     :   The type of the None singleton.
 
+<a id="CommentCreatedBy"></a>
+
 `CommentCreatedBy(**data: Any)`
 :   User who created the comment
     
@@ -1222,6 +1292,8 @@ Classes
 
     `object_: str | Any | None`
     :   The type of the None singleton.
+
+<a id="CommentsListResponse"></a>
 
 `CommentsListResponse(**data: Any)`
 :   Paginated list of comments
@@ -1263,6 +1335,8 @@ Classes
     `type_: str | Any | None`
     :   The type of the None singleton.
 
+<a id="CommentsListResultMeta"></a>
+
 `CommentsListResultMeta(**data: Any)`
 :   Metadata for comments.Action.LIST operation
     
@@ -1287,6 +1361,8 @@ Classes
 
     `next_cursor: str | Any | None`
     :   The type of the None singleton.
+
+<a id="DataSource"></a>
 
 `DataSource(**data: Any)`
 :   A Notion data source object
@@ -1370,6 +1446,8 @@ Classes
     `url: str | Any | None`
     :   The type of the None singleton.
 
+<a id="DataSourceCreatedBy"></a>
+
 `DataSourceCreatedBy(**data: Any)`
 :   User who created the data source
     
@@ -1395,6 +1473,8 @@ Classes
     `object_: str | Any | None`
     :   The type of the None singleton.
 
+<a id="DataSourceLastEditedBy"></a>
+
 `DataSourceLastEditedBy(**data: Any)`
 :   User who last edited the data source
     
@@ -1419,6 +1499,8 @@ Classes
 
     `object_: str | Any | None`
     :   The type of the None singleton.
+
+<a id="DataSourcesListResponse"></a>
 
 `DataSourcesListResponse(**data: Any)`
 :   Paginated list of data sources
@@ -1460,6 +1542,8 @@ Classes
     `type_: str | Any | None`
     :   The type of the None singleton.
 
+<a id="DataSourcesListResultMeta"></a>
+
 `DataSourcesListResultMeta(**data: Any)`
 :   Metadata for data_sources.Action.LIST operation
     
@@ -1484,6 +1568,8 @@ Classes
 
     `next_cursor: str | Any | None`
     :   The type of the None singleton.
+
+<a id="DataSourcesSearchData"></a>
 
 `DataSourcesSearchData(**data: Any)`
 :   Search result data for data_sources entity.
@@ -1555,6 +1641,8 @@ Classes
     `url: str | None`
     :   URL or reference to access the data source.
 
+<a id="NotionAccessTokenAuthConfig"></a>
+
 `NotionAccessTokenAuthConfig(**data: Any)`
 :   Access Token
     
@@ -1576,6 +1664,8 @@ Classes
 
     `token: str`
     :   Notion internal integration token (starts with ntn_ or secret_)
+
+<a id="NotionCheckResult"></a>
 
 `NotionCheckResult(**data: Any)`
 :   Result of a health check operation.
@@ -1610,6 +1700,8 @@ Classes
     `status: str`
     :   Health check status: 'healthy' or 'unhealthy'.
 
+<a id="NotionExecuteResult"></a>
+
 `NotionExecuteResult(**data: Any)`
 :   Response envelope with data only.
     
@@ -1638,6 +1730,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="NotionExecuteResultWithMeta"></a>
 
 `NotionExecuteResultWithMeta(**data: Any)`
 :   Response envelope with data and metadata.
@@ -1694,6 +1788,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="BlocksListResult"></a>
+
 `BlocksListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -1736,6 +1832,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="CommentsListResult"></a>
 
 `CommentsListResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -1780,6 +1878,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="DataSourcesListResult"></a>
+
 `DataSourcesListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -1822,6 +1922,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="PagesListResult"></a>
 
 `PagesListResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -1866,6 +1968,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="UsersListResult"></a>
+
 `UsersListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -1884,6 +1988,8 @@ Classes
     * airbyte_agent_sdk.connectors.notion.models.NotionExecuteResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="NotionOAuthCredentials"></a>
 
 `NotionOAuthCredentials(**data: Any)`
 :   Notion OAuth App Credentials - Provide your own Notion OAuth app credentials to override the default Airbyte-managed ones.
@@ -1909,6 +2015,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="NotionOauth20AuthConfig"></a>
 
 `NotionOauth20AuthConfig(**data: Any)`
 :   OAuth2.0
@@ -1937,6 +2045,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="Page"></a>
 
 `Page(**data: Any)`
 :   A Notion page object
@@ -2008,6 +2118,8 @@ Classes
     `url: str | Any | None`
     :   The type of the None singleton.
 
+<a id="PageCreatedBy"></a>
+
 `PageCreatedBy(**data: Any)`
 :   User who created the page
     
@@ -2033,6 +2145,8 @@ Classes
     `object_: str | Any | None`
     :   The type of the None singleton.
 
+<a id="PageLastEditedBy"></a>
+
 `PageLastEditedBy(**data: Any)`
 :   User who last edited the page
     
@@ -2057,6 +2171,8 @@ Classes
 
     `object_: str | Any | None`
     :   The type of the None singleton.
+
+<a id="PagesListResponse"></a>
 
 `PagesListResponse(**data: Any)`
 :   Paginated list of pages
@@ -2098,6 +2214,8 @@ Classes
     `type_: str | Any | None`
     :   The type of the None singleton.
 
+<a id="PagesListResultMeta"></a>
+
 `PagesListResultMeta(**data: Any)`
 :   Metadata for pages.Action.LIST operation
     
@@ -2122,6 +2240,8 @@ Classes
 
     `next_cursor: str | Any | None`
     :   The type of the None singleton.
+
+<a id="PagesSearchData"></a>
 
 `PagesSearchData(**data: Any)`
 :   Search result data for pages entity.
@@ -2184,6 +2304,8 @@ Classes
     `url: str | None`
     :   URL of the page within the service.
 
+<a id="Parent"></a>
+
 `Parent(**data: Any)`
 :   Parent object reference
     
@@ -2221,6 +2343,8 @@ Classes
     `workspace: bool | Any | None`
     :   The type of the None singleton.
 
+<a id="RichText"></a>
+
 `RichText(**data: Any)`
 :   A rich text object
     
@@ -2254,6 +2378,8 @@ Classes
 
     `type_: str | Any | None`
     :   The type of the None singleton.
+
+<a id="RichTextAnnotations"></a>
 
 `RichTextAnnotations(**data: Any)`
 :   Text annotations (bold, italic, etc.)
@@ -2292,6 +2418,8 @@ Classes
     `underline: bool | Any | None`
     :   The type of the None singleton.
 
+<a id="RichTextText"></a>
+
 `RichTextText(**data: Any)`
 :   Text content
     
@@ -2316,6 +2444,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="User"></a>
 
 `User(**data: Any)`
 :   A Notion user object
@@ -2360,6 +2490,8 @@ Classes
     `type_: str | Any | None`
     :   The type of the None singleton.
 
+<a id="UserBot"></a>
+
 `UserBot(**data: Any)`
 :   Bot-specific data
     
@@ -2385,6 +2517,8 @@ Classes
     `workspace_name: str | Any | None`
     :   Name of the workspace the bot belongs to
 
+<a id="UserPerson"></a>
+
 `UserPerson(**data: Any)`
 :   Person-specific data
     
@@ -2406,6 +2540,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="UsersListResponse"></a>
 
 `UsersListResponse(**data: Any)`
 :   Paginated list of users
@@ -2447,6 +2583,8 @@ Classes
     `user: dict[str, typing.Any] | Any | None`
     :   The type of the None singleton.
 
+<a id="UsersListResultMeta"></a>
+
 `UsersListResultMeta(**data: Any)`
 :   Metadata for users.Action.LIST operation
     
@@ -2471,6 +2609,8 @@ Classes
 
     `next_cursor: str | Any | None`
     :   The type of the None singleton.
+
+<a id="UsersSearchData"></a>
 
 `UsersSearchData(**data: Any)`
 :   Search result data for users entity.

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/notion/types.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/notion/types.md
@@ -10,6 +10,8 @@ Type definitions for notion connector.
 Classes
 -------
 
+<a id="AirbyteSearchParams"></a>
+
 `AirbyteSearchParams(*args, **kwargs)`
 :   Parameters for Airbyte cache search operations (generic, use entity-specific query types for better type hints).
 
@@ -31,6 +33,8 @@ Classes
     `query: dict[str, typing.Any]`
     :   The type of the None singleton.
 
+<a id="BlocksAndCondition"></a>
+
 `BlocksAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -51,6 +55,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.notion.types.BlocksEqCondition | airbyte_agent_sdk.connectors.notion.types.BlocksNeqCondition | airbyte_agent_sdk.connectors.notion.types.BlocksGtCondition | airbyte_agent_sdk.connectors.notion.types.BlocksGteCondition | airbyte_agent_sdk.connectors.notion.types.BlocksLtCondition | airbyte_agent_sdk.connectors.notion.types.BlocksLteCondition | airbyte_agent_sdk.connectors.notion.types.BlocksInCondition | airbyte_agent_sdk.connectors.notion.types.BlocksLikeCondition | airbyte_agent_sdk.connectors.notion.types.BlocksFuzzyCondition | airbyte_agent_sdk.connectors.notion.types.BlocksKeywordCondition | airbyte_agent_sdk.connectors.notion.types.BlocksContainsCondition | airbyte_agent_sdk.connectors.notion.types.BlocksNotCondition | airbyte_agent_sdk.connectors.notion.types.BlocksAndCondition | airbyte_agent_sdk.connectors.notion.types.BlocksOrCondition | airbyte_agent_sdk.connectors.notion.types.BlocksAnyCondition]`
     :   The type of the None singleton.
 
+<a id="BlocksAnyCondition"></a>
+
 `BlocksAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -70,6 +76,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.notion.types.BlocksAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="BlocksAnyValueFilter"></a>
 
 `BlocksAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -206,6 +214,8 @@ Classes
     `video: Any`
     :   Represents a video block.
 
+<a id="BlocksContainsCondition"></a>
+
 `BlocksContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -217,6 +227,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.notion.types.BlocksAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="BlocksEqCondition"></a>
 
 `BlocksEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -230,6 +242,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.notion.types.BlocksSearchFilter`
     :   The type of the None singleton.
 
+<a id="BlocksFuzzyCondition"></a>
+
 `BlocksFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -241,6 +255,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.notion.types.BlocksStringFilter`
     :   The type of the None singleton.
+
+<a id="BlocksGetParams"></a>
 
 `BlocksGetParams(*args, **kwargs)`
 :   Parameters for blocks.get operation
@@ -254,6 +270,8 @@ Classes
     `block_id: str`
     :   The type of the None singleton.
 
+<a id="BlocksGtCondition"></a>
+
 `BlocksGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -266,6 +284,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.notion.types.BlocksSearchFilter`
     :   The type of the None singleton.
 
+<a id="BlocksGteCondition"></a>
+
 `BlocksGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -277,6 +297,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.notion.types.BlocksSearchFilter`
     :   The type of the None singleton.
+
+<a id="BlocksInCondition"></a>
 
 `BlocksInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -297,6 +319,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.notion.types.BlocksInFilter`
     :   The type of the None singleton.
+
+<a id="BlocksInFilter"></a>
 
 `BlocksInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -433,6 +457,8 @@ Classes
     `video: list[dict[str, typing.Any]]`
     :   Represents a video block.
 
+<a id="BlocksKeywordCondition"></a>
+
 `BlocksKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -445,6 +471,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.notion.types.BlocksStringFilter`
     :   The type of the None singleton.
 
+<a id="BlocksLikeCondition"></a>
+
 `BlocksLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -456,6 +484,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.notion.types.BlocksStringFilter`
     :   The type of the None singleton.
+
+<a id="BlocksListParams"></a>
 
 `BlocksListParams(*args, **kwargs)`
 :   Parameters for blocks.list operation
@@ -475,6 +505,8 @@ Classes
     `start_cursor: str`
     :   The type of the None singleton.
 
+<a id="BlocksLtCondition"></a>
+
 `BlocksLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -486,6 +518,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.notion.types.BlocksSearchFilter`
     :   The type of the None singleton.
+
+<a id="BlocksLteCondition"></a>
 
 `BlocksLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -499,6 +533,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.notion.types.BlocksSearchFilter`
     :   The type of the None singleton.
 
+<a id="BlocksNeqCondition"></a>
+
 `BlocksNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -510,6 +546,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.notion.types.BlocksSearchFilter`
     :   The type of the None singleton.
+
+<a id="BlocksNotCondition"></a>
 
 `BlocksNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -531,6 +569,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.notion.types.BlocksEqCondition | airbyte_agent_sdk.connectors.notion.types.BlocksNeqCondition | airbyte_agent_sdk.connectors.notion.types.BlocksGtCondition | airbyte_agent_sdk.connectors.notion.types.BlocksGteCondition | airbyte_agent_sdk.connectors.notion.types.BlocksLtCondition | airbyte_agent_sdk.connectors.notion.types.BlocksLteCondition | airbyte_agent_sdk.connectors.notion.types.BlocksInCondition | airbyte_agent_sdk.connectors.notion.types.BlocksLikeCondition | airbyte_agent_sdk.connectors.notion.types.BlocksFuzzyCondition | airbyte_agent_sdk.connectors.notion.types.BlocksKeywordCondition | airbyte_agent_sdk.connectors.notion.types.BlocksContainsCondition | airbyte_agent_sdk.connectors.notion.types.BlocksNotCondition | airbyte_agent_sdk.connectors.notion.types.BlocksAndCondition | airbyte_agent_sdk.connectors.notion.types.BlocksOrCondition | airbyte_agent_sdk.connectors.notion.types.BlocksAnyCondition`
     :   The type of the None singleton.
 
+<a id="BlocksOrCondition"></a>
+
 `BlocksOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -550,6 +590,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.notion.types.BlocksEqCondition | airbyte_agent_sdk.connectors.notion.types.BlocksNeqCondition | airbyte_agent_sdk.connectors.notion.types.BlocksGtCondition | airbyte_agent_sdk.connectors.notion.types.BlocksGteCondition | airbyte_agent_sdk.connectors.notion.types.BlocksLtCondition | airbyte_agent_sdk.connectors.notion.types.BlocksLteCondition | airbyte_agent_sdk.connectors.notion.types.BlocksInCondition | airbyte_agent_sdk.connectors.notion.types.BlocksLikeCondition | airbyte_agent_sdk.connectors.notion.types.BlocksFuzzyCondition | airbyte_agent_sdk.connectors.notion.types.BlocksKeywordCondition | airbyte_agent_sdk.connectors.notion.types.BlocksContainsCondition | airbyte_agent_sdk.connectors.notion.types.BlocksNotCondition | airbyte_agent_sdk.connectors.notion.types.BlocksAndCondition | airbyte_agent_sdk.connectors.notion.types.BlocksOrCondition | airbyte_agent_sdk.connectors.notion.types.BlocksAnyCondition]`
     :   The type of the None singleton.
+
+<a id="BlocksSearchFilter"></a>
 
 `BlocksSearchFilter(*args, **kwargs)`
 :   Available fields for filtering blocks search queries.
@@ -686,6 +728,8 @@ Classes
     `video: dict[str, typing.Any] | None`
     :   Represents a video block.
 
+<a id="BlocksSearchQuery"></a>
+
 `BlocksSearchQuery(*args, **kwargs)`
 :   Search query for blocks entity.
 
@@ -700,6 +744,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.notion.types.BlocksSortFilter]`
     :   The type of the None singleton.
+
+<a id="BlocksSortFilter"></a>
 
 `BlocksSortFilter(*args, **kwargs)`
 :   Available fields for sorting blocks search results.
@@ -836,6 +882,8 @@ Classes
     `video: Literal['asc', 'desc']`
     :   Represents a video block.
 
+<a id="BlocksStringFilter"></a>
+
 `BlocksStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -971,6 +1019,8 @@ Classes
     `video: str`
     :   Represents a video block.
 
+<a id="CommentsListParams"></a>
+
 `CommentsListParams(*args, **kwargs)`
 :   Parameters for comments.list operation
 
@@ -988,6 +1038,8 @@ Classes
 
     `start_cursor: str`
     :   The type of the None singleton.
+
+<a id="DataSourcesAndCondition"></a>
 
 `DataSourcesAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -1009,6 +1061,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.notion.types.DataSourcesEqCondition | airbyte_agent_sdk.connectors.notion.types.DataSourcesNeqCondition | airbyte_agent_sdk.connectors.notion.types.DataSourcesGtCondition | airbyte_agent_sdk.connectors.notion.types.DataSourcesGteCondition | airbyte_agent_sdk.connectors.notion.types.DataSourcesLtCondition | airbyte_agent_sdk.connectors.notion.types.DataSourcesLteCondition | airbyte_agent_sdk.connectors.notion.types.DataSourcesInCondition | airbyte_agent_sdk.connectors.notion.types.DataSourcesLikeCondition | airbyte_agent_sdk.connectors.notion.types.DataSourcesFuzzyCondition | airbyte_agent_sdk.connectors.notion.types.DataSourcesKeywordCondition | airbyte_agent_sdk.connectors.notion.types.DataSourcesContainsCondition | airbyte_agent_sdk.connectors.notion.types.DataSourcesNotCondition | airbyte_agent_sdk.connectors.notion.types.DataSourcesAndCondition | airbyte_agent_sdk.connectors.notion.types.DataSourcesOrCondition | airbyte_agent_sdk.connectors.notion.types.DataSourcesAnyCondition]`
     :   The type of the None singleton.
 
+<a id="DataSourcesAnyCondition"></a>
+
 `DataSourcesAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1028,6 +1082,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.notion.types.DataSourcesAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="DataSourcesAnyValueFilter"></a>
 
 `DataSourcesAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -1089,6 +1145,8 @@ Classes
     `url: Any`
     :   URL or reference to access the data source.
 
+<a id="DataSourcesContainsCondition"></a>
+
 `DataSourcesContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -1100,6 +1158,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.notion.types.DataSourcesAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="DataSourcesEqCondition"></a>
 
 `DataSourcesEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -1113,6 +1173,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.notion.types.DataSourcesSearchFilter`
     :   The type of the None singleton.
 
+<a id="DataSourcesFuzzyCondition"></a>
+
 `DataSourcesFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -1124,6 +1186,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.notion.types.DataSourcesStringFilter`
     :   The type of the None singleton.
+
+<a id="DataSourcesGetParams"></a>
 
 `DataSourcesGetParams(*args, **kwargs)`
 :   Parameters for data_sources.get operation
@@ -1137,6 +1201,8 @@ Classes
     `data_source_id: str`
     :   The type of the None singleton.
 
+<a id="DataSourcesGtCondition"></a>
+
 `DataSourcesGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -1149,6 +1215,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.notion.types.DataSourcesSearchFilter`
     :   The type of the None singleton.
 
+<a id="DataSourcesGteCondition"></a>
+
 `DataSourcesGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -1160,6 +1228,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.notion.types.DataSourcesSearchFilter`
     :   The type of the None singleton.
+
+<a id="DataSourcesInCondition"></a>
 
 `DataSourcesInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -1180,6 +1250,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.notion.types.DataSourcesInFilter`
     :   The type of the None singleton.
+
+<a id="DataSourcesInFilter"></a>
 
 `DataSourcesInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -1241,6 +1313,8 @@ Classes
     `url: list[str]`
     :   URL or reference to access the data source.
 
+<a id="DataSourcesKeywordCondition"></a>
+
 `DataSourcesKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -1253,6 +1327,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.notion.types.DataSourcesStringFilter`
     :   The type of the None singleton.
 
+<a id="DataSourcesLikeCondition"></a>
+
 `DataSourcesLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -1264,6 +1340,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.notion.types.DataSourcesStringFilter`
     :   The type of the None singleton.
+
+<a id="DataSourcesListParams"></a>
 
 `DataSourcesListParams(*args, **kwargs)`
 :   Parameters for data_sources.list operation
@@ -1286,6 +1364,8 @@ Classes
     `start_cursor: str`
     :   The type of the None singleton.
 
+<a id="DataSourcesListParamsFilter"></a>
+
 `DataSourcesListParamsFilter(*args, **kwargs)`
 :   Nested schema for DataSourcesListParams.filter
 
@@ -1300,6 +1380,8 @@ Classes
 
     `value: str`
     :   The type of the None singleton.
+
+<a id="DataSourcesListParamsSort"></a>
 
 `DataSourcesListParamsSort(*args, **kwargs)`
 :   Nested schema for DataSourcesListParams.sort
@@ -1316,6 +1398,8 @@ Classes
     `timestamp: str`
     :   The type of the None singleton.
 
+<a id="DataSourcesLtCondition"></a>
+
 `DataSourcesLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -1327,6 +1411,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.notion.types.DataSourcesSearchFilter`
     :   The type of the None singleton.
+
+<a id="DataSourcesLteCondition"></a>
 
 `DataSourcesLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -1340,6 +1426,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.notion.types.DataSourcesSearchFilter`
     :   The type of the None singleton.
 
+<a id="DataSourcesNeqCondition"></a>
+
 `DataSourcesNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -1351,6 +1439,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.notion.types.DataSourcesSearchFilter`
     :   The type of the None singleton.
+
+<a id="DataSourcesNotCondition"></a>
 
 `DataSourcesNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -1372,6 +1462,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.notion.types.DataSourcesEqCondition | airbyte_agent_sdk.connectors.notion.types.DataSourcesNeqCondition | airbyte_agent_sdk.connectors.notion.types.DataSourcesGtCondition | airbyte_agent_sdk.connectors.notion.types.DataSourcesGteCondition | airbyte_agent_sdk.connectors.notion.types.DataSourcesLtCondition | airbyte_agent_sdk.connectors.notion.types.DataSourcesLteCondition | airbyte_agent_sdk.connectors.notion.types.DataSourcesInCondition | airbyte_agent_sdk.connectors.notion.types.DataSourcesLikeCondition | airbyte_agent_sdk.connectors.notion.types.DataSourcesFuzzyCondition | airbyte_agent_sdk.connectors.notion.types.DataSourcesKeywordCondition | airbyte_agent_sdk.connectors.notion.types.DataSourcesContainsCondition | airbyte_agent_sdk.connectors.notion.types.DataSourcesNotCondition | airbyte_agent_sdk.connectors.notion.types.DataSourcesAndCondition | airbyte_agent_sdk.connectors.notion.types.DataSourcesOrCondition | airbyte_agent_sdk.connectors.notion.types.DataSourcesAnyCondition`
     :   The type of the None singleton.
 
+<a id="DataSourcesOrCondition"></a>
+
 `DataSourcesOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1391,6 +1483,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.notion.types.DataSourcesEqCondition | airbyte_agent_sdk.connectors.notion.types.DataSourcesNeqCondition | airbyte_agent_sdk.connectors.notion.types.DataSourcesGtCondition | airbyte_agent_sdk.connectors.notion.types.DataSourcesGteCondition | airbyte_agent_sdk.connectors.notion.types.DataSourcesLtCondition | airbyte_agent_sdk.connectors.notion.types.DataSourcesLteCondition | airbyte_agent_sdk.connectors.notion.types.DataSourcesInCondition | airbyte_agent_sdk.connectors.notion.types.DataSourcesLikeCondition | airbyte_agent_sdk.connectors.notion.types.DataSourcesFuzzyCondition | airbyte_agent_sdk.connectors.notion.types.DataSourcesKeywordCondition | airbyte_agent_sdk.connectors.notion.types.DataSourcesContainsCondition | airbyte_agent_sdk.connectors.notion.types.DataSourcesNotCondition | airbyte_agent_sdk.connectors.notion.types.DataSourcesAndCondition | airbyte_agent_sdk.connectors.notion.types.DataSourcesOrCondition | airbyte_agent_sdk.connectors.notion.types.DataSourcesAnyCondition]`
     :   The type of the None singleton.
+
+<a id="DataSourcesSearchFilter"></a>
 
 `DataSourcesSearchFilter(*args, **kwargs)`
 :   Available fields for filtering data_sources search queries.
@@ -1452,6 +1546,8 @@ Classes
     `url: str | None`
     :   URL or reference to access the data source.
 
+<a id="DataSourcesSearchQuery"></a>
+
 `DataSourcesSearchQuery(*args, **kwargs)`
 :   Search query for data_sources entity.
 
@@ -1466,6 +1562,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.notion.types.DataSourcesSortFilter]`
     :   The type of the None singleton.
+
+<a id="DataSourcesSortFilter"></a>
 
 `DataSourcesSortFilter(*args, **kwargs)`
 :   Available fields for sorting data_sources search results.
@@ -1527,6 +1625,8 @@ Classes
     `url: Literal['asc', 'desc']`
     :   URL or reference to access the data source.
 
+<a id="DataSourcesStringFilter"></a>
+
 `DataSourcesStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -1587,6 +1687,8 @@ Classes
     `url: str`
     :   URL or reference to access the data source.
 
+<a id="PagesAndCondition"></a>
+
 `PagesAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1607,6 +1709,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.notion.types.PagesEqCondition | airbyte_agent_sdk.connectors.notion.types.PagesNeqCondition | airbyte_agent_sdk.connectors.notion.types.PagesGtCondition | airbyte_agent_sdk.connectors.notion.types.PagesGteCondition | airbyte_agent_sdk.connectors.notion.types.PagesLtCondition | airbyte_agent_sdk.connectors.notion.types.PagesLteCondition | airbyte_agent_sdk.connectors.notion.types.PagesInCondition | airbyte_agent_sdk.connectors.notion.types.PagesLikeCondition | airbyte_agent_sdk.connectors.notion.types.PagesFuzzyCondition | airbyte_agent_sdk.connectors.notion.types.PagesKeywordCondition | airbyte_agent_sdk.connectors.notion.types.PagesContainsCondition | airbyte_agent_sdk.connectors.notion.types.PagesNotCondition | airbyte_agent_sdk.connectors.notion.types.PagesAndCondition | airbyte_agent_sdk.connectors.notion.types.PagesOrCondition | airbyte_agent_sdk.connectors.notion.types.PagesAnyCondition]`
     :   The type of the None singleton.
 
+<a id="PagesAnyCondition"></a>
+
 `PagesAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1626,6 +1730,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.notion.types.PagesAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="PagesAnyValueFilter"></a>
 
 `PagesAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -1678,6 +1784,8 @@ Classes
     `url: Any`
     :   URL of the page within the service.
 
+<a id="PagesContainsCondition"></a>
+
 `PagesContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -1689,6 +1797,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.notion.types.PagesAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="PagesEqCondition"></a>
 
 `PagesEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -1702,6 +1812,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.notion.types.PagesSearchFilter`
     :   The type of the None singleton.
 
+<a id="PagesFuzzyCondition"></a>
+
 `PagesFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -1713,6 +1825,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.notion.types.PagesStringFilter`
     :   The type of the None singleton.
+
+<a id="PagesGetParams"></a>
 
 `PagesGetParams(*args, **kwargs)`
 :   Parameters for pages.get operation
@@ -1726,6 +1840,8 @@ Classes
     `page_id: str`
     :   The type of the None singleton.
 
+<a id="PagesGtCondition"></a>
+
 `PagesGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -1738,6 +1854,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.notion.types.PagesSearchFilter`
     :   The type of the None singleton.
 
+<a id="PagesGteCondition"></a>
+
 `PagesGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -1749,6 +1867,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.notion.types.PagesSearchFilter`
     :   The type of the None singleton.
+
+<a id="PagesInCondition"></a>
 
 `PagesInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -1769,6 +1889,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.notion.types.PagesInFilter`
     :   The type of the None singleton.
+
+<a id="PagesInFilter"></a>
 
 `PagesInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -1821,6 +1943,8 @@ Classes
     `url: list[str]`
     :   URL of the page within the service.
 
+<a id="PagesKeywordCondition"></a>
+
 `PagesKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -1833,6 +1957,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.notion.types.PagesStringFilter`
     :   The type of the None singleton.
 
+<a id="PagesLikeCondition"></a>
+
 `PagesLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -1844,6 +1970,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.notion.types.PagesStringFilter`
     :   The type of the None singleton.
+
+<a id="PagesListParams"></a>
 
 `PagesListParams(*args, **kwargs)`
 :   Parameters for pages.list operation
@@ -1866,6 +1994,8 @@ Classes
     `start_cursor: str`
     :   The type of the None singleton.
 
+<a id="PagesListParamsFilter"></a>
+
 `PagesListParamsFilter(*args, **kwargs)`
 :   Nested schema for PagesListParams.filter
 
@@ -1880,6 +2010,8 @@ Classes
 
     `value: str`
     :   The type of the None singleton.
+
+<a id="PagesListParamsSort"></a>
 
 `PagesListParamsSort(*args, **kwargs)`
 :   Nested schema for PagesListParams.sort
@@ -1896,6 +2028,8 @@ Classes
     `timestamp: str`
     :   The type of the None singleton.
 
+<a id="PagesLtCondition"></a>
+
 `PagesLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -1907,6 +2041,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.notion.types.PagesSearchFilter`
     :   The type of the None singleton.
+
+<a id="PagesLteCondition"></a>
 
 `PagesLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -1920,6 +2056,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.notion.types.PagesSearchFilter`
     :   The type of the None singleton.
 
+<a id="PagesNeqCondition"></a>
+
 `PagesNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -1931,6 +2069,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.notion.types.PagesSearchFilter`
     :   The type of the None singleton.
+
+<a id="PagesNotCondition"></a>
 
 `PagesNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -1952,6 +2092,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.notion.types.PagesEqCondition | airbyte_agent_sdk.connectors.notion.types.PagesNeqCondition | airbyte_agent_sdk.connectors.notion.types.PagesGtCondition | airbyte_agent_sdk.connectors.notion.types.PagesGteCondition | airbyte_agent_sdk.connectors.notion.types.PagesLtCondition | airbyte_agent_sdk.connectors.notion.types.PagesLteCondition | airbyte_agent_sdk.connectors.notion.types.PagesInCondition | airbyte_agent_sdk.connectors.notion.types.PagesLikeCondition | airbyte_agent_sdk.connectors.notion.types.PagesFuzzyCondition | airbyte_agent_sdk.connectors.notion.types.PagesKeywordCondition | airbyte_agent_sdk.connectors.notion.types.PagesContainsCondition | airbyte_agent_sdk.connectors.notion.types.PagesNotCondition | airbyte_agent_sdk.connectors.notion.types.PagesAndCondition | airbyte_agent_sdk.connectors.notion.types.PagesOrCondition | airbyte_agent_sdk.connectors.notion.types.PagesAnyCondition`
     :   The type of the None singleton.
 
+<a id="PagesOrCondition"></a>
+
 `PagesOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1971,6 +2113,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.notion.types.PagesEqCondition | airbyte_agent_sdk.connectors.notion.types.PagesNeqCondition | airbyte_agent_sdk.connectors.notion.types.PagesGtCondition | airbyte_agent_sdk.connectors.notion.types.PagesGteCondition | airbyte_agent_sdk.connectors.notion.types.PagesLtCondition | airbyte_agent_sdk.connectors.notion.types.PagesLteCondition | airbyte_agent_sdk.connectors.notion.types.PagesInCondition | airbyte_agent_sdk.connectors.notion.types.PagesLikeCondition | airbyte_agent_sdk.connectors.notion.types.PagesFuzzyCondition | airbyte_agent_sdk.connectors.notion.types.PagesKeywordCondition | airbyte_agent_sdk.connectors.notion.types.PagesContainsCondition | airbyte_agent_sdk.connectors.notion.types.PagesNotCondition | airbyte_agent_sdk.connectors.notion.types.PagesAndCondition | airbyte_agent_sdk.connectors.notion.types.PagesOrCondition | airbyte_agent_sdk.connectors.notion.types.PagesAnyCondition]`
     :   The type of the None singleton.
+
+<a id="PagesSearchFilter"></a>
 
 `PagesSearchFilter(*args, **kwargs)`
 :   Available fields for filtering pages search queries.
@@ -2023,6 +2167,8 @@ Classes
     `url: str | None`
     :   URL of the page within the service.
 
+<a id="PagesSearchQuery"></a>
+
 `PagesSearchQuery(*args, **kwargs)`
 :   Search query for pages entity.
 
@@ -2037,6 +2183,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.notion.types.PagesSortFilter]`
     :   The type of the None singleton.
+
+<a id="PagesSortFilter"></a>
 
 `PagesSortFilter(*args, **kwargs)`
 :   Available fields for sorting pages search results.
@@ -2089,6 +2237,8 @@ Classes
     `url: Literal['asc', 'desc']`
     :   URL of the page within the service.
 
+<a id="PagesStringFilter"></a>
+
 `PagesStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -2140,6 +2290,8 @@ Classes
     `url: str`
     :   URL of the page within the service.
 
+<a id="UsersAndCondition"></a>
+
 `UsersAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -2160,6 +2312,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.notion.types.UsersEqCondition | airbyte_agent_sdk.connectors.notion.types.UsersNeqCondition | airbyte_agent_sdk.connectors.notion.types.UsersGtCondition | airbyte_agent_sdk.connectors.notion.types.UsersGteCondition | airbyte_agent_sdk.connectors.notion.types.UsersLtCondition | airbyte_agent_sdk.connectors.notion.types.UsersLteCondition | airbyte_agent_sdk.connectors.notion.types.UsersInCondition | airbyte_agent_sdk.connectors.notion.types.UsersLikeCondition | airbyte_agent_sdk.connectors.notion.types.UsersFuzzyCondition | airbyte_agent_sdk.connectors.notion.types.UsersKeywordCondition | airbyte_agent_sdk.connectors.notion.types.UsersContainsCondition | airbyte_agent_sdk.connectors.notion.types.UsersNotCondition | airbyte_agent_sdk.connectors.notion.types.UsersAndCondition | airbyte_agent_sdk.connectors.notion.types.UsersOrCondition | airbyte_agent_sdk.connectors.notion.types.UsersAnyCondition]`
     :   The type of the None singleton.
 
+<a id="UsersAnyCondition"></a>
+
 `UsersAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -2179,6 +2333,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.notion.types.UsersAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="UsersAnyValueFilter"></a>
 
 `UsersAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -2210,6 +2366,8 @@ Classes
     `type_: Any`
     :   Type of user (person or bot)
 
+<a id="UsersContainsCondition"></a>
+
 `UsersContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -2221,6 +2379,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.notion.types.UsersAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="UsersEqCondition"></a>
 
 `UsersEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -2234,6 +2394,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.notion.types.UsersSearchFilter`
     :   The type of the None singleton.
 
+<a id="UsersFuzzyCondition"></a>
+
 `UsersFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -2245,6 +2407,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.notion.types.UsersStringFilter`
     :   The type of the None singleton.
+
+<a id="UsersGetParams"></a>
 
 `UsersGetParams(*args, **kwargs)`
 :   Parameters for users.get operation
@@ -2258,6 +2422,8 @@ Classes
     `user_id: str`
     :   The type of the None singleton.
 
+<a id="UsersGtCondition"></a>
+
 `UsersGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -2270,6 +2436,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.notion.types.UsersSearchFilter`
     :   The type of the None singleton.
 
+<a id="UsersGteCondition"></a>
+
 `UsersGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -2281,6 +2449,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.notion.types.UsersSearchFilter`
     :   The type of the None singleton.
+
+<a id="UsersInCondition"></a>
 
 `UsersInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -2301,6 +2471,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.notion.types.UsersInFilter`
     :   The type of the None singleton.
+
+<a id="UsersInFilter"></a>
 
 `UsersInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -2332,6 +2504,8 @@ Classes
     `type_: list[dict[str, typing.Any]]`
     :   Type of user (person or bot)
 
+<a id="UsersKeywordCondition"></a>
+
 `UsersKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -2344,6 +2518,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.notion.types.UsersStringFilter`
     :   The type of the None singleton.
 
+<a id="UsersLikeCondition"></a>
+
 `UsersLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -2355,6 +2531,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.notion.types.UsersStringFilter`
     :   The type of the None singleton.
+
+<a id="UsersListParams"></a>
 
 `UsersListParams(*args, **kwargs)`
 :   Parameters for users.list operation
@@ -2371,6 +2549,8 @@ Classes
     `start_cursor: str`
     :   The type of the None singleton.
 
+<a id="UsersLtCondition"></a>
+
 `UsersLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -2382,6 +2562,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.notion.types.UsersSearchFilter`
     :   The type of the None singleton.
+
+<a id="UsersLteCondition"></a>
 
 `UsersLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -2395,6 +2577,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.notion.types.UsersSearchFilter`
     :   The type of the None singleton.
 
+<a id="UsersNeqCondition"></a>
+
 `UsersNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -2406,6 +2590,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.notion.types.UsersSearchFilter`
     :   The type of the None singleton.
+
+<a id="UsersNotCondition"></a>
 
 `UsersNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -2427,6 +2613,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.notion.types.UsersEqCondition | airbyte_agent_sdk.connectors.notion.types.UsersNeqCondition | airbyte_agent_sdk.connectors.notion.types.UsersGtCondition | airbyte_agent_sdk.connectors.notion.types.UsersGteCondition | airbyte_agent_sdk.connectors.notion.types.UsersLtCondition | airbyte_agent_sdk.connectors.notion.types.UsersLteCondition | airbyte_agent_sdk.connectors.notion.types.UsersInCondition | airbyte_agent_sdk.connectors.notion.types.UsersLikeCondition | airbyte_agent_sdk.connectors.notion.types.UsersFuzzyCondition | airbyte_agent_sdk.connectors.notion.types.UsersKeywordCondition | airbyte_agent_sdk.connectors.notion.types.UsersContainsCondition | airbyte_agent_sdk.connectors.notion.types.UsersNotCondition | airbyte_agent_sdk.connectors.notion.types.UsersAndCondition | airbyte_agent_sdk.connectors.notion.types.UsersOrCondition | airbyte_agent_sdk.connectors.notion.types.UsersAnyCondition`
     :   The type of the None singleton.
 
+<a id="UsersOrCondition"></a>
+
 `UsersOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -2446,6 +2634,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.notion.types.UsersEqCondition | airbyte_agent_sdk.connectors.notion.types.UsersNeqCondition | airbyte_agent_sdk.connectors.notion.types.UsersGtCondition | airbyte_agent_sdk.connectors.notion.types.UsersGteCondition | airbyte_agent_sdk.connectors.notion.types.UsersLtCondition | airbyte_agent_sdk.connectors.notion.types.UsersLteCondition | airbyte_agent_sdk.connectors.notion.types.UsersInCondition | airbyte_agent_sdk.connectors.notion.types.UsersLikeCondition | airbyte_agent_sdk.connectors.notion.types.UsersFuzzyCondition | airbyte_agent_sdk.connectors.notion.types.UsersKeywordCondition | airbyte_agent_sdk.connectors.notion.types.UsersContainsCondition | airbyte_agent_sdk.connectors.notion.types.UsersNotCondition | airbyte_agent_sdk.connectors.notion.types.UsersAndCondition | airbyte_agent_sdk.connectors.notion.types.UsersOrCondition | airbyte_agent_sdk.connectors.notion.types.UsersAnyCondition]`
     :   The type of the None singleton.
+
+<a id="UsersSearchFilter"></a>
 
 `UsersSearchFilter(*args, **kwargs)`
 :   Available fields for filtering users search queries.
@@ -2477,6 +2667,8 @@ Classes
     `type_: dict[str, typing.Any] | None`
     :   Type of user (person or bot)
 
+<a id="UsersSearchQuery"></a>
+
 `UsersSearchQuery(*args, **kwargs)`
 :   Search query for users entity.
 
@@ -2491,6 +2683,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.notion.types.UsersSortFilter]`
     :   The type of the None singleton.
+
+<a id="UsersSortFilter"></a>
 
 `UsersSortFilter(*args, **kwargs)`
 :   Available fields for sorting users search results.
@@ -2521,6 +2715,8 @@ Classes
 
     `type_: Literal['asc', 'desc']`
     :   Type of user (person or bot)
+
+<a id="UsersStringFilter"></a>
 
 `UsersStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/orb/connector.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/orb/connector.md
@@ -10,6 +10,8 @@ Orb connector.
 Classes
 -------
 
+<a id="CustomersQuery"></a>
+
 `CustomersQuery(connector: OrbConnector)`
 :   Query class for Customers entity operations.
     
@@ -69,6 +71,8 @@ Classes
         
         Returns:
             CustomersListResult
+
+<a id="InvoicesQuery"></a>
 
 `InvoicesQuery(connector: OrbConnector)`
 :   Query class for Invoices entity operations.
@@ -142,6 +146,8 @@ Classes
         
         Returns:
             InvoicesListResult
+
+<a id="OrbConnector"></a>
 
 `OrbConnector(auth_config: OrbAuthConfig | AirbyteAuthConfig | BaseModel | None = None, on_token_refresh: Any | None = None)`
 :   Type-safe Orb API connector.
@@ -343,6 +349,8 @@ Classes
             for entity in entities:
                 print(f"\{entity['entity_name']\}: \{entity['available_actions']\}")
 
+<a id="PlansQuery"></a>
+
 `PlansQuery(connector: OrbConnector)`
 :   Query class for Plans entity operations.
     
@@ -398,6 +406,8 @@ Classes
         
         Returns:
             PlansListResult
+
+<a id="SubscriptionsQuery"></a>
 
 `SubscriptionsQuery(connector: OrbConnector)`
 :   Query class for Subscriptions entity operations.

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/orb/index.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/orb/index.md
@@ -19,6 +19,8 @@ Sub-modules
 Classes
 -------
 
+<a id="AirbyteAuthConfig"></a>
+
 `AirbyteAuthConfig(**data: Any)`
 :   Authentication configuration for Airbyte hosted mode execution.
     
@@ -87,6 +89,8 @@ Classes
     `workspace_name: str | None`
     :   The type of the None singleton.
 
+<a id="AirbyteSearchMeta"></a>
+
 `AirbyteSearchMeta(**data: Any)`
 :   Pagination metadata for search responses.
     
@@ -114,6 +118,8 @@ Classes
 
     `took_ms: int | None`
     :   Time taken to execute the search in milliseconds.
+
+<a id="AirbyteSearchResult"></a>
 
 `AirbyteSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -148,6 +154,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="CustomersSearchResult"></a>
+
 `CustomersSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -163,6 +171,8 @@ Classes
     * airbyte_agent_sdk.connectors.orb.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="InvoicesSearchResult"></a>
 
 `InvoicesSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -180,6 +190,8 @@ Classes
     * pydantic.main.BaseModel
     * typing.Generic
 
+<a id="PlansSearchResult"></a>
+
 `PlansSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -196,6 +208,8 @@ Classes
     * pydantic.main.BaseModel
     * typing.Generic
 
+<a id="SubscriptionsSearchResult"></a>
+
 `SubscriptionsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -211,6 +225,8 @@ Classes
     * airbyte_agent_sdk.connectors.orb.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="CustomersSearchData"></a>
 
 `CustomersSearchData(**data: Any)`
 :   Search result data for customers entity.
@@ -260,6 +276,8 @@ Classes
 
     `timezone: str | None`
     :   The timezone setting of the customer
+
+<a id="InvoicesSearchData"></a>
 
 `InvoicesSearchData(**data: Any)`
 :   Search result data for invoices entity.
@@ -325,6 +343,8 @@ Classes
     `total: str | None`
     :   The total amount of the invoice
 
+<a id="OrbAuthConfig"></a>
+
 `OrbAuthConfig(**data: Any)`
 :   API Key Authentication
     
@@ -346,6 +366,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="OrbConnector"></a>
 
 `OrbConnector(auth_config: OrbAuthConfig | AirbyteAuthConfig | BaseModel | None = None, on_token_refresh: Any | None = None)`
 :   Type-safe Orb API connector.
@@ -547,6 +569,8 @@ Classes
             for entity in entities:
                 print(f"\{entity['entity_name']\}: \{entity['available_actions']\}")
 
+<a id="OrbReplicationConfig"></a>
+
 `OrbReplicationConfig(**data: Any)`
 :   Replication Configuration - Settings for data replication from Orb.
     
@@ -568,6 +592,8 @@ Classes
 
     `start_date: str`
     :   UTC date and time in the format YYYY-MM-DDTHH:mm:ssZ from which to start replicating data.
+
+<a id="PlansSearchData"></a>
 
 `PlansSearchData(**data: Any)`
 :   Search result data for plans entity.
@@ -605,6 +631,8 @@ Classes
 
     `product: dict[str, typing.Any] | None`
     :   The product associated with the plan
+
+<a id="SubscriptionsSearchData"></a>
 
 `SubscriptionsSearchData(**data: Any)`
 :   Search result data for subscriptions entity.

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/orb/models.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/orb/models.md
@@ -13,6 +13,8 @@ and response envelope types.
 Classes
 -------
 
+<a id="Address"></a>
+
 `Address(**data: Any)`
 :   Address object
     
@@ -50,6 +52,8 @@ Classes
     `state: str | Any | None`
     :   The type of the None singleton.
 
+<a id="AirbyteSearchMeta"></a>
+
 `AirbyteSearchMeta(**data: Any)`
 :   Pagination metadata for search responses.
     
@@ -77,6 +81,8 @@ Classes
 
     `took_ms: int | None`
     :   Time taken to execute the search in milliseconds.
+
+<a id="AirbyteSearchResult"></a>
 
 `AirbyteSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -132,6 +138,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="CustomersSearchResult"></a>
+
 `CustomersSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -168,6 +176,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="InvoicesSearchResult"></a>
 
 `InvoicesSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -206,6 +216,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="PlansSearchResult"></a>
+
 `PlansSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -243,6 +255,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="SubscriptionsSearchResult"></a>
+
 `SubscriptionsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -258,6 +272,8 @@ Classes
     * airbyte_agent_sdk.connectors.orb.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="Customer"></a>
 
 `Customer(**data: Any)`
 :   Customer object
@@ -323,6 +339,8 @@ Classes
     `timezone: str | Any | None`
     :   The type of the None singleton.
 
+<a id="CustomerTaxId"></a>
+
 `CustomerTaxId(**data: Any)`
 :   Tax identification information
     
@@ -351,6 +369,8 @@ Classes
     `value: str | Any | None`
     :   The value of the tax ID
 
+<a id="CustomersList"></a>
+
 `CustomersList(**data: Any)`
 :   Paginated list of customers
     
@@ -376,6 +396,8 @@ Classes
     `pagination_metadata: airbyte_agent_sdk.connectors.orb.models.PaginationMetadata | Any`
     :   The type of the None singleton.
 
+<a id="CustomersListResultMeta"></a>
+
 `CustomersListResultMeta(**data: Any)`
 :   Metadata for customers.Action.LIST operation
     
@@ -397,6 +419,8 @@ Classes
 
     `next_cursor: str | Any | None`
     :   The type of the None singleton.
+
+<a id="CustomersSearchData"></a>
 
 `CustomersSearchData(**data: Any)`
 :   Search result data for customers entity.
@@ -446,6 +470,8 @@ Classes
 
     `timezone: str | None`
     :   The timezone setting of the customer
+
+<a id="Invoice"></a>
 
 `Invoice(**data: Any)`
 :   Invoice object
@@ -568,6 +594,8 @@ Classes
     `will_auto_issue: bool | Any | None`
     :   The type of the None singleton.
 
+<a id="InvoiceCustomer"></a>
+
 `InvoiceCustomer(**data: Any)`
 :   The customer associated with the invoice
     
@@ -592,6 +620,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="InvoiceLineItemsItem"></a>
 
 `InvoiceLineItemsItem(**data: Any)`
 :   Nested schema for Invoice.line_items_item
@@ -630,6 +660,8 @@ Classes
     `start_date: str | Any | None`
     :   The start date of the line item
 
+<a id="InvoiceSubscription"></a>
+
 `InvoiceSubscription(**data: Any)`
 :   The subscription associated with the invoice
     
@@ -651,6 +683,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="InvoicesList"></a>
 
 `InvoicesList(**data: Any)`
 :   Paginated list of invoices
@@ -677,6 +711,8 @@ Classes
     `pagination_metadata: airbyte_agent_sdk.connectors.orb.models.PaginationMetadata | Any`
     :   The type of the None singleton.
 
+<a id="InvoicesListResultMeta"></a>
+
 `InvoicesListResultMeta(**data: Any)`
 :   Metadata for invoices.Action.LIST operation
     
@@ -698,6 +734,8 @@ Classes
 
     `next_cursor: str | Any | None`
     :   The type of the None singleton.
+
+<a id="InvoicesSearchData"></a>
 
 `InvoicesSearchData(**data: Any)`
 :   Search result data for invoices entity.
@@ -763,6 +801,8 @@ Classes
     `total: str | None`
     :   The total amount of the invoice
 
+<a id="OrbAuthConfig"></a>
+
 `OrbAuthConfig(**data: Any)`
 :   API Key Authentication
     
@@ -784,6 +824,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="OrbCheckResult"></a>
 
 `OrbCheckResult(**data: Any)`
 :   Result of a health check operation.
@@ -818,6 +860,8 @@ Classes
     `status: str`
     :   Health check status: 'healthy' or 'unhealthy'.
 
+<a id="OrbExecuteResult"></a>
+
 `OrbExecuteResult(**data: Any)`
 :   Response envelope with data only.
     
@@ -846,6 +890,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="OrbExecuteResultWithMeta"></a>
 
 `OrbExecuteResultWithMeta(**data: Any)`
 :   Response envelope with data and metadata.
@@ -901,6 +947,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="CustomersListResult"></a>
+
 `CustomersListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -943,6 +991,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="InvoicesListResult"></a>
 
 `InvoicesListResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -987,6 +1037,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="PlansListResult"></a>
+
 `PlansListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -1030,6 +1082,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="SubscriptionsListResult"></a>
+
 `SubscriptionsListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -1048,6 +1102,8 @@ Classes
     * airbyte_agent_sdk.connectors.orb.models.OrbExecuteResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="OrbReplicationConfig"></a>
 
 `OrbReplicationConfig(**data: Any)`
 :   Replication Configuration - Settings for data replication from Orb.
@@ -1070,6 +1126,8 @@ Classes
 
     `start_date: str`
     :   UTC date and time in the format YYYY-MM-DDTHH:mm:ssZ from which to start replicating data.
+
+<a id="PaginationMetadata"></a>
 
 `PaginationMetadata(**data: Any)`
 :   Pagination metadata
@@ -1095,6 +1153,8 @@ Classes
 
     `next_cursor: str | Any | None`
     :   The type of the None singleton.
+
+<a id="Plan"></a>
 
 `Plan(**data: Any)`
 :   Plan object
@@ -1169,6 +1229,8 @@ Classes
     `trial_config: dict[str, typing.Any] | Any | None`
     :   The type of the None singleton.
 
+<a id="PlanPricesItem"></a>
+
 `PlanPricesItem(**data: Any)`
 :   Nested schema for Plan.prices_item
     
@@ -1203,6 +1265,8 @@ Classes
     `price_type: str | Any | None`
     :   The type of price
 
+<a id="PlanProduct"></a>
+
 `PlanProduct(**data: Any)`
 :   The product associated with the plan
     
@@ -1227,6 +1291,8 @@ Classes
 
     `name: str | Any | None`
     :   The product name
+
+<a id="PlansList"></a>
 
 `PlansList(**data: Any)`
 :   Paginated list of plans
@@ -1253,6 +1319,8 @@ Classes
     `pagination_metadata: airbyte_agent_sdk.connectors.orb.models.PaginationMetadata | Any`
     :   The type of the None singleton.
 
+<a id="PlansListResultMeta"></a>
+
 `PlansListResultMeta(**data: Any)`
 :   Metadata for plans.Action.LIST operation
     
@@ -1274,6 +1342,8 @@ Classes
 
     `next_cursor: str | Any | None`
     :   The type of the None singleton.
+
+<a id="PlansSearchData"></a>
 
 `PlansSearchData(**data: Any)`
 :   Search result data for plans entity.
@@ -1311,6 +1381,8 @@ Classes
 
     `product: dict[str, typing.Any] | None`
     :   The product associated with the plan
+
+<a id="Subscription"></a>
 
 `Subscription(**data: Any)`
 :   Subscription object
@@ -1385,6 +1457,8 @@ Classes
     `status: str | Any | None`
     :   The type of the None singleton.
 
+<a id="SubscriptionCustomer"></a>
+
 `SubscriptionCustomer(**data: Any)`
 :   The customer associated with the subscription
     
@@ -1409,6 +1483,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="SubscriptionPlan"></a>
 
 `SubscriptionPlan(**data: Any)`
 :   The plan associated with the subscription
@@ -1435,6 +1511,8 @@ Classes
     `name: str | Any | None`
     :   The plan name
 
+<a id="SubscriptionsList"></a>
+
 `SubscriptionsList(**data: Any)`
 :   Paginated list of subscriptions
     
@@ -1460,6 +1538,8 @@ Classes
     `pagination_metadata: airbyte_agent_sdk.connectors.orb.models.PaginationMetadata | Any`
     :   The type of the None singleton.
 
+<a id="SubscriptionsListResultMeta"></a>
+
 `SubscriptionsListResultMeta(**data: Any)`
 :   Metadata for subscriptions.Action.LIST operation
     
@@ -1481,6 +1561,8 @@ Classes
 
     `next_cursor: str | Any | None`
     :   The type of the None singleton.
+
+<a id="SubscriptionsSearchData"></a>
 
 `SubscriptionsSearchData(**data: Any)`
 :   Search result data for subscriptions entity.

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/orb/types.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/orb/types.md
@@ -10,6 +10,8 @@ Type definitions for orb connector.
 Classes
 -------
 
+<a id="AirbyteSearchParams"></a>
+
 `AirbyteSearchParams(*args, **kwargs)`
 :   Parameters for Airbyte cache search operations (generic, use entity-specific query types for better type hints).
 
@@ -31,6 +33,8 @@ Classes
     `query: dict[str, typing.Any]`
     :   The type of the None singleton.
 
+<a id="CustomersAndCondition"></a>
+
 `CustomersAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -51,6 +55,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.orb.types.CustomersEqCondition | airbyte_agent_sdk.connectors.orb.types.CustomersNeqCondition | airbyte_agent_sdk.connectors.orb.types.CustomersGtCondition | airbyte_agent_sdk.connectors.orb.types.CustomersGteCondition | airbyte_agent_sdk.connectors.orb.types.CustomersLtCondition | airbyte_agent_sdk.connectors.orb.types.CustomersLteCondition | airbyte_agent_sdk.connectors.orb.types.CustomersInCondition | airbyte_agent_sdk.connectors.orb.types.CustomersLikeCondition | airbyte_agent_sdk.connectors.orb.types.CustomersFuzzyCondition | airbyte_agent_sdk.connectors.orb.types.CustomersKeywordCondition | airbyte_agent_sdk.connectors.orb.types.CustomersContainsCondition | airbyte_agent_sdk.connectors.orb.types.CustomersNotCondition | airbyte_agent_sdk.connectors.orb.types.CustomersAndCondition | airbyte_agent_sdk.connectors.orb.types.CustomersOrCondition | airbyte_agent_sdk.connectors.orb.types.CustomersAnyCondition]`
     :   The type of the None singleton.
 
+<a id="CustomersAnyCondition"></a>
+
 `CustomersAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -70,6 +76,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.orb.types.CustomersAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="CustomersAnyValueFilter"></a>
 
 `CustomersAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -110,6 +118,8 @@ Classes
     `timezone: Any`
     :   The timezone setting of the customer
 
+<a id="CustomersContainsCondition"></a>
+
 `CustomersContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -121,6 +131,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.orb.types.CustomersAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="CustomersEqCondition"></a>
 
 `CustomersEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -134,6 +146,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.orb.types.CustomersSearchFilter`
     :   The type of the None singleton.
 
+<a id="CustomersFuzzyCondition"></a>
+
 `CustomersFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -145,6 +159,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.orb.types.CustomersStringFilter`
     :   The type of the None singleton.
+
+<a id="CustomersGetParams"></a>
 
 `CustomersGetParams(*args, **kwargs)`
 :   Parameters for customers.get operation
@@ -158,6 +174,8 @@ Classes
     `customer_id: str`
     :   The type of the None singleton.
 
+<a id="CustomersGtCondition"></a>
+
 `CustomersGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -170,6 +188,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.orb.types.CustomersSearchFilter`
     :   The type of the None singleton.
 
+<a id="CustomersGteCondition"></a>
+
 `CustomersGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -181,6 +201,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.orb.types.CustomersSearchFilter`
     :   The type of the None singleton.
+
+<a id="CustomersInCondition"></a>
 
 `CustomersInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -201,6 +223,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.orb.types.CustomersInFilter`
     :   The type of the None singleton.
+
+<a id="CustomersInFilter"></a>
 
 `CustomersInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -241,6 +265,8 @@ Classes
     `timezone: list[str]`
     :   The timezone setting of the customer
 
+<a id="CustomersKeywordCondition"></a>
+
 `CustomersKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -253,6 +279,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.orb.types.CustomersStringFilter`
     :   The type of the None singleton.
 
+<a id="CustomersLikeCondition"></a>
+
 `CustomersLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -264,6 +292,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.orb.types.CustomersStringFilter`
     :   The type of the None singleton.
+
+<a id="CustomersListParams"></a>
 
 `CustomersListParams(*args, **kwargs)`
 :   Parameters for customers.list operation
@@ -280,6 +310,8 @@ Classes
     `limit: int`
     :   The type of the None singleton.
 
+<a id="CustomersLtCondition"></a>
+
 `CustomersLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -291,6 +323,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.orb.types.CustomersSearchFilter`
     :   The type of the None singleton.
+
+<a id="CustomersLteCondition"></a>
 
 `CustomersLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -304,6 +338,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.orb.types.CustomersSearchFilter`
     :   The type of the None singleton.
 
+<a id="CustomersNeqCondition"></a>
+
 `CustomersNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -315,6 +351,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.orb.types.CustomersSearchFilter`
     :   The type of the None singleton.
+
+<a id="CustomersNotCondition"></a>
 
 `CustomersNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -336,6 +374,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.orb.types.CustomersEqCondition | airbyte_agent_sdk.connectors.orb.types.CustomersNeqCondition | airbyte_agent_sdk.connectors.orb.types.CustomersGtCondition | airbyte_agent_sdk.connectors.orb.types.CustomersGteCondition | airbyte_agent_sdk.connectors.orb.types.CustomersLtCondition | airbyte_agent_sdk.connectors.orb.types.CustomersLteCondition | airbyte_agent_sdk.connectors.orb.types.CustomersInCondition | airbyte_agent_sdk.connectors.orb.types.CustomersLikeCondition | airbyte_agent_sdk.connectors.orb.types.CustomersFuzzyCondition | airbyte_agent_sdk.connectors.orb.types.CustomersKeywordCondition | airbyte_agent_sdk.connectors.orb.types.CustomersContainsCondition | airbyte_agent_sdk.connectors.orb.types.CustomersNotCondition | airbyte_agent_sdk.connectors.orb.types.CustomersAndCondition | airbyte_agent_sdk.connectors.orb.types.CustomersOrCondition | airbyte_agent_sdk.connectors.orb.types.CustomersAnyCondition`
     :   The type of the None singleton.
 
+<a id="CustomersOrCondition"></a>
+
 `CustomersOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -355,6 +395,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.orb.types.CustomersEqCondition | airbyte_agent_sdk.connectors.orb.types.CustomersNeqCondition | airbyte_agent_sdk.connectors.orb.types.CustomersGtCondition | airbyte_agent_sdk.connectors.orb.types.CustomersGteCondition | airbyte_agent_sdk.connectors.orb.types.CustomersLtCondition | airbyte_agent_sdk.connectors.orb.types.CustomersLteCondition | airbyte_agent_sdk.connectors.orb.types.CustomersInCondition | airbyte_agent_sdk.connectors.orb.types.CustomersLikeCondition | airbyte_agent_sdk.connectors.orb.types.CustomersFuzzyCondition | airbyte_agent_sdk.connectors.orb.types.CustomersKeywordCondition | airbyte_agent_sdk.connectors.orb.types.CustomersContainsCondition | airbyte_agent_sdk.connectors.orb.types.CustomersNotCondition | airbyte_agent_sdk.connectors.orb.types.CustomersAndCondition | airbyte_agent_sdk.connectors.orb.types.CustomersOrCondition | airbyte_agent_sdk.connectors.orb.types.CustomersAnyCondition]`
     :   The type of the None singleton.
+
+<a id="CustomersSearchFilter"></a>
 
 `CustomersSearchFilter(*args, **kwargs)`
 :   Available fields for filtering customers search queries.
@@ -395,6 +437,8 @@ Classes
     `timezone: str | None`
     :   The timezone setting of the customer
 
+<a id="CustomersSearchQuery"></a>
+
 `CustomersSearchQuery(*args, **kwargs)`
 :   Search query for customers entity.
 
@@ -409,6 +453,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.orb.types.CustomersSortFilter]`
     :   The type of the None singleton.
+
+<a id="CustomersSortFilter"></a>
 
 `CustomersSortFilter(*args, **kwargs)`
 :   Available fields for sorting customers search results.
@@ -449,6 +495,8 @@ Classes
     `timezone: Literal['asc', 'desc']`
     :   The timezone setting of the customer
 
+<a id="CustomersStringFilter"></a>
+
 `CustomersStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -488,6 +536,8 @@ Classes
     `timezone: str`
     :   The timezone setting of the customer
 
+<a id="InvoicesAndCondition"></a>
+
 `InvoicesAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -508,6 +558,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.orb.types.InvoicesEqCondition | airbyte_agent_sdk.connectors.orb.types.InvoicesNeqCondition | airbyte_agent_sdk.connectors.orb.types.InvoicesGtCondition | airbyte_agent_sdk.connectors.orb.types.InvoicesGteCondition | airbyte_agent_sdk.connectors.orb.types.InvoicesLtCondition | airbyte_agent_sdk.connectors.orb.types.InvoicesLteCondition | airbyte_agent_sdk.connectors.orb.types.InvoicesInCondition | airbyte_agent_sdk.connectors.orb.types.InvoicesLikeCondition | airbyte_agent_sdk.connectors.orb.types.InvoicesFuzzyCondition | airbyte_agent_sdk.connectors.orb.types.InvoicesKeywordCondition | airbyte_agent_sdk.connectors.orb.types.InvoicesContainsCondition | airbyte_agent_sdk.connectors.orb.types.InvoicesNotCondition | airbyte_agent_sdk.connectors.orb.types.InvoicesAndCondition | airbyte_agent_sdk.connectors.orb.types.InvoicesOrCondition | airbyte_agent_sdk.connectors.orb.types.InvoicesAnyCondition]`
     :   The type of the None singleton.
 
+<a id="InvoicesAnyCondition"></a>
+
 `InvoicesAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -527,6 +579,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.orb.types.InvoicesAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="InvoicesAnyValueFilter"></a>
 
 `InvoicesAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -582,6 +636,8 @@ Classes
     `total: Any`
     :   The total amount of the invoice
 
+<a id="InvoicesContainsCondition"></a>
+
 `InvoicesContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -593,6 +649,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.orb.types.InvoicesAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="InvoicesEqCondition"></a>
 
 `InvoicesEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -606,6 +664,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.orb.types.InvoicesSearchFilter`
     :   The type of the None singleton.
 
+<a id="InvoicesFuzzyCondition"></a>
+
 `InvoicesFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -617,6 +677,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.orb.types.InvoicesStringFilter`
     :   The type of the None singleton.
+
+<a id="InvoicesGetParams"></a>
 
 `InvoicesGetParams(*args, **kwargs)`
 :   Parameters for invoices.get operation
@@ -630,6 +692,8 @@ Classes
     `invoice_id: str`
     :   The type of the None singleton.
 
+<a id="InvoicesGtCondition"></a>
+
 `InvoicesGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -642,6 +706,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.orb.types.InvoicesSearchFilter`
     :   The type of the None singleton.
 
+<a id="InvoicesGteCondition"></a>
+
 `InvoicesGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -653,6 +719,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.orb.types.InvoicesSearchFilter`
     :   The type of the None singleton.
+
+<a id="InvoicesInCondition"></a>
 
 `InvoicesInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -673,6 +741,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.orb.types.InvoicesInFilter`
     :   The type of the None singleton.
+
+<a id="InvoicesInFilter"></a>
 
 `InvoicesInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -728,6 +798,8 @@ Classes
     `total: list[str]`
     :   The total amount of the invoice
 
+<a id="InvoicesKeywordCondition"></a>
+
 `InvoicesKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -740,6 +812,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.orb.types.InvoicesStringFilter`
     :   The type of the None singleton.
 
+<a id="InvoicesLikeCondition"></a>
+
 `InvoicesLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -751,6 +825,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.orb.types.InvoicesStringFilter`
     :   The type of the None singleton.
+
+<a id="InvoicesListParams"></a>
 
 `InvoicesListParams(*args, **kwargs)`
 :   Parameters for invoices.list operation
@@ -791,6 +867,8 @@ Classes
     `subscription_id: str`
     :   The type of the None singleton.
 
+<a id="InvoicesLtCondition"></a>
+
 `InvoicesLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -802,6 +880,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.orb.types.InvoicesSearchFilter`
     :   The type of the None singleton.
+
+<a id="InvoicesLteCondition"></a>
 
 `InvoicesLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -815,6 +895,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.orb.types.InvoicesSearchFilter`
     :   The type of the None singleton.
 
+<a id="InvoicesNeqCondition"></a>
+
 `InvoicesNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -826,6 +908,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.orb.types.InvoicesSearchFilter`
     :   The type of the None singleton.
+
+<a id="InvoicesNotCondition"></a>
 
 `InvoicesNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -847,6 +931,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.orb.types.InvoicesEqCondition | airbyte_agent_sdk.connectors.orb.types.InvoicesNeqCondition | airbyte_agent_sdk.connectors.orb.types.InvoicesGtCondition | airbyte_agent_sdk.connectors.orb.types.InvoicesGteCondition | airbyte_agent_sdk.connectors.orb.types.InvoicesLtCondition | airbyte_agent_sdk.connectors.orb.types.InvoicesLteCondition | airbyte_agent_sdk.connectors.orb.types.InvoicesInCondition | airbyte_agent_sdk.connectors.orb.types.InvoicesLikeCondition | airbyte_agent_sdk.connectors.orb.types.InvoicesFuzzyCondition | airbyte_agent_sdk.connectors.orb.types.InvoicesKeywordCondition | airbyte_agent_sdk.connectors.orb.types.InvoicesContainsCondition | airbyte_agent_sdk.connectors.orb.types.InvoicesNotCondition | airbyte_agent_sdk.connectors.orb.types.InvoicesAndCondition | airbyte_agent_sdk.connectors.orb.types.InvoicesOrCondition | airbyte_agent_sdk.connectors.orb.types.InvoicesAnyCondition`
     :   The type of the None singleton.
 
+<a id="InvoicesOrCondition"></a>
+
 `InvoicesOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -866,6 +952,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.orb.types.InvoicesEqCondition | airbyte_agent_sdk.connectors.orb.types.InvoicesNeqCondition | airbyte_agent_sdk.connectors.orb.types.InvoicesGtCondition | airbyte_agent_sdk.connectors.orb.types.InvoicesGteCondition | airbyte_agent_sdk.connectors.orb.types.InvoicesLtCondition | airbyte_agent_sdk.connectors.orb.types.InvoicesLteCondition | airbyte_agent_sdk.connectors.orb.types.InvoicesInCondition | airbyte_agent_sdk.connectors.orb.types.InvoicesLikeCondition | airbyte_agent_sdk.connectors.orb.types.InvoicesFuzzyCondition | airbyte_agent_sdk.connectors.orb.types.InvoicesKeywordCondition | airbyte_agent_sdk.connectors.orb.types.InvoicesContainsCondition | airbyte_agent_sdk.connectors.orb.types.InvoicesNotCondition | airbyte_agent_sdk.connectors.orb.types.InvoicesAndCondition | airbyte_agent_sdk.connectors.orb.types.InvoicesOrCondition | airbyte_agent_sdk.connectors.orb.types.InvoicesAnyCondition]`
     :   The type of the None singleton.
+
+<a id="InvoicesSearchFilter"></a>
 
 `InvoicesSearchFilter(*args, **kwargs)`
 :   Available fields for filtering invoices search queries.
@@ -921,6 +1009,8 @@ Classes
     `total: str | None`
     :   The total amount of the invoice
 
+<a id="InvoicesSearchQuery"></a>
+
 `InvoicesSearchQuery(*args, **kwargs)`
 :   Search query for invoices entity.
 
@@ -935,6 +1025,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.orb.types.InvoicesSortFilter]`
     :   The type of the None singleton.
+
+<a id="InvoicesSortFilter"></a>
 
 `InvoicesSortFilter(*args, **kwargs)`
 :   Available fields for sorting invoices search results.
@@ -990,6 +1082,8 @@ Classes
     `total: Literal['asc', 'desc']`
     :   The total amount of the invoice
 
+<a id="InvoicesStringFilter"></a>
+
 `InvoicesStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -1044,6 +1138,8 @@ Classes
     `total: str`
     :   The total amount of the invoice
 
+<a id="PlansAndCondition"></a>
+
 `PlansAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1064,6 +1160,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.orb.types.PlansEqCondition | airbyte_agent_sdk.connectors.orb.types.PlansNeqCondition | airbyte_agent_sdk.connectors.orb.types.PlansGtCondition | airbyte_agent_sdk.connectors.orb.types.PlansGteCondition | airbyte_agent_sdk.connectors.orb.types.PlansLtCondition | airbyte_agent_sdk.connectors.orb.types.PlansLteCondition | airbyte_agent_sdk.connectors.orb.types.PlansInCondition | airbyte_agent_sdk.connectors.orb.types.PlansLikeCondition | airbyte_agent_sdk.connectors.orb.types.PlansFuzzyCondition | airbyte_agent_sdk.connectors.orb.types.PlansKeywordCondition | airbyte_agent_sdk.connectors.orb.types.PlansContainsCondition | airbyte_agent_sdk.connectors.orb.types.PlansNotCondition | airbyte_agent_sdk.connectors.orb.types.PlansAndCondition | airbyte_agent_sdk.connectors.orb.types.PlansOrCondition | airbyte_agent_sdk.connectors.orb.types.PlansAnyCondition]`
     :   The type of the None singleton.
 
+<a id="PlansAnyCondition"></a>
+
 `PlansAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1083,6 +1181,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.orb.types.PlansAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="PlansAnyValueFilter"></a>
 
 `PlansAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -1111,6 +1211,8 @@ Classes
     `product: Any`
     :   The product associated with the plan
 
+<a id="PlansContainsCondition"></a>
+
 `PlansContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -1122,6 +1224,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.orb.types.PlansAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="PlansEqCondition"></a>
 
 `PlansEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -1135,6 +1239,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.orb.types.PlansSearchFilter`
     :   The type of the None singleton.
 
+<a id="PlansFuzzyCondition"></a>
+
 `PlansFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -1146,6 +1252,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.orb.types.PlansStringFilter`
     :   The type of the None singleton.
+
+<a id="PlansGetParams"></a>
 
 `PlansGetParams(*args, **kwargs)`
 :   Parameters for plans.get operation
@@ -1159,6 +1267,8 @@ Classes
     `plan_id: str`
     :   The type of the None singleton.
 
+<a id="PlansGtCondition"></a>
+
 `PlansGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -1171,6 +1281,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.orb.types.PlansSearchFilter`
     :   The type of the None singleton.
 
+<a id="PlansGteCondition"></a>
+
 `PlansGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -1182,6 +1294,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.orb.types.PlansSearchFilter`
     :   The type of the None singleton.
+
+<a id="PlansInCondition"></a>
 
 `PlansInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -1202,6 +1316,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.orb.types.PlansInFilter`
     :   The type of the None singleton.
+
+<a id="PlansInFilter"></a>
 
 `PlansInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -1230,6 +1346,8 @@ Classes
     `product: list[dict[str, typing.Any]]`
     :   The product associated with the plan
 
+<a id="PlansKeywordCondition"></a>
+
 `PlansKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -1242,6 +1360,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.orb.types.PlansStringFilter`
     :   The type of the None singleton.
 
+<a id="PlansLikeCondition"></a>
+
 `PlansLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -1253,6 +1373,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.orb.types.PlansStringFilter`
     :   The type of the None singleton.
+
+<a id="PlansListParams"></a>
 
 `PlansListParams(*args, **kwargs)`
 :   Parameters for plans.list operation
@@ -1269,6 +1391,8 @@ Classes
     `limit: int`
     :   The type of the None singleton.
 
+<a id="PlansLtCondition"></a>
+
 `PlansLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -1280,6 +1404,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.orb.types.PlansSearchFilter`
     :   The type of the None singleton.
+
+<a id="PlansLteCondition"></a>
 
 `PlansLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -1293,6 +1419,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.orb.types.PlansSearchFilter`
     :   The type of the None singleton.
 
+<a id="PlansNeqCondition"></a>
+
 `PlansNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -1304,6 +1432,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.orb.types.PlansSearchFilter`
     :   The type of the None singleton.
+
+<a id="PlansNotCondition"></a>
 
 `PlansNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -1325,6 +1455,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.orb.types.PlansEqCondition | airbyte_agent_sdk.connectors.orb.types.PlansNeqCondition | airbyte_agent_sdk.connectors.orb.types.PlansGtCondition | airbyte_agent_sdk.connectors.orb.types.PlansGteCondition | airbyte_agent_sdk.connectors.orb.types.PlansLtCondition | airbyte_agent_sdk.connectors.orb.types.PlansLteCondition | airbyte_agent_sdk.connectors.orb.types.PlansInCondition | airbyte_agent_sdk.connectors.orb.types.PlansLikeCondition | airbyte_agent_sdk.connectors.orb.types.PlansFuzzyCondition | airbyte_agent_sdk.connectors.orb.types.PlansKeywordCondition | airbyte_agent_sdk.connectors.orb.types.PlansContainsCondition | airbyte_agent_sdk.connectors.orb.types.PlansNotCondition | airbyte_agent_sdk.connectors.orb.types.PlansAndCondition | airbyte_agent_sdk.connectors.orb.types.PlansOrCondition | airbyte_agent_sdk.connectors.orb.types.PlansAnyCondition`
     :   The type of the None singleton.
 
+<a id="PlansOrCondition"></a>
+
 `PlansOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1344,6 +1476,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.orb.types.PlansEqCondition | airbyte_agent_sdk.connectors.orb.types.PlansNeqCondition | airbyte_agent_sdk.connectors.orb.types.PlansGtCondition | airbyte_agent_sdk.connectors.orb.types.PlansGteCondition | airbyte_agent_sdk.connectors.orb.types.PlansLtCondition | airbyte_agent_sdk.connectors.orb.types.PlansLteCondition | airbyte_agent_sdk.connectors.orb.types.PlansInCondition | airbyte_agent_sdk.connectors.orb.types.PlansLikeCondition | airbyte_agent_sdk.connectors.orb.types.PlansFuzzyCondition | airbyte_agent_sdk.connectors.orb.types.PlansKeywordCondition | airbyte_agent_sdk.connectors.orb.types.PlansContainsCondition | airbyte_agent_sdk.connectors.orb.types.PlansNotCondition | airbyte_agent_sdk.connectors.orb.types.PlansAndCondition | airbyte_agent_sdk.connectors.orb.types.PlansOrCondition | airbyte_agent_sdk.connectors.orb.types.PlansAnyCondition]`
     :   The type of the None singleton.
+
+<a id="PlansSearchFilter"></a>
 
 `PlansSearchFilter(*args, **kwargs)`
 :   Available fields for filtering plans search queries.
@@ -1372,6 +1506,8 @@ Classes
     `product: dict[str, typing.Any] | None`
     :   The product associated with the plan
 
+<a id="PlansSearchQuery"></a>
+
 `PlansSearchQuery(*args, **kwargs)`
 :   Search query for plans entity.
 
@@ -1386,6 +1522,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.orb.types.PlansSortFilter]`
     :   The type of the None singleton.
+
+<a id="PlansSortFilter"></a>
 
 `PlansSortFilter(*args, **kwargs)`
 :   Available fields for sorting plans search results.
@@ -1414,6 +1552,8 @@ Classes
     `product: Literal['asc', 'desc']`
     :   The product associated with the plan
 
+<a id="PlansStringFilter"></a>
+
 `PlansStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -1441,6 +1581,8 @@ Classes
     `product: str`
     :   The product associated with the plan
 
+<a id="SubscriptionsAndCondition"></a>
+
 `SubscriptionsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1461,6 +1603,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.orb.types.SubscriptionsEqCondition | airbyte_agent_sdk.connectors.orb.types.SubscriptionsNeqCondition | airbyte_agent_sdk.connectors.orb.types.SubscriptionsGtCondition | airbyte_agent_sdk.connectors.orb.types.SubscriptionsGteCondition | airbyte_agent_sdk.connectors.orb.types.SubscriptionsLtCondition | airbyte_agent_sdk.connectors.orb.types.SubscriptionsLteCondition | airbyte_agent_sdk.connectors.orb.types.SubscriptionsInCondition | airbyte_agent_sdk.connectors.orb.types.SubscriptionsLikeCondition | airbyte_agent_sdk.connectors.orb.types.SubscriptionsFuzzyCondition | airbyte_agent_sdk.connectors.orb.types.SubscriptionsKeywordCondition | airbyte_agent_sdk.connectors.orb.types.SubscriptionsContainsCondition | airbyte_agent_sdk.connectors.orb.types.SubscriptionsNotCondition | airbyte_agent_sdk.connectors.orb.types.SubscriptionsAndCondition | airbyte_agent_sdk.connectors.orb.types.SubscriptionsOrCondition | airbyte_agent_sdk.connectors.orb.types.SubscriptionsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="SubscriptionsAnyCondition"></a>
+
 `SubscriptionsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1480,6 +1624,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.orb.types.SubscriptionsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="SubscriptionsAnyValueFilter"></a>
 
 `SubscriptionsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -1505,6 +1651,8 @@ Classes
     `status: Any`
     :   The current status of the subscription
 
+<a id="SubscriptionsContainsCondition"></a>
+
 `SubscriptionsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -1516,6 +1664,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.orb.types.SubscriptionsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="SubscriptionsEqCondition"></a>
 
 `SubscriptionsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -1529,6 +1679,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.orb.types.SubscriptionsSearchFilter`
     :   The type of the None singleton.
 
+<a id="SubscriptionsFuzzyCondition"></a>
+
 `SubscriptionsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -1540,6 +1692,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.orb.types.SubscriptionsStringFilter`
     :   The type of the None singleton.
+
+<a id="SubscriptionsGetParams"></a>
 
 `SubscriptionsGetParams(*args, **kwargs)`
 :   Parameters for subscriptions.get operation
@@ -1553,6 +1707,8 @@ Classes
     `subscription_id: str`
     :   The type of the None singleton.
 
+<a id="SubscriptionsGtCondition"></a>
+
 `SubscriptionsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -1565,6 +1721,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.orb.types.SubscriptionsSearchFilter`
     :   The type of the None singleton.
 
+<a id="SubscriptionsGteCondition"></a>
+
 `SubscriptionsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -1576,6 +1734,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.orb.types.SubscriptionsSearchFilter`
     :   The type of the None singleton.
+
+<a id="SubscriptionsInCondition"></a>
 
 `SubscriptionsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -1596,6 +1756,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.orb.types.SubscriptionsInFilter`
     :   The type of the None singleton.
+
+<a id="SubscriptionsInFilter"></a>
 
 `SubscriptionsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -1621,6 +1783,8 @@ Classes
     `status: list[str]`
     :   The current status of the subscription
 
+<a id="SubscriptionsKeywordCondition"></a>
+
 `SubscriptionsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -1633,6 +1797,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.orb.types.SubscriptionsStringFilter`
     :   The type of the None singleton.
 
+<a id="SubscriptionsLikeCondition"></a>
+
 `SubscriptionsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -1644,6 +1810,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.orb.types.SubscriptionsStringFilter`
     :   The type of the None singleton.
+
+<a id="SubscriptionsListParams"></a>
 
 `SubscriptionsListParams(*args, **kwargs)`
 :   Parameters for subscriptions.list operation
@@ -1669,6 +1837,8 @@ Classes
     `status: str`
     :   The type of the None singleton.
 
+<a id="SubscriptionsLtCondition"></a>
+
 `SubscriptionsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -1680,6 +1850,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.orb.types.SubscriptionsSearchFilter`
     :   The type of the None singleton.
+
+<a id="SubscriptionsLteCondition"></a>
 
 `SubscriptionsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -1693,6 +1865,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.orb.types.SubscriptionsSearchFilter`
     :   The type of the None singleton.
 
+<a id="SubscriptionsNeqCondition"></a>
+
 `SubscriptionsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -1704,6 +1878,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.orb.types.SubscriptionsSearchFilter`
     :   The type of the None singleton.
+
+<a id="SubscriptionsNotCondition"></a>
 
 `SubscriptionsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -1725,6 +1901,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.orb.types.SubscriptionsEqCondition | airbyte_agent_sdk.connectors.orb.types.SubscriptionsNeqCondition | airbyte_agent_sdk.connectors.orb.types.SubscriptionsGtCondition | airbyte_agent_sdk.connectors.orb.types.SubscriptionsGteCondition | airbyte_agent_sdk.connectors.orb.types.SubscriptionsLtCondition | airbyte_agent_sdk.connectors.orb.types.SubscriptionsLteCondition | airbyte_agent_sdk.connectors.orb.types.SubscriptionsInCondition | airbyte_agent_sdk.connectors.orb.types.SubscriptionsLikeCondition | airbyte_agent_sdk.connectors.orb.types.SubscriptionsFuzzyCondition | airbyte_agent_sdk.connectors.orb.types.SubscriptionsKeywordCondition | airbyte_agent_sdk.connectors.orb.types.SubscriptionsContainsCondition | airbyte_agent_sdk.connectors.orb.types.SubscriptionsNotCondition | airbyte_agent_sdk.connectors.orb.types.SubscriptionsAndCondition | airbyte_agent_sdk.connectors.orb.types.SubscriptionsOrCondition | airbyte_agent_sdk.connectors.orb.types.SubscriptionsAnyCondition`
     :   The type of the None singleton.
 
+<a id="SubscriptionsOrCondition"></a>
+
 `SubscriptionsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1744,6 +1922,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.orb.types.SubscriptionsEqCondition | airbyte_agent_sdk.connectors.orb.types.SubscriptionsNeqCondition | airbyte_agent_sdk.connectors.orb.types.SubscriptionsGtCondition | airbyte_agent_sdk.connectors.orb.types.SubscriptionsGteCondition | airbyte_agent_sdk.connectors.orb.types.SubscriptionsLtCondition | airbyte_agent_sdk.connectors.orb.types.SubscriptionsLteCondition | airbyte_agent_sdk.connectors.orb.types.SubscriptionsInCondition | airbyte_agent_sdk.connectors.orb.types.SubscriptionsLikeCondition | airbyte_agent_sdk.connectors.orb.types.SubscriptionsFuzzyCondition | airbyte_agent_sdk.connectors.orb.types.SubscriptionsKeywordCondition | airbyte_agent_sdk.connectors.orb.types.SubscriptionsContainsCondition | airbyte_agent_sdk.connectors.orb.types.SubscriptionsNotCondition | airbyte_agent_sdk.connectors.orb.types.SubscriptionsAndCondition | airbyte_agent_sdk.connectors.orb.types.SubscriptionsOrCondition | airbyte_agent_sdk.connectors.orb.types.SubscriptionsAnyCondition]`
     :   The type of the None singleton.
+
+<a id="SubscriptionsSearchFilter"></a>
 
 `SubscriptionsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering subscriptions search queries.
@@ -1769,6 +1949,8 @@ Classes
     `status: str | None`
     :   The current status of the subscription
 
+<a id="SubscriptionsSearchQuery"></a>
+
 `SubscriptionsSearchQuery(*args, **kwargs)`
 :   Search query for subscriptions entity.
 
@@ -1783,6 +1965,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.orb.types.SubscriptionsSortFilter]`
     :   The type of the None singleton.
+
+<a id="SubscriptionsSortFilter"></a>
 
 `SubscriptionsSortFilter(*args, **kwargs)`
 :   Available fields for sorting subscriptions search results.
@@ -1807,6 +1991,8 @@ Classes
 
     `status: Literal['asc', 'desc']`
     :   The current status of the subscription
+
+<a id="SubscriptionsStringFilter"></a>
 
 `SubscriptionsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/paypal_transaction/connector.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/paypal_transaction/connector.md
@@ -10,6 +10,8 @@ Paypal-Transaction connector.
 Classes
 -------
 
+<a id="BalancesQuery"></a>
+
 `BalancesQuery(connector: PaypalTransactionConnector)`
 :   Query class for Balances entity operations.
     
@@ -56,6 +58,8 @@ Classes
         
         Returns:
             BalancesListResult
+
+<a id="ListDisputesQuery"></a>
 
 `ListDisputesQuery(connector: PaypalTransactionConnector)`
 :   Query class for ListDisputes entity operations.
@@ -113,6 +117,8 @@ Classes
         Returns:
             ListDisputesListResult
 
+<a id="ListPaymentsQuery"></a>
+
 `ListPaymentsQuery(connector: PaypalTransactionConnector)`
 :   Query class for ListPayments entity operations.
     
@@ -165,6 +171,8 @@ Classes
         Returns:
             ListPaymentsListResult
 
+<a id="ListProductsQuery"></a>
+
 `ListProductsQuery(connector: PaypalTransactionConnector)`
 :   Query class for ListProducts entity operations.
     
@@ -209,6 +217,8 @@ Classes
         
         Returns:
             ListProductsListResult
+
+<a id="PaypalTransactionConnector"></a>
 
 `PaypalTransactionConnector(auth_config: PaypalTransactionAuthConfig | AirbyteAuthConfig | BaseModel | None = None, on_token_refresh: Any | None = None)`
 :   Type-safe Paypal-Transaction API connector.
@@ -466,6 +476,8 @@ Classes
             for entity in entities:
                 print(f"\{entity['entity_name']\}: \{entity['available_actions']\}")
 
+<a id="SearchInvoicesQuery"></a>
+
 `SearchInvoicesQuery(connector: PaypalTransactionConnector)`
 :   Query class for SearchInvoices entity operations.
     
@@ -522,6 +534,8 @@ Classes
         Returns:
             SearchInvoicesListResult
 
+<a id="ShowProductDetailsQuery"></a>
+
 `ShowProductDetailsQuery(connector: PaypalTransactionConnector)`
 :   Query class for ShowProductDetails entity operations.
     
@@ -570,6 +584,8 @@ Classes
         
         Returns:
             ProductDetails
+
+<a id="TransactionsQuery"></a>
 
 `TransactionsQuery(connector: PaypalTransactionConnector)`
 :   Query class for Transactions entity operations.

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/paypal_transaction/index.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/paypal_transaction/index.md
@@ -19,6 +19,8 @@ Sub-modules
 Classes
 -------
 
+<a id="AirbyteAuthConfig"></a>
+
 `AirbyteAuthConfig(**data: Any)`
 :   Authentication configuration for Airbyte hosted mode execution.
     
@@ -87,6 +89,8 @@ Classes
     `workspace_name: str | None`
     :   The type of the None singleton.
 
+<a id="AirbyteSearchMeta"></a>
+
 `AirbyteSearchMeta(**data: Any)`
 :   Pagination metadata for search responses.
     
@@ -114,6 +118,8 @@ Classes
 
     `took_ms: int | None`
     :   Time taken to execute the search in milliseconds.
+
+<a id="AirbyteSearchResult"></a>
 
 `AirbyteSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -151,6 +157,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="BalancesSearchResult"></a>
+
 `BalancesSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -166,6 +174,8 @@ Classes
     * airbyte_agent_sdk.connectors.paypal_transaction.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="ListDisputesSearchResult"></a>
 
 `ListDisputesSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -183,6 +193,8 @@ Classes
     * pydantic.main.BaseModel
     * typing.Generic
 
+<a id="ListPaymentsSearchResult"></a>
+
 `ListPaymentsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -198,6 +210,8 @@ Classes
     * airbyte_agent_sdk.connectors.paypal_transaction.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="ListProductsSearchResult"></a>
 
 `ListProductsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -215,6 +229,8 @@ Classes
     * pydantic.main.BaseModel
     * typing.Generic
 
+<a id="SearchInvoicesSearchResult"></a>
+
 `SearchInvoicesSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -230,6 +246,8 @@ Classes
     * airbyte_agent_sdk.connectors.paypal_transaction.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="ShowProductDetailsSearchResult"></a>
 
 `ShowProductDetailsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -247,6 +265,8 @@ Classes
     * pydantic.main.BaseModel
     * typing.Generic
 
+<a id="TransactionsSearchResult"></a>
+
 `TransactionsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -262,6 +282,8 @@ Classes
     * airbyte_agent_sdk.connectors.paypal_transaction.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="BalancesSearchData"></a>
 
 `BalancesSearchData(**data: Any)`
 :   Search result data for balances entity.
@@ -293,6 +315,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="ListDisputesSearchData"></a>
 
 `ListDisputesSearchData(**data: Any)`
 :   Search result data for list_disputes entity.
@@ -352,6 +376,8 @@ Classes
     `updated_time_cut: str | None`
     :   The cut-off timestamp for the last update.
 
+<a id="ListPaymentsSearchData"></a>
+
 `ListPaymentsSearchData(**data: Any)`
 :   Search result data for list_payments entity.
     
@@ -398,6 +424,8 @@ Classes
     `update_time: str | None`
     :   The date and time when the payment was last updated.
 
+<a id="ListProductsSearchData"></a>
+
 `ListProductsSearchData(**data: Any)`
 :   Search result data for list_products entity.
     
@@ -432,6 +460,8 @@ Classes
     `name: str | None`
     :   The name or title of the product
 
+<a id="PaypalTransactionAuthConfig"></a>
+
 `PaypalTransactionAuthConfig(**data: Any)`
 :   PayPal OAuth2 Authentication
     
@@ -459,6 +489,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="PaypalTransactionConnector"></a>
 
 `PaypalTransactionConnector(auth_config: PaypalTransactionAuthConfig | AirbyteAuthConfig | BaseModel | None = None, on_token_refresh: Any | None = None)`
 :   Type-safe Paypal-Transaction API connector.
@@ -716,6 +748,8 @@ Classes
             for entity in entities:
                 print(f"\{entity['entity_name']\}: \{entity['available_actions']\}")
 
+<a id="PaypalTransactionReplicationConfig"></a>
+
 `PaypalTransactionReplicationConfig(**data: Any)`
 :   Replication Configuration - Settings for data replication from PayPal.
     
@@ -737,6 +771,8 @@ Classes
 
     `start_date: str`
     :   Start date for data extraction in ISO 8601 format. Date must be in range from 3 years till 12 hours before present time.
+
+<a id="SearchInvoicesSearchData"></a>
 
 `SearchInvoicesSearchData(**data: Any)`
 :   Search result data for search_invoices entity.
@@ -799,6 +835,8 @@ Classes
     `status: str | None`
     :   Current status of the invoice
 
+<a id="ShowProductDetailsSearchData"></a>
+
 `ShowProductDetailsSearchData(**data: Any)`
 :   Search result data for show_product_details entity.
     
@@ -847,6 +885,8 @@ Classes
 
     `update_time: str | None`
     :   The date and time when the product was last updated
+
+<a id="TransactionsSearchData"></a>
 
 `TransactionsSearchData(**data: Any)`
 :   Search result data for transactions entity.

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/paypal_transaction/models.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/paypal_transaction/models.md
@@ -13,6 +13,8 @@ and response envelope types.
 Classes
 -------
 
+<a id="AirbyteSearchMeta"></a>
+
 `AirbyteSearchMeta(**data: Any)`
 :   Pagination metadata for search responses.
     
@@ -40,6 +42,8 @@ Classes
 
     `took_ms: int | None`
     :   Time taken to execute the search in milliseconds.
+
+<a id="AirbyteSearchResult"></a>
 
 `AirbyteSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -98,6 +102,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="BalancesSearchResult"></a>
+
 `BalancesSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -134,6 +140,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="ListDisputesSearchResult"></a>
 
 `ListDisputesSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -172,6 +180,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="ListPaymentsSearchResult"></a>
+
 `ListPaymentsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -208,6 +218,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="ListProductsSearchResult"></a>
 
 `ListProductsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -246,6 +258,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="SearchInvoicesSearchResult"></a>
+
 `SearchInvoicesSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -282,6 +296,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="ShowProductDetailsSearchResult"></a>
 
 `ShowProductDetailsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -320,6 +336,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="TransactionsSearchResult"></a>
+
 `TransactionsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -335,6 +353,8 @@ Classes
     * airbyte_agent_sdk.connectors.paypal_transaction.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="AuctionInfo"></a>
 
 `AuctionInfo(**data: Any)`
 :   Auction information.
@@ -366,6 +386,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="BalanceDetail"></a>
 
 `BalanceDetail(**data: Any)`
 :   Balance information for a single currency.
@@ -401,6 +423,8 @@ Classes
     `withheld_balance: airbyte_agent_sdk.connectors.paypal_transaction.models.Money | Any`
     :   The type of the None singleton.
 
+<a id="BalancesResponse"></a>
+
 `BalancesResponse(**data: Any)`
 :   Balances response with account balance details.
     
@@ -431,6 +455,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="BalancesSearchData"></a>
 
 `BalancesSearchData(**data: Any)`
 :   Search result data for balances entity.
@@ -463,6 +489,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="CartInfo"></a>
+
 `CartInfo(**data: Any)`
 :   Cart information for the transaction.
     
@@ -490,6 +518,8 @@ Classes
 
     `tax_inclusive: bool | Any`
     :   The type of the None singleton.
+
+<a id="Dispute"></a>
 
 `Dispute(**data: Any)`
 :   A PayPal dispute object.
@@ -546,6 +576,8 @@ Classes
     `update_time: str | Any`
     :   The type of the None singleton.
 
+<a id="DisputeDisputedTransactionsItem"></a>
+
 `DisputeDisputedTransactionsItem(**data: Any)`
 :   Nested schema for Dispute.disputed_transactions_item
     
@@ -571,6 +603,8 @@ Classes
     `seller: airbyte_agent_sdk.connectors.paypal_transaction.models.DisputeDisputedTransactionsItemSeller | Any`
     :   The type of the None singleton.
 
+<a id="DisputeDisputedTransactionsItemSeller"></a>
+
 `DisputeDisputedTransactionsItemSeller(**data: Any)`
 :   Nested schema for DisputeDisputedTransactionsItem.seller
     
@@ -592,6 +626,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="DisputeLinksItem"></a>
 
 `DisputeLinksItem(**data: Any)`
 :   Nested schema for Dispute.links_item
@@ -621,6 +657,8 @@ Classes
     `rel: str | Any`
     :   The type of the None singleton.
 
+<a id="DisputesList"></a>
+
 `DisputesList(**data: Any)`
 :   List of disputes.
     
@@ -645,6 +683,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="DisputesListLinksItem"></a>
 
 `DisputesListLinksItem(**data: Any)`
 :   Nested schema for DisputesList.links_item
@@ -673,6 +713,8 @@ Classes
 
     `rel: str | Any`
     :   The type of the None singleton.
+
+<a id="IncentiveDetail"></a>
 
 `IncentiveDetail(**data: Any)`
 :   Incentive detail.
@@ -705,6 +747,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="IncentiveInfo"></a>
+
 `IncentiveInfo(**data: Any)`
 :   Incentive information.
     
@@ -726,6 +770,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="Invoice"></a>
 
 `Invoice(**data: Any)`
 :   A PayPal invoice object.
@@ -785,6 +831,8 @@ Classes
     `status: str | Any`
     :   The type of the None singleton.
 
+<a id="InvoiceAmount"></a>
+
 `InvoiceAmount(**data: Any)`
 :   Total invoice amount.
     
@@ -812,6 +860,8 @@ Classes
 
     `value: str | Any`
     :   The type of the None singleton.
+
+<a id="InvoiceAmountBreakdown"></a>
 
 `InvoiceAmountBreakdown(**data: Any)`
 :   Nested schema for InvoiceAmount.breakdown
@@ -847,6 +897,8 @@ Classes
     `tax_total: airbyte_agent_sdk.connectors.paypal_transaction.models.Money | Any`
     :   The type of the None singleton.
 
+<a id="InvoiceConfiguration"></a>
+
 `InvoiceConfiguration(**data: Any)`
 :   Invoice configuration.
     
@@ -881,6 +933,8 @@ Classes
     `template_id: str | Any`
     :   The type of the None singleton.
 
+<a id="InvoiceConfigurationPartialPayment"></a>
+
 `InvoiceConfigurationPartialPayment(**data: Any)`
 :   Nested schema for InvoiceConfiguration.partial_payment
     
@@ -905,6 +959,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="InvoiceDetail"></a>
 
 `InvoiceDetail(**data: Any)`
 :   Invoice detail information.
@@ -951,6 +1007,8 @@ Classes
 
     `terms_and_conditions: str | Any`
     :   Terms and conditions.
+
+<a id="InvoiceDetailMetadata"></a>
 
 `InvoiceDetailMetadata(**data: Any)`
 :   Nested schema for InvoiceDetail.metadata
@@ -1004,6 +1062,8 @@ Classes
     `recipient_view_url: str | Any`
     :   Recipient view URL.
 
+<a id="InvoiceDetailPaymentTerm"></a>
+
 `InvoiceDetailPaymentTerm(**data: Any)`
 :   Nested schema for InvoiceDetail.payment_term
     
@@ -1028,6 +1088,8 @@ Classes
 
     `term_type: str | Any`
     :   Payment term type.
+
+<a id="InvoiceInvoicer"></a>
 
 `InvoiceInvoicer(**data: Any)`
 :   Invoicer details.
@@ -1057,6 +1119,8 @@ Classes
     `name: airbyte_agent_sdk.connectors.paypal_transaction.models.InvoiceInvoicerName | Any`
     :   The type of the None singleton.
 
+<a id="InvoiceInvoicerName"></a>
+
 `InvoiceInvoicerName(**data: Any)`
 :   Nested schema for InvoiceInvoicer.name
     
@@ -1084,6 +1148,8 @@ Classes
 
     `surname: str | Any`
     :   The type of the None singleton.
+
+<a id="InvoiceItemsItem"></a>
 
 `InvoiceItemsItem(**data: Any)`
 :   Nested schema for Invoice.items_item
@@ -1122,6 +1188,8 @@ Classes
     `unit_of_measure: str | Any`
     :   The type of the None singleton.
 
+<a id="InvoiceItemsItemTax"></a>
+
 `InvoiceItemsItemTax(**data: Any)`
 :   Nested schema for InvoiceItemsItem.tax
     
@@ -1149,6 +1217,8 @@ Classes
 
     `percent: str | Any`
     :   The type of the None singleton.
+
+<a id="InvoiceLinksItem"></a>
 
 `InvoiceLinksItem(**data: Any)`
 :   Nested schema for Invoice.links_item
@@ -1178,6 +1248,8 @@ Classes
     `rel: str | Any`
     :   The type of the None singleton.
 
+<a id="InvoicePayments"></a>
+
 `InvoicePayments(**data: Any)`
 :   Payment records for this invoice.
     
@@ -1203,6 +1275,8 @@ Classes
     `transactions: list[dict[str, typing.Any]] | Any`
     :   The type of the None singleton.
 
+<a id="InvoicePrimaryRecipientsItem"></a>
+
 `InvoicePrimaryRecipientsItem(**data: Any)`
 :   Nested schema for Invoice.primary_recipients_item
     
@@ -1224,6 +1298,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="InvoicePrimaryRecipientsItemBillingInfo"></a>
 
 `InvoicePrimaryRecipientsItemBillingInfo(**data: Any)`
 :   Nested schema for InvoicePrimaryRecipientsItem.billing_info
@@ -1253,6 +1329,8 @@ Classes
     `name: airbyte_agent_sdk.connectors.paypal_transaction.models.InvoicePrimaryRecipientsItemBillingInfoName | Any`
     :   The type of the None singleton.
 
+<a id="InvoicePrimaryRecipientsItemBillingInfoName"></a>
+
 `InvoicePrimaryRecipientsItemBillingInfoName(**data: Any)`
 :   Nested schema for InvoicePrimaryRecipientsItemBillingInfo.name
     
@@ -1281,6 +1359,8 @@ Classes
     `surname: str | Any`
     :   The type of the None singleton.
 
+<a id="InvoiceRefunds"></a>
+
 `InvoiceRefunds(**data: Any)`
 :   Refund records for this invoice.
     
@@ -1306,6 +1386,8 @@ Classes
     `transactions: list[dict[str, typing.Any]] | Any`
     :   The type of the None singleton.
 
+<a id="InvoiceSearchParams"></a>
+
 `InvoiceSearchParams(**data: Any)`
 :   Parameters for searching invoices.
     
@@ -1327,6 +1409,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="InvoiceSearchParamsCreationDateRange"></a>
 
 `InvoiceSearchParamsCreationDateRange(**data: Any)`
 :   Filter by invoice creation date range.
@@ -1352,6 +1436,8 @@ Classes
 
     `start: str | Any`
     :   Start date in ISO 8601 format.
+
+<a id="InvoicesList"></a>
 
 `InvoicesList(**data: Any)`
 :   Paginated list of invoices from search.
@@ -1384,6 +1470,8 @@ Classes
     `total_pages: int | Any`
     :   The type of the None singleton.
 
+<a id="InvoicesListLinksItem"></a>
+
 `InvoicesListLinksItem(**data: Any)`
 :   Nested schema for InvoicesList.links_item
     
@@ -1411,6 +1499,8 @@ Classes
 
     `rel: str | Any`
     :   The type of the None singleton.
+
+<a id="ItemDetail"></a>
 
 `ItemDetail(**data: Any)`
 :   Details for a single cart item.
@@ -1458,6 +1548,8 @@ Classes
     `total_item_amount: airbyte_agent_sdk.connectors.paypal_transaction.models.Money | Any`
     :   The type of the None singleton.
 
+<a id="ItemDetailTaxAmountsItem"></a>
+
 `ItemDetailTaxAmountsItem(**data: Any)`
 :   Nested schema for ItemDetail.tax_amounts_item
     
@@ -1480,6 +1572,8 @@ Classes
     `tax_amount: airbyte_agent_sdk.connectors.paypal_transaction.models.Money | Any`
     :   The type of the None singleton.
 
+<a id="ListDisputesListResultMeta"></a>
+
 `ListDisputesListResultMeta(**data: Any)`
 :   Metadata for list_disputes.Action.LIST operation
     
@@ -1501,6 +1595,8 @@ Classes
 
     `next: list[dict[str, typing.Any]] | Any`
     :   The type of the None singleton.
+
+<a id="ListDisputesSearchData"></a>
 
 `ListDisputesSearchData(**data: Any)`
 :   Search result data for list_disputes entity.
@@ -1560,6 +1656,8 @@ Classes
     `updated_time_cut: str | None`
     :   The cut-off timestamp for the last update.
 
+<a id="ListPaymentsListResultMeta"></a>
+
 `ListPaymentsListResultMeta(**data: Any)`
 :   Metadata for list_payments.Action.LIST operation
     
@@ -1581,6 +1679,8 @@ Classes
 
     `next_id: str | Any`
     :   The type of the None singleton.
+
+<a id="ListPaymentsSearchData"></a>
 
 `ListPaymentsSearchData(**data: Any)`
 :   Search result data for list_payments entity.
@@ -1628,6 +1728,8 @@ Classes
     `update_time: str | None`
     :   The date and time when the payment was last updated.
 
+<a id="ListProductsListResultMeta"></a>
+
 `ListProductsListResultMeta(**data: Any)`
 :   Metadata for list_products.Action.LIST operation
     
@@ -1649,6 +1751,8 @@ Classes
 
     `next: list[dict[str, typing.Any]] | Any`
     :   The type of the None singleton.
+
+<a id="ListProductsSearchData"></a>
 
 `ListProductsSearchData(**data: Any)`
 :   Search result data for list_products entity.
@@ -1684,6 +1788,8 @@ Classes
     `name: str | None`
     :   The name or title of the product
 
+<a id="Money"></a>
+
 `Money(**data: Any)`
 :   Currency amount with code and value.
     
@@ -1708,6 +1814,8 @@ Classes
 
     `value: str | Any`
     :   The type of the None singleton.
+
+<a id="PayerInfo"></a>
 
 `PayerInfo(**data: Any)`
 :   Information about the payer.
@@ -1746,6 +1854,8 @@ Classes
     `payer_status: str | Any`
     :   The type of the None singleton.
 
+<a id="PayerName"></a>
+
 `PayerName(**data: Any)`
 :   Payer name details.
     
@@ -1773,6 +1883,8 @@ Classes
 
     `surname: str | Any`
     :   The type of the None singleton.
+
+<a id="Payment"></a>
 
 `Payment(**data: Any)`
 :   A PayPal payment object.
@@ -1820,6 +1932,8 @@ Classes
     `update_time: str | Any`
     :   The type of the None singleton.
 
+<a id="PaymentLinksItem"></a>
+
 `PaymentLinksItem(**data: Any)`
 :   Nested schema for Payment.links_item
     
@@ -1848,6 +1962,8 @@ Classes
     `rel: str | Any`
     :   The type of the None singleton.
 
+<a id="PaymentPayer"></a>
+
 `PaymentPayer(**data: Any)`
 :   Payer information.
     
@@ -1875,6 +1991,8 @@ Classes
 
     `status: str | Any`
     :   Payer status.
+
+<a id="PaymentPayerPayerInfo"></a>
 
 `PaymentPayerPayerInfo(**data: Any)`
 :   Nested schema for PaymentPayer.payer_info
@@ -1910,6 +2028,8 @@ Classes
     `payer_id: str | Any`
     :   Payer ID.
 
+<a id="PaymentTransactionsItem"></a>
+
 `PaymentTransactionsItem(**data: Any)`
 :   Nested schema for Payment.transactions_item
     
@@ -1938,6 +2058,8 @@ Classes
     `related_resources: list[dict[str, typing.Any]] | Any`
     :   The type of the None singleton.
 
+<a id="PaymentTransactionsItemAmount"></a>
+
 `PaymentTransactionsItemAmount(**data: Any)`
 :   Nested schema for PaymentTransactionsItem.amount
     
@@ -1965,6 +2087,8 @@ Classes
 
     `total: str | Any`
     :   Total amount.
+
+<a id="PaymentTransactionsItemAmountDetails"></a>
 
 `PaymentTransactionsItemAmountDetails(**data: Any)`
 :   Nested schema for PaymentTransactionsItemAmount.details
@@ -2000,6 +2124,8 @@ Classes
     `subtotal: str | Any`
     :   The type of the None singleton.
 
+<a id="PaymentsList"></a>
+
 `PaymentsList(**data: Any)`
 :   List of payments.
     
@@ -2028,6 +2154,8 @@ Classes
     `payments: list[airbyte_agent_sdk.connectors.paypal_transaction.models.Payment] | Any`
     :   The type of the None singleton.
 
+<a id="PaypalTransactionAuthConfig"></a>
+
 `PaypalTransactionAuthConfig(**data: Any)`
 :   PayPal OAuth2 Authentication
     
@@ -2055,6 +2183,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="PaypalTransactionCheckResult"></a>
 
 `PaypalTransactionCheckResult(**data: Any)`
 :   Result of a health check operation.
@@ -2089,6 +2219,8 @@ Classes
     `status: str`
     :   Health check status: 'healthy' or 'unhealthy'.
 
+<a id="PaypalTransactionExecuteResult"></a>
+
 `PaypalTransactionExecuteResult(**data: Any)`
 :   Response envelope with data only.
     
@@ -2118,6 +2250,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="PaypalTransactionExecuteResultWithMeta"></a>
 
 `PaypalTransactionExecuteResultWithMeta(**data: Any)`
 :   Response envelope with data and metadata.
@@ -2174,6 +2308,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="ListDisputesListResult"></a>
+
 `ListDisputesListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -2216,6 +2352,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="SearchInvoicesListResult"></a>
 
 `SearchInvoicesListResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -2260,6 +2398,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="ListPaymentsListResult"></a>
+
 `ListPaymentsListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -2302,6 +2442,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="ListProductsListResult"></a>
 
 `ListProductsListResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -2346,6 +2488,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="TransactionsListResult"></a>
+
 `TransactionsListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -2388,6 +2532,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="BalancesListResult"></a>
+
 `BalancesListResult(**data: Any)`
 :   Response envelope with data only.
     
@@ -2405,6 +2551,8 @@ Classes
     * airbyte_agent_sdk.connectors.paypal_transaction.models.PaypalTransactionExecuteResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="PaypalTransactionReplicationConfig"></a>
 
 `PaypalTransactionReplicationConfig(**data: Any)`
 :   Replication Configuration - Settings for data replication from PayPal.
@@ -2427,6 +2575,8 @@ Classes
 
     `start_date: str`
     :   Start date for data extraction in ISO 8601 format. Date must be in range from 3 years till 12 hours before present time.
+
+<a id="Product"></a>
 
 `Product(**data: Any)`
 :   A PayPal catalog product (summary).
@@ -2461,6 +2611,8 @@ Classes
 
     `name: str | Any`
     :   The type of the None singleton.
+
+<a id="ProductDetails"></a>
 
 `ProductDetails(**data: Any)`
 :   Detailed catalog product information.
@@ -2511,6 +2663,8 @@ Classes
     `update_time: str | Any`
     :   The type of the None singleton.
 
+<a id="ProductDetailsLinksItem"></a>
+
 `ProductDetailsLinksItem(**data: Any)`
 :   Nested schema for ProductDetails.links_item
     
@@ -2538,6 +2692,8 @@ Classes
 
     `rel: str | Any`
     :   The type of the None singleton.
+
+<a id="ProductLinksItem"></a>
 
 `ProductLinksItem(**data: Any)`
 :   Nested schema for Product.links_item
@@ -2567,6 +2723,8 @@ Classes
     `rel: str | Any`
     :   The type of the None singleton.
 
+<a id="ProductsList"></a>
+
 `ProductsList(**data: Any)`
 :   List of catalog products.
     
@@ -2591,6 +2749,8 @@ Classes
 
     `products: list[airbyte_agent_sdk.connectors.paypal_transaction.models.Product] | Any`
     :   The type of the None singleton.
+
+<a id="ProductsListLinksItem"></a>
 
 `ProductsListLinksItem(**data: Any)`
 :   Nested schema for ProductsList.links_item
@@ -2620,6 +2780,8 @@ Classes
     `rel: str | Any`
     :   The type of the None singleton.
 
+<a id="SearchInvoicesListResultMeta"></a>
+
 `SearchInvoicesListResultMeta(**data: Any)`
 :   Metadata for search_invoices.Action.LIST operation
     
@@ -2641,6 +2803,8 @@ Classes
 
     `next: list[dict[str, typing.Any]] | Any`
     :   The type of the None singleton.
+
+<a id="SearchInvoicesSearchData"></a>
 
 `SearchInvoicesSearchData(**data: Any)`
 :   Search result data for search_invoices entity.
@@ -2703,6 +2867,8 @@ Classes
     `status: str | None`
     :   Current status of the invoice
 
+<a id="ShippingAddress"></a>
+
 `ShippingAddress(**data: Any)`
 :   Shipping address details.
     
@@ -2737,6 +2903,8 @@ Classes
     `postal_code: str | Any`
     :   The type of the None singleton.
 
+<a id="ShippingInfo"></a>
+
 `ShippingInfo(**data: Any)`
 :   Shipping information for the transaction.
     
@@ -2761,6 +2929,8 @@ Classes
 
     `name: str | Any`
     :   The type of the None singleton.
+
+<a id="ShowProductDetailsSearchData"></a>
 
 `ShowProductDetailsSearchData(**data: Any)`
 :   Search result data for show_product_details entity.
@@ -2811,6 +2981,8 @@ Classes
     `update_time: str | None`
     :   The date and time when the product was last updated
 
+<a id="StoreInfo"></a>
+
 `StoreInfo(**data: Any)`
 :   Store information.
     
@@ -2835,6 +3007,8 @@ Classes
 
     `terminal_id: str | Any`
     :   The type of the None singleton.
+
+<a id="Transaction"></a>
 
 `Transaction(**data: Any)`
 :   A single PayPal transaction with full details.
@@ -2881,6 +3055,8 @@ Classes
 
     `transaction_updated_date: str | Any`
     :   The type of the None singleton.
+
+<a id="TransactionInfo"></a>
 
 `TransactionInfo(**data: Any)`
 :   Detailed transaction information.
@@ -2955,6 +3131,8 @@ Classes
     `transaction_updated_date: str | Any`
     :   The type of the None singleton.
 
+<a id="TransactionsList"></a>
+
 `TransactionsList(**data: Any)`
 :   Paginated list of transactions.
     
@@ -3001,6 +3179,8 @@ Classes
     `transaction_details: list[airbyte_agent_sdk.connectors.paypal_transaction.models.Transaction] | Any`
     :   The type of the None singleton.
 
+<a id="TransactionsListLinksItem"></a>
+
 `TransactionsListLinksItem(**data: Any)`
 :   Nested schema for TransactionsList.links_item
     
@@ -3029,6 +3209,8 @@ Classes
     `rel: str | Any`
     :   The type of the None singleton.
 
+<a id="TransactionsListResultMeta"></a>
+
 `TransactionsListResultMeta(**data: Any)`
 :   Metadata for transactions.Action.LIST operation
     
@@ -3056,6 +3238,8 @@ Classes
 
     `total_pages: int | Any`
     :   The type of the None singleton.
+
+<a id="TransactionsSearchData"></a>
 
 `TransactionsSearchData(**data: Any)`
 :   Search result data for transactions entity.

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/paypal_transaction/types.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/paypal_transaction/types.md
@@ -10,6 +10,8 @@ Type definitions for paypal-transaction connector.
 Classes
 -------
 
+<a id="AirbyteSearchParams"></a>
+
 `AirbyteSearchParams(*args, **kwargs)`
 :   Parameters for Airbyte cache search operations (generic, use entity-specific query types for better type hints).
 
@@ -31,6 +33,8 @@ Classes
     `query: dict[str, typing.Any]`
     :   The type of the None singleton.
 
+<a id="BalancesAndCondition"></a>
+
 `BalancesAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -51,6 +55,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.paypal_transaction.types.BalancesEqCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.BalancesNeqCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.BalancesGtCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.BalancesGteCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.BalancesLtCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.BalancesLteCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.BalancesInCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.BalancesLikeCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.BalancesFuzzyCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.BalancesKeywordCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.BalancesContainsCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.BalancesNotCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.BalancesAndCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.BalancesOrCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.BalancesAnyCondition]`
     :   The type of the None singleton.
 
+<a id="BalancesAnyCondition"></a>
+
 `BalancesAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -70,6 +76,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.paypal_transaction.types.BalancesAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="BalancesAnyValueFilter"></a>
 
 `BalancesAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -92,6 +100,8 @@ Classes
     `last_refresh_time: Any`
     :   The timestamp when the balances data was last refreshed.
 
+<a id="BalancesContainsCondition"></a>
+
 `BalancesContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -103,6 +113,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.paypal_transaction.types.BalancesAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="BalancesEqCondition"></a>
 
 `BalancesEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -116,6 +128,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.paypal_transaction.types.BalancesSearchFilter`
     :   The type of the None singleton.
 
+<a id="BalancesFuzzyCondition"></a>
+
 `BalancesFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -127,6 +141,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.paypal_transaction.types.BalancesStringFilter`
     :   The type of the None singleton.
+
+<a id="BalancesGtCondition"></a>
 
 `BalancesGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
@@ -140,6 +156,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.paypal_transaction.types.BalancesSearchFilter`
     :   The type of the None singleton.
 
+<a id="BalancesGteCondition"></a>
+
 `BalancesGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -151,6 +169,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.paypal_transaction.types.BalancesSearchFilter`
     :   The type of the None singleton.
+
+<a id="BalancesInCondition"></a>
 
 `BalancesInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -171,6 +191,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.paypal_transaction.types.BalancesInFilter`
     :   The type of the None singleton.
+
+<a id="BalancesInFilter"></a>
 
 `BalancesInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -193,6 +215,8 @@ Classes
     `last_refresh_time: list[str]`
     :   The timestamp when the balances data was last refreshed.
 
+<a id="BalancesKeywordCondition"></a>
+
 `BalancesKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -205,6 +229,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.paypal_transaction.types.BalancesStringFilter`
     :   The type of the None singleton.
 
+<a id="BalancesLikeCondition"></a>
+
 `BalancesLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -216,6 +242,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.paypal_transaction.types.BalancesStringFilter`
     :   The type of the None singleton.
+
+<a id="BalancesListParams"></a>
 
 `BalancesListParams(*args, **kwargs)`
 :   Parameters for balances.list operation
@@ -232,6 +260,8 @@ Classes
     `currency_code: str`
     :   The type of the None singleton.
 
+<a id="BalancesLtCondition"></a>
+
 `BalancesLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -243,6 +273,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.paypal_transaction.types.BalancesSearchFilter`
     :   The type of the None singleton.
+
+<a id="BalancesLteCondition"></a>
 
 `BalancesLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -256,6 +288,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.paypal_transaction.types.BalancesSearchFilter`
     :   The type of the None singleton.
 
+<a id="BalancesNeqCondition"></a>
+
 `BalancesNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -267,6 +301,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.paypal_transaction.types.BalancesSearchFilter`
     :   The type of the None singleton.
+
+<a id="BalancesNotCondition"></a>
 
 `BalancesNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -288,6 +324,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.paypal_transaction.types.BalancesEqCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.BalancesNeqCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.BalancesGtCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.BalancesGteCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.BalancesLtCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.BalancesLteCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.BalancesInCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.BalancesLikeCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.BalancesFuzzyCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.BalancesKeywordCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.BalancesContainsCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.BalancesNotCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.BalancesAndCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.BalancesOrCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.BalancesAnyCondition`
     :   The type of the None singleton.
 
+<a id="BalancesOrCondition"></a>
+
 `BalancesOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -307,6 +345,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.paypal_transaction.types.BalancesEqCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.BalancesNeqCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.BalancesGtCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.BalancesGteCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.BalancesLtCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.BalancesLteCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.BalancesInCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.BalancesLikeCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.BalancesFuzzyCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.BalancesKeywordCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.BalancesContainsCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.BalancesNotCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.BalancesAndCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.BalancesOrCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.BalancesAnyCondition]`
     :   The type of the None singleton.
+
+<a id="BalancesSearchFilter"></a>
 
 `BalancesSearchFilter(*args, **kwargs)`
 :   Available fields for filtering balances search queries.
@@ -329,6 +369,8 @@ Classes
     `last_refresh_time: str | None`
     :   The timestamp when the balances data was last refreshed.
 
+<a id="BalancesSearchQuery"></a>
+
 `BalancesSearchQuery(*args, **kwargs)`
 :   Search query for balances entity.
 
@@ -343,6 +385,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.paypal_transaction.types.BalancesSortFilter]`
     :   The type of the None singleton.
+
+<a id="BalancesSortFilter"></a>
 
 `BalancesSortFilter(*args, **kwargs)`
 :   Available fields for sorting balances search results.
@@ -365,6 +409,8 @@ Classes
     `last_refresh_time: Literal['asc', 'desc']`
     :   The timestamp when the balances data was last refreshed.
 
+<a id="BalancesStringFilter"></a>
+
 `BalancesStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -386,6 +432,8 @@ Classes
     `last_refresh_time: str`
     :   The timestamp when the balances data was last refreshed.
 
+<a id="ListDisputesAndCondition"></a>
+
 `ListDisputesAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -406,6 +454,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.paypal_transaction.types.ListDisputesEqCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.ListDisputesNeqCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.ListDisputesGtCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.ListDisputesGteCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.ListDisputesLtCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.ListDisputesLteCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.ListDisputesInCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.ListDisputesLikeCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.ListDisputesFuzzyCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.ListDisputesKeywordCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.ListDisputesContainsCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.ListDisputesNotCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.ListDisputesAndCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.ListDisputesOrCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.ListDisputesAnyCondition]`
     :   The type of the None singleton.
 
+<a id="ListDisputesAnyCondition"></a>
+
 `ListDisputesAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -425,6 +475,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.paypal_transaction.types.ListDisputesAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="ListDisputesAnyValueFilter"></a>
 
 `ListDisputesAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -474,6 +526,8 @@ Classes
     `updated_time_cut: Any`
     :   The cut-off timestamp for the last update.
 
+<a id="ListDisputesContainsCondition"></a>
+
 `ListDisputesContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -485,6 +539,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.paypal_transaction.types.ListDisputesAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="ListDisputesEqCondition"></a>
 
 `ListDisputesEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -498,6 +554,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.paypal_transaction.types.ListDisputesSearchFilter`
     :   The type of the None singleton.
 
+<a id="ListDisputesFuzzyCondition"></a>
+
 `ListDisputesFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -509,6 +567,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.paypal_transaction.types.ListDisputesStringFilter`
     :   The type of the None singleton.
+
+<a id="ListDisputesGtCondition"></a>
 
 `ListDisputesGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
@@ -522,6 +582,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.paypal_transaction.types.ListDisputesSearchFilter`
     :   The type of the None singleton.
 
+<a id="ListDisputesGteCondition"></a>
+
 `ListDisputesGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -533,6 +595,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.paypal_transaction.types.ListDisputesSearchFilter`
     :   The type of the None singleton.
+
+<a id="ListDisputesInCondition"></a>
 
 `ListDisputesInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -553,6 +617,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.paypal_transaction.types.ListDisputesInFilter`
     :   The type of the None singleton.
+
+<a id="ListDisputesInFilter"></a>
 
 `ListDisputesInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -602,6 +668,8 @@ Classes
     `updated_time_cut: list[str]`
     :   The cut-off timestamp for the last update.
 
+<a id="ListDisputesKeywordCondition"></a>
+
 `ListDisputesKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -614,6 +682,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.paypal_transaction.types.ListDisputesStringFilter`
     :   The type of the None singleton.
 
+<a id="ListDisputesLikeCondition"></a>
+
 `ListDisputesLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -625,6 +695,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.paypal_transaction.types.ListDisputesStringFilter`
     :   The type of the None singleton.
+
+<a id="ListDisputesListParams"></a>
 
 `ListDisputesListParams(*args, **kwargs)`
 :   Parameters for list_disputes.list operation
@@ -647,6 +719,8 @@ Classes
     `update_time_before: str`
     :   The type of the None singleton.
 
+<a id="ListDisputesLtCondition"></a>
+
 `ListDisputesLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -658,6 +732,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.paypal_transaction.types.ListDisputesSearchFilter`
     :   The type of the None singleton.
+
+<a id="ListDisputesLteCondition"></a>
 
 `ListDisputesLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -671,6 +747,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.paypal_transaction.types.ListDisputesSearchFilter`
     :   The type of the None singleton.
 
+<a id="ListDisputesNeqCondition"></a>
+
 `ListDisputesNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -682,6 +760,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.paypal_transaction.types.ListDisputesSearchFilter`
     :   The type of the None singleton.
+
+<a id="ListDisputesNotCondition"></a>
 
 `ListDisputesNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -703,6 +783,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.paypal_transaction.types.ListDisputesEqCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.ListDisputesNeqCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.ListDisputesGtCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.ListDisputesGteCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.ListDisputesLtCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.ListDisputesLteCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.ListDisputesInCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.ListDisputesLikeCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.ListDisputesFuzzyCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.ListDisputesKeywordCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.ListDisputesContainsCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.ListDisputesNotCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.ListDisputesAndCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.ListDisputesOrCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.ListDisputesAnyCondition`
     :   The type of the None singleton.
 
+<a id="ListDisputesOrCondition"></a>
+
 `ListDisputesOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -722,6 +804,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.paypal_transaction.types.ListDisputesEqCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.ListDisputesNeqCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.ListDisputesGtCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.ListDisputesGteCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.ListDisputesLtCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.ListDisputesLteCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.ListDisputesInCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.ListDisputesLikeCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.ListDisputesFuzzyCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.ListDisputesKeywordCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.ListDisputesContainsCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.ListDisputesNotCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.ListDisputesAndCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.ListDisputesOrCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.ListDisputesAnyCondition]`
     :   The type of the None singleton.
+
+<a id="ListDisputesSearchFilter"></a>
 
 `ListDisputesSearchFilter(*args, **kwargs)`
 :   Available fields for filtering list_disputes search queries.
@@ -771,6 +855,8 @@ Classes
     `updated_time_cut: str | None`
     :   The cut-off timestamp for the last update.
 
+<a id="ListDisputesSearchQuery"></a>
+
 `ListDisputesSearchQuery(*args, **kwargs)`
 :   Search query for list_disputes entity.
 
@@ -785,6 +871,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.paypal_transaction.types.ListDisputesSortFilter]`
     :   The type of the None singleton.
+
+<a id="ListDisputesSortFilter"></a>
 
 `ListDisputesSortFilter(*args, **kwargs)`
 :   Available fields for sorting list_disputes search results.
@@ -834,6 +922,8 @@ Classes
     `updated_time_cut: Literal['asc', 'desc']`
     :   The cut-off timestamp for the last update.
 
+<a id="ListDisputesStringFilter"></a>
+
 `ListDisputesStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -882,6 +972,8 @@ Classes
     `updated_time_cut: str`
     :   The cut-off timestamp for the last update.
 
+<a id="ListPaymentsAndCondition"></a>
+
 `ListPaymentsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -902,6 +994,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.paypal_transaction.types.ListPaymentsEqCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.ListPaymentsNeqCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.ListPaymentsGtCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.ListPaymentsGteCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.ListPaymentsLtCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.ListPaymentsLteCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.ListPaymentsInCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.ListPaymentsLikeCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.ListPaymentsFuzzyCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.ListPaymentsKeywordCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.ListPaymentsContainsCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.ListPaymentsNotCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.ListPaymentsAndCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.ListPaymentsOrCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.ListPaymentsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="ListPaymentsAnyCondition"></a>
+
 `ListPaymentsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -921,6 +1015,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.paypal_transaction.types.ListPaymentsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="ListPaymentsAnyValueFilter"></a>
 
 `ListPaymentsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -958,6 +1054,8 @@ Classes
     `update_time: Any`
     :   The date and time when the payment was last updated.
 
+<a id="ListPaymentsContainsCondition"></a>
+
 `ListPaymentsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -969,6 +1067,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.paypal_transaction.types.ListPaymentsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="ListPaymentsEqCondition"></a>
 
 `ListPaymentsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -982,6 +1082,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.paypal_transaction.types.ListPaymentsSearchFilter`
     :   The type of the None singleton.
 
+<a id="ListPaymentsFuzzyCondition"></a>
+
 `ListPaymentsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -993,6 +1095,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.paypal_transaction.types.ListPaymentsStringFilter`
     :   The type of the None singleton.
+
+<a id="ListPaymentsGtCondition"></a>
 
 `ListPaymentsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
@@ -1006,6 +1110,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.paypal_transaction.types.ListPaymentsSearchFilter`
     :   The type of the None singleton.
 
+<a id="ListPaymentsGteCondition"></a>
+
 `ListPaymentsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -1017,6 +1123,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.paypal_transaction.types.ListPaymentsSearchFilter`
     :   The type of the None singleton.
+
+<a id="ListPaymentsInCondition"></a>
 
 `ListPaymentsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -1037,6 +1145,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.paypal_transaction.types.ListPaymentsInFilter`
     :   The type of the None singleton.
+
+<a id="ListPaymentsInFilter"></a>
 
 `ListPaymentsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -1074,6 +1184,8 @@ Classes
     `update_time: list[str]`
     :   The date and time when the payment was last updated.
 
+<a id="ListPaymentsKeywordCondition"></a>
+
 `ListPaymentsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -1086,6 +1198,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.paypal_transaction.types.ListPaymentsStringFilter`
     :   The type of the None singleton.
 
+<a id="ListPaymentsLikeCondition"></a>
+
 `ListPaymentsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -1097,6 +1211,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.paypal_transaction.types.ListPaymentsStringFilter`
     :   The type of the None singleton.
+
+<a id="ListPaymentsListParams"></a>
 
 `ListPaymentsListParams(*args, **kwargs)`
 :   Parameters for list_payments.list operation
@@ -1119,6 +1235,8 @@ Classes
     `start_time: str`
     :   The type of the None singleton.
 
+<a id="ListPaymentsLtCondition"></a>
+
 `ListPaymentsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -1130,6 +1248,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.paypal_transaction.types.ListPaymentsSearchFilter`
     :   The type of the None singleton.
+
+<a id="ListPaymentsLteCondition"></a>
 
 `ListPaymentsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -1143,6 +1263,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.paypal_transaction.types.ListPaymentsSearchFilter`
     :   The type of the None singleton.
 
+<a id="ListPaymentsNeqCondition"></a>
+
 `ListPaymentsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -1154,6 +1276,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.paypal_transaction.types.ListPaymentsSearchFilter`
     :   The type of the None singleton.
+
+<a id="ListPaymentsNotCondition"></a>
 
 `ListPaymentsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -1175,6 +1299,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.paypal_transaction.types.ListPaymentsEqCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.ListPaymentsNeqCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.ListPaymentsGtCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.ListPaymentsGteCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.ListPaymentsLtCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.ListPaymentsLteCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.ListPaymentsInCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.ListPaymentsLikeCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.ListPaymentsFuzzyCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.ListPaymentsKeywordCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.ListPaymentsContainsCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.ListPaymentsNotCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.ListPaymentsAndCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.ListPaymentsOrCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.ListPaymentsAnyCondition`
     :   The type of the None singleton.
 
+<a id="ListPaymentsOrCondition"></a>
+
 `ListPaymentsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1194,6 +1320,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.paypal_transaction.types.ListPaymentsEqCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.ListPaymentsNeqCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.ListPaymentsGtCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.ListPaymentsGteCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.ListPaymentsLtCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.ListPaymentsLteCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.ListPaymentsInCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.ListPaymentsLikeCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.ListPaymentsFuzzyCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.ListPaymentsKeywordCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.ListPaymentsContainsCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.ListPaymentsNotCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.ListPaymentsAndCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.ListPaymentsOrCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.ListPaymentsAnyCondition]`
     :   The type of the None singleton.
+
+<a id="ListPaymentsSearchFilter"></a>
 
 `ListPaymentsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering list_payments search queries.
@@ -1231,6 +1359,8 @@ Classes
     `update_time: str | None`
     :   The date and time when the payment was last updated.
 
+<a id="ListPaymentsSearchQuery"></a>
+
 `ListPaymentsSearchQuery(*args, **kwargs)`
 :   Search query for list_payments entity.
 
@@ -1245,6 +1375,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.paypal_transaction.types.ListPaymentsSortFilter]`
     :   The type of the None singleton.
+
+<a id="ListPaymentsSortFilter"></a>
 
 `ListPaymentsSortFilter(*args, **kwargs)`
 :   Available fields for sorting list_payments search results.
@@ -1282,6 +1414,8 @@ Classes
     `update_time: Literal['asc', 'desc']`
     :   The date and time when the payment was last updated.
 
+<a id="ListPaymentsStringFilter"></a>
+
 `ListPaymentsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -1318,6 +1452,8 @@ Classes
     `update_time: str`
     :   The date and time when the payment was last updated.
 
+<a id="ListProductsAndCondition"></a>
+
 `ListProductsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1338,6 +1474,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.paypal_transaction.types.ListProductsEqCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.ListProductsNeqCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.ListProductsGtCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.ListProductsGteCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.ListProductsLtCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.ListProductsLteCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.ListProductsInCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.ListProductsLikeCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.ListProductsFuzzyCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.ListProductsKeywordCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.ListProductsContainsCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.ListProductsNotCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.ListProductsAndCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.ListProductsOrCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.ListProductsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="ListProductsAnyCondition"></a>
+
 `ListProductsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1357,6 +1495,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.paypal_transaction.types.ListProductsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="ListProductsAnyValueFilter"></a>
 
 `ListProductsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -1382,6 +1522,8 @@ Classes
     `name: Any`
     :   The name or title of the product
 
+<a id="ListProductsContainsCondition"></a>
+
 `ListProductsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -1393,6 +1535,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.paypal_transaction.types.ListProductsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="ListProductsEqCondition"></a>
 
 `ListProductsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -1406,6 +1550,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.paypal_transaction.types.ListProductsSearchFilter`
     :   The type of the None singleton.
 
+<a id="ListProductsFuzzyCondition"></a>
+
 `ListProductsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -1417,6 +1563,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.paypal_transaction.types.ListProductsStringFilter`
     :   The type of the None singleton.
+
+<a id="ListProductsGtCondition"></a>
 
 `ListProductsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
@@ -1430,6 +1578,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.paypal_transaction.types.ListProductsSearchFilter`
     :   The type of the None singleton.
 
+<a id="ListProductsGteCondition"></a>
+
 `ListProductsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -1441,6 +1591,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.paypal_transaction.types.ListProductsSearchFilter`
     :   The type of the None singleton.
+
+<a id="ListProductsInCondition"></a>
 
 `ListProductsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -1461,6 +1613,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.paypal_transaction.types.ListProductsInFilter`
     :   The type of the None singleton.
+
+<a id="ListProductsInFilter"></a>
 
 `ListProductsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -1486,6 +1640,8 @@ Classes
     `name: list[str]`
     :   The name or title of the product
 
+<a id="ListProductsKeywordCondition"></a>
+
 `ListProductsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -1498,6 +1654,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.paypal_transaction.types.ListProductsStringFilter`
     :   The type of the None singleton.
 
+<a id="ListProductsLikeCondition"></a>
+
 `ListProductsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -1509,6 +1667,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.paypal_transaction.types.ListProductsStringFilter`
     :   The type of the None singleton.
+
+<a id="ListProductsListParams"></a>
 
 `ListProductsListParams(*args, **kwargs)`
 :   Parameters for list_products.list operation
@@ -1525,6 +1685,8 @@ Classes
     `page_size: int`
     :   The type of the None singleton.
 
+<a id="ListProductsLtCondition"></a>
+
 `ListProductsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -1536,6 +1698,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.paypal_transaction.types.ListProductsSearchFilter`
     :   The type of the None singleton.
+
+<a id="ListProductsLteCondition"></a>
 
 `ListProductsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -1549,6 +1713,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.paypal_transaction.types.ListProductsSearchFilter`
     :   The type of the None singleton.
 
+<a id="ListProductsNeqCondition"></a>
+
 `ListProductsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -1560,6 +1726,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.paypal_transaction.types.ListProductsSearchFilter`
     :   The type of the None singleton.
+
+<a id="ListProductsNotCondition"></a>
 
 `ListProductsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -1581,6 +1749,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.paypal_transaction.types.ListProductsEqCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.ListProductsNeqCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.ListProductsGtCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.ListProductsGteCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.ListProductsLtCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.ListProductsLteCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.ListProductsInCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.ListProductsLikeCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.ListProductsFuzzyCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.ListProductsKeywordCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.ListProductsContainsCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.ListProductsNotCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.ListProductsAndCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.ListProductsOrCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.ListProductsAnyCondition`
     :   The type of the None singleton.
 
+<a id="ListProductsOrCondition"></a>
+
 `ListProductsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1600,6 +1770,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.paypal_transaction.types.ListProductsEqCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.ListProductsNeqCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.ListProductsGtCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.ListProductsGteCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.ListProductsLtCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.ListProductsLteCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.ListProductsInCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.ListProductsLikeCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.ListProductsFuzzyCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.ListProductsKeywordCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.ListProductsContainsCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.ListProductsNotCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.ListProductsAndCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.ListProductsOrCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.ListProductsAnyCondition]`
     :   The type of the None singleton.
+
+<a id="ListProductsSearchFilter"></a>
 
 `ListProductsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering list_products search queries.
@@ -1625,6 +1797,8 @@ Classes
     `name: str | None`
     :   The name or title of the product
 
+<a id="ListProductsSearchQuery"></a>
+
 `ListProductsSearchQuery(*args, **kwargs)`
 :   Search query for list_products entity.
 
@@ -1639,6 +1813,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.paypal_transaction.types.ListProductsSortFilter]`
     :   The type of the None singleton.
+
+<a id="ListProductsSortFilter"></a>
 
 `ListProductsSortFilter(*args, **kwargs)`
 :   Available fields for sorting list_products search results.
@@ -1664,6 +1840,8 @@ Classes
     `name: Literal['asc', 'desc']`
     :   The name or title of the product
 
+<a id="ListProductsStringFilter"></a>
+
 `ListProductsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -1688,6 +1866,8 @@ Classes
     `name: str`
     :   The name or title of the product
 
+<a id="SearchInvoicesAndCondition"></a>
+
 `SearchInvoicesAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1708,6 +1888,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.paypal_transaction.types.SearchInvoicesEqCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.SearchInvoicesNeqCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.SearchInvoicesGtCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.SearchInvoicesGteCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.SearchInvoicesLtCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.SearchInvoicesLteCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.SearchInvoicesInCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.SearchInvoicesLikeCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.SearchInvoicesFuzzyCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.SearchInvoicesKeywordCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.SearchInvoicesContainsCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.SearchInvoicesNotCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.SearchInvoicesAndCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.SearchInvoicesOrCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.SearchInvoicesAnyCondition]`
     :   The type of the None singleton.
 
+<a id="SearchInvoicesAnyCondition"></a>
+
 `SearchInvoicesAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1727,6 +1909,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.paypal_transaction.types.SearchInvoicesAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="SearchInvoicesAnyValueFilter"></a>
 
 `SearchInvoicesAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -1779,6 +1963,8 @@ Classes
     `status: Any`
     :   Current status of the invoice
 
+<a id="SearchInvoicesContainsCondition"></a>
+
 `SearchInvoicesContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -1790,6 +1976,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.paypal_transaction.types.SearchInvoicesAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="SearchInvoicesEqCondition"></a>
 
 `SearchInvoicesEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -1803,6 +1991,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.paypal_transaction.types.SearchInvoicesSearchFilter`
     :   The type of the None singleton.
 
+<a id="SearchInvoicesFuzzyCondition"></a>
+
 `SearchInvoicesFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -1814,6 +2004,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.paypal_transaction.types.SearchInvoicesStringFilter`
     :   The type of the None singleton.
+
+<a id="SearchInvoicesGtCondition"></a>
 
 `SearchInvoicesGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
@@ -1827,6 +2019,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.paypal_transaction.types.SearchInvoicesSearchFilter`
     :   The type of the None singleton.
 
+<a id="SearchInvoicesGteCondition"></a>
+
 `SearchInvoicesGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -1838,6 +2032,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.paypal_transaction.types.SearchInvoicesSearchFilter`
     :   The type of the None singleton.
+
+<a id="SearchInvoicesInCondition"></a>
 
 `SearchInvoicesInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -1858,6 +2054,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.paypal_transaction.types.SearchInvoicesInFilter`
     :   The type of the None singleton.
+
+<a id="SearchInvoicesInFilter"></a>
 
 `SearchInvoicesInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -1910,6 +2108,8 @@ Classes
     `status: list[str]`
     :   Current status of the invoice
 
+<a id="SearchInvoicesKeywordCondition"></a>
+
 `SearchInvoicesKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -1922,6 +2122,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.paypal_transaction.types.SearchInvoicesStringFilter`
     :   The type of the None singleton.
 
+<a id="SearchInvoicesLikeCondition"></a>
+
 `SearchInvoicesLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -1933,6 +2135,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.paypal_transaction.types.SearchInvoicesStringFilter`
     :   The type of the None singleton.
+
+<a id="SearchInvoicesListParams"></a>
 
 `SearchInvoicesListParams(*args, **kwargs)`
 :   Parameters for search_invoices.list operation
@@ -1952,6 +2156,8 @@ Classes
     `page_size: int`
     :   The type of the None singleton.
 
+<a id="SearchInvoicesListParamsCreationDateRange"></a>
+
 `SearchInvoicesListParamsCreationDateRange(*args, **kwargs)`
 :   Filter by invoice creation date range.
 
@@ -1967,6 +2173,8 @@ Classes
     `start: str`
     :   The type of the None singleton.
 
+<a id="SearchInvoicesLtCondition"></a>
+
 `SearchInvoicesLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -1978,6 +2186,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.paypal_transaction.types.SearchInvoicesSearchFilter`
     :   The type of the None singleton.
+
+<a id="SearchInvoicesLteCondition"></a>
 
 `SearchInvoicesLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -1991,6 +2201,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.paypal_transaction.types.SearchInvoicesSearchFilter`
     :   The type of the None singleton.
 
+<a id="SearchInvoicesNeqCondition"></a>
+
 `SearchInvoicesNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -2002,6 +2214,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.paypal_transaction.types.SearchInvoicesSearchFilter`
     :   The type of the None singleton.
+
+<a id="SearchInvoicesNotCondition"></a>
 
 `SearchInvoicesNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -2023,6 +2237,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.paypal_transaction.types.SearchInvoicesEqCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.SearchInvoicesNeqCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.SearchInvoicesGtCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.SearchInvoicesGteCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.SearchInvoicesLtCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.SearchInvoicesLteCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.SearchInvoicesInCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.SearchInvoicesLikeCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.SearchInvoicesFuzzyCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.SearchInvoicesKeywordCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.SearchInvoicesContainsCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.SearchInvoicesNotCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.SearchInvoicesAndCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.SearchInvoicesOrCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.SearchInvoicesAnyCondition`
     :   The type of the None singleton.
 
+<a id="SearchInvoicesOrCondition"></a>
+
 `SearchInvoicesOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -2042,6 +2258,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.paypal_transaction.types.SearchInvoicesEqCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.SearchInvoicesNeqCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.SearchInvoicesGtCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.SearchInvoicesGteCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.SearchInvoicesLtCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.SearchInvoicesLteCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.SearchInvoicesInCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.SearchInvoicesLikeCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.SearchInvoicesFuzzyCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.SearchInvoicesKeywordCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.SearchInvoicesContainsCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.SearchInvoicesNotCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.SearchInvoicesAndCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.SearchInvoicesOrCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.SearchInvoicesAnyCondition]`
     :   The type of the None singleton.
+
+<a id="SearchInvoicesSearchFilter"></a>
 
 `SearchInvoicesSearchFilter(*args, **kwargs)`
 :   Available fields for filtering search_invoices search queries.
@@ -2094,6 +2312,8 @@ Classes
     `status: str | None`
     :   Current status of the invoice
 
+<a id="SearchInvoicesSearchQuery"></a>
+
 `SearchInvoicesSearchQuery(*args, **kwargs)`
 :   Search query for search_invoices entity.
 
@@ -2108,6 +2328,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.paypal_transaction.types.SearchInvoicesSortFilter]`
     :   The type of the None singleton.
+
+<a id="SearchInvoicesSortFilter"></a>
 
 `SearchInvoicesSortFilter(*args, **kwargs)`
 :   Available fields for sorting search_invoices search results.
@@ -2160,6 +2382,8 @@ Classes
     `status: Literal['asc', 'desc']`
     :   Current status of the invoice
 
+<a id="SearchInvoicesStringFilter"></a>
+
 `SearchInvoicesStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -2211,6 +2435,8 @@ Classes
     `status: str`
     :   Current status of the invoice
 
+<a id="ShowProductDetailsAndCondition"></a>
+
 `ShowProductDetailsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -2231,6 +2457,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.paypal_transaction.types.ShowProductDetailsEqCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.ShowProductDetailsNeqCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.ShowProductDetailsGtCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.ShowProductDetailsGteCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.ShowProductDetailsLtCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.ShowProductDetailsLteCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.ShowProductDetailsInCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.ShowProductDetailsLikeCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.ShowProductDetailsFuzzyCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.ShowProductDetailsKeywordCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.ShowProductDetailsContainsCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.ShowProductDetailsNotCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.ShowProductDetailsAndCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.ShowProductDetailsOrCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.ShowProductDetailsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="ShowProductDetailsAnyCondition"></a>
+
 `ShowProductDetailsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -2250,6 +2478,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.paypal_transaction.types.ShowProductDetailsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="ShowProductDetailsAnyValueFilter"></a>
 
 `ShowProductDetailsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -2290,6 +2520,8 @@ Classes
     `update_time: Any`
     :   The date and time when the product was last updated
 
+<a id="ShowProductDetailsContainsCondition"></a>
+
 `ShowProductDetailsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -2301,6 +2533,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.paypal_transaction.types.ShowProductDetailsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="ShowProductDetailsEqCondition"></a>
 
 `ShowProductDetailsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -2314,6 +2548,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.paypal_transaction.types.ShowProductDetailsSearchFilter`
     :   The type of the None singleton.
 
+<a id="ShowProductDetailsFuzzyCondition"></a>
+
 `ShowProductDetailsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -2325,6 +2561,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.paypal_transaction.types.ShowProductDetailsStringFilter`
     :   The type of the None singleton.
+
+<a id="ShowProductDetailsGetParams"></a>
 
 `ShowProductDetailsGetParams(*args, **kwargs)`
 :   Parameters for show_product_details.get operation
@@ -2338,6 +2576,8 @@ Classes
     `id: str`
     :   The type of the None singleton.
 
+<a id="ShowProductDetailsGtCondition"></a>
+
 `ShowProductDetailsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -2350,6 +2590,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.paypal_transaction.types.ShowProductDetailsSearchFilter`
     :   The type of the None singleton.
 
+<a id="ShowProductDetailsGteCondition"></a>
+
 `ShowProductDetailsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -2361,6 +2603,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.paypal_transaction.types.ShowProductDetailsSearchFilter`
     :   The type of the None singleton.
+
+<a id="ShowProductDetailsInCondition"></a>
 
 `ShowProductDetailsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -2381,6 +2625,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.paypal_transaction.types.ShowProductDetailsInFilter`
     :   The type of the None singleton.
+
+<a id="ShowProductDetailsInFilter"></a>
 
 `ShowProductDetailsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -2421,6 +2667,8 @@ Classes
     `update_time: list[str]`
     :   The date and time when the product was last updated
 
+<a id="ShowProductDetailsKeywordCondition"></a>
+
 `ShowProductDetailsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -2432,6 +2680,8 @@ Classes
 
     `keyword: airbyte_agent_sdk.connectors.paypal_transaction.types.ShowProductDetailsStringFilter`
     :   The type of the None singleton.
+
+<a id="ShowProductDetailsLikeCondition"></a>
 
 `ShowProductDetailsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
@@ -2445,6 +2695,8 @@ Classes
     `like: airbyte_agent_sdk.connectors.paypal_transaction.types.ShowProductDetailsStringFilter`
     :   The type of the None singleton.
 
+<a id="ShowProductDetailsLtCondition"></a>
+
 `ShowProductDetailsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -2456,6 +2708,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.paypal_transaction.types.ShowProductDetailsSearchFilter`
     :   The type of the None singleton.
+
+<a id="ShowProductDetailsLteCondition"></a>
 
 `ShowProductDetailsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -2469,6 +2723,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.paypal_transaction.types.ShowProductDetailsSearchFilter`
     :   The type of the None singleton.
 
+<a id="ShowProductDetailsNeqCondition"></a>
+
 `ShowProductDetailsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -2480,6 +2736,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.paypal_transaction.types.ShowProductDetailsSearchFilter`
     :   The type of the None singleton.
+
+<a id="ShowProductDetailsNotCondition"></a>
 
 `ShowProductDetailsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -2501,6 +2759,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.paypal_transaction.types.ShowProductDetailsEqCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.ShowProductDetailsNeqCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.ShowProductDetailsGtCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.ShowProductDetailsGteCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.ShowProductDetailsLtCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.ShowProductDetailsLteCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.ShowProductDetailsInCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.ShowProductDetailsLikeCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.ShowProductDetailsFuzzyCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.ShowProductDetailsKeywordCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.ShowProductDetailsContainsCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.ShowProductDetailsNotCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.ShowProductDetailsAndCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.ShowProductDetailsOrCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.ShowProductDetailsAnyCondition`
     :   The type of the None singleton.
 
+<a id="ShowProductDetailsOrCondition"></a>
+
 `ShowProductDetailsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -2520,6 +2780,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.paypal_transaction.types.ShowProductDetailsEqCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.ShowProductDetailsNeqCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.ShowProductDetailsGtCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.ShowProductDetailsGteCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.ShowProductDetailsLtCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.ShowProductDetailsLteCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.ShowProductDetailsInCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.ShowProductDetailsLikeCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.ShowProductDetailsFuzzyCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.ShowProductDetailsKeywordCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.ShowProductDetailsContainsCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.ShowProductDetailsNotCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.ShowProductDetailsAndCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.ShowProductDetailsOrCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.ShowProductDetailsAnyCondition]`
     :   The type of the None singleton.
+
+<a id="ShowProductDetailsSearchFilter"></a>
 
 `ShowProductDetailsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering show_product_details search queries.
@@ -2560,6 +2822,8 @@ Classes
     `update_time: str | None`
     :   The date and time when the product was last updated
 
+<a id="ShowProductDetailsSearchQuery"></a>
+
 `ShowProductDetailsSearchQuery(*args, **kwargs)`
 :   Search query for show_product_details entity.
 
@@ -2574,6 +2838,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.paypal_transaction.types.ShowProductDetailsSortFilter]`
     :   The type of the None singleton.
+
+<a id="ShowProductDetailsSortFilter"></a>
 
 `ShowProductDetailsSortFilter(*args, **kwargs)`
 :   Available fields for sorting show_product_details search results.
@@ -2614,6 +2880,8 @@ Classes
     `update_time: Literal['asc', 'desc']`
     :   The date and time when the product was last updated
 
+<a id="ShowProductDetailsStringFilter"></a>
+
 `ShowProductDetailsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -2653,6 +2921,8 @@ Classes
     `update_time: str`
     :   The date and time when the product was last updated
 
+<a id="TransactionsAndCondition"></a>
+
 `TransactionsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -2673,6 +2943,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.paypal_transaction.types.TransactionsEqCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.TransactionsNeqCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.TransactionsGtCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.TransactionsGteCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.TransactionsLtCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.TransactionsLteCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.TransactionsInCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.TransactionsLikeCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.TransactionsFuzzyCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.TransactionsKeywordCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.TransactionsContainsCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.TransactionsNotCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.TransactionsAndCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.TransactionsOrCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.TransactionsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="TransactionsAnyCondition"></a>
+
 `TransactionsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -2692,6 +2964,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.paypal_transaction.types.TransactionsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="TransactionsAnyValueFilter"></a>
 
 `TransactionsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -2732,6 +3006,8 @@ Classes
     `transaction_updated_date: Any`
     :   Date and time when the transaction was last updated
 
+<a id="TransactionsContainsCondition"></a>
+
 `TransactionsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -2743,6 +3019,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.paypal_transaction.types.TransactionsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="TransactionsEqCondition"></a>
 
 `TransactionsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -2756,6 +3034,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.paypal_transaction.types.TransactionsSearchFilter`
     :   The type of the None singleton.
 
+<a id="TransactionsFuzzyCondition"></a>
+
 `TransactionsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -2767,6 +3047,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.paypal_transaction.types.TransactionsStringFilter`
     :   The type of the None singleton.
+
+<a id="TransactionsGtCondition"></a>
 
 `TransactionsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
@@ -2780,6 +3062,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.paypal_transaction.types.TransactionsSearchFilter`
     :   The type of the None singleton.
 
+<a id="TransactionsGteCondition"></a>
+
 `TransactionsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -2791,6 +3075,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.paypal_transaction.types.TransactionsSearchFilter`
     :   The type of the None singleton.
+
+<a id="TransactionsInCondition"></a>
 
 `TransactionsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -2811,6 +3097,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.paypal_transaction.types.TransactionsInFilter`
     :   The type of the None singleton.
+
+<a id="TransactionsInFilter"></a>
 
 `TransactionsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -2851,6 +3139,8 @@ Classes
     `transaction_updated_date: list[str]`
     :   Date and time when the transaction was last updated
 
+<a id="TransactionsKeywordCondition"></a>
+
 `TransactionsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -2863,6 +3153,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.paypal_transaction.types.TransactionsStringFilter`
     :   The type of the None singleton.
 
+<a id="TransactionsLikeCondition"></a>
+
 `TransactionsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -2874,6 +3166,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.paypal_transaction.types.TransactionsStringFilter`
     :   The type of the None singleton.
+
+<a id="TransactionsListParams"></a>
 
 `TransactionsListParams(*args, **kwargs)`
 :   Parameters for transactions.list operation
@@ -2914,6 +3208,8 @@ Classes
     `transaction_type: str`
     :   The type of the None singleton.
 
+<a id="TransactionsLtCondition"></a>
+
 `TransactionsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -2925,6 +3221,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.paypal_transaction.types.TransactionsSearchFilter`
     :   The type of the None singleton.
+
+<a id="TransactionsLteCondition"></a>
 
 `TransactionsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -2938,6 +3236,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.paypal_transaction.types.TransactionsSearchFilter`
     :   The type of the None singleton.
 
+<a id="TransactionsNeqCondition"></a>
+
 `TransactionsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -2949,6 +3249,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.paypal_transaction.types.TransactionsSearchFilter`
     :   The type of the None singleton.
+
+<a id="TransactionsNotCondition"></a>
 
 `TransactionsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -2970,6 +3272,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.paypal_transaction.types.TransactionsEqCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.TransactionsNeqCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.TransactionsGtCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.TransactionsGteCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.TransactionsLtCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.TransactionsLteCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.TransactionsInCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.TransactionsLikeCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.TransactionsFuzzyCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.TransactionsKeywordCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.TransactionsContainsCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.TransactionsNotCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.TransactionsAndCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.TransactionsOrCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.TransactionsAnyCondition`
     :   The type of the None singleton.
 
+<a id="TransactionsOrCondition"></a>
+
 `TransactionsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -2989,6 +3293,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.paypal_transaction.types.TransactionsEqCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.TransactionsNeqCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.TransactionsGtCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.TransactionsGteCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.TransactionsLtCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.TransactionsLteCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.TransactionsInCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.TransactionsLikeCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.TransactionsFuzzyCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.TransactionsKeywordCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.TransactionsContainsCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.TransactionsNotCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.TransactionsAndCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.TransactionsOrCondition | airbyte_agent_sdk.connectors.paypal_transaction.types.TransactionsAnyCondition]`
     :   The type of the None singleton.
+
+<a id="TransactionsSearchFilter"></a>
 
 `TransactionsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering transactions search queries.
@@ -3029,6 +3335,8 @@ Classes
     `transaction_updated_date: str | None`
     :   Date and time when the transaction was last updated
 
+<a id="TransactionsSearchQuery"></a>
+
 `TransactionsSearchQuery(*args, **kwargs)`
 :   Search query for transactions entity.
 
@@ -3043,6 +3351,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.paypal_transaction.types.TransactionsSortFilter]`
     :   The type of the None singleton.
+
+<a id="TransactionsSortFilter"></a>
 
 `TransactionsSortFilter(*args, **kwargs)`
 :   Available fields for sorting transactions search results.
@@ -3082,6 +3392,8 @@ Classes
 
     `transaction_updated_date: Literal['asc', 'desc']`
     :   Date and time when the transaction was last updated
+
+<a id="TransactionsStringFilter"></a>
 
 `TransactionsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/pinterest/connector.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/pinterest/connector.md
@@ -10,6 +10,8 @@ Pinterest connector.
 Classes
 -------
 
+<a id="AdAccountsQuery"></a>
+
 `AdAccountsQuery(connector: PinterestConnector)`
 :   Query class for AdAccounts entity operations.
     
@@ -68,6 +70,8 @@ Classes
         
         Returns:
             AdAccountsListResult
+
+<a id="AdGroupsQuery"></a>
 
 `AdGroupsQuery(connector: PinterestConnector)`
 :   Query class for AdGroups entity operations.
@@ -136,6 +140,8 @@ Classes
         
         Returns:
             AdGroupsListResult
+
+<a id="AdsQuery"></a>
 
 `AdsQuery(connector: PinterestConnector)`
 :   Query class for Ads entity operations.
@@ -208,6 +214,8 @@ Classes
         Returns:
             AdsListResult
 
+<a id="AudiencesQuery"></a>
+
 `AudiencesQuery(connector: PinterestConnector)`
 :   Query class for Audiences entity operations.
     
@@ -259,6 +267,8 @@ Classes
         
         Returns:
             AudiencesListResult
+
+<a id="BoardPinsQuery"></a>
 
 `BoardPinsQuery(connector: PinterestConnector)`
 :   Query class for BoardPins entity operations.
@@ -318,6 +328,8 @@ Classes
         Returns:
             BoardPinsListResult
 
+<a id="BoardSectionsQuery"></a>
+
 `BoardSectionsQuery(connector: PinterestConnector)`
 :   Query class for BoardSections entity operations.
     
@@ -360,6 +372,8 @@ Classes
         
         Returns:
             BoardSectionsListResult
+
+<a id="BoardsQuery"></a>
 
 `BoardsQuery(connector: PinterestConnector)`
 :   Query class for Boards entity operations.
@@ -423,6 +437,8 @@ Classes
         Returns:
             BoardsListResult
 
+<a id="CampaignsQuery"></a>
+
 `CampaignsQuery(connector: PinterestConnector)`
 :   Query class for Campaigns entity operations.
     
@@ -483,6 +499,8 @@ Classes
         Returns:
             CampaignsListResult
 
+<a id="CatalogsFeedsQuery"></a>
+
 `CatalogsFeedsQuery(connector: PinterestConnector)`
 :   Query class for CatalogsFeeds entity operations.
     
@@ -536,6 +554,8 @@ Classes
         Returns:
             CatalogsFeedsListResult
 
+<a id="CatalogsProductGroupsQuery"></a>
+
 `CatalogsProductGroupsQuery(connector: PinterestConnector)`
 :   Query class for CatalogsProductGroups entity operations.
     
@@ -585,6 +605,8 @@ Classes
         Returns:
             CatalogsProductGroupsListResult
 
+<a id="CatalogsQuery"></a>
+
 `CatalogsQuery(connector: PinterestConnector)`
 :   Query class for Catalogs entity operations.
     
@@ -629,6 +651,8 @@ Classes
         
         Returns:
             CatalogsListResult
+
+<a id="ConversionTagsQuery"></a>
 
 `ConversionTagsQuery(connector: PinterestConnector)`
 :   Query class for ConversionTags entity operations.
@@ -679,6 +703,8 @@ Classes
         
         Returns:
             ConversionTagsListResult
+
+<a id="CustomerListsQuery"></a>
 
 `CustomerListsQuery(connector: PinterestConnector)`
 :   Query class for CustomerLists entity operations.
@@ -731,6 +757,8 @@ Classes
         Returns:
             CustomerListsListResult
 
+<a id="KeywordsQuery"></a>
+
 `KeywordsQuery(connector: PinterestConnector)`
 :   Query class for Keywords entity operations.
     
@@ -780,6 +808,8 @@ Classes
         
         Returns:
             KeywordsListResult
+
+<a id="PinterestConnector"></a>
 
 `PinterestConnector(auth_config: PinterestAuthConfig | AirbyteAuthConfig | BaseModel | None = None, on_token_refresh: Any | None = None)`
 :   Type-safe Pinterest API connector.

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/pinterest/index.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/pinterest/index.md
@@ -19,6 +19,8 @@ Sub-modules
 Classes
 -------
 
+<a id="AdAccountsSearchData"></a>
+
 `AdAccountsSearchData(**data: Any)`
 :   Search result data for ad_accounts entity.
     
@@ -61,6 +63,8 @@ Classes
 
     `updated_time: int | None`
     :   Timestamp when the ad account was last updated (Unix seconds)
+
+<a id="AdGroupsSearchData"></a>
 
 `AdGroupsSearchData(**data: Any)`
 :   Search result data for ad_groups entity.
@@ -155,6 +159,8 @@ Classes
 
     `updated_time: float | None`
     :   Last update timestamp (Unix seconds)
+
+<a id="AdsSearchData"></a>
 
 `AdsSearchData(**data: Any)`
 :   Search result data for ads entity.
@@ -259,6 +265,8 @@ Classes
     `view_tracking_url: str | None`
     :   View tracking URL
 
+<a id="AirbyteAuthConfig"></a>
+
 `AirbyteAuthConfig(**data: Any)`
 :   Authentication configuration for Airbyte hosted mode execution.
     
@@ -327,6 +335,8 @@ Classes
     `workspace_name: str | None`
     :   The type of the None singleton.
 
+<a id="AirbyteSearchMeta"></a>
+
 `AirbyteSearchMeta(**data: Any)`
 :   Pagination metadata for search responses.
     
@@ -354,6 +364,8 @@ Classes
 
     `took_ms: int | None`
     :   Time taken to execute the search in milliseconds.
+
+<a id="AirbyteSearchResult"></a>
 
 `AirbyteSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -398,6 +410,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="AdAccountsSearchResult"></a>
+
 `AdAccountsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -413,6 +427,8 @@ Classes
     * airbyte_agent_sdk.connectors.pinterest.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="AdGroupsSearchResult"></a>
 
 `AdGroupsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -430,6 +446,8 @@ Classes
     * pydantic.main.BaseModel
     * typing.Generic
 
+<a id="AdsSearchResult"></a>
+
 `AdsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -445,6 +463,8 @@ Classes
     * airbyte_agent_sdk.connectors.pinterest.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="AudiencesSearchResult"></a>
 
 `AudiencesSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -462,6 +482,8 @@ Classes
     * pydantic.main.BaseModel
     * typing.Generic
 
+<a id="BoardPinsSearchResult"></a>
+
 `BoardPinsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -477,6 +499,8 @@ Classes
     * airbyte_agent_sdk.connectors.pinterest.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="BoardSectionsSearchResult"></a>
 
 `BoardSectionsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -494,6 +518,8 @@ Classes
     * pydantic.main.BaseModel
     * typing.Generic
 
+<a id="BoardsSearchResult"></a>
+
 `BoardsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -509,6 +535,8 @@ Classes
     * airbyte_agent_sdk.connectors.pinterest.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="CampaignsSearchResult"></a>
 
 `CampaignsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -526,6 +554,8 @@ Classes
     * pydantic.main.BaseModel
     * typing.Generic
 
+<a id="CatalogsFeedsSearchResult"></a>
+
 `CatalogsFeedsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -541,6 +571,8 @@ Classes
     * airbyte_agent_sdk.connectors.pinterest.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="CatalogsProductGroupsSearchResult"></a>
 
 `CatalogsProductGroupsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -558,6 +590,8 @@ Classes
     * pydantic.main.BaseModel
     * typing.Generic
 
+<a id="CatalogsSearchResult"></a>
+
 `CatalogsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -573,6 +607,8 @@ Classes
     * airbyte_agent_sdk.connectors.pinterest.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="ConversionTagsSearchResult"></a>
 
 `ConversionTagsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -590,6 +626,8 @@ Classes
     * pydantic.main.BaseModel
     * typing.Generic
 
+<a id="CustomerListsSearchResult"></a>
+
 `CustomerListsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -606,6 +644,8 @@ Classes
     * pydantic.main.BaseModel
     * typing.Generic
 
+<a id="KeywordsSearchResult"></a>
+
 `KeywordsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -621,6 +661,8 @@ Classes
     * airbyte_agent_sdk.connectors.pinterest.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="AudiencesSearchData"></a>
 
 `AudiencesSearchData(**data: Any)`
 :   Search result data for audiences entity.
@@ -673,6 +715,8 @@ Classes
 
     `updated_timestamp: int | None`
     :   Last update time (Unix seconds)
+
+<a id="BoardPinsSearchData"></a>
 
 `BoardPinsSearchData(**data: Any)`
 :   Search result data for board_pins entity.
@@ -744,6 +788,8 @@ Classes
     `title: str | None`
     :   Pin title
 
+<a id="BoardSectionsSearchData"></a>
+
 `BoardSectionsSearchData(**data: Any)`
 :   Search result data for board_sections entity.
     
@@ -768,6 +814,8 @@ Classes
 
     `name: str | None`
     :   Name of the board section
+
+<a id="BoardsSearchData"></a>
 
 `BoardsSearchData(**data: Any)`
 :   Search result data for boards entity.
@@ -820,6 +868,8 @@ Classes
 
     `privacy: str | None`
     :   Board privacy setting
+
+<a id="CampaignsSearchData"></a>
 
 `CampaignsSearchData(**data: Any)`
 :   Search result data for campaigns entity.
@@ -891,6 +941,8 @@ Classes
     `updated_time: int | None`
     :   Last update timestamp (Unix seconds)
 
+<a id="CatalogsFeedsSearchData"></a>
+
 `CatalogsFeedsSearchData(**data: Any)`
 :   Search result data for catalogs_feeds entity.
     
@@ -949,6 +1001,8 @@ Classes
     `updated_at: str | None`
     :   Timestamp when the feed was last updated
 
+<a id="CatalogsProductGroupsSearchData"></a>
+
 `CatalogsProductGroupsSearchData(**data: Any)`
 :   Search result data for catalogs_product_groups entity.
     
@@ -995,6 +1049,8 @@ Classes
     `updated_at: int | None`
     :   Last update timestamp (Unix seconds)
 
+<a id="CatalogsSearchData"></a>
+
 `CatalogsSearchData(**data: Any)`
 :   Search result data for catalogs entity.
     
@@ -1028,6 +1084,8 @@ Classes
 
     `updated_at: str | None`
     :   Timestamp when the catalog was last updated
+
+<a id="ConversionTagsSearchData"></a>
 
 `ConversionTagsSearchData(**data: Any)`
 :   Search result data for conversion_tags entity.
@@ -1074,6 +1132,8 @@ Classes
 
     `version: str | None`
     :   Version number
+
+<a id="CustomerListsSearchData"></a>
 
 `CustomerListsSearchData(**data: Any)`
 :   Search result data for customer_lists entity.
@@ -1124,6 +1184,8 @@ Classes
     `updated_time: int | None`
     :   Last update time (Unix seconds)
 
+<a id="KeywordsSearchData"></a>
+
 `KeywordsSearchData(**data: Any)`
 :   Search result data for keywords entity.
     
@@ -1167,6 +1229,8 @@ Classes
     `value: str | None`
     :   Keyword text value
 
+<a id="PinterestAuthConfig"></a>
+
 `PinterestAuthConfig(**data: Any)`
 :   OAuth 2.0 Authentication
     
@@ -1194,6 +1258,8 @@ Classes
 
     `refresh_token: str`
     :   Pinterest OAuth2 refresh token.
+
+<a id="PinterestConnector"></a>
 
 `PinterestConnector(auth_config: PinterestAuthConfig | AirbyteAuthConfig | BaseModel | None = None, on_token_refresh: Any | None = None)`
 :   Type-safe Pinterest API connector.
@@ -1450,6 +1516,8 @@ Classes
             entities = connector.list_entities()
             for entity in entities:
                 print(f"\{entity['entity_name']\}: \{entity['available_actions']\}")
+
+<a id="PinterestReplicationConfig"></a>
 
 `PinterestReplicationConfig(**data: Any)`
 :   Replication Configuration - Settings for data replication from Pinterest.

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/pinterest/models.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/pinterest/models.md
@@ -13,6 +13,8 @@ and response envelope types.
 Classes
 -------
 
+<a id="Ad"></a>
+
 `Ad(**data: Any)`
 :   Pinterest ad object
     
@@ -131,6 +133,8 @@ Classes
     `view_tracking_url: str | Any | None`
     :   The type of the None singleton.
 
+<a id="AdAccount"></a>
+
 `AdAccount(**data: Any)`
 :   Pinterest ad account object
     
@@ -174,6 +178,8 @@ Classes
     `updated_time: int | Any | None`
     :   The type of the None singleton.
 
+<a id="AdAccountOwner"></a>
+
 `AdAccountOwner(**data: Any)`
 :   Owner details of the ad account
     
@@ -198,6 +204,8 @@ Classes
 
     `username: str | Any | None`
     :   Username of the owner
+
+<a id="AdAccountsList"></a>
 
 `AdAccountsList(**data: Any)`
 :   Paginated list of ad accounts
@@ -224,6 +232,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="AdAccountsListResultMeta"></a>
+
 `AdAccountsListResultMeta(**data: Any)`
 :   Metadata for ad_accounts.Action.LIST operation
     
@@ -245,6 +255,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="AdAccountsSearchData"></a>
 
 `AdAccountsSearchData(**data: Any)`
 :   Search result data for ad_accounts entity.
@@ -288,6 +300,8 @@ Classes
 
     `updated_time: int | None`
     :   Timestamp when the ad account was last updated (Unix seconds)
+
+<a id="AdGroup"></a>
 
 `AdGroup(**data: Any)`
 :   Pinterest ad group object
@@ -404,6 +418,8 @@ Classes
     `updated_time: float | Any | None`
     :   The type of the None singleton.
 
+<a id="AdGroupTrackingUrls"></a>
+
 `AdGroupTrackingUrls(**data: Any)`
 :   Third-party tracking URLs
     
@@ -438,6 +454,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="AdGroupsList"></a>
+
 `AdGroupsList(**data: Any)`
 :   Paginated list of ad groups
     
@@ -463,6 +481,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="AdGroupsListResultMeta"></a>
+
 `AdGroupsListResultMeta(**data: Any)`
 :   Metadata for ad_groups.Action.LIST operation
     
@@ -484,6 +504,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="AdGroupsSearchData"></a>
 
 `AdGroupsSearchData(**data: Any)`
 :   Search result data for ad_groups entity.
@@ -579,6 +601,8 @@ Classes
     `updated_time: float | None`
     :   Last update timestamp (Unix seconds)
 
+<a id="AdTrackingUrls"></a>
+
 `AdTrackingUrls(**data: Any)`
 :   Third-party tracking URLs
     
@@ -613,6 +637,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="AdsList"></a>
+
 `AdsList(**data: Any)`
 :   Paginated list of ads
     
@@ -638,6 +664,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="AdsListResultMeta"></a>
+
 `AdsListResultMeta(**data: Any)`
 :   Metadata for ads.Action.LIST operation
     
@@ -659,6 +687,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="AdsSearchData"></a>
 
 `AdsSearchData(**data: Any)`
 :   Search result data for ads entity.
@@ -763,6 +793,8 @@ Classes
     `view_tracking_url: str | None`
     :   View tracking URL
 
+<a id="AirbyteSearchMeta"></a>
+
 `AirbyteSearchMeta(**data: Any)`
 :   Pagination metadata for search responses.
     
@@ -790,6 +822,8 @@ Classes
 
     `took_ms: int | None`
     :   Time taken to execute the search in milliseconds.
+
+<a id="AirbyteSearchResult"></a>
 
 `AirbyteSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -855,6 +889,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="AdAccountsSearchResult"></a>
+
 `AdAccountsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -891,6 +927,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="AdGroupsSearchResult"></a>
 
 `AdGroupsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -929,6 +967,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="AdsSearchResult"></a>
+
 `AdsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -965,6 +1005,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="AudiencesSearchResult"></a>
 
 `AudiencesSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -1003,6 +1045,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="BoardPinsSearchResult"></a>
+
 `BoardPinsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -1039,6 +1083,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="BoardSectionsSearchResult"></a>
 
 `BoardSectionsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -1077,6 +1123,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="BoardsSearchResult"></a>
+
 `BoardsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -1113,6 +1161,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="CampaignsSearchResult"></a>
 
 `CampaignsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -1151,6 +1201,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="CatalogsFeedsSearchResult"></a>
+
 `CatalogsFeedsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -1187,6 +1239,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="CatalogsProductGroupsSearchResult"></a>
 
 `CatalogsProductGroupsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -1225,6 +1279,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="CatalogsSearchResult"></a>
+
 `CatalogsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -1261,6 +1317,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="ConversionTagsSearchResult"></a>
 
 `ConversionTagsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -1299,6 +1357,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="CustomerListsSearchResult"></a>
+
 `CustomerListsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -1336,6 +1396,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="KeywordsSearchResult"></a>
+
 `KeywordsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -1351,6 +1413,8 @@ Classes
     * airbyte_agent_sdk.connectors.pinterest.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="Audience"></a>
 
 `Audience(**data: Any)`
 :   Pinterest audience object
@@ -1407,6 +1471,8 @@ Classes
     `updated_timestamp: int | Any | None`
     :   The type of the None singleton.
 
+<a id="AudienceRule"></a>
+
 `AudienceRule(**data: Any)`
 :   Audience targeting rules
     
@@ -1447,6 +1513,8 @@ Classes
     `visitor_source_id: str | Any | None`
     :   Visitor source ID
 
+<a id="AudiencesList"></a>
+
 `AudiencesList(**data: Any)`
 :   Paginated list of audiences
     
@@ -1472,6 +1540,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="AudiencesListResultMeta"></a>
+
 `AudiencesListResultMeta(**data: Any)`
 :   Metadata for audiences.Action.LIST operation
     
@@ -1493,6 +1563,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="AudiencesSearchData"></a>
 
 `AudiencesSearchData(**data: Any)`
 :   Search result data for audiences entity.
@@ -1545,6 +1617,8 @@ Classes
 
     `updated_timestamp: int | None`
     :   Last update time (Unix seconds)
+
+<a id="Board"></a>
 
 `Board(**data: Any)`
 :   Pinterest board object
@@ -1601,6 +1675,8 @@ Classes
     `privacy: str | Any | None`
     :   The type of the None singleton.
 
+<a id="BoardMedia"></a>
+
 `BoardMedia(**data: Any)`
 :   Media content for the board
     
@@ -1626,6 +1702,8 @@ Classes
     `pin_thumbnail_urls: list[str] | Any | None`
     :   Thumbnail URLs of pins
 
+<a id="BoardOwner"></a>
+
 `BoardOwner(**data: Any)`
 :   Board owner details
     
@@ -1647,6 +1725,8 @@ Classes
 
     `username: str | Any | None`
     :   Username of the board owner
+
+<a id="BoardPin"></a>
 
 `BoardPin(**data: Any)`
 :   Pinterest pin on a board
@@ -1724,6 +1804,8 @@ Classes
     `title: str | Any | None`
     :   The type of the None singleton.
 
+<a id="BoardPinBoardOwner"></a>
+
 `BoardPinBoardOwner(**data: Any)`
 :   Board owner info
     
@@ -1746,6 +1828,8 @@ Classes
     `username: str | Any | None`
     :   Username of the board owner
 
+<a id="BoardPinMedia"></a>
+
 `BoardPinMedia(**data: Any)`
 :   Media content
     
@@ -1767,6 +1851,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="BoardPinsList"></a>
 
 `BoardPinsList(**data: Any)`
 :   Paginated list of board pins
@@ -1793,6 +1879,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="BoardPinsListResultMeta"></a>
+
 `BoardPinsListResultMeta(**data: Any)`
 :   Metadata for board_pins.Action.LIST operation
     
@@ -1814,6 +1902,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="BoardPinsSearchData"></a>
 
 `BoardPinsSearchData(**data: Any)`
 :   Search result data for board_pins entity.
@@ -1885,6 +1975,8 @@ Classes
     `title: str | None`
     :   Pin title
 
+<a id="BoardSection"></a>
+
 `BoardSection(**data: Any)`
 :   Pinterest board section object
     
@@ -1909,6 +2001,8 @@ Classes
 
     `name: str | Any | None`
     :   The type of the None singleton.
+
+<a id="BoardSectionsList"></a>
 
 `BoardSectionsList(**data: Any)`
 :   Paginated list of board sections
@@ -1935,6 +2029,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="BoardSectionsListResultMeta"></a>
+
 `BoardSectionsListResultMeta(**data: Any)`
 :   Metadata for board_sections.Action.LIST operation
     
@@ -1956,6 +2052,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="BoardSectionsSearchData"></a>
 
 `BoardSectionsSearchData(**data: Any)`
 :   Search result data for board_sections entity.
@@ -1982,6 +2080,8 @@ Classes
     `name: str | None`
     :   Name of the board section
 
+<a id="BoardsList"></a>
+
 `BoardsList(**data: Any)`
 :   Paginated list of boards
     
@@ -2007,6 +2107,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="BoardsListResultMeta"></a>
+
 `BoardsListResultMeta(**data: Any)`
 :   Metadata for boards.Action.LIST operation
     
@@ -2028,6 +2130,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="BoardsSearchData"></a>
 
 `BoardsSearchData(**data: Any)`
 :   Search result data for boards entity.
@@ -2080,6 +2184,8 @@ Classes
 
     `privacy: str | None`
     :   Board privacy setting
+
+<a id="Campaign"></a>
 
 `Campaign(**data: Any)`
 :   Pinterest campaign object
@@ -2163,6 +2269,8 @@ Classes
     `updated_time: int | Any | None`
     :   The type of the None singleton.
 
+<a id="CampaignTrackingUrls"></a>
+
 `CampaignTrackingUrls(**data: Any)`
 :   Third-party tracking URLs
     
@@ -2197,6 +2305,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="CampaignsList"></a>
+
 `CampaignsList(**data: Any)`
 :   Paginated list of campaigns
     
@@ -2222,6 +2332,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="CampaignsListResultMeta"></a>
+
 `CampaignsListResultMeta(**data: Any)`
 :   Metadata for campaigns.Action.LIST operation
     
@@ -2243,6 +2355,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="CampaignsSearchData"></a>
 
 `CampaignsSearchData(**data: Any)`
 :   Search result data for campaigns entity.
@@ -2314,6 +2428,8 @@ Classes
     `updated_time: int | None`
     :   Last update timestamp (Unix seconds)
 
+<a id="Catalog"></a>
+
 `Catalog(**data: Any)`
 :   Pinterest catalog object
     
@@ -2347,6 +2463,8 @@ Classes
 
     `updated_at: str | Any | None`
     :   The type of the None singleton.
+
+<a id="CatalogsFeed"></a>
 
 `CatalogsFeed(**data: Any)`
 :   Pinterest catalog feed object
@@ -2406,6 +2524,8 @@ Classes
     `updated_at: str | Any | None`
     :   The type of the None singleton.
 
+<a id="CatalogsFeedPreferredProcessingSchedule"></a>
+
 `CatalogsFeedPreferredProcessingSchedule(**data: Any)`
 :   Preferred processing schedule
     
@@ -2430,6 +2550,8 @@ Classes
 
     `timezone: str | Any | None`
     :   Timezone for processing
+
+<a id="CatalogsFeedsList"></a>
 
 `CatalogsFeedsList(**data: Any)`
 :   Paginated list of catalog feeds
@@ -2456,6 +2578,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="CatalogsFeedsListResultMeta"></a>
+
 `CatalogsFeedsListResultMeta(**data: Any)`
 :   Metadata for catalogs_feeds.Action.LIST operation
     
@@ -2477,6 +2601,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="CatalogsFeedsSearchData"></a>
 
 `CatalogsFeedsSearchData(**data: Any)`
 :   Search result data for catalogs_feeds entity.
@@ -2536,6 +2662,8 @@ Classes
     `updated_at: str | None`
     :   Timestamp when the feed was last updated
 
+<a id="CatalogsList"></a>
+
 `CatalogsList(**data: Any)`
 :   Paginated list of catalogs
     
@@ -2561,6 +2689,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="CatalogsListResultMeta"></a>
+
 `CatalogsListResultMeta(**data: Any)`
 :   Metadata for catalogs.Action.LIST operation
     
@@ -2582,6 +2712,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="CatalogsProductGroup"></a>
 
 `CatalogsProductGroup(**data: Any)`
 :   Pinterest catalog product group object
@@ -2629,6 +2761,8 @@ Classes
     `updated_at: int | Any | None`
     :   The type of the None singleton.
 
+<a id="CatalogsProductGroupsList"></a>
+
 `CatalogsProductGroupsList(**data: Any)`
 :   Paginated list of catalog product groups
     
@@ -2654,6 +2788,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="CatalogsProductGroupsListResultMeta"></a>
+
 `CatalogsProductGroupsListResultMeta(**data: Any)`
 :   Metadata for catalogs_product_groups.Action.LIST operation
     
@@ -2675,6 +2811,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="CatalogsProductGroupsSearchData"></a>
 
 `CatalogsProductGroupsSearchData(**data: Any)`
 :   Search result data for catalogs_product_groups entity.
@@ -2722,6 +2860,8 @@ Classes
     `updated_at: int | None`
     :   Last update timestamp (Unix seconds)
 
+<a id="CatalogsSearchData"></a>
+
 `CatalogsSearchData(**data: Any)`
 :   Search result data for catalogs entity.
     
@@ -2755,6 +2895,8 @@ Classes
 
     `updated_at: str | None`
     :   Timestamp when the catalog was last updated
+
+<a id="ConversionTag"></a>
 
 `ConversionTag(**data: Any)`
 :   Pinterest conversion tag object
@@ -2802,6 +2944,8 @@ Classes
     `version: str | Any | None`
     :   The type of the None singleton.
 
+<a id="ConversionTagConfigs"></a>
+
 `ConversionTagConfigs(**data: Any)`
 :   Tag configurations
     
@@ -2842,6 +2986,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="ConversionTagsList"></a>
+
 `ConversionTagsList(**data: Any)`
 :   Paginated list of conversion tags
     
@@ -2867,6 +3013,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="ConversionTagsListResultMeta"></a>
+
 `ConversionTagsListResultMeta(**data: Any)`
 :   Metadata for conversion_tags.Action.LIST operation
     
@@ -2888,6 +3036,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="ConversionTagsSearchData"></a>
 
 `ConversionTagsSearchData(**data: Any)`
 :   Search result data for conversion_tags entity.
@@ -2934,6 +3084,8 @@ Classes
 
     `version: str | None`
     :   Version number
+
+<a id="CustomerList"></a>
 
 `CustomerList(**data: Any)`
 :   Pinterest customer list object
@@ -2984,6 +3136,8 @@ Classes
     `updated_time: int | Any | None`
     :   The type of the None singleton.
 
+<a id="CustomerListsList"></a>
+
 `CustomerListsList(**data: Any)`
 :   Paginated list of customer lists
     
@@ -3009,6 +3163,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="CustomerListsListResultMeta"></a>
+
 `CustomerListsListResultMeta(**data: Any)`
 :   Metadata for customer_lists.Action.LIST operation
     
@@ -3030,6 +3186,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="CustomerListsSearchData"></a>
 
 `CustomerListsSearchData(**data: Any)`
 :   Search result data for customer_lists entity.
@@ -3080,6 +3238,8 @@ Classes
     `updated_time: int | None`
     :   Last update time (Unix seconds)
 
+<a id="Keyword"></a>
+
 `Keyword(**data: Any)`
 :   Pinterest keyword object
     
@@ -3123,6 +3283,8 @@ Classes
     `value: str | Any | None`
     :   The type of the None singleton.
 
+<a id="KeywordsList"></a>
+
 `KeywordsList(**data: Any)`
 :   Paginated list of keywords
     
@@ -3148,6 +3310,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="KeywordsListResultMeta"></a>
+
 `KeywordsListResultMeta(**data: Any)`
 :   Metadata for keywords.Action.LIST operation
     
@@ -3169,6 +3333,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="KeywordsSearchData"></a>
 
 `KeywordsSearchData(**data: Any)`
 :   Search result data for keywords entity.
@@ -3213,6 +3379,8 @@ Classes
     `value: str | None`
     :   Keyword text value
 
+<a id="PinterestAuthConfig"></a>
+
 `PinterestAuthConfig(**data: Any)`
 :   OAuth 2.0 Authentication
     
@@ -3240,6 +3408,8 @@ Classes
 
     `refresh_token: str`
     :   Pinterest OAuth2 refresh token.
+
+<a id="PinterestCheckResult"></a>
 
 `PinterestCheckResult(**data: Any)`
 :   Result of a health check operation.
@@ -3274,6 +3444,8 @@ Classes
     `status: str`
     :   Health check status: 'healthy' or 'unhealthy'.
 
+<a id="PinterestExecuteResult"></a>
+
 `PinterestExecuteResult(**data: Any)`
 :   Response envelope with data only.
     
@@ -3302,6 +3474,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="PinterestExecuteResultWithMeta"></a>
 
 `PinterestExecuteResultWithMeta(**data: Any)`
 :   Response envelope with data and metadata.
@@ -3367,6 +3541,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="AdAccountsListResult"></a>
+
 `AdAccountsListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -3409,6 +3585,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="AdGroupsListResult"></a>
 
 `AdGroupsListResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -3453,6 +3631,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="AdsListResult"></a>
+
 `AdsListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -3495,6 +3675,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="AudiencesListResult"></a>
 
 `AudiencesListResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -3539,6 +3721,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="BoardPinsListResult"></a>
+
 `BoardPinsListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -3581,6 +3765,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="BoardSectionsListResult"></a>
 
 `BoardSectionsListResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -3625,6 +3811,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="BoardsListResult"></a>
+
 `BoardsListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -3667,6 +3855,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="CampaignsListResult"></a>
 
 `CampaignsListResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -3711,6 +3901,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="CatalogsListResult"></a>
+
 `CatalogsListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -3753,6 +3945,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="CatalogsFeedsListResult"></a>
 
 `CatalogsFeedsListResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -3797,6 +3991,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="CatalogsProductGroupsListResult"></a>
+
 `CatalogsProductGroupsListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -3839,6 +4035,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="ConversionTagsListResult"></a>
 
 `ConversionTagsListResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -3883,6 +4081,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="CustomerListsListResult"></a>
+
 `CustomerListsListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -3926,6 +4126,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="KeywordsListResult"></a>
+
 `KeywordsListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -3944,6 +4146,8 @@ Classes
     * airbyte_agent_sdk.connectors.pinterest.models.PinterestExecuteResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="PinterestReplicationConfig"></a>
 
 `PinterestReplicationConfig(**data: Any)`
 :   Replication Configuration - Settings for data replication from Pinterest.

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/pinterest/types.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/pinterest/types.md
@@ -10,6 +10,8 @@ Type definitions for pinterest connector.
 Classes
 -------
 
+<a id="AdAccountsAndCondition"></a>
+
 `AdAccountsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -30,6 +32,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.pinterest.types.AdAccountsEqCondition | airbyte_agent_sdk.connectors.pinterest.types.AdAccountsNeqCondition | airbyte_agent_sdk.connectors.pinterest.types.AdAccountsGtCondition | airbyte_agent_sdk.connectors.pinterest.types.AdAccountsGteCondition | airbyte_agent_sdk.connectors.pinterest.types.AdAccountsLtCondition | airbyte_agent_sdk.connectors.pinterest.types.AdAccountsLteCondition | airbyte_agent_sdk.connectors.pinterest.types.AdAccountsInCondition | airbyte_agent_sdk.connectors.pinterest.types.AdAccountsLikeCondition | airbyte_agent_sdk.connectors.pinterest.types.AdAccountsFuzzyCondition | airbyte_agent_sdk.connectors.pinterest.types.AdAccountsKeywordCondition | airbyte_agent_sdk.connectors.pinterest.types.AdAccountsContainsCondition | airbyte_agent_sdk.connectors.pinterest.types.AdAccountsNotCondition | airbyte_agent_sdk.connectors.pinterest.types.AdAccountsAndCondition | airbyte_agent_sdk.connectors.pinterest.types.AdAccountsOrCondition | airbyte_agent_sdk.connectors.pinterest.types.AdAccountsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="AdAccountsAnyCondition"></a>
+
 `AdAccountsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -49,6 +53,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.pinterest.types.AdAccountsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="AdAccountsAnyValueFilter"></a>
 
 `AdAccountsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -83,6 +89,8 @@ Classes
     `updated_time: Any`
     :   Timestamp when the ad account was last updated (Unix seconds)
 
+<a id="AdAccountsContainsCondition"></a>
+
 `AdAccountsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -94,6 +102,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.pinterest.types.AdAccountsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="AdAccountsEqCondition"></a>
 
 `AdAccountsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -107,6 +117,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.pinterest.types.AdAccountsSearchFilter`
     :   The type of the None singleton.
 
+<a id="AdAccountsFuzzyCondition"></a>
+
 `AdAccountsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -118,6 +130,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.pinterest.types.AdAccountsStringFilter`
     :   The type of the None singleton.
+
+<a id="AdAccountsGetParams"></a>
 
 `AdAccountsGetParams(*args, **kwargs)`
 :   Parameters for ad_accounts.get operation
@@ -131,6 +145,8 @@ Classes
     `ad_account_id: str`
     :   The type of the None singleton.
 
+<a id="AdAccountsGtCondition"></a>
+
 `AdAccountsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -143,6 +159,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.pinterest.types.AdAccountsSearchFilter`
     :   The type of the None singleton.
 
+<a id="AdAccountsGteCondition"></a>
+
 `AdAccountsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -154,6 +172,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.pinterest.types.AdAccountsSearchFilter`
     :   The type of the None singleton.
+
+<a id="AdAccountsInCondition"></a>
 
 `AdAccountsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -174,6 +194,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.pinterest.types.AdAccountsInFilter`
     :   The type of the None singleton.
+
+<a id="AdAccountsInFilter"></a>
 
 `AdAccountsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -208,6 +230,8 @@ Classes
     `updated_time: list[int]`
     :   Timestamp when the ad account was last updated (Unix seconds)
 
+<a id="AdAccountsKeywordCondition"></a>
+
 `AdAccountsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -220,6 +244,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.pinterest.types.AdAccountsStringFilter`
     :   The type of the None singleton.
 
+<a id="AdAccountsLikeCondition"></a>
+
 `AdAccountsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -231,6 +257,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.pinterest.types.AdAccountsStringFilter`
     :   The type of the None singleton.
+
+<a id="AdAccountsListParams"></a>
 
 `AdAccountsListParams(*args, **kwargs)`
 :   Parameters for ad_accounts.list operation
@@ -250,6 +278,8 @@ Classes
     `page_size: int`
     :   The type of the None singleton.
 
+<a id="AdAccountsLtCondition"></a>
+
 `AdAccountsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -261,6 +291,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.pinterest.types.AdAccountsSearchFilter`
     :   The type of the None singleton.
+
+<a id="AdAccountsLteCondition"></a>
 
 `AdAccountsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -274,6 +306,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.pinterest.types.AdAccountsSearchFilter`
     :   The type of the None singleton.
 
+<a id="AdAccountsNeqCondition"></a>
+
 `AdAccountsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -285,6 +319,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.pinterest.types.AdAccountsSearchFilter`
     :   The type of the None singleton.
+
+<a id="AdAccountsNotCondition"></a>
 
 `AdAccountsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -306,6 +342,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.pinterest.types.AdAccountsEqCondition | airbyte_agent_sdk.connectors.pinterest.types.AdAccountsNeqCondition | airbyte_agent_sdk.connectors.pinterest.types.AdAccountsGtCondition | airbyte_agent_sdk.connectors.pinterest.types.AdAccountsGteCondition | airbyte_agent_sdk.connectors.pinterest.types.AdAccountsLtCondition | airbyte_agent_sdk.connectors.pinterest.types.AdAccountsLteCondition | airbyte_agent_sdk.connectors.pinterest.types.AdAccountsInCondition | airbyte_agent_sdk.connectors.pinterest.types.AdAccountsLikeCondition | airbyte_agent_sdk.connectors.pinterest.types.AdAccountsFuzzyCondition | airbyte_agent_sdk.connectors.pinterest.types.AdAccountsKeywordCondition | airbyte_agent_sdk.connectors.pinterest.types.AdAccountsContainsCondition | airbyte_agent_sdk.connectors.pinterest.types.AdAccountsNotCondition | airbyte_agent_sdk.connectors.pinterest.types.AdAccountsAndCondition | airbyte_agent_sdk.connectors.pinterest.types.AdAccountsOrCondition | airbyte_agent_sdk.connectors.pinterest.types.AdAccountsAnyCondition`
     :   The type of the None singleton.
 
+<a id="AdAccountsOrCondition"></a>
+
 `AdAccountsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -325,6 +363,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.pinterest.types.AdAccountsEqCondition | airbyte_agent_sdk.connectors.pinterest.types.AdAccountsNeqCondition | airbyte_agent_sdk.connectors.pinterest.types.AdAccountsGtCondition | airbyte_agent_sdk.connectors.pinterest.types.AdAccountsGteCondition | airbyte_agent_sdk.connectors.pinterest.types.AdAccountsLtCondition | airbyte_agent_sdk.connectors.pinterest.types.AdAccountsLteCondition | airbyte_agent_sdk.connectors.pinterest.types.AdAccountsInCondition | airbyte_agent_sdk.connectors.pinterest.types.AdAccountsLikeCondition | airbyte_agent_sdk.connectors.pinterest.types.AdAccountsFuzzyCondition | airbyte_agent_sdk.connectors.pinterest.types.AdAccountsKeywordCondition | airbyte_agent_sdk.connectors.pinterest.types.AdAccountsContainsCondition | airbyte_agent_sdk.connectors.pinterest.types.AdAccountsNotCondition | airbyte_agent_sdk.connectors.pinterest.types.AdAccountsAndCondition | airbyte_agent_sdk.connectors.pinterest.types.AdAccountsOrCondition | airbyte_agent_sdk.connectors.pinterest.types.AdAccountsAnyCondition]`
     :   The type of the None singleton.
+
+<a id="AdAccountsSearchFilter"></a>
 
 `AdAccountsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering ad_accounts search queries.
@@ -359,6 +399,8 @@ Classes
     `updated_time: int | None`
     :   Timestamp when the ad account was last updated (Unix seconds)
 
+<a id="AdAccountsSearchQuery"></a>
+
 `AdAccountsSearchQuery(*args, **kwargs)`
 :   Search query for ad_accounts entity.
 
@@ -373,6 +415,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.pinterest.types.AdAccountsSortFilter]`
     :   The type of the None singleton.
+
+<a id="AdAccountsSortFilter"></a>
 
 `AdAccountsSortFilter(*args, **kwargs)`
 :   Available fields for sorting ad_accounts search results.
@@ -407,6 +451,8 @@ Classes
     `updated_time: Literal['asc', 'desc']`
     :   Timestamp when the ad account was last updated (Unix seconds)
 
+<a id="AdAccountsStringFilter"></a>
+
 `AdAccountsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -440,6 +486,8 @@ Classes
     `updated_time: str`
     :   Timestamp when the ad account was last updated (Unix seconds)
 
+<a id="AdGroupsAndCondition"></a>
+
 `AdGroupsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -460,6 +508,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.pinterest.types.AdGroupsEqCondition | airbyte_agent_sdk.connectors.pinterest.types.AdGroupsNeqCondition | airbyte_agent_sdk.connectors.pinterest.types.AdGroupsGtCondition | airbyte_agent_sdk.connectors.pinterest.types.AdGroupsGteCondition | airbyte_agent_sdk.connectors.pinterest.types.AdGroupsLtCondition | airbyte_agent_sdk.connectors.pinterest.types.AdGroupsLteCondition | airbyte_agent_sdk.connectors.pinterest.types.AdGroupsInCondition | airbyte_agent_sdk.connectors.pinterest.types.AdGroupsLikeCondition | airbyte_agent_sdk.connectors.pinterest.types.AdGroupsFuzzyCondition | airbyte_agent_sdk.connectors.pinterest.types.AdGroupsKeywordCondition | airbyte_agent_sdk.connectors.pinterest.types.AdGroupsContainsCondition | airbyte_agent_sdk.connectors.pinterest.types.AdGroupsNotCondition | airbyte_agent_sdk.connectors.pinterest.types.AdGroupsAndCondition | airbyte_agent_sdk.connectors.pinterest.types.AdGroupsOrCondition | airbyte_agent_sdk.connectors.pinterest.types.AdGroupsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="AdGroupsAnyCondition"></a>
+
 `AdGroupsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -479,6 +529,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.pinterest.types.AdGroupsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="AdGroupsAnyValueFilter"></a>
 
 `AdGroupsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -564,6 +616,8 @@ Classes
     `updated_time: Any`
     :   Last update timestamp (Unix seconds)
 
+<a id="AdGroupsContainsCondition"></a>
+
 `AdGroupsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -575,6 +629,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.pinterest.types.AdGroupsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="AdGroupsEqCondition"></a>
 
 `AdGroupsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -588,6 +644,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.pinterest.types.AdGroupsSearchFilter`
     :   The type of the None singleton.
 
+<a id="AdGroupsFuzzyCondition"></a>
+
 `AdGroupsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -599,6 +657,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.pinterest.types.AdGroupsStringFilter`
     :   The type of the None singleton.
+
+<a id="AdGroupsGtCondition"></a>
 
 `AdGroupsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
@@ -612,6 +672,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.pinterest.types.AdGroupsSearchFilter`
     :   The type of the None singleton.
 
+<a id="AdGroupsGteCondition"></a>
+
 `AdGroupsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -623,6 +685,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.pinterest.types.AdGroupsSearchFilter`
     :   The type of the None singleton.
+
+<a id="AdGroupsInCondition"></a>
 
 `AdGroupsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -643,6 +707,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.pinterest.types.AdGroupsInFilter`
     :   The type of the None singleton.
+
+<a id="AdGroupsInFilter"></a>
 
 `AdGroupsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -728,6 +794,8 @@ Classes
     `updated_time: list[float]`
     :   Last update timestamp (Unix seconds)
 
+<a id="AdGroupsKeywordCondition"></a>
+
 `AdGroupsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -740,6 +808,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.pinterest.types.AdGroupsStringFilter`
     :   The type of the None singleton.
 
+<a id="AdGroupsLikeCondition"></a>
+
 `AdGroupsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -751,6 +821,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.pinterest.types.AdGroupsStringFilter`
     :   The type of the None singleton.
+
+<a id="AdGroupsListParams"></a>
 
 `AdGroupsListParams(*args, **kwargs)`
 :   Parameters for ad_groups.list operation
@@ -776,6 +848,8 @@ Classes
     `page_size: int`
     :   The type of the None singleton.
 
+<a id="AdGroupsLtCondition"></a>
+
 `AdGroupsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -787,6 +861,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.pinterest.types.AdGroupsSearchFilter`
     :   The type of the None singleton.
+
+<a id="AdGroupsLteCondition"></a>
 
 `AdGroupsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -800,6 +876,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.pinterest.types.AdGroupsSearchFilter`
     :   The type of the None singleton.
 
+<a id="AdGroupsNeqCondition"></a>
+
 `AdGroupsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -811,6 +889,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.pinterest.types.AdGroupsSearchFilter`
     :   The type of the None singleton.
+
+<a id="AdGroupsNotCondition"></a>
 
 `AdGroupsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -832,6 +912,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.pinterest.types.AdGroupsEqCondition | airbyte_agent_sdk.connectors.pinterest.types.AdGroupsNeqCondition | airbyte_agent_sdk.connectors.pinterest.types.AdGroupsGtCondition | airbyte_agent_sdk.connectors.pinterest.types.AdGroupsGteCondition | airbyte_agent_sdk.connectors.pinterest.types.AdGroupsLtCondition | airbyte_agent_sdk.connectors.pinterest.types.AdGroupsLteCondition | airbyte_agent_sdk.connectors.pinterest.types.AdGroupsInCondition | airbyte_agent_sdk.connectors.pinterest.types.AdGroupsLikeCondition | airbyte_agent_sdk.connectors.pinterest.types.AdGroupsFuzzyCondition | airbyte_agent_sdk.connectors.pinterest.types.AdGroupsKeywordCondition | airbyte_agent_sdk.connectors.pinterest.types.AdGroupsContainsCondition | airbyte_agent_sdk.connectors.pinterest.types.AdGroupsNotCondition | airbyte_agent_sdk.connectors.pinterest.types.AdGroupsAndCondition | airbyte_agent_sdk.connectors.pinterest.types.AdGroupsOrCondition | airbyte_agent_sdk.connectors.pinterest.types.AdGroupsAnyCondition`
     :   The type of the None singleton.
 
+<a id="AdGroupsOrCondition"></a>
+
 `AdGroupsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -851,6 +933,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.pinterest.types.AdGroupsEqCondition | airbyte_agent_sdk.connectors.pinterest.types.AdGroupsNeqCondition | airbyte_agent_sdk.connectors.pinterest.types.AdGroupsGtCondition | airbyte_agent_sdk.connectors.pinterest.types.AdGroupsGteCondition | airbyte_agent_sdk.connectors.pinterest.types.AdGroupsLtCondition | airbyte_agent_sdk.connectors.pinterest.types.AdGroupsLteCondition | airbyte_agent_sdk.connectors.pinterest.types.AdGroupsInCondition | airbyte_agent_sdk.connectors.pinterest.types.AdGroupsLikeCondition | airbyte_agent_sdk.connectors.pinterest.types.AdGroupsFuzzyCondition | airbyte_agent_sdk.connectors.pinterest.types.AdGroupsKeywordCondition | airbyte_agent_sdk.connectors.pinterest.types.AdGroupsContainsCondition | airbyte_agent_sdk.connectors.pinterest.types.AdGroupsNotCondition | airbyte_agent_sdk.connectors.pinterest.types.AdGroupsAndCondition | airbyte_agent_sdk.connectors.pinterest.types.AdGroupsOrCondition | airbyte_agent_sdk.connectors.pinterest.types.AdGroupsAnyCondition]`
     :   The type of the None singleton.
+
+<a id="AdGroupsSearchFilter"></a>
 
 `AdGroupsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering ad_groups search queries.
@@ -936,6 +1020,8 @@ Classes
     `updated_time: float | None`
     :   Last update timestamp (Unix seconds)
 
+<a id="AdGroupsSearchQuery"></a>
+
 `AdGroupsSearchQuery(*args, **kwargs)`
 :   Search query for ad_groups entity.
 
@@ -950,6 +1036,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.pinterest.types.AdGroupsSortFilter]`
     :   The type of the None singleton.
+
+<a id="AdGroupsSortFilter"></a>
 
 `AdGroupsSortFilter(*args, **kwargs)`
 :   Available fields for sorting ad_groups search results.
@@ -1035,6 +1123,8 @@ Classes
     `updated_time: Literal['asc', 'desc']`
     :   Last update timestamp (Unix seconds)
 
+<a id="AdGroupsStringFilter"></a>
+
 `AdGroupsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -1119,6 +1209,8 @@ Classes
     `updated_time: str`
     :   Last update timestamp (Unix seconds)
 
+<a id="AdsAndCondition"></a>
+
 `AdsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1139,6 +1231,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.pinterest.types.AdsEqCondition | airbyte_agent_sdk.connectors.pinterest.types.AdsNeqCondition | airbyte_agent_sdk.connectors.pinterest.types.AdsGtCondition | airbyte_agent_sdk.connectors.pinterest.types.AdsGteCondition | airbyte_agent_sdk.connectors.pinterest.types.AdsLtCondition | airbyte_agent_sdk.connectors.pinterest.types.AdsLteCondition | airbyte_agent_sdk.connectors.pinterest.types.AdsInCondition | airbyte_agent_sdk.connectors.pinterest.types.AdsLikeCondition | airbyte_agent_sdk.connectors.pinterest.types.AdsFuzzyCondition | airbyte_agent_sdk.connectors.pinterest.types.AdsKeywordCondition | airbyte_agent_sdk.connectors.pinterest.types.AdsContainsCondition | airbyte_agent_sdk.connectors.pinterest.types.AdsNotCondition | airbyte_agent_sdk.connectors.pinterest.types.AdsAndCondition | airbyte_agent_sdk.connectors.pinterest.types.AdsOrCondition | airbyte_agent_sdk.connectors.pinterest.types.AdsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="AdsAnyCondition"></a>
+
 `AdsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1158,6 +1252,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.pinterest.types.AdsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="AdsAnyValueFilter"></a>
 
 `AdsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -1252,6 +1348,8 @@ Classes
     `view_tracking_url: Any`
     :   View tracking URL
 
+<a id="AdsContainsCondition"></a>
+
 `AdsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -1263,6 +1361,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.pinterest.types.AdsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="AdsEqCondition"></a>
 
 `AdsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -1276,6 +1376,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.pinterest.types.AdsSearchFilter`
     :   The type of the None singleton.
 
+<a id="AdsFuzzyCondition"></a>
+
 `AdsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -1287,6 +1389,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.pinterest.types.AdsStringFilter`
     :   The type of the None singleton.
+
+<a id="AdsGtCondition"></a>
 
 `AdsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
@@ -1300,6 +1404,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.pinterest.types.AdsSearchFilter`
     :   The type of the None singleton.
 
+<a id="AdsGteCondition"></a>
+
 `AdsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -1311,6 +1417,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.pinterest.types.AdsSearchFilter`
     :   The type of the None singleton.
+
+<a id="AdsInCondition"></a>
 
 `AdsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -1331,6 +1439,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.pinterest.types.AdsInFilter`
     :   The type of the None singleton.
+
+<a id="AdsInFilter"></a>
 
 `AdsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -1425,6 +1535,8 @@ Classes
     `view_tracking_url: list[str]`
     :   View tracking URL
 
+<a id="AdsKeywordCondition"></a>
+
 `AdsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -1437,6 +1549,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.pinterest.types.AdsStringFilter`
     :   The type of the None singleton.
 
+<a id="AdsLikeCondition"></a>
+
 `AdsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -1448,6 +1562,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.pinterest.types.AdsStringFilter`
     :   The type of the None singleton.
+
+<a id="AdsListParams"></a>
 
 `AdsListParams(*args, **kwargs)`
 :   Parameters for ads.list operation
@@ -1473,6 +1589,8 @@ Classes
     `page_size: int`
     :   The type of the None singleton.
 
+<a id="AdsLtCondition"></a>
+
 `AdsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -1484,6 +1602,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.pinterest.types.AdsSearchFilter`
     :   The type of the None singleton.
+
+<a id="AdsLteCondition"></a>
 
 `AdsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -1497,6 +1617,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.pinterest.types.AdsSearchFilter`
     :   The type of the None singleton.
 
+<a id="AdsNeqCondition"></a>
+
 `AdsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -1508,6 +1630,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.pinterest.types.AdsSearchFilter`
     :   The type of the None singleton.
+
+<a id="AdsNotCondition"></a>
 
 `AdsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -1529,6 +1653,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.pinterest.types.AdsEqCondition | airbyte_agent_sdk.connectors.pinterest.types.AdsNeqCondition | airbyte_agent_sdk.connectors.pinterest.types.AdsGtCondition | airbyte_agent_sdk.connectors.pinterest.types.AdsGteCondition | airbyte_agent_sdk.connectors.pinterest.types.AdsLtCondition | airbyte_agent_sdk.connectors.pinterest.types.AdsLteCondition | airbyte_agent_sdk.connectors.pinterest.types.AdsInCondition | airbyte_agent_sdk.connectors.pinterest.types.AdsLikeCondition | airbyte_agent_sdk.connectors.pinterest.types.AdsFuzzyCondition | airbyte_agent_sdk.connectors.pinterest.types.AdsKeywordCondition | airbyte_agent_sdk.connectors.pinterest.types.AdsContainsCondition | airbyte_agent_sdk.connectors.pinterest.types.AdsNotCondition | airbyte_agent_sdk.connectors.pinterest.types.AdsAndCondition | airbyte_agent_sdk.connectors.pinterest.types.AdsOrCondition | airbyte_agent_sdk.connectors.pinterest.types.AdsAnyCondition`
     :   The type of the None singleton.
 
+<a id="AdsOrCondition"></a>
+
 `AdsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1548,6 +1674,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.pinterest.types.AdsEqCondition | airbyte_agent_sdk.connectors.pinterest.types.AdsNeqCondition | airbyte_agent_sdk.connectors.pinterest.types.AdsGtCondition | airbyte_agent_sdk.connectors.pinterest.types.AdsGteCondition | airbyte_agent_sdk.connectors.pinterest.types.AdsLtCondition | airbyte_agent_sdk.connectors.pinterest.types.AdsLteCondition | airbyte_agent_sdk.connectors.pinterest.types.AdsInCondition | airbyte_agent_sdk.connectors.pinterest.types.AdsLikeCondition | airbyte_agent_sdk.connectors.pinterest.types.AdsFuzzyCondition | airbyte_agent_sdk.connectors.pinterest.types.AdsKeywordCondition | airbyte_agent_sdk.connectors.pinterest.types.AdsContainsCondition | airbyte_agent_sdk.connectors.pinterest.types.AdsNotCondition | airbyte_agent_sdk.connectors.pinterest.types.AdsAndCondition | airbyte_agent_sdk.connectors.pinterest.types.AdsOrCondition | airbyte_agent_sdk.connectors.pinterest.types.AdsAnyCondition]`
     :   The type of the None singleton.
+
+<a id="AdsSearchFilter"></a>
 
 `AdsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering ads search queries.
@@ -1642,6 +1770,8 @@ Classes
     `view_tracking_url: str | None`
     :   View tracking URL
 
+<a id="AdsSearchQuery"></a>
+
 `AdsSearchQuery(*args, **kwargs)`
 :   Search query for ads entity.
 
@@ -1656,6 +1786,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.pinterest.types.AdsSortFilter]`
     :   The type of the None singleton.
+
+<a id="AdsSortFilter"></a>
 
 `AdsSortFilter(*args, **kwargs)`
 :   Available fields for sorting ads search results.
@@ -1750,6 +1882,8 @@ Classes
     `view_tracking_url: Literal['asc', 'desc']`
     :   View tracking URL
 
+<a id="AdsStringFilter"></a>
+
 `AdsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -1843,6 +1977,8 @@ Classes
     `view_tracking_url: str`
     :   View tracking URL
 
+<a id="AirbyteSearchParams"></a>
+
 `AirbyteSearchParams(*args, **kwargs)`
 :   Parameters for Airbyte cache search operations (generic, use entity-specific query types for better type hints).
 
@@ -1864,6 +2000,8 @@ Classes
     `query: dict[str, typing.Any]`
     :   The type of the None singleton.
 
+<a id="AudiencesAndCondition"></a>
+
 `AudiencesAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1884,6 +2022,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.pinterest.types.AudiencesEqCondition | airbyte_agent_sdk.connectors.pinterest.types.AudiencesNeqCondition | airbyte_agent_sdk.connectors.pinterest.types.AudiencesGtCondition | airbyte_agent_sdk.connectors.pinterest.types.AudiencesGteCondition | airbyte_agent_sdk.connectors.pinterest.types.AudiencesLtCondition | airbyte_agent_sdk.connectors.pinterest.types.AudiencesLteCondition | airbyte_agent_sdk.connectors.pinterest.types.AudiencesInCondition | airbyte_agent_sdk.connectors.pinterest.types.AudiencesLikeCondition | airbyte_agent_sdk.connectors.pinterest.types.AudiencesFuzzyCondition | airbyte_agent_sdk.connectors.pinterest.types.AudiencesKeywordCondition | airbyte_agent_sdk.connectors.pinterest.types.AudiencesContainsCondition | airbyte_agent_sdk.connectors.pinterest.types.AudiencesNotCondition | airbyte_agent_sdk.connectors.pinterest.types.AudiencesAndCondition | airbyte_agent_sdk.connectors.pinterest.types.AudiencesOrCondition | airbyte_agent_sdk.connectors.pinterest.types.AudiencesAnyCondition]`
     :   The type of the None singleton.
 
+<a id="AudiencesAnyCondition"></a>
+
 `AudiencesAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1903,6 +2043,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.pinterest.types.AudiencesAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="AudiencesAnyValueFilter"></a>
 
 `AudiencesAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -1946,6 +2088,8 @@ Classes
     `updated_timestamp: Any`
     :   Last update time (Unix seconds)
 
+<a id="AudiencesContainsCondition"></a>
+
 `AudiencesContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -1957,6 +2101,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.pinterest.types.AudiencesAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="AudiencesEqCondition"></a>
 
 `AudiencesEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -1970,6 +2116,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.pinterest.types.AudiencesSearchFilter`
     :   The type of the None singleton.
 
+<a id="AudiencesFuzzyCondition"></a>
+
 `AudiencesFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -1981,6 +2129,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.pinterest.types.AudiencesStringFilter`
     :   The type of the None singleton.
+
+<a id="AudiencesGtCondition"></a>
 
 `AudiencesGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
@@ -1994,6 +2144,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.pinterest.types.AudiencesSearchFilter`
     :   The type of the None singleton.
 
+<a id="AudiencesGteCondition"></a>
+
 `AudiencesGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -2005,6 +2157,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.pinterest.types.AudiencesSearchFilter`
     :   The type of the None singleton.
+
+<a id="AudiencesInCondition"></a>
 
 `AudiencesInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -2025,6 +2179,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.pinterest.types.AudiencesInFilter`
     :   The type of the None singleton.
+
+<a id="AudiencesInFilter"></a>
 
 `AudiencesInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -2068,6 +2224,8 @@ Classes
     `updated_timestamp: list[int]`
     :   Last update time (Unix seconds)
 
+<a id="AudiencesKeywordCondition"></a>
+
 `AudiencesKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -2080,6 +2238,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.pinterest.types.AudiencesStringFilter`
     :   The type of the None singleton.
 
+<a id="AudiencesLikeCondition"></a>
+
 `AudiencesLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -2091,6 +2251,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.pinterest.types.AudiencesStringFilter`
     :   The type of the None singleton.
+
+<a id="AudiencesListParams"></a>
 
 `AudiencesListParams(*args, **kwargs)`
 :   Parameters for audiences.list operation
@@ -2110,6 +2272,8 @@ Classes
     `page_size: int`
     :   The type of the None singleton.
 
+<a id="AudiencesLtCondition"></a>
+
 `AudiencesLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -2121,6 +2285,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.pinterest.types.AudiencesSearchFilter`
     :   The type of the None singleton.
+
+<a id="AudiencesLteCondition"></a>
 
 `AudiencesLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -2134,6 +2300,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.pinterest.types.AudiencesSearchFilter`
     :   The type of the None singleton.
 
+<a id="AudiencesNeqCondition"></a>
+
 `AudiencesNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -2145,6 +2313,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.pinterest.types.AudiencesSearchFilter`
     :   The type of the None singleton.
+
+<a id="AudiencesNotCondition"></a>
 
 `AudiencesNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -2166,6 +2336,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.pinterest.types.AudiencesEqCondition | airbyte_agent_sdk.connectors.pinterest.types.AudiencesNeqCondition | airbyte_agent_sdk.connectors.pinterest.types.AudiencesGtCondition | airbyte_agent_sdk.connectors.pinterest.types.AudiencesGteCondition | airbyte_agent_sdk.connectors.pinterest.types.AudiencesLtCondition | airbyte_agent_sdk.connectors.pinterest.types.AudiencesLteCondition | airbyte_agent_sdk.connectors.pinterest.types.AudiencesInCondition | airbyte_agent_sdk.connectors.pinterest.types.AudiencesLikeCondition | airbyte_agent_sdk.connectors.pinterest.types.AudiencesFuzzyCondition | airbyte_agent_sdk.connectors.pinterest.types.AudiencesKeywordCondition | airbyte_agent_sdk.connectors.pinterest.types.AudiencesContainsCondition | airbyte_agent_sdk.connectors.pinterest.types.AudiencesNotCondition | airbyte_agent_sdk.connectors.pinterest.types.AudiencesAndCondition | airbyte_agent_sdk.connectors.pinterest.types.AudiencesOrCondition | airbyte_agent_sdk.connectors.pinterest.types.AudiencesAnyCondition`
     :   The type of the None singleton.
 
+<a id="AudiencesOrCondition"></a>
+
 `AudiencesOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -2185,6 +2357,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.pinterest.types.AudiencesEqCondition | airbyte_agent_sdk.connectors.pinterest.types.AudiencesNeqCondition | airbyte_agent_sdk.connectors.pinterest.types.AudiencesGtCondition | airbyte_agent_sdk.connectors.pinterest.types.AudiencesGteCondition | airbyte_agent_sdk.connectors.pinterest.types.AudiencesLtCondition | airbyte_agent_sdk.connectors.pinterest.types.AudiencesLteCondition | airbyte_agent_sdk.connectors.pinterest.types.AudiencesInCondition | airbyte_agent_sdk.connectors.pinterest.types.AudiencesLikeCondition | airbyte_agent_sdk.connectors.pinterest.types.AudiencesFuzzyCondition | airbyte_agent_sdk.connectors.pinterest.types.AudiencesKeywordCondition | airbyte_agent_sdk.connectors.pinterest.types.AudiencesContainsCondition | airbyte_agent_sdk.connectors.pinterest.types.AudiencesNotCondition | airbyte_agent_sdk.connectors.pinterest.types.AudiencesAndCondition | airbyte_agent_sdk.connectors.pinterest.types.AudiencesOrCondition | airbyte_agent_sdk.connectors.pinterest.types.AudiencesAnyCondition]`
     :   The type of the None singleton.
+
+<a id="AudiencesSearchFilter"></a>
 
 `AudiencesSearchFilter(*args, **kwargs)`
 :   Available fields for filtering audiences search queries.
@@ -2228,6 +2402,8 @@ Classes
     `updated_timestamp: int | None`
     :   Last update time (Unix seconds)
 
+<a id="AudiencesSearchQuery"></a>
+
 `AudiencesSearchQuery(*args, **kwargs)`
 :   Search query for audiences entity.
 
@@ -2242,6 +2418,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.pinterest.types.AudiencesSortFilter]`
     :   The type of the None singleton.
+
+<a id="AudiencesSortFilter"></a>
 
 `AudiencesSortFilter(*args, **kwargs)`
 :   Available fields for sorting audiences search results.
@@ -2285,6 +2463,8 @@ Classes
     `updated_timestamp: Literal['asc', 'desc']`
     :   Last update time (Unix seconds)
 
+<a id="AudiencesStringFilter"></a>
+
 `AudiencesStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -2327,6 +2507,8 @@ Classes
     `updated_timestamp: str`
     :   Last update time (Unix seconds)
 
+<a id="BoardPinsAndCondition"></a>
+
 `BoardPinsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -2347,6 +2529,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.pinterest.types.BoardPinsEqCondition | airbyte_agent_sdk.connectors.pinterest.types.BoardPinsNeqCondition | airbyte_agent_sdk.connectors.pinterest.types.BoardPinsGtCondition | airbyte_agent_sdk.connectors.pinterest.types.BoardPinsGteCondition | airbyte_agent_sdk.connectors.pinterest.types.BoardPinsLtCondition | airbyte_agent_sdk.connectors.pinterest.types.BoardPinsLteCondition | airbyte_agent_sdk.connectors.pinterest.types.BoardPinsInCondition | airbyte_agent_sdk.connectors.pinterest.types.BoardPinsLikeCondition | airbyte_agent_sdk.connectors.pinterest.types.BoardPinsFuzzyCondition | airbyte_agent_sdk.connectors.pinterest.types.BoardPinsKeywordCondition | airbyte_agent_sdk.connectors.pinterest.types.BoardPinsContainsCondition | airbyte_agent_sdk.connectors.pinterest.types.BoardPinsNotCondition | airbyte_agent_sdk.connectors.pinterest.types.BoardPinsAndCondition | airbyte_agent_sdk.connectors.pinterest.types.BoardPinsOrCondition | airbyte_agent_sdk.connectors.pinterest.types.BoardPinsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="BoardPinsAnyCondition"></a>
+
 `BoardPinsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -2366,6 +2550,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.pinterest.types.BoardPinsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="BoardPinsAnyValueFilter"></a>
 
 `BoardPinsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -2427,6 +2613,8 @@ Classes
     `title: Any`
     :   Pin title
 
+<a id="BoardPinsContainsCondition"></a>
+
 `BoardPinsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -2438,6 +2626,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.pinterest.types.BoardPinsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="BoardPinsEqCondition"></a>
 
 `BoardPinsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -2451,6 +2641,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.pinterest.types.BoardPinsSearchFilter`
     :   The type of the None singleton.
 
+<a id="BoardPinsFuzzyCondition"></a>
+
 `BoardPinsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -2462,6 +2654,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.pinterest.types.BoardPinsStringFilter`
     :   The type of the None singleton.
+
+<a id="BoardPinsGtCondition"></a>
 
 `BoardPinsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
@@ -2475,6 +2669,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.pinterest.types.BoardPinsSearchFilter`
     :   The type of the None singleton.
 
+<a id="BoardPinsGteCondition"></a>
+
 `BoardPinsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -2486,6 +2682,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.pinterest.types.BoardPinsSearchFilter`
     :   The type of the None singleton.
+
+<a id="BoardPinsInCondition"></a>
 
 `BoardPinsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -2506,6 +2704,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.pinterest.types.BoardPinsInFilter`
     :   The type of the None singleton.
+
+<a id="BoardPinsInFilter"></a>
 
 `BoardPinsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -2567,6 +2767,8 @@ Classes
     `title: list[str]`
     :   Pin title
 
+<a id="BoardPinsKeywordCondition"></a>
+
 `BoardPinsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -2579,6 +2781,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.pinterest.types.BoardPinsStringFilter`
     :   The type of the None singleton.
 
+<a id="BoardPinsLikeCondition"></a>
+
 `BoardPinsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -2590,6 +2794,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.pinterest.types.BoardPinsStringFilter`
     :   The type of the None singleton.
+
+<a id="BoardPinsListParams"></a>
 
 `BoardPinsListParams(*args, **kwargs)`
 :   Parameters for board_pins.list operation
@@ -2609,6 +2815,8 @@ Classes
     `page_size: int`
     :   The type of the None singleton.
 
+<a id="BoardPinsLtCondition"></a>
+
 `BoardPinsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -2620,6 +2828,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.pinterest.types.BoardPinsSearchFilter`
     :   The type of the None singleton.
+
+<a id="BoardPinsLteCondition"></a>
 
 `BoardPinsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -2633,6 +2843,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.pinterest.types.BoardPinsSearchFilter`
     :   The type of the None singleton.
 
+<a id="BoardPinsNeqCondition"></a>
+
 `BoardPinsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -2644,6 +2856,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.pinterest.types.BoardPinsSearchFilter`
     :   The type of the None singleton.
+
+<a id="BoardPinsNotCondition"></a>
 
 `BoardPinsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -2665,6 +2879,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.pinterest.types.BoardPinsEqCondition | airbyte_agent_sdk.connectors.pinterest.types.BoardPinsNeqCondition | airbyte_agent_sdk.connectors.pinterest.types.BoardPinsGtCondition | airbyte_agent_sdk.connectors.pinterest.types.BoardPinsGteCondition | airbyte_agent_sdk.connectors.pinterest.types.BoardPinsLtCondition | airbyte_agent_sdk.connectors.pinterest.types.BoardPinsLteCondition | airbyte_agent_sdk.connectors.pinterest.types.BoardPinsInCondition | airbyte_agent_sdk.connectors.pinterest.types.BoardPinsLikeCondition | airbyte_agent_sdk.connectors.pinterest.types.BoardPinsFuzzyCondition | airbyte_agent_sdk.connectors.pinterest.types.BoardPinsKeywordCondition | airbyte_agent_sdk.connectors.pinterest.types.BoardPinsContainsCondition | airbyte_agent_sdk.connectors.pinterest.types.BoardPinsNotCondition | airbyte_agent_sdk.connectors.pinterest.types.BoardPinsAndCondition | airbyte_agent_sdk.connectors.pinterest.types.BoardPinsOrCondition | airbyte_agent_sdk.connectors.pinterest.types.BoardPinsAnyCondition`
     :   The type of the None singleton.
 
+<a id="BoardPinsOrCondition"></a>
+
 `BoardPinsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -2684,6 +2900,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.pinterest.types.BoardPinsEqCondition | airbyte_agent_sdk.connectors.pinterest.types.BoardPinsNeqCondition | airbyte_agent_sdk.connectors.pinterest.types.BoardPinsGtCondition | airbyte_agent_sdk.connectors.pinterest.types.BoardPinsGteCondition | airbyte_agent_sdk.connectors.pinterest.types.BoardPinsLtCondition | airbyte_agent_sdk.connectors.pinterest.types.BoardPinsLteCondition | airbyte_agent_sdk.connectors.pinterest.types.BoardPinsInCondition | airbyte_agent_sdk.connectors.pinterest.types.BoardPinsLikeCondition | airbyte_agent_sdk.connectors.pinterest.types.BoardPinsFuzzyCondition | airbyte_agent_sdk.connectors.pinterest.types.BoardPinsKeywordCondition | airbyte_agent_sdk.connectors.pinterest.types.BoardPinsContainsCondition | airbyte_agent_sdk.connectors.pinterest.types.BoardPinsNotCondition | airbyte_agent_sdk.connectors.pinterest.types.BoardPinsAndCondition | airbyte_agent_sdk.connectors.pinterest.types.BoardPinsOrCondition | airbyte_agent_sdk.connectors.pinterest.types.BoardPinsAnyCondition]`
     :   The type of the None singleton.
+
+<a id="BoardPinsSearchFilter"></a>
 
 `BoardPinsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering board_pins search queries.
@@ -2745,6 +2963,8 @@ Classes
     `title: str | None`
     :   Pin title
 
+<a id="BoardPinsSearchQuery"></a>
+
 `BoardPinsSearchQuery(*args, **kwargs)`
 :   Search query for board_pins entity.
 
@@ -2759,6 +2979,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.pinterest.types.BoardPinsSortFilter]`
     :   The type of the None singleton.
+
+<a id="BoardPinsSortFilter"></a>
 
 `BoardPinsSortFilter(*args, **kwargs)`
 :   Available fields for sorting board_pins search results.
@@ -2820,6 +3042,8 @@ Classes
     `title: Literal['asc', 'desc']`
     :   Pin title
 
+<a id="BoardPinsStringFilter"></a>
+
 `BoardPinsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -2880,6 +3104,8 @@ Classes
     `title: str`
     :   Pin title
 
+<a id="BoardSectionsAndCondition"></a>
+
 `BoardSectionsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -2899,6 +3125,8 @@ Classes
 
     `and: list[airbyte_agent_sdk.connectors.pinterest.types.BoardSectionsEqCondition | airbyte_agent_sdk.connectors.pinterest.types.BoardSectionsNeqCondition | airbyte_agent_sdk.connectors.pinterest.types.BoardSectionsGtCondition | airbyte_agent_sdk.connectors.pinterest.types.BoardSectionsGteCondition | airbyte_agent_sdk.connectors.pinterest.types.BoardSectionsLtCondition | airbyte_agent_sdk.connectors.pinterest.types.BoardSectionsLteCondition | airbyte_agent_sdk.connectors.pinterest.types.BoardSectionsInCondition | airbyte_agent_sdk.connectors.pinterest.types.BoardSectionsLikeCondition | airbyte_agent_sdk.connectors.pinterest.types.BoardSectionsFuzzyCondition | airbyte_agent_sdk.connectors.pinterest.types.BoardSectionsKeywordCondition | airbyte_agent_sdk.connectors.pinterest.types.BoardSectionsContainsCondition | airbyte_agent_sdk.connectors.pinterest.types.BoardSectionsNotCondition | airbyte_agent_sdk.connectors.pinterest.types.BoardSectionsAndCondition | airbyte_agent_sdk.connectors.pinterest.types.BoardSectionsOrCondition | airbyte_agent_sdk.connectors.pinterest.types.BoardSectionsAnyCondition]`
     :   The type of the None singleton.
+
+<a id="BoardSectionsAnyCondition"></a>
 
 `BoardSectionsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -2920,6 +3148,8 @@ Classes
     `any: airbyte_agent_sdk.connectors.pinterest.types.BoardSectionsAnyValueFilter`
     :   The type of the None singleton.
 
+<a id="BoardSectionsAnyValueFilter"></a>
+
 `BoardSectionsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
 
@@ -2935,6 +3165,8 @@ Classes
     `name: Any`
     :   Name of the board section
 
+<a id="BoardSectionsContainsCondition"></a>
+
 `BoardSectionsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -2946,6 +3178,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.pinterest.types.BoardSectionsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="BoardSectionsEqCondition"></a>
 
 `BoardSectionsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -2959,6 +3193,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.pinterest.types.BoardSectionsSearchFilter`
     :   The type of the None singleton.
 
+<a id="BoardSectionsFuzzyCondition"></a>
+
 `BoardSectionsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -2970,6 +3206,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.pinterest.types.BoardSectionsStringFilter`
     :   The type of the None singleton.
+
+<a id="BoardSectionsGtCondition"></a>
 
 `BoardSectionsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
@@ -2983,6 +3221,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.pinterest.types.BoardSectionsSearchFilter`
     :   The type of the None singleton.
 
+<a id="BoardSectionsGteCondition"></a>
+
 `BoardSectionsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -2994,6 +3234,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.pinterest.types.BoardSectionsSearchFilter`
     :   The type of the None singleton.
+
+<a id="BoardSectionsInCondition"></a>
 
 `BoardSectionsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -3015,6 +3257,8 @@ Classes
     `in: airbyte_agent_sdk.connectors.pinterest.types.BoardSectionsInFilter`
     :   The type of the None singleton.
 
+<a id="BoardSectionsInFilter"></a>
+
 `BoardSectionsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
 
@@ -3030,6 +3274,8 @@ Classes
     `name: list[str]`
     :   Name of the board section
 
+<a id="BoardSectionsKeywordCondition"></a>
+
 `BoardSectionsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -3042,6 +3288,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.pinterest.types.BoardSectionsStringFilter`
     :   The type of the None singleton.
 
+<a id="BoardSectionsLikeCondition"></a>
+
 `BoardSectionsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -3053,6 +3301,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.pinterest.types.BoardSectionsStringFilter`
     :   The type of the None singleton.
+
+<a id="BoardSectionsListParams"></a>
 
 `BoardSectionsListParams(*args, **kwargs)`
 :   Parameters for board_sections.list operation
@@ -3072,6 +3322,8 @@ Classes
     `page_size: int`
     :   The type of the None singleton.
 
+<a id="BoardSectionsLtCondition"></a>
+
 `BoardSectionsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -3083,6 +3335,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.pinterest.types.BoardSectionsSearchFilter`
     :   The type of the None singleton.
+
+<a id="BoardSectionsLteCondition"></a>
 
 `BoardSectionsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -3096,6 +3350,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.pinterest.types.BoardSectionsSearchFilter`
     :   The type of the None singleton.
 
+<a id="BoardSectionsNeqCondition"></a>
+
 `BoardSectionsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -3107,6 +3363,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.pinterest.types.BoardSectionsSearchFilter`
     :   The type of the None singleton.
+
+<a id="BoardSectionsNotCondition"></a>
 
 `BoardSectionsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -3128,6 +3386,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.pinterest.types.BoardSectionsEqCondition | airbyte_agent_sdk.connectors.pinterest.types.BoardSectionsNeqCondition | airbyte_agent_sdk.connectors.pinterest.types.BoardSectionsGtCondition | airbyte_agent_sdk.connectors.pinterest.types.BoardSectionsGteCondition | airbyte_agent_sdk.connectors.pinterest.types.BoardSectionsLtCondition | airbyte_agent_sdk.connectors.pinterest.types.BoardSectionsLteCondition | airbyte_agent_sdk.connectors.pinterest.types.BoardSectionsInCondition | airbyte_agent_sdk.connectors.pinterest.types.BoardSectionsLikeCondition | airbyte_agent_sdk.connectors.pinterest.types.BoardSectionsFuzzyCondition | airbyte_agent_sdk.connectors.pinterest.types.BoardSectionsKeywordCondition | airbyte_agent_sdk.connectors.pinterest.types.BoardSectionsContainsCondition | airbyte_agent_sdk.connectors.pinterest.types.BoardSectionsNotCondition | airbyte_agent_sdk.connectors.pinterest.types.BoardSectionsAndCondition | airbyte_agent_sdk.connectors.pinterest.types.BoardSectionsOrCondition | airbyte_agent_sdk.connectors.pinterest.types.BoardSectionsAnyCondition`
     :   The type of the None singleton.
 
+<a id="BoardSectionsOrCondition"></a>
+
 `BoardSectionsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -3148,6 +3408,8 @@ Classes
     `or: list[airbyte_agent_sdk.connectors.pinterest.types.BoardSectionsEqCondition | airbyte_agent_sdk.connectors.pinterest.types.BoardSectionsNeqCondition | airbyte_agent_sdk.connectors.pinterest.types.BoardSectionsGtCondition | airbyte_agent_sdk.connectors.pinterest.types.BoardSectionsGteCondition | airbyte_agent_sdk.connectors.pinterest.types.BoardSectionsLtCondition | airbyte_agent_sdk.connectors.pinterest.types.BoardSectionsLteCondition | airbyte_agent_sdk.connectors.pinterest.types.BoardSectionsInCondition | airbyte_agent_sdk.connectors.pinterest.types.BoardSectionsLikeCondition | airbyte_agent_sdk.connectors.pinterest.types.BoardSectionsFuzzyCondition | airbyte_agent_sdk.connectors.pinterest.types.BoardSectionsKeywordCondition | airbyte_agent_sdk.connectors.pinterest.types.BoardSectionsContainsCondition | airbyte_agent_sdk.connectors.pinterest.types.BoardSectionsNotCondition | airbyte_agent_sdk.connectors.pinterest.types.BoardSectionsAndCondition | airbyte_agent_sdk.connectors.pinterest.types.BoardSectionsOrCondition | airbyte_agent_sdk.connectors.pinterest.types.BoardSectionsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="BoardSectionsSearchFilter"></a>
+
 `BoardSectionsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering board_sections search queries.
 
@@ -3162,6 +3424,8 @@ Classes
 
     `name: str | None`
     :   Name of the board section
+
+<a id="BoardSectionsSearchQuery"></a>
 
 `BoardSectionsSearchQuery(*args, **kwargs)`
 :   Search query for board_sections entity.
@@ -3178,6 +3442,8 @@ Classes
     `sort: list[airbyte_agent_sdk.connectors.pinterest.types.BoardSectionsSortFilter]`
     :   The type of the None singleton.
 
+<a id="BoardSectionsSortFilter"></a>
+
 `BoardSectionsSortFilter(*args, **kwargs)`
 :   Available fields for sorting board_sections search results.
 
@@ -3193,6 +3459,8 @@ Classes
     `name: Literal['asc', 'desc']`
     :   Name of the board section
 
+<a id="BoardSectionsStringFilter"></a>
+
 `BoardSectionsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -3207,6 +3475,8 @@ Classes
 
     `name: str`
     :   Name of the board section
+
+<a id="BoardsAndCondition"></a>
 
 `BoardsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -3228,6 +3498,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.pinterest.types.BoardsEqCondition | airbyte_agent_sdk.connectors.pinterest.types.BoardsNeqCondition | airbyte_agent_sdk.connectors.pinterest.types.BoardsGtCondition | airbyte_agent_sdk.connectors.pinterest.types.BoardsGteCondition | airbyte_agent_sdk.connectors.pinterest.types.BoardsLtCondition | airbyte_agent_sdk.connectors.pinterest.types.BoardsLteCondition | airbyte_agent_sdk.connectors.pinterest.types.BoardsInCondition | airbyte_agent_sdk.connectors.pinterest.types.BoardsLikeCondition | airbyte_agent_sdk.connectors.pinterest.types.BoardsFuzzyCondition | airbyte_agent_sdk.connectors.pinterest.types.BoardsKeywordCondition | airbyte_agent_sdk.connectors.pinterest.types.BoardsContainsCondition | airbyte_agent_sdk.connectors.pinterest.types.BoardsNotCondition | airbyte_agent_sdk.connectors.pinterest.types.BoardsAndCondition | airbyte_agent_sdk.connectors.pinterest.types.BoardsOrCondition | airbyte_agent_sdk.connectors.pinterest.types.BoardsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="BoardsAnyCondition"></a>
+
 `BoardsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -3247,6 +3519,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.pinterest.types.BoardsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="BoardsAnyValueFilter"></a>
 
 `BoardsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -3290,6 +3564,8 @@ Classes
     `privacy: Any`
     :   Board privacy setting
 
+<a id="BoardsContainsCondition"></a>
+
 `BoardsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -3301,6 +3577,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.pinterest.types.BoardsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="BoardsEqCondition"></a>
 
 `BoardsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -3314,6 +3592,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.pinterest.types.BoardsSearchFilter`
     :   The type of the None singleton.
 
+<a id="BoardsFuzzyCondition"></a>
+
 `BoardsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -3325,6 +3605,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.pinterest.types.BoardsStringFilter`
     :   The type of the None singleton.
+
+<a id="BoardsGetParams"></a>
 
 `BoardsGetParams(*args, **kwargs)`
 :   Parameters for boards.get operation
@@ -3338,6 +3620,8 @@ Classes
     `board_id: str`
     :   The type of the None singleton.
 
+<a id="BoardsGtCondition"></a>
+
 `BoardsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -3350,6 +3634,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.pinterest.types.BoardsSearchFilter`
     :   The type of the None singleton.
 
+<a id="BoardsGteCondition"></a>
+
 `BoardsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -3361,6 +3647,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.pinterest.types.BoardsSearchFilter`
     :   The type of the None singleton.
+
+<a id="BoardsInCondition"></a>
 
 `BoardsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -3381,6 +3669,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.pinterest.types.BoardsInFilter`
     :   The type of the None singleton.
+
+<a id="BoardsInFilter"></a>
 
 `BoardsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -3424,6 +3714,8 @@ Classes
     `privacy: list[str]`
     :   Board privacy setting
 
+<a id="BoardsKeywordCondition"></a>
+
 `BoardsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -3436,6 +3728,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.pinterest.types.BoardsStringFilter`
     :   The type of the None singleton.
 
+<a id="BoardsLikeCondition"></a>
+
 `BoardsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -3447,6 +3741,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.pinterest.types.BoardsStringFilter`
     :   The type of the None singleton.
+
+<a id="BoardsListParams"></a>
 
 `BoardsListParams(*args, **kwargs)`
 :   Parameters for boards.list operation
@@ -3466,6 +3762,8 @@ Classes
     `privacy: str`
     :   The type of the None singleton.
 
+<a id="BoardsLtCondition"></a>
+
 `BoardsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -3477,6 +3775,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.pinterest.types.BoardsSearchFilter`
     :   The type of the None singleton.
+
+<a id="BoardsLteCondition"></a>
 
 `BoardsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -3490,6 +3790,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.pinterest.types.BoardsSearchFilter`
     :   The type of the None singleton.
 
+<a id="BoardsNeqCondition"></a>
+
 `BoardsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -3501,6 +3803,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.pinterest.types.BoardsSearchFilter`
     :   The type of the None singleton.
+
+<a id="BoardsNotCondition"></a>
 
 `BoardsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -3522,6 +3826,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.pinterest.types.BoardsEqCondition | airbyte_agent_sdk.connectors.pinterest.types.BoardsNeqCondition | airbyte_agent_sdk.connectors.pinterest.types.BoardsGtCondition | airbyte_agent_sdk.connectors.pinterest.types.BoardsGteCondition | airbyte_agent_sdk.connectors.pinterest.types.BoardsLtCondition | airbyte_agent_sdk.connectors.pinterest.types.BoardsLteCondition | airbyte_agent_sdk.connectors.pinterest.types.BoardsInCondition | airbyte_agent_sdk.connectors.pinterest.types.BoardsLikeCondition | airbyte_agent_sdk.connectors.pinterest.types.BoardsFuzzyCondition | airbyte_agent_sdk.connectors.pinterest.types.BoardsKeywordCondition | airbyte_agent_sdk.connectors.pinterest.types.BoardsContainsCondition | airbyte_agent_sdk.connectors.pinterest.types.BoardsNotCondition | airbyte_agent_sdk.connectors.pinterest.types.BoardsAndCondition | airbyte_agent_sdk.connectors.pinterest.types.BoardsOrCondition | airbyte_agent_sdk.connectors.pinterest.types.BoardsAnyCondition`
     :   The type of the None singleton.
 
+<a id="BoardsOrCondition"></a>
+
 `BoardsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -3541,6 +3847,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.pinterest.types.BoardsEqCondition | airbyte_agent_sdk.connectors.pinterest.types.BoardsNeqCondition | airbyte_agent_sdk.connectors.pinterest.types.BoardsGtCondition | airbyte_agent_sdk.connectors.pinterest.types.BoardsGteCondition | airbyte_agent_sdk.connectors.pinterest.types.BoardsLtCondition | airbyte_agent_sdk.connectors.pinterest.types.BoardsLteCondition | airbyte_agent_sdk.connectors.pinterest.types.BoardsInCondition | airbyte_agent_sdk.connectors.pinterest.types.BoardsLikeCondition | airbyte_agent_sdk.connectors.pinterest.types.BoardsFuzzyCondition | airbyte_agent_sdk.connectors.pinterest.types.BoardsKeywordCondition | airbyte_agent_sdk.connectors.pinterest.types.BoardsContainsCondition | airbyte_agent_sdk.connectors.pinterest.types.BoardsNotCondition | airbyte_agent_sdk.connectors.pinterest.types.BoardsAndCondition | airbyte_agent_sdk.connectors.pinterest.types.BoardsOrCondition | airbyte_agent_sdk.connectors.pinterest.types.BoardsAnyCondition]`
     :   The type of the None singleton.
+
+<a id="BoardsSearchFilter"></a>
 
 `BoardsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering boards search queries.
@@ -3584,6 +3892,8 @@ Classes
     `privacy: str | None`
     :   Board privacy setting
 
+<a id="BoardsSearchQuery"></a>
+
 `BoardsSearchQuery(*args, **kwargs)`
 :   Search query for boards entity.
 
@@ -3598,6 +3908,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.pinterest.types.BoardsSortFilter]`
     :   The type of the None singleton.
+
+<a id="BoardsSortFilter"></a>
 
 `BoardsSortFilter(*args, **kwargs)`
 :   Available fields for sorting boards search results.
@@ -3641,6 +3953,8 @@ Classes
     `privacy: Literal['asc', 'desc']`
     :   Board privacy setting
 
+<a id="BoardsStringFilter"></a>
+
 `BoardsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -3683,6 +3997,8 @@ Classes
     `privacy: str`
     :   Board privacy setting
 
+<a id="CampaignsAndCondition"></a>
+
 `CampaignsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -3703,6 +4019,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.pinterest.types.CampaignsEqCondition | airbyte_agent_sdk.connectors.pinterest.types.CampaignsNeqCondition | airbyte_agent_sdk.connectors.pinterest.types.CampaignsGtCondition | airbyte_agent_sdk.connectors.pinterest.types.CampaignsGteCondition | airbyte_agent_sdk.connectors.pinterest.types.CampaignsLtCondition | airbyte_agent_sdk.connectors.pinterest.types.CampaignsLteCondition | airbyte_agent_sdk.connectors.pinterest.types.CampaignsInCondition | airbyte_agent_sdk.connectors.pinterest.types.CampaignsLikeCondition | airbyte_agent_sdk.connectors.pinterest.types.CampaignsFuzzyCondition | airbyte_agent_sdk.connectors.pinterest.types.CampaignsKeywordCondition | airbyte_agent_sdk.connectors.pinterest.types.CampaignsContainsCondition | airbyte_agent_sdk.connectors.pinterest.types.CampaignsNotCondition | airbyte_agent_sdk.connectors.pinterest.types.CampaignsAndCondition | airbyte_agent_sdk.connectors.pinterest.types.CampaignsOrCondition | airbyte_agent_sdk.connectors.pinterest.types.CampaignsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="CampaignsAnyCondition"></a>
+
 `CampaignsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -3722,6 +4040,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.pinterest.types.CampaignsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="CampaignsAnyValueFilter"></a>
 
 `CampaignsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -3783,6 +4103,8 @@ Classes
     `updated_time: Any`
     :   Last update timestamp (Unix seconds)
 
+<a id="CampaignsContainsCondition"></a>
+
 `CampaignsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -3794,6 +4116,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.pinterest.types.CampaignsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="CampaignsEqCondition"></a>
 
 `CampaignsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -3807,6 +4131,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.pinterest.types.CampaignsSearchFilter`
     :   The type of the None singleton.
 
+<a id="CampaignsFuzzyCondition"></a>
+
 `CampaignsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -3818,6 +4144,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.pinterest.types.CampaignsStringFilter`
     :   The type of the None singleton.
+
+<a id="CampaignsGtCondition"></a>
 
 `CampaignsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
@@ -3831,6 +4159,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.pinterest.types.CampaignsSearchFilter`
     :   The type of the None singleton.
 
+<a id="CampaignsGteCondition"></a>
+
 `CampaignsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -3842,6 +4172,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.pinterest.types.CampaignsSearchFilter`
     :   The type of the None singleton.
+
+<a id="CampaignsInCondition"></a>
 
 `CampaignsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -3862,6 +4194,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.pinterest.types.CampaignsInFilter`
     :   The type of the None singleton.
+
+<a id="CampaignsInFilter"></a>
 
 `CampaignsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -3923,6 +4257,8 @@ Classes
     `updated_time: list[int]`
     :   Last update timestamp (Unix seconds)
 
+<a id="CampaignsKeywordCondition"></a>
+
 `CampaignsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -3935,6 +4271,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.pinterest.types.CampaignsStringFilter`
     :   The type of the None singleton.
 
+<a id="CampaignsLikeCondition"></a>
+
 `CampaignsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -3946,6 +4284,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.pinterest.types.CampaignsStringFilter`
     :   The type of the None singleton.
+
+<a id="CampaignsListParams"></a>
 
 `CampaignsListParams(*args, **kwargs)`
 :   Parameters for campaigns.list operation
@@ -3971,6 +4311,8 @@ Classes
     `page_size: int`
     :   The type of the None singleton.
 
+<a id="CampaignsLtCondition"></a>
+
 `CampaignsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -3982,6 +4324,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.pinterest.types.CampaignsSearchFilter`
     :   The type of the None singleton.
+
+<a id="CampaignsLteCondition"></a>
 
 `CampaignsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -3995,6 +4339,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.pinterest.types.CampaignsSearchFilter`
     :   The type of the None singleton.
 
+<a id="CampaignsNeqCondition"></a>
+
 `CampaignsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -4006,6 +4352,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.pinterest.types.CampaignsSearchFilter`
     :   The type of the None singleton.
+
+<a id="CampaignsNotCondition"></a>
 
 `CampaignsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -4027,6 +4375,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.pinterest.types.CampaignsEqCondition | airbyte_agent_sdk.connectors.pinterest.types.CampaignsNeqCondition | airbyte_agent_sdk.connectors.pinterest.types.CampaignsGtCondition | airbyte_agent_sdk.connectors.pinterest.types.CampaignsGteCondition | airbyte_agent_sdk.connectors.pinterest.types.CampaignsLtCondition | airbyte_agent_sdk.connectors.pinterest.types.CampaignsLteCondition | airbyte_agent_sdk.connectors.pinterest.types.CampaignsInCondition | airbyte_agent_sdk.connectors.pinterest.types.CampaignsLikeCondition | airbyte_agent_sdk.connectors.pinterest.types.CampaignsFuzzyCondition | airbyte_agent_sdk.connectors.pinterest.types.CampaignsKeywordCondition | airbyte_agent_sdk.connectors.pinterest.types.CampaignsContainsCondition | airbyte_agent_sdk.connectors.pinterest.types.CampaignsNotCondition | airbyte_agent_sdk.connectors.pinterest.types.CampaignsAndCondition | airbyte_agent_sdk.connectors.pinterest.types.CampaignsOrCondition | airbyte_agent_sdk.connectors.pinterest.types.CampaignsAnyCondition`
     :   The type of the None singleton.
 
+<a id="CampaignsOrCondition"></a>
+
 `CampaignsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -4046,6 +4396,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.pinterest.types.CampaignsEqCondition | airbyte_agent_sdk.connectors.pinterest.types.CampaignsNeqCondition | airbyte_agent_sdk.connectors.pinterest.types.CampaignsGtCondition | airbyte_agent_sdk.connectors.pinterest.types.CampaignsGteCondition | airbyte_agent_sdk.connectors.pinterest.types.CampaignsLtCondition | airbyte_agent_sdk.connectors.pinterest.types.CampaignsLteCondition | airbyte_agent_sdk.connectors.pinterest.types.CampaignsInCondition | airbyte_agent_sdk.connectors.pinterest.types.CampaignsLikeCondition | airbyte_agent_sdk.connectors.pinterest.types.CampaignsFuzzyCondition | airbyte_agent_sdk.connectors.pinterest.types.CampaignsKeywordCondition | airbyte_agent_sdk.connectors.pinterest.types.CampaignsContainsCondition | airbyte_agent_sdk.connectors.pinterest.types.CampaignsNotCondition | airbyte_agent_sdk.connectors.pinterest.types.CampaignsAndCondition | airbyte_agent_sdk.connectors.pinterest.types.CampaignsOrCondition | airbyte_agent_sdk.connectors.pinterest.types.CampaignsAnyCondition]`
     :   The type of the None singleton.
+
+<a id="CampaignsSearchFilter"></a>
 
 `CampaignsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering campaigns search queries.
@@ -4107,6 +4459,8 @@ Classes
     `updated_time: int | None`
     :   Last update timestamp (Unix seconds)
 
+<a id="CampaignsSearchQuery"></a>
+
 `CampaignsSearchQuery(*args, **kwargs)`
 :   Search query for campaigns entity.
 
@@ -4121,6 +4475,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.pinterest.types.CampaignsSortFilter]`
     :   The type of the None singleton.
+
+<a id="CampaignsSortFilter"></a>
 
 `CampaignsSortFilter(*args, **kwargs)`
 :   Available fields for sorting campaigns search results.
@@ -4182,6 +4538,8 @@ Classes
     `updated_time: Literal['asc', 'desc']`
     :   Last update timestamp (Unix seconds)
 
+<a id="CampaignsStringFilter"></a>
+
 `CampaignsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -4242,6 +4600,8 @@ Classes
     `updated_time: str`
     :   Last update timestamp (Unix seconds)
 
+<a id="CatalogsAndCondition"></a>
+
 `CatalogsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -4262,6 +4622,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.pinterest.types.CatalogsEqCondition | airbyte_agent_sdk.connectors.pinterest.types.CatalogsNeqCondition | airbyte_agent_sdk.connectors.pinterest.types.CatalogsGtCondition | airbyte_agent_sdk.connectors.pinterest.types.CatalogsGteCondition | airbyte_agent_sdk.connectors.pinterest.types.CatalogsLtCondition | airbyte_agent_sdk.connectors.pinterest.types.CatalogsLteCondition | airbyte_agent_sdk.connectors.pinterest.types.CatalogsInCondition | airbyte_agent_sdk.connectors.pinterest.types.CatalogsLikeCondition | airbyte_agent_sdk.connectors.pinterest.types.CatalogsFuzzyCondition | airbyte_agent_sdk.connectors.pinterest.types.CatalogsKeywordCondition | airbyte_agent_sdk.connectors.pinterest.types.CatalogsContainsCondition | airbyte_agent_sdk.connectors.pinterest.types.CatalogsNotCondition | airbyte_agent_sdk.connectors.pinterest.types.CatalogsAndCondition | airbyte_agent_sdk.connectors.pinterest.types.CatalogsOrCondition | airbyte_agent_sdk.connectors.pinterest.types.CatalogsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="CatalogsAnyCondition"></a>
+
 `CatalogsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -4281,6 +4643,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.pinterest.types.CatalogsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="CatalogsAnyValueFilter"></a>
 
 `CatalogsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -4306,6 +4670,8 @@ Classes
     `updated_at: Any`
     :   Timestamp when the catalog was last updated
 
+<a id="CatalogsContainsCondition"></a>
+
 `CatalogsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -4318,6 +4684,8 @@ Classes
     `contains: airbyte_agent_sdk.connectors.pinterest.types.CatalogsAnyValueFilter`
     :   The type of the None singleton.
 
+<a id="CatalogsEqCondition"></a>
+
 `CatalogsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
 
@@ -4329,6 +4697,8 @@ Classes
 
     `eq: airbyte_agent_sdk.connectors.pinterest.types.CatalogsSearchFilter`
     :   The type of the None singleton.
+
+<a id="CatalogsFeedsAndCondition"></a>
 
 `CatalogsFeedsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -4350,6 +4720,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.pinterest.types.CatalogsFeedsEqCondition | airbyte_agent_sdk.connectors.pinterest.types.CatalogsFeedsNeqCondition | airbyte_agent_sdk.connectors.pinterest.types.CatalogsFeedsGtCondition | airbyte_agent_sdk.connectors.pinterest.types.CatalogsFeedsGteCondition | airbyte_agent_sdk.connectors.pinterest.types.CatalogsFeedsLtCondition | airbyte_agent_sdk.connectors.pinterest.types.CatalogsFeedsLteCondition | airbyte_agent_sdk.connectors.pinterest.types.CatalogsFeedsInCondition | airbyte_agent_sdk.connectors.pinterest.types.CatalogsFeedsLikeCondition | airbyte_agent_sdk.connectors.pinterest.types.CatalogsFeedsFuzzyCondition | airbyte_agent_sdk.connectors.pinterest.types.CatalogsFeedsKeywordCondition | airbyte_agent_sdk.connectors.pinterest.types.CatalogsFeedsContainsCondition | airbyte_agent_sdk.connectors.pinterest.types.CatalogsFeedsNotCondition | airbyte_agent_sdk.connectors.pinterest.types.CatalogsFeedsAndCondition | airbyte_agent_sdk.connectors.pinterest.types.CatalogsFeedsOrCondition | airbyte_agent_sdk.connectors.pinterest.types.CatalogsFeedsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="CatalogsFeedsAnyCondition"></a>
+
 `CatalogsFeedsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -4369,6 +4741,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.pinterest.types.CatalogsFeedsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="CatalogsFeedsAnyValueFilter"></a>
 
 `CatalogsFeedsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -4418,6 +4792,8 @@ Classes
     `updated_at: Any`
     :   Timestamp when the feed was last updated
 
+<a id="CatalogsFeedsContainsCondition"></a>
+
 `CatalogsFeedsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -4429,6 +4805,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.pinterest.types.CatalogsFeedsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="CatalogsFeedsEqCondition"></a>
 
 `CatalogsFeedsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -4442,6 +4820,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.pinterest.types.CatalogsFeedsSearchFilter`
     :   The type of the None singleton.
 
+<a id="CatalogsFeedsFuzzyCondition"></a>
+
 `CatalogsFeedsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -4453,6 +4833,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.pinterest.types.CatalogsFeedsStringFilter`
     :   The type of the None singleton.
+
+<a id="CatalogsFeedsGtCondition"></a>
 
 `CatalogsFeedsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
@@ -4466,6 +4848,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.pinterest.types.CatalogsFeedsSearchFilter`
     :   The type of the None singleton.
 
+<a id="CatalogsFeedsGteCondition"></a>
+
 `CatalogsFeedsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -4477,6 +4861,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.pinterest.types.CatalogsFeedsSearchFilter`
     :   The type of the None singleton.
+
+<a id="CatalogsFeedsInCondition"></a>
 
 `CatalogsFeedsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -4497,6 +4883,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.pinterest.types.CatalogsFeedsInFilter`
     :   The type of the None singleton.
+
+<a id="CatalogsFeedsInFilter"></a>
 
 `CatalogsFeedsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -4546,6 +4934,8 @@ Classes
     `updated_at: list[str]`
     :   Timestamp when the feed was last updated
 
+<a id="CatalogsFeedsKeywordCondition"></a>
+
 `CatalogsFeedsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -4558,6 +4948,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.pinterest.types.CatalogsFeedsStringFilter`
     :   The type of the None singleton.
 
+<a id="CatalogsFeedsLikeCondition"></a>
+
 `CatalogsFeedsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -4569,6 +4961,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.pinterest.types.CatalogsFeedsStringFilter`
     :   The type of the None singleton.
+
+<a id="CatalogsFeedsListParams"></a>
 
 `CatalogsFeedsListParams(*args, **kwargs)`
 :   Parameters for catalogs_feeds.list operation
@@ -4585,6 +4979,8 @@ Classes
     `page_size: int`
     :   The type of the None singleton.
 
+<a id="CatalogsFeedsLtCondition"></a>
+
 `CatalogsFeedsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -4596,6 +4992,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.pinterest.types.CatalogsFeedsSearchFilter`
     :   The type of the None singleton.
+
+<a id="CatalogsFeedsLteCondition"></a>
 
 `CatalogsFeedsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -4609,6 +5007,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.pinterest.types.CatalogsFeedsSearchFilter`
     :   The type of the None singleton.
 
+<a id="CatalogsFeedsNeqCondition"></a>
+
 `CatalogsFeedsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -4620,6 +5020,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.pinterest.types.CatalogsFeedsSearchFilter`
     :   The type of the None singleton.
+
+<a id="CatalogsFeedsNotCondition"></a>
 
 `CatalogsFeedsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -4641,6 +5043,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.pinterest.types.CatalogsFeedsEqCondition | airbyte_agent_sdk.connectors.pinterest.types.CatalogsFeedsNeqCondition | airbyte_agent_sdk.connectors.pinterest.types.CatalogsFeedsGtCondition | airbyte_agent_sdk.connectors.pinterest.types.CatalogsFeedsGteCondition | airbyte_agent_sdk.connectors.pinterest.types.CatalogsFeedsLtCondition | airbyte_agent_sdk.connectors.pinterest.types.CatalogsFeedsLteCondition | airbyte_agent_sdk.connectors.pinterest.types.CatalogsFeedsInCondition | airbyte_agent_sdk.connectors.pinterest.types.CatalogsFeedsLikeCondition | airbyte_agent_sdk.connectors.pinterest.types.CatalogsFeedsFuzzyCondition | airbyte_agent_sdk.connectors.pinterest.types.CatalogsFeedsKeywordCondition | airbyte_agent_sdk.connectors.pinterest.types.CatalogsFeedsContainsCondition | airbyte_agent_sdk.connectors.pinterest.types.CatalogsFeedsNotCondition | airbyte_agent_sdk.connectors.pinterest.types.CatalogsFeedsAndCondition | airbyte_agent_sdk.connectors.pinterest.types.CatalogsFeedsOrCondition | airbyte_agent_sdk.connectors.pinterest.types.CatalogsFeedsAnyCondition`
     :   The type of the None singleton.
 
+<a id="CatalogsFeedsOrCondition"></a>
+
 `CatalogsFeedsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -4660,6 +5064,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.pinterest.types.CatalogsFeedsEqCondition | airbyte_agent_sdk.connectors.pinterest.types.CatalogsFeedsNeqCondition | airbyte_agent_sdk.connectors.pinterest.types.CatalogsFeedsGtCondition | airbyte_agent_sdk.connectors.pinterest.types.CatalogsFeedsGteCondition | airbyte_agent_sdk.connectors.pinterest.types.CatalogsFeedsLtCondition | airbyte_agent_sdk.connectors.pinterest.types.CatalogsFeedsLteCondition | airbyte_agent_sdk.connectors.pinterest.types.CatalogsFeedsInCondition | airbyte_agent_sdk.connectors.pinterest.types.CatalogsFeedsLikeCondition | airbyte_agent_sdk.connectors.pinterest.types.CatalogsFeedsFuzzyCondition | airbyte_agent_sdk.connectors.pinterest.types.CatalogsFeedsKeywordCondition | airbyte_agent_sdk.connectors.pinterest.types.CatalogsFeedsContainsCondition | airbyte_agent_sdk.connectors.pinterest.types.CatalogsFeedsNotCondition | airbyte_agent_sdk.connectors.pinterest.types.CatalogsFeedsAndCondition | airbyte_agent_sdk.connectors.pinterest.types.CatalogsFeedsOrCondition | airbyte_agent_sdk.connectors.pinterest.types.CatalogsFeedsAnyCondition]`
     :   The type of the None singleton.
+
+<a id="CatalogsFeedsSearchFilter"></a>
 
 `CatalogsFeedsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering catalogs_feeds search queries.
@@ -4709,6 +5115,8 @@ Classes
     `updated_at: str | None`
     :   Timestamp when the feed was last updated
 
+<a id="CatalogsFeedsSearchQuery"></a>
+
 `CatalogsFeedsSearchQuery(*args, **kwargs)`
 :   Search query for catalogs_feeds entity.
 
@@ -4723,6 +5131,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.pinterest.types.CatalogsFeedsSortFilter]`
     :   The type of the None singleton.
+
+<a id="CatalogsFeedsSortFilter"></a>
 
 `CatalogsFeedsSortFilter(*args, **kwargs)`
 :   Available fields for sorting catalogs_feeds search results.
@@ -4772,6 +5182,8 @@ Classes
     `updated_at: Literal['asc', 'desc']`
     :   Timestamp when the feed was last updated
 
+<a id="CatalogsFeedsStringFilter"></a>
+
 `CatalogsFeedsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -4820,6 +5232,8 @@ Classes
     `updated_at: str`
     :   Timestamp when the feed was last updated
 
+<a id="CatalogsFuzzyCondition"></a>
+
 `CatalogsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -4831,6 +5245,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.pinterest.types.CatalogsStringFilter`
     :   The type of the None singleton.
+
+<a id="CatalogsGtCondition"></a>
 
 `CatalogsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
@@ -4844,6 +5260,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.pinterest.types.CatalogsSearchFilter`
     :   The type of the None singleton.
 
+<a id="CatalogsGteCondition"></a>
+
 `CatalogsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -4855,6 +5273,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.pinterest.types.CatalogsSearchFilter`
     :   The type of the None singleton.
+
+<a id="CatalogsInCondition"></a>
 
 `CatalogsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -4875,6 +5295,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.pinterest.types.CatalogsInFilter`
     :   The type of the None singleton.
+
+<a id="CatalogsInFilter"></a>
 
 `CatalogsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -4900,6 +5322,8 @@ Classes
     `updated_at: list[str]`
     :   Timestamp when the catalog was last updated
 
+<a id="CatalogsKeywordCondition"></a>
+
 `CatalogsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -4912,6 +5336,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.pinterest.types.CatalogsStringFilter`
     :   The type of the None singleton.
 
+<a id="CatalogsLikeCondition"></a>
+
 `CatalogsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -4923,6 +5349,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.pinterest.types.CatalogsStringFilter`
     :   The type of the None singleton.
+
+<a id="CatalogsListParams"></a>
 
 `CatalogsListParams(*args, **kwargs)`
 :   Parameters for catalogs.list operation
@@ -4939,6 +5367,8 @@ Classes
     `page_size: int`
     :   The type of the None singleton.
 
+<a id="CatalogsLtCondition"></a>
+
 `CatalogsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -4950,6 +5380,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.pinterest.types.CatalogsSearchFilter`
     :   The type of the None singleton.
+
+<a id="CatalogsLteCondition"></a>
 
 `CatalogsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -4963,6 +5395,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.pinterest.types.CatalogsSearchFilter`
     :   The type of the None singleton.
 
+<a id="CatalogsNeqCondition"></a>
+
 `CatalogsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -4974,6 +5408,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.pinterest.types.CatalogsSearchFilter`
     :   The type of the None singleton.
+
+<a id="CatalogsNotCondition"></a>
 
 `CatalogsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -4995,6 +5431,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.pinterest.types.CatalogsEqCondition | airbyte_agent_sdk.connectors.pinterest.types.CatalogsNeqCondition | airbyte_agent_sdk.connectors.pinterest.types.CatalogsGtCondition | airbyte_agent_sdk.connectors.pinterest.types.CatalogsGteCondition | airbyte_agent_sdk.connectors.pinterest.types.CatalogsLtCondition | airbyte_agent_sdk.connectors.pinterest.types.CatalogsLteCondition | airbyte_agent_sdk.connectors.pinterest.types.CatalogsInCondition | airbyte_agent_sdk.connectors.pinterest.types.CatalogsLikeCondition | airbyte_agent_sdk.connectors.pinterest.types.CatalogsFuzzyCondition | airbyte_agent_sdk.connectors.pinterest.types.CatalogsKeywordCondition | airbyte_agent_sdk.connectors.pinterest.types.CatalogsContainsCondition | airbyte_agent_sdk.connectors.pinterest.types.CatalogsNotCondition | airbyte_agent_sdk.connectors.pinterest.types.CatalogsAndCondition | airbyte_agent_sdk.connectors.pinterest.types.CatalogsOrCondition | airbyte_agent_sdk.connectors.pinterest.types.CatalogsAnyCondition`
     :   The type of the None singleton.
 
+<a id="CatalogsOrCondition"></a>
+
 `CatalogsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -5014,6 +5452,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.pinterest.types.CatalogsEqCondition | airbyte_agent_sdk.connectors.pinterest.types.CatalogsNeqCondition | airbyte_agent_sdk.connectors.pinterest.types.CatalogsGtCondition | airbyte_agent_sdk.connectors.pinterest.types.CatalogsGteCondition | airbyte_agent_sdk.connectors.pinterest.types.CatalogsLtCondition | airbyte_agent_sdk.connectors.pinterest.types.CatalogsLteCondition | airbyte_agent_sdk.connectors.pinterest.types.CatalogsInCondition | airbyte_agent_sdk.connectors.pinterest.types.CatalogsLikeCondition | airbyte_agent_sdk.connectors.pinterest.types.CatalogsFuzzyCondition | airbyte_agent_sdk.connectors.pinterest.types.CatalogsKeywordCondition | airbyte_agent_sdk.connectors.pinterest.types.CatalogsContainsCondition | airbyte_agent_sdk.connectors.pinterest.types.CatalogsNotCondition | airbyte_agent_sdk.connectors.pinterest.types.CatalogsAndCondition | airbyte_agent_sdk.connectors.pinterest.types.CatalogsOrCondition | airbyte_agent_sdk.connectors.pinterest.types.CatalogsAnyCondition]`
     :   The type of the None singleton.
+
+<a id="CatalogsProductGroupsAndCondition"></a>
 
 `CatalogsProductGroupsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -5035,6 +5475,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.pinterest.types.CatalogsProductGroupsEqCondition | airbyte_agent_sdk.connectors.pinterest.types.CatalogsProductGroupsNeqCondition | airbyte_agent_sdk.connectors.pinterest.types.CatalogsProductGroupsGtCondition | airbyte_agent_sdk.connectors.pinterest.types.CatalogsProductGroupsGteCondition | airbyte_agent_sdk.connectors.pinterest.types.CatalogsProductGroupsLtCondition | airbyte_agent_sdk.connectors.pinterest.types.CatalogsProductGroupsLteCondition | airbyte_agent_sdk.connectors.pinterest.types.CatalogsProductGroupsInCondition | airbyte_agent_sdk.connectors.pinterest.types.CatalogsProductGroupsLikeCondition | airbyte_agent_sdk.connectors.pinterest.types.CatalogsProductGroupsFuzzyCondition | airbyte_agent_sdk.connectors.pinterest.types.CatalogsProductGroupsKeywordCondition | airbyte_agent_sdk.connectors.pinterest.types.CatalogsProductGroupsContainsCondition | airbyte_agent_sdk.connectors.pinterest.types.CatalogsProductGroupsNotCondition | airbyte_agent_sdk.connectors.pinterest.types.CatalogsProductGroupsAndCondition | airbyte_agent_sdk.connectors.pinterest.types.CatalogsProductGroupsOrCondition | airbyte_agent_sdk.connectors.pinterest.types.CatalogsProductGroupsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="CatalogsProductGroupsAnyCondition"></a>
+
 `CatalogsProductGroupsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -5054,6 +5496,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.pinterest.types.CatalogsProductGroupsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="CatalogsProductGroupsAnyValueFilter"></a>
 
 `CatalogsProductGroupsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -5091,6 +5535,8 @@ Classes
     `updated_at: Any`
     :   Last update timestamp (Unix seconds)
 
+<a id="CatalogsProductGroupsContainsCondition"></a>
+
 `CatalogsProductGroupsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -5102,6 +5548,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.pinterest.types.CatalogsProductGroupsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="CatalogsProductGroupsEqCondition"></a>
 
 `CatalogsProductGroupsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -5115,6 +5563,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.pinterest.types.CatalogsProductGroupsSearchFilter`
     :   The type of the None singleton.
 
+<a id="CatalogsProductGroupsFuzzyCondition"></a>
+
 `CatalogsProductGroupsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -5126,6 +5576,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.pinterest.types.CatalogsProductGroupsStringFilter`
     :   The type of the None singleton.
+
+<a id="CatalogsProductGroupsGtCondition"></a>
 
 `CatalogsProductGroupsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
@@ -5139,6 +5591,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.pinterest.types.CatalogsProductGroupsSearchFilter`
     :   The type of the None singleton.
 
+<a id="CatalogsProductGroupsGteCondition"></a>
+
 `CatalogsProductGroupsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -5150,6 +5604,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.pinterest.types.CatalogsProductGroupsSearchFilter`
     :   The type of the None singleton.
+
+<a id="CatalogsProductGroupsInCondition"></a>
 
 `CatalogsProductGroupsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -5170,6 +5626,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.pinterest.types.CatalogsProductGroupsInFilter`
     :   The type of the None singleton.
+
+<a id="CatalogsProductGroupsInFilter"></a>
 
 `CatalogsProductGroupsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -5207,6 +5665,8 @@ Classes
     `updated_at: list[int]`
     :   Last update timestamp (Unix seconds)
 
+<a id="CatalogsProductGroupsKeywordCondition"></a>
+
 `CatalogsProductGroupsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -5219,6 +5679,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.pinterest.types.CatalogsProductGroupsStringFilter`
     :   The type of the None singleton.
 
+<a id="CatalogsProductGroupsLikeCondition"></a>
+
 `CatalogsProductGroupsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -5230,6 +5692,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.pinterest.types.CatalogsProductGroupsStringFilter`
     :   The type of the None singleton.
+
+<a id="CatalogsProductGroupsListParams"></a>
 
 `CatalogsProductGroupsListParams(*args, **kwargs)`
 :   Parameters for catalogs_product_groups.list operation
@@ -5246,6 +5710,8 @@ Classes
     `page_size: int`
     :   The type of the None singleton.
 
+<a id="CatalogsProductGroupsLtCondition"></a>
+
 `CatalogsProductGroupsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -5257,6 +5723,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.pinterest.types.CatalogsProductGroupsSearchFilter`
     :   The type of the None singleton.
+
+<a id="CatalogsProductGroupsLteCondition"></a>
 
 `CatalogsProductGroupsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -5270,6 +5738,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.pinterest.types.CatalogsProductGroupsSearchFilter`
     :   The type of the None singleton.
 
+<a id="CatalogsProductGroupsNeqCondition"></a>
+
 `CatalogsProductGroupsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -5281,6 +5751,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.pinterest.types.CatalogsProductGroupsSearchFilter`
     :   The type of the None singleton.
+
+<a id="CatalogsProductGroupsNotCondition"></a>
 
 `CatalogsProductGroupsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -5302,6 +5774,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.pinterest.types.CatalogsProductGroupsEqCondition | airbyte_agent_sdk.connectors.pinterest.types.CatalogsProductGroupsNeqCondition | airbyte_agent_sdk.connectors.pinterest.types.CatalogsProductGroupsGtCondition | airbyte_agent_sdk.connectors.pinterest.types.CatalogsProductGroupsGteCondition | airbyte_agent_sdk.connectors.pinterest.types.CatalogsProductGroupsLtCondition | airbyte_agent_sdk.connectors.pinterest.types.CatalogsProductGroupsLteCondition | airbyte_agent_sdk.connectors.pinterest.types.CatalogsProductGroupsInCondition | airbyte_agent_sdk.connectors.pinterest.types.CatalogsProductGroupsLikeCondition | airbyte_agent_sdk.connectors.pinterest.types.CatalogsProductGroupsFuzzyCondition | airbyte_agent_sdk.connectors.pinterest.types.CatalogsProductGroupsKeywordCondition | airbyte_agent_sdk.connectors.pinterest.types.CatalogsProductGroupsContainsCondition | airbyte_agent_sdk.connectors.pinterest.types.CatalogsProductGroupsNotCondition | airbyte_agent_sdk.connectors.pinterest.types.CatalogsProductGroupsAndCondition | airbyte_agent_sdk.connectors.pinterest.types.CatalogsProductGroupsOrCondition | airbyte_agent_sdk.connectors.pinterest.types.CatalogsProductGroupsAnyCondition`
     :   The type of the None singleton.
 
+<a id="CatalogsProductGroupsOrCondition"></a>
+
 `CatalogsProductGroupsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -5321,6 +5795,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.pinterest.types.CatalogsProductGroupsEqCondition | airbyte_agent_sdk.connectors.pinterest.types.CatalogsProductGroupsNeqCondition | airbyte_agent_sdk.connectors.pinterest.types.CatalogsProductGroupsGtCondition | airbyte_agent_sdk.connectors.pinterest.types.CatalogsProductGroupsGteCondition | airbyte_agent_sdk.connectors.pinterest.types.CatalogsProductGroupsLtCondition | airbyte_agent_sdk.connectors.pinterest.types.CatalogsProductGroupsLteCondition | airbyte_agent_sdk.connectors.pinterest.types.CatalogsProductGroupsInCondition | airbyte_agent_sdk.connectors.pinterest.types.CatalogsProductGroupsLikeCondition | airbyte_agent_sdk.connectors.pinterest.types.CatalogsProductGroupsFuzzyCondition | airbyte_agent_sdk.connectors.pinterest.types.CatalogsProductGroupsKeywordCondition | airbyte_agent_sdk.connectors.pinterest.types.CatalogsProductGroupsContainsCondition | airbyte_agent_sdk.connectors.pinterest.types.CatalogsProductGroupsNotCondition | airbyte_agent_sdk.connectors.pinterest.types.CatalogsProductGroupsAndCondition | airbyte_agent_sdk.connectors.pinterest.types.CatalogsProductGroupsOrCondition | airbyte_agent_sdk.connectors.pinterest.types.CatalogsProductGroupsAnyCondition]`
     :   The type of the None singleton.
+
+<a id="CatalogsProductGroupsSearchFilter"></a>
 
 `CatalogsProductGroupsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering catalogs_product_groups search queries.
@@ -5358,6 +5834,8 @@ Classes
     `updated_at: int | None`
     :   Last update timestamp (Unix seconds)
 
+<a id="CatalogsProductGroupsSearchQuery"></a>
+
 `CatalogsProductGroupsSearchQuery(*args, **kwargs)`
 :   Search query for catalogs_product_groups entity.
 
@@ -5372,6 +5850,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.pinterest.types.CatalogsProductGroupsSortFilter]`
     :   The type of the None singleton.
+
+<a id="CatalogsProductGroupsSortFilter"></a>
 
 `CatalogsProductGroupsSortFilter(*args, **kwargs)`
 :   Available fields for sorting catalogs_product_groups search results.
@@ -5409,6 +5889,8 @@ Classes
     `updated_at: Literal['asc', 'desc']`
     :   Last update timestamp (Unix seconds)
 
+<a id="CatalogsProductGroupsStringFilter"></a>
+
 `CatalogsProductGroupsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -5445,6 +5927,8 @@ Classes
     `updated_at: str`
     :   Last update timestamp (Unix seconds)
 
+<a id="CatalogsSearchFilter"></a>
+
 `CatalogsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering catalogs search queries.
 
@@ -5469,6 +5953,8 @@ Classes
     `updated_at: str | None`
     :   Timestamp when the catalog was last updated
 
+<a id="CatalogsSearchQuery"></a>
+
 `CatalogsSearchQuery(*args, **kwargs)`
 :   Search query for catalogs entity.
 
@@ -5483,6 +5969,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.pinterest.types.CatalogsSortFilter]`
     :   The type of the None singleton.
+
+<a id="CatalogsSortFilter"></a>
 
 `CatalogsSortFilter(*args, **kwargs)`
 :   Available fields for sorting catalogs search results.
@@ -5508,6 +5996,8 @@ Classes
     `updated_at: Literal['asc', 'desc']`
     :   Timestamp when the catalog was last updated
 
+<a id="CatalogsStringFilter"></a>
+
 `CatalogsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -5532,6 +6022,8 @@ Classes
     `updated_at: str`
     :   Timestamp when the catalog was last updated
 
+<a id="ConversionTagsAndCondition"></a>
+
 `ConversionTagsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -5552,6 +6044,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.pinterest.types.ConversionTagsEqCondition | airbyte_agent_sdk.connectors.pinterest.types.ConversionTagsNeqCondition | airbyte_agent_sdk.connectors.pinterest.types.ConversionTagsGtCondition | airbyte_agent_sdk.connectors.pinterest.types.ConversionTagsGteCondition | airbyte_agent_sdk.connectors.pinterest.types.ConversionTagsLtCondition | airbyte_agent_sdk.connectors.pinterest.types.ConversionTagsLteCondition | airbyte_agent_sdk.connectors.pinterest.types.ConversionTagsInCondition | airbyte_agent_sdk.connectors.pinterest.types.ConversionTagsLikeCondition | airbyte_agent_sdk.connectors.pinterest.types.ConversionTagsFuzzyCondition | airbyte_agent_sdk.connectors.pinterest.types.ConversionTagsKeywordCondition | airbyte_agent_sdk.connectors.pinterest.types.ConversionTagsContainsCondition | airbyte_agent_sdk.connectors.pinterest.types.ConversionTagsNotCondition | airbyte_agent_sdk.connectors.pinterest.types.ConversionTagsAndCondition | airbyte_agent_sdk.connectors.pinterest.types.ConversionTagsOrCondition | airbyte_agent_sdk.connectors.pinterest.types.ConversionTagsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="ConversionTagsAnyCondition"></a>
+
 `ConversionTagsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -5571,6 +6065,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.pinterest.types.ConversionTagsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="ConversionTagsAnyValueFilter"></a>
 
 `ConversionTagsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -5608,6 +6104,8 @@ Classes
     `version: Any`
     :   Version number
 
+<a id="ConversionTagsContainsCondition"></a>
+
 `ConversionTagsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -5619,6 +6117,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.pinterest.types.ConversionTagsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="ConversionTagsEqCondition"></a>
 
 `ConversionTagsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -5632,6 +6132,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.pinterest.types.ConversionTagsSearchFilter`
     :   The type of the None singleton.
 
+<a id="ConversionTagsFuzzyCondition"></a>
+
 `ConversionTagsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -5643,6 +6145,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.pinterest.types.ConversionTagsStringFilter`
     :   The type of the None singleton.
+
+<a id="ConversionTagsGtCondition"></a>
 
 `ConversionTagsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
@@ -5656,6 +6160,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.pinterest.types.ConversionTagsSearchFilter`
     :   The type of the None singleton.
 
+<a id="ConversionTagsGteCondition"></a>
+
 `ConversionTagsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -5667,6 +6173,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.pinterest.types.ConversionTagsSearchFilter`
     :   The type of the None singleton.
+
+<a id="ConversionTagsInCondition"></a>
 
 `ConversionTagsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -5687,6 +6195,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.pinterest.types.ConversionTagsInFilter`
     :   The type of the None singleton.
+
+<a id="ConversionTagsInFilter"></a>
 
 `ConversionTagsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -5724,6 +6234,8 @@ Classes
     `version: list[str]`
     :   Version number
 
+<a id="ConversionTagsKeywordCondition"></a>
+
 `ConversionTagsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -5736,6 +6248,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.pinterest.types.ConversionTagsStringFilter`
     :   The type of the None singleton.
 
+<a id="ConversionTagsLikeCondition"></a>
+
 `ConversionTagsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -5747,6 +6261,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.pinterest.types.ConversionTagsStringFilter`
     :   The type of the None singleton.
+
+<a id="ConversionTagsListParams"></a>
 
 `ConversionTagsListParams(*args, **kwargs)`
 :   Parameters for conversion_tags.list operation
@@ -5766,6 +6282,8 @@ Classes
     `page_size: int`
     :   The type of the None singleton.
 
+<a id="ConversionTagsLtCondition"></a>
+
 `ConversionTagsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -5777,6 +6295,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.pinterest.types.ConversionTagsSearchFilter`
     :   The type of the None singleton.
+
+<a id="ConversionTagsLteCondition"></a>
 
 `ConversionTagsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -5790,6 +6310,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.pinterest.types.ConversionTagsSearchFilter`
     :   The type of the None singleton.
 
+<a id="ConversionTagsNeqCondition"></a>
+
 `ConversionTagsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -5801,6 +6323,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.pinterest.types.ConversionTagsSearchFilter`
     :   The type of the None singleton.
+
+<a id="ConversionTagsNotCondition"></a>
 
 `ConversionTagsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -5822,6 +6346,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.pinterest.types.ConversionTagsEqCondition | airbyte_agent_sdk.connectors.pinterest.types.ConversionTagsNeqCondition | airbyte_agent_sdk.connectors.pinterest.types.ConversionTagsGtCondition | airbyte_agent_sdk.connectors.pinterest.types.ConversionTagsGteCondition | airbyte_agent_sdk.connectors.pinterest.types.ConversionTagsLtCondition | airbyte_agent_sdk.connectors.pinterest.types.ConversionTagsLteCondition | airbyte_agent_sdk.connectors.pinterest.types.ConversionTagsInCondition | airbyte_agent_sdk.connectors.pinterest.types.ConversionTagsLikeCondition | airbyte_agent_sdk.connectors.pinterest.types.ConversionTagsFuzzyCondition | airbyte_agent_sdk.connectors.pinterest.types.ConversionTagsKeywordCondition | airbyte_agent_sdk.connectors.pinterest.types.ConversionTagsContainsCondition | airbyte_agent_sdk.connectors.pinterest.types.ConversionTagsNotCondition | airbyte_agent_sdk.connectors.pinterest.types.ConversionTagsAndCondition | airbyte_agent_sdk.connectors.pinterest.types.ConversionTagsOrCondition | airbyte_agent_sdk.connectors.pinterest.types.ConversionTagsAnyCondition`
     :   The type of the None singleton.
 
+<a id="ConversionTagsOrCondition"></a>
+
 `ConversionTagsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -5841,6 +6367,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.pinterest.types.ConversionTagsEqCondition | airbyte_agent_sdk.connectors.pinterest.types.ConversionTagsNeqCondition | airbyte_agent_sdk.connectors.pinterest.types.ConversionTagsGtCondition | airbyte_agent_sdk.connectors.pinterest.types.ConversionTagsGteCondition | airbyte_agent_sdk.connectors.pinterest.types.ConversionTagsLtCondition | airbyte_agent_sdk.connectors.pinterest.types.ConversionTagsLteCondition | airbyte_agent_sdk.connectors.pinterest.types.ConversionTagsInCondition | airbyte_agent_sdk.connectors.pinterest.types.ConversionTagsLikeCondition | airbyte_agent_sdk.connectors.pinterest.types.ConversionTagsFuzzyCondition | airbyte_agent_sdk.connectors.pinterest.types.ConversionTagsKeywordCondition | airbyte_agent_sdk.connectors.pinterest.types.ConversionTagsContainsCondition | airbyte_agent_sdk.connectors.pinterest.types.ConversionTagsNotCondition | airbyte_agent_sdk.connectors.pinterest.types.ConversionTagsAndCondition | airbyte_agent_sdk.connectors.pinterest.types.ConversionTagsOrCondition | airbyte_agent_sdk.connectors.pinterest.types.ConversionTagsAnyCondition]`
     :   The type of the None singleton.
+
+<a id="ConversionTagsSearchFilter"></a>
 
 `ConversionTagsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering conversion_tags search queries.
@@ -5878,6 +6406,8 @@ Classes
     `version: str | None`
     :   Version number
 
+<a id="ConversionTagsSearchQuery"></a>
+
 `ConversionTagsSearchQuery(*args, **kwargs)`
 :   Search query for conversion_tags entity.
 
@@ -5892,6 +6422,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.pinterest.types.ConversionTagsSortFilter]`
     :   The type of the None singleton.
+
+<a id="ConversionTagsSortFilter"></a>
 
 `ConversionTagsSortFilter(*args, **kwargs)`
 :   Available fields for sorting conversion_tags search results.
@@ -5929,6 +6461,8 @@ Classes
     `version: Literal['asc', 'desc']`
     :   Version number
 
+<a id="ConversionTagsStringFilter"></a>
+
 `ConversionTagsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -5965,6 +6499,8 @@ Classes
     `version: str`
     :   Version number
 
+<a id="CustomerListsAndCondition"></a>
+
 `CustomerListsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -5985,6 +6521,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.pinterest.types.CustomerListsEqCondition | airbyte_agent_sdk.connectors.pinterest.types.CustomerListsNeqCondition | airbyte_agent_sdk.connectors.pinterest.types.CustomerListsGtCondition | airbyte_agent_sdk.connectors.pinterest.types.CustomerListsGteCondition | airbyte_agent_sdk.connectors.pinterest.types.CustomerListsLtCondition | airbyte_agent_sdk.connectors.pinterest.types.CustomerListsLteCondition | airbyte_agent_sdk.connectors.pinterest.types.CustomerListsInCondition | airbyte_agent_sdk.connectors.pinterest.types.CustomerListsLikeCondition | airbyte_agent_sdk.connectors.pinterest.types.CustomerListsFuzzyCondition | airbyte_agent_sdk.connectors.pinterest.types.CustomerListsKeywordCondition | airbyte_agent_sdk.connectors.pinterest.types.CustomerListsContainsCondition | airbyte_agent_sdk.connectors.pinterest.types.CustomerListsNotCondition | airbyte_agent_sdk.connectors.pinterest.types.CustomerListsAndCondition | airbyte_agent_sdk.connectors.pinterest.types.CustomerListsOrCondition | airbyte_agent_sdk.connectors.pinterest.types.CustomerListsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="CustomerListsAnyCondition"></a>
+
 `CustomerListsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -6004,6 +6542,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.pinterest.types.CustomerListsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="CustomerListsAnyValueFilter"></a>
 
 `CustomerListsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -6044,6 +6584,8 @@ Classes
     `updated_time: Any`
     :   Last update time (Unix seconds)
 
+<a id="CustomerListsContainsCondition"></a>
+
 `CustomerListsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -6055,6 +6597,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.pinterest.types.CustomerListsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="CustomerListsEqCondition"></a>
 
 `CustomerListsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -6068,6 +6612,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.pinterest.types.CustomerListsSearchFilter`
     :   The type of the None singleton.
 
+<a id="CustomerListsFuzzyCondition"></a>
+
 `CustomerListsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -6079,6 +6625,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.pinterest.types.CustomerListsStringFilter`
     :   The type of the None singleton.
+
+<a id="CustomerListsGtCondition"></a>
 
 `CustomerListsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
@@ -6092,6 +6640,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.pinterest.types.CustomerListsSearchFilter`
     :   The type of the None singleton.
 
+<a id="CustomerListsGteCondition"></a>
+
 `CustomerListsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -6103,6 +6653,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.pinterest.types.CustomerListsSearchFilter`
     :   The type of the None singleton.
+
+<a id="CustomerListsInCondition"></a>
 
 `CustomerListsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -6123,6 +6675,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.pinterest.types.CustomerListsInFilter`
     :   The type of the None singleton.
+
+<a id="CustomerListsInFilter"></a>
 
 `CustomerListsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -6163,6 +6717,8 @@ Classes
     `updated_time: list[int]`
     :   Last update time (Unix seconds)
 
+<a id="CustomerListsKeywordCondition"></a>
+
 `CustomerListsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -6175,6 +6731,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.pinterest.types.CustomerListsStringFilter`
     :   The type of the None singleton.
 
+<a id="CustomerListsLikeCondition"></a>
+
 `CustomerListsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -6186,6 +6744,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.pinterest.types.CustomerListsStringFilter`
     :   The type of the None singleton.
+
+<a id="CustomerListsListParams"></a>
 
 `CustomerListsListParams(*args, **kwargs)`
 :   Parameters for customer_lists.list operation
@@ -6205,6 +6765,8 @@ Classes
     `page_size: int`
     :   The type of the None singleton.
 
+<a id="CustomerListsLtCondition"></a>
+
 `CustomerListsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -6216,6 +6778,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.pinterest.types.CustomerListsSearchFilter`
     :   The type of the None singleton.
+
+<a id="CustomerListsLteCondition"></a>
 
 `CustomerListsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -6229,6 +6793,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.pinterest.types.CustomerListsSearchFilter`
     :   The type of the None singleton.
 
+<a id="CustomerListsNeqCondition"></a>
+
 `CustomerListsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -6240,6 +6806,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.pinterest.types.CustomerListsSearchFilter`
     :   The type of the None singleton.
+
+<a id="CustomerListsNotCondition"></a>
 
 `CustomerListsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -6261,6 +6829,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.pinterest.types.CustomerListsEqCondition | airbyte_agent_sdk.connectors.pinterest.types.CustomerListsNeqCondition | airbyte_agent_sdk.connectors.pinterest.types.CustomerListsGtCondition | airbyte_agent_sdk.connectors.pinterest.types.CustomerListsGteCondition | airbyte_agent_sdk.connectors.pinterest.types.CustomerListsLtCondition | airbyte_agent_sdk.connectors.pinterest.types.CustomerListsLteCondition | airbyte_agent_sdk.connectors.pinterest.types.CustomerListsInCondition | airbyte_agent_sdk.connectors.pinterest.types.CustomerListsLikeCondition | airbyte_agent_sdk.connectors.pinterest.types.CustomerListsFuzzyCondition | airbyte_agent_sdk.connectors.pinterest.types.CustomerListsKeywordCondition | airbyte_agent_sdk.connectors.pinterest.types.CustomerListsContainsCondition | airbyte_agent_sdk.connectors.pinterest.types.CustomerListsNotCondition | airbyte_agent_sdk.connectors.pinterest.types.CustomerListsAndCondition | airbyte_agent_sdk.connectors.pinterest.types.CustomerListsOrCondition | airbyte_agent_sdk.connectors.pinterest.types.CustomerListsAnyCondition`
     :   The type of the None singleton.
 
+<a id="CustomerListsOrCondition"></a>
+
 `CustomerListsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -6280,6 +6850,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.pinterest.types.CustomerListsEqCondition | airbyte_agent_sdk.connectors.pinterest.types.CustomerListsNeqCondition | airbyte_agent_sdk.connectors.pinterest.types.CustomerListsGtCondition | airbyte_agent_sdk.connectors.pinterest.types.CustomerListsGteCondition | airbyte_agent_sdk.connectors.pinterest.types.CustomerListsLtCondition | airbyte_agent_sdk.connectors.pinterest.types.CustomerListsLteCondition | airbyte_agent_sdk.connectors.pinterest.types.CustomerListsInCondition | airbyte_agent_sdk.connectors.pinterest.types.CustomerListsLikeCondition | airbyte_agent_sdk.connectors.pinterest.types.CustomerListsFuzzyCondition | airbyte_agent_sdk.connectors.pinterest.types.CustomerListsKeywordCondition | airbyte_agent_sdk.connectors.pinterest.types.CustomerListsContainsCondition | airbyte_agent_sdk.connectors.pinterest.types.CustomerListsNotCondition | airbyte_agent_sdk.connectors.pinterest.types.CustomerListsAndCondition | airbyte_agent_sdk.connectors.pinterest.types.CustomerListsOrCondition | airbyte_agent_sdk.connectors.pinterest.types.CustomerListsAnyCondition]`
     :   The type of the None singleton.
+
+<a id="CustomerListsSearchFilter"></a>
 
 `CustomerListsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering customer_lists search queries.
@@ -6320,6 +6892,8 @@ Classes
     `updated_time: int | None`
     :   Last update time (Unix seconds)
 
+<a id="CustomerListsSearchQuery"></a>
+
 `CustomerListsSearchQuery(*args, **kwargs)`
 :   Search query for customer_lists entity.
 
@@ -6334,6 +6908,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.pinterest.types.CustomerListsSortFilter]`
     :   The type of the None singleton.
+
+<a id="CustomerListsSortFilter"></a>
 
 `CustomerListsSortFilter(*args, **kwargs)`
 :   Available fields for sorting customer_lists search results.
@@ -6374,6 +6950,8 @@ Classes
     `updated_time: Literal['asc', 'desc']`
     :   Last update time (Unix seconds)
 
+<a id="CustomerListsStringFilter"></a>
+
 `CustomerListsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -6413,6 +6991,8 @@ Classes
     `updated_time: str`
     :   Last update time (Unix seconds)
 
+<a id="KeywordsAndCondition"></a>
+
 `KeywordsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -6433,6 +7013,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.pinterest.types.KeywordsEqCondition | airbyte_agent_sdk.connectors.pinterest.types.KeywordsNeqCondition | airbyte_agent_sdk.connectors.pinterest.types.KeywordsGtCondition | airbyte_agent_sdk.connectors.pinterest.types.KeywordsGteCondition | airbyte_agent_sdk.connectors.pinterest.types.KeywordsLtCondition | airbyte_agent_sdk.connectors.pinterest.types.KeywordsLteCondition | airbyte_agent_sdk.connectors.pinterest.types.KeywordsInCondition | airbyte_agent_sdk.connectors.pinterest.types.KeywordsLikeCondition | airbyte_agent_sdk.connectors.pinterest.types.KeywordsFuzzyCondition | airbyte_agent_sdk.connectors.pinterest.types.KeywordsKeywordCondition | airbyte_agent_sdk.connectors.pinterest.types.KeywordsContainsCondition | airbyte_agent_sdk.connectors.pinterest.types.KeywordsNotCondition | airbyte_agent_sdk.connectors.pinterest.types.KeywordsAndCondition | airbyte_agent_sdk.connectors.pinterest.types.KeywordsOrCondition | airbyte_agent_sdk.connectors.pinterest.types.KeywordsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="KeywordsAnyCondition"></a>
+
 `KeywordsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -6452,6 +7034,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.pinterest.types.KeywordsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="KeywordsAnyValueFilter"></a>
 
 `KeywordsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -6486,6 +7070,8 @@ Classes
     `value: Any`
     :   Keyword text value
 
+<a id="KeywordsContainsCondition"></a>
+
 `KeywordsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -6497,6 +7083,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.pinterest.types.KeywordsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="KeywordsEqCondition"></a>
 
 `KeywordsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -6510,6 +7098,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.pinterest.types.KeywordsSearchFilter`
     :   The type of the None singleton.
 
+<a id="KeywordsFuzzyCondition"></a>
+
 `KeywordsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -6521,6 +7111,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.pinterest.types.KeywordsStringFilter`
     :   The type of the None singleton.
+
+<a id="KeywordsGtCondition"></a>
 
 `KeywordsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
@@ -6534,6 +7126,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.pinterest.types.KeywordsSearchFilter`
     :   The type of the None singleton.
 
+<a id="KeywordsGteCondition"></a>
+
 `KeywordsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -6545,6 +7139,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.pinterest.types.KeywordsSearchFilter`
     :   The type of the None singleton.
+
+<a id="KeywordsInCondition"></a>
 
 `KeywordsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -6565,6 +7161,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.pinterest.types.KeywordsInFilter`
     :   The type of the None singleton.
+
+<a id="KeywordsInFilter"></a>
 
 `KeywordsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -6599,6 +7197,8 @@ Classes
     `value: list[str]`
     :   Keyword text value
 
+<a id="KeywordsKeywordCondition"></a>
+
 `KeywordsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -6611,6 +7211,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.pinterest.types.KeywordsStringFilter`
     :   The type of the None singleton.
 
+<a id="KeywordsLikeCondition"></a>
+
 `KeywordsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -6622,6 +7224,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.pinterest.types.KeywordsStringFilter`
     :   The type of the None singleton.
+
+<a id="KeywordsListParams"></a>
 
 `KeywordsListParams(*args, **kwargs)`
 :   Parameters for keywords.list operation
@@ -6644,6 +7248,8 @@ Classes
     `page_size: int`
     :   The type of the None singleton.
 
+<a id="KeywordsLtCondition"></a>
+
 `KeywordsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -6655,6 +7261,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.pinterest.types.KeywordsSearchFilter`
     :   The type of the None singleton.
+
+<a id="KeywordsLteCondition"></a>
 
 `KeywordsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -6668,6 +7276,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.pinterest.types.KeywordsSearchFilter`
     :   The type of the None singleton.
 
+<a id="KeywordsNeqCondition"></a>
+
 `KeywordsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -6679,6 +7289,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.pinterest.types.KeywordsSearchFilter`
     :   The type of the None singleton.
+
+<a id="KeywordsNotCondition"></a>
 
 `KeywordsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -6700,6 +7312,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.pinterest.types.KeywordsEqCondition | airbyte_agent_sdk.connectors.pinterest.types.KeywordsNeqCondition | airbyte_agent_sdk.connectors.pinterest.types.KeywordsGtCondition | airbyte_agent_sdk.connectors.pinterest.types.KeywordsGteCondition | airbyte_agent_sdk.connectors.pinterest.types.KeywordsLtCondition | airbyte_agent_sdk.connectors.pinterest.types.KeywordsLteCondition | airbyte_agent_sdk.connectors.pinterest.types.KeywordsInCondition | airbyte_agent_sdk.connectors.pinterest.types.KeywordsLikeCondition | airbyte_agent_sdk.connectors.pinterest.types.KeywordsFuzzyCondition | airbyte_agent_sdk.connectors.pinterest.types.KeywordsKeywordCondition | airbyte_agent_sdk.connectors.pinterest.types.KeywordsContainsCondition | airbyte_agent_sdk.connectors.pinterest.types.KeywordsNotCondition | airbyte_agent_sdk.connectors.pinterest.types.KeywordsAndCondition | airbyte_agent_sdk.connectors.pinterest.types.KeywordsOrCondition | airbyte_agent_sdk.connectors.pinterest.types.KeywordsAnyCondition`
     :   The type of the None singleton.
 
+<a id="KeywordsOrCondition"></a>
+
 `KeywordsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -6719,6 +7333,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.pinterest.types.KeywordsEqCondition | airbyte_agent_sdk.connectors.pinterest.types.KeywordsNeqCondition | airbyte_agent_sdk.connectors.pinterest.types.KeywordsGtCondition | airbyte_agent_sdk.connectors.pinterest.types.KeywordsGteCondition | airbyte_agent_sdk.connectors.pinterest.types.KeywordsLtCondition | airbyte_agent_sdk.connectors.pinterest.types.KeywordsLteCondition | airbyte_agent_sdk.connectors.pinterest.types.KeywordsInCondition | airbyte_agent_sdk.connectors.pinterest.types.KeywordsLikeCondition | airbyte_agent_sdk.connectors.pinterest.types.KeywordsFuzzyCondition | airbyte_agent_sdk.connectors.pinterest.types.KeywordsKeywordCondition | airbyte_agent_sdk.connectors.pinterest.types.KeywordsContainsCondition | airbyte_agent_sdk.connectors.pinterest.types.KeywordsNotCondition | airbyte_agent_sdk.connectors.pinterest.types.KeywordsAndCondition | airbyte_agent_sdk.connectors.pinterest.types.KeywordsOrCondition | airbyte_agent_sdk.connectors.pinterest.types.KeywordsAnyCondition]`
     :   The type of the None singleton.
+
+<a id="KeywordsSearchFilter"></a>
 
 `KeywordsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering keywords search queries.
@@ -6753,6 +7369,8 @@ Classes
     `value: str | None`
     :   Keyword text value
 
+<a id="KeywordsSearchQuery"></a>
+
 `KeywordsSearchQuery(*args, **kwargs)`
 :   Search query for keywords entity.
 
@@ -6767,6 +7385,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.pinterest.types.KeywordsSortFilter]`
     :   The type of the None singleton.
+
+<a id="KeywordsSortFilter"></a>
 
 `KeywordsSortFilter(*args, **kwargs)`
 :   Available fields for sorting keywords search results.
@@ -6800,6 +7420,8 @@ Classes
 
     `value: Literal['asc', 'desc']`
     :   Keyword text value
+
+<a id="KeywordsStringFilter"></a>
 
 `KeywordsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/pylon/connector.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/pylon/connector.md
@@ -10,6 +10,8 @@ Pylon connector.
 Classes
 -------
 
+<a id="AccountsQuery"></a>
+
 `AccountsQuery(connector: PylonConnector)`
 :   Query class for Accounts entity operations.
     
@@ -69,6 +71,8 @@ Classes
         Returns:
             AccountResponse
 
+<a id="ArticlesQuery"></a>
+
 `ArticlesQuery(connector: PylonConnector)`
 :   Query class for Articles entity operations.
     
@@ -104,6 +108,8 @@ Classes
         Returns:
             ArticleResponse
 
+<a id="CollectionsQuery"></a>
+
 `CollectionsQuery(connector: PylonConnector)`
 :   Query class for Collections entity operations.
     
@@ -123,6 +129,8 @@ Classes
         
         Returns:
             CollectionResponse
+
+<a id="ContactsQuery"></a>
 
 `ContactsQuery(connector: PylonConnector)`
 :   Query class for Contacts entity operations.
@@ -177,6 +185,8 @@ Classes
         Returns:
             ContactResponse
 
+<a id="CustomFieldsQuery"></a>
+
 `CustomFieldsQuery(connector: PylonConnector)`
 :   Query class for CustomFields entity operations.
     
@@ -205,6 +215,8 @@ Classes
         Returns:
             CustomFieldsListResult
 
+<a id="IssueNotesQuery"></a>
+
 `IssueNotesQuery(connector: PylonConnector)`
 :   Query class for IssueNotes entity operations.
     
@@ -225,6 +237,8 @@ Classes
         Returns:
             IssueNoteResponse
 
+<a id="IssueThreadsQuery"></a>
+
 `IssueThreadsQuery(connector: PylonConnector)`
 :   Query class for IssueThreads entity operations.
     
@@ -242,6 +256,8 @@ Classes
         
         Returns:
             IssueThreadResponse
+
+<a id="IssuesQuery"></a>
 
 `IssuesQuery(connector: PylonConnector)`
 :   Query class for Issues entity operations.
@@ -305,6 +321,8 @@ Classes
         Returns:
             IssueResponse
 
+<a id="MeQuery"></a>
+
 `MeQuery(connector: PylonConnector)`
 :   Query class for Me entity operations.
     
@@ -317,6 +335,8 @@ Classes
         
         Returns:
             User
+
+<a id="MessagesQuery"></a>
 
 `MessagesQuery(connector: PylonConnector)`
 :   Query class for Messages entity operations.
@@ -335,6 +355,8 @@ Classes
         
         Returns:
             MessagesListResult
+
+<a id="MilestonesQuery"></a>
 
 `MilestonesQuery(connector: PylonConnector)`
 :   Query class for Milestones entity operations.
@@ -366,6 +388,8 @@ Classes
         
         Returns:
             MilestoneResponse
+
+<a id="ProjectsQuery"></a>
 
 `ProjectsQuery(connector: PylonConnector)`
 :   Query class for Projects entity operations.
@@ -400,6 +424,8 @@ Classes
         
         Returns:
             ProjectResponse
+
+<a id="PylonConnector"></a>
 
 `PylonConnector(auth_config: PylonAuthConfig | AirbyteAuthConfig | BaseModel | None = None, on_token_refresh: Any | None = None)`
 :   Type-safe Pylon API connector.
@@ -589,6 +615,8 @@ Classes
             for entity in entities:
                 print(f"\{entity['entity_name']\}: \{entity['available_actions']\}")
 
+<a id="TagsQuery"></a>
+
 `TagsQuery(connector: PylonConnector)`
 :   Query class for Tags entity operations.
     
@@ -640,6 +668,8 @@ Classes
         Returns:
             TagResponse
 
+<a id="TasksQuery"></a>
+
 `TasksQuery(connector: PylonConnector)`
 :   Query class for Tasks entity operations.
     
@@ -676,6 +706,8 @@ Classes
         
         Returns:
             TaskResponse
+
+<a id="TeamsQuery"></a>
 
 `TeamsQuery(connector: PylonConnector)`
 :   Query class for Teams entity operations.
@@ -725,6 +757,8 @@ Classes
         Returns:
             TeamResponse
 
+<a id="TicketFormsQuery"></a>
+
 `TicketFormsQuery(connector: PylonConnector)`
 :   Query class for TicketForms entity operations.
     
@@ -742,6 +776,8 @@ Classes
         Returns:
             TicketFormsListResult
 
+<a id="UserRolesQuery"></a>
+
 `UserRolesQuery(connector: PylonConnector)`
 :   Query class for UserRoles entity operations.
     
@@ -758,6 +794,8 @@ Classes
         
         Returns:
             UserRolesListResult
+
+<a id="UsersQuery"></a>
 
 `UsersQuery(connector: PylonConnector)`
 :   Query class for Users entity operations.

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/pylon/index.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/pylon/index.md
@@ -19,6 +19,8 @@ Sub-modules
 Classes
 -------
 
+<a id="AirbyteAuthConfig"></a>
+
 `AirbyteAuthConfig(**data: Any)`
 :   Authentication configuration for Airbyte hosted mode execution.
     
@@ -87,6 +89,8 @@ Classes
     `workspace_name: str | None`
     :   The type of the None singleton.
 
+<a id="PylonAuthConfig"></a>
+
 `PylonAuthConfig(**data: Any)`
 :   API Token Authentication
     
@@ -108,6 +112,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="PylonConnector"></a>
 
 `PylonConnector(auth_config: PylonAuthConfig | AirbyteAuthConfig | BaseModel | None = None, on_token_refresh: Any | None = None)`
 :   Type-safe Pylon API connector.

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/pylon/models.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/pylon/models.md
@@ -13,6 +13,8 @@ and response envelope types.
 Classes
 -------
 
+<a id="Account"></a>
+
 `Account(**data: Any)`
 :   Account type definition
     
@@ -74,6 +76,8 @@ Classes
     `type_: str | Any | None`
     :   The type of the None singleton.
 
+<a id="AccountChannel"></a>
+
 `AccountChannel(**data: Any)`
 :   AccountChannel type definition
     
@@ -101,6 +105,8 @@ Classes
 
     `source: str | Any | None`
     :   The type of the None singleton.
+
+<a id="AccountCreateParams"></a>
 
 `AccountCreateParams(**data: Any)`
 :   AccountCreateParams type definition
@@ -139,6 +145,8 @@ Classes
     `tags: list[str] | Any`
     :   The type of the None singleton.
 
+<a id="AccountResponse"></a>
+
 `AccountResponse(**data: Any)`
 :   AccountResponse type definition
     
@@ -163,6 +171,8 @@ Classes
 
     `request_id: str | Any`
     :   The type of the None singleton.
+
+<a id="AccountUpdateParams"></a>
 
 `AccountUpdateParams(**data: Any)`
 :   AccountUpdateParams type definition
@@ -204,6 +214,8 @@ Classes
     `tags: list[str] | Any`
     :   The type of the None singleton.
 
+<a id="AccountsListResultMeta"></a>
+
 `AccountsListResultMeta(**data: Any)`
 :   Metadata for accounts.Action.LIST operation
     
@@ -228,6 +240,8 @@ Classes
 
     `next_cursor: str | Any | None`
     :   The type of the None singleton.
+
+<a id="AccountsResponse"></a>
 
 `AccountsResponse(**data: Any)`
 :   AccountsResponse type definition
@@ -256,6 +270,8 @@ Classes
 
     `request_id: str | Any`
     :   The type of the None singleton.
+
+<a id="Article"></a>
 
 `Article(**data: Any)`
 :   Article type definition
@@ -300,6 +316,8 @@ Classes
     `updated_at: str | Any | None`
     :   The type of the None singleton.
 
+<a id="ArticleCreateParams"></a>
+
 `ArticleCreateParams(**data: Any)`
 :   ArticleCreateParams type definition
     
@@ -334,6 +352,8 @@ Classes
     `title: str | Any`
     :   The type of the None singleton.
 
+<a id="ArticleResponse"></a>
+
 `ArticleResponse(**data: Any)`
 :   ArticleResponse type definition
     
@@ -358,6 +378,8 @@ Classes
 
     `request_id: str | Any`
     :   The type of the None singleton.
+
+<a id="ArticleUpdateParams"></a>
 
 `ArticleUpdateParams(**data: Any)`
 :   ArticleUpdateParams type definition
@@ -384,6 +406,8 @@ Classes
     `title: str | Any`
     :   The type of the None singleton.
 
+<a id="CSATResponse"></a>
+
 `CSATResponse(**data: Any)`
 :   CSATResponse type definition
     
@@ -408,6 +432,8 @@ Classes
 
     `score: int | Any | None`
     :   The type of the None singleton.
+
+<a id="Collection"></a>
 
 `Collection(**data: Any)`
 :   Collection type definition
@@ -443,6 +469,8 @@ Classes
     `title: str | Any | None`
     :   The type of the None singleton.
 
+<a id="CollectionCreateParams"></a>
+
 `CollectionCreateParams(**data: Any)`
 :   CollectionCreateParams type definition
     
@@ -471,6 +499,8 @@ Classes
     `title: str | Any`
     :   The type of the None singleton.
 
+<a id="CollectionResponse"></a>
+
 `CollectionResponse(**data: Any)`
 :   CollectionResponse type definition
     
@@ -495,6 +525,8 @@ Classes
 
     `request_id: str | Any`
     :   The type of the None singleton.
+
+<a id="Contact"></a>
 
 `Contact(**data: Any)`
 :   Contact type definition
@@ -548,6 +580,8 @@ Classes
     `portal_role_id: str | Any | None`
     :   The type of the None singleton.
 
+<a id="ContactCreateParams"></a>
+
 `ContactCreateParams(**data: Any)`
 :   ContactCreateParams type definition
     
@@ -579,6 +613,8 @@ Classes
     `name: str | Any`
     :   The type of the None singleton.
 
+<a id="ContactResponse"></a>
+
 `ContactResponse(**data: Any)`
 :   ContactResponse type definition
     
@@ -603,6 +639,8 @@ Classes
 
     `request_id: str | Any`
     :   The type of the None singleton.
+
+<a id="ContactUpdateParams"></a>
 
 `ContactUpdateParams(**data: Any)`
 :   ContactUpdateParams type definition
@@ -632,6 +670,8 @@ Classes
     `name: str | Any`
     :   The type of the None singleton.
 
+<a id="ContactsListResultMeta"></a>
+
 `ContactsListResultMeta(**data: Any)`
 :   Metadata for contacts.Action.LIST operation
     
@@ -656,6 +696,8 @@ Classes
 
     `next_cursor: str | Any | None`
     :   The type of the None singleton.
+
+<a id="ContactsResponse"></a>
 
 `ContactsResponse(**data: Any)`
 :   ContactsResponse type definition
@@ -684,6 +726,8 @@ Classes
 
     `request_id: str | Any`
     :   The type of the None singleton.
+
+<a id="CustomField"></a>
 
 `CustomField(**data: Any)`
 :   CustomField type definition
@@ -746,6 +790,8 @@ Classes
     `updated_at: str | Any | None`
     :   The type of the None singleton.
 
+<a id="CustomFieldResponse"></a>
+
 `CustomFieldResponse(**data: Any)`
 :   CustomFieldResponse type definition
     
@@ -770,6 +816,8 @@ Classes
 
     `request_id: str | Any`
     :   The type of the None singleton.
+
+<a id="CustomFieldValue"></a>
 
 `CustomFieldValue(**data: Any)`
 :   CustomFieldValue type definition
@@ -799,6 +847,8 @@ Classes
     `values: list[str] | Any | None`
     :   The type of the None singleton.
 
+<a id="CustomFieldsListResultMeta"></a>
+
 `CustomFieldsListResultMeta(**data: Any)`
 :   Metadata for custom_fields.Action.LIST operation
     
@@ -823,6 +873,8 @@ Classes
 
     `next_cursor: str | Any | None`
     :   The type of the None singleton.
+
+<a id="CustomFieldsResponse"></a>
 
 `CustomFieldsResponse(**data: Any)`
 :   CustomFieldsResponse type definition
@@ -851,6 +903,8 @@ Classes
 
     `request_id: str | Any`
     :   The type of the None singleton.
+
+<a id="EmailMessageInfo"></a>
 
 `EmailMessageInfo(**data: Any)`
 :   EmailMessageInfo type definition
@@ -886,6 +940,8 @@ Classes
     `to_emails: list[str] | Any | None`
     :   The type of the None singleton.
 
+<a id="ExternalIssue"></a>
+
 `ExternalIssue(**data: Any)`
 :   ExternalIssue type definition
     
@@ -914,6 +970,8 @@ Classes
     `source: str | Any | None`
     :   The type of the None singleton.
 
+<a id="IntegrationUserId"></a>
+
 `IntegrationUserId(**data: Any)`
 :   IntegrationUserId type definition
     
@@ -938,6 +996,8 @@ Classes
 
     `source: str | Any | None`
     :   The type of the None singleton.
+
+<a id="Issue"></a>
 
 `Issue(**data: Any)`
 :   Issue type definition
@@ -1051,6 +1111,8 @@ Classes
     `type_: Any`
     :   The type of the None singleton.
 
+<a id="IssueChatWidgetInfo"></a>
+
 `IssueChatWidgetInfo(**data: Any)`
 :   IssueChatWidgetInfo type definition
     
@@ -1072,6 +1134,8 @@ Classes
 
     `page_url: str | Any | None`
     :   The type of the None singleton.
+
+<a id="IssueCreateParams"></a>
 
 `IssueCreateParams(**data: Any)`
 :   IssueCreateParams type definition
@@ -1119,6 +1183,8 @@ Classes
     `title: str | Any`
     :   The type of the None singleton.
 
+<a id="IssueNote"></a>
+
 `IssueNote(**data: Any)`
 :   IssueNote type definition
     
@@ -1146,6 +1212,8 @@ Classes
 
     `timestamp: str | Any | None`
     :   The type of the None singleton.
+
+<a id="IssueNoteCreateParams"></a>
 
 `IssueNoteCreateParams(**data: Any)`
 :   IssueNoteCreateParams type definition
@@ -1175,6 +1243,8 @@ Classes
     `thread_id: str | Any`
     :   The type of the None singleton.
 
+<a id="IssueNoteResponse"></a>
+
 `IssueNoteResponse(**data: Any)`
 :   IssueNoteResponse type definition
     
@@ -1199,6 +1269,8 @@ Classes
 
     `request_id: str | Any`
     :   The type of the None singleton.
+
+<a id="IssueResponse"></a>
 
 `IssueResponse(**data: Any)`
 :   IssueResponse type definition
@@ -1225,6 +1297,8 @@ Classes
     `request_id: str | Any`
     :   The type of the None singleton.
 
+<a id="IssueThread"></a>
+
 `IssueThread(**data: Any)`
 :   IssueThread type definition
     
@@ -1250,6 +1324,8 @@ Classes
     `name: str | Any | None`
     :   The type of the None singleton.
 
+<a id="IssueThreadCreateParams"></a>
+
 `IssueThreadCreateParams(**data: Any)`
 :   IssueThreadCreateParams type definition
     
@@ -1271,6 +1347,8 @@ Classes
 
     `name: str | Any`
     :   The type of the None singleton.
+
+<a id="IssueThreadResponse"></a>
 
 `IssueThreadResponse(**data: Any)`
 :   IssueThreadResponse type definition
@@ -1296,6 +1374,8 @@ Classes
 
     `request_id: str | Any`
     :   The type of the None singleton.
+
+<a id="IssueUpdateParams"></a>
 
 `IssueUpdateParams(**data: Any)`
 :   IssueUpdateParams type definition
@@ -1331,6 +1411,8 @@ Classes
     `team_id: str | Any`
     :   The type of the None singleton.
 
+<a id="IssuesListResultMeta"></a>
+
 `IssuesListResultMeta(**data: Any)`
 :   Metadata for issues.Action.LIST operation
     
@@ -1355,6 +1437,8 @@ Classes
 
     `next_cursor: str | Any | None`
     :   The type of the None singleton.
+
+<a id="IssuesResponse"></a>
 
 `IssuesResponse(**data: Any)`
 :   IssuesResponse type definition
@@ -1384,6 +1468,8 @@ Classes
     `request_id: str | Any`
     :   The type of the None singleton.
 
+<a id="MeResponse"></a>
+
 `MeResponse(**data: Any)`
 :   MeResponse type definition
     
@@ -1408,6 +1494,8 @@ Classes
 
     `request_id: str | Any`
     :   The type of the None singleton.
+
+<a id="Message"></a>
 
 `Message(**data: Any)`
 :   Message type definition
@@ -1455,6 +1543,8 @@ Classes
     `timestamp: str | Any | None`
     :   The type of the None singleton.
 
+<a id="MessageAuthor"></a>
+
 `MessageAuthor(**data: Any)`
 :   MessageAuthor type definition
     
@@ -1486,6 +1576,8 @@ Classes
     `user: Any`
     :   The type of the None singleton.
 
+<a id="MessagesListResultMeta"></a>
+
 `MessagesListResultMeta(**data: Any)`
 :   Metadata for messages.Action.LIST operation
     
@@ -1510,6 +1602,8 @@ Classes
 
     `next_cursor: str | Any | None`
     :   The type of the None singleton.
+
+<a id="MessagesResponse"></a>
 
 `MessagesResponse(**data: Any)`
 :   MessagesResponse type definition
@@ -1538,6 +1632,8 @@ Classes
 
     `request_id: str | Any`
     :   The type of the None singleton.
+
+<a id="Milestone"></a>
 
 `Milestone(**data: Any)`
 :   Milestone type definition
@@ -1576,6 +1672,8 @@ Classes
     `updated_at: str | Any | None`
     :   The type of the None singleton.
 
+<a id="MilestoneCreateParams"></a>
+
 `MilestoneCreateParams(**data: Any)`
 :   MilestoneCreateParams type definition
     
@@ -1604,6 +1702,8 @@ Classes
     `project_id: str | Any`
     :   The type of the None singleton.
 
+<a id="MilestoneResponse"></a>
+
 `MilestoneResponse(**data: Any)`
 :   MilestoneResponse type definition
     
@@ -1628,6 +1728,8 @@ Classes
 
     `request_id: str | Any`
     :   The type of the None singleton.
+
+<a id="MilestoneUpdateParams"></a>
 
 `MilestoneUpdateParams(**data: Any)`
 :   MilestoneUpdateParams type definition
@@ -1654,6 +1756,8 @@ Classes
     `name: str | Any`
     :   The type of the None singleton.
 
+<a id="MiniAccount"></a>
+
 `MiniAccount(**data: Any)`
 :   MiniAccount type definition
     
@@ -1675,6 +1779,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="MiniContact"></a>
 
 `MiniContact(**data: Any)`
 :   MiniContact type definition
@@ -1701,6 +1807,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="MiniTeam"></a>
+
 `MiniTeam(**data: Any)`
 :   MiniTeam type definition
     
@@ -1722,6 +1830,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="MiniUser"></a>
 
 `MiniUser(**data: Any)`
 :   MiniUser type definition
@@ -1747,6 +1857,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="NumberMetadata"></a>
 
 `NumberMetadata(**data: Any)`
 :   NumberMetadata type definition
@@ -1776,6 +1888,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="Pagination"></a>
+
 `Pagination(**data: Any)`
 :   Pagination type definition
     
@@ -1800,6 +1914,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="Project"></a>
 
 `Project(**data: Any)`
 :   Project type definition
@@ -1850,6 +1966,8 @@ Classes
     `updated_at: str | Any | None`
     :   The type of the None singleton.
 
+<a id="ProjectCreateParams"></a>
+
 `ProjectCreateParams(**data: Any)`
 :   ProjectCreateParams type definition
     
@@ -1884,6 +2002,8 @@ Classes
     `start_date: str | Any`
     :   The type of the None singleton.
 
+<a id="ProjectResponse"></a>
+
 `ProjectResponse(**data: Any)`
 :   ProjectResponse type definition
     
@@ -1908,6 +2028,8 @@ Classes
 
     `request_id: str | Any`
     :   The type of the None singleton.
+
+<a id="ProjectUpdateParams"></a>
 
 `ProjectUpdateParams(**data: Any)`
 :   ProjectUpdateParams type definition
@@ -1937,6 +2059,8 @@ Classes
     `name: str | Any`
     :   The type of the None singleton.
 
+<a id="PylonAuthConfig"></a>
+
 `PylonAuthConfig(**data: Any)`
 :   API Token Authentication
     
@@ -1958,6 +2082,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="PylonCheckResult"></a>
 
 `PylonCheckResult(**data: Any)`
 :   Result of a health check operation.
@@ -1992,6 +2118,8 @@ Classes
     `status: str`
     :   Health check status: 'healthy' or 'unhealthy'.
 
+<a id="PylonExecuteResult"></a>
+
 `PylonExecuteResult(**data: Any)`
 :   Response envelope with data only.
     
@@ -2020,6 +2148,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="PylonExecuteResultWithMeta"></a>
 
 `PylonExecuteResultWithMeta(**data: Any)`
 :   Response envelope with data and metadata.
@@ -2081,6 +2211,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="AccountsListResult"></a>
+
 `AccountsListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -2123,6 +2255,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="ContactsListResult"></a>
 
 `ContactsListResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -2167,6 +2301,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="CustomFieldsListResult"></a>
+
 `CustomFieldsListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -2209,6 +2345,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="IssuesListResult"></a>
 
 `IssuesListResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -2253,6 +2391,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="MessagesListResult"></a>
+
 `MessagesListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -2295,6 +2435,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="TagsListResult"></a>
 
 `TagsListResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -2339,6 +2481,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="TeamsListResult"></a>
+
 `TeamsListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -2381,6 +2525,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="TicketFormsListResult"></a>
 
 `TicketFormsListResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -2425,6 +2571,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="UserRolesListResult"></a>
+
 `UserRolesListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -2468,6 +2616,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="UsersListResult"></a>
+
 `UsersListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -2486,6 +2636,8 @@ Classes
     * airbyte_agent_sdk.connectors.pylon.models.PylonExecuteResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="SelectMetadata"></a>
 
 `SelectMetadata(**data: Any)`
 :   SelectMetadata type definition
@@ -2508,6 +2660,8 @@ Classes
 
     `options: list[airbyte_agent_sdk.connectors.pylon.models.SelectOption] | Any | None`
     :   The type of the None singleton.
+
+<a id="SelectOption"></a>
 
 `SelectOption(**data: Any)`
 :   SelectOption type definition
@@ -2533,6 +2687,8 @@ Classes
 
     `slug: str | Any | None`
     :   The type of the None singleton.
+
+<a id="SlackInfo"></a>
 
 `SlackInfo(**data: Any)`
 :   SlackInfo type definition
@@ -2561,6 +2717,8 @@ Classes
 
     `workspace_id: str | Any | None`
     :   The type of the None singleton.
+
+<a id="Tag"></a>
 
 `Tag(**data: Any)`
 :   Tag type definition
@@ -2593,6 +2751,8 @@ Classes
     `value: str | Any | None`
     :   The type of the None singleton.
 
+<a id="TagCreateParams"></a>
+
 `TagCreateParams(**data: Any)`
 :   TagCreateParams type definition
     
@@ -2621,6 +2781,8 @@ Classes
     `value: str | Any`
     :   The type of the None singleton.
 
+<a id="TagResponse"></a>
+
 `TagResponse(**data: Any)`
 :   TagResponse type definition
     
@@ -2645,6 +2807,8 @@ Classes
 
     `request_id: str | Any`
     :   The type of the None singleton.
+
+<a id="TagUpdateParams"></a>
 
 `TagUpdateParams(**data: Any)`
 :   TagUpdateParams type definition
@@ -2671,6 +2835,8 @@ Classes
     `value: str | Any`
     :   The type of the None singleton.
 
+<a id="TagsListResultMeta"></a>
+
 `TagsListResultMeta(**data: Any)`
 :   Metadata for tags.Action.LIST operation
     
@@ -2695,6 +2861,8 @@ Classes
 
     `next_cursor: str | Any | None`
     :   The type of the None singleton.
+
+<a id="TagsResponse"></a>
 
 `TagsResponse(**data: Any)`
 :   TagsResponse type definition
@@ -2723,6 +2891,8 @@ Classes
 
     `request_id: str | Any`
     :   The type of the None singleton.
+
+<a id="Task"></a>
 
 `Task(**data: Any)`
 :   Task type definition
@@ -2773,6 +2943,8 @@ Classes
     `updated_at: str | Any | None`
     :   The type of the None singleton.
 
+<a id="TaskCreateParams"></a>
+
 `TaskCreateParams(**data: Any)`
 :   TaskCreateParams type definition
     
@@ -2813,6 +2985,8 @@ Classes
     `title: str | Any`
     :   The type of the None singleton.
 
+<a id="TaskResponse"></a>
+
 `TaskResponse(**data: Any)`
 :   TaskResponse type definition
     
@@ -2837,6 +3011,8 @@ Classes
 
     `request_id: str | Any`
     :   The type of the None singleton.
+
+<a id="TaskUpdateParams"></a>
 
 `TaskUpdateParams(**data: Any)`
 :   TaskUpdateParams type definition
@@ -2869,6 +3045,8 @@ Classes
     `title: str | Any`
     :   The type of the None singleton.
 
+<a id="Team"></a>
+
 `Team(**data: Any)`
 :   Team type definition
     
@@ -2897,6 +3075,8 @@ Classes
     `users: list[airbyte_agent_sdk.connectors.pylon.models.MiniUser] | Any | None`
     :   The type of the None singleton.
 
+<a id="TeamCreateParams"></a>
+
 `TeamCreateParams(**data: Any)`
 :   TeamCreateParams type definition
     
@@ -2918,6 +3098,8 @@ Classes
 
     `name: str | Any`
     :   The type of the None singleton.
+
+<a id="TeamResponse"></a>
 
 `TeamResponse(**data: Any)`
 :   TeamResponse type definition
@@ -2944,6 +3126,8 @@ Classes
     `request_id: str | Any`
     :   The type of the None singleton.
 
+<a id="TeamUpdateParams"></a>
+
 `TeamUpdateParams(**data: Any)`
 :   TeamUpdateParams type definition
     
@@ -2965,6 +3149,8 @@ Classes
 
     `name: str | Any`
     :   The type of the None singleton.
+
+<a id="TeamsListResultMeta"></a>
 
 `TeamsListResultMeta(**data: Any)`
 :   Metadata for teams.Action.LIST operation
@@ -2990,6 +3176,8 @@ Classes
 
     `next_cursor: str | Any | None`
     :   The type of the None singleton.
+
+<a id="TeamsResponse"></a>
 
 `TeamsResponse(**data: Any)`
 :   TeamsResponse type definition
@@ -3018,6 +3206,8 @@ Classes
 
     `request_id: str | Any`
     :   The type of the None singleton.
+
+<a id="TicketForm"></a>
 
 `TicketForm(**data: Any)`
 :   TicketForm type definition
@@ -3059,6 +3249,8 @@ Classes
     `url: str | Any | None`
     :   The type of the None singleton.
 
+<a id="TicketFormField"></a>
+
 `TicketFormField(**data: Any)`
 :   TicketFormField type definition
     
@@ -3090,6 +3282,8 @@ Classes
     `type_: str | Any | None`
     :   The type of the None singleton.
 
+<a id="TicketFormsListResultMeta"></a>
+
 `TicketFormsListResultMeta(**data: Any)`
 :   Metadata for ticket_forms.Action.LIST operation
     
@@ -3114,6 +3308,8 @@ Classes
 
     `next_cursor: str | Any | None`
     :   The type of the None singleton.
+
+<a id="TicketFormsResponse"></a>
 
 `TicketFormsResponse(**data: Any)`
 :   TicketFormsResponse type definition
@@ -3142,6 +3338,8 @@ Classes
 
     `request_id: str | Any`
     :   The type of the None singleton.
+
+<a id="User"></a>
 
 `User(**data: Any)`
 :   User type definition
@@ -3183,6 +3381,8 @@ Classes
     `status: str | Any | None`
     :   The type of the None singleton.
 
+<a id="UserResponse"></a>
+
 `UserResponse(**data: Any)`
 :   UserResponse type definition
     
@@ -3207,6 +3407,8 @@ Classes
 
     `request_id: str | Any`
     :   The type of the None singleton.
+
+<a id="UserRole"></a>
 
 `UserRole(**data: Any)`
 :   UserRole type definition
@@ -3236,6 +3438,8 @@ Classes
     `slug: str | Any | None`
     :   The type of the None singleton.
 
+<a id="UserRolesListResultMeta"></a>
+
 `UserRolesListResultMeta(**data: Any)`
 :   Metadata for user_roles.Action.LIST operation
     
@@ -3260,6 +3464,8 @@ Classes
 
     `next_cursor: str | Any | None`
     :   The type of the None singleton.
+
+<a id="UserRolesResponse"></a>
 
 `UserRolesResponse(**data: Any)`
 :   UserRolesResponse type definition
@@ -3289,6 +3495,8 @@ Classes
     `request_id: str | Any`
     :   The type of the None singleton.
 
+<a id="UsersListResultMeta"></a>
+
 `UsersListResultMeta(**data: Any)`
 :   Metadata for users.Action.LIST operation
     
@@ -3313,6 +3521,8 @@ Classes
 
     `next_cursor: str | Any | None`
     :   The type of the None singleton.
+
+<a id="UsersResponse"></a>
 
 `UsersResponse(**data: Any)`
 :   UsersResponse type definition

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/pylon/types.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/pylon/types.md
@@ -10,6 +10,8 @@ Type definitions for pylon connector.
 Classes
 -------
 
+<a id="AccountsCreateParams"></a>
+
 `AccountsCreateParams(*args, **kwargs)`
 :   Parameters for accounts.create operation
 
@@ -37,6 +39,8 @@ Classes
     `tags: list[str]`
     :   The type of the None singleton.
 
+<a id="AccountsGetParams"></a>
+
 `AccountsGetParams(*args, **kwargs)`
 :   Parameters for accounts.get operation
 
@@ -49,6 +53,8 @@ Classes
     `id: str`
     :   The type of the None singleton.
 
+<a id="AccountsListParams"></a>
+
 `AccountsListParams(*args, **kwargs)`
 :   Parameters for accounts.list operation
 
@@ -60,6 +66,8 @@ Classes
 
     `cursor: str`
     :   The type of the None singleton.
+
+<a id="AccountsUpdateParams"></a>
 
 `AccountsUpdateParams(*args, **kwargs)`
 :   Parameters for accounts.update operation
@@ -94,6 +102,8 @@ Classes
     `tags: list[str]`
     :   The type of the None singleton.
 
+<a id="ArticlesCreateParams"></a>
+
 `ArticlesCreateParams(*args, **kwargs)`
 :   Parameters for articles.create operation
 
@@ -121,6 +131,8 @@ Classes
     `title: str`
     :   The type of the None singleton.
 
+<a id="ArticlesUpdateParams"></a>
+
 `ArticlesUpdateParams(*args, **kwargs)`
 :   Parameters for articles.update operation
 
@@ -141,6 +153,8 @@ Classes
 
     `title: str`
     :   The type of the None singleton.
+
+<a id="CollectionsCreateParams"></a>
 
 `CollectionsCreateParams(*args, **kwargs)`
 :   Parameters for collections.create operation
@@ -163,6 +177,8 @@ Classes
     `title: str`
     :   The type of the None singleton.
 
+<a id="ContactsCreateParams"></a>
+
 `ContactsCreateParams(*args, **kwargs)`
 :   Parameters for contacts.create operation
 
@@ -184,6 +200,8 @@ Classes
     `name: str`
     :   The type of the None singleton.
 
+<a id="ContactsGetParams"></a>
+
 `ContactsGetParams(*args, **kwargs)`
 :   Parameters for contacts.get operation
 
@@ -196,6 +214,8 @@ Classes
     `id: str`
     :   The type of the None singleton.
 
+<a id="ContactsListParams"></a>
+
 `ContactsListParams(*args, **kwargs)`
 :   Parameters for contacts.list operation
 
@@ -207,6 +227,8 @@ Classes
 
     `cursor: str`
     :   The type of the None singleton.
+
+<a id="ContactsUpdateParams"></a>
 
 `ContactsUpdateParams(*args, **kwargs)`
 :   Parameters for contacts.update operation
@@ -229,6 +251,8 @@ Classes
     `name: str`
     :   The type of the None singleton.
 
+<a id="CustomFieldsGetParams"></a>
+
 `CustomFieldsGetParams(*args, **kwargs)`
 :   Parameters for custom_fields.get operation
 
@@ -240,6 +264,8 @@ Classes
 
     `id: str`
     :   The type of the None singleton.
+
+<a id="CustomFieldsListParams"></a>
 
 `CustomFieldsListParams(*args, **kwargs)`
 :   Parameters for custom_fields.list operation
@@ -255,6 +281,8 @@ Classes
 
     `object_type: str`
     :   The type of the None singleton.
+
+<a id="IssueNotesCreateParams"></a>
 
 `IssueNotesCreateParams(*args, **kwargs)`
 :   Parameters for issue_notes.create operation
@@ -277,6 +305,8 @@ Classes
     `thread_id: str`
     :   The type of the None singleton.
 
+<a id="IssueThreadsCreateParams"></a>
+
 `IssueThreadsCreateParams(*args, **kwargs)`
 :   Parameters for issue_threads.create operation
 
@@ -291,6 +321,8 @@ Classes
 
     `name: str`
     :   The type of the None singleton.
+
+<a id="IssuesCreateParams"></a>
 
 `IssuesCreateParams(*args, **kwargs)`
 :   Parameters for issues.create operation
@@ -328,6 +360,8 @@ Classes
     `title: str`
     :   The type of the None singleton.
 
+<a id="IssuesGetParams"></a>
+
 `IssuesGetParams(*args, **kwargs)`
 :   Parameters for issues.get operation
 
@@ -339,6 +373,8 @@ Classes
 
     `id: str`
     :   The type of the None singleton.
+
+<a id="IssuesListParams"></a>
 
 `IssuesListParams(*args, **kwargs)`
 :   Parameters for issues.list operation
@@ -357,6 +393,8 @@ Classes
 
     `start_time: str`
     :   The type of the None singleton.
+
+<a id="IssuesUpdateParams"></a>
 
 `IssuesUpdateParams(*args, **kwargs)`
 :   Parameters for issues.update operation
@@ -385,12 +423,16 @@ Classes
     `team_id: str`
     :   The type of the None singleton.
 
+<a id="MeGetParams"></a>
+
 `MeGetParams(*args, **kwargs)`
 :   Parameters for me.get operation
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="MessagesListParams"></a>
 
 `MessagesListParams(*args, **kwargs)`
 :   Parameters for messages.list operation
@@ -406,6 +448,8 @@ Classes
 
     `id: str`
     :   The type of the None singleton.
+
+<a id="MilestonesCreateParams"></a>
 
 `MilestonesCreateParams(*args, **kwargs)`
 :   Parameters for milestones.create operation
@@ -425,6 +469,8 @@ Classes
     `project_id: str`
     :   The type of the None singleton.
 
+<a id="MilestonesUpdateParams"></a>
+
 `MilestonesUpdateParams(*args, **kwargs)`
 :   Parameters for milestones.update operation
 
@@ -442,6 +488,8 @@ Classes
 
     `name: str`
     :   The type of the None singleton.
+
+<a id="ProjectsCreateParams"></a>
 
 `ProjectsCreateParams(*args, **kwargs)`
 :   Parameters for projects.create operation
@@ -467,6 +515,8 @@ Classes
     `start_date: str`
     :   The type of the None singleton.
 
+<a id="ProjectsUpdateParams"></a>
+
 `ProjectsUpdateParams(*args, **kwargs)`
 :   Parameters for projects.update operation
 
@@ -488,6 +538,8 @@ Classes
     `name: str`
     :   The type of the None singleton.
 
+<a id="TagsCreateParams"></a>
+
 `TagsCreateParams(*args, **kwargs)`
 :   Parameters for tags.create operation
 
@@ -506,6 +558,8 @@ Classes
     `value: str`
     :   The type of the None singleton.
 
+<a id="TagsGetParams"></a>
+
 `TagsGetParams(*args, **kwargs)`
 :   Parameters for tags.get operation
 
@@ -518,6 +572,8 @@ Classes
     `id: str`
     :   The type of the None singleton.
 
+<a id="TagsListParams"></a>
+
 `TagsListParams(*args, **kwargs)`
 :   Parameters for tags.list operation
 
@@ -529,6 +585,8 @@ Classes
 
     `cursor: str`
     :   The type of the None singleton.
+
+<a id="TagsUpdateParams"></a>
 
 `TagsUpdateParams(*args, **kwargs)`
 :   Parameters for tags.update operation
@@ -547,6 +605,8 @@ Classes
 
     `value: str`
     :   The type of the None singleton.
+
+<a id="TasksCreateParams"></a>
 
 `TasksCreateParams(*args, **kwargs)`
 :   Parameters for tasks.create operation
@@ -578,6 +638,8 @@ Classes
     `title: str`
     :   The type of the None singleton.
 
+<a id="TasksUpdateParams"></a>
+
 `TasksUpdateParams(*args, **kwargs)`
 :   Parameters for tasks.update operation
 
@@ -602,6 +664,8 @@ Classes
     `title: str`
     :   The type of the None singleton.
 
+<a id="TeamsCreateParams"></a>
+
 `TeamsCreateParams(*args, **kwargs)`
 :   Parameters for teams.create operation
 
@@ -613,6 +677,8 @@ Classes
 
     `name: str`
     :   The type of the None singleton.
+
+<a id="TeamsGetParams"></a>
 
 `TeamsGetParams(*args, **kwargs)`
 :   Parameters for teams.get operation
@@ -626,6 +692,8 @@ Classes
     `id: str`
     :   The type of the None singleton.
 
+<a id="TeamsListParams"></a>
+
 `TeamsListParams(*args, **kwargs)`
 :   Parameters for teams.list operation
 
@@ -637,6 +705,8 @@ Classes
 
     `cursor: str`
     :   The type of the None singleton.
+
+<a id="TeamsUpdateParams"></a>
 
 `TeamsUpdateParams(*args, **kwargs)`
 :   Parameters for teams.update operation
@@ -653,6 +723,8 @@ Classes
     `name: str`
     :   The type of the None singleton.
 
+<a id="TicketFormsListParams"></a>
+
 `TicketFormsListParams(*args, **kwargs)`
 :   Parameters for ticket_forms.list operation
 
@@ -664,6 +736,8 @@ Classes
 
     `cursor: str`
     :   The type of the None singleton.
+
+<a id="UserRolesListParams"></a>
 
 `UserRolesListParams(*args, **kwargs)`
 :   Parameters for user_roles.list operation
@@ -677,6 +751,8 @@ Classes
     `cursor: str`
     :   The type of the None singleton.
 
+<a id="UsersGetParams"></a>
+
 `UsersGetParams(*args, **kwargs)`
 :   Parameters for users.get operation
 
@@ -688,6 +764,8 @@ Classes
 
     `id: str`
     :   The type of the None singleton.
+
+<a id="UsersListParams"></a>
 
 `UsersListParams(*args, **kwargs)`
 :   Parameters for users.list operation

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/salesforce/connector.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/salesforce/connector.md
@@ -10,6 +10,8 @@ Salesforce connector.
 Classes
 -------
 
+<a id="AccountsQuery"></a>
+
 `AccountsQuery(connector: SalesforceConnector)`
 :   Query class for Accounts entity operations.
     
@@ -117,6 +119,8 @@ Classes
                 Returns:
                     AccountsListResult
 
+<a id="AttachmentsQuery"></a>
+
 `AttachmentsQuery(connector: SalesforceConnector)`
 :   Query class for Attachments entity operations.
     
@@ -191,6 +195,8 @@ Classes
                 Returns:
                     AttachmentsListResult
 
+<a id="CampaignsQuery"></a>
+
 `CampaignsQuery(connector: SalesforceConnector)`
 :   Query class for Campaigns entity operations.
     
@@ -244,6 +250,8 @@ Classes
                 Returns:
                     CampaignsListResult
 
+<a id="CasesQuery"></a>
+
 `CasesQuery(connector: SalesforceConnector)`
 :   Query class for Cases entity operations.
     
@@ -296,6 +304,8 @@ Classes
         
                 Returns:
                     CasesListResult
+
+<a id="ContactsQuery"></a>
 
 `ContactsQuery(connector: SalesforceConnector)`
 :   Query class for Contacts entity operations.
@@ -398,6 +408,8 @@ Classes
                 Returns:
                     ContactsListResult
 
+<a id="ContentVersionsQuery"></a>
+
 `ContentVersionsQuery(connector: SalesforceConnector)`
 :   Query class for ContentVersions entity operations.
     
@@ -471,6 +483,8 @@ Classes
                 Returns:
                     ContentVersionsListResult
 
+<a id="EventsQuery"></a>
+
 `EventsQuery(connector: SalesforceConnector)`
 :   Query class for Events entity operations.
     
@@ -523,6 +537,8 @@ Classes
         
                 Returns:
                     EventsListResult
+
+<a id="LeadsQuery"></a>
 
 `LeadsQuery(connector: SalesforceConnector)`
 :   Query class for Leads entity operations.
@@ -633,6 +649,8 @@ Classes
                 Returns:
                     LeadsListResult
 
+<a id="NotesQuery"></a>
+
 `NotesQuery(connector: SalesforceConnector)`
 :   Query class for Notes entity operations.
     
@@ -685,6 +703,8 @@ Classes
         
                 Returns:
                     NotesListResult
+
+<a id="OpportunitiesQuery"></a>
 
 `OpportunitiesQuery(connector: SalesforceConnector)`
 :   Query class for Opportunities entity operations.
@@ -787,6 +807,8 @@ Classes
                 Returns:
                     OpportunitiesListResult
 
+<a id="QueryQuery"></a>
+
 `QueryQuery(connector: SalesforceConnector)`
 :   Query class for Query entity operations.
     
@@ -810,6 +832,8 @@ Classes
         
                 Returns:
                     QueryListResult
+
+<a id="ReportsQuery"></a>
 
 `ReportsQuery(connector: SalesforceConnector)`
 :   Query class for Reports entity operations.
@@ -845,6 +869,8 @@ Classes
         
                 Returns:
                     ReportsListResult
+
+<a id="SalesforceConnector"></a>
 
 `SalesforceConnector(auth_config: SalesforceAuthConfig | AirbyteAuthConfig | BaseModel | None = None, on_token_refresh: Any | None = None, instance_url: str | None = None)`
 :   Type-safe Salesforce API connector.
@@ -1088,6 +1114,8 @@ Classes
             for entity in entities:
                 print(f"\{entity['entity_name']\}: \{entity['available_actions']\}")
 
+<a id="SobjectsQuery"></a>
+
 `SobjectsQuery(connector: SalesforceConnector)`
 :   Query class for Sobjects entity operations.
     
@@ -1102,6 +1130,8 @@ Classes
         
                 Returns:
                     SobjectsListResult
+
+<a id="TasksQuery"></a>
 
 `TasksQuery(connector: SalesforceConnector)`
 :   Query class for Tasks entity operations.

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/salesforce/index.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/salesforce/index.md
@@ -19,6 +19,8 @@ Sub-modules
 Classes
 -------
 
+<a id="AccountsSearchData"></a>
+
 `AccountsSearchData(**data: Any)`
 :   Search result data for accounts entity.
     
@@ -128,6 +130,8 @@ Classes
     `website: str | None`
     :   Website URL for the account
 
+<a id="AirbyteAuthConfig"></a>
+
 `AirbyteAuthConfig(**data: Any)`
 :   Authentication configuration for Airbyte hosted mode execution.
     
@@ -196,6 +200,8 @@ Classes
     `workspace_name: str | None`
     :   The type of the None singleton.
 
+<a id="AirbyteSearchMeta"></a>
+
 `AirbyteSearchMeta(**data: Any)`
 :   Pagination metadata for search responses.
     
@@ -223,6 +229,8 @@ Classes
 
     `took_ms: int | None`
     :   Time taken to execute the search in milliseconds.
+
+<a id="AirbyteSearchResult"></a>
 
 `AirbyteSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -258,6 +266,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="AccountsSearchResult"></a>
+
 `AccountsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -273,6 +283,8 @@ Classes
     * airbyte_agent_sdk.connectors.salesforce.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="ContactsSearchResult"></a>
 
 `ContactsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -290,6 +302,8 @@ Classes
     * pydantic.main.BaseModel
     * typing.Generic
 
+<a id="LeadsSearchResult"></a>
+
 `LeadsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -305,6 +319,8 @@ Classes
     * airbyte_agent_sdk.connectors.salesforce.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="OpportunitiesSearchResult"></a>
 
 `OpportunitiesSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -322,6 +338,8 @@ Classes
     * pydantic.main.BaseModel
     * typing.Generic
 
+<a id="TasksSearchResult"></a>
+
 `TasksSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -337,6 +355,8 @@ Classes
     * airbyte_agent_sdk.connectors.salesforce.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="ContactsSearchData"></a>
 
 `ContactsSearchData(**data: Any)`
 :   Search result data for contacts entity.
@@ -434,6 +454,8 @@ Classes
 
     `title: str | None`
     :   Job title of the contact
+
+<a id="LeadsSearchData"></a>
 
 `LeadsSearchData(**data: Any)`
 :   Search result data for leads entity.
@@ -556,6 +578,8 @@ Classes
     `website: str | None`
     :   Website URL for the lead's company
 
+<a id="OpportunitiesSearchData"></a>
+
 `OpportunitiesSearchData(**data: Any)`
 :   Search result data for opportunities entity.
     
@@ -653,6 +677,8 @@ Classes
     `type_: str | None`
     :   Type of opportunity (e.g., New Business, Existing Business)
 
+<a id="SalesforceAuthConfig"></a>
+
 `SalesforceAuthConfig(**data: Any)`
 :   Salesforce OAuth 2.0
     
@@ -680,6 +706,8 @@ Classes
 
     `refresh_token: str`
     :   OAuth refresh token for automatic token renewal
+
+<a id="SalesforceConnector"></a>
 
 `SalesforceConnector(auth_config: SalesforceAuthConfig | AirbyteAuthConfig | BaseModel | None = None, on_token_refresh: Any | None = None, instance_url: str | None = None)`
 :   Type-safe Salesforce API connector.
@@ -922,6 +950,8 @@ Classes
             entities = connector.list_entities()
             for entity in entities:
                 print(f"\{entity['entity_name']\}: \{entity['available_actions']\}")
+
+<a id="TasksSearchData"></a>
 
 `TasksSearchData(**data: Any)`
 :   Search result data for tasks entity.

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/salesforce/models.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/salesforce/models.md
@@ -13,6 +13,8 @@ and response envelope types.
 Classes
 -------
 
+<a id="Account"></a>
+
 `Account(**data: Any)`
 :   Salesforce Account object - uses FIELDS(STANDARD) so all standard fields are returned
     
@@ -41,6 +43,8 @@ Classes
     `name: str | Any`
     :   The type of the None singleton.
 
+<a id="AccountAttributes"></a>
+
 `AccountAttributes(**data: Any)`
 :   Nested schema for Account.attributes
     
@@ -65,6 +69,8 @@ Classes
 
     `url: str | Any`
     :   The type of the None singleton.
+
+<a id="AccountQueryResult"></a>
 
 `AccountQueryResult(**data: Any)`
 :   SOQL query result for accounts
@@ -97,6 +103,8 @@ Classes
     `total_size: int | Any`
     :   The type of the None singleton.
 
+<a id="AccountsListResultMeta"></a>
+
 `AccountsListResultMeta(**data: Any)`
 :   Metadata for accounts.Action.LIST operation
     
@@ -121,6 +129,8 @@ Classes
 
     `next_records_url: str | Any`
     :   The type of the None singleton.
+
+<a id="AccountsSearchData"></a>
 
 `AccountsSearchData(**data: Any)`
 :   Search result data for accounts entity.
@@ -231,6 +241,8 @@ Classes
     `website: str | None`
     :   Website URL for the account
 
+<a id="AirbyteSearchMeta"></a>
+
 `AirbyteSearchMeta(**data: Any)`
 :   Pagination metadata for search responses.
     
@@ -258,6 +270,8 @@ Classes
 
     `took_ms: int | None`
     :   Time taken to execute the search in milliseconds.
+
+<a id="AirbyteSearchResult"></a>
 
 `AirbyteSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -314,6 +328,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="AccountsSearchResult"></a>
+
 `AccountsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -350,6 +366,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="ContactsSearchResult"></a>
 
 `ContactsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -388,6 +406,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="LeadsSearchResult"></a>
+
 `LeadsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -424,6 +444,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="OpportunitiesSearchResult"></a>
 
 `OpportunitiesSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -462,6 +484,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="TasksSearchResult"></a>
+
 `TasksSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -477,6 +501,8 @@ Classes
     * airbyte_agent_sdk.connectors.salesforce.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="Attachment"></a>
 
 `Attachment(**data: Any)`
 :   Salesforce Attachment object - legacy file attachment on a record
@@ -515,6 +541,8 @@ Classes
     `parent_id: str | Any`
     :   The type of the None singleton.
 
+<a id="AttachmentAttributes"></a>
+
 `AttachmentAttributes(**data: Any)`
 :   Nested schema for Attachment.attributes
     
@@ -539,6 +567,8 @@ Classes
 
     `url: str | Any`
     :   The type of the None singleton.
+
+<a id="AttachmentQueryResult"></a>
 
 `AttachmentQueryResult(**data: Any)`
 :   SOQL query result for attachments
@@ -571,6 +601,8 @@ Classes
     `total_size: int | Any`
     :   The type of the None singleton.
 
+<a id="AttachmentsListResultMeta"></a>
+
 `AttachmentsListResultMeta(**data: Any)`
 :   Metadata for attachments.Action.LIST operation
     
@@ -595,6 +627,8 @@ Classes
 
     `next_records_url: str | Any`
     :   The type of the None singleton.
+
+<a id="Campaign"></a>
 
 `Campaign(**data: Any)`
 :   Salesforce Campaign object - uses FIELDS(STANDARD) so all standard fields are returned
@@ -624,6 +658,8 @@ Classes
     `name: str | Any`
     :   The type of the None singleton.
 
+<a id="CampaignAttributes"></a>
+
 `CampaignAttributes(**data: Any)`
 :   Nested schema for Campaign.attributes
     
@@ -648,6 +684,8 @@ Classes
 
     `url: str | Any`
     :   The type of the None singleton.
+
+<a id="CampaignQueryResult"></a>
 
 `CampaignQueryResult(**data: Any)`
 :   SOQL query result for campaigns
@@ -680,6 +718,8 @@ Classes
     `total_size: int | Any`
     :   The type of the None singleton.
 
+<a id="CampaignsListResultMeta"></a>
+
 `CampaignsListResultMeta(**data: Any)`
 :   Metadata for campaigns.Action.LIST operation
     
@@ -704,6 +744,8 @@ Classes
 
     `next_records_url: str | Any`
     :   The type of the None singleton.
+
+<a id="Case"></a>
 
 `Case(**data: Any)`
 :   Salesforce Case object - uses FIELDS(STANDARD) so all standard fields are returned
@@ -736,6 +778,8 @@ Classes
     `subject: str | Any`
     :   The type of the None singleton.
 
+<a id="CaseAttributes"></a>
+
 `CaseAttributes(**data: Any)`
 :   Nested schema for Case.attributes
     
@@ -760,6 +804,8 @@ Classes
 
     `url: str | Any`
     :   The type of the None singleton.
+
+<a id="CaseQueryResult"></a>
 
 `CaseQueryResult(**data: Any)`
 :   SOQL query result for cases
@@ -792,6 +838,8 @@ Classes
     `total_size: int | Any`
     :   The type of the None singleton.
 
+<a id="CasesListResultMeta"></a>
+
 `CasesListResultMeta(**data: Any)`
 :   Metadata for cases.Action.LIST operation
     
@@ -816,6 +864,8 @@ Classes
 
     `next_records_url: str | Any`
     :   The type of the None singleton.
+
+<a id="Contact"></a>
 
 `Contact(**data: Any)`
 :   Salesforce Contact object - uses FIELDS(STANDARD) so all standard fields are returned
@@ -845,6 +895,8 @@ Classes
     `name: str | Any`
     :   The type of the None singleton.
 
+<a id="ContactAttributes"></a>
+
 `ContactAttributes(**data: Any)`
 :   Nested schema for Contact.attributes
     
@@ -869,6 +921,8 @@ Classes
 
     `url: str | Any`
     :   The type of the None singleton.
+
+<a id="ContactQueryResult"></a>
 
 `ContactQueryResult(**data: Any)`
 :   SOQL query result for contacts
@@ -901,6 +955,8 @@ Classes
     `total_size: int | Any`
     :   The type of the None singleton.
 
+<a id="ContactsListResultMeta"></a>
+
 `ContactsListResultMeta(**data: Any)`
 :   Metadata for contacts.Action.LIST operation
     
@@ -925,6 +981,8 @@ Classes
 
     `next_records_url: str | Any`
     :   The type of the None singleton.
+
+<a id="ContactsSearchData"></a>
 
 `ContactsSearchData(**data: Any)`
 :   Search result data for contacts entity.
@@ -1023,6 +1081,8 @@ Classes
     `title: str | None`
     :   Job title of the contact
 
+<a id="ContentVersion"></a>
+
 `ContentVersion(**data: Any)`
 :   Salesforce ContentVersion object - represents a file version in Salesforce Files
     
@@ -1066,6 +1126,8 @@ Classes
     `version_number: str | Any`
     :   The type of the None singleton.
 
+<a id="ContentVersionAttributes"></a>
+
 `ContentVersionAttributes(**data: Any)`
 :   Nested schema for ContentVersion.attributes
     
@@ -1090,6 +1152,8 @@ Classes
 
     `url: str | Any`
     :   The type of the None singleton.
+
+<a id="ContentVersionQueryResult"></a>
 
 `ContentVersionQueryResult(**data: Any)`
 :   SOQL query result for content versions
@@ -1122,6 +1186,8 @@ Classes
     `total_size: int | Any`
     :   The type of the None singleton.
 
+<a id="ContentVersionsListResultMeta"></a>
+
 `ContentVersionsListResultMeta(**data: Any)`
 :   Metadata for content_versions.Action.LIST operation
     
@@ -1146,6 +1212,8 @@ Classes
 
     `next_records_url: str | Any`
     :   The type of the None singleton.
+
+<a id="Event"></a>
 
 `Event(**data: Any)`
 :   Salesforce Event object - uses FIELDS(STANDARD) so all standard fields are returned
@@ -1175,6 +1243,8 @@ Classes
     `subject: str | Any`
     :   The type of the None singleton.
 
+<a id="EventAttributes"></a>
+
 `EventAttributes(**data: Any)`
 :   Nested schema for Event.attributes
     
@@ -1199,6 +1269,8 @@ Classes
 
     `url: str | Any`
     :   The type of the None singleton.
+
+<a id="EventQueryResult"></a>
 
 `EventQueryResult(**data: Any)`
 :   SOQL query result for events
@@ -1231,6 +1303,8 @@ Classes
     `total_size: int | Any`
     :   The type of the None singleton.
 
+<a id="EventsListResultMeta"></a>
+
 `EventsListResultMeta(**data: Any)`
 :   Metadata for events.Action.LIST operation
     
@@ -1255,6 +1329,8 @@ Classes
 
     `next_records_url: str | Any`
     :   The type of the None singleton.
+
+<a id="Lead"></a>
 
 `Lead(**data: Any)`
 :   Salesforce Lead object - uses FIELDS(STANDARD) so all standard fields are returned
@@ -1284,6 +1360,8 @@ Classes
     `name: str | Any`
     :   The type of the None singleton.
 
+<a id="LeadAttributes"></a>
+
 `LeadAttributes(**data: Any)`
 :   Nested schema for Lead.attributes
     
@@ -1308,6 +1386,8 @@ Classes
 
     `url: str | Any`
     :   The type of the None singleton.
+
+<a id="LeadQueryResult"></a>
 
 `LeadQueryResult(**data: Any)`
 :   SOQL query result for leads
@@ -1340,6 +1420,8 @@ Classes
     `total_size: int | Any`
     :   The type of the None singleton.
 
+<a id="LeadsListResultMeta"></a>
+
 `LeadsListResultMeta(**data: Any)`
 :   Metadata for leads.Action.LIST operation
     
@@ -1364,6 +1446,8 @@ Classes
 
     `next_records_url: str | Any`
     :   The type of the None singleton.
+
+<a id="LeadsSearchData"></a>
 
 `LeadsSearchData(**data: Any)`
 :   Search result data for leads entity.
@@ -1486,6 +1570,8 @@ Classes
     `website: str | None`
     :   Website URL for the lead's company
 
+<a id="Note"></a>
+
 `Note(**data: Any)`
 :   Salesforce Note object - uses FIELDS(STANDARD) so all standard fields are returned
     
@@ -1514,6 +1600,8 @@ Classes
     `title: str | Any`
     :   The type of the None singleton.
 
+<a id="NoteAttributes"></a>
+
 `NoteAttributes(**data: Any)`
 :   Nested schema for Note.attributes
     
@@ -1538,6 +1626,8 @@ Classes
 
     `url: str | Any`
     :   The type of the None singleton.
+
+<a id="NoteQueryResult"></a>
 
 `NoteQueryResult(**data: Any)`
 :   SOQL query result for notes
@@ -1570,6 +1660,8 @@ Classes
     `total_size: int | Any`
     :   The type of the None singleton.
 
+<a id="NotesListResultMeta"></a>
+
 `NotesListResultMeta(**data: Any)`
 :   Metadata for notes.Action.LIST operation
     
@@ -1595,6 +1687,8 @@ Classes
     `next_records_url: str | Any`
     :   The type of the None singleton.
 
+<a id="OpportunitiesListResultMeta"></a>
+
 `OpportunitiesListResultMeta(**data: Any)`
 :   Metadata for opportunities.Action.LIST operation
     
@@ -1619,6 +1713,8 @@ Classes
 
     `next_records_url: str | Any`
     :   The type of the None singleton.
+
+<a id="OpportunitiesSearchData"></a>
 
 `OpportunitiesSearchData(**data: Any)`
 :   Search result data for opportunities entity.
@@ -1717,6 +1813,8 @@ Classes
     `type_: str | None`
     :   Type of opportunity (e.g., New Business, Existing Business)
 
+<a id="Opportunity"></a>
+
 `Opportunity(**data: Any)`
 :   Salesforce Opportunity object - uses FIELDS(STANDARD) so all standard fields are returned
     
@@ -1745,6 +1843,8 @@ Classes
     `name: str | Any`
     :   The type of the None singleton.
 
+<a id="OpportunityAttributes"></a>
+
 `OpportunityAttributes(**data: Any)`
 :   Nested schema for Opportunity.attributes
     
@@ -1769,6 +1869,8 @@ Classes
 
     `url: str | Any`
     :   The type of the None singleton.
+
+<a id="OpportunityQueryResult"></a>
 
 `OpportunityQueryResult(**data: Any)`
 :   SOQL query result for opportunities
@@ -1801,6 +1903,8 @@ Classes
     `total_size: int | Any`
     :   The type of the None singleton.
 
+<a id="QueryListResultMeta"></a>
+
 `QueryListResultMeta(**data: Any)`
 :   Metadata for query.Action.LIST operation
     
@@ -1825,6 +1929,8 @@ Classes
 
     `next_records_url: str | Any`
     :   The type of the None singleton.
+
+<a id="QueryResult"></a>
 
 `QueryResult(**data: Any)`
 :   Generic SOQL query result
@@ -1856,6 +1962,8 @@ Classes
 
     `total_size: int | Any`
     :   The type of the None singleton.
+
+<a id="Report"></a>
 
 `Report(**data: Any)`
 :   Salesforce Report metadata from the Analytics API
@@ -1890,6 +1998,8 @@ Classes
 
     `url: str | Any | None`
     :   The type of the None singleton.
+
+<a id="ReportResults"></a>
 
 `ReportResults(**data: Any)`
 :   Executed report results including data rows, aggregates, and metadata
@@ -1933,6 +2043,8 @@ Classes
 
     `report_metadata: dict[str, typing.Any] | Any | None`
     :   The type of the None singleton.
+
+<a id="SObject"></a>
 
 `SObject(**data: Any)`
 :   Salesforce sObject metadata
@@ -1986,6 +2098,8 @@ Classes
     `urls: dict[str, typing.Any] | Any | None`
     :   The type of the None singleton.
 
+<a id="SObjectsResponse"></a>
+
 `SObjectsResponse(**data: Any)`
 :   Response from the sobjects endpoint listing all available Salesforce objects
     
@@ -2014,6 +2128,8 @@ Classes
     `sobjects: list[airbyte_agent_sdk.connectors.salesforce.models.SObject] | Any`
     :   The type of the None singleton.
 
+<a id="SalesforceAuthConfig"></a>
+
 `SalesforceAuthConfig(**data: Any)`
 :   Salesforce OAuth 2.0
     
@@ -2041,6 +2157,8 @@ Classes
 
     `refresh_token: str`
     :   OAuth refresh token for automatic token renewal
+
+<a id="SalesforceCheckResult"></a>
 
 `SalesforceCheckResult(**data: Any)`
 :   Result of a health check operation.
@@ -2075,6 +2193,8 @@ Classes
     `status: str`
     :   Health check status: 'healthy' or 'unhealthy'.
 
+<a id="SalesforceExecuteResult"></a>
+
 `SalesforceExecuteResult(**data: Any)`
 :   Response envelope with data only.
     
@@ -2106,6 +2226,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="SalesforceExecuteResultWithMeta"></a>
 
 `SalesforceExecuteResultWithMeta(**data: Any)`
 :   Response envelope with data and metadata.
@@ -2169,6 +2291,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="AccountsListResult"></a>
+
 `AccountsListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -2211,6 +2335,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="AttachmentsListResult"></a>
 
 `AttachmentsListResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -2255,6 +2381,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="CampaignsListResult"></a>
+
 `CampaignsListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -2297,6 +2425,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="CasesListResult"></a>
 
 `CasesListResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -2341,6 +2471,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="ContactsListResult"></a>
+
 `ContactsListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -2383,6 +2515,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="ContentVersionsListResult"></a>
 
 `ContentVersionsListResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -2427,6 +2561,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="EventsListResult"></a>
+
 `EventsListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -2469,6 +2605,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="LeadsListResult"></a>
 
 `LeadsListResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -2513,6 +2651,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="NotesListResult"></a>
+
 `NotesListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -2555,6 +2695,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="OpportunitiesListResult"></a>
 
 `OpportunitiesListResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -2599,6 +2741,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="TasksListResult"></a>
+
 `TasksListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -2642,6 +2786,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="QueryListResult"></a>
+
 `QueryListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -2684,6 +2830,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="AccountsApiSearchResult"></a>
+
 `AccountsApiSearchResult(**data: Any)`
 :   Response envelope with data only.
     
@@ -2706,6 +2854,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="ContactsApiSearchResult"></a>
 
 `ContactsApiSearchResult(**data: Any)`
 :   Response envelope with data only.
@@ -2730,6 +2880,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="LeadsApiSearchResult"></a>
+
 `LeadsApiSearchResult(**data: Any)`
 :   Response envelope with data only.
     
@@ -2752,6 +2904,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="OpportunitiesApiSearchResult"></a>
 
 `OpportunitiesApiSearchResult(**data: Any)`
 :   Response envelope with data only.
@@ -2776,6 +2930,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="TasksApiSearchResult"></a>
+
 `TasksApiSearchResult(**data: Any)`
 :   Response envelope with data only.
     
@@ -2798,6 +2954,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="EventsApiSearchResult"></a>
 
 `EventsApiSearchResult(**data: Any)`
 :   Response envelope with data only.
@@ -2822,6 +2980,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="CampaignsApiSearchResult"></a>
+
 `CampaignsApiSearchResult(**data: Any)`
 :   Response envelope with data only.
     
@@ -2845,6 +3005,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="CasesApiSearchResult"></a>
+
 `CasesApiSearchResult(**data: Any)`
 :   Response envelope with data only.
     
@@ -2867,6 +3029,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="NotesApiSearchResult"></a>
 
 `NotesApiSearchResult(**data: Any)`
 :   Response envelope with data only.
@@ -2909,6 +3073,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="ReportsListResult"></a>
+
 `ReportsListResult(**data: Any)`
 :   Response envelope with data only.
     
@@ -2950,6 +3116,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="SobjectsListResult"></a>
+
 `SobjectsListResult(**data: Any)`
 :   Response envelope with data only.
     
@@ -2967,6 +3135,8 @@ Classes
     * airbyte_agent_sdk.connectors.salesforce.models.SalesforceExecuteResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="SearchResult"></a>
 
 `SearchResult(**data: Any)`
 :   SOSL search result
@@ -2989,6 +3159,8 @@ Classes
 
     `search_records: list[airbyte_agent_sdk.connectors.salesforce.models.SearchResultSearchrecordsItem] | Any`
     :   The type of the None singleton.
+
+<a id="SearchResultSearchrecordsItem"></a>
 
 `SearchResultSearchrecordsItem(**data: Any)`
 :   Nested schema for SearchResult.searchRecords_item
@@ -3015,6 +3187,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="SearchResultSearchrecordsItemAttributes"></a>
+
 `SearchResultSearchrecordsItemAttributes(**data: Any)`
 :   Nested schema for SearchResultSearchrecordsItem.attributes
     
@@ -3039,6 +3213,8 @@ Classes
 
     `url: str | Any`
     :   The type of the None singleton.
+
+<a id="Task"></a>
 
 `Task(**data: Any)`
 :   Salesforce Task object - uses FIELDS(STANDARD) so all standard fields are returned
@@ -3068,6 +3244,8 @@ Classes
     `subject: str | Any`
     :   The type of the None singleton.
 
+<a id="TaskAttributes"></a>
+
 `TaskAttributes(**data: Any)`
 :   Nested schema for Task.attributes
     
@@ -3092,6 +3270,8 @@ Classes
 
     `url: str | Any`
     :   The type of the None singleton.
+
+<a id="TaskQueryResult"></a>
 
 `TaskQueryResult(**data: Any)`
 :   SOQL query result for tasks
@@ -3124,6 +3304,8 @@ Classes
     `total_size: int | Any`
     :   The type of the None singleton.
 
+<a id="TasksListResultMeta"></a>
+
 `TasksListResultMeta(**data: Any)`
 :   Metadata for tasks.Action.LIST operation
     
@@ -3148,6 +3330,8 @@ Classes
 
     `next_records_url: str | Any`
     :   The type of the None singleton.
+
+<a id="TasksSearchData"></a>
 
 `TasksSearchData(**data: Any)`
 :   Search result data for tasks entity.

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/salesforce/types.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/salesforce/types.md
@@ -10,6 +10,8 @@ Type definitions for salesforce connector.
 Classes
 -------
 
+<a id="AccountsAndCondition"></a>
+
 `AccountsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -30,6 +32,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.salesforce.types.AccountsEqCondition | airbyte_agent_sdk.connectors.salesforce.types.AccountsNeqCondition | airbyte_agent_sdk.connectors.salesforce.types.AccountsGtCondition | airbyte_agent_sdk.connectors.salesforce.types.AccountsGteCondition | airbyte_agent_sdk.connectors.salesforce.types.AccountsLtCondition | airbyte_agent_sdk.connectors.salesforce.types.AccountsLteCondition | airbyte_agent_sdk.connectors.salesforce.types.AccountsInCondition | airbyte_agent_sdk.connectors.salesforce.types.AccountsLikeCondition | airbyte_agent_sdk.connectors.salesforce.types.AccountsFuzzyCondition | airbyte_agent_sdk.connectors.salesforce.types.AccountsKeywordCondition | airbyte_agent_sdk.connectors.salesforce.types.AccountsContainsCondition | airbyte_agent_sdk.connectors.salesforce.types.AccountsNotCondition | airbyte_agent_sdk.connectors.salesforce.types.AccountsAndCondition | airbyte_agent_sdk.connectors.salesforce.types.AccountsOrCondition | airbyte_agent_sdk.connectors.salesforce.types.AccountsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="AccountsAnyCondition"></a>
+
 `AccountsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -49,6 +53,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.salesforce.types.AccountsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="AccountsAnyValueFilter"></a>
 
 `AccountsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -149,6 +155,8 @@ Classes
     `website: Any`
     :   Website URL for the account
 
+<a id="AccountsApiSearchParams"></a>
+
 `AccountsApiSearchParams(*args, **kwargs)`
 :   Parameters for accounts.api_search operation
 
@@ -160,6 +168,8 @@ Classes
 
     `q: str`
     :   The type of the None singleton.
+
+<a id="AccountsContainsCondition"></a>
 
 `AccountsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
@@ -173,6 +183,8 @@ Classes
     `contains: airbyte_agent_sdk.connectors.salesforce.types.AccountsAnyValueFilter`
     :   The type of the None singleton.
 
+<a id="AccountsEqCondition"></a>
+
 `AccountsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
 
@@ -185,6 +197,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.salesforce.types.AccountsSearchFilter`
     :   The type of the None singleton.
 
+<a id="AccountsFuzzyCondition"></a>
+
 `AccountsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -196,6 +210,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.salesforce.types.AccountsStringFilter`
     :   The type of the None singleton.
+
+<a id="AccountsGetParams"></a>
 
 `AccountsGetParams(*args, **kwargs)`
 :   Parameters for accounts.get operation
@@ -212,6 +228,8 @@ Classes
     `id: str`
     :   The type of the None singleton.
 
+<a id="AccountsGtCondition"></a>
+
 `AccountsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -224,6 +242,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.salesforce.types.AccountsSearchFilter`
     :   The type of the None singleton.
 
+<a id="AccountsGteCondition"></a>
+
 `AccountsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -235,6 +255,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.salesforce.types.AccountsSearchFilter`
     :   The type of the None singleton.
+
+<a id="AccountsInCondition"></a>
 
 `AccountsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -255,6 +277,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.salesforce.types.AccountsInFilter`
     :   The type of the None singleton.
+
+<a id="AccountsInFilter"></a>
 
 `AccountsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -355,6 +379,8 @@ Classes
     `website: list[str]`
     :   Website URL for the account
 
+<a id="AccountsKeywordCondition"></a>
+
 `AccountsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -366,6 +392,8 @@ Classes
 
     `keyword: airbyte_agent_sdk.connectors.salesforce.types.AccountsStringFilter`
     :   The type of the None singleton.
+
+<a id="AccountsLikeCondition"></a>
 
 `AccountsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
@@ -379,6 +407,8 @@ Classes
     `like: airbyte_agent_sdk.connectors.salesforce.types.AccountsStringFilter`
     :   The type of the None singleton.
 
+<a id="AccountsListParams"></a>
+
 `AccountsListParams(*args, **kwargs)`
 :   Parameters for accounts.list operation
 
@@ -390,6 +420,8 @@ Classes
 
     `q: str`
     :   The type of the None singleton.
+
+<a id="AccountsLtCondition"></a>
 
 `AccountsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
@@ -403,6 +435,8 @@ Classes
     `lt: airbyte_agent_sdk.connectors.salesforce.types.AccountsSearchFilter`
     :   The type of the None singleton.
 
+<a id="AccountsLteCondition"></a>
+
 `AccountsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
 
@@ -415,6 +449,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.salesforce.types.AccountsSearchFilter`
     :   The type of the None singleton.
 
+<a id="AccountsNeqCondition"></a>
+
 `AccountsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -426,6 +462,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.salesforce.types.AccountsSearchFilter`
     :   The type of the None singleton.
+
+<a id="AccountsNotCondition"></a>
 
 `AccountsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -447,6 +485,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.salesforce.types.AccountsEqCondition | airbyte_agent_sdk.connectors.salesforce.types.AccountsNeqCondition | airbyte_agent_sdk.connectors.salesforce.types.AccountsGtCondition | airbyte_agent_sdk.connectors.salesforce.types.AccountsGteCondition | airbyte_agent_sdk.connectors.salesforce.types.AccountsLtCondition | airbyte_agent_sdk.connectors.salesforce.types.AccountsLteCondition | airbyte_agent_sdk.connectors.salesforce.types.AccountsInCondition | airbyte_agent_sdk.connectors.salesforce.types.AccountsLikeCondition | airbyte_agent_sdk.connectors.salesforce.types.AccountsFuzzyCondition | airbyte_agent_sdk.connectors.salesforce.types.AccountsKeywordCondition | airbyte_agent_sdk.connectors.salesforce.types.AccountsContainsCondition | airbyte_agent_sdk.connectors.salesforce.types.AccountsNotCondition | airbyte_agent_sdk.connectors.salesforce.types.AccountsAndCondition | airbyte_agent_sdk.connectors.salesforce.types.AccountsOrCondition | airbyte_agent_sdk.connectors.salesforce.types.AccountsAnyCondition`
     :   The type of the None singleton.
 
+<a id="AccountsOrCondition"></a>
+
 `AccountsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -466,6 +506,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.salesforce.types.AccountsEqCondition | airbyte_agent_sdk.connectors.salesforce.types.AccountsNeqCondition | airbyte_agent_sdk.connectors.salesforce.types.AccountsGtCondition | airbyte_agent_sdk.connectors.salesforce.types.AccountsGteCondition | airbyte_agent_sdk.connectors.salesforce.types.AccountsLtCondition | airbyte_agent_sdk.connectors.salesforce.types.AccountsLteCondition | airbyte_agent_sdk.connectors.salesforce.types.AccountsInCondition | airbyte_agent_sdk.connectors.salesforce.types.AccountsLikeCondition | airbyte_agent_sdk.connectors.salesforce.types.AccountsFuzzyCondition | airbyte_agent_sdk.connectors.salesforce.types.AccountsKeywordCondition | airbyte_agent_sdk.connectors.salesforce.types.AccountsContainsCondition | airbyte_agent_sdk.connectors.salesforce.types.AccountsNotCondition | airbyte_agent_sdk.connectors.salesforce.types.AccountsAndCondition | airbyte_agent_sdk.connectors.salesforce.types.AccountsOrCondition | airbyte_agent_sdk.connectors.salesforce.types.AccountsAnyCondition]`
     :   The type of the None singleton.
+
+<a id="AccountsSearchFilter"></a>
 
 `AccountsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering accounts search queries.
@@ -566,6 +608,8 @@ Classes
     `website: str | None`
     :   Website URL for the account
 
+<a id="AccountsSearchQuery"></a>
+
 `AccountsSearchQuery(*args, **kwargs)`
 :   Search query for accounts entity.
 
@@ -580,6 +624,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.salesforce.types.AccountsSortFilter]`
     :   The type of the None singleton.
+
+<a id="AccountsSortFilter"></a>
 
 `AccountsSortFilter(*args, **kwargs)`
 :   Available fields for sorting accounts search results.
@@ -680,6 +726,8 @@ Classes
     `website: Literal['asc', 'desc']`
     :   Website URL for the account
 
+<a id="AccountsStringFilter"></a>
+
 `AccountsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -779,6 +827,8 @@ Classes
     `website: str`
     :   Website URL for the account
 
+<a id="AirbyteSearchParams"></a>
+
 `AirbyteSearchParams(*args, **kwargs)`
 :   Parameters for Airbyte cache search operations (generic, use entity-specific query types for better type hints).
 
@@ -800,6 +850,8 @@ Classes
     `query: dict[str, typing.Any]`
     :   The type of the None singleton.
 
+<a id="AttachmentsDownloadParams"></a>
+
 `AttachmentsDownloadParams(*args, **kwargs)`
 :   Parameters for attachments.download operation
 
@@ -814,6 +866,8 @@ Classes
 
     `range_header: str`
     :   The type of the None singleton.
+
+<a id="AttachmentsGetParams"></a>
 
 `AttachmentsGetParams(*args, **kwargs)`
 :   Parameters for attachments.get operation
@@ -830,6 +884,8 @@ Classes
     `id: str`
     :   The type of the None singleton.
 
+<a id="AttachmentsListParams"></a>
+
 `AttachmentsListParams(*args, **kwargs)`
 :   Parameters for attachments.list operation
 
@@ -842,6 +898,8 @@ Classes
     `q: str`
     :   The type of the None singleton.
 
+<a id="CampaignsApiSearchParams"></a>
+
 `CampaignsApiSearchParams(*args, **kwargs)`
 :   Parameters for campaigns.api_search operation
 
@@ -853,6 +911,8 @@ Classes
 
     `q: str`
     :   The type of the None singleton.
+
+<a id="CampaignsGetParams"></a>
 
 `CampaignsGetParams(*args, **kwargs)`
 :   Parameters for campaigns.get operation
@@ -869,6 +929,8 @@ Classes
     `id: str`
     :   The type of the None singleton.
 
+<a id="CampaignsListParams"></a>
+
 `CampaignsListParams(*args, **kwargs)`
 :   Parameters for campaigns.list operation
 
@@ -881,6 +943,8 @@ Classes
     `q: str`
     :   The type of the None singleton.
 
+<a id="CasesApiSearchParams"></a>
+
 `CasesApiSearchParams(*args, **kwargs)`
 :   Parameters for cases.api_search operation
 
@@ -892,6 +956,8 @@ Classes
 
     `q: str`
     :   The type of the None singleton.
+
+<a id="CasesGetParams"></a>
 
 `CasesGetParams(*args, **kwargs)`
 :   Parameters for cases.get operation
@@ -908,6 +974,8 @@ Classes
     `id: str`
     :   The type of the None singleton.
 
+<a id="CasesListParams"></a>
+
 `CasesListParams(*args, **kwargs)`
 :   Parameters for cases.list operation
 
@@ -919,6 +987,8 @@ Classes
 
     `q: str`
     :   The type of the None singleton.
+
+<a id="ContactsAndCondition"></a>
 
 `ContactsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -940,6 +1010,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.salesforce.types.ContactsEqCondition | airbyte_agent_sdk.connectors.salesforce.types.ContactsNeqCondition | airbyte_agent_sdk.connectors.salesforce.types.ContactsGtCondition | airbyte_agent_sdk.connectors.salesforce.types.ContactsGteCondition | airbyte_agent_sdk.connectors.salesforce.types.ContactsLtCondition | airbyte_agent_sdk.connectors.salesforce.types.ContactsLteCondition | airbyte_agent_sdk.connectors.salesforce.types.ContactsInCondition | airbyte_agent_sdk.connectors.salesforce.types.ContactsLikeCondition | airbyte_agent_sdk.connectors.salesforce.types.ContactsFuzzyCondition | airbyte_agent_sdk.connectors.salesforce.types.ContactsKeywordCondition | airbyte_agent_sdk.connectors.salesforce.types.ContactsContainsCondition | airbyte_agent_sdk.connectors.salesforce.types.ContactsNotCondition | airbyte_agent_sdk.connectors.salesforce.types.ContactsAndCondition | airbyte_agent_sdk.connectors.salesforce.types.ContactsOrCondition | airbyte_agent_sdk.connectors.salesforce.types.ContactsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="ContactsAnyCondition"></a>
+
 `ContactsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -959,6 +1031,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.salesforce.types.ContactsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="ContactsAnyValueFilter"></a>
 
 `ContactsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -1047,6 +1121,8 @@ Classes
     `title: Any`
     :   Job title of the contact
 
+<a id="ContactsApiSearchParams"></a>
+
 `ContactsApiSearchParams(*args, **kwargs)`
 :   Parameters for contacts.api_search operation
 
@@ -1058,6 +1134,8 @@ Classes
 
     `q: str`
     :   The type of the None singleton.
+
+<a id="ContactsContainsCondition"></a>
 
 `ContactsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
@@ -1071,6 +1149,8 @@ Classes
     `contains: airbyte_agent_sdk.connectors.salesforce.types.ContactsAnyValueFilter`
     :   The type of the None singleton.
 
+<a id="ContactsEqCondition"></a>
+
 `ContactsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
 
@@ -1083,6 +1163,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.salesforce.types.ContactsSearchFilter`
     :   The type of the None singleton.
 
+<a id="ContactsFuzzyCondition"></a>
+
 `ContactsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -1094,6 +1176,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.salesforce.types.ContactsStringFilter`
     :   The type of the None singleton.
+
+<a id="ContactsGetParams"></a>
 
 `ContactsGetParams(*args, **kwargs)`
 :   Parameters for contacts.get operation
@@ -1110,6 +1194,8 @@ Classes
     `id: str`
     :   The type of the None singleton.
 
+<a id="ContactsGtCondition"></a>
+
 `ContactsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -1122,6 +1208,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.salesforce.types.ContactsSearchFilter`
     :   The type of the None singleton.
 
+<a id="ContactsGteCondition"></a>
+
 `ContactsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -1133,6 +1221,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.salesforce.types.ContactsSearchFilter`
     :   The type of the None singleton.
+
+<a id="ContactsInCondition"></a>
 
 `ContactsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -1153,6 +1243,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.salesforce.types.ContactsInFilter`
     :   The type of the None singleton.
+
+<a id="ContactsInFilter"></a>
 
 `ContactsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -1241,6 +1333,8 @@ Classes
     `title: list[str]`
     :   Job title of the contact
 
+<a id="ContactsKeywordCondition"></a>
+
 `ContactsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -1252,6 +1346,8 @@ Classes
 
     `keyword: airbyte_agent_sdk.connectors.salesforce.types.ContactsStringFilter`
     :   The type of the None singleton.
+
+<a id="ContactsLikeCondition"></a>
 
 `ContactsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
@@ -1265,6 +1361,8 @@ Classes
     `like: airbyte_agent_sdk.connectors.salesforce.types.ContactsStringFilter`
     :   The type of the None singleton.
 
+<a id="ContactsListParams"></a>
+
 `ContactsListParams(*args, **kwargs)`
 :   Parameters for contacts.list operation
 
@@ -1276,6 +1374,8 @@ Classes
 
     `q: str`
     :   The type of the None singleton.
+
+<a id="ContactsLtCondition"></a>
 
 `ContactsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
@@ -1289,6 +1389,8 @@ Classes
     `lt: airbyte_agent_sdk.connectors.salesforce.types.ContactsSearchFilter`
     :   The type of the None singleton.
 
+<a id="ContactsLteCondition"></a>
+
 `ContactsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
 
@@ -1301,6 +1403,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.salesforce.types.ContactsSearchFilter`
     :   The type of the None singleton.
 
+<a id="ContactsNeqCondition"></a>
+
 `ContactsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -1312,6 +1416,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.salesforce.types.ContactsSearchFilter`
     :   The type of the None singleton.
+
+<a id="ContactsNotCondition"></a>
 
 `ContactsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -1333,6 +1439,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.salesforce.types.ContactsEqCondition | airbyte_agent_sdk.connectors.salesforce.types.ContactsNeqCondition | airbyte_agent_sdk.connectors.salesforce.types.ContactsGtCondition | airbyte_agent_sdk.connectors.salesforce.types.ContactsGteCondition | airbyte_agent_sdk.connectors.salesforce.types.ContactsLtCondition | airbyte_agent_sdk.connectors.salesforce.types.ContactsLteCondition | airbyte_agent_sdk.connectors.salesforce.types.ContactsInCondition | airbyte_agent_sdk.connectors.salesforce.types.ContactsLikeCondition | airbyte_agent_sdk.connectors.salesforce.types.ContactsFuzzyCondition | airbyte_agent_sdk.connectors.salesforce.types.ContactsKeywordCondition | airbyte_agent_sdk.connectors.salesforce.types.ContactsContainsCondition | airbyte_agent_sdk.connectors.salesforce.types.ContactsNotCondition | airbyte_agent_sdk.connectors.salesforce.types.ContactsAndCondition | airbyte_agent_sdk.connectors.salesforce.types.ContactsOrCondition | airbyte_agent_sdk.connectors.salesforce.types.ContactsAnyCondition`
     :   The type of the None singleton.
 
+<a id="ContactsOrCondition"></a>
+
 `ContactsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1352,6 +1460,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.salesforce.types.ContactsEqCondition | airbyte_agent_sdk.connectors.salesforce.types.ContactsNeqCondition | airbyte_agent_sdk.connectors.salesforce.types.ContactsGtCondition | airbyte_agent_sdk.connectors.salesforce.types.ContactsGteCondition | airbyte_agent_sdk.connectors.salesforce.types.ContactsLtCondition | airbyte_agent_sdk.connectors.salesforce.types.ContactsLteCondition | airbyte_agent_sdk.connectors.salesforce.types.ContactsInCondition | airbyte_agent_sdk.connectors.salesforce.types.ContactsLikeCondition | airbyte_agent_sdk.connectors.salesforce.types.ContactsFuzzyCondition | airbyte_agent_sdk.connectors.salesforce.types.ContactsKeywordCondition | airbyte_agent_sdk.connectors.salesforce.types.ContactsContainsCondition | airbyte_agent_sdk.connectors.salesforce.types.ContactsNotCondition | airbyte_agent_sdk.connectors.salesforce.types.ContactsAndCondition | airbyte_agent_sdk.connectors.salesforce.types.ContactsOrCondition | airbyte_agent_sdk.connectors.salesforce.types.ContactsAnyCondition]`
     :   The type of the None singleton.
+
+<a id="ContactsSearchFilter"></a>
 
 `ContactsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering contacts search queries.
@@ -1440,6 +1550,8 @@ Classes
     `title: str | None`
     :   Job title of the contact
 
+<a id="ContactsSearchQuery"></a>
+
 `ContactsSearchQuery(*args, **kwargs)`
 :   Search query for contacts entity.
 
@@ -1454,6 +1566,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.salesforce.types.ContactsSortFilter]`
     :   The type of the None singleton.
+
+<a id="ContactsSortFilter"></a>
 
 `ContactsSortFilter(*args, **kwargs)`
 :   Available fields for sorting contacts search results.
@@ -1542,6 +1656,8 @@ Classes
     `title: Literal['asc', 'desc']`
     :   Job title of the contact
 
+<a id="ContactsStringFilter"></a>
+
 `ContactsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -1629,6 +1745,8 @@ Classes
     `title: str`
     :   Job title of the contact
 
+<a id="ContentVersionsDownloadParams"></a>
+
 `ContentVersionsDownloadParams(*args, **kwargs)`
 :   Parameters for content_versions.download operation
 
@@ -1643,6 +1761,8 @@ Classes
 
     `range_header: str`
     :   The type of the None singleton.
+
+<a id="ContentVersionsGetParams"></a>
 
 `ContentVersionsGetParams(*args, **kwargs)`
 :   Parameters for content_versions.get operation
@@ -1659,6 +1779,8 @@ Classes
     `id: str`
     :   The type of the None singleton.
 
+<a id="ContentVersionsListParams"></a>
+
 `ContentVersionsListParams(*args, **kwargs)`
 :   Parameters for content_versions.list operation
 
@@ -1671,6 +1793,8 @@ Classes
     `q: str`
     :   The type of the None singleton.
 
+<a id="EventsApiSearchParams"></a>
+
 `EventsApiSearchParams(*args, **kwargs)`
 :   Parameters for events.api_search operation
 
@@ -1682,6 +1806,8 @@ Classes
 
     `q: str`
     :   The type of the None singleton.
+
+<a id="EventsGetParams"></a>
 
 `EventsGetParams(*args, **kwargs)`
 :   Parameters for events.get operation
@@ -1698,6 +1824,8 @@ Classes
     `id: str`
     :   The type of the None singleton.
 
+<a id="EventsListParams"></a>
+
 `EventsListParams(*args, **kwargs)`
 :   Parameters for events.list operation
 
@@ -1709,6 +1837,8 @@ Classes
 
     `q: str`
     :   The type of the None singleton.
+
+<a id="LeadsAndCondition"></a>
 
 `LeadsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -1730,6 +1860,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.salesforce.types.LeadsEqCondition | airbyte_agent_sdk.connectors.salesforce.types.LeadsNeqCondition | airbyte_agent_sdk.connectors.salesforce.types.LeadsGtCondition | airbyte_agent_sdk.connectors.salesforce.types.LeadsGteCondition | airbyte_agent_sdk.connectors.salesforce.types.LeadsLtCondition | airbyte_agent_sdk.connectors.salesforce.types.LeadsLteCondition | airbyte_agent_sdk.connectors.salesforce.types.LeadsInCondition | airbyte_agent_sdk.connectors.salesforce.types.LeadsLikeCondition | airbyte_agent_sdk.connectors.salesforce.types.LeadsFuzzyCondition | airbyte_agent_sdk.connectors.salesforce.types.LeadsKeywordCondition | airbyte_agent_sdk.connectors.salesforce.types.LeadsContainsCondition | airbyte_agent_sdk.connectors.salesforce.types.LeadsNotCondition | airbyte_agent_sdk.connectors.salesforce.types.LeadsAndCondition | airbyte_agent_sdk.connectors.salesforce.types.LeadsOrCondition | airbyte_agent_sdk.connectors.salesforce.types.LeadsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="LeadsAnyCondition"></a>
+
 `LeadsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1749,6 +1881,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.salesforce.types.LeadsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="LeadsAnyValueFilter"></a>
 
 `LeadsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -1861,6 +1995,8 @@ Classes
     `website: Any`
     :   Website URL for the lead's company
 
+<a id="LeadsApiSearchParams"></a>
+
 `LeadsApiSearchParams(*args, **kwargs)`
 :   Parameters for leads.api_search operation
 
@@ -1872,6 +2008,8 @@ Classes
 
     `q: str`
     :   The type of the None singleton.
+
+<a id="LeadsContainsCondition"></a>
 
 `LeadsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
@@ -1885,6 +2023,8 @@ Classes
     `contains: airbyte_agent_sdk.connectors.salesforce.types.LeadsAnyValueFilter`
     :   The type of the None singleton.
 
+<a id="LeadsEqCondition"></a>
+
 `LeadsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
 
@@ -1897,6 +2037,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.salesforce.types.LeadsSearchFilter`
     :   The type of the None singleton.
 
+<a id="LeadsFuzzyCondition"></a>
+
 `LeadsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -1908,6 +2050,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.salesforce.types.LeadsStringFilter`
     :   The type of the None singleton.
+
+<a id="LeadsGetParams"></a>
 
 `LeadsGetParams(*args, **kwargs)`
 :   Parameters for leads.get operation
@@ -1924,6 +2068,8 @@ Classes
     `id: str`
     :   The type of the None singleton.
 
+<a id="LeadsGtCondition"></a>
+
 `LeadsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -1936,6 +2082,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.salesforce.types.LeadsSearchFilter`
     :   The type of the None singleton.
 
+<a id="LeadsGteCondition"></a>
+
 `LeadsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -1947,6 +2095,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.salesforce.types.LeadsSearchFilter`
     :   The type of the None singleton.
+
+<a id="LeadsInCondition"></a>
 
 `LeadsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -1967,6 +2117,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.salesforce.types.LeadsInFilter`
     :   The type of the None singleton.
+
+<a id="LeadsInFilter"></a>
 
 `LeadsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -2079,6 +2231,8 @@ Classes
     `website: list[str]`
     :   Website URL for the lead's company
 
+<a id="LeadsKeywordCondition"></a>
+
 `LeadsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -2090,6 +2244,8 @@ Classes
 
     `keyword: airbyte_agent_sdk.connectors.salesforce.types.LeadsStringFilter`
     :   The type of the None singleton.
+
+<a id="LeadsLikeCondition"></a>
 
 `LeadsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
@@ -2103,6 +2259,8 @@ Classes
     `like: airbyte_agent_sdk.connectors.salesforce.types.LeadsStringFilter`
     :   The type of the None singleton.
 
+<a id="LeadsListParams"></a>
+
 `LeadsListParams(*args, **kwargs)`
 :   Parameters for leads.list operation
 
@@ -2114,6 +2272,8 @@ Classes
 
     `q: str`
     :   The type of the None singleton.
+
+<a id="LeadsLtCondition"></a>
 
 `LeadsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
@@ -2127,6 +2287,8 @@ Classes
     `lt: airbyte_agent_sdk.connectors.salesforce.types.LeadsSearchFilter`
     :   The type of the None singleton.
 
+<a id="LeadsLteCondition"></a>
+
 `LeadsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
 
@@ -2139,6 +2301,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.salesforce.types.LeadsSearchFilter`
     :   The type of the None singleton.
 
+<a id="LeadsNeqCondition"></a>
+
 `LeadsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -2150,6 +2314,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.salesforce.types.LeadsSearchFilter`
     :   The type of the None singleton.
+
+<a id="LeadsNotCondition"></a>
 
 `LeadsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -2171,6 +2337,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.salesforce.types.LeadsEqCondition | airbyte_agent_sdk.connectors.salesforce.types.LeadsNeqCondition | airbyte_agent_sdk.connectors.salesforce.types.LeadsGtCondition | airbyte_agent_sdk.connectors.salesforce.types.LeadsGteCondition | airbyte_agent_sdk.connectors.salesforce.types.LeadsLtCondition | airbyte_agent_sdk.connectors.salesforce.types.LeadsLteCondition | airbyte_agent_sdk.connectors.salesforce.types.LeadsInCondition | airbyte_agent_sdk.connectors.salesforce.types.LeadsLikeCondition | airbyte_agent_sdk.connectors.salesforce.types.LeadsFuzzyCondition | airbyte_agent_sdk.connectors.salesforce.types.LeadsKeywordCondition | airbyte_agent_sdk.connectors.salesforce.types.LeadsContainsCondition | airbyte_agent_sdk.connectors.salesforce.types.LeadsNotCondition | airbyte_agent_sdk.connectors.salesforce.types.LeadsAndCondition | airbyte_agent_sdk.connectors.salesforce.types.LeadsOrCondition | airbyte_agent_sdk.connectors.salesforce.types.LeadsAnyCondition`
     :   The type of the None singleton.
 
+<a id="LeadsOrCondition"></a>
+
 `LeadsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -2190,6 +2358,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.salesforce.types.LeadsEqCondition | airbyte_agent_sdk.connectors.salesforce.types.LeadsNeqCondition | airbyte_agent_sdk.connectors.salesforce.types.LeadsGtCondition | airbyte_agent_sdk.connectors.salesforce.types.LeadsGteCondition | airbyte_agent_sdk.connectors.salesforce.types.LeadsLtCondition | airbyte_agent_sdk.connectors.salesforce.types.LeadsLteCondition | airbyte_agent_sdk.connectors.salesforce.types.LeadsInCondition | airbyte_agent_sdk.connectors.salesforce.types.LeadsLikeCondition | airbyte_agent_sdk.connectors.salesforce.types.LeadsFuzzyCondition | airbyte_agent_sdk.connectors.salesforce.types.LeadsKeywordCondition | airbyte_agent_sdk.connectors.salesforce.types.LeadsContainsCondition | airbyte_agent_sdk.connectors.salesforce.types.LeadsNotCondition | airbyte_agent_sdk.connectors.salesforce.types.LeadsAndCondition | airbyte_agent_sdk.connectors.salesforce.types.LeadsOrCondition | airbyte_agent_sdk.connectors.salesforce.types.LeadsAnyCondition]`
     :   The type of the None singleton.
+
+<a id="LeadsSearchFilter"></a>
 
 `LeadsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering leads search queries.
@@ -2302,6 +2472,8 @@ Classes
     `website: str | None`
     :   Website URL for the lead's company
 
+<a id="LeadsSearchQuery"></a>
+
 `LeadsSearchQuery(*args, **kwargs)`
 :   Search query for leads entity.
 
@@ -2316,6 +2488,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.salesforce.types.LeadsSortFilter]`
     :   The type of the None singleton.
+
+<a id="LeadsSortFilter"></a>
 
 `LeadsSortFilter(*args, **kwargs)`
 :   Available fields for sorting leads search results.
@@ -2428,6 +2602,8 @@ Classes
     `website: Literal['asc', 'desc']`
     :   Website URL for the lead's company
 
+<a id="LeadsStringFilter"></a>
+
 `LeadsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -2539,6 +2715,8 @@ Classes
     `website: str`
     :   Website URL for the lead's company
 
+<a id="NotesApiSearchParams"></a>
+
 `NotesApiSearchParams(*args, **kwargs)`
 :   Parameters for notes.api_search operation
 
@@ -2550,6 +2728,8 @@ Classes
 
     `q: str`
     :   The type of the None singleton.
+
+<a id="NotesGetParams"></a>
 
 `NotesGetParams(*args, **kwargs)`
 :   Parameters for notes.get operation
@@ -2566,6 +2746,8 @@ Classes
     `id: str`
     :   The type of the None singleton.
 
+<a id="NotesListParams"></a>
+
 `NotesListParams(*args, **kwargs)`
 :   Parameters for notes.list operation
 
@@ -2577,6 +2759,8 @@ Classes
 
     `q: str`
     :   The type of the None singleton.
+
+<a id="OpportunitiesAndCondition"></a>
 
 `OpportunitiesAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -2598,6 +2782,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.salesforce.types.OpportunitiesEqCondition | airbyte_agent_sdk.connectors.salesforce.types.OpportunitiesNeqCondition | airbyte_agent_sdk.connectors.salesforce.types.OpportunitiesGtCondition | airbyte_agent_sdk.connectors.salesforce.types.OpportunitiesGteCondition | airbyte_agent_sdk.connectors.salesforce.types.OpportunitiesLtCondition | airbyte_agent_sdk.connectors.salesforce.types.OpportunitiesLteCondition | airbyte_agent_sdk.connectors.salesforce.types.OpportunitiesInCondition | airbyte_agent_sdk.connectors.salesforce.types.OpportunitiesLikeCondition | airbyte_agent_sdk.connectors.salesforce.types.OpportunitiesFuzzyCondition | airbyte_agent_sdk.connectors.salesforce.types.OpportunitiesKeywordCondition | airbyte_agent_sdk.connectors.salesforce.types.OpportunitiesContainsCondition | airbyte_agent_sdk.connectors.salesforce.types.OpportunitiesNotCondition | airbyte_agent_sdk.connectors.salesforce.types.OpportunitiesAndCondition | airbyte_agent_sdk.connectors.salesforce.types.OpportunitiesOrCondition | airbyte_agent_sdk.connectors.salesforce.types.OpportunitiesAnyCondition]`
     :   The type of the None singleton.
 
+<a id="OpportunitiesAnyCondition"></a>
+
 `OpportunitiesAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -2617,6 +2803,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.salesforce.types.OpportunitiesAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="OpportunitiesAnyValueFilter"></a>
 
 `OpportunitiesAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -2705,6 +2893,8 @@ Classes
     `type_: Any`
     :   Type of opportunity (e.g., New Business, Existing Business)
 
+<a id="OpportunitiesApiSearchParams"></a>
+
 `OpportunitiesApiSearchParams(*args, **kwargs)`
 :   Parameters for opportunities.api_search operation
 
@@ -2716,6 +2906,8 @@ Classes
 
     `q: str`
     :   The type of the None singleton.
+
+<a id="OpportunitiesContainsCondition"></a>
 
 `OpportunitiesContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
@@ -2729,6 +2921,8 @@ Classes
     `contains: airbyte_agent_sdk.connectors.salesforce.types.OpportunitiesAnyValueFilter`
     :   The type of the None singleton.
 
+<a id="OpportunitiesEqCondition"></a>
+
 `OpportunitiesEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
 
@@ -2741,6 +2935,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.salesforce.types.OpportunitiesSearchFilter`
     :   The type of the None singleton.
 
+<a id="OpportunitiesFuzzyCondition"></a>
+
 `OpportunitiesFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -2752,6 +2948,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.salesforce.types.OpportunitiesStringFilter`
     :   The type of the None singleton.
+
+<a id="OpportunitiesGetParams"></a>
 
 `OpportunitiesGetParams(*args, **kwargs)`
 :   Parameters for opportunities.get operation
@@ -2768,6 +2966,8 @@ Classes
     `id: str`
     :   The type of the None singleton.
 
+<a id="OpportunitiesGtCondition"></a>
+
 `OpportunitiesGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -2780,6 +2980,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.salesforce.types.OpportunitiesSearchFilter`
     :   The type of the None singleton.
 
+<a id="OpportunitiesGteCondition"></a>
+
 `OpportunitiesGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -2791,6 +2993,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.salesforce.types.OpportunitiesSearchFilter`
     :   The type of the None singleton.
+
+<a id="OpportunitiesInCondition"></a>
 
 `OpportunitiesInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -2811,6 +3015,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.salesforce.types.OpportunitiesInFilter`
     :   The type of the None singleton.
+
+<a id="OpportunitiesInFilter"></a>
 
 `OpportunitiesInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -2899,6 +3105,8 @@ Classes
     `type_: list[str]`
     :   Type of opportunity (e.g., New Business, Existing Business)
 
+<a id="OpportunitiesKeywordCondition"></a>
+
 `OpportunitiesKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -2910,6 +3118,8 @@ Classes
 
     `keyword: airbyte_agent_sdk.connectors.salesforce.types.OpportunitiesStringFilter`
     :   The type of the None singleton.
+
+<a id="OpportunitiesLikeCondition"></a>
 
 `OpportunitiesLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
@@ -2923,6 +3133,8 @@ Classes
     `like: airbyte_agent_sdk.connectors.salesforce.types.OpportunitiesStringFilter`
     :   The type of the None singleton.
 
+<a id="OpportunitiesListParams"></a>
+
 `OpportunitiesListParams(*args, **kwargs)`
 :   Parameters for opportunities.list operation
 
@@ -2934,6 +3146,8 @@ Classes
 
     `q: str`
     :   The type of the None singleton.
+
+<a id="OpportunitiesLtCondition"></a>
 
 `OpportunitiesLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
@@ -2947,6 +3161,8 @@ Classes
     `lt: airbyte_agent_sdk.connectors.salesforce.types.OpportunitiesSearchFilter`
     :   The type of the None singleton.
 
+<a id="OpportunitiesLteCondition"></a>
+
 `OpportunitiesLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
 
@@ -2959,6 +3175,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.salesforce.types.OpportunitiesSearchFilter`
     :   The type of the None singleton.
 
+<a id="OpportunitiesNeqCondition"></a>
+
 `OpportunitiesNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -2970,6 +3188,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.salesforce.types.OpportunitiesSearchFilter`
     :   The type of the None singleton.
+
+<a id="OpportunitiesNotCondition"></a>
 
 `OpportunitiesNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -2991,6 +3211,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.salesforce.types.OpportunitiesEqCondition | airbyte_agent_sdk.connectors.salesforce.types.OpportunitiesNeqCondition | airbyte_agent_sdk.connectors.salesforce.types.OpportunitiesGtCondition | airbyte_agent_sdk.connectors.salesforce.types.OpportunitiesGteCondition | airbyte_agent_sdk.connectors.salesforce.types.OpportunitiesLtCondition | airbyte_agent_sdk.connectors.salesforce.types.OpportunitiesLteCondition | airbyte_agent_sdk.connectors.salesforce.types.OpportunitiesInCondition | airbyte_agent_sdk.connectors.salesforce.types.OpportunitiesLikeCondition | airbyte_agent_sdk.connectors.salesforce.types.OpportunitiesFuzzyCondition | airbyte_agent_sdk.connectors.salesforce.types.OpportunitiesKeywordCondition | airbyte_agent_sdk.connectors.salesforce.types.OpportunitiesContainsCondition | airbyte_agent_sdk.connectors.salesforce.types.OpportunitiesNotCondition | airbyte_agent_sdk.connectors.salesforce.types.OpportunitiesAndCondition | airbyte_agent_sdk.connectors.salesforce.types.OpportunitiesOrCondition | airbyte_agent_sdk.connectors.salesforce.types.OpportunitiesAnyCondition`
     :   The type of the None singleton.
 
+<a id="OpportunitiesOrCondition"></a>
+
 `OpportunitiesOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -3010,6 +3232,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.salesforce.types.OpportunitiesEqCondition | airbyte_agent_sdk.connectors.salesforce.types.OpportunitiesNeqCondition | airbyte_agent_sdk.connectors.salesforce.types.OpportunitiesGtCondition | airbyte_agent_sdk.connectors.salesforce.types.OpportunitiesGteCondition | airbyte_agent_sdk.connectors.salesforce.types.OpportunitiesLtCondition | airbyte_agent_sdk.connectors.salesforce.types.OpportunitiesLteCondition | airbyte_agent_sdk.connectors.salesforce.types.OpportunitiesInCondition | airbyte_agent_sdk.connectors.salesforce.types.OpportunitiesLikeCondition | airbyte_agent_sdk.connectors.salesforce.types.OpportunitiesFuzzyCondition | airbyte_agent_sdk.connectors.salesforce.types.OpportunitiesKeywordCondition | airbyte_agent_sdk.connectors.salesforce.types.OpportunitiesContainsCondition | airbyte_agent_sdk.connectors.salesforce.types.OpportunitiesNotCondition | airbyte_agent_sdk.connectors.salesforce.types.OpportunitiesAndCondition | airbyte_agent_sdk.connectors.salesforce.types.OpportunitiesOrCondition | airbyte_agent_sdk.connectors.salesforce.types.OpportunitiesAnyCondition]`
     :   The type of the None singleton.
+
+<a id="OpportunitiesSearchFilter"></a>
 
 `OpportunitiesSearchFilter(*args, **kwargs)`
 :   Available fields for filtering opportunities search queries.
@@ -3098,6 +3322,8 @@ Classes
     `type_: str | None`
     :   Type of opportunity (e.g., New Business, Existing Business)
 
+<a id="OpportunitiesSearchQuery"></a>
+
 `OpportunitiesSearchQuery(*args, **kwargs)`
 :   Search query for opportunities entity.
 
@@ -3112,6 +3338,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.salesforce.types.OpportunitiesSortFilter]`
     :   The type of the None singleton.
+
+<a id="OpportunitiesSortFilter"></a>
 
 `OpportunitiesSortFilter(*args, **kwargs)`
 :   Available fields for sorting opportunities search results.
@@ -3200,6 +3428,8 @@ Classes
     `type_: Literal['asc', 'desc']`
     :   Type of opportunity (e.g., New Business, Existing Business)
 
+<a id="OpportunitiesStringFilter"></a>
+
 `OpportunitiesStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -3287,6 +3517,8 @@ Classes
     `type_: str`
     :   Type of opportunity (e.g., New Business, Existing Business)
 
+<a id="QueryListParams"></a>
+
 `QueryListParams(*args, **kwargs)`
 :   Parameters for query.list operation
 
@@ -3298,6 +3530,8 @@ Classes
 
     `q: str`
     :   The type of the None singleton.
+
+<a id="ReportsGetParams"></a>
 
 `ReportsGetParams(*args, **kwargs)`
 :   Parameters for reports.get operation
@@ -3314,6 +3548,8 @@ Classes
     `include_details: bool`
     :   The type of the None singleton.
 
+<a id="ReportsListParams"></a>
+
 `ReportsListParams(*args, **kwargs)`
 :   Parameters for reports.list operation
 
@@ -3321,12 +3557,16 @@ Classes
 
     * builtins.dict
 
+<a id="SobjectsListParams"></a>
+
 `SobjectsListParams(*args, **kwargs)`
 :   Parameters for sobjects.list operation
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="TasksAndCondition"></a>
 
 `TasksAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -3348,6 +3588,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.salesforce.types.TasksEqCondition | airbyte_agent_sdk.connectors.salesforce.types.TasksNeqCondition | airbyte_agent_sdk.connectors.salesforce.types.TasksGtCondition | airbyte_agent_sdk.connectors.salesforce.types.TasksGteCondition | airbyte_agent_sdk.connectors.salesforce.types.TasksLtCondition | airbyte_agent_sdk.connectors.salesforce.types.TasksLteCondition | airbyte_agent_sdk.connectors.salesforce.types.TasksInCondition | airbyte_agent_sdk.connectors.salesforce.types.TasksLikeCondition | airbyte_agent_sdk.connectors.salesforce.types.TasksFuzzyCondition | airbyte_agent_sdk.connectors.salesforce.types.TasksKeywordCondition | airbyte_agent_sdk.connectors.salesforce.types.TasksContainsCondition | airbyte_agent_sdk.connectors.salesforce.types.TasksNotCondition | airbyte_agent_sdk.connectors.salesforce.types.TasksAndCondition | airbyte_agent_sdk.connectors.salesforce.types.TasksOrCondition | airbyte_agent_sdk.connectors.salesforce.types.TasksAnyCondition]`
     :   The type of the None singleton.
 
+<a id="TasksAnyCondition"></a>
+
 `TasksAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -3367,6 +3609,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.salesforce.types.TasksAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="TasksAnyValueFilter"></a>
 
 `TasksAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -3449,6 +3693,8 @@ Classes
     `who_id: Any`
     :   ID of the related person (Contact or Lead)
 
+<a id="TasksApiSearchParams"></a>
+
 `TasksApiSearchParams(*args, **kwargs)`
 :   Parameters for tasks.api_search operation
 
@@ -3460,6 +3706,8 @@ Classes
 
     `q: str`
     :   The type of the None singleton.
+
+<a id="TasksContainsCondition"></a>
 
 `TasksContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
@@ -3473,6 +3721,8 @@ Classes
     `contains: airbyte_agent_sdk.connectors.salesforce.types.TasksAnyValueFilter`
     :   The type of the None singleton.
 
+<a id="TasksEqCondition"></a>
+
 `TasksEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
 
@@ -3485,6 +3735,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.salesforce.types.TasksSearchFilter`
     :   The type of the None singleton.
 
+<a id="TasksFuzzyCondition"></a>
+
 `TasksFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -3496,6 +3748,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.salesforce.types.TasksStringFilter`
     :   The type of the None singleton.
+
+<a id="TasksGetParams"></a>
 
 `TasksGetParams(*args, **kwargs)`
 :   Parameters for tasks.get operation
@@ -3512,6 +3766,8 @@ Classes
     `id: str`
     :   The type of the None singleton.
 
+<a id="TasksGtCondition"></a>
+
 `TasksGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -3524,6 +3780,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.salesforce.types.TasksSearchFilter`
     :   The type of the None singleton.
 
+<a id="TasksGteCondition"></a>
+
 `TasksGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -3535,6 +3793,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.salesforce.types.TasksSearchFilter`
     :   The type of the None singleton.
+
+<a id="TasksInCondition"></a>
 
 `TasksInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -3555,6 +3815,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.salesforce.types.TasksInFilter`
     :   The type of the None singleton.
+
+<a id="TasksInFilter"></a>
 
 `TasksInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -3637,6 +3899,8 @@ Classes
     `who_id: list[str]`
     :   ID of the related person (Contact or Lead)
 
+<a id="TasksKeywordCondition"></a>
+
 `TasksKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -3648,6 +3912,8 @@ Classes
 
     `keyword: airbyte_agent_sdk.connectors.salesforce.types.TasksStringFilter`
     :   The type of the None singleton.
+
+<a id="TasksLikeCondition"></a>
 
 `TasksLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
@@ -3661,6 +3927,8 @@ Classes
     `like: airbyte_agent_sdk.connectors.salesforce.types.TasksStringFilter`
     :   The type of the None singleton.
 
+<a id="TasksListParams"></a>
+
 `TasksListParams(*args, **kwargs)`
 :   Parameters for tasks.list operation
 
@@ -3672,6 +3940,8 @@ Classes
 
     `q: str`
     :   The type of the None singleton.
+
+<a id="TasksLtCondition"></a>
 
 `TasksLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
@@ -3685,6 +3955,8 @@ Classes
     `lt: airbyte_agent_sdk.connectors.salesforce.types.TasksSearchFilter`
     :   The type of the None singleton.
 
+<a id="TasksLteCondition"></a>
+
 `TasksLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
 
@@ -3697,6 +3969,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.salesforce.types.TasksSearchFilter`
     :   The type of the None singleton.
 
+<a id="TasksNeqCondition"></a>
+
 `TasksNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -3708,6 +3982,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.salesforce.types.TasksSearchFilter`
     :   The type of the None singleton.
+
+<a id="TasksNotCondition"></a>
 
 `TasksNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -3729,6 +4005,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.salesforce.types.TasksEqCondition | airbyte_agent_sdk.connectors.salesforce.types.TasksNeqCondition | airbyte_agent_sdk.connectors.salesforce.types.TasksGtCondition | airbyte_agent_sdk.connectors.salesforce.types.TasksGteCondition | airbyte_agent_sdk.connectors.salesforce.types.TasksLtCondition | airbyte_agent_sdk.connectors.salesforce.types.TasksLteCondition | airbyte_agent_sdk.connectors.salesforce.types.TasksInCondition | airbyte_agent_sdk.connectors.salesforce.types.TasksLikeCondition | airbyte_agent_sdk.connectors.salesforce.types.TasksFuzzyCondition | airbyte_agent_sdk.connectors.salesforce.types.TasksKeywordCondition | airbyte_agent_sdk.connectors.salesforce.types.TasksContainsCondition | airbyte_agent_sdk.connectors.salesforce.types.TasksNotCondition | airbyte_agent_sdk.connectors.salesforce.types.TasksAndCondition | airbyte_agent_sdk.connectors.salesforce.types.TasksOrCondition | airbyte_agent_sdk.connectors.salesforce.types.TasksAnyCondition`
     :   The type of the None singleton.
 
+<a id="TasksOrCondition"></a>
+
 `TasksOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -3748,6 +4026,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.salesforce.types.TasksEqCondition | airbyte_agent_sdk.connectors.salesforce.types.TasksNeqCondition | airbyte_agent_sdk.connectors.salesforce.types.TasksGtCondition | airbyte_agent_sdk.connectors.salesforce.types.TasksGteCondition | airbyte_agent_sdk.connectors.salesforce.types.TasksLtCondition | airbyte_agent_sdk.connectors.salesforce.types.TasksLteCondition | airbyte_agent_sdk.connectors.salesforce.types.TasksInCondition | airbyte_agent_sdk.connectors.salesforce.types.TasksLikeCondition | airbyte_agent_sdk.connectors.salesforce.types.TasksFuzzyCondition | airbyte_agent_sdk.connectors.salesforce.types.TasksKeywordCondition | airbyte_agent_sdk.connectors.salesforce.types.TasksContainsCondition | airbyte_agent_sdk.connectors.salesforce.types.TasksNotCondition | airbyte_agent_sdk.connectors.salesforce.types.TasksAndCondition | airbyte_agent_sdk.connectors.salesforce.types.TasksOrCondition | airbyte_agent_sdk.connectors.salesforce.types.TasksAnyCondition]`
     :   The type of the None singleton.
+
+<a id="TasksSearchFilter"></a>
 
 `TasksSearchFilter(*args, **kwargs)`
 :   Available fields for filtering tasks search queries.
@@ -3830,6 +4110,8 @@ Classes
     `who_id: str | None`
     :   ID of the related person (Contact or Lead)
 
+<a id="TasksSearchQuery"></a>
+
 `TasksSearchQuery(*args, **kwargs)`
 :   Search query for tasks entity.
 
@@ -3844,6 +4126,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.salesforce.types.TasksSortFilter]`
     :   The type of the None singleton.
+
+<a id="TasksSortFilter"></a>
 
 `TasksSortFilter(*args, **kwargs)`
 :   Available fields for sorting tasks search results.
@@ -3925,6 +4209,8 @@ Classes
 
     `who_id: Literal['asc', 'desc']`
     :   ID of the related person (Contact or Lead)
+
+<a id="TasksStringFilter"></a>
 
 `TasksStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/sendgrid/connector.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/sendgrid/connector.md
@@ -10,6 +10,8 @@ Sendgrid connector.
 Classes
 -------
 
+<a id="BlocksQuery"></a>
+
 `BlocksQuery(connector: SendgridConnector)`
 :   Query class for Blocks entity operations.
     
@@ -54,6 +56,8 @@ Classes
         Returns:
             BlocksListResult
 
+<a id="BouncesQuery"></a>
+
 `BouncesQuery(connector: SendgridConnector)`
 :   Query class for Bounces entity operations.
     
@@ -97,6 +101,8 @@ Classes
         
         Returns:
             BouncesListResult
+
+<a id="CampaignsQuery"></a>
 
 `CampaignsQuery(connector: SendgridConnector)`
 :   Query class for Campaigns entity operations.
@@ -143,6 +149,8 @@ Classes
         
         Returns:
             CampaignsListResult
+
+<a id="ContactsQuery"></a>
 
 `ContactsQuery(connector: SendgridConnector)`
 :   Query class for Contacts entity operations.
@@ -209,6 +217,8 @@ Classes
         Returns:
             ContactsListResult
 
+<a id="GlobalSuppressionsQuery"></a>
+
 `GlobalSuppressionsQuery(connector: SendgridConnector)`
 :   Query class for GlobalSuppressions entity operations.
     
@@ -250,6 +260,8 @@ Classes
         
         Returns:
             GlobalSuppressionsListResult
+
+<a id="InvalidEmailsQuery"></a>
 
 `InvalidEmailsQuery(connector: SendgridConnector)`
 :   Query class for InvalidEmails entity operations.
@@ -293,6 +305,8 @@ Classes
         
         Returns:
             InvalidEmailsListResult
+
+<a id="ListsQuery"></a>
 
 `ListsQuery(connector: SendgridConnector)`
 :   Query class for Lists entity operations.
@@ -346,6 +360,8 @@ Classes
         
         Returns:
             ListsListResult
+
+<a id="SegmentsQuery"></a>
 
 `SegmentsQuery(connector: SendgridConnector)`
 :   Query class for Segments entity operations.
@@ -401,6 +417,8 @@ Classes
         
         Returns:
             SegmentsListResult
+
+<a id="SendgridConnector"></a>
 
 `SendgridConnector(auth_config: SendgridAuthConfig | AirbyteAuthConfig | BaseModel | None = None, on_token_refresh: Any | None = None)`
 :   Type-safe Sendgrid API connector.
@@ -602,6 +620,8 @@ Classes
             for entity in entities:
                 print(f"\{entity['entity_name']\}: \{entity['available_actions']\}")
 
+<a id="SinglesendStatsQuery"></a>
+
 `SinglesendStatsQuery(connector: SendgridConnector)`
 :   Query class for SinglesendStats entity operations.
     
@@ -645,6 +665,8 @@ Classes
         
         Returns:
             SinglesendStatsListResult
+
+<a id="SinglesendsQuery"></a>
 
 `SinglesendsQuery(connector: SendgridConnector)`
 :   Query class for Singlesends entity operations.
@@ -703,6 +725,8 @@ Classes
         Returns:
             SinglesendsListResult
 
+<a id="SpamReportsQuery"></a>
+
 `SpamReportsQuery(connector: SendgridConnector)`
 :   Query class for SpamReports entity operations.
     
@@ -720,6 +744,8 @@ Classes
         
         Returns:
             SpamReportsListResult
+
+<a id="SuppressionGroupMembersQuery"></a>
 
 `SuppressionGroupMembersQuery(connector: SendgridConnector)`
 :   Query class for SuppressionGroupMembers entity operations.
@@ -764,6 +790,8 @@ Classes
         
         Returns:
             SuppressionGroupMembersListResult
+
+<a id="SuppressionGroupsQuery"></a>
 
 `SuppressionGroupsQuery(connector: SendgridConnector)`
 :   Query class for SuppressionGroups entity operations.
@@ -814,6 +842,8 @@ Classes
         
         Returns:
             SuppressionGroupsListResult
+
+<a id="TemplatesQuery"></a>
 
 `TemplatesQuery(connector: SendgridConnector)`
 :   Query class for Templates entity operations.

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/sendgrid/index.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/sendgrid/index.md
@@ -19,6 +19,8 @@ Sub-modules
 Classes
 -------
 
+<a id="AirbyteAuthConfig"></a>
+
 `AirbyteAuthConfig(**data: Any)`
 :   Authentication configuration for Airbyte hosted mode execution.
     
@@ -87,6 +89,8 @@ Classes
     `workspace_name: str | None`
     :   The type of the None singleton.
 
+<a id="AirbyteSearchMeta"></a>
+
 `AirbyteSearchMeta(**data: Any)`
 :   Pagination metadata for search responses.
     
@@ -114,6 +118,8 @@ Classes
 
     `took_ms: int | None`
     :   Time taken to execute the search in milliseconds.
+
+<a id="AirbyteSearchResult"></a>
 
 `AirbyteSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -157,6 +163,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="BlocksSearchResult"></a>
+
 `BlocksSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -172,6 +180,8 @@ Classes
     * airbyte_agent_sdk.connectors.sendgrid.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="BouncesSearchResult"></a>
 
 `BouncesSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -189,6 +199,8 @@ Classes
     * pydantic.main.BaseModel
     * typing.Generic
 
+<a id="CampaignsSearchResult"></a>
+
 `CampaignsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -204,6 +216,8 @@ Classes
     * airbyte_agent_sdk.connectors.sendgrid.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="ContactsSearchResult"></a>
 
 `ContactsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -221,6 +235,8 @@ Classes
     * pydantic.main.BaseModel
     * typing.Generic
 
+<a id="GlobalSuppressionsSearchResult"></a>
+
 `GlobalSuppressionsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -236,6 +252,8 @@ Classes
     * airbyte_agent_sdk.connectors.sendgrid.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="InvalidEmailsSearchResult"></a>
 
 `InvalidEmailsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -253,6 +271,8 @@ Classes
     * pydantic.main.BaseModel
     * typing.Generic
 
+<a id="ListsSearchResult"></a>
+
 `ListsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -268,6 +288,8 @@ Classes
     * airbyte_agent_sdk.connectors.sendgrid.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="SegmentsSearchResult"></a>
 
 `SegmentsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -285,6 +307,8 @@ Classes
     * pydantic.main.BaseModel
     * typing.Generic
 
+<a id="SinglesendStatsSearchResult"></a>
+
 `SinglesendStatsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -300,6 +324,8 @@ Classes
     * airbyte_agent_sdk.connectors.sendgrid.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="SinglesendsSearchResult"></a>
 
 `SinglesendsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -317,6 +343,8 @@ Classes
     * pydantic.main.BaseModel
     * typing.Generic
 
+<a id="SuppressionGroupMembersSearchResult"></a>
+
 `SuppressionGroupMembersSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -332,6 +360,8 @@ Classes
     * airbyte_agent_sdk.connectors.sendgrid.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="SuppressionGroupsSearchResult"></a>
 
 `SuppressionGroupsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -349,6 +379,8 @@ Classes
     * pydantic.main.BaseModel
     * typing.Generic
 
+<a id="TemplatesSearchResult"></a>
+
 `TemplatesSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -364,6 +396,8 @@ Classes
     * airbyte_agent_sdk.connectors.sendgrid.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="BlocksSearchData"></a>
 
 `BlocksSearchData(**data: Any)`
 :   Search result data for blocks entity.
@@ -396,6 +430,8 @@ Classes
     `status: str | None`
     :   The status code for the block
 
+<a id="BouncesSearchData"></a>
+
 `BouncesSearchData(**data: Any)`
 :   Search result data for bounces entity.
     
@@ -426,6 +462,8 @@ Classes
 
     `status: str | None`
     :   The enhanced status code for the bounce
+
+<a id="CampaignsSearchData"></a>
 
 `CampaignsSearchData(**data: Any)`
 :   Search result data for campaigns entity.
@@ -466,6 +504,8 @@ Classes
 
     `updated_at: str | None`
     :   When the campaign was last updated
+
+<a id="ContactsSearchData"></a>
 
 `ContactsSearchData(**data: Any)`
 :   Search result data for contacts entity.
@@ -546,6 +586,8 @@ Classes
     `whatsapp: str | None`
     :   WhatsApp number
 
+<a id="GlobalSuppressionsSearchData"></a>
+
 `GlobalSuppressionsSearchData(**data: Any)`
 :   Search result data for global_suppressions entity.
     
@@ -570,6 +612,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="InvalidEmailsSearchData"></a>
 
 `InvalidEmailsSearchData(**data: Any)`
 :   Search result data for invalid_emails entity.
@@ -598,6 +642,8 @@ Classes
 
     `reason: str | None`
     :   The reason the email is invalid
+
+<a id="ListsSearchData"></a>
 
 `ListsSearchData(**data: Any)`
 :   Search result data for lists entity.
@@ -629,6 +675,8 @@ Classes
 
     `name: str | None`
     :   Name of the list
+
+<a id="SegmentsSearchData"></a>
 
 `SegmentsSearchData(**data: Any)`
 :   Search result data for segments entity.
@@ -679,6 +727,8 @@ Classes
     `updated_at: str | None`
     :   When the segment was last updated
 
+<a id="SendgridAuthConfig"></a>
+
 `SendgridAuthConfig(**data: Any)`
 :   API Key Authentication
     
@@ -700,6 +750,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="SendgridConnector"></a>
 
 `SendgridConnector(auth_config: SendgridAuthConfig | AirbyteAuthConfig | BaseModel | None = None, on_token_refresh: Any | None = None)`
 :   Type-safe Sendgrid API connector.
@@ -901,6 +953,8 @@ Classes
             for entity in entities:
                 print(f"\{entity['entity_name']\}: \{entity['available_actions']\}")
 
+<a id="SendgridReplicationConfig"></a>
+
 `SendgridReplicationConfig(**data: Any)`
 :   Replication Configuration - Settings for data replication from SendGrid.
     
@@ -922,6 +976,8 @@ Classes
 
     `start_date: str`
     :   UTC date and time in the format 2017-01-25T00:00:00Z. Any data before this date will not be replicated.
+
+<a id="SinglesendStatsSearchData"></a>
 
 `SinglesendStatsSearchData(**data: Any)`
 :   Search result data for singlesend_stats entity.
@@ -956,6 +1012,8 @@ Classes
 
     `stats: dict[str, typing.Any] | None`
     :   Email statistics for the single send
+
+<a id="SinglesendsSearchData"></a>
 
 `SinglesendsSearchData(**data: Any)`
 :   Search result data for singlesends entity.
@@ -1000,6 +1058,8 @@ Classes
     `updated_at: str | None`
     :   When the single send was last updated
 
+<a id="SuppressionGroupMembersSearchData"></a>
+
 `SuppressionGroupMembersSearchData(**data: Any)`
 :   Search result data for suppression_group_members entity.
     
@@ -1030,6 +1090,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="SuppressionGroupsSearchData"></a>
 
 `SuppressionGroupsSearchData(**data: Any)`
 :   Search result data for suppression_groups entity.
@@ -1064,6 +1126,8 @@ Classes
 
     `unsubscribes: int | None`
     :   Number of unsubscribes in this group
+
+<a id="TemplatesSearchData"></a>
 
 `TemplatesSearchData(**data: Any)`
 :   Search result data for templates entity.

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/sendgrid/models.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/sendgrid/models.md
@@ -13,6 +13,8 @@ and response envelope types.
 Classes
 -------
 
+<a id="AirbyteSearchMeta"></a>
+
 `AirbyteSearchMeta(**data: Any)`
 :   Pagination metadata for search responses.
     
@@ -40,6 +42,8 @@ Classes
 
     `took_ms: int | None`
     :   Time taken to execute the search in milliseconds.
+
+<a id="AirbyteSearchResult"></a>
 
 `AirbyteSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -104,6 +108,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="BlocksSearchResult"></a>
+
 `BlocksSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -140,6 +146,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="BouncesSearchResult"></a>
 
 `BouncesSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -178,6 +186,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="CampaignsSearchResult"></a>
+
 `CampaignsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -214,6 +224,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="ContactsSearchResult"></a>
 
 `ContactsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -252,6 +264,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="GlobalSuppressionsSearchResult"></a>
+
 `GlobalSuppressionsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -288,6 +302,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="InvalidEmailsSearchResult"></a>
 
 `InvalidEmailsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -326,6 +342,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="ListsSearchResult"></a>
+
 `ListsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -362,6 +380,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="SegmentsSearchResult"></a>
 
 `SegmentsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -400,6 +420,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="SinglesendStatsSearchResult"></a>
+
 `SinglesendStatsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -436,6 +458,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="SinglesendsSearchResult"></a>
 
 `SinglesendsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -474,6 +498,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="SuppressionGroupMembersSearchResult"></a>
+
 `SuppressionGroupMembersSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -510,6 +536,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="SuppressionGroupsSearchResult"></a>
 
 `SuppressionGroupsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -548,6 +576,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="TemplatesSearchResult"></a>
+
 `TemplatesSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -563,6 +593,8 @@ Classes
     * airbyte_agent_sdk.connectors.sendgrid.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="Block"></a>
 
 `Block(**data: Any)`
 :   A blocked email record
@@ -595,6 +627,8 @@ Classes
     `status: str | Any`
     :   The type of the None singleton.
 
+<a id="BlocksListResultMeta"></a>
+
 `BlocksListResultMeta(**data: Any)`
 :   Metadata for blocks.Action.LIST operation
     
@@ -616,6 +650,8 @@ Classes
 
     `next: str | Any | None`
     :   The type of the None singleton.
+
+<a id="BlocksSearchData"></a>
 
 `BlocksSearchData(**data: Any)`
 :   Search result data for blocks entity.
@@ -648,6 +684,8 @@ Classes
     `status: str | None`
     :   The status code for the block
 
+<a id="Bounce"></a>
+
 `Bounce(**data: Any)`
 :   A bounced email record
     
@@ -679,6 +717,8 @@ Classes
     `status: str | Any`
     :   The type of the None singleton.
 
+<a id="BouncesListResultMeta"></a>
+
 `BouncesListResultMeta(**data: Any)`
 :   Metadata for bounces.Action.LIST operation
     
@@ -700,6 +740,8 @@ Classes
 
     `next: str | Any | None`
     :   The type of the None singleton.
+
+<a id="BouncesSearchData"></a>
 
 `BouncesSearchData(**data: Any)`
 :   Search result data for bounces entity.
@@ -731,6 +773,8 @@ Classes
 
     `status: str | None`
     :   The enhanced status code for the bounce
+
+<a id="Campaign"></a>
 
 `Campaign(**data: Any)`
 :   A SendGrid marketing campaign
@@ -772,6 +816,8 @@ Classes
     `updated_at: str | Any | None`
     :   The type of the None singleton.
 
+<a id="CampaignsList"></a>
+
 `CampaignsList(**data: Any)`
 :   Response containing a list of campaigns
     
@@ -797,6 +843,8 @@ Classes
     `result: list[airbyte_agent_sdk.connectors.sendgrid.models.Campaign] | Any`
     :   The type of the None singleton.
 
+<a id="CampaignsListMetadata"></a>
+
 `CampaignsListMetadata(**data: Any)`
 :   Nested schema for CampaignsList._metadata
     
@@ -819,6 +867,8 @@ Classes
     `next: str | Any | None`
     :   The type of the None singleton.
 
+<a id="CampaignsListResultMeta"></a>
+
 `CampaignsListResultMeta(**data: Any)`
 :   Metadata for campaigns.Action.LIST operation
     
@@ -840,6 +890,8 @@ Classes
 
     `next: str | Any | None`
     :   The type of the None singleton.
+
+<a id="CampaignsSearchData"></a>
 
 `CampaignsSearchData(**data: Any)`
 :   Search result data for campaigns entity.
@@ -880,6 +932,8 @@ Classes
 
     `updated_at: str | None`
     :   When the campaign was last updated
+
+<a id="Contact"></a>
 
 `Contact(**data: Any)`
 :   A SendGrid marketing contact
@@ -963,6 +1017,8 @@ Classes
     `whatsapp: str | Any | None`
     :   The type of the None singleton.
 
+<a id="ContactsList"></a>
+
 `ContactsList(**data: Any)`
 :   Response containing a list of contacts
     
@@ -991,6 +1047,8 @@ Classes
     `result: list[airbyte_agent_sdk.connectors.sendgrid.models.Contact] | Any`
     :   The type of the None singleton.
 
+<a id="ContactsListMetadata"></a>
+
 `ContactsListMetadata(**data: Any)`
 :   Nested schema for ContactsList._metadata
     
@@ -1012,6 +1070,8 @@ Classes
 
     `next: str | Any | None`
     :   The type of the None singleton.
+
+<a id="ContactsListResultMeta"></a>
 
 `ContactsListResultMeta(**data: Any)`
 :   Metadata for contacts.Action.LIST operation
@@ -1037,6 +1097,8 @@ Classes
 
     `next: str | Any | None`
     :   The type of the None singleton.
+
+<a id="ContactsSearchData"></a>
 
 `ContactsSearchData(**data: Any)`
 :   Search result data for contacts entity.
@@ -1117,6 +1179,8 @@ Classes
     `whatsapp: str | None`
     :   WhatsApp number
 
+<a id="GlobalSuppression"></a>
+
 `GlobalSuppression(**data: Any)`
 :   A globally suppressed email address
     
@@ -1142,6 +1206,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="GlobalSuppressionsListResultMeta"></a>
+
 `GlobalSuppressionsListResultMeta(**data: Any)`
 :   Metadata for global_suppressions.Action.LIST operation
     
@@ -1163,6 +1229,8 @@ Classes
 
     `next: str | Any | None`
     :   The type of the None singleton.
+
+<a id="GlobalSuppressionsSearchData"></a>
 
 `GlobalSuppressionsSearchData(**data: Any)`
 :   Search result data for global_suppressions entity.
@@ -1188,6 +1256,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="InvalidEmail"></a>
 
 `InvalidEmail(**data: Any)`
 :   An invalid email record
@@ -1217,6 +1287,8 @@ Classes
     `reason: str | Any`
     :   The type of the None singleton.
 
+<a id="InvalidEmailsListResultMeta"></a>
+
 `InvalidEmailsListResultMeta(**data: Any)`
 :   Metadata for invalid_emails.Action.LIST operation
     
@@ -1238,6 +1310,8 @@ Classes
 
     `next: str | Any | None`
     :   The type of the None singleton.
+
+<a id="InvalidEmailsSearchData"></a>
 
 `InvalidEmailsSearchData(**data: Any)`
 :   Search result data for invalid_emails entity.
@@ -1266,6 +1340,8 @@ Classes
 
     `reason: str | None`
     :   The reason the email is invalid
+
+<a id="List"></a>
 
 `List(**data: Any)`
 :   A SendGrid marketing list
@@ -1298,6 +1374,8 @@ Classes
     `name: str | Any`
     :   The type of the None singleton.
 
+<a id="ListMetadata"></a>
+
 `ListMetadata(**data: Any)`
 :   Metadata about the list resource
     
@@ -1319,6 +1397,8 @@ Classes
 
     `self: str | Any`
     :   The type of the None singleton.
+
+<a id="ListsList"></a>
 
 `ListsList(**data: Any)`
 :   Response containing a list of marketing lists
@@ -1345,6 +1425,8 @@ Classes
     `result: list[airbyte_agent_sdk.connectors.sendgrid.models.List] | Any`
     :   The type of the None singleton.
 
+<a id="ListsListMetadata"></a>
+
 `ListsListMetadata(**data: Any)`
 :   Nested schema for ListsList._metadata
     
@@ -1367,6 +1449,8 @@ Classes
     `next: str | Any | None`
     :   The type of the None singleton.
 
+<a id="ListsListResultMeta"></a>
+
 `ListsListResultMeta(**data: Any)`
 :   Metadata for lists.Action.LIST operation
     
@@ -1388,6 +1472,8 @@ Classes
 
     `next: str | Any | None`
     :   The type of the None singleton.
+
+<a id="ListsSearchData"></a>
 
 `ListsSearchData(**data: Any)`
 :   Search result data for lists entity.
@@ -1419,6 +1505,8 @@ Classes
 
     `name: str | None`
     :   Name of the list
+
+<a id="Segment"></a>
 
 `Segment(**data: Any)`
 :   A SendGrid marketing segment
@@ -1469,6 +1557,8 @@ Classes
     `updated_at: str | Any | None`
     :   The type of the None singleton.
 
+<a id="SegmentStatus"></a>
+
 `SegmentStatus(**data: Any)`
 :   Segment status details
     
@@ -1491,6 +1581,8 @@ Classes
     `query_validation: str | Any`
     :   The type of the None singleton.
 
+<a id="SegmentsList"></a>
+
 `SegmentsList(**data: Any)`
 :   Response containing a list of segments
     
@@ -1512,6 +1604,8 @@ Classes
 
     `results: list[airbyte_agent_sdk.connectors.sendgrid.models.Segment] | Any`
     :   The type of the None singleton.
+
+<a id="SegmentsSearchData"></a>
 
 `SegmentsSearchData(**data: Any)`
 :   Search result data for segments entity.
@@ -1562,6 +1656,8 @@ Classes
     `updated_at: str | None`
     :   When the segment was last updated
 
+<a id="SendgridAuthConfig"></a>
+
 `SendgridAuthConfig(**data: Any)`
 :   API Key Authentication
     
@@ -1583,6 +1679,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="SendgridCheckResult"></a>
 
 `SendgridCheckResult(**data: Any)`
 :   Result of a health check operation.
@@ -1617,6 +1715,8 @@ Classes
     `status: str`
     :   Health check status: 'healthy' or 'unhealthy'.
 
+<a id="SendgridExecuteResult"></a>
+
 `SendgridExecuteResult(**data: Any)`
 :   Response envelope with data only.
     
@@ -1647,6 +1747,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="SendgridExecuteResultWithMeta"></a>
 
 `SendgridExecuteResultWithMeta(**data: Any)`
 :   Response envelope with data and metadata.
@@ -1710,6 +1812,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="BlocksListResult"></a>
+
 `BlocksListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -1752,6 +1856,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="BouncesListResult"></a>
 
 `BouncesListResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -1796,6 +1902,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="CampaignsListResult"></a>
+
 `CampaignsListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -1838,6 +1946,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="ContactsListResult"></a>
 
 `ContactsListResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -1882,6 +1992,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="GlobalSuppressionsListResult"></a>
+
 `GlobalSuppressionsListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -1924,6 +2036,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="InvalidEmailsListResult"></a>
 
 `InvalidEmailsListResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -1968,6 +2082,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="ListsListResult"></a>
+
 `ListsListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -2010,6 +2126,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="SinglesendStatsListResult"></a>
 
 `SinglesendStatsListResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -2054,6 +2172,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="SinglesendsListResult"></a>
+
 `SinglesendsListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -2096,6 +2216,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="SpamReportsListResult"></a>
 
 `SpamReportsListResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -2140,6 +2262,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="SuppressionGroupMembersListResult"></a>
+
 `SuppressionGroupMembersListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -2183,6 +2307,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="TemplatesListResult"></a>
+
 `TemplatesListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -2225,6 +2351,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="SegmentsListResult"></a>
+
 `SegmentsListResult(**data: Any)`
 :   Response envelope with data only.
     
@@ -2266,6 +2394,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="SuppressionGroupsListResult"></a>
+
 `SuppressionGroupsListResult(**data: Any)`
 :   Response envelope with data only.
     
@@ -2283,6 +2413,8 @@ Classes
     * airbyte_agent_sdk.connectors.sendgrid.models.SendgridExecuteResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="SendgridReplicationConfig"></a>
 
 `SendgridReplicationConfig(**data: Any)`
 :   Replication Configuration - Settings for data replication from SendGrid.
@@ -2305,6 +2437,8 @@ Classes
 
     `start_date: str`
     :   UTC date and time in the format 2017-01-25T00:00:00Z. Any data before this date will not be replicated.
+
+<a id="SingleSend"></a>
 
 `SingleSend(**data: Any)`
 :   A SendGrid single send
@@ -2355,6 +2489,8 @@ Classes
     `updated_at: str | Any`
     :   The type of the None singleton.
 
+<a id="SingleSendEmailConfig"></a>
+
 `SingleSendEmailConfig(**data: Any)`
 :   Email configuration details
     
@@ -2404,6 +2540,8 @@ Classes
     `suppression_group_id: int | Any | None`
     :   The type of the None singleton.
 
+<a id="SingleSendSendTo"></a>
+
 `SingleSendSendTo(**data: Any)`
 :   Recipients configuration
     
@@ -2431,6 +2569,8 @@ Classes
 
     `segment_ids: list[str] | Any | None`
     :   The type of the None singleton.
+
+<a id="SingleSendStats"></a>
 
 `SingleSendStats(**data: Any)`
 :   Stats for a single send
@@ -2466,6 +2606,8 @@ Classes
     `stats: airbyte_agent_sdk.connectors.sendgrid.models.SingleSendStatsStats | Any | None`
     :   The type of the None singleton.
 
+<a id="SingleSendStatsList"></a>
+
 `SingleSendStatsList(**data: Any)`
 :   Response containing a list of single send stats
     
@@ -2491,6 +2633,8 @@ Classes
     `results: list[airbyte_agent_sdk.connectors.sendgrid.models.SingleSendStats] | Any`
     :   The type of the None singleton.
 
+<a id="SingleSendStatsListMetadata"></a>
+
 `SingleSendStatsListMetadata(**data: Any)`
 :   Nested schema for SingleSendStatsList._metadata
     
@@ -2512,6 +2656,8 @@ Classes
 
     `next: str | Any | None`
     :   The type of the None singleton.
+
+<a id="SingleSendStatsStats"></a>
 
 `SingleSendStatsStats(**data: Any)`
 :   Email statistics for the single send
@@ -2568,6 +2714,8 @@ Classes
     `unsubscribes: int | Any`
     :   The type of the None singleton.
 
+<a id="SingleSendsList"></a>
+
 `SingleSendsList(**data: Any)`
 :   Response containing a list of single sends
     
@@ -2593,6 +2741,8 @@ Classes
     `result: list[airbyte_agent_sdk.connectors.sendgrid.models.SingleSend] | Any`
     :   The type of the None singleton.
 
+<a id="SingleSendsListMetadata"></a>
+
 `SingleSendsListMetadata(**data: Any)`
 :   Nested schema for SingleSendsList._metadata
     
@@ -2615,6 +2765,8 @@ Classes
     `next: str | Any | None`
     :   The type of the None singleton.
 
+<a id="SinglesendStatsListResultMeta"></a>
+
 `SinglesendStatsListResultMeta(**data: Any)`
 :   Metadata for singlesend_stats.Action.LIST operation
     
@@ -2636,6 +2788,8 @@ Classes
 
     `next: str | Any | None`
     :   The type of the None singleton.
+
+<a id="SinglesendStatsSearchData"></a>
 
 `SinglesendStatsSearchData(**data: Any)`
 :   Search result data for singlesend_stats entity.
@@ -2671,6 +2825,8 @@ Classes
     `stats: dict[str, typing.Any] | None`
     :   Email statistics for the single send
 
+<a id="SinglesendsListResultMeta"></a>
+
 `SinglesendsListResultMeta(**data: Any)`
 :   Metadata for singlesends.Action.LIST operation
     
@@ -2692,6 +2848,8 @@ Classes
 
     `next: str | Any | None`
     :   The type of the None singleton.
+
+<a id="SinglesendsSearchData"></a>
 
 `SinglesendsSearchData(**data: Any)`
 :   Search result data for singlesends entity.
@@ -2736,6 +2894,8 @@ Classes
     `updated_at: str | None`
     :   When the single send was last updated
 
+<a id="SpamReport"></a>
+
 `SpamReport(**data: Any)`
 :   A spam report record
     
@@ -2764,6 +2924,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="SpamReportsListResultMeta"></a>
+
 `SpamReportsListResultMeta(**data: Any)`
 :   Metadata for spam_reports.Action.LIST operation
     
@@ -2785,6 +2947,8 @@ Classes
 
     `next: str | Any | None`
     :   The type of the None singleton.
+
+<a id="SuppressionGroup"></a>
 
 `SuppressionGroup(**data: Any)`
 :   A suppression (unsubscribe) group
@@ -2820,6 +2984,8 @@ Classes
     `unsubscribes: int | Any`
     :   The type of the None singleton.
 
+<a id="SuppressionGroupMember"></a>
+
 `SuppressionGroupMember(**data: Any)`
 :   A member of a suppression group
     
@@ -2851,6 +3017,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="SuppressionGroupMembersListResultMeta"></a>
+
 `SuppressionGroupMembersListResultMeta(**data: Any)`
 :   Metadata for suppression_group_members.Action.LIST operation
     
@@ -2872,6 +3040,8 @@ Classes
 
     `next: str | Any | None`
     :   The type of the None singleton.
+
+<a id="SuppressionGroupMembersSearchData"></a>
 
 `SuppressionGroupMembersSearchData(**data: Any)`
 :   Search result data for suppression_group_members entity.
@@ -2903,6 +3073,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="SuppressionGroupsSearchData"></a>
 
 `SuppressionGroupsSearchData(**data: Any)`
 :   Search result data for suppression_groups entity.
@@ -2938,6 +3110,8 @@ Classes
     `unsubscribes: int | None`
     :   Number of unsubscribes in this group
 
+<a id="Template"></a>
+
 `Template(**data: Any)`
 :   A SendGrid transactional template
     
@@ -2972,6 +3146,8 @@ Classes
     `versions: list[typing.Any] | Any | None`
     :   The type of the None singleton.
 
+<a id="TemplatesList"></a>
+
 `TemplatesList(**data: Any)`
 :   Response containing a list of templates
     
@@ -2997,6 +3173,8 @@ Classes
     `templates: list[airbyte_agent_sdk.connectors.sendgrid.models.Template] | Any`
     :   The type of the None singleton.
 
+<a id="TemplatesListMetadata"></a>
+
 `TemplatesListMetadata(**data: Any)`
 :   Nested schema for TemplatesList._metadata
     
@@ -3019,6 +3197,8 @@ Classes
     `next: str | Any | None`
     :   The type of the None singleton.
 
+<a id="TemplatesListResultMeta"></a>
+
 `TemplatesListResultMeta(**data: Any)`
 :   Metadata for templates.Action.LIST operation
     
@@ -3040,6 +3220,8 @@ Classes
 
     `next: str | Any | None`
     :   The type of the None singleton.
+
+<a id="TemplatesSearchData"></a>
 
 `TemplatesSearchData(**data: Any)`
 :   Search result data for templates entity.

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/sendgrid/types.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/sendgrid/types.md
@@ -10,6 +10,8 @@ Type definitions for sendgrid connector.
 Classes
 -------
 
+<a id="AirbyteSearchParams"></a>
+
 `AirbyteSearchParams(*args, **kwargs)`
 :   Parameters for Airbyte cache search operations (generic, use entity-specific query types for better type hints).
 
@@ -31,6 +33,8 @@ Classes
     `query: dict[str, typing.Any]`
     :   The type of the None singleton.
 
+<a id="BlocksAndCondition"></a>
+
 `BlocksAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -51,6 +55,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.sendgrid.types.BlocksEqCondition | airbyte_agent_sdk.connectors.sendgrid.types.BlocksNeqCondition | airbyte_agent_sdk.connectors.sendgrid.types.BlocksGtCondition | airbyte_agent_sdk.connectors.sendgrid.types.BlocksGteCondition | airbyte_agent_sdk.connectors.sendgrid.types.BlocksLtCondition | airbyte_agent_sdk.connectors.sendgrid.types.BlocksLteCondition | airbyte_agent_sdk.connectors.sendgrid.types.BlocksInCondition | airbyte_agent_sdk.connectors.sendgrid.types.BlocksLikeCondition | airbyte_agent_sdk.connectors.sendgrid.types.BlocksFuzzyCondition | airbyte_agent_sdk.connectors.sendgrid.types.BlocksKeywordCondition | airbyte_agent_sdk.connectors.sendgrid.types.BlocksContainsCondition | airbyte_agent_sdk.connectors.sendgrid.types.BlocksNotCondition | airbyte_agent_sdk.connectors.sendgrid.types.BlocksAndCondition | airbyte_agent_sdk.connectors.sendgrid.types.BlocksOrCondition | airbyte_agent_sdk.connectors.sendgrid.types.BlocksAnyCondition]`
     :   The type of the None singleton.
 
+<a id="BlocksAnyCondition"></a>
+
 `BlocksAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -70,6 +76,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.sendgrid.types.BlocksAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="BlocksAnyValueFilter"></a>
 
 `BlocksAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -92,6 +100,8 @@ Classes
     `status: Any`
     :   The status code for the block
 
+<a id="BlocksContainsCondition"></a>
+
 `BlocksContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -103,6 +113,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.sendgrid.types.BlocksAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="BlocksEqCondition"></a>
 
 `BlocksEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -116,6 +128,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.sendgrid.types.BlocksSearchFilter`
     :   The type of the None singleton.
 
+<a id="BlocksFuzzyCondition"></a>
+
 `BlocksFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -127,6 +141,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.sendgrid.types.BlocksStringFilter`
     :   The type of the None singleton.
+
+<a id="BlocksGtCondition"></a>
 
 `BlocksGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
@@ -140,6 +156,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.sendgrid.types.BlocksSearchFilter`
     :   The type of the None singleton.
 
+<a id="BlocksGteCondition"></a>
+
 `BlocksGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -151,6 +169,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.sendgrid.types.BlocksSearchFilter`
     :   The type of the None singleton.
+
+<a id="BlocksInCondition"></a>
 
 `BlocksInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -171,6 +191,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.sendgrid.types.BlocksInFilter`
     :   The type of the None singleton.
+
+<a id="BlocksInFilter"></a>
 
 `BlocksInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -193,6 +215,8 @@ Classes
     `status: list[str]`
     :   The status code for the block
 
+<a id="BlocksKeywordCondition"></a>
+
 `BlocksKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -205,6 +229,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.sendgrid.types.BlocksStringFilter`
     :   The type of the None singleton.
 
+<a id="BlocksLikeCondition"></a>
+
 `BlocksLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -216,6 +242,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.sendgrid.types.BlocksStringFilter`
     :   The type of the None singleton.
+
+<a id="BlocksListParams"></a>
 
 `BlocksListParams(*args, **kwargs)`
 :   Parameters for blocks.list operation
@@ -232,6 +260,8 @@ Classes
     `offset: int`
     :   The type of the None singleton.
 
+<a id="BlocksLtCondition"></a>
+
 `BlocksLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -243,6 +273,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.sendgrid.types.BlocksSearchFilter`
     :   The type of the None singleton.
+
+<a id="BlocksLteCondition"></a>
 
 `BlocksLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -256,6 +288,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.sendgrid.types.BlocksSearchFilter`
     :   The type of the None singleton.
 
+<a id="BlocksNeqCondition"></a>
+
 `BlocksNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -267,6 +301,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.sendgrid.types.BlocksSearchFilter`
     :   The type of the None singleton.
+
+<a id="BlocksNotCondition"></a>
 
 `BlocksNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -288,6 +324,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.sendgrid.types.BlocksEqCondition | airbyte_agent_sdk.connectors.sendgrid.types.BlocksNeqCondition | airbyte_agent_sdk.connectors.sendgrid.types.BlocksGtCondition | airbyte_agent_sdk.connectors.sendgrid.types.BlocksGteCondition | airbyte_agent_sdk.connectors.sendgrid.types.BlocksLtCondition | airbyte_agent_sdk.connectors.sendgrid.types.BlocksLteCondition | airbyte_agent_sdk.connectors.sendgrid.types.BlocksInCondition | airbyte_agent_sdk.connectors.sendgrid.types.BlocksLikeCondition | airbyte_agent_sdk.connectors.sendgrid.types.BlocksFuzzyCondition | airbyte_agent_sdk.connectors.sendgrid.types.BlocksKeywordCondition | airbyte_agent_sdk.connectors.sendgrid.types.BlocksContainsCondition | airbyte_agent_sdk.connectors.sendgrid.types.BlocksNotCondition | airbyte_agent_sdk.connectors.sendgrid.types.BlocksAndCondition | airbyte_agent_sdk.connectors.sendgrid.types.BlocksOrCondition | airbyte_agent_sdk.connectors.sendgrid.types.BlocksAnyCondition`
     :   The type of the None singleton.
 
+<a id="BlocksOrCondition"></a>
+
 `BlocksOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -307,6 +345,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.sendgrid.types.BlocksEqCondition | airbyte_agent_sdk.connectors.sendgrid.types.BlocksNeqCondition | airbyte_agent_sdk.connectors.sendgrid.types.BlocksGtCondition | airbyte_agent_sdk.connectors.sendgrid.types.BlocksGteCondition | airbyte_agent_sdk.connectors.sendgrid.types.BlocksLtCondition | airbyte_agent_sdk.connectors.sendgrid.types.BlocksLteCondition | airbyte_agent_sdk.connectors.sendgrid.types.BlocksInCondition | airbyte_agent_sdk.connectors.sendgrid.types.BlocksLikeCondition | airbyte_agent_sdk.connectors.sendgrid.types.BlocksFuzzyCondition | airbyte_agent_sdk.connectors.sendgrid.types.BlocksKeywordCondition | airbyte_agent_sdk.connectors.sendgrid.types.BlocksContainsCondition | airbyte_agent_sdk.connectors.sendgrid.types.BlocksNotCondition | airbyte_agent_sdk.connectors.sendgrid.types.BlocksAndCondition | airbyte_agent_sdk.connectors.sendgrid.types.BlocksOrCondition | airbyte_agent_sdk.connectors.sendgrid.types.BlocksAnyCondition]`
     :   The type of the None singleton.
+
+<a id="BlocksSearchFilter"></a>
 
 `BlocksSearchFilter(*args, **kwargs)`
 :   Available fields for filtering blocks search queries.
@@ -329,6 +369,8 @@ Classes
     `status: str | None`
     :   The status code for the block
 
+<a id="BlocksSearchQuery"></a>
+
 `BlocksSearchQuery(*args, **kwargs)`
 :   Search query for blocks entity.
 
@@ -343,6 +385,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.sendgrid.types.BlocksSortFilter]`
     :   The type of the None singleton.
+
+<a id="BlocksSortFilter"></a>
 
 `BlocksSortFilter(*args, **kwargs)`
 :   Available fields for sorting blocks search results.
@@ -365,6 +409,8 @@ Classes
     `status: Literal['asc', 'desc']`
     :   The status code for the block
 
+<a id="BlocksStringFilter"></a>
+
 `BlocksStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -386,6 +432,8 @@ Classes
     `status: str`
     :   The status code for the block
 
+<a id="BouncesAndCondition"></a>
+
 `BouncesAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -406,6 +454,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.sendgrid.types.BouncesEqCondition | airbyte_agent_sdk.connectors.sendgrid.types.BouncesNeqCondition | airbyte_agent_sdk.connectors.sendgrid.types.BouncesGtCondition | airbyte_agent_sdk.connectors.sendgrid.types.BouncesGteCondition | airbyte_agent_sdk.connectors.sendgrid.types.BouncesLtCondition | airbyte_agent_sdk.connectors.sendgrid.types.BouncesLteCondition | airbyte_agent_sdk.connectors.sendgrid.types.BouncesInCondition | airbyte_agent_sdk.connectors.sendgrid.types.BouncesLikeCondition | airbyte_agent_sdk.connectors.sendgrid.types.BouncesFuzzyCondition | airbyte_agent_sdk.connectors.sendgrid.types.BouncesKeywordCondition | airbyte_agent_sdk.connectors.sendgrid.types.BouncesContainsCondition | airbyte_agent_sdk.connectors.sendgrid.types.BouncesNotCondition | airbyte_agent_sdk.connectors.sendgrid.types.BouncesAndCondition | airbyte_agent_sdk.connectors.sendgrid.types.BouncesOrCondition | airbyte_agent_sdk.connectors.sendgrid.types.BouncesAnyCondition]`
     :   The type of the None singleton.
 
+<a id="BouncesAnyCondition"></a>
+
 `BouncesAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -425,6 +475,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.sendgrid.types.BouncesAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="BouncesAnyValueFilter"></a>
 
 `BouncesAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -447,6 +499,8 @@ Classes
     `status: Any`
     :   The enhanced status code for the bounce
 
+<a id="BouncesContainsCondition"></a>
+
 `BouncesContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -458,6 +512,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.sendgrid.types.BouncesAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="BouncesEqCondition"></a>
 
 `BouncesEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -471,6 +527,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.sendgrid.types.BouncesSearchFilter`
     :   The type of the None singleton.
 
+<a id="BouncesFuzzyCondition"></a>
+
 `BouncesFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -482,6 +540,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.sendgrid.types.BouncesStringFilter`
     :   The type of the None singleton.
+
+<a id="BouncesGtCondition"></a>
 
 `BouncesGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
@@ -495,6 +555,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.sendgrid.types.BouncesSearchFilter`
     :   The type of the None singleton.
 
+<a id="BouncesGteCondition"></a>
+
 `BouncesGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -506,6 +568,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.sendgrid.types.BouncesSearchFilter`
     :   The type of the None singleton.
+
+<a id="BouncesInCondition"></a>
 
 `BouncesInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -526,6 +590,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.sendgrid.types.BouncesInFilter`
     :   The type of the None singleton.
+
+<a id="BouncesInFilter"></a>
 
 `BouncesInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -548,6 +614,8 @@ Classes
     `status: list[str]`
     :   The enhanced status code for the bounce
 
+<a id="BouncesKeywordCondition"></a>
+
 `BouncesKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -560,6 +628,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.sendgrid.types.BouncesStringFilter`
     :   The type of the None singleton.
 
+<a id="BouncesLikeCondition"></a>
+
 `BouncesLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -571,6 +641,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.sendgrid.types.BouncesStringFilter`
     :   The type of the None singleton.
+
+<a id="BouncesListParams"></a>
 
 `BouncesListParams(*args, **kwargs)`
 :   Parameters for bounces.list operation
@@ -587,6 +659,8 @@ Classes
     `offset: int`
     :   The type of the None singleton.
 
+<a id="BouncesLtCondition"></a>
+
 `BouncesLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -598,6 +672,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.sendgrid.types.BouncesSearchFilter`
     :   The type of the None singleton.
+
+<a id="BouncesLteCondition"></a>
 
 `BouncesLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -611,6 +687,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.sendgrid.types.BouncesSearchFilter`
     :   The type of the None singleton.
 
+<a id="BouncesNeqCondition"></a>
+
 `BouncesNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -622,6 +700,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.sendgrid.types.BouncesSearchFilter`
     :   The type of the None singleton.
+
+<a id="BouncesNotCondition"></a>
 
 `BouncesNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -643,6 +723,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.sendgrid.types.BouncesEqCondition | airbyte_agent_sdk.connectors.sendgrid.types.BouncesNeqCondition | airbyte_agent_sdk.connectors.sendgrid.types.BouncesGtCondition | airbyte_agent_sdk.connectors.sendgrid.types.BouncesGteCondition | airbyte_agent_sdk.connectors.sendgrid.types.BouncesLtCondition | airbyte_agent_sdk.connectors.sendgrid.types.BouncesLteCondition | airbyte_agent_sdk.connectors.sendgrid.types.BouncesInCondition | airbyte_agent_sdk.connectors.sendgrid.types.BouncesLikeCondition | airbyte_agent_sdk.connectors.sendgrid.types.BouncesFuzzyCondition | airbyte_agent_sdk.connectors.sendgrid.types.BouncesKeywordCondition | airbyte_agent_sdk.connectors.sendgrid.types.BouncesContainsCondition | airbyte_agent_sdk.connectors.sendgrid.types.BouncesNotCondition | airbyte_agent_sdk.connectors.sendgrid.types.BouncesAndCondition | airbyte_agent_sdk.connectors.sendgrid.types.BouncesOrCondition | airbyte_agent_sdk.connectors.sendgrid.types.BouncesAnyCondition`
     :   The type of the None singleton.
 
+<a id="BouncesOrCondition"></a>
+
 `BouncesOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -662,6 +744,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.sendgrid.types.BouncesEqCondition | airbyte_agent_sdk.connectors.sendgrid.types.BouncesNeqCondition | airbyte_agent_sdk.connectors.sendgrid.types.BouncesGtCondition | airbyte_agent_sdk.connectors.sendgrid.types.BouncesGteCondition | airbyte_agent_sdk.connectors.sendgrid.types.BouncesLtCondition | airbyte_agent_sdk.connectors.sendgrid.types.BouncesLteCondition | airbyte_agent_sdk.connectors.sendgrid.types.BouncesInCondition | airbyte_agent_sdk.connectors.sendgrid.types.BouncesLikeCondition | airbyte_agent_sdk.connectors.sendgrid.types.BouncesFuzzyCondition | airbyte_agent_sdk.connectors.sendgrid.types.BouncesKeywordCondition | airbyte_agent_sdk.connectors.sendgrid.types.BouncesContainsCondition | airbyte_agent_sdk.connectors.sendgrid.types.BouncesNotCondition | airbyte_agent_sdk.connectors.sendgrid.types.BouncesAndCondition | airbyte_agent_sdk.connectors.sendgrid.types.BouncesOrCondition | airbyte_agent_sdk.connectors.sendgrid.types.BouncesAnyCondition]`
     :   The type of the None singleton.
+
+<a id="BouncesSearchFilter"></a>
 
 `BouncesSearchFilter(*args, **kwargs)`
 :   Available fields for filtering bounces search queries.
@@ -684,6 +768,8 @@ Classes
     `status: str | None`
     :   The enhanced status code for the bounce
 
+<a id="BouncesSearchQuery"></a>
+
 `BouncesSearchQuery(*args, **kwargs)`
 :   Search query for bounces entity.
 
@@ -698,6 +784,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.sendgrid.types.BouncesSortFilter]`
     :   The type of the None singleton.
+
+<a id="BouncesSortFilter"></a>
 
 `BouncesSortFilter(*args, **kwargs)`
 :   Available fields for sorting bounces search results.
@@ -720,6 +808,8 @@ Classes
     `status: Literal['asc', 'desc']`
     :   The enhanced status code for the bounce
 
+<a id="BouncesStringFilter"></a>
+
 `BouncesStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -741,6 +831,8 @@ Classes
     `status: str`
     :   The enhanced status code for the bounce
 
+<a id="CampaignsAndCondition"></a>
+
 `CampaignsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -761,6 +853,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.sendgrid.types.CampaignsEqCondition | airbyte_agent_sdk.connectors.sendgrid.types.CampaignsNeqCondition | airbyte_agent_sdk.connectors.sendgrid.types.CampaignsGtCondition | airbyte_agent_sdk.connectors.sendgrid.types.CampaignsGteCondition | airbyte_agent_sdk.connectors.sendgrid.types.CampaignsLtCondition | airbyte_agent_sdk.connectors.sendgrid.types.CampaignsLteCondition | airbyte_agent_sdk.connectors.sendgrid.types.CampaignsInCondition | airbyte_agent_sdk.connectors.sendgrid.types.CampaignsLikeCondition | airbyte_agent_sdk.connectors.sendgrid.types.CampaignsFuzzyCondition | airbyte_agent_sdk.connectors.sendgrid.types.CampaignsKeywordCondition | airbyte_agent_sdk.connectors.sendgrid.types.CampaignsContainsCondition | airbyte_agent_sdk.connectors.sendgrid.types.CampaignsNotCondition | airbyte_agent_sdk.connectors.sendgrid.types.CampaignsAndCondition | airbyte_agent_sdk.connectors.sendgrid.types.CampaignsOrCondition | airbyte_agent_sdk.connectors.sendgrid.types.CampaignsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="CampaignsAnyCondition"></a>
+
 `CampaignsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -780,6 +874,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.sendgrid.types.CampaignsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="CampaignsAnyValueFilter"></a>
 
 `CampaignsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -811,6 +907,8 @@ Classes
     `updated_at: Any`
     :   When the campaign was last updated
 
+<a id="CampaignsContainsCondition"></a>
+
 `CampaignsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -822,6 +920,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.sendgrid.types.CampaignsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="CampaignsEqCondition"></a>
 
 `CampaignsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -835,6 +935,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.sendgrid.types.CampaignsSearchFilter`
     :   The type of the None singleton.
 
+<a id="CampaignsFuzzyCondition"></a>
+
 `CampaignsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -846,6 +948,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.sendgrid.types.CampaignsStringFilter`
     :   The type of the None singleton.
+
+<a id="CampaignsGtCondition"></a>
 
 `CampaignsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
@@ -859,6 +963,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.sendgrid.types.CampaignsSearchFilter`
     :   The type of the None singleton.
 
+<a id="CampaignsGteCondition"></a>
+
 `CampaignsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -870,6 +976,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.sendgrid.types.CampaignsSearchFilter`
     :   The type of the None singleton.
+
+<a id="CampaignsInCondition"></a>
 
 `CampaignsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -890,6 +998,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.sendgrid.types.CampaignsInFilter`
     :   The type of the None singleton.
+
+<a id="CampaignsInFilter"></a>
 
 `CampaignsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -921,6 +1031,8 @@ Classes
     `updated_at: list[str]`
     :   When the campaign was last updated
 
+<a id="CampaignsKeywordCondition"></a>
+
 `CampaignsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -932,6 +1044,8 @@ Classes
 
     `keyword: airbyte_agent_sdk.connectors.sendgrid.types.CampaignsStringFilter`
     :   The type of the None singleton.
+
+<a id="CampaignsLikeCondition"></a>
 
 `CampaignsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
@@ -945,6 +1059,8 @@ Classes
     `like: airbyte_agent_sdk.connectors.sendgrid.types.CampaignsStringFilter`
     :   The type of the None singleton.
 
+<a id="CampaignsListParams"></a>
+
 `CampaignsListParams(*args, **kwargs)`
 :   Parameters for campaigns.list operation
 
@@ -956,6 +1072,8 @@ Classes
 
     `page_size: int`
     :   The type of the None singleton.
+
+<a id="CampaignsLtCondition"></a>
 
 `CampaignsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
@@ -969,6 +1087,8 @@ Classes
     `lt: airbyte_agent_sdk.connectors.sendgrid.types.CampaignsSearchFilter`
     :   The type of the None singleton.
 
+<a id="CampaignsLteCondition"></a>
+
 `CampaignsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
 
@@ -981,6 +1101,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.sendgrid.types.CampaignsSearchFilter`
     :   The type of the None singleton.
 
+<a id="CampaignsNeqCondition"></a>
+
 `CampaignsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -992,6 +1114,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.sendgrid.types.CampaignsSearchFilter`
     :   The type of the None singleton.
+
+<a id="CampaignsNotCondition"></a>
 
 `CampaignsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -1013,6 +1137,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.sendgrid.types.CampaignsEqCondition | airbyte_agent_sdk.connectors.sendgrid.types.CampaignsNeqCondition | airbyte_agent_sdk.connectors.sendgrid.types.CampaignsGtCondition | airbyte_agent_sdk.connectors.sendgrid.types.CampaignsGteCondition | airbyte_agent_sdk.connectors.sendgrid.types.CampaignsLtCondition | airbyte_agent_sdk.connectors.sendgrid.types.CampaignsLteCondition | airbyte_agent_sdk.connectors.sendgrid.types.CampaignsInCondition | airbyte_agent_sdk.connectors.sendgrid.types.CampaignsLikeCondition | airbyte_agent_sdk.connectors.sendgrid.types.CampaignsFuzzyCondition | airbyte_agent_sdk.connectors.sendgrid.types.CampaignsKeywordCondition | airbyte_agent_sdk.connectors.sendgrid.types.CampaignsContainsCondition | airbyte_agent_sdk.connectors.sendgrid.types.CampaignsNotCondition | airbyte_agent_sdk.connectors.sendgrid.types.CampaignsAndCondition | airbyte_agent_sdk.connectors.sendgrid.types.CampaignsOrCondition | airbyte_agent_sdk.connectors.sendgrid.types.CampaignsAnyCondition`
     :   The type of the None singleton.
 
+<a id="CampaignsOrCondition"></a>
+
 `CampaignsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1032,6 +1158,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.sendgrid.types.CampaignsEqCondition | airbyte_agent_sdk.connectors.sendgrid.types.CampaignsNeqCondition | airbyte_agent_sdk.connectors.sendgrid.types.CampaignsGtCondition | airbyte_agent_sdk.connectors.sendgrid.types.CampaignsGteCondition | airbyte_agent_sdk.connectors.sendgrid.types.CampaignsLtCondition | airbyte_agent_sdk.connectors.sendgrid.types.CampaignsLteCondition | airbyte_agent_sdk.connectors.sendgrid.types.CampaignsInCondition | airbyte_agent_sdk.connectors.sendgrid.types.CampaignsLikeCondition | airbyte_agent_sdk.connectors.sendgrid.types.CampaignsFuzzyCondition | airbyte_agent_sdk.connectors.sendgrid.types.CampaignsKeywordCondition | airbyte_agent_sdk.connectors.sendgrid.types.CampaignsContainsCondition | airbyte_agent_sdk.connectors.sendgrid.types.CampaignsNotCondition | airbyte_agent_sdk.connectors.sendgrid.types.CampaignsAndCondition | airbyte_agent_sdk.connectors.sendgrid.types.CampaignsOrCondition | airbyte_agent_sdk.connectors.sendgrid.types.CampaignsAnyCondition]`
     :   The type of the None singleton.
+
+<a id="CampaignsSearchFilter"></a>
 
 `CampaignsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering campaigns search queries.
@@ -1063,6 +1191,8 @@ Classes
     `updated_at: str | None`
     :   When the campaign was last updated
 
+<a id="CampaignsSearchQuery"></a>
+
 `CampaignsSearchQuery(*args, **kwargs)`
 :   Search query for campaigns entity.
 
@@ -1077,6 +1207,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.sendgrid.types.CampaignsSortFilter]`
     :   The type of the None singleton.
+
+<a id="CampaignsSortFilter"></a>
 
 `CampaignsSortFilter(*args, **kwargs)`
 :   Available fields for sorting campaigns search results.
@@ -1108,6 +1240,8 @@ Classes
     `updated_at: Literal['asc', 'desc']`
     :   When the campaign was last updated
 
+<a id="CampaignsStringFilter"></a>
+
 `CampaignsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -1138,6 +1272,8 @@ Classes
     `updated_at: str`
     :   When the campaign was last updated
 
+<a id="ContactsAndCondition"></a>
+
 `ContactsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1158,6 +1294,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.sendgrid.types.ContactsEqCondition | airbyte_agent_sdk.connectors.sendgrid.types.ContactsNeqCondition | airbyte_agent_sdk.connectors.sendgrid.types.ContactsGtCondition | airbyte_agent_sdk.connectors.sendgrid.types.ContactsGteCondition | airbyte_agent_sdk.connectors.sendgrid.types.ContactsLtCondition | airbyte_agent_sdk.connectors.sendgrid.types.ContactsLteCondition | airbyte_agent_sdk.connectors.sendgrid.types.ContactsInCondition | airbyte_agent_sdk.connectors.sendgrid.types.ContactsLikeCondition | airbyte_agent_sdk.connectors.sendgrid.types.ContactsFuzzyCondition | airbyte_agent_sdk.connectors.sendgrid.types.ContactsKeywordCondition | airbyte_agent_sdk.connectors.sendgrid.types.ContactsContainsCondition | airbyte_agent_sdk.connectors.sendgrid.types.ContactsNotCondition | airbyte_agent_sdk.connectors.sendgrid.types.ContactsAndCondition | airbyte_agent_sdk.connectors.sendgrid.types.ContactsOrCondition | airbyte_agent_sdk.connectors.sendgrid.types.ContactsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="ContactsAnyCondition"></a>
+
 `ContactsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1177,6 +1315,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.sendgrid.types.ContactsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="ContactsAnyValueFilter"></a>
 
 `ContactsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -1247,6 +1387,8 @@ Classes
     `whatsapp: Any`
     :   WhatsApp number
 
+<a id="ContactsContainsCondition"></a>
+
 `ContactsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -1258,6 +1400,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.sendgrid.types.ContactsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="ContactsEqCondition"></a>
 
 `ContactsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -1271,6 +1415,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.sendgrid.types.ContactsSearchFilter`
     :   The type of the None singleton.
 
+<a id="ContactsFuzzyCondition"></a>
+
 `ContactsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -1282,6 +1428,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.sendgrid.types.ContactsStringFilter`
     :   The type of the None singleton.
+
+<a id="ContactsGetParams"></a>
 
 `ContactsGetParams(*args, **kwargs)`
 :   Parameters for contacts.get operation
@@ -1295,6 +1443,8 @@ Classes
     `id: str`
     :   The type of the None singleton.
 
+<a id="ContactsGtCondition"></a>
+
 `ContactsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -1307,6 +1457,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.sendgrid.types.ContactsSearchFilter`
     :   The type of the None singleton.
 
+<a id="ContactsGteCondition"></a>
+
 `ContactsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -1318,6 +1470,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.sendgrid.types.ContactsSearchFilter`
     :   The type of the None singleton.
+
+<a id="ContactsInCondition"></a>
 
 `ContactsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -1338,6 +1492,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.sendgrid.types.ContactsInFilter`
     :   The type of the None singleton.
+
+<a id="ContactsInFilter"></a>
 
 `ContactsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -1408,6 +1564,8 @@ Classes
     `whatsapp: list[str]`
     :   WhatsApp number
 
+<a id="ContactsKeywordCondition"></a>
+
 `ContactsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -1419,6 +1577,8 @@ Classes
 
     `keyword: airbyte_agent_sdk.connectors.sendgrid.types.ContactsStringFilter`
     :   The type of the None singleton.
+
+<a id="ContactsLikeCondition"></a>
 
 `ContactsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
@@ -1432,12 +1592,16 @@ Classes
     `like: airbyte_agent_sdk.connectors.sendgrid.types.ContactsStringFilter`
     :   The type of the None singleton.
 
+<a id="ContactsListParams"></a>
+
 `ContactsListParams(*args, **kwargs)`
 :   Parameters for contacts.list operation
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="ContactsLtCondition"></a>
 
 `ContactsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
@@ -1451,6 +1615,8 @@ Classes
     `lt: airbyte_agent_sdk.connectors.sendgrid.types.ContactsSearchFilter`
     :   The type of the None singleton.
 
+<a id="ContactsLteCondition"></a>
+
 `ContactsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
 
@@ -1463,6 +1629,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.sendgrid.types.ContactsSearchFilter`
     :   The type of the None singleton.
 
+<a id="ContactsNeqCondition"></a>
+
 `ContactsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -1474,6 +1642,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.sendgrid.types.ContactsSearchFilter`
     :   The type of the None singleton.
+
+<a id="ContactsNotCondition"></a>
 
 `ContactsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -1495,6 +1665,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.sendgrid.types.ContactsEqCondition | airbyte_agent_sdk.connectors.sendgrid.types.ContactsNeqCondition | airbyte_agent_sdk.connectors.sendgrid.types.ContactsGtCondition | airbyte_agent_sdk.connectors.sendgrid.types.ContactsGteCondition | airbyte_agent_sdk.connectors.sendgrid.types.ContactsLtCondition | airbyte_agent_sdk.connectors.sendgrid.types.ContactsLteCondition | airbyte_agent_sdk.connectors.sendgrid.types.ContactsInCondition | airbyte_agent_sdk.connectors.sendgrid.types.ContactsLikeCondition | airbyte_agent_sdk.connectors.sendgrid.types.ContactsFuzzyCondition | airbyte_agent_sdk.connectors.sendgrid.types.ContactsKeywordCondition | airbyte_agent_sdk.connectors.sendgrid.types.ContactsContainsCondition | airbyte_agent_sdk.connectors.sendgrid.types.ContactsNotCondition | airbyte_agent_sdk.connectors.sendgrid.types.ContactsAndCondition | airbyte_agent_sdk.connectors.sendgrid.types.ContactsOrCondition | airbyte_agent_sdk.connectors.sendgrid.types.ContactsAnyCondition`
     :   The type of the None singleton.
 
+<a id="ContactsOrCondition"></a>
+
 `ContactsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1514,6 +1686,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.sendgrid.types.ContactsEqCondition | airbyte_agent_sdk.connectors.sendgrid.types.ContactsNeqCondition | airbyte_agent_sdk.connectors.sendgrid.types.ContactsGtCondition | airbyte_agent_sdk.connectors.sendgrid.types.ContactsGteCondition | airbyte_agent_sdk.connectors.sendgrid.types.ContactsLtCondition | airbyte_agent_sdk.connectors.sendgrid.types.ContactsLteCondition | airbyte_agent_sdk.connectors.sendgrid.types.ContactsInCondition | airbyte_agent_sdk.connectors.sendgrid.types.ContactsLikeCondition | airbyte_agent_sdk.connectors.sendgrid.types.ContactsFuzzyCondition | airbyte_agent_sdk.connectors.sendgrid.types.ContactsKeywordCondition | airbyte_agent_sdk.connectors.sendgrid.types.ContactsContainsCondition | airbyte_agent_sdk.connectors.sendgrid.types.ContactsNotCondition | airbyte_agent_sdk.connectors.sendgrid.types.ContactsAndCondition | airbyte_agent_sdk.connectors.sendgrid.types.ContactsOrCondition | airbyte_agent_sdk.connectors.sendgrid.types.ContactsAnyCondition]`
     :   The type of the None singleton.
+
+<a id="ContactsSearchFilter"></a>
 
 `ContactsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering contacts search queries.
@@ -1584,6 +1758,8 @@ Classes
     `whatsapp: str | None`
     :   WhatsApp number
 
+<a id="ContactsSearchQuery"></a>
+
 `ContactsSearchQuery(*args, **kwargs)`
 :   Search query for contacts entity.
 
@@ -1598,6 +1774,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.sendgrid.types.ContactsSortFilter]`
     :   The type of the None singleton.
+
+<a id="ContactsSortFilter"></a>
 
 `ContactsSortFilter(*args, **kwargs)`
 :   Available fields for sorting contacts search results.
@@ -1668,6 +1846,8 @@ Classes
     `whatsapp: Literal['asc', 'desc']`
     :   WhatsApp number
 
+<a id="ContactsStringFilter"></a>
+
 `ContactsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -1737,6 +1917,8 @@ Classes
     `whatsapp: str`
     :   WhatsApp number
 
+<a id="GlobalSuppressionsAndCondition"></a>
+
 `GlobalSuppressionsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1756,6 +1938,8 @@ Classes
 
     `and: list[airbyte_agent_sdk.connectors.sendgrid.types.GlobalSuppressionsEqCondition | airbyte_agent_sdk.connectors.sendgrid.types.GlobalSuppressionsNeqCondition | airbyte_agent_sdk.connectors.sendgrid.types.GlobalSuppressionsGtCondition | airbyte_agent_sdk.connectors.sendgrid.types.GlobalSuppressionsGteCondition | airbyte_agent_sdk.connectors.sendgrid.types.GlobalSuppressionsLtCondition | airbyte_agent_sdk.connectors.sendgrid.types.GlobalSuppressionsLteCondition | airbyte_agent_sdk.connectors.sendgrid.types.GlobalSuppressionsInCondition | airbyte_agent_sdk.connectors.sendgrid.types.GlobalSuppressionsLikeCondition | airbyte_agent_sdk.connectors.sendgrid.types.GlobalSuppressionsFuzzyCondition | airbyte_agent_sdk.connectors.sendgrid.types.GlobalSuppressionsKeywordCondition | airbyte_agent_sdk.connectors.sendgrid.types.GlobalSuppressionsContainsCondition | airbyte_agent_sdk.connectors.sendgrid.types.GlobalSuppressionsNotCondition | airbyte_agent_sdk.connectors.sendgrid.types.GlobalSuppressionsAndCondition | airbyte_agent_sdk.connectors.sendgrid.types.GlobalSuppressionsOrCondition | airbyte_agent_sdk.connectors.sendgrid.types.GlobalSuppressionsAnyCondition]`
     :   The type of the None singleton.
+
+<a id="GlobalSuppressionsAnyCondition"></a>
 
 `GlobalSuppressionsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -1777,6 +1961,8 @@ Classes
     `any: airbyte_agent_sdk.connectors.sendgrid.types.GlobalSuppressionsAnyValueFilter`
     :   The type of the None singleton.
 
+<a id="GlobalSuppressionsAnyValueFilter"></a>
+
 `GlobalSuppressionsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
 
@@ -1792,6 +1978,8 @@ Classes
     `email: Any`
     :   The globally suppressed email address
 
+<a id="GlobalSuppressionsContainsCondition"></a>
+
 `GlobalSuppressionsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -1803,6 +1991,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.sendgrid.types.GlobalSuppressionsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="GlobalSuppressionsEqCondition"></a>
 
 `GlobalSuppressionsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -1816,6 +2006,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.sendgrid.types.GlobalSuppressionsSearchFilter`
     :   The type of the None singleton.
 
+<a id="GlobalSuppressionsFuzzyCondition"></a>
+
 `GlobalSuppressionsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -1827,6 +2019,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.sendgrid.types.GlobalSuppressionsStringFilter`
     :   The type of the None singleton.
+
+<a id="GlobalSuppressionsGtCondition"></a>
 
 `GlobalSuppressionsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
@@ -1840,6 +2034,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.sendgrid.types.GlobalSuppressionsSearchFilter`
     :   The type of the None singleton.
 
+<a id="GlobalSuppressionsGteCondition"></a>
+
 `GlobalSuppressionsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -1851,6 +2047,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.sendgrid.types.GlobalSuppressionsSearchFilter`
     :   The type of the None singleton.
+
+<a id="GlobalSuppressionsInCondition"></a>
 
 `GlobalSuppressionsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -1872,6 +2070,8 @@ Classes
     `in: airbyte_agent_sdk.connectors.sendgrid.types.GlobalSuppressionsInFilter`
     :   The type of the None singleton.
 
+<a id="GlobalSuppressionsInFilter"></a>
+
 `GlobalSuppressionsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
 
@@ -1887,6 +2087,8 @@ Classes
     `email: list[str]`
     :   The globally suppressed email address
 
+<a id="GlobalSuppressionsKeywordCondition"></a>
+
 `GlobalSuppressionsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -1899,6 +2101,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.sendgrid.types.GlobalSuppressionsStringFilter`
     :   The type of the None singleton.
 
+<a id="GlobalSuppressionsLikeCondition"></a>
+
 `GlobalSuppressionsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -1910,6 +2114,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.sendgrid.types.GlobalSuppressionsStringFilter`
     :   The type of the None singleton.
+
+<a id="GlobalSuppressionsListParams"></a>
 
 `GlobalSuppressionsListParams(*args, **kwargs)`
 :   Parameters for global_suppressions.list operation
@@ -1926,6 +2132,8 @@ Classes
     `offset: int`
     :   The type of the None singleton.
 
+<a id="GlobalSuppressionsLtCondition"></a>
+
 `GlobalSuppressionsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -1937,6 +2145,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.sendgrid.types.GlobalSuppressionsSearchFilter`
     :   The type of the None singleton.
+
+<a id="GlobalSuppressionsLteCondition"></a>
 
 `GlobalSuppressionsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -1950,6 +2160,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.sendgrid.types.GlobalSuppressionsSearchFilter`
     :   The type of the None singleton.
 
+<a id="GlobalSuppressionsNeqCondition"></a>
+
 `GlobalSuppressionsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -1961,6 +2173,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.sendgrid.types.GlobalSuppressionsSearchFilter`
     :   The type of the None singleton.
+
+<a id="GlobalSuppressionsNotCondition"></a>
 
 `GlobalSuppressionsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -1982,6 +2196,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.sendgrid.types.GlobalSuppressionsEqCondition | airbyte_agent_sdk.connectors.sendgrid.types.GlobalSuppressionsNeqCondition | airbyte_agent_sdk.connectors.sendgrid.types.GlobalSuppressionsGtCondition | airbyte_agent_sdk.connectors.sendgrid.types.GlobalSuppressionsGteCondition | airbyte_agent_sdk.connectors.sendgrid.types.GlobalSuppressionsLtCondition | airbyte_agent_sdk.connectors.sendgrid.types.GlobalSuppressionsLteCondition | airbyte_agent_sdk.connectors.sendgrid.types.GlobalSuppressionsInCondition | airbyte_agent_sdk.connectors.sendgrid.types.GlobalSuppressionsLikeCondition | airbyte_agent_sdk.connectors.sendgrid.types.GlobalSuppressionsFuzzyCondition | airbyte_agent_sdk.connectors.sendgrid.types.GlobalSuppressionsKeywordCondition | airbyte_agent_sdk.connectors.sendgrid.types.GlobalSuppressionsContainsCondition | airbyte_agent_sdk.connectors.sendgrid.types.GlobalSuppressionsNotCondition | airbyte_agent_sdk.connectors.sendgrid.types.GlobalSuppressionsAndCondition | airbyte_agent_sdk.connectors.sendgrid.types.GlobalSuppressionsOrCondition | airbyte_agent_sdk.connectors.sendgrid.types.GlobalSuppressionsAnyCondition`
     :   The type of the None singleton.
 
+<a id="GlobalSuppressionsOrCondition"></a>
+
 `GlobalSuppressionsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -2002,6 +2218,8 @@ Classes
     `or: list[airbyte_agent_sdk.connectors.sendgrid.types.GlobalSuppressionsEqCondition | airbyte_agent_sdk.connectors.sendgrid.types.GlobalSuppressionsNeqCondition | airbyte_agent_sdk.connectors.sendgrid.types.GlobalSuppressionsGtCondition | airbyte_agent_sdk.connectors.sendgrid.types.GlobalSuppressionsGteCondition | airbyte_agent_sdk.connectors.sendgrid.types.GlobalSuppressionsLtCondition | airbyte_agent_sdk.connectors.sendgrid.types.GlobalSuppressionsLteCondition | airbyte_agent_sdk.connectors.sendgrid.types.GlobalSuppressionsInCondition | airbyte_agent_sdk.connectors.sendgrid.types.GlobalSuppressionsLikeCondition | airbyte_agent_sdk.connectors.sendgrid.types.GlobalSuppressionsFuzzyCondition | airbyte_agent_sdk.connectors.sendgrid.types.GlobalSuppressionsKeywordCondition | airbyte_agent_sdk.connectors.sendgrid.types.GlobalSuppressionsContainsCondition | airbyte_agent_sdk.connectors.sendgrid.types.GlobalSuppressionsNotCondition | airbyte_agent_sdk.connectors.sendgrid.types.GlobalSuppressionsAndCondition | airbyte_agent_sdk.connectors.sendgrid.types.GlobalSuppressionsOrCondition | airbyte_agent_sdk.connectors.sendgrid.types.GlobalSuppressionsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="GlobalSuppressionsSearchFilter"></a>
+
 `GlobalSuppressionsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering global_suppressions search queries.
 
@@ -2016,6 +2234,8 @@ Classes
 
     `email: str | None`
     :   The globally suppressed email address
+
+<a id="GlobalSuppressionsSearchQuery"></a>
 
 `GlobalSuppressionsSearchQuery(*args, **kwargs)`
 :   Search query for global_suppressions entity.
@@ -2032,6 +2252,8 @@ Classes
     `sort: list[airbyte_agent_sdk.connectors.sendgrid.types.GlobalSuppressionsSortFilter]`
     :   The type of the None singleton.
 
+<a id="GlobalSuppressionsSortFilter"></a>
+
 `GlobalSuppressionsSortFilter(*args, **kwargs)`
 :   Available fields for sorting global_suppressions search results.
 
@@ -2047,6 +2269,8 @@ Classes
     `email: Literal['asc', 'desc']`
     :   The globally suppressed email address
 
+<a id="GlobalSuppressionsStringFilter"></a>
+
 `GlobalSuppressionsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -2061,6 +2285,8 @@ Classes
 
     `email: str`
     :   The globally suppressed email address
+
+<a id="InvalidEmailsAndCondition"></a>
 
 `InvalidEmailsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -2082,6 +2308,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.sendgrid.types.InvalidEmailsEqCondition | airbyte_agent_sdk.connectors.sendgrid.types.InvalidEmailsNeqCondition | airbyte_agent_sdk.connectors.sendgrid.types.InvalidEmailsGtCondition | airbyte_agent_sdk.connectors.sendgrid.types.InvalidEmailsGteCondition | airbyte_agent_sdk.connectors.sendgrid.types.InvalidEmailsLtCondition | airbyte_agent_sdk.connectors.sendgrid.types.InvalidEmailsLteCondition | airbyte_agent_sdk.connectors.sendgrid.types.InvalidEmailsInCondition | airbyte_agent_sdk.connectors.sendgrid.types.InvalidEmailsLikeCondition | airbyte_agent_sdk.connectors.sendgrid.types.InvalidEmailsFuzzyCondition | airbyte_agent_sdk.connectors.sendgrid.types.InvalidEmailsKeywordCondition | airbyte_agent_sdk.connectors.sendgrid.types.InvalidEmailsContainsCondition | airbyte_agent_sdk.connectors.sendgrid.types.InvalidEmailsNotCondition | airbyte_agent_sdk.connectors.sendgrid.types.InvalidEmailsAndCondition | airbyte_agent_sdk.connectors.sendgrid.types.InvalidEmailsOrCondition | airbyte_agent_sdk.connectors.sendgrid.types.InvalidEmailsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="InvalidEmailsAnyCondition"></a>
+
 `InvalidEmailsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -2102,6 +2330,8 @@ Classes
     `any: airbyte_agent_sdk.connectors.sendgrid.types.InvalidEmailsAnyValueFilter`
     :   The type of the None singleton.
 
+<a id="InvalidEmailsAnyValueFilter"></a>
+
 `InvalidEmailsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
 
@@ -2120,6 +2350,8 @@ Classes
     `reason: Any`
     :   The reason the email is invalid
 
+<a id="InvalidEmailsContainsCondition"></a>
+
 `InvalidEmailsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -2131,6 +2363,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.sendgrid.types.InvalidEmailsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="InvalidEmailsEqCondition"></a>
 
 `InvalidEmailsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -2144,6 +2378,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.sendgrid.types.InvalidEmailsSearchFilter`
     :   The type of the None singleton.
 
+<a id="InvalidEmailsFuzzyCondition"></a>
+
 `InvalidEmailsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -2155,6 +2391,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.sendgrid.types.InvalidEmailsStringFilter`
     :   The type of the None singleton.
+
+<a id="InvalidEmailsGtCondition"></a>
 
 `InvalidEmailsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
@@ -2168,6 +2406,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.sendgrid.types.InvalidEmailsSearchFilter`
     :   The type of the None singleton.
 
+<a id="InvalidEmailsGteCondition"></a>
+
 `InvalidEmailsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -2179,6 +2419,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.sendgrid.types.InvalidEmailsSearchFilter`
     :   The type of the None singleton.
+
+<a id="InvalidEmailsInCondition"></a>
 
 `InvalidEmailsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -2200,6 +2442,8 @@ Classes
     `in: airbyte_agent_sdk.connectors.sendgrid.types.InvalidEmailsInFilter`
     :   The type of the None singleton.
 
+<a id="InvalidEmailsInFilter"></a>
+
 `InvalidEmailsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
 
@@ -2218,6 +2462,8 @@ Classes
     `reason: list[str]`
     :   The reason the email is invalid
 
+<a id="InvalidEmailsKeywordCondition"></a>
+
 `InvalidEmailsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -2230,6 +2476,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.sendgrid.types.InvalidEmailsStringFilter`
     :   The type of the None singleton.
 
+<a id="InvalidEmailsLikeCondition"></a>
+
 `InvalidEmailsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -2241,6 +2489,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.sendgrid.types.InvalidEmailsStringFilter`
     :   The type of the None singleton.
+
+<a id="InvalidEmailsListParams"></a>
 
 `InvalidEmailsListParams(*args, **kwargs)`
 :   Parameters for invalid_emails.list operation
@@ -2257,6 +2507,8 @@ Classes
     `offset: int`
     :   The type of the None singleton.
 
+<a id="InvalidEmailsLtCondition"></a>
+
 `InvalidEmailsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -2268,6 +2520,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.sendgrid.types.InvalidEmailsSearchFilter`
     :   The type of the None singleton.
+
+<a id="InvalidEmailsLteCondition"></a>
 
 `InvalidEmailsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -2281,6 +2535,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.sendgrid.types.InvalidEmailsSearchFilter`
     :   The type of the None singleton.
 
+<a id="InvalidEmailsNeqCondition"></a>
+
 `InvalidEmailsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -2292,6 +2548,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.sendgrid.types.InvalidEmailsSearchFilter`
     :   The type of the None singleton.
+
+<a id="InvalidEmailsNotCondition"></a>
 
 `InvalidEmailsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -2313,6 +2571,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.sendgrid.types.InvalidEmailsEqCondition | airbyte_agent_sdk.connectors.sendgrid.types.InvalidEmailsNeqCondition | airbyte_agent_sdk.connectors.sendgrid.types.InvalidEmailsGtCondition | airbyte_agent_sdk.connectors.sendgrid.types.InvalidEmailsGteCondition | airbyte_agent_sdk.connectors.sendgrid.types.InvalidEmailsLtCondition | airbyte_agent_sdk.connectors.sendgrid.types.InvalidEmailsLteCondition | airbyte_agent_sdk.connectors.sendgrid.types.InvalidEmailsInCondition | airbyte_agent_sdk.connectors.sendgrid.types.InvalidEmailsLikeCondition | airbyte_agent_sdk.connectors.sendgrid.types.InvalidEmailsFuzzyCondition | airbyte_agent_sdk.connectors.sendgrid.types.InvalidEmailsKeywordCondition | airbyte_agent_sdk.connectors.sendgrid.types.InvalidEmailsContainsCondition | airbyte_agent_sdk.connectors.sendgrid.types.InvalidEmailsNotCondition | airbyte_agent_sdk.connectors.sendgrid.types.InvalidEmailsAndCondition | airbyte_agent_sdk.connectors.sendgrid.types.InvalidEmailsOrCondition | airbyte_agent_sdk.connectors.sendgrid.types.InvalidEmailsAnyCondition`
     :   The type of the None singleton.
 
+<a id="InvalidEmailsOrCondition"></a>
+
 `InvalidEmailsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -2333,6 +2593,8 @@ Classes
     `or: list[airbyte_agent_sdk.connectors.sendgrid.types.InvalidEmailsEqCondition | airbyte_agent_sdk.connectors.sendgrid.types.InvalidEmailsNeqCondition | airbyte_agent_sdk.connectors.sendgrid.types.InvalidEmailsGtCondition | airbyte_agent_sdk.connectors.sendgrid.types.InvalidEmailsGteCondition | airbyte_agent_sdk.connectors.sendgrid.types.InvalidEmailsLtCondition | airbyte_agent_sdk.connectors.sendgrid.types.InvalidEmailsLteCondition | airbyte_agent_sdk.connectors.sendgrid.types.InvalidEmailsInCondition | airbyte_agent_sdk.connectors.sendgrid.types.InvalidEmailsLikeCondition | airbyte_agent_sdk.connectors.sendgrid.types.InvalidEmailsFuzzyCondition | airbyte_agent_sdk.connectors.sendgrid.types.InvalidEmailsKeywordCondition | airbyte_agent_sdk.connectors.sendgrid.types.InvalidEmailsContainsCondition | airbyte_agent_sdk.connectors.sendgrid.types.InvalidEmailsNotCondition | airbyte_agent_sdk.connectors.sendgrid.types.InvalidEmailsAndCondition | airbyte_agent_sdk.connectors.sendgrid.types.InvalidEmailsOrCondition | airbyte_agent_sdk.connectors.sendgrid.types.InvalidEmailsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="InvalidEmailsSearchFilter"></a>
+
 `InvalidEmailsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering invalid_emails search queries.
 
@@ -2351,6 +2613,8 @@ Classes
     `reason: str | None`
     :   The reason the email is invalid
 
+<a id="InvalidEmailsSearchQuery"></a>
+
 `InvalidEmailsSearchQuery(*args, **kwargs)`
 :   Search query for invalid_emails entity.
 
@@ -2365,6 +2629,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.sendgrid.types.InvalidEmailsSortFilter]`
     :   The type of the None singleton.
+
+<a id="InvalidEmailsSortFilter"></a>
 
 `InvalidEmailsSortFilter(*args, **kwargs)`
 :   Available fields for sorting invalid_emails search results.
@@ -2384,6 +2650,8 @@ Classes
     `reason: Literal['asc', 'desc']`
     :   The reason the email is invalid
 
+<a id="InvalidEmailsStringFilter"></a>
+
 `InvalidEmailsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -2401,6 +2669,8 @@ Classes
 
     `reason: str`
     :   The reason the email is invalid
+
+<a id="ListsAndCondition"></a>
 
 `ListsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -2422,6 +2692,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.sendgrid.types.ListsEqCondition | airbyte_agent_sdk.connectors.sendgrid.types.ListsNeqCondition | airbyte_agent_sdk.connectors.sendgrid.types.ListsGtCondition | airbyte_agent_sdk.connectors.sendgrid.types.ListsGteCondition | airbyte_agent_sdk.connectors.sendgrid.types.ListsLtCondition | airbyte_agent_sdk.connectors.sendgrid.types.ListsLteCondition | airbyte_agent_sdk.connectors.sendgrid.types.ListsInCondition | airbyte_agent_sdk.connectors.sendgrid.types.ListsLikeCondition | airbyte_agent_sdk.connectors.sendgrid.types.ListsFuzzyCondition | airbyte_agent_sdk.connectors.sendgrid.types.ListsKeywordCondition | airbyte_agent_sdk.connectors.sendgrid.types.ListsContainsCondition | airbyte_agent_sdk.connectors.sendgrid.types.ListsNotCondition | airbyte_agent_sdk.connectors.sendgrid.types.ListsAndCondition | airbyte_agent_sdk.connectors.sendgrid.types.ListsOrCondition | airbyte_agent_sdk.connectors.sendgrid.types.ListsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="ListsAnyCondition"></a>
+
 `ListsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -2441,6 +2713,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.sendgrid.types.ListsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="ListsAnyValueFilter"></a>
 
 `ListsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -2463,6 +2737,8 @@ Classes
     `name: Any`
     :   Name of the list
 
+<a id="ListsContainsCondition"></a>
+
 `ListsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -2474,6 +2750,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.sendgrid.types.ListsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="ListsEqCondition"></a>
 
 `ListsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -2487,6 +2765,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.sendgrid.types.ListsSearchFilter`
     :   The type of the None singleton.
 
+<a id="ListsFuzzyCondition"></a>
+
 `ListsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -2498,6 +2778,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.sendgrid.types.ListsStringFilter`
     :   The type of the None singleton.
+
+<a id="ListsGetParams"></a>
 
 `ListsGetParams(*args, **kwargs)`
 :   Parameters for lists.get operation
@@ -2511,6 +2793,8 @@ Classes
     `id: str`
     :   The type of the None singleton.
 
+<a id="ListsGtCondition"></a>
+
 `ListsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -2523,6 +2807,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.sendgrid.types.ListsSearchFilter`
     :   The type of the None singleton.
 
+<a id="ListsGteCondition"></a>
+
 `ListsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -2534,6 +2820,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.sendgrid.types.ListsSearchFilter`
     :   The type of the None singleton.
+
+<a id="ListsInCondition"></a>
 
 `ListsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -2554,6 +2842,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.sendgrid.types.ListsInFilter`
     :   The type of the None singleton.
+
+<a id="ListsInFilter"></a>
 
 `ListsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -2576,6 +2866,8 @@ Classes
     `name: list[str]`
     :   Name of the list
 
+<a id="ListsKeywordCondition"></a>
+
 `ListsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -2587,6 +2879,8 @@ Classes
 
     `keyword: airbyte_agent_sdk.connectors.sendgrid.types.ListsStringFilter`
     :   The type of the None singleton.
+
+<a id="ListsLikeCondition"></a>
 
 `ListsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
@@ -2600,6 +2894,8 @@ Classes
     `like: airbyte_agent_sdk.connectors.sendgrid.types.ListsStringFilter`
     :   The type of the None singleton.
 
+<a id="ListsListParams"></a>
+
 `ListsListParams(*args, **kwargs)`
 :   Parameters for lists.list operation
 
@@ -2611,6 +2907,8 @@ Classes
 
     `page_size: int`
     :   The type of the None singleton.
+
+<a id="ListsLtCondition"></a>
 
 `ListsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
@@ -2624,6 +2922,8 @@ Classes
     `lt: airbyte_agent_sdk.connectors.sendgrid.types.ListsSearchFilter`
     :   The type of the None singleton.
 
+<a id="ListsLteCondition"></a>
+
 `ListsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
 
@@ -2636,6 +2936,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.sendgrid.types.ListsSearchFilter`
     :   The type of the None singleton.
 
+<a id="ListsNeqCondition"></a>
+
 `ListsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -2647,6 +2949,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.sendgrid.types.ListsSearchFilter`
     :   The type of the None singleton.
+
+<a id="ListsNotCondition"></a>
 
 `ListsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -2668,6 +2972,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.sendgrid.types.ListsEqCondition | airbyte_agent_sdk.connectors.sendgrid.types.ListsNeqCondition | airbyte_agent_sdk.connectors.sendgrid.types.ListsGtCondition | airbyte_agent_sdk.connectors.sendgrid.types.ListsGteCondition | airbyte_agent_sdk.connectors.sendgrid.types.ListsLtCondition | airbyte_agent_sdk.connectors.sendgrid.types.ListsLteCondition | airbyte_agent_sdk.connectors.sendgrid.types.ListsInCondition | airbyte_agent_sdk.connectors.sendgrid.types.ListsLikeCondition | airbyte_agent_sdk.connectors.sendgrid.types.ListsFuzzyCondition | airbyte_agent_sdk.connectors.sendgrid.types.ListsKeywordCondition | airbyte_agent_sdk.connectors.sendgrid.types.ListsContainsCondition | airbyte_agent_sdk.connectors.sendgrid.types.ListsNotCondition | airbyte_agent_sdk.connectors.sendgrid.types.ListsAndCondition | airbyte_agent_sdk.connectors.sendgrid.types.ListsOrCondition | airbyte_agent_sdk.connectors.sendgrid.types.ListsAnyCondition`
     :   The type of the None singleton.
 
+<a id="ListsOrCondition"></a>
+
 `ListsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -2687,6 +2993,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.sendgrid.types.ListsEqCondition | airbyte_agent_sdk.connectors.sendgrid.types.ListsNeqCondition | airbyte_agent_sdk.connectors.sendgrid.types.ListsGtCondition | airbyte_agent_sdk.connectors.sendgrid.types.ListsGteCondition | airbyte_agent_sdk.connectors.sendgrid.types.ListsLtCondition | airbyte_agent_sdk.connectors.sendgrid.types.ListsLteCondition | airbyte_agent_sdk.connectors.sendgrid.types.ListsInCondition | airbyte_agent_sdk.connectors.sendgrid.types.ListsLikeCondition | airbyte_agent_sdk.connectors.sendgrid.types.ListsFuzzyCondition | airbyte_agent_sdk.connectors.sendgrid.types.ListsKeywordCondition | airbyte_agent_sdk.connectors.sendgrid.types.ListsContainsCondition | airbyte_agent_sdk.connectors.sendgrid.types.ListsNotCondition | airbyte_agent_sdk.connectors.sendgrid.types.ListsAndCondition | airbyte_agent_sdk.connectors.sendgrid.types.ListsOrCondition | airbyte_agent_sdk.connectors.sendgrid.types.ListsAnyCondition]`
     :   The type of the None singleton.
+
+<a id="ListsSearchFilter"></a>
 
 `ListsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering lists search queries.
@@ -2709,6 +3017,8 @@ Classes
     `name: str | None`
     :   Name of the list
 
+<a id="ListsSearchQuery"></a>
+
 `ListsSearchQuery(*args, **kwargs)`
 :   Search query for lists entity.
 
@@ -2723,6 +3033,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.sendgrid.types.ListsSortFilter]`
     :   The type of the None singleton.
+
+<a id="ListsSortFilter"></a>
 
 `ListsSortFilter(*args, **kwargs)`
 :   Available fields for sorting lists search results.
@@ -2745,6 +3057,8 @@ Classes
     `name: Literal['asc', 'desc']`
     :   Name of the list
 
+<a id="ListsStringFilter"></a>
+
 `ListsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -2766,6 +3080,8 @@ Classes
     `name: str`
     :   Name of the list
 
+<a id="SegmentsAndCondition"></a>
+
 `SegmentsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -2786,6 +3102,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.sendgrid.types.SegmentsEqCondition | airbyte_agent_sdk.connectors.sendgrid.types.SegmentsNeqCondition | airbyte_agent_sdk.connectors.sendgrid.types.SegmentsGtCondition | airbyte_agent_sdk.connectors.sendgrid.types.SegmentsGteCondition | airbyte_agent_sdk.connectors.sendgrid.types.SegmentsLtCondition | airbyte_agent_sdk.connectors.sendgrid.types.SegmentsLteCondition | airbyte_agent_sdk.connectors.sendgrid.types.SegmentsInCondition | airbyte_agent_sdk.connectors.sendgrid.types.SegmentsLikeCondition | airbyte_agent_sdk.connectors.sendgrid.types.SegmentsFuzzyCondition | airbyte_agent_sdk.connectors.sendgrid.types.SegmentsKeywordCondition | airbyte_agent_sdk.connectors.sendgrid.types.SegmentsContainsCondition | airbyte_agent_sdk.connectors.sendgrid.types.SegmentsNotCondition | airbyte_agent_sdk.connectors.sendgrid.types.SegmentsAndCondition | airbyte_agent_sdk.connectors.sendgrid.types.SegmentsOrCondition | airbyte_agent_sdk.connectors.sendgrid.types.SegmentsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="SegmentsAnyCondition"></a>
+
 `SegmentsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -2805,6 +3123,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.sendgrid.types.SegmentsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="SegmentsAnyValueFilter"></a>
 
 `SegmentsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -2845,6 +3165,8 @@ Classes
     `updated_at: Any`
     :   When the segment was last updated
 
+<a id="SegmentsContainsCondition"></a>
+
 `SegmentsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -2856,6 +3178,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.sendgrid.types.SegmentsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="SegmentsEqCondition"></a>
 
 `SegmentsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -2869,6 +3193,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.sendgrid.types.SegmentsSearchFilter`
     :   The type of the None singleton.
 
+<a id="SegmentsFuzzyCondition"></a>
+
 `SegmentsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -2880,6 +3206,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.sendgrid.types.SegmentsStringFilter`
     :   The type of the None singleton.
+
+<a id="SegmentsGetParams"></a>
 
 `SegmentsGetParams(*args, **kwargs)`
 :   Parameters for segments.get operation
@@ -2893,6 +3221,8 @@ Classes
     `segment_id: str`
     :   The type of the None singleton.
 
+<a id="SegmentsGtCondition"></a>
+
 `SegmentsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -2905,6 +3235,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.sendgrid.types.SegmentsSearchFilter`
     :   The type of the None singleton.
 
+<a id="SegmentsGteCondition"></a>
+
 `SegmentsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -2916,6 +3248,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.sendgrid.types.SegmentsSearchFilter`
     :   The type of the None singleton.
+
+<a id="SegmentsInCondition"></a>
 
 `SegmentsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -2936,6 +3270,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.sendgrid.types.SegmentsInFilter`
     :   The type of the None singleton.
+
+<a id="SegmentsInFilter"></a>
 
 `SegmentsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -2976,6 +3312,8 @@ Classes
     `updated_at: list[str]`
     :   When the segment was last updated
 
+<a id="SegmentsKeywordCondition"></a>
+
 `SegmentsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -2987,6 +3325,8 @@ Classes
 
     `keyword: airbyte_agent_sdk.connectors.sendgrid.types.SegmentsStringFilter`
     :   The type of the None singleton.
+
+<a id="SegmentsLikeCondition"></a>
 
 `SegmentsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
@@ -3000,12 +3340,16 @@ Classes
     `like: airbyte_agent_sdk.connectors.sendgrid.types.SegmentsStringFilter`
     :   The type of the None singleton.
 
+<a id="SegmentsListParams"></a>
+
 `SegmentsListParams(*args, **kwargs)`
 :   Parameters for segments.list operation
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="SegmentsLtCondition"></a>
 
 `SegmentsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
@@ -3019,6 +3363,8 @@ Classes
     `lt: airbyte_agent_sdk.connectors.sendgrid.types.SegmentsSearchFilter`
     :   The type of the None singleton.
 
+<a id="SegmentsLteCondition"></a>
+
 `SegmentsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
 
@@ -3031,6 +3377,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.sendgrid.types.SegmentsSearchFilter`
     :   The type of the None singleton.
 
+<a id="SegmentsNeqCondition"></a>
+
 `SegmentsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -3042,6 +3390,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.sendgrid.types.SegmentsSearchFilter`
     :   The type of the None singleton.
+
+<a id="SegmentsNotCondition"></a>
 
 `SegmentsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -3063,6 +3413,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.sendgrid.types.SegmentsEqCondition | airbyte_agent_sdk.connectors.sendgrid.types.SegmentsNeqCondition | airbyte_agent_sdk.connectors.sendgrid.types.SegmentsGtCondition | airbyte_agent_sdk.connectors.sendgrid.types.SegmentsGteCondition | airbyte_agent_sdk.connectors.sendgrid.types.SegmentsLtCondition | airbyte_agent_sdk.connectors.sendgrid.types.SegmentsLteCondition | airbyte_agent_sdk.connectors.sendgrid.types.SegmentsInCondition | airbyte_agent_sdk.connectors.sendgrid.types.SegmentsLikeCondition | airbyte_agent_sdk.connectors.sendgrid.types.SegmentsFuzzyCondition | airbyte_agent_sdk.connectors.sendgrid.types.SegmentsKeywordCondition | airbyte_agent_sdk.connectors.sendgrid.types.SegmentsContainsCondition | airbyte_agent_sdk.connectors.sendgrid.types.SegmentsNotCondition | airbyte_agent_sdk.connectors.sendgrid.types.SegmentsAndCondition | airbyte_agent_sdk.connectors.sendgrid.types.SegmentsOrCondition | airbyte_agent_sdk.connectors.sendgrid.types.SegmentsAnyCondition`
     :   The type of the None singleton.
 
+<a id="SegmentsOrCondition"></a>
+
 `SegmentsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -3082,6 +3434,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.sendgrid.types.SegmentsEqCondition | airbyte_agent_sdk.connectors.sendgrid.types.SegmentsNeqCondition | airbyte_agent_sdk.connectors.sendgrid.types.SegmentsGtCondition | airbyte_agent_sdk.connectors.sendgrid.types.SegmentsGteCondition | airbyte_agent_sdk.connectors.sendgrid.types.SegmentsLtCondition | airbyte_agent_sdk.connectors.sendgrid.types.SegmentsLteCondition | airbyte_agent_sdk.connectors.sendgrid.types.SegmentsInCondition | airbyte_agent_sdk.connectors.sendgrid.types.SegmentsLikeCondition | airbyte_agent_sdk.connectors.sendgrid.types.SegmentsFuzzyCondition | airbyte_agent_sdk.connectors.sendgrid.types.SegmentsKeywordCondition | airbyte_agent_sdk.connectors.sendgrid.types.SegmentsContainsCondition | airbyte_agent_sdk.connectors.sendgrid.types.SegmentsNotCondition | airbyte_agent_sdk.connectors.sendgrid.types.SegmentsAndCondition | airbyte_agent_sdk.connectors.sendgrid.types.SegmentsOrCondition | airbyte_agent_sdk.connectors.sendgrid.types.SegmentsAnyCondition]`
     :   The type of the None singleton.
+
+<a id="SegmentsSearchFilter"></a>
 
 `SegmentsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering segments search queries.
@@ -3122,6 +3476,8 @@ Classes
     `updated_at: str | None`
     :   When the segment was last updated
 
+<a id="SegmentsSearchQuery"></a>
+
 `SegmentsSearchQuery(*args, **kwargs)`
 :   Search query for segments entity.
 
@@ -3136,6 +3492,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.sendgrid.types.SegmentsSortFilter]`
     :   The type of the None singleton.
+
+<a id="SegmentsSortFilter"></a>
 
 `SegmentsSortFilter(*args, **kwargs)`
 :   Available fields for sorting segments search results.
@@ -3176,6 +3534,8 @@ Classes
     `updated_at: Literal['asc', 'desc']`
     :   When the segment was last updated
 
+<a id="SegmentsStringFilter"></a>
+
 `SegmentsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -3215,6 +3575,8 @@ Classes
     `updated_at: str`
     :   When the segment was last updated
 
+<a id="SinglesendStatsAndCondition"></a>
+
 `SinglesendStatsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -3235,6 +3597,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.sendgrid.types.SinglesendStatsEqCondition | airbyte_agent_sdk.connectors.sendgrid.types.SinglesendStatsNeqCondition | airbyte_agent_sdk.connectors.sendgrid.types.SinglesendStatsGtCondition | airbyte_agent_sdk.connectors.sendgrid.types.SinglesendStatsGteCondition | airbyte_agent_sdk.connectors.sendgrid.types.SinglesendStatsLtCondition | airbyte_agent_sdk.connectors.sendgrid.types.SinglesendStatsLteCondition | airbyte_agent_sdk.connectors.sendgrid.types.SinglesendStatsInCondition | airbyte_agent_sdk.connectors.sendgrid.types.SinglesendStatsLikeCondition | airbyte_agent_sdk.connectors.sendgrid.types.SinglesendStatsFuzzyCondition | airbyte_agent_sdk.connectors.sendgrid.types.SinglesendStatsKeywordCondition | airbyte_agent_sdk.connectors.sendgrid.types.SinglesendStatsContainsCondition | airbyte_agent_sdk.connectors.sendgrid.types.SinglesendStatsNotCondition | airbyte_agent_sdk.connectors.sendgrid.types.SinglesendStatsAndCondition | airbyte_agent_sdk.connectors.sendgrid.types.SinglesendStatsOrCondition | airbyte_agent_sdk.connectors.sendgrid.types.SinglesendStatsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="SinglesendStatsAnyCondition"></a>
+
 `SinglesendStatsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -3254,6 +3618,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.sendgrid.types.SinglesendStatsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="SinglesendStatsAnyValueFilter"></a>
 
 `SinglesendStatsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -3279,6 +3645,8 @@ Classes
     `stats: Any`
     :   Email statistics for the single send
 
+<a id="SinglesendStatsContainsCondition"></a>
+
 `SinglesendStatsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -3290,6 +3658,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.sendgrid.types.SinglesendStatsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="SinglesendStatsEqCondition"></a>
 
 `SinglesendStatsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -3303,6 +3673,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.sendgrid.types.SinglesendStatsSearchFilter`
     :   The type of the None singleton.
 
+<a id="SinglesendStatsFuzzyCondition"></a>
+
 `SinglesendStatsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -3314,6 +3686,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.sendgrid.types.SinglesendStatsStringFilter`
     :   The type of the None singleton.
+
+<a id="SinglesendStatsGtCondition"></a>
 
 `SinglesendStatsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
@@ -3327,6 +3701,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.sendgrid.types.SinglesendStatsSearchFilter`
     :   The type of the None singleton.
 
+<a id="SinglesendStatsGteCondition"></a>
+
 `SinglesendStatsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -3338,6 +3714,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.sendgrid.types.SinglesendStatsSearchFilter`
     :   The type of the None singleton.
+
+<a id="SinglesendStatsInCondition"></a>
 
 `SinglesendStatsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -3358,6 +3736,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.sendgrid.types.SinglesendStatsInFilter`
     :   The type of the None singleton.
+
+<a id="SinglesendStatsInFilter"></a>
 
 `SinglesendStatsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -3383,6 +3763,8 @@ Classes
     `stats: list[dict[str, typing.Any]]`
     :   Email statistics for the single send
 
+<a id="SinglesendStatsKeywordCondition"></a>
+
 `SinglesendStatsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -3394,6 +3776,8 @@ Classes
 
     `keyword: airbyte_agent_sdk.connectors.sendgrid.types.SinglesendStatsStringFilter`
     :   The type of the None singleton.
+
+<a id="SinglesendStatsLikeCondition"></a>
 
 `SinglesendStatsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
@@ -3407,6 +3791,8 @@ Classes
     `like: airbyte_agent_sdk.connectors.sendgrid.types.SinglesendStatsStringFilter`
     :   The type of the None singleton.
 
+<a id="SinglesendStatsListParams"></a>
+
 `SinglesendStatsListParams(*args, **kwargs)`
 :   Parameters for singlesend_stats.list operation
 
@@ -3418,6 +3804,8 @@ Classes
 
     `page_size: int`
     :   The type of the None singleton.
+
+<a id="SinglesendStatsLtCondition"></a>
 
 `SinglesendStatsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
@@ -3431,6 +3819,8 @@ Classes
     `lt: airbyte_agent_sdk.connectors.sendgrid.types.SinglesendStatsSearchFilter`
     :   The type of the None singleton.
 
+<a id="SinglesendStatsLteCondition"></a>
+
 `SinglesendStatsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
 
@@ -3443,6 +3833,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.sendgrid.types.SinglesendStatsSearchFilter`
     :   The type of the None singleton.
 
+<a id="SinglesendStatsNeqCondition"></a>
+
 `SinglesendStatsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -3454,6 +3846,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.sendgrid.types.SinglesendStatsSearchFilter`
     :   The type of the None singleton.
+
+<a id="SinglesendStatsNotCondition"></a>
 
 `SinglesendStatsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -3475,6 +3869,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.sendgrid.types.SinglesendStatsEqCondition | airbyte_agent_sdk.connectors.sendgrid.types.SinglesendStatsNeqCondition | airbyte_agent_sdk.connectors.sendgrid.types.SinglesendStatsGtCondition | airbyte_agent_sdk.connectors.sendgrid.types.SinglesendStatsGteCondition | airbyte_agent_sdk.connectors.sendgrid.types.SinglesendStatsLtCondition | airbyte_agent_sdk.connectors.sendgrid.types.SinglesendStatsLteCondition | airbyte_agent_sdk.connectors.sendgrid.types.SinglesendStatsInCondition | airbyte_agent_sdk.connectors.sendgrid.types.SinglesendStatsLikeCondition | airbyte_agent_sdk.connectors.sendgrid.types.SinglesendStatsFuzzyCondition | airbyte_agent_sdk.connectors.sendgrid.types.SinglesendStatsKeywordCondition | airbyte_agent_sdk.connectors.sendgrid.types.SinglesendStatsContainsCondition | airbyte_agent_sdk.connectors.sendgrid.types.SinglesendStatsNotCondition | airbyte_agent_sdk.connectors.sendgrid.types.SinglesendStatsAndCondition | airbyte_agent_sdk.connectors.sendgrid.types.SinglesendStatsOrCondition | airbyte_agent_sdk.connectors.sendgrid.types.SinglesendStatsAnyCondition`
     :   The type of the None singleton.
 
+<a id="SinglesendStatsOrCondition"></a>
+
 `SinglesendStatsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -3494,6 +3890,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.sendgrid.types.SinglesendStatsEqCondition | airbyte_agent_sdk.connectors.sendgrid.types.SinglesendStatsNeqCondition | airbyte_agent_sdk.connectors.sendgrid.types.SinglesendStatsGtCondition | airbyte_agent_sdk.connectors.sendgrid.types.SinglesendStatsGteCondition | airbyte_agent_sdk.connectors.sendgrid.types.SinglesendStatsLtCondition | airbyte_agent_sdk.connectors.sendgrid.types.SinglesendStatsLteCondition | airbyte_agent_sdk.connectors.sendgrid.types.SinglesendStatsInCondition | airbyte_agent_sdk.connectors.sendgrid.types.SinglesendStatsLikeCondition | airbyte_agent_sdk.connectors.sendgrid.types.SinglesendStatsFuzzyCondition | airbyte_agent_sdk.connectors.sendgrid.types.SinglesendStatsKeywordCondition | airbyte_agent_sdk.connectors.sendgrid.types.SinglesendStatsContainsCondition | airbyte_agent_sdk.connectors.sendgrid.types.SinglesendStatsNotCondition | airbyte_agent_sdk.connectors.sendgrid.types.SinglesendStatsAndCondition | airbyte_agent_sdk.connectors.sendgrid.types.SinglesendStatsOrCondition | airbyte_agent_sdk.connectors.sendgrid.types.SinglesendStatsAnyCondition]`
     :   The type of the None singleton.
+
+<a id="SinglesendStatsSearchFilter"></a>
 
 `SinglesendStatsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering singlesend_stats search queries.
@@ -3519,6 +3917,8 @@ Classes
     `stats: dict[str, typing.Any] | None`
     :   Email statistics for the single send
 
+<a id="SinglesendStatsSearchQuery"></a>
+
 `SinglesendStatsSearchQuery(*args, **kwargs)`
 :   Search query for singlesend_stats entity.
 
@@ -3533,6 +3933,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.sendgrid.types.SinglesendStatsSortFilter]`
     :   The type of the None singleton.
+
+<a id="SinglesendStatsSortFilter"></a>
 
 `SinglesendStatsSortFilter(*args, **kwargs)`
 :   Available fields for sorting singlesend_stats search results.
@@ -3558,6 +3960,8 @@ Classes
     `stats: Literal['asc', 'desc']`
     :   Email statistics for the single send
 
+<a id="SinglesendStatsStringFilter"></a>
+
 `SinglesendStatsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -3582,6 +3986,8 @@ Classes
     `stats: str`
     :   Email statistics for the single send
 
+<a id="SinglesendsAndCondition"></a>
+
 `SinglesendsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -3602,6 +4008,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.sendgrid.types.SinglesendsEqCondition | airbyte_agent_sdk.connectors.sendgrid.types.SinglesendsNeqCondition | airbyte_agent_sdk.connectors.sendgrid.types.SinglesendsGtCondition | airbyte_agent_sdk.connectors.sendgrid.types.SinglesendsGteCondition | airbyte_agent_sdk.connectors.sendgrid.types.SinglesendsLtCondition | airbyte_agent_sdk.connectors.sendgrid.types.SinglesendsLteCondition | airbyte_agent_sdk.connectors.sendgrid.types.SinglesendsInCondition | airbyte_agent_sdk.connectors.sendgrid.types.SinglesendsLikeCondition | airbyte_agent_sdk.connectors.sendgrid.types.SinglesendsFuzzyCondition | airbyte_agent_sdk.connectors.sendgrid.types.SinglesendsKeywordCondition | airbyte_agent_sdk.connectors.sendgrid.types.SinglesendsContainsCondition | airbyte_agent_sdk.connectors.sendgrid.types.SinglesendsNotCondition | airbyte_agent_sdk.connectors.sendgrid.types.SinglesendsAndCondition | airbyte_agent_sdk.connectors.sendgrid.types.SinglesendsOrCondition | airbyte_agent_sdk.connectors.sendgrid.types.SinglesendsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="SinglesendsAnyCondition"></a>
+
 `SinglesendsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -3621,6 +4029,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.sendgrid.types.SinglesendsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="SinglesendsAnyValueFilter"></a>
 
 `SinglesendsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -3655,6 +4065,8 @@ Classes
     `updated_at: Any`
     :   When the single send was last updated
 
+<a id="SinglesendsContainsCondition"></a>
+
 `SinglesendsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -3666,6 +4078,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.sendgrid.types.SinglesendsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="SinglesendsEqCondition"></a>
 
 `SinglesendsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -3679,6 +4093,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.sendgrid.types.SinglesendsSearchFilter`
     :   The type of the None singleton.
 
+<a id="SinglesendsFuzzyCondition"></a>
+
 `SinglesendsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -3690,6 +4106,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.sendgrid.types.SinglesendsStringFilter`
     :   The type of the None singleton.
+
+<a id="SinglesendsGetParams"></a>
 
 `SinglesendsGetParams(*args, **kwargs)`
 :   Parameters for singlesends.get operation
@@ -3703,6 +4121,8 @@ Classes
     `id: str`
     :   The type of the None singleton.
 
+<a id="SinglesendsGtCondition"></a>
+
 `SinglesendsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -3715,6 +4135,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.sendgrid.types.SinglesendsSearchFilter`
     :   The type of the None singleton.
 
+<a id="SinglesendsGteCondition"></a>
+
 `SinglesendsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -3726,6 +4148,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.sendgrid.types.SinglesendsSearchFilter`
     :   The type of the None singleton.
+
+<a id="SinglesendsInCondition"></a>
 
 `SinglesendsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -3746,6 +4170,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.sendgrid.types.SinglesendsInFilter`
     :   The type of the None singleton.
+
+<a id="SinglesendsInFilter"></a>
 
 `SinglesendsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -3780,6 +4206,8 @@ Classes
     `updated_at: list[str]`
     :   When the single send was last updated
 
+<a id="SinglesendsKeywordCondition"></a>
+
 `SinglesendsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -3791,6 +4219,8 @@ Classes
 
     `keyword: airbyte_agent_sdk.connectors.sendgrid.types.SinglesendsStringFilter`
     :   The type of the None singleton.
+
+<a id="SinglesendsLikeCondition"></a>
 
 `SinglesendsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
@@ -3804,6 +4234,8 @@ Classes
     `like: airbyte_agent_sdk.connectors.sendgrid.types.SinglesendsStringFilter`
     :   The type of the None singleton.
 
+<a id="SinglesendsListParams"></a>
+
 `SinglesendsListParams(*args, **kwargs)`
 :   Parameters for singlesends.list operation
 
@@ -3815,6 +4247,8 @@ Classes
 
     `page_size: int`
     :   The type of the None singleton.
+
+<a id="SinglesendsLtCondition"></a>
 
 `SinglesendsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
@@ -3828,6 +4262,8 @@ Classes
     `lt: airbyte_agent_sdk.connectors.sendgrid.types.SinglesendsSearchFilter`
     :   The type of the None singleton.
 
+<a id="SinglesendsLteCondition"></a>
+
 `SinglesendsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
 
@@ -3840,6 +4276,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.sendgrid.types.SinglesendsSearchFilter`
     :   The type of the None singleton.
 
+<a id="SinglesendsNeqCondition"></a>
+
 `SinglesendsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -3851,6 +4289,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.sendgrid.types.SinglesendsSearchFilter`
     :   The type of the None singleton.
+
+<a id="SinglesendsNotCondition"></a>
 
 `SinglesendsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -3872,6 +4312,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.sendgrid.types.SinglesendsEqCondition | airbyte_agent_sdk.connectors.sendgrid.types.SinglesendsNeqCondition | airbyte_agent_sdk.connectors.sendgrid.types.SinglesendsGtCondition | airbyte_agent_sdk.connectors.sendgrid.types.SinglesendsGteCondition | airbyte_agent_sdk.connectors.sendgrid.types.SinglesendsLtCondition | airbyte_agent_sdk.connectors.sendgrid.types.SinglesendsLteCondition | airbyte_agent_sdk.connectors.sendgrid.types.SinglesendsInCondition | airbyte_agent_sdk.connectors.sendgrid.types.SinglesendsLikeCondition | airbyte_agent_sdk.connectors.sendgrid.types.SinglesendsFuzzyCondition | airbyte_agent_sdk.connectors.sendgrid.types.SinglesendsKeywordCondition | airbyte_agent_sdk.connectors.sendgrid.types.SinglesendsContainsCondition | airbyte_agent_sdk.connectors.sendgrid.types.SinglesendsNotCondition | airbyte_agent_sdk.connectors.sendgrid.types.SinglesendsAndCondition | airbyte_agent_sdk.connectors.sendgrid.types.SinglesendsOrCondition | airbyte_agent_sdk.connectors.sendgrid.types.SinglesendsAnyCondition`
     :   The type of the None singleton.
 
+<a id="SinglesendsOrCondition"></a>
+
 `SinglesendsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -3891,6 +4333,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.sendgrid.types.SinglesendsEqCondition | airbyte_agent_sdk.connectors.sendgrid.types.SinglesendsNeqCondition | airbyte_agent_sdk.connectors.sendgrid.types.SinglesendsGtCondition | airbyte_agent_sdk.connectors.sendgrid.types.SinglesendsGteCondition | airbyte_agent_sdk.connectors.sendgrid.types.SinglesendsLtCondition | airbyte_agent_sdk.connectors.sendgrid.types.SinglesendsLteCondition | airbyte_agent_sdk.connectors.sendgrid.types.SinglesendsInCondition | airbyte_agent_sdk.connectors.sendgrid.types.SinglesendsLikeCondition | airbyte_agent_sdk.connectors.sendgrid.types.SinglesendsFuzzyCondition | airbyte_agent_sdk.connectors.sendgrid.types.SinglesendsKeywordCondition | airbyte_agent_sdk.connectors.sendgrid.types.SinglesendsContainsCondition | airbyte_agent_sdk.connectors.sendgrid.types.SinglesendsNotCondition | airbyte_agent_sdk.connectors.sendgrid.types.SinglesendsAndCondition | airbyte_agent_sdk.connectors.sendgrid.types.SinglesendsOrCondition | airbyte_agent_sdk.connectors.sendgrid.types.SinglesendsAnyCondition]`
     :   The type of the None singleton.
+
+<a id="SinglesendsSearchFilter"></a>
 
 `SinglesendsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering singlesends search queries.
@@ -3925,6 +4369,8 @@ Classes
     `updated_at: str | None`
     :   When the single send was last updated
 
+<a id="SinglesendsSearchQuery"></a>
+
 `SinglesendsSearchQuery(*args, **kwargs)`
 :   Search query for singlesends entity.
 
@@ -3939,6 +4385,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.sendgrid.types.SinglesendsSortFilter]`
     :   The type of the None singleton.
+
+<a id="SinglesendsSortFilter"></a>
 
 `SinglesendsSortFilter(*args, **kwargs)`
 :   Available fields for sorting singlesends search results.
@@ -3973,6 +4421,8 @@ Classes
     `updated_at: Literal['asc', 'desc']`
     :   When the single send was last updated
 
+<a id="SinglesendsStringFilter"></a>
+
 `SinglesendsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -4006,6 +4456,8 @@ Classes
     `updated_at: str`
     :   When the single send was last updated
 
+<a id="SpamReportsListParams"></a>
+
 `SpamReportsListParams(*args, **kwargs)`
 :   Parameters for spam_reports.list operation
 
@@ -4020,6 +4472,8 @@ Classes
 
     `offset: int`
     :   The type of the None singleton.
+
+<a id="SuppressionGroupMembersAndCondition"></a>
 
 `SuppressionGroupMembersAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -4041,6 +4495,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.sendgrid.types.SuppressionGroupMembersEqCondition | airbyte_agent_sdk.connectors.sendgrid.types.SuppressionGroupMembersNeqCondition | airbyte_agent_sdk.connectors.sendgrid.types.SuppressionGroupMembersGtCondition | airbyte_agent_sdk.connectors.sendgrid.types.SuppressionGroupMembersGteCondition | airbyte_agent_sdk.connectors.sendgrid.types.SuppressionGroupMembersLtCondition | airbyte_agent_sdk.connectors.sendgrid.types.SuppressionGroupMembersLteCondition | airbyte_agent_sdk.connectors.sendgrid.types.SuppressionGroupMembersInCondition | airbyte_agent_sdk.connectors.sendgrid.types.SuppressionGroupMembersLikeCondition | airbyte_agent_sdk.connectors.sendgrid.types.SuppressionGroupMembersFuzzyCondition | airbyte_agent_sdk.connectors.sendgrid.types.SuppressionGroupMembersKeywordCondition | airbyte_agent_sdk.connectors.sendgrid.types.SuppressionGroupMembersContainsCondition | airbyte_agent_sdk.connectors.sendgrid.types.SuppressionGroupMembersNotCondition | airbyte_agent_sdk.connectors.sendgrid.types.SuppressionGroupMembersAndCondition | airbyte_agent_sdk.connectors.sendgrid.types.SuppressionGroupMembersOrCondition | airbyte_agent_sdk.connectors.sendgrid.types.SuppressionGroupMembersAnyCondition]`
     :   The type of the None singleton.
 
+<a id="SuppressionGroupMembersAnyCondition"></a>
+
 `SuppressionGroupMembersAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -4060,6 +4516,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.sendgrid.types.SuppressionGroupMembersAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="SuppressionGroupMembersAnyValueFilter"></a>
 
 `SuppressionGroupMembersAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -4082,6 +4540,8 @@ Classes
     `group_name: Any`
     :   Name of the suppression group
 
+<a id="SuppressionGroupMembersContainsCondition"></a>
+
 `SuppressionGroupMembersContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -4093,6 +4553,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.sendgrid.types.SuppressionGroupMembersAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="SuppressionGroupMembersEqCondition"></a>
 
 `SuppressionGroupMembersEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -4106,6 +4568,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.sendgrid.types.SuppressionGroupMembersSearchFilter`
     :   The type of the None singleton.
 
+<a id="SuppressionGroupMembersFuzzyCondition"></a>
+
 `SuppressionGroupMembersFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -4117,6 +4581,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.sendgrid.types.SuppressionGroupMembersStringFilter`
     :   The type of the None singleton.
+
+<a id="SuppressionGroupMembersGtCondition"></a>
 
 `SuppressionGroupMembersGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
@@ -4130,6 +4596,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.sendgrid.types.SuppressionGroupMembersSearchFilter`
     :   The type of the None singleton.
 
+<a id="SuppressionGroupMembersGteCondition"></a>
+
 `SuppressionGroupMembersGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -4141,6 +4609,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.sendgrid.types.SuppressionGroupMembersSearchFilter`
     :   The type of the None singleton.
+
+<a id="SuppressionGroupMembersInCondition"></a>
 
 `SuppressionGroupMembersInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -4161,6 +4631,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.sendgrid.types.SuppressionGroupMembersInFilter`
     :   The type of the None singleton.
+
+<a id="SuppressionGroupMembersInFilter"></a>
 
 `SuppressionGroupMembersInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -4183,6 +4655,8 @@ Classes
     `group_name: list[str]`
     :   Name of the suppression group
 
+<a id="SuppressionGroupMembersKeywordCondition"></a>
+
 `SuppressionGroupMembersKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -4195,6 +4669,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.sendgrid.types.SuppressionGroupMembersStringFilter`
     :   The type of the None singleton.
 
+<a id="SuppressionGroupMembersLikeCondition"></a>
+
 `SuppressionGroupMembersLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -4206,6 +4682,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.sendgrid.types.SuppressionGroupMembersStringFilter`
     :   The type of the None singleton.
+
+<a id="SuppressionGroupMembersListParams"></a>
 
 `SuppressionGroupMembersListParams(*args, **kwargs)`
 :   Parameters for suppression_group_members.list operation
@@ -4222,6 +4700,8 @@ Classes
     `offset: int`
     :   The type of the None singleton.
 
+<a id="SuppressionGroupMembersLtCondition"></a>
+
 `SuppressionGroupMembersLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -4233,6 +4713,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.sendgrid.types.SuppressionGroupMembersSearchFilter`
     :   The type of the None singleton.
+
+<a id="SuppressionGroupMembersLteCondition"></a>
 
 `SuppressionGroupMembersLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -4246,6 +4728,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.sendgrid.types.SuppressionGroupMembersSearchFilter`
     :   The type of the None singleton.
 
+<a id="SuppressionGroupMembersNeqCondition"></a>
+
 `SuppressionGroupMembersNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -4257,6 +4741,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.sendgrid.types.SuppressionGroupMembersSearchFilter`
     :   The type of the None singleton.
+
+<a id="SuppressionGroupMembersNotCondition"></a>
 
 `SuppressionGroupMembersNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -4278,6 +4764,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.sendgrid.types.SuppressionGroupMembersEqCondition | airbyte_agent_sdk.connectors.sendgrid.types.SuppressionGroupMembersNeqCondition | airbyte_agent_sdk.connectors.sendgrid.types.SuppressionGroupMembersGtCondition | airbyte_agent_sdk.connectors.sendgrid.types.SuppressionGroupMembersGteCondition | airbyte_agent_sdk.connectors.sendgrid.types.SuppressionGroupMembersLtCondition | airbyte_agent_sdk.connectors.sendgrid.types.SuppressionGroupMembersLteCondition | airbyte_agent_sdk.connectors.sendgrid.types.SuppressionGroupMembersInCondition | airbyte_agent_sdk.connectors.sendgrid.types.SuppressionGroupMembersLikeCondition | airbyte_agent_sdk.connectors.sendgrid.types.SuppressionGroupMembersFuzzyCondition | airbyte_agent_sdk.connectors.sendgrid.types.SuppressionGroupMembersKeywordCondition | airbyte_agent_sdk.connectors.sendgrid.types.SuppressionGroupMembersContainsCondition | airbyte_agent_sdk.connectors.sendgrid.types.SuppressionGroupMembersNotCondition | airbyte_agent_sdk.connectors.sendgrid.types.SuppressionGroupMembersAndCondition | airbyte_agent_sdk.connectors.sendgrid.types.SuppressionGroupMembersOrCondition | airbyte_agent_sdk.connectors.sendgrid.types.SuppressionGroupMembersAnyCondition`
     :   The type of the None singleton.
 
+<a id="SuppressionGroupMembersOrCondition"></a>
+
 `SuppressionGroupMembersOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -4297,6 +4785,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.sendgrid.types.SuppressionGroupMembersEqCondition | airbyte_agent_sdk.connectors.sendgrid.types.SuppressionGroupMembersNeqCondition | airbyte_agent_sdk.connectors.sendgrid.types.SuppressionGroupMembersGtCondition | airbyte_agent_sdk.connectors.sendgrid.types.SuppressionGroupMembersGteCondition | airbyte_agent_sdk.connectors.sendgrid.types.SuppressionGroupMembersLtCondition | airbyte_agent_sdk.connectors.sendgrid.types.SuppressionGroupMembersLteCondition | airbyte_agent_sdk.connectors.sendgrid.types.SuppressionGroupMembersInCondition | airbyte_agent_sdk.connectors.sendgrid.types.SuppressionGroupMembersLikeCondition | airbyte_agent_sdk.connectors.sendgrid.types.SuppressionGroupMembersFuzzyCondition | airbyte_agent_sdk.connectors.sendgrid.types.SuppressionGroupMembersKeywordCondition | airbyte_agent_sdk.connectors.sendgrid.types.SuppressionGroupMembersContainsCondition | airbyte_agent_sdk.connectors.sendgrid.types.SuppressionGroupMembersNotCondition | airbyte_agent_sdk.connectors.sendgrid.types.SuppressionGroupMembersAndCondition | airbyte_agent_sdk.connectors.sendgrid.types.SuppressionGroupMembersOrCondition | airbyte_agent_sdk.connectors.sendgrid.types.SuppressionGroupMembersAnyCondition]`
     :   The type of the None singleton.
+
+<a id="SuppressionGroupMembersSearchFilter"></a>
 
 `SuppressionGroupMembersSearchFilter(*args, **kwargs)`
 :   Available fields for filtering suppression_group_members search queries.
@@ -4319,6 +4809,8 @@ Classes
     `group_name: str | None`
     :   Name of the suppression group
 
+<a id="SuppressionGroupMembersSearchQuery"></a>
+
 `SuppressionGroupMembersSearchQuery(*args, **kwargs)`
 :   Search query for suppression_group_members entity.
 
@@ -4333,6 +4825,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.sendgrid.types.SuppressionGroupMembersSortFilter]`
     :   The type of the None singleton.
+
+<a id="SuppressionGroupMembersSortFilter"></a>
 
 `SuppressionGroupMembersSortFilter(*args, **kwargs)`
 :   Available fields for sorting suppression_group_members search results.
@@ -4355,6 +4849,8 @@ Classes
     `group_name: Literal['asc', 'desc']`
     :   Name of the suppression group
 
+<a id="SuppressionGroupMembersStringFilter"></a>
+
 `SuppressionGroupMembersStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -4376,6 +4872,8 @@ Classes
     `group_name: str`
     :   Name of the suppression group
 
+<a id="SuppressionGroupsAndCondition"></a>
+
 `SuppressionGroupsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -4396,6 +4894,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.sendgrid.types.SuppressionGroupsEqCondition | airbyte_agent_sdk.connectors.sendgrid.types.SuppressionGroupsNeqCondition | airbyte_agent_sdk.connectors.sendgrid.types.SuppressionGroupsGtCondition | airbyte_agent_sdk.connectors.sendgrid.types.SuppressionGroupsGteCondition | airbyte_agent_sdk.connectors.sendgrid.types.SuppressionGroupsLtCondition | airbyte_agent_sdk.connectors.sendgrid.types.SuppressionGroupsLteCondition | airbyte_agent_sdk.connectors.sendgrid.types.SuppressionGroupsInCondition | airbyte_agent_sdk.connectors.sendgrid.types.SuppressionGroupsLikeCondition | airbyte_agent_sdk.connectors.sendgrid.types.SuppressionGroupsFuzzyCondition | airbyte_agent_sdk.connectors.sendgrid.types.SuppressionGroupsKeywordCondition | airbyte_agent_sdk.connectors.sendgrid.types.SuppressionGroupsContainsCondition | airbyte_agent_sdk.connectors.sendgrid.types.SuppressionGroupsNotCondition | airbyte_agent_sdk.connectors.sendgrid.types.SuppressionGroupsAndCondition | airbyte_agent_sdk.connectors.sendgrid.types.SuppressionGroupsOrCondition | airbyte_agent_sdk.connectors.sendgrid.types.SuppressionGroupsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="SuppressionGroupsAnyCondition"></a>
+
 `SuppressionGroupsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -4415,6 +4915,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.sendgrid.types.SuppressionGroupsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="SuppressionGroupsAnyValueFilter"></a>
 
 `SuppressionGroupsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -4440,6 +4942,8 @@ Classes
     `unsubscribes: Any`
     :   Number of unsubscribes in this group
 
+<a id="SuppressionGroupsContainsCondition"></a>
+
 `SuppressionGroupsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -4451,6 +4955,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.sendgrid.types.SuppressionGroupsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="SuppressionGroupsEqCondition"></a>
 
 `SuppressionGroupsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -4464,6 +4970,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.sendgrid.types.SuppressionGroupsSearchFilter`
     :   The type of the None singleton.
 
+<a id="SuppressionGroupsFuzzyCondition"></a>
+
 `SuppressionGroupsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -4475,6 +4983,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.sendgrid.types.SuppressionGroupsStringFilter`
     :   The type of the None singleton.
+
+<a id="SuppressionGroupsGetParams"></a>
 
 `SuppressionGroupsGetParams(*args, **kwargs)`
 :   Parameters for suppression_groups.get operation
@@ -4488,6 +4998,8 @@ Classes
     `group_id: str`
     :   The type of the None singleton.
 
+<a id="SuppressionGroupsGtCondition"></a>
+
 `SuppressionGroupsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -4500,6 +5012,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.sendgrid.types.SuppressionGroupsSearchFilter`
     :   The type of the None singleton.
 
+<a id="SuppressionGroupsGteCondition"></a>
+
 `SuppressionGroupsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -4511,6 +5025,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.sendgrid.types.SuppressionGroupsSearchFilter`
     :   The type of the None singleton.
+
+<a id="SuppressionGroupsInCondition"></a>
 
 `SuppressionGroupsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -4531,6 +5047,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.sendgrid.types.SuppressionGroupsInFilter`
     :   The type of the None singleton.
+
+<a id="SuppressionGroupsInFilter"></a>
 
 `SuppressionGroupsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -4556,6 +5074,8 @@ Classes
     `unsubscribes: list[int]`
     :   Number of unsubscribes in this group
 
+<a id="SuppressionGroupsKeywordCondition"></a>
+
 `SuppressionGroupsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -4567,6 +5087,8 @@ Classes
 
     `keyword: airbyte_agent_sdk.connectors.sendgrid.types.SuppressionGroupsStringFilter`
     :   The type of the None singleton.
+
+<a id="SuppressionGroupsLikeCondition"></a>
 
 `SuppressionGroupsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
@@ -4580,12 +5102,16 @@ Classes
     `like: airbyte_agent_sdk.connectors.sendgrid.types.SuppressionGroupsStringFilter`
     :   The type of the None singleton.
 
+<a id="SuppressionGroupsListParams"></a>
+
 `SuppressionGroupsListParams(*args, **kwargs)`
 :   Parameters for suppression_groups.list operation
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="SuppressionGroupsLtCondition"></a>
 
 `SuppressionGroupsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
@@ -4599,6 +5125,8 @@ Classes
     `lt: airbyte_agent_sdk.connectors.sendgrid.types.SuppressionGroupsSearchFilter`
     :   The type of the None singleton.
 
+<a id="SuppressionGroupsLteCondition"></a>
+
 `SuppressionGroupsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
 
@@ -4611,6 +5139,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.sendgrid.types.SuppressionGroupsSearchFilter`
     :   The type of the None singleton.
 
+<a id="SuppressionGroupsNeqCondition"></a>
+
 `SuppressionGroupsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -4622,6 +5152,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.sendgrid.types.SuppressionGroupsSearchFilter`
     :   The type of the None singleton.
+
+<a id="SuppressionGroupsNotCondition"></a>
 
 `SuppressionGroupsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -4643,6 +5175,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.sendgrid.types.SuppressionGroupsEqCondition | airbyte_agent_sdk.connectors.sendgrid.types.SuppressionGroupsNeqCondition | airbyte_agent_sdk.connectors.sendgrid.types.SuppressionGroupsGtCondition | airbyte_agent_sdk.connectors.sendgrid.types.SuppressionGroupsGteCondition | airbyte_agent_sdk.connectors.sendgrid.types.SuppressionGroupsLtCondition | airbyte_agent_sdk.connectors.sendgrid.types.SuppressionGroupsLteCondition | airbyte_agent_sdk.connectors.sendgrid.types.SuppressionGroupsInCondition | airbyte_agent_sdk.connectors.sendgrid.types.SuppressionGroupsLikeCondition | airbyte_agent_sdk.connectors.sendgrid.types.SuppressionGroupsFuzzyCondition | airbyte_agent_sdk.connectors.sendgrid.types.SuppressionGroupsKeywordCondition | airbyte_agent_sdk.connectors.sendgrid.types.SuppressionGroupsContainsCondition | airbyte_agent_sdk.connectors.sendgrid.types.SuppressionGroupsNotCondition | airbyte_agent_sdk.connectors.sendgrid.types.SuppressionGroupsAndCondition | airbyte_agent_sdk.connectors.sendgrid.types.SuppressionGroupsOrCondition | airbyte_agent_sdk.connectors.sendgrid.types.SuppressionGroupsAnyCondition`
     :   The type of the None singleton.
 
+<a id="SuppressionGroupsOrCondition"></a>
+
 `SuppressionGroupsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -4662,6 +5196,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.sendgrid.types.SuppressionGroupsEqCondition | airbyte_agent_sdk.connectors.sendgrid.types.SuppressionGroupsNeqCondition | airbyte_agent_sdk.connectors.sendgrid.types.SuppressionGroupsGtCondition | airbyte_agent_sdk.connectors.sendgrid.types.SuppressionGroupsGteCondition | airbyte_agent_sdk.connectors.sendgrid.types.SuppressionGroupsLtCondition | airbyte_agent_sdk.connectors.sendgrid.types.SuppressionGroupsLteCondition | airbyte_agent_sdk.connectors.sendgrid.types.SuppressionGroupsInCondition | airbyte_agent_sdk.connectors.sendgrid.types.SuppressionGroupsLikeCondition | airbyte_agent_sdk.connectors.sendgrid.types.SuppressionGroupsFuzzyCondition | airbyte_agent_sdk.connectors.sendgrid.types.SuppressionGroupsKeywordCondition | airbyte_agent_sdk.connectors.sendgrid.types.SuppressionGroupsContainsCondition | airbyte_agent_sdk.connectors.sendgrid.types.SuppressionGroupsNotCondition | airbyte_agent_sdk.connectors.sendgrid.types.SuppressionGroupsAndCondition | airbyte_agent_sdk.connectors.sendgrid.types.SuppressionGroupsOrCondition | airbyte_agent_sdk.connectors.sendgrid.types.SuppressionGroupsAnyCondition]`
     :   The type of the None singleton.
+
+<a id="SuppressionGroupsSearchFilter"></a>
 
 `SuppressionGroupsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering suppression_groups search queries.
@@ -4687,6 +5223,8 @@ Classes
     `unsubscribes: int | None`
     :   Number of unsubscribes in this group
 
+<a id="SuppressionGroupsSearchQuery"></a>
+
 `SuppressionGroupsSearchQuery(*args, **kwargs)`
 :   Search query for suppression_groups entity.
 
@@ -4701,6 +5239,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.sendgrid.types.SuppressionGroupsSortFilter]`
     :   The type of the None singleton.
+
+<a id="SuppressionGroupsSortFilter"></a>
 
 `SuppressionGroupsSortFilter(*args, **kwargs)`
 :   Available fields for sorting suppression_groups search results.
@@ -4726,6 +5266,8 @@ Classes
     `unsubscribes: Literal['asc', 'desc']`
     :   Number of unsubscribes in this group
 
+<a id="SuppressionGroupsStringFilter"></a>
+
 `SuppressionGroupsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -4750,6 +5292,8 @@ Classes
     `unsubscribes: str`
     :   Number of unsubscribes in this group
 
+<a id="TemplatesAndCondition"></a>
+
 `TemplatesAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -4770,6 +5314,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.sendgrid.types.TemplatesEqCondition | airbyte_agent_sdk.connectors.sendgrid.types.TemplatesNeqCondition | airbyte_agent_sdk.connectors.sendgrid.types.TemplatesGtCondition | airbyte_agent_sdk.connectors.sendgrid.types.TemplatesGteCondition | airbyte_agent_sdk.connectors.sendgrid.types.TemplatesLtCondition | airbyte_agent_sdk.connectors.sendgrid.types.TemplatesLteCondition | airbyte_agent_sdk.connectors.sendgrid.types.TemplatesInCondition | airbyte_agent_sdk.connectors.sendgrid.types.TemplatesLikeCondition | airbyte_agent_sdk.connectors.sendgrid.types.TemplatesFuzzyCondition | airbyte_agent_sdk.connectors.sendgrid.types.TemplatesKeywordCondition | airbyte_agent_sdk.connectors.sendgrid.types.TemplatesContainsCondition | airbyte_agent_sdk.connectors.sendgrid.types.TemplatesNotCondition | airbyte_agent_sdk.connectors.sendgrid.types.TemplatesAndCondition | airbyte_agent_sdk.connectors.sendgrid.types.TemplatesOrCondition | airbyte_agent_sdk.connectors.sendgrid.types.TemplatesAnyCondition]`
     :   The type of the None singleton.
 
+<a id="TemplatesAnyCondition"></a>
+
 `TemplatesAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -4789,6 +5335,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.sendgrid.types.TemplatesAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="TemplatesAnyValueFilter"></a>
 
 `TemplatesAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -4814,6 +5362,8 @@ Classes
     `versions: Any`
     :   Template versions
 
+<a id="TemplatesContainsCondition"></a>
+
 `TemplatesContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -4825,6 +5375,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.sendgrid.types.TemplatesAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="TemplatesEqCondition"></a>
 
 `TemplatesEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -4838,6 +5390,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.sendgrid.types.TemplatesSearchFilter`
     :   The type of the None singleton.
 
+<a id="TemplatesFuzzyCondition"></a>
+
 `TemplatesFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -4849,6 +5403,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.sendgrid.types.TemplatesStringFilter`
     :   The type of the None singleton.
+
+<a id="TemplatesGetParams"></a>
 
 `TemplatesGetParams(*args, **kwargs)`
 :   Parameters for templates.get operation
@@ -4862,6 +5418,8 @@ Classes
     `template_id: str`
     :   The type of the None singleton.
 
+<a id="TemplatesGtCondition"></a>
+
 `TemplatesGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -4874,6 +5432,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.sendgrid.types.TemplatesSearchFilter`
     :   The type of the None singleton.
 
+<a id="TemplatesGteCondition"></a>
+
 `TemplatesGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -4885,6 +5445,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.sendgrid.types.TemplatesSearchFilter`
     :   The type of the None singleton.
+
+<a id="TemplatesInCondition"></a>
 
 `TemplatesInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -4905,6 +5467,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.sendgrid.types.TemplatesInFilter`
     :   The type of the None singleton.
+
+<a id="TemplatesInFilter"></a>
 
 `TemplatesInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -4930,6 +5494,8 @@ Classes
     `versions: list[list[typing.Any]]`
     :   Template versions
 
+<a id="TemplatesKeywordCondition"></a>
+
 `TemplatesKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -4942,6 +5508,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.sendgrid.types.TemplatesStringFilter`
     :   The type of the None singleton.
 
+<a id="TemplatesLikeCondition"></a>
+
 `TemplatesLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -4953,6 +5521,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.sendgrid.types.TemplatesStringFilter`
     :   The type of the None singleton.
+
+<a id="TemplatesListParams"></a>
 
 `TemplatesListParams(*args, **kwargs)`
 :   Parameters for templates.list operation
@@ -4969,6 +5539,8 @@ Classes
     `page_size: int`
     :   The type of the None singleton.
 
+<a id="TemplatesLtCondition"></a>
+
 `TemplatesLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -4980,6 +5552,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.sendgrid.types.TemplatesSearchFilter`
     :   The type of the None singleton.
+
+<a id="TemplatesLteCondition"></a>
 
 `TemplatesLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -4993,6 +5567,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.sendgrid.types.TemplatesSearchFilter`
     :   The type of the None singleton.
 
+<a id="TemplatesNeqCondition"></a>
+
 `TemplatesNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -5004,6 +5580,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.sendgrid.types.TemplatesSearchFilter`
     :   The type of the None singleton.
+
+<a id="TemplatesNotCondition"></a>
 
 `TemplatesNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -5025,6 +5603,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.sendgrid.types.TemplatesEqCondition | airbyte_agent_sdk.connectors.sendgrid.types.TemplatesNeqCondition | airbyte_agent_sdk.connectors.sendgrid.types.TemplatesGtCondition | airbyte_agent_sdk.connectors.sendgrid.types.TemplatesGteCondition | airbyte_agent_sdk.connectors.sendgrid.types.TemplatesLtCondition | airbyte_agent_sdk.connectors.sendgrid.types.TemplatesLteCondition | airbyte_agent_sdk.connectors.sendgrid.types.TemplatesInCondition | airbyte_agent_sdk.connectors.sendgrid.types.TemplatesLikeCondition | airbyte_agent_sdk.connectors.sendgrid.types.TemplatesFuzzyCondition | airbyte_agent_sdk.connectors.sendgrid.types.TemplatesKeywordCondition | airbyte_agent_sdk.connectors.sendgrid.types.TemplatesContainsCondition | airbyte_agent_sdk.connectors.sendgrid.types.TemplatesNotCondition | airbyte_agent_sdk.connectors.sendgrid.types.TemplatesAndCondition | airbyte_agent_sdk.connectors.sendgrid.types.TemplatesOrCondition | airbyte_agent_sdk.connectors.sendgrid.types.TemplatesAnyCondition`
     :   The type of the None singleton.
 
+<a id="TemplatesOrCondition"></a>
+
 `TemplatesOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -5044,6 +5624,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.sendgrid.types.TemplatesEqCondition | airbyte_agent_sdk.connectors.sendgrid.types.TemplatesNeqCondition | airbyte_agent_sdk.connectors.sendgrid.types.TemplatesGtCondition | airbyte_agent_sdk.connectors.sendgrid.types.TemplatesGteCondition | airbyte_agent_sdk.connectors.sendgrid.types.TemplatesLtCondition | airbyte_agent_sdk.connectors.sendgrid.types.TemplatesLteCondition | airbyte_agent_sdk.connectors.sendgrid.types.TemplatesInCondition | airbyte_agent_sdk.connectors.sendgrid.types.TemplatesLikeCondition | airbyte_agent_sdk.connectors.sendgrid.types.TemplatesFuzzyCondition | airbyte_agent_sdk.connectors.sendgrid.types.TemplatesKeywordCondition | airbyte_agent_sdk.connectors.sendgrid.types.TemplatesContainsCondition | airbyte_agent_sdk.connectors.sendgrid.types.TemplatesNotCondition | airbyte_agent_sdk.connectors.sendgrid.types.TemplatesAndCondition | airbyte_agent_sdk.connectors.sendgrid.types.TemplatesOrCondition | airbyte_agent_sdk.connectors.sendgrid.types.TemplatesAnyCondition]`
     :   The type of the None singleton.
+
+<a id="TemplatesSearchFilter"></a>
 
 `TemplatesSearchFilter(*args, **kwargs)`
 :   Available fields for filtering templates search queries.
@@ -5069,6 +5651,8 @@ Classes
     `versions: list[typing.Any] | None`
     :   Template versions
 
+<a id="TemplatesSearchQuery"></a>
+
 `TemplatesSearchQuery(*args, **kwargs)`
 :   Search query for templates entity.
 
@@ -5083,6 +5667,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.sendgrid.types.TemplatesSortFilter]`
     :   The type of the None singleton.
+
+<a id="TemplatesSortFilter"></a>
 
 `TemplatesSortFilter(*args, **kwargs)`
 :   Available fields for sorting templates search results.
@@ -5107,6 +5693,8 @@ Classes
 
     `versions: Literal['asc', 'desc']`
     :   Template versions
+
+<a id="TemplatesStringFilter"></a>
 
 `TemplatesStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/sentry/connector.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/sentry/connector.md
@@ -10,6 +10,8 @@ Sentry connector.
 Classes
 -------
 
+<a id="EventsQuery"></a>
+
 `EventsQuery(connector: SentryConnector)`
 :   Query class for Events entity operations.
     
@@ -92,6 +94,8 @@ Classes
         
         Returns:
             EventsListResult
+
+<a id="IssuesQuery"></a>
 
 `IssuesQuery(connector: SentryConnector)`
 :   Query class for Issues entity operations.
@@ -178,6 +182,8 @@ Classes
         Returns:
             IssuesListResult
 
+<a id="ProjectDetailQuery"></a>
+
 `ProjectDetailQuery(connector: SentryConnector)`
 :   Query class for ProjectDetail entity operations.
     
@@ -195,6 +201,8 @@ Classes
         
         Returns:
             ProjectDetail
+
+<a id="ProjectsQuery"></a>
 
 `ProjectsQuery(connector: SentryConnector)`
 :   Query class for Projects entity operations.
@@ -272,6 +280,8 @@ Classes
         Returns:
             ProjectsListResult
 
+<a id="ReleasesQuery"></a>
+
 `ReleasesQuery(connector: SentryConnector)`
 :   Query class for Releases entity operations.
     
@@ -345,6 +355,8 @@ Classes
         
         Returns:
             ReleasesListResult
+
+<a id="SentryConnector"></a>
 
 `SentryConnector(auth_config: SentryAuthConfig | AirbyteAuthConfig | BaseModel | None = None, on_token_refresh: Any | None = None, hostname: str | None = None)`
 :   Type-safe Sentry API connector.

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/sentry/index.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/sentry/index.md
@@ -19,6 +19,8 @@ Sub-modules
 Classes
 -------
 
+<a id="AirbyteAuthConfig"></a>
+
 `AirbyteAuthConfig(**data: Any)`
 :   Authentication configuration for Airbyte hosted mode execution.
     
@@ -87,6 +89,8 @@ Classes
     `workspace_name: str | None`
     :   The type of the None singleton.
 
+<a id="AirbyteSearchMeta"></a>
+
 `AirbyteSearchMeta(**data: Any)`
 :   Pagination metadata for search responses.
     
@@ -114,6 +118,8 @@ Classes
 
     `took_ms: int | None`
     :   Time taken to execute the search in milliseconds.
+
+<a id="AirbyteSearchResult"></a>
 
 `AirbyteSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -148,6 +154,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="EventsSearchResult"></a>
+
 `EventsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -163,6 +171,8 @@ Classes
     * airbyte_agent_sdk.connectors.sentry.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="IssuesSearchResult"></a>
 
 `IssuesSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -180,6 +190,8 @@ Classes
     * pydantic.main.BaseModel
     * typing.Generic
 
+<a id="ProjectsSearchResult"></a>
+
 `ProjectsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -196,6 +208,8 @@ Classes
     * pydantic.main.BaseModel
     * typing.Generic
 
+<a id="ReleasesSearchResult"></a>
+
 `ReleasesSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -211,6 +225,8 @@ Classes
     * airbyte_agent_sdk.connectors.sentry.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="EventsSearchData"></a>
 
 `EventsSearchData(**data: Any)`
 :   Search result data for events entity.
@@ -317,6 +333,8 @@ Classes
 
     `user: dict[str, typing.Any] | None`
     :   User associated with the event.
+
+<a id="IssuesSearchData"></a>
 
 `IssuesSearchData(**data: Any)`
 :   Search result data for issues entity.
@@ -430,6 +448,8 @@ Classes
     `user_count: int | None`
     :   Number of users affected.
 
+<a id="ProjectsSearchData"></a>
+
 `ProjectsSearchData(**data: Any)`
 :   Search result data for projects entity.
     
@@ -527,6 +547,8 @@ Classes
     `status: str | None`
     :   Project status.
 
+<a id="ReleasesSearchData"></a>
+
 `ReleasesSearchData(**data: Any)`
 :   Search result data for releases entity.
     
@@ -612,6 +634,8 @@ Classes
     `version_info: dict[str, typing.Any] | None`
     :   Parsed version information.
 
+<a id="SentryAuthConfig"></a>
+
 `SentryAuthConfig(**data: Any)`
 :   Authentication Token
     
@@ -633,6 +657,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="SentryConnector"></a>
 
 `SentryConnector(auth_config: SentryAuthConfig | AirbyteAuthConfig | BaseModel | None = None, on_token_refresh: Any | None = None, hostname: str | None = None)`
 :   Type-safe Sentry API connector.
@@ -833,6 +859,8 @@ Classes
             entities = connector.list_entities()
             for entity in entities:
                 print(f"\{entity['entity_name']\}: \{entity['available_actions']\}")
+
+<a id="SentryReplicationConfig"></a>
 
 `SentryReplicationConfig(**data: Any)`
 :   Replication Configuration - Settings for data replication from Sentry.

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/sentry/models.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/sentry/models.md
@@ -13,6 +13,8 @@ and response envelope types.
 Classes
 -------
 
+<a id="AirbyteSearchMeta"></a>
+
 `AirbyteSearchMeta(**data: Any)`
 :   Pagination metadata for search responses.
     
@@ -40,6 +42,8 @@ Classes
 
     `took_ms: int | None`
     :   Time taken to execute the search in milliseconds.
+
+<a id="AirbyteSearchResult"></a>
 
 `AirbyteSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -95,6 +99,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="EventsSearchResult"></a>
+
 `EventsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -131,6 +137,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="IssuesSearchResult"></a>
 
 `IssuesSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -169,6 +177,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="ProjectsSearchResult"></a>
+
 `ProjectsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -206,6 +216,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="ReleasesSearchResult"></a>
+
 `ReleasesSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -221,6 +233,8 @@ Classes
     * airbyte_agent_sdk.connectors.sentry.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="Event"></a>
 
 `Event(**data: Any)`
 :   A Sentry event (individual error occurrence).
@@ -325,6 +339,8 @@ Classes
     `user: airbyte_agent_sdk.connectors.sentry.models.EventUser | Any | None`
     :   The type of the None singleton.
 
+<a id="EventGroupingconfig"></a>
+
 `EventGroupingconfig(**data: Any)`
 :   Grouping configuration.
     
@@ -350,6 +366,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="EventMetadata"></a>
+
 `EventMetadata(**data: Any)`
 :   Event metadata.
     
@@ -371,6 +389,8 @@ Classes
 
     `title: str | Any | None`
     :   The type of the None singleton.
+
+<a id="EventTagsItem"></a>
 
 `EventTagsItem(**data: Any)`
 :   Nested schema for Event.tags_item
@@ -396,6 +416,8 @@ Classes
 
     `value: str | Any | None`
     :   The type of the None singleton.
+
+<a id="EventUser"></a>
 
 `EventUser(**data: Any)`
 :   User associated with the event.
@@ -431,6 +453,8 @@ Classes
     `username: str | Any | None`
     :   The type of the None singleton.
 
+<a id="EventsListResultMeta"></a>
+
 `EventsListResultMeta(**data: Any)`
 :   Metadata for events.Action.LIST operation
     
@@ -452,6 +476,8 @@ Classes
 
     `next: str | Any | None`
     :   The type of the None singleton.
+
+<a id="EventsSearchData"></a>
 
 `EventsSearchData(**data: Any)`
 :   Search result data for events entity.
@@ -558,6 +584,8 @@ Classes
 
     `user: dict[str, typing.Any] | None`
     :   User associated with the event.
+
+<a id="Issue"></a>
 
 `Issue(**data: Any)`
 :   A Sentry issue (group of similar events).
@@ -671,6 +699,8 @@ Classes
     `user_count: int | Any | None`
     :   The type of the None singleton.
 
+<a id="IssueMetadata"></a>
+
 `IssueMetadata(**data: Any)`
 :   Issue metadata.
     
@@ -702,6 +732,8 @@ Classes
     `value: str | Any | None`
     :   The type of the None singleton.
 
+<a id="IssueProject"></a>
+
 `IssueProject(**data: Any)`
 :   Project this issue belongs to.
     
@@ -730,6 +762,8 @@ Classes
     `slug: str | Any | None`
     :   The type of the None singleton.
 
+<a id="IssuesListResultMeta"></a>
+
 `IssuesListResultMeta(**data: Any)`
 :   Metadata for issues.Action.LIST operation
     
@@ -751,6 +785,8 @@ Classes
 
     `next: str | Any | None`
     :   The type of the None singleton.
+
+<a id="IssuesSearchData"></a>
 
 `IssuesSearchData(**data: Any)`
 :   Search result data for issues entity.
@@ -863,6 +899,8 @@ Classes
 
     `user_count: int | None`
     :   Number of users affected.
+
+<a id="Project"></a>
 
 `Project(**data: Any)`
 :   A Sentry project (summary view from list endpoint).
@@ -997,6 +1035,8 @@ Classes
     `status: str | Any | None`
     :   The type of the None singleton.
 
+<a id="ProjectAvatar"></a>
+
 `ProjectAvatar(**data: Any)`
 :   Project avatar information.
     
@@ -1024,6 +1064,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="ProjectDetail"></a>
 
 `ProjectDetail(**data: Any)`
 :   Detailed project information.
@@ -1281,6 +1323,8 @@ Classes
     `verify_ssl: bool | Any | None`
     :   The type of the None singleton.
 
+<a id="ProjectDetailAvatar"></a>
+
 `ProjectDetailAvatar(**data: Any)`
 :   Project avatar information.
     
@@ -1308,6 +1352,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="ProjectDetailOrganization"></a>
 
 `ProjectDetailOrganization(**data: Any)`
 :   Organization this project belongs to.
@@ -1337,6 +1383,8 @@ Classes
     `slug: str | Any | None`
     :   The type of the None singleton.
 
+<a id="ProjectDetailTeam"></a>
+
 `ProjectDetailTeam(**data: Any)`
 :   Primary team for this project.
     
@@ -1364,6 +1412,8 @@ Classes
 
     `slug: str | Any | None`
     :   The type of the None singleton.
+
+<a id="ProjectDetailTeamsItem"></a>
 
 `ProjectDetailTeamsItem(**data: Any)`
 :   Nested schema for ProjectDetail.teams_item
@@ -1393,6 +1443,8 @@ Classes
     `slug: str | Any | None`
     :   The type of the None singleton.
 
+<a id="ProjectOrganization"></a>
+
 `ProjectOrganization(**data: Any)`
 :   Organization this project belongs to.
     
@@ -1421,6 +1473,8 @@ Classes
     `slug: str | Any | None`
     :   The type of the None singleton.
 
+<a id="ProjectsListResultMeta"></a>
+
 `ProjectsListResultMeta(**data: Any)`
 :   Metadata for projects.Action.LIST operation
     
@@ -1442,6 +1496,8 @@ Classes
 
     `next: str | Any | None`
     :   The type of the None singleton.
+
+<a id="ProjectsSearchData"></a>
 
 `ProjectsSearchData(**data: Any)`
 :   Search result data for projects entity.
@@ -1540,6 +1596,8 @@ Classes
     `status: str | None`
     :   Project status.
 
+<a id="Release"></a>
+
 `Release(**data: Any)`
 :   A Sentry release.
     
@@ -1625,6 +1683,8 @@ Classes
     `version_info: airbyte_agent_sdk.connectors.sentry.models.ReleaseVersioninfo | Any | None`
     :   The type of the None singleton.
 
+<a id="ReleaseAuthorsItem"></a>
+
 `ReleaseAuthorsItem(**data: Any)`
 :   Nested schema for Release.authors_item
     
@@ -1649,6 +1709,8 @@ Classes
 
     `name: str | Any | None`
     :   The type of the None singleton.
+
+<a id="ReleaseProjectsItem"></a>
 
 `ReleaseProjectsItem(**data: Any)`
 :   Nested schema for Release.projects_item
@@ -1687,6 +1749,8 @@ Classes
     `slug: str | Any | None`
     :   The type of the None singleton.
 
+<a id="ReleaseVersioninfo"></a>
+
 `ReleaseVersioninfo(**data: Any)`
 :   Parsed version information.
     
@@ -1717,6 +1781,8 @@ Classes
 
     `version: airbyte_agent_sdk.connectors.sentry.models.ReleaseVersioninfoVersion | Any | None`
     :   The type of the None singleton.
+
+<a id="ReleaseVersioninfoVersion"></a>
 
 `ReleaseVersioninfoVersion(**data: Any)`
 :   Nested schema for ReleaseVersioninfo.version
@@ -1758,6 +1824,8 @@ Classes
     `raw: str | Any | None`
     :   The type of the None singleton.
 
+<a id="ReleasesListResultMeta"></a>
+
 `ReleasesListResultMeta(**data: Any)`
 :   Metadata for releases.Action.LIST operation
     
@@ -1779,6 +1847,8 @@ Classes
 
     `next: str | Any | None`
     :   The type of the None singleton.
+
+<a id="ReleasesSearchData"></a>
 
 `ReleasesSearchData(**data: Any)`
 :   Search result data for releases entity.
@@ -1865,6 +1935,8 @@ Classes
     `version_info: dict[str, typing.Any] | None`
     :   Parsed version information.
 
+<a id="SentryAuthConfig"></a>
+
 `SentryAuthConfig(**data: Any)`
 :   Authentication Token
     
@@ -1886,6 +1958,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="SentryCheckResult"></a>
 
 `SentryCheckResult(**data: Any)`
 :   Result of a health check operation.
@@ -1920,6 +1994,8 @@ Classes
     `status: str`
     :   Health check status: 'healthy' or 'unhealthy'.
 
+<a id="SentryExecuteResult"></a>
+
 `SentryExecuteResult(**data: Any)`
 :   Response envelope with data only.
     
@@ -1948,6 +2024,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="SentryExecuteResultWithMeta"></a>
 
 `SentryExecuteResultWithMeta(**data: Any)`
 :   Response envelope with data and metadata.
@@ -2003,6 +2081,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="EventsListResult"></a>
+
 `EventsListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -2045,6 +2125,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="IssuesListResult"></a>
 
 `IssuesListResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -2089,6 +2171,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="ProjectsListResult"></a>
+
 `ProjectsListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -2132,6 +2216,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="ReleasesListResult"></a>
+
 `ReleasesListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -2150,6 +2236,8 @@ Classes
     * airbyte_agent_sdk.connectors.sentry.models.SentryExecuteResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="SentryReplicationConfig"></a>
 
 `SentryReplicationConfig(**data: Any)`
 :   Replication Configuration - Settings for data replication from Sentry.

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/sentry/types.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/sentry/types.md
@@ -10,6 +10,8 @@ Type definitions for sentry connector.
 Classes
 -------
 
+<a id="AirbyteSearchParams"></a>
+
 `AirbyteSearchParams(*args, **kwargs)`
 :   Parameters for Airbyte cache search operations (generic, use entity-specific query types for better type hints).
 
@@ -31,6 +33,8 @@ Classes
     `query: dict[str, typing.Any]`
     :   The type of the None singleton.
 
+<a id="EventsAndCondition"></a>
+
 `EventsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -51,6 +55,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.sentry.types.EventsEqCondition | airbyte_agent_sdk.connectors.sentry.types.EventsNeqCondition | airbyte_agent_sdk.connectors.sentry.types.EventsGtCondition | airbyte_agent_sdk.connectors.sentry.types.EventsGteCondition | airbyte_agent_sdk.connectors.sentry.types.EventsLtCondition | airbyte_agent_sdk.connectors.sentry.types.EventsLteCondition | airbyte_agent_sdk.connectors.sentry.types.EventsInCondition | airbyte_agent_sdk.connectors.sentry.types.EventsLikeCondition | airbyte_agent_sdk.connectors.sentry.types.EventsFuzzyCondition | airbyte_agent_sdk.connectors.sentry.types.EventsKeywordCondition | airbyte_agent_sdk.connectors.sentry.types.EventsContainsCondition | airbyte_agent_sdk.connectors.sentry.types.EventsNotCondition | airbyte_agent_sdk.connectors.sentry.types.EventsAndCondition | airbyte_agent_sdk.connectors.sentry.types.EventsOrCondition | airbyte_agent_sdk.connectors.sentry.types.EventsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="EventsAnyCondition"></a>
+
 `EventsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -70,6 +76,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.sentry.types.EventsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="EventsAnyValueFilter"></a>
 
 `EventsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -167,6 +175,8 @@ Classes
     `user: Any`
     :   User associated with the event.
 
+<a id="EventsContainsCondition"></a>
+
 `EventsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -178,6 +188,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.sentry.types.EventsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="EventsEqCondition"></a>
 
 `EventsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -191,6 +203,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.sentry.types.EventsSearchFilter`
     :   The type of the None singleton.
 
+<a id="EventsFuzzyCondition"></a>
+
 `EventsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -202,6 +216,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.sentry.types.EventsStringFilter`
     :   The type of the None singleton.
+
+<a id="EventsGetParams"></a>
 
 `EventsGetParams(*args, **kwargs)`
 :   Parameters for events.get operation
@@ -221,6 +237,8 @@ Classes
     `project_slug: str`
     :   The type of the None singleton.
 
+<a id="EventsGtCondition"></a>
+
 `EventsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -233,6 +251,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.sentry.types.EventsSearchFilter`
     :   The type of the None singleton.
 
+<a id="EventsGteCondition"></a>
+
 `EventsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -244,6 +264,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.sentry.types.EventsSearchFilter`
     :   The type of the None singleton.
+
+<a id="EventsInCondition"></a>
 
 `EventsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -264,6 +286,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.sentry.types.EventsInFilter`
     :   The type of the None singleton.
+
+<a id="EventsInFilter"></a>
 
 `EventsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -361,6 +385,8 @@ Classes
     `user: list[dict[str, typing.Any]]`
     :   User associated with the event.
 
+<a id="EventsKeywordCondition"></a>
+
 `EventsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -373,6 +399,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.sentry.types.EventsStringFilter`
     :   The type of the None singleton.
 
+<a id="EventsLikeCondition"></a>
+
 `EventsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -384,6 +412,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.sentry.types.EventsStringFilter`
     :   The type of the None singleton.
+
+<a id="EventsListParams"></a>
 
 `EventsListParams(*args, **kwargs)`
 :   Parameters for events.list operation
@@ -406,6 +436,8 @@ Classes
     `project_slug: str`
     :   The type of the None singleton.
 
+<a id="EventsLtCondition"></a>
+
 `EventsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -417,6 +449,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.sentry.types.EventsSearchFilter`
     :   The type of the None singleton.
+
+<a id="EventsLteCondition"></a>
 
 `EventsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -430,6 +464,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.sentry.types.EventsSearchFilter`
     :   The type of the None singleton.
 
+<a id="EventsNeqCondition"></a>
+
 `EventsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -441,6 +477,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.sentry.types.EventsSearchFilter`
     :   The type of the None singleton.
+
+<a id="EventsNotCondition"></a>
 
 `EventsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -462,6 +500,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.sentry.types.EventsEqCondition | airbyte_agent_sdk.connectors.sentry.types.EventsNeqCondition | airbyte_agent_sdk.connectors.sentry.types.EventsGtCondition | airbyte_agent_sdk.connectors.sentry.types.EventsGteCondition | airbyte_agent_sdk.connectors.sentry.types.EventsLtCondition | airbyte_agent_sdk.connectors.sentry.types.EventsLteCondition | airbyte_agent_sdk.connectors.sentry.types.EventsInCondition | airbyte_agent_sdk.connectors.sentry.types.EventsLikeCondition | airbyte_agent_sdk.connectors.sentry.types.EventsFuzzyCondition | airbyte_agent_sdk.connectors.sentry.types.EventsKeywordCondition | airbyte_agent_sdk.connectors.sentry.types.EventsContainsCondition | airbyte_agent_sdk.connectors.sentry.types.EventsNotCondition | airbyte_agent_sdk.connectors.sentry.types.EventsAndCondition | airbyte_agent_sdk.connectors.sentry.types.EventsOrCondition | airbyte_agent_sdk.connectors.sentry.types.EventsAnyCondition`
     :   The type of the None singleton.
 
+<a id="EventsOrCondition"></a>
+
 `EventsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -481,6 +521,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.sentry.types.EventsEqCondition | airbyte_agent_sdk.connectors.sentry.types.EventsNeqCondition | airbyte_agent_sdk.connectors.sentry.types.EventsGtCondition | airbyte_agent_sdk.connectors.sentry.types.EventsGteCondition | airbyte_agent_sdk.connectors.sentry.types.EventsLtCondition | airbyte_agent_sdk.connectors.sentry.types.EventsLteCondition | airbyte_agent_sdk.connectors.sentry.types.EventsInCondition | airbyte_agent_sdk.connectors.sentry.types.EventsLikeCondition | airbyte_agent_sdk.connectors.sentry.types.EventsFuzzyCondition | airbyte_agent_sdk.connectors.sentry.types.EventsKeywordCondition | airbyte_agent_sdk.connectors.sentry.types.EventsContainsCondition | airbyte_agent_sdk.connectors.sentry.types.EventsNotCondition | airbyte_agent_sdk.connectors.sentry.types.EventsAndCondition | airbyte_agent_sdk.connectors.sentry.types.EventsOrCondition | airbyte_agent_sdk.connectors.sentry.types.EventsAnyCondition]`
     :   The type of the None singleton.
+
+<a id="EventsSearchFilter"></a>
 
 `EventsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering events search queries.
@@ -578,6 +620,8 @@ Classes
     `user: dict[str, typing.Any] | None`
     :   User associated with the event.
 
+<a id="EventsSearchQuery"></a>
+
 `EventsSearchQuery(*args, **kwargs)`
 :   Search query for events entity.
 
@@ -592,6 +636,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.sentry.types.EventsSortFilter]`
     :   The type of the None singleton.
+
+<a id="EventsSortFilter"></a>
 
 `EventsSortFilter(*args, **kwargs)`
 :   Available fields for sorting events search results.
@@ -689,6 +735,8 @@ Classes
     `user: Literal['asc', 'desc']`
     :   User associated with the event.
 
+<a id="EventsStringFilter"></a>
+
 `EventsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -785,6 +833,8 @@ Classes
     `user: str`
     :   User associated with the event.
 
+<a id="IssuesAndCondition"></a>
+
 `IssuesAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -805,6 +855,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.sentry.types.IssuesEqCondition | airbyte_agent_sdk.connectors.sentry.types.IssuesNeqCondition | airbyte_agent_sdk.connectors.sentry.types.IssuesGtCondition | airbyte_agent_sdk.connectors.sentry.types.IssuesGteCondition | airbyte_agent_sdk.connectors.sentry.types.IssuesLtCondition | airbyte_agent_sdk.connectors.sentry.types.IssuesLteCondition | airbyte_agent_sdk.connectors.sentry.types.IssuesInCondition | airbyte_agent_sdk.connectors.sentry.types.IssuesLikeCondition | airbyte_agent_sdk.connectors.sentry.types.IssuesFuzzyCondition | airbyte_agent_sdk.connectors.sentry.types.IssuesKeywordCondition | airbyte_agent_sdk.connectors.sentry.types.IssuesContainsCondition | airbyte_agent_sdk.connectors.sentry.types.IssuesNotCondition | airbyte_agent_sdk.connectors.sentry.types.IssuesAndCondition | airbyte_agent_sdk.connectors.sentry.types.IssuesOrCondition | airbyte_agent_sdk.connectors.sentry.types.IssuesAnyCondition]`
     :   The type of the None singleton.
 
+<a id="IssuesAnyCondition"></a>
+
 `IssuesAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -824,6 +876,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.sentry.types.IssuesAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="IssuesAnyValueFilter"></a>
 
 `IssuesAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -927,6 +981,8 @@ Classes
     `user_count: Any`
     :   Number of users affected.
 
+<a id="IssuesContainsCondition"></a>
+
 `IssuesContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -938,6 +994,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.sentry.types.IssuesAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="IssuesEqCondition"></a>
 
 `IssuesEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -951,6 +1009,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.sentry.types.IssuesSearchFilter`
     :   The type of the None singleton.
 
+<a id="IssuesFuzzyCondition"></a>
+
 `IssuesFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -962,6 +1022,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.sentry.types.IssuesStringFilter`
     :   The type of the None singleton.
+
+<a id="IssuesGetParams"></a>
 
 `IssuesGetParams(*args, **kwargs)`
 :   Parameters for issues.get operation
@@ -978,6 +1040,8 @@ Classes
     `organization_slug: str`
     :   The type of the None singleton.
 
+<a id="IssuesGtCondition"></a>
+
 `IssuesGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -990,6 +1054,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.sentry.types.IssuesSearchFilter`
     :   The type of the None singleton.
 
+<a id="IssuesGteCondition"></a>
+
 `IssuesGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -1001,6 +1067,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.sentry.types.IssuesSearchFilter`
     :   The type of the None singleton.
+
+<a id="IssuesInCondition"></a>
 
 `IssuesInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -1021,6 +1089,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.sentry.types.IssuesInFilter`
     :   The type of the None singleton.
+
+<a id="IssuesInFilter"></a>
 
 `IssuesInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -1124,6 +1194,8 @@ Classes
     `user_count: list[int]`
     :   Number of users affected.
 
+<a id="IssuesKeywordCondition"></a>
+
 `IssuesKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -1136,6 +1208,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.sentry.types.IssuesStringFilter`
     :   The type of the None singleton.
 
+<a id="IssuesLikeCondition"></a>
+
 `IssuesLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -1147,6 +1221,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.sentry.types.IssuesStringFilter`
     :   The type of the None singleton.
+
+<a id="IssuesListParams"></a>
 
 `IssuesListParams(*args, **kwargs)`
 :   Parameters for issues.list operation
@@ -1172,6 +1248,8 @@ Classes
     `stats_period: str`
     :   The type of the None singleton.
 
+<a id="IssuesLtCondition"></a>
+
 `IssuesLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -1183,6 +1261,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.sentry.types.IssuesSearchFilter`
     :   The type of the None singleton.
+
+<a id="IssuesLteCondition"></a>
 
 `IssuesLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -1196,6 +1276,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.sentry.types.IssuesSearchFilter`
     :   The type of the None singleton.
 
+<a id="IssuesNeqCondition"></a>
+
 `IssuesNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -1207,6 +1289,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.sentry.types.IssuesSearchFilter`
     :   The type of the None singleton.
+
+<a id="IssuesNotCondition"></a>
 
 `IssuesNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -1228,6 +1312,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.sentry.types.IssuesEqCondition | airbyte_agent_sdk.connectors.sentry.types.IssuesNeqCondition | airbyte_agent_sdk.connectors.sentry.types.IssuesGtCondition | airbyte_agent_sdk.connectors.sentry.types.IssuesGteCondition | airbyte_agent_sdk.connectors.sentry.types.IssuesLtCondition | airbyte_agent_sdk.connectors.sentry.types.IssuesLteCondition | airbyte_agent_sdk.connectors.sentry.types.IssuesInCondition | airbyte_agent_sdk.connectors.sentry.types.IssuesLikeCondition | airbyte_agent_sdk.connectors.sentry.types.IssuesFuzzyCondition | airbyte_agent_sdk.connectors.sentry.types.IssuesKeywordCondition | airbyte_agent_sdk.connectors.sentry.types.IssuesContainsCondition | airbyte_agent_sdk.connectors.sentry.types.IssuesNotCondition | airbyte_agent_sdk.connectors.sentry.types.IssuesAndCondition | airbyte_agent_sdk.connectors.sentry.types.IssuesOrCondition | airbyte_agent_sdk.connectors.sentry.types.IssuesAnyCondition`
     :   The type of the None singleton.
 
+<a id="IssuesOrCondition"></a>
+
 `IssuesOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1247,6 +1333,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.sentry.types.IssuesEqCondition | airbyte_agent_sdk.connectors.sentry.types.IssuesNeqCondition | airbyte_agent_sdk.connectors.sentry.types.IssuesGtCondition | airbyte_agent_sdk.connectors.sentry.types.IssuesGteCondition | airbyte_agent_sdk.connectors.sentry.types.IssuesLtCondition | airbyte_agent_sdk.connectors.sentry.types.IssuesLteCondition | airbyte_agent_sdk.connectors.sentry.types.IssuesInCondition | airbyte_agent_sdk.connectors.sentry.types.IssuesLikeCondition | airbyte_agent_sdk.connectors.sentry.types.IssuesFuzzyCondition | airbyte_agent_sdk.connectors.sentry.types.IssuesKeywordCondition | airbyte_agent_sdk.connectors.sentry.types.IssuesContainsCondition | airbyte_agent_sdk.connectors.sentry.types.IssuesNotCondition | airbyte_agent_sdk.connectors.sentry.types.IssuesAndCondition | airbyte_agent_sdk.connectors.sentry.types.IssuesOrCondition | airbyte_agent_sdk.connectors.sentry.types.IssuesAnyCondition]`
     :   The type of the None singleton.
+
+<a id="IssuesSearchFilter"></a>
 
 `IssuesSearchFilter(*args, **kwargs)`
 :   Available fields for filtering issues search queries.
@@ -1350,6 +1438,8 @@ Classes
     `user_count: int | None`
     :   Number of users affected.
 
+<a id="IssuesSearchQuery"></a>
+
 `IssuesSearchQuery(*args, **kwargs)`
 :   Search query for issues entity.
 
@@ -1364,6 +1454,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.sentry.types.IssuesSortFilter]`
     :   The type of the None singleton.
+
+<a id="IssuesSortFilter"></a>
 
 `IssuesSortFilter(*args, **kwargs)`
 :   Available fields for sorting issues search results.
@@ -1467,6 +1559,8 @@ Classes
     `user_count: Literal['asc', 'desc']`
     :   Number of users affected.
 
+<a id="IssuesStringFilter"></a>
+
 `IssuesStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -1569,6 +1663,8 @@ Classes
     `user_count: str`
     :   Number of users affected.
 
+<a id="ProjectDetailGetParams"></a>
+
 `ProjectDetailGetParams(*args, **kwargs)`
 :   Parameters for project_detail.get operation
 
@@ -1583,6 +1679,8 @@ Classes
 
     `project_slug: str`
     :   The type of the None singleton.
+
+<a id="ProjectsAndCondition"></a>
 
 `ProjectsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -1604,6 +1702,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.sentry.types.ProjectsEqCondition | airbyte_agent_sdk.connectors.sentry.types.ProjectsNeqCondition | airbyte_agent_sdk.connectors.sentry.types.ProjectsGtCondition | airbyte_agent_sdk.connectors.sentry.types.ProjectsGteCondition | airbyte_agent_sdk.connectors.sentry.types.ProjectsLtCondition | airbyte_agent_sdk.connectors.sentry.types.ProjectsLteCondition | airbyte_agent_sdk.connectors.sentry.types.ProjectsInCondition | airbyte_agent_sdk.connectors.sentry.types.ProjectsLikeCondition | airbyte_agent_sdk.connectors.sentry.types.ProjectsFuzzyCondition | airbyte_agent_sdk.connectors.sentry.types.ProjectsKeywordCondition | airbyte_agent_sdk.connectors.sentry.types.ProjectsContainsCondition | airbyte_agent_sdk.connectors.sentry.types.ProjectsNotCondition | airbyte_agent_sdk.connectors.sentry.types.ProjectsAndCondition | airbyte_agent_sdk.connectors.sentry.types.ProjectsOrCondition | airbyte_agent_sdk.connectors.sentry.types.ProjectsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="ProjectsAnyCondition"></a>
+
 `ProjectsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1623,6 +1723,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.sentry.types.ProjectsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="ProjectsAnyValueFilter"></a>
 
 `ProjectsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -1711,6 +1813,8 @@ Classes
     `status: Any`
     :   Project status.
 
+<a id="ProjectsContainsCondition"></a>
+
 `ProjectsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -1722,6 +1826,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.sentry.types.ProjectsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="ProjectsEqCondition"></a>
 
 `ProjectsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -1735,6 +1841,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.sentry.types.ProjectsSearchFilter`
     :   The type of the None singleton.
 
+<a id="ProjectsFuzzyCondition"></a>
+
 `ProjectsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -1746,6 +1854,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.sentry.types.ProjectsStringFilter`
     :   The type of the None singleton.
+
+<a id="ProjectsGetParams"></a>
 
 `ProjectsGetParams(*args, **kwargs)`
 :   Parameters for projects.get operation
@@ -1762,6 +1872,8 @@ Classes
     `project_slug: str`
     :   The type of the None singleton.
 
+<a id="ProjectsGtCondition"></a>
+
 `ProjectsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -1774,6 +1886,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.sentry.types.ProjectsSearchFilter`
     :   The type of the None singleton.
 
+<a id="ProjectsGteCondition"></a>
+
 `ProjectsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -1785,6 +1899,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.sentry.types.ProjectsSearchFilter`
     :   The type of the None singleton.
+
+<a id="ProjectsInCondition"></a>
 
 `ProjectsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -1805,6 +1921,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.sentry.types.ProjectsInFilter`
     :   The type of the None singleton.
+
+<a id="ProjectsInFilter"></a>
 
 `ProjectsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -1893,6 +2011,8 @@ Classes
     `status: list[str]`
     :   Project status.
 
+<a id="ProjectsKeywordCondition"></a>
+
 `ProjectsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -1904,6 +2024,8 @@ Classes
 
     `keyword: airbyte_agent_sdk.connectors.sentry.types.ProjectsStringFilter`
     :   The type of the None singleton.
+
+<a id="ProjectsLikeCondition"></a>
 
 `ProjectsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
@@ -1917,6 +2039,8 @@ Classes
     `like: airbyte_agent_sdk.connectors.sentry.types.ProjectsStringFilter`
     :   The type of the None singleton.
 
+<a id="ProjectsListParams"></a>
+
 `ProjectsListParams(*args, **kwargs)`
 :   Parameters for projects.list operation
 
@@ -1928,6 +2052,8 @@ Classes
 
     `cursor: str`
     :   The type of the None singleton.
+
+<a id="ProjectsLtCondition"></a>
 
 `ProjectsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
@@ -1941,6 +2067,8 @@ Classes
     `lt: airbyte_agent_sdk.connectors.sentry.types.ProjectsSearchFilter`
     :   The type of the None singleton.
 
+<a id="ProjectsLteCondition"></a>
+
 `ProjectsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
 
@@ -1953,6 +2081,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.sentry.types.ProjectsSearchFilter`
     :   The type of the None singleton.
 
+<a id="ProjectsNeqCondition"></a>
+
 `ProjectsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -1964,6 +2094,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.sentry.types.ProjectsSearchFilter`
     :   The type of the None singleton.
+
+<a id="ProjectsNotCondition"></a>
 
 `ProjectsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -1985,6 +2117,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.sentry.types.ProjectsEqCondition | airbyte_agent_sdk.connectors.sentry.types.ProjectsNeqCondition | airbyte_agent_sdk.connectors.sentry.types.ProjectsGtCondition | airbyte_agent_sdk.connectors.sentry.types.ProjectsGteCondition | airbyte_agent_sdk.connectors.sentry.types.ProjectsLtCondition | airbyte_agent_sdk.connectors.sentry.types.ProjectsLteCondition | airbyte_agent_sdk.connectors.sentry.types.ProjectsInCondition | airbyte_agent_sdk.connectors.sentry.types.ProjectsLikeCondition | airbyte_agent_sdk.connectors.sentry.types.ProjectsFuzzyCondition | airbyte_agent_sdk.connectors.sentry.types.ProjectsKeywordCondition | airbyte_agent_sdk.connectors.sentry.types.ProjectsContainsCondition | airbyte_agent_sdk.connectors.sentry.types.ProjectsNotCondition | airbyte_agent_sdk.connectors.sentry.types.ProjectsAndCondition | airbyte_agent_sdk.connectors.sentry.types.ProjectsOrCondition | airbyte_agent_sdk.connectors.sentry.types.ProjectsAnyCondition`
     :   The type of the None singleton.
 
+<a id="ProjectsOrCondition"></a>
+
 `ProjectsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -2004,6 +2138,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.sentry.types.ProjectsEqCondition | airbyte_agent_sdk.connectors.sentry.types.ProjectsNeqCondition | airbyte_agent_sdk.connectors.sentry.types.ProjectsGtCondition | airbyte_agent_sdk.connectors.sentry.types.ProjectsGteCondition | airbyte_agent_sdk.connectors.sentry.types.ProjectsLtCondition | airbyte_agent_sdk.connectors.sentry.types.ProjectsLteCondition | airbyte_agent_sdk.connectors.sentry.types.ProjectsInCondition | airbyte_agent_sdk.connectors.sentry.types.ProjectsLikeCondition | airbyte_agent_sdk.connectors.sentry.types.ProjectsFuzzyCondition | airbyte_agent_sdk.connectors.sentry.types.ProjectsKeywordCondition | airbyte_agent_sdk.connectors.sentry.types.ProjectsContainsCondition | airbyte_agent_sdk.connectors.sentry.types.ProjectsNotCondition | airbyte_agent_sdk.connectors.sentry.types.ProjectsAndCondition | airbyte_agent_sdk.connectors.sentry.types.ProjectsOrCondition | airbyte_agent_sdk.connectors.sentry.types.ProjectsAnyCondition]`
     :   The type of the None singleton.
+
+<a id="ProjectsSearchFilter"></a>
 
 `ProjectsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering projects search queries.
@@ -2092,6 +2228,8 @@ Classes
     `status: str | None`
     :   Project status.
 
+<a id="ProjectsSearchQuery"></a>
+
 `ProjectsSearchQuery(*args, **kwargs)`
 :   Search query for projects entity.
 
@@ -2106,6 +2244,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.sentry.types.ProjectsSortFilter]`
     :   The type of the None singleton.
+
+<a id="ProjectsSortFilter"></a>
 
 `ProjectsSortFilter(*args, **kwargs)`
 :   Available fields for sorting projects search results.
@@ -2194,6 +2334,8 @@ Classes
     `status: Literal['asc', 'desc']`
     :   Project status.
 
+<a id="ProjectsStringFilter"></a>
+
 `ProjectsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -2281,6 +2423,8 @@ Classes
     `status: str`
     :   Project status.
 
+<a id="ReleasesAndCondition"></a>
+
 `ReleasesAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -2301,6 +2445,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.sentry.types.ReleasesEqCondition | airbyte_agent_sdk.connectors.sentry.types.ReleasesNeqCondition | airbyte_agent_sdk.connectors.sentry.types.ReleasesGtCondition | airbyte_agent_sdk.connectors.sentry.types.ReleasesGteCondition | airbyte_agent_sdk.connectors.sentry.types.ReleasesLtCondition | airbyte_agent_sdk.connectors.sentry.types.ReleasesLteCondition | airbyte_agent_sdk.connectors.sentry.types.ReleasesInCondition | airbyte_agent_sdk.connectors.sentry.types.ReleasesLikeCondition | airbyte_agent_sdk.connectors.sentry.types.ReleasesFuzzyCondition | airbyte_agent_sdk.connectors.sentry.types.ReleasesKeywordCondition | airbyte_agent_sdk.connectors.sentry.types.ReleasesContainsCondition | airbyte_agent_sdk.connectors.sentry.types.ReleasesNotCondition | airbyte_agent_sdk.connectors.sentry.types.ReleasesAndCondition | airbyte_agent_sdk.connectors.sentry.types.ReleasesOrCondition | airbyte_agent_sdk.connectors.sentry.types.ReleasesAnyCondition]`
     :   The type of the None singleton.
 
+<a id="ReleasesAnyCondition"></a>
+
 `ReleasesAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -2320,6 +2466,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.sentry.types.ReleasesAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="ReleasesAnyValueFilter"></a>
 
 `ReleasesAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -2396,6 +2544,8 @@ Classes
     `version_info: Any`
     :   Parsed version information.
 
+<a id="ReleasesContainsCondition"></a>
+
 `ReleasesContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -2407,6 +2557,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.sentry.types.ReleasesAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="ReleasesEqCondition"></a>
 
 `ReleasesEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -2420,6 +2572,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.sentry.types.ReleasesSearchFilter`
     :   The type of the None singleton.
 
+<a id="ReleasesFuzzyCondition"></a>
+
 `ReleasesFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -2431,6 +2585,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.sentry.types.ReleasesStringFilter`
     :   The type of the None singleton.
+
+<a id="ReleasesGetParams"></a>
 
 `ReleasesGetParams(*args, **kwargs)`
 :   Parameters for releases.get operation
@@ -2447,6 +2603,8 @@ Classes
     `version: str`
     :   The type of the None singleton.
 
+<a id="ReleasesGtCondition"></a>
+
 `ReleasesGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -2459,6 +2617,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.sentry.types.ReleasesSearchFilter`
     :   The type of the None singleton.
 
+<a id="ReleasesGteCondition"></a>
+
 `ReleasesGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -2470,6 +2630,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.sentry.types.ReleasesSearchFilter`
     :   The type of the None singleton.
+
+<a id="ReleasesInCondition"></a>
 
 `ReleasesInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -2490,6 +2652,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.sentry.types.ReleasesInFilter`
     :   The type of the None singleton.
+
+<a id="ReleasesInFilter"></a>
 
 `ReleasesInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -2566,6 +2730,8 @@ Classes
     `version_info: list[dict[str, typing.Any]]`
     :   Parsed version information.
 
+<a id="ReleasesKeywordCondition"></a>
+
 `ReleasesKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -2578,6 +2744,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.sentry.types.ReleasesStringFilter`
     :   The type of the None singleton.
 
+<a id="ReleasesLikeCondition"></a>
+
 `ReleasesLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -2589,6 +2757,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.sentry.types.ReleasesStringFilter`
     :   The type of the None singleton.
+
+<a id="ReleasesListParams"></a>
 
 `ReleasesListParams(*args, **kwargs)`
 :   Parameters for releases.list operation
@@ -2608,6 +2778,8 @@ Classes
     `query: str`
     :   The type of the None singleton.
 
+<a id="ReleasesLtCondition"></a>
+
 `ReleasesLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -2619,6 +2791,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.sentry.types.ReleasesSearchFilter`
     :   The type of the None singleton.
+
+<a id="ReleasesLteCondition"></a>
 
 `ReleasesLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -2632,6 +2806,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.sentry.types.ReleasesSearchFilter`
     :   The type of the None singleton.
 
+<a id="ReleasesNeqCondition"></a>
+
 `ReleasesNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -2643,6 +2819,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.sentry.types.ReleasesSearchFilter`
     :   The type of the None singleton.
+
+<a id="ReleasesNotCondition"></a>
 
 `ReleasesNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -2664,6 +2842,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.sentry.types.ReleasesEqCondition | airbyte_agent_sdk.connectors.sentry.types.ReleasesNeqCondition | airbyte_agent_sdk.connectors.sentry.types.ReleasesGtCondition | airbyte_agent_sdk.connectors.sentry.types.ReleasesGteCondition | airbyte_agent_sdk.connectors.sentry.types.ReleasesLtCondition | airbyte_agent_sdk.connectors.sentry.types.ReleasesLteCondition | airbyte_agent_sdk.connectors.sentry.types.ReleasesInCondition | airbyte_agent_sdk.connectors.sentry.types.ReleasesLikeCondition | airbyte_agent_sdk.connectors.sentry.types.ReleasesFuzzyCondition | airbyte_agent_sdk.connectors.sentry.types.ReleasesKeywordCondition | airbyte_agent_sdk.connectors.sentry.types.ReleasesContainsCondition | airbyte_agent_sdk.connectors.sentry.types.ReleasesNotCondition | airbyte_agent_sdk.connectors.sentry.types.ReleasesAndCondition | airbyte_agent_sdk.connectors.sentry.types.ReleasesOrCondition | airbyte_agent_sdk.connectors.sentry.types.ReleasesAnyCondition`
     :   The type of the None singleton.
 
+<a id="ReleasesOrCondition"></a>
+
 `ReleasesOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -2683,6 +2863,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.sentry.types.ReleasesEqCondition | airbyte_agent_sdk.connectors.sentry.types.ReleasesNeqCondition | airbyte_agent_sdk.connectors.sentry.types.ReleasesGtCondition | airbyte_agent_sdk.connectors.sentry.types.ReleasesGteCondition | airbyte_agent_sdk.connectors.sentry.types.ReleasesLtCondition | airbyte_agent_sdk.connectors.sentry.types.ReleasesLteCondition | airbyte_agent_sdk.connectors.sentry.types.ReleasesInCondition | airbyte_agent_sdk.connectors.sentry.types.ReleasesLikeCondition | airbyte_agent_sdk.connectors.sentry.types.ReleasesFuzzyCondition | airbyte_agent_sdk.connectors.sentry.types.ReleasesKeywordCondition | airbyte_agent_sdk.connectors.sentry.types.ReleasesContainsCondition | airbyte_agent_sdk.connectors.sentry.types.ReleasesNotCondition | airbyte_agent_sdk.connectors.sentry.types.ReleasesAndCondition | airbyte_agent_sdk.connectors.sentry.types.ReleasesOrCondition | airbyte_agent_sdk.connectors.sentry.types.ReleasesAnyCondition]`
     :   The type of the None singleton.
+
+<a id="ReleasesSearchFilter"></a>
 
 `ReleasesSearchFilter(*args, **kwargs)`
 :   Available fields for filtering releases search queries.
@@ -2759,6 +2941,8 @@ Classes
     `version_info: dict[str, typing.Any] | None`
     :   Parsed version information.
 
+<a id="ReleasesSearchQuery"></a>
+
 `ReleasesSearchQuery(*args, **kwargs)`
 :   Search query for releases entity.
 
@@ -2773,6 +2957,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.sentry.types.ReleasesSortFilter]`
     :   The type of the None singleton.
+
+<a id="ReleasesSortFilter"></a>
 
 `ReleasesSortFilter(*args, **kwargs)`
 :   Available fields for sorting releases search results.
@@ -2848,6 +3034,8 @@ Classes
 
     `version_info: Literal['asc', 'desc']`
     :   Parsed version information.
+
+<a id="ReleasesStringFilter"></a>
 
 `ReleasesStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/shopify/connector.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/shopify/connector.md
@@ -10,6 +10,8 @@ Shopify connector.
 Classes
 -------
 
+<a id="AbandonedCheckoutsQuery"></a>
+
 `AbandonedCheckoutsQuery(connector: ShopifyConnector)`
 :   Query class for AbandonedCheckouts entity operations.
     
@@ -54,6 +56,8 @@ Classes
         
         Returns:
             AbandonedCheckoutsListResult
+
+<a id="CollectsQuery"></a>
 
 `CollectsQuery(connector: ShopifyConnector)`
 :   Query class for Collects entity operations.
@@ -107,6 +111,8 @@ Classes
         Returns:
             CollectsListResult
 
+<a id="CountriesQuery"></a>
+
 `CountriesQuery(connector: ShopifyConnector)`
 :   Query class for Countries entity operations.
     
@@ -155,6 +161,8 @@ Classes
         
         Returns:
             CountriesListResult
+
+<a id="CustomCollectionsQuery"></a>
 
 `CustomCollectionsQuery(connector: ShopifyConnector)`
 :   Query class for CustomCollections entity operations.
@@ -210,6 +218,8 @@ Classes
         Returns:
             CustomCollectionsListResult
 
+<a id="CustomerAddressQuery"></a>
+
 `CustomerAddressQuery(connector: ShopifyConnector)`
 :   Query class for CustomerAddress entity operations.
     
@@ -238,6 +248,8 @@ Classes
         
         Returns:
             CustomerAddressListResult
+
+<a id="CustomersQuery"></a>
 
 `CustomersQuery(connector: ShopifyConnector)`
 :   Query class for Customers entity operations.
@@ -293,6 +305,8 @@ Classes
         Returns:
             CustomersListResult
 
+<a id="DiscountCodesQuery"></a>
+
 `DiscountCodesQuery(connector: ShopifyConnector)`
 :   Query class for DiscountCodes entity operations.
     
@@ -343,6 +357,8 @@ Classes
         
         Returns:
             DiscountCodesListResult
+
+<a id="DraftOrdersQuery"></a>
 
 `DraftOrdersQuery(connector: ShopifyConnector)`
 :   Query class for DraftOrders entity operations.
@@ -397,6 +413,8 @@ Classes
         Returns:
             DraftOrdersListResult
 
+<a id="FulfillmentOrdersQuery"></a>
+
 `FulfillmentOrdersQuery(connector: ShopifyConnector)`
 :   Query class for FulfillmentOrders entity operations.
     
@@ -445,6 +463,8 @@ Classes
         
         Returns:
             FulfillmentOrdersListResult
+
+<a id="FulfillmentsQuery"></a>
 
 `FulfillmentsQuery(connector: ShopifyConnector)`
 :   Query class for Fulfillments entity operations.
@@ -502,6 +522,8 @@ Classes
         Returns:
             FulfillmentsListResult
 
+<a id="InventoryItemsQuery"></a>
+
 `InventoryItemsQuery(connector: ShopifyConnector)`
 :   Query class for InventoryItems entity operations.
     
@@ -552,6 +574,8 @@ Classes
         Returns:
             InventoryItemsListResult
 
+<a id="InventoryLevelsQuery"></a>
+
 `InventoryLevelsQuery(connector: ShopifyConnector)`
 :   Query class for InventoryLevels entity operations.
     
@@ -591,6 +615,8 @@ Classes
         
         Returns:
             InventoryLevelsListResult
+
+<a id="LocationsQuery"></a>
 
 `LocationsQuery(connector: ShopifyConnector)`
 :   Query class for Locations entity operations.
@@ -637,6 +663,8 @@ Classes
         Returns:
             LocationsListResult
 
+<a id="MetafieldCustomersQuery"></a>
+
 `MetafieldCustomersQuery(connector: ShopifyConnector)`
 :   Query class for MetafieldCustomers entity operations.
     
@@ -679,6 +707,8 @@ Classes
         
         Returns:
             MetafieldCustomersListResult
+
+<a id="MetafieldDraftOrdersQuery"></a>
 
 `MetafieldDraftOrdersQuery(connector: ShopifyConnector)`
 :   Query class for MetafieldDraftOrders entity operations.
@@ -723,6 +753,8 @@ Classes
         Returns:
             MetafieldDraftOrdersListResult
 
+<a id="MetafieldLocationsQuery"></a>
+
 `MetafieldLocationsQuery(connector: ShopifyConnector)`
 :   Query class for MetafieldLocations entity operations.
     
@@ -766,6 +798,8 @@ Classes
         Returns:
             MetafieldLocationsListResult
 
+<a id="MetafieldOrdersQuery"></a>
+
 `MetafieldOrdersQuery(connector: ShopifyConnector)`
 :   Query class for MetafieldOrders entity operations.
     
@@ -808,6 +842,8 @@ Classes
         
         Returns:
             MetafieldOrdersListResult
+
+<a id="MetafieldProductImagesQuery"></a>
 
 `MetafieldProductImagesQuery(connector: ShopifyConnector)`
 :   Query class for MetafieldProductImages entity operations.
@@ -853,6 +889,8 @@ Classes
         Returns:
             MetafieldProductImagesListResult
 
+<a id="MetafieldProductVariantsQuery"></a>
+
 `MetafieldProductVariantsQuery(connector: ShopifyConnector)`
 :   Query class for MetafieldProductVariants entity operations.
     
@@ -896,6 +934,8 @@ Classes
         Returns:
             MetafieldProductVariantsListResult
 
+<a id="MetafieldProductsQuery"></a>
+
 `MetafieldProductsQuery(connector: ShopifyConnector)`
 :   Query class for MetafieldProducts entity operations.
     
@@ -938,6 +978,8 @@ Classes
         
         Returns:
             MetafieldProductsListResult
+
+<a id="MetafieldShopsQuery"></a>
 
 `MetafieldShopsQuery(connector: ShopifyConnector)`
 :   Query class for MetafieldShops entity operations.
@@ -992,6 +1034,8 @@ Classes
         Returns:
             MetafieldShopsListResult
 
+<a id="MetafieldSmartCollectionsQuery"></a>
+
 `MetafieldSmartCollectionsQuery(connector: ShopifyConnector)`
 :   Query class for MetafieldSmartCollections entity operations.
     
@@ -1034,6 +1078,8 @@ Classes
         
         Returns:
             MetafieldSmartCollectionsListResult
+
+<a id="OrderRefundsQuery"></a>
 
 `OrderRefundsQuery(connector: ShopifyConnector)`
 :   Query class for OrderRefunds entity operations.
@@ -1086,6 +1132,8 @@ Classes
         Returns:
             OrderRefundsListResult
 
+<a id="OrdersQuery"></a>
+
 `OrdersQuery(connector: ShopifyConnector)`
 :   Query class for Orders entity operations.
     
@@ -1120,6 +1168,8 @@ Classes
         
         Returns:
             OrdersListResult
+
+<a id="PriceRulesQuery"></a>
 
 `PriceRulesQuery(connector: ShopifyConnector)`
 :   Query class for PriceRules entity operations.
@@ -1175,6 +1225,8 @@ Classes
         Returns:
             PriceRulesListResult
 
+<a id="ProductImagesQuery"></a>
+
 `ProductImagesQuery(connector: ShopifyConnector)`
 :   Query class for ProductImages entity operations.
     
@@ -1225,6 +1277,8 @@ Classes
         
         Returns:
             ProductImagesListResult
+
+<a id="ProductVariantsQuery"></a>
 
 `ProductVariantsQuery(connector: ShopifyConnector)`
 :   Query class for ProductVariants entity operations.
@@ -1277,6 +1331,8 @@ Classes
         Returns:
             ProductVariantsListResult
 
+<a id="ProductsQuery"></a>
+
 `ProductsQuery(connector: ShopifyConnector)`
 :   Query class for Products entity operations.
     
@@ -1313,6 +1369,8 @@ Classes
         Returns:
             ProductsListResult
 
+<a id="ShopQuery"></a>
+
 `ShopQuery(connector: ShopifyConnector)`
 :   Query class for Shop entity operations.
     
@@ -1347,6 +1405,8 @@ Classes
         
         Returns:
             Shop
+
+<a id="ShopifyConnector"></a>
 
 `ShopifyConnector(auth_config: ShopifyAuthConfig | AirbyteAuthConfig | BaseModel | None = None, on_token_refresh: Any | None = None, shop: str | None = None)`
 :   Type-safe Shopify API connector.
@@ -1536,6 +1596,8 @@ Classes
             for entity in entities:
                 print(f"\{entity['entity_name']\}: \{entity['available_actions']\}")
 
+<a id="SmartCollectionsQuery"></a>
+
 `SmartCollectionsQuery(connector: ShopifyConnector)`
 :   Query class for SmartCollections entity operations.
     
@@ -1590,6 +1652,8 @@ Classes
         Returns:
             SmartCollectionsListResult
 
+<a id="TenderTransactionsQuery"></a>
+
 `TenderTransactionsQuery(connector: ShopifyConnector)`
 :   Query class for TenderTransactions entity operations.
     
@@ -1632,6 +1696,8 @@ Classes
         
         Returns:
             TenderTransactionsListResult
+
+<a id="TransactionsQuery"></a>
 
 `TransactionsQuery(connector: ShopifyConnector)`
 :   Query class for Transactions entity operations.

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/shopify/index.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/shopify/index.md
@@ -19,6 +19,8 @@ Sub-modules
 Classes
 -------
 
+<a id="AbandonedCheckoutsSearchData"></a>
+
 `AbandonedCheckoutsSearchData(**data: Any)`
 :   Search result data for abandoned_checkouts entity.
     
@@ -37,6 +39,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="AirbyteAuthConfig"></a>
 
 `AirbyteAuthConfig(**data: Any)`
 :   Authentication configuration for Airbyte hosted mode execution.
@@ -106,6 +110,8 @@ Classes
     `workspace_name: str | None`
     :   The type of the None singleton.
 
+<a id="AirbyteSearchMeta"></a>
+
 `AirbyteSearchMeta(**data: Any)`
 :   Pagination metadata for search responses.
     
@@ -133,6 +139,8 @@ Classes
 
     `took_ms: int | None`
     :   Time taken to execute the search in milliseconds.
+
+<a id="AirbyteSearchResult"></a>
 
 `AirbyteSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -191,6 +199,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="AbandonedCheckoutsSearchResult"></a>
+
 `AbandonedCheckoutsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -206,6 +216,8 @@ Classes
     * airbyte_agent_sdk.connectors.shopify.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="CollectsSearchResult"></a>
 
 `CollectsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -223,6 +235,8 @@ Classes
     * pydantic.main.BaseModel
     * typing.Generic
 
+<a id="CountriesSearchResult"></a>
+
 `CountriesSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -238,6 +252,8 @@ Classes
     * airbyte_agent_sdk.connectors.shopify.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="CustomCollectionsSearchResult"></a>
 
 `CustomCollectionsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -255,6 +271,8 @@ Classes
     * pydantic.main.BaseModel
     * typing.Generic
 
+<a id="CustomersSearchResult"></a>
+
 `CustomersSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -270,6 +288,8 @@ Classes
     * airbyte_agent_sdk.connectors.shopify.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="DiscountCodesSearchResult"></a>
 
 `DiscountCodesSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -287,6 +307,8 @@ Classes
     * pydantic.main.BaseModel
     * typing.Generic
 
+<a id="DraftOrdersSearchResult"></a>
+
 `DraftOrdersSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -302,6 +324,8 @@ Classes
     * airbyte_agent_sdk.connectors.shopify.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="FulfillmentOrdersSearchResult"></a>
 
 `FulfillmentOrdersSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -319,6 +343,8 @@ Classes
     * pydantic.main.BaseModel
     * typing.Generic
 
+<a id="FulfillmentsSearchResult"></a>
+
 `FulfillmentsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -334,6 +360,8 @@ Classes
     * airbyte_agent_sdk.connectors.shopify.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="InventoryItemsSearchResult"></a>
 
 `InventoryItemsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -351,6 +379,8 @@ Classes
     * pydantic.main.BaseModel
     * typing.Generic
 
+<a id="InventoryLevelsSearchResult"></a>
+
 `InventoryLevelsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -366,6 +396,8 @@ Classes
     * airbyte_agent_sdk.connectors.shopify.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="LocationsSearchResult"></a>
 
 `LocationsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -383,6 +415,8 @@ Classes
     * pydantic.main.BaseModel
     * typing.Generic
 
+<a id="MetafieldCustomersSearchResult"></a>
+
 `MetafieldCustomersSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -398,6 +432,8 @@ Classes
     * airbyte_agent_sdk.connectors.shopify.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="MetafieldDraftOrdersSearchResult"></a>
 
 `MetafieldDraftOrdersSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -415,6 +451,8 @@ Classes
     * pydantic.main.BaseModel
     * typing.Generic
 
+<a id="MetafieldLocationsSearchResult"></a>
+
 `MetafieldLocationsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -430,6 +468,8 @@ Classes
     * airbyte_agent_sdk.connectors.shopify.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="MetafieldOrdersSearchResult"></a>
 
 `MetafieldOrdersSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -447,6 +487,8 @@ Classes
     * pydantic.main.BaseModel
     * typing.Generic
 
+<a id="MetafieldProductImagesSearchResult"></a>
+
 `MetafieldProductImagesSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -462,6 +504,8 @@ Classes
     * airbyte_agent_sdk.connectors.shopify.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="MetafieldProductVariantsSearchResult"></a>
 
 `MetafieldProductVariantsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -479,6 +523,8 @@ Classes
     * pydantic.main.BaseModel
     * typing.Generic
 
+<a id="MetafieldProductsSearchResult"></a>
+
 `MetafieldProductsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -494,6 +540,8 @@ Classes
     * airbyte_agent_sdk.connectors.shopify.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="MetafieldShopsSearchResult"></a>
 
 `MetafieldShopsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -511,6 +559,8 @@ Classes
     * pydantic.main.BaseModel
     * typing.Generic
 
+<a id="MetafieldSmartCollectionsSearchResult"></a>
+
 `MetafieldSmartCollectionsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -526,6 +576,8 @@ Classes
     * airbyte_agent_sdk.connectors.shopify.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="OrderRefundsSearchResult"></a>
 
 `OrderRefundsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -543,6 +595,8 @@ Classes
     * pydantic.main.BaseModel
     * typing.Generic
 
+<a id="PriceRulesSearchResult"></a>
+
 `PriceRulesSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -558,6 +612,8 @@ Classes
     * airbyte_agent_sdk.connectors.shopify.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="ProductImagesSearchResult"></a>
 
 `ProductImagesSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -575,6 +631,8 @@ Classes
     * pydantic.main.BaseModel
     * typing.Generic
 
+<a id="ProductVariantsSearchResult"></a>
+
 `ProductVariantsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -590,6 +648,8 @@ Classes
     * airbyte_agent_sdk.connectors.shopify.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="ShopSearchResult"></a>
 
 `ShopSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -607,6 +667,8 @@ Classes
     * pydantic.main.BaseModel
     * typing.Generic
 
+<a id="SmartCollectionsSearchResult"></a>
+
 `SmartCollectionsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -623,6 +685,8 @@ Classes
     * pydantic.main.BaseModel
     * typing.Generic
 
+<a id="TenderTransactionsSearchResult"></a>
+
 `TenderTransactionsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -638,6 +702,8 @@ Classes
     * airbyte_agent_sdk.connectors.shopify.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="CollectsSearchData"></a>
 
 `CollectsSearchData(**data: Any)`
 :   Search result data for collects entity.
@@ -658,6 +724,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="CountriesSearchData"></a>
+
 `CountriesSearchData(**data: Any)`
 :   Search result data for countries entity.
     
@@ -676,6 +744,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="CustomCollectionsSearchData"></a>
 
 `CustomCollectionsSearchData(**data: Any)`
 :   Search result data for custom_collections entity.
@@ -696,6 +766,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="CustomersSearchData"></a>
+
 `CustomersSearchData(**data: Any)`
 :   Search result data for customers entity.
     
@@ -714,6 +786,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="DiscountCodesSearchData"></a>
 
 `DiscountCodesSearchData(**data: Any)`
 :   Search result data for discount_codes entity.
@@ -734,6 +808,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="DraftOrdersSearchData"></a>
+
 `DraftOrdersSearchData(**data: Any)`
 :   Search result data for draft_orders entity.
     
@@ -752,6 +828,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="FulfillmentOrdersSearchData"></a>
 
 `FulfillmentOrdersSearchData(**data: Any)`
 :   Search result data for fulfillment_orders entity.
@@ -772,6 +850,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="FulfillmentsSearchData"></a>
+
 `FulfillmentsSearchData(**data: Any)`
 :   Search result data for fulfillments entity.
     
@@ -790,6 +870,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="InventoryItemsSearchData"></a>
 
 `InventoryItemsSearchData(**data: Any)`
 :   Search result data for inventory_items entity.
@@ -810,6 +892,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="InventoryLevelsSearchData"></a>
+
 `InventoryLevelsSearchData(**data: Any)`
 :   Search result data for inventory_levels entity.
     
@@ -828,6 +912,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="LocationsSearchData"></a>
 
 `LocationsSearchData(**data: Any)`
 :   Search result data for locations entity.
@@ -848,6 +934,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="MetafieldCustomersSearchData"></a>
+
 `MetafieldCustomersSearchData(**data: Any)`
 :   Search result data for metafield_customers entity.
     
@@ -866,6 +954,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="MetafieldDraftOrdersSearchData"></a>
 
 `MetafieldDraftOrdersSearchData(**data: Any)`
 :   Search result data for metafield_draft_orders entity.
@@ -886,6 +976,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="MetafieldLocationsSearchData"></a>
+
 `MetafieldLocationsSearchData(**data: Any)`
 :   Search result data for metafield_locations entity.
     
@@ -904,6 +996,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="MetafieldOrdersSearchData"></a>
 
 `MetafieldOrdersSearchData(**data: Any)`
 :   Search result data for metafield_orders entity.
@@ -924,6 +1018,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="MetafieldProductImagesSearchData"></a>
+
 `MetafieldProductImagesSearchData(**data: Any)`
 :   Search result data for metafield_product_images entity.
     
@@ -942,6 +1038,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="MetafieldProductVariantsSearchData"></a>
 
 `MetafieldProductVariantsSearchData(**data: Any)`
 :   Search result data for metafield_product_variants entity.
@@ -962,6 +1060,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="MetafieldProductsSearchData"></a>
+
 `MetafieldProductsSearchData(**data: Any)`
 :   Search result data for metafield_products entity.
     
@@ -980,6 +1080,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="MetafieldShopsSearchData"></a>
 
 `MetafieldShopsSearchData(**data: Any)`
 :   Search result data for metafield_shops entity.
@@ -1000,6 +1102,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="MetafieldSmartCollectionsSearchData"></a>
+
 `MetafieldSmartCollectionsSearchData(**data: Any)`
 :   Search result data for metafield_smart_collections entity.
     
@@ -1018,6 +1122,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="OrderRefundsSearchData"></a>
 
 `OrderRefundsSearchData(**data: Any)`
 :   Search result data for order_refunds entity.
@@ -1038,6 +1144,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="PriceRulesSearchData"></a>
+
 `PriceRulesSearchData(**data: Any)`
 :   Search result data for price_rules entity.
     
@@ -1056,6 +1164,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="ProductImagesSearchData"></a>
 
 `ProductImagesSearchData(**data: Any)`
 :   Search result data for product_images entity.
@@ -1076,6 +1186,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="ProductVariantsSearchData"></a>
+
 `ProductVariantsSearchData(**data: Any)`
 :   Search result data for product_variants entity.
     
@@ -1095,6 +1207,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="ShopSearchData"></a>
+
 `ShopSearchData(**data: Any)`
 :   Search result data for shop entity.
     
@@ -1113,6 +1227,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="ShopifyAuthConfig"></a>
 
 `ShopifyAuthConfig(**data: Any)`
 :   Access Token Authentication
@@ -1135,6 +1251,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="ShopifyConnector"></a>
 
 `ShopifyConnector(auth_config: ShopifyAuthConfig | AirbyteAuthConfig | BaseModel | None = None, on_token_refresh: Any | None = None, shop: str | None = None)`
 :   Type-safe Shopify API connector.
@@ -1324,6 +1442,8 @@ Classes
             for entity in entities:
                 print(f"\{entity['entity_name']\}: \{entity['available_actions']\}")
 
+<a id="SmartCollectionsSearchData"></a>
+
 `SmartCollectionsSearchData(**data: Any)`
 :   Search result data for smart_collections entity.
     
@@ -1342,6 +1462,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="TenderTransactionsSearchData"></a>
 
 `TenderTransactionsSearchData(**data: Any)`
 :   Search result data for tender_transactions entity.

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/shopify/models.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/shopify/models.md
@@ -13,6 +13,8 @@ and response envelope types.
 Classes
 -------
 
+<a id="AbandonedCheckout"></a>
+
 `AbandonedCheckout(**data: Any)`
 :   An abandoned checkout
     
@@ -167,6 +169,8 @@ Classes
     `user_id: int | Any | None`
     :   The type of the None singleton.
 
+<a id="AbandonedCheckoutList"></a>
+
 `AbandonedCheckoutList(**data: Any)`
 :   AbandonedCheckoutList type definition
     
@@ -188,6 +192,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="AbandonedCheckoutsListResultMeta"></a>
 
 `AbandonedCheckoutsListResultMeta(**data: Any)`
 :   Metadata for abandoned_checkouts.Action.LIST operation
@@ -211,6 +217,8 @@ Classes
     `next_page_url: str | Any | None`
     :   The type of the None singleton.
 
+<a id="AbandonedCheckoutsSearchData"></a>
+
 `AbandonedCheckoutsSearchData(**data: Any)`
 :   Search result data for abandoned_checkouts entity.
     
@@ -229,6 +237,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="AirbyteSearchMeta"></a>
 
 `AirbyteSearchMeta(**data: Any)`
 :   Pagination metadata for search responses.
@@ -257,6 +267,8 @@ Classes
 
     `took_ms: int | None`
     :   Time taken to execute the search in milliseconds.
+
+<a id="AirbyteSearchResult"></a>
 
 `AirbyteSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -336,6 +348,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="AbandonedCheckoutsSearchResult"></a>
+
 `AbandonedCheckoutsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -372,6 +386,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="CollectsSearchResult"></a>
 
 `CollectsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -410,6 +426,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="CountriesSearchResult"></a>
+
 `CountriesSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -446,6 +464,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="CustomCollectionsSearchResult"></a>
 
 `CustomCollectionsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -484,6 +504,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="CustomersSearchResult"></a>
+
 `CustomersSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -520,6 +542,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="DiscountCodesSearchResult"></a>
 
 `DiscountCodesSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -558,6 +582,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="DraftOrdersSearchResult"></a>
+
 `DraftOrdersSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -594,6 +620,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="FulfillmentOrdersSearchResult"></a>
 
 `FulfillmentOrdersSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -632,6 +660,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="FulfillmentsSearchResult"></a>
+
 `FulfillmentsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -668,6 +698,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="InventoryItemsSearchResult"></a>
 
 `InventoryItemsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -706,6 +738,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="InventoryLevelsSearchResult"></a>
+
 `InventoryLevelsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -742,6 +776,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="LocationsSearchResult"></a>
 
 `LocationsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -780,6 +816,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="MetafieldCustomersSearchResult"></a>
+
 `MetafieldCustomersSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -816,6 +854,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="MetafieldDraftOrdersSearchResult"></a>
 
 `MetafieldDraftOrdersSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -854,6 +894,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="MetafieldLocationsSearchResult"></a>
+
 `MetafieldLocationsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -890,6 +932,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="MetafieldOrdersSearchResult"></a>
 
 `MetafieldOrdersSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -928,6 +972,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="MetafieldProductImagesSearchResult"></a>
+
 `MetafieldProductImagesSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -964,6 +1010,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="MetafieldProductVariantsSearchResult"></a>
 
 `MetafieldProductVariantsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -1002,6 +1050,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="MetafieldProductsSearchResult"></a>
+
 `MetafieldProductsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -1038,6 +1088,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="MetafieldShopsSearchResult"></a>
 
 `MetafieldShopsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -1076,6 +1128,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="MetafieldSmartCollectionsSearchResult"></a>
+
 `MetafieldSmartCollectionsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -1112,6 +1166,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="OrderRefundsSearchResult"></a>
 
 `OrderRefundsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -1150,6 +1206,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="PriceRulesSearchResult"></a>
+
 `PriceRulesSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -1186,6 +1244,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="ProductImagesSearchResult"></a>
 
 `ProductImagesSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -1224,6 +1284,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="ProductVariantsSearchResult"></a>
+
 `ProductVariantsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -1260,6 +1322,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="ShopSearchResult"></a>
 
 `ShopSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -1298,6 +1362,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="SmartCollectionsSearchResult"></a>
+
 `SmartCollectionsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -1335,6 +1401,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="TenderTransactionsSearchResult"></a>
+
 `TenderTransactionsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -1350,6 +1418,8 @@ Classes
     * airbyte_agent_sdk.connectors.shopify.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="Collect"></a>
 
 `Collect(**data: Any)`
 :   A collect (product-collection link)
@@ -1391,6 +1461,8 @@ Classes
     `updated_at: str | Any | None`
     :   The type of the None singleton.
 
+<a id="CollectList"></a>
+
 `CollectList(**data: Any)`
 :   CollectList type definition
     
@@ -1412,6 +1484,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="CollectsListResultMeta"></a>
 
 `CollectsListResultMeta(**data: Any)`
 :   Metadata for collects.Action.LIST operation
@@ -1435,6 +1509,8 @@ Classes
     `next_page_url: str | Any | None`
     :   The type of the None singleton.
 
+<a id="CollectsSearchData"></a>
+
 `CollectsSearchData(**data: Any)`
 :   Search result data for collects entity.
     
@@ -1453,6 +1529,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="CountriesListResultMeta"></a>
 
 `CountriesListResultMeta(**data: Any)`
 :   Metadata for countries.Action.LIST operation
@@ -1476,6 +1554,8 @@ Classes
     `next_page_url: str | Any | None`
     :   The type of the None singleton.
 
+<a id="CountriesSearchData"></a>
+
 `CountriesSearchData(**data: Any)`
 :   Search result data for countries entity.
     
@@ -1494,6 +1574,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="Country"></a>
 
 `Country(**data: Any)`
 :   A country
@@ -1532,6 +1614,8 @@ Classes
     `tax_name: str | Any | None`
     :   The type of the None singleton.
 
+<a id="CountryList"></a>
+
 `CountryList(**data: Any)`
 :   CountryList type definition
     
@@ -1553,6 +1637,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="CustomCollection"></a>
 
 `CustomCollection(**data: Any)`
 :   A custom collection
@@ -1609,6 +1695,8 @@ Classes
     `updated_at: str | Any | None`
     :   The type of the None singleton.
 
+<a id="CustomCollectionList"></a>
+
 `CustomCollectionList(**data: Any)`
 :   CustomCollectionList type definition
     
@@ -1630,6 +1718,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="CustomCollectionsListResultMeta"></a>
 
 `CustomCollectionsListResultMeta(**data: Any)`
 :   Metadata for custom_collections.Action.LIST operation
@@ -1653,6 +1743,8 @@ Classes
     `next_page_url: str | Any | None`
     :   The type of the None singleton.
 
+<a id="CustomCollectionsSearchData"></a>
+
 `CustomCollectionsSearchData(**data: Any)`
 :   Search result data for custom_collections entity.
     
@@ -1671,6 +1763,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="Customer"></a>
 
 `Customer(**data: Any)`
 :   A Shopify customer
@@ -1772,6 +1866,8 @@ Classes
     `verified_email: bool | Any | None`
     :   The type of the None singleton.
 
+<a id="CustomerAddress"></a>
+
 `CustomerAddress(**data: Any)`
 :   A customer address
     
@@ -1842,6 +1938,8 @@ Classes
     `zip: str | Any | None`
     :   The type of the None singleton.
 
+<a id="CustomerAddressList"></a>
+
 `CustomerAddressList(**data: Any)`
 :   CustomerAddressList type definition
     
@@ -1863,6 +1961,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="CustomerAddressListResultMeta"></a>
 
 `CustomerAddressListResultMeta(**data: Any)`
 :   Metadata for customer_address.Action.LIST operation
@@ -1886,6 +1986,8 @@ Classes
     `next_page_url: str | Any | None`
     :   The type of the None singleton.
 
+<a id="CustomerList"></a>
+
 `CustomerList(**data: Any)`
 :   CustomerList type definition
     
@@ -1907,6 +2009,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="CustomersListResultMeta"></a>
 
 `CustomersListResultMeta(**data: Any)`
 :   Metadata for customers.Action.LIST operation
@@ -1930,6 +2034,8 @@ Classes
     `next_page_url: str | Any | None`
     :   The type of the None singleton.
 
+<a id="CustomersSearchData"></a>
+
 `CustomersSearchData(**data: Any)`
 :   Search result data for customers entity.
     
@@ -1948,6 +2054,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="DiscountCode"></a>
 
 `DiscountCode(**data: Any)`
 :   A discount code
@@ -1986,6 +2094,8 @@ Classes
     `usage_count: int | Any | None`
     :   The type of the None singleton.
 
+<a id="DiscountCodeList"></a>
+
 `DiscountCodeList(**data: Any)`
 :   DiscountCodeList type definition
     
@@ -2007,6 +2117,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="DiscountCodesListResultMeta"></a>
 
 `DiscountCodesListResultMeta(**data: Any)`
 :   Metadata for discount_codes.Action.LIST operation
@@ -2030,6 +2142,8 @@ Classes
     `next_page_url: str | Any | None`
     :   The type of the None singleton.
 
+<a id="DiscountCodesSearchData"></a>
+
 `DiscountCodesSearchData(**data: Any)`
 :   Search result data for discount_codes entity.
     
@@ -2048,6 +2162,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="DraftOrder"></a>
 
 `DraftOrder(**data: Any)`
 :   A draft order
@@ -2164,6 +2280,8 @@ Classes
     `updated_at: str | Any | None`
     :   The type of the None singleton.
 
+<a id="DraftOrderList"></a>
+
 `DraftOrderList(**data: Any)`
 :   DraftOrderList type definition
     
@@ -2185,6 +2303,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="DraftOrdersListResultMeta"></a>
 
 `DraftOrdersListResultMeta(**data: Any)`
 :   Metadata for draft_orders.Action.LIST operation
@@ -2208,6 +2328,8 @@ Classes
     `next_page_url: str | Any | None`
     :   The type of the None singleton.
 
+<a id="DraftOrdersSearchData"></a>
+
 `DraftOrdersSearchData(**data: Any)`
 :   Search result data for draft_orders entity.
     
@@ -2226,6 +2348,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="Fulfillment"></a>
 
 `Fulfillment(**data: Any)`
 :   A fulfillment
@@ -2300,6 +2424,8 @@ Classes
     `updated_at: str | Any | None`
     :   The type of the None singleton.
 
+<a id="FulfillmentList"></a>
+
 `FulfillmentList(**data: Any)`
 :   FulfillmentList type definition
     
@@ -2321,6 +2447,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="FulfillmentOrder"></a>
 
 `FulfillmentOrder(**data: Any)`
 :   A fulfillment order
@@ -2395,6 +2523,8 @@ Classes
     `updated_at: str | Any | None`
     :   The type of the None singleton.
 
+<a id="FulfillmentOrderList"></a>
+
 `FulfillmentOrderList(**data: Any)`
 :   FulfillmentOrderList type definition
     
@@ -2416,6 +2546,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="FulfillmentOrdersListResultMeta"></a>
 
 `FulfillmentOrdersListResultMeta(**data: Any)`
 :   Metadata for fulfillment_orders.Action.LIST operation
@@ -2439,6 +2571,8 @@ Classes
     `next_page_url: str | Any | None`
     :   The type of the None singleton.
 
+<a id="FulfillmentOrdersSearchData"></a>
+
 `FulfillmentOrdersSearchData(**data: Any)`
 :   Search result data for fulfillment_orders entity.
     
@@ -2457,6 +2591,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="FulfillmentsListResultMeta"></a>
 
 `FulfillmentsListResultMeta(**data: Any)`
 :   Metadata for fulfillments.Action.LIST operation
@@ -2480,6 +2616,8 @@ Classes
     `next_page_url: str | Any | None`
     :   The type of the None singleton.
 
+<a id="FulfillmentsSearchData"></a>
+
 `FulfillmentsSearchData(**data: Any)`
 :   Search result data for fulfillments entity.
     
@@ -2498,6 +2636,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="InventoryItem"></a>
 
 `InventoryItem(**data: Any)`
 :   An inventory item
@@ -2554,6 +2694,8 @@ Classes
     `updated_at: str | Any | None`
     :   The type of the None singleton.
 
+<a id="InventoryItemList"></a>
+
 `InventoryItemList(**data: Any)`
 :   InventoryItemList type definition
     
@@ -2575,6 +2717,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="InventoryItemsListResultMeta"></a>
 
 `InventoryItemsListResultMeta(**data: Any)`
 :   Metadata for inventory_items.Action.LIST operation
@@ -2598,6 +2742,8 @@ Classes
     `next_page_url: str | Any | None`
     :   The type of the None singleton.
 
+<a id="InventoryItemsSearchData"></a>
+
 `InventoryItemsSearchData(**data: Any)`
 :   Search result data for inventory_items entity.
     
@@ -2616,6 +2762,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="InventoryLevel"></a>
 
 `InventoryLevel(**data: Any)`
 :   An inventory level
@@ -2651,6 +2799,8 @@ Classes
     `updated_at: str | Any | None`
     :   The type of the None singleton.
 
+<a id="InventoryLevelList"></a>
+
 `InventoryLevelList(**data: Any)`
 :   InventoryLevelList type definition
     
@@ -2672,6 +2822,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="InventoryLevelsListResultMeta"></a>
 
 `InventoryLevelsListResultMeta(**data: Any)`
 :   Metadata for inventory_levels.Action.LIST operation
@@ -2695,6 +2847,8 @@ Classes
     `next_page_url: str | Any | None`
     :   The type of the None singleton.
 
+<a id="InventoryLevelsSearchData"></a>
+
 `InventoryLevelsSearchData(**data: Any)`
 :   Search result data for inventory_levels entity.
     
@@ -2713,6 +2867,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="LineItem"></a>
 
 `LineItem(**data: Any)`
 :   LineItem type definition
@@ -2820,6 +2976,8 @@ Classes
     `vendor: str | Any | None`
     :   The type of the None singleton.
 
+<a id="Location"></a>
+
 `Location(**data: Any)`
 :   A store location
     
@@ -2896,6 +3054,8 @@ Classes
     `zip: str | Any | None`
     :   The type of the None singleton.
 
+<a id="LocationList"></a>
+
 `LocationList(**data: Any)`
 :   LocationList type definition
     
@@ -2917,6 +3077,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="LocationsListResultMeta"></a>
 
 `LocationsListResultMeta(**data: Any)`
 :   Metadata for locations.Action.LIST operation
@@ -2940,6 +3102,8 @@ Classes
     `next_page_url: str | Any | None`
     :   The type of the None singleton.
 
+<a id="LocationsSearchData"></a>
+
 `LocationsSearchData(**data: Any)`
 :   Search result data for locations entity.
     
@@ -2958,6 +3122,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="MarketingConsent"></a>
 
 `MarketingConsent(**data: Any)`
 :   MarketingConsent type definition
@@ -2989,6 +3155,8 @@ Classes
 
     `state: str | Any | None`
     :   The type of the None singleton.
+
+<a id="Metafield"></a>
 
 `Metafield(**data: Any)`
 :   A metafield
@@ -3042,6 +3210,8 @@ Classes
     `value: Any`
     :   The type of the None singleton.
 
+<a id="MetafieldCustomersListResultMeta"></a>
+
 `MetafieldCustomersListResultMeta(**data: Any)`
 :   Metadata for metafield_customers.Action.LIST operation
     
@@ -3064,6 +3234,8 @@ Classes
     `next_page_url: str | Any | None`
     :   The type of the None singleton.
 
+<a id="MetafieldCustomersSearchData"></a>
+
 `MetafieldCustomersSearchData(**data: Any)`
 :   Search result data for metafield_customers entity.
     
@@ -3082,6 +3254,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="MetafieldDraftOrdersListResultMeta"></a>
 
 `MetafieldDraftOrdersListResultMeta(**data: Any)`
 :   Metadata for metafield_draft_orders.Action.LIST operation
@@ -3105,6 +3279,8 @@ Classes
     `next_page_url: str | Any | None`
     :   The type of the None singleton.
 
+<a id="MetafieldDraftOrdersSearchData"></a>
+
 `MetafieldDraftOrdersSearchData(**data: Any)`
 :   Search result data for metafield_draft_orders entity.
     
@@ -3123,6 +3299,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="MetafieldList"></a>
 
 `MetafieldList(**data: Any)`
 :   MetafieldList type definition
@@ -3146,6 +3324,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="MetafieldLocationsListResultMeta"></a>
+
 `MetafieldLocationsListResultMeta(**data: Any)`
 :   Metadata for metafield_locations.Action.LIST operation
     
@@ -3168,6 +3348,8 @@ Classes
     `next_page_url: str | Any | None`
     :   The type of the None singleton.
 
+<a id="MetafieldLocationsSearchData"></a>
+
 `MetafieldLocationsSearchData(**data: Any)`
 :   Search result data for metafield_locations entity.
     
@@ -3186,6 +3368,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="MetafieldOrdersListResultMeta"></a>
 
 `MetafieldOrdersListResultMeta(**data: Any)`
 :   Metadata for metafield_orders.Action.LIST operation
@@ -3209,6 +3393,8 @@ Classes
     `next_page_url: str | Any | None`
     :   The type of the None singleton.
 
+<a id="MetafieldOrdersSearchData"></a>
+
 `MetafieldOrdersSearchData(**data: Any)`
 :   Search result data for metafield_orders entity.
     
@@ -3227,6 +3413,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="MetafieldProductImagesListResultMeta"></a>
 
 `MetafieldProductImagesListResultMeta(**data: Any)`
 :   Metadata for metafield_product_images.Action.LIST operation
@@ -3250,6 +3438,8 @@ Classes
     `next_page_url: str | Any | None`
     :   The type of the None singleton.
 
+<a id="MetafieldProductImagesSearchData"></a>
+
 `MetafieldProductImagesSearchData(**data: Any)`
 :   Search result data for metafield_product_images entity.
     
@@ -3268,6 +3458,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="MetafieldProductVariantsListResultMeta"></a>
 
 `MetafieldProductVariantsListResultMeta(**data: Any)`
 :   Metadata for metafield_product_variants.Action.LIST operation
@@ -3291,6 +3483,8 @@ Classes
     `next_page_url: str | Any | None`
     :   The type of the None singleton.
 
+<a id="MetafieldProductVariantsSearchData"></a>
+
 `MetafieldProductVariantsSearchData(**data: Any)`
 :   Search result data for metafield_product_variants entity.
     
@@ -3309,6 +3503,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="MetafieldProductsListResultMeta"></a>
 
 `MetafieldProductsListResultMeta(**data: Any)`
 :   Metadata for metafield_products.Action.LIST operation
@@ -3332,6 +3528,8 @@ Classes
     `next_page_url: str | Any | None`
     :   The type of the None singleton.
 
+<a id="MetafieldProductsSearchData"></a>
+
 `MetafieldProductsSearchData(**data: Any)`
 :   Search result data for metafield_products entity.
     
@@ -3350,6 +3548,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="MetafieldShopsListResultMeta"></a>
 
 `MetafieldShopsListResultMeta(**data: Any)`
 :   Metadata for metafield_shops.Action.LIST operation
@@ -3373,6 +3573,8 @@ Classes
     `next_page_url: str | Any | None`
     :   The type of the None singleton.
 
+<a id="MetafieldShopsSearchData"></a>
+
 `MetafieldShopsSearchData(**data: Any)`
 :   Search result data for metafield_shops entity.
     
@@ -3391,6 +3593,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="MetafieldSmartCollectionsListResultMeta"></a>
 
 `MetafieldSmartCollectionsListResultMeta(**data: Any)`
 :   Metadata for metafield_smart_collections.Action.LIST operation
@@ -3414,6 +3618,8 @@ Classes
     `next_page_url: str | Any | None`
     :   The type of the None singleton.
 
+<a id="MetafieldSmartCollectionsSearchData"></a>
+
 `MetafieldSmartCollectionsSearchData(**data: Any)`
 :   Search result data for metafield_smart_collections entity.
     
@@ -3432,6 +3638,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="Order"></a>
 
 `Order(**data: Any)`
 :   A Shopify order
@@ -3731,6 +3939,8 @@ Classes
     `user_id: int | Any | None`
     :   The type of the None singleton.
 
+<a id="OrderAddress"></a>
+
 `OrderAddress(**data: Any)`
 :   An address in an order (shipping or billing) - does not have id field
     
@@ -3795,6 +4005,8 @@ Classes
     `zip: str | Any | None`
     :   The type of the None singleton.
 
+<a id="OrderList"></a>
+
 `OrderList(**data: Any)`
 :   OrderList type definition
     
@@ -3816,6 +4028,8 @@ Classes
 
     `orders: list[airbyte_agent_sdk.connectors.shopify.models.Order] | Any`
     :   The type of the None singleton.
+
+<a id="OrderRefundsListResultMeta"></a>
 
 `OrderRefundsListResultMeta(**data: Any)`
 :   Metadata for order_refunds.Action.LIST operation
@@ -3839,6 +4053,8 @@ Classes
     `next_page_url: str | Any | None`
     :   The type of the None singleton.
 
+<a id="OrderRefundsSearchData"></a>
+
 `OrderRefundsSearchData(**data: Any)`
 :   Search result data for order_refunds entity.
     
@@ -3857,6 +4073,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="OrdersListResultMeta"></a>
 
 `OrdersListResultMeta(**data: Any)`
 :   Metadata for orders.Action.LIST operation
@@ -3879,6 +4097,8 @@ Classes
 
     `next_page_url: str | Any | None`
     :   The type of the None singleton.
+
+<a id="PriceRule"></a>
 
 `PriceRule(**data: Any)`
 :   A price rule
@@ -3989,6 +4209,8 @@ Classes
     `value_type: str | Any | None`
     :   The type of the None singleton.
 
+<a id="PriceRuleList"></a>
+
 `PriceRuleList(**data: Any)`
 :   PriceRuleList type definition
     
@@ -4010,6 +4232,8 @@ Classes
 
     `price_rules: list[airbyte_agent_sdk.connectors.shopify.models.PriceRule] | Any`
     :   The type of the None singleton.
+
+<a id="PriceRulesListResultMeta"></a>
 
 `PriceRulesListResultMeta(**data: Any)`
 :   Metadata for price_rules.Action.LIST operation
@@ -4033,6 +4257,8 @@ Classes
     `next_page_url: str | Any | None`
     :   The type of the None singleton.
 
+<a id="PriceRulesSearchData"></a>
+
 `PriceRulesSearchData(**data: Any)`
 :   Search result data for price_rules entity.
     
@@ -4051,6 +4277,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="Product"></a>
 
 `Product(**data: Any)`
 :   A Shopify product
@@ -4125,6 +4353,8 @@ Classes
     `vendor: str | Any | None`
     :   The type of the None singleton.
 
+<a id="ProductImage"></a>
+
 `ProductImage(**data: Any)`
 :   A product image
     
@@ -4177,6 +4407,8 @@ Classes
     `width: int | Any | None`
     :   The type of the None singleton.
 
+<a id="ProductImageList"></a>
+
 `ProductImageList(**data: Any)`
 :   ProductImageList type definition
     
@@ -4198,6 +4430,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="ProductImagesListResultMeta"></a>
 
 `ProductImagesListResultMeta(**data: Any)`
 :   Metadata for product_images.Action.LIST operation
@@ -4221,6 +4455,8 @@ Classes
     `next_page_url: str | Any | None`
     :   The type of the None singleton.
 
+<a id="ProductImagesSearchData"></a>
+
 `ProductImagesSearchData(**data: Any)`
 :   Search result data for product_images entity.
     
@@ -4239,6 +4475,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="ProductList"></a>
 
 `ProductList(**data: Any)`
 :   ProductList type definition
@@ -4261,6 +4499,8 @@ Classes
 
     `products: list[airbyte_agent_sdk.connectors.shopify.models.Product] | Any`
     :   The type of the None singleton.
+
+<a id="ProductVariant"></a>
 
 `ProductVariant(**data: Any)`
 :   A product variant
@@ -4359,6 +4599,8 @@ Classes
     `weight_unit: str | Any | None`
     :   The type of the None singleton.
 
+<a id="ProductVariantList"></a>
+
 `ProductVariantList(**data: Any)`
 :   ProductVariantList type definition
     
@@ -4380,6 +4622,8 @@ Classes
 
     `variants: list[airbyte_agent_sdk.connectors.shopify.models.ProductVariant] | Any`
     :   The type of the None singleton.
+
+<a id="ProductVariantsListResultMeta"></a>
 
 `ProductVariantsListResultMeta(**data: Any)`
 :   Metadata for product_variants.Action.LIST operation
@@ -4403,6 +4647,8 @@ Classes
     `next_page_url: str | Any | None`
     :   The type of the None singleton.
 
+<a id="ProductVariantsSearchData"></a>
+
 `ProductVariantsSearchData(**data: Any)`
 :   Search result data for product_variants entity.
     
@@ -4421,6 +4667,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="ProductsListResultMeta"></a>
 
 `ProductsListResultMeta(**data: Any)`
 :   Metadata for products.Action.LIST operation
@@ -4443,6 +4691,8 @@ Classes
 
     `next_page_url: str | Any | None`
     :   The type of the None singleton.
+
+<a id="Refund"></a>
 
 `Refund(**data: Any)`
 :   An order refund
@@ -4508,6 +4758,8 @@ Classes
     `user_id: int | Any | None`
     :   The type of the None singleton.
 
+<a id="RefundList"></a>
+
 `RefundList(**data: Any)`
 :   RefundList type definition
     
@@ -4529,6 +4781,8 @@ Classes
 
     `refunds: list[airbyte_agent_sdk.connectors.shopify.models.Refund] | Any`
     :   The type of the None singleton.
+
+<a id="Shop"></a>
 
 `Shop(**data: Any)`
 :   Shop configuration
@@ -4711,6 +4965,8 @@ Classes
     `zip: str | Any | None`
     :   The type of the None singleton.
 
+<a id="ShopSearchData"></a>
+
 `ShopSearchData(**data: Any)`
 :   Search result data for shop entity.
     
@@ -4729,6 +4985,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="ShopifyAuthConfig"></a>
 
 `ShopifyAuthConfig(**data: Any)`
 :   Access Token Authentication
@@ -4751,6 +5009,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="ShopifyCheckResult"></a>
 
 `ShopifyCheckResult(**data: Any)`
 :   Result of a health check operation.
@@ -4785,6 +5045,8 @@ Classes
     `status: str`
     :   Health check status: 'healthy' or 'unhealthy'.
 
+<a id="ShopifyExecuteResult"></a>
+
 `ShopifyExecuteResult(**data: Any)`
 :   Response envelope with data only.
     
@@ -4813,6 +5075,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="ShopifyExecuteResultWithMeta"></a>
 
 `ShopifyExecuteResultWithMeta(**data: Any)`
 :   Response envelope with data and metadata.
@@ -4895,6 +5159,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="AbandonedCheckoutsListResult"></a>
+
 `AbandonedCheckoutsListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -4937,6 +5203,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="CollectsListResult"></a>
 
 `CollectsListResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -4981,6 +5249,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="CountriesListResult"></a>
+
 `CountriesListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -5023,6 +5293,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="CustomCollectionsListResult"></a>
 
 `CustomCollectionsListResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -5067,6 +5339,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="CustomerAddressListResult"></a>
+
 `CustomerAddressListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -5109,6 +5383,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="CustomersListResult"></a>
 
 `CustomersListResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -5153,6 +5429,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="DiscountCodesListResult"></a>
+
 `DiscountCodesListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -5195,6 +5473,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="DraftOrdersListResult"></a>
 
 `DraftOrdersListResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -5239,6 +5519,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="FulfillmentOrdersListResult"></a>
+
 `FulfillmentOrdersListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -5281,6 +5563,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="FulfillmentsListResult"></a>
 
 `FulfillmentsListResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -5325,6 +5609,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="InventoryItemsListResult"></a>
+
 `InventoryItemsListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -5367,6 +5653,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="InventoryLevelsListResult"></a>
 
 `InventoryLevelsListResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -5411,6 +5699,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="LocationsListResult"></a>
+
 `LocationsListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -5453,6 +5743,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="MetafieldCustomersListResult"></a>
 
 `MetafieldCustomersListResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -5497,6 +5789,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="MetafieldDraftOrdersListResult"></a>
+
 `MetafieldDraftOrdersListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -5539,6 +5833,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="MetafieldLocationsListResult"></a>
 
 `MetafieldLocationsListResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -5583,6 +5879,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="MetafieldOrdersListResult"></a>
+
 `MetafieldOrdersListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -5625,6 +5923,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="MetafieldProductImagesListResult"></a>
 
 `MetafieldProductImagesListResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -5669,6 +5969,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="MetafieldProductVariantsListResult"></a>
+
 `MetafieldProductVariantsListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -5711,6 +6013,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="MetafieldProductsListResult"></a>
 
 `MetafieldProductsListResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -5755,6 +6059,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="MetafieldShopsListResult"></a>
+
 `MetafieldShopsListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -5797,6 +6103,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="MetafieldSmartCollectionsListResult"></a>
 
 `MetafieldSmartCollectionsListResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -5841,6 +6149,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="OrdersListResult"></a>
+
 `OrdersListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -5883,6 +6193,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="PriceRulesListResult"></a>
 
 `PriceRulesListResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -5927,6 +6239,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="ProductImagesListResult"></a>
+
 `ProductImagesListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -5969,6 +6283,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="ProductVariantsListResult"></a>
 
 `ProductVariantsListResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -6013,6 +6329,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="ProductsListResult"></a>
+
 `ProductsListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -6055,6 +6373,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="OrderRefundsListResult"></a>
 
 `OrderRefundsListResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -6099,6 +6419,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="SmartCollectionsListResult"></a>
+
 `SmartCollectionsListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -6141,6 +6463,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="TenderTransactionsListResult"></a>
 
 `TenderTransactionsListResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -6185,6 +6509,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="TransactionsListResult"></a>
+
 `TransactionsListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -6203,6 +6529,8 @@ Classes
     * airbyte_agent_sdk.connectors.shopify.models.ShopifyExecuteResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="SmartCollection"></a>
 
 `SmartCollection(**data: Any)`
 :   A smart collection
@@ -6265,6 +6593,8 @@ Classes
     `updated_at: str | Any | None`
     :   The type of the None singleton.
 
+<a id="SmartCollectionList"></a>
+
 `SmartCollectionList(**data: Any)`
 :   SmartCollectionList type definition
     
@@ -6286,6 +6616,8 @@ Classes
 
     `smart_collections: list[airbyte_agent_sdk.connectors.shopify.models.SmartCollection] | Any`
     :   The type of the None singleton.
+
+<a id="SmartCollectionsListResultMeta"></a>
 
 `SmartCollectionsListResultMeta(**data: Any)`
 :   Metadata for smart_collections.Action.LIST operation
@@ -6309,6 +6641,8 @@ Classes
     `next_page_url: str | Any | None`
     :   The type of the None singleton.
 
+<a id="SmartCollectionsSearchData"></a>
+
 `SmartCollectionsSearchData(**data: Any)`
 :   Search result data for smart_collections entity.
     
@@ -6327,6 +6661,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="TenderTransaction"></a>
 
 `TenderTransaction(**data: Any)`
 :   A tender transaction
@@ -6377,6 +6713,8 @@ Classes
     `user_id: int | Any | None`
     :   The type of the None singleton.
 
+<a id="TenderTransactionList"></a>
+
 `TenderTransactionList(**data: Any)`
 :   TenderTransactionList type definition
     
@@ -6398,6 +6736,8 @@ Classes
 
     `tender_transactions: list[airbyte_agent_sdk.connectors.shopify.models.TenderTransaction] | Any`
     :   The type of the None singleton.
+
+<a id="TenderTransactionsListResultMeta"></a>
 
 `TenderTransactionsListResultMeta(**data: Any)`
 :   Metadata for tender_transactions.Action.LIST operation
@@ -6421,6 +6761,8 @@ Classes
     `next_page_url: str | Any | None`
     :   The type of the None singleton.
 
+<a id="TenderTransactionsSearchData"></a>
+
 `TenderTransactionsSearchData(**data: Any)`
 :   Search result data for tender_transactions entity.
     
@@ -6439,6 +6781,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="Transaction"></a>
 
 `Transaction(**data: Any)`
 :   An order transaction
@@ -6531,6 +6875,8 @@ Classes
     `user_id: int | Any | None`
     :   The type of the None singleton.
 
+<a id="TransactionList"></a>
+
 `TransactionList(**data: Any)`
 :   TransactionList type definition
     
@@ -6552,6 +6898,8 @@ Classes
 
     `transactions: list[airbyte_agent_sdk.connectors.shopify.models.Transaction] | Any`
     :   The type of the None singleton.
+
+<a id="TransactionsListResultMeta"></a>
 
 `TransactionsListResultMeta(**data: Any)`
 :   Metadata for transactions.Action.LIST operation

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/shopify/types.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/shopify/types.md
@@ -10,6 +10,8 @@ Type definitions for shopify connector.
 Classes
 -------
 
+<a id="AbandonedCheckoutsAndCondition"></a>
+
 `AbandonedCheckoutsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -29,6 +31,8 @@ Classes
 
     `and: list[airbyte_agent_sdk.connectors.shopify.types.AbandonedCheckoutsEqCondition | airbyte_agent_sdk.connectors.shopify.types.AbandonedCheckoutsNeqCondition | airbyte_agent_sdk.connectors.shopify.types.AbandonedCheckoutsGtCondition | airbyte_agent_sdk.connectors.shopify.types.AbandonedCheckoutsGteCondition | airbyte_agent_sdk.connectors.shopify.types.AbandonedCheckoutsLtCondition | airbyte_agent_sdk.connectors.shopify.types.AbandonedCheckoutsLteCondition | airbyte_agent_sdk.connectors.shopify.types.AbandonedCheckoutsInCondition | airbyte_agent_sdk.connectors.shopify.types.AbandonedCheckoutsLikeCondition | airbyte_agent_sdk.connectors.shopify.types.AbandonedCheckoutsFuzzyCondition | airbyte_agent_sdk.connectors.shopify.types.AbandonedCheckoutsKeywordCondition | airbyte_agent_sdk.connectors.shopify.types.AbandonedCheckoutsContainsCondition | airbyte_agent_sdk.connectors.shopify.types.AbandonedCheckoutsNotCondition | airbyte_agent_sdk.connectors.shopify.types.AbandonedCheckoutsAndCondition | airbyte_agent_sdk.connectors.shopify.types.AbandonedCheckoutsOrCondition | airbyte_agent_sdk.connectors.shopify.types.AbandonedCheckoutsAnyCondition]`
     :   The type of the None singleton.
+
+<a id="AbandonedCheckoutsAnyCondition"></a>
 
 `AbandonedCheckoutsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -50,12 +54,16 @@ Classes
     `any: airbyte_agent_sdk.connectors.shopify.types.AbandonedCheckoutsAnyValueFilter`
     :   The type of the None singleton.
 
+<a id="AbandonedCheckoutsAnyValueFilter"></a>
+
 `AbandonedCheckoutsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="AbandonedCheckoutsContainsCondition"></a>
 
 `AbandonedCheckoutsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
@@ -69,6 +77,8 @@ Classes
     `contains: airbyte_agent_sdk.connectors.shopify.types.AbandonedCheckoutsAnyValueFilter`
     :   The type of the None singleton.
 
+<a id="AbandonedCheckoutsEqCondition"></a>
+
 `AbandonedCheckoutsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
 
@@ -80,6 +90,8 @@ Classes
 
     `eq: airbyte_agent_sdk.connectors.shopify.types.AbandonedCheckoutsSearchFilter`
     :   The type of the None singleton.
+
+<a id="AbandonedCheckoutsFuzzyCondition"></a>
 
 `AbandonedCheckoutsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
@@ -93,6 +105,8 @@ Classes
     `fuzzy: airbyte_agent_sdk.connectors.shopify.types.AbandonedCheckoutsStringFilter`
     :   The type of the None singleton.
 
+<a id="AbandonedCheckoutsGtCondition"></a>
+
 `AbandonedCheckoutsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -105,6 +119,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.shopify.types.AbandonedCheckoutsSearchFilter`
     :   The type of the None singleton.
 
+<a id="AbandonedCheckoutsGteCondition"></a>
+
 `AbandonedCheckoutsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -116,6 +132,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.shopify.types.AbandonedCheckoutsSearchFilter`
     :   The type of the None singleton.
+
+<a id="AbandonedCheckoutsInCondition"></a>
 
 `AbandonedCheckoutsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -137,12 +155,16 @@ Classes
     `in: airbyte_agent_sdk.connectors.shopify.types.AbandonedCheckoutsInFilter`
     :   The type of the None singleton.
 
+<a id="AbandonedCheckoutsInFilter"></a>
+
 `AbandonedCheckoutsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="AbandonedCheckoutsKeywordCondition"></a>
 
 `AbandonedCheckoutsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
@@ -156,6 +178,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.shopify.types.AbandonedCheckoutsStringFilter`
     :   The type of the None singleton.
 
+<a id="AbandonedCheckoutsLikeCondition"></a>
+
 `AbandonedCheckoutsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -167,6 +191,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.shopify.types.AbandonedCheckoutsStringFilter`
     :   The type of the None singleton.
+
+<a id="AbandonedCheckoutsListParams"></a>
 
 `AbandonedCheckoutsListParams(*args, **kwargs)`
 :   Parameters for abandoned_checkouts.list operation
@@ -198,6 +224,8 @@ Classes
     `updated_at_min: str`
     :   The type of the None singleton.
 
+<a id="AbandonedCheckoutsLtCondition"></a>
+
 `AbandonedCheckoutsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -209,6 +237,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.shopify.types.AbandonedCheckoutsSearchFilter`
     :   The type of the None singleton.
+
+<a id="AbandonedCheckoutsLteCondition"></a>
 
 `AbandonedCheckoutsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -222,6 +252,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.shopify.types.AbandonedCheckoutsSearchFilter`
     :   The type of the None singleton.
 
+<a id="AbandonedCheckoutsNeqCondition"></a>
+
 `AbandonedCheckoutsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -233,6 +265,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.shopify.types.AbandonedCheckoutsSearchFilter`
     :   The type of the None singleton.
+
+<a id="AbandonedCheckoutsNotCondition"></a>
 
 `AbandonedCheckoutsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -254,6 +288,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.shopify.types.AbandonedCheckoutsEqCondition | airbyte_agent_sdk.connectors.shopify.types.AbandonedCheckoutsNeqCondition | airbyte_agent_sdk.connectors.shopify.types.AbandonedCheckoutsGtCondition | airbyte_agent_sdk.connectors.shopify.types.AbandonedCheckoutsGteCondition | airbyte_agent_sdk.connectors.shopify.types.AbandonedCheckoutsLtCondition | airbyte_agent_sdk.connectors.shopify.types.AbandonedCheckoutsLteCondition | airbyte_agent_sdk.connectors.shopify.types.AbandonedCheckoutsInCondition | airbyte_agent_sdk.connectors.shopify.types.AbandonedCheckoutsLikeCondition | airbyte_agent_sdk.connectors.shopify.types.AbandonedCheckoutsFuzzyCondition | airbyte_agent_sdk.connectors.shopify.types.AbandonedCheckoutsKeywordCondition | airbyte_agent_sdk.connectors.shopify.types.AbandonedCheckoutsContainsCondition | airbyte_agent_sdk.connectors.shopify.types.AbandonedCheckoutsNotCondition | airbyte_agent_sdk.connectors.shopify.types.AbandonedCheckoutsAndCondition | airbyte_agent_sdk.connectors.shopify.types.AbandonedCheckoutsOrCondition | airbyte_agent_sdk.connectors.shopify.types.AbandonedCheckoutsAnyCondition`
     :   The type of the None singleton.
 
+<a id="AbandonedCheckoutsOrCondition"></a>
+
 `AbandonedCheckoutsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -274,12 +310,16 @@ Classes
     `or: list[airbyte_agent_sdk.connectors.shopify.types.AbandonedCheckoutsEqCondition | airbyte_agent_sdk.connectors.shopify.types.AbandonedCheckoutsNeqCondition | airbyte_agent_sdk.connectors.shopify.types.AbandonedCheckoutsGtCondition | airbyte_agent_sdk.connectors.shopify.types.AbandonedCheckoutsGteCondition | airbyte_agent_sdk.connectors.shopify.types.AbandonedCheckoutsLtCondition | airbyte_agent_sdk.connectors.shopify.types.AbandonedCheckoutsLteCondition | airbyte_agent_sdk.connectors.shopify.types.AbandonedCheckoutsInCondition | airbyte_agent_sdk.connectors.shopify.types.AbandonedCheckoutsLikeCondition | airbyte_agent_sdk.connectors.shopify.types.AbandonedCheckoutsFuzzyCondition | airbyte_agent_sdk.connectors.shopify.types.AbandonedCheckoutsKeywordCondition | airbyte_agent_sdk.connectors.shopify.types.AbandonedCheckoutsContainsCondition | airbyte_agent_sdk.connectors.shopify.types.AbandonedCheckoutsNotCondition | airbyte_agent_sdk.connectors.shopify.types.AbandonedCheckoutsAndCondition | airbyte_agent_sdk.connectors.shopify.types.AbandonedCheckoutsOrCondition | airbyte_agent_sdk.connectors.shopify.types.AbandonedCheckoutsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="AbandonedCheckoutsSearchFilter"></a>
+
 `AbandonedCheckoutsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering abandoned_checkouts search queries.
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="AbandonedCheckoutsSearchQuery"></a>
 
 `AbandonedCheckoutsSearchQuery(*args, **kwargs)`
 :   Search query for abandoned_checkouts entity.
@@ -296,6 +336,8 @@ Classes
     `sort: list[airbyte_agent_sdk.connectors.shopify.types.AbandonedCheckoutsSortFilter]`
     :   The type of the None singleton.
 
+<a id="AbandonedCheckoutsSortFilter"></a>
+
 `AbandonedCheckoutsSortFilter(*args, **kwargs)`
 :   Available fields for sorting abandoned_checkouts search results.
 
@@ -303,12 +345,16 @@ Classes
 
     * builtins.dict
 
+<a id="AbandonedCheckoutsStringFilter"></a>
+
 `AbandonedCheckoutsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="AirbyteSearchParams"></a>
 
 `AirbyteSearchParams(*args, **kwargs)`
 :   Parameters for Airbyte cache search operations (generic, use entity-specific query types for better type hints).
@@ -331,6 +377,8 @@ Classes
     `query: dict[str, typing.Any]`
     :   The type of the None singleton.
 
+<a id="CollectsAndCondition"></a>
+
 `CollectsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -350,6 +398,8 @@ Classes
 
     `and: list[airbyte_agent_sdk.connectors.shopify.types.CollectsEqCondition | airbyte_agent_sdk.connectors.shopify.types.CollectsNeqCondition | airbyte_agent_sdk.connectors.shopify.types.CollectsGtCondition | airbyte_agent_sdk.connectors.shopify.types.CollectsGteCondition | airbyte_agent_sdk.connectors.shopify.types.CollectsLtCondition | airbyte_agent_sdk.connectors.shopify.types.CollectsLteCondition | airbyte_agent_sdk.connectors.shopify.types.CollectsInCondition | airbyte_agent_sdk.connectors.shopify.types.CollectsLikeCondition | airbyte_agent_sdk.connectors.shopify.types.CollectsFuzzyCondition | airbyte_agent_sdk.connectors.shopify.types.CollectsKeywordCondition | airbyte_agent_sdk.connectors.shopify.types.CollectsContainsCondition | airbyte_agent_sdk.connectors.shopify.types.CollectsNotCondition | airbyte_agent_sdk.connectors.shopify.types.CollectsAndCondition | airbyte_agent_sdk.connectors.shopify.types.CollectsOrCondition | airbyte_agent_sdk.connectors.shopify.types.CollectsAnyCondition]`
     :   The type of the None singleton.
+
+<a id="CollectsAnyCondition"></a>
 
 `CollectsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -371,12 +421,16 @@ Classes
     `any: airbyte_agent_sdk.connectors.shopify.types.CollectsAnyValueFilter`
     :   The type of the None singleton.
 
+<a id="CollectsAnyValueFilter"></a>
+
 `CollectsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="CollectsContainsCondition"></a>
 
 `CollectsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
@@ -390,6 +444,8 @@ Classes
     `contains: airbyte_agent_sdk.connectors.shopify.types.CollectsAnyValueFilter`
     :   The type of the None singleton.
 
+<a id="CollectsEqCondition"></a>
+
 `CollectsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
 
@@ -401,6 +457,8 @@ Classes
 
     `eq: airbyte_agent_sdk.connectors.shopify.types.CollectsSearchFilter`
     :   The type of the None singleton.
+
+<a id="CollectsFuzzyCondition"></a>
 
 `CollectsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
@@ -414,6 +472,8 @@ Classes
     `fuzzy: airbyte_agent_sdk.connectors.shopify.types.CollectsStringFilter`
     :   The type of the None singleton.
 
+<a id="CollectsGetParams"></a>
+
 `CollectsGetParams(*args, **kwargs)`
 :   Parameters for collects.get operation
 
@@ -425,6 +485,8 @@ Classes
 
     `collect_id: str`
     :   The type of the None singleton.
+
+<a id="CollectsGtCondition"></a>
 
 `CollectsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
@@ -438,6 +500,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.shopify.types.CollectsSearchFilter`
     :   The type of the None singleton.
 
+<a id="CollectsGteCondition"></a>
+
 `CollectsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -449,6 +513,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.shopify.types.CollectsSearchFilter`
     :   The type of the None singleton.
+
+<a id="CollectsInCondition"></a>
 
 `CollectsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -470,12 +536,16 @@ Classes
     `in: airbyte_agent_sdk.connectors.shopify.types.CollectsInFilter`
     :   The type of the None singleton.
 
+<a id="CollectsInFilter"></a>
+
 `CollectsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="CollectsKeywordCondition"></a>
 
 `CollectsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
@@ -489,6 +559,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.shopify.types.CollectsStringFilter`
     :   The type of the None singleton.
 
+<a id="CollectsLikeCondition"></a>
+
 `CollectsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -500,6 +572,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.shopify.types.CollectsStringFilter`
     :   The type of the None singleton.
+
+<a id="CollectsListParams"></a>
 
 `CollectsListParams(*args, **kwargs)`
 :   Parameters for collects.list operation
@@ -522,6 +596,8 @@ Classes
     `since_id: int`
     :   The type of the None singleton.
 
+<a id="CollectsLtCondition"></a>
+
 `CollectsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -533,6 +609,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.shopify.types.CollectsSearchFilter`
     :   The type of the None singleton.
+
+<a id="CollectsLteCondition"></a>
 
 `CollectsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -546,6 +624,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.shopify.types.CollectsSearchFilter`
     :   The type of the None singleton.
 
+<a id="CollectsNeqCondition"></a>
+
 `CollectsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -557,6 +637,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.shopify.types.CollectsSearchFilter`
     :   The type of the None singleton.
+
+<a id="CollectsNotCondition"></a>
 
 `CollectsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -578,6 +660,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.shopify.types.CollectsEqCondition | airbyte_agent_sdk.connectors.shopify.types.CollectsNeqCondition | airbyte_agent_sdk.connectors.shopify.types.CollectsGtCondition | airbyte_agent_sdk.connectors.shopify.types.CollectsGteCondition | airbyte_agent_sdk.connectors.shopify.types.CollectsLtCondition | airbyte_agent_sdk.connectors.shopify.types.CollectsLteCondition | airbyte_agent_sdk.connectors.shopify.types.CollectsInCondition | airbyte_agent_sdk.connectors.shopify.types.CollectsLikeCondition | airbyte_agent_sdk.connectors.shopify.types.CollectsFuzzyCondition | airbyte_agent_sdk.connectors.shopify.types.CollectsKeywordCondition | airbyte_agent_sdk.connectors.shopify.types.CollectsContainsCondition | airbyte_agent_sdk.connectors.shopify.types.CollectsNotCondition | airbyte_agent_sdk.connectors.shopify.types.CollectsAndCondition | airbyte_agent_sdk.connectors.shopify.types.CollectsOrCondition | airbyte_agent_sdk.connectors.shopify.types.CollectsAnyCondition`
     :   The type of the None singleton.
 
+<a id="CollectsOrCondition"></a>
+
 `CollectsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -598,12 +682,16 @@ Classes
     `or: list[airbyte_agent_sdk.connectors.shopify.types.CollectsEqCondition | airbyte_agent_sdk.connectors.shopify.types.CollectsNeqCondition | airbyte_agent_sdk.connectors.shopify.types.CollectsGtCondition | airbyte_agent_sdk.connectors.shopify.types.CollectsGteCondition | airbyte_agent_sdk.connectors.shopify.types.CollectsLtCondition | airbyte_agent_sdk.connectors.shopify.types.CollectsLteCondition | airbyte_agent_sdk.connectors.shopify.types.CollectsInCondition | airbyte_agent_sdk.connectors.shopify.types.CollectsLikeCondition | airbyte_agent_sdk.connectors.shopify.types.CollectsFuzzyCondition | airbyte_agent_sdk.connectors.shopify.types.CollectsKeywordCondition | airbyte_agent_sdk.connectors.shopify.types.CollectsContainsCondition | airbyte_agent_sdk.connectors.shopify.types.CollectsNotCondition | airbyte_agent_sdk.connectors.shopify.types.CollectsAndCondition | airbyte_agent_sdk.connectors.shopify.types.CollectsOrCondition | airbyte_agent_sdk.connectors.shopify.types.CollectsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="CollectsSearchFilter"></a>
+
 `CollectsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering collects search queries.
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="CollectsSearchQuery"></a>
 
 `CollectsSearchQuery(*args, **kwargs)`
 :   Search query for collects entity.
@@ -620,6 +708,8 @@ Classes
     `sort: list[airbyte_agent_sdk.connectors.shopify.types.CollectsSortFilter]`
     :   The type of the None singleton.
 
+<a id="CollectsSortFilter"></a>
+
 `CollectsSortFilter(*args, **kwargs)`
 :   Available fields for sorting collects search results.
 
@@ -627,12 +717,16 @@ Classes
 
     * builtins.dict
 
+<a id="CollectsStringFilter"></a>
+
 `CollectsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="CountriesAndCondition"></a>
 
 `CountriesAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -654,6 +748,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.shopify.types.CountriesEqCondition | airbyte_agent_sdk.connectors.shopify.types.CountriesNeqCondition | airbyte_agent_sdk.connectors.shopify.types.CountriesGtCondition | airbyte_agent_sdk.connectors.shopify.types.CountriesGteCondition | airbyte_agent_sdk.connectors.shopify.types.CountriesLtCondition | airbyte_agent_sdk.connectors.shopify.types.CountriesLteCondition | airbyte_agent_sdk.connectors.shopify.types.CountriesInCondition | airbyte_agent_sdk.connectors.shopify.types.CountriesLikeCondition | airbyte_agent_sdk.connectors.shopify.types.CountriesFuzzyCondition | airbyte_agent_sdk.connectors.shopify.types.CountriesKeywordCondition | airbyte_agent_sdk.connectors.shopify.types.CountriesContainsCondition | airbyte_agent_sdk.connectors.shopify.types.CountriesNotCondition | airbyte_agent_sdk.connectors.shopify.types.CountriesAndCondition | airbyte_agent_sdk.connectors.shopify.types.CountriesOrCondition | airbyte_agent_sdk.connectors.shopify.types.CountriesAnyCondition]`
     :   The type of the None singleton.
 
+<a id="CountriesAnyCondition"></a>
+
 `CountriesAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -674,12 +770,16 @@ Classes
     `any: airbyte_agent_sdk.connectors.shopify.types.CountriesAnyValueFilter`
     :   The type of the None singleton.
 
+<a id="CountriesAnyValueFilter"></a>
+
 `CountriesAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="CountriesContainsCondition"></a>
 
 `CountriesContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
@@ -693,6 +793,8 @@ Classes
     `contains: airbyte_agent_sdk.connectors.shopify.types.CountriesAnyValueFilter`
     :   The type of the None singleton.
 
+<a id="CountriesEqCondition"></a>
+
 `CountriesEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
 
@@ -704,6 +806,8 @@ Classes
 
     `eq: airbyte_agent_sdk.connectors.shopify.types.CountriesSearchFilter`
     :   The type of the None singleton.
+
+<a id="CountriesFuzzyCondition"></a>
 
 `CountriesFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
@@ -717,6 +821,8 @@ Classes
     `fuzzy: airbyte_agent_sdk.connectors.shopify.types.CountriesStringFilter`
     :   The type of the None singleton.
 
+<a id="CountriesGetParams"></a>
+
 `CountriesGetParams(*args, **kwargs)`
 :   Parameters for countries.get operation
 
@@ -728,6 +834,8 @@ Classes
 
     `country_id: str`
     :   The type of the None singleton.
+
+<a id="CountriesGtCondition"></a>
 
 `CountriesGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
@@ -741,6 +849,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.shopify.types.CountriesSearchFilter`
     :   The type of the None singleton.
 
+<a id="CountriesGteCondition"></a>
+
 `CountriesGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -752,6 +862,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.shopify.types.CountriesSearchFilter`
     :   The type of the None singleton.
+
+<a id="CountriesInCondition"></a>
 
 `CountriesInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -773,12 +885,16 @@ Classes
     `in: airbyte_agent_sdk.connectors.shopify.types.CountriesInFilter`
     :   The type of the None singleton.
 
+<a id="CountriesInFilter"></a>
+
 `CountriesInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="CountriesKeywordCondition"></a>
 
 `CountriesKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
@@ -792,6 +908,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.shopify.types.CountriesStringFilter`
     :   The type of the None singleton.
 
+<a id="CountriesLikeCondition"></a>
+
 `CountriesLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -803,6 +921,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.shopify.types.CountriesStringFilter`
     :   The type of the None singleton.
+
+<a id="CountriesListParams"></a>
 
 `CountriesListParams(*args, **kwargs)`
 :   Parameters for countries.list operation
@@ -816,6 +936,8 @@ Classes
     `since_id: int`
     :   The type of the None singleton.
 
+<a id="CountriesLtCondition"></a>
+
 `CountriesLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -827,6 +949,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.shopify.types.CountriesSearchFilter`
     :   The type of the None singleton.
+
+<a id="CountriesLteCondition"></a>
 
 `CountriesLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -840,6 +964,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.shopify.types.CountriesSearchFilter`
     :   The type of the None singleton.
 
+<a id="CountriesNeqCondition"></a>
+
 `CountriesNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -851,6 +977,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.shopify.types.CountriesSearchFilter`
     :   The type of the None singleton.
+
+<a id="CountriesNotCondition"></a>
 
 `CountriesNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -872,6 +1000,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.shopify.types.CountriesEqCondition | airbyte_agent_sdk.connectors.shopify.types.CountriesNeqCondition | airbyte_agent_sdk.connectors.shopify.types.CountriesGtCondition | airbyte_agent_sdk.connectors.shopify.types.CountriesGteCondition | airbyte_agent_sdk.connectors.shopify.types.CountriesLtCondition | airbyte_agent_sdk.connectors.shopify.types.CountriesLteCondition | airbyte_agent_sdk.connectors.shopify.types.CountriesInCondition | airbyte_agent_sdk.connectors.shopify.types.CountriesLikeCondition | airbyte_agent_sdk.connectors.shopify.types.CountriesFuzzyCondition | airbyte_agent_sdk.connectors.shopify.types.CountriesKeywordCondition | airbyte_agent_sdk.connectors.shopify.types.CountriesContainsCondition | airbyte_agent_sdk.connectors.shopify.types.CountriesNotCondition | airbyte_agent_sdk.connectors.shopify.types.CountriesAndCondition | airbyte_agent_sdk.connectors.shopify.types.CountriesOrCondition | airbyte_agent_sdk.connectors.shopify.types.CountriesAnyCondition`
     :   The type of the None singleton.
 
+<a id="CountriesOrCondition"></a>
+
 `CountriesOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -892,12 +1022,16 @@ Classes
     `or: list[airbyte_agent_sdk.connectors.shopify.types.CountriesEqCondition | airbyte_agent_sdk.connectors.shopify.types.CountriesNeqCondition | airbyte_agent_sdk.connectors.shopify.types.CountriesGtCondition | airbyte_agent_sdk.connectors.shopify.types.CountriesGteCondition | airbyte_agent_sdk.connectors.shopify.types.CountriesLtCondition | airbyte_agent_sdk.connectors.shopify.types.CountriesLteCondition | airbyte_agent_sdk.connectors.shopify.types.CountriesInCondition | airbyte_agent_sdk.connectors.shopify.types.CountriesLikeCondition | airbyte_agent_sdk.connectors.shopify.types.CountriesFuzzyCondition | airbyte_agent_sdk.connectors.shopify.types.CountriesKeywordCondition | airbyte_agent_sdk.connectors.shopify.types.CountriesContainsCondition | airbyte_agent_sdk.connectors.shopify.types.CountriesNotCondition | airbyte_agent_sdk.connectors.shopify.types.CountriesAndCondition | airbyte_agent_sdk.connectors.shopify.types.CountriesOrCondition | airbyte_agent_sdk.connectors.shopify.types.CountriesAnyCondition]`
     :   The type of the None singleton.
 
+<a id="CountriesSearchFilter"></a>
+
 `CountriesSearchFilter(*args, **kwargs)`
 :   Available fields for filtering countries search queries.
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="CountriesSearchQuery"></a>
 
 `CountriesSearchQuery(*args, **kwargs)`
 :   Search query for countries entity.
@@ -914,6 +1048,8 @@ Classes
     `sort: list[airbyte_agent_sdk.connectors.shopify.types.CountriesSortFilter]`
     :   The type of the None singleton.
 
+<a id="CountriesSortFilter"></a>
+
 `CountriesSortFilter(*args, **kwargs)`
 :   Available fields for sorting countries search results.
 
@@ -921,12 +1057,16 @@ Classes
 
     * builtins.dict
 
+<a id="CountriesStringFilter"></a>
+
 `CountriesStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="CustomCollectionsAndCondition"></a>
 
 `CustomCollectionsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -948,6 +1088,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.shopify.types.CustomCollectionsEqCondition | airbyte_agent_sdk.connectors.shopify.types.CustomCollectionsNeqCondition | airbyte_agent_sdk.connectors.shopify.types.CustomCollectionsGtCondition | airbyte_agent_sdk.connectors.shopify.types.CustomCollectionsGteCondition | airbyte_agent_sdk.connectors.shopify.types.CustomCollectionsLtCondition | airbyte_agent_sdk.connectors.shopify.types.CustomCollectionsLteCondition | airbyte_agent_sdk.connectors.shopify.types.CustomCollectionsInCondition | airbyte_agent_sdk.connectors.shopify.types.CustomCollectionsLikeCondition | airbyte_agent_sdk.connectors.shopify.types.CustomCollectionsFuzzyCondition | airbyte_agent_sdk.connectors.shopify.types.CustomCollectionsKeywordCondition | airbyte_agent_sdk.connectors.shopify.types.CustomCollectionsContainsCondition | airbyte_agent_sdk.connectors.shopify.types.CustomCollectionsNotCondition | airbyte_agent_sdk.connectors.shopify.types.CustomCollectionsAndCondition | airbyte_agent_sdk.connectors.shopify.types.CustomCollectionsOrCondition | airbyte_agent_sdk.connectors.shopify.types.CustomCollectionsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="CustomCollectionsAnyCondition"></a>
+
 `CustomCollectionsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -968,12 +1110,16 @@ Classes
     `any: airbyte_agent_sdk.connectors.shopify.types.CustomCollectionsAnyValueFilter`
     :   The type of the None singleton.
 
+<a id="CustomCollectionsAnyValueFilter"></a>
+
 `CustomCollectionsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="CustomCollectionsContainsCondition"></a>
 
 `CustomCollectionsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
@@ -987,6 +1133,8 @@ Classes
     `contains: airbyte_agent_sdk.connectors.shopify.types.CustomCollectionsAnyValueFilter`
     :   The type of the None singleton.
 
+<a id="CustomCollectionsEqCondition"></a>
+
 `CustomCollectionsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
 
@@ -998,6 +1146,8 @@ Classes
 
     `eq: airbyte_agent_sdk.connectors.shopify.types.CustomCollectionsSearchFilter`
     :   The type of the None singleton.
+
+<a id="CustomCollectionsFuzzyCondition"></a>
 
 `CustomCollectionsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
@@ -1011,6 +1161,8 @@ Classes
     `fuzzy: airbyte_agent_sdk.connectors.shopify.types.CustomCollectionsStringFilter`
     :   The type of the None singleton.
 
+<a id="CustomCollectionsGetParams"></a>
+
 `CustomCollectionsGetParams(*args, **kwargs)`
 :   Parameters for custom_collections.get operation
 
@@ -1022,6 +1174,8 @@ Classes
 
     `collection_id: str`
     :   The type of the None singleton.
+
+<a id="CustomCollectionsGtCondition"></a>
 
 `CustomCollectionsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
@@ -1035,6 +1189,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.shopify.types.CustomCollectionsSearchFilter`
     :   The type of the None singleton.
 
+<a id="CustomCollectionsGteCondition"></a>
+
 `CustomCollectionsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -1046,6 +1202,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.shopify.types.CustomCollectionsSearchFilter`
     :   The type of the None singleton.
+
+<a id="CustomCollectionsInCondition"></a>
 
 `CustomCollectionsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -1067,12 +1225,16 @@ Classes
     `in: airbyte_agent_sdk.connectors.shopify.types.CustomCollectionsInFilter`
     :   The type of the None singleton.
 
+<a id="CustomCollectionsInFilter"></a>
+
 `CustomCollectionsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="CustomCollectionsKeywordCondition"></a>
 
 `CustomCollectionsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
@@ -1086,6 +1248,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.shopify.types.CustomCollectionsStringFilter`
     :   The type of the None singleton.
 
+<a id="CustomCollectionsLikeCondition"></a>
+
 `CustomCollectionsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -1097,6 +1261,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.shopify.types.CustomCollectionsStringFilter`
     :   The type of the None singleton.
+
+<a id="CustomCollectionsListParams"></a>
 
 `CustomCollectionsListParams(*args, **kwargs)`
 :   Parameters for custom_collections.list operation
@@ -1125,6 +1291,8 @@ Classes
     `updated_at_min: str`
     :   The type of the None singleton.
 
+<a id="CustomCollectionsLtCondition"></a>
+
 `CustomCollectionsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -1136,6 +1304,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.shopify.types.CustomCollectionsSearchFilter`
     :   The type of the None singleton.
+
+<a id="CustomCollectionsLteCondition"></a>
 
 `CustomCollectionsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -1149,6 +1319,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.shopify.types.CustomCollectionsSearchFilter`
     :   The type of the None singleton.
 
+<a id="CustomCollectionsNeqCondition"></a>
+
 `CustomCollectionsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -1160,6 +1332,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.shopify.types.CustomCollectionsSearchFilter`
     :   The type of the None singleton.
+
+<a id="CustomCollectionsNotCondition"></a>
 
 `CustomCollectionsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -1181,6 +1355,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.shopify.types.CustomCollectionsEqCondition | airbyte_agent_sdk.connectors.shopify.types.CustomCollectionsNeqCondition | airbyte_agent_sdk.connectors.shopify.types.CustomCollectionsGtCondition | airbyte_agent_sdk.connectors.shopify.types.CustomCollectionsGteCondition | airbyte_agent_sdk.connectors.shopify.types.CustomCollectionsLtCondition | airbyte_agent_sdk.connectors.shopify.types.CustomCollectionsLteCondition | airbyte_agent_sdk.connectors.shopify.types.CustomCollectionsInCondition | airbyte_agent_sdk.connectors.shopify.types.CustomCollectionsLikeCondition | airbyte_agent_sdk.connectors.shopify.types.CustomCollectionsFuzzyCondition | airbyte_agent_sdk.connectors.shopify.types.CustomCollectionsKeywordCondition | airbyte_agent_sdk.connectors.shopify.types.CustomCollectionsContainsCondition | airbyte_agent_sdk.connectors.shopify.types.CustomCollectionsNotCondition | airbyte_agent_sdk.connectors.shopify.types.CustomCollectionsAndCondition | airbyte_agent_sdk.connectors.shopify.types.CustomCollectionsOrCondition | airbyte_agent_sdk.connectors.shopify.types.CustomCollectionsAnyCondition`
     :   The type of the None singleton.
 
+<a id="CustomCollectionsOrCondition"></a>
+
 `CustomCollectionsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1201,12 +1377,16 @@ Classes
     `or: list[airbyte_agent_sdk.connectors.shopify.types.CustomCollectionsEqCondition | airbyte_agent_sdk.connectors.shopify.types.CustomCollectionsNeqCondition | airbyte_agent_sdk.connectors.shopify.types.CustomCollectionsGtCondition | airbyte_agent_sdk.connectors.shopify.types.CustomCollectionsGteCondition | airbyte_agent_sdk.connectors.shopify.types.CustomCollectionsLtCondition | airbyte_agent_sdk.connectors.shopify.types.CustomCollectionsLteCondition | airbyte_agent_sdk.connectors.shopify.types.CustomCollectionsInCondition | airbyte_agent_sdk.connectors.shopify.types.CustomCollectionsLikeCondition | airbyte_agent_sdk.connectors.shopify.types.CustomCollectionsFuzzyCondition | airbyte_agent_sdk.connectors.shopify.types.CustomCollectionsKeywordCondition | airbyte_agent_sdk.connectors.shopify.types.CustomCollectionsContainsCondition | airbyte_agent_sdk.connectors.shopify.types.CustomCollectionsNotCondition | airbyte_agent_sdk.connectors.shopify.types.CustomCollectionsAndCondition | airbyte_agent_sdk.connectors.shopify.types.CustomCollectionsOrCondition | airbyte_agent_sdk.connectors.shopify.types.CustomCollectionsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="CustomCollectionsSearchFilter"></a>
+
 `CustomCollectionsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering custom_collections search queries.
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="CustomCollectionsSearchQuery"></a>
 
 `CustomCollectionsSearchQuery(*args, **kwargs)`
 :   Search query for custom_collections entity.
@@ -1223,6 +1403,8 @@ Classes
     `sort: list[airbyte_agent_sdk.connectors.shopify.types.CustomCollectionsSortFilter]`
     :   The type of the None singleton.
 
+<a id="CustomCollectionsSortFilter"></a>
+
 `CustomCollectionsSortFilter(*args, **kwargs)`
 :   Available fields for sorting custom_collections search results.
 
@@ -1230,12 +1412,16 @@ Classes
 
     * builtins.dict
 
+<a id="CustomCollectionsStringFilter"></a>
+
 `CustomCollectionsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="CustomerAddressGetParams"></a>
 
 `CustomerAddressGetParams(*args, **kwargs)`
 :   Parameters for customer_address.get operation
@@ -1252,6 +1438,8 @@ Classes
     `customer_id: str`
     :   The type of the None singleton.
 
+<a id="CustomerAddressListParams"></a>
+
 `CustomerAddressListParams(*args, **kwargs)`
 :   Parameters for customer_address.list operation
 
@@ -1266,6 +1454,8 @@ Classes
 
     `limit: int`
     :   The type of the None singleton.
+
+<a id="CustomersAndCondition"></a>
 
 `CustomersAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -1287,6 +1477,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.shopify.types.CustomersEqCondition | airbyte_agent_sdk.connectors.shopify.types.CustomersNeqCondition | airbyte_agent_sdk.connectors.shopify.types.CustomersGtCondition | airbyte_agent_sdk.connectors.shopify.types.CustomersGteCondition | airbyte_agent_sdk.connectors.shopify.types.CustomersLtCondition | airbyte_agent_sdk.connectors.shopify.types.CustomersLteCondition | airbyte_agent_sdk.connectors.shopify.types.CustomersInCondition | airbyte_agent_sdk.connectors.shopify.types.CustomersLikeCondition | airbyte_agent_sdk.connectors.shopify.types.CustomersFuzzyCondition | airbyte_agent_sdk.connectors.shopify.types.CustomersKeywordCondition | airbyte_agent_sdk.connectors.shopify.types.CustomersContainsCondition | airbyte_agent_sdk.connectors.shopify.types.CustomersNotCondition | airbyte_agent_sdk.connectors.shopify.types.CustomersAndCondition | airbyte_agent_sdk.connectors.shopify.types.CustomersOrCondition | airbyte_agent_sdk.connectors.shopify.types.CustomersAnyCondition]`
     :   The type of the None singleton.
 
+<a id="CustomersAnyCondition"></a>
+
 `CustomersAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1307,12 +1499,16 @@ Classes
     `any: airbyte_agent_sdk.connectors.shopify.types.CustomersAnyValueFilter`
     :   The type of the None singleton.
 
+<a id="CustomersAnyValueFilter"></a>
+
 `CustomersAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="CustomersContainsCondition"></a>
 
 `CustomersContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
@@ -1326,6 +1522,8 @@ Classes
     `contains: airbyte_agent_sdk.connectors.shopify.types.CustomersAnyValueFilter`
     :   The type of the None singleton.
 
+<a id="CustomersEqCondition"></a>
+
 `CustomersEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
 
@@ -1337,6 +1535,8 @@ Classes
 
     `eq: airbyte_agent_sdk.connectors.shopify.types.CustomersSearchFilter`
     :   The type of the None singleton.
+
+<a id="CustomersFuzzyCondition"></a>
 
 `CustomersFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
@@ -1350,6 +1550,8 @@ Classes
     `fuzzy: airbyte_agent_sdk.connectors.shopify.types.CustomersStringFilter`
     :   The type of the None singleton.
 
+<a id="CustomersGetParams"></a>
+
 `CustomersGetParams(*args, **kwargs)`
 :   Parameters for customers.get operation
 
@@ -1361,6 +1563,8 @@ Classes
 
     `customer_id: str`
     :   The type of the None singleton.
+
+<a id="CustomersGtCondition"></a>
 
 `CustomersGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
@@ -1374,6 +1578,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.shopify.types.CustomersSearchFilter`
     :   The type of the None singleton.
 
+<a id="CustomersGteCondition"></a>
+
 `CustomersGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -1385,6 +1591,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.shopify.types.CustomersSearchFilter`
     :   The type of the None singleton.
+
+<a id="CustomersInCondition"></a>
 
 `CustomersInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -1406,12 +1614,16 @@ Classes
     `in: airbyte_agent_sdk.connectors.shopify.types.CustomersInFilter`
     :   The type of the None singleton.
 
+<a id="CustomersInFilter"></a>
+
 `CustomersInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="CustomersKeywordCondition"></a>
 
 `CustomersKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
@@ -1425,6 +1637,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.shopify.types.CustomersStringFilter`
     :   The type of the None singleton.
 
+<a id="CustomersLikeCondition"></a>
+
 `CustomersLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -1436,6 +1650,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.shopify.types.CustomersStringFilter`
     :   The type of the None singleton.
+
+<a id="CustomersListParams"></a>
 
 `CustomersListParams(*args, **kwargs)`
 :   Parameters for customers.list operation
@@ -1464,6 +1680,8 @@ Classes
     `updated_at_min: str`
     :   The type of the None singleton.
 
+<a id="CustomersLtCondition"></a>
+
 `CustomersLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -1475,6 +1693,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.shopify.types.CustomersSearchFilter`
     :   The type of the None singleton.
+
+<a id="CustomersLteCondition"></a>
 
 `CustomersLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -1488,6 +1708,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.shopify.types.CustomersSearchFilter`
     :   The type of the None singleton.
 
+<a id="CustomersNeqCondition"></a>
+
 `CustomersNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -1499,6 +1721,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.shopify.types.CustomersSearchFilter`
     :   The type of the None singleton.
+
+<a id="CustomersNotCondition"></a>
 
 `CustomersNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -1520,6 +1744,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.shopify.types.CustomersEqCondition | airbyte_agent_sdk.connectors.shopify.types.CustomersNeqCondition | airbyte_agent_sdk.connectors.shopify.types.CustomersGtCondition | airbyte_agent_sdk.connectors.shopify.types.CustomersGteCondition | airbyte_agent_sdk.connectors.shopify.types.CustomersLtCondition | airbyte_agent_sdk.connectors.shopify.types.CustomersLteCondition | airbyte_agent_sdk.connectors.shopify.types.CustomersInCondition | airbyte_agent_sdk.connectors.shopify.types.CustomersLikeCondition | airbyte_agent_sdk.connectors.shopify.types.CustomersFuzzyCondition | airbyte_agent_sdk.connectors.shopify.types.CustomersKeywordCondition | airbyte_agent_sdk.connectors.shopify.types.CustomersContainsCondition | airbyte_agent_sdk.connectors.shopify.types.CustomersNotCondition | airbyte_agent_sdk.connectors.shopify.types.CustomersAndCondition | airbyte_agent_sdk.connectors.shopify.types.CustomersOrCondition | airbyte_agent_sdk.connectors.shopify.types.CustomersAnyCondition`
     :   The type of the None singleton.
 
+<a id="CustomersOrCondition"></a>
+
 `CustomersOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1540,12 +1766,16 @@ Classes
     `or: list[airbyte_agent_sdk.connectors.shopify.types.CustomersEqCondition | airbyte_agent_sdk.connectors.shopify.types.CustomersNeqCondition | airbyte_agent_sdk.connectors.shopify.types.CustomersGtCondition | airbyte_agent_sdk.connectors.shopify.types.CustomersGteCondition | airbyte_agent_sdk.connectors.shopify.types.CustomersLtCondition | airbyte_agent_sdk.connectors.shopify.types.CustomersLteCondition | airbyte_agent_sdk.connectors.shopify.types.CustomersInCondition | airbyte_agent_sdk.connectors.shopify.types.CustomersLikeCondition | airbyte_agent_sdk.connectors.shopify.types.CustomersFuzzyCondition | airbyte_agent_sdk.connectors.shopify.types.CustomersKeywordCondition | airbyte_agent_sdk.connectors.shopify.types.CustomersContainsCondition | airbyte_agent_sdk.connectors.shopify.types.CustomersNotCondition | airbyte_agent_sdk.connectors.shopify.types.CustomersAndCondition | airbyte_agent_sdk.connectors.shopify.types.CustomersOrCondition | airbyte_agent_sdk.connectors.shopify.types.CustomersAnyCondition]`
     :   The type of the None singleton.
 
+<a id="CustomersSearchFilter"></a>
+
 `CustomersSearchFilter(*args, **kwargs)`
 :   Available fields for filtering customers search queries.
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="CustomersSearchQuery"></a>
 
 `CustomersSearchQuery(*args, **kwargs)`
 :   Search query for customers entity.
@@ -1562,6 +1792,8 @@ Classes
     `sort: list[airbyte_agent_sdk.connectors.shopify.types.CustomersSortFilter]`
     :   The type of the None singleton.
 
+<a id="CustomersSortFilter"></a>
+
 `CustomersSortFilter(*args, **kwargs)`
 :   Available fields for sorting customers search results.
 
@@ -1569,12 +1801,16 @@ Classes
 
     * builtins.dict
 
+<a id="CustomersStringFilter"></a>
+
 `CustomersStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="DiscountCodesAndCondition"></a>
 
 `DiscountCodesAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -1596,6 +1832,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.shopify.types.DiscountCodesEqCondition | airbyte_agent_sdk.connectors.shopify.types.DiscountCodesNeqCondition | airbyte_agent_sdk.connectors.shopify.types.DiscountCodesGtCondition | airbyte_agent_sdk.connectors.shopify.types.DiscountCodesGteCondition | airbyte_agent_sdk.connectors.shopify.types.DiscountCodesLtCondition | airbyte_agent_sdk.connectors.shopify.types.DiscountCodesLteCondition | airbyte_agent_sdk.connectors.shopify.types.DiscountCodesInCondition | airbyte_agent_sdk.connectors.shopify.types.DiscountCodesLikeCondition | airbyte_agent_sdk.connectors.shopify.types.DiscountCodesFuzzyCondition | airbyte_agent_sdk.connectors.shopify.types.DiscountCodesKeywordCondition | airbyte_agent_sdk.connectors.shopify.types.DiscountCodesContainsCondition | airbyte_agent_sdk.connectors.shopify.types.DiscountCodesNotCondition | airbyte_agent_sdk.connectors.shopify.types.DiscountCodesAndCondition | airbyte_agent_sdk.connectors.shopify.types.DiscountCodesOrCondition | airbyte_agent_sdk.connectors.shopify.types.DiscountCodesAnyCondition]`
     :   The type of the None singleton.
 
+<a id="DiscountCodesAnyCondition"></a>
+
 `DiscountCodesAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1616,12 +1854,16 @@ Classes
     `any: airbyte_agent_sdk.connectors.shopify.types.DiscountCodesAnyValueFilter`
     :   The type of the None singleton.
 
+<a id="DiscountCodesAnyValueFilter"></a>
+
 `DiscountCodesAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="DiscountCodesContainsCondition"></a>
 
 `DiscountCodesContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
@@ -1635,6 +1877,8 @@ Classes
     `contains: airbyte_agent_sdk.connectors.shopify.types.DiscountCodesAnyValueFilter`
     :   The type of the None singleton.
 
+<a id="DiscountCodesEqCondition"></a>
+
 `DiscountCodesEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
 
@@ -1647,6 +1891,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.shopify.types.DiscountCodesSearchFilter`
     :   The type of the None singleton.
 
+<a id="DiscountCodesFuzzyCondition"></a>
+
 `DiscountCodesFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -1658,6 +1904,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.shopify.types.DiscountCodesStringFilter`
     :   The type of the None singleton.
+
+<a id="DiscountCodesGetParams"></a>
 
 `DiscountCodesGetParams(*args, **kwargs)`
 :   Parameters for discount_codes.get operation
@@ -1674,6 +1922,8 @@ Classes
     `price_rule_id: str`
     :   The type of the None singleton.
 
+<a id="DiscountCodesGtCondition"></a>
+
 `DiscountCodesGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -1686,6 +1936,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.shopify.types.DiscountCodesSearchFilter`
     :   The type of the None singleton.
 
+<a id="DiscountCodesGteCondition"></a>
+
 `DiscountCodesGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -1697,6 +1949,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.shopify.types.DiscountCodesSearchFilter`
     :   The type of the None singleton.
+
+<a id="DiscountCodesInCondition"></a>
 
 `DiscountCodesInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -1718,12 +1972,16 @@ Classes
     `in: airbyte_agent_sdk.connectors.shopify.types.DiscountCodesInFilter`
     :   The type of the None singleton.
 
+<a id="DiscountCodesInFilter"></a>
+
 `DiscountCodesInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="DiscountCodesKeywordCondition"></a>
 
 `DiscountCodesKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
@@ -1737,6 +1995,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.shopify.types.DiscountCodesStringFilter`
     :   The type of the None singleton.
 
+<a id="DiscountCodesLikeCondition"></a>
+
 `DiscountCodesLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -1748,6 +2008,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.shopify.types.DiscountCodesStringFilter`
     :   The type of the None singleton.
+
+<a id="DiscountCodesListParams"></a>
 
 `DiscountCodesListParams(*args, **kwargs)`
 :   Parameters for discount_codes.list operation
@@ -1764,6 +2026,8 @@ Classes
     `price_rule_id: str`
     :   The type of the None singleton.
 
+<a id="DiscountCodesLtCondition"></a>
+
 `DiscountCodesLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -1775,6 +2039,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.shopify.types.DiscountCodesSearchFilter`
     :   The type of the None singleton.
+
+<a id="DiscountCodesLteCondition"></a>
 
 `DiscountCodesLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -1788,6 +2054,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.shopify.types.DiscountCodesSearchFilter`
     :   The type of the None singleton.
 
+<a id="DiscountCodesNeqCondition"></a>
+
 `DiscountCodesNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -1799,6 +2067,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.shopify.types.DiscountCodesSearchFilter`
     :   The type of the None singleton.
+
+<a id="DiscountCodesNotCondition"></a>
 
 `DiscountCodesNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -1820,6 +2090,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.shopify.types.DiscountCodesEqCondition | airbyte_agent_sdk.connectors.shopify.types.DiscountCodesNeqCondition | airbyte_agent_sdk.connectors.shopify.types.DiscountCodesGtCondition | airbyte_agent_sdk.connectors.shopify.types.DiscountCodesGteCondition | airbyte_agent_sdk.connectors.shopify.types.DiscountCodesLtCondition | airbyte_agent_sdk.connectors.shopify.types.DiscountCodesLteCondition | airbyte_agent_sdk.connectors.shopify.types.DiscountCodesInCondition | airbyte_agent_sdk.connectors.shopify.types.DiscountCodesLikeCondition | airbyte_agent_sdk.connectors.shopify.types.DiscountCodesFuzzyCondition | airbyte_agent_sdk.connectors.shopify.types.DiscountCodesKeywordCondition | airbyte_agent_sdk.connectors.shopify.types.DiscountCodesContainsCondition | airbyte_agent_sdk.connectors.shopify.types.DiscountCodesNotCondition | airbyte_agent_sdk.connectors.shopify.types.DiscountCodesAndCondition | airbyte_agent_sdk.connectors.shopify.types.DiscountCodesOrCondition | airbyte_agent_sdk.connectors.shopify.types.DiscountCodesAnyCondition`
     :   The type of the None singleton.
 
+<a id="DiscountCodesOrCondition"></a>
+
 `DiscountCodesOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1840,12 +2112,16 @@ Classes
     `or: list[airbyte_agent_sdk.connectors.shopify.types.DiscountCodesEqCondition | airbyte_agent_sdk.connectors.shopify.types.DiscountCodesNeqCondition | airbyte_agent_sdk.connectors.shopify.types.DiscountCodesGtCondition | airbyte_agent_sdk.connectors.shopify.types.DiscountCodesGteCondition | airbyte_agent_sdk.connectors.shopify.types.DiscountCodesLtCondition | airbyte_agent_sdk.connectors.shopify.types.DiscountCodesLteCondition | airbyte_agent_sdk.connectors.shopify.types.DiscountCodesInCondition | airbyte_agent_sdk.connectors.shopify.types.DiscountCodesLikeCondition | airbyte_agent_sdk.connectors.shopify.types.DiscountCodesFuzzyCondition | airbyte_agent_sdk.connectors.shopify.types.DiscountCodesKeywordCondition | airbyte_agent_sdk.connectors.shopify.types.DiscountCodesContainsCondition | airbyte_agent_sdk.connectors.shopify.types.DiscountCodesNotCondition | airbyte_agent_sdk.connectors.shopify.types.DiscountCodesAndCondition | airbyte_agent_sdk.connectors.shopify.types.DiscountCodesOrCondition | airbyte_agent_sdk.connectors.shopify.types.DiscountCodesAnyCondition]`
     :   The type of the None singleton.
 
+<a id="DiscountCodesSearchFilter"></a>
+
 `DiscountCodesSearchFilter(*args, **kwargs)`
 :   Available fields for filtering discount_codes search queries.
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="DiscountCodesSearchQuery"></a>
 
 `DiscountCodesSearchQuery(*args, **kwargs)`
 :   Search query for discount_codes entity.
@@ -1862,6 +2138,8 @@ Classes
     `sort: list[airbyte_agent_sdk.connectors.shopify.types.DiscountCodesSortFilter]`
     :   The type of the None singleton.
 
+<a id="DiscountCodesSortFilter"></a>
+
 `DiscountCodesSortFilter(*args, **kwargs)`
 :   Available fields for sorting discount_codes search results.
 
@@ -1869,12 +2147,16 @@ Classes
 
     * builtins.dict
 
+<a id="DiscountCodesStringFilter"></a>
+
 `DiscountCodesStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="DraftOrdersAndCondition"></a>
 
 `DraftOrdersAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -1896,6 +2178,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.shopify.types.DraftOrdersEqCondition | airbyte_agent_sdk.connectors.shopify.types.DraftOrdersNeqCondition | airbyte_agent_sdk.connectors.shopify.types.DraftOrdersGtCondition | airbyte_agent_sdk.connectors.shopify.types.DraftOrdersGteCondition | airbyte_agent_sdk.connectors.shopify.types.DraftOrdersLtCondition | airbyte_agent_sdk.connectors.shopify.types.DraftOrdersLteCondition | airbyte_agent_sdk.connectors.shopify.types.DraftOrdersInCondition | airbyte_agent_sdk.connectors.shopify.types.DraftOrdersLikeCondition | airbyte_agent_sdk.connectors.shopify.types.DraftOrdersFuzzyCondition | airbyte_agent_sdk.connectors.shopify.types.DraftOrdersKeywordCondition | airbyte_agent_sdk.connectors.shopify.types.DraftOrdersContainsCondition | airbyte_agent_sdk.connectors.shopify.types.DraftOrdersNotCondition | airbyte_agent_sdk.connectors.shopify.types.DraftOrdersAndCondition | airbyte_agent_sdk.connectors.shopify.types.DraftOrdersOrCondition | airbyte_agent_sdk.connectors.shopify.types.DraftOrdersAnyCondition]`
     :   The type of the None singleton.
 
+<a id="DraftOrdersAnyCondition"></a>
+
 `DraftOrdersAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1916,12 +2200,16 @@ Classes
     `any: airbyte_agent_sdk.connectors.shopify.types.DraftOrdersAnyValueFilter`
     :   The type of the None singleton.
 
+<a id="DraftOrdersAnyValueFilter"></a>
+
 `DraftOrdersAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="DraftOrdersContainsCondition"></a>
 
 `DraftOrdersContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
@@ -1935,6 +2223,8 @@ Classes
     `contains: airbyte_agent_sdk.connectors.shopify.types.DraftOrdersAnyValueFilter`
     :   The type of the None singleton.
 
+<a id="DraftOrdersEqCondition"></a>
+
 `DraftOrdersEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
 
@@ -1946,6 +2236,8 @@ Classes
 
     `eq: airbyte_agent_sdk.connectors.shopify.types.DraftOrdersSearchFilter`
     :   The type of the None singleton.
+
+<a id="DraftOrdersFuzzyCondition"></a>
 
 `DraftOrdersFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
@@ -1959,6 +2251,8 @@ Classes
     `fuzzy: airbyte_agent_sdk.connectors.shopify.types.DraftOrdersStringFilter`
     :   The type of the None singleton.
 
+<a id="DraftOrdersGetParams"></a>
+
 `DraftOrdersGetParams(*args, **kwargs)`
 :   Parameters for draft_orders.get operation
 
@@ -1970,6 +2264,8 @@ Classes
 
     `draft_order_id: str`
     :   The type of the None singleton.
+
+<a id="DraftOrdersGtCondition"></a>
 
 `DraftOrdersGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
@@ -1983,6 +2279,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.shopify.types.DraftOrdersSearchFilter`
     :   The type of the None singleton.
 
+<a id="DraftOrdersGteCondition"></a>
+
 `DraftOrdersGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -1994,6 +2292,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.shopify.types.DraftOrdersSearchFilter`
     :   The type of the None singleton.
+
+<a id="DraftOrdersInCondition"></a>
 
 `DraftOrdersInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -2015,12 +2315,16 @@ Classes
     `in: airbyte_agent_sdk.connectors.shopify.types.DraftOrdersInFilter`
     :   The type of the None singleton.
 
+<a id="DraftOrdersInFilter"></a>
+
 `DraftOrdersInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="DraftOrdersKeywordCondition"></a>
 
 `DraftOrdersKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
@@ -2034,6 +2338,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.shopify.types.DraftOrdersStringFilter`
     :   The type of the None singleton.
 
+<a id="DraftOrdersLikeCondition"></a>
+
 `DraftOrdersLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -2045,6 +2351,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.shopify.types.DraftOrdersStringFilter`
     :   The type of the None singleton.
+
+<a id="DraftOrdersListParams"></a>
 
 `DraftOrdersListParams(*args, **kwargs)`
 :   Parameters for draft_orders.list operation
@@ -2070,6 +2378,8 @@ Classes
     `updated_at_min: str`
     :   The type of the None singleton.
 
+<a id="DraftOrdersLtCondition"></a>
+
 `DraftOrdersLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -2081,6 +2391,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.shopify.types.DraftOrdersSearchFilter`
     :   The type of the None singleton.
+
+<a id="DraftOrdersLteCondition"></a>
 
 `DraftOrdersLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -2094,6 +2406,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.shopify.types.DraftOrdersSearchFilter`
     :   The type of the None singleton.
 
+<a id="DraftOrdersNeqCondition"></a>
+
 `DraftOrdersNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -2105,6 +2419,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.shopify.types.DraftOrdersSearchFilter`
     :   The type of the None singleton.
+
+<a id="DraftOrdersNotCondition"></a>
 
 `DraftOrdersNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -2126,6 +2442,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.shopify.types.DraftOrdersEqCondition | airbyte_agent_sdk.connectors.shopify.types.DraftOrdersNeqCondition | airbyte_agent_sdk.connectors.shopify.types.DraftOrdersGtCondition | airbyte_agent_sdk.connectors.shopify.types.DraftOrdersGteCondition | airbyte_agent_sdk.connectors.shopify.types.DraftOrdersLtCondition | airbyte_agent_sdk.connectors.shopify.types.DraftOrdersLteCondition | airbyte_agent_sdk.connectors.shopify.types.DraftOrdersInCondition | airbyte_agent_sdk.connectors.shopify.types.DraftOrdersLikeCondition | airbyte_agent_sdk.connectors.shopify.types.DraftOrdersFuzzyCondition | airbyte_agent_sdk.connectors.shopify.types.DraftOrdersKeywordCondition | airbyte_agent_sdk.connectors.shopify.types.DraftOrdersContainsCondition | airbyte_agent_sdk.connectors.shopify.types.DraftOrdersNotCondition | airbyte_agent_sdk.connectors.shopify.types.DraftOrdersAndCondition | airbyte_agent_sdk.connectors.shopify.types.DraftOrdersOrCondition | airbyte_agent_sdk.connectors.shopify.types.DraftOrdersAnyCondition`
     :   The type of the None singleton.
 
+<a id="DraftOrdersOrCondition"></a>
+
 `DraftOrdersOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -2146,12 +2464,16 @@ Classes
     `or: list[airbyte_agent_sdk.connectors.shopify.types.DraftOrdersEqCondition | airbyte_agent_sdk.connectors.shopify.types.DraftOrdersNeqCondition | airbyte_agent_sdk.connectors.shopify.types.DraftOrdersGtCondition | airbyte_agent_sdk.connectors.shopify.types.DraftOrdersGteCondition | airbyte_agent_sdk.connectors.shopify.types.DraftOrdersLtCondition | airbyte_agent_sdk.connectors.shopify.types.DraftOrdersLteCondition | airbyte_agent_sdk.connectors.shopify.types.DraftOrdersInCondition | airbyte_agent_sdk.connectors.shopify.types.DraftOrdersLikeCondition | airbyte_agent_sdk.connectors.shopify.types.DraftOrdersFuzzyCondition | airbyte_agent_sdk.connectors.shopify.types.DraftOrdersKeywordCondition | airbyte_agent_sdk.connectors.shopify.types.DraftOrdersContainsCondition | airbyte_agent_sdk.connectors.shopify.types.DraftOrdersNotCondition | airbyte_agent_sdk.connectors.shopify.types.DraftOrdersAndCondition | airbyte_agent_sdk.connectors.shopify.types.DraftOrdersOrCondition | airbyte_agent_sdk.connectors.shopify.types.DraftOrdersAnyCondition]`
     :   The type of the None singleton.
 
+<a id="DraftOrdersSearchFilter"></a>
+
 `DraftOrdersSearchFilter(*args, **kwargs)`
 :   Available fields for filtering draft_orders search queries.
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="DraftOrdersSearchQuery"></a>
 
 `DraftOrdersSearchQuery(*args, **kwargs)`
 :   Search query for draft_orders entity.
@@ -2168,6 +2490,8 @@ Classes
     `sort: list[airbyte_agent_sdk.connectors.shopify.types.DraftOrdersSortFilter]`
     :   The type of the None singleton.
 
+<a id="DraftOrdersSortFilter"></a>
+
 `DraftOrdersSortFilter(*args, **kwargs)`
 :   Available fields for sorting draft_orders search results.
 
@@ -2175,12 +2499,16 @@ Classes
 
     * builtins.dict
 
+<a id="DraftOrdersStringFilter"></a>
+
 `DraftOrdersStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="FulfillmentOrdersAndCondition"></a>
 
 `FulfillmentOrdersAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -2202,6 +2530,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.shopify.types.FulfillmentOrdersEqCondition | airbyte_agent_sdk.connectors.shopify.types.FulfillmentOrdersNeqCondition | airbyte_agent_sdk.connectors.shopify.types.FulfillmentOrdersGtCondition | airbyte_agent_sdk.connectors.shopify.types.FulfillmentOrdersGteCondition | airbyte_agent_sdk.connectors.shopify.types.FulfillmentOrdersLtCondition | airbyte_agent_sdk.connectors.shopify.types.FulfillmentOrdersLteCondition | airbyte_agent_sdk.connectors.shopify.types.FulfillmentOrdersInCondition | airbyte_agent_sdk.connectors.shopify.types.FulfillmentOrdersLikeCondition | airbyte_agent_sdk.connectors.shopify.types.FulfillmentOrdersFuzzyCondition | airbyte_agent_sdk.connectors.shopify.types.FulfillmentOrdersKeywordCondition | airbyte_agent_sdk.connectors.shopify.types.FulfillmentOrdersContainsCondition | airbyte_agent_sdk.connectors.shopify.types.FulfillmentOrdersNotCondition | airbyte_agent_sdk.connectors.shopify.types.FulfillmentOrdersAndCondition | airbyte_agent_sdk.connectors.shopify.types.FulfillmentOrdersOrCondition | airbyte_agent_sdk.connectors.shopify.types.FulfillmentOrdersAnyCondition]`
     :   The type of the None singleton.
 
+<a id="FulfillmentOrdersAnyCondition"></a>
+
 `FulfillmentOrdersAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -2222,12 +2552,16 @@ Classes
     `any: airbyte_agent_sdk.connectors.shopify.types.FulfillmentOrdersAnyValueFilter`
     :   The type of the None singleton.
 
+<a id="FulfillmentOrdersAnyValueFilter"></a>
+
 `FulfillmentOrdersAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="FulfillmentOrdersContainsCondition"></a>
 
 `FulfillmentOrdersContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
@@ -2241,6 +2575,8 @@ Classes
     `contains: airbyte_agent_sdk.connectors.shopify.types.FulfillmentOrdersAnyValueFilter`
     :   The type of the None singleton.
 
+<a id="FulfillmentOrdersEqCondition"></a>
+
 `FulfillmentOrdersEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
 
@@ -2252,6 +2588,8 @@ Classes
 
     `eq: airbyte_agent_sdk.connectors.shopify.types.FulfillmentOrdersSearchFilter`
     :   The type of the None singleton.
+
+<a id="FulfillmentOrdersFuzzyCondition"></a>
 
 `FulfillmentOrdersFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
@@ -2265,6 +2603,8 @@ Classes
     `fuzzy: airbyte_agent_sdk.connectors.shopify.types.FulfillmentOrdersStringFilter`
     :   The type of the None singleton.
 
+<a id="FulfillmentOrdersGetParams"></a>
+
 `FulfillmentOrdersGetParams(*args, **kwargs)`
 :   Parameters for fulfillment_orders.get operation
 
@@ -2276,6 +2616,8 @@ Classes
 
     `fulfillment_order_id: str`
     :   The type of the None singleton.
+
+<a id="FulfillmentOrdersGtCondition"></a>
 
 `FulfillmentOrdersGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
@@ -2289,6 +2631,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.shopify.types.FulfillmentOrdersSearchFilter`
     :   The type of the None singleton.
 
+<a id="FulfillmentOrdersGteCondition"></a>
+
 `FulfillmentOrdersGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -2300,6 +2644,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.shopify.types.FulfillmentOrdersSearchFilter`
     :   The type of the None singleton.
+
+<a id="FulfillmentOrdersInCondition"></a>
 
 `FulfillmentOrdersInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -2321,12 +2667,16 @@ Classes
     `in: airbyte_agent_sdk.connectors.shopify.types.FulfillmentOrdersInFilter`
     :   The type of the None singleton.
 
+<a id="FulfillmentOrdersInFilter"></a>
+
 `FulfillmentOrdersInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="FulfillmentOrdersKeywordCondition"></a>
 
 `FulfillmentOrdersKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
@@ -2340,6 +2690,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.shopify.types.FulfillmentOrdersStringFilter`
     :   The type of the None singleton.
 
+<a id="FulfillmentOrdersLikeCondition"></a>
+
 `FulfillmentOrdersLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -2351,6 +2703,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.shopify.types.FulfillmentOrdersStringFilter`
     :   The type of the None singleton.
+
+<a id="FulfillmentOrdersListParams"></a>
 
 `FulfillmentOrdersListParams(*args, **kwargs)`
 :   Parameters for fulfillment_orders.list operation
@@ -2364,6 +2718,8 @@ Classes
     `order_id: str`
     :   The type of the None singleton.
 
+<a id="FulfillmentOrdersLtCondition"></a>
+
 `FulfillmentOrdersLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -2375,6 +2731,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.shopify.types.FulfillmentOrdersSearchFilter`
     :   The type of the None singleton.
+
+<a id="FulfillmentOrdersLteCondition"></a>
 
 `FulfillmentOrdersLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -2388,6 +2746,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.shopify.types.FulfillmentOrdersSearchFilter`
     :   The type of the None singleton.
 
+<a id="FulfillmentOrdersNeqCondition"></a>
+
 `FulfillmentOrdersNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -2399,6 +2759,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.shopify.types.FulfillmentOrdersSearchFilter`
     :   The type of the None singleton.
+
+<a id="FulfillmentOrdersNotCondition"></a>
 
 `FulfillmentOrdersNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -2420,6 +2782,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.shopify.types.FulfillmentOrdersEqCondition | airbyte_agent_sdk.connectors.shopify.types.FulfillmentOrdersNeqCondition | airbyte_agent_sdk.connectors.shopify.types.FulfillmentOrdersGtCondition | airbyte_agent_sdk.connectors.shopify.types.FulfillmentOrdersGteCondition | airbyte_agent_sdk.connectors.shopify.types.FulfillmentOrdersLtCondition | airbyte_agent_sdk.connectors.shopify.types.FulfillmentOrdersLteCondition | airbyte_agent_sdk.connectors.shopify.types.FulfillmentOrdersInCondition | airbyte_agent_sdk.connectors.shopify.types.FulfillmentOrdersLikeCondition | airbyte_agent_sdk.connectors.shopify.types.FulfillmentOrdersFuzzyCondition | airbyte_agent_sdk.connectors.shopify.types.FulfillmentOrdersKeywordCondition | airbyte_agent_sdk.connectors.shopify.types.FulfillmentOrdersContainsCondition | airbyte_agent_sdk.connectors.shopify.types.FulfillmentOrdersNotCondition | airbyte_agent_sdk.connectors.shopify.types.FulfillmentOrdersAndCondition | airbyte_agent_sdk.connectors.shopify.types.FulfillmentOrdersOrCondition | airbyte_agent_sdk.connectors.shopify.types.FulfillmentOrdersAnyCondition`
     :   The type of the None singleton.
 
+<a id="FulfillmentOrdersOrCondition"></a>
+
 `FulfillmentOrdersOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -2440,12 +2804,16 @@ Classes
     `or: list[airbyte_agent_sdk.connectors.shopify.types.FulfillmentOrdersEqCondition | airbyte_agent_sdk.connectors.shopify.types.FulfillmentOrdersNeqCondition | airbyte_agent_sdk.connectors.shopify.types.FulfillmentOrdersGtCondition | airbyte_agent_sdk.connectors.shopify.types.FulfillmentOrdersGteCondition | airbyte_agent_sdk.connectors.shopify.types.FulfillmentOrdersLtCondition | airbyte_agent_sdk.connectors.shopify.types.FulfillmentOrdersLteCondition | airbyte_agent_sdk.connectors.shopify.types.FulfillmentOrdersInCondition | airbyte_agent_sdk.connectors.shopify.types.FulfillmentOrdersLikeCondition | airbyte_agent_sdk.connectors.shopify.types.FulfillmentOrdersFuzzyCondition | airbyte_agent_sdk.connectors.shopify.types.FulfillmentOrdersKeywordCondition | airbyte_agent_sdk.connectors.shopify.types.FulfillmentOrdersContainsCondition | airbyte_agent_sdk.connectors.shopify.types.FulfillmentOrdersNotCondition | airbyte_agent_sdk.connectors.shopify.types.FulfillmentOrdersAndCondition | airbyte_agent_sdk.connectors.shopify.types.FulfillmentOrdersOrCondition | airbyte_agent_sdk.connectors.shopify.types.FulfillmentOrdersAnyCondition]`
     :   The type of the None singleton.
 
+<a id="FulfillmentOrdersSearchFilter"></a>
+
 `FulfillmentOrdersSearchFilter(*args, **kwargs)`
 :   Available fields for filtering fulfillment_orders search queries.
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="FulfillmentOrdersSearchQuery"></a>
 
 `FulfillmentOrdersSearchQuery(*args, **kwargs)`
 :   Search query for fulfillment_orders entity.
@@ -2462,6 +2830,8 @@ Classes
     `sort: list[airbyte_agent_sdk.connectors.shopify.types.FulfillmentOrdersSortFilter]`
     :   The type of the None singleton.
 
+<a id="FulfillmentOrdersSortFilter"></a>
+
 `FulfillmentOrdersSortFilter(*args, **kwargs)`
 :   Available fields for sorting fulfillment_orders search results.
 
@@ -2469,12 +2839,16 @@ Classes
 
     * builtins.dict
 
+<a id="FulfillmentOrdersStringFilter"></a>
+
 `FulfillmentOrdersStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="FulfillmentsAndCondition"></a>
 
 `FulfillmentsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -2496,6 +2870,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.shopify.types.FulfillmentsEqCondition | airbyte_agent_sdk.connectors.shopify.types.FulfillmentsNeqCondition | airbyte_agent_sdk.connectors.shopify.types.FulfillmentsGtCondition | airbyte_agent_sdk.connectors.shopify.types.FulfillmentsGteCondition | airbyte_agent_sdk.connectors.shopify.types.FulfillmentsLtCondition | airbyte_agent_sdk.connectors.shopify.types.FulfillmentsLteCondition | airbyte_agent_sdk.connectors.shopify.types.FulfillmentsInCondition | airbyte_agent_sdk.connectors.shopify.types.FulfillmentsLikeCondition | airbyte_agent_sdk.connectors.shopify.types.FulfillmentsFuzzyCondition | airbyte_agent_sdk.connectors.shopify.types.FulfillmentsKeywordCondition | airbyte_agent_sdk.connectors.shopify.types.FulfillmentsContainsCondition | airbyte_agent_sdk.connectors.shopify.types.FulfillmentsNotCondition | airbyte_agent_sdk.connectors.shopify.types.FulfillmentsAndCondition | airbyte_agent_sdk.connectors.shopify.types.FulfillmentsOrCondition | airbyte_agent_sdk.connectors.shopify.types.FulfillmentsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="FulfillmentsAnyCondition"></a>
+
 `FulfillmentsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -2516,12 +2892,16 @@ Classes
     `any: airbyte_agent_sdk.connectors.shopify.types.FulfillmentsAnyValueFilter`
     :   The type of the None singleton.
 
+<a id="FulfillmentsAnyValueFilter"></a>
+
 `FulfillmentsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="FulfillmentsContainsCondition"></a>
 
 `FulfillmentsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
@@ -2535,6 +2915,8 @@ Classes
     `contains: airbyte_agent_sdk.connectors.shopify.types.FulfillmentsAnyValueFilter`
     :   The type of the None singleton.
 
+<a id="FulfillmentsEqCondition"></a>
+
 `FulfillmentsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
 
@@ -2547,6 +2929,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.shopify.types.FulfillmentsSearchFilter`
     :   The type of the None singleton.
 
+<a id="FulfillmentsFuzzyCondition"></a>
+
 `FulfillmentsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -2558,6 +2942,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.shopify.types.FulfillmentsStringFilter`
     :   The type of the None singleton.
+
+<a id="FulfillmentsGetParams"></a>
 
 `FulfillmentsGetParams(*args, **kwargs)`
 :   Parameters for fulfillments.get operation
@@ -2574,6 +2960,8 @@ Classes
     `order_id: str`
     :   The type of the None singleton.
 
+<a id="FulfillmentsGtCondition"></a>
+
 `FulfillmentsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -2586,6 +2974,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.shopify.types.FulfillmentsSearchFilter`
     :   The type of the None singleton.
 
+<a id="FulfillmentsGteCondition"></a>
+
 `FulfillmentsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -2597,6 +2987,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.shopify.types.FulfillmentsSearchFilter`
     :   The type of the None singleton.
+
+<a id="FulfillmentsInCondition"></a>
 
 `FulfillmentsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -2618,12 +3010,16 @@ Classes
     `in: airbyte_agent_sdk.connectors.shopify.types.FulfillmentsInFilter`
     :   The type of the None singleton.
 
+<a id="FulfillmentsInFilter"></a>
+
 `FulfillmentsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="FulfillmentsKeywordCondition"></a>
 
 `FulfillmentsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
@@ -2637,6 +3033,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.shopify.types.FulfillmentsStringFilter`
     :   The type of the None singleton.
 
+<a id="FulfillmentsLikeCondition"></a>
+
 `FulfillmentsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -2648,6 +3046,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.shopify.types.FulfillmentsStringFilter`
     :   The type of the None singleton.
+
+<a id="FulfillmentsListParams"></a>
 
 `FulfillmentsListParams(*args, **kwargs)`
 :   Parameters for fulfillments.list operation
@@ -2679,6 +3079,8 @@ Classes
     `updated_at_min: str`
     :   The type of the None singleton.
 
+<a id="FulfillmentsLtCondition"></a>
+
 `FulfillmentsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -2690,6 +3092,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.shopify.types.FulfillmentsSearchFilter`
     :   The type of the None singleton.
+
+<a id="FulfillmentsLteCondition"></a>
 
 `FulfillmentsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -2703,6 +3107,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.shopify.types.FulfillmentsSearchFilter`
     :   The type of the None singleton.
 
+<a id="FulfillmentsNeqCondition"></a>
+
 `FulfillmentsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -2714,6 +3120,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.shopify.types.FulfillmentsSearchFilter`
     :   The type of the None singleton.
+
+<a id="FulfillmentsNotCondition"></a>
 
 `FulfillmentsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -2735,6 +3143,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.shopify.types.FulfillmentsEqCondition | airbyte_agent_sdk.connectors.shopify.types.FulfillmentsNeqCondition | airbyte_agent_sdk.connectors.shopify.types.FulfillmentsGtCondition | airbyte_agent_sdk.connectors.shopify.types.FulfillmentsGteCondition | airbyte_agent_sdk.connectors.shopify.types.FulfillmentsLtCondition | airbyte_agent_sdk.connectors.shopify.types.FulfillmentsLteCondition | airbyte_agent_sdk.connectors.shopify.types.FulfillmentsInCondition | airbyte_agent_sdk.connectors.shopify.types.FulfillmentsLikeCondition | airbyte_agent_sdk.connectors.shopify.types.FulfillmentsFuzzyCondition | airbyte_agent_sdk.connectors.shopify.types.FulfillmentsKeywordCondition | airbyte_agent_sdk.connectors.shopify.types.FulfillmentsContainsCondition | airbyte_agent_sdk.connectors.shopify.types.FulfillmentsNotCondition | airbyte_agent_sdk.connectors.shopify.types.FulfillmentsAndCondition | airbyte_agent_sdk.connectors.shopify.types.FulfillmentsOrCondition | airbyte_agent_sdk.connectors.shopify.types.FulfillmentsAnyCondition`
     :   The type of the None singleton.
 
+<a id="FulfillmentsOrCondition"></a>
+
 `FulfillmentsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -2755,12 +3165,16 @@ Classes
     `or: list[airbyte_agent_sdk.connectors.shopify.types.FulfillmentsEqCondition | airbyte_agent_sdk.connectors.shopify.types.FulfillmentsNeqCondition | airbyte_agent_sdk.connectors.shopify.types.FulfillmentsGtCondition | airbyte_agent_sdk.connectors.shopify.types.FulfillmentsGteCondition | airbyte_agent_sdk.connectors.shopify.types.FulfillmentsLtCondition | airbyte_agent_sdk.connectors.shopify.types.FulfillmentsLteCondition | airbyte_agent_sdk.connectors.shopify.types.FulfillmentsInCondition | airbyte_agent_sdk.connectors.shopify.types.FulfillmentsLikeCondition | airbyte_agent_sdk.connectors.shopify.types.FulfillmentsFuzzyCondition | airbyte_agent_sdk.connectors.shopify.types.FulfillmentsKeywordCondition | airbyte_agent_sdk.connectors.shopify.types.FulfillmentsContainsCondition | airbyte_agent_sdk.connectors.shopify.types.FulfillmentsNotCondition | airbyte_agent_sdk.connectors.shopify.types.FulfillmentsAndCondition | airbyte_agent_sdk.connectors.shopify.types.FulfillmentsOrCondition | airbyte_agent_sdk.connectors.shopify.types.FulfillmentsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="FulfillmentsSearchFilter"></a>
+
 `FulfillmentsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering fulfillments search queries.
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="FulfillmentsSearchQuery"></a>
 
 `FulfillmentsSearchQuery(*args, **kwargs)`
 :   Search query for fulfillments entity.
@@ -2777,6 +3191,8 @@ Classes
     `sort: list[airbyte_agent_sdk.connectors.shopify.types.FulfillmentsSortFilter]`
     :   The type of the None singleton.
 
+<a id="FulfillmentsSortFilter"></a>
+
 `FulfillmentsSortFilter(*args, **kwargs)`
 :   Available fields for sorting fulfillments search results.
 
@@ -2784,12 +3200,16 @@ Classes
 
     * builtins.dict
 
+<a id="FulfillmentsStringFilter"></a>
+
 `FulfillmentsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="InventoryItemsAndCondition"></a>
 
 `InventoryItemsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -2811,6 +3231,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.shopify.types.InventoryItemsEqCondition | airbyte_agent_sdk.connectors.shopify.types.InventoryItemsNeqCondition | airbyte_agent_sdk.connectors.shopify.types.InventoryItemsGtCondition | airbyte_agent_sdk.connectors.shopify.types.InventoryItemsGteCondition | airbyte_agent_sdk.connectors.shopify.types.InventoryItemsLtCondition | airbyte_agent_sdk.connectors.shopify.types.InventoryItemsLteCondition | airbyte_agent_sdk.connectors.shopify.types.InventoryItemsInCondition | airbyte_agent_sdk.connectors.shopify.types.InventoryItemsLikeCondition | airbyte_agent_sdk.connectors.shopify.types.InventoryItemsFuzzyCondition | airbyte_agent_sdk.connectors.shopify.types.InventoryItemsKeywordCondition | airbyte_agent_sdk.connectors.shopify.types.InventoryItemsContainsCondition | airbyte_agent_sdk.connectors.shopify.types.InventoryItemsNotCondition | airbyte_agent_sdk.connectors.shopify.types.InventoryItemsAndCondition | airbyte_agent_sdk.connectors.shopify.types.InventoryItemsOrCondition | airbyte_agent_sdk.connectors.shopify.types.InventoryItemsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="InventoryItemsAnyCondition"></a>
+
 `InventoryItemsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -2831,12 +3253,16 @@ Classes
     `any: airbyte_agent_sdk.connectors.shopify.types.InventoryItemsAnyValueFilter`
     :   The type of the None singleton.
 
+<a id="InventoryItemsAnyValueFilter"></a>
+
 `InventoryItemsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="InventoryItemsContainsCondition"></a>
 
 `InventoryItemsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
@@ -2850,6 +3276,8 @@ Classes
     `contains: airbyte_agent_sdk.connectors.shopify.types.InventoryItemsAnyValueFilter`
     :   The type of the None singleton.
 
+<a id="InventoryItemsEqCondition"></a>
+
 `InventoryItemsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
 
@@ -2861,6 +3289,8 @@ Classes
 
     `eq: airbyte_agent_sdk.connectors.shopify.types.InventoryItemsSearchFilter`
     :   The type of the None singleton.
+
+<a id="InventoryItemsFuzzyCondition"></a>
 
 `InventoryItemsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
@@ -2874,6 +3304,8 @@ Classes
     `fuzzy: airbyte_agent_sdk.connectors.shopify.types.InventoryItemsStringFilter`
     :   The type of the None singleton.
 
+<a id="InventoryItemsGetParams"></a>
+
 `InventoryItemsGetParams(*args, **kwargs)`
 :   Parameters for inventory_items.get operation
 
@@ -2885,6 +3317,8 @@ Classes
 
     `inventory_item_id: str`
     :   The type of the None singleton.
+
+<a id="InventoryItemsGtCondition"></a>
 
 `InventoryItemsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
@@ -2898,6 +3332,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.shopify.types.InventoryItemsSearchFilter`
     :   The type of the None singleton.
 
+<a id="InventoryItemsGteCondition"></a>
+
 `InventoryItemsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -2909,6 +3345,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.shopify.types.InventoryItemsSearchFilter`
     :   The type of the None singleton.
+
+<a id="InventoryItemsInCondition"></a>
 
 `InventoryItemsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -2930,12 +3368,16 @@ Classes
     `in: airbyte_agent_sdk.connectors.shopify.types.InventoryItemsInFilter`
     :   The type of the None singleton.
 
+<a id="InventoryItemsInFilter"></a>
+
 `InventoryItemsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="InventoryItemsKeywordCondition"></a>
 
 `InventoryItemsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
@@ -2949,6 +3391,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.shopify.types.InventoryItemsStringFilter`
     :   The type of the None singleton.
 
+<a id="InventoryItemsLikeCondition"></a>
+
 `InventoryItemsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -2960,6 +3404,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.shopify.types.InventoryItemsStringFilter`
     :   The type of the None singleton.
+
+<a id="InventoryItemsListParams"></a>
 
 `InventoryItemsListParams(*args, **kwargs)`
 :   Parameters for inventory_items.list operation
@@ -2976,6 +3422,8 @@ Classes
     `limit: int`
     :   The type of the None singleton.
 
+<a id="InventoryItemsLtCondition"></a>
+
 `InventoryItemsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -2987,6 +3435,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.shopify.types.InventoryItemsSearchFilter`
     :   The type of the None singleton.
+
+<a id="InventoryItemsLteCondition"></a>
 
 `InventoryItemsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -3000,6 +3450,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.shopify.types.InventoryItemsSearchFilter`
     :   The type of the None singleton.
 
+<a id="InventoryItemsNeqCondition"></a>
+
 `InventoryItemsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -3011,6 +3463,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.shopify.types.InventoryItemsSearchFilter`
     :   The type of the None singleton.
+
+<a id="InventoryItemsNotCondition"></a>
 
 `InventoryItemsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -3032,6 +3486,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.shopify.types.InventoryItemsEqCondition | airbyte_agent_sdk.connectors.shopify.types.InventoryItemsNeqCondition | airbyte_agent_sdk.connectors.shopify.types.InventoryItemsGtCondition | airbyte_agent_sdk.connectors.shopify.types.InventoryItemsGteCondition | airbyte_agent_sdk.connectors.shopify.types.InventoryItemsLtCondition | airbyte_agent_sdk.connectors.shopify.types.InventoryItemsLteCondition | airbyte_agent_sdk.connectors.shopify.types.InventoryItemsInCondition | airbyte_agent_sdk.connectors.shopify.types.InventoryItemsLikeCondition | airbyte_agent_sdk.connectors.shopify.types.InventoryItemsFuzzyCondition | airbyte_agent_sdk.connectors.shopify.types.InventoryItemsKeywordCondition | airbyte_agent_sdk.connectors.shopify.types.InventoryItemsContainsCondition | airbyte_agent_sdk.connectors.shopify.types.InventoryItemsNotCondition | airbyte_agent_sdk.connectors.shopify.types.InventoryItemsAndCondition | airbyte_agent_sdk.connectors.shopify.types.InventoryItemsOrCondition | airbyte_agent_sdk.connectors.shopify.types.InventoryItemsAnyCondition`
     :   The type of the None singleton.
 
+<a id="InventoryItemsOrCondition"></a>
+
 `InventoryItemsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -3052,12 +3508,16 @@ Classes
     `or: list[airbyte_agent_sdk.connectors.shopify.types.InventoryItemsEqCondition | airbyte_agent_sdk.connectors.shopify.types.InventoryItemsNeqCondition | airbyte_agent_sdk.connectors.shopify.types.InventoryItemsGtCondition | airbyte_agent_sdk.connectors.shopify.types.InventoryItemsGteCondition | airbyte_agent_sdk.connectors.shopify.types.InventoryItemsLtCondition | airbyte_agent_sdk.connectors.shopify.types.InventoryItemsLteCondition | airbyte_agent_sdk.connectors.shopify.types.InventoryItemsInCondition | airbyte_agent_sdk.connectors.shopify.types.InventoryItemsLikeCondition | airbyte_agent_sdk.connectors.shopify.types.InventoryItemsFuzzyCondition | airbyte_agent_sdk.connectors.shopify.types.InventoryItemsKeywordCondition | airbyte_agent_sdk.connectors.shopify.types.InventoryItemsContainsCondition | airbyte_agent_sdk.connectors.shopify.types.InventoryItemsNotCondition | airbyte_agent_sdk.connectors.shopify.types.InventoryItemsAndCondition | airbyte_agent_sdk.connectors.shopify.types.InventoryItemsOrCondition | airbyte_agent_sdk.connectors.shopify.types.InventoryItemsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="InventoryItemsSearchFilter"></a>
+
 `InventoryItemsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering inventory_items search queries.
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="InventoryItemsSearchQuery"></a>
 
 `InventoryItemsSearchQuery(*args, **kwargs)`
 :   Search query for inventory_items entity.
@@ -3074,6 +3534,8 @@ Classes
     `sort: list[airbyte_agent_sdk.connectors.shopify.types.InventoryItemsSortFilter]`
     :   The type of the None singleton.
 
+<a id="InventoryItemsSortFilter"></a>
+
 `InventoryItemsSortFilter(*args, **kwargs)`
 :   Available fields for sorting inventory_items search results.
 
@@ -3081,12 +3543,16 @@ Classes
 
     * builtins.dict
 
+<a id="InventoryItemsStringFilter"></a>
+
 `InventoryItemsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="InventoryLevelsAndCondition"></a>
 
 `InventoryLevelsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -3108,6 +3574,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.shopify.types.InventoryLevelsEqCondition | airbyte_agent_sdk.connectors.shopify.types.InventoryLevelsNeqCondition | airbyte_agent_sdk.connectors.shopify.types.InventoryLevelsGtCondition | airbyte_agent_sdk.connectors.shopify.types.InventoryLevelsGteCondition | airbyte_agent_sdk.connectors.shopify.types.InventoryLevelsLtCondition | airbyte_agent_sdk.connectors.shopify.types.InventoryLevelsLteCondition | airbyte_agent_sdk.connectors.shopify.types.InventoryLevelsInCondition | airbyte_agent_sdk.connectors.shopify.types.InventoryLevelsLikeCondition | airbyte_agent_sdk.connectors.shopify.types.InventoryLevelsFuzzyCondition | airbyte_agent_sdk.connectors.shopify.types.InventoryLevelsKeywordCondition | airbyte_agent_sdk.connectors.shopify.types.InventoryLevelsContainsCondition | airbyte_agent_sdk.connectors.shopify.types.InventoryLevelsNotCondition | airbyte_agent_sdk.connectors.shopify.types.InventoryLevelsAndCondition | airbyte_agent_sdk.connectors.shopify.types.InventoryLevelsOrCondition | airbyte_agent_sdk.connectors.shopify.types.InventoryLevelsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="InventoryLevelsAnyCondition"></a>
+
 `InventoryLevelsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -3128,12 +3596,16 @@ Classes
     `any: airbyte_agent_sdk.connectors.shopify.types.InventoryLevelsAnyValueFilter`
     :   The type of the None singleton.
 
+<a id="InventoryLevelsAnyValueFilter"></a>
+
 `InventoryLevelsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="InventoryLevelsContainsCondition"></a>
 
 `InventoryLevelsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
@@ -3147,6 +3619,8 @@ Classes
     `contains: airbyte_agent_sdk.connectors.shopify.types.InventoryLevelsAnyValueFilter`
     :   The type of the None singleton.
 
+<a id="InventoryLevelsEqCondition"></a>
+
 `InventoryLevelsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
 
@@ -3158,6 +3632,8 @@ Classes
 
     `eq: airbyte_agent_sdk.connectors.shopify.types.InventoryLevelsSearchFilter`
     :   The type of the None singleton.
+
+<a id="InventoryLevelsFuzzyCondition"></a>
 
 `InventoryLevelsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
@@ -3171,6 +3647,8 @@ Classes
     `fuzzy: airbyte_agent_sdk.connectors.shopify.types.InventoryLevelsStringFilter`
     :   The type of the None singleton.
 
+<a id="InventoryLevelsGtCondition"></a>
+
 `InventoryLevelsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -3183,6 +3661,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.shopify.types.InventoryLevelsSearchFilter`
     :   The type of the None singleton.
 
+<a id="InventoryLevelsGteCondition"></a>
+
 `InventoryLevelsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -3194,6 +3674,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.shopify.types.InventoryLevelsSearchFilter`
     :   The type of the None singleton.
+
+<a id="InventoryLevelsInCondition"></a>
 
 `InventoryLevelsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -3215,12 +3697,16 @@ Classes
     `in: airbyte_agent_sdk.connectors.shopify.types.InventoryLevelsInFilter`
     :   The type of the None singleton.
 
+<a id="InventoryLevelsInFilter"></a>
+
 `InventoryLevelsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="InventoryLevelsKeywordCondition"></a>
 
 `InventoryLevelsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
@@ -3234,6 +3720,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.shopify.types.InventoryLevelsStringFilter`
     :   The type of the None singleton.
 
+<a id="InventoryLevelsLikeCondition"></a>
+
 `InventoryLevelsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -3245,6 +3733,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.shopify.types.InventoryLevelsStringFilter`
     :   The type of the None singleton.
+
+<a id="InventoryLevelsListParams"></a>
 
 `InventoryLevelsListParams(*args, **kwargs)`
 :   Parameters for inventory_levels.list operation
@@ -3261,6 +3751,8 @@ Classes
     `location_id: str`
     :   The type of the None singleton.
 
+<a id="InventoryLevelsLtCondition"></a>
+
 `InventoryLevelsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -3272,6 +3764,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.shopify.types.InventoryLevelsSearchFilter`
     :   The type of the None singleton.
+
+<a id="InventoryLevelsLteCondition"></a>
 
 `InventoryLevelsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -3285,6 +3779,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.shopify.types.InventoryLevelsSearchFilter`
     :   The type of the None singleton.
 
+<a id="InventoryLevelsNeqCondition"></a>
+
 `InventoryLevelsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -3296,6 +3792,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.shopify.types.InventoryLevelsSearchFilter`
     :   The type of the None singleton.
+
+<a id="InventoryLevelsNotCondition"></a>
 
 `InventoryLevelsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -3317,6 +3815,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.shopify.types.InventoryLevelsEqCondition | airbyte_agent_sdk.connectors.shopify.types.InventoryLevelsNeqCondition | airbyte_agent_sdk.connectors.shopify.types.InventoryLevelsGtCondition | airbyte_agent_sdk.connectors.shopify.types.InventoryLevelsGteCondition | airbyte_agent_sdk.connectors.shopify.types.InventoryLevelsLtCondition | airbyte_agent_sdk.connectors.shopify.types.InventoryLevelsLteCondition | airbyte_agent_sdk.connectors.shopify.types.InventoryLevelsInCondition | airbyte_agent_sdk.connectors.shopify.types.InventoryLevelsLikeCondition | airbyte_agent_sdk.connectors.shopify.types.InventoryLevelsFuzzyCondition | airbyte_agent_sdk.connectors.shopify.types.InventoryLevelsKeywordCondition | airbyte_agent_sdk.connectors.shopify.types.InventoryLevelsContainsCondition | airbyte_agent_sdk.connectors.shopify.types.InventoryLevelsNotCondition | airbyte_agent_sdk.connectors.shopify.types.InventoryLevelsAndCondition | airbyte_agent_sdk.connectors.shopify.types.InventoryLevelsOrCondition | airbyte_agent_sdk.connectors.shopify.types.InventoryLevelsAnyCondition`
     :   The type of the None singleton.
 
+<a id="InventoryLevelsOrCondition"></a>
+
 `InventoryLevelsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -3337,12 +3837,16 @@ Classes
     `or: list[airbyte_agent_sdk.connectors.shopify.types.InventoryLevelsEqCondition | airbyte_agent_sdk.connectors.shopify.types.InventoryLevelsNeqCondition | airbyte_agent_sdk.connectors.shopify.types.InventoryLevelsGtCondition | airbyte_agent_sdk.connectors.shopify.types.InventoryLevelsGteCondition | airbyte_agent_sdk.connectors.shopify.types.InventoryLevelsLtCondition | airbyte_agent_sdk.connectors.shopify.types.InventoryLevelsLteCondition | airbyte_agent_sdk.connectors.shopify.types.InventoryLevelsInCondition | airbyte_agent_sdk.connectors.shopify.types.InventoryLevelsLikeCondition | airbyte_agent_sdk.connectors.shopify.types.InventoryLevelsFuzzyCondition | airbyte_agent_sdk.connectors.shopify.types.InventoryLevelsKeywordCondition | airbyte_agent_sdk.connectors.shopify.types.InventoryLevelsContainsCondition | airbyte_agent_sdk.connectors.shopify.types.InventoryLevelsNotCondition | airbyte_agent_sdk.connectors.shopify.types.InventoryLevelsAndCondition | airbyte_agent_sdk.connectors.shopify.types.InventoryLevelsOrCondition | airbyte_agent_sdk.connectors.shopify.types.InventoryLevelsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="InventoryLevelsSearchFilter"></a>
+
 `InventoryLevelsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering inventory_levels search queries.
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="InventoryLevelsSearchQuery"></a>
 
 `InventoryLevelsSearchQuery(*args, **kwargs)`
 :   Search query for inventory_levels entity.
@@ -3359,6 +3863,8 @@ Classes
     `sort: list[airbyte_agent_sdk.connectors.shopify.types.InventoryLevelsSortFilter]`
     :   The type of the None singleton.
 
+<a id="InventoryLevelsSortFilter"></a>
+
 `InventoryLevelsSortFilter(*args, **kwargs)`
 :   Available fields for sorting inventory_levels search results.
 
@@ -3366,12 +3872,16 @@ Classes
 
     * builtins.dict
 
+<a id="InventoryLevelsStringFilter"></a>
+
 `InventoryLevelsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="LocationsAndCondition"></a>
 
 `LocationsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -3393,6 +3903,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.shopify.types.LocationsEqCondition | airbyte_agent_sdk.connectors.shopify.types.LocationsNeqCondition | airbyte_agent_sdk.connectors.shopify.types.LocationsGtCondition | airbyte_agent_sdk.connectors.shopify.types.LocationsGteCondition | airbyte_agent_sdk.connectors.shopify.types.LocationsLtCondition | airbyte_agent_sdk.connectors.shopify.types.LocationsLteCondition | airbyte_agent_sdk.connectors.shopify.types.LocationsInCondition | airbyte_agent_sdk.connectors.shopify.types.LocationsLikeCondition | airbyte_agent_sdk.connectors.shopify.types.LocationsFuzzyCondition | airbyte_agent_sdk.connectors.shopify.types.LocationsKeywordCondition | airbyte_agent_sdk.connectors.shopify.types.LocationsContainsCondition | airbyte_agent_sdk.connectors.shopify.types.LocationsNotCondition | airbyte_agent_sdk.connectors.shopify.types.LocationsAndCondition | airbyte_agent_sdk.connectors.shopify.types.LocationsOrCondition | airbyte_agent_sdk.connectors.shopify.types.LocationsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="LocationsAnyCondition"></a>
+
 `LocationsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -3413,12 +3925,16 @@ Classes
     `any: airbyte_agent_sdk.connectors.shopify.types.LocationsAnyValueFilter`
     :   The type of the None singleton.
 
+<a id="LocationsAnyValueFilter"></a>
+
 `LocationsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="LocationsContainsCondition"></a>
 
 `LocationsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
@@ -3432,6 +3948,8 @@ Classes
     `contains: airbyte_agent_sdk.connectors.shopify.types.LocationsAnyValueFilter`
     :   The type of the None singleton.
 
+<a id="LocationsEqCondition"></a>
+
 `LocationsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
 
@@ -3443,6 +3961,8 @@ Classes
 
     `eq: airbyte_agent_sdk.connectors.shopify.types.LocationsSearchFilter`
     :   The type of the None singleton.
+
+<a id="LocationsFuzzyCondition"></a>
 
 `LocationsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
@@ -3456,6 +3976,8 @@ Classes
     `fuzzy: airbyte_agent_sdk.connectors.shopify.types.LocationsStringFilter`
     :   The type of the None singleton.
 
+<a id="LocationsGetParams"></a>
+
 `LocationsGetParams(*args, **kwargs)`
 :   Parameters for locations.get operation
 
@@ -3467,6 +3989,8 @@ Classes
 
     `location_id: str`
     :   The type of the None singleton.
+
+<a id="LocationsGtCondition"></a>
 
 `LocationsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
@@ -3480,6 +4004,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.shopify.types.LocationsSearchFilter`
     :   The type of the None singleton.
 
+<a id="LocationsGteCondition"></a>
+
 `LocationsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -3491,6 +4017,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.shopify.types.LocationsSearchFilter`
     :   The type of the None singleton.
+
+<a id="LocationsInCondition"></a>
 
 `LocationsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -3512,12 +4040,16 @@ Classes
     `in: airbyte_agent_sdk.connectors.shopify.types.LocationsInFilter`
     :   The type of the None singleton.
 
+<a id="LocationsInFilter"></a>
+
 `LocationsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="LocationsKeywordCondition"></a>
 
 `LocationsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
@@ -3531,6 +4063,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.shopify.types.LocationsStringFilter`
     :   The type of the None singleton.
 
+<a id="LocationsLikeCondition"></a>
+
 `LocationsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -3543,12 +4077,16 @@ Classes
     `like: airbyte_agent_sdk.connectors.shopify.types.LocationsStringFilter`
     :   The type of the None singleton.
 
+<a id="LocationsListParams"></a>
+
 `LocationsListParams(*args, **kwargs)`
 :   Parameters for locations.list operation
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="LocationsLtCondition"></a>
 
 `LocationsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
@@ -3562,6 +4100,8 @@ Classes
     `lt: airbyte_agent_sdk.connectors.shopify.types.LocationsSearchFilter`
     :   The type of the None singleton.
 
+<a id="LocationsLteCondition"></a>
+
 `LocationsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
 
@@ -3574,6 +4114,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.shopify.types.LocationsSearchFilter`
     :   The type of the None singleton.
 
+<a id="LocationsNeqCondition"></a>
+
 `LocationsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -3585,6 +4127,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.shopify.types.LocationsSearchFilter`
     :   The type of the None singleton.
+
+<a id="LocationsNotCondition"></a>
 
 `LocationsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -3606,6 +4150,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.shopify.types.LocationsEqCondition | airbyte_agent_sdk.connectors.shopify.types.LocationsNeqCondition | airbyte_agent_sdk.connectors.shopify.types.LocationsGtCondition | airbyte_agent_sdk.connectors.shopify.types.LocationsGteCondition | airbyte_agent_sdk.connectors.shopify.types.LocationsLtCondition | airbyte_agent_sdk.connectors.shopify.types.LocationsLteCondition | airbyte_agent_sdk.connectors.shopify.types.LocationsInCondition | airbyte_agent_sdk.connectors.shopify.types.LocationsLikeCondition | airbyte_agent_sdk.connectors.shopify.types.LocationsFuzzyCondition | airbyte_agent_sdk.connectors.shopify.types.LocationsKeywordCondition | airbyte_agent_sdk.connectors.shopify.types.LocationsContainsCondition | airbyte_agent_sdk.connectors.shopify.types.LocationsNotCondition | airbyte_agent_sdk.connectors.shopify.types.LocationsAndCondition | airbyte_agent_sdk.connectors.shopify.types.LocationsOrCondition | airbyte_agent_sdk.connectors.shopify.types.LocationsAnyCondition`
     :   The type of the None singleton.
 
+<a id="LocationsOrCondition"></a>
+
 `LocationsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -3626,12 +4172,16 @@ Classes
     `or: list[airbyte_agent_sdk.connectors.shopify.types.LocationsEqCondition | airbyte_agent_sdk.connectors.shopify.types.LocationsNeqCondition | airbyte_agent_sdk.connectors.shopify.types.LocationsGtCondition | airbyte_agent_sdk.connectors.shopify.types.LocationsGteCondition | airbyte_agent_sdk.connectors.shopify.types.LocationsLtCondition | airbyte_agent_sdk.connectors.shopify.types.LocationsLteCondition | airbyte_agent_sdk.connectors.shopify.types.LocationsInCondition | airbyte_agent_sdk.connectors.shopify.types.LocationsLikeCondition | airbyte_agent_sdk.connectors.shopify.types.LocationsFuzzyCondition | airbyte_agent_sdk.connectors.shopify.types.LocationsKeywordCondition | airbyte_agent_sdk.connectors.shopify.types.LocationsContainsCondition | airbyte_agent_sdk.connectors.shopify.types.LocationsNotCondition | airbyte_agent_sdk.connectors.shopify.types.LocationsAndCondition | airbyte_agent_sdk.connectors.shopify.types.LocationsOrCondition | airbyte_agent_sdk.connectors.shopify.types.LocationsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="LocationsSearchFilter"></a>
+
 `LocationsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering locations search queries.
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="LocationsSearchQuery"></a>
 
 `LocationsSearchQuery(*args, **kwargs)`
 :   Search query for locations entity.
@@ -3648,6 +4198,8 @@ Classes
     `sort: list[airbyte_agent_sdk.connectors.shopify.types.LocationsSortFilter]`
     :   The type of the None singleton.
 
+<a id="LocationsSortFilter"></a>
+
 `LocationsSortFilter(*args, **kwargs)`
 :   Available fields for sorting locations search results.
 
@@ -3655,12 +4207,16 @@ Classes
 
     * builtins.dict
 
+<a id="LocationsStringFilter"></a>
+
 `LocationsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="MetafieldCustomersAndCondition"></a>
 
 `MetafieldCustomersAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -3682,6 +4238,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.shopify.types.MetafieldCustomersEqCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldCustomersNeqCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldCustomersGtCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldCustomersGteCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldCustomersLtCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldCustomersLteCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldCustomersInCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldCustomersLikeCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldCustomersFuzzyCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldCustomersKeywordCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldCustomersContainsCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldCustomersNotCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldCustomersAndCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldCustomersOrCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldCustomersAnyCondition]`
     :   The type of the None singleton.
 
+<a id="MetafieldCustomersAnyCondition"></a>
+
 `MetafieldCustomersAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -3702,12 +4260,16 @@ Classes
     `any: airbyte_agent_sdk.connectors.shopify.types.MetafieldCustomersAnyValueFilter`
     :   The type of the None singleton.
 
+<a id="MetafieldCustomersAnyValueFilter"></a>
+
 `MetafieldCustomersAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="MetafieldCustomersContainsCondition"></a>
 
 `MetafieldCustomersContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
@@ -3721,6 +4283,8 @@ Classes
     `contains: airbyte_agent_sdk.connectors.shopify.types.MetafieldCustomersAnyValueFilter`
     :   The type of the None singleton.
 
+<a id="MetafieldCustomersEqCondition"></a>
+
 `MetafieldCustomersEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
 
@@ -3732,6 +4296,8 @@ Classes
 
     `eq: airbyte_agent_sdk.connectors.shopify.types.MetafieldCustomersSearchFilter`
     :   The type of the None singleton.
+
+<a id="MetafieldCustomersFuzzyCondition"></a>
 
 `MetafieldCustomersFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
@@ -3745,6 +4311,8 @@ Classes
     `fuzzy: airbyte_agent_sdk.connectors.shopify.types.MetafieldCustomersStringFilter`
     :   The type of the None singleton.
 
+<a id="MetafieldCustomersGtCondition"></a>
+
 `MetafieldCustomersGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -3757,6 +4325,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.shopify.types.MetafieldCustomersSearchFilter`
     :   The type of the None singleton.
 
+<a id="MetafieldCustomersGteCondition"></a>
+
 `MetafieldCustomersGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -3768,6 +4338,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.shopify.types.MetafieldCustomersSearchFilter`
     :   The type of the None singleton.
+
+<a id="MetafieldCustomersInCondition"></a>
 
 `MetafieldCustomersInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -3789,12 +4361,16 @@ Classes
     `in: airbyte_agent_sdk.connectors.shopify.types.MetafieldCustomersInFilter`
     :   The type of the None singleton.
 
+<a id="MetafieldCustomersInFilter"></a>
+
 `MetafieldCustomersInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="MetafieldCustomersKeywordCondition"></a>
 
 `MetafieldCustomersKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
@@ -3808,6 +4384,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.shopify.types.MetafieldCustomersStringFilter`
     :   The type of the None singleton.
 
+<a id="MetafieldCustomersLikeCondition"></a>
+
 `MetafieldCustomersLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -3819,6 +4397,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.shopify.types.MetafieldCustomersStringFilter`
     :   The type of the None singleton.
+
+<a id="MetafieldCustomersListParams"></a>
 
 `MetafieldCustomersListParams(*args, **kwargs)`
 :   Parameters for metafield_customers.list operation
@@ -3844,6 +4424,8 @@ Classes
     `since_id: int`
     :   The type of the None singleton.
 
+<a id="MetafieldCustomersLtCondition"></a>
+
 `MetafieldCustomersLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -3855,6 +4437,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.shopify.types.MetafieldCustomersSearchFilter`
     :   The type of the None singleton.
+
+<a id="MetafieldCustomersLteCondition"></a>
 
 `MetafieldCustomersLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -3868,6 +4452,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.shopify.types.MetafieldCustomersSearchFilter`
     :   The type of the None singleton.
 
+<a id="MetafieldCustomersNeqCondition"></a>
+
 `MetafieldCustomersNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -3879,6 +4465,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.shopify.types.MetafieldCustomersSearchFilter`
     :   The type of the None singleton.
+
+<a id="MetafieldCustomersNotCondition"></a>
 
 `MetafieldCustomersNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -3900,6 +4488,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.shopify.types.MetafieldCustomersEqCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldCustomersNeqCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldCustomersGtCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldCustomersGteCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldCustomersLtCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldCustomersLteCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldCustomersInCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldCustomersLikeCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldCustomersFuzzyCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldCustomersKeywordCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldCustomersContainsCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldCustomersNotCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldCustomersAndCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldCustomersOrCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldCustomersAnyCondition`
     :   The type of the None singleton.
 
+<a id="MetafieldCustomersOrCondition"></a>
+
 `MetafieldCustomersOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -3920,12 +4510,16 @@ Classes
     `or: list[airbyte_agent_sdk.connectors.shopify.types.MetafieldCustomersEqCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldCustomersNeqCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldCustomersGtCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldCustomersGteCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldCustomersLtCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldCustomersLteCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldCustomersInCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldCustomersLikeCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldCustomersFuzzyCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldCustomersKeywordCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldCustomersContainsCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldCustomersNotCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldCustomersAndCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldCustomersOrCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldCustomersAnyCondition]`
     :   The type of the None singleton.
 
+<a id="MetafieldCustomersSearchFilter"></a>
+
 `MetafieldCustomersSearchFilter(*args, **kwargs)`
 :   Available fields for filtering metafield_customers search queries.
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="MetafieldCustomersSearchQuery"></a>
 
 `MetafieldCustomersSearchQuery(*args, **kwargs)`
 :   Search query for metafield_customers entity.
@@ -3942,6 +4536,8 @@ Classes
     `sort: list[airbyte_agent_sdk.connectors.shopify.types.MetafieldCustomersSortFilter]`
     :   The type of the None singleton.
 
+<a id="MetafieldCustomersSortFilter"></a>
+
 `MetafieldCustomersSortFilter(*args, **kwargs)`
 :   Available fields for sorting metafield_customers search results.
 
@@ -3949,12 +4545,16 @@ Classes
 
     * builtins.dict
 
+<a id="MetafieldCustomersStringFilter"></a>
+
 `MetafieldCustomersStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="MetafieldDraftOrdersAndCondition"></a>
 
 `MetafieldDraftOrdersAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -3976,6 +4576,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.shopify.types.MetafieldDraftOrdersEqCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldDraftOrdersNeqCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldDraftOrdersGtCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldDraftOrdersGteCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldDraftOrdersLtCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldDraftOrdersLteCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldDraftOrdersInCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldDraftOrdersLikeCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldDraftOrdersFuzzyCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldDraftOrdersKeywordCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldDraftOrdersContainsCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldDraftOrdersNotCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldDraftOrdersAndCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldDraftOrdersOrCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldDraftOrdersAnyCondition]`
     :   The type of the None singleton.
 
+<a id="MetafieldDraftOrdersAnyCondition"></a>
+
 `MetafieldDraftOrdersAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -3996,12 +4598,16 @@ Classes
     `any: airbyte_agent_sdk.connectors.shopify.types.MetafieldDraftOrdersAnyValueFilter`
     :   The type of the None singleton.
 
+<a id="MetafieldDraftOrdersAnyValueFilter"></a>
+
 `MetafieldDraftOrdersAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="MetafieldDraftOrdersContainsCondition"></a>
 
 `MetafieldDraftOrdersContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
@@ -4015,6 +4621,8 @@ Classes
     `contains: airbyte_agent_sdk.connectors.shopify.types.MetafieldDraftOrdersAnyValueFilter`
     :   The type of the None singleton.
 
+<a id="MetafieldDraftOrdersEqCondition"></a>
+
 `MetafieldDraftOrdersEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
 
@@ -4026,6 +4634,8 @@ Classes
 
     `eq: airbyte_agent_sdk.connectors.shopify.types.MetafieldDraftOrdersSearchFilter`
     :   The type of the None singleton.
+
+<a id="MetafieldDraftOrdersFuzzyCondition"></a>
 
 `MetafieldDraftOrdersFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
@@ -4039,6 +4649,8 @@ Classes
     `fuzzy: airbyte_agent_sdk.connectors.shopify.types.MetafieldDraftOrdersStringFilter`
     :   The type of the None singleton.
 
+<a id="MetafieldDraftOrdersGtCondition"></a>
+
 `MetafieldDraftOrdersGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -4051,6 +4663,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.shopify.types.MetafieldDraftOrdersSearchFilter`
     :   The type of the None singleton.
 
+<a id="MetafieldDraftOrdersGteCondition"></a>
+
 `MetafieldDraftOrdersGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -4062,6 +4676,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.shopify.types.MetafieldDraftOrdersSearchFilter`
     :   The type of the None singleton.
+
+<a id="MetafieldDraftOrdersInCondition"></a>
 
 `MetafieldDraftOrdersInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -4083,12 +4699,16 @@ Classes
     `in: airbyte_agent_sdk.connectors.shopify.types.MetafieldDraftOrdersInFilter`
     :   The type of the None singleton.
 
+<a id="MetafieldDraftOrdersInFilter"></a>
+
 `MetafieldDraftOrdersInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="MetafieldDraftOrdersKeywordCondition"></a>
 
 `MetafieldDraftOrdersKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
@@ -4102,6 +4722,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.shopify.types.MetafieldDraftOrdersStringFilter`
     :   The type of the None singleton.
 
+<a id="MetafieldDraftOrdersLikeCondition"></a>
+
 `MetafieldDraftOrdersLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -4113,6 +4735,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.shopify.types.MetafieldDraftOrdersStringFilter`
     :   The type of the None singleton.
+
+<a id="MetafieldDraftOrdersListParams"></a>
 
 `MetafieldDraftOrdersListParams(*args, **kwargs)`
 :   Parameters for metafield_draft_orders.list operation
@@ -4138,6 +4762,8 @@ Classes
     `since_id: int`
     :   The type of the None singleton.
 
+<a id="MetafieldDraftOrdersLtCondition"></a>
+
 `MetafieldDraftOrdersLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -4149,6 +4775,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.shopify.types.MetafieldDraftOrdersSearchFilter`
     :   The type of the None singleton.
+
+<a id="MetafieldDraftOrdersLteCondition"></a>
 
 `MetafieldDraftOrdersLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -4162,6 +4790,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.shopify.types.MetafieldDraftOrdersSearchFilter`
     :   The type of the None singleton.
 
+<a id="MetafieldDraftOrdersNeqCondition"></a>
+
 `MetafieldDraftOrdersNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -4173,6 +4803,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.shopify.types.MetafieldDraftOrdersSearchFilter`
     :   The type of the None singleton.
+
+<a id="MetafieldDraftOrdersNotCondition"></a>
 
 `MetafieldDraftOrdersNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -4194,6 +4826,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.shopify.types.MetafieldDraftOrdersEqCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldDraftOrdersNeqCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldDraftOrdersGtCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldDraftOrdersGteCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldDraftOrdersLtCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldDraftOrdersLteCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldDraftOrdersInCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldDraftOrdersLikeCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldDraftOrdersFuzzyCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldDraftOrdersKeywordCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldDraftOrdersContainsCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldDraftOrdersNotCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldDraftOrdersAndCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldDraftOrdersOrCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldDraftOrdersAnyCondition`
     :   The type of the None singleton.
 
+<a id="MetafieldDraftOrdersOrCondition"></a>
+
 `MetafieldDraftOrdersOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -4214,12 +4848,16 @@ Classes
     `or: list[airbyte_agent_sdk.connectors.shopify.types.MetafieldDraftOrdersEqCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldDraftOrdersNeqCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldDraftOrdersGtCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldDraftOrdersGteCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldDraftOrdersLtCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldDraftOrdersLteCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldDraftOrdersInCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldDraftOrdersLikeCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldDraftOrdersFuzzyCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldDraftOrdersKeywordCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldDraftOrdersContainsCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldDraftOrdersNotCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldDraftOrdersAndCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldDraftOrdersOrCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldDraftOrdersAnyCondition]`
     :   The type of the None singleton.
 
+<a id="MetafieldDraftOrdersSearchFilter"></a>
+
 `MetafieldDraftOrdersSearchFilter(*args, **kwargs)`
 :   Available fields for filtering metafield_draft_orders search queries.
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="MetafieldDraftOrdersSearchQuery"></a>
 
 `MetafieldDraftOrdersSearchQuery(*args, **kwargs)`
 :   Search query for metafield_draft_orders entity.
@@ -4236,6 +4874,8 @@ Classes
     `sort: list[airbyte_agent_sdk.connectors.shopify.types.MetafieldDraftOrdersSortFilter]`
     :   The type of the None singleton.
 
+<a id="MetafieldDraftOrdersSortFilter"></a>
+
 `MetafieldDraftOrdersSortFilter(*args, **kwargs)`
 :   Available fields for sorting metafield_draft_orders search results.
 
@@ -4243,12 +4883,16 @@ Classes
 
     * builtins.dict
 
+<a id="MetafieldDraftOrdersStringFilter"></a>
+
 `MetafieldDraftOrdersStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="MetafieldLocationsAndCondition"></a>
 
 `MetafieldLocationsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -4270,6 +4914,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.shopify.types.MetafieldLocationsEqCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldLocationsNeqCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldLocationsGtCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldLocationsGteCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldLocationsLtCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldLocationsLteCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldLocationsInCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldLocationsLikeCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldLocationsFuzzyCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldLocationsKeywordCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldLocationsContainsCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldLocationsNotCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldLocationsAndCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldLocationsOrCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldLocationsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="MetafieldLocationsAnyCondition"></a>
+
 `MetafieldLocationsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -4290,12 +4936,16 @@ Classes
     `any: airbyte_agent_sdk.connectors.shopify.types.MetafieldLocationsAnyValueFilter`
     :   The type of the None singleton.
 
+<a id="MetafieldLocationsAnyValueFilter"></a>
+
 `MetafieldLocationsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="MetafieldLocationsContainsCondition"></a>
 
 `MetafieldLocationsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
@@ -4309,6 +4959,8 @@ Classes
     `contains: airbyte_agent_sdk.connectors.shopify.types.MetafieldLocationsAnyValueFilter`
     :   The type of the None singleton.
 
+<a id="MetafieldLocationsEqCondition"></a>
+
 `MetafieldLocationsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
 
@@ -4320,6 +4972,8 @@ Classes
 
     `eq: airbyte_agent_sdk.connectors.shopify.types.MetafieldLocationsSearchFilter`
     :   The type of the None singleton.
+
+<a id="MetafieldLocationsFuzzyCondition"></a>
 
 `MetafieldLocationsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
@@ -4333,6 +4987,8 @@ Classes
     `fuzzy: airbyte_agent_sdk.connectors.shopify.types.MetafieldLocationsStringFilter`
     :   The type of the None singleton.
 
+<a id="MetafieldLocationsGtCondition"></a>
+
 `MetafieldLocationsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -4345,6 +5001,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.shopify.types.MetafieldLocationsSearchFilter`
     :   The type of the None singleton.
 
+<a id="MetafieldLocationsGteCondition"></a>
+
 `MetafieldLocationsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -4356,6 +5014,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.shopify.types.MetafieldLocationsSearchFilter`
     :   The type of the None singleton.
+
+<a id="MetafieldLocationsInCondition"></a>
 
 `MetafieldLocationsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -4377,12 +5037,16 @@ Classes
     `in: airbyte_agent_sdk.connectors.shopify.types.MetafieldLocationsInFilter`
     :   The type of the None singleton.
 
+<a id="MetafieldLocationsInFilter"></a>
+
 `MetafieldLocationsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="MetafieldLocationsKeywordCondition"></a>
 
 `MetafieldLocationsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
@@ -4396,6 +5060,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.shopify.types.MetafieldLocationsStringFilter`
     :   The type of the None singleton.
 
+<a id="MetafieldLocationsLikeCondition"></a>
+
 `MetafieldLocationsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -4407,6 +5073,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.shopify.types.MetafieldLocationsStringFilter`
     :   The type of the None singleton.
+
+<a id="MetafieldLocationsListParams"></a>
 
 `MetafieldLocationsListParams(*args, **kwargs)`
 :   Parameters for metafield_locations.list operation
@@ -4432,6 +5100,8 @@ Classes
     `since_id: int`
     :   The type of the None singleton.
 
+<a id="MetafieldLocationsLtCondition"></a>
+
 `MetafieldLocationsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -4443,6 +5113,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.shopify.types.MetafieldLocationsSearchFilter`
     :   The type of the None singleton.
+
+<a id="MetafieldLocationsLteCondition"></a>
 
 `MetafieldLocationsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -4456,6 +5128,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.shopify.types.MetafieldLocationsSearchFilter`
     :   The type of the None singleton.
 
+<a id="MetafieldLocationsNeqCondition"></a>
+
 `MetafieldLocationsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -4467,6 +5141,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.shopify.types.MetafieldLocationsSearchFilter`
     :   The type of the None singleton.
+
+<a id="MetafieldLocationsNotCondition"></a>
 
 `MetafieldLocationsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -4488,6 +5164,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.shopify.types.MetafieldLocationsEqCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldLocationsNeqCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldLocationsGtCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldLocationsGteCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldLocationsLtCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldLocationsLteCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldLocationsInCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldLocationsLikeCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldLocationsFuzzyCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldLocationsKeywordCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldLocationsContainsCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldLocationsNotCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldLocationsAndCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldLocationsOrCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldLocationsAnyCondition`
     :   The type of the None singleton.
 
+<a id="MetafieldLocationsOrCondition"></a>
+
 `MetafieldLocationsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -4508,12 +5186,16 @@ Classes
     `or: list[airbyte_agent_sdk.connectors.shopify.types.MetafieldLocationsEqCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldLocationsNeqCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldLocationsGtCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldLocationsGteCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldLocationsLtCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldLocationsLteCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldLocationsInCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldLocationsLikeCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldLocationsFuzzyCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldLocationsKeywordCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldLocationsContainsCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldLocationsNotCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldLocationsAndCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldLocationsOrCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldLocationsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="MetafieldLocationsSearchFilter"></a>
+
 `MetafieldLocationsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering metafield_locations search queries.
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="MetafieldLocationsSearchQuery"></a>
 
 `MetafieldLocationsSearchQuery(*args, **kwargs)`
 :   Search query for metafield_locations entity.
@@ -4530,6 +5212,8 @@ Classes
     `sort: list[airbyte_agent_sdk.connectors.shopify.types.MetafieldLocationsSortFilter]`
     :   The type of the None singleton.
 
+<a id="MetafieldLocationsSortFilter"></a>
+
 `MetafieldLocationsSortFilter(*args, **kwargs)`
 :   Available fields for sorting metafield_locations search results.
 
@@ -4537,12 +5221,16 @@ Classes
 
     * builtins.dict
 
+<a id="MetafieldLocationsStringFilter"></a>
+
 `MetafieldLocationsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="MetafieldOrdersAndCondition"></a>
 
 `MetafieldOrdersAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -4564,6 +5252,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.shopify.types.MetafieldOrdersEqCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldOrdersNeqCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldOrdersGtCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldOrdersGteCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldOrdersLtCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldOrdersLteCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldOrdersInCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldOrdersLikeCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldOrdersFuzzyCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldOrdersKeywordCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldOrdersContainsCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldOrdersNotCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldOrdersAndCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldOrdersOrCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldOrdersAnyCondition]`
     :   The type of the None singleton.
 
+<a id="MetafieldOrdersAnyCondition"></a>
+
 `MetafieldOrdersAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -4584,12 +5274,16 @@ Classes
     `any: airbyte_agent_sdk.connectors.shopify.types.MetafieldOrdersAnyValueFilter`
     :   The type of the None singleton.
 
+<a id="MetafieldOrdersAnyValueFilter"></a>
+
 `MetafieldOrdersAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="MetafieldOrdersContainsCondition"></a>
 
 `MetafieldOrdersContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
@@ -4603,6 +5297,8 @@ Classes
     `contains: airbyte_agent_sdk.connectors.shopify.types.MetafieldOrdersAnyValueFilter`
     :   The type of the None singleton.
 
+<a id="MetafieldOrdersEqCondition"></a>
+
 `MetafieldOrdersEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
 
@@ -4614,6 +5310,8 @@ Classes
 
     `eq: airbyte_agent_sdk.connectors.shopify.types.MetafieldOrdersSearchFilter`
     :   The type of the None singleton.
+
+<a id="MetafieldOrdersFuzzyCondition"></a>
 
 `MetafieldOrdersFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
@@ -4627,6 +5325,8 @@ Classes
     `fuzzy: airbyte_agent_sdk.connectors.shopify.types.MetafieldOrdersStringFilter`
     :   The type of the None singleton.
 
+<a id="MetafieldOrdersGtCondition"></a>
+
 `MetafieldOrdersGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -4639,6 +5339,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.shopify.types.MetafieldOrdersSearchFilter`
     :   The type of the None singleton.
 
+<a id="MetafieldOrdersGteCondition"></a>
+
 `MetafieldOrdersGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -4650,6 +5352,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.shopify.types.MetafieldOrdersSearchFilter`
     :   The type of the None singleton.
+
+<a id="MetafieldOrdersInCondition"></a>
 
 `MetafieldOrdersInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -4671,12 +5375,16 @@ Classes
     `in: airbyte_agent_sdk.connectors.shopify.types.MetafieldOrdersInFilter`
     :   The type of the None singleton.
 
+<a id="MetafieldOrdersInFilter"></a>
+
 `MetafieldOrdersInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="MetafieldOrdersKeywordCondition"></a>
 
 `MetafieldOrdersKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
@@ -4690,6 +5398,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.shopify.types.MetafieldOrdersStringFilter`
     :   The type of the None singleton.
 
+<a id="MetafieldOrdersLikeCondition"></a>
+
 `MetafieldOrdersLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -4701,6 +5411,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.shopify.types.MetafieldOrdersStringFilter`
     :   The type of the None singleton.
+
+<a id="MetafieldOrdersListParams"></a>
 
 `MetafieldOrdersListParams(*args, **kwargs)`
 :   Parameters for metafield_orders.list operation
@@ -4726,6 +5438,8 @@ Classes
     `since_id: int`
     :   The type of the None singleton.
 
+<a id="MetafieldOrdersLtCondition"></a>
+
 `MetafieldOrdersLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -4737,6 +5451,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.shopify.types.MetafieldOrdersSearchFilter`
     :   The type of the None singleton.
+
+<a id="MetafieldOrdersLteCondition"></a>
 
 `MetafieldOrdersLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -4750,6 +5466,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.shopify.types.MetafieldOrdersSearchFilter`
     :   The type of the None singleton.
 
+<a id="MetafieldOrdersNeqCondition"></a>
+
 `MetafieldOrdersNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -4761,6 +5479,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.shopify.types.MetafieldOrdersSearchFilter`
     :   The type of the None singleton.
+
+<a id="MetafieldOrdersNotCondition"></a>
 
 `MetafieldOrdersNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -4782,6 +5502,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.shopify.types.MetafieldOrdersEqCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldOrdersNeqCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldOrdersGtCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldOrdersGteCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldOrdersLtCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldOrdersLteCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldOrdersInCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldOrdersLikeCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldOrdersFuzzyCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldOrdersKeywordCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldOrdersContainsCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldOrdersNotCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldOrdersAndCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldOrdersOrCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldOrdersAnyCondition`
     :   The type of the None singleton.
 
+<a id="MetafieldOrdersOrCondition"></a>
+
 `MetafieldOrdersOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -4802,12 +5524,16 @@ Classes
     `or: list[airbyte_agent_sdk.connectors.shopify.types.MetafieldOrdersEqCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldOrdersNeqCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldOrdersGtCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldOrdersGteCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldOrdersLtCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldOrdersLteCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldOrdersInCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldOrdersLikeCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldOrdersFuzzyCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldOrdersKeywordCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldOrdersContainsCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldOrdersNotCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldOrdersAndCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldOrdersOrCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldOrdersAnyCondition]`
     :   The type of the None singleton.
 
+<a id="MetafieldOrdersSearchFilter"></a>
+
 `MetafieldOrdersSearchFilter(*args, **kwargs)`
 :   Available fields for filtering metafield_orders search queries.
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="MetafieldOrdersSearchQuery"></a>
 
 `MetafieldOrdersSearchQuery(*args, **kwargs)`
 :   Search query for metafield_orders entity.
@@ -4824,6 +5550,8 @@ Classes
     `sort: list[airbyte_agent_sdk.connectors.shopify.types.MetafieldOrdersSortFilter]`
     :   The type of the None singleton.
 
+<a id="MetafieldOrdersSortFilter"></a>
+
 `MetafieldOrdersSortFilter(*args, **kwargs)`
 :   Available fields for sorting metafield_orders search results.
 
@@ -4831,12 +5559,16 @@ Classes
 
     * builtins.dict
 
+<a id="MetafieldOrdersStringFilter"></a>
+
 `MetafieldOrdersStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="MetafieldProductImagesAndCondition"></a>
 
 `MetafieldProductImagesAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -4858,6 +5590,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.shopify.types.MetafieldProductImagesEqCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldProductImagesNeqCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldProductImagesGtCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldProductImagesGteCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldProductImagesLtCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldProductImagesLteCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldProductImagesInCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldProductImagesLikeCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldProductImagesFuzzyCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldProductImagesKeywordCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldProductImagesContainsCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldProductImagesNotCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldProductImagesAndCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldProductImagesOrCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldProductImagesAnyCondition]`
     :   The type of the None singleton.
 
+<a id="MetafieldProductImagesAnyCondition"></a>
+
 `MetafieldProductImagesAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -4878,12 +5612,16 @@ Classes
     `any: airbyte_agent_sdk.connectors.shopify.types.MetafieldProductImagesAnyValueFilter`
     :   The type of the None singleton.
 
+<a id="MetafieldProductImagesAnyValueFilter"></a>
+
 `MetafieldProductImagesAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="MetafieldProductImagesContainsCondition"></a>
 
 `MetafieldProductImagesContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
@@ -4897,6 +5635,8 @@ Classes
     `contains: airbyte_agent_sdk.connectors.shopify.types.MetafieldProductImagesAnyValueFilter`
     :   The type of the None singleton.
 
+<a id="MetafieldProductImagesEqCondition"></a>
+
 `MetafieldProductImagesEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
 
@@ -4908,6 +5648,8 @@ Classes
 
     `eq: airbyte_agent_sdk.connectors.shopify.types.MetafieldProductImagesSearchFilter`
     :   The type of the None singleton.
+
+<a id="MetafieldProductImagesFuzzyCondition"></a>
 
 `MetafieldProductImagesFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
@@ -4921,6 +5663,8 @@ Classes
     `fuzzy: airbyte_agent_sdk.connectors.shopify.types.MetafieldProductImagesStringFilter`
     :   The type of the None singleton.
 
+<a id="MetafieldProductImagesGtCondition"></a>
+
 `MetafieldProductImagesGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -4933,6 +5677,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.shopify.types.MetafieldProductImagesSearchFilter`
     :   The type of the None singleton.
 
+<a id="MetafieldProductImagesGteCondition"></a>
+
 `MetafieldProductImagesGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -4944,6 +5690,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.shopify.types.MetafieldProductImagesSearchFilter`
     :   The type of the None singleton.
+
+<a id="MetafieldProductImagesInCondition"></a>
 
 `MetafieldProductImagesInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -4965,12 +5713,16 @@ Classes
     `in: airbyte_agent_sdk.connectors.shopify.types.MetafieldProductImagesInFilter`
     :   The type of the None singleton.
 
+<a id="MetafieldProductImagesInFilter"></a>
+
 `MetafieldProductImagesInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="MetafieldProductImagesKeywordCondition"></a>
 
 `MetafieldProductImagesKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
@@ -4984,6 +5736,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.shopify.types.MetafieldProductImagesStringFilter`
     :   The type of the None singleton.
 
+<a id="MetafieldProductImagesLikeCondition"></a>
+
 `MetafieldProductImagesLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -4995,6 +5749,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.shopify.types.MetafieldProductImagesStringFilter`
     :   The type of the None singleton.
+
+<a id="MetafieldProductImagesListParams"></a>
 
 `MetafieldProductImagesListParams(*args, **kwargs)`
 :   Parameters for metafield_product_images.list operation
@@ -5023,6 +5779,8 @@ Classes
     `since_id: int`
     :   The type of the None singleton.
 
+<a id="MetafieldProductImagesLtCondition"></a>
+
 `MetafieldProductImagesLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -5034,6 +5792,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.shopify.types.MetafieldProductImagesSearchFilter`
     :   The type of the None singleton.
+
+<a id="MetafieldProductImagesLteCondition"></a>
 
 `MetafieldProductImagesLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -5047,6 +5807,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.shopify.types.MetafieldProductImagesSearchFilter`
     :   The type of the None singleton.
 
+<a id="MetafieldProductImagesNeqCondition"></a>
+
 `MetafieldProductImagesNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -5058,6 +5820,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.shopify.types.MetafieldProductImagesSearchFilter`
     :   The type of the None singleton.
+
+<a id="MetafieldProductImagesNotCondition"></a>
 
 `MetafieldProductImagesNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -5079,6 +5843,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.shopify.types.MetafieldProductImagesEqCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldProductImagesNeqCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldProductImagesGtCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldProductImagesGteCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldProductImagesLtCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldProductImagesLteCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldProductImagesInCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldProductImagesLikeCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldProductImagesFuzzyCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldProductImagesKeywordCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldProductImagesContainsCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldProductImagesNotCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldProductImagesAndCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldProductImagesOrCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldProductImagesAnyCondition`
     :   The type of the None singleton.
 
+<a id="MetafieldProductImagesOrCondition"></a>
+
 `MetafieldProductImagesOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -5099,12 +5865,16 @@ Classes
     `or: list[airbyte_agent_sdk.connectors.shopify.types.MetafieldProductImagesEqCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldProductImagesNeqCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldProductImagesGtCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldProductImagesGteCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldProductImagesLtCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldProductImagesLteCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldProductImagesInCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldProductImagesLikeCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldProductImagesFuzzyCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldProductImagesKeywordCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldProductImagesContainsCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldProductImagesNotCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldProductImagesAndCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldProductImagesOrCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldProductImagesAnyCondition]`
     :   The type of the None singleton.
 
+<a id="MetafieldProductImagesSearchFilter"></a>
+
 `MetafieldProductImagesSearchFilter(*args, **kwargs)`
 :   Available fields for filtering metafield_product_images search queries.
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="MetafieldProductImagesSearchQuery"></a>
 
 `MetafieldProductImagesSearchQuery(*args, **kwargs)`
 :   Search query for metafield_product_images entity.
@@ -5121,6 +5891,8 @@ Classes
     `sort: list[airbyte_agent_sdk.connectors.shopify.types.MetafieldProductImagesSortFilter]`
     :   The type of the None singleton.
 
+<a id="MetafieldProductImagesSortFilter"></a>
+
 `MetafieldProductImagesSortFilter(*args, **kwargs)`
 :   Available fields for sorting metafield_product_images search results.
 
@@ -5128,12 +5900,16 @@ Classes
 
     * builtins.dict
 
+<a id="MetafieldProductImagesStringFilter"></a>
+
 `MetafieldProductImagesStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="MetafieldProductVariantsAndCondition"></a>
 
 `MetafieldProductVariantsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -5155,6 +5931,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.shopify.types.MetafieldProductVariantsEqCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldProductVariantsNeqCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldProductVariantsGtCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldProductVariantsGteCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldProductVariantsLtCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldProductVariantsLteCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldProductVariantsInCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldProductVariantsLikeCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldProductVariantsFuzzyCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldProductVariantsKeywordCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldProductVariantsContainsCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldProductVariantsNotCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldProductVariantsAndCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldProductVariantsOrCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldProductVariantsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="MetafieldProductVariantsAnyCondition"></a>
+
 `MetafieldProductVariantsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -5175,12 +5953,16 @@ Classes
     `any: airbyte_agent_sdk.connectors.shopify.types.MetafieldProductVariantsAnyValueFilter`
     :   The type of the None singleton.
 
+<a id="MetafieldProductVariantsAnyValueFilter"></a>
+
 `MetafieldProductVariantsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="MetafieldProductVariantsContainsCondition"></a>
 
 `MetafieldProductVariantsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
@@ -5194,6 +5976,8 @@ Classes
     `contains: airbyte_agent_sdk.connectors.shopify.types.MetafieldProductVariantsAnyValueFilter`
     :   The type of the None singleton.
 
+<a id="MetafieldProductVariantsEqCondition"></a>
+
 `MetafieldProductVariantsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
 
@@ -5205,6 +5989,8 @@ Classes
 
     `eq: airbyte_agent_sdk.connectors.shopify.types.MetafieldProductVariantsSearchFilter`
     :   The type of the None singleton.
+
+<a id="MetafieldProductVariantsFuzzyCondition"></a>
 
 `MetafieldProductVariantsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
@@ -5218,6 +6004,8 @@ Classes
     `fuzzy: airbyte_agent_sdk.connectors.shopify.types.MetafieldProductVariantsStringFilter`
     :   The type of the None singleton.
 
+<a id="MetafieldProductVariantsGtCondition"></a>
+
 `MetafieldProductVariantsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -5230,6 +6018,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.shopify.types.MetafieldProductVariantsSearchFilter`
     :   The type of the None singleton.
 
+<a id="MetafieldProductVariantsGteCondition"></a>
+
 `MetafieldProductVariantsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -5241,6 +6031,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.shopify.types.MetafieldProductVariantsSearchFilter`
     :   The type of the None singleton.
+
+<a id="MetafieldProductVariantsInCondition"></a>
 
 `MetafieldProductVariantsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -5262,12 +6054,16 @@ Classes
     `in: airbyte_agent_sdk.connectors.shopify.types.MetafieldProductVariantsInFilter`
     :   The type of the None singleton.
 
+<a id="MetafieldProductVariantsInFilter"></a>
+
 `MetafieldProductVariantsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="MetafieldProductVariantsKeywordCondition"></a>
 
 `MetafieldProductVariantsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
@@ -5281,6 +6077,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.shopify.types.MetafieldProductVariantsStringFilter`
     :   The type of the None singleton.
 
+<a id="MetafieldProductVariantsLikeCondition"></a>
+
 `MetafieldProductVariantsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -5292,6 +6090,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.shopify.types.MetafieldProductVariantsStringFilter`
     :   The type of the None singleton.
+
+<a id="MetafieldProductVariantsListParams"></a>
 
 `MetafieldProductVariantsListParams(*args, **kwargs)`
 :   Parameters for metafield_product_variants.list operation
@@ -5317,6 +6117,8 @@ Classes
     `variant_id: str`
     :   The type of the None singleton.
 
+<a id="MetafieldProductVariantsLtCondition"></a>
+
 `MetafieldProductVariantsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -5328,6 +6130,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.shopify.types.MetafieldProductVariantsSearchFilter`
     :   The type of the None singleton.
+
+<a id="MetafieldProductVariantsLteCondition"></a>
 
 `MetafieldProductVariantsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -5341,6 +6145,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.shopify.types.MetafieldProductVariantsSearchFilter`
     :   The type of the None singleton.
 
+<a id="MetafieldProductVariantsNeqCondition"></a>
+
 `MetafieldProductVariantsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -5352,6 +6158,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.shopify.types.MetafieldProductVariantsSearchFilter`
     :   The type of the None singleton.
+
+<a id="MetafieldProductVariantsNotCondition"></a>
 
 `MetafieldProductVariantsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -5373,6 +6181,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.shopify.types.MetafieldProductVariantsEqCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldProductVariantsNeqCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldProductVariantsGtCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldProductVariantsGteCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldProductVariantsLtCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldProductVariantsLteCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldProductVariantsInCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldProductVariantsLikeCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldProductVariantsFuzzyCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldProductVariantsKeywordCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldProductVariantsContainsCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldProductVariantsNotCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldProductVariantsAndCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldProductVariantsOrCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldProductVariantsAnyCondition`
     :   The type of the None singleton.
 
+<a id="MetafieldProductVariantsOrCondition"></a>
+
 `MetafieldProductVariantsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -5393,12 +6203,16 @@ Classes
     `or: list[airbyte_agent_sdk.connectors.shopify.types.MetafieldProductVariantsEqCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldProductVariantsNeqCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldProductVariantsGtCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldProductVariantsGteCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldProductVariantsLtCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldProductVariantsLteCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldProductVariantsInCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldProductVariantsLikeCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldProductVariantsFuzzyCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldProductVariantsKeywordCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldProductVariantsContainsCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldProductVariantsNotCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldProductVariantsAndCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldProductVariantsOrCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldProductVariantsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="MetafieldProductVariantsSearchFilter"></a>
+
 `MetafieldProductVariantsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering metafield_product_variants search queries.
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="MetafieldProductVariantsSearchQuery"></a>
 
 `MetafieldProductVariantsSearchQuery(*args, **kwargs)`
 :   Search query for metafield_product_variants entity.
@@ -5415,6 +6229,8 @@ Classes
     `sort: list[airbyte_agent_sdk.connectors.shopify.types.MetafieldProductVariantsSortFilter]`
     :   The type of the None singleton.
 
+<a id="MetafieldProductVariantsSortFilter"></a>
+
 `MetafieldProductVariantsSortFilter(*args, **kwargs)`
 :   Available fields for sorting metafield_product_variants search results.
 
@@ -5422,12 +6238,16 @@ Classes
 
     * builtins.dict
 
+<a id="MetafieldProductVariantsStringFilter"></a>
+
 `MetafieldProductVariantsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="MetafieldProductsAndCondition"></a>
 
 `MetafieldProductsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -5449,6 +6269,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.shopify.types.MetafieldProductsEqCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldProductsNeqCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldProductsGtCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldProductsGteCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldProductsLtCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldProductsLteCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldProductsInCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldProductsLikeCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldProductsFuzzyCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldProductsKeywordCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldProductsContainsCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldProductsNotCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldProductsAndCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldProductsOrCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldProductsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="MetafieldProductsAnyCondition"></a>
+
 `MetafieldProductsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -5469,12 +6291,16 @@ Classes
     `any: airbyte_agent_sdk.connectors.shopify.types.MetafieldProductsAnyValueFilter`
     :   The type of the None singleton.
 
+<a id="MetafieldProductsAnyValueFilter"></a>
+
 `MetafieldProductsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="MetafieldProductsContainsCondition"></a>
 
 `MetafieldProductsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
@@ -5488,6 +6314,8 @@ Classes
     `contains: airbyte_agent_sdk.connectors.shopify.types.MetafieldProductsAnyValueFilter`
     :   The type of the None singleton.
 
+<a id="MetafieldProductsEqCondition"></a>
+
 `MetafieldProductsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
 
@@ -5499,6 +6327,8 @@ Classes
 
     `eq: airbyte_agent_sdk.connectors.shopify.types.MetafieldProductsSearchFilter`
     :   The type of the None singleton.
+
+<a id="MetafieldProductsFuzzyCondition"></a>
 
 `MetafieldProductsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
@@ -5512,6 +6342,8 @@ Classes
     `fuzzy: airbyte_agent_sdk.connectors.shopify.types.MetafieldProductsStringFilter`
     :   The type of the None singleton.
 
+<a id="MetafieldProductsGtCondition"></a>
+
 `MetafieldProductsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -5524,6 +6356,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.shopify.types.MetafieldProductsSearchFilter`
     :   The type of the None singleton.
 
+<a id="MetafieldProductsGteCondition"></a>
+
 `MetafieldProductsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -5535,6 +6369,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.shopify.types.MetafieldProductsSearchFilter`
     :   The type of the None singleton.
+
+<a id="MetafieldProductsInCondition"></a>
 
 `MetafieldProductsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -5556,12 +6392,16 @@ Classes
     `in: airbyte_agent_sdk.connectors.shopify.types.MetafieldProductsInFilter`
     :   The type of the None singleton.
 
+<a id="MetafieldProductsInFilter"></a>
+
 `MetafieldProductsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="MetafieldProductsKeywordCondition"></a>
 
 `MetafieldProductsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
@@ -5575,6 +6415,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.shopify.types.MetafieldProductsStringFilter`
     :   The type of the None singleton.
 
+<a id="MetafieldProductsLikeCondition"></a>
+
 `MetafieldProductsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -5586,6 +6428,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.shopify.types.MetafieldProductsStringFilter`
     :   The type of the None singleton.
+
+<a id="MetafieldProductsListParams"></a>
 
 `MetafieldProductsListParams(*args, **kwargs)`
 :   Parameters for metafield_products.list operation
@@ -5611,6 +6455,8 @@ Classes
     `since_id: int`
     :   The type of the None singleton.
 
+<a id="MetafieldProductsLtCondition"></a>
+
 `MetafieldProductsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -5622,6 +6468,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.shopify.types.MetafieldProductsSearchFilter`
     :   The type of the None singleton.
+
+<a id="MetafieldProductsLteCondition"></a>
 
 `MetafieldProductsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -5635,6 +6483,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.shopify.types.MetafieldProductsSearchFilter`
     :   The type of the None singleton.
 
+<a id="MetafieldProductsNeqCondition"></a>
+
 `MetafieldProductsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -5646,6 +6496,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.shopify.types.MetafieldProductsSearchFilter`
     :   The type of the None singleton.
+
+<a id="MetafieldProductsNotCondition"></a>
 
 `MetafieldProductsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -5667,6 +6519,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.shopify.types.MetafieldProductsEqCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldProductsNeqCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldProductsGtCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldProductsGteCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldProductsLtCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldProductsLteCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldProductsInCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldProductsLikeCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldProductsFuzzyCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldProductsKeywordCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldProductsContainsCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldProductsNotCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldProductsAndCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldProductsOrCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldProductsAnyCondition`
     :   The type of the None singleton.
 
+<a id="MetafieldProductsOrCondition"></a>
+
 `MetafieldProductsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -5687,12 +6541,16 @@ Classes
     `or: list[airbyte_agent_sdk.connectors.shopify.types.MetafieldProductsEqCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldProductsNeqCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldProductsGtCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldProductsGteCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldProductsLtCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldProductsLteCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldProductsInCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldProductsLikeCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldProductsFuzzyCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldProductsKeywordCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldProductsContainsCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldProductsNotCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldProductsAndCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldProductsOrCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldProductsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="MetafieldProductsSearchFilter"></a>
+
 `MetafieldProductsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering metafield_products search queries.
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="MetafieldProductsSearchQuery"></a>
 
 `MetafieldProductsSearchQuery(*args, **kwargs)`
 :   Search query for metafield_products entity.
@@ -5709,6 +6567,8 @@ Classes
     `sort: list[airbyte_agent_sdk.connectors.shopify.types.MetafieldProductsSortFilter]`
     :   The type of the None singleton.
 
+<a id="MetafieldProductsSortFilter"></a>
+
 `MetafieldProductsSortFilter(*args, **kwargs)`
 :   Available fields for sorting metafield_products search results.
 
@@ -5716,12 +6576,16 @@ Classes
 
     * builtins.dict
 
+<a id="MetafieldProductsStringFilter"></a>
+
 `MetafieldProductsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="MetafieldShopsAndCondition"></a>
 
 `MetafieldShopsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -5743,6 +6607,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.shopify.types.MetafieldShopsEqCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldShopsNeqCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldShopsGtCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldShopsGteCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldShopsLtCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldShopsLteCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldShopsInCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldShopsLikeCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldShopsFuzzyCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldShopsKeywordCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldShopsContainsCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldShopsNotCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldShopsAndCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldShopsOrCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldShopsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="MetafieldShopsAnyCondition"></a>
+
 `MetafieldShopsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -5763,12 +6629,16 @@ Classes
     `any: airbyte_agent_sdk.connectors.shopify.types.MetafieldShopsAnyValueFilter`
     :   The type of the None singleton.
 
+<a id="MetafieldShopsAnyValueFilter"></a>
+
 `MetafieldShopsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="MetafieldShopsContainsCondition"></a>
 
 `MetafieldShopsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
@@ -5782,6 +6652,8 @@ Classes
     `contains: airbyte_agent_sdk.connectors.shopify.types.MetafieldShopsAnyValueFilter`
     :   The type of the None singleton.
 
+<a id="MetafieldShopsEqCondition"></a>
+
 `MetafieldShopsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
 
@@ -5793,6 +6665,8 @@ Classes
 
     `eq: airbyte_agent_sdk.connectors.shopify.types.MetafieldShopsSearchFilter`
     :   The type of the None singleton.
+
+<a id="MetafieldShopsFuzzyCondition"></a>
 
 `MetafieldShopsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
@@ -5806,6 +6680,8 @@ Classes
     `fuzzy: airbyte_agent_sdk.connectors.shopify.types.MetafieldShopsStringFilter`
     :   The type of the None singleton.
 
+<a id="MetafieldShopsGetParams"></a>
+
 `MetafieldShopsGetParams(*args, **kwargs)`
 :   Parameters for metafield_shops.get operation
 
@@ -5817,6 +6693,8 @@ Classes
 
     `metafield_id: str`
     :   The type of the None singleton.
+
+<a id="MetafieldShopsGtCondition"></a>
 
 `MetafieldShopsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
@@ -5830,6 +6708,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.shopify.types.MetafieldShopsSearchFilter`
     :   The type of the None singleton.
 
+<a id="MetafieldShopsGteCondition"></a>
+
 `MetafieldShopsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -5841,6 +6721,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.shopify.types.MetafieldShopsSearchFilter`
     :   The type of the None singleton.
+
+<a id="MetafieldShopsInCondition"></a>
 
 `MetafieldShopsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -5862,12 +6744,16 @@ Classes
     `in: airbyte_agent_sdk.connectors.shopify.types.MetafieldShopsInFilter`
     :   The type of the None singleton.
 
+<a id="MetafieldShopsInFilter"></a>
+
 `MetafieldShopsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="MetafieldShopsKeywordCondition"></a>
 
 `MetafieldShopsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
@@ -5881,6 +6767,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.shopify.types.MetafieldShopsStringFilter`
     :   The type of the None singleton.
 
+<a id="MetafieldShopsLikeCondition"></a>
+
 `MetafieldShopsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -5892,6 +6780,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.shopify.types.MetafieldShopsStringFilter`
     :   The type of the None singleton.
+
+<a id="MetafieldShopsListParams"></a>
 
 `MetafieldShopsListParams(*args, **kwargs)`
 :   Parameters for metafield_shops.list operation
@@ -5917,6 +6807,8 @@ Classes
     `type: str`
     :   The type of the None singleton.
 
+<a id="MetafieldShopsLtCondition"></a>
+
 `MetafieldShopsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -5928,6 +6820,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.shopify.types.MetafieldShopsSearchFilter`
     :   The type of the None singleton.
+
+<a id="MetafieldShopsLteCondition"></a>
 
 `MetafieldShopsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -5941,6 +6835,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.shopify.types.MetafieldShopsSearchFilter`
     :   The type of the None singleton.
 
+<a id="MetafieldShopsNeqCondition"></a>
+
 `MetafieldShopsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -5952,6 +6848,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.shopify.types.MetafieldShopsSearchFilter`
     :   The type of the None singleton.
+
+<a id="MetafieldShopsNotCondition"></a>
 
 `MetafieldShopsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -5973,6 +6871,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.shopify.types.MetafieldShopsEqCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldShopsNeqCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldShopsGtCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldShopsGteCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldShopsLtCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldShopsLteCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldShopsInCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldShopsLikeCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldShopsFuzzyCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldShopsKeywordCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldShopsContainsCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldShopsNotCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldShopsAndCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldShopsOrCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldShopsAnyCondition`
     :   The type of the None singleton.
 
+<a id="MetafieldShopsOrCondition"></a>
+
 `MetafieldShopsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -5993,12 +6893,16 @@ Classes
     `or: list[airbyte_agent_sdk.connectors.shopify.types.MetafieldShopsEqCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldShopsNeqCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldShopsGtCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldShopsGteCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldShopsLtCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldShopsLteCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldShopsInCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldShopsLikeCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldShopsFuzzyCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldShopsKeywordCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldShopsContainsCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldShopsNotCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldShopsAndCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldShopsOrCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldShopsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="MetafieldShopsSearchFilter"></a>
+
 `MetafieldShopsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering metafield_shops search queries.
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="MetafieldShopsSearchQuery"></a>
 
 `MetafieldShopsSearchQuery(*args, **kwargs)`
 :   Search query for metafield_shops entity.
@@ -6015,6 +6919,8 @@ Classes
     `sort: list[airbyte_agent_sdk.connectors.shopify.types.MetafieldShopsSortFilter]`
     :   The type of the None singleton.
 
+<a id="MetafieldShopsSortFilter"></a>
+
 `MetafieldShopsSortFilter(*args, **kwargs)`
 :   Available fields for sorting metafield_shops search results.
 
@@ -6022,12 +6928,16 @@ Classes
 
     * builtins.dict
 
+<a id="MetafieldShopsStringFilter"></a>
+
 `MetafieldShopsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="MetafieldSmartCollectionsAndCondition"></a>
 
 `MetafieldSmartCollectionsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -6049,6 +6959,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.shopify.types.MetafieldSmartCollectionsEqCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldSmartCollectionsNeqCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldSmartCollectionsGtCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldSmartCollectionsGteCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldSmartCollectionsLtCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldSmartCollectionsLteCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldSmartCollectionsInCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldSmartCollectionsLikeCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldSmartCollectionsFuzzyCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldSmartCollectionsKeywordCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldSmartCollectionsContainsCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldSmartCollectionsNotCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldSmartCollectionsAndCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldSmartCollectionsOrCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldSmartCollectionsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="MetafieldSmartCollectionsAnyCondition"></a>
+
 `MetafieldSmartCollectionsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -6069,12 +6981,16 @@ Classes
     `any: airbyte_agent_sdk.connectors.shopify.types.MetafieldSmartCollectionsAnyValueFilter`
     :   The type of the None singleton.
 
+<a id="MetafieldSmartCollectionsAnyValueFilter"></a>
+
 `MetafieldSmartCollectionsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="MetafieldSmartCollectionsContainsCondition"></a>
 
 `MetafieldSmartCollectionsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
@@ -6088,6 +7004,8 @@ Classes
     `contains: airbyte_agent_sdk.connectors.shopify.types.MetafieldSmartCollectionsAnyValueFilter`
     :   The type of the None singleton.
 
+<a id="MetafieldSmartCollectionsEqCondition"></a>
+
 `MetafieldSmartCollectionsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
 
@@ -6099,6 +7017,8 @@ Classes
 
     `eq: airbyte_agent_sdk.connectors.shopify.types.MetafieldSmartCollectionsSearchFilter`
     :   The type of the None singleton.
+
+<a id="MetafieldSmartCollectionsFuzzyCondition"></a>
 
 `MetafieldSmartCollectionsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
@@ -6112,6 +7032,8 @@ Classes
     `fuzzy: airbyte_agent_sdk.connectors.shopify.types.MetafieldSmartCollectionsStringFilter`
     :   The type of the None singleton.
 
+<a id="MetafieldSmartCollectionsGtCondition"></a>
+
 `MetafieldSmartCollectionsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -6124,6 +7046,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.shopify.types.MetafieldSmartCollectionsSearchFilter`
     :   The type of the None singleton.
 
+<a id="MetafieldSmartCollectionsGteCondition"></a>
+
 `MetafieldSmartCollectionsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -6135,6 +7059,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.shopify.types.MetafieldSmartCollectionsSearchFilter`
     :   The type of the None singleton.
+
+<a id="MetafieldSmartCollectionsInCondition"></a>
 
 `MetafieldSmartCollectionsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -6156,12 +7082,16 @@ Classes
     `in: airbyte_agent_sdk.connectors.shopify.types.MetafieldSmartCollectionsInFilter`
     :   The type of the None singleton.
 
+<a id="MetafieldSmartCollectionsInFilter"></a>
+
 `MetafieldSmartCollectionsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="MetafieldSmartCollectionsKeywordCondition"></a>
 
 `MetafieldSmartCollectionsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
@@ -6175,6 +7105,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.shopify.types.MetafieldSmartCollectionsStringFilter`
     :   The type of the None singleton.
 
+<a id="MetafieldSmartCollectionsLikeCondition"></a>
+
 `MetafieldSmartCollectionsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -6186,6 +7118,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.shopify.types.MetafieldSmartCollectionsStringFilter`
     :   The type of the None singleton.
+
+<a id="MetafieldSmartCollectionsListParams"></a>
 
 `MetafieldSmartCollectionsListParams(*args, **kwargs)`
 :   Parameters for metafield_smart_collections.list operation
@@ -6211,6 +7145,8 @@ Classes
     `since_id: int`
     :   The type of the None singleton.
 
+<a id="MetafieldSmartCollectionsLtCondition"></a>
+
 `MetafieldSmartCollectionsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -6222,6 +7158,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.shopify.types.MetafieldSmartCollectionsSearchFilter`
     :   The type of the None singleton.
+
+<a id="MetafieldSmartCollectionsLteCondition"></a>
 
 `MetafieldSmartCollectionsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -6235,6 +7173,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.shopify.types.MetafieldSmartCollectionsSearchFilter`
     :   The type of the None singleton.
 
+<a id="MetafieldSmartCollectionsNeqCondition"></a>
+
 `MetafieldSmartCollectionsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -6246,6 +7186,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.shopify.types.MetafieldSmartCollectionsSearchFilter`
     :   The type of the None singleton.
+
+<a id="MetafieldSmartCollectionsNotCondition"></a>
 
 `MetafieldSmartCollectionsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -6267,6 +7209,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.shopify.types.MetafieldSmartCollectionsEqCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldSmartCollectionsNeqCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldSmartCollectionsGtCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldSmartCollectionsGteCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldSmartCollectionsLtCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldSmartCollectionsLteCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldSmartCollectionsInCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldSmartCollectionsLikeCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldSmartCollectionsFuzzyCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldSmartCollectionsKeywordCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldSmartCollectionsContainsCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldSmartCollectionsNotCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldSmartCollectionsAndCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldSmartCollectionsOrCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldSmartCollectionsAnyCondition`
     :   The type of the None singleton.
 
+<a id="MetafieldSmartCollectionsOrCondition"></a>
+
 `MetafieldSmartCollectionsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -6287,12 +7231,16 @@ Classes
     `or: list[airbyte_agent_sdk.connectors.shopify.types.MetafieldSmartCollectionsEqCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldSmartCollectionsNeqCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldSmartCollectionsGtCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldSmartCollectionsGteCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldSmartCollectionsLtCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldSmartCollectionsLteCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldSmartCollectionsInCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldSmartCollectionsLikeCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldSmartCollectionsFuzzyCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldSmartCollectionsKeywordCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldSmartCollectionsContainsCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldSmartCollectionsNotCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldSmartCollectionsAndCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldSmartCollectionsOrCondition | airbyte_agent_sdk.connectors.shopify.types.MetafieldSmartCollectionsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="MetafieldSmartCollectionsSearchFilter"></a>
+
 `MetafieldSmartCollectionsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering metafield_smart_collections search queries.
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="MetafieldSmartCollectionsSearchQuery"></a>
 
 `MetafieldSmartCollectionsSearchQuery(*args, **kwargs)`
 :   Search query for metafield_smart_collections entity.
@@ -6309,6 +7257,8 @@ Classes
     `sort: list[airbyte_agent_sdk.connectors.shopify.types.MetafieldSmartCollectionsSortFilter]`
     :   The type of the None singleton.
 
+<a id="MetafieldSmartCollectionsSortFilter"></a>
+
 `MetafieldSmartCollectionsSortFilter(*args, **kwargs)`
 :   Available fields for sorting metafield_smart_collections search results.
 
@@ -6316,12 +7266,16 @@ Classes
 
     * builtins.dict
 
+<a id="MetafieldSmartCollectionsStringFilter"></a>
+
 `MetafieldSmartCollectionsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="OrderRefundsAndCondition"></a>
 
 `OrderRefundsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -6343,6 +7297,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.shopify.types.OrderRefundsEqCondition | airbyte_agent_sdk.connectors.shopify.types.OrderRefundsNeqCondition | airbyte_agent_sdk.connectors.shopify.types.OrderRefundsGtCondition | airbyte_agent_sdk.connectors.shopify.types.OrderRefundsGteCondition | airbyte_agent_sdk.connectors.shopify.types.OrderRefundsLtCondition | airbyte_agent_sdk.connectors.shopify.types.OrderRefundsLteCondition | airbyte_agent_sdk.connectors.shopify.types.OrderRefundsInCondition | airbyte_agent_sdk.connectors.shopify.types.OrderRefundsLikeCondition | airbyte_agent_sdk.connectors.shopify.types.OrderRefundsFuzzyCondition | airbyte_agent_sdk.connectors.shopify.types.OrderRefundsKeywordCondition | airbyte_agent_sdk.connectors.shopify.types.OrderRefundsContainsCondition | airbyte_agent_sdk.connectors.shopify.types.OrderRefundsNotCondition | airbyte_agent_sdk.connectors.shopify.types.OrderRefundsAndCondition | airbyte_agent_sdk.connectors.shopify.types.OrderRefundsOrCondition | airbyte_agent_sdk.connectors.shopify.types.OrderRefundsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="OrderRefundsAnyCondition"></a>
+
 `OrderRefundsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -6363,12 +7319,16 @@ Classes
     `any: airbyte_agent_sdk.connectors.shopify.types.OrderRefundsAnyValueFilter`
     :   The type of the None singleton.
 
+<a id="OrderRefundsAnyValueFilter"></a>
+
 `OrderRefundsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="OrderRefundsContainsCondition"></a>
 
 `OrderRefundsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
@@ -6382,6 +7342,8 @@ Classes
     `contains: airbyte_agent_sdk.connectors.shopify.types.OrderRefundsAnyValueFilter`
     :   The type of the None singleton.
 
+<a id="OrderRefundsEqCondition"></a>
+
 `OrderRefundsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
 
@@ -6394,6 +7356,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.shopify.types.OrderRefundsSearchFilter`
     :   The type of the None singleton.
 
+<a id="OrderRefundsFuzzyCondition"></a>
+
 `OrderRefundsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -6405,6 +7369,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.shopify.types.OrderRefundsStringFilter`
     :   The type of the None singleton.
+
+<a id="OrderRefundsGetParams"></a>
 
 `OrderRefundsGetParams(*args, **kwargs)`
 :   Parameters for order_refunds.get operation
@@ -6421,6 +7387,8 @@ Classes
     `refund_id: str`
     :   The type of the None singleton.
 
+<a id="OrderRefundsGtCondition"></a>
+
 `OrderRefundsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -6433,6 +7401,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.shopify.types.OrderRefundsSearchFilter`
     :   The type of the None singleton.
 
+<a id="OrderRefundsGteCondition"></a>
+
 `OrderRefundsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -6444,6 +7414,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.shopify.types.OrderRefundsSearchFilter`
     :   The type of the None singleton.
+
+<a id="OrderRefundsInCondition"></a>
 
 `OrderRefundsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -6465,12 +7437,16 @@ Classes
     `in: airbyte_agent_sdk.connectors.shopify.types.OrderRefundsInFilter`
     :   The type of the None singleton.
 
+<a id="OrderRefundsInFilter"></a>
+
 `OrderRefundsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="OrderRefundsKeywordCondition"></a>
 
 `OrderRefundsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
@@ -6484,6 +7460,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.shopify.types.OrderRefundsStringFilter`
     :   The type of the None singleton.
 
+<a id="OrderRefundsLikeCondition"></a>
+
 `OrderRefundsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -6495,6 +7473,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.shopify.types.OrderRefundsStringFilter`
     :   The type of the None singleton.
+
+<a id="OrderRefundsListParams"></a>
 
 `OrderRefundsListParams(*args, **kwargs)`
 :   Parameters for order_refunds.list operation
@@ -6511,6 +7491,8 @@ Classes
     `order_id: str`
     :   The type of the None singleton.
 
+<a id="OrderRefundsLtCondition"></a>
+
 `OrderRefundsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -6522,6 +7504,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.shopify.types.OrderRefundsSearchFilter`
     :   The type of the None singleton.
+
+<a id="OrderRefundsLteCondition"></a>
 
 `OrderRefundsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -6535,6 +7519,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.shopify.types.OrderRefundsSearchFilter`
     :   The type of the None singleton.
 
+<a id="OrderRefundsNeqCondition"></a>
+
 `OrderRefundsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -6546,6 +7532,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.shopify.types.OrderRefundsSearchFilter`
     :   The type of the None singleton.
+
+<a id="OrderRefundsNotCondition"></a>
 
 `OrderRefundsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -6567,6 +7555,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.shopify.types.OrderRefundsEqCondition | airbyte_agent_sdk.connectors.shopify.types.OrderRefundsNeqCondition | airbyte_agent_sdk.connectors.shopify.types.OrderRefundsGtCondition | airbyte_agent_sdk.connectors.shopify.types.OrderRefundsGteCondition | airbyte_agent_sdk.connectors.shopify.types.OrderRefundsLtCondition | airbyte_agent_sdk.connectors.shopify.types.OrderRefundsLteCondition | airbyte_agent_sdk.connectors.shopify.types.OrderRefundsInCondition | airbyte_agent_sdk.connectors.shopify.types.OrderRefundsLikeCondition | airbyte_agent_sdk.connectors.shopify.types.OrderRefundsFuzzyCondition | airbyte_agent_sdk.connectors.shopify.types.OrderRefundsKeywordCondition | airbyte_agent_sdk.connectors.shopify.types.OrderRefundsContainsCondition | airbyte_agent_sdk.connectors.shopify.types.OrderRefundsNotCondition | airbyte_agent_sdk.connectors.shopify.types.OrderRefundsAndCondition | airbyte_agent_sdk.connectors.shopify.types.OrderRefundsOrCondition | airbyte_agent_sdk.connectors.shopify.types.OrderRefundsAnyCondition`
     :   The type of the None singleton.
 
+<a id="OrderRefundsOrCondition"></a>
+
 `OrderRefundsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -6587,12 +7577,16 @@ Classes
     `or: list[airbyte_agent_sdk.connectors.shopify.types.OrderRefundsEqCondition | airbyte_agent_sdk.connectors.shopify.types.OrderRefundsNeqCondition | airbyte_agent_sdk.connectors.shopify.types.OrderRefundsGtCondition | airbyte_agent_sdk.connectors.shopify.types.OrderRefundsGteCondition | airbyte_agent_sdk.connectors.shopify.types.OrderRefundsLtCondition | airbyte_agent_sdk.connectors.shopify.types.OrderRefundsLteCondition | airbyte_agent_sdk.connectors.shopify.types.OrderRefundsInCondition | airbyte_agent_sdk.connectors.shopify.types.OrderRefundsLikeCondition | airbyte_agent_sdk.connectors.shopify.types.OrderRefundsFuzzyCondition | airbyte_agent_sdk.connectors.shopify.types.OrderRefundsKeywordCondition | airbyte_agent_sdk.connectors.shopify.types.OrderRefundsContainsCondition | airbyte_agent_sdk.connectors.shopify.types.OrderRefundsNotCondition | airbyte_agent_sdk.connectors.shopify.types.OrderRefundsAndCondition | airbyte_agent_sdk.connectors.shopify.types.OrderRefundsOrCondition | airbyte_agent_sdk.connectors.shopify.types.OrderRefundsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="OrderRefundsSearchFilter"></a>
+
 `OrderRefundsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering order_refunds search queries.
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="OrderRefundsSearchQuery"></a>
 
 `OrderRefundsSearchQuery(*args, **kwargs)`
 :   Search query for order_refunds entity.
@@ -6609,6 +7603,8 @@ Classes
     `sort: list[airbyte_agent_sdk.connectors.shopify.types.OrderRefundsSortFilter]`
     :   The type of the None singleton.
 
+<a id="OrderRefundsSortFilter"></a>
+
 `OrderRefundsSortFilter(*args, **kwargs)`
 :   Available fields for sorting order_refunds search results.
 
@@ -6616,12 +7612,16 @@ Classes
 
     * builtins.dict
 
+<a id="OrderRefundsStringFilter"></a>
+
 `OrderRefundsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="OrdersGetParams"></a>
 
 `OrdersGetParams(*args, **kwargs)`
 :   Parameters for orders.get operation
@@ -6634,6 +7634,8 @@ Classes
 
     `order_id: str`
     :   The type of the None singleton.
+
+<a id="OrdersListParams"></a>
 
 `OrdersListParams(*args, **kwargs)`
 :   Parameters for orders.list operation
@@ -6671,6 +7673,8 @@ Classes
     `updated_at_min: str`
     :   The type of the None singleton.
 
+<a id="PriceRulesAndCondition"></a>
+
 `PriceRulesAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -6690,6 +7694,8 @@ Classes
 
     `and: list[airbyte_agent_sdk.connectors.shopify.types.PriceRulesEqCondition | airbyte_agent_sdk.connectors.shopify.types.PriceRulesNeqCondition | airbyte_agent_sdk.connectors.shopify.types.PriceRulesGtCondition | airbyte_agent_sdk.connectors.shopify.types.PriceRulesGteCondition | airbyte_agent_sdk.connectors.shopify.types.PriceRulesLtCondition | airbyte_agent_sdk.connectors.shopify.types.PriceRulesLteCondition | airbyte_agent_sdk.connectors.shopify.types.PriceRulesInCondition | airbyte_agent_sdk.connectors.shopify.types.PriceRulesLikeCondition | airbyte_agent_sdk.connectors.shopify.types.PriceRulesFuzzyCondition | airbyte_agent_sdk.connectors.shopify.types.PriceRulesKeywordCondition | airbyte_agent_sdk.connectors.shopify.types.PriceRulesContainsCondition | airbyte_agent_sdk.connectors.shopify.types.PriceRulesNotCondition | airbyte_agent_sdk.connectors.shopify.types.PriceRulesAndCondition | airbyte_agent_sdk.connectors.shopify.types.PriceRulesOrCondition | airbyte_agent_sdk.connectors.shopify.types.PriceRulesAnyCondition]`
     :   The type of the None singleton.
+
+<a id="PriceRulesAnyCondition"></a>
 
 `PriceRulesAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -6711,12 +7717,16 @@ Classes
     `any: airbyte_agent_sdk.connectors.shopify.types.PriceRulesAnyValueFilter`
     :   The type of the None singleton.
 
+<a id="PriceRulesAnyValueFilter"></a>
+
 `PriceRulesAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="PriceRulesContainsCondition"></a>
 
 `PriceRulesContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
@@ -6730,6 +7740,8 @@ Classes
     `contains: airbyte_agent_sdk.connectors.shopify.types.PriceRulesAnyValueFilter`
     :   The type of the None singleton.
 
+<a id="PriceRulesEqCondition"></a>
+
 `PriceRulesEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
 
@@ -6741,6 +7753,8 @@ Classes
 
     `eq: airbyte_agent_sdk.connectors.shopify.types.PriceRulesSearchFilter`
     :   The type of the None singleton.
+
+<a id="PriceRulesFuzzyCondition"></a>
 
 `PriceRulesFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
@@ -6754,6 +7768,8 @@ Classes
     `fuzzy: airbyte_agent_sdk.connectors.shopify.types.PriceRulesStringFilter`
     :   The type of the None singleton.
 
+<a id="PriceRulesGetParams"></a>
+
 `PriceRulesGetParams(*args, **kwargs)`
 :   Parameters for price_rules.get operation
 
@@ -6765,6 +7781,8 @@ Classes
 
     `price_rule_id: str`
     :   The type of the None singleton.
+
+<a id="PriceRulesGtCondition"></a>
 
 `PriceRulesGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
@@ -6778,6 +7796,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.shopify.types.PriceRulesSearchFilter`
     :   The type of the None singleton.
 
+<a id="PriceRulesGteCondition"></a>
+
 `PriceRulesGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -6789,6 +7809,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.shopify.types.PriceRulesSearchFilter`
     :   The type of the None singleton.
+
+<a id="PriceRulesInCondition"></a>
 
 `PriceRulesInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -6810,12 +7832,16 @@ Classes
     `in: airbyte_agent_sdk.connectors.shopify.types.PriceRulesInFilter`
     :   The type of the None singleton.
 
+<a id="PriceRulesInFilter"></a>
+
 `PriceRulesInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="PriceRulesKeywordCondition"></a>
 
 `PriceRulesKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
@@ -6829,6 +7855,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.shopify.types.PriceRulesStringFilter`
     :   The type of the None singleton.
 
+<a id="PriceRulesLikeCondition"></a>
+
 `PriceRulesLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -6840,6 +7868,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.shopify.types.PriceRulesStringFilter`
     :   The type of the None singleton.
+
+<a id="PriceRulesListParams"></a>
 
 `PriceRulesListParams(*args, **kwargs)`
 :   Parameters for price_rules.list operation
@@ -6868,6 +7898,8 @@ Classes
     `updated_at_min: str`
     :   The type of the None singleton.
 
+<a id="PriceRulesLtCondition"></a>
+
 `PriceRulesLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -6879,6 +7911,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.shopify.types.PriceRulesSearchFilter`
     :   The type of the None singleton.
+
+<a id="PriceRulesLteCondition"></a>
 
 `PriceRulesLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -6892,6 +7926,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.shopify.types.PriceRulesSearchFilter`
     :   The type of the None singleton.
 
+<a id="PriceRulesNeqCondition"></a>
+
 `PriceRulesNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -6903,6 +7939,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.shopify.types.PriceRulesSearchFilter`
     :   The type of the None singleton.
+
+<a id="PriceRulesNotCondition"></a>
 
 `PriceRulesNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -6924,6 +7962,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.shopify.types.PriceRulesEqCondition | airbyte_agent_sdk.connectors.shopify.types.PriceRulesNeqCondition | airbyte_agent_sdk.connectors.shopify.types.PriceRulesGtCondition | airbyte_agent_sdk.connectors.shopify.types.PriceRulesGteCondition | airbyte_agent_sdk.connectors.shopify.types.PriceRulesLtCondition | airbyte_agent_sdk.connectors.shopify.types.PriceRulesLteCondition | airbyte_agent_sdk.connectors.shopify.types.PriceRulesInCondition | airbyte_agent_sdk.connectors.shopify.types.PriceRulesLikeCondition | airbyte_agent_sdk.connectors.shopify.types.PriceRulesFuzzyCondition | airbyte_agent_sdk.connectors.shopify.types.PriceRulesKeywordCondition | airbyte_agent_sdk.connectors.shopify.types.PriceRulesContainsCondition | airbyte_agent_sdk.connectors.shopify.types.PriceRulesNotCondition | airbyte_agent_sdk.connectors.shopify.types.PriceRulesAndCondition | airbyte_agent_sdk.connectors.shopify.types.PriceRulesOrCondition | airbyte_agent_sdk.connectors.shopify.types.PriceRulesAnyCondition`
     :   The type of the None singleton.
 
+<a id="PriceRulesOrCondition"></a>
+
 `PriceRulesOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -6944,12 +7984,16 @@ Classes
     `or: list[airbyte_agent_sdk.connectors.shopify.types.PriceRulesEqCondition | airbyte_agent_sdk.connectors.shopify.types.PriceRulesNeqCondition | airbyte_agent_sdk.connectors.shopify.types.PriceRulesGtCondition | airbyte_agent_sdk.connectors.shopify.types.PriceRulesGteCondition | airbyte_agent_sdk.connectors.shopify.types.PriceRulesLtCondition | airbyte_agent_sdk.connectors.shopify.types.PriceRulesLteCondition | airbyte_agent_sdk.connectors.shopify.types.PriceRulesInCondition | airbyte_agent_sdk.connectors.shopify.types.PriceRulesLikeCondition | airbyte_agent_sdk.connectors.shopify.types.PriceRulesFuzzyCondition | airbyte_agent_sdk.connectors.shopify.types.PriceRulesKeywordCondition | airbyte_agent_sdk.connectors.shopify.types.PriceRulesContainsCondition | airbyte_agent_sdk.connectors.shopify.types.PriceRulesNotCondition | airbyte_agent_sdk.connectors.shopify.types.PriceRulesAndCondition | airbyte_agent_sdk.connectors.shopify.types.PriceRulesOrCondition | airbyte_agent_sdk.connectors.shopify.types.PriceRulesAnyCondition]`
     :   The type of the None singleton.
 
+<a id="PriceRulesSearchFilter"></a>
+
 `PriceRulesSearchFilter(*args, **kwargs)`
 :   Available fields for filtering price_rules search queries.
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="PriceRulesSearchQuery"></a>
 
 `PriceRulesSearchQuery(*args, **kwargs)`
 :   Search query for price_rules entity.
@@ -6966,6 +8010,8 @@ Classes
     `sort: list[airbyte_agent_sdk.connectors.shopify.types.PriceRulesSortFilter]`
     :   The type of the None singleton.
 
+<a id="PriceRulesSortFilter"></a>
+
 `PriceRulesSortFilter(*args, **kwargs)`
 :   Available fields for sorting price_rules search results.
 
@@ -6973,12 +8019,16 @@ Classes
 
     * builtins.dict
 
+<a id="PriceRulesStringFilter"></a>
+
 `PriceRulesStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="ProductImagesAndCondition"></a>
 
 `ProductImagesAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -7000,6 +8050,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.shopify.types.ProductImagesEqCondition | airbyte_agent_sdk.connectors.shopify.types.ProductImagesNeqCondition | airbyte_agent_sdk.connectors.shopify.types.ProductImagesGtCondition | airbyte_agent_sdk.connectors.shopify.types.ProductImagesGteCondition | airbyte_agent_sdk.connectors.shopify.types.ProductImagesLtCondition | airbyte_agent_sdk.connectors.shopify.types.ProductImagesLteCondition | airbyte_agent_sdk.connectors.shopify.types.ProductImagesInCondition | airbyte_agent_sdk.connectors.shopify.types.ProductImagesLikeCondition | airbyte_agent_sdk.connectors.shopify.types.ProductImagesFuzzyCondition | airbyte_agent_sdk.connectors.shopify.types.ProductImagesKeywordCondition | airbyte_agent_sdk.connectors.shopify.types.ProductImagesContainsCondition | airbyte_agent_sdk.connectors.shopify.types.ProductImagesNotCondition | airbyte_agent_sdk.connectors.shopify.types.ProductImagesAndCondition | airbyte_agent_sdk.connectors.shopify.types.ProductImagesOrCondition | airbyte_agent_sdk.connectors.shopify.types.ProductImagesAnyCondition]`
     :   The type of the None singleton.
 
+<a id="ProductImagesAnyCondition"></a>
+
 `ProductImagesAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -7020,12 +8072,16 @@ Classes
     `any: airbyte_agent_sdk.connectors.shopify.types.ProductImagesAnyValueFilter`
     :   The type of the None singleton.
 
+<a id="ProductImagesAnyValueFilter"></a>
+
 `ProductImagesAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="ProductImagesContainsCondition"></a>
 
 `ProductImagesContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
@@ -7039,6 +8095,8 @@ Classes
     `contains: airbyte_agent_sdk.connectors.shopify.types.ProductImagesAnyValueFilter`
     :   The type of the None singleton.
 
+<a id="ProductImagesEqCondition"></a>
+
 `ProductImagesEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
 
@@ -7051,6 +8109,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.shopify.types.ProductImagesSearchFilter`
     :   The type of the None singleton.
 
+<a id="ProductImagesFuzzyCondition"></a>
+
 `ProductImagesFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -7062,6 +8122,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.shopify.types.ProductImagesStringFilter`
     :   The type of the None singleton.
+
+<a id="ProductImagesGetParams"></a>
 
 `ProductImagesGetParams(*args, **kwargs)`
 :   Parameters for product_images.get operation
@@ -7078,6 +8140,8 @@ Classes
     `product_id: str`
     :   The type of the None singleton.
 
+<a id="ProductImagesGtCondition"></a>
+
 `ProductImagesGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -7090,6 +8154,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.shopify.types.ProductImagesSearchFilter`
     :   The type of the None singleton.
 
+<a id="ProductImagesGteCondition"></a>
+
 `ProductImagesGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -7101,6 +8167,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.shopify.types.ProductImagesSearchFilter`
     :   The type of the None singleton.
+
+<a id="ProductImagesInCondition"></a>
 
 `ProductImagesInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -7122,12 +8190,16 @@ Classes
     `in: airbyte_agent_sdk.connectors.shopify.types.ProductImagesInFilter`
     :   The type of the None singleton.
 
+<a id="ProductImagesInFilter"></a>
+
 `ProductImagesInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="ProductImagesKeywordCondition"></a>
 
 `ProductImagesKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
@@ -7141,6 +8213,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.shopify.types.ProductImagesStringFilter`
     :   The type of the None singleton.
 
+<a id="ProductImagesLikeCondition"></a>
+
 `ProductImagesLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -7152,6 +8226,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.shopify.types.ProductImagesStringFilter`
     :   The type of the None singleton.
+
+<a id="ProductImagesListParams"></a>
 
 `ProductImagesListParams(*args, **kwargs)`
 :   Parameters for product_images.list operation
@@ -7168,6 +8244,8 @@ Classes
     `since_id: int`
     :   The type of the None singleton.
 
+<a id="ProductImagesLtCondition"></a>
+
 `ProductImagesLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -7179,6 +8257,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.shopify.types.ProductImagesSearchFilter`
     :   The type of the None singleton.
+
+<a id="ProductImagesLteCondition"></a>
 
 `ProductImagesLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -7192,6 +8272,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.shopify.types.ProductImagesSearchFilter`
     :   The type of the None singleton.
 
+<a id="ProductImagesNeqCondition"></a>
+
 `ProductImagesNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -7203,6 +8285,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.shopify.types.ProductImagesSearchFilter`
     :   The type of the None singleton.
+
+<a id="ProductImagesNotCondition"></a>
 
 `ProductImagesNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -7224,6 +8308,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.shopify.types.ProductImagesEqCondition | airbyte_agent_sdk.connectors.shopify.types.ProductImagesNeqCondition | airbyte_agent_sdk.connectors.shopify.types.ProductImagesGtCondition | airbyte_agent_sdk.connectors.shopify.types.ProductImagesGteCondition | airbyte_agent_sdk.connectors.shopify.types.ProductImagesLtCondition | airbyte_agent_sdk.connectors.shopify.types.ProductImagesLteCondition | airbyte_agent_sdk.connectors.shopify.types.ProductImagesInCondition | airbyte_agent_sdk.connectors.shopify.types.ProductImagesLikeCondition | airbyte_agent_sdk.connectors.shopify.types.ProductImagesFuzzyCondition | airbyte_agent_sdk.connectors.shopify.types.ProductImagesKeywordCondition | airbyte_agent_sdk.connectors.shopify.types.ProductImagesContainsCondition | airbyte_agent_sdk.connectors.shopify.types.ProductImagesNotCondition | airbyte_agent_sdk.connectors.shopify.types.ProductImagesAndCondition | airbyte_agent_sdk.connectors.shopify.types.ProductImagesOrCondition | airbyte_agent_sdk.connectors.shopify.types.ProductImagesAnyCondition`
     :   The type of the None singleton.
 
+<a id="ProductImagesOrCondition"></a>
+
 `ProductImagesOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -7244,12 +8330,16 @@ Classes
     `or: list[airbyte_agent_sdk.connectors.shopify.types.ProductImagesEqCondition | airbyte_agent_sdk.connectors.shopify.types.ProductImagesNeqCondition | airbyte_agent_sdk.connectors.shopify.types.ProductImagesGtCondition | airbyte_agent_sdk.connectors.shopify.types.ProductImagesGteCondition | airbyte_agent_sdk.connectors.shopify.types.ProductImagesLtCondition | airbyte_agent_sdk.connectors.shopify.types.ProductImagesLteCondition | airbyte_agent_sdk.connectors.shopify.types.ProductImagesInCondition | airbyte_agent_sdk.connectors.shopify.types.ProductImagesLikeCondition | airbyte_agent_sdk.connectors.shopify.types.ProductImagesFuzzyCondition | airbyte_agent_sdk.connectors.shopify.types.ProductImagesKeywordCondition | airbyte_agent_sdk.connectors.shopify.types.ProductImagesContainsCondition | airbyte_agent_sdk.connectors.shopify.types.ProductImagesNotCondition | airbyte_agent_sdk.connectors.shopify.types.ProductImagesAndCondition | airbyte_agent_sdk.connectors.shopify.types.ProductImagesOrCondition | airbyte_agent_sdk.connectors.shopify.types.ProductImagesAnyCondition]`
     :   The type of the None singleton.
 
+<a id="ProductImagesSearchFilter"></a>
+
 `ProductImagesSearchFilter(*args, **kwargs)`
 :   Available fields for filtering product_images search queries.
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="ProductImagesSearchQuery"></a>
 
 `ProductImagesSearchQuery(*args, **kwargs)`
 :   Search query for product_images entity.
@@ -7266,6 +8356,8 @@ Classes
     `sort: list[airbyte_agent_sdk.connectors.shopify.types.ProductImagesSortFilter]`
     :   The type of the None singleton.
 
+<a id="ProductImagesSortFilter"></a>
+
 `ProductImagesSortFilter(*args, **kwargs)`
 :   Available fields for sorting product_images search results.
 
@@ -7273,12 +8365,16 @@ Classes
 
     * builtins.dict
 
+<a id="ProductImagesStringFilter"></a>
+
 `ProductImagesStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="ProductVariantsAndCondition"></a>
 
 `ProductVariantsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -7300,6 +8396,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.shopify.types.ProductVariantsEqCondition | airbyte_agent_sdk.connectors.shopify.types.ProductVariantsNeqCondition | airbyte_agent_sdk.connectors.shopify.types.ProductVariantsGtCondition | airbyte_agent_sdk.connectors.shopify.types.ProductVariantsGteCondition | airbyte_agent_sdk.connectors.shopify.types.ProductVariantsLtCondition | airbyte_agent_sdk.connectors.shopify.types.ProductVariantsLteCondition | airbyte_agent_sdk.connectors.shopify.types.ProductVariantsInCondition | airbyte_agent_sdk.connectors.shopify.types.ProductVariantsLikeCondition | airbyte_agent_sdk.connectors.shopify.types.ProductVariantsFuzzyCondition | airbyte_agent_sdk.connectors.shopify.types.ProductVariantsKeywordCondition | airbyte_agent_sdk.connectors.shopify.types.ProductVariantsContainsCondition | airbyte_agent_sdk.connectors.shopify.types.ProductVariantsNotCondition | airbyte_agent_sdk.connectors.shopify.types.ProductVariantsAndCondition | airbyte_agent_sdk.connectors.shopify.types.ProductVariantsOrCondition | airbyte_agent_sdk.connectors.shopify.types.ProductVariantsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="ProductVariantsAnyCondition"></a>
+
 `ProductVariantsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -7320,12 +8418,16 @@ Classes
     `any: airbyte_agent_sdk.connectors.shopify.types.ProductVariantsAnyValueFilter`
     :   The type of the None singleton.
 
+<a id="ProductVariantsAnyValueFilter"></a>
+
 `ProductVariantsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="ProductVariantsContainsCondition"></a>
 
 `ProductVariantsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
@@ -7339,6 +8441,8 @@ Classes
     `contains: airbyte_agent_sdk.connectors.shopify.types.ProductVariantsAnyValueFilter`
     :   The type of the None singleton.
 
+<a id="ProductVariantsEqCondition"></a>
+
 `ProductVariantsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
 
@@ -7350,6 +8454,8 @@ Classes
 
     `eq: airbyte_agent_sdk.connectors.shopify.types.ProductVariantsSearchFilter`
     :   The type of the None singleton.
+
+<a id="ProductVariantsFuzzyCondition"></a>
 
 `ProductVariantsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
@@ -7363,6 +8469,8 @@ Classes
     `fuzzy: airbyte_agent_sdk.connectors.shopify.types.ProductVariantsStringFilter`
     :   The type of the None singleton.
 
+<a id="ProductVariantsGetParams"></a>
+
 `ProductVariantsGetParams(*args, **kwargs)`
 :   Parameters for product_variants.get operation
 
@@ -7374,6 +8482,8 @@ Classes
 
     `variant_id: str`
     :   The type of the None singleton.
+
+<a id="ProductVariantsGtCondition"></a>
 
 `ProductVariantsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
@@ -7387,6 +8497,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.shopify.types.ProductVariantsSearchFilter`
     :   The type of the None singleton.
 
+<a id="ProductVariantsGteCondition"></a>
+
 `ProductVariantsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -7398,6 +8510,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.shopify.types.ProductVariantsSearchFilter`
     :   The type of the None singleton.
+
+<a id="ProductVariantsInCondition"></a>
 
 `ProductVariantsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -7419,12 +8533,16 @@ Classes
     `in: airbyte_agent_sdk.connectors.shopify.types.ProductVariantsInFilter`
     :   The type of the None singleton.
 
+<a id="ProductVariantsInFilter"></a>
+
 `ProductVariantsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="ProductVariantsKeywordCondition"></a>
 
 `ProductVariantsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
@@ -7438,6 +8556,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.shopify.types.ProductVariantsStringFilter`
     :   The type of the None singleton.
 
+<a id="ProductVariantsLikeCondition"></a>
+
 `ProductVariantsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -7449,6 +8569,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.shopify.types.ProductVariantsStringFilter`
     :   The type of the None singleton.
+
+<a id="ProductVariantsListParams"></a>
 
 `ProductVariantsListParams(*args, **kwargs)`
 :   Parameters for product_variants.list operation
@@ -7468,6 +8590,8 @@ Classes
     `since_id: int`
     :   The type of the None singleton.
 
+<a id="ProductVariantsLtCondition"></a>
+
 `ProductVariantsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -7479,6 +8603,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.shopify.types.ProductVariantsSearchFilter`
     :   The type of the None singleton.
+
+<a id="ProductVariantsLteCondition"></a>
 
 `ProductVariantsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -7492,6 +8618,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.shopify.types.ProductVariantsSearchFilter`
     :   The type of the None singleton.
 
+<a id="ProductVariantsNeqCondition"></a>
+
 `ProductVariantsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -7503,6 +8631,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.shopify.types.ProductVariantsSearchFilter`
     :   The type of the None singleton.
+
+<a id="ProductVariantsNotCondition"></a>
 
 `ProductVariantsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -7524,6 +8654,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.shopify.types.ProductVariantsEqCondition | airbyte_agent_sdk.connectors.shopify.types.ProductVariantsNeqCondition | airbyte_agent_sdk.connectors.shopify.types.ProductVariantsGtCondition | airbyte_agent_sdk.connectors.shopify.types.ProductVariantsGteCondition | airbyte_agent_sdk.connectors.shopify.types.ProductVariantsLtCondition | airbyte_agent_sdk.connectors.shopify.types.ProductVariantsLteCondition | airbyte_agent_sdk.connectors.shopify.types.ProductVariantsInCondition | airbyte_agent_sdk.connectors.shopify.types.ProductVariantsLikeCondition | airbyte_agent_sdk.connectors.shopify.types.ProductVariantsFuzzyCondition | airbyte_agent_sdk.connectors.shopify.types.ProductVariantsKeywordCondition | airbyte_agent_sdk.connectors.shopify.types.ProductVariantsContainsCondition | airbyte_agent_sdk.connectors.shopify.types.ProductVariantsNotCondition | airbyte_agent_sdk.connectors.shopify.types.ProductVariantsAndCondition | airbyte_agent_sdk.connectors.shopify.types.ProductVariantsOrCondition | airbyte_agent_sdk.connectors.shopify.types.ProductVariantsAnyCondition`
     :   The type of the None singleton.
 
+<a id="ProductVariantsOrCondition"></a>
+
 `ProductVariantsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -7544,12 +8676,16 @@ Classes
     `or: list[airbyte_agent_sdk.connectors.shopify.types.ProductVariantsEqCondition | airbyte_agent_sdk.connectors.shopify.types.ProductVariantsNeqCondition | airbyte_agent_sdk.connectors.shopify.types.ProductVariantsGtCondition | airbyte_agent_sdk.connectors.shopify.types.ProductVariantsGteCondition | airbyte_agent_sdk.connectors.shopify.types.ProductVariantsLtCondition | airbyte_agent_sdk.connectors.shopify.types.ProductVariantsLteCondition | airbyte_agent_sdk.connectors.shopify.types.ProductVariantsInCondition | airbyte_agent_sdk.connectors.shopify.types.ProductVariantsLikeCondition | airbyte_agent_sdk.connectors.shopify.types.ProductVariantsFuzzyCondition | airbyte_agent_sdk.connectors.shopify.types.ProductVariantsKeywordCondition | airbyte_agent_sdk.connectors.shopify.types.ProductVariantsContainsCondition | airbyte_agent_sdk.connectors.shopify.types.ProductVariantsNotCondition | airbyte_agent_sdk.connectors.shopify.types.ProductVariantsAndCondition | airbyte_agent_sdk.connectors.shopify.types.ProductVariantsOrCondition | airbyte_agent_sdk.connectors.shopify.types.ProductVariantsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="ProductVariantsSearchFilter"></a>
+
 `ProductVariantsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering product_variants search queries.
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="ProductVariantsSearchQuery"></a>
 
 `ProductVariantsSearchQuery(*args, **kwargs)`
 :   Search query for product_variants entity.
@@ -7566,6 +8702,8 @@ Classes
     `sort: list[airbyte_agent_sdk.connectors.shopify.types.ProductVariantsSortFilter]`
     :   The type of the None singleton.
 
+<a id="ProductVariantsSortFilter"></a>
+
 `ProductVariantsSortFilter(*args, **kwargs)`
 :   Available fields for sorting product_variants search results.
 
@@ -7573,12 +8711,16 @@ Classes
 
     * builtins.dict
 
+<a id="ProductVariantsStringFilter"></a>
+
 `ProductVariantsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="ProductsGetParams"></a>
 
 `ProductsGetParams(*args, **kwargs)`
 :   Parameters for products.get operation
@@ -7591,6 +8733,8 @@ Classes
 
     `product_id: str`
     :   The type of the None singleton.
+
+<a id="ProductsListParams"></a>
 
 `ProductsListParams(*args, **kwargs)`
 :   Parameters for products.list operation
@@ -7631,6 +8775,8 @@ Classes
     `vendor: str`
     :   The type of the None singleton.
 
+<a id="ShopAndCondition"></a>
+
 `ShopAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -7650,6 +8796,8 @@ Classes
 
     `and: list[airbyte_agent_sdk.connectors.shopify.types.ShopEqCondition | airbyte_agent_sdk.connectors.shopify.types.ShopNeqCondition | airbyte_agent_sdk.connectors.shopify.types.ShopGtCondition | airbyte_agent_sdk.connectors.shopify.types.ShopGteCondition | airbyte_agent_sdk.connectors.shopify.types.ShopLtCondition | airbyte_agent_sdk.connectors.shopify.types.ShopLteCondition | airbyte_agent_sdk.connectors.shopify.types.ShopInCondition | airbyte_agent_sdk.connectors.shopify.types.ShopLikeCondition | airbyte_agent_sdk.connectors.shopify.types.ShopFuzzyCondition | airbyte_agent_sdk.connectors.shopify.types.ShopKeywordCondition | airbyte_agent_sdk.connectors.shopify.types.ShopContainsCondition | airbyte_agent_sdk.connectors.shopify.types.ShopNotCondition | airbyte_agent_sdk.connectors.shopify.types.ShopAndCondition | airbyte_agent_sdk.connectors.shopify.types.ShopOrCondition | airbyte_agent_sdk.connectors.shopify.types.ShopAnyCondition]`
     :   The type of the None singleton.
+
+<a id="ShopAnyCondition"></a>
 
 `ShopAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -7671,12 +8819,16 @@ Classes
     `any: airbyte_agent_sdk.connectors.shopify.types.ShopAnyValueFilter`
     :   The type of the None singleton.
 
+<a id="ShopAnyValueFilter"></a>
+
 `ShopAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="ShopContainsCondition"></a>
 
 `ShopContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
@@ -7690,6 +8842,8 @@ Classes
     `contains: airbyte_agent_sdk.connectors.shopify.types.ShopAnyValueFilter`
     :   The type of the None singleton.
 
+<a id="ShopEqCondition"></a>
+
 `ShopEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
 
@@ -7701,6 +8855,8 @@ Classes
 
     `eq: airbyte_agent_sdk.connectors.shopify.types.ShopSearchFilter`
     :   The type of the None singleton.
+
+<a id="ShopFuzzyCondition"></a>
 
 `ShopFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
@@ -7714,12 +8870,16 @@ Classes
     `fuzzy: airbyte_agent_sdk.connectors.shopify.types.ShopStringFilter`
     :   The type of the None singleton.
 
+<a id="ShopGetParams"></a>
+
 `ShopGetParams(*args, **kwargs)`
 :   Parameters for shop.get operation
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="ShopGtCondition"></a>
 
 `ShopGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
@@ -7733,6 +8893,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.shopify.types.ShopSearchFilter`
     :   The type of the None singleton.
 
+<a id="ShopGteCondition"></a>
+
 `ShopGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -7744,6 +8906,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.shopify.types.ShopSearchFilter`
     :   The type of the None singleton.
+
+<a id="ShopInCondition"></a>
 
 `ShopInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -7765,12 +8929,16 @@ Classes
     `in: airbyte_agent_sdk.connectors.shopify.types.ShopInFilter`
     :   The type of the None singleton.
 
+<a id="ShopInFilter"></a>
+
 `ShopInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="ShopKeywordCondition"></a>
 
 `ShopKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
@@ -7784,6 +8952,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.shopify.types.ShopStringFilter`
     :   The type of the None singleton.
 
+<a id="ShopLikeCondition"></a>
+
 `ShopLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -7795,6 +8965,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.shopify.types.ShopStringFilter`
     :   The type of the None singleton.
+
+<a id="ShopLtCondition"></a>
 
 `ShopLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
@@ -7808,6 +8980,8 @@ Classes
     `lt: airbyte_agent_sdk.connectors.shopify.types.ShopSearchFilter`
     :   The type of the None singleton.
 
+<a id="ShopLteCondition"></a>
+
 `ShopLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
 
@@ -7820,6 +8994,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.shopify.types.ShopSearchFilter`
     :   The type of the None singleton.
 
+<a id="ShopNeqCondition"></a>
+
 `ShopNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -7831,6 +9007,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.shopify.types.ShopSearchFilter`
     :   The type of the None singleton.
+
+<a id="ShopNotCondition"></a>
 
 `ShopNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -7852,6 +9030,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.shopify.types.ShopEqCondition | airbyte_agent_sdk.connectors.shopify.types.ShopNeqCondition | airbyte_agent_sdk.connectors.shopify.types.ShopGtCondition | airbyte_agent_sdk.connectors.shopify.types.ShopGteCondition | airbyte_agent_sdk.connectors.shopify.types.ShopLtCondition | airbyte_agent_sdk.connectors.shopify.types.ShopLteCondition | airbyte_agent_sdk.connectors.shopify.types.ShopInCondition | airbyte_agent_sdk.connectors.shopify.types.ShopLikeCondition | airbyte_agent_sdk.connectors.shopify.types.ShopFuzzyCondition | airbyte_agent_sdk.connectors.shopify.types.ShopKeywordCondition | airbyte_agent_sdk.connectors.shopify.types.ShopContainsCondition | airbyte_agent_sdk.connectors.shopify.types.ShopNotCondition | airbyte_agent_sdk.connectors.shopify.types.ShopAndCondition | airbyte_agent_sdk.connectors.shopify.types.ShopOrCondition | airbyte_agent_sdk.connectors.shopify.types.ShopAnyCondition`
     :   The type of the None singleton.
 
+<a id="ShopOrCondition"></a>
+
 `ShopOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -7872,12 +9052,16 @@ Classes
     `or: list[airbyte_agent_sdk.connectors.shopify.types.ShopEqCondition | airbyte_agent_sdk.connectors.shopify.types.ShopNeqCondition | airbyte_agent_sdk.connectors.shopify.types.ShopGtCondition | airbyte_agent_sdk.connectors.shopify.types.ShopGteCondition | airbyte_agent_sdk.connectors.shopify.types.ShopLtCondition | airbyte_agent_sdk.connectors.shopify.types.ShopLteCondition | airbyte_agent_sdk.connectors.shopify.types.ShopInCondition | airbyte_agent_sdk.connectors.shopify.types.ShopLikeCondition | airbyte_agent_sdk.connectors.shopify.types.ShopFuzzyCondition | airbyte_agent_sdk.connectors.shopify.types.ShopKeywordCondition | airbyte_agent_sdk.connectors.shopify.types.ShopContainsCondition | airbyte_agent_sdk.connectors.shopify.types.ShopNotCondition | airbyte_agent_sdk.connectors.shopify.types.ShopAndCondition | airbyte_agent_sdk.connectors.shopify.types.ShopOrCondition | airbyte_agent_sdk.connectors.shopify.types.ShopAnyCondition]`
     :   The type of the None singleton.
 
+<a id="ShopSearchFilter"></a>
+
 `ShopSearchFilter(*args, **kwargs)`
 :   Available fields for filtering shop search queries.
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="ShopSearchQuery"></a>
 
 `ShopSearchQuery(*args, **kwargs)`
 :   Search query for shop entity.
@@ -7894,6 +9078,8 @@ Classes
     `sort: list[airbyte_agent_sdk.connectors.shopify.types.ShopSortFilter]`
     :   The type of the None singleton.
 
+<a id="ShopSortFilter"></a>
+
 `ShopSortFilter(*args, **kwargs)`
 :   Available fields for sorting shop search results.
 
@@ -7901,12 +9087,16 @@ Classes
 
     * builtins.dict
 
+<a id="ShopStringFilter"></a>
+
 `ShopStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="SmartCollectionsAndCondition"></a>
 
 `SmartCollectionsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -7928,6 +9118,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.shopify.types.SmartCollectionsEqCondition | airbyte_agent_sdk.connectors.shopify.types.SmartCollectionsNeqCondition | airbyte_agent_sdk.connectors.shopify.types.SmartCollectionsGtCondition | airbyte_agent_sdk.connectors.shopify.types.SmartCollectionsGteCondition | airbyte_agent_sdk.connectors.shopify.types.SmartCollectionsLtCondition | airbyte_agent_sdk.connectors.shopify.types.SmartCollectionsLteCondition | airbyte_agent_sdk.connectors.shopify.types.SmartCollectionsInCondition | airbyte_agent_sdk.connectors.shopify.types.SmartCollectionsLikeCondition | airbyte_agent_sdk.connectors.shopify.types.SmartCollectionsFuzzyCondition | airbyte_agent_sdk.connectors.shopify.types.SmartCollectionsKeywordCondition | airbyte_agent_sdk.connectors.shopify.types.SmartCollectionsContainsCondition | airbyte_agent_sdk.connectors.shopify.types.SmartCollectionsNotCondition | airbyte_agent_sdk.connectors.shopify.types.SmartCollectionsAndCondition | airbyte_agent_sdk.connectors.shopify.types.SmartCollectionsOrCondition | airbyte_agent_sdk.connectors.shopify.types.SmartCollectionsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="SmartCollectionsAnyCondition"></a>
+
 `SmartCollectionsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -7948,12 +9140,16 @@ Classes
     `any: airbyte_agent_sdk.connectors.shopify.types.SmartCollectionsAnyValueFilter`
     :   The type of the None singleton.
 
+<a id="SmartCollectionsAnyValueFilter"></a>
+
 `SmartCollectionsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="SmartCollectionsContainsCondition"></a>
 
 `SmartCollectionsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
@@ -7967,6 +9163,8 @@ Classes
     `contains: airbyte_agent_sdk.connectors.shopify.types.SmartCollectionsAnyValueFilter`
     :   The type of the None singleton.
 
+<a id="SmartCollectionsEqCondition"></a>
+
 `SmartCollectionsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
 
@@ -7978,6 +9176,8 @@ Classes
 
     `eq: airbyte_agent_sdk.connectors.shopify.types.SmartCollectionsSearchFilter`
     :   The type of the None singleton.
+
+<a id="SmartCollectionsFuzzyCondition"></a>
 
 `SmartCollectionsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
@@ -7991,6 +9191,8 @@ Classes
     `fuzzy: airbyte_agent_sdk.connectors.shopify.types.SmartCollectionsStringFilter`
     :   The type of the None singleton.
 
+<a id="SmartCollectionsGetParams"></a>
+
 `SmartCollectionsGetParams(*args, **kwargs)`
 :   Parameters for smart_collections.get operation
 
@@ -8002,6 +9204,8 @@ Classes
 
     `collection_id: str`
     :   The type of the None singleton.
+
+<a id="SmartCollectionsGtCondition"></a>
 
 `SmartCollectionsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
@@ -8015,6 +9219,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.shopify.types.SmartCollectionsSearchFilter`
     :   The type of the None singleton.
 
+<a id="SmartCollectionsGteCondition"></a>
+
 `SmartCollectionsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -8026,6 +9232,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.shopify.types.SmartCollectionsSearchFilter`
     :   The type of the None singleton.
+
+<a id="SmartCollectionsInCondition"></a>
 
 `SmartCollectionsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -8047,12 +9255,16 @@ Classes
     `in: airbyte_agent_sdk.connectors.shopify.types.SmartCollectionsInFilter`
     :   The type of the None singleton.
 
+<a id="SmartCollectionsInFilter"></a>
+
 `SmartCollectionsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="SmartCollectionsKeywordCondition"></a>
 
 `SmartCollectionsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
@@ -8066,6 +9278,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.shopify.types.SmartCollectionsStringFilter`
     :   The type of the None singleton.
 
+<a id="SmartCollectionsLikeCondition"></a>
+
 `SmartCollectionsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -8077,6 +9291,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.shopify.types.SmartCollectionsStringFilter`
     :   The type of the None singleton.
+
+<a id="SmartCollectionsListParams"></a>
 
 `SmartCollectionsListParams(*args, **kwargs)`
 :   Parameters for smart_collections.list operation
@@ -8105,6 +9321,8 @@ Classes
     `updated_at_min: str`
     :   The type of the None singleton.
 
+<a id="SmartCollectionsLtCondition"></a>
+
 `SmartCollectionsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -8116,6 +9334,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.shopify.types.SmartCollectionsSearchFilter`
     :   The type of the None singleton.
+
+<a id="SmartCollectionsLteCondition"></a>
 
 `SmartCollectionsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -8129,6 +9349,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.shopify.types.SmartCollectionsSearchFilter`
     :   The type of the None singleton.
 
+<a id="SmartCollectionsNeqCondition"></a>
+
 `SmartCollectionsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -8140,6 +9362,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.shopify.types.SmartCollectionsSearchFilter`
     :   The type of the None singleton.
+
+<a id="SmartCollectionsNotCondition"></a>
 
 `SmartCollectionsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -8161,6 +9385,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.shopify.types.SmartCollectionsEqCondition | airbyte_agent_sdk.connectors.shopify.types.SmartCollectionsNeqCondition | airbyte_agent_sdk.connectors.shopify.types.SmartCollectionsGtCondition | airbyte_agent_sdk.connectors.shopify.types.SmartCollectionsGteCondition | airbyte_agent_sdk.connectors.shopify.types.SmartCollectionsLtCondition | airbyte_agent_sdk.connectors.shopify.types.SmartCollectionsLteCondition | airbyte_agent_sdk.connectors.shopify.types.SmartCollectionsInCondition | airbyte_agent_sdk.connectors.shopify.types.SmartCollectionsLikeCondition | airbyte_agent_sdk.connectors.shopify.types.SmartCollectionsFuzzyCondition | airbyte_agent_sdk.connectors.shopify.types.SmartCollectionsKeywordCondition | airbyte_agent_sdk.connectors.shopify.types.SmartCollectionsContainsCondition | airbyte_agent_sdk.connectors.shopify.types.SmartCollectionsNotCondition | airbyte_agent_sdk.connectors.shopify.types.SmartCollectionsAndCondition | airbyte_agent_sdk.connectors.shopify.types.SmartCollectionsOrCondition | airbyte_agent_sdk.connectors.shopify.types.SmartCollectionsAnyCondition`
     :   The type of the None singleton.
 
+<a id="SmartCollectionsOrCondition"></a>
+
 `SmartCollectionsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -8181,12 +9407,16 @@ Classes
     `or: list[airbyte_agent_sdk.connectors.shopify.types.SmartCollectionsEqCondition | airbyte_agent_sdk.connectors.shopify.types.SmartCollectionsNeqCondition | airbyte_agent_sdk.connectors.shopify.types.SmartCollectionsGtCondition | airbyte_agent_sdk.connectors.shopify.types.SmartCollectionsGteCondition | airbyte_agent_sdk.connectors.shopify.types.SmartCollectionsLtCondition | airbyte_agent_sdk.connectors.shopify.types.SmartCollectionsLteCondition | airbyte_agent_sdk.connectors.shopify.types.SmartCollectionsInCondition | airbyte_agent_sdk.connectors.shopify.types.SmartCollectionsLikeCondition | airbyte_agent_sdk.connectors.shopify.types.SmartCollectionsFuzzyCondition | airbyte_agent_sdk.connectors.shopify.types.SmartCollectionsKeywordCondition | airbyte_agent_sdk.connectors.shopify.types.SmartCollectionsContainsCondition | airbyte_agent_sdk.connectors.shopify.types.SmartCollectionsNotCondition | airbyte_agent_sdk.connectors.shopify.types.SmartCollectionsAndCondition | airbyte_agent_sdk.connectors.shopify.types.SmartCollectionsOrCondition | airbyte_agent_sdk.connectors.shopify.types.SmartCollectionsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="SmartCollectionsSearchFilter"></a>
+
 `SmartCollectionsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering smart_collections search queries.
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="SmartCollectionsSearchQuery"></a>
 
 `SmartCollectionsSearchQuery(*args, **kwargs)`
 :   Search query for smart_collections entity.
@@ -8203,6 +9433,8 @@ Classes
     `sort: list[airbyte_agent_sdk.connectors.shopify.types.SmartCollectionsSortFilter]`
     :   The type of the None singleton.
 
+<a id="SmartCollectionsSortFilter"></a>
+
 `SmartCollectionsSortFilter(*args, **kwargs)`
 :   Available fields for sorting smart_collections search results.
 
@@ -8210,12 +9442,16 @@ Classes
 
     * builtins.dict
 
+<a id="SmartCollectionsStringFilter"></a>
+
 `SmartCollectionsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="TenderTransactionsAndCondition"></a>
 
 `TenderTransactionsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -8237,6 +9473,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.shopify.types.TenderTransactionsEqCondition | airbyte_agent_sdk.connectors.shopify.types.TenderTransactionsNeqCondition | airbyte_agent_sdk.connectors.shopify.types.TenderTransactionsGtCondition | airbyte_agent_sdk.connectors.shopify.types.TenderTransactionsGteCondition | airbyte_agent_sdk.connectors.shopify.types.TenderTransactionsLtCondition | airbyte_agent_sdk.connectors.shopify.types.TenderTransactionsLteCondition | airbyte_agent_sdk.connectors.shopify.types.TenderTransactionsInCondition | airbyte_agent_sdk.connectors.shopify.types.TenderTransactionsLikeCondition | airbyte_agent_sdk.connectors.shopify.types.TenderTransactionsFuzzyCondition | airbyte_agent_sdk.connectors.shopify.types.TenderTransactionsKeywordCondition | airbyte_agent_sdk.connectors.shopify.types.TenderTransactionsContainsCondition | airbyte_agent_sdk.connectors.shopify.types.TenderTransactionsNotCondition | airbyte_agent_sdk.connectors.shopify.types.TenderTransactionsAndCondition | airbyte_agent_sdk.connectors.shopify.types.TenderTransactionsOrCondition | airbyte_agent_sdk.connectors.shopify.types.TenderTransactionsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="TenderTransactionsAnyCondition"></a>
+
 `TenderTransactionsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -8257,12 +9495,16 @@ Classes
     `any: airbyte_agent_sdk.connectors.shopify.types.TenderTransactionsAnyValueFilter`
     :   The type of the None singleton.
 
+<a id="TenderTransactionsAnyValueFilter"></a>
+
 `TenderTransactionsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="TenderTransactionsContainsCondition"></a>
 
 `TenderTransactionsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
@@ -8276,6 +9518,8 @@ Classes
     `contains: airbyte_agent_sdk.connectors.shopify.types.TenderTransactionsAnyValueFilter`
     :   The type of the None singleton.
 
+<a id="TenderTransactionsEqCondition"></a>
+
 `TenderTransactionsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
 
@@ -8287,6 +9531,8 @@ Classes
 
     `eq: airbyte_agent_sdk.connectors.shopify.types.TenderTransactionsSearchFilter`
     :   The type of the None singleton.
+
+<a id="TenderTransactionsFuzzyCondition"></a>
 
 `TenderTransactionsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
@@ -8300,6 +9546,8 @@ Classes
     `fuzzy: airbyte_agent_sdk.connectors.shopify.types.TenderTransactionsStringFilter`
     :   The type of the None singleton.
 
+<a id="TenderTransactionsGtCondition"></a>
+
 `TenderTransactionsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -8312,6 +9560,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.shopify.types.TenderTransactionsSearchFilter`
     :   The type of the None singleton.
 
+<a id="TenderTransactionsGteCondition"></a>
+
 `TenderTransactionsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -8323,6 +9573,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.shopify.types.TenderTransactionsSearchFilter`
     :   The type of the None singleton.
+
+<a id="TenderTransactionsInCondition"></a>
 
 `TenderTransactionsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -8344,12 +9596,16 @@ Classes
     `in: airbyte_agent_sdk.connectors.shopify.types.TenderTransactionsInFilter`
     :   The type of the None singleton.
 
+<a id="TenderTransactionsInFilter"></a>
+
 `TenderTransactionsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="TenderTransactionsKeywordCondition"></a>
 
 `TenderTransactionsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
@@ -8363,6 +9619,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.shopify.types.TenderTransactionsStringFilter`
     :   The type of the None singleton.
 
+<a id="TenderTransactionsLikeCondition"></a>
+
 `TenderTransactionsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -8374,6 +9632,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.shopify.types.TenderTransactionsStringFilter`
     :   The type of the None singleton.
+
+<a id="TenderTransactionsListParams"></a>
 
 `TenderTransactionsListParams(*args, **kwargs)`
 :   Parameters for tender_transactions.list operation
@@ -8399,6 +9659,8 @@ Classes
     `since_id: int`
     :   The type of the None singleton.
 
+<a id="TenderTransactionsLtCondition"></a>
+
 `TenderTransactionsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -8410,6 +9672,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.shopify.types.TenderTransactionsSearchFilter`
     :   The type of the None singleton.
+
+<a id="TenderTransactionsLteCondition"></a>
 
 `TenderTransactionsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -8423,6 +9687,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.shopify.types.TenderTransactionsSearchFilter`
     :   The type of the None singleton.
 
+<a id="TenderTransactionsNeqCondition"></a>
+
 `TenderTransactionsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -8434,6 +9700,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.shopify.types.TenderTransactionsSearchFilter`
     :   The type of the None singleton.
+
+<a id="TenderTransactionsNotCondition"></a>
 
 `TenderTransactionsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -8455,6 +9723,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.shopify.types.TenderTransactionsEqCondition | airbyte_agent_sdk.connectors.shopify.types.TenderTransactionsNeqCondition | airbyte_agent_sdk.connectors.shopify.types.TenderTransactionsGtCondition | airbyte_agent_sdk.connectors.shopify.types.TenderTransactionsGteCondition | airbyte_agent_sdk.connectors.shopify.types.TenderTransactionsLtCondition | airbyte_agent_sdk.connectors.shopify.types.TenderTransactionsLteCondition | airbyte_agent_sdk.connectors.shopify.types.TenderTransactionsInCondition | airbyte_agent_sdk.connectors.shopify.types.TenderTransactionsLikeCondition | airbyte_agent_sdk.connectors.shopify.types.TenderTransactionsFuzzyCondition | airbyte_agent_sdk.connectors.shopify.types.TenderTransactionsKeywordCondition | airbyte_agent_sdk.connectors.shopify.types.TenderTransactionsContainsCondition | airbyte_agent_sdk.connectors.shopify.types.TenderTransactionsNotCondition | airbyte_agent_sdk.connectors.shopify.types.TenderTransactionsAndCondition | airbyte_agent_sdk.connectors.shopify.types.TenderTransactionsOrCondition | airbyte_agent_sdk.connectors.shopify.types.TenderTransactionsAnyCondition`
     :   The type of the None singleton.
 
+<a id="TenderTransactionsOrCondition"></a>
+
 `TenderTransactionsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -8475,12 +9745,16 @@ Classes
     `or: list[airbyte_agent_sdk.connectors.shopify.types.TenderTransactionsEqCondition | airbyte_agent_sdk.connectors.shopify.types.TenderTransactionsNeqCondition | airbyte_agent_sdk.connectors.shopify.types.TenderTransactionsGtCondition | airbyte_agent_sdk.connectors.shopify.types.TenderTransactionsGteCondition | airbyte_agent_sdk.connectors.shopify.types.TenderTransactionsLtCondition | airbyte_agent_sdk.connectors.shopify.types.TenderTransactionsLteCondition | airbyte_agent_sdk.connectors.shopify.types.TenderTransactionsInCondition | airbyte_agent_sdk.connectors.shopify.types.TenderTransactionsLikeCondition | airbyte_agent_sdk.connectors.shopify.types.TenderTransactionsFuzzyCondition | airbyte_agent_sdk.connectors.shopify.types.TenderTransactionsKeywordCondition | airbyte_agent_sdk.connectors.shopify.types.TenderTransactionsContainsCondition | airbyte_agent_sdk.connectors.shopify.types.TenderTransactionsNotCondition | airbyte_agent_sdk.connectors.shopify.types.TenderTransactionsAndCondition | airbyte_agent_sdk.connectors.shopify.types.TenderTransactionsOrCondition | airbyte_agent_sdk.connectors.shopify.types.TenderTransactionsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="TenderTransactionsSearchFilter"></a>
+
 `TenderTransactionsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering tender_transactions search queries.
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="TenderTransactionsSearchQuery"></a>
 
 `TenderTransactionsSearchQuery(*args, **kwargs)`
 :   Search query for tender_transactions entity.
@@ -8497,6 +9771,8 @@ Classes
     `sort: list[airbyte_agent_sdk.connectors.shopify.types.TenderTransactionsSortFilter]`
     :   The type of the None singleton.
 
+<a id="TenderTransactionsSortFilter"></a>
+
 `TenderTransactionsSortFilter(*args, **kwargs)`
 :   Available fields for sorting tender_transactions search results.
 
@@ -8504,12 +9780,16 @@ Classes
 
     * builtins.dict
 
+<a id="TenderTransactionsStringFilter"></a>
+
 `TenderTransactionsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="TransactionsGetParams"></a>
 
 `TransactionsGetParams(*args, **kwargs)`
 :   Parameters for transactions.get operation
@@ -8525,6 +9805,8 @@ Classes
 
     `transaction_id: str`
     :   The type of the None singleton.
+
+<a id="TransactionsListParams"></a>
 
 `TransactionsListParams(*args, **kwargs)`
 :   Parameters for transactions.list operation

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/slack/connector.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/slack/connector.md
@@ -10,6 +10,8 @@ Slack connector.
 Classes
 -------
 
+<a id="ChannelInvitesQuery"></a>
+
 `ChannelInvitesQuery(connector: SlackConnector)`
 :   Query class for ChannelInvites entity operations.
     
@@ -28,6 +30,8 @@ Classes
         
         Returns:
             Channel
+
+<a id="ChannelMessagesQuery"></a>
 
 `ChannelMessagesQuery(connector: SlackConnector)`
 :   Query class for ChannelMessages entity operations.
@@ -91,6 +95,8 @@ Classes
         Returns:
             ChannelMessagesListResult
 
+<a id="ChannelPurposesQuery"></a>
+
 `ChannelPurposesQuery(connector: SlackConnector)`
 :   Query class for ChannelPurposes entity operations.
     
@@ -109,6 +115,8 @@ Classes
         Returns:
             Channel
 
+<a id="ChannelTopicsQuery"></a>
+
 `ChannelTopicsQuery(connector: SlackConnector)`
 :   Query class for ChannelTopics entity operations.
     
@@ -126,6 +134,8 @@ Classes
         
         Returns:
             Channel
+
+<a id="ChannelsQuery"></a>
 
 `ChannelsQuery(connector: SlackConnector)`
 :   Query class for Channels entity operations.
@@ -232,6 +242,8 @@ Classes
         Returns:
             Channel
 
+<a id="MessagesQuery"></a>
+
 `MessagesQuery(connector: SlackConnector)`
 :   Query class for Messages entity operations.
     
@@ -266,6 +278,8 @@ Classes
         Returns:
             CreatedMessage
 
+<a id="ReactionsQuery"></a>
+
 `ReactionsQuery(connector: SlackConnector)`
 :   Query class for Reactions entity operations.
     
@@ -284,6 +298,8 @@ Classes
         
         Returns:
             ReactionAddResponse
+
+<a id="SlackConnector"></a>
 
 `SlackConnector(auth_config: SlackAuthConfig | AirbyteAuthConfig | BaseModel | None = None, on_token_refresh: Any | None = None)`
 :   Type-safe Slack API connector.
@@ -541,6 +557,8 @@ Classes
             for entity in entities:
                 print(f"\{entity['entity_name']\}: \{entity['available_actions']\}")
 
+<a id="ThreadsQuery"></a>
+
 `ThreadsQuery(connector: SlackConnector)`
 :   Query class for Threads entity operations.
     
@@ -601,6 +619,8 @@ Classes
         
         Returns:
             ThreadsListResult
+
+<a id="UsersQuery"></a>
 
 `UsersQuery(connector: SlackConnector)`
 :   Query class for Users entity operations.

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/slack/index.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/slack/index.md
@@ -19,6 +19,8 @@ Sub-modules
 Classes
 -------
 
+<a id="AirbyteAuthConfig"></a>
+
 `AirbyteAuthConfig(**data: Any)`
 :   Authentication configuration for Airbyte hosted mode execution.
     
@@ -87,6 +89,8 @@ Classes
     `workspace_name: str | None`
     :   The type of the None singleton.
 
+<a id="AirbyteSearchMeta"></a>
+
 `AirbyteSearchMeta(**data: Any)`
 :   Pagination metadata for search responses.
     
@@ -114,6 +118,8 @@ Classes
 
     `took_ms: int | None`
     :   Time taken to execute the search in milliseconds.
+
+<a id="AirbyteSearchResult"></a>
 
 `AirbyteSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -148,6 +154,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="ChannelMessagesSearchResult"></a>
+
 `ChannelMessagesSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -163,6 +171,8 @@ Classes
     * airbyte_agent_sdk.connectors.slack.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="ChannelsSearchResult"></a>
 
 `ChannelsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -180,6 +190,8 @@ Classes
     * pydantic.main.BaseModel
     * typing.Generic
 
+<a id="ThreadsSearchResult"></a>
+
 `ThreadsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -196,6 +208,8 @@ Classes
     * pydantic.main.BaseModel
     * typing.Generic
 
+<a id="UsersSearchResult"></a>
+
 `UsersSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -211,6 +225,8 @@ Classes
     * airbyte_agent_sdk.connectors.slack.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="ChannelMessagesSearchData"></a>
 
 `ChannelMessagesSearchData(**data: Any)`
 :   Search result data for channel_messages entity.
@@ -284,6 +300,8 @@ Classes
 
     `user: str | None`
     :   User ID who sent the message.
+
+<a id="ChannelsSearchData"></a>
 
 `ChannelsSearchData(**data: Any)`
 :   Search result data for channels entity.
@@ -396,6 +414,8 @@ Classes
 
     `updated: int | None`
     :   The timestamp when the channel was last updated.
+
+<a id="SlackConnector"></a>
 
 `SlackConnector(auth_config: SlackAuthConfig | AirbyteAuthConfig | BaseModel | None = None, on_token_refresh: Any | None = None)`
 :   Type-safe Slack API connector.
@@ -653,6 +673,8 @@ Classes
             for entity in entities:
                 print(f"\{entity['entity_name']\}: \{entity['available_actions']\}")
 
+<a id="SlackReplicationConfig"></a>
+
 `SlackReplicationConfig(**data: Any)`
 :   Replication Configuration - Settings for data replication from Slack.
     
@@ -680,6 +702,8 @@ Classes
 
     `start_date: str`
     :   UTC date and time in the format YYYY-MM-DDTHH:mm:ssZ from which to start replicating data.
+
+<a id="ThreadsSearchData"></a>
 
 `ThreadsSearchData(**data: Any)`
 :   Search result data for threads entity.
@@ -747,6 +771,8 @@ Classes
 
     `user: str | None`
     :   User ID who sent the message.
+
+<a id="UsersSearchData"></a>
 
 `UsersSearchData(**data: Any)`
 :   Search result data for users entity.

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/slack/models.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/slack/models.md
@@ -13,6 +13,8 @@ and response envelope types.
 Classes
 -------
 
+<a id="AirbyteSearchMeta"></a>
+
 `AirbyteSearchMeta(**data: Any)`
 :   Pagination metadata for search responses.
     
@@ -40,6 +42,8 @@ Classes
 
     `took_ms: int | None`
     :   Time taken to execute the search in milliseconds.
+
+<a id="AirbyteSearchResult"></a>
 
 `AirbyteSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -95,6 +99,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="ChannelMessagesSearchResult"></a>
+
 `ChannelMessagesSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -131,6 +137,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="ChannelsSearchResult"></a>
 
 `ChannelsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -169,6 +177,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="ThreadsSearchResult"></a>
+
 `ThreadsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -206,6 +216,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="UsersSearchResult"></a>
+
 `UsersSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -221,6 +233,8 @@ Classes
     * airbyte_agent_sdk.connectors.slack.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="Attachment"></a>
 
 `Attachment(**data: Any)`
 :   Message attachment
@@ -289,6 +303,8 @@ Classes
     `ts: Any`
     :   The type of the None singleton.
 
+<a id="BotProfile"></a>
+
 `BotProfile(**data: Any)`
 :   Bot profile information
     
@@ -325,6 +341,8 @@ Classes
 
     `updated: int | Any | None`
     :   The type of the None singleton.
+
+<a id="Channel"></a>
 
 `Channel(**data: Any)`
 :   Slack channel object
@@ -438,6 +456,8 @@ Classes
     `updated: int | Any | None`
     :   The type of the None singleton.
 
+<a id="ChannelCreateParams"></a>
+
 `ChannelCreateParams(**data: Any)`
 :   Parameters for creating a channel
     
@@ -463,6 +483,8 @@ Classes
     `name: str | Any`
     :   The type of the None singleton.
 
+<a id="ChannelCreateResponse"></a>
+
 `ChannelCreateResponse(**data: Any)`
 :   Response from creating a channel
     
@@ -487,6 +509,8 @@ Classes
 
     `ok: bool | Any`
     :   The type of the None singleton.
+
+<a id="ChannelInviteParams"></a>
 
 `ChannelInviteParams(**data: Any)`
 :   Parameters for inviting users to a channel
@@ -516,6 +540,8 @@ Classes
     `users: str | Any`
     :   The type of the None singleton.
 
+<a id="ChannelInviteResponse"></a>
+
 `ChannelInviteResponse(**data: Any)`
 :   Response from inviting users to a channel
     
@@ -541,6 +567,8 @@ Classes
     `ok: bool | Any`
     :   The type of the None singleton.
 
+<a id="ChannelMessagesListResultMeta"></a>
+
 `ChannelMessagesListResultMeta(**data: Any)`
 :   Metadata for channel_messages.Action.LIST operation
     
@@ -565,6 +593,8 @@ Classes
 
     `next_cursor: str | Any | None`
     :   The type of the None singleton.
+
+<a id="ChannelMessagesSearchData"></a>
 
 `ChannelMessagesSearchData(**data: Any)`
 :   Search result data for channel_messages entity.
@@ -639,6 +669,8 @@ Classes
     `user: str | None`
     :   User ID who sent the message.
 
+<a id="ChannelPurpose"></a>
+
 `ChannelPurpose(**data: Any)`
 :   Channel purpose information
     
@@ -667,6 +699,8 @@ Classes
     `value: str | Any | None`
     :   The type of the None singleton.
 
+<a id="ChannelPurposeParams"></a>
+
 `ChannelPurposeParams(**data: Any)`
 :   Parameters for setting channel purpose
     
@@ -691,6 +725,8 @@ Classes
 
     `purpose: str | Any`
     :   The type of the None singleton.
+
+<a id="ChannelPurposeResponse"></a>
 
 `ChannelPurposeResponse(**data: Any)`
 :   Response from setting channel purpose
@@ -717,6 +753,8 @@ Classes
     `ok: bool | Any`
     :   The type of the None singleton.
 
+<a id="ChannelRenameParams"></a>
+
 `ChannelRenameParams(**data: Any)`
 :   Parameters for renaming a channel
     
@@ -741,6 +779,8 @@ Classes
 
     `name: str | Any`
     :   The type of the None singleton.
+
+<a id="ChannelRenameResponse"></a>
 
 `ChannelRenameResponse(**data: Any)`
 :   Response from renaming a channel
@@ -767,6 +807,8 @@ Classes
     `ok: bool | Any`
     :   The type of the None singleton.
 
+<a id="ChannelResponse"></a>
+
 `ChannelResponse(**data: Any)`
 :   Response containing single channel
     
@@ -791,6 +833,8 @@ Classes
 
     `ok: bool | Any`
     :   The type of the None singleton.
+
+<a id="ChannelTopic"></a>
 
 `ChannelTopic(**data: Any)`
 :   Channel topic information
@@ -820,6 +864,8 @@ Classes
     `value: str | Any | None`
     :   The type of the None singleton.
 
+<a id="ChannelTopicParams"></a>
+
 `ChannelTopicParams(**data: Any)`
 :   Parameters for setting channel topic
     
@@ -845,6 +891,8 @@ Classes
     `topic: str | Any`
     :   The type of the None singleton.
 
+<a id="ChannelTopicResponse"></a>
+
 `ChannelTopicResponse(**data: Any)`
 :   Response from setting channel topic
     
@@ -869,6 +917,8 @@ Classes
 
     `ok: bool | Any`
     :   The type of the None singleton.
+
+<a id="ChannelsListResponse"></a>
 
 `ChannelsListResponse(**data: Any)`
 :   Response containing list of channels
@@ -898,6 +948,8 @@ Classes
     `response_metadata: airbyte_agent_sdk.connectors.slack.models.ResponseMetadata | Any`
     :   The type of the None singleton.
 
+<a id="ChannelsListResultMeta"></a>
+
 `ChannelsListResultMeta(**data: Any)`
 :   Metadata for channels.Action.LIST operation
     
@@ -919,6 +971,8 @@ Classes
 
     `next_cursor: str | Any | None`
     :   The type of the None singleton.
+
+<a id="ChannelsSearchData"></a>
 
 `ChannelsSearchData(**data: Any)`
 :   Search result data for channels entity.
@@ -1032,6 +1086,8 @@ Classes
     `updated: int | None`
     :   The timestamp when the channel was last updated.
 
+<a id="CreatedMessage"></a>
+
 `CreatedMessage(**data: Any)`
 :   A message object returned from create/update operations
     
@@ -1078,6 +1134,8 @@ Classes
     `user: str | Any | None`
     :   The type of the None singleton.
 
+<a id="EditedInfo"></a>
+
 `EditedInfo(**data: Any)`
 :   Message edit information
     
@@ -1102,6 +1160,8 @@ Classes
 
     `user: str | Any | None`
     :   The type of the None singleton.
+
+<a id="File"></a>
 
 `File(**data: Any)`
 :   File object
@@ -1178,6 +1238,8 @@ Classes
 
     `user: str | Any | None`
     :   The type of the None singleton.
+
+<a id="Message"></a>
 
 `Message(**data: Any)`
 :   Slack message object
@@ -1261,6 +1323,8 @@ Classes
     `user: str | Any | None`
     :   The type of the None singleton.
 
+<a id="MessageCreateParams"></a>
+
 `MessageCreateParams(**data: Any)`
 :   Parameters for creating a message
     
@@ -1298,6 +1362,8 @@ Classes
     `unfurl_media: bool | Any`
     :   The type of the None singleton.
 
+<a id="MessageCreateResponse"></a>
+
 `MessageCreateResponse(**data: Any)`
 :   Response from creating a message
     
@@ -1329,6 +1395,8 @@ Classes
     `ts: str | Any | None`
     :   The type of the None singleton.
 
+<a id="MessageUpdateParams"></a>
+
 `MessageUpdateParams(**data: Any)`
 :   Parameters for updating a message
     
@@ -1356,6 +1424,8 @@ Classes
 
     `ts: str | Any`
     :   The type of the None singleton.
+
+<a id="MessageUpdateResponse"></a>
 
 `MessageUpdateResponse(**data: Any)`
 :   Response from updating a message
@@ -1391,6 +1461,8 @@ Classes
     `ts: str | Any | None`
     :   The type of the None singleton.
 
+<a id="MessagesListResponse"></a>
+
 `MessagesListResponse(**data: Any)`
 :   Response containing list of messages
     
@@ -1425,6 +1497,8 @@ Classes
     `response_metadata: airbyte_agent_sdk.connectors.slack.models.ResponseMetadata | Any`
     :   The type of the None singleton.
 
+<a id="Reaction"></a>
+
 `Reaction(**data: Any)`
 :   Message reaction
     
@@ -1452,6 +1526,8 @@ Classes
 
     `users: list[str] | Any | None`
     :   The type of the None singleton.
+
+<a id="ReactionAddParams"></a>
 
 `ReactionAddParams(**data: Any)`
 :   Parameters for adding a reaction
@@ -1481,6 +1557,8 @@ Classes
     `timestamp: str | Any`
     :   The type of the None singleton.
 
+<a id="ReactionAddResponse"></a>
+
 `ReactionAddResponse(**data: Any)`
 :   Response from adding a reaction
     
@@ -1503,6 +1581,8 @@ Classes
     `ok: bool | Any`
     :   The type of the None singleton.
 
+<a id="ResponseMetadata"></a>
+
 `ResponseMetadata(**data: Any)`
 :   Response metadata including pagination
     
@@ -1524,6 +1604,8 @@ Classes
 
     `next_cursor: str | Any | None`
     :   The type of the None singleton.
+
+<a id="SlackCheckResult"></a>
 
 `SlackCheckResult(**data: Any)`
 :   Result of a health check operation.
@@ -1558,6 +1640,8 @@ Classes
     `status: str`
     :   Health check status: 'healthy' or 'unhealthy'.
 
+<a id="SlackExecuteResult"></a>
+
 `SlackExecuteResult(**data: Any)`
 :   Response envelope with data only.
     
@@ -1586,6 +1670,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="SlackExecuteResultWithMeta"></a>
 
 `SlackExecuteResultWithMeta(**data: Any)`
 :   Response envelope with data and metadata.
@@ -1641,6 +1727,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="ChannelsListResult"></a>
+
 `ChannelsListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -1683,6 +1771,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="ChannelMessagesListResult"></a>
 
 `ChannelMessagesListResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -1727,6 +1817,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="ThreadsListResult"></a>
+
 `ThreadsListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -1770,6 +1862,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="UsersListResult"></a>
+
 `UsersListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -1788,6 +1882,8 @@ Classes
     * airbyte_agent_sdk.connectors.slack.models.SlackExecuteResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="SlackOauth20AuthenticationAuthConfig"></a>
 
 `SlackOauth20AuthenticationAuthConfig(**data: Any)`
 :   OAuth 2.0 Authentication
@@ -1817,6 +1913,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="SlackReplicationConfig"></a>
+
 `SlackReplicationConfig(**data: Any)`
 :   Replication Configuration - Settings for data replication from Slack.
     
@@ -1845,6 +1943,8 @@ Classes
     `start_date: str`
     :   UTC date and time in the format YYYY-MM-DDTHH:mm:ssZ from which to start replicating data.
 
+<a id="SlackTokenAuthenticationAuthConfig"></a>
+
 `SlackTokenAuthenticationAuthConfig(**data: Any)`
 :   Token Authentication
     
@@ -1866,6 +1966,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="Thread"></a>
 
 `Thread(**data: Any)`
 :   Slack thread reply message object
@@ -1952,6 +2054,8 @@ Classes
     `user: str | Any | None`
     :   The type of the None singleton.
 
+<a id="ThreadRepliesResponse"></a>
+
 `ThreadRepliesResponse(**data: Any)`
 :   Response containing thread replies
     
@@ -1983,6 +2087,8 @@ Classes
     `response_metadata: airbyte_agent_sdk.connectors.slack.models.ResponseMetadata | Any`
     :   The type of the None singleton.
 
+<a id="ThreadsListResultMeta"></a>
+
 `ThreadsListResultMeta(**data: Any)`
 :   Metadata for threads.Action.LIST operation
     
@@ -2007,6 +2113,8 @@ Classes
 
     `next_cursor: str | Any | None`
     :   The type of the None singleton.
+
+<a id="ThreadsSearchData"></a>
 
 `ThreadsSearchData(**data: Any)`
 :   Search result data for threads entity.
@@ -2074,6 +2182,8 @@ Classes
 
     `user: str | None`
     :   User ID who sent the message.
+
+<a id="User"></a>
 
 `User(**data: Any)`
 :   Slack user object
@@ -2153,6 +2263,8 @@ Classes
 
     `who_can_share_contact_card: str | Any | None`
     :   The type of the None singleton.
+
+<a id="UserProfile"></a>
 
 `UserProfile(**data: Any)`
 :   User profile information
@@ -2236,6 +2348,8 @@ Classes
     `title: str | Any | None`
     :   The type of the None singleton.
 
+<a id="UserResponse"></a>
+
 `UserResponse(**data: Any)`
 :   Response containing single user
     
@@ -2260,6 +2374,8 @@ Classes
 
     `user: airbyte_agent_sdk.connectors.slack.models.User | Any`
     :   The type of the None singleton.
+
+<a id="UsersListResponse"></a>
 
 `UsersListResponse(**data: Any)`
 :   Response containing list of users
@@ -2292,6 +2408,8 @@ Classes
     `response_metadata: airbyte_agent_sdk.connectors.slack.models.ResponseMetadata | Any`
     :   The type of the None singleton.
 
+<a id="UsersListResultMeta"></a>
+
 `UsersListResultMeta(**data: Any)`
 :   Metadata for users.Action.LIST operation
     
@@ -2313,6 +2431,8 @@ Classes
 
     `next_cursor: str | Any | None`
     :   The type of the None singleton.
+
+<a id="UsersSearchData"></a>
 
 `UsersSearchData(**data: Any)`
 :   Search result data for users entity.

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/slack/types.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/slack/types.md
@@ -10,6 +10,8 @@ Type definitions for slack connector.
 Classes
 -------
 
+<a id="AirbyteSearchParams"></a>
+
 `AirbyteSearchParams(*args, **kwargs)`
 :   Parameters for Airbyte cache search operations (generic, use entity-specific query types for better type hints).
 
@@ -31,6 +33,8 @@ Classes
     `query: dict[str, typing.Any]`
     :   The type of the None singleton.
 
+<a id="ChannelInvitesCreateParams"></a>
+
 `ChannelInvitesCreateParams(*args, **kwargs)`
 :   Parameters for channel_invites.create operation
 
@@ -48,6 +52,8 @@ Classes
 
     `users: str`
     :   The type of the None singleton.
+
+<a id="ChannelMessagesAndCondition"></a>
 
 `ChannelMessagesAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -69,6 +75,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.slack.types.ChannelMessagesEqCondition | airbyte_agent_sdk.connectors.slack.types.ChannelMessagesNeqCondition | airbyte_agent_sdk.connectors.slack.types.ChannelMessagesGtCondition | airbyte_agent_sdk.connectors.slack.types.ChannelMessagesGteCondition | airbyte_agent_sdk.connectors.slack.types.ChannelMessagesLtCondition | airbyte_agent_sdk.connectors.slack.types.ChannelMessagesLteCondition | airbyte_agent_sdk.connectors.slack.types.ChannelMessagesInCondition | airbyte_agent_sdk.connectors.slack.types.ChannelMessagesLikeCondition | airbyte_agent_sdk.connectors.slack.types.ChannelMessagesFuzzyCondition | airbyte_agent_sdk.connectors.slack.types.ChannelMessagesKeywordCondition | airbyte_agent_sdk.connectors.slack.types.ChannelMessagesContainsCondition | airbyte_agent_sdk.connectors.slack.types.ChannelMessagesNotCondition | airbyte_agent_sdk.connectors.slack.types.ChannelMessagesAndCondition | airbyte_agent_sdk.connectors.slack.types.ChannelMessagesOrCondition | airbyte_agent_sdk.connectors.slack.types.ChannelMessagesAnyCondition]`
     :   The type of the None singleton.
 
+<a id="ChannelMessagesAnyCondition"></a>
+
 `ChannelMessagesAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -88,6 +96,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.slack.types.ChannelMessagesAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="ChannelMessagesAnyValueFilter"></a>
 
 `ChannelMessagesAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -152,6 +162,8 @@ Classes
     `user: Any`
     :   User ID who sent the message.
 
+<a id="ChannelMessagesContainsCondition"></a>
+
 `ChannelMessagesContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -163,6 +175,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.slack.types.ChannelMessagesAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="ChannelMessagesEqCondition"></a>
 
 `ChannelMessagesEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -176,6 +190,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.slack.types.ChannelMessagesSearchFilter`
     :   The type of the None singleton.
 
+<a id="ChannelMessagesFuzzyCondition"></a>
+
 `ChannelMessagesFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -187,6 +203,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.slack.types.ChannelMessagesStringFilter`
     :   The type of the None singleton.
+
+<a id="ChannelMessagesGtCondition"></a>
 
 `ChannelMessagesGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
@@ -200,6 +218,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.slack.types.ChannelMessagesSearchFilter`
     :   The type of the None singleton.
 
+<a id="ChannelMessagesGteCondition"></a>
+
 `ChannelMessagesGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -211,6 +231,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.slack.types.ChannelMessagesSearchFilter`
     :   The type of the None singleton.
+
+<a id="ChannelMessagesInCondition"></a>
 
 `ChannelMessagesInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -231,6 +253,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.slack.types.ChannelMessagesInFilter`
     :   The type of the None singleton.
+
+<a id="ChannelMessagesInFilter"></a>
 
 `ChannelMessagesInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -295,6 +319,8 @@ Classes
     `user: list[str]`
     :   User ID who sent the message.
 
+<a id="ChannelMessagesKeywordCondition"></a>
+
 `ChannelMessagesKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -307,6 +333,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.slack.types.ChannelMessagesStringFilter`
     :   The type of the None singleton.
 
+<a id="ChannelMessagesLikeCondition"></a>
+
 `ChannelMessagesLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -318,6 +346,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.slack.types.ChannelMessagesStringFilter`
     :   The type of the None singleton.
+
+<a id="ChannelMessagesListParams"></a>
 
 `ChannelMessagesListParams(*args, **kwargs)`
 :   Parameters for channel_messages.list operation
@@ -346,6 +376,8 @@ Classes
     `oldest: str`
     :   The type of the None singleton.
 
+<a id="ChannelMessagesLtCondition"></a>
+
 `ChannelMessagesLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -357,6 +389,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.slack.types.ChannelMessagesSearchFilter`
     :   The type of the None singleton.
+
+<a id="ChannelMessagesLteCondition"></a>
 
 `ChannelMessagesLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -370,6 +404,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.slack.types.ChannelMessagesSearchFilter`
     :   The type of the None singleton.
 
+<a id="ChannelMessagesNeqCondition"></a>
+
 `ChannelMessagesNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -381,6 +417,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.slack.types.ChannelMessagesSearchFilter`
     :   The type of the None singleton.
+
+<a id="ChannelMessagesNotCondition"></a>
 
 `ChannelMessagesNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -402,6 +440,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.slack.types.ChannelMessagesEqCondition | airbyte_agent_sdk.connectors.slack.types.ChannelMessagesNeqCondition | airbyte_agent_sdk.connectors.slack.types.ChannelMessagesGtCondition | airbyte_agent_sdk.connectors.slack.types.ChannelMessagesGteCondition | airbyte_agent_sdk.connectors.slack.types.ChannelMessagesLtCondition | airbyte_agent_sdk.connectors.slack.types.ChannelMessagesLteCondition | airbyte_agent_sdk.connectors.slack.types.ChannelMessagesInCondition | airbyte_agent_sdk.connectors.slack.types.ChannelMessagesLikeCondition | airbyte_agent_sdk.connectors.slack.types.ChannelMessagesFuzzyCondition | airbyte_agent_sdk.connectors.slack.types.ChannelMessagesKeywordCondition | airbyte_agent_sdk.connectors.slack.types.ChannelMessagesContainsCondition | airbyte_agent_sdk.connectors.slack.types.ChannelMessagesNotCondition | airbyte_agent_sdk.connectors.slack.types.ChannelMessagesAndCondition | airbyte_agent_sdk.connectors.slack.types.ChannelMessagesOrCondition | airbyte_agent_sdk.connectors.slack.types.ChannelMessagesAnyCondition`
     :   The type of the None singleton.
 
+<a id="ChannelMessagesOrCondition"></a>
+
 `ChannelMessagesOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -421,6 +461,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.slack.types.ChannelMessagesEqCondition | airbyte_agent_sdk.connectors.slack.types.ChannelMessagesNeqCondition | airbyte_agent_sdk.connectors.slack.types.ChannelMessagesGtCondition | airbyte_agent_sdk.connectors.slack.types.ChannelMessagesGteCondition | airbyte_agent_sdk.connectors.slack.types.ChannelMessagesLtCondition | airbyte_agent_sdk.connectors.slack.types.ChannelMessagesLteCondition | airbyte_agent_sdk.connectors.slack.types.ChannelMessagesInCondition | airbyte_agent_sdk.connectors.slack.types.ChannelMessagesLikeCondition | airbyte_agent_sdk.connectors.slack.types.ChannelMessagesFuzzyCondition | airbyte_agent_sdk.connectors.slack.types.ChannelMessagesKeywordCondition | airbyte_agent_sdk.connectors.slack.types.ChannelMessagesContainsCondition | airbyte_agent_sdk.connectors.slack.types.ChannelMessagesNotCondition | airbyte_agent_sdk.connectors.slack.types.ChannelMessagesAndCondition | airbyte_agent_sdk.connectors.slack.types.ChannelMessagesOrCondition | airbyte_agent_sdk.connectors.slack.types.ChannelMessagesAnyCondition]`
     :   The type of the None singleton.
+
+<a id="ChannelMessagesSearchFilter"></a>
 
 `ChannelMessagesSearchFilter(*args, **kwargs)`
 :   Available fields for filtering channel_messages search queries.
@@ -485,6 +527,8 @@ Classes
     `user: str | None`
     :   User ID who sent the message.
 
+<a id="ChannelMessagesSearchQuery"></a>
+
 `ChannelMessagesSearchQuery(*args, **kwargs)`
 :   Search query for channel_messages entity.
 
@@ -499,6 +543,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.slack.types.ChannelMessagesSortFilter]`
     :   The type of the None singleton.
+
+<a id="ChannelMessagesSortFilter"></a>
 
 `ChannelMessagesSortFilter(*args, **kwargs)`
 :   Available fields for sorting channel_messages search results.
@@ -563,6 +609,8 @@ Classes
     `user: Literal['asc', 'desc']`
     :   User ID who sent the message.
 
+<a id="ChannelMessagesStringFilter"></a>
+
 `ChannelMessagesStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -626,6 +674,8 @@ Classes
     `user: str`
     :   User ID who sent the message.
 
+<a id="ChannelPurposesCreateParams"></a>
+
 `ChannelPurposesCreateParams(*args, **kwargs)`
 :   Parameters for channel_purposes.create operation
 
@@ -641,6 +691,8 @@ Classes
     `purpose: str`
     :   The type of the None singleton.
 
+<a id="ChannelTopicsCreateParams"></a>
+
 `ChannelTopicsCreateParams(*args, **kwargs)`
 :   Parameters for channel_topics.create operation
 
@@ -655,6 +707,8 @@ Classes
 
     `topic: str`
     :   The type of the None singleton.
+
+<a id="ChannelsAndCondition"></a>
 
 `ChannelsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -676,6 +730,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.slack.types.ChannelsEqCondition | airbyte_agent_sdk.connectors.slack.types.ChannelsNeqCondition | airbyte_agent_sdk.connectors.slack.types.ChannelsGtCondition | airbyte_agent_sdk.connectors.slack.types.ChannelsGteCondition | airbyte_agent_sdk.connectors.slack.types.ChannelsLtCondition | airbyte_agent_sdk.connectors.slack.types.ChannelsLteCondition | airbyte_agent_sdk.connectors.slack.types.ChannelsInCondition | airbyte_agent_sdk.connectors.slack.types.ChannelsLikeCondition | airbyte_agent_sdk.connectors.slack.types.ChannelsFuzzyCondition | airbyte_agent_sdk.connectors.slack.types.ChannelsKeywordCondition | airbyte_agent_sdk.connectors.slack.types.ChannelsContainsCondition | airbyte_agent_sdk.connectors.slack.types.ChannelsNotCondition | airbyte_agent_sdk.connectors.slack.types.ChannelsAndCondition | airbyte_agent_sdk.connectors.slack.types.ChannelsOrCondition | airbyte_agent_sdk.connectors.slack.types.ChannelsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="ChannelsAnyCondition"></a>
+
 `ChannelsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -695,6 +751,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.slack.types.ChannelsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="ChannelsAnyValueFilter"></a>
 
 `ChannelsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -798,6 +856,8 @@ Classes
     `updated: Any`
     :   The timestamp when the channel was last updated.
 
+<a id="ChannelsContainsCondition"></a>
+
 `ChannelsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -809,6 +869,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.slack.types.ChannelsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="ChannelsCreateParams"></a>
 
 `ChannelsCreateParams(*args, **kwargs)`
 :   Parameters for channels.create operation
@@ -825,6 +887,8 @@ Classes
     `name: str`
     :   The type of the None singleton.
 
+<a id="ChannelsEqCondition"></a>
+
 `ChannelsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
 
@@ -836,6 +900,8 @@ Classes
 
     `eq: airbyte_agent_sdk.connectors.slack.types.ChannelsSearchFilter`
     :   The type of the None singleton.
+
+<a id="ChannelsFuzzyCondition"></a>
 
 `ChannelsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
@@ -849,6 +915,8 @@ Classes
     `fuzzy: airbyte_agent_sdk.connectors.slack.types.ChannelsStringFilter`
     :   The type of the None singleton.
 
+<a id="ChannelsGetParams"></a>
+
 `ChannelsGetParams(*args, **kwargs)`
 :   Parameters for channels.get operation
 
@@ -860,6 +928,8 @@ Classes
 
     `channel: str`
     :   The type of the None singleton.
+
+<a id="ChannelsGtCondition"></a>
 
 `ChannelsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
@@ -873,6 +943,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.slack.types.ChannelsSearchFilter`
     :   The type of the None singleton.
 
+<a id="ChannelsGteCondition"></a>
+
 `ChannelsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -884,6 +956,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.slack.types.ChannelsSearchFilter`
     :   The type of the None singleton.
+
+<a id="ChannelsInCondition"></a>
 
 `ChannelsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -904,6 +978,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.slack.types.ChannelsInFilter`
     :   The type of the None singleton.
+
+<a id="ChannelsInFilter"></a>
 
 `ChannelsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -1007,6 +1083,8 @@ Classes
     `updated: list[int]`
     :   The timestamp when the channel was last updated.
 
+<a id="ChannelsKeywordCondition"></a>
+
 `ChannelsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -1019,6 +1097,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.slack.types.ChannelsStringFilter`
     :   The type of the None singleton.
 
+<a id="ChannelsLikeCondition"></a>
+
 `ChannelsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -1030,6 +1110,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.slack.types.ChannelsStringFilter`
     :   The type of the None singleton.
+
+<a id="ChannelsListParams"></a>
 
 `ChannelsListParams(*args, **kwargs)`
 :   Parameters for channels.list operation
@@ -1052,6 +1134,8 @@ Classes
     `types: str`
     :   The type of the None singleton.
 
+<a id="ChannelsLtCondition"></a>
+
 `ChannelsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -1063,6 +1147,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.slack.types.ChannelsSearchFilter`
     :   The type of the None singleton.
+
+<a id="ChannelsLteCondition"></a>
 
 `ChannelsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -1076,6 +1162,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.slack.types.ChannelsSearchFilter`
     :   The type of the None singleton.
 
+<a id="ChannelsNeqCondition"></a>
+
 `ChannelsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -1087,6 +1175,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.slack.types.ChannelsSearchFilter`
     :   The type of the None singleton.
+
+<a id="ChannelsNotCondition"></a>
 
 `ChannelsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -1108,6 +1198,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.slack.types.ChannelsEqCondition | airbyte_agent_sdk.connectors.slack.types.ChannelsNeqCondition | airbyte_agent_sdk.connectors.slack.types.ChannelsGtCondition | airbyte_agent_sdk.connectors.slack.types.ChannelsGteCondition | airbyte_agent_sdk.connectors.slack.types.ChannelsLtCondition | airbyte_agent_sdk.connectors.slack.types.ChannelsLteCondition | airbyte_agent_sdk.connectors.slack.types.ChannelsInCondition | airbyte_agent_sdk.connectors.slack.types.ChannelsLikeCondition | airbyte_agent_sdk.connectors.slack.types.ChannelsFuzzyCondition | airbyte_agent_sdk.connectors.slack.types.ChannelsKeywordCondition | airbyte_agent_sdk.connectors.slack.types.ChannelsContainsCondition | airbyte_agent_sdk.connectors.slack.types.ChannelsNotCondition | airbyte_agent_sdk.connectors.slack.types.ChannelsAndCondition | airbyte_agent_sdk.connectors.slack.types.ChannelsOrCondition | airbyte_agent_sdk.connectors.slack.types.ChannelsAnyCondition`
     :   The type of the None singleton.
 
+<a id="ChannelsOrCondition"></a>
+
 `ChannelsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1127,6 +1219,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.slack.types.ChannelsEqCondition | airbyte_agent_sdk.connectors.slack.types.ChannelsNeqCondition | airbyte_agent_sdk.connectors.slack.types.ChannelsGtCondition | airbyte_agent_sdk.connectors.slack.types.ChannelsGteCondition | airbyte_agent_sdk.connectors.slack.types.ChannelsLtCondition | airbyte_agent_sdk.connectors.slack.types.ChannelsLteCondition | airbyte_agent_sdk.connectors.slack.types.ChannelsInCondition | airbyte_agent_sdk.connectors.slack.types.ChannelsLikeCondition | airbyte_agent_sdk.connectors.slack.types.ChannelsFuzzyCondition | airbyte_agent_sdk.connectors.slack.types.ChannelsKeywordCondition | airbyte_agent_sdk.connectors.slack.types.ChannelsContainsCondition | airbyte_agent_sdk.connectors.slack.types.ChannelsNotCondition | airbyte_agent_sdk.connectors.slack.types.ChannelsAndCondition | airbyte_agent_sdk.connectors.slack.types.ChannelsOrCondition | airbyte_agent_sdk.connectors.slack.types.ChannelsAnyCondition]`
     :   The type of the None singleton.
+
+<a id="ChannelsSearchFilter"></a>
 
 `ChannelsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering channels search queries.
@@ -1230,6 +1324,8 @@ Classes
     `updated: int | None`
     :   The timestamp when the channel was last updated.
 
+<a id="ChannelsSearchQuery"></a>
+
 `ChannelsSearchQuery(*args, **kwargs)`
 :   Search query for channels entity.
 
@@ -1244,6 +1340,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.slack.types.ChannelsSortFilter]`
     :   The type of the None singleton.
+
+<a id="ChannelsSortFilter"></a>
 
 `ChannelsSortFilter(*args, **kwargs)`
 :   Available fields for sorting channels search results.
@@ -1347,6 +1445,8 @@ Classes
     `updated: Literal['asc', 'desc']`
     :   The timestamp when the channel was last updated.
 
+<a id="ChannelsStringFilter"></a>
+
 `ChannelsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -1449,6 +1549,8 @@ Classes
     `updated: str`
     :   The timestamp when the channel was last updated.
 
+<a id="ChannelsUpdateParams"></a>
+
 `ChannelsUpdateParams(*args, **kwargs)`
 :   Parameters for channels.update operation
 
@@ -1463,6 +1565,8 @@ Classes
 
     `name: str`
     :   The type of the None singleton.
+
+<a id="MessagesCreateParams"></a>
 
 `MessagesCreateParams(*args, **kwargs)`
 :   Parameters for messages.create operation
@@ -1491,6 +1595,8 @@ Classes
     `unfurl_media: bool`
     :   The type of the None singleton.
 
+<a id="MessagesUpdateParams"></a>
+
 `MessagesUpdateParams(*args, **kwargs)`
 :   Parameters for messages.update operation
 
@@ -1509,6 +1615,8 @@ Classes
     `ts: str`
     :   The type of the None singleton.
 
+<a id="ReactionsCreateParams"></a>
+
 `ReactionsCreateParams(*args, **kwargs)`
 :   Parameters for reactions.create operation
 
@@ -1526,6 +1634,8 @@ Classes
 
     `timestamp: str`
     :   The type of the None singleton.
+
+<a id="ThreadsAndCondition"></a>
 
 `ThreadsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -1547,6 +1657,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.slack.types.ThreadsEqCondition | airbyte_agent_sdk.connectors.slack.types.ThreadsNeqCondition | airbyte_agent_sdk.connectors.slack.types.ThreadsGtCondition | airbyte_agent_sdk.connectors.slack.types.ThreadsGteCondition | airbyte_agent_sdk.connectors.slack.types.ThreadsLtCondition | airbyte_agent_sdk.connectors.slack.types.ThreadsLteCondition | airbyte_agent_sdk.connectors.slack.types.ThreadsInCondition | airbyte_agent_sdk.connectors.slack.types.ThreadsLikeCondition | airbyte_agent_sdk.connectors.slack.types.ThreadsFuzzyCondition | airbyte_agent_sdk.connectors.slack.types.ThreadsKeywordCondition | airbyte_agent_sdk.connectors.slack.types.ThreadsContainsCondition | airbyte_agent_sdk.connectors.slack.types.ThreadsNotCondition | airbyte_agent_sdk.connectors.slack.types.ThreadsAndCondition | airbyte_agent_sdk.connectors.slack.types.ThreadsOrCondition | airbyte_agent_sdk.connectors.slack.types.ThreadsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="ThreadsAnyCondition"></a>
+
 `ThreadsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1566,6 +1678,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.slack.types.ThreadsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="ThreadsAnyValueFilter"></a>
 
 `ThreadsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -1624,6 +1738,8 @@ Classes
     `user: Any`
     :   User ID who sent the message.
 
+<a id="ThreadsContainsCondition"></a>
+
 `ThreadsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -1635,6 +1751,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.slack.types.ThreadsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="ThreadsEqCondition"></a>
 
 `ThreadsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -1648,6 +1766,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.slack.types.ThreadsSearchFilter`
     :   The type of the None singleton.
 
+<a id="ThreadsFuzzyCondition"></a>
+
 `ThreadsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -1659,6 +1779,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.slack.types.ThreadsStringFilter`
     :   The type of the None singleton.
+
+<a id="ThreadsGtCondition"></a>
 
 `ThreadsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
@@ -1672,6 +1794,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.slack.types.ThreadsSearchFilter`
     :   The type of the None singleton.
 
+<a id="ThreadsGteCondition"></a>
+
 `ThreadsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -1683,6 +1807,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.slack.types.ThreadsSearchFilter`
     :   The type of the None singleton.
+
+<a id="ThreadsInCondition"></a>
 
 `ThreadsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -1703,6 +1829,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.slack.types.ThreadsInFilter`
     :   The type of the None singleton.
+
+<a id="ThreadsInFilter"></a>
 
 `ThreadsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -1761,6 +1889,8 @@ Classes
     `user: list[str]`
     :   User ID who sent the message.
 
+<a id="ThreadsKeywordCondition"></a>
+
 `ThreadsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -1773,6 +1903,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.slack.types.ThreadsStringFilter`
     :   The type of the None singleton.
 
+<a id="ThreadsLikeCondition"></a>
+
 `ThreadsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -1784,6 +1916,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.slack.types.ThreadsStringFilter`
     :   The type of the None singleton.
+
+<a id="ThreadsListParams"></a>
 
 `ThreadsListParams(*args, **kwargs)`
 :   Parameters for threads.list operation
@@ -1815,6 +1949,8 @@ Classes
     `ts: str`
     :   The type of the None singleton.
 
+<a id="ThreadsLtCondition"></a>
+
 `ThreadsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -1826,6 +1962,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.slack.types.ThreadsSearchFilter`
     :   The type of the None singleton.
+
+<a id="ThreadsLteCondition"></a>
 
 `ThreadsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -1839,6 +1977,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.slack.types.ThreadsSearchFilter`
     :   The type of the None singleton.
 
+<a id="ThreadsNeqCondition"></a>
+
 `ThreadsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -1850,6 +1990,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.slack.types.ThreadsSearchFilter`
     :   The type of the None singleton.
+
+<a id="ThreadsNotCondition"></a>
 
 `ThreadsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -1871,6 +2013,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.slack.types.ThreadsEqCondition | airbyte_agent_sdk.connectors.slack.types.ThreadsNeqCondition | airbyte_agent_sdk.connectors.slack.types.ThreadsGtCondition | airbyte_agent_sdk.connectors.slack.types.ThreadsGteCondition | airbyte_agent_sdk.connectors.slack.types.ThreadsLtCondition | airbyte_agent_sdk.connectors.slack.types.ThreadsLteCondition | airbyte_agent_sdk.connectors.slack.types.ThreadsInCondition | airbyte_agent_sdk.connectors.slack.types.ThreadsLikeCondition | airbyte_agent_sdk.connectors.slack.types.ThreadsFuzzyCondition | airbyte_agent_sdk.connectors.slack.types.ThreadsKeywordCondition | airbyte_agent_sdk.connectors.slack.types.ThreadsContainsCondition | airbyte_agent_sdk.connectors.slack.types.ThreadsNotCondition | airbyte_agent_sdk.connectors.slack.types.ThreadsAndCondition | airbyte_agent_sdk.connectors.slack.types.ThreadsOrCondition | airbyte_agent_sdk.connectors.slack.types.ThreadsAnyCondition`
     :   The type of the None singleton.
 
+<a id="ThreadsOrCondition"></a>
+
 `ThreadsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1890,6 +2034,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.slack.types.ThreadsEqCondition | airbyte_agent_sdk.connectors.slack.types.ThreadsNeqCondition | airbyte_agent_sdk.connectors.slack.types.ThreadsGtCondition | airbyte_agent_sdk.connectors.slack.types.ThreadsGteCondition | airbyte_agent_sdk.connectors.slack.types.ThreadsLtCondition | airbyte_agent_sdk.connectors.slack.types.ThreadsLteCondition | airbyte_agent_sdk.connectors.slack.types.ThreadsInCondition | airbyte_agent_sdk.connectors.slack.types.ThreadsLikeCondition | airbyte_agent_sdk.connectors.slack.types.ThreadsFuzzyCondition | airbyte_agent_sdk.connectors.slack.types.ThreadsKeywordCondition | airbyte_agent_sdk.connectors.slack.types.ThreadsContainsCondition | airbyte_agent_sdk.connectors.slack.types.ThreadsNotCondition | airbyte_agent_sdk.connectors.slack.types.ThreadsAndCondition | airbyte_agent_sdk.connectors.slack.types.ThreadsOrCondition | airbyte_agent_sdk.connectors.slack.types.ThreadsAnyCondition]`
     :   The type of the None singleton.
+
+<a id="ThreadsSearchFilter"></a>
 
 `ThreadsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering threads search queries.
@@ -1948,6 +2094,8 @@ Classes
     `user: str | None`
     :   User ID who sent the message.
 
+<a id="ThreadsSearchQuery"></a>
+
 `ThreadsSearchQuery(*args, **kwargs)`
 :   Search query for threads entity.
 
@@ -1962,6 +2110,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.slack.types.ThreadsSortFilter]`
     :   The type of the None singleton.
+
+<a id="ThreadsSortFilter"></a>
 
 `ThreadsSortFilter(*args, **kwargs)`
 :   Available fields for sorting threads search results.
@@ -2020,6 +2170,8 @@ Classes
     `user: Literal['asc', 'desc']`
     :   User ID who sent the message.
 
+<a id="ThreadsStringFilter"></a>
+
 `ThreadsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -2077,6 +2229,8 @@ Classes
     `user: str`
     :   User ID who sent the message.
 
+<a id="UsersAndCondition"></a>
+
 `UsersAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -2097,6 +2251,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.slack.types.UsersEqCondition | airbyte_agent_sdk.connectors.slack.types.UsersNeqCondition | airbyte_agent_sdk.connectors.slack.types.UsersGtCondition | airbyte_agent_sdk.connectors.slack.types.UsersGteCondition | airbyte_agent_sdk.connectors.slack.types.UsersLtCondition | airbyte_agent_sdk.connectors.slack.types.UsersLteCondition | airbyte_agent_sdk.connectors.slack.types.UsersInCondition | airbyte_agent_sdk.connectors.slack.types.UsersLikeCondition | airbyte_agent_sdk.connectors.slack.types.UsersFuzzyCondition | airbyte_agent_sdk.connectors.slack.types.UsersKeywordCondition | airbyte_agent_sdk.connectors.slack.types.UsersContainsCondition | airbyte_agent_sdk.connectors.slack.types.UsersNotCondition | airbyte_agent_sdk.connectors.slack.types.UsersAndCondition | airbyte_agent_sdk.connectors.slack.types.UsersOrCondition | airbyte_agent_sdk.connectors.slack.types.UsersAnyCondition]`
     :   The type of the None singleton.
 
+<a id="UsersAnyCondition"></a>
+
 `UsersAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -2116,6 +2272,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.slack.types.UsersAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="UsersAnyValueFilter"></a>
 
 `UsersAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -2195,6 +2353,8 @@ Classes
     `who_can_share_contact_card: Any`
     :   Specifies who can share the user's contact card.
 
+<a id="UsersContainsCondition"></a>
+
 `UsersContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -2206,6 +2366,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.slack.types.UsersAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="UsersEqCondition"></a>
 
 `UsersEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -2219,6 +2381,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.slack.types.UsersSearchFilter`
     :   The type of the None singleton.
 
+<a id="UsersFuzzyCondition"></a>
+
 `UsersFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -2230,6 +2394,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.slack.types.UsersStringFilter`
     :   The type of the None singleton.
+
+<a id="UsersGetParams"></a>
 
 `UsersGetParams(*args, **kwargs)`
 :   Parameters for users.get operation
@@ -2243,6 +2409,8 @@ Classes
     `user: str`
     :   The type of the None singleton.
 
+<a id="UsersGtCondition"></a>
+
 `UsersGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -2255,6 +2423,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.slack.types.UsersSearchFilter`
     :   The type of the None singleton.
 
+<a id="UsersGteCondition"></a>
+
 `UsersGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -2266,6 +2436,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.slack.types.UsersSearchFilter`
     :   The type of the None singleton.
+
+<a id="UsersInCondition"></a>
 
 `UsersInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -2286,6 +2458,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.slack.types.UsersInFilter`
     :   The type of the None singleton.
+
+<a id="UsersInFilter"></a>
 
 `UsersInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -2365,6 +2539,8 @@ Classes
     `who_can_share_contact_card: list[str]`
     :   Specifies who can share the user's contact card.
 
+<a id="UsersKeywordCondition"></a>
+
 `UsersKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -2377,6 +2553,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.slack.types.UsersStringFilter`
     :   The type of the None singleton.
 
+<a id="UsersLikeCondition"></a>
+
 `UsersLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -2388,6 +2566,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.slack.types.UsersStringFilter`
     :   The type of the None singleton.
+
+<a id="UsersListParams"></a>
 
 `UsersListParams(*args, **kwargs)`
 :   Parameters for users.list operation
@@ -2404,6 +2584,8 @@ Classes
     `limit: int`
     :   The type of the None singleton.
 
+<a id="UsersLtCondition"></a>
+
 `UsersLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -2415,6 +2597,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.slack.types.UsersSearchFilter`
     :   The type of the None singleton.
+
+<a id="UsersLteCondition"></a>
 
 `UsersLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -2428,6 +2612,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.slack.types.UsersSearchFilter`
     :   The type of the None singleton.
 
+<a id="UsersNeqCondition"></a>
+
 `UsersNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -2439,6 +2625,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.slack.types.UsersSearchFilter`
     :   The type of the None singleton.
+
+<a id="UsersNotCondition"></a>
 
 `UsersNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -2460,6 +2648,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.slack.types.UsersEqCondition | airbyte_agent_sdk.connectors.slack.types.UsersNeqCondition | airbyte_agent_sdk.connectors.slack.types.UsersGtCondition | airbyte_agent_sdk.connectors.slack.types.UsersGteCondition | airbyte_agent_sdk.connectors.slack.types.UsersLtCondition | airbyte_agent_sdk.connectors.slack.types.UsersLteCondition | airbyte_agent_sdk.connectors.slack.types.UsersInCondition | airbyte_agent_sdk.connectors.slack.types.UsersLikeCondition | airbyte_agent_sdk.connectors.slack.types.UsersFuzzyCondition | airbyte_agent_sdk.connectors.slack.types.UsersKeywordCondition | airbyte_agent_sdk.connectors.slack.types.UsersContainsCondition | airbyte_agent_sdk.connectors.slack.types.UsersNotCondition | airbyte_agent_sdk.connectors.slack.types.UsersAndCondition | airbyte_agent_sdk.connectors.slack.types.UsersOrCondition | airbyte_agent_sdk.connectors.slack.types.UsersAnyCondition`
     :   The type of the None singleton.
 
+<a id="UsersOrCondition"></a>
+
 `UsersOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -2479,6 +2669,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.slack.types.UsersEqCondition | airbyte_agent_sdk.connectors.slack.types.UsersNeqCondition | airbyte_agent_sdk.connectors.slack.types.UsersGtCondition | airbyte_agent_sdk.connectors.slack.types.UsersGteCondition | airbyte_agent_sdk.connectors.slack.types.UsersLtCondition | airbyte_agent_sdk.connectors.slack.types.UsersLteCondition | airbyte_agent_sdk.connectors.slack.types.UsersInCondition | airbyte_agent_sdk.connectors.slack.types.UsersLikeCondition | airbyte_agent_sdk.connectors.slack.types.UsersFuzzyCondition | airbyte_agent_sdk.connectors.slack.types.UsersKeywordCondition | airbyte_agent_sdk.connectors.slack.types.UsersContainsCondition | airbyte_agent_sdk.connectors.slack.types.UsersNotCondition | airbyte_agent_sdk.connectors.slack.types.UsersAndCondition | airbyte_agent_sdk.connectors.slack.types.UsersOrCondition | airbyte_agent_sdk.connectors.slack.types.UsersAnyCondition]`
     :   The type of the None singleton.
+
+<a id="UsersSearchFilter"></a>
 
 `UsersSearchFilter(*args, **kwargs)`
 :   Available fields for filtering users search queries.
@@ -2558,6 +2750,8 @@ Classes
     `who_can_share_contact_card: str | None`
     :   Specifies who can share the user's contact card.
 
+<a id="UsersSearchQuery"></a>
+
 `UsersSearchQuery(*args, **kwargs)`
 :   Search query for users entity.
 
@@ -2572,6 +2766,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.slack.types.UsersSortFilter]`
     :   The type of the None singleton.
+
+<a id="UsersSortFilter"></a>
 
 `UsersSortFilter(*args, **kwargs)`
 :   Available fields for sorting users search results.
@@ -2650,6 +2846,8 @@ Classes
 
     `who_can_share_contact_card: Literal['asc', 'desc']`
     :   Specifies who can share the user's contact card.
+
+<a id="UsersStringFilter"></a>
 
 `UsersStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/snapchat_marketing/connector.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/snapchat_marketing/connector.md
@@ -10,6 +10,8 @@ Snapchat-Marketing connector.
 Classes
 -------
 
+<a id="AdaccountsQuery"></a>
+
 `AdaccountsQuery(connector: SnapchatMarketingConnector)`
 :   Query class for Adaccounts entity operations.
     
@@ -75,6 +77,8 @@ Classes
         Returns:
             AdaccountsListResult
 
+<a id="AdsQuery"></a>
+
 `AdsQuery(connector: SnapchatMarketingConnector)`
 :   Query class for Ads entity operations.
     
@@ -135,6 +139,8 @@ Classes
         
         Returns:
             AdsListResult
+
+<a id="AdsquadsQuery"></a>
 
 `AdsquadsQuery(connector: SnapchatMarketingConnector)`
 :   Query class for Adsquads entity operations.
@@ -213,6 +219,8 @@ Classes
         Returns:
             AdsquadsListResult
 
+<a id="CampaignsQuery"></a>
+
 `CampaignsQuery(connector: SnapchatMarketingConnector)`
 :   Query class for Campaigns entity operations.
     
@@ -272,6 +280,8 @@ Classes
         
         Returns:
             CampaignsListResult
+
+<a id="CreativesQuery"></a>
 
 `CreativesQuery(connector: SnapchatMarketingConnector)`
 :   Query class for Creatives entity operations.
@@ -342,6 +352,8 @@ Classes
         Returns:
             CreativesListResult
 
+<a id="MediaQuery"></a>
+
 `MediaQuery(connector: SnapchatMarketingConnector)`
 :   Query class for Media entity operations.
     
@@ -407,6 +419,8 @@ Classes
         
         Returns:
             MediaListResult
+
+<a id="OrganizationsQuery"></a>
 
 `OrganizationsQuery(connector: SnapchatMarketingConnector)`
 :   Query class for Organizations entity operations.
@@ -475,6 +489,8 @@ Classes
         Returns:
             OrganizationsListResult
 
+<a id="SegmentsQuery"></a>
+
 `SegmentsQuery(connector: SnapchatMarketingConnector)`
 :   Query class for Segments entity operations.
     
@@ -537,6 +553,8 @@ Classes
         
         Returns:
             SegmentsListResult
+
+<a id="SnapchatMarketingConnector"></a>
 
 `SnapchatMarketingConnector(auth_config: SnapchatMarketingAuthConfig | AirbyteAuthConfig | BaseModel | None = None, on_token_refresh: Any | None = None)`
 :   Type-safe Snapchat-Marketing API connector.

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/snapchat_marketing/index.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/snapchat_marketing/index.md
@@ -19,6 +19,8 @@ Sub-modules
 Classes
 -------
 
+<a id="AdaccountsSearchData"></a>
+
 `AdaccountsSearchData(**data: Any)`
 :   Search result data for adaccounts entity.
     
@@ -86,6 +88,8 @@ Classes
     `updated_at: str | None`
     :   Last update timestamp
 
+<a id="AdsSearchData"></a>
+
 `AdsSearchData(**data: Any)`
 :   Search result data for ads entity.
     
@@ -140,6 +144,8 @@ Classes
 
     `updated_at: str | None`
     :   Last update timestamp
+
+<a id="AdsquadsSearchData"></a>
 
 `AdsquadsSearchData(**data: Any)`
 :   Search result data for adsquads entity.
@@ -244,6 +250,8 @@ Classes
     `updated_at: str | None`
     :   Last update timestamp
 
+<a id="AirbyteAuthConfig"></a>
+
 `AirbyteAuthConfig(**data: Any)`
 :   Authentication configuration for Airbyte hosted mode execution.
     
@@ -312,6 +320,8 @@ Classes
     `workspace_name: str | None`
     :   The type of the None singleton.
 
+<a id="AirbyteSearchMeta"></a>
+
 `AirbyteSearchMeta(**data: Any)`
 :   Pagination metadata for search responses.
     
@@ -339,6 +349,8 @@ Classes
 
     `took_ms: int | None`
     :   Time taken to execute the search in milliseconds.
+
+<a id="AirbyteSearchResult"></a>
 
 `AirbyteSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -377,6 +389,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="AdaccountsSearchResult"></a>
+
 `AdaccountsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -392,6 +406,8 @@ Classes
     * airbyte_agent_sdk.connectors.snapchat_marketing.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="AdsSearchResult"></a>
 
 `AdsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -409,6 +425,8 @@ Classes
     * pydantic.main.BaseModel
     * typing.Generic
 
+<a id="AdsquadsSearchResult"></a>
+
 `AdsquadsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -424,6 +442,8 @@ Classes
     * airbyte_agent_sdk.connectors.snapchat_marketing.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="CampaignsSearchResult"></a>
 
 `CampaignsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -441,6 +461,8 @@ Classes
     * pydantic.main.BaseModel
     * typing.Generic
 
+<a id="CreativesSearchResult"></a>
+
 `CreativesSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -456,6 +478,8 @@ Classes
     * airbyte_agent_sdk.connectors.snapchat_marketing.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="MediaSearchResult"></a>
 
 `MediaSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -473,6 +497,8 @@ Classes
     * pydantic.main.BaseModel
     * typing.Generic
 
+<a id="OrganizationsSearchResult"></a>
+
 `OrganizationsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -489,6 +515,8 @@ Classes
     * pydantic.main.BaseModel
     * typing.Generic
 
+<a id="SegmentsSearchResult"></a>
+
 `SegmentsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -504,6 +532,8 @@ Classes
     * airbyte_agent_sdk.connectors.snapchat_marketing.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="CampaignsSearchData"></a>
 
 `CampaignsSearchData(**data: Any)`
 :   Search result data for campaigns entity.
@@ -556,6 +586,8 @@ Classes
 
     `updated_at: str | None`
     :   Last update timestamp
+
+<a id="CreativesSearchData"></a>
 
 `CreativesSearchData(**data: Any)`
 :   Search result data for creatives entity.
@@ -636,6 +668,8 @@ Classes
     `web_view_properties: dict[str, typing.Any] | None`
     :   Web view properties
 
+<a id="MediaSearchData"></a>
+
 `MediaSearchData(**data: Any)`
 :   Search result data for media entity.
     
@@ -705,6 +739,8 @@ Classes
 
     `visibility: str | None`
     :   Media visibility setting
+
+<a id="OrganizationsSearchData"></a>
 
 `OrganizationsSearchData(**data: Any)`
 :   Search result data for organizations entity.
@@ -791,6 +827,8 @@ Classes
     `updated_at: str | None`
     :   Last update timestamp
 
+<a id="SegmentsSearchData"></a>
+
 `SegmentsSearchData(**data: Any)`
 :   Search result data for segments entity.
     
@@ -852,6 +890,8 @@ Classes
     `visible_to: list[typing.Any] | None`
     :   Visibility settings
 
+<a id="SnapchatMarketingAuthConfig"></a>
+
 `SnapchatMarketingAuthConfig(**data: Any)`
 :   Authentication
     
@@ -879,6 +919,8 @@ Classes
 
     `refresh_token: str`
     :   Refresh Token to renew the expired Access Token
+
+<a id="SnapchatMarketingConnector"></a>
 
 `SnapchatMarketingConnector(auth_config: SnapchatMarketingAuthConfig | AirbyteAuthConfig | BaseModel | None = None, on_token_refresh: Any | None = None)`
 :   Type-safe Snapchat-Marketing API connector.
@@ -1135,6 +1177,8 @@ Classes
             entities = connector.list_entities()
             for entity in entities:
                 print(f"\{entity['entity_name']\}: \{entity['available_actions']\}")
+
+<a id="SnapchatMarketingReplicationConfig"></a>
 
 `SnapchatMarketingReplicationConfig(**data: Any)`
 :   Replication Configuration - Settings for data replication from Snapchat Marketing.

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/snapchat_marketing/models.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/snapchat_marketing/models.md
@@ -13,6 +13,8 @@ and response envelope types.
 Classes
 -------
 
+<a id="Ad"></a>
+
 `Ad(**data: Any)`
 :   Snapchat ad object
     
@@ -67,6 +69,8 @@ Classes
 
     `updated_at: str | Any`
     :   The type of the None singleton.
+
+<a id="AdAccount"></a>
 
 `AdAccount(**data: Any)`
 :   Snapchat ad account object
@@ -135,6 +139,8 @@ Classes
     `updated_at: str | Any`
     :   The type of the None singleton.
 
+<a id="AdAccountRegulations"></a>
+
 `AdAccountRegulations(**data: Any)`
 :   Regulatory settings
     
@@ -156,6 +162,8 @@ Classes
 
     `restricted_delivery_signals: bool | Any`
     :   Whether restricted delivery signals are enabled
+
+<a id="AdSquad"></a>
 
 `AdSquad(**data: Any)`
 :   Snapchat ad squad object
@@ -260,6 +268,8 @@ Classes
     `updated_at: str | Any`
     :   The type of the None singleton.
 
+<a id="AdSquadSkadnetworkProperties"></a>
+
 `AdSquadSkadnetworkProperties(**data: Any)`
 :   SKAdNetwork properties
     
@@ -287,6 +297,8 @@ Classes
 
     `status: str | Any`
     :   The type of the None singleton.
+
+<a id="AdSquadTargeting"></a>
 
 `AdSquadTargeting(**data: Any)`
 :   Targeting specification
@@ -328,6 +340,8 @@ Classes
     `regulated_content: bool | Any`
     :   The type of the None singleton.
 
+<a id="AdSquadTargetingAutoExpansionOptions"></a>
+
 `AdSquadTargetingAutoExpansionOptions(**data: Any)`
 :   Nested schema for AdSquadTargeting.auto_expansion_options
     
@@ -350,6 +364,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="AdSquadTargetingAutoExpansionOptionsInterestExpansionOption"></a>
+
 `AdSquadTargetingAutoExpansionOptionsInterestExpansionOption(**data: Any)`
 :   Nested schema for AdSquadTargetingAutoExpansionOptions.interest_expansion_option
     
@@ -371,6 +387,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="AdSquadTargetingGeosItem"></a>
 
 `AdSquadTargetingGeosItem(**data: Any)`
 :   Nested schema for AdSquadTargeting.geos_item
@@ -397,6 +415,8 @@ Classes
     `operation: str | Any`
     :   The type of the None singleton.
 
+<a id="AdaccountsListResultMeta"></a>
+
 `AdaccountsListResultMeta(**data: Any)`
 :   Metadata for adaccounts.Action.LIST operation
     
@@ -418,6 +438,8 @@ Classes
 
     `next_link: str | Any`
     :   The type of the None singleton.
+
+<a id="AdaccountsSearchData"></a>
 
 `AdaccountsSearchData(**data: Any)`
 :   Search result data for adaccounts entity.
@@ -486,6 +508,8 @@ Classes
     `updated_at: str | None`
     :   Last update timestamp
 
+<a id="AdsListResultMeta"></a>
+
 `AdsListResultMeta(**data: Any)`
 :   Metadata for ads.Action.LIST operation
     
@@ -507,6 +531,8 @@ Classes
 
     `next_link: str | Any`
     :   The type of the None singleton.
+
+<a id="AdsSearchData"></a>
 
 `AdsSearchData(**data: Any)`
 :   Search result data for ads entity.
@@ -563,6 +589,8 @@ Classes
     `updated_at: str | None`
     :   Last update timestamp
 
+<a id="AdsquadsListResultMeta"></a>
+
 `AdsquadsListResultMeta(**data: Any)`
 :   Metadata for adsquads.Action.LIST operation
     
@@ -584,6 +612,8 @@ Classes
 
     `next_link: str | Any`
     :   The type of the None singleton.
+
+<a id="AdsquadsSearchData"></a>
 
 `AdsquadsSearchData(**data: Any)`
 :   Search result data for adsquads entity.
@@ -688,6 +718,8 @@ Classes
     `updated_at: str | None`
     :   Last update timestamp
 
+<a id="AirbyteSearchMeta"></a>
+
 `AirbyteSearchMeta(**data: Any)`
 :   Pagination metadata for search responses.
     
@@ -715,6 +747,8 @@ Classes
 
     `took_ms: int | None`
     :   Time taken to execute the search in milliseconds.
+
+<a id="AirbyteSearchResult"></a>
 
 `AirbyteSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -774,6 +808,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="AdaccountsSearchResult"></a>
+
 `AdaccountsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -810,6 +846,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="AdsSearchResult"></a>
 
 `AdsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -848,6 +886,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="AdsquadsSearchResult"></a>
+
 `AdsquadsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -884,6 +924,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="CampaignsSearchResult"></a>
 
 `CampaignsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -922,6 +964,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="CreativesSearchResult"></a>
+
 `CreativesSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -958,6 +1002,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="MediaSearchResult"></a>
 
 `MediaSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -996,6 +1042,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="OrganizationsSearchResult"></a>
+
 `OrganizationsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -1033,6 +1081,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="SegmentsSearchResult"></a>
+
 `SegmentsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -1048,6 +1098,8 @@ Classes
     * airbyte_agent_sdk.connectors.snapchat_marketing.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="Campaign"></a>
 
 `Campaign(**data: Any)`
 :   Snapchat campaign object
@@ -1107,6 +1159,8 @@ Classes
     `updated_at: str | Any`
     :   The type of the None singleton.
 
+<a id="CampaignObjectiveV2Properties"></a>
+
 `CampaignObjectiveV2Properties(**data: Any)`
 :   Objective V2 properties for the campaign
     
@@ -1132,6 +1186,8 @@ Classes
     `objective_v2_type: str | Any`
     :   The type of the None singleton.
 
+<a id="CampaignsListResultMeta"></a>
+
 `CampaignsListResultMeta(**data: Any)`
 :   Metadata for campaigns.Action.LIST operation
     
@@ -1153,6 +1209,8 @@ Classes
 
     `next_link: str | Any`
     :   The type of the None singleton.
+
+<a id="CampaignsSearchData"></a>
 
 `CampaignsSearchData(**data: Any)`
 :   Search result data for campaigns entity.
@@ -1205,6 +1263,8 @@ Classes
 
     `updated_at: str | None`
     :   Last update timestamp
+
+<a id="Creative"></a>
 
 `Creative(**data: Any)`
 :   Snapchat creative object
@@ -1285,6 +1345,8 @@ Classes
     `web_view_properties: airbyte_agent_sdk.connectors.snapchat_marketing.models.CreativeWebViewProperties | Any`
     :   The type of the None singleton.
 
+<a id="CreativeAdToPlaceProperties"></a>
+
 `CreativeAdToPlaceProperties(**data: Any)`
 :   Ad-to-place properties
     
@@ -1306,6 +1368,8 @@ Classes
 
     `place_id: str | Any`
     :   The type of the None singleton.
+
+<a id="CreativeWebViewProperties"></a>
 
 `CreativeWebViewProperties(**data: Any)`
 :   Web view properties
@@ -1341,6 +1405,8 @@ Classes
     `use_immersive_mode: bool | Any`
     :   The type of the None singleton.
 
+<a id="CreativesListResultMeta"></a>
+
 `CreativesListResultMeta(**data: Any)`
 :   Metadata for creatives.Action.LIST operation
     
@@ -1362,6 +1428,8 @@ Classes
 
     `next_link: str | Any`
     :   The type of the None singleton.
+
+<a id="CreativesSearchData"></a>
 
 `CreativesSearchData(**data: Any)`
 :   Search result data for creatives entity.
@@ -1442,6 +1510,8 @@ Classes
     `web_view_properties: dict[str, typing.Any] | None`
     :   Web view properties
 
+<a id="Media"></a>
+
 `Media(**data: Any)`
 :   Snapchat media object
     
@@ -1512,6 +1582,8 @@ Classes
     `visibility: str | Any`
     :   The type of the None singleton.
 
+<a id="MediaImageMetadata"></a>
+
 `MediaImageMetadata(**data: Any)`
 :   Image-specific metadata
     
@@ -1540,6 +1612,8 @@ Classes
     `width_px: int | Any`
     :   The type of the None singleton.
 
+<a id="MediaListResultMeta"></a>
+
 `MediaListResultMeta(**data: Any)`
 :   Metadata for media.Action.LIST operation
     
@@ -1561,6 +1635,8 @@ Classes
 
     `next_link: str | Any`
     :   The type of the None singleton.
+
+<a id="MediaSearchData"></a>
 
 `MediaSearchData(**data: Any)`
 :   Search result data for media entity.
@@ -1631,6 +1707,8 @@ Classes
 
     `visibility: str | None`
     :   Media visibility setting
+
+<a id="Organization"></a>
 
 `Organization(**data: Any)`
 :   Snapchat organization object
@@ -1726,6 +1804,8 @@ Classes
     `verification_request_id: str | Any`
     :   The type of the None singleton.
 
+<a id="OrganizationConfigurationSettings"></a>
+
 `OrganizationConfigurationSettings(**data: Any)`
 :   Organization configuration settings
     
@@ -1748,6 +1828,8 @@ Classes
     `notifications_enabled: bool | Any`
     :   Whether notifications are enabled
 
+<a id="OrganizationsListResultMeta"></a>
+
 `OrganizationsListResultMeta(**data: Any)`
 :   Metadata for organizations.Action.LIST operation
     
@@ -1769,6 +1851,8 @@ Classes
 
     `next_link: str | Any`
     :   The type of the None singleton.
+
+<a id="OrganizationsSearchData"></a>
 
 `OrganizationsSearchData(**data: Any)`
 :   Search result data for organizations entity.
@@ -1855,6 +1939,8 @@ Classes
     `updated_at: str | None`
     :   Last update timestamp
 
+<a id="Segment"></a>
+
 `Segment(**data: Any)`
 :   Snapchat audience segment object
     
@@ -1919,6 +2005,8 @@ Classes
     `visible_to: list[str] | Any`
     :   The type of the None singleton.
 
+<a id="SegmentsListResultMeta"></a>
+
 `SegmentsListResultMeta(**data: Any)`
 :   Metadata for segments.Action.LIST operation
     
@@ -1940,6 +2028,8 @@ Classes
 
     `next_link: str | Any`
     :   The type of the None singleton.
+
+<a id="SegmentsSearchData"></a>
 
 `SegmentsSearchData(**data: Any)`
 :   Search result data for segments entity.
@@ -2002,6 +2092,8 @@ Classes
     `visible_to: list[typing.Any] | None`
     :   Visibility settings
 
+<a id="SnapchatMarketingAuthConfig"></a>
+
 `SnapchatMarketingAuthConfig(**data: Any)`
 :   Authentication
     
@@ -2029,6 +2121,8 @@ Classes
 
     `refresh_token: str`
     :   Refresh Token to renew the expired Access Token
+
+<a id="SnapchatMarketingCheckResult"></a>
 
 `SnapchatMarketingCheckResult(**data: Any)`
 :   Result of a health check operation.
@@ -2063,6 +2157,8 @@ Classes
     `status: str`
     :   Health check status: 'healthy' or 'unhealthy'.
 
+<a id="SnapchatMarketingExecuteResult"></a>
+
 `SnapchatMarketingExecuteResult(**data: Any)`
 :   Response envelope with data only.
     
@@ -2091,6 +2187,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="SnapchatMarketingExecuteResultWithMeta"></a>
 
 `SnapchatMarketingExecuteResultWithMeta(**data: Any)`
 :   Response envelope with data and metadata.
@@ -2150,6 +2248,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="AdaccountsListResult"></a>
+
 `AdaccountsListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -2192,6 +2292,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="AdsquadsListResult"></a>
 
 `AdsquadsListResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -2236,6 +2338,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="AdsListResult"></a>
+
 `AdsListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -2278,6 +2382,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="CampaignsListResult"></a>
 
 `CampaignsListResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -2322,6 +2428,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="CreativesListResult"></a>
+
 `CreativesListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -2364,6 +2472,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="MediaListResult"></a>
 
 `MediaListResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -2408,6 +2518,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="OrganizationsListResult"></a>
+
 `OrganizationsListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -2451,6 +2563,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="SegmentsListResult"></a>
+
 `SegmentsListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -2469,6 +2583,8 @@ Classes
     * airbyte_agent_sdk.connectors.snapchat_marketing.models.SnapchatMarketingExecuteResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="SnapchatMarketingReplicationConfig"></a>
 
 `SnapchatMarketingReplicationConfig(**data: Any)`
 :   Replication Configuration - Settings for data replication from Snapchat Marketing.

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/snapchat_marketing/types.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/snapchat_marketing/types.md
@@ -10,6 +10,8 @@ Type definitions for snapchat-marketing connector.
 Classes
 -------
 
+<a id="AdaccountsAndCondition"></a>
+
 `AdaccountsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -30,6 +32,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.snapchat_marketing.types.AdaccountsEqCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.AdaccountsNeqCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.AdaccountsGtCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.AdaccountsGteCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.AdaccountsLtCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.AdaccountsLteCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.AdaccountsInCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.AdaccountsLikeCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.AdaccountsFuzzyCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.AdaccountsKeywordCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.AdaccountsContainsCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.AdaccountsNotCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.AdaccountsAndCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.AdaccountsOrCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.AdaccountsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="AdaccountsAnyCondition"></a>
+
 `AdaccountsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -49,6 +53,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.snapchat_marketing.types.AdaccountsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="AdaccountsAnyValueFilter"></a>
 
 `AdaccountsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -107,6 +113,8 @@ Classes
     `updated_at: Any`
     :   Last update timestamp
 
+<a id="AdaccountsContainsCondition"></a>
+
 `AdaccountsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -118,6 +126,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.snapchat_marketing.types.AdaccountsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="AdaccountsEqCondition"></a>
 
 `AdaccountsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -131,6 +141,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.snapchat_marketing.types.AdaccountsSearchFilter`
     :   The type of the None singleton.
 
+<a id="AdaccountsFuzzyCondition"></a>
+
 `AdaccountsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -142,6 +154,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.snapchat_marketing.types.AdaccountsStringFilter`
     :   The type of the None singleton.
+
+<a id="AdaccountsGetParams"></a>
 
 `AdaccountsGetParams(*args, **kwargs)`
 :   Parameters for adaccounts.get operation
@@ -155,6 +169,8 @@ Classes
     `id: str`
     :   The type of the None singleton.
 
+<a id="AdaccountsGtCondition"></a>
+
 `AdaccountsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -167,6 +183,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.snapchat_marketing.types.AdaccountsSearchFilter`
     :   The type of the None singleton.
 
+<a id="AdaccountsGteCondition"></a>
+
 `AdaccountsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -178,6 +196,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.snapchat_marketing.types.AdaccountsSearchFilter`
     :   The type of the None singleton.
+
+<a id="AdaccountsInCondition"></a>
 
 `AdaccountsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -198,6 +218,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.snapchat_marketing.types.AdaccountsInFilter`
     :   The type of the None singleton.
+
+<a id="AdaccountsInFilter"></a>
 
 `AdaccountsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -256,6 +278,8 @@ Classes
     `updated_at: list[str]`
     :   Last update timestamp
 
+<a id="AdaccountsKeywordCondition"></a>
+
 `AdaccountsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -267,6 +291,8 @@ Classes
 
     `keyword: airbyte_agent_sdk.connectors.snapchat_marketing.types.AdaccountsStringFilter`
     :   The type of the None singleton.
+
+<a id="AdaccountsLikeCondition"></a>
 
 `AdaccountsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
@@ -280,6 +306,8 @@ Classes
     `like: airbyte_agent_sdk.connectors.snapchat_marketing.types.AdaccountsStringFilter`
     :   The type of the None singleton.
 
+<a id="AdaccountsListParams"></a>
+
 `AdaccountsListParams(*args, **kwargs)`
 :   Parameters for adaccounts.list operation
 
@@ -291,6 +319,8 @@ Classes
 
     `organization_id: str`
     :   The type of the None singleton.
+
+<a id="AdaccountsLtCondition"></a>
 
 `AdaccountsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
@@ -304,6 +334,8 @@ Classes
     `lt: airbyte_agent_sdk.connectors.snapchat_marketing.types.AdaccountsSearchFilter`
     :   The type of the None singleton.
 
+<a id="AdaccountsLteCondition"></a>
+
 `AdaccountsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
 
@@ -316,6 +348,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.snapchat_marketing.types.AdaccountsSearchFilter`
     :   The type of the None singleton.
 
+<a id="AdaccountsNeqCondition"></a>
+
 `AdaccountsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -327,6 +361,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.snapchat_marketing.types.AdaccountsSearchFilter`
     :   The type of the None singleton.
+
+<a id="AdaccountsNotCondition"></a>
 
 `AdaccountsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -348,6 +384,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.snapchat_marketing.types.AdaccountsEqCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.AdaccountsNeqCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.AdaccountsGtCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.AdaccountsGteCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.AdaccountsLtCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.AdaccountsLteCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.AdaccountsInCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.AdaccountsLikeCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.AdaccountsFuzzyCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.AdaccountsKeywordCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.AdaccountsContainsCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.AdaccountsNotCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.AdaccountsAndCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.AdaccountsOrCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.AdaccountsAnyCondition`
     :   The type of the None singleton.
 
+<a id="AdaccountsOrCondition"></a>
+
 `AdaccountsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -367,6 +405,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.snapchat_marketing.types.AdaccountsEqCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.AdaccountsNeqCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.AdaccountsGtCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.AdaccountsGteCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.AdaccountsLtCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.AdaccountsLteCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.AdaccountsInCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.AdaccountsLikeCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.AdaccountsFuzzyCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.AdaccountsKeywordCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.AdaccountsContainsCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.AdaccountsNotCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.AdaccountsAndCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.AdaccountsOrCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.AdaccountsAnyCondition]`
     :   The type of the None singleton.
+
+<a id="AdaccountsSearchFilter"></a>
 
 `AdaccountsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering adaccounts search queries.
@@ -425,6 +465,8 @@ Classes
     `updated_at: str | None`
     :   Last update timestamp
 
+<a id="AdaccountsSearchQuery"></a>
+
 `AdaccountsSearchQuery(*args, **kwargs)`
 :   Search query for adaccounts entity.
 
@@ -439,6 +481,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.snapchat_marketing.types.AdaccountsSortFilter]`
     :   The type of the None singleton.
+
+<a id="AdaccountsSortFilter"></a>
 
 `AdaccountsSortFilter(*args, **kwargs)`
 :   Available fields for sorting adaccounts search results.
@@ -497,6 +541,8 @@ Classes
     `updated_at: Literal['asc', 'desc']`
     :   Last update timestamp
 
+<a id="AdaccountsStringFilter"></a>
+
 `AdaccountsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -554,6 +600,8 @@ Classes
     `updated_at: str`
     :   Last update timestamp
 
+<a id="AdsAndCondition"></a>
+
 `AdsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -574,6 +622,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.snapchat_marketing.types.AdsEqCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.AdsNeqCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.AdsGtCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.AdsGteCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.AdsLtCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.AdsLteCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.AdsInCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.AdsLikeCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.AdsFuzzyCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.AdsKeywordCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.AdsContainsCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.AdsNotCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.AdsAndCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.AdsOrCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.AdsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="AdsAnyCondition"></a>
+
 `AdsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -593,6 +643,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.snapchat_marketing.types.AdsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="AdsAnyValueFilter"></a>
 
 `AdsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -639,6 +691,8 @@ Classes
     `updated_at: Any`
     :   Last update timestamp
 
+<a id="AdsContainsCondition"></a>
+
 `AdsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -650,6 +704,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.snapchat_marketing.types.AdsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="AdsEqCondition"></a>
 
 `AdsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -663,6 +719,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.snapchat_marketing.types.AdsSearchFilter`
     :   The type of the None singleton.
 
+<a id="AdsFuzzyCondition"></a>
+
 `AdsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -674,6 +732,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.snapchat_marketing.types.AdsStringFilter`
     :   The type of the None singleton.
+
+<a id="AdsGetParams"></a>
 
 `AdsGetParams(*args, **kwargs)`
 :   Parameters for ads.get operation
@@ -687,6 +747,8 @@ Classes
     `id: str`
     :   The type of the None singleton.
 
+<a id="AdsGtCondition"></a>
+
 `AdsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -699,6 +761,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.snapchat_marketing.types.AdsSearchFilter`
     :   The type of the None singleton.
 
+<a id="AdsGteCondition"></a>
+
 `AdsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -710,6 +774,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.snapchat_marketing.types.AdsSearchFilter`
     :   The type of the None singleton.
+
+<a id="AdsInCondition"></a>
 
 `AdsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -730,6 +796,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.snapchat_marketing.types.AdsInFilter`
     :   The type of the None singleton.
+
+<a id="AdsInFilter"></a>
 
 `AdsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -776,6 +844,8 @@ Classes
     `updated_at: list[str]`
     :   Last update timestamp
 
+<a id="AdsKeywordCondition"></a>
+
 `AdsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -787,6 +857,8 @@ Classes
 
     `keyword: airbyte_agent_sdk.connectors.snapchat_marketing.types.AdsStringFilter`
     :   The type of the None singleton.
+
+<a id="AdsLikeCondition"></a>
 
 `AdsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
@@ -800,6 +872,8 @@ Classes
     `like: airbyte_agent_sdk.connectors.snapchat_marketing.types.AdsStringFilter`
     :   The type of the None singleton.
 
+<a id="AdsListParams"></a>
+
 `AdsListParams(*args, **kwargs)`
 :   Parameters for ads.list operation
 
@@ -811,6 +885,8 @@ Classes
 
     `ad_account_id: str`
     :   The type of the None singleton.
+
+<a id="AdsLtCondition"></a>
 
 `AdsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
@@ -824,6 +900,8 @@ Classes
     `lt: airbyte_agent_sdk.connectors.snapchat_marketing.types.AdsSearchFilter`
     :   The type of the None singleton.
 
+<a id="AdsLteCondition"></a>
+
 `AdsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
 
@@ -836,6 +914,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.snapchat_marketing.types.AdsSearchFilter`
     :   The type of the None singleton.
 
+<a id="AdsNeqCondition"></a>
+
 `AdsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -847,6 +927,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.snapchat_marketing.types.AdsSearchFilter`
     :   The type of the None singleton.
+
+<a id="AdsNotCondition"></a>
 
 `AdsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -868,6 +950,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.snapchat_marketing.types.AdsEqCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.AdsNeqCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.AdsGtCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.AdsGteCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.AdsLtCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.AdsLteCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.AdsInCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.AdsLikeCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.AdsFuzzyCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.AdsKeywordCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.AdsContainsCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.AdsNotCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.AdsAndCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.AdsOrCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.AdsAnyCondition`
     :   The type of the None singleton.
 
+<a id="AdsOrCondition"></a>
+
 `AdsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -887,6 +971,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.snapchat_marketing.types.AdsEqCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.AdsNeqCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.AdsGtCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.AdsGteCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.AdsLtCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.AdsLteCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.AdsInCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.AdsLikeCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.AdsFuzzyCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.AdsKeywordCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.AdsContainsCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.AdsNotCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.AdsAndCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.AdsOrCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.AdsAnyCondition]`
     :   The type of the None singleton.
+
+<a id="AdsSearchFilter"></a>
 
 `AdsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering ads search queries.
@@ -933,6 +1019,8 @@ Classes
     `updated_at: str | None`
     :   Last update timestamp
 
+<a id="AdsSearchQuery"></a>
+
 `AdsSearchQuery(*args, **kwargs)`
 :   Search query for ads entity.
 
@@ -947,6 +1035,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.snapchat_marketing.types.AdsSortFilter]`
     :   The type of the None singleton.
+
+<a id="AdsSortFilter"></a>
 
 `AdsSortFilter(*args, **kwargs)`
 :   Available fields for sorting ads search results.
@@ -993,6 +1083,8 @@ Classes
     `updated_at: Literal['asc', 'desc']`
     :   Last update timestamp
 
+<a id="AdsStringFilter"></a>
+
 `AdsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -1038,6 +1130,8 @@ Classes
     `updated_at: str`
     :   Last update timestamp
 
+<a id="AdsquadsAndCondition"></a>
+
 `AdsquadsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1058,6 +1152,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.snapchat_marketing.types.AdsquadsEqCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.AdsquadsNeqCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.AdsquadsGtCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.AdsquadsGteCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.AdsquadsLtCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.AdsquadsLteCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.AdsquadsInCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.AdsquadsLikeCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.AdsquadsFuzzyCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.AdsquadsKeywordCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.AdsquadsContainsCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.AdsquadsNotCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.AdsquadsAndCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.AdsquadsOrCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.AdsquadsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="AdsquadsAnyCondition"></a>
+
 `AdsquadsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1077,6 +1173,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.snapchat_marketing.types.AdsquadsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="AdsquadsAnyValueFilter"></a>
 
 `AdsquadsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -1171,6 +1269,8 @@ Classes
     `updated_at: Any`
     :   Last update timestamp
 
+<a id="AdsquadsContainsCondition"></a>
+
 `AdsquadsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -1182,6 +1282,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.snapchat_marketing.types.AdsquadsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="AdsquadsEqCondition"></a>
 
 `AdsquadsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -1195,6 +1297,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.snapchat_marketing.types.AdsquadsSearchFilter`
     :   The type of the None singleton.
 
+<a id="AdsquadsFuzzyCondition"></a>
+
 `AdsquadsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -1206,6 +1310,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.snapchat_marketing.types.AdsquadsStringFilter`
     :   The type of the None singleton.
+
+<a id="AdsquadsGetParams"></a>
 
 `AdsquadsGetParams(*args, **kwargs)`
 :   Parameters for adsquads.get operation
@@ -1219,6 +1325,8 @@ Classes
     `id: str`
     :   The type of the None singleton.
 
+<a id="AdsquadsGtCondition"></a>
+
 `AdsquadsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -1231,6 +1339,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.snapchat_marketing.types.AdsquadsSearchFilter`
     :   The type of the None singleton.
 
+<a id="AdsquadsGteCondition"></a>
+
 `AdsquadsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -1242,6 +1352,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.snapchat_marketing.types.AdsquadsSearchFilter`
     :   The type of the None singleton.
+
+<a id="AdsquadsInCondition"></a>
 
 `AdsquadsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -1262,6 +1374,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.snapchat_marketing.types.AdsquadsInFilter`
     :   The type of the None singleton.
+
+<a id="AdsquadsInFilter"></a>
 
 `AdsquadsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -1356,6 +1470,8 @@ Classes
     `updated_at: list[str]`
     :   Last update timestamp
 
+<a id="AdsquadsKeywordCondition"></a>
+
 `AdsquadsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -1367,6 +1483,8 @@ Classes
 
     `keyword: airbyte_agent_sdk.connectors.snapchat_marketing.types.AdsquadsStringFilter`
     :   The type of the None singleton.
+
+<a id="AdsquadsLikeCondition"></a>
 
 `AdsquadsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
@@ -1380,6 +1498,8 @@ Classes
     `like: airbyte_agent_sdk.connectors.snapchat_marketing.types.AdsquadsStringFilter`
     :   The type of the None singleton.
 
+<a id="AdsquadsListParams"></a>
+
 `AdsquadsListParams(*args, **kwargs)`
 :   Parameters for adsquads.list operation
 
@@ -1391,6 +1511,8 @@ Classes
 
     `ad_account_id: str`
     :   The type of the None singleton.
+
+<a id="AdsquadsLtCondition"></a>
 
 `AdsquadsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
@@ -1404,6 +1526,8 @@ Classes
     `lt: airbyte_agent_sdk.connectors.snapchat_marketing.types.AdsquadsSearchFilter`
     :   The type of the None singleton.
 
+<a id="AdsquadsLteCondition"></a>
+
 `AdsquadsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
 
@@ -1416,6 +1540,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.snapchat_marketing.types.AdsquadsSearchFilter`
     :   The type of the None singleton.
 
+<a id="AdsquadsNeqCondition"></a>
+
 `AdsquadsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -1427,6 +1553,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.snapchat_marketing.types.AdsquadsSearchFilter`
     :   The type of the None singleton.
+
+<a id="AdsquadsNotCondition"></a>
 
 `AdsquadsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -1448,6 +1576,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.snapchat_marketing.types.AdsquadsEqCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.AdsquadsNeqCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.AdsquadsGtCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.AdsquadsGteCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.AdsquadsLtCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.AdsquadsLteCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.AdsquadsInCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.AdsquadsLikeCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.AdsquadsFuzzyCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.AdsquadsKeywordCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.AdsquadsContainsCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.AdsquadsNotCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.AdsquadsAndCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.AdsquadsOrCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.AdsquadsAnyCondition`
     :   The type of the None singleton.
 
+<a id="AdsquadsOrCondition"></a>
+
 `AdsquadsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1467,6 +1597,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.snapchat_marketing.types.AdsquadsEqCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.AdsquadsNeqCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.AdsquadsGtCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.AdsquadsGteCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.AdsquadsLtCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.AdsquadsLteCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.AdsquadsInCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.AdsquadsLikeCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.AdsquadsFuzzyCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.AdsquadsKeywordCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.AdsquadsContainsCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.AdsquadsNotCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.AdsquadsAndCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.AdsquadsOrCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.AdsquadsAnyCondition]`
     :   The type of the None singleton.
+
+<a id="AdsquadsSearchFilter"></a>
 
 `AdsquadsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering adsquads search queries.
@@ -1561,6 +1693,8 @@ Classes
     `updated_at: str | None`
     :   Last update timestamp
 
+<a id="AdsquadsSearchQuery"></a>
+
 `AdsquadsSearchQuery(*args, **kwargs)`
 :   Search query for adsquads entity.
 
@@ -1575,6 +1709,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.snapchat_marketing.types.AdsquadsSortFilter]`
     :   The type of the None singleton.
+
+<a id="AdsquadsSortFilter"></a>
 
 `AdsquadsSortFilter(*args, **kwargs)`
 :   Available fields for sorting adsquads search results.
@@ -1669,6 +1805,8 @@ Classes
     `updated_at: Literal['asc', 'desc']`
     :   Last update timestamp
 
+<a id="AdsquadsStringFilter"></a>
+
 `AdsquadsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -1762,6 +1900,8 @@ Classes
     `updated_at: str`
     :   Last update timestamp
 
+<a id="AirbyteSearchParams"></a>
+
 `AirbyteSearchParams(*args, **kwargs)`
 :   Parameters for Airbyte cache search operations (generic, use entity-specific query types for better type hints).
 
@@ -1783,6 +1923,8 @@ Classes
     `query: dict[str, typing.Any]`
     :   The type of the None singleton.
 
+<a id="CampaignsAndCondition"></a>
+
 `CampaignsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1803,6 +1945,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.snapchat_marketing.types.CampaignsEqCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.CampaignsNeqCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.CampaignsGtCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.CampaignsGteCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.CampaignsLtCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.CampaignsLteCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.CampaignsInCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.CampaignsLikeCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.CampaignsFuzzyCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.CampaignsKeywordCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.CampaignsContainsCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.CampaignsNotCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.CampaignsAndCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.CampaignsOrCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.CampaignsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="CampaignsAnyCondition"></a>
+
 `CampaignsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1822,6 +1966,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.snapchat_marketing.types.CampaignsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="CampaignsAnyValueFilter"></a>
 
 `CampaignsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -1865,6 +2011,8 @@ Classes
     `updated_at: Any`
     :   Last update timestamp
 
+<a id="CampaignsContainsCondition"></a>
+
 `CampaignsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -1876,6 +2024,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.snapchat_marketing.types.CampaignsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="CampaignsEqCondition"></a>
 
 `CampaignsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -1889,6 +2039,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.snapchat_marketing.types.CampaignsSearchFilter`
     :   The type of the None singleton.
 
+<a id="CampaignsFuzzyCondition"></a>
+
 `CampaignsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -1900,6 +2052,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.snapchat_marketing.types.CampaignsStringFilter`
     :   The type of the None singleton.
+
+<a id="CampaignsGetParams"></a>
 
 `CampaignsGetParams(*args, **kwargs)`
 :   Parameters for campaigns.get operation
@@ -1913,6 +2067,8 @@ Classes
     `id: str`
     :   The type of the None singleton.
 
+<a id="CampaignsGtCondition"></a>
+
 `CampaignsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -1925,6 +2081,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.snapchat_marketing.types.CampaignsSearchFilter`
     :   The type of the None singleton.
 
+<a id="CampaignsGteCondition"></a>
+
 `CampaignsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -1936,6 +2094,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.snapchat_marketing.types.CampaignsSearchFilter`
     :   The type of the None singleton.
+
+<a id="CampaignsInCondition"></a>
 
 `CampaignsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -1956,6 +2116,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.snapchat_marketing.types.CampaignsInFilter`
     :   The type of the None singleton.
+
+<a id="CampaignsInFilter"></a>
 
 `CampaignsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -1999,6 +2161,8 @@ Classes
     `updated_at: list[str]`
     :   Last update timestamp
 
+<a id="CampaignsKeywordCondition"></a>
+
 `CampaignsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -2010,6 +2174,8 @@ Classes
 
     `keyword: airbyte_agent_sdk.connectors.snapchat_marketing.types.CampaignsStringFilter`
     :   The type of the None singleton.
+
+<a id="CampaignsLikeCondition"></a>
 
 `CampaignsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
@@ -2023,6 +2189,8 @@ Classes
     `like: airbyte_agent_sdk.connectors.snapchat_marketing.types.CampaignsStringFilter`
     :   The type of the None singleton.
 
+<a id="CampaignsListParams"></a>
+
 `CampaignsListParams(*args, **kwargs)`
 :   Parameters for campaigns.list operation
 
@@ -2034,6 +2202,8 @@ Classes
 
     `ad_account_id: str`
     :   The type of the None singleton.
+
+<a id="CampaignsLtCondition"></a>
 
 `CampaignsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
@@ -2047,6 +2217,8 @@ Classes
     `lt: airbyte_agent_sdk.connectors.snapchat_marketing.types.CampaignsSearchFilter`
     :   The type of the None singleton.
 
+<a id="CampaignsLteCondition"></a>
+
 `CampaignsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
 
@@ -2059,6 +2231,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.snapchat_marketing.types.CampaignsSearchFilter`
     :   The type of the None singleton.
 
+<a id="CampaignsNeqCondition"></a>
+
 `CampaignsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -2070,6 +2244,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.snapchat_marketing.types.CampaignsSearchFilter`
     :   The type of the None singleton.
+
+<a id="CampaignsNotCondition"></a>
 
 `CampaignsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -2091,6 +2267,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.snapchat_marketing.types.CampaignsEqCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.CampaignsNeqCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.CampaignsGtCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.CampaignsGteCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.CampaignsLtCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.CampaignsLteCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.CampaignsInCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.CampaignsLikeCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.CampaignsFuzzyCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.CampaignsKeywordCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.CampaignsContainsCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.CampaignsNotCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.CampaignsAndCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.CampaignsOrCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.CampaignsAnyCondition`
     :   The type of the None singleton.
 
+<a id="CampaignsOrCondition"></a>
+
 `CampaignsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -2110,6 +2288,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.snapchat_marketing.types.CampaignsEqCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.CampaignsNeqCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.CampaignsGtCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.CampaignsGteCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.CampaignsLtCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.CampaignsLteCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.CampaignsInCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.CampaignsLikeCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.CampaignsFuzzyCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.CampaignsKeywordCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.CampaignsContainsCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.CampaignsNotCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.CampaignsAndCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.CampaignsOrCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.CampaignsAnyCondition]`
     :   The type of the None singleton.
+
+<a id="CampaignsSearchFilter"></a>
 
 `CampaignsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering campaigns search queries.
@@ -2153,6 +2333,8 @@ Classes
     `updated_at: str | None`
     :   Last update timestamp
 
+<a id="CampaignsSearchQuery"></a>
+
 `CampaignsSearchQuery(*args, **kwargs)`
 :   Search query for campaigns entity.
 
@@ -2167,6 +2349,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.snapchat_marketing.types.CampaignsSortFilter]`
     :   The type of the None singleton.
+
+<a id="CampaignsSortFilter"></a>
 
 `CampaignsSortFilter(*args, **kwargs)`
 :   Available fields for sorting campaigns search results.
@@ -2210,6 +2394,8 @@ Classes
     `updated_at: Literal['asc', 'desc']`
     :   Last update timestamp
 
+<a id="CampaignsStringFilter"></a>
+
 `CampaignsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -2252,6 +2438,8 @@ Classes
     `updated_at: str`
     :   Last update timestamp
 
+<a id="CreativesAndCondition"></a>
+
 `CreativesAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -2272,6 +2460,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.snapchat_marketing.types.CreativesEqCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.CreativesNeqCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.CreativesGtCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.CreativesGteCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.CreativesLtCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.CreativesLteCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.CreativesInCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.CreativesLikeCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.CreativesFuzzyCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.CreativesKeywordCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.CreativesContainsCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.CreativesNotCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.CreativesAndCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.CreativesOrCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.CreativesAnyCondition]`
     :   The type of the None singleton.
 
+<a id="CreativesAnyCondition"></a>
+
 `CreativesAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -2291,6 +2481,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.snapchat_marketing.types.CreativesAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="CreativesAnyValueFilter"></a>
 
 `CreativesAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -2361,6 +2553,8 @@ Classes
     `web_view_properties: Any`
     :   Web view properties
 
+<a id="CreativesContainsCondition"></a>
+
 `CreativesContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -2372,6 +2566,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.snapchat_marketing.types.CreativesAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="CreativesEqCondition"></a>
 
 `CreativesEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -2385,6 +2581,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.snapchat_marketing.types.CreativesSearchFilter`
     :   The type of the None singleton.
 
+<a id="CreativesFuzzyCondition"></a>
+
 `CreativesFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -2396,6 +2594,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.snapchat_marketing.types.CreativesStringFilter`
     :   The type of the None singleton.
+
+<a id="CreativesGetParams"></a>
 
 `CreativesGetParams(*args, **kwargs)`
 :   Parameters for creatives.get operation
@@ -2409,6 +2609,8 @@ Classes
     `id: str`
     :   The type of the None singleton.
 
+<a id="CreativesGtCondition"></a>
+
 `CreativesGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -2421,6 +2623,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.snapchat_marketing.types.CreativesSearchFilter`
     :   The type of the None singleton.
 
+<a id="CreativesGteCondition"></a>
+
 `CreativesGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -2432,6 +2636,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.snapchat_marketing.types.CreativesSearchFilter`
     :   The type of the None singleton.
+
+<a id="CreativesInCondition"></a>
 
 `CreativesInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -2452,6 +2658,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.snapchat_marketing.types.CreativesInFilter`
     :   The type of the None singleton.
+
+<a id="CreativesInFilter"></a>
 
 `CreativesInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -2522,6 +2730,8 @@ Classes
     `web_view_properties: list[dict[str, typing.Any]]`
     :   Web view properties
 
+<a id="CreativesKeywordCondition"></a>
+
 `CreativesKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -2533,6 +2743,8 @@ Classes
 
     `keyword: airbyte_agent_sdk.connectors.snapchat_marketing.types.CreativesStringFilter`
     :   The type of the None singleton.
+
+<a id="CreativesLikeCondition"></a>
 
 `CreativesLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
@@ -2546,6 +2758,8 @@ Classes
     `like: airbyte_agent_sdk.connectors.snapchat_marketing.types.CreativesStringFilter`
     :   The type of the None singleton.
 
+<a id="CreativesListParams"></a>
+
 `CreativesListParams(*args, **kwargs)`
 :   Parameters for creatives.list operation
 
@@ -2557,6 +2771,8 @@ Classes
 
     `ad_account_id: str`
     :   The type of the None singleton.
+
+<a id="CreativesLtCondition"></a>
 
 `CreativesLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
@@ -2570,6 +2786,8 @@ Classes
     `lt: airbyte_agent_sdk.connectors.snapchat_marketing.types.CreativesSearchFilter`
     :   The type of the None singleton.
 
+<a id="CreativesLteCondition"></a>
+
 `CreativesLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
 
@@ -2582,6 +2800,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.snapchat_marketing.types.CreativesSearchFilter`
     :   The type of the None singleton.
 
+<a id="CreativesNeqCondition"></a>
+
 `CreativesNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -2593,6 +2813,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.snapchat_marketing.types.CreativesSearchFilter`
     :   The type of the None singleton.
+
+<a id="CreativesNotCondition"></a>
 
 `CreativesNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -2614,6 +2836,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.snapchat_marketing.types.CreativesEqCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.CreativesNeqCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.CreativesGtCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.CreativesGteCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.CreativesLtCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.CreativesLteCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.CreativesInCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.CreativesLikeCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.CreativesFuzzyCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.CreativesKeywordCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.CreativesContainsCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.CreativesNotCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.CreativesAndCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.CreativesOrCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.CreativesAnyCondition`
     :   The type of the None singleton.
 
+<a id="CreativesOrCondition"></a>
+
 `CreativesOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -2633,6 +2857,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.snapchat_marketing.types.CreativesEqCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.CreativesNeqCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.CreativesGtCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.CreativesGteCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.CreativesLtCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.CreativesLteCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.CreativesInCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.CreativesLikeCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.CreativesFuzzyCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.CreativesKeywordCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.CreativesContainsCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.CreativesNotCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.CreativesAndCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.CreativesOrCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.CreativesAnyCondition]`
     :   The type of the None singleton.
+
+<a id="CreativesSearchFilter"></a>
 
 `CreativesSearchFilter(*args, **kwargs)`
 :   Available fields for filtering creatives search queries.
@@ -2703,6 +2929,8 @@ Classes
     `web_view_properties: dict[str, typing.Any] | None`
     :   Web view properties
 
+<a id="CreativesSearchQuery"></a>
+
 `CreativesSearchQuery(*args, **kwargs)`
 :   Search query for creatives entity.
 
@@ -2717,6 +2945,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.snapchat_marketing.types.CreativesSortFilter]`
     :   The type of the None singleton.
+
+<a id="CreativesSortFilter"></a>
 
 `CreativesSortFilter(*args, **kwargs)`
 :   Available fields for sorting creatives search results.
@@ -2787,6 +3017,8 @@ Classes
     `web_view_properties: Literal['asc', 'desc']`
     :   Web view properties
 
+<a id="CreativesStringFilter"></a>
+
 `CreativesStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -2856,6 +3088,8 @@ Classes
     `web_view_properties: str`
     :   Web view properties
 
+<a id="MediaAndCondition"></a>
+
 `MediaAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -2876,6 +3110,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.snapchat_marketing.types.MediaEqCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.MediaNeqCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.MediaGtCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.MediaGteCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.MediaLtCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.MediaLteCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.MediaInCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.MediaLikeCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.MediaFuzzyCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.MediaKeywordCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.MediaContainsCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.MediaNotCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.MediaAndCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.MediaOrCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.MediaAnyCondition]`
     :   The type of the None singleton.
 
+<a id="MediaAnyCondition"></a>
+
 `MediaAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -2895,6 +3131,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.snapchat_marketing.types.MediaAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="MediaAnyValueFilter"></a>
 
 `MediaAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -2956,6 +3194,8 @@ Classes
     `visibility: Any`
     :   Media visibility setting
 
+<a id="MediaContainsCondition"></a>
+
 `MediaContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -2967,6 +3207,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.snapchat_marketing.types.MediaAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="MediaEqCondition"></a>
 
 `MediaEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -2980,6 +3222,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.snapchat_marketing.types.MediaSearchFilter`
     :   The type of the None singleton.
 
+<a id="MediaFuzzyCondition"></a>
+
 `MediaFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -2991,6 +3235,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.snapchat_marketing.types.MediaStringFilter`
     :   The type of the None singleton.
+
+<a id="MediaGetParams"></a>
 
 `MediaGetParams(*args, **kwargs)`
 :   Parameters for media.get operation
@@ -3004,6 +3250,8 @@ Classes
     `id: str`
     :   The type of the None singleton.
 
+<a id="MediaGtCondition"></a>
+
 `MediaGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -3016,6 +3264,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.snapchat_marketing.types.MediaSearchFilter`
     :   The type of the None singleton.
 
+<a id="MediaGteCondition"></a>
+
 `MediaGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -3027,6 +3277,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.snapchat_marketing.types.MediaSearchFilter`
     :   The type of the None singleton.
+
+<a id="MediaInCondition"></a>
 
 `MediaInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -3047,6 +3299,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.snapchat_marketing.types.MediaInFilter`
     :   The type of the None singleton.
+
+<a id="MediaInFilter"></a>
 
 `MediaInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -3108,6 +3362,8 @@ Classes
     `visibility: list[str]`
     :   Media visibility setting
 
+<a id="MediaKeywordCondition"></a>
+
 `MediaKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -3119,6 +3375,8 @@ Classes
 
     `keyword: airbyte_agent_sdk.connectors.snapchat_marketing.types.MediaStringFilter`
     :   The type of the None singleton.
+
+<a id="MediaLikeCondition"></a>
 
 `MediaLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
@@ -3132,6 +3390,8 @@ Classes
     `like: airbyte_agent_sdk.connectors.snapchat_marketing.types.MediaStringFilter`
     :   The type of the None singleton.
 
+<a id="MediaListParams"></a>
+
 `MediaListParams(*args, **kwargs)`
 :   Parameters for media.list operation
 
@@ -3143,6 +3403,8 @@ Classes
 
     `ad_account_id: str`
     :   The type of the None singleton.
+
+<a id="MediaLtCondition"></a>
 
 `MediaLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
@@ -3156,6 +3418,8 @@ Classes
     `lt: airbyte_agent_sdk.connectors.snapchat_marketing.types.MediaSearchFilter`
     :   The type of the None singleton.
 
+<a id="MediaLteCondition"></a>
+
 `MediaLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
 
@@ -3168,6 +3432,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.snapchat_marketing.types.MediaSearchFilter`
     :   The type of the None singleton.
 
+<a id="MediaNeqCondition"></a>
+
 `MediaNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -3179,6 +3445,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.snapchat_marketing.types.MediaSearchFilter`
     :   The type of the None singleton.
+
+<a id="MediaNotCondition"></a>
 
 `MediaNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -3200,6 +3468,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.snapchat_marketing.types.MediaEqCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.MediaNeqCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.MediaGtCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.MediaGteCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.MediaLtCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.MediaLteCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.MediaInCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.MediaLikeCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.MediaFuzzyCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.MediaKeywordCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.MediaContainsCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.MediaNotCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.MediaAndCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.MediaOrCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.MediaAnyCondition`
     :   The type of the None singleton.
 
+<a id="MediaOrCondition"></a>
+
 `MediaOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -3219,6 +3489,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.snapchat_marketing.types.MediaEqCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.MediaNeqCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.MediaGtCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.MediaGteCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.MediaLtCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.MediaLteCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.MediaInCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.MediaLikeCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.MediaFuzzyCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.MediaKeywordCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.MediaContainsCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.MediaNotCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.MediaAndCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.MediaOrCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.MediaAnyCondition]`
     :   The type of the None singleton.
+
+<a id="MediaSearchFilter"></a>
 
 `MediaSearchFilter(*args, **kwargs)`
 :   Available fields for filtering media search queries.
@@ -3280,6 +3552,8 @@ Classes
     `visibility: str | None`
     :   Media visibility setting
 
+<a id="MediaSearchQuery"></a>
+
 `MediaSearchQuery(*args, **kwargs)`
 :   Search query for media entity.
 
@@ -3294,6 +3568,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.snapchat_marketing.types.MediaSortFilter]`
     :   The type of the None singleton.
+
+<a id="MediaSortFilter"></a>
 
 `MediaSortFilter(*args, **kwargs)`
 :   Available fields for sorting media search results.
@@ -3355,6 +3631,8 @@ Classes
     `visibility: Literal['asc', 'desc']`
     :   Media visibility setting
 
+<a id="MediaStringFilter"></a>
+
 `MediaStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -3415,6 +3693,8 @@ Classes
     `visibility: str`
     :   Media visibility setting
 
+<a id="OrganizationsAndCondition"></a>
+
 `OrganizationsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -3435,6 +3715,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.snapchat_marketing.types.OrganizationsEqCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.OrganizationsNeqCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.OrganizationsGtCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.OrganizationsGteCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.OrganizationsLtCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.OrganizationsLteCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.OrganizationsInCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.OrganizationsLikeCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.OrganizationsFuzzyCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.OrganizationsKeywordCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.OrganizationsContainsCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.OrganizationsNotCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.OrganizationsAndCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.OrganizationsOrCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.OrganizationsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="OrganizationsAnyCondition"></a>
+
 `OrganizationsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -3454,6 +3736,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.snapchat_marketing.types.OrganizationsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="OrganizationsAnyValueFilter"></a>
 
 `OrganizationsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -3530,6 +3814,8 @@ Classes
     `updated_at: Any`
     :   Last update timestamp
 
+<a id="OrganizationsContainsCondition"></a>
+
 `OrganizationsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -3541,6 +3827,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.snapchat_marketing.types.OrganizationsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="OrganizationsEqCondition"></a>
 
 `OrganizationsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -3554,6 +3842,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.snapchat_marketing.types.OrganizationsSearchFilter`
     :   The type of the None singleton.
 
+<a id="OrganizationsFuzzyCondition"></a>
+
 `OrganizationsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -3565,6 +3855,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.snapchat_marketing.types.OrganizationsStringFilter`
     :   The type of the None singleton.
+
+<a id="OrganizationsGetParams"></a>
 
 `OrganizationsGetParams(*args, **kwargs)`
 :   Parameters for organizations.get operation
@@ -3578,6 +3870,8 @@ Classes
     `id: str`
     :   The type of the None singleton.
 
+<a id="OrganizationsGtCondition"></a>
+
 `OrganizationsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -3590,6 +3884,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.snapchat_marketing.types.OrganizationsSearchFilter`
     :   The type of the None singleton.
 
+<a id="OrganizationsGteCondition"></a>
+
 `OrganizationsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -3601,6 +3897,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.snapchat_marketing.types.OrganizationsSearchFilter`
     :   The type of the None singleton.
+
+<a id="OrganizationsInCondition"></a>
 
 `OrganizationsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -3621,6 +3919,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.snapchat_marketing.types.OrganizationsInFilter`
     :   The type of the None singleton.
+
+<a id="OrganizationsInFilter"></a>
 
 `OrganizationsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -3697,6 +3997,8 @@ Classes
     `updated_at: list[str]`
     :   Last update timestamp
 
+<a id="OrganizationsKeywordCondition"></a>
+
 `OrganizationsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -3708,6 +4010,8 @@ Classes
 
     `keyword: airbyte_agent_sdk.connectors.snapchat_marketing.types.OrganizationsStringFilter`
     :   The type of the None singleton.
+
+<a id="OrganizationsLikeCondition"></a>
 
 `OrganizationsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
@@ -3721,12 +4025,16 @@ Classes
     `like: airbyte_agent_sdk.connectors.snapchat_marketing.types.OrganizationsStringFilter`
     :   The type of the None singleton.
 
+<a id="OrganizationsListParams"></a>
+
 `OrganizationsListParams(*args, **kwargs)`
 :   Parameters for organizations.list operation
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="OrganizationsLtCondition"></a>
 
 `OrganizationsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
@@ -3740,6 +4048,8 @@ Classes
     `lt: airbyte_agent_sdk.connectors.snapchat_marketing.types.OrganizationsSearchFilter`
     :   The type of the None singleton.
 
+<a id="OrganizationsLteCondition"></a>
+
 `OrganizationsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
 
@@ -3752,6 +4062,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.snapchat_marketing.types.OrganizationsSearchFilter`
     :   The type of the None singleton.
 
+<a id="OrganizationsNeqCondition"></a>
+
 `OrganizationsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -3763,6 +4075,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.snapchat_marketing.types.OrganizationsSearchFilter`
     :   The type of the None singleton.
+
+<a id="OrganizationsNotCondition"></a>
 
 `OrganizationsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -3784,6 +4098,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.snapchat_marketing.types.OrganizationsEqCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.OrganizationsNeqCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.OrganizationsGtCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.OrganizationsGteCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.OrganizationsLtCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.OrganizationsLteCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.OrganizationsInCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.OrganizationsLikeCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.OrganizationsFuzzyCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.OrganizationsKeywordCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.OrganizationsContainsCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.OrganizationsNotCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.OrganizationsAndCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.OrganizationsOrCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.OrganizationsAnyCondition`
     :   The type of the None singleton.
 
+<a id="OrganizationsOrCondition"></a>
+
 `OrganizationsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -3803,6 +4119,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.snapchat_marketing.types.OrganizationsEqCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.OrganizationsNeqCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.OrganizationsGtCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.OrganizationsGteCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.OrganizationsLtCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.OrganizationsLteCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.OrganizationsInCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.OrganizationsLikeCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.OrganizationsFuzzyCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.OrganizationsKeywordCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.OrganizationsContainsCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.OrganizationsNotCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.OrganizationsAndCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.OrganizationsOrCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.OrganizationsAnyCondition]`
     :   The type of the None singleton.
+
+<a id="OrganizationsSearchFilter"></a>
 
 `OrganizationsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering organizations search queries.
@@ -3879,6 +4197,8 @@ Classes
     `updated_at: str | None`
     :   Last update timestamp
 
+<a id="OrganizationsSearchQuery"></a>
+
 `OrganizationsSearchQuery(*args, **kwargs)`
 :   Search query for organizations entity.
 
@@ -3893,6 +4213,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.snapchat_marketing.types.OrganizationsSortFilter]`
     :   The type of the None singleton.
+
+<a id="OrganizationsSortFilter"></a>
 
 `OrganizationsSortFilter(*args, **kwargs)`
 :   Available fields for sorting organizations search results.
@@ -3969,6 +4291,8 @@ Classes
     `updated_at: Literal['asc', 'desc']`
     :   Last update timestamp
 
+<a id="OrganizationsStringFilter"></a>
+
 `OrganizationsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -4044,6 +4368,8 @@ Classes
     `updated_at: str`
     :   Last update timestamp
 
+<a id="SegmentsAndCondition"></a>
+
 `SegmentsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -4064,6 +4390,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.snapchat_marketing.types.SegmentsEqCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.SegmentsNeqCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.SegmentsGtCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.SegmentsGteCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.SegmentsLtCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.SegmentsLteCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.SegmentsInCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.SegmentsLikeCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.SegmentsFuzzyCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.SegmentsKeywordCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.SegmentsContainsCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.SegmentsNotCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.SegmentsAndCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.SegmentsOrCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.SegmentsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="SegmentsAnyCondition"></a>
+
 `SegmentsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -4083,6 +4411,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.snapchat_marketing.types.SegmentsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="SegmentsAnyValueFilter"></a>
 
 `SegmentsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -4135,6 +4465,8 @@ Classes
     `visible_to: Any`
     :   Visibility settings
 
+<a id="SegmentsContainsCondition"></a>
+
 `SegmentsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -4146,6 +4478,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.snapchat_marketing.types.SegmentsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="SegmentsEqCondition"></a>
 
 `SegmentsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -4159,6 +4493,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.snapchat_marketing.types.SegmentsSearchFilter`
     :   The type of the None singleton.
 
+<a id="SegmentsFuzzyCondition"></a>
+
 `SegmentsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -4170,6 +4506,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.snapchat_marketing.types.SegmentsStringFilter`
     :   The type of the None singleton.
+
+<a id="SegmentsGetParams"></a>
 
 `SegmentsGetParams(*args, **kwargs)`
 :   Parameters for segments.get operation
@@ -4183,6 +4521,8 @@ Classes
     `id: str`
     :   The type of the None singleton.
 
+<a id="SegmentsGtCondition"></a>
+
 `SegmentsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -4195,6 +4535,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.snapchat_marketing.types.SegmentsSearchFilter`
     :   The type of the None singleton.
 
+<a id="SegmentsGteCondition"></a>
+
 `SegmentsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -4206,6 +4548,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.snapchat_marketing.types.SegmentsSearchFilter`
     :   The type of the None singleton.
+
+<a id="SegmentsInCondition"></a>
 
 `SegmentsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -4226,6 +4570,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.snapchat_marketing.types.SegmentsInFilter`
     :   The type of the None singleton.
+
+<a id="SegmentsInFilter"></a>
 
 `SegmentsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -4278,6 +4624,8 @@ Classes
     `visible_to: list[list[typing.Any]]`
     :   Visibility settings
 
+<a id="SegmentsKeywordCondition"></a>
+
 `SegmentsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -4289,6 +4637,8 @@ Classes
 
     `keyword: airbyte_agent_sdk.connectors.snapchat_marketing.types.SegmentsStringFilter`
     :   The type of the None singleton.
+
+<a id="SegmentsLikeCondition"></a>
 
 `SegmentsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
@@ -4302,6 +4652,8 @@ Classes
     `like: airbyte_agent_sdk.connectors.snapchat_marketing.types.SegmentsStringFilter`
     :   The type of the None singleton.
 
+<a id="SegmentsListParams"></a>
+
 `SegmentsListParams(*args, **kwargs)`
 :   Parameters for segments.list operation
 
@@ -4313,6 +4665,8 @@ Classes
 
     `ad_account_id: str`
     :   The type of the None singleton.
+
+<a id="SegmentsLtCondition"></a>
 
 `SegmentsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
@@ -4326,6 +4680,8 @@ Classes
     `lt: airbyte_agent_sdk.connectors.snapchat_marketing.types.SegmentsSearchFilter`
     :   The type of the None singleton.
 
+<a id="SegmentsLteCondition"></a>
+
 `SegmentsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
 
@@ -4338,6 +4694,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.snapchat_marketing.types.SegmentsSearchFilter`
     :   The type of the None singleton.
 
+<a id="SegmentsNeqCondition"></a>
+
 `SegmentsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -4349,6 +4707,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.snapchat_marketing.types.SegmentsSearchFilter`
     :   The type of the None singleton.
+
+<a id="SegmentsNotCondition"></a>
 
 `SegmentsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -4370,6 +4730,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.snapchat_marketing.types.SegmentsEqCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.SegmentsNeqCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.SegmentsGtCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.SegmentsGteCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.SegmentsLtCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.SegmentsLteCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.SegmentsInCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.SegmentsLikeCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.SegmentsFuzzyCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.SegmentsKeywordCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.SegmentsContainsCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.SegmentsNotCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.SegmentsAndCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.SegmentsOrCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.SegmentsAnyCondition`
     :   The type of the None singleton.
 
+<a id="SegmentsOrCondition"></a>
+
 `SegmentsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -4389,6 +4751,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.snapchat_marketing.types.SegmentsEqCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.SegmentsNeqCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.SegmentsGtCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.SegmentsGteCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.SegmentsLtCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.SegmentsLteCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.SegmentsInCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.SegmentsLikeCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.SegmentsFuzzyCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.SegmentsKeywordCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.SegmentsContainsCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.SegmentsNotCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.SegmentsAndCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.SegmentsOrCondition | airbyte_agent_sdk.connectors.snapchat_marketing.types.SegmentsAnyCondition]`
     :   The type of the None singleton.
+
+<a id="SegmentsSearchFilter"></a>
 
 `SegmentsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering segments search queries.
@@ -4441,6 +4805,8 @@ Classes
     `visible_to: list[typing.Any] | None`
     :   Visibility settings
 
+<a id="SegmentsSearchQuery"></a>
+
 `SegmentsSearchQuery(*args, **kwargs)`
 :   Search query for segments entity.
 
@@ -4455,6 +4821,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.snapchat_marketing.types.SegmentsSortFilter]`
     :   The type of the None singleton.
+
+<a id="SegmentsSortFilter"></a>
 
 `SegmentsSortFilter(*args, **kwargs)`
 :   Available fields for sorting segments search results.
@@ -4506,6 +4874,8 @@ Classes
 
     `visible_to: Literal['asc', 'desc']`
     :   Visibility settings
+
+<a id="SegmentsStringFilter"></a>
 
 `SegmentsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/stripe/connector.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/stripe/connector.md
@@ -10,6 +10,8 @@ Stripe connector.
 Classes
 -------
 
+<a id="BalanceQuery"></a>
+
 `BalanceQuery(connector: StripeConnector)`
 :   Query class for Balance entity operations.
     
@@ -22,6 +24,8 @@ Classes
         
         Returns:
             Balance
+
+<a id="BalanceTransactionsQuery"></a>
 
 `BalanceTransactionsQuery(connector: StripeConnector)`
 :   Query class for BalanceTransactions entity operations.
@@ -56,6 +60,8 @@ Classes
         
         Returns:
             BalanceTransactionsListResult
+
+<a id="ChargesQuery"></a>
 
 `ChargesQuery(connector: StripeConnector)`
 :   Query class for Charges entity operations.
@@ -173,6 +179,8 @@ Classes
         
         Returns:
             ChargesListResult
+
+<a id="CustomersQuery"></a>
 
 `CustomersQuery(connector: StripeConnector)`
 :   Query class for Customers entity operations.
@@ -296,6 +304,8 @@ Classes
         Returns:
             Customer
 
+<a id="DisputesQuery"></a>
+
 `DisputesQuery(connector: StripeConnector)`
 :   Query class for Disputes entity operations.
     
@@ -327,6 +337,8 @@ Classes
         
         Returns:
             DisputesListResult
+
+<a id="InvoicesQuery"></a>
 
 `InvoicesQuery(connector: StripeConnector)`
 :   Query class for Invoices entity operations.
@@ -487,6 +499,8 @@ Classes
         Returns:
             InvoicesListResult
 
+<a id="PaymentIntentsQuery"></a>
+
 `PaymentIntentsQuery(connector: StripeConnector)`
 :   Query class for PaymentIntents entity operations.
     
@@ -531,6 +545,8 @@ Classes
         Returns:
             PaymentIntentsListResult
 
+<a id="PayoutsQuery"></a>
+
 `PayoutsQuery(connector: StripeConnector)`
 :   Query class for Payouts entity operations.
     
@@ -563,6 +579,8 @@ Classes
         
         Returns:
             PayoutsListResult
+
+<a id="ProductsQuery"></a>
 
 `ProductsQuery(connector: StripeConnector)`
 :   Query class for Products entity operations.
@@ -635,6 +653,8 @@ Classes
         
         Returns:
             Product
+
+<a id="RefundsQuery"></a>
 
 `RefundsQuery(connector: StripeConnector)`
 :   Query class for Refunds entity operations.
@@ -711,6 +731,8 @@ Classes
         
         Returns:
             RefundsListResult
+
+<a id="StripeConnector"></a>
 
 `StripeConnector(auth_config: StripeAuthConfig | AirbyteAuthConfig | BaseModel | None = None, on_token_refresh: Any | None = None)`
 :   Type-safe Stripe API connector.
@@ -911,6 +933,8 @@ Classes
             entities = connector.list_entities()
             for entity in entities:
                 print(f"\{entity['entity_name']\}: \{entity['available_actions']\}")
+
+<a id="SubscriptionsQuery"></a>
 
 `SubscriptionsQuery(connector: StripeConnector)`
 :   Query class for Subscriptions entity operations.

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/stripe/index.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/stripe/index.md
@@ -19,6 +19,8 @@ Sub-modules
 Classes
 -------
 
+<a id="AirbyteAuthConfig"></a>
+
 `AirbyteAuthConfig(**data: Any)`
 :   Authentication configuration for Airbyte hosted mode execution.
     
@@ -87,6 +89,8 @@ Classes
     `workspace_name: str | None`
     :   The type of the None singleton.
 
+<a id="AirbyteSearchMeta"></a>
+
 `AirbyteSearchMeta(**data: Any)`
 :   Pagination metadata for search responses.
     
@@ -114,6 +118,8 @@ Classes
 
     `took_ms: int | None`
     :   Time taken to execute the search in milliseconds.
+
+<a id="AirbyteSearchResult"></a>
 
 `AirbyteSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -149,6 +155,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="ChargesSearchResult"></a>
+
 `ChargesSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -164,6 +172,8 @@ Classes
     * airbyte_agent_sdk.connectors.stripe.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="CustomersSearchResult"></a>
 
 `CustomersSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -181,6 +191,8 @@ Classes
     * pydantic.main.BaseModel
     * typing.Generic
 
+<a id="InvoicesSearchResult"></a>
+
 `InvoicesSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -196,6 +208,8 @@ Classes
     * airbyte_agent_sdk.connectors.stripe.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="RefundsSearchResult"></a>
 
 `RefundsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -213,6 +227,8 @@ Classes
     * pydantic.main.BaseModel
     * typing.Generic
 
+<a id="SubscriptionsSearchResult"></a>
+
 `SubscriptionsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -228,6 +244,8 @@ Classes
     * airbyte_agent_sdk.connectors.stripe.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="ChargesSearchData"></a>
 
 `ChargesSearchData(**data: Any)`
 :   Search result data for charges entity.
@@ -401,6 +419,8 @@ Classes
     `updated: int | None`
     :   Timestamp of the last update to this charge object.
 
+<a id="CustomersSearchData"></a>
+
 `CustomersSearchData(**data: Any)`
 :   Search result data for customers entity.
     
@@ -512,6 +532,8 @@ Classes
 
     `updated: int | None`
     :   Timestamp indicating when the customer object was last updated.
+
+<a id="InvoicesSearchData"></a>
 
 `InvoicesSearchData(**data: Any)`
 :   Search result data for invoices entity.
@@ -802,6 +824,8 @@ Classes
     `webhooks_delivered_at: float | None`
     :   Timestamp indicating when webhooks for this invoice were successfully delivered.
 
+<a id="RefundsSearchData"></a>
+
 `RefundsSearchData(**data: Any)`
 :   Search result data for refunds entity.
     
@@ -869,6 +893,8 @@ Classes
     `updated: int | None`
     :   Timestamp indicating when the refund was last updated.
 
+<a id="StripeAuthConfig"></a>
+
 `StripeAuthConfig(**data: Any)`
 :   API Key Authentication
     
@@ -890,6 +916,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="StripeConnector"></a>
 
 `StripeConnector(auth_config: StripeAuthConfig | AirbyteAuthConfig | BaseModel | None = None, on_token_refresh: Any | None = None)`
 :   Type-safe Stripe API connector.
@@ -1091,6 +1119,8 @@ Classes
             for entity in entities:
                 print(f"\{entity['entity_name']\}: \{entity['available_actions']\}")
 
+<a id="StripeReplicationConfig"></a>
+
 `StripeReplicationConfig(**data: Any)`
 :   Replication Configuration - Settings for data replication from Stripe.
     
@@ -1112,6 +1142,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="SubscriptionsSearchData"></a>
 
 `SubscriptionsSearchData(**data: Any)`
 :   Search result data for subscriptions entity.

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/stripe/models.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/stripe/models.md
@@ -13,6 +13,8 @@ and response envelope types.
 Classes
 -------
 
+<a id="AirbyteSearchMeta"></a>
+
 `AirbyteSearchMeta(**data: Any)`
 :   Pagination metadata for search responses.
     
@@ -40,6 +42,8 @@ Classes
 
     `took_ms: int | None`
     :   Time taken to execute the search in milliseconds.
+
+<a id="AirbyteSearchResult"></a>
 
 `AirbyteSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -96,6 +100,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="ChargesSearchResult"></a>
+
 `ChargesSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -132,6 +138,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="CustomersSearchResult"></a>
 
 `CustomersSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -170,6 +178,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="InvoicesSearchResult"></a>
+
 `InvoicesSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -206,6 +216,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="RefundsSearchResult"></a>
 
 `RefundsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -244,6 +256,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="SubscriptionsSearchResult"></a>
+
 `SubscriptionsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -259,6 +273,8 @@ Classes
     * airbyte_agent_sdk.connectors.stripe.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="Balance"></a>
 
 `Balance(**data: Any)`
 :   Balance type definition
@@ -303,6 +319,8 @@ Classes
     `refund_and_dispute_prefunding: airbyte_agent_sdk.connectors.stripe.models.BalanceRefundAndDisputePrefunding | Any | None`
     :   The type of the None singleton.
 
+<a id="BalanceAvailableItem"></a>
+
 `BalanceAvailableItem(**data: Any)`
 :   Nested schema for Balance.available_item
     
@@ -330,6 +348,8 @@ Classes
 
     `source_types: airbyte_agent_sdk.connectors.stripe.models.BalanceAvailableItemSourceTypes | Any | None`
     :   Breakdown of balance by source types
+
+<a id="BalanceAvailableItemSourceTypes"></a>
 
 `BalanceAvailableItemSourceTypes(**data: Any)`
 :   Breakdown of balance by source types
@@ -359,6 +379,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="BalanceConnectReservedItem"></a>
+
 `BalanceConnectReservedItem(**data: Any)`
 :   Nested schema for Balance.connect_reserved_item
     
@@ -387,6 +409,8 @@ Classes
     `source_types: airbyte_agent_sdk.connectors.stripe.models.BalanceConnectReservedItemSourceTypes | Any | None`
     :   Breakdown of balance by source types
 
+<a id="BalanceConnectReservedItemSourceTypes"></a>
+
 `BalanceConnectReservedItemSourceTypes(**data: Any)`
 :   Breakdown of balance by source types
     
@@ -414,6 +438,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="BalanceInstantAvailableItem"></a>
 
 `BalanceInstantAvailableItem(**data: Any)`
 :   Nested schema for Balance.instant_available_item
@@ -446,6 +472,8 @@ Classes
     `source_types: airbyte_agent_sdk.connectors.stripe.models.BalanceInstantAvailableItemSourceTypes | Any | None`
     :   Breakdown of balance by source types
 
+<a id="BalanceInstantAvailableItemNetAvailableItem"></a>
+
 `BalanceInstantAvailableItemNetAvailableItem(**data: Any)`
 :   Nested schema for BalanceInstantAvailableItem.net_available_item
     
@@ -473,6 +501,8 @@ Classes
 
     `source_types: airbyte_agent_sdk.connectors.stripe.models.BalanceInstantAvailableItemNetAvailableItemSourceTypes | Any | None`
     :   Breakdown of balance by source types
+
+<a id="BalanceInstantAvailableItemNetAvailableItemSourceTypes"></a>
 
 `BalanceInstantAvailableItemNetAvailableItemSourceTypes(**data: Any)`
 :   Breakdown of balance by source types
@@ -502,6 +532,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="BalanceInstantAvailableItemSourceTypes"></a>
+
 `BalanceInstantAvailableItemSourceTypes(**data: Any)`
 :   Breakdown of balance by source types
     
@@ -530,6 +562,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="BalanceIssuing"></a>
+
 `BalanceIssuing(**data: Any)`
 :   Funds that are available for use with Issuing cards
     
@@ -551,6 +585,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="BalanceIssuingAvailableItem"></a>
 
 `BalanceIssuingAvailableItem(**data: Any)`
 :   Nested schema for BalanceIssuing.available_item
@@ -580,6 +616,8 @@ Classes
     `source_types: airbyte_agent_sdk.connectors.stripe.models.BalanceIssuingAvailableItemSourceTypes | Any | None`
     :   Breakdown of balance by source types
 
+<a id="BalanceIssuingAvailableItemSourceTypes"></a>
+
 `BalanceIssuingAvailableItemSourceTypes(**data: Any)`
 :   Breakdown of balance by source types
     
@@ -607,6 +645,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="BalancePendingItem"></a>
 
 `BalancePendingItem(**data: Any)`
 :   Nested schema for Balance.pending_item
@@ -636,6 +676,8 @@ Classes
     `source_types: airbyte_agent_sdk.connectors.stripe.models.BalancePendingItemSourceTypes | Any | None`
     :   Breakdown of balance by source types
 
+<a id="BalancePendingItemSourceTypes"></a>
+
 `BalancePendingItemSourceTypes(**data: Any)`
 :   Breakdown of balance by source types
     
@@ -664,6 +706,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="BalanceRefundAndDisputePrefunding"></a>
+
 `BalanceRefundAndDisputePrefunding(**data: Any)`
 :   Funds reserved for covering future refunds or disputes
     
@@ -688,6 +732,8 @@ Classes
 
     `pending: list[airbyte_agent_sdk.connectors.stripe.models.BalanceRefundAndDisputePrefundingPendingItem] | Any`
     :   Pending funds for refunds and disputes
+
+<a id="BalanceRefundAndDisputePrefundingAvailableItem"></a>
 
 `BalanceRefundAndDisputePrefundingAvailableItem(**data: Any)`
 :   Nested schema for BalanceRefundAndDisputePrefunding.available_item
@@ -717,6 +763,8 @@ Classes
     `source_types: airbyte_agent_sdk.connectors.stripe.models.BalanceRefundAndDisputePrefundingAvailableItemSourceTypes | Any | None`
     :   Breakdown of balance by source types
 
+<a id="BalanceRefundAndDisputePrefundingAvailableItemSourceTypes"></a>
+
 `BalanceRefundAndDisputePrefundingAvailableItemSourceTypes(**data: Any)`
 :   Breakdown of balance by source types
     
@@ -744,6 +792,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="BalanceRefundAndDisputePrefundingPendingItem"></a>
 
 `BalanceRefundAndDisputePrefundingPendingItem(**data: Any)`
 :   Nested schema for BalanceRefundAndDisputePrefunding.pending_item
@@ -773,6 +823,8 @@ Classes
     `source_types: airbyte_agent_sdk.connectors.stripe.models.BalanceRefundAndDisputePrefundingPendingItemSourceTypes | Any | None`
     :   Breakdown of balance by source types
 
+<a id="BalanceRefundAndDisputePrefundingPendingItemSourceTypes"></a>
+
 `BalanceRefundAndDisputePrefundingPendingItemSourceTypes(**data: Any)`
 :   Breakdown of balance by source types
     
@@ -800,6 +852,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="BalanceTransaction"></a>
 
 `BalanceTransaction(**data: Any)`
 :   BalanceTransaction type definition
@@ -868,6 +922,8 @@ Classes
     `type_: str | Any`
     :   The type of the None singleton.
 
+<a id="BalanceTransactionFeeDetailsItem"></a>
+
 `BalanceTransactionFeeDetailsItem(**data: Any)`
 :   Nested schema for BalanceTransaction.fee_details_item
     
@@ -902,6 +958,8 @@ Classes
     `type_: str | Any`
     :   Type of the fee
 
+<a id="BalanceTransactionList"></a>
+
 `BalanceTransactionList(**data: Any)`
 :   BalanceTransactionList type definition
     
@@ -933,6 +991,8 @@ Classes
     `url: str | Any`
     :   The type of the None singleton.
 
+<a id="BalanceTransactionsListResultMeta"></a>
+
 `BalanceTransactionsListResultMeta(**data: Any)`
 :   Metadata for balance_transactions.Action.LIST operation
     
@@ -954,6 +1014,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="Charge"></a>
 
 `Charge(**data: Any)`
 :   Charge type definition
@@ -1124,6 +1186,8 @@ Classes
     `transfer_group: str | Any | None`
     :   The type of the None singleton.
 
+<a id="ChargeBillingDetails"></a>
+
 `ChargeBillingDetails(**data: Any)`
 :   Billing information associated with the payment method
     
@@ -1157,6 +1221,8 @@ Classes
 
     `tax_id: str | Any | None`
     :   The type of the None singleton.
+
+<a id="ChargeBillingDetailsAddress"></a>
 
 `ChargeBillingDetailsAddress(**data: Any)`
 :   Nested schema for ChargeBillingDetails.address
@@ -1195,6 +1261,8 @@ Classes
     `state: str | Any | None`
     :   The type of the None singleton.
 
+<a id="ChargeFraudDetails"></a>
+
 `ChargeFraudDetails(**data: Any)`
 :   Information on fraud assessments for the charge
     
@@ -1219,6 +1287,8 @@ Classes
 
     `user_report: str | Any | None`
     :   Assessments from you or your users. Possible values are `fraudulent` and `safe`
+
+<a id="ChargeList"></a>
 
 `ChargeList(**data: Any)`
 :   ChargeList type definition
@@ -1250,6 +1320,8 @@ Classes
 
     `url: str | Any`
     :   The type of the None singleton.
+
+<a id="ChargeOutcome"></a>
 
 `ChargeOutcome(**data: Any)`
 :   Details about whether the payment was accepted, and why
@@ -1297,6 +1369,8 @@ Classes
     `type_: str | Any`
     :   The type of the None singleton.
 
+<a id="ChargePaymentMethodDetails"></a>
+
 `ChargePaymentMethodDetails(**data: Any)`
 :   Details about the payment method at the time of the transaction
     
@@ -1321,6 +1395,8 @@ Classes
 
     `type_: str | Any`
     :   The type of the None singleton.
+
+<a id="ChargePaymentMethodDetailsCard"></a>
 
 `ChargePaymentMethodDetailsCard(**data: Any)`
 :   Nested schema for ChargePaymentMethodDetails.card
@@ -1407,6 +1483,8 @@ Classes
     `wallet: dict[str, typing.Any] | Any | None`
     :   Digital wallet details if used
 
+<a id="ChargePaymentMethodDetailsCardChecks"></a>
+
 `ChargePaymentMethodDetailsCardChecks(**data: Any)`
 :   Check results by Card networks on Card address and CVC
     
@@ -1435,6 +1513,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="ChargePaymentMethodDetailsCardExtendedAuthorization"></a>
+
 `ChargePaymentMethodDetailsCardExtendedAuthorization(**data: Any)`
 :   Extended authorization details
     
@@ -1456,6 +1536,8 @@ Classes
 
     `status: str | Any`
     :   The type of the None singleton.
+
+<a id="ChargePaymentMethodDetailsCardIncrementalAuthorization"></a>
 
 `ChargePaymentMethodDetailsCardIncrementalAuthorization(**data: Any)`
 :   Incremental authorization details
@@ -1479,6 +1561,8 @@ Classes
     `status: str | Any`
     :   The type of the None singleton.
 
+<a id="ChargePaymentMethodDetailsCardMulticapture"></a>
+
 `ChargePaymentMethodDetailsCardMulticapture(**data: Any)`
 :   Multicapture details
     
@@ -1501,6 +1585,8 @@ Classes
     `status: str | Any`
     :   The type of the None singleton.
 
+<a id="ChargePaymentMethodDetailsCardNetworkToken"></a>
+
 `ChargePaymentMethodDetailsCardNetworkToken(**data: Any)`
 :   Network token details
     
@@ -1522,6 +1608,8 @@ Classes
 
     `used: bool | Any`
     :   The type of the None singleton.
+
+<a id="ChargePaymentMethodDetailsCardOvercapture"></a>
 
 `ChargePaymentMethodDetailsCardOvercapture(**data: Any)`
 :   Overcapture details
@@ -1547,6 +1635,8 @@ Classes
 
     `status: str | Any`
     :   The type of the None singleton.
+
+<a id="ChargePresentmentDetails"></a>
 
 `ChargePresentmentDetails(**data: Any)`
 :   Currency presentation information for multi-currency charges
@@ -1575,6 +1665,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="ChargeRefunds"></a>
 
 `ChargeRefunds(**data: Any)`
 :   A list of refunds that have been applied to the charge
@@ -1610,6 +1702,8 @@ Classes
     `url: str | Any`
     :   URL to access the refunds list
 
+<a id="ChargeSearchResult"></a>
+
 `ChargeSearchResult(**data: Any)`
 :   ChargeSearchResult type definition
     
@@ -1644,6 +1738,8 @@ Classes
     `url: str | Any`
     :   The type of the None singleton.
 
+<a id="ChargesListResultMeta"></a>
+
 `ChargesListResultMeta(**data: Any)`
 :   Metadata for charges.Action.LIST operation
     
@@ -1665,6 +1761,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="ChargesSearchData"></a>
 
 `ChargesSearchData(**data: Any)`
 :   Search result data for charges entity.
@@ -1838,6 +1936,8 @@ Classes
     `updated: int | None`
     :   Timestamp of the last update to this charge object.
 
+<a id="Customer"></a>
+
 `Customer(**data: Any)`
 :   Customer type definition
     
@@ -1947,6 +2047,8 @@ Classes
     `test_clock: str | Any | None`
     :   The type of the None singleton.
 
+<a id="CustomerAddress"></a>
+
 `CustomerAddress(**data: Any)`
 :   The customer's address
     
@@ -1983,6 +2085,8 @@ Classes
 
     `state: str | Any | None`
     :   State, county, province, or region
+
+<a id="CustomerCashBalance"></a>
 
 `CustomerCashBalance(**data: Any)`
 :   The current funds being held by Stripe on behalf of the customer
@@ -2021,6 +2125,8 @@ Classes
     `settings: airbyte_agent_sdk.connectors.stripe.models.CustomerCashBalanceSettings | Any`
     :   A hash of settings for this cash balance
 
+<a id="CustomerCashBalanceSettings"></a>
+
 `CustomerCashBalanceSettings(**data: Any)`
 :   A hash of settings for this cash balance
     
@@ -2045,6 +2151,8 @@ Classes
 
     `using_merchant_default: bool | Any`
     :   A flag to indicate if reconciliation mode returned is the user's default or is specific to this customer cash balance
+
+<a id="CustomerCreateParams"></a>
 
 `CustomerCreateParams(**data: Any)`
 :   CustomerCreateParams type definition
@@ -2083,6 +2191,8 @@ Classes
     `phone: str | Any`
     :   The type of the None singleton.
 
+<a id="CustomerCreateParamsAddress"></a>
+
 `CustomerCreateParamsAddress(**data: Any)`
 :   The customer's address
     
@@ -2120,6 +2230,8 @@ Classes
     `state: str | Any`
     :   State, county, province, or region
 
+<a id="CustomerDeletedResponse"></a>
+
 `CustomerDeletedResponse(**data: Any)`
 :   CustomerDeletedResponse type definition
     
@@ -2147,6 +2259,8 @@ Classes
 
     `object_: str | Any`
     :   The type of the None singleton.
+
+<a id="CustomerDiscount"></a>
 
 `CustomerDiscount(**data: Any)`
 :   Describes the current discount active on the customer, if there is one
@@ -2206,6 +2320,8 @@ Classes
     `subscription_item: str | Any | None`
     :   The subscription item that this coupon is applied to
 
+<a id="CustomerDiscountSource"></a>
+
 `CustomerDiscountSource(**data: Any)`
 :   The source of the discount
     
@@ -2230,6 +2346,8 @@ Classes
 
     `type_: str | Any`
     :   The source type of the discount
+
+<a id="CustomerInvoiceSettings"></a>
 
 `CustomerInvoiceSettings(**data: Any)`
 :   The customer's default invoice settings
@@ -2262,6 +2380,8 @@ Classes
     `rendering_options: airbyte_agent_sdk.connectors.stripe.models.CustomerInvoiceSettingsRenderingOptions | Any | None`
     :   Default options for invoice PDF rendering for this customer
 
+<a id="CustomerInvoiceSettingsCustomFieldsItem"></a>
+
 `CustomerInvoiceSettingsCustomFieldsItem(**data: Any)`
 :   Nested schema for CustomerInvoiceSettings.custom_fields_item
     
@@ -2287,6 +2407,8 @@ Classes
     `value: str | Any`
     :   The value of the custom field
 
+<a id="CustomerInvoiceSettingsRenderingOptions"></a>
+
 `CustomerInvoiceSettingsRenderingOptions(**data: Any)`
 :   Default options for invoice PDF rendering for this customer
     
@@ -2311,6 +2433,8 @@ Classes
 
     `template: str | Any | None`
     :   ID of the invoice rendering template to be used for this customer's invoices
+
+<a id="CustomerList"></a>
 
 `CustomerList(**data: Any)`
 :   CustomerList type definition
@@ -2342,6 +2466,8 @@ Classes
 
     `url: str | Any`
     :   The type of the None singleton.
+
+<a id="CustomerSearchResult"></a>
 
 `CustomerSearchResult(**data: Any)`
 :   CustomerSearchResult type definition
@@ -2377,6 +2503,8 @@ Classes
     `url: str | Any`
     :   The type of the None singleton.
 
+<a id="CustomerShipping"></a>
+
 `CustomerShipping(**data: Any)`
 :   Mailing and shipping address for the customer
     
@@ -2404,6 +2532,8 @@ Classes
 
     `phone: str | Any | None`
     :   Customer phone (including extension)
+
+<a id="CustomerShippingAddress"></a>
 
 `CustomerShippingAddress(**data: Any)`
 :   Customer shipping address
@@ -2442,6 +2572,8 @@ Classes
     `state: str | Any | None`
     :   State, county, province, or region
 
+<a id="CustomerSources"></a>
+
 `CustomerSources(**data: Any)`
 :   The customer's payment sources, if any
     
@@ -2472,6 +2604,8 @@ Classes
 
     `url: str | Any`
     :   The URL where this list can be accessed
+
+<a id="CustomerSourcesDataItem"></a>
 
 `CustomerSourcesDataItem(**data: Any)`
 :   Nested schema for CustomerSources.data_item
@@ -2540,6 +2674,8 @@ Classes
     `status: str | Any`
     :   The status of the bank account
 
+<a id="CustomerSubscriptions"></a>
+
 `CustomerSubscriptions(**data: Any)`
 :   The customer's current subscriptions, if any
     
@@ -2570,6 +2706,8 @@ Classes
 
     `url: str | Any`
     :   The URL where this list can be accessed
+
+<a id="CustomerUpdateParams"></a>
 
 `CustomerUpdateParams(**data: Any)`
 :   CustomerUpdateParams type definition
@@ -2608,6 +2746,8 @@ Classes
     `phone: str | Any`
     :   The type of the None singleton.
 
+<a id="CustomerUpdateParamsAddress"></a>
+
 `CustomerUpdateParamsAddress(**data: Any)`
 :   The customer's address
     
@@ -2645,6 +2785,8 @@ Classes
     `state: str | Any`
     :   State, county, province, or region
 
+<a id="CustomersApiSearchResultMeta"></a>
+
 `CustomersApiSearchResultMeta(**data: Any)`
 :   Metadata for customers.Action.API_SEARCH operation
     
@@ -2667,6 +2809,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="CustomersListResultMeta"></a>
+
 `CustomersListResultMeta(**data: Any)`
 :   Metadata for customers.Action.LIST operation
     
@@ -2688,6 +2832,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="CustomersSearchData"></a>
 
 `CustomersSearchData(**data: Any)`
 :   Search result data for customers entity.
@@ -2801,6 +2947,8 @@ Classes
     `updated: int | None`
     :   Timestamp indicating when the customer object was last updated.
 
+<a id="Dispute"></a>
+
 `Dispute(**data: Any)`
 :   Dispute type definition
     
@@ -2871,6 +3019,8 @@ Classes
     `status: str | Any`
     :   The type of the None singleton.
 
+<a id="DisputeEvidenceDetails"></a>
+
 `DisputeEvidenceDetails(**data: Any)`
 :   Information about the evidence submission
     
@@ -2901,6 +3051,8 @@ Classes
 
     `submission_count: int | Any`
     :   The number of times evidence has been submitted
+
+<a id="DisputeList"></a>
 
 `DisputeList(**data: Any)`
 :   DisputeList type definition
@@ -2933,6 +3085,8 @@ Classes
     `url: str | Any`
     :   The type of the None singleton.
 
+<a id="DisputesListResultMeta"></a>
+
 `DisputesListResultMeta(**data: Any)`
 :   Metadata for disputes.Action.LIST operation
     
@@ -2954,6 +3108,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="Invoice"></a>
 
 `Invoice(**data: Any)`
 :   Invoice type definition
@@ -3244,6 +3400,8 @@ Classes
     `webhooks_delivered_at: int | Any | None`
     :   The type of the None singleton.
 
+<a id="InvoiceAutomaticTax"></a>
+
 `InvoiceAutomaticTax(**data: Any)`
 :   Settings and latest results for automatic tax lookup for this invoice
     
@@ -3278,6 +3436,8 @@ Classes
     `status: str | Any | None`
     :   The status of the most recent automated tax calculation for this invoice
 
+<a id="InvoiceAutomaticTaxLiability"></a>
+
 `InvoiceAutomaticTaxLiability(**data: Any)`
 :   The account that's liable for tax
     
@@ -3302,6 +3462,8 @@ Classes
 
     `type_: str | Any`
     :   Type of the account referenced
+
+<a id="InvoiceConfirmationSecret"></a>
 
 `InvoiceConfirmationSecret(**data: Any)`
 :   The confirmation secret associated with this invoice
@@ -3328,6 +3490,8 @@ Classes
     `type_: str | Any`
     :   The type of client_secret
 
+<a id="InvoiceCustomFieldsItem"></a>
+
 `InvoiceCustomFieldsItem(**data: Any)`
 :   Nested schema for Invoice.custom_fields_item
     
@@ -3352,6 +3516,8 @@ Classes
 
     `value: str | Any`
     :   The value of the custom field
+
+<a id="InvoiceCustomerAddress"></a>
 
 `InvoiceCustomerAddress(**data: Any)`
 :   The customer's address
@@ -3390,6 +3556,8 @@ Classes
     `state: str | Any | None`
     :   State, county, province, or region
 
+<a id="InvoiceCustomerShipping"></a>
+
 `InvoiceCustomerShipping(**data: Any)`
 :   The customer's shipping information
     
@@ -3417,6 +3585,8 @@ Classes
 
     `phone: str | Any | None`
     :   Customer phone (including extension)
+
+<a id="InvoiceCustomerShippingAddress"></a>
 
 `InvoiceCustomerShippingAddress(**data: Any)`
 :   Customer shipping address
@@ -3455,6 +3625,8 @@ Classes
     `state: str | Any | None`
     :   State, county, province, or region
 
+<a id="InvoiceCustomerTaxIdsItem"></a>
+
 `InvoiceCustomerTaxIdsItem(**data: Any)`
 :   Nested schema for Invoice.customer_tax_ids_item
     
@@ -3479,6 +3651,8 @@ Classes
 
     `value: str | Any | None`
     :   The value of the tax ID
+
+<a id="InvoiceDefaultTaxRatesItem"></a>
 
 `InvoiceDefaultTaxRatesItem(**data: Any)`
 :   Nested schema for Invoice.default_tax_rates_item
@@ -3553,6 +3727,8 @@ Classes
     `tax_type: str | Any | None`
     :   The high-level tax type
 
+<a id="InvoiceDefaultTaxRatesItemFlatAmount"></a>
+
 `InvoiceDefaultTaxRatesItemFlatAmount(**data: Any)`
 :   The amount of the tax rate when the rate_type is flat_amount
     
@@ -3577,6 +3753,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="InvoiceDiscount"></a>
 
 `InvoiceDiscount(**data: Any)`
 :   The discount applied to the invoice
@@ -3635,6 +3813,8 @@ Classes
 
     `subscription_item: str | Any | None`
     :   The type of the None singleton.
+
+<a id="InvoiceDiscountCoupon"></a>
 
 `InvoiceDiscountCoupon(**data: Any)`
 :   Nested schema for InvoiceDiscount.coupon
@@ -3700,6 +3880,8 @@ Classes
     `valid: bool | Any`
     :   The type of the None singleton.
 
+<a id="InvoiceFromInvoice"></a>
+
 `InvoiceFromInvoice(**data: Any)`
 :   Details of the invoice that was cloned
     
@@ -3725,6 +3907,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="InvoiceIssuer"></a>
+
 `InvoiceIssuer(**data: Any)`
 :   The connected account that issues the invoice
     
@@ -3749,6 +3933,8 @@ Classes
 
     `type_: str | Any`
     :   Type of the account referenced
+
+<a id="InvoiceLastFinalizationError"></a>
 
 `InvoiceLastFinalizationError(**data: Any)`
 :   The error encountered during the last finalization attempt
@@ -3796,6 +3982,8 @@ Classes
     `type_: str | Any`
     :   The type of error returned
 
+<a id="InvoiceLines"></a>
+
 `InvoiceLines(**data: Any)`
 :   The individual line items that make up the invoice
     
@@ -3829,6 +4017,8 @@ Classes
 
     `url: str | Any | None`
     :   The type of the None singleton.
+
+<a id="InvoiceLinesDataItem"></a>
 
 `InvoiceLinesDataItem(**data: Any)`
 :   Nested schema for InvoiceLines.data_item
@@ -3891,6 +4081,8 @@ Classes
     `quantity: int | Any | None`
     :   The quantity of the subscription
 
+<a id="InvoiceLinesDataItemDiscountAmountsItem"></a>
+
 `InvoiceLinesDataItemDiscountAmountsItem(**data: Any)`
 :   Nested schema for InvoiceLinesDataItem.discount_amounts_item
     
@@ -3916,6 +4108,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="InvoiceLinesDataItemPeriod"></a>
+
 `InvoiceLinesDataItemPeriod(**data: Any)`
 :   The period this line_item covers
     
@@ -3940,6 +4134,8 @@ Classes
 
     `start: int | Any`
     :   The start of the period
+
+<a id="InvoiceList"></a>
 
 `InvoiceList(**data: Any)`
 :   InvoiceList type definition
@@ -3972,6 +4168,8 @@ Classes
     `url: str | Any`
     :   The type of the None singleton.
 
+<a id="InvoiceParent"></a>
+
 `InvoiceParent(**data: Any)`
 :   The parent that generated this invoice
     
@@ -4000,6 +4198,8 @@ Classes
     `type_: str | Any`
     :   The type of parent that generated this invoice
 
+<a id="InvoiceParentQuoteDetails"></a>
+
 `InvoiceParentQuoteDetails(**data: Any)`
 :   Details about the quote that generated this invoice
     
@@ -4021,6 +4221,8 @@ Classes
 
     `quote: str | Any`
     :   The quote that generated this invoice
+
+<a id="InvoiceParentSubscriptionDetails"></a>
 
 `InvoiceParentSubscriptionDetails(**data: Any)`
 :   Details about the subscription that generated this invoice
@@ -4050,6 +4252,8 @@ Classes
     `subscription_proration_date: int | Any | None`
     :   Only set for upcoming invoices that preview prorations
 
+<a id="InvoicePaymentSettings"></a>
+
 `InvoicePaymentSettings(**data: Any)`
 :   Configuration settings for the PaymentIntent that is generated when the invoice is finalized
     
@@ -4077,6 +4281,8 @@ Classes
 
     `payment_method_types: list[str] | Any | None`
     :   The list of payment method types to provide to the invoice's PaymentIntent
+
+<a id="InvoicePayments"></a>
 
 `InvoicePayments(**data: Any)`
 :   Payments for this invoice
@@ -4108,6 +4314,8 @@ Classes
 
     `url: str | Any`
     :   The URL where this list can be accessed
+
+<a id="InvoicePaymentsDataItem"></a>
 
 `InvoicePaymentsDataItem(**data: Any)`
 :   Nested schema for InvoicePayments.data_item
@@ -4158,6 +4366,8 @@ Classes
     `status: str | Any`
     :   The status of the payment
 
+<a id="InvoiceRendering"></a>
+
 `InvoiceRendering(**data: Any)`
 :   The rendering-related settings that control how the invoice is displayed
     
@@ -4189,6 +4399,8 @@ Classes
     `template_version: int | Any | None`
     :   Version of the rendering template that the invoice is using
 
+<a id="InvoiceRenderingPdf"></a>
+
 `InvoiceRenderingPdf(**data: Any)`
 :   Invoice pdf rendering options
     
@@ -4210,6 +4422,8 @@ Classes
 
     `page_size: str | Any | None`
     :   Page size of invoice pdf
+
+<a id="InvoiceSearchResult"></a>
 
 `InvoiceSearchResult(**data: Any)`
 :   InvoiceSearchResult type definition
@@ -4245,6 +4459,8 @@ Classes
     `url: str | Any`
     :   The type of the None singleton.
 
+<a id="InvoiceShippingCost"></a>
+
 `InvoiceShippingCost(**data: Any)`
 :   The details of the cost of shipping
     
@@ -4279,6 +4495,8 @@ Classes
     `taxes: list[airbyte_agent_sdk.connectors.stripe.models.InvoiceShippingCostTaxesItem] | Any | None`
     :   The taxes applied to the shipping rate
 
+<a id="InvoiceShippingCostTaxesItem"></a>
+
 `InvoiceShippingCostTaxesItem(**data: Any)`
 :   Nested schema for InvoiceShippingCost.taxes_item
     
@@ -4307,6 +4525,8 @@ Classes
     `taxable_amount: int | Any | None`
     :   The amount on which tax is calculated
 
+<a id="InvoiceShippingDetails"></a>
+
 `InvoiceShippingDetails(**data: Any)`
 :   Shipping details for the invoice
     
@@ -4334,6 +4554,8 @@ Classes
 
     `phone: str | Any | None`
     :   Recipient phone
+
+<a id="InvoiceShippingDetailsAddress"></a>
 
 `InvoiceShippingDetailsAddress(**data: Any)`
 :   Shipping address
@@ -4372,6 +4594,8 @@ Classes
     `state: str | Any | None`
     :   State, county, province, or region
 
+<a id="InvoiceStatusTransitions"></a>
+
 `InvoiceStatusTransitions(**data: Any)`
 :   Status transition timestamps
     
@@ -4403,6 +4627,8 @@ Classes
     `voided_at: int | Any | None`
     :   The time that the invoice was voided
 
+<a id="InvoiceSubscriptionDetails"></a>
+
 `InvoiceSubscriptionDetails(**data: Any)`
 :   Details about the subscription that this invoice was prepared for, if any
     
@@ -4424,6 +4650,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="InvoiceThresholdReason"></a>
 
 `InvoiceThresholdReason(**data: Any)`
 :   If billing_reason is set to subscription_threshold this returns more information
@@ -4450,6 +4678,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="InvoiceThresholdReasonItemReasonsItem"></a>
+
 `InvoiceThresholdReasonItemReasonsItem(**data: Any)`
 :   Nested schema for InvoiceThresholdReason.item_reasons_item
     
@@ -4475,6 +4705,8 @@ Classes
     `usage_gte: int | Any`
     :   The quantity threshold boundary that applied to the given line item
 
+<a id="InvoiceTotalDiscountAmountsItem"></a>
+
 `InvoiceTotalDiscountAmountsItem(**data: Any)`
 :   Nested schema for Invoice.total_discount_amounts_item
     
@@ -4499,6 +4731,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="InvoiceTotalPretaxCreditAmountsItem"></a>
 
 `InvoiceTotalPretaxCreditAmountsItem(**data: Any)`
 :   Nested schema for Invoice.total_pretax_credit_amounts_item
@@ -4530,6 +4764,8 @@ Classes
 
     `type_: str | Any`
     :   Type of the pretax credit amount referenced
+
+<a id="InvoiceTotalTaxAmountsItem"></a>
 
 `InvoiceTotalTaxAmountsItem(**data: Any)`
 :   Nested schema for Invoice.total_tax_amounts_item
@@ -4564,6 +4800,8 @@ Classes
 
     `taxable_amount: int | Any`
     :   The amount on which tax is calculated
+
+<a id="InvoiceTotalTaxesItem"></a>
 
 `InvoiceTotalTaxesItem(**data: Any)`
 :   Nested schema for Invoice.total_taxes_item
@@ -4602,6 +4840,8 @@ Classes
     `type_: str | Any`
     :   The type of tax information
 
+<a id="InvoicesListResultMeta"></a>
+
 `InvoicesListResultMeta(**data: Any)`
 :   Metadata for invoices.Action.LIST operation
     
@@ -4623,6 +4863,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="InvoicesSearchData"></a>
 
 `InvoicesSearchData(**data: Any)`
 :   Search result data for invoices entity.
@@ -4913,6 +5155,8 @@ Classes
     `webhooks_delivered_at: float | None`
     :   Timestamp indicating when webhooks for this invoice were successfully delivered.
 
+<a id="PaymentIntent"></a>
+
 `PaymentIntent(**data: Any)`
 :   PaymentIntent type definition
     
@@ -4989,6 +5233,8 @@ Classes
     `status: str | Any`
     :   The type of the None singleton.
 
+<a id="PaymentIntentList"></a>
+
 `PaymentIntentList(**data: Any)`
 :   PaymentIntentList type definition
     
@@ -5019,6 +5265,8 @@ Classes
 
     `url: str | Any`
     :   The type of the None singleton.
+
+<a id="PaymentIntentSearchResult"></a>
 
 `PaymentIntentSearchResult(**data: Any)`
 :   PaymentIntentSearchResult type definition
@@ -5054,6 +5302,8 @@ Classes
     `url: str | Any`
     :   The type of the None singleton.
 
+<a id="PaymentIntentsApiSearchResultMeta"></a>
+
 `PaymentIntentsApiSearchResultMeta(**data: Any)`
 :   Metadata for payment_intents.Action.API_SEARCH operation
     
@@ -5076,6 +5326,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="PaymentIntentsListResultMeta"></a>
+
 `PaymentIntentsListResultMeta(**data: Any)`
 :   Metadata for payment_intents.Action.LIST operation
     
@@ -5097,6 +5349,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="Payout"></a>
 
 `Payout(**data: Any)`
 :   Payout type definition
@@ -5201,6 +5455,8 @@ Classes
     `type_: str | Any`
     :   The type of the None singleton.
 
+<a id="PayoutList"></a>
+
 `PayoutList(**data: Any)`
 :   PayoutList type definition
     
@@ -5232,6 +5488,8 @@ Classes
     `url: str | Any`
     :   The type of the None singleton.
 
+<a id="PayoutTraceId"></a>
+
 `PayoutTraceId(**data: Any)`
 :   A string that identifies this payout as part of a group
     
@@ -5257,6 +5515,8 @@ Classes
     `value: str | Any | None`
     :   The trace ID value
 
+<a id="PayoutsListResultMeta"></a>
+
 `PayoutsListResultMeta(**data: Any)`
 :   Metadata for payouts.Action.LIST operation
     
@@ -5278,6 +5538,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="Product"></a>
 
 `Product(**data: Any)`
 :   Product type definition
@@ -5361,6 +5623,8 @@ Classes
     `url: str | Any | None`
     :   The type of the None singleton.
 
+<a id="ProductCreateParams"></a>
+
 `ProductCreateParams(**data: Any)`
 :   ProductCreateParams type definition
     
@@ -5419,6 +5683,8 @@ Classes
     `url: str | Any`
     :   The type of the None singleton.
 
+<a id="ProductCreateParamsMarketingFeaturesItem"></a>
+
 `ProductCreateParamsMarketingFeaturesItem(**data: Any)`
 :   Nested schema for ProductCreateParams.marketing_features_item
     
@@ -5440,6 +5706,8 @@ Classes
 
     `name: str | Any`
     :   The marketing feature name. Up to 80 characters long
+
+<a id="ProductCreateParamsPackageDimensions"></a>
 
 `ProductCreateParamsPackageDimensions(**data: Any)`
 :   The dimensions of this product for shipping purposes
@@ -5472,6 +5740,8 @@ Classes
     `width: float | Any`
     :   Width, in inches
 
+<a id="ProductDeletedResponse"></a>
+
 `ProductDeletedResponse(**data: Any)`
 :   ProductDeletedResponse type definition
     
@@ -5500,6 +5770,8 @@ Classes
     `object_: str | Any`
     :   The type of the None singleton.
 
+<a id="ProductFeaturesItem"></a>
+
 `ProductFeaturesItem(**data: Any)`
 :   Nested schema for Product.features_item
     
@@ -5521,6 +5793,8 @@ Classes
 
     `name: str | Any`
     :   The feature name
+
+<a id="ProductList"></a>
 
 `ProductList(**data: Any)`
 :   ProductList type definition
@@ -5553,6 +5827,8 @@ Classes
     `url: str | Any`
     :   The type of the None singleton.
 
+<a id="ProductMarketingFeaturesItem"></a>
+
 `ProductMarketingFeaturesItem(**data: Any)`
 :   Nested schema for Product.marketing_features_item
     
@@ -5574,6 +5850,8 @@ Classes
 
     `name: str | Any | None`
     :   The marketing feature name. Up to 80 characters long
+
+<a id="ProductPackageDimensions"></a>
 
 `ProductPackageDimensions(**data: Any)`
 :   The dimensions of this product for shipping purposes
@@ -5605,6 +5883,8 @@ Classes
 
     `width: float | Any`
     :   Width, in inches
+
+<a id="ProductSearchResult"></a>
 
 `ProductSearchResult(**data: Any)`
 :   ProductSearchResult type definition
@@ -5639,6 +5919,8 @@ Classes
 
     `url: str | Any`
     :   The type of the None singleton.
+
+<a id="ProductUpdateParams"></a>
 
 `ProductUpdateParams(**data: Any)`
 :   ProductUpdateParams type definition
@@ -5698,6 +5980,8 @@ Classes
     `url: str | Any`
     :   The type of the None singleton.
 
+<a id="ProductUpdateParamsMarketingFeaturesItem"></a>
+
 `ProductUpdateParamsMarketingFeaturesItem(**data: Any)`
 :   Nested schema for ProductUpdateParams.marketing_features_item
     
@@ -5719,6 +6003,8 @@ Classes
 
     `name: str | Any`
     :   The marketing feature name. Up to 80 characters long
+
+<a id="ProductUpdateParamsPackageDimensions"></a>
 
 `ProductUpdateParamsPackageDimensions(**data: Any)`
 :   The dimensions of this product for shipping purposes
@@ -5751,6 +6037,8 @@ Classes
     `width: float | Any`
     :   Width, in inches
 
+<a id="ProductsApiSearchResultMeta"></a>
+
 `ProductsApiSearchResultMeta(**data: Any)`
 :   Metadata for products.Action.API_SEARCH operation
     
@@ -5773,6 +6061,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="ProductsListResultMeta"></a>
+
 `ProductsListResultMeta(**data: Any)`
 :   Metadata for products.Action.LIST operation
     
@@ -5794,6 +6084,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="Refund"></a>
 
 `Refund(**data: Any)`
 :   Refund type definition
@@ -5877,6 +6169,8 @@ Classes
     `transfer_reversal: str | Any | None`
     :   The type of the None singleton.
 
+<a id="RefundCreateParams"></a>
+
 `RefundCreateParams(**data: Any)`
 :   RefundCreateParams type definition
     
@@ -5916,6 +6210,8 @@ Classes
 
     `reverse_transfer: bool | Any`
     :   The type of the None singleton.
+
+<a id="RefundDestinationDetails"></a>
 
 `RefundDestinationDetails(**data: Any)`
 :   Transaction-specific details for the refund
@@ -6044,6 +6340,8 @@ Classes
     `zip: dict[str, typing.Any] | Any | None`
     :   If this is a zip refund, this hash contains the transaction specific details
 
+<a id="RefundDestinationDetailsBlik"></a>
+
 `RefundDestinationDetailsBlik(**data: Any)`
 :   If this is a blik refund, this hash contains the transaction specific details
     
@@ -6072,6 +6370,8 @@ Classes
     `reference_status: str | Any | None`
     :   Status of the reference on the refund
 
+<a id="RefundDestinationDetailsBrBankTransfer"></a>
+
 `RefundDestinationDetailsBrBankTransfer(**data: Any)`
 :   If this is a br_bank_transfer refund, this hash contains the transaction specific details
     
@@ -6096,6 +6396,8 @@ Classes
 
     `reference_status: str | Any | None`
     :   Status of the reference on the refund
+
+<a id="RefundDestinationDetailsCard"></a>
 
 `RefundDestinationDetailsCard(**data: Any)`
 :   If this is a card refund, this hash contains the transaction specific details
@@ -6128,6 +6430,8 @@ Classes
     `type_: str | Any`
     :   The type of refund
 
+<a id="RefundDestinationDetailsCrypto"></a>
+
 `RefundDestinationDetailsCrypto(**data: Any)`
 :   If this is a crypto refund, this hash contains the transaction specific details
     
@@ -6149,6 +6453,8 @@ Classes
 
     `reference: str | Any | None`
     :   The transaction hash of the refund
+
+<a id="RefundDestinationDetailsEuBankTransfer"></a>
 
 `RefundDestinationDetailsEuBankTransfer(**data: Any)`
 :   If this is a eu_bank_transfer refund, this hash contains the transaction specific details
@@ -6175,6 +6481,8 @@ Classes
     `reference_status: str | Any | None`
     :   Status of the reference on the refund
 
+<a id="RefundDestinationDetailsGbBankTransfer"></a>
+
 `RefundDestinationDetailsGbBankTransfer(**data: Any)`
 :   If this is a gb_bank_transfer refund, this hash contains the transaction specific details
     
@@ -6199,6 +6507,8 @@ Classes
 
     `reference_status: str | Any | None`
     :   Status of the reference on the refund
+
+<a id="RefundDestinationDetailsJpBankTransfer"></a>
 
 `RefundDestinationDetailsJpBankTransfer(**data: Any)`
 :   If this is a jp_bank_transfer refund, this hash contains the transaction specific details
@@ -6225,6 +6535,8 @@ Classes
     `reference_status: str | Any | None`
     :   Status of the reference on the refund
 
+<a id="RefundDestinationDetailsMbWay"></a>
+
 `RefundDestinationDetailsMbWay(**data: Any)`
 :   If this is a mb_way refund, this hash contains the transaction specific details
     
@@ -6249,6 +6561,8 @@ Classes
 
     `reference_status: str | Any | None`
     :   Status of the reference on the refund
+
+<a id="RefundDestinationDetailsMultibanco"></a>
 
 `RefundDestinationDetailsMultibanco(**data: Any)`
 :   If this is a multibanco refund, this hash contains the transaction specific details
@@ -6275,6 +6589,8 @@ Classes
     `reference_status: str | Any | None`
     :   Status of the reference on the refund
 
+<a id="RefundDestinationDetailsMxBankTransfer"></a>
+
 `RefundDestinationDetailsMxBankTransfer(**data: Any)`
 :   If this is a mx_bank_transfer refund, this hash contains the transaction specific details
     
@@ -6299,6 +6615,8 @@ Classes
 
     `reference_status: str | Any | None`
     :   Status of the reference on the refund
+
+<a id="RefundDestinationDetailsP24"></a>
 
 `RefundDestinationDetailsP24(**data: Any)`
 :   If this is a p24 refund, this hash contains the transaction specific details
@@ -6325,6 +6643,8 @@ Classes
     `reference_status: str | Any | None`
     :   Status of the reference on the refund
 
+<a id="RefundDestinationDetailsPaypal"></a>
+
 `RefundDestinationDetailsPaypal(**data: Any)`
 :   If this is a paypal refund, this hash contains the transaction specific details
     
@@ -6346,6 +6666,8 @@ Classes
 
     `network_decline_code: str | Any | None`
     :   For refunds declined by the network, a decline code provided by the network
+
+<a id="RefundDestinationDetailsSwish"></a>
 
 `RefundDestinationDetailsSwish(**data: Any)`
 :   If this is a swish refund, this hash contains the transaction specific details
@@ -6375,6 +6697,8 @@ Classes
     `reference_status: str | Any | None`
     :   Status of the reference on the refund
 
+<a id="RefundDestinationDetailsThBankTransfer"></a>
+
 `RefundDestinationDetailsThBankTransfer(**data: Any)`
 :   If this is a th_bank_transfer refund, this hash contains the transaction specific details
     
@@ -6400,6 +6724,8 @@ Classes
     `reference_status: str | Any | None`
     :   Status of the reference on the refund
 
+<a id="RefundDestinationDetailsUsBankTransfer"></a>
+
 `RefundDestinationDetailsUsBankTransfer(**data: Any)`
 :   If this is a us_bank_transfer refund, this hash contains the transaction specific details
     
@@ -6424,6 +6750,8 @@ Classes
 
     `reference_status: str | Any | None`
     :   Status of the reference on the refund
+
+<a id="RefundList"></a>
 
 `RefundList(**data: Any)`
 :   RefundList type definition
@@ -6459,6 +6787,8 @@ Classes
     `url: str | Any`
     :   The type of the None singleton.
 
+<a id="RefundNextAction"></a>
+
 `RefundNextAction(**data: Any)`
 :   If the refund has a status of requires_action, this property describes what the refund needs to continue processing
     
@@ -6483,6 +6813,8 @@ Classes
 
     `type_: str | Any`
     :   Type of the next action to perform
+
+<a id="RefundNextActionDisplayDetails"></a>
 
 `RefundNextActionDisplayDetails(**data: Any)`
 :   Contains the refund details
@@ -6509,6 +6841,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="RefundNextActionDisplayDetailsEmailSent"></a>
+
 `RefundNextActionDisplayDetailsEmailSent(**data: Any)`
 :   Contains information about the email sent to the customer
     
@@ -6534,6 +6868,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="RefundsListResultMeta"></a>
+
 `RefundsListResultMeta(**data: Any)`
 :   Metadata for refunds.Action.LIST operation
     
@@ -6555,6 +6891,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="RefundsSearchData"></a>
 
 `RefundsSearchData(**data: Any)`
 :   Search result data for refunds entity.
@@ -6623,6 +6961,8 @@ Classes
     `updated: int | None`
     :   Timestamp indicating when the refund was last updated.
 
+<a id="StripeAuthConfig"></a>
+
 `StripeAuthConfig(**data: Any)`
 :   API Key Authentication
     
@@ -6644,6 +6984,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="StripeCheckResult"></a>
 
 `StripeCheckResult(**data: Any)`
 :   Result of a health check operation.
@@ -6678,6 +7020,8 @@ Classes
     `status: str`
     :   Health check status: 'healthy' or 'unhealthy'.
 
+<a id="StripeExecuteResult"></a>
+
 `StripeExecuteResult(**data: Any)`
 :   Response envelope with data only.
     
@@ -6709,6 +7053,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="StripeExecuteResultWithMeta"></a>
 
 `StripeExecuteResultWithMeta(**data: Any)`
 :   Response envelope with data and metadata.
@@ -6773,6 +7119,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="BalanceTransactionsListResult"></a>
+
 `BalanceTransactionsListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -6815,6 +7163,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="ChargesListResult"></a>
 
 `ChargesListResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -6859,6 +7209,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="CustomersApiSearchResult"></a>
+
 `CustomersApiSearchResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -6901,6 +7253,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="CustomersListResult"></a>
 
 `CustomersListResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -6945,6 +7299,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="DisputesListResult"></a>
+
 `DisputesListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -6987,6 +7343,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="InvoicesListResult"></a>
 
 `InvoicesListResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -7031,6 +7389,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="PaymentIntentsApiSearchResult"></a>
+
 `PaymentIntentsApiSearchResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -7073,6 +7433,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="PaymentIntentsListResult"></a>
 
 `PaymentIntentsListResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -7117,6 +7479,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="PayoutsListResult"></a>
+
 `PayoutsListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -7159,6 +7523,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="ProductsApiSearchResult"></a>
 
 `ProductsApiSearchResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -7203,6 +7569,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="ProductsListResult"></a>
+
 `ProductsListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -7245,6 +7613,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="RefundsListResult"></a>
 
 `RefundsListResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -7289,6 +7659,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="SubscriptionsListResult"></a>
+
 `SubscriptionsListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -7331,6 +7703,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="ChargesApiSearchResult"></a>
+
 `ChargesApiSearchResult(**data: Any)`
 :   Response envelope with data only.
     
@@ -7371,6 +7745,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="InvoicesApiSearchResult"></a>
 
 `InvoicesApiSearchResult(**data: Any)`
 :   Response envelope with data only.
@@ -7413,6 +7789,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="SubscriptionsApiSearchResult"></a>
+
 `SubscriptionsApiSearchResult(**data: Any)`
 :   Response envelope with data only.
     
@@ -7430,6 +7808,8 @@ Classes
     * airbyte_agent_sdk.connectors.stripe.models.StripeExecuteResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="StripeReplicationConfig"></a>
 
 `StripeReplicationConfig(**data: Any)`
 :   Replication Configuration - Settings for data replication from Stripe.
@@ -7452,6 +7832,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="Subscription"></a>
 
 `Subscription(**data: Any)`
 :   Subscription type definition
@@ -7622,6 +8004,8 @@ Classes
     `trial_start: int | Any | None`
     :   The type of the None singleton.
 
+<a id="SubscriptionAutomaticTax"></a>
+
 `SubscriptionAutomaticTax(**data: Any)`
 :   Automatic tax settings for this subscription
     
@@ -7650,6 +8034,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="SubscriptionAutomaticTaxLiability"></a>
+
 `SubscriptionAutomaticTaxLiability(**data: Any)`
 :   The account that's liable for tax
     
@@ -7674,6 +8060,8 @@ Classes
 
     `type_: str | Any`
     :   Type of the account referenced
+
+<a id="SubscriptionBillingCycleAnchorConfig"></a>
 
 `SubscriptionBillingCycleAnchorConfig(**data: Any)`
 :   The fixed values used to calculate the billing_cycle_anchor
@@ -7709,6 +8097,8 @@ Classes
     `second: int | Any | None`
     :   The second of the minute of the billing_cycle_anchor
 
+<a id="SubscriptionBillingMode"></a>
+
 `SubscriptionBillingMode(**data: Any)`
 :   Controls how prorations and invoices for subscriptions are calculated and orchestrated
     
@@ -7737,6 +8127,8 @@ Classes
     `updated_at: int | Any | None`
     :   Details on when the current billing_mode was adopted
 
+<a id="SubscriptionBillingModeFlexible"></a>
+
 `SubscriptionBillingModeFlexible(**data: Any)`
 :   Configure behavior for flexible billing mode
     
@@ -7758,6 +8150,8 @@ Classes
 
     `proration_discounts: str | Any`
     :   Controls how invoices and invoice items display proration amounts and discount amounts
+
+<a id="SubscriptionBillingThresholds"></a>
 
 `SubscriptionBillingThresholds(**data: Any)`
 :   Define thresholds at which an invoice will be sent, and the subscription advanced to a new billing period
@@ -7783,6 +8177,8 @@ Classes
 
     `reset_billing_cycle_anchor: bool | Any | None`
     :   Indicates if the billing_cycle_anchor should be reset when a threshold is reached
+
+<a id="SubscriptionCancellationDetails"></a>
 
 `SubscriptionCancellationDetails(**data: Any)`
 :   Details about why this subscription was cancelled
@@ -7811,6 +8207,8 @@ Classes
 
     `reason: str | Any | None`
     :   Why this subscription was canceled
+
+<a id="SubscriptionDefaultTaxRatesItem"></a>
 
 `SubscriptionDefaultTaxRatesItem(**data: Any)`
 :   Nested schema for Subscription.default_tax_rates_item
@@ -7885,6 +8283,8 @@ Classes
     `tax_type: str | Any | None`
     :   The high-level tax type
 
+<a id="SubscriptionDefaultTaxRatesItemFlatAmount"></a>
+
 `SubscriptionDefaultTaxRatesItemFlatAmount(**data: Any)`
 :   The amount of the tax rate when the rate_type is flat_amount
     
@@ -7909,6 +8309,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="SubscriptionInvoiceSettings"></a>
 
 `SubscriptionInvoiceSettings(**data: Any)`
 :   All invoices will be billed using the specified settings
@@ -7935,6 +8337,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="SubscriptionInvoiceSettingsIssuer"></a>
+
 `SubscriptionInvoiceSettingsIssuer(**data: Any)`
 :   The connected account that issues the invoice
     
@@ -7959,6 +8363,8 @@ Classes
 
     `type_: str | Any`
     :   Type of the account referenced
+
+<a id="SubscriptionItems"></a>
 
 `SubscriptionItems(**data: Any)`
 :   List of subscription items, each with an attached price
@@ -7993,6 +8399,8 @@ Classes
 
     `url: str | Any`
     :   The URL where this list can be accessed
+
+<a id="SubscriptionItemsDataItem"></a>
 
 `SubscriptionItemsDataItem(**data: Any)`
 :   Nested schema for SubscriptionItems.data_item
@@ -8052,6 +8460,8 @@ Classes
     `tax_rates: list[dict[str, typing.Any]] | Any | None`
     :   The tax rates which apply to this subscription_item
 
+<a id="SubscriptionItemsDataItemBillingThresholds"></a>
+
 `SubscriptionItemsDataItemBillingThresholds(**data: Any)`
 :   Define thresholds at which an invoice will be sent
     
@@ -8073,6 +8483,8 @@ Classes
 
     `usage_gte: int | Any | None`
     :   Usage threshold that triggers the subscription to create an invoice
+
+<a id="SubscriptionList"></a>
 
 `SubscriptionList(**data: Any)`
 :   SubscriptionList type definition
@@ -8105,6 +8517,8 @@ Classes
     `url: str | Any`
     :   The type of the None singleton.
 
+<a id="SubscriptionPauseCollection"></a>
+
 `SubscriptionPauseCollection(**data: Any)`
 :   If specified, payment collection for this subscription will be paused
     
@@ -8130,6 +8544,8 @@ Classes
     `resumes_at: int | Any | None`
     :   The time after which the subscription will resume collecting payments
 
+<a id="SubscriptionPaymentSettings"></a>
+
 `SubscriptionPaymentSettings(**data: Any)`
 :   Payment settings passed on to invoices created by the subscription
     
@@ -8154,6 +8570,8 @@ Classes
 
     `payment_method_types: list[str] | Any | None`
     :   The list of payment method types to provide to every invoice
+
+<a id="SubscriptionSearchResult"></a>
 
 `SubscriptionSearchResult(**data: Any)`
 :   SubscriptionSearchResult type definition
@@ -8189,6 +8607,8 @@ Classes
     `url: str | Any`
     :   The type of the None singleton.
 
+<a id="SubscriptionTrialSettings"></a>
+
 `SubscriptionTrialSettings(**data: Any)`
 :   Settings related to subscription trials
     
@@ -8210,6 +8630,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="SubscriptionTrialSettingsEndBehavior"></a>
 
 `SubscriptionTrialSettingsEndBehavior(**data: Any)`
 :   Nested schema for SubscriptionTrialSettings.end_behavior
@@ -8233,6 +8655,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="SubscriptionsListResultMeta"></a>
+
 `SubscriptionsListResultMeta(**data: Any)`
 :   Metadata for subscriptions.Action.LIST operation
     
@@ -8254,6 +8678,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="SubscriptionsSearchData"></a>
 
 `SubscriptionsSearchData(**data: Any)`
 :   Search result data for subscriptions entity.

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/stripe/types.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/stripe/types.md
@@ -10,6 +10,8 @@ Type definitions for stripe connector.
 Classes
 -------
 
+<a id="AirbyteSearchParams"></a>
+
 `AirbyteSearchParams(*args, **kwargs)`
 :   Parameters for Airbyte cache search operations (generic, use entity-specific query types for better type hints).
 
@@ -31,12 +33,16 @@ Classes
     `query: dict[str, typing.Any]`
     :   The type of the None singleton.
 
+<a id="BalanceGetParams"></a>
+
 `BalanceGetParams(*args, **kwargs)`
 :   Parameters for balance.get operation
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="BalanceTransactionsGetParams"></a>
 
 `BalanceTransactionsGetParams(*args, **kwargs)`
 :   Parameters for balance_transactions.get operation
@@ -49,6 +55,8 @@ Classes
 
     `id: str`
     :   The type of the None singleton.
+
+<a id="BalanceTransactionsListParams"></a>
 
 `BalanceTransactionsListParams(*args, **kwargs)`
 :   Parameters for balance_transactions.list operation
@@ -83,6 +91,8 @@ Classes
     `type: str`
     :   The type of the None singleton.
 
+<a id="BalanceTransactionsListParamsCreated"></a>
+
 `BalanceTransactionsListParamsCreated(*args, **kwargs)`
 :   Nested schema for BalanceTransactionsListParams.created
 
@@ -104,6 +114,8 @@ Classes
     `lte: int`
     :   The type of the None singleton.
 
+<a id="ChargesAndCondition"></a>
+
 `ChargesAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -124,6 +136,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.stripe.types.ChargesEqCondition | airbyte_agent_sdk.connectors.stripe.types.ChargesNeqCondition | airbyte_agent_sdk.connectors.stripe.types.ChargesGtCondition | airbyte_agent_sdk.connectors.stripe.types.ChargesGteCondition | airbyte_agent_sdk.connectors.stripe.types.ChargesLtCondition | airbyte_agent_sdk.connectors.stripe.types.ChargesLteCondition | airbyte_agent_sdk.connectors.stripe.types.ChargesInCondition | airbyte_agent_sdk.connectors.stripe.types.ChargesLikeCondition | airbyte_agent_sdk.connectors.stripe.types.ChargesFuzzyCondition | airbyte_agent_sdk.connectors.stripe.types.ChargesKeywordCondition | airbyte_agent_sdk.connectors.stripe.types.ChargesContainsCondition | airbyte_agent_sdk.connectors.stripe.types.ChargesNotCondition | airbyte_agent_sdk.connectors.stripe.types.ChargesAndCondition | airbyte_agent_sdk.connectors.stripe.types.ChargesOrCondition | airbyte_agent_sdk.connectors.stripe.types.ChargesAnyCondition]`
     :   The type of the None singleton.
 
+<a id="ChargesAnyCondition"></a>
+
 `ChargesAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -143,6 +157,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.stripe.types.ChargesAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="ChargesAnyValueFilter"></a>
 
 `ChargesAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -306,6 +322,8 @@ Classes
     `updated: Any`
     :   Timestamp of the last update to this charge object.
 
+<a id="ChargesApiSearchParams"></a>
+
 `ChargesApiSearchParams(*args, **kwargs)`
 :   Parameters for charges.api_search operation
 
@@ -324,6 +342,8 @@ Classes
     `query: str`
     :   The type of the None singleton.
 
+<a id="ChargesContainsCondition"></a>
+
 `ChargesContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -335,6 +355,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.stripe.types.ChargesAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="ChargesEqCondition"></a>
 
 `ChargesEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -348,6 +370,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.stripe.types.ChargesSearchFilter`
     :   The type of the None singleton.
 
+<a id="ChargesFuzzyCondition"></a>
+
 `ChargesFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -359,6 +383,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.stripe.types.ChargesStringFilter`
     :   The type of the None singleton.
+
+<a id="ChargesGetParams"></a>
 
 `ChargesGetParams(*args, **kwargs)`
 :   Parameters for charges.get operation
@@ -372,6 +398,8 @@ Classes
     `id: str`
     :   The type of the None singleton.
 
+<a id="ChargesGtCondition"></a>
+
 `ChargesGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -384,6 +412,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.stripe.types.ChargesSearchFilter`
     :   The type of the None singleton.
 
+<a id="ChargesGteCondition"></a>
+
 `ChargesGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -395,6 +425,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.stripe.types.ChargesSearchFilter`
     :   The type of the None singleton.
+
+<a id="ChargesInCondition"></a>
 
 `ChargesInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -415,6 +447,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.stripe.types.ChargesInFilter`
     :   The type of the None singleton.
+
+<a id="ChargesInFilter"></a>
 
 `ChargesInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -578,6 +612,8 @@ Classes
     `updated: list[int]`
     :   Timestamp of the last update to this charge object.
 
+<a id="ChargesKeywordCondition"></a>
+
 `ChargesKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -590,6 +626,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.stripe.types.ChargesStringFilter`
     :   The type of the None singleton.
 
+<a id="ChargesLikeCondition"></a>
+
 `ChargesLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -601,6 +639,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.stripe.types.ChargesStringFilter`
     :   The type of the None singleton.
+
+<a id="ChargesListParams"></a>
 
 `ChargesListParams(*args, **kwargs)`
 :   Parameters for charges.list operation
@@ -629,6 +669,8 @@ Classes
     `starting_after: str`
     :   The type of the None singleton.
 
+<a id="ChargesListParamsCreated"></a>
+
 `ChargesListParamsCreated(*args, **kwargs)`
 :   Nested schema for ChargesListParams.created
 
@@ -650,6 +692,8 @@ Classes
     `lte: int`
     :   The type of the None singleton.
 
+<a id="ChargesLtCondition"></a>
+
 `ChargesLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -661,6 +705,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.stripe.types.ChargesSearchFilter`
     :   The type of the None singleton.
+
+<a id="ChargesLteCondition"></a>
 
 `ChargesLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -674,6 +720,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.stripe.types.ChargesSearchFilter`
     :   The type of the None singleton.
 
+<a id="ChargesNeqCondition"></a>
+
 `ChargesNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -685,6 +733,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.stripe.types.ChargesSearchFilter`
     :   The type of the None singleton.
+
+<a id="ChargesNotCondition"></a>
 
 `ChargesNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -706,6 +756,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.stripe.types.ChargesEqCondition | airbyte_agent_sdk.connectors.stripe.types.ChargesNeqCondition | airbyte_agent_sdk.connectors.stripe.types.ChargesGtCondition | airbyte_agent_sdk.connectors.stripe.types.ChargesGteCondition | airbyte_agent_sdk.connectors.stripe.types.ChargesLtCondition | airbyte_agent_sdk.connectors.stripe.types.ChargesLteCondition | airbyte_agent_sdk.connectors.stripe.types.ChargesInCondition | airbyte_agent_sdk.connectors.stripe.types.ChargesLikeCondition | airbyte_agent_sdk.connectors.stripe.types.ChargesFuzzyCondition | airbyte_agent_sdk.connectors.stripe.types.ChargesKeywordCondition | airbyte_agent_sdk.connectors.stripe.types.ChargesContainsCondition | airbyte_agent_sdk.connectors.stripe.types.ChargesNotCondition | airbyte_agent_sdk.connectors.stripe.types.ChargesAndCondition | airbyte_agent_sdk.connectors.stripe.types.ChargesOrCondition | airbyte_agent_sdk.connectors.stripe.types.ChargesAnyCondition`
     :   The type of the None singleton.
 
+<a id="ChargesOrCondition"></a>
+
 `ChargesOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -725,6 +777,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.stripe.types.ChargesEqCondition | airbyte_agent_sdk.connectors.stripe.types.ChargesNeqCondition | airbyte_agent_sdk.connectors.stripe.types.ChargesGtCondition | airbyte_agent_sdk.connectors.stripe.types.ChargesGteCondition | airbyte_agent_sdk.connectors.stripe.types.ChargesLtCondition | airbyte_agent_sdk.connectors.stripe.types.ChargesLteCondition | airbyte_agent_sdk.connectors.stripe.types.ChargesInCondition | airbyte_agent_sdk.connectors.stripe.types.ChargesLikeCondition | airbyte_agent_sdk.connectors.stripe.types.ChargesFuzzyCondition | airbyte_agent_sdk.connectors.stripe.types.ChargesKeywordCondition | airbyte_agent_sdk.connectors.stripe.types.ChargesContainsCondition | airbyte_agent_sdk.connectors.stripe.types.ChargesNotCondition | airbyte_agent_sdk.connectors.stripe.types.ChargesAndCondition | airbyte_agent_sdk.connectors.stripe.types.ChargesOrCondition | airbyte_agent_sdk.connectors.stripe.types.ChargesAnyCondition]`
     :   The type of the None singleton.
+
+<a id="ChargesSearchFilter"></a>
 
 `ChargesSearchFilter(*args, **kwargs)`
 :   Available fields for filtering charges search queries.
@@ -888,6 +942,8 @@ Classes
     `updated: int | None`
     :   Timestamp of the last update to this charge object.
 
+<a id="ChargesSearchQuery"></a>
+
 `ChargesSearchQuery(*args, **kwargs)`
 :   Search query for charges entity.
 
@@ -902,6 +958,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.stripe.types.ChargesSortFilter]`
     :   The type of the None singleton.
+
+<a id="ChargesSortFilter"></a>
 
 `ChargesSortFilter(*args, **kwargs)`
 :   Available fields for sorting charges search results.
@@ -1065,6 +1123,8 @@ Classes
     `updated: Literal['asc', 'desc']`
     :   Timestamp of the last update to this charge object.
 
+<a id="ChargesStringFilter"></a>
+
 `ChargesStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -1227,6 +1287,8 @@ Classes
     `updated: str`
     :   Timestamp of the last update to this charge object.
 
+<a id="CustomersAndCondition"></a>
+
 `CustomersAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1247,6 +1309,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.stripe.types.CustomersEqCondition | airbyte_agent_sdk.connectors.stripe.types.CustomersNeqCondition | airbyte_agent_sdk.connectors.stripe.types.CustomersGtCondition | airbyte_agent_sdk.connectors.stripe.types.CustomersGteCondition | airbyte_agent_sdk.connectors.stripe.types.CustomersLtCondition | airbyte_agent_sdk.connectors.stripe.types.CustomersLteCondition | airbyte_agent_sdk.connectors.stripe.types.CustomersInCondition | airbyte_agent_sdk.connectors.stripe.types.CustomersLikeCondition | airbyte_agent_sdk.connectors.stripe.types.CustomersFuzzyCondition | airbyte_agent_sdk.connectors.stripe.types.CustomersKeywordCondition | airbyte_agent_sdk.connectors.stripe.types.CustomersContainsCondition | airbyte_agent_sdk.connectors.stripe.types.CustomersNotCondition | airbyte_agent_sdk.connectors.stripe.types.CustomersAndCondition | airbyte_agent_sdk.connectors.stripe.types.CustomersOrCondition | airbyte_agent_sdk.connectors.stripe.types.CustomersAnyCondition]`
     :   The type of the None singleton.
 
+<a id="CustomersAnyCondition"></a>
+
 `CustomersAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1266,6 +1330,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.stripe.types.CustomersAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="CustomersAnyValueFilter"></a>
 
 `CustomersAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -1369,6 +1435,8 @@ Classes
     `updated: Any`
     :   Timestamp indicating when the customer object was last updated.
 
+<a id="CustomersApiSearchParams"></a>
+
 `CustomersApiSearchParams(*args, **kwargs)`
 :   Parameters for customers.api_search operation
 
@@ -1387,6 +1455,8 @@ Classes
     `query: str`
     :   The type of the None singleton.
 
+<a id="CustomersContainsCondition"></a>
+
 `CustomersContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -1399,12 +1469,16 @@ Classes
     `contains: airbyte_agent_sdk.connectors.stripe.types.CustomersAnyValueFilter`
     :   The type of the None singleton.
 
+<a id="CustomersCreateParams"></a>
+
 `CustomersCreateParams(*args, **kwargs)`
 :   Parameters for customers.create operation
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="CustomersDeleteParams"></a>
 
 `CustomersDeleteParams(*args, **kwargs)`
 :   Parameters for customers.delete operation
@@ -1418,6 +1492,8 @@ Classes
     `id: str`
     :   The type of the None singleton.
 
+<a id="CustomersEqCondition"></a>
+
 `CustomersEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
 
@@ -1429,6 +1505,8 @@ Classes
 
     `eq: airbyte_agent_sdk.connectors.stripe.types.CustomersSearchFilter`
     :   The type of the None singleton.
+
+<a id="CustomersFuzzyCondition"></a>
 
 `CustomersFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
@@ -1442,6 +1520,8 @@ Classes
     `fuzzy: airbyte_agent_sdk.connectors.stripe.types.CustomersStringFilter`
     :   The type of the None singleton.
 
+<a id="CustomersGetParams"></a>
+
 `CustomersGetParams(*args, **kwargs)`
 :   Parameters for customers.get operation
 
@@ -1453,6 +1533,8 @@ Classes
 
     `id: str`
     :   The type of the None singleton.
+
+<a id="CustomersGtCondition"></a>
 
 `CustomersGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
@@ -1466,6 +1548,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.stripe.types.CustomersSearchFilter`
     :   The type of the None singleton.
 
+<a id="CustomersGteCondition"></a>
+
 `CustomersGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -1477,6 +1561,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.stripe.types.CustomersSearchFilter`
     :   The type of the None singleton.
+
+<a id="CustomersInCondition"></a>
 
 `CustomersInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -1497,6 +1583,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.stripe.types.CustomersInFilter`
     :   The type of the None singleton.
+
+<a id="CustomersInFilter"></a>
 
 `CustomersInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -1600,6 +1688,8 @@ Classes
     `updated: list[int]`
     :   Timestamp indicating when the customer object was last updated.
 
+<a id="CustomersKeywordCondition"></a>
+
 `CustomersKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -1612,6 +1702,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.stripe.types.CustomersStringFilter`
     :   The type of the None singleton.
 
+<a id="CustomersLikeCondition"></a>
+
 `CustomersLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -1623,6 +1715,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.stripe.types.CustomersStringFilter`
     :   The type of the None singleton.
+
+<a id="CustomersListParams"></a>
 
 `CustomersListParams(*args, **kwargs)`
 :   Parameters for customers.list operation
@@ -1648,6 +1742,8 @@ Classes
     `starting_after: str`
     :   The type of the None singleton.
 
+<a id="CustomersListParamsCreated"></a>
+
 `CustomersListParamsCreated(*args, **kwargs)`
 :   Nested schema for CustomersListParams.created
 
@@ -1669,6 +1765,8 @@ Classes
     `lte: int`
     :   The type of the None singleton.
 
+<a id="CustomersLtCondition"></a>
+
 `CustomersLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -1680,6 +1778,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.stripe.types.CustomersSearchFilter`
     :   The type of the None singleton.
+
+<a id="CustomersLteCondition"></a>
 
 `CustomersLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -1693,6 +1793,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.stripe.types.CustomersSearchFilter`
     :   The type of the None singleton.
 
+<a id="CustomersNeqCondition"></a>
+
 `CustomersNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -1704,6 +1806,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.stripe.types.CustomersSearchFilter`
     :   The type of the None singleton.
+
+<a id="CustomersNotCondition"></a>
 
 `CustomersNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -1725,6 +1829,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.stripe.types.CustomersEqCondition | airbyte_agent_sdk.connectors.stripe.types.CustomersNeqCondition | airbyte_agent_sdk.connectors.stripe.types.CustomersGtCondition | airbyte_agent_sdk.connectors.stripe.types.CustomersGteCondition | airbyte_agent_sdk.connectors.stripe.types.CustomersLtCondition | airbyte_agent_sdk.connectors.stripe.types.CustomersLteCondition | airbyte_agent_sdk.connectors.stripe.types.CustomersInCondition | airbyte_agent_sdk.connectors.stripe.types.CustomersLikeCondition | airbyte_agent_sdk.connectors.stripe.types.CustomersFuzzyCondition | airbyte_agent_sdk.connectors.stripe.types.CustomersKeywordCondition | airbyte_agent_sdk.connectors.stripe.types.CustomersContainsCondition | airbyte_agent_sdk.connectors.stripe.types.CustomersNotCondition | airbyte_agent_sdk.connectors.stripe.types.CustomersAndCondition | airbyte_agent_sdk.connectors.stripe.types.CustomersOrCondition | airbyte_agent_sdk.connectors.stripe.types.CustomersAnyCondition`
     :   The type of the None singleton.
 
+<a id="CustomersOrCondition"></a>
+
 `CustomersOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1744,6 +1850,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.stripe.types.CustomersEqCondition | airbyte_agent_sdk.connectors.stripe.types.CustomersNeqCondition | airbyte_agent_sdk.connectors.stripe.types.CustomersGtCondition | airbyte_agent_sdk.connectors.stripe.types.CustomersGteCondition | airbyte_agent_sdk.connectors.stripe.types.CustomersLtCondition | airbyte_agent_sdk.connectors.stripe.types.CustomersLteCondition | airbyte_agent_sdk.connectors.stripe.types.CustomersInCondition | airbyte_agent_sdk.connectors.stripe.types.CustomersLikeCondition | airbyte_agent_sdk.connectors.stripe.types.CustomersFuzzyCondition | airbyte_agent_sdk.connectors.stripe.types.CustomersKeywordCondition | airbyte_agent_sdk.connectors.stripe.types.CustomersContainsCondition | airbyte_agent_sdk.connectors.stripe.types.CustomersNotCondition | airbyte_agent_sdk.connectors.stripe.types.CustomersAndCondition | airbyte_agent_sdk.connectors.stripe.types.CustomersOrCondition | airbyte_agent_sdk.connectors.stripe.types.CustomersAnyCondition]`
     :   The type of the None singleton.
+
+<a id="CustomersSearchFilter"></a>
 
 `CustomersSearchFilter(*args, **kwargs)`
 :   Available fields for filtering customers search queries.
@@ -1847,6 +1955,8 @@ Classes
     `updated: int | None`
     :   Timestamp indicating when the customer object was last updated.
 
+<a id="CustomersSearchQuery"></a>
+
 `CustomersSearchQuery(*args, **kwargs)`
 :   Search query for customers entity.
 
@@ -1861,6 +1971,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.stripe.types.CustomersSortFilter]`
     :   The type of the None singleton.
+
+<a id="CustomersSortFilter"></a>
 
 `CustomersSortFilter(*args, **kwargs)`
 :   Available fields for sorting customers search results.
@@ -1964,6 +2076,8 @@ Classes
     `updated: Literal['asc', 'desc']`
     :   Timestamp indicating when the customer object was last updated.
 
+<a id="CustomersStringFilter"></a>
+
 `CustomersStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -2066,6 +2180,8 @@ Classes
     `updated: str`
     :   Timestamp indicating when the customer object was last updated.
 
+<a id="CustomersUpdateParams"></a>
+
 `CustomersUpdateParams(*args, **kwargs)`
 :   Parameters for customers.update operation
 
@@ -2078,6 +2194,8 @@ Classes
     `id: str`
     :   The type of the None singleton.
 
+<a id="DisputesGetParams"></a>
+
 `DisputesGetParams(*args, **kwargs)`
 :   Parameters for disputes.get operation
 
@@ -2089,6 +2207,8 @@ Classes
 
     `id: str`
     :   The type of the None singleton.
+
+<a id="DisputesListParams"></a>
 
 `DisputesListParams(*args, **kwargs)`
 :   Parameters for disputes.list operation
@@ -2117,6 +2237,8 @@ Classes
     `starting_after: str`
     :   The type of the None singleton.
 
+<a id="DisputesListParamsCreated"></a>
+
 `DisputesListParamsCreated(*args, **kwargs)`
 :   Nested schema for DisputesListParams.created
 
@@ -2138,6 +2260,8 @@ Classes
     `lte: int`
     :   The type of the None singleton.
 
+<a id="InvoicesAndCondition"></a>
+
 `InvoicesAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -2158,6 +2282,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.stripe.types.InvoicesEqCondition | airbyte_agent_sdk.connectors.stripe.types.InvoicesNeqCondition | airbyte_agent_sdk.connectors.stripe.types.InvoicesGtCondition | airbyte_agent_sdk.connectors.stripe.types.InvoicesGteCondition | airbyte_agent_sdk.connectors.stripe.types.InvoicesLtCondition | airbyte_agent_sdk.connectors.stripe.types.InvoicesLteCondition | airbyte_agent_sdk.connectors.stripe.types.InvoicesInCondition | airbyte_agent_sdk.connectors.stripe.types.InvoicesLikeCondition | airbyte_agent_sdk.connectors.stripe.types.InvoicesFuzzyCondition | airbyte_agent_sdk.connectors.stripe.types.InvoicesKeywordCondition | airbyte_agent_sdk.connectors.stripe.types.InvoicesContainsCondition | airbyte_agent_sdk.connectors.stripe.types.InvoicesNotCondition | airbyte_agent_sdk.connectors.stripe.types.InvoicesAndCondition | airbyte_agent_sdk.connectors.stripe.types.InvoicesOrCondition | airbyte_agent_sdk.connectors.stripe.types.InvoicesAnyCondition]`
     :   The type of the None singleton.
 
+<a id="InvoicesAnyCondition"></a>
+
 `InvoicesAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -2177,6 +2303,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.stripe.types.InvoicesAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="InvoicesAnyValueFilter"></a>
 
 `InvoicesAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -2457,6 +2585,8 @@ Classes
     `webhooks_delivered_at: Any`
     :   Timestamp indicating when webhooks for this invoice were successfully delivered.
 
+<a id="InvoicesApiSearchParams"></a>
+
 `InvoicesApiSearchParams(*args, **kwargs)`
 :   Parameters for invoices.api_search operation
 
@@ -2475,6 +2605,8 @@ Classes
     `query: str`
     :   The type of the None singleton.
 
+<a id="InvoicesContainsCondition"></a>
+
 `InvoicesContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -2486,6 +2618,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.stripe.types.InvoicesAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="InvoicesEqCondition"></a>
 
 `InvoicesEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -2499,6 +2633,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.stripe.types.InvoicesSearchFilter`
     :   The type of the None singleton.
 
+<a id="InvoicesFuzzyCondition"></a>
+
 `InvoicesFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -2510,6 +2646,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.stripe.types.InvoicesStringFilter`
     :   The type of the None singleton.
+
+<a id="InvoicesGetParams"></a>
 
 `InvoicesGetParams(*args, **kwargs)`
 :   Parameters for invoices.get operation
@@ -2523,6 +2661,8 @@ Classes
     `id: str`
     :   The type of the None singleton.
 
+<a id="InvoicesGtCondition"></a>
+
 `InvoicesGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -2535,6 +2675,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.stripe.types.InvoicesSearchFilter`
     :   The type of the None singleton.
 
+<a id="InvoicesGteCondition"></a>
+
 `InvoicesGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -2546,6 +2688,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.stripe.types.InvoicesSearchFilter`
     :   The type of the None singleton.
+
+<a id="InvoicesInCondition"></a>
 
 `InvoicesInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -2566,6 +2710,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.stripe.types.InvoicesInFilter`
     :   The type of the None singleton.
+
+<a id="InvoicesInFilter"></a>
 
 `InvoicesInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -2846,6 +2992,8 @@ Classes
     `webhooks_delivered_at: list[float]`
     :   Timestamp indicating when webhooks for this invoice were successfully delivered.
 
+<a id="InvoicesKeywordCondition"></a>
+
 `InvoicesKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -2858,6 +3006,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.stripe.types.InvoicesStringFilter`
     :   The type of the None singleton.
 
+<a id="InvoicesLikeCondition"></a>
+
 `InvoicesLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -2869,6 +3019,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.stripe.types.InvoicesStringFilter`
     :   The type of the None singleton.
+
+<a id="InvoicesListParams"></a>
 
 `InvoicesListParams(*args, **kwargs)`
 :   Parameters for invoices.list operation
@@ -2906,6 +3058,8 @@ Classes
     `subscription: str`
     :   The type of the None singleton.
 
+<a id="InvoicesListParamsCreated"></a>
+
 `InvoicesListParamsCreated(*args, **kwargs)`
 :   Nested schema for InvoicesListParams.created
 
@@ -2927,6 +3081,8 @@ Classes
     `lte: int`
     :   The type of the None singleton.
 
+<a id="InvoicesLtCondition"></a>
+
 `InvoicesLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -2938,6 +3094,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.stripe.types.InvoicesSearchFilter`
     :   The type of the None singleton.
+
+<a id="InvoicesLteCondition"></a>
 
 `InvoicesLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -2951,6 +3109,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.stripe.types.InvoicesSearchFilter`
     :   The type of the None singleton.
 
+<a id="InvoicesNeqCondition"></a>
+
 `InvoicesNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -2962,6 +3122,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.stripe.types.InvoicesSearchFilter`
     :   The type of the None singleton.
+
+<a id="InvoicesNotCondition"></a>
 
 `InvoicesNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -2983,6 +3145,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.stripe.types.InvoicesEqCondition | airbyte_agent_sdk.connectors.stripe.types.InvoicesNeqCondition | airbyte_agent_sdk.connectors.stripe.types.InvoicesGtCondition | airbyte_agent_sdk.connectors.stripe.types.InvoicesGteCondition | airbyte_agent_sdk.connectors.stripe.types.InvoicesLtCondition | airbyte_agent_sdk.connectors.stripe.types.InvoicesLteCondition | airbyte_agent_sdk.connectors.stripe.types.InvoicesInCondition | airbyte_agent_sdk.connectors.stripe.types.InvoicesLikeCondition | airbyte_agent_sdk.connectors.stripe.types.InvoicesFuzzyCondition | airbyte_agent_sdk.connectors.stripe.types.InvoicesKeywordCondition | airbyte_agent_sdk.connectors.stripe.types.InvoicesContainsCondition | airbyte_agent_sdk.connectors.stripe.types.InvoicesNotCondition | airbyte_agent_sdk.connectors.stripe.types.InvoicesAndCondition | airbyte_agent_sdk.connectors.stripe.types.InvoicesOrCondition | airbyte_agent_sdk.connectors.stripe.types.InvoicesAnyCondition`
     :   The type of the None singleton.
 
+<a id="InvoicesOrCondition"></a>
+
 `InvoicesOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -3002,6 +3166,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.stripe.types.InvoicesEqCondition | airbyte_agent_sdk.connectors.stripe.types.InvoicesNeqCondition | airbyte_agent_sdk.connectors.stripe.types.InvoicesGtCondition | airbyte_agent_sdk.connectors.stripe.types.InvoicesGteCondition | airbyte_agent_sdk.connectors.stripe.types.InvoicesLtCondition | airbyte_agent_sdk.connectors.stripe.types.InvoicesLteCondition | airbyte_agent_sdk.connectors.stripe.types.InvoicesInCondition | airbyte_agent_sdk.connectors.stripe.types.InvoicesLikeCondition | airbyte_agent_sdk.connectors.stripe.types.InvoicesFuzzyCondition | airbyte_agent_sdk.connectors.stripe.types.InvoicesKeywordCondition | airbyte_agent_sdk.connectors.stripe.types.InvoicesContainsCondition | airbyte_agent_sdk.connectors.stripe.types.InvoicesNotCondition | airbyte_agent_sdk.connectors.stripe.types.InvoicesAndCondition | airbyte_agent_sdk.connectors.stripe.types.InvoicesOrCondition | airbyte_agent_sdk.connectors.stripe.types.InvoicesAnyCondition]`
     :   The type of the None singleton.
+
+<a id="InvoicesSearchFilter"></a>
 
 `InvoicesSearchFilter(*args, **kwargs)`
 :   Available fields for filtering invoices search queries.
@@ -3282,6 +3448,8 @@ Classes
     `webhooks_delivered_at: float | None`
     :   Timestamp indicating when webhooks for this invoice were successfully delivered.
 
+<a id="InvoicesSearchQuery"></a>
+
 `InvoicesSearchQuery(*args, **kwargs)`
 :   Search query for invoices entity.
 
@@ -3296,6 +3464,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.stripe.types.InvoicesSortFilter]`
     :   The type of the None singleton.
+
+<a id="InvoicesSortFilter"></a>
 
 `InvoicesSortFilter(*args, **kwargs)`
 :   Available fields for sorting invoices search results.
@@ -3576,6 +3746,8 @@ Classes
     `webhooks_delivered_at: Literal['asc', 'desc']`
     :   Timestamp indicating when webhooks for this invoice were successfully delivered.
 
+<a id="InvoicesStringFilter"></a>
+
 `InvoicesStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -3855,6 +4027,8 @@ Classes
     `webhooks_delivered_at: str`
     :   Timestamp indicating when webhooks for this invoice were successfully delivered.
 
+<a id="PaymentIntentsApiSearchParams"></a>
+
 `PaymentIntentsApiSearchParams(*args, **kwargs)`
 :   Parameters for payment_intents.api_search operation
 
@@ -3873,6 +4047,8 @@ Classes
     `query: str`
     :   The type of the None singleton.
 
+<a id="PaymentIntentsGetParams"></a>
+
 `PaymentIntentsGetParams(*args, **kwargs)`
 :   Parameters for payment_intents.get operation
 
@@ -3884,6 +4060,8 @@ Classes
 
     `id: str`
     :   The type of the None singleton.
+
+<a id="PaymentIntentsListParams"></a>
 
 `PaymentIntentsListParams(*args, **kwargs)`
 :   Parameters for payment_intents.list operation
@@ -3912,6 +4090,8 @@ Classes
     `starting_after: str`
     :   The type of the None singleton.
 
+<a id="PaymentIntentsListParamsCreated"></a>
+
 `PaymentIntentsListParamsCreated(*args, **kwargs)`
 :   Nested schema for PaymentIntentsListParams.created
 
@@ -3933,6 +4113,8 @@ Classes
     `lte: int`
     :   The type of the None singleton.
 
+<a id="PayoutsGetParams"></a>
+
 `PayoutsGetParams(*args, **kwargs)`
 :   Parameters for payouts.get operation
 
@@ -3944,6 +4126,8 @@ Classes
 
     `id: str`
     :   The type of the None singleton.
+
+<a id="PayoutsListParams"></a>
 
 `PayoutsListParams(*args, **kwargs)`
 :   Parameters for payouts.list operation
@@ -3975,6 +4159,8 @@ Classes
     `status: str`
     :   The type of the None singleton.
 
+<a id="PayoutsListParamsArrivalDate"></a>
+
 `PayoutsListParamsArrivalDate(*args, **kwargs)`
 :   Nested schema for PayoutsListParams.arrival_date
 
@@ -3995,6 +4181,8 @@ Classes
 
     `lte: int`
     :   The type of the None singleton.
+
+<a id="PayoutsListParamsCreated"></a>
 
 `PayoutsListParamsCreated(*args, **kwargs)`
 :   Nested schema for PayoutsListParams.created
@@ -4017,6 +4205,8 @@ Classes
     `lte: int`
     :   The type of the None singleton.
 
+<a id="ProductsApiSearchParams"></a>
+
 `ProductsApiSearchParams(*args, **kwargs)`
 :   Parameters for products.api_search operation
 
@@ -4035,12 +4225,16 @@ Classes
     `query: str`
     :   The type of the None singleton.
 
+<a id="ProductsCreateParams"></a>
+
 `ProductsCreateParams(*args, **kwargs)`
 :   Parameters for products.create operation
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="ProductsDeleteParams"></a>
 
 `ProductsDeleteParams(*args, **kwargs)`
 :   Parameters for products.delete operation
@@ -4054,6 +4248,8 @@ Classes
     `id: str`
     :   The type of the None singleton.
 
+<a id="ProductsGetParams"></a>
+
 `ProductsGetParams(*args, **kwargs)`
 :   Parameters for products.get operation
 
@@ -4065,6 +4261,8 @@ Classes
 
     `id: str`
     :   The type of the None singleton.
+
+<a id="ProductsListParams"></a>
 
 `ProductsListParams(*args, **kwargs)`
 :   Parameters for products.list operation
@@ -4099,6 +4297,8 @@ Classes
     `url: str`
     :   The type of the None singleton.
 
+<a id="ProductsListParamsCreated"></a>
+
 `ProductsListParamsCreated(*args, **kwargs)`
 :   Nested schema for ProductsListParams.created
 
@@ -4120,6 +4320,8 @@ Classes
     `lte: int`
     :   The type of the None singleton.
 
+<a id="ProductsUpdateParams"></a>
+
 `ProductsUpdateParams(*args, **kwargs)`
 :   Parameters for products.update operation
 
@@ -4131,6 +4333,8 @@ Classes
 
     `id: str`
     :   The type of the None singleton.
+
+<a id="RefundsAndCondition"></a>
 
 `RefundsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -4152,6 +4356,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.stripe.types.RefundsEqCondition | airbyte_agent_sdk.connectors.stripe.types.RefundsNeqCondition | airbyte_agent_sdk.connectors.stripe.types.RefundsGtCondition | airbyte_agent_sdk.connectors.stripe.types.RefundsGteCondition | airbyte_agent_sdk.connectors.stripe.types.RefundsLtCondition | airbyte_agent_sdk.connectors.stripe.types.RefundsLteCondition | airbyte_agent_sdk.connectors.stripe.types.RefundsInCondition | airbyte_agent_sdk.connectors.stripe.types.RefundsLikeCondition | airbyte_agent_sdk.connectors.stripe.types.RefundsFuzzyCondition | airbyte_agent_sdk.connectors.stripe.types.RefundsKeywordCondition | airbyte_agent_sdk.connectors.stripe.types.RefundsContainsCondition | airbyte_agent_sdk.connectors.stripe.types.RefundsNotCondition | airbyte_agent_sdk.connectors.stripe.types.RefundsAndCondition | airbyte_agent_sdk.connectors.stripe.types.RefundsOrCondition | airbyte_agent_sdk.connectors.stripe.types.RefundsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="RefundsAnyCondition"></a>
+
 `RefundsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -4171,6 +4377,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.stripe.types.RefundsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="RefundsAnyValueFilter"></a>
 
 `RefundsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -4229,6 +4437,8 @@ Classes
     `updated: Any`
     :   Timestamp indicating when the refund was last updated.
 
+<a id="RefundsContainsCondition"></a>
+
 `RefundsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -4241,12 +4451,16 @@ Classes
     `contains: airbyte_agent_sdk.connectors.stripe.types.RefundsAnyValueFilter`
     :   The type of the None singleton.
 
+<a id="RefundsCreateParams"></a>
+
 `RefundsCreateParams(*args, **kwargs)`
 :   Parameters for refunds.create operation
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="RefundsEqCondition"></a>
 
 `RefundsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -4260,6 +4474,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.stripe.types.RefundsSearchFilter`
     :   The type of the None singleton.
 
+<a id="RefundsFuzzyCondition"></a>
+
 `RefundsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -4271,6 +4487,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.stripe.types.RefundsStringFilter`
     :   The type of the None singleton.
+
+<a id="RefundsGetParams"></a>
 
 `RefundsGetParams(*args, **kwargs)`
 :   Parameters for refunds.get operation
@@ -4284,6 +4502,8 @@ Classes
     `id: str`
     :   The type of the None singleton.
 
+<a id="RefundsGtCondition"></a>
+
 `RefundsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -4296,6 +4516,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.stripe.types.RefundsSearchFilter`
     :   The type of the None singleton.
 
+<a id="RefundsGteCondition"></a>
+
 `RefundsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -4307,6 +4529,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.stripe.types.RefundsSearchFilter`
     :   The type of the None singleton.
+
+<a id="RefundsInCondition"></a>
 
 `RefundsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -4327,6 +4551,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.stripe.types.RefundsInFilter`
     :   The type of the None singleton.
+
+<a id="RefundsInFilter"></a>
 
 `RefundsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -4385,6 +4611,8 @@ Classes
     `updated: list[int]`
     :   Timestamp indicating when the refund was last updated.
 
+<a id="RefundsKeywordCondition"></a>
+
 `RefundsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -4397,6 +4625,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.stripe.types.RefundsStringFilter`
     :   The type of the None singleton.
 
+<a id="RefundsLikeCondition"></a>
+
 `RefundsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -4408,6 +4638,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.stripe.types.RefundsStringFilter`
     :   The type of the None singleton.
+
+<a id="RefundsListParams"></a>
 
 `RefundsListParams(*args, **kwargs)`
 :   Parameters for refunds.list operation
@@ -4436,6 +4668,8 @@ Classes
     `starting_after: str`
     :   The type of the None singleton.
 
+<a id="RefundsListParamsCreated"></a>
+
 `RefundsListParamsCreated(*args, **kwargs)`
 :   Nested schema for RefundsListParams.created
 
@@ -4457,6 +4691,8 @@ Classes
     `lte: int`
     :   The type of the None singleton.
 
+<a id="RefundsLtCondition"></a>
+
 `RefundsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -4468,6 +4704,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.stripe.types.RefundsSearchFilter`
     :   The type of the None singleton.
+
+<a id="RefundsLteCondition"></a>
 
 `RefundsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -4481,6 +4719,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.stripe.types.RefundsSearchFilter`
     :   The type of the None singleton.
 
+<a id="RefundsNeqCondition"></a>
+
 `RefundsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -4492,6 +4732,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.stripe.types.RefundsSearchFilter`
     :   The type of the None singleton.
+
+<a id="RefundsNotCondition"></a>
 
 `RefundsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -4513,6 +4755,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.stripe.types.RefundsEqCondition | airbyte_agent_sdk.connectors.stripe.types.RefundsNeqCondition | airbyte_agent_sdk.connectors.stripe.types.RefundsGtCondition | airbyte_agent_sdk.connectors.stripe.types.RefundsGteCondition | airbyte_agent_sdk.connectors.stripe.types.RefundsLtCondition | airbyte_agent_sdk.connectors.stripe.types.RefundsLteCondition | airbyte_agent_sdk.connectors.stripe.types.RefundsInCondition | airbyte_agent_sdk.connectors.stripe.types.RefundsLikeCondition | airbyte_agent_sdk.connectors.stripe.types.RefundsFuzzyCondition | airbyte_agent_sdk.connectors.stripe.types.RefundsKeywordCondition | airbyte_agent_sdk.connectors.stripe.types.RefundsContainsCondition | airbyte_agent_sdk.connectors.stripe.types.RefundsNotCondition | airbyte_agent_sdk.connectors.stripe.types.RefundsAndCondition | airbyte_agent_sdk.connectors.stripe.types.RefundsOrCondition | airbyte_agent_sdk.connectors.stripe.types.RefundsAnyCondition`
     :   The type of the None singleton.
 
+<a id="RefundsOrCondition"></a>
+
 `RefundsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -4532,6 +4776,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.stripe.types.RefundsEqCondition | airbyte_agent_sdk.connectors.stripe.types.RefundsNeqCondition | airbyte_agent_sdk.connectors.stripe.types.RefundsGtCondition | airbyte_agent_sdk.connectors.stripe.types.RefundsGteCondition | airbyte_agent_sdk.connectors.stripe.types.RefundsLtCondition | airbyte_agent_sdk.connectors.stripe.types.RefundsLteCondition | airbyte_agent_sdk.connectors.stripe.types.RefundsInCondition | airbyte_agent_sdk.connectors.stripe.types.RefundsLikeCondition | airbyte_agent_sdk.connectors.stripe.types.RefundsFuzzyCondition | airbyte_agent_sdk.connectors.stripe.types.RefundsKeywordCondition | airbyte_agent_sdk.connectors.stripe.types.RefundsContainsCondition | airbyte_agent_sdk.connectors.stripe.types.RefundsNotCondition | airbyte_agent_sdk.connectors.stripe.types.RefundsAndCondition | airbyte_agent_sdk.connectors.stripe.types.RefundsOrCondition | airbyte_agent_sdk.connectors.stripe.types.RefundsAnyCondition]`
     :   The type of the None singleton.
+
+<a id="RefundsSearchFilter"></a>
 
 `RefundsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering refunds search queries.
@@ -4590,6 +4836,8 @@ Classes
     `updated: int | None`
     :   Timestamp indicating when the refund was last updated.
 
+<a id="RefundsSearchQuery"></a>
+
 `RefundsSearchQuery(*args, **kwargs)`
 :   Search query for refunds entity.
 
@@ -4604,6 +4852,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.stripe.types.RefundsSortFilter]`
     :   The type of the None singleton.
+
+<a id="RefundsSortFilter"></a>
 
 `RefundsSortFilter(*args, **kwargs)`
 :   Available fields for sorting refunds search results.
@@ -4662,6 +4912,8 @@ Classes
     `updated: Literal['asc', 'desc']`
     :   Timestamp indicating when the refund was last updated.
 
+<a id="RefundsStringFilter"></a>
+
 `RefundsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -4719,6 +4971,8 @@ Classes
     `updated: str`
     :   Timestamp indicating when the refund was last updated.
 
+<a id="SubscriptionsAndCondition"></a>
+
 `SubscriptionsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -4739,6 +4993,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.stripe.types.SubscriptionsEqCondition | airbyte_agent_sdk.connectors.stripe.types.SubscriptionsNeqCondition | airbyte_agent_sdk.connectors.stripe.types.SubscriptionsGtCondition | airbyte_agent_sdk.connectors.stripe.types.SubscriptionsGteCondition | airbyte_agent_sdk.connectors.stripe.types.SubscriptionsLtCondition | airbyte_agent_sdk.connectors.stripe.types.SubscriptionsLteCondition | airbyte_agent_sdk.connectors.stripe.types.SubscriptionsInCondition | airbyte_agent_sdk.connectors.stripe.types.SubscriptionsLikeCondition | airbyte_agent_sdk.connectors.stripe.types.SubscriptionsFuzzyCondition | airbyte_agent_sdk.connectors.stripe.types.SubscriptionsKeywordCondition | airbyte_agent_sdk.connectors.stripe.types.SubscriptionsContainsCondition | airbyte_agent_sdk.connectors.stripe.types.SubscriptionsNotCondition | airbyte_agent_sdk.connectors.stripe.types.SubscriptionsAndCondition | airbyte_agent_sdk.connectors.stripe.types.SubscriptionsOrCondition | airbyte_agent_sdk.connectors.stripe.types.SubscriptionsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="SubscriptionsAnyCondition"></a>
+
 `SubscriptionsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -4758,6 +5014,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.stripe.types.SubscriptionsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="SubscriptionsAnyValueFilter"></a>
 
 `SubscriptionsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -4923,6 +5181,8 @@ Classes
     `items(self, /) ‑> Any`
     :   Return a set-like object providing a view on the dict's items.
 
+<a id="SubscriptionsApiSearchParams"></a>
+
 `SubscriptionsApiSearchParams(*args, **kwargs)`
 :   Parameters for subscriptions.api_search operation
 
@@ -4941,6 +5201,8 @@ Classes
     `query: str`
     :   The type of the None singleton.
 
+<a id="SubscriptionsContainsCondition"></a>
+
 `SubscriptionsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -4952,6 +5214,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.stripe.types.SubscriptionsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="SubscriptionsEqCondition"></a>
 
 `SubscriptionsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -4965,6 +5229,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.stripe.types.SubscriptionsSearchFilter`
     :   The type of the None singleton.
 
+<a id="SubscriptionsFuzzyCondition"></a>
+
 `SubscriptionsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -4976,6 +5242,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.stripe.types.SubscriptionsStringFilter`
     :   The type of the None singleton.
+
+<a id="SubscriptionsGetParams"></a>
 
 `SubscriptionsGetParams(*args, **kwargs)`
 :   Parameters for subscriptions.get operation
@@ -4989,6 +5257,8 @@ Classes
     `id: str`
     :   The type of the None singleton.
 
+<a id="SubscriptionsGtCondition"></a>
+
 `SubscriptionsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -5001,6 +5271,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.stripe.types.SubscriptionsSearchFilter`
     :   The type of the None singleton.
 
+<a id="SubscriptionsGteCondition"></a>
+
 `SubscriptionsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -5012,6 +5284,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.stripe.types.SubscriptionsSearchFilter`
     :   The type of the None singleton.
+
+<a id="SubscriptionsInCondition"></a>
 
 `SubscriptionsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -5032,6 +5306,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.stripe.types.SubscriptionsInFilter`
     :   The type of the None singleton.
+
+<a id="SubscriptionsInFilter"></a>
 
 `SubscriptionsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -5197,6 +5473,8 @@ Classes
     `items(self, /) ‑> list[dict[str, typing.Any]]`
     :   Return a set-like object providing a view on the dict's items.
 
+<a id="SubscriptionsKeywordCondition"></a>
+
 `SubscriptionsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -5209,6 +5487,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.stripe.types.SubscriptionsStringFilter`
     :   The type of the None singleton.
 
+<a id="SubscriptionsLikeCondition"></a>
+
 `SubscriptionsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -5220,6 +5500,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.stripe.types.SubscriptionsStringFilter`
     :   The type of the None singleton.
+
+<a id="SubscriptionsListParams"></a>
 
 `SubscriptionsListParams(*args, **kwargs)`
 :   Parameters for subscriptions.list operation
@@ -5266,6 +5548,8 @@ Classes
     `status: str`
     :   The type of the None singleton.
 
+<a id="SubscriptionsListParamsAutomaticTax"></a>
+
 `SubscriptionsListParamsAutomaticTax(*args, **kwargs)`
 :   Nested schema for SubscriptionsListParams.automatic_tax
 
@@ -5277,6 +5561,8 @@ Classes
 
     `enabled: bool`
     :   The type of the None singleton.
+
+<a id="SubscriptionsListParamsCreated"></a>
 
 `SubscriptionsListParamsCreated(*args, **kwargs)`
 :   Nested schema for SubscriptionsListParams.created
@@ -5299,6 +5585,8 @@ Classes
     `lte: int`
     :   The type of the None singleton.
 
+<a id="SubscriptionsListParamsCurrentPeriodEnd"></a>
+
 `SubscriptionsListParamsCurrentPeriodEnd(*args, **kwargs)`
 :   Nested schema for SubscriptionsListParams.current_period_end
 
@@ -5319,6 +5607,8 @@ Classes
 
     `lte: int`
     :   The type of the None singleton.
+
+<a id="SubscriptionsListParamsCurrentPeriodStart"></a>
 
 `SubscriptionsListParamsCurrentPeriodStart(*args, **kwargs)`
 :   Nested schema for SubscriptionsListParams.current_period_start
@@ -5341,6 +5631,8 @@ Classes
     `lte: int`
     :   The type of the None singleton.
 
+<a id="SubscriptionsLtCondition"></a>
+
 `SubscriptionsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -5352,6 +5644,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.stripe.types.SubscriptionsSearchFilter`
     :   The type of the None singleton.
+
+<a id="SubscriptionsLteCondition"></a>
 
 `SubscriptionsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -5365,6 +5659,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.stripe.types.SubscriptionsSearchFilter`
     :   The type of the None singleton.
 
+<a id="SubscriptionsNeqCondition"></a>
+
 `SubscriptionsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -5376,6 +5672,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.stripe.types.SubscriptionsSearchFilter`
     :   The type of the None singleton.
+
+<a id="SubscriptionsNotCondition"></a>
 
 `SubscriptionsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -5397,6 +5695,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.stripe.types.SubscriptionsEqCondition | airbyte_agent_sdk.connectors.stripe.types.SubscriptionsNeqCondition | airbyte_agent_sdk.connectors.stripe.types.SubscriptionsGtCondition | airbyte_agent_sdk.connectors.stripe.types.SubscriptionsGteCondition | airbyte_agent_sdk.connectors.stripe.types.SubscriptionsLtCondition | airbyte_agent_sdk.connectors.stripe.types.SubscriptionsLteCondition | airbyte_agent_sdk.connectors.stripe.types.SubscriptionsInCondition | airbyte_agent_sdk.connectors.stripe.types.SubscriptionsLikeCondition | airbyte_agent_sdk.connectors.stripe.types.SubscriptionsFuzzyCondition | airbyte_agent_sdk.connectors.stripe.types.SubscriptionsKeywordCondition | airbyte_agent_sdk.connectors.stripe.types.SubscriptionsContainsCondition | airbyte_agent_sdk.connectors.stripe.types.SubscriptionsNotCondition | airbyte_agent_sdk.connectors.stripe.types.SubscriptionsAndCondition | airbyte_agent_sdk.connectors.stripe.types.SubscriptionsOrCondition | airbyte_agent_sdk.connectors.stripe.types.SubscriptionsAnyCondition`
     :   The type of the None singleton.
 
+<a id="SubscriptionsOrCondition"></a>
+
 `SubscriptionsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -5416,6 +5716,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.stripe.types.SubscriptionsEqCondition | airbyte_agent_sdk.connectors.stripe.types.SubscriptionsNeqCondition | airbyte_agent_sdk.connectors.stripe.types.SubscriptionsGtCondition | airbyte_agent_sdk.connectors.stripe.types.SubscriptionsGteCondition | airbyte_agent_sdk.connectors.stripe.types.SubscriptionsLtCondition | airbyte_agent_sdk.connectors.stripe.types.SubscriptionsLteCondition | airbyte_agent_sdk.connectors.stripe.types.SubscriptionsInCondition | airbyte_agent_sdk.connectors.stripe.types.SubscriptionsLikeCondition | airbyte_agent_sdk.connectors.stripe.types.SubscriptionsFuzzyCondition | airbyte_agent_sdk.connectors.stripe.types.SubscriptionsKeywordCondition | airbyte_agent_sdk.connectors.stripe.types.SubscriptionsContainsCondition | airbyte_agent_sdk.connectors.stripe.types.SubscriptionsNotCondition | airbyte_agent_sdk.connectors.stripe.types.SubscriptionsAndCondition | airbyte_agent_sdk.connectors.stripe.types.SubscriptionsOrCondition | airbyte_agent_sdk.connectors.stripe.types.SubscriptionsAnyCondition]`
     :   The type of the None singleton.
+
+<a id="SubscriptionsSearchFilter"></a>
 
 `SubscriptionsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering subscriptions search queries.
@@ -5581,6 +5883,8 @@ Classes
     `items(self, /) ‑> dict[str, typing.Any] | None`
     :   Return a set-like object providing a view on the dict's items.
 
+<a id="SubscriptionsSearchQuery"></a>
+
 `SubscriptionsSearchQuery(*args, **kwargs)`
 :   Search query for subscriptions entity.
 
@@ -5595,6 +5899,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.stripe.types.SubscriptionsSortFilter]`
     :   The type of the None singleton.
+
+<a id="SubscriptionsSortFilter"></a>
 
 `SubscriptionsSortFilter(*args, **kwargs)`
 :   Available fields for sorting subscriptions search results.
@@ -5759,6 +6065,8 @@ Classes
 
     `items(self, /) ‑> Literal['asc', 'desc']`
     :   Return a set-like object providing a view on the dict's items.
+
+<a id="SubscriptionsStringFilter"></a>
 
 `SubscriptionsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/tiktok_marketing/connector.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/tiktok_marketing/connector.md
@@ -10,6 +10,8 @@ Tiktok-Marketing connector.
 Classes
 -------
 
+<a id="AdGroupsQuery"></a>
+
 `AdGroupsQuery(connector: TiktokMarketingConnector)`
 :   Query class for AdGroups entity operations.
     
@@ -63,6 +65,8 @@ Classes
         
         Returns:
             AdGroupsListResult
+
+<a id="AdGroupsReportsDailyQuery"></a>
 
 `AdGroupsReportsDailyQuery(connector: TiktokMarketingConnector)`
 :   Query class for AdGroupsReportsDaily entity operations.
@@ -160,6 +164,8 @@ Classes
         Returns:
             AdGroupsReportsDailyListResult
 
+<a id="AdsQuery"></a>
+
 `AdsQuery(connector: TiktokMarketingConnector)`
 :   Query class for Ads entity operations.
     
@@ -215,6 +221,8 @@ Classes
         
         Returns:
             AdsListResult
+
+<a id="AdsReportsDailyQuery"></a>
 
 `AdsReportsDailyQuery(connector: TiktokMarketingConnector)`
 :   Query class for AdsReportsDaily entity operations.
@@ -315,6 +323,8 @@ Classes
         Returns:
             AdsReportsDailyListResult
 
+<a id="AdvertisersQuery"></a>
+
 `AdvertisersQuery(connector: TiktokMarketingConnector)`
 :   Query class for Advertisers entity operations.
     
@@ -384,6 +394,8 @@ Classes
         
         Returns:
             AdvertisersListResult
+
+<a id="AdvertisersReportsDailyQuery"></a>
 
 `AdvertisersReportsDailyQuery(connector: TiktokMarketingConnector)`
 :   Query class for AdvertisersReportsDaily entity operations.
@@ -464,6 +476,8 @@ Classes
         Returns:
             AdvertisersReportsDailyListResult
 
+<a id="AudiencesQuery"></a>
+
 `AudiencesQuery(connector: TiktokMarketingConnector)`
 :   Query class for Audiences entity operations.
     
@@ -511,6 +525,8 @@ Classes
         
         Returns:
             AudiencesListResult
+
+<a id="CampaignsQuery"></a>
 
 `CampaignsQuery(connector: TiktokMarketingConnector)`
 :   Query class for Campaigns entity operations.
@@ -575,6 +591,8 @@ Classes
         
         Returns:
             CampaignsListResult
+
+<a id="CampaignsReportsDailyQuery"></a>
 
 `CampaignsReportsDailyQuery(connector: TiktokMarketingConnector)`
 :   Query class for CampaignsReportsDaily entity operations.
@@ -654,6 +672,8 @@ Classes
         Returns:
             CampaignsReportsDailyListResult
 
+<a id="CreativeAssetsImagesQuery"></a>
+
 `CreativeAssetsImagesQuery(connector: TiktokMarketingConnector)`
 :   Query class for CreativeAssetsImages entity operations.
     
@@ -703,6 +723,8 @@ Classes
         
         Returns:
             CreativeAssetsImagesListResult
+
+<a id="CreativeAssetsVideosQuery"></a>
 
 `CreativeAssetsVideosQuery(connector: TiktokMarketingConnector)`
 :   Query class for CreativeAssetsVideos entity operations.
@@ -754,6 +776,8 @@ Classes
         
         Returns:
             CreativeAssetsVideosListResult
+
+<a id="TiktokMarketingConnector"></a>
 
 `TiktokMarketingConnector(auth_config: TiktokMarketingAuthConfig | AirbyteAuthConfig | BaseModel | None = None, on_token_refresh: Any | None = None)`
 :   Type-safe Tiktok-Marketing API connector.

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/tiktok_marketing/index.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/tiktok_marketing/index.md
@@ -19,6 +19,8 @@ Sub-modules
 Classes
 -------
 
+<a id="AdGroupsReportsDailySearchData"></a>
+
 `AdGroupsReportsDailySearchData(**data: Any)`
 :   Search result data for ad_groups_reports_daily entity.
     
@@ -182,6 +184,8 @@ Classes
     `video_watched_6s: float | None`
     :   Number of times video was watched for at least 6 seconds.
 
+<a id="AdGroupsSearchData"></a>
+
 `AdGroupsSearchData(**data: Any)`
 :   Search result data for ad_groups entity.
     
@@ -239,6 +243,8 @@ Classes
 
     `secondary_status: str | None`
     :   The secondary status of the ad group
+
+<a id="AdsReportsDailySearchData"></a>
 
 `AdsReportsDailySearchData(**data: Any)`
 :   Search result data for ads_reports_daily entity.
@@ -412,6 +418,8 @@ Classes
     `video_watched_6s: float | None`
     :   Number of times video was watched for at least 6 seconds.
 
+<a id="AdsSearchData"></a>
+
 `AdsSearchData(**data: Any)`
 :   Search result data for ads entity.
     
@@ -475,6 +483,8 @@ Classes
 
     `video_id: str | None`
     :   The unique identifier of the video
+
+<a id="AdvertisersReportsDailySearchData"></a>
 
 `AdvertisersReportsDailySearchData(**data: Any)`
 :   Search result data for advertisers_reports_daily entity.
@@ -588,6 +598,8 @@ Classes
     `voucher_spend: str | None`
     :   Amount spent using vouchers.
 
+<a id="AdvertisersSearchData"></a>
+
 `AdvertisersSearchData(**data: Any)`
 :   Search result data for advertisers entity.
     
@@ -694,6 +706,8 @@ Classes
     `timezone: str | None`
     :   The timezone setting for the advertiser's activities.
 
+<a id="AirbyteAuthConfig"></a>
+
 `AirbyteAuthConfig(**data: Any)`
 :   Authentication configuration for Airbyte hosted mode execution.
     
@@ -762,6 +776,8 @@ Classes
     `workspace_name: str | None`
     :   The type of the None singleton.
 
+<a id="AirbyteSearchMeta"></a>
+
 `AirbyteSearchMeta(**data: Any)`
 :   Pagination metadata for search responses.
     
@@ -789,6 +805,8 @@ Classes
 
     `took_ms: int | None`
     :   Time taken to execute the search in milliseconds.
+
+<a id="AirbyteSearchResult"></a>
 
 `AirbyteSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -830,6 +848,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="AdGroupsReportsDailySearchResult"></a>
+
 `AdGroupsReportsDailySearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -845,6 +865,8 @@ Classes
     * airbyte_agent_sdk.connectors.tiktok_marketing.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="AdGroupsSearchResult"></a>
 
 `AdGroupsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -862,6 +884,8 @@ Classes
     * pydantic.main.BaseModel
     * typing.Generic
 
+<a id="AdsReportsDailySearchResult"></a>
+
 `AdsReportsDailySearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -877,6 +901,8 @@ Classes
     * airbyte_agent_sdk.connectors.tiktok_marketing.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="AdsSearchResult"></a>
 
 `AdsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -894,6 +920,8 @@ Classes
     * pydantic.main.BaseModel
     * typing.Generic
 
+<a id="AdvertisersReportsDailySearchResult"></a>
+
 `AdvertisersReportsDailySearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -909,6 +937,8 @@ Classes
     * airbyte_agent_sdk.connectors.tiktok_marketing.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="AdvertisersSearchResult"></a>
 
 `AdvertisersSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -926,6 +956,8 @@ Classes
     * pydantic.main.BaseModel
     * typing.Generic
 
+<a id="AudiencesSearchResult"></a>
+
 `AudiencesSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -941,6 +973,8 @@ Classes
     * airbyte_agent_sdk.connectors.tiktok_marketing.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="CampaignsReportsDailySearchResult"></a>
 
 `CampaignsReportsDailySearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -958,6 +992,8 @@ Classes
     * pydantic.main.BaseModel
     * typing.Generic
 
+<a id="CampaignsSearchResult"></a>
+
 `CampaignsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -973,6 +1009,8 @@ Classes
     * airbyte_agent_sdk.connectors.tiktok_marketing.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="CreativeAssetsImagesSearchResult"></a>
 
 `CreativeAssetsImagesSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -990,6 +1028,8 @@ Classes
     * pydantic.main.BaseModel
     * typing.Generic
 
+<a id="CreativeAssetsVideosSearchResult"></a>
+
 `CreativeAssetsVideosSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -1005,6 +1045,8 @@ Classes
     * airbyte_agent_sdk.connectors.tiktok_marketing.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="AudiencesSearchData"></a>
 
 `AudiencesSearchData(**data: Any)`
 :   Search result data for audiences entity.
@@ -1045,6 +1087,8 @@ Classes
 
     `shared: bool | None`
     :   Flag indicating if the audience is shared
+
+<a id="CampaignsReportsDailySearchData"></a>
 
 `CampaignsReportsDailySearchData(**data: Any)`
 :   Search result data for campaigns_reports_daily entity.
@@ -1155,6 +1199,8 @@ Classes
     `video_watched_6s: float | None`
     :   Number of times video was watched for at least 6 seconds.
 
+<a id="CampaignsSearchData"></a>
+
 `CampaignsSearchData(**data: Any)`
 :   Search result data for campaigns entity.
     
@@ -1243,6 +1289,8 @@ Classes
     `split_test_variable: str | None`
     :   Variable being tested in a split test campaign
 
+<a id="CreativeAssetsImagesSearchData"></a>
+
 `CreativeAssetsImagesSearchData(**data: Any)`
 :   Search result data for creative_assets_images entity.
     
@@ -1288,6 +1336,8 @@ Classes
 
     `width: int | None`
     :   The width dimension of the image.
+
+<a id="CreativeAssetsVideosSearchData"></a>
 
 `CreativeAssetsVideosSearchData(**data: Any)`
 :   Search result data for creative_assets_videos entity.
@@ -1338,6 +1388,8 @@ Classes
     `width: int | None`
     :   Width of the video in pixels.
 
+<a id="TiktokMarketingAuthConfig"></a>
+
 `TiktokMarketingAuthConfig(**data: Any)`
 :   OAuth Access Token
     
@@ -1359,6 +1411,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="TiktokMarketingConnector"></a>
 
 `TiktokMarketingConnector(auth_config: TiktokMarketingAuthConfig | AirbyteAuthConfig | BaseModel | None = None, on_token_refresh: Any | None = None)`
 :   Type-safe Tiktok-Marketing API connector.
@@ -1559,6 +1613,8 @@ Classes
             entities = connector.list_entities()
             for entity in entities:
                 print(f"\{entity['entity_name']\}: \{entity['available_actions']\}")
+
+<a id="TiktokMarketingReplicationConfig"></a>
 
 `TiktokMarketingReplicationConfig(**data: Any)`
 :   Replication Configuration - Settings for data replication from TikTok Marketing.

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/tiktok_marketing/models.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/tiktok_marketing/models.md
@@ -13,6 +13,8 @@ and response envelope types.
 Classes
 -------
 
+<a id="Ad"></a>
+
 `Ad(**data: Any)`
 :   TikTok ad
     
@@ -178,6 +180,8 @@ Classes
 
     `viewability_vast_url: str | Any | None`
     :   The type of the None singleton.
+
+<a id="AdGroup"></a>
 
 `AdGroup(**data: Any)`
 :   TikTok ad group
@@ -486,6 +490,8 @@ Classes
     `zipcode_ids: list[typing.Any] | Any | None`
     :   The type of the None singleton.
 
+<a id="AdGroupsListResultMeta"></a>
+
 `AdGroupsListResultMeta(**data: Any)`
 :   Metadata for ad_groups.Action.LIST operation
     
@@ -507,6 +513,8 @@ Classes
 
     `page_info: dict[str, typing.Any] | Any`
     :   The type of the None singleton.
+
+<a id="AdGroupsReportDaily"></a>
 
 `AdGroupsReportDaily(**data: Any)`
 :   Daily performance report at the ad group level
@@ -671,6 +679,8 @@ Classes
     `video_watched_6s: float | Any | None`
     :   The type of the None singleton.
 
+<a id="AdGroupsReportsDailyListResultMeta"></a>
+
 `AdGroupsReportsDailyListResultMeta(**data: Any)`
 :   Metadata for ad_groups_reports_daily.Action.LIST operation
     
@@ -692,6 +702,8 @@ Classes
 
     `page_info: dict[str, typing.Any] | Any`
     :   The type of the None singleton.
+
+<a id="AdGroupsReportsDailySearchData"></a>
 
 `AdGroupsReportsDailySearchData(**data: Any)`
 :   Search result data for ad_groups_reports_daily entity.
@@ -856,6 +868,8 @@ Classes
     `video_watched_6s: float | None`
     :   Number of times video was watched for at least 6 seconds.
 
+<a id="AdGroupsSearchData"></a>
+
 `AdGroupsSearchData(**data: Any)`
 :   Search result data for ad_groups entity.
     
@@ -914,6 +928,8 @@ Classes
     `secondary_status: str | None`
     :   The secondary status of the ad group
 
+<a id="AdsListResultMeta"></a>
+
 `AdsListResultMeta(**data: Any)`
 :   Metadata for ads.Action.LIST operation
     
@@ -935,6 +951,8 @@ Classes
 
     `page_info: dict[str, typing.Any] | Any`
     :   The type of the None singleton.
+
+<a id="AdsReportDaily"></a>
 
 `AdsReportDaily(**data: Any)`
 :   Daily performance report at the ad level
@@ -1108,6 +1126,8 @@ Classes
     `video_watched_6s: float | Any | None`
     :   The type of the None singleton.
 
+<a id="AdsReportsDailyListResultMeta"></a>
+
 `AdsReportsDailyListResultMeta(**data: Any)`
 :   Metadata for ads_reports_daily.Action.LIST operation
     
@@ -1129,6 +1149,8 @@ Classes
 
     `page_info: dict[str, typing.Any] | Any`
     :   The type of the None singleton.
+
+<a id="AdsReportsDailySearchData"></a>
 
 `AdsReportsDailySearchData(**data: Any)`
 :   Search result data for ads_reports_daily entity.
@@ -1302,6 +1324,8 @@ Classes
     `video_watched_6s: float | None`
     :   Number of times video was watched for at least 6 seconds.
 
+<a id="AdsSearchData"></a>
+
 `AdsSearchData(**data: Any)`
 :   Search result data for ads entity.
     
@@ -1365,6 +1389,8 @@ Classes
 
     `video_id: str | None`
     :   The unique identifier of the video
+
+<a id="Advertiser"></a>
 
 `Advertiser(**data: Any)`
 :   TikTok advertiser account
@@ -1472,6 +1498,8 @@ Classes
     `timezone: str | Any | None`
     :   The type of the None singleton.
 
+<a id="AdvertisersListResultMeta"></a>
+
 `AdvertisersListResultMeta(**data: Any)`
 :   Metadata for advertisers.Action.LIST operation
     
@@ -1493,6 +1521,8 @@ Classes
 
     `page_info: dict[str, typing.Any] | Any`
     :   The type of the None singleton.
+
+<a id="AdvertisersReportDaily"></a>
 
 `AdvertisersReportDaily(**data: Any)`
 :   Daily performance report at the advertiser level
@@ -1606,6 +1636,8 @@ Classes
     `voucher_spend: str | Any | None`
     :   The type of the None singleton.
 
+<a id="AdvertisersReportsDailyListResultMeta"></a>
+
 `AdvertisersReportsDailyListResultMeta(**data: Any)`
 :   Metadata for advertisers_reports_daily.Action.LIST operation
     
@@ -1627,6 +1659,8 @@ Classes
 
     `page_info: dict[str, typing.Any] | Any`
     :   The type of the None singleton.
+
+<a id="AdvertisersReportsDailySearchData"></a>
 
 `AdvertisersReportsDailySearchData(**data: Any)`
 :   Search result data for advertisers_reports_daily entity.
@@ -1740,6 +1774,8 @@ Classes
     `voucher_spend: str | None`
     :   Amount spent using vouchers.
 
+<a id="AdvertisersSearchData"></a>
+
 `AdvertisersSearchData(**data: Any)`
 :   Search result data for advertisers entity.
     
@@ -1846,6 +1882,8 @@ Classes
     `timezone: str | None`
     :   The timezone setting for the advertiser's activities.
 
+<a id="AirbyteSearchMeta"></a>
+
 `AirbyteSearchMeta(**data: Any)`
 :   Pagination metadata for search responses.
     
@@ -1873,6 +1911,8 @@ Classes
 
     `took_ms: int | None`
     :   Time taken to execute the search in milliseconds.
+
+<a id="AirbyteSearchResult"></a>
 
 `AirbyteSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -1935,6 +1975,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="AdGroupsReportsDailySearchResult"></a>
+
 `AdGroupsReportsDailySearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -1971,6 +2013,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="AdGroupsSearchResult"></a>
 
 `AdGroupsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -2009,6 +2053,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="AdsReportsDailySearchResult"></a>
+
 `AdsReportsDailySearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -2045,6 +2091,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="AdsSearchResult"></a>
 
 `AdsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -2083,6 +2131,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="AdvertisersReportsDailySearchResult"></a>
+
 `AdvertisersReportsDailySearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -2119,6 +2169,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="AdvertisersSearchResult"></a>
 
 `AdvertisersSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -2157,6 +2209,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="AudiencesSearchResult"></a>
+
 `AudiencesSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -2193,6 +2247,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="CampaignsReportsDailySearchResult"></a>
 
 `CampaignsReportsDailySearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -2231,6 +2287,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="CampaignsSearchResult"></a>
+
 `CampaignsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -2267,6 +2325,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="CreativeAssetsImagesSearchResult"></a>
 
 `CreativeAssetsImagesSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -2305,6 +2365,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="CreativeAssetsVideosSearchResult"></a>
+
 `CreativeAssetsVideosSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -2320,6 +2382,8 @@ Classes
     * airbyte_agent_sdk.connectors.tiktok_marketing.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="Audience"></a>
 
 `Audience(**data: Any)`
 :   TikTok custom audience
@@ -2373,6 +2437,8 @@ Classes
     `shared: bool | Any | None`
     :   The type of the None singleton.
 
+<a id="AudiencesListResultMeta"></a>
+
 `AudiencesListResultMeta(**data: Any)`
 :   Metadata for audiences.Action.LIST operation
     
@@ -2394,6 +2460,8 @@ Classes
 
     `page_info: dict[str, typing.Any] | Any`
     :   The type of the None singleton.
+
+<a id="AudiencesSearchData"></a>
 
 `AudiencesSearchData(**data: Any)`
 :   Search result data for audiences entity.
@@ -2434,6 +2502,8 @@ Classes
 
     `shared: bool | None`
     :   Flag indicating if the audience is shared
+
+<a id="Campaign"></a>
 
 `Campaign(**data: Any)`
 :   TikTok marketing campaign
@@ -2541,6 +2611,8 @@ Classes
     `split_test_variable: str | Any | None`
     :   The type of the None singleton.
 
+<a id="CampaignsListResultMeta"></a>
+
 `CampaignsListResultMeta(**data: Any)`
 :   Metadata for campaigns.Action.LIST operation
     
@@ -2562,6 +2634,8 @@ Classes
 
     `page_info: dict[str, typing.Any] | Any`
     :   The type of the None singleton.
+
+<a id="CampaignsReportDaily"></a>
 
 `CampaignsReportDaily(**data: Any)`
 :   Daily performance report at the campaign level
@@ -2672,6 +2746,8 @@ Classes
     `video_watched_6s: float | Any | None`
     :   The type of the None singleton.
 
+<a id="CampaignsReportsDailyListResultMeta"></a>
+
 `CampaignsReportsDailyListResultMeta(**data: Any)`
 :   Metadata for campaigns_reports_daily.Action.LIST operation
     
@@ -2693,6 +2769,8 @@ Classes
 
     `page_info: dict[str, typing.Any] | Any`
     :   The type of the None singleton.
+
+<a id="CampaignsReportsDailySearchData"></a>
 
 `CampaignsReportsDailySearchData(**data: Any)`
 :   Search result data for campaigns_reports_daily entity.
@@ -2803,6 +2881,8 @@ Classes
     `video_watched_6s: float | None`
     :   Number of times video was watched for at least 6 seconds.
 
+<a id="CampaignsSearchData"></a>
+
 `CampaignsSearchData(**data: Any)`
 :   Search result data for campaigns entity.
     
@@ -2891,6 +2971,8 @@ Classes
     `split_test_variable: str | None`
     :   Variable being tested in a split test campaign
 
+<a id="CreativeAssetImage"></a>
+
 `CreativeAssetImage(**data: Any)`
 :   TikTok creative asset image
     
@@ -2948,6 +3030,8 @@ Classes
 
     `width: int | Any | None`
     :   The type of the None singleton.
+
+<a id="CreativeAssetVideo"></a>
 
 `CreativeAssetVideo(**data: Any)`
 :   TikTok creative asset video
@@ -3028,6 +3112,8 @@ Classes
     `width: int | Any | None`
     :   The type of the None singleton.
 
+<a id="CreativeAssetsImagesListResultMeta"></a>
+
 `CreativeAssetsImagesListResultMeta(**data: Any)`
 :   Metadata for creative_assets_images.Action.LIST operation
     
@@ -3049,6 +3135,8 @@ Classes
 
     `page_info: dict[str, typing.Any] | Any`
     :   The type of the None singleton.
+
+<a id="CreativeAssetsImagesSearchData"></a>
 
 `CreativeAssetsImagesSearchData(**data: Any)`
 :   Search result data for creative_assets_images entity.
@@ -3096,6 +3184,8 @@ Classes
     `width: int | None`
     :   The width dimension of the image.
 
+<a id="CreativeAssetsVideosListResultMeta"></a>
+
 `CreativeAssetsVideosListResultMeta(**data: Any)`
 :   Metadata for creative_assets_videos.Action.LIST operation
     
@@ -3117,6 +3207,8 @@ Classes
 
     `page_info: dict[str, typing.Any] | Any`
     :   The type of the None singleton.
+
+<a id="CreativeAssetsVideosSearchData"></a>
 
 `CreativeAssetsVideosSearchData(**data: Any)`
 :   Search result data for creative_assets_videos entity.
@@ -3167,6 +3259,8 @@ Classes
     `width: int | None`
     :   Width of the video in pixels.
 
+<a id="TiktokMarketingAuthConfig"></a>
+
 `TiktokMarketingAuthConfig(**data: Any)`
 :   OAuth Access Token
     
@@ -3188,6 +3282,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="TiktokMarketingCheckResult"></a>
 
 `TiktokMarketingCheckResult(**data: Any)`
 :   Result of a health check operation.
@@ -3222,6 +3318,8 @@ Classes
     `status: str`
     :   Health check status: 'healthy' or 'unhealthy'.
 
+<a id="TiktokMarketingExecuteResult"></a>
+
 `TiktokMarketingExecuteResult(**data: Any)`
 :   Response envelope with data only.
     
@@ -3250,6 +3348,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="TiktokMarketingExecuteResultWithMeta"></a>
 
 `TiktokMarketingExecuteResultWithMeta(**data: Any)`
 :   Response envelope with data and metadata.
@@ -3312,6 +3412,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="AdGroupsListResult"></a>
+
 `AdGroupsListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -3354,6 +3456,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="AdGroupsReportsDailyListResult"></a>
 
 `AdGroupsReportsDailyListResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -3398,6 +3502,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="AdsListResult"></a>
+
 `AdsListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -3440,6 +3546,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="AdsReportsDailyListResult"></a>
 
 `AdsReportsDailyListResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -3484,6 +3592,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="AdvertisersListResult"></a>
+
 `AdvertisersListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -3526,6 +3636,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="AdvertisersReportsDailyListResult"></a>
 
 `AdvertisersReportsDailyListResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -3570,6 +3682,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="AudiencesListResult"></a>
+
 `AudiencesListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -3612,6 +3726,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="CampaignsListResult"></a>
 
 `CampaignsListResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -3656,6 +3772,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="CampaignsReportsDailyListResult"></a>
+
 `CampaignsReportsDailyListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -3698,6 +3816,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="CreativeAssetsImagesListResult"></a>
 
 `CreativeAssetsImagesListResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -3742,6 +3862,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="CreativeAssetsVideosListResult"></a>
+
 `CreativeAssetsVideosListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -3760,6 +3882,8 @@ Classes
     * airbyte_agent_sdk.connectors.tiktok_marketing.models.TiktokMarketingExecuteResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="TiktokMarketingReplicationConfig"></a>
 
 `TiktokMarketingReplicationConfig(**data: Any)`
 :   Replication Configuration - Settings for data replication from TikTok Marketing.

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/tiktok_marketing/types.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/tiktok_marketing/types.md
@@ -10,6 +10,8 @@ Type definitions for tiktok-marketing connector.
 Classes
 -------
 
+<a id="AdGroupsAndCondition"></a>
+
 `AdGroupsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -30,6 +32,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.tiktok_marketing.types.AdGroupsEqCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdGroupsNeqCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdGroupsGtCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdGroupsGteCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdGroupsLtCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdGroupsLteCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdGroupsInCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdGroupsLikeCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdGroupsFuzzyCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdGroupsKeywordCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdGroupsContainsCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdGroupsNotCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdGroupsAndCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdGroupsOrCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdGroupsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="AdGroupsAnyCondition"></a>
+
 `AdGroupsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -49,6 +53,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.tiktok_marketing.types.AdGroupsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="AdGroupsAnyValueFilter"></a>
 
 `AdGroupsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -98,6 +104,8 @@ Classes
     `secondary_status: Any`
     :   The secondary status of the ad group
 
+<a id="AdGroupsContainsCondition"></a>
+
 `AdGroupsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -109,6 +117,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.tiktok_marketing.types.AdGroupsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="AdGroupsEqCondition"></a>
 
 `AdGroupsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -122,6 +132,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.tiktok_marketing.types.AdGroupsSearchFilter`
     :   The type of the None singleton.
 
+<a id="AdGroupsFuzzyCondition"></a>
+
 `AdGroupsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -133,6 +145,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.tiktok_marketing.types.AdGroupsStringFilter`
     :   The type of the None singleton.
+
+<a id="AdGroupsGtCondition"></a>
 
 `AdGroupsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
@@ -146,6 +160,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.tiktok_marketing.types.AdGroupsSearchFilter`
     :   The type of the None singleton.
 
+<a id="AdGroupsGteCondition"></a>
+
 `AdGroupsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -157,6 +173,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.tiktok_marketing.types.AdGroupsSearchFilter`
     :   The type of the None singleton.
+
+<a id="AdGroupsInCondition"></a>
 
 `AdGroupsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -177,6 +195,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.tiktok_marketing.types.AdGroupsInFilter`
     :   The type of the None singleton.
+
+<a id="AdGroupsInFilter"></a>
 
 `AdGroupsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -226,6 +246,8 @@ Classes
     `secondary_status: list[str]`
     :   The secondary status of the ad group
 
+<a id="AdGroupsKeywordCondition"></a>
+
 `AdGroupsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -238,6 +260,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.tiktok_marketing.types.AdGroupsStringFilter`
     :   The type of the None singleton.
 
+<a id="AdGroupsLikeCondition"></a>
+
 `AdGroupsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -249,6 +273,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.tiktok_marketing.types.AdGroupsStringFilter`
     :   The type of the None singleton.
+
+<a id="AdGroupsListParams"></a>
 
 `AdGroupsListParams(*args, **kwargs)`
 :   Parameters for ad_groups.list operation
@@ -268,6 +294,8 @@ Classes
     `page_size: int`
     :   The type of the None singleton.
 
+<a id="AdGroupsLtCondition"></a>
+
 `AdGroupsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -279,6 +307,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.tiktok_marketing.types.AdGroupsSearchFilter`
     :   The type of the None singleton.
+
+<a id="AdGroupsLteCondition"></a>
 
 `AdGroupsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -292,6 +322,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.tiktok_marketing.types.AdGroupsSearchFilter`
     :   The type of the None singleton.
 
+<a id="AdGroupsNeqCondition"></a>
+
 `AdGroupsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -303,6 +335,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.tiktok_marketing.types.AdGroupsSearchFilter`
     :   The type of the None singleton.
+
+<a id="AdGroupsNotCondition"></a>
 
 `AdGroupsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -324,6 +358,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.tiktok_marketing.types.AdGroupsEqCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdGroupsNeqCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdGroupsGtCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdGroupsGteCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdGroupsLtCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdGroupsLteCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdGroupsInCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdGroupsLikeCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdGroupsFuzzyCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdGroupsKeywordCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdGroupsContainsCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdGroupsNotCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdGroupsAndCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdGroupsOrCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdGroupsAnyCondition`
     :   The type of the None singleton.
 
+<a id="AdGroupsOrCondition"></a>
+
 `AdGroupsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -343,6 +379,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.tiktok_marketing.types.AdGroupsEqCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdGroupsNeqCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdGroupsGtCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdGroupsGteCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdGroupsLtCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdGroupsLteCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdGroupsInCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdGroupsLikeCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdGroupsFuzzyCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdGroupsKeywordCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdGroupsContainsCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdGroupsNotCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdGroupsAndCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdGroupsOrCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdGroupsAnyCondition]`
     :   The type of the None singleton.
+
+<a id="AdGroupsReportsDailyAndCondition"></a>
 
 `AdGroupsReportsDailyAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -364,6 +402,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.tiktok_marketing.types.AdGroupsReportsDailyEqCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdGroupsReportsDailyNeqCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdGroupsReportsDailyGtCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdGroupsReportsDailyGteCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdGroupsReportsDailyLtCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdGroupsReportsDailyLteCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdGroupsReportsDailyInCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdGroupsReportsDailyLikeCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdGroupsReportsDailyFuzzyCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdGroupsReportsDailyKeywordCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdGroupsReportsDailyContainsCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdGroupsReportsDailyNotCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdGroupsReportsDailyAndCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdGroupsReportsDailyOrCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdGroupsReportsDailyAnyCondition]`
     :   The type of the None singleton.
 
+<a id="AdGroupsReportsDailyAnyCondition"></a>
+
 `AdGroupsReportsDailyAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -383,6 +423,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.tiktok_marketing.types.AdGroupsReportsDailyAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="AdGroupsReportsDailyAnyValueFilter"></a>
 
 `AdGroupsReportsDailyAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -537,6 +579,8 @@ Classes
     `video_watched_6s: Any`
     :   Number of times video was watched for at least 6 seconds.
 
+<a id="AdGroupsReportsDailyContainsCondition"></a>
+
 `AdGroupsReportsDailyContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -548,6 +592,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.tiktok_marketing.types.AdGroupsReportsDailyAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="AdGroupsReportsDailyEqCondition"></a>
 
 `AdGroupsReportsDailyEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -561,6 +607,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.tiktok_marketing.types.AdGroupsReportsDailySearchFilter`
     :   The type of the None singleton.
 
+<a id="AdGroupsReportsDailyFuzzyCondition"></a>
+
 `AdGroupsReportsDailyFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -572,6 +620,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.tiktok_marketing.types.AdGroupsReportsDailyStringFilter`
     :   The type of the None singleton.
+
+<a id="AdGroupsReportsDailyGtCondition"></a>
 
 `AdGroupsReportsDailyGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
@@ -585,6 +635,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.tiktok_marketing.types.AdGroupsReportsDailySearchFilter`
     :   The type of the None singleton.
 
+<a id="AdGroupsReportsDailyGteCondition"></a>
+
 `AdGroupsReportsDailyGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -596,6 +648,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.tiktok_marketing.types.AdGroupsReportsDailySearchFilter`
     :   The type of the None singleton.
+
+<a id="AdGroupsReportsDailyInCondition"></a>
 
 `AdGroupsReportsDailyInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -616,6 +670,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.tiktok_marketing.types.AdGroupsReportsDailyInFilter`
     :   The type of the None singleton.
+
+<a id="AdGroupsReportsDailyInFilter"></a>
 
 `AdGroupsReportsDailyInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -770,6 +826,8 @@ Classes
     `video_watched_6s: list[float]`
     :   Number of times video was watched for at least 6 seconds.
 
+<a id="AdGroupsReportsDailyKeywordCondition"></a>
+
 `AdGroupsReportsDailyKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -782,6 +840,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.tiktok_marketing.types.AdGroupsReportsDailyStringFilter`
     :   The type of the None singleton.
 
+<a id="AdGroupsReportsDailyLikeCondition"></a>
+
 `AdGroupsReportsDailyLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -793,6 +853,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.tiktok_marketing.types.AdGroupsReportsDailyStringFilter`
     :   The type of the None singleton.
+
+<a id="AdGroupsReportsDailyListParams"></a>
 
 `AdGroupsReportsDailyListParams(*args, **kwargs)`
 :   Parameters for ad_groups_reports_daily.list operation
@@ -833,6 +895,8 @@ Classes
     `start_date: str`
     :   The type of the None singleton.
 
+<a id="AdGroupsReportsDailyLtCondition"></a>
+
 `AdGroupsReportsDailyLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -844,6 +908,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.tiktok_marketing.types.AdGroupsReportsDailySearchFilter`
     :   The type of the None singleton.
+
+<a id="AdGroupsReportsDailyLteCondition"></a>
 
 `AdGroupsReportsDailyLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -857,6 +923,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.tiktok_marketing.types.AdGroupsReportsDailySearchFilter`
     :   The type of the None singleton.
 
+<a id="AdGroupsReportsDailyNeqCondition"></a>
+
 `AdGroupsReportsDailyNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -868,6 +936,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.tiktok_marketing.types.AdGroupsReportsDailySearchFilter`
     :   The type of the None singleton.
+
+<a id="AdGroupsReportsDailyNotCondition"></a>
 
 `AdGroupsReportsDailyNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -889,6 +959,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.tiktok_marketing.types.AdGroupsReportsDailyEqCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdGroupsReportsDailyNeqCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdGroupsReportsDailyGtCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdGroupsReportsDailyGteCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdGroupsReportsDailyLtCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdGroupsReportsDailyLteCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdGroupsReportsDailyInCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdGroupsReportsDailyLikeCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdGroupsReportsDailyFuzzyCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdGroupsReportsDailyKeywordCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdGroupsReportsDailyContainsCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdGroupsReportsDailyNotCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdGroupsReportsDailyAndCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdGroupsReportsDailyOrCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdGroupsReportsDailyAnyCondition`
     :   The type of the None singleton.
 
+<a id="AdGroupsReportsDailyOrCondition"></a>
+
 `AdGroupsReportsDailyOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -908,6 +980,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.tiktok_marketing.types.AdGroupsReportsDailyEqCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdGroupsReportsDailyNeqCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdGroupsReportsDailyGtCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdGroupsReportsDailyGteCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdGroupsReportsDailyLtCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdGroupsReportsDailyLteCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdGroupsReportsDailyInCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdGroupsReportsDailyLikeCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdGroupsReportsDailyFuzzyCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdGroupsReportsDailyKeywordCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdGroupsReportsDailyContainsCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdGroupsReportsDailyNotCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdGroupsReportsDailyAndCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdGroupsReportsDailyOrCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdGroupsReportsDailyAnyCondition]`
     :   The type of the None singleton.
+
+<a id="AdGroupsReportsDailySearchFilter"></a>
 
 `AdGroupsReportsDailySearchFilter(*args, **kwargs)`
 :   Available fields for filtering ad_groups_reports_daily search queries.
@@ -1062,6 +1136,8 @@ Classes
     `video_watched_6s: float | None`
     :   Number of times video was watched for at least 6 seconds.
 
+<a id="AdGroupsReportsDailySearchQuery"></a>
+
 `AdGroupsReportsDailySearchQuery(*args, **kwargs)`
 :   Search query for ad_groups_reports_daily entity.
 
@@ -1076,6 +1152,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.tiktok_marketing.types.AdGroupsReportsDailySortFilter]`
     :   The type of the None singleton.
+
+<a id="AdGroupsReportsDailySortFilter"></a>
 
 `AdGroupsReportsDailySortFilter(*args, **kwargs)`
 :   Available fields for sorting ad_groups_reports_daily search results.
@@ -1230,6 +1308,8 @@ Classes
     `video_watched_6s: Literal['asc', 'desc']`
     :   Number of times video was watched for at least 6 seconds.
 
+<a id="AdGroupsReportsDailyStringFilter"></a>
+
 `AdGroupsReportsDailyStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -1383,6 +1463,8 @@ Classes
     `video_watched_6s: str`
     :   Number of times video was watched for at least 6 seconds.
 
+<a id="AdGroupsSearchFilter"></a>
+
 `AdGroupsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering ad_groups search queries.
 
@@ -1431,6 +1513,8 @@ Classes
     `secondary_status: str | None`
     :   The secondary status of the ad group
 
+<a id="AdGroupsSearchQuery"></a>
+
 `AdGroupsSearchQuery(*args, **kwargs)`
 :   Search query for ad_groups entity.
 
@@ -1445,6 +1529,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.tiktok_marketing.types.AdGroupsSortFilter]`
     :   The type of the None singleton.
+
+<a id="AdGroupsSortFilter"></a>
 
 `AdGroupsSortFilter(*args, **kwargs)`
 :   Available fields for sorting ad_groups search results.
@@ -1494,6 +1580,8 @@ Classes
     `secondary_status: Literal['asc', 'desc']`
     :   The secondary status of the ad group
 
+<a id="AdGroupsStringFilter"></a>
+
 `AdGroupsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -1542,6 +1630,8 @@ Classes
     `secondary_status: str`
     :   The secondary status of the ad group
 
+<a id="AdsAndCondition"></a>
+
 `AdsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1562,6 +1652,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.tiktok_marketing.types.AdsEqCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdsNeqCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdsGtCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdsGteCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdsLtCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdsLteCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdsInCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdsLikeCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdsFuzzyCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdsKeywordCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdsContainsCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdsNotCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdsAndCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdsOrCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="AdsAnyCondition"></a>
+
 `AdsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1581,6 +1673,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.tiktok_marketing.types.AdsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="AdsAnyValueFilter"></a>
 
 `AdsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -1636,6 +1730,8 @@ Classes
     `video_id: Any`
     :   The unique identifier of the video
 
+<a id="AdsContainsCondition"></a>
+
 `AdsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -1647,6 +1743,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.tiktok_marketing.types.AdsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="AdsEqCondition"></a>
 
 `AdsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -1660,6 +1758,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.tiktok_marketing.types.AdsSearchFilter`
     :   The type of the None singleton.
 
+<a id="AdsFuzzyCondition"></a>
+
 `AdsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -1671,6 +1771,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.tiktok_marketing.types.AdsStringFilter`
     :   The type of the None singleton.
+
+<a id="AdsGtCondition"></a>
 
 `AdsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
@@ -1684,6 +1786,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.tiktok_marketing.types.AdsSearchFilter`
     :   The type of the None singleton.
 
+<a id="AdsGteCondition"></a>
+
 `AdsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -1695,6 +1799,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.tiktok_marketing.types.AdsSearchFilter`
     :   The type of the None singleton.
+
+<a id="AdsInCondition"></a>
 
 `AdsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -1715,6 +1821,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.tiktok_marketing.types.AdsInFilter`
     :   The type of the None singleton.
+
+<a id="AdsInFilter"></a>
 
 `AdsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -1770,6 +1878,8 @@ Classes
     `video_id: list[str]`
     :   The unique identifier of the video
 
+<a id="AdsKeywordCondition"></a>
+
 `AdsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -1782,6 +1892,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.tiktok_marketing.types.AdsStringFilter`
     :   The type of the None singleton.
 
+<a id="AdsLikeCondition"></a>
+
 `AdsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -1793,6 +1905,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.tiktok_marketing.types.AdsStringFilter`
     :   The type of the None singleton.
+
+<a id="AdsListParams"></a>
 
 `AdsListParams(*args, **kwargs)`
 :   Parameters for ads.list operation
@@ -1812,6 +1926,8 @@ Classes
     `page_size: int`
     :   The type of the None singleton.
 
+<a id="AdsLtCondition"></a>
+
 `AdsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -1823,6 +1939,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.tiktok_marketing.types.AdsSearchFilter`
     :   The type of the None singleton.
+
+<a id="AdsLteCondition"></a>
 
 `AdsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -1836,6 +1954,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.tiktok_marketing.types.AdsSearchFilter`
     :   The type of the None singleton.
 
+<a id="AdsNeqCondition"></a>
+
 `AdsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -1847,6 +1967,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.tiktok_marketing.types.AdsSearchFilter`
     :   The type of the None singleton.
+
+<a id="AdsNotCondition"></a>
 
 `AdsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -1868,6 +1990,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.tiktok_marketing.types.AdsEqCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdsNeqCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdsGtCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdsGteCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdsLtCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdsLteCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdsInCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdsLikeCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdsFuzzyCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdsKeywordCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdsContainsCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdsNotCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdsAndCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdsOrCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdsAnyCondition`
     :   The type of the None singleton.
 
+<a id="AdsOrCondition"></a>
+
 `AdsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1887,6 +2011,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.tiktok_marketing.types.AdsEqCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdsNeqCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdsGtCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdsGteCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdsLtCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdsLteCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdsInCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdsLikeCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdsFuzzyCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdsKeywordCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdsContainsCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdsNotCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdsAndCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdsOrCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdsAnyCondition]`
     :   The type of the None singleton.
+
+<a id="AdsReportsDailyAndCondition"></a>
 
 `AdsReportsDailyAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -1908,6 +2034,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.tiktok_marketing.types.AdsReportsDailyEqCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdsReportsDailyNeqCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdsReportsDailyGtCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdsReportsDailyGteCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdsReportsDailyLtCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdsReportsDailyLteCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdsReportsDailyInCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdsReportsDailyLikeCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdsReportsDailyFuzzyCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdsReportsDailyKeywordCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdsReportsDailyContainsCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdsReportsDailyNotCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdsReportsDailyAndCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdsReportsDailyOrCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdsReportsDailyAnyCondition]`
     :   The type of the None singleton.
 
+<a id="AdsReportsDailyAnyCondition"></a>
+
 `AdsReportsDailyAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1927,6 +2055,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.tiktok_marketing.types.AdsReportsDailyAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="AdsReportsDailyAnyValueFilter"></a>
 
 `AdsReportsDailyAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -2090,6 +2220,8 @@ Classes
     `video_watched_6s: Any`
     :   Number of times video was watched for at least 6 seconds.
 
+<a id="AdsReportsDailyContainsCondition"></a>
+
 `AdsReportsDailyContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -2101,6 +2233,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.tiktok_marketing.types.AdsReportsDailyAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="AdsReportsDailyEqCondition"></a>
 
 `AdsReportsDailyEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -2114,6 +2248,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.tiktok_marketing.types.AdsReportsDailySearchFilter`
     :   The type of the None singleton.
 
+<a id="AdsReportsDailyFuzzyCondition"></a>
+
 `AdsReportsDailyFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -2125,6 +2261,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.tiktok_marketing.types.AdsReportsDailyStringFilter`
     :   The type of the None singleton.
+
+<a id="AdsReportsDailyGtCondition"></a>
 
 `AdsReportsDailyGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
@@ -2138,6 +2276,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.tiktok_marketing.types.AdsReportsDailySearchFilter`
     :   The type of the None singleton.
 
+<a id="AdsReportsDailyGteCondition"></a>
+
 `AdsReportsDailyGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -2149,6 +2289,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.tiktok_marketing.types.AdsReportsDailySearchFilter`
     :   The type of the None singleton.
+
+<a id="AdsReportsDailyInCondition"></a>
 
 `AdsReportsDailyInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -2169,6 +2311,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.tiktok_marketing.types.AdsReportsDailyInFilter`
     :   The type of the None singleton.
+
+<a id="AdsReportsDailyInFilter"></a>
 
 `AdsReportsDailyInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -2332,6 +2476,8 @@ Classes
     `video_watched_6s: list[float]`
     :   Number of times video was watched for at least 6 seconds.
 
+<a id="AdsReportsDailyKeywordCondition"></a>
+
 `AdsReportsDailyKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -2344,6 +2490,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.tiktok_marketing.types.AdsReportsDailyStringFilter`
     :   The type of the None singleton.
 
+<a id="AdsReportsDailyLikeCondition"></a>
+
 `AdsReportsDailyLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -2355,6 +2503,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.tiktok_marketing.types.AdsReportsDailyStringFilter`
     :   The type of the None singleton.
+
+<a id="AdsReportsDailyListParams"></a>
 
 `AdsReportsDailyListParams(*args, **kwargs)`
 :   Parameters for ads_reports_daily.list operation
@@ -2395,6 +2545,8 @@ Classes
     `start_date: str`
     :   The type of the None singleton.
 
+<a id="AdsReportsDailyLtCondition"></a>
+
 `AdsReportsDailyLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -2406,6 +2558,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.tiktok_marketing.types.AdsReportsDailySearchFilter`
     :   The type of the None singleton.
+
+<a id="AdsReportsDailyLteCondition"></a>
 
 `AdsReportsDailyLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -2419,6 +2573,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.tiktok_marketing.types.AdsReportsDailySearchFilter`
     :   The type of the None singleton.
 
+<a id="AdsReportsDailyNeqCondition"></a>
+
 `AdsReportsDailyNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -2430,6 +2586,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.tiktok_marketing.types.AdsReportsDailySearchFilter`
     :   The type of the None singleton.
+
+<a id="AdsReportsDailyNotCondition"></a>
 
 `AdsReportsDailyNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -2451,6 +2609,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.tiktok_marketing.types.AdsReportsDailyEqCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdsReportsDailyNeqCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdsReportsDailyGtCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdsReportsDailyGteCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdsReportsDailyLtCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdsReportsDailyLteCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdsReportsDailyInCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdsReportsDailyLikeCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdsReportsDailyFuzzyCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdsReportsDailyKeywordCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdsReportsDailyContainsCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdsReportsDailyNotCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdsReportsDailyAndCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdsReportsDailyOrCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdsReportsDailyAnyCondition`
     :   The type of the None singleton.
 
+<a id="AdsReportsDailyOrCondition"></a>
+
 `AdsReportsDailyOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -2470,6 +2630,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.tiktok_marketing.types.AdsReportsDailyEqCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdsReportsDailyNeqCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdsReportsDailyGtCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdsReportsDailyGteCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdsReportsDailyLtCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdsReportsDailyLteCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdsReportsDailyInCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdsReportsDailyLikeCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdsReportsDailyFuzzyCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdsReportsDailyKeywordCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdsReportsDailyContainsCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdsReportsDailyNotCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdsReportsDailyAndCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdsReportsDailyOrCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdsReportsDailyAnyCondition]`
     :   The type of the None singleton.
+
+<a id="AdsReportsDailySearchFilter"></a>
 
 `AdsReportsDailySearchFilter(*args, **kwargs)`
 :   Available fields for filtering ads_reports_daily search queries.
@@ -2633,6 +2795,8 @@ Classes
     `video_watched_6s: float | None`
     :   Number of times video was watched for at least 6 seconds.
 
+<a id="AdsReportsDailySearchQuery"></a>
+
 `AdsReportsDailySearchQuery(*args, **kwargs)`
 :   Search query for ads_reports_daily entity.
 
@@ -2647,6 +2811,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.tiktok_marketing.types.AdsReportsDailySortFilter]`
     :   The type of the None singleton.
+
+<a id="AdsReportsDailySortFilter"></a>
 
 `AdsReportsDailySortFilter(*args, **kwargs)`
 :   Available fields for sorting ads_reports_daily search results.
@@ -2810,6 +2976,8 @@ Classes
     `video_watched_6s: Literal['asc', 'desc']`
     :   Number of times video was watched for at least 6 seconds.
 
+<a id="AdsReportsDailyStringFilter"></a>
+
 `AdsReportsDailyStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -2972,6 +3140,8 @@ Classes
     `video_watched_6s: str`
     :   Number of times video was watched for at least 6 seconds.
 
+<a id="AdsSearchFilter"></a>
+
 `AdsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering ads search queries.
 
@@ -3026,6 +3196,8 @@ Classes
     `video_id: str | None`
     :   The unique identifier of the video
 
+<a id="AdsSearchQuery"></a>
+
 `AdsSearchQuery(*args, **kwargs)`
 :   Search query for ads entity.
 
@@ -3040,6 +3212,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.tiktok_marketing.types.AdsSortFilter]`
     :   The type of the None singleton.
+
+<a id="AdsSortFilter"></a>
 
 `AdsSortFilter(*args, **kwargs)`
 :   Available fields for sorting ads search results.
@@ -3095,6 +3269,8 @@ Classes
     `video_id: Literal['asc', 'desc']`
     :   The unique identifier of the video
 
+<a id="AdsStringFilter"></a>
+
 `AdsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -3149,6 +3325,8 @@ Classes
     `video_id: str`
     :   The unique identifier of the video
 
+<a id="AdvertisersAndCondition"></a>
+
 `AdvertisersAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -3169,6 +3347,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.tiktok_marketing.types.AdvertisersEqCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdvertisersNeqCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdvertisersGtCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdvertisersGteCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdvertisersLtCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdvertisersLteCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdvertisersInCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdvertisersLikeCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdvertisersFuzzyCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdvertisersKeywordCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdvertisersContainsCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdvertisersNotCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdvertisersAndCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdvertisersOrCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdvertisersAnyCondition]`
     :   The type of the None singleton.
 
+<a id="AdvertisersAnyCondition"></a>
+
 `AdvertisersAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -3188,6 +3368,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.tiktok_marketing.types.AdvertisersAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="AdvertisersAnyValueFilter"></a>
 
 `AdvertisersAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -3285,6 +3467,8 @@ Classes
     `timezone: Any`
     :   The timezone setting for the advertiser's activities.
 
+<a id="AdvertisersContainsCondition"></a>
+
 `AdvertisersContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -3296,6 +3480,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.tiktok_marketing.types.AdvertisersAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="AdvertisersEqCondition"></a>
 
 `AdvertisersEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -3309,6 +3495,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.tiktok_marketing.types.AdvertisersSearchFilter`
     :   The type of the None singleton.
 
+<a id="AdvertisersFuzzyCondition"></a>
+
 `AdvertisersFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -3320,6 +3508,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.tiktok_marketing.types.AdvertisersStringFilter`
     :   The type of the None singleton.
+
+<a id="AdvertisersGtCondition"></a>
 
 `AdvertisersGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
@@ -3333,6 +3523,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.tiktok_marketing.types.AdvertisersSearchFilter`
     :   The type of the None singleton.
 
+<a id="AdvertisersGteCondition"></a>
+
 `AdvertisersGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -3344,6 +3536,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.tiktok_marketing.types.AdvertisersSearchFilter`
     :   The type of the None singleton.
+
+<a id="AdvertisersInCondition"></a>
 
 `AdvertisersInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -3364,6 +3558,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.tiktok_marketing.types.AdvertisersInFilter`
     :   The type of the None singleton.
+
+<a id="AdvertisersInFilter"></a>
 
 `AdvertisersInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -3461,6 +3657,8 @@ Classes
     `timezone: list[str]`
     :   The timezone setting for the advertiser's activities.
 
+<a id="AdvertisersKeywordCondition"></a>
+
 `AdvertisersKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -3473,6 +3671,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.tiktok_marketing.types.AdvertisersStringFilter`
     :   The type of the None singleton.
 
+<a id="AdvertisersLikeCondition"></a>
+
 `AdvertisersLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -3484,6 +3684,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.tiktok_marketing.types.AdvertisersStringFilter`
     :   The type of the None singleton.
+
+<a id="AdvertisersListParams"></a>
 
 `AdvertisersListParams(*args, **kwargs)`
 :   Parameters for advertisers.list operation
@@ -3503,6 +3705,8 @@ Classes
     `page_size: int`
     :   The type of the None singleton.
 
+<a id="AdvertisersLtCondition"></a>
+
 `AdvertisersLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -3514,6 +3718,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.tiktok_marketing.types.AdvertisersSearchFilter`
     :   The type of the None singleton.
+
+<a id="AdvertisersLteCondition"></a>
 
 `AdvertisersLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -3527,6 +3733,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.tiktok_marketing.types.AdvertisersSearchFilter`
     :   The type of the None singleton.
 
+<a id="AdvertisersNeqCondition"></a>
+
 `AdvertisersNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -3538,6 +3746,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.tiktok_marketing.types.AdvertisersSearchFilter`
     :   The type of the None singleton.
+
+<a id="AdvertisersNotCondition"></a>
 
 `AdvertisersNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -3559,6 +3769,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.tiktok_marketing.types.AdvertisersEqCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdvertisersNeqCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdvertisersGtCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdvertisersGteCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdvertisersLtCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdvertisersLteCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdvertisersInCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdvertisersLikeCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdvertisersFuzzyCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdvertisersKeywordCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdvertisersContainsCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdvertisersNotCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdvertisersAndCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdvertisersOrCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdvertisersAnyCondition`
     :   The type of the None singleton.
 
+<a id="AdvertisersOrCondition"></a>
+
 `AdvertisersOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -3578,6 +3790,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.tiktok_marketing.types.AdvertisersEqCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdvertisersNeqCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdvertisersGtCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdvertisersGteCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdvertisersLtCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdvertisersLteCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdvertisersInCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdvertisersLikeCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdvertisersFuzzyCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdvertisersKeywordCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdvertisersContainsCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdvertisersNotCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdvertisersAndCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdvertisersOrCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdvertisersAnyCondition]`
     :   The type of the None singleton.
+
+<a id="AdvertisersReportsDailyAndCondition"></a>
 
 `AdvertisersReportsDailyAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -3599,6 +3813,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.tiktok_marketing.types.AdvertisersReportsDailyEqCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdvertisersReportsDailyNeqCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdvertisersReportsDailyGtCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdvertisersReportsDailyGteCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdvertisersReportsDailyLtCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdvertisersReportsDailyLteCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdvertisersReportsDailyInCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdvertisersReportsDailyLikeCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdvertisersReportsDailyFuzzyCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdvertisersReportsDailyKeywordCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdvertisersReportsDailyContainsCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdvertisersReportsDailyNotCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdvertisersReportsDailyAndCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdvertisersReportsDailyOrCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdvertisersReportsDailyAnyCondition]`
     :   The type of the None singleton.
 
+<a id="AdvertisersReportsDailyAnyCondition"></a>
+
 `AdvertisersReportsDailyAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -3618,6 +3834,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.tiktok_marketing.types.AdvertisersReportsDailyAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="AdvertisersReportsDailyAnyValueFilter"></a>
 
 `AdvertisersReportsDailyAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -3721,6 +3939,8 @@ Classes
     `voucher_spend: Any`
     :   Amount spent using vouchers.
 
+<a id="AdvertisersReportsDailyContainsCondition"></a>
+
 `AdvertisersReportsDailyContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -3732,6 +3952,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.tiktok_marketing.types.AdvertisersReportsDailyAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="AdvertisersReportsDailyEqCondition"></a>
 
 `AdvertisersReportsDailyEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -3745,6 +3967,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.tiktok_marketing.types.AdvertisersReportsDailySearchFilter`
     :   The type of the None singleton.
 
+<a id="AdvertisersReportsDailyFuzzyCondition"></a>
+
 `AdvertisersReportsDailyFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -3756,6 +3980,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.tiktok_marketing.types.AdvertisersReportsDailyStringFilter`
     :   The type of the None singleton.
+
+<a id="AdvertisersReportsDailyGtCondition"></a>
 
 `AdvertisersReportsDailyGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
@@ -3769,6 +3995,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.tiktok_marketing.types.AdvertisersReportsDailySearchFilter`
     :   The type of the None singleton.
 
+<a id="AdvertisersReportsDailyGteCondition"></a>
+
 `AdvertisersReportsDailyGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -3780,6 +4008,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.tiktok_marketing.types.AdvertisersReportsDailySearchFilter`
     :   The type of the None singleton.
+
+<a id="AdvertisersReportsDailyInCondition"></a>
 
 `AdvertisersReportsDailyInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -3800,6 +4030,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.tiktok_marketing.types.AdvertisersReportsDailyInFilter`
     :   The type of the None singleton.
+
+<a id="AdvertisersReportsDailyInFilter"></a>
 
 `AdvertisersReportsDailyInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -3903,6 +4135,8 @@ Classes
     `voucher_spend: list[str]`
     :   Amount spent using vouchers.
 
+<a id="AdvertisersReportsDailyKeywordCondition"></a>
+
 `AdvertisersReportsDailyKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -3915,6 +4149,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.tiktok_marketing.types.AdvertisersReportsDailyStringFilter`
     :   The type of the None singleton.
 
+<a id="AdvertisersReportsDailyLikeCondition"></a>
+
 `AdvertisersReportsDailyLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -3926,6 +4162,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.tiktok_marketing.types.AdvertisersReportsDailyStringFilter`
     :   The type of the None singleton.
+
+<a id="AdvertisersReportsDailyListParams"></a>
 
 `AdvertisersReportsDailyListParams(*args, **kwargs)`
 :   Parameters for advertisers_reports_daily.list operation
@@ -3966,6 +4204,8 @@ Classes
     `start_date: str`
     :   The type of the None singleton.
 
+<a id="AdvertisersReportsDailyLtCondition"></a>
+
 `AdvertisersReportsDailyLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -3977,6 +4217,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.tiktok_marketing.types.AdvertisersReportsDailySearchFilter`
     :   The type of the None singleton.
+
+<a id="AdvertisersReportsDailyLteCondition"></a>
 
 `AdvertisersReportsDailyLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -3990,6 +4232,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.tiktok_marketing.types.AdvertisersReportsDailySearchFilter`
     :   The type of the None singleton.
 
+<a id="AdvertisersReportsDailyNeqCondition"></a>
+
 `AdvertisersReportsDailyNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -4001,6 +4245,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.tiktok_marketing.types.AdvertisersReportsDailySearchFilter`
     :   The type of the None singleton.
+
+<a id="AdvertisersReportsDailyNotCondition"></a>
 
 `AdvertisersReportsDailyNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -4022,6 +4268,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.tiktok_marketing.types.AdvertisersReportsDailyEqCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdvertisersReportsDailyNeqCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdvertisersReportsDailyGtCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdvertisersReportsDailyGteCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdvertisersReportsDailyLtCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdvertisersReportsDailyLteCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdvertisersReportsDailyInCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdvertisersReportsDailyLikeCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdvertisersReportsDailyFuzzyCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdvertisersReportsDailyKeywordCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdvertisersReportsDailyContainsCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdvertisersReportsDailyNotCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdvertisersReportsDailyAndCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdvertisersReportsDailyOrCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdvertisersReportsDailyAnyCondition`
     :   The type of the None singleton.
 
+<a id="AdvertisersReportsDailyOrCondition"></a>
+
 `AdvertisersReportsDailyOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -4041,6 +4289,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.tiktok_marketing.types.AdvertisersReportsDailyEqCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdvertisersReportsDailyNeqCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdvertisersReportsDailyGtCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdvertisersReportsDailyGteCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdvertisersReportsDailyLtCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdvertisersReportsDailyLteCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdvertisersReportsDailyInCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdvertisersReportsDailyLikeCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdvertisersReportsDailyFuzzyCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdvertisersReportsDailyKeywordCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdvertisersReportsDailyContainsCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdvertisersReportsDailyNotCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdvertisersReportsDailyAndCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdvertisersReportsDailyOrCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AdvertisersReportsDailyAnyCondition]`
     :   The type of the None singleton.
+
+<a id="AdvertisersReportsDailySearchFilter"></a>
 
 `AdvertisersReportsDailySearchFilter(*args, **kwargs)`
 :   Available fields for filtering advertisers_reports_daily search queries.
@@ -4144,6 +4394,8 @@ Classes
     `voucher_spend: str | None`
     :   Amount spent using vouchers.
 
+<a id="AdvertisersReportsDailySearchQuery"></a>
+
 `AdvertisersReportsDailySearchQuery(*args, **kwargs)`
 :   Search query for advertisers_reports_daily entity.
 
@@ -4158,6 +4410,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.tiktok_marketing.types.AdvertisersReportsDailySortFilter]`
     :   The type of the None singleton.
+
+<a id="AdvertisersReportsDailySortFilter"></a>
 
 `AdvertisersReportsDailySortFilter(*args, **kwargs)`
 :   Available fields for sorting advertisers_reports_daily search results.
@@ -4261,6 +4515,8 @@ Classes
     `voucher_spend: Literal['asc', 'desc']`
     :   Amount spent using vouchers.
 
+<a id="AdvertisersReportsDailyStringFilter"></a>
+
 `AdvertisersReportsDailyStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -4363,6 +4619,8 @@ Classes
     `voucher_spend: str`
     :   Amount spent using vouchers.
 
+<a id="AdvertisersSearchFilter"></a>
+
 `AdvertisersSearchFilter(*args, **kwargs)`
 :   Available fields for filtering advertisers search queries.
 
@@ -4459,6 +4717,8 @@ Classes
     `timezone: str | None`
     :   The timezone setting for the advertiser's activities.
 
+<a id="AdvertisersSearchQuery"></a>
+
 `AdvertisersSearchQuery(*args, **kwargs)`
 :   Search query for advertisers entity.
 
@@ -4473,6 +4733,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.tiktok_marketing.types.AdvertisersSortFilter]`
     :   The type of the None singleton.
+
+<a id="AdvertisersSortFilter"></a>
 
 `AdvertisersSortFilter(*args, **kwargs)`
 :   Available fields for sorting advertisers search results.
@@ -4570,6 +4832,8 @@ Classes
     `timezone: Literal['asc', 'desc']`
     :   The timezone setting for the advertiser's activities.
 
+<a id="AdvertisersStringFilter"></a>
+
 `AdvertisersStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -4666,6 +4930,8 @@ Classes
     `timezone: str`
     :   The timezone setting for the advertiser's activities.
 
+<a id="AirbyteSearchParams"></a>
+
 `AirbyteSearchParams(*args, **kwargs)`
 :   Parameters for Airbyte cache search operations (generic, use entity-specific query types for better type hints).
 
@@ -4687,6 +4953,8 @@ Classes
     `query: dict[str, typing.Any]`
     :   The type of the None singleton.
 
+<a id="AudiencesAndCondition"></a>
+
 `AudiencesAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -4707,6 +4975,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.tiktok_marketing.types.AudiencesEqCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AudiencesNeqCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AudiencesGtCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AudiencesGteCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AudiencesLtCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AudiencesLteCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AudiencesInCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AudiencesLikeCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AudiencesFuzzyCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AudiencesKeywordCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AudiencesContainsCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AudiencesNotCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AudiencesAndCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AudiencesOrCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AudiencesAnyCondition]`
     :   The type of the None singleton.
 
+<a id="AudiencesAnyCondition"></a>
+
 `AudiencesAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -4726,6 +4996,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.tiktok_marketing.types.AudiencesAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="AudiencesAnyValueFilter"></a>
 
 `AudiencesAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -4757,6 +5029,8 @@ Classes
     `shared: Any`
     :   Flag indicating if the audience is shared
 
+<a id="AudiencesContainsCondition"></a>
+
 `AudiencesContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -4768,6 +5042,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.tiktok_marketing.types.AudiencesAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="AudiencesEqCondition"></a>
 
 `AudiencesEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -4781,6 +5057,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.tiktok_marketing.types.AudiencesSearchFilter`
     :   The type of the None singleton.
 
+<a id="AudiencesFuzzyCondition"></a>
+
 `AudiencesFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -4792,6 +5070,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.tiktok_marketing.types.AudiencesStringFilter`
     :   The type of the None singleton.
+
+<a id="AudiencesGtCondition"></a>
 
 `AudiencesGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
@@ -4805,6 +5085,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.tiktok_marketing.types.AudiencesSearchFilter`
     :   The type of the None singleton.
 
+<a id="AudiencesGteCondition"></a>
+
 `AudiencesGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -4816,6 +5098,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.tiktok_marketing.types.AudiencesSearchFilter`
     :   The type of the None singleton.
+
+<a id="AudiencesInCondition"></a>
 
 `AudiencesInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -4836,6 +5120,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.tiktok_marketing.types.AudiencesInFilter`
     :   The type of the None singleton.
+
+<a id="AudiencesInFilter"></a>
 
 `AudiencesInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -4867,6 +5153,8 @@ Classes
     `shared: list[bool]`
     :   Flag indicating if the audience is shared
 
+<a id="AudiencesKeywordCondition"></a>
+
 `AudiencesKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -4879,6 +5167,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.tiktok_marketing.types.AudiencesStringFilter`
     :   The type of the None singleton.
 
+<a id="AudiencesLikeCondition"></a>
+
 `AudiencesLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -4890,6 +5180,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.tiktok_marketing.types.AudiencesStringFilter`
     :   The type of the None singleton.
+
+<a id="AudiencesListParams"></a>
 
 `AudiencesListParams(*args, **kwargs)`
 :   Parameters for audiences.list operation
@@ -4909,6 +5201,8 @@ Classes
     `page_size: int`
     :   The type of the None singleton.
 
+<a id="AudiencesLtCondition"></a>
+
 `AudiencesLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -4920,6 +5214,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.tiktok_marketing.types.AudiencesSearchFilter`
     :   The type of the None singleton.
+
+<a id="AudiencesLteCondition"></a>
 
 `AudiencesLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -4933,6 +5229,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.tiktok_marketing.types.AudiencesSearchFilter`
     :   The type of the None singleton.
 
+<a id="AudiencesNeqCondition"></a>
+
 `AudiencesNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -4944,6 +5242,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.tiktok_marketing.types.AudiencesSearchFilter`
     :   The type of the None singleton.
+
+<a id="AudiencesNotCondition"></a>
 
 `AudiencesNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -4965,6 +5265,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.tiktok_marketing.types.AudiencesEqCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AudiencesNeqCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AudiencesGtCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AudiencesGteCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AudiencesLtCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AudiencesLteCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AudiencesInCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AudiencesLikeCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AudiencesFuzzyCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AudiencesKeywordCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AudiencesContainsCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AudiencesNotCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AudiencesAndCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AudiencesOrCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AudiencesAnyCondition`
     :   The type of the None singleton.
 
+<a id="AudiencesOrCondition"></a>
+
 `AudiencesOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -4984,6 +5286,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.tiktok_marketing.types.AudiencesEqCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AudiencesNeqCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AudiencesGtCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AudiencesGteCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AudiencesLtCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AudiencesLteCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AudiencesInCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AudiencesLikeCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AudiencesFuzzyCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AudiencesKeywordCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AudiencesContainsCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AudiencesNotCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AudiencesAndCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AudiencesOrCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.AudiencesAnyCondition]`
     :   The type of the None singleton.
+
+<a id="AudiencesSearchFilter"></a>
 
 `AudiencesSearchFilter(*args, **kwargs)`
 :   Available fields for filtering audiences search queries.
@@ -5015,6 +5319,8 @@ Classes
     `shared: bool | None`
     :   Flag indicating if the audience is shared
 
+<a id="AudiencesSearchQuery"></a>
+
 `AudiencesSearchQuery(*args, **kwargs)`
 :   Search query for audiences entity.
 
@@ -5029,6 +5335,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.tiktok_marketing.types.AudiencesSortFilter]`
     :   The type of the None singleton.
+
+<a id="AudiencesSortFilter"></a>
 
 `AudiencesSortFilter(*args, **kwargs)`
 :   Available fields for sorting audiences search results.
@@ -5060,6 +5368,8 @@ Classes
     `shared: Literal['asc', 'desc']`
     :   Flag indicating if the audience is shared
 
+<a id="AudiencesStringFilter"></a>
+
 `AudiencesStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -5090,6 +5400,8 @@ Classes
     `shared: str`
     :   Flag indicating if the audience is shared
 
+<a id="CampaignsAndCondition"></a>
+
 `CampaignsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -5110,6 +5422,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.tiktok_marketing.types.CampaignsEqCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.CampaignsNeqCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.CampaignsGtCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.CampaignsGteCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.CampaignsLtCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.CampaignsLteCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.CampaignsInCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.CampaignsLikeCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.CampaignsFuzzyCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.CampaignsKeywordCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.CampaignsContainsCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.CampaignsNotCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.CampaignsAndCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.CampaignsOrCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.CampaignsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="CampaignsAnyCondition"></a>
+
 `CampaignsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -5129,6 +5443,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.tiktok_marketing.types.CampaignsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="CampaignsAnyValueFilter"></a>
 
 `CampaignsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -5208,6 +5524,8 @@ Classes
     `split_test_variable: Any`
     :   Variable being tested in a split test campaign
 
+<a id="CampaignsContainsCondition"></a>
+
 `CampaignsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -5219,6 +5537,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.tiktok_marketing.types.CampaignsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="CampaignsEqCondition"></a>
 
 `CampaignsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -5232,6 +5552,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.tiktok_marketing.types.CampaignsSearchFilter`
     :   The type of the None singleton.
 
+<a id="CampaignsFuzzyCondition"></a>
+
 `CampaignsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -5243,6 +5565,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.tiktok_marketing.types.CampaignsStringFilter`
     :   The type of the None singleton.
+
+<a id="CampaignsGtCondition"></a>
 
 `CampaignsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
@@ -5256,6 +5580,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.tiktok_marketing.types.CampaignsSearchFilter`
     :   The type of the None singleton.
 
+<a id="CampaignsGteCondition"></a>
+
 `CampaignsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -5267,6 +5593,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.tiktok_marketing.types.CampaignsSearchFilter`
     :   The type of the None singleton.
+
+<a id="CampaignsInCondition"></a>
 
 `CampaignsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -5287,6 +5615,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.tiktok_marketing.types.CampaignsInFilter`
     :   The type of the None singleton.
+
+<a id="CampaignsInFilter"></a>
 
 `CampaignsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -5366,6 +5696,8 @@ Classes
     `split_test_variable: list[str]`
     :   Variable being tested in a split test campaign
 
+<a id="CampaignsKeywordCondition"></a>
+
 `CampaignsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -5378,6 +5710,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.tiktok_marketing.types.CampaignsStringFilter`
     :   The type of the None singleton.
 
+<a id="CampaignsLikeCondition"></a>
+
 `CampaignsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -5389,6 +5723,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.tiktok_marketing.types.CampaignsStringFilter`
     :   The type of the None singleton.
+
+<a id="CampaignsListParams"></a>
 
 `CampaignsListParams(*args, **kwargs)`
 :   Parameters for campaigns.list operation
@@ -5408,6 +5744,8 @@ Classes
     `page_size: int`
     :   The type of the None singleton.
 
+<a id="CampaignsLtCondition"></a>
+
 `CampaignsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -5419,6 +5757,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.tiktok_marketing.types.CampaignsSearchFilter`
     :   The type of the None singleton.
+
+<a id="CampaignsLteCondition"></a>
 
 `CampaignsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -5432,6 +5772,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.tiktok_marketing.types.CampaignsSearchFilter`
     :   The type of the None singleton.
 
+<a id="CampaignsNeqCondition"></a>
+
 `CampaignsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -5443,6 +5785,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.tiktok_marketing.types.CampaignsSearchFilter`
     :   The type of the None singleton.
+
+<a id="CampaignsNotCondition"></a>
 
 `CampaignsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -5464,6 +5808,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.tiktok_marketing.types.CampaignsEqCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.CampaignsNeqCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.CampaignsGtCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.CampaignsGteCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.CampaignsLtCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.CampaignsLteCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.CampaignsInCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.CampaignsLikeCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.CampaignsFuzzyCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.CampaignsKeywordCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.CampaignsContainsCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.CampaignsNotCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.CampaignsAndCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.CampaignsOrCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.CampaignsAnyCondition`
     :   The type of the None singleton.
 
+<a id="CampaignsOrCondition"></a>
+
 `CampaignsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -5483,6 +5829,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.tiktok_marketing.types.CampaignsEqCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.CampaignsNeqCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.CampaignsGtCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.CampaignsGteCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.CampaignsLtCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.CampaignsLteCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.CampaignsInCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.CampaignsLikeCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.CampaignsFuzzyCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.CampaignsKeywordCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.CampaignsContainsCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.CampaignsNotCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.CampaignsAndCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.CampaignsOrCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.CampaignsAnyCondition]`
     :   The type of the None singleton.
+
+<a id="CampaignsReportsDailyAndCondition"></a>
 
 `CampaignsReportsDailyAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -5504,6 +5852,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.tiktok_marketing.types.CampaignsReportsDailyEqCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.CampaignsReportsDailyNeqCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.CampaignsReportsDailyGtCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.CampaignsReportsDailyGteCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.CampaignsReportsDailyLtCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.CampaignsReportsDailyLteCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.CampaignsReportsDailyInCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.CampaignsReportsDailyLikeCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.CampaignsReportsDailyFuzzyCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.CampaignsReportsDailyKeywordCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.CampaignsReportsDailyContainsCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.CampaignsReportsDailyNotCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.CampaignsReportsDailyAndCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.CampaignsReportsDailyOrCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.CampaignsReportsDailyAnyCondition]`
     :   The type of the None singleton.
 
+<a id="CampaignsReportsDailyAnyCondition"></a>
+
 `CampaignsReportsDailyAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -5523,6 +5873,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.tiktok_marketing.types.CampaignsReportsDailyAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="CampaignsReportsDailyAnyValueFilter"></a>
 
 `CampaignsReportsDailyAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -5623,6 +5975,8 @@ Classes
     `video_watched_6s: Any`
     :   Number of times video was watched for at least 6 seconds.
 
+<a id="CampaignsReportsDailyContainsCondition"></a>
+
 `CampaignsReportsDailyContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -5634,6 +5988,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.tiktok_marketing.types.CampaignsReportsDailyAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="CampaignsReportsDailyEqCondition"></a>
 
 `CampaignsReportsDailyEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -5647,6 +6003,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.tiktok_marketing.types.CampaignsReportsDailySearchFilter`
     :   The type of the None singleton.
 
+<a id="CampaignsReportsDailyFuzzyCondition"></a>
+
 `CampaignsReportsDailyFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -5658,6 +6016,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.tiktok_marketing.types.CampaignsReportsDailyStringFilter`
     :   The type of the None singleton.
+
+<a id="CampaignsReportsDailyGtCondition"></a>
 
 `CampaignsReportsDailyGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
@@ -5671,6 +6031,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.tiktok_marketing.types.CampaignsReportsDailySearchFilter`
     :   The type of the None singleton.
 
+<a id="CampaignsReportsDailyGteCondition"></a>
+
 `CampaignsReportsDailyGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -5682,6 +6044,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.tiktok_marketing.types.CampaignsReportsDailySearchFilter`
     :   The type of the None singleton.
+
+<a id="CampaignsReportsDailyInCondition"></a>
 
 `CampaignsReportsDailyInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -5702,6 +6066,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.tiktok_marketing.types.CampaignsReportsDailyInFilter`
     :   The type of the None singleton.
+
+<a id="CampaignsReportsDailyInFilter"></a>
 
 `CampaignsReportsDailyInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -5802,6 +6168,8 @@ Classes
     `video_watched_6s: list[float]`
     :   Number of times video was watched for at least 6 seconds.
 
+<a id="CampaignsReportsDailyKeywordCondition"></a>
+
 `CampaignsReportsDailyKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -5814,6 +6182,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.tiktok_marketing.types.CampaignsReportsDailyStringFilter`
     :   The type of the None singleton.
 
+<a id="CampaignsReportsDailyLikeCondition"></a>
+
 `CampaignsReportsDailyLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -5825,6 +6195,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.tiktok_marketing.types.CampaignsReportsDailyStringFilter`
     :   The type of the None singleton.
+
+<a id="CampaignsReportsDailyListParams"></a>
 
 `CampaignsReportsDailyListParams(*args, **kwargs)`
 :   Parameters for campaigns_reports_daily.list operation
@@ -5865,6 +6237,8 @@ Classes
     `start_date: str`
     :   The type of the None singleton.
 
+<a id="CampaignsReportsDailyLtCondition"></a>
+
 `CampaignsReportsDailyLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -5876,6 +6250,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.tiktok_marketing.types.CampaignsReportsDailySearchFilter`
     :   The type of the None singleton.
+
+<a id="CampaignsReportsDailyLteCondition"></a>
 
 `CampaignsReportsDailyLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -5889,6 +6265,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.tiktok_marketing.types.CampaignsReportsDailySearchFilter`
     :   The type of the None singleton.
 
+<a id="CampaignsReportsDailyNeqCondition"></a>
+
 `CampaignsReportsDailyNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -5900,6 +6278,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.tiktok_marketing.types.CampaignsReportsDailySearchFilter`
     :   The type of the None singleton.
+
+<a id="CampaignsReportsDailyNotCondition"></a>
 
 `CampaignsReportsDailyNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -5921,6 +6301,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.tiktok_marketing.types.CampaignsReportsDailyEqCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.CampaignsReportsDailyNeqCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.CampaignsReportsDailyGtCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.CampaignsReportsDailyGteCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.CampaignsReportsDailyLtCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.CampaignsReportsDailyLteCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.CampaignsReportsDailyInCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.CampaignsReportsDailyLikeCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.CampaignsReportsDailyFuzzyCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.CampaignsReportsDailyKeywordCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.CampaignsReportsDailyContainsCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.CampaignsReportsDailyNotCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.CampaignsReportsDailyAndCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.CampaignsReportsDailyOrCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.CampaignsReportsDailyAnyCondition`
     :   The type of the None singleton.
 
+<a id="CampaignsReportsDailyOrCondition"></a>
+
 `CampaignsReportsDailyOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -5940,6 +6322,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.tiktok_marketing.types.CampaignsReportsDailyEqCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.CampaignsReportsDailyNeqCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.CampaignsReportsDailyGtCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.CampaignsReportsDailyGteCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.CampaignsReportsDailyLtCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.CampaignsReportsDailyLteCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.CampaignsReportsDailyInCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.CampaignsReportsDailyLikeCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.CampaignsReportsDailyFuzzyCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.CampaignsReportsDailyKeywordCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.CampaignsReportsDailyContainsCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.CampaignsReportsDailyNotCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.CampaignsReportsDailyAndCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.CampaignsReportsDailyOrCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.CampaignsReportsDailyAnyCondition]`
     :   The type of the None singleton.
+
+<a id="CampaignsReportsDailySearchFilter"></a>
 
 `CampaignsReportsDailySearchFilter(*args, **kwargs)`
 :   Available fields for filtering campaigns_reports_daily search queries.
@@ -6040,6 +6424,8 @@ Classes
     `video_watched_6s: float | None`
     :   Number of times video was watched for at least 6 seconds.
 
+<a id="CampaignsReportsDailySearchQuery"></a>
+
 `CampaignsReportsDailySearchQuery(*args, **kwargs)`
 :   Search query for campaigns_reports_daily entity.
 
@@ -6054,6 +6440,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.tiktok_marketing.types.CampaignsReportsDailySortFilter]`
     :   The type of the None singleton.
+
+<a id="CampaignsReportsDailySortFilter"></a>
 
 `CampaignsReportsDailySortFilter(*args, **kwargs)`
 :   Available fields for sorting campaigns_reports_daily search results.
@@ -6154,6 +6542,8 @@ Classes
     `video_watched_6s: Literal['asc', 'desc']`
     :   Number of times video was watched for at least 6 seconds.
 
+<a id="CampaignsReportsDailyStringFilter"></a>
+
 `CampaignsReportsDailyStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -6253,6 +6643,8 @@ Classes
     `video_watched_6s: str`
     :   Number of times video was watched for at least 6 seconds.
 
+<a id="CampaignsSearchFilter"></a>
+
 `CampaignsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering campaigns search queries.
 
@@ -6331,6 +6723,8 @@ Classes
     `split_test_variable: str | None`
     :   Variable being tested in a split test campaign
 
+<a id="CampaignsSearchQuery"></a>
+
 `CampaignsSearchQuery(*args, **kwargs)`
 :   Search query for campaigns entity.
 
@@ -6345,6 +6739,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.tiktok_marketing.types.CampaignsSortFilter]`
     :   The type of the None singleton.
+
+<a id="CampaignsSortFilter"></a>
 
 `CampaignsSortFilter(*args, **kwargs)`
 :   Available fields for sorting campaigns search results.
@@ -6424,6 +6820,8 @@ Classes
     `split_test_variable: Literal['asc', 'desc']`
     :   Variable being tested in a split test campaign
 
+<a id="CampaignsStringFilter"></a>
+
 `CampaignsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -6502,6 +6900,8 @@ Classes
     `split_test_variable: str`
     :   Variable being tested in a split test campaign
 
+<a id="CreativeAssetsImagesAndCondition"></a>
+
 `CreativeAssetsImagesAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -6522,6 +6922,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.tiktok_marketing.types.CreativeAssetsImagesEqCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.CreativeAssetsImagesNeqCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.CreativeAssetsImagesGtCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.CreativeAssetsImagesGteCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.CreativeAssetsImagesLtCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.CreativeAssetsImagesLteCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.CreativeAssetsImagesInCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.CreativeAssetsImagesLikeCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.CreativeAssetsImagesFuzzyCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.CreativeAssetsImagesKeywordCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.CreativeAssetsImagesContainsCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.CreativeAssetsImagesNotCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.CreativeAssetsImagesAndCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.CreativeAssetsImagesOrCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.CreativeAssetsImagesAnyCondition]`
     :   The type of the None singleton.
 
+<a id="CreativeAssetsImagesAnyCondition"></a>
+
 `CreativeAssetsImagesAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -6541,6 +6943,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.tiktok_marketing.types.CreativeAssetsImagesAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="CreativeAssetsImagesAnyValueFilter"></a>
 
 `CreativeAssetsImagesAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -6578,6 +6982,8 @@ Classes
     `width: Any`
     :   The width dimension of the image.
 
+<a id="CreativeAssetsImagesContainsCondition"></a>
+
 `CreativeAssetsImagesContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -6589,6 +6995,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.tiktok_marketing.types.CreativeAssetsImagesAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="CreativeAssetsImagesEqCondition"></a>
 
 `CreativeAssetsImagesEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -6602,6 +7010,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.tiktok_marketing.types.CreativeAssetsImagesSearchFilter`
     :   The type of the None singleton.
 
+<a id="CreativeAssetsImagesFuzzyCondition"></a>
+
 `CreativeAssetsImagesFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -6613,6 +7023,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.tiktok_marketing.types.CreativeAssetsImagesStringFilter`
     :   The type of the None singleton.
+
+<a id="CreativeAssetsImagesGtCondition"></a>
 
 `CreativeAssetsImagesGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
@@ -6626,6 +7038,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.tiktok_marketing.types.CreativeAssetsImagesSearchFilter`
     :   The type of the None singleton.
 
+<a id="CreativeAssetsImagesGteCondition"></a>
+
 `CreativeAssetsImagesGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -6637,6 +7051,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.tiktok_marketing.types.CreativeAssetsImagesSearchFilter`
     :   The type of the None singleton.
+
+<a id="CreativeAssetsImagesInCondition"></a>
 
 `CreativeAssetsImagesInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -6657,6 +7073,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.tiktok_marketing.types.CreativeAssetsImagesInFilter`
     :   The type of the None singleton.
+
+<a id="CreativeAssetsImagesInFilter"></a>
 
 `CreativeAssetsImagesInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -6694,6 +7112,8 @@ Classes
     `width: list[int]`
     :   The width dimension of the image.
 
+<a id="CreativeAssetsImagesKeywordCondition"></a>
+
 `CreativeAssetsImagesKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -6706,6 +7126,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.tiktok_marketing.types.CreativeAssetsImagesStringFilter`
     :   The type of the None singleton.
 
+<a id="CreativeAssetsImagesLikeCondition"></a>
+
 `CreativeAssetsImagesLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -6717,6 +7139,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.tiktok_marketing.types.CreativeAssetsImagesStringFilter`
     :   The type of the None singleton.
+
+<a id="CreativeAssetsImagesListParams"></a>
 
 `CreativeAssetsImagesListParams(*args, **kwargs)`
 :   Parameters for creative_assets_images.list operation
@@ -6736,6 +7160,8 @@ Classes
     `page_size: int`
     :   The type of the None singleton.
 
+<a id="CreativeAssetsImagesLtCondition"></a>
+
 `CreativeAssetsImagesLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -6747,6 +7173,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.tiktok_marketing.types.CreativeAssetsImagesSearchFilter`
     :   The type of the None singleton.
+
+<a id="CreativeAssetsImagesLteCondition"></a>
 
 `CreativeAssetsImagesLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -6760,6 +7188,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.tiktok_marketing.types.CreativeAssetsImagesSearchFilter`
     :   The type of the None singleton.
 
+<a id="CreativeAssetsImagesNeqCondition"></a>
+
 `CreativeAssetsImagesNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -6771,6 +7201,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.tiktok_marketing.types.CreativeAssetsImagesSearchFilter`
     :   The type of the None singleton.
+
+<a id="CreativeAssetsImagesNotCondition"></a>
 
 `CreativeAssetsImagesNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -6792,6 +7224,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.tiktok_marketing.types.CreativeAssetsImagesEqCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.CreativeAssetsImagesNeqCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.CreativeAssetsImagesGtCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.CreativeAssetsImagesGteCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.CreativeAssetsImagesLtCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.CreativeAssetsImagesLteCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.CreativeAssetsImagesInCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.CreativeAssetsImagesLikeCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.CreativeAssetsImagesFuzzyCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.CreativeAssetsImagesKeywordCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.CreativeAssetsImagesContainsCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.CreativeAssetsImagesNotCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.CreativeAssetsImagesAndCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.CreativeAssetsImagesOrCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.CreativeAssetsImagesAnyCondition`
     :   The type of the None singleton.
 
+<a id="CreativeAssetsImagesOrCondition"></a>
+
 `CreativeAssetsImagesOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -6811,6 +7245,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.tiktok_marketing.types.CreativeAssetsImagesEqCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.CreativeAssetsImagesNeqCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.CreativeAssetsImagesGtCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.CreativeAssetsImagesGteCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.CreativeAssetsImagesLtCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.CreativeAssetsImagesLteCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.CreativeAssetsImagesInCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.CreativeAssetsImagesLikeCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.CreativeAssetsImagesFuzzyCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.CreativeAssetsImagesKeywordCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.CreativeAssetsImagesContainsCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.CreativeAssetsImagesNotCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.CreativeAssetsImagesAndCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.CreativeAssetsImagesOrCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.CreativeAssetsImagesAnyCondition]`
     :   The type of the None singleton.
+
+<a id="CreativeAssetsImagesSearchFilter"></a>
 
 `CreativeAssetsImagesSearchFilter(*args, **kwargs)`
 :   Available fields for filtering creative_assets_images search queries.
@@ -6848,6 +7284,8 @@ Classes
     `width: int | None`
     :   The width dimension of the image.
 
+<a id="CreativeAssetsImagesSearchQuery"></a>
+
 `CreativeAssetsImagesSearchQuery(*args, **kwargs)`
 :   Search query for creative_assets_images entity.
 
@@ -6862,6 +7300,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.tiktok_marketing.types.CreativeAssetsImagesSortFilter]`
     :   The type of the None singleton.
+
+<a id="CreativeAssetsImagesSortFilter"></a>
 
 `CreativeAssetsImagesSortFilter(*args, **kwargs)`
 :   Available fields for sorting creative_assets_images search results.
@@ -6899,6 +7339,8 @@ Classes
     `width: Literal['asc', 'desc']`
     :   The width dimension of the image.
 
+<a id="CreativeAssetsImagesStringFilter"></a>
+
 `CreativeAssetsImagesStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -6935,6 +7377,8 @@ Classes
     `width: str`
     :   The width dimension of the image.
 
+<a id="CreativeAssetsVideosAndCondition"></a>
+
 `CreativeAssetsVideosAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -6955,6 +7399,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.tiktok_marketing.types.CreativeAssetsVideosEqCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.CreativeAssetsVideosNeqCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.CreativeAssetsVideosGtCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.CreativeAssetsVideosGteCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.CreativeAssetsVideosLtCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.CreativeAssetsVideosLteCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.CreativeAssetsVideosInCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.CreativeAssetsVideosLikeCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.CreativeAssetsVideosFuzzyCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.CreativeAssetsVideosKeywordCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.CreativeAssetsVideosContainsCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.CreativeAssetsVideosNotCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.CreativeAssetsVideosAndCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.CreativeAssetsVideosOrCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.CreativeAssetsVideosAnyCondition]`
     :   The type of the None singleton.
 
+<a id="CreativeAssetsVideosAnyCondition"></a>
+
 `CreativeAssetsVideosAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -6974,6 +7420,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.tiktok_marketing.types.CreativeAssetsVideosAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="CreativeAssetsVideosAnyValueFilter"></a>
 
 `CreativeAssetsVideosAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -7014,6 +7462,8 @@ Classes
     `width: Any`
     :   Width of the video in pixels.
 
+<a id="CreativeAssetsVideosContainsCondition"></a>
+
 `CreativeAssetsVideosContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -7025,6 +7475,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.tiktok_marketing.types.CreativeAssetsVideosAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="CreativeAssetsVideosEqCondition"></a>
 
 `CreativeAssetsVideosEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -7038,6 +7490,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.tiktok_marketing.types.CreativeAssetsVideosSearchFilter`
     :   The type of the None singleton.
 
+<a id="CreativeAssetsVideosFuzzyCondition"></a>
+
 `CreativeAssetsVideosFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -7049,6 +7503,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.tiktok_marketing.types.CreativeAssetsVideosStringFilter`
     :   The type of the None singleton.
+
+<a id="CreativeAssetsVideosGtCondition"></a>
 
 `CreativeAssetsVideosGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
@@ -7062,6 +7518,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.tiktok_marketing.types.CreativeAssetsVideosSearchFilter`
     :   The type of the None singleton.
 
+<a id="CreativeAssetsVideosGteCondition"></a>
+
 `CreativeAssetsVideosGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -7073,6 +7531,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.tiktok_marketing.types.CreativeAssetsVideosSearchFilter`
     :   The type of the None singleton.
+
+<a id="CreativeAssetsVideosInCondition"></a>
 
 `CreativeAssetsVideosInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -7093,6 +7553,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.tiktok_marketing.types.CreativeAssetsVideosInFilter`
     :   The type of the None singleton.
+
+<a id="CreativeAssetsVideosInFilter"></a>
 
 `CreativeAssetsVideosInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -7133,6 +7595,8 @@ Classes
     `width: list[int]`
     :   Width of the video in pixels.
 
+<a id="CreativeAssetsVideosKeywordCondition"></a>
+
 `CreativeAssetsVideosKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -7145,6 +7609,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.tiktok_marketing.types.CreativeAssetsVideosStringFilter`
     :   The type of the None singleton.
 
+<a id="CreativeAssetsVideosLikeCondition"></a>
+
 `CreativeAssetsVideosLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -7156,6 +7622,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.tiktok_marketing.types.CreativeAssetsVideosStringFilter`
     :   The type of the None singleton.
+
+<a id="CreativeAssetsVideosListParams"></a>
 
 `CreativeAssetsVideosListParams(*args, **kwargs)`
 :   Parameters for creative_assets_videos.list operation
@@ -7175,6 +7643,8 @@ Classes
     `page_size: int`
     :   The type of the None singleton.
 
+<a id="CreativeAssetsVideosLtCondition"></a>
+
 `CreativeAssetsVideosLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -7186,6 +7656,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.tiktok_marketing.types.CreativeAssetsVideosSearchFilter`
     :   The type of the None singleton.
+
+<a id="CreativeAssetsVideosLteCondition"></a>
 
 `CreativeAssetsVideosLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -7199,6 +7671,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.tiktok_marketing.types.CreativeAssetsVideosSearchFilter`
     :   The type of the None singleton.
 
+<a id="CreativeAssetsVideosNeqCondition"></a>
+
 `CreativeAssetsVideosNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -7210,6 +7684,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.tiktok_marketing.types.CreativeAssetsVideosSearchFilter`
     :   The type of the None singleton.
+
+<a id="CreativeAssetsVideosNotCondition"></a>
 
 `CreativeAssetsVideosNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -7231,6 +7707,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.tiktok_marketing.types.CreativeAssetsVideosEqCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.CreativeAssetsVideosNeqCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.CreativeAssetsVideosGtCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.CreativeAssetsVideosGteCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.CreativeAssetsVideosLtCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.CreativeAssetsVideosLteCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.CreativeAssetsVideosInCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.CreativeAssetsVideosLikeCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.CreativeAssetsVideosFuzzyCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.CreativeAssetsVideosKeywordCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.CreativeAssetsVideosContainsCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.CreativeAssetsVideosNotCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.CreativeAssetsVideosAndCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.CreativeAssetsVideosOrCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.CreativeAssetsVideosAnyCondition`
     :   The type of the None singleton.
 
+<a id="CreativeAssetsVideosOrCondition"></a>
+
 `CreativeAssetsVideosOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -7250,6 +7728,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.tiktok_marketing.types.CreativeAssetsVideosEqCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.CreativeAssetsVideosNeqCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.CreativeAssetsVideosGtCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.CreativeAssetsVideosGteCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.CreativeAssetsVideosLtCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.CreativeAssetsVideosLteCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.CreativeAssetsVideosInCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.CreativeAssetsVideosLikeCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.CreativeAssetsVideosFuzzyCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.CreativeAssetsVideosKeywordCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.CreativeAssetsVideosContainsCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.CreativeAssetsVideosNotCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.CreativeAssetsVideosAndCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.CreativeAssetsVideosOrCondition | airbyte_agent_sdk.connectors.tiktok_marketing.types.CreativeAssetsVideosAnyCondition]`
     :   The type of the None singleton.
+
+<a id="CreativeAssetsVideosSearchFilter"></a>
 
 `CreativeAssetsVideosSearchFilter(*args, **kwargs)`
 :   Available fields for filtering creative_assets_videos search queries.
@@ -7290,6 +7770,8 @@ Classes
     `width: int | None`
     :   Width of the video in pixels.
 
+<a id="CreativeAssetsVideosSearchQuery"></a>
+
 `CreativeAssetsVideosSearchQuery(*args, **kwargs)`
 :   Search query for creative_assets_videos entity.
 
@@ -7304,6 +7786,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.tiktok_marketing.types.CreativeAssetsVideosSortFilter]`
     :   The type of the None singleton.
+
+<a id="CreativeAssetsVideosSortFilter"></a>
 
 `CreativeAssetsVideosSortFilter(*args, **kwargs)`
 :   Available fields for sorting creative_assets_videos search results.
@@ -7343,6 +7827,8 @@ Classes
 
     `width: Literal['asc', 'desc']`
     :   Width of the video in pixels.
+
+<a id="CreativeAssetsVideosStringFilter"></a>
 
 `CreativeAssetsVideosStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/twilio/connector.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/twilio/connector.md
@@ -10,6 +10,8 @@ Twilio connector.
 Classes
 -------
 
+<a id="AccountsQuery"></a>
+
 `AccountsQuery(connector: TwilioConnector)`
 :   Query class for Accounts entity operations.
     
@@ -66,6 +68,8 @@ Classes
         
         Returns:
             AccountsListResult
+
+<a id="AddressesQuery"></a>
 
 `AddressesQuery(connector: TwilioConnector)`
 :   Query class for Addresses entity operations.
@@ -128,6 +132,8 @@ Classes
         
         Returns:
             AddressesListResult
+
+<a id="CallsQuery"></a>
 
 `CallsQuery(connector: TwilioConnector)`
 :   Query class for Calls entity operations.
@@ -193,6 +199,8 @@ Classes
         Returns:
             CallsListResult
 
+<a id="ConferencesQuery"></a>
+
 `ConferencesQuery(connector: TwilioConnector)`
 :   Query class for Conferences entity operations.
     
@@ -250,6 +258,8 @@ Classes
         
         Returns:
             ConferencesListResult
+
+<a id="IncomingPhoneNumbersQuery"></a>
 
 `IncomingPhoneNumbersQuery(connector: TwilioConnector)`
 :   Query class for IncomingPhoneNumbers entity operations.
@@ -309,6 +319,8 @@ Classes
         
         Returns:
             IncomingPhoneNumbersListResult
+
+<a id="MessagesQuery"></a>
 
 `MessagesQuery(connector: TwilioConnector)`
 :   Query class for Messages entity operations.
@@ -376,6 +388,8 @@ Classes
         Returns:
             MessagesListResult
 
+<a id="OutgoingCallerIdsQuery"></a>
+
 `OutgoingCallerIdsQuery(connector: TwilioConnector)`
 :   Query class for OutgoingCallerIds entity operations.
     
@@ -432,6 +446,8 @@ Classes
         
         Returns:
             OutgoingCallerIdsListResult
+
+<a id="QueuesQuery"></a>
 
 `QueuesQuery(connector: TwilioConnector)`
 :   Query class for Queues entity operations.
@@ -491,6 +507,8 @@ Classes
         
         Returns:
             QueuesListResult
+
+<a id="RecordingsQuery"></a>
 
 `RecordingsQuery(connector: TwilioConnector)`
 :   Query class for Recordings entity operations.
@@ -553,6 +571,8 @@ Classes
         Returns:
             RecordingsListResult
 
+<a id="TranscriptionsQuery"></a>
+
 `TranscriptionsQuery(connector: TwilioConnector)`
 :   Query class for Transcriptions entity operations.
     
@@ -612,6 +632,8 @@ Classes
         
         Returns:
             TranscriptionsListResult
+
+<a id="TwilioConnector"></a>
 
 `TwilioConnector(auth_config: TwilioAuthConfig | AirbyteAuthConfig | BaseModel | None = None, on_token_refresh: Any | None = None)`
 :   Type-safe Twilio API connector.
@@ -812,6 +834,8 @@ Classes
             entities = connector.list_entities()
             for entity in entities:
                 print(f"\{entity['entity_name']\}: \{entity['available_actions']\}")
+
+<a id="UsageRecordsQuery"></a>
 
 `UsageRecordsQuery(connector: TwilioConnector)`
 :   Query class for UsageRecords entity operations.

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/twilio/index.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/twilio/index.md
@@ -19,6 +19,8 @@ Sub-modules
 Classes
 -------
 
+<a id="AccountsSearchData"></a>
+
 `AccountsSearchData(**data: Any)`
 :   Search result data for accounts entity.
     
@@ -61,6 +63,8 @@ Classes
 
     `uri: str | None`
     :   The URI for accessing the account resource
+
+<a id="AddressesSearchData"></a>
 
 `AddressesSearchData(**data: Any)`
 :   Search result data for addresses entity.
@@ -113,6 +117,8 @@ Classes
 
     `verified: bool | None`
     :   Whether the address has been verified
+
+<a id="AirbyteAuthConfig"></a>
 
 `AirbyteAuthConfig(**data: Any)`
 :   Authentication configuration for Airbyte hosted mode execution.
@@ -182,6 +188,8 @@ Classes
     `workspace_name: str | None`
     :   The type of the None singleton.
 
+<a id="AirbyteSearchMeta"></a>
+
 `AirbyteSearchMeta(**data: Any)`
 :   Pagination metadata for search responses.
     
@@ -209,6 +217,8 @@ Classes
 
     `took_ms: int | None`
     :   Time taken to execute the search in milliseconds.
+
+<a id="AirbyteSearchResult"></a>
 
 `AirbyteSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -250,6 +260,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="AccountsSearchResult"></a>
+
 `AccountsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -265,6 +277,8 @@ Classes
     * airbyte_agent_sdk.connectors.twilio.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="AddressesSearchResult"></a>
 
 `AddressesSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -282,6 +296,8 @@ Classes
     * pydantic.main.BaseModel
     * typing.Generic
 
+<a id="CallsSearchResult"></a>
+
 `CallsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -297,6 +313,8 @@ Classes
     * airbyte_agent_sdk.connectors.twilio.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="ConferencesSearchResult"></a>
 
 `ConferencesSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -314,6 +332,8 @@ Classes
     * pydantic.main.BaseModel
     * typing.Generic
 
+<a id="IncomingPhoneNumbersSearchResult"></a>
+
 `IncomingPhoneNumbersSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -329,6 +349,8 @@ Classes
     * airbyte_agent_sdk.connectors.twilio.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="MessagesSearchResult"></a>
 
 `MessagesSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -346,6 +368,8 @@ Classes
     * pydantic.main.BaseModel
     * typing.Generic
 
+<a id="OutgoingCallerIdsSearchResult"></a>
+
 `OutgoingCallerIdsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -361,6 +385,8 @@ Classes
     * airbyte_agent_sdk.connectors.twilio.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="QueuesSearchResult"></a>
 
 `QueuesSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -378,6 +404,8 @@ Classes
     * pydantic.main.BaseModel
     * typing.Generic
 
+<a id="RecordingsSearchResult"></a>
+
 `RecordingsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -393,6 +421,8 @@ Classes
     * airbyte_agent_sdk.connectors.twilio.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="TranscriptionsSearchResult"></a>
 
 `TranscriptionsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -410,6 +440,8 @@ Classes
     * pydantic.main.BaseModel
     * typing.Generic
 
+<a id="UsageRecordsSearchResult"></a>
+
 `UsageRecordsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -425,6 +457,8 @@ Classes
     * airbyte_agent_sdk.connectors.twilio.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="CallsSearchData"></a>
 
 `CallsSearchData(**data: Any)`
 :   Search result data for calls entity.
@@ -484,6 +518,8 @@ Classes
     `to: str | None`
     :   The phone number that received the call
 
+<a id="ConferencesSearchData"></a>
+
 `ConferencesSearchData(**data: Any)`
 :   Search result data for conferences entity.
     
@@ -523,6 +559,8 @@ Classes
 
     `status: str | None`
     :   The current status of the conference
+
+<a id="IncomingPhoneNumbersSearchData"></a>
 
 `IncomingPhoneNumbersSearchData(**data: Any)`
 :   Search result data for incoming_phone_numbers entity.
@@ -566,6 +604,8 @@ Classes
 
     `status: str | None`
     :   Status of the phone number
+
+<a id="MessagesSearchData"></a>
 
 `MessagesSearchData(**data: Any)`
 :   Search result data for messages entity.
@@ -631,6 +671,8 @@ Classes
     `to: str | None`
     :   The phone number or recipient ID the message was sent to
 
+<a id="OutgoingCallerIdsSearchData"></a>
+
 `OutgoingCallerIdsSearchData(**data: Any)`
 :   Search result data for outgoing_caller_ids entity.
     
@@ -667,6 +709,8 @@ Classes
 
     `sid: str | None`
     :   The unique identifier
+
+<a id="QueuesSearchData"></a>
 
 `QueuesSearchData(**data: Any)`
 :   Search result data for queues entity.
@@ -710,6 +754,8 @@ Classes
 
     `sid: str | None`
     :   The unique identifier for the queue
+
+<a id="RecordingsSearchData"></a>
 
 `RecordingsSearchData(**data: Any)`
 :   Search result data for recordings entity.
@@ -760,6 +806,8 @@ Classes
     `status: str | None`
     :   The status of the recording
 
+<a id="TranscriptionsSearchData"></a>
+
 `TranscriptionsSearchData(**data: Any)`
 :   Search result data for transcriptions entity.
     
@@ -806,6 +854,8 @@ Classes
     `status: str | None`
     :   The status of the transcription
 
+<a id="TwilioAuthConfig"></a>
+
 `TwilioAuthConfig(**data: Any)`
 :   Twilio Authentication
     
@@ -830,6 +880,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="TwilioConnector"></a>
 
 `TwilioConnector(auth_config: TwilioAuthConfig | AirbyteAuthConfig | BaseModel | None = None, on_token_refresh: Any | None = None)`
 :   Type-safe Twilio API connector.
@@ -1031,6 +1083,8 @@ Classes
             for entity in entities:
                 print(f"\{entity['entity_name']\}: \{entity['available_actions']\}")
 
+<a id="TwilioReplicationConfig"></a>
+
 `TwilioReplicationConfig(**data: Any)`
 :   Replication Configuration - Settings for data replication from Twilio.
     
@@ -1052,6 +1106,8 @@ Classes
 
     `start_date: str`
     :   UTC date and time in the format YYYY-MM-DDTHH:mm:ssZ. Any data before this date will not be replicated.
+
+<a id="UsageRecordsSearchData"></a>
 
 `UsageRecordsSearchData(**data: Any)`
 :   Search result data for usage_records entity.

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/twilio/models.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/twilio/models.md
@@ -13,6 +13,8 @@ and response envelope types.
 Classes
 -------
 
+<a id="Account"></a>
+
 `Account(**data: Any)`
 :   A Twilio account
     
@@ -62,6 +64,8 @@ Classes
     `uri: str | Any | None`
     :   The type of the None singleton.
 
+<a id="AccountsList"></a>
+
 `AccountsList(**data: Any)`
 :   Paginated list of accounts
     
@@ -102,6 +106,8 @@ Classes
     `uri: str | Any | None`
     :   The type of the None singleton.
 
+<a id="AccountsListResultMeta"></a>
+
 `AccountsListResultMeta(**data: Any)`
 :   Metadata for accounts.Action.LIST operation
     
@@ -132,6 +138,8 @@ Classes
 
     `page_size: int | Any | None`
     :   The type of the None singleton.
+
+<a id="AccountsSearchData"></a>
 
 `AccountsSearchData(**data: Any)`
 :   Search result data for accounts entity.
@@ -175,6 +183,8 @@ Classes
 
     `uri: str | None`
     :   The URI for accessing the account resource
+
+<a id="Address"></a>
 
 `Address(**data: Any)`
 :   A Twilio address
@@ -243,6 +253,8 @@ Classes
     `verified: bool | Any | None`
     :   The type of the None singleton.
 
+<a id="AddressesList"></a>
+
 `AddressesList(**data: Any)`
 :   Paginated list of addresses
     
@@ -283,6 +295,8 @@ Classes
     `uri: str | Any | None`
     :   The type of the None singleton.
 
+<a id="AddressesListResultMeta"></a>
+
 `AddressesListResultMeta(**data: Any)`
 :   Metadata for addresses.Action.LIST operation
     
@@ -313,6 +327,8 @@ Classes
 
     `page_size: int | Any | None`
     :   The type of the None singleton.
+
+<a id="AddressesSearchData"></a>
 
 `AddressesSearchData(**data: Any)`
 :   Search result data for addresses entity.
@@ -366,6 +382,8 @@ Classes
     `verified: bool | None`
     :   Whether the address has been verified
 
+<a id="AirbyteSearchMeta"></a>
+
 `AirbyteSearchMeta(**data: Any)`
 :   Pagination metadata for search responses.
     
@@ -393,6 +411,8 @@ Classes
 
     `took_ms: int | None`
     :   Time taken to execute the search in milliseconds.
+
+<a id="AirbyteSearchResult"></a>
 
 `AirbyteSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -455,6 +475,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="AccountsSearchResult"></a>
+
 `AccountsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -491,6 +513,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="AddressesSearchResult"></a>
 
 `AddressesSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -529,6 +553,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="CallsSearchResult"></a>
+
 `CallsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -565,6 +591,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="ConferencesSearchResult"></a>
 
 `ConferencesSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -603,6 +631,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="IncomingPhoneNumbersSearchResult"></a>
+
 `IncomingPhoneNumbersSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -639,6 +669,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="MessagesSearchResult"></a>
 
 `MessagesSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -677,6 +709,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="OutgoingCallerIdsSearchResult"></a>
+
 `OutgoingCallerIdsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -713,6 +747,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="QueuesSearchResult"></a>
 
 `QueuesSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -751,6 +787,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="RecordingsSearchResult"></a>
+
 `RecordingsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -787,6 +825,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="TranscriptionsSearchResult"></a>
 
 `TranscriptionsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -825,6 +865,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="UsageRecordsSearchResult"></a>
+
 `UsageRecordsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -840,6 +882,8 @@ Classes
     * airbyte_agent_sdk.connectors.twilio.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="Call"></a>
 
 `Call(**data: Any)`
 :   A Twilio call
@@ -941,6 +985,8 @@ Classes
     `uri: str | Any | None`
     :   The type of the None singleton.
 
+<a id="CallsList"></a>
+
 `CallsList(**data: Any)`
 :   Paginated list of calls
     
@@ -981,6 +1027,8 @@ Classes
     `uri: str | Any | None`
     :   The type of the None singleton.
 
+<a id="CallsListResultMeta"></a>
+
 `CallsListResultMeta(**data: Any)`
 :   Metadata for calls.Action.LIST operation
     
@@ -1011,6 +1059,8 @@ Classes
 
     `page_size: int | Any | None`
     :   The type of the None singleton.
+
+<a id="CallsSearchData"></a>
 
 `CallsSearchData(**data: Any)`
 :   Search result data for calls entity.
@@ -1070,6 +1120,8 @@ Classes
     `to: str | None`
     :   The phone number that received the call
 
+<a id="Conference"></a>
+
 `Conference(**data: Any)`
 :   A Twilio conference
     
@@ -1125,6 +1177,8 @@ Classes
     `uri: str | Any | None`
     :   The type of the None singleton.
 
+<a id="ConferencesList"></a>
+
 `ConferencesList(**data: Any)`
 :   Paginated list of conferences
     
@@ -1165,6 +1219,8 @@ Classes
     `uri: str | Any | None`
     :   The type of the None singleton.
 
+<a id="ConferencesListResultMeta"></a>
+
 `ConferencesListResultMeta(**data: Any)`
 :   Metadata for conferences.Action.LIST operation
     
@@ -1195,6 +1251,8 @@ Classes
 
     `page_size: int | Any | None`
     :   The type of the None singleton.
+
+<a id="ConferencesSearchData"></a>
 
 `ConferencesSearchData(**data: Any)`
 :   Search result data for conferences entity.
@@ -1235,6 +1293,8 @@ Classes
 
     `status: str | None`
     :   The current status of the conference
+
+<a id="IncomingPhoneNumber"></a>
 
 `IncomingPhoneNumber(**data: Any)`
 :   A Twilio incoming phone number
@@ -1363,6 +1423,8 @@ Classes
     `voice_url: str | Any | None`
     :   The type of the None singleton.
 
+<a id="IncomingPhoneNumberCapabilities"></a>
+
 `IncomingPhoneNumberCapabilities(**data: Any)`
 :   Capabilities of this phone number
     
@@ -1393,6 +1455,8 @@ Classes
 
     `voice: bool | Any | None`
     :   The type of the None singleton.
+
+<a id="IncomingPhoneNumbersList"></a>
 
 `IncomingPhoneNumbersList(**data: Any)`
 :   Paginated list of incoming phone numbers
@@ -1434,6 +1498,8 @@ Classes
     `uri: str | Any | None`
     :   The type of the None singleton.
 
+<a id="IncomingPhoneNumbersListResultMeta"></a>
+
 `IncomingPhoneNumbersListResultMeta(**data: Any)`
 :   Metadata for incoming_phone_numbers.Action.LIST operation
     
@@ -1464,6 +1530,8 @@ Classes
 
     `page_size: int | Any | None`
     :   The type of the None singleton.
+
+<a id="IncomingPhoneNumbersSearchData"></a>
 
 `IncomingPhoneNumbersSearchData(**data: Any)`
 :   Search result data for incoming_phone_numbers entity.
@@ -1507,6 +1575,8 @@ Classes
 
     `status: str | None`
     :   Status of the phone number
+
+<a id="Message"></a>
 
 `Message(**data: Any)`
 :   A Twilio message
@@ -1587,6 +1657,8 @@ Classes
     `uri: str | Any | None`
     :   The type of the None singleton.
 
+<a id="MessagesList"></a>
+
 `MessagesList(**data: Any)`
 :   Paginated list of messages
     
@@ -1627,6 +1699,8 @@ Classes
     `uri: str | Any | None`
     :   The type of the None singleton.
 
+<a id="MessagesListResultMeta"></a>
+
 `MessagesListResultMeta(**data: Any)`
 :   Metadata for messages.Action.LIST operation
     
@@ -1657,6 +1731,8 @@ Classes
 
     `page_size: int | Any | None`
     :   The type of the None singleton.
+
+<a id="MessagesSearchData"></a>
 
 `MessagesSearchData(**data: Any)`
 :   Search result data for messages entity.
@@ -1722,6 +1798,8 @@ Classes
     `to: str | None`
     :   The phone number or recipient ID the message was sent to
 
+<a id="OutgoingCallerId"></a>
+
 `OutgoingCallerId(**data: Any)`
 :   A Twilio outgoing caller ID
     
@@ -1761,6 +1839,8 @@ Classes
 
     `uri: str | Any | None`
     :   The type of the None singleton.
+
+<a id="OutgoingCallerIdsList"></a>
 
 `OutgoingCallerIdsList(**data: Any)`
 :   Paginated list of outgoing caller IDs
@@ -1802,6 +1882,8 @@ Classes
     `uri: str | Any | None`
     :   The type of the None singleton.
 
+<a id="OutgoingCallerIdsListResultMeta"></a>
+
 `OutgoingCallerIdsListResultMeta(**data: Any)`
 :   Metadata for outgoing_caller_ids.Action.LIST operation
     
@@ -1832,6 +1914,8 @@ Classes
 
     `page_size: int | Any | None`
     :   The type of the None singleton.
+
+<a id="OutgoingCallerIdsSearchData"></a>
 
 `OutgoingCallerIdsSearchData(**data: Any)`
 :   Search result data for outgoing_caller_ids entity.
@@ -1869,6 +1953,8 @@ Classes
 
     `sid: str | None`
     :   The unique identifier
+
+<a id="Queue"></a>
 
 `Queue(**data: Any)`
 :   A Twilio queue
@@ -1919,6 +2005,8 @@ Classes
     `uri: str | Any | None`
     :   The type of the None singleton.
 
+<a id="QueuesList"></a>
+
 `QueuesList(**data: Any)`
 :   Paginated list of queues
     
@@ -1959,6 +2047,8 @@ Classes
     `uri: str | Any | None`
     :   The type of the None singleton.
 
+<a id="QueuesListResultMeta"></a>
+
 `QueuesListResultMeta(**data: Any)`
 :   Metadata for queues.Action.LIST operation
     
@@ -1989,6 +2079,8 @@ Classes
 
     `page_size: int | Any | None`
     :   The type of the None singleton.
+
+<a id="QueuesSearchData"></a>
 
 `QueuesSearchData(**data: Any)`
 :   Search result data for queues entity.
@@ -2032,6 +2124,8 @@ Classes
 
     `sid: str | None`
     :   The unique identifier for the queue
+
+<a id="Recording"></a>
 
 `Recording(**data: Any)`
 :   A Twilio recording
@@ -2109,6 +2203,8 @@ Classes
     `uri: str | Any | None`
     :   The type of the None singleton.
 
+<a id="RecordingsList"></a>
+
 `RecordingsList(**data: Any)`
 :   Paginated list of recordings
     
@@ -2149,6 +2245,8 @@ Classes
     `uri: str | Any | None`
     :   The type of the None singleton.
 
+<a id="RecordingsListResultMeta"></a>
+
 `RecordingsListResultMeta(**data: Any)`
 :   Metadata for recordings.Action.LIST operation
     
@@ -2179,6 +2277,8 @@ Classes
 
     `page_size: int | Any | None`
     :   The type of the None singleton.
+
+<a id="RecordingsSearchData"></a>
 
 `RecordingsSearchData(**data: Any)`
 :   Search result data for recordings entity.
@@ -2228,6 +2328,8 @@ Classes
 
     `status: str | None`
     :   The status of the recording
+
+<a id="Transcription"></a>
 
 `Transcription(**data: Any)`
 :   A Twilio transcription
@@ -2287,6 +2389,8 @@ Classes
     `uri: str | Any | None`
     :   The type of the None singleton.
 
+<a id="TranscriptionsList"></a>
+
 `TranscriptionsList(**data: Any)`
 :   Paginated list of transcriptions
     
@@ -2327,6 +2431,8 @@ Classes
     `uri: str | Any | None`
     :   The type of the None singleton.
 
+<a id="TranscriptionsListResultMeta"></a>
+
 `TranscriptionsListResultMeta(**data: Any)`
 :   Metadata for transcriptions.Action.LIST operation
     
@@ -2357,6 +2463,8 @@ Classes
 
     `page_size: int | Any | None`
     :   The type of the None singleton.
+
+<a id="TranscriptionsSearchData"></a>
 
 `TranscriptionsSearchData(**data: Any)`
 :   Search result data for transcriptions entity.
@@ -2404,6 +2512,8 @@ Classes
     `status: str | None`
     :   The status of the transcription
 
+<a id="TwilioAuthConfig"></a>
+
 `TwilioAuthConfig(**data: Any)`
 :   Twilio Authentication
     
@@ -2428,6 +2538,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="TwilioCheckResult"></a>
 
 `TwilioCheckResult(**data: Any)`
 :   Result of a health check operation.
@@ -2462,6 +2574,8 @@ Classes
     `status: str`
     :   Health check status: 'healthy' or 'unhealthy'.
 
+<a id="TwilioExecuteResult"></a>
+
 `TwilioExecuteResult(**data: Any)`
 :   Response envelope with data only.
     
@@ -2490,6 +2604,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="TwilioExecuteResultWithMeta"></a>
 
 `TwilioExecuteResultWithMeta(**data: Any)`
 :   Response envelope with data and metadata.
@@ -2552,6 +2668,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="AccountsListResult"></a>
+
 `AccountsListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -2594,6 +2712,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="AddressesListResult"></a>
 
 `AddressesListResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -2638,6 +2758,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="CallsListResult"></a>
+
 `CallsListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -2680,6 +2802,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="ConferencesListResult"></a>
 
 `ConferencesListResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -2724,6 +2848,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="IncomingPhoneNumbersListResult"></a>
+
 `IncomingPhoneNumbersListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -2766,6 +2892,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="MessagesListResult"></a>
 
 `MessagesListResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -2810,6 +2938,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="OutgoingCallerIdsListResult"></a>
+
 `OutgoingCallerIdsListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -2852,6 +2982,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="QueuesListResult"></a>
 
 `QueuesListResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -2896,6 +3028,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="RecordingsListResult"></a>
+
 `RecordingsListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -2938,6 +3072,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="TranscriptionsListResult"></a>
 
 `TranscriptionsListResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -2982,6 +3118,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="UsageRecordsListResult"></a>
+
 `UsageRecordsListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -3000,6 +3138,8 @@ Classes
     * airbyte_agent_sdk.connectors.twilio.models.TwilioExecuteResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="TwilioReplicationConfig"></a>
 
 `TwilioReplicationConfig(**data: Any)`
 :   Replication Configuration - Settings for data replication from Twilio.
@@ -3022,6 +3162,8 @@ Classes
 
     `start_date: str`
     :   UTC date and time in the format YYYY-MM-DDTHH:mm:ssZ. Any data before this date will not be replicated.
+
+<a id="UsageRecord"></a>
 
 `UsageRecord(**data: Any)`
 :   A Twilio usage record
@@ -3087,6 +3229,8 @@ Classes
     `usage_unit: str | Any | None`
     :   The type of the None singleton.
 
+<a id="UsageRecordsList"></a>
+
 `UsageRecordsList(**data: Any)`
 :   Paginated list of usage records
     
@@ -3127,6 +3271,8 @@ Classes
     `usage_records: list[airbyte_agent_sdk.connectors.twilio.models.UsageRecord] | Any`
     :   The type of the None singleton.
 
+<a id="UsageRecordsListResultMeta"></a>
+
 `UsageRecordsListResultMeta(**data: Any)`
 :   Metadata for usage_records.Action.LIST operation
     
@@ -3157,6 +3303,8 @@ Classes
 
     `page_size: int | Any | None`
     :   The type of the None singleton.
+
+<a id="UsageRecordsSearchData"></a>
 
 `UsageRecordsSearchData(**data: Any)`
 :   Search result data for usage_records entity.

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/twilio/types.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/twilio/types.md
@@ -10,6 +10,8 @@ Type definitions for twilio connector.
 Classes
 -------
 
+<a id="AccountsAndCondition"></a>
+
 `AccountsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -30,6 +32,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.twilio.types.AccountsEqCondition | airbyte_agent_sdk.connectors.twilio.types.AccountsNeqCondition | airbyte_agent_sdk.connectors.twilio.types.AccountsGtCondition | airbyte_agent_sdk.connectors.twilio.types.AccountsGteCondition | airbyte_agent_sdk.connectors.twilio.types.AccountsLtCondition | airbyte_agent_sdk.connectors.twilio.types.AccountsLteCondition | airbyte_agent_sdk.connectors.twilio.types.AccountsInCondition | airbyte_agent_sdk.connectors.twilio.types.AccountsLikeCondition | airbyte_agent_sdk.connectors.twilio.types.AccountsFuzzyCondition | airbyte_agent_sdk.connectors.twilio.types.AccountsKeywordCondition | airbyte_agent_sdk.connectors.twilio.types.AccountsContainsCondition | airbyte_agent_sdk.connectors.twilio.types.AccountsNotCondition | airbyte_agent_sdk.connectors.twilio.types.AccountsAndCondition | airbyte_agent_sdk.connectors.twilio.types.AccountsOrCondition | airbyte_agent_sdk.connectors.twilio.types.AccountsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="AccountsAnyCondition"></a>
+
 `AccountsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -49,6 +53,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.twilio.types.AccountsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="AccountsAnyValueFilter"></a>
 
 `AccountsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -83,6 +89,8 @@ Classes
     `uri: Any`
     :   The URI for accessing the account resource
 
+<a id="AccountsContainsCondition"></a>
+
 `AccountsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -94,6 +102,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.twilio.types.AccountsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="AccountsEqCondition"></a>
 
 `AccountsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -107,6 +117,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.twilio.types.AccountsSearchFilter`
     :   The type of the None singleton.
 
+<a id="AccountsFuzzyCondition"></a>
+
 `AccountsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -118,6 +130,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.twilio.types.AccountsStringFilter`
     :   The type of the None singleton.
+
+<a id="AccountsGetParams"></a>
 
 `AccountsGetParams(*args, **kwargs)`
 :   Parameters for accounts.get operation
@@ -131,6 +145,8 @@ Classes
     `sid: str`
     :   The type of the None singleton.
 
+<a id="AccountsGtCondition"></a>
+
 `AccountsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -143,6 +159,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.twilio.types.AccountsSearchFilter`
     :   The type of the None singleton.
 
+<a id="AccountsGteCondition"></a>
+
 `AccountsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -154,6 +172,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.twilio.types.AccountsSearchFilter`
     :   The type of the None singleton.
+
+<a id="AccountsInCondition"></a>
 
 `AccountsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -174,6 +194,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.twilio.types.AccountsInFilter`
     :   The type of the None singleton.
+
+<a id="AccountsInFilter"></a>
 
 `AccountsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -208,6 +230,8 @@ Classes
     `uri: list[str]`
     :   The URI for accessing the account resource
 
+<a id="AccountsKeywordCondition"></a>
+
 `AccountsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -219,6 +243,8 @@ Classes
 
     `keyword: airbyte_agent_sdk.connectors.twilio.types.AccountsStringFilter`
     :   The type of the None singleton.
+
+<a id="AccountsLikeCondition"></a>
 
 `AccountsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
@@ -232,6 +258,8 @@ Classes
     `like: airbyte_agent_sdk.connectors.twilio.types.AccountsStringFilter`
     :   The type of the None singleton.
 
+<a id="AccountsListParams"></a>
+
 `AccountsListParams(*args, **kwargs)`
 :   Parameters for accounts.list operation
 
@@ -243,6 +271,8 @@ Classes
 
     `page_size: int`
     :   The type of the None singleton.
+
+<a id="AccountsLtCondition"></a>
 
 `AccountsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
@@ -256,6 +286,8 @@ Classes
     `lt: airbyte_agent_sdk.connectors.twilio.types.AccountsSearchFilter`
     :   The type of the None singleton.
 
+<a id="AccountsLteCondition"></a>
+
 `AccountsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
 
@@ -268,6 +300,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.twilio.types.AccountsSearchFilter`
     :   The type of the None singleton.
 
+<a id="AccountsNeqCondition"></a>
+
 `AccountsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -279,6 +313,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.twilio.types.AccountsSearchFilter`
     :   The type of the None singleton.
+
+<a id="AccountsNotCondition"></a>
 
 `AccountsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -300,6 +336,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.twilio.types.AccountsEqCondition | airbyte_agent_sdk.connectors.twilio.types.AccountsNeqCondition | airbyte_agent_sdk.connectors.twilio.types.AccountsGtCondition | airbyte_agent_sdk.connectors.twilio.types.AccountsGteCondition | airbyte_agent_sdk.connectors.twilio.types.AccountsLtCondition | airbyte_agent_sdk.connectors.twilio.types.AccountsLteCondition | airbyte_agent_sdk.connectors.twilio.types.AccountsInCondition | airbyte_agent_sdk.connectors.twilio.types.AccountsLikeCondition | airbyte_agent_sdk.connectors.twilio.types.AccountsFuzzyCondition | airbyte_agent_sdk.connectors.twilio.types.AccountsKeywordCondition | airbyte_agent_sdk.connectors.twilio.types.AccountsContainsCondition | airbyte_agent_sdk.connectors.twilio.types.AccountsNotCondition | airbyte_agent_sdk.connectors.twilio.types.AccountsAndCondition | airbyte_agent_sdk.connectors.twilio.types.AccountsOrCondition | airbyte_agent_sdk.connectors.twilio.types.AccountsAnyCondition`
     :   The type of the None singleton.
 
+<a id="AccountsOrCondition"></a>
+
 `AccountsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -319,6 +357,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.twilio.types.AccountsEqCondition | airbyte_agent_sdk.connectors.twilio.types.AccountsNeqCondition | airbyte_agent_sdk.connectors.twilio.types.AccountsGtCondition | airbyte_agent_sdk.connectors.twilio.types.AccountsGteCondition | airbyte_agent_sdk.connectors.twilio.types.AccountsLtCondition | airbyte_agent_sdk.connectors.twilio.types.AccountsLteCondition | airbyte_agent_sdk.connectors.twilio.types.AccountsInCondition | airbyte_agent_sdk.connectors.twilio.types.AccountsLikeCondition | airbyte_agent_sdk.connectors.twilio.types.AccountsFuzzyCondition | airbyte_agent_sdk.connectors.twilio.types.AccountsKeywordCondition | airbyte_agent_sdk.connectors.twilio.types.AccountsContainsCondition | airbyte_agent_sdk.connectors.twilio.types.AccountsNotCondition | airbyte_agent_sdk.connectors.twilio.types.AccountsAndCondition | airbyte_agent_sdk.connectors.twilio.types.AccountsOrCondition | airbyte_agent_sdk.connectors.twilio.types.AccountsAnyCondition]`
     :   The type of the None singleton.
+
+<a id="AccountsSearchFilter"></a>
 
 `AccountsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering accounts search queries.
@@ -353,6 +393,8 @@ Classes
     `uri: str | None`
     :   The URI for accessing the account resource
 
+<a id="AccountsSearchQuery"></a>
+
 `AccountsSearchQuery(*args, **kwargs)`
 :   Search query for accounts entity.
 
@@ -367,6 +409,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.twilio.types.AccountsSortFilter]`
     :   The type of the None singleton.
+
+<a id="AccountsSortFilter"></a>
 
 `AccountsSortFilter(*args, **kwargs)`
 :   Available fields for sorting accounts search results.
@@ -401,6 +445,8 @@ Classes
     `uri: Literal['asc', 'desc']`
     :   The URI for accessing the account resource
 
+<a id="AccountsStringFilter"></a>
+
 `AccountsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -434,6 +480,8 @@ Classes
     `uri: str`
     :   The URI for accessing the account resource
 
+<a id="AddressesAndCondition"></a>
+
 `AddressesAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -454,6 +502,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.twilio.types.AddressesEqCondition | airbyte_agent_sdk.connectors.twilio.types.AddressesNeqCondition | airbyte_agent_sdk.connectors.twilio.types.AddressesGtCondition | airbyte_agent_sdk.connectors.twilio.types.AddressesGteCondition | airbyte_agent_sdk.connectors.twilio.types.AddressesLtCondition | airbyte_agent_sdk.connectors.twilio.types.AddressesLteCondition | airbyte_agent_sdk.connectors.twilio.types.AddressesInCondition | airbyte_agent_sdk.connectors.twilio.types.AddressesLikeCondition | airbyte_agent_sdk.connectors.twilio.types.AddressesFuzzyCondition | airbyte_agent_sdk.connectors.twilio.types.AddressesKeywordCondition | airbyte_agent_sdk.connectors.twilio.types.AddressesContainsCondition | airbyte_agent_sdk.connectors.twilio.types.AddressesNotCondition | airbyte_agent_sdk.connectors.twilio.types.AddressesAndCondition | airbyte_agent_sdk.connectors.twilio.types.AddressesOrCondition | airbyte_agent_sdk.connectors.twilio.types.AddressesAnyCondition]`
     :   The type of the None singleton.
 
+<a id="AddressesAnyCondition"></a>
+
 `AddressesAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -473,6 +523,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.twilio.types.AddressesAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="AddressesAnyValueFilter"></a>
 
 `AddressesAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -516,6 +568,8 @@ Classes
     `verified: Any`
     :   Whether the address has been verified
 
+<a id="AddressesContainsCondition"></a>
+
 `AddressesContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -527,6 +581,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.twilio.types.AddressesAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="AddressesEqCondition"></a>
 
 `AddressesEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -540,6 +596,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.twilio.types.AddressesSearchFilter`
     :   The type of the None singleton.
 
+<a id="AddressesFuzzyCondition"></a>
+
 `AddressesFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -551,6 +609,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.twilio.types.AddressesStringFilter`
     :   The type of the None singleton.
+
+<a id="AddressesGetParams"></a>
 
 `AddressesGetParams(*args, **kwargs)`
 :   Parameters for addresses.get operation
@@ -567,6 +627,8 @@ Classes
     `sid: str`
     :   The type of the None singleton.
 
+<a id="AddressesGtCondition"></a>
+
 `AddressesGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -579,6 +641,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.twilio.types.AddressesSearchFilter`
     :   The type of the None singleton.
 
+<a id="AddressesGteCondition"></a>
+
 `AddressesGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -590,6 +654,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.twilio.types.AddressesSearchFilter`
     :   The type of the None singleton.
+
+<a id="AddressesInCondition"></a>
 
 `AddressesInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -610,6 +676,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.twilio.types.AddressesInFilter`
     :   The type of the None singleton.
+
+<a id="AddressesInFilter"></a>
 
 `AddressesInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -653,6 +721,8 @@ Classes
     `verified: list[bool]`
     :   Whether the address has been verified
 
+<a id="AddressesKeywordCondition"></a>
+
 `AddressesKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -665,6 +735,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.twilio.types.AddressesStringFilter`
     :   The type of the None singleton.
 
+<a id="AddressesLikeCondition"></a>
+
 `AddressesLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -676,6 +748,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.twilio.types.AddressesStringFilter`
     :   The type of the None singleton.
+
+<a id="AddressesListParams"></a>
 
 `AddressesListParams(*args, **kwargs)`
 :   Parameters for addresses.list operation
@@ -692,6 +766,8 @@ Classes
     `page_size: int`
     :   The type of the None singleton.
 
+<a id="AddressesLtCondition"></a>
+
 `AddressesLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -703,6 +779,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.twilio.types.AddressesSearchFilter`
     :   The type of the None singleton.
+
+<a id="AddressesLteCondition"></a>
 
 `AddressesLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -716,6 +794,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.twilio.types.AddressesSearchFilter`
     :   The type of the None singleton.
 
+<a id="AddressesNeqCondition"></a>
+
 `AddressesNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -727,6 +807,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.twilio.types.AddressesSearchFilter`
     :   The type of the None singleton.
+
+<a id="AddressesNotCondition"></a>
 
 `AddressesNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -748,6 +830,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.twilio.types.AddressesEqCondition | airbyte_agent_sdk.connectors.twilio.types.AddressesNeqCondition | airbyte_agent_sdk.connectors.twilio.types.AddressesGtCondition | airbyte_agent_sdk.connectors.twilio.types.AddressesGteCondition | airbyte_agent_sdk.connectors.twilio.types.AddressesLtCondition | airbyte_agent_sdk.connectors.twilio.types.AddressesLteCondition | airbyte_agent_sdk.connectors.twilio.types.AddressesInCondition | airbyte_agent_sdk.connectors.twilio.types.AddressesLikeCondition | airbyte_agent_sdk.connectors.twilio.types.AddressesFuzzyCondition | airbyte_agent_sdk.connectors.twilio.types.AddressesKeywordCondition | airbyte_agent_sdk.connectors.twilio.types.AddressesContainsCondition | airbyte_agent_sdk.connectors.twilio.types.AddressesNotCondition | airbyte_agent_sdk.connectors.twilio.types.AddressesAndCondition | airbyte_agent_sdk.connectors.twilio.types.AddressesOrCondition | airbyte_agent_sdk.connectors.twilio.types.AddressesAnyCondition`
     :   The type of the None singleton.
 
+<a id="AddressesOrCondition"></a>
+
 `AddressesOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -767,6 +851,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.twilio.types.AddressesEqCondition | airbyte_agent_sdk.connectors.twilio.types.AddressesNeqCondition | airbyte_agent_sdk.connectors.twilio.types.AddressesGtCondition | airbyte_agent_sdk.connectors.twilio.types.AddressesGteCondition | airbyte_agent_sdk.connectors.twilio.types.AddressesLtCondition | airbyte_agent_sdk.connectors.twilio.types.AddressesLteCondition | airbyte_agent_sdk.connectors.twilio.types.AddressesInCondition | airbyte_agent_sdk.connectors.twilio.types.AddressesLikeCondition | airbyte_agent_sdk.connectors.twilio.types.AddressesFuzzyCondition | airbyte_agent_sdk.connectors.twilio.types.AddressesKeywordCondition | airbyte_agent_sdk.connectors.twilio.types.AddressesContainsCondition | airbyte_agent_sdk.connectors.twilio.types.AddressesNotCondition | airbyte_agent_sdk.connectors.twilio.types.AddressesAndCondition | airbyte_agent_sdk.connectors.twilio.types.AddressesOrCondition | airbyte_agent_sdk.connectors.twilio.types.AddressesAnyCondition]`
     :   The type of the None singleton.
+
+<a id="AddressesSearchFilter"></a>
 
 `AddressesSearchFilter(*args, **kwargs)`
 :   Available fields for filtering addresses search queries.
@@ -810,6 +896,8 @@ Classes
     `verified: bool | None`
     :   Whether the address has been verified
 
+<a id="AddressesSearchQuery"></a>
+
 `AddressesSearchQuery(*args, **kwargs)`
 :   Search query for addresses entity.
 
@@ -824,6 +912,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.twilio.types.AddressesSortFilter]`
     :   The type of the None singleton.
+
+<a id="AddressesSortFilter"></a>
 
 `AddressesSortFilter(*args, **kwargs)`
 :   Available fields for sorting addresses search results.
@@ -867,6 +957,8 @@ Classes
     `verified: Literal['asc', 'desc']`
     :   Whether the address has been verified
 
+<a id="AddressesStringFilter"></a>
+
 `AddressesStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -909,6 +1001,8 @@ Classes
     `verified: str`
     :   Whether the address has been verified
 
+<a id="AirbyteSearchParams"></a>
+
 `AirbyteSearchParams(*args, **kwargs)`
 :   Parameters for Airbyte cache search operations (generic, use entity-specific query types for better type hints).
 
@@ -930,6 +1024,8 @@ Classes
     `query: dict[str, typing.Any]`
     :   The type of the None singleton.
 
+<a id="CallsAndCondition"></a>
+
 `CallsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -950,6 +1046,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.twilio.types.CallsEqCondition | airbyte_agent_sdk.connectors.twilio.types.CallsNeqCondition | airbyte_agent_sdk.connectors.twilio.types.CallsGtCondition | airbyte_agent_sdk.connectors.twilio.types.CallsGteCondition | airbyte_agent_sdk.connectors.twilio.types.CallsLtCondition | airbyte_agent_sdk.connectors.twilio.types.CallsLteCondition | airbyte_agent_sdk.connectors.twilio.types.CallsInCondition | airbyte_agent_sdk.connectors.twilio.types.CallsLikeCondition | airbyte_agent_sdk.connectors.twilio.types.CallsFuzzyCondition | airbyte_agent_sdk.connectors.twilio.types.CallsKeywordCondition | airbyte_agent_sdk.connectors.twilio.types.CallsContainsCondition | airbyte_agent_sdk.connectors.twilio.types.CallsNotCondition | airbyte_agent_sdk.connectors.twilio.types.CallsAndCondition | airbyte_agent_sdk.connectors.twilio.types.CallsOrCondition | airbyte_agent_sdk.connectors.twilio.types.CallsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="CallsAnyCondition"></a>
+
 `CallsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -969,6 +1067,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.twilio.types.CallsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="CallsAnyValueFilter"></a>
 
 `CallsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -1018,6 +1118,8 @@ Classes
     `to: Any`
     :   The phone number that received the call
 
+<a id="CallsContainsCondition"></a>
+
 `CallsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -1029,6 +1131,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.twilio.types.CallsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="CallsEqCondition"></a>
 
 `CallsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -1042,6 +1146,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.twilio.types.CallsSearchFilter`
     :   The type of the None singleton.
 
+<a id="CallsFuzzyCondition"></a>
+
 `CallsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -1053,6 +1159,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.twilio.types.CallsStringFilter`
     :   The type of the None singleton.
+
+<a id="CallsGetParams"></a>
 
 `CallsGetParams(*args, **kwargs)`
 :   Parameters for calls.get operation
@@ -1069,6 +1177,8 @@ Classes
     `sid: str`
     :   The type of the None singleton.
 
+<a id="CallsGtCondition"></a>
+
 `CallsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -1081,6 +1191,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.twilio.types.CallsSearchFilter`
     :   The type of the None singleton.
 
+<a id="CallsGteCondition"></a>
+
 `CallsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -1092,6 +1204,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.twilio.types.CallsSearchFilter`
     :   The type of the None singleton.
+
+<a id="CallsInCondition"></a>
 
 `CallsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -1112,6 +1226,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.twilio.types.CallsInFilter`
     :   The type of the None singleton.
+
+<a id="CallsInFilter"></a>
 
 `CallsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -1161,6 +1277,8 @@ Classes
     `to: list[str]`
     :   The phone number that received the call
 
+<a id="CallsKeywordCondition"></a>
+
 `CallsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -1173,6 +1291,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.twilio.types.CallsStringFilter`
     :   The type of the None singleton.
 
+<a id="CallsLikeCondition"></a>
+
 `CallsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -1184,6 +1304,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.twilio.types.CallsStringFilter`
     :   The type of the None singleton.
+
+<a id="CallsListParams"></a>
 
 `CallsListParams(*args, **kwargs)`
 :   Parameters for calls.list operation
@@ -1200,6 +1322,8 @@ Classes
     `page_size: int`
     :   The type of the None singleton.
 
+<a id="CallsLtCondition"></a>
+
 `CallsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -1211,6 +1335,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.twilio.types.CallsSearchFilter`
     :   The type of the None singleton.
+
+<a id="CallsLteCondition"></a>
 
 `CallsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -1224,6 +1350,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.twilio.types.CallsSearchFilter`
     :   The type of the None singleton.
 
+<a id="CallsNeqCondition"></a>
+
 `CallsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -1235,6 +1363,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.twilio.types.CallsSearchFilter`
     :   The type of the None singleton.
+
+<a id="CallsNotCondition"></a>
 
 `CallsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -1256,6 +1386,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.twilio.types.CallsEqCondition | airbyte_agent_sdk.connectors.twilio.types.CallsNeqCondition | airbyte_agent_sdk.connectors.twilio.types.CallsGtCondition | airbyte_agent_sdk.connectors.twilio.types.CallsGteCondition | airbyte_agent_sdk.connectors.twilio.types.CallsLtCondition | airbyte_agent_sdk.connectors.twilio.types.CallsLteCondition | airbyte_agent_sdk.connectors.twilio.types.CallsInCondition | airbyte_agent_sdk.connectors.twilio.types.CallsLikeCondition | airbyte_agent_sdk.connectors.twilio.types.CallsFuzzyCondition | airbyte_agent_sdk.connectors.twilio.types.CallsKeywordCondition | airbyte_agent_sdk.connectors.twilio.types.CallsContainsCondition | airbyte_agent_sdk.connectors.twilio.types.CallsNotCondition | airbyte_agent_sdk.connectors.twilio.types.CallsAndCondition | airbyte_agent_sdk.connectors.twilio.types.CallsOrCondition | airbyte_agent_sdk.connectors.twilio.types.CallsAnyCondition`
     :   The type of the None singleton.
 
+<a id="CallsOrCondition"></a>
+
 `CallsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1275,6 +1407,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.twilio.types.CallsEqCondition | airbyte_agent_sdk.connectors.twilio.types.CallsNeqCondition | airbyte_agent_sdk.connectors.twilio.types.CallsGtCondition | airbyte_agent_sdk.connectors.twilio.types.CallsGteCondition | airbyte_agent_sdk.connectors.twilio.types.CallsLtCondition | airbyte_agent_sdk.connectors.twilio.types.CallsLteCondition | airbyte_agent_sdk.connectors.twilio.types.CallsInCondition | airbyte_agent_sdk.connectors.twilio.types.CallsLikeCondition | airbyte_agent_sdk.connectors.twilio.types.CallsFuzzyCondition | airbyte_agent_sdk.connectors.twilio.types.CallsKeywordCondition | airbyte_agent_sdk.connectors.twilio.types.CallsContainsCondition | airbyte_agent_sdk.connectors.twilio.types.CallsNotCondition | airbyte_agent_sdk.connectors.twilio.types.CallsAndCondition | airbyte_agent_sdk.connectors.twilio.types.CallsOrCondition | airbyte_agent_sdk.connectors.twilio.types.CallsAnyCondition]`
     :   The type of the None singleton.
+
+<a id="CallsSearchFilter"></a>
 
 `CallsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering calls search queries.
@@ -1324,6 +1458,8 @@ Classes
     `to: str | None`
     :   The phone number that received the call
 
+<a id="CallsSearchQuery"></a>
+
 `CallsSearchQuery(*args, **kwargs)`
 :   Search query for calls entity.
 
@@ -1338,6 +1474,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.twilio.types.CallsSortFilter]`
     :   The type of the None singleton.
+
+<a id="CallsSortFilter"></a>
 
 `CallsSortFilter(*args, **kwargs)`
 :   Available fields for sorting calls search results.
@@ -1387,6 +1525,8 @@ Classes
     `to: Literal['asc', 'desc']`
     :   The phone number that received the call
 
+<a id="CallsStringFilter"></a>
+
 `CallsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -1435,6 +1575,8 @@ Classes
     `to: str`
     :   The phone number that received the call
 
+<a id="ConferencesAndCondition"></a>
+
 `ConferencesAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1455,6 +1597,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.twilio.types.ConferencesEqCondition | airbyte_agent_sdk.connectors.twilio.types.ConferencesNeqCondition | airbyte_agent_sdk.connectors.twilio.types.ConferencesGtCondition | airbyte_agent_sdk.connectors.twilio.types.ConferencesGteCondition | airbyte_agent_sdk.connectors.twilio.types.ConferencesLtCondition | airbyte_agent_sdk.connectors.twilio.types.ConferencesLteCondition | airbyte_agent_sdk.connectors.twilio.types.ConferencesInCondition | airbyte_agent_sdk.connectors.twilio.types.ConferencesLikeCondition | airbyte_agent_sdk.connectors.twilio.types.ConferencesFuzzyCondition | airbyte_agent_sdk.connectors.twilio.types.ConferencesKeywordCondition | airbyte_agent_sdk.connectors.twilio.types.ConferencesContainsCondition | airbyte_agent_sdk.connectors.twilio.types.ConferencesNotCondition | airbyte_agent_sdk.connectors.twilio.types.ConferencesAndCondition | airbyte_agent_sdk.connectors.twilio.types.ConferencesOrCondition | airbyte_agent_sdk.connectors.twilio.types.ConferencesAnyCondition]`
     :   The type of the None singleton.
 
+<a id="ConferencesAnyCondition"></a>
+
 `ConferencesAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1474,6 +1618,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.twilio.types.ConferencesAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="ConferencesAnyValueFilter"></a>
 
 `ConferencesAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -1505,6 +1651,8 @@ Classes
     `status: Any`
     :   The current status of the conference
 
+<a id="ConferencesContainsCondition"></a>
+
 `ConferencesContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -1516,6 +1664,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.twilio.types.ConferencesAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="ConferencesEqCondition"></a>
 
 `ConferencesEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -1529,6 +1679,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.twilio.types.ConferencesSearchFilter`
     :   The type of the None singleton.
 
+<a id="ConferencesFuzzyCondition"></a>
+
 `ConferencesFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -1540,6 +1692,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.twilio.types.ConferencesStringFilter`
     :   The type of the None singleton.
+
+<a id="ConferencesGetParams"></a>
 
 `ConferencesGetParams(*args, **kwargs)`
 :   Parameters for conferences.get operation
@@ -1556,6 +1710,8 @@ Classes
     `sid: str`
     :   The type of the None singleton.
 
+<a id="ConferencesGtCondition"></a>
+
 `ConferencesGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -1568,6 +1724,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.twilio.types.ConferencesSearchFilter`
     :   The type of the None singleton.
 
+<a id="ConferencesGteCondition"></a>
+
 `ConferencesGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -1579,6 +1737,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.twilio.types.ConferencesSearchFilter`
     :   The type of the None singleton.
+
+<a id="ConferencesInCondition"></a>
 
 `ConferencesInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -1599,6 +1759,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.twilio.types.ConferencesInFilter`
     :   The type of the None singleton.
+
+<a id="ConferencesInFilter"></a>
 
 `ConferencesInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -1630,6 +1792,8 @@ Classes
     `status: list[str]`
     :   The current status of the conference
 
+<a id="ConferencesKeywordCondition"></a>
+
 `ConferencesKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -1642,6 +1806,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.twilio.types.ConferencesStringFilter`
     :   The type of the None singleton.
 
+<a id="ConferencesLikeCondition"></a>
+
 `ConferencesLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -1653,6 +1819,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.twilio.types.ConferencesStringFilter`
     :   The type of the None singleton.
+
+<a id="ConferencesListParams"></a>
 
 `ConferencesListParams(*args, **kwargs)`
 :   Parameters for conferences.list operation
@@ -1669,6 +1837,8 @@ Classes
     `page_size: int`
     :   The type of the None singleton.
 
+<a id="ConferencesLtCondition"></a>
+
 `ConferencesLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -1680,6 +1850,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.twilio.types.ConferencesSearchFilter`
     :   The type of the None singleton.
+
+<a id="ConferencesLteCondition"></a>
 
 `ConferencesLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -1693,6 +1865,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.twilio.types.ConferencesSearchFilter`
     :   The type of the None singleton.
 
+<a id="ConferencesNeqCondition"></a>
+
 `ConferencesNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -1704,6 +1878,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.twilio.types.ConferencesSearchFilter`
     :   The type of the None singleton.
+
+<a id="ConferencesNotCondition"></a>
 
 `ConferencesNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -1725,6 +1901,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.twilio.types.ConferencesEqCondition | airbyte_agent_sdk.connectors.twilio.types.ConferencesNeqCondition | airbyte_agent_sdk.connectors.twilio.types.ConferencesGtCondition | airbyte_agent_sdk.connectors.twilio.types.ConferencesGteCondition | airbyte_agent_sdk.connectors.twilio.types.ConferencesLtCondition | airbyte_agent_sdk.connectors.twilio.types.ConferencesLteCondition | airbyte_agent_sdk.connectors.twilio.types.ConferencesInCondition | airbyte_agent_sdk.connectors.twilio.types.ConferencesLikeCondition | airbyte_agent_sdk.connectors.twilio.types.ConferencesFuzzyCondition | airbyte_agent_sdk.connectors.twilio.types.ConferencesKeywordCondition | airbyte_agent_sdk.connectors.twilio.types.ConferencesContainsCondition | airbyte_agent_sdk.connectors.twilio.types.ConferencesNotCondition | airbyte_agent_sdk.connectors.twilio.types.ConferencesAndCondition | airbyte_agent_sdk.connectors.twilio.types.ConferencesOrCondition | airbyte_agent_sdk.connectors.twilio.types.ConferencesAnyCondition`
     :   The type of the None singleton.
 
+<a id="ConferencesOrCondition"></a>
+
 `ConferencesOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1744,6 +1922,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.twilio.types.ConferencesEqCondition | airbyte_agent_sdk.connectors.twilio.types.ConferencesNeqCondition | airbyte_agent_sdk.connectors.twilio.types.ConferencesGtCondition | airbyte_agent_sdk.connectors.twilio.types.ConferencesGteCondition | airbyte_agent_sdk.connectors.twilio.types.ConferencesLtCondition | airbyte_agent_sdk.connectors.twilio.types.ConferencesLteCondition | airbyte_agent_sdk.connectors.twilio.types.ConferencesInCondition | airbyte_agent_sdk.connectors.twilio.types.ConferencesLikeCondition | airbyte_agent_sdk.connectors.twilio.types.ConferencesFuzzyCondition | airbyte_agent_sdk.connectors.twilio.types.ConferencesKeywordCondition | airbyte_agent_sdk.connectors.twilio.types.ConferencesContainsCondition | airbyte_agent_sdk.connectors.twilio.types.ConferencesNotCondition | airbyte_agent_sdk.connectors.twilio.types.ConferencesAndCondition | airbyte_agent_sdk.connectors.twilio.types.ConferencesOrCondition | airbyte_agent_sdk.connectors.twilio.types.ConferencesAnyCondition]`
     :   The type of the None singleton.
+
+<a id="ConferencesSearchFilter"></a>
 
 `ConferencesSearchFilter(*args, **kwargs)`
 :   Available fields for filtering conferences search queries.
@@ -1775,6 +1955,8 @@ Classes
     `status: str | None`
     :   The current status of the conference
 
+<a id="ConferencesSearchQuery"></a>
+
 `ConferencesSearchQuery(*args, **kwargs)`
 :   Search query for conferences entity.
 
@@ -1789,6 +1971,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.twilio.types.ConferencesSortFilter]`
     :   The type of the None singleton.
+
+<a id="ConferencesSortFilter"></a>
 
 `ConferencesSortFilter(*args, **kwargs)`
 :   Available fields for sorting conferences search results.
@@ -1820,6 +2004,8 @@ Classes
     `status: Literal['asc', 'desc']`
     :   The current status of the conference
 
+<a id="ConferencesStringFilter"></a>
+
 `ConferencesStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -1850,6 +2036,8 @@ Classes
     `status: str`
     :   The current status of the conference
 
+<a id="IncomingPhoneNumbersAndCondition"></a>
+
 `IncomingPhoneNumbersAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1870,6 +2058,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.twilio.types.IncomingPhoneNumbersEqCondition | airbyte_agent_sdk.connectors.twilio.types.IncomingPhoneNumbersNeqCondition | airbyte_agent_sdk.connectors.twilio.types.IncomingPhoneNumbersGtCondition | airbyte_agent_sdk.connectors.twilio.types.IncomingPhoneNumbersGteCondition | airbyte_agent_sdk.connectors.twilio.types.IncomingPhoneNumbersLtCondition | airbyte_agent_sdk.connectors.twilio.types.IncomingPhoneNumbersLteCondition | airbyte_agent_sdk.connectors.twilio.types.IncomingPhoneNumbersInCondition | airbyte_agent_sdk.connectors.twilio.types.IncomingPhoneNumbersLikeCondition | airbyte_agent_sdk.connectors.twilio.types.IncomingPhoneNumbersFuzzyCondition | airbyte_agent_sdk.connectors.twilio.types.IncomingPhoneNumbersKeywordCondition | airbyte_agent_sdk.connectors.twilio.types.IncomingPhoneNumbersContainsCondition | airbyte_agent_sdk.connectors.twilio.types.IncomingPhoneNumbersNotCondition | airbyte_agent_sdk.connectors.twilio.types.IncomingPhoneNumbersAndCondition | airbyte_agent_sdk.connectors.twilio.types.IncomingPhoneNumbersOrCondition | airbyte_agent_sdk.connectors.twilio.types.IncomingPhoneNumbersAnyCondition]`
     :   The type of the None singleton.
 
+<a id="IncomingPhoneNumbersAnyCondition"></a>
+
 `IncomingPhoneNumbersAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1889,6 +2079,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.twilio.types.IncomingPhoneNumbersAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="IncomingPhoneNumbersAnyValueFilter"></a>
 
 `IncomingPhoneNumbersAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -1923,6 +2115,8 @@ Classes
     `status: Any`
     :   Status of the phone number
 
+<a id="IncomingPhoneNumbersContainsCondition"></a>
+
 `IncomingPhoneNumbersContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -1934,6 +2128,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.twilio.types.IncomingPhoneNumbersAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="IncomingPhoneNumbersEqCondition"></a>
 
 `IncomingPhoneNumbersEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -1947,6 +2143,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.twilio.types.IncomingPhoneNumbersSearchFilter`
     :   The type of the None singleton.
 
+<a id="IncomingPhoneNumbersFuzzyCondition"></a>
+
 `IncomingPhoneNumbersFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -1958,6 +2156,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.twilio.types.IncomingPhoneNumbersStringFilter`
     :   The type of the None singleton.
+
+<a id="IncomingPhoneNumbersGetParams"></a>
 
 `IncomingPhoneNumbersGetParams(*args, **kwargs)`
 :   Parameters for incoming_phone_numbers.get operation
@@ -1974,6 +2174,8 @@ Classes
     `sid: str`
     :   The type of the None singleton.
 
+<a id="IncomingPhoneNumbersGtCondition"></a>
+
 `IncomingPhoneNumbersGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -1986,6 +2188,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.twilio.types.IncomingPhoneNumbersSearchFilter`
     :   The type of the None singleton.
 
+<a id="IncomingPhoneNumbersGteCondition"></a>
+
 `IncomingPhoneNumbersGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -1997,6 +2201,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.twilio.types.IncomingPhoneNumbersSearchFilter`
     :   The type of the None singleton.
+
+<a id="IncomingPhoneNumbersInCondition"></a>
 
 `IncomingPhoneNumbersInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -2017,6 +2223,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.twilio.types.IncomingPhoneNumbersInFilter`
     :   The type of the None singleton.
+
+<a id="IncomingPhoneNumbersInFilter"></a>
 
 `IncomingPhoneNumbersInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -2051,6 +2259,8 @@ Classes
     `status: list[str]`
     :   Status of the phone number
 
+<a id="IncomingPhoneNumbersKeywordCondition"></a>
+
 `IncomingPhoneNumbersKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -2063,6 +2273,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.twilio.types.IncomingPhoneNumbersStringFilter`
     :   The type of the None singleton.
 
+<a id="IncomingPhoneNumbersLikeCondition"></a>
+
 `IncomingPhoneNumbersLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -2074,6 +2286,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.twilio.types.IncomingPhoneNumbersStringFilter`
     :   The type of the None singleton.
+
+<a id="IncomingPhoneNumbersListParams"></a>
 
 `IncomingPhoneNumbersListParams(*args, **kwargs)`
 :   Parameters for incoming_phone_numbers.list operation
@@ -2090,6 +2304,8 @@ Classes
     `page_size: int`
     :   The type of the None singleton.
 
+<a id="IncomingPhoneNumbersLtCondition"></a>
+
 `IncomingPhoneNumbersLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -2101,6 +2317,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.twilio.types.IncomingPhoneNumbersSearchFilter`
     :   The type of the None singleton.
+
+<a id="IncomingPhoneNumbersLteCondition"></a>
 
 `IncomingPhoneNumbersLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -2114,6 +2332,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.twilio.types.IncomingPhoneNumbersSearchFilter`
     :   The type of the None singleton.
 
+<a id="IncomingPhoneNumbersNeqCondition"></a>
+
 `IncomingPhoneNumbersNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -2125,6 +2345,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.twilio.types.IncomingPhoneNumbersSearchFilter`
     :   The type of the None singleton.
+
+<a id="IncomingPhoneNumbersNotCondition"></a>
 
 `IncomingPhoneNumbersNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -2146,6 +2368,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.twilio.types.IncomingPhoneNumbersEqCondition | airbyte_agent_sdk.connectors.twilio.types.IncomingPhoneNumbersNeqCondition | airbyte_agent_sdk.connectors.twilio.types.IncomingPhoneNumbersGtCondition | airbyte_agent_sdk.connectors.twilio.types.IncomingPhoneNumbersGteCondition | airbyte_agent_sdk.connectors.twilio.types.IncomingPhoneNumbersLtCondition | airbyte_agent_sdk.connectors.twilio.types.IncomingPhoneNumbersLteCondition | airbyte_agent_sdk.connectors.twilio.types.IncomingPhoneNumbersInCondition | airbyte_agent_sdk.connectors.twilio.types.IncomingPhoneNumbersLikeCondition | airbyte_agent_sdk.connectors.twilio.types.IncomingPhoneNumbersFuzzyCondition | airbyte_agent_sdk.connectors.twilio.types.IncomingPhoneNumbersKeywordCondition | airbyte_agent_sdk.connectors.twilio.types.IncomingPhoneNumbersContainsCondition | airbyte_agent_sdk.connectors.twilio.types.IncomingPhoneNumbersNotCondition | airbyte_agent_sdk.connectors.twilio.types.IncomingPhoneNumbersAndCondition | airbyte_agent_sdk.connectors.twilio.types.IncomingPhoneNumbersOrCondition | airbyte_agent_sdk.connectors.twilio.types.IncomingPhoneNumbersAnyCondition`
     :   The type of the None singleton.
 
+<a id="IncomingPhoneNumbersOrCondition"></a>
+
 `IncomingPhoneNumbersOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -2165,6 +2389,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.twilio.types.IncomingPhoneNumbersEqCondition | airbyte_agent_sdk.connectors.twilio.types.IncomingPhoneNumbersNeqCondition | airbyte_agent_sdk.connectors.twilio.types.IncomingPhoneNumbersGtCondition | airbyte_agent_sdk.connectors.twilio.types.IncomingPhoneNumbersGteCondition | airbyte_agent_sdk.connectors.twilio.types.IncomingPhoneNumbersLtCondition | airbyte_agent_sdk.connectors.twilio.types.IncomingPhoneNumbersLteCondition | airbyte_agent_sdk.connectors.twilio.types.IncomingPhoneNumbersInCondition | airbyte_agent_sdk.connectors.twilio.types.IncomingPhoneNumbersLikeCondition | airbyte_agent_sdk.connectors.twilio.types.IncomingPhoneNumbersFuzzyCondition | airbyte_agent_sdk.connectors.twilio.types.IncomingPhoneNumbersKeywordCondition | airbyte_agent_sdk.connectors.twilio.types.IncomingPhoneNumbersContainsCondition | airbyte_agent_sdk.connectors.twilio.types.IncomingPhoneNumbersNotCondition | airbyte_agent_sdk.connectors.twilio.types.IncomingPhoneNumbersAndCondition | airbyte_agent_sdk.connectors.twilio.types.IncomingPhoneNumbersOrCondition | airbyte_agent_sdk.connectors.twilio.types.IncomingPhoneNumbersAnyCondition]`
     :   The type of the None singleton.
+
+<a id="IncomingPhoneNumbersSearchFilter"></a>
 
 `IncomingPhoneNumbersSearchFilter(*args, **kwargs)`
 :   Available fields for filtering incoming_phone_numbers search queries.
@@ -2199,6 +2425,8 @@ Classes
     `status: str | None`
     :   Status of the phone number
 
+<a id="IncomingPhoneNumbersSearchQuery"></a>
+
 `IncomingPhoneNumbersSearchQuery(*args, **kwargs)`
 :   Search query for incoming_phone_numbers entity.
 
@@ -2213,6 +2441,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.twilio.types.IncomingPhoneNumbersSortFilter]`
     :   The type of the None singleton.
+
+<a id="IncomingPhoneNumbersSortFilter"></a>
 
 `IncomingPhoneNumbersSortFilter(*args, **kwargs)`
 :   Available fields for sorting incoming_phone_numbers search results.
@@ -2247,6 +2477,8 @@ Classes
     `status: Literal['asc', 'desc']`
     :   Status of the phone number
 
+<a id="IncomingPhoneNumbersStringFilter"></a>
+
 `IncomingPhoneNumbersStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -2280,6 +2512,8 @@ Classes
     `status: str`
     :   Status of the phone number
 
+<a id="MessagesAndCondition"></a>
+
 `MessagesAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -2300,6 +2534,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.twilio.types.MessagesEqCondition | airbyte_agent_sdk.connectors.twilio.types.MessagesNeqCondition | airbyte_agent_sdk.connectors.twilio.types.MessagesGtCondition | airbyte_agent_sdk.connectors.twilio.types.MessagesGteCondition | airbyte_agent_sdk.connectors.twilio.types.MessagesLtCondition | airbyte_agent_sdk.connectors.twilio.types.MessagesLteCondition | airbyte_agent_sdk.connectors.twilio.types.MessagesInCondition | airbyte_agent_sdk.connectors.twilio.types.MessagesLikeCondition | airbyte_agent_sdk.connectors.twilio.types.MessagesFuzzyCondition | airbyte_agent_sdk.connectors.twilio.types.MessagesKeywordCondition | airbyte_agent_sdk.connectors.twilio.types.MessagesContainsCondition | airbyte_agent_sdk.connectors.twilio.types.MessagesNotCondition | airbyte_agent_sdk.connectors.twilio.types.MessagesAndCondition | airbyte_agent_sdk.connectors.twilio.types.MessagesOrCondition | airbyte_agent_sdk.connectors.twilio.types.MessagesAnyCondition]`
     :   The type of the None singleton.
 
+<a id="MessagesAnyCondition"></a>
+
 `MessagesAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -2319,6 +2555,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.twilio.types.MessagesAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="MessagesAnyValueFilter"></a>
 
 `MessagesAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -2374,6 +2612,8 @@ Classes
     `to: Any`
     :   The phone number or recipient ID the message was sent to
 
+<a id="MessagesContainsCondition"></a>
+
 `MessagesContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -2385,6 +2625,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.twilio.types.MessagesAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="MessagesEqCondition"></a>
 
 `MessagesEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -2398,6 +2640,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.twilio.types.MessagesSearchFilter`
     :   The type of the None singleton.
 
+<a id="MessagesFuzzyCondition"></a>
+
 `MessagesFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -2409,6 +2653,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.twilio.types.MessagesStringFilter`
     :   The type of the None singleton.
+
+<a id="MessagesGetParams"></a>
 
 `MessagesGetParams(*args, **kwargs)`
 :   Parameters for messages.get operation
@@ -2425,6 +2671,8 @@ Classes
     `sid: str`
     :   The type of the None singleton.
 
+<a id="MessagesGtCondition"></a>
+
 `MessagesGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -2437,6 +2685,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.twilio.types.MessagesSearchFilter`
     :   The type of the None singleton.
 
+<a id="MessagesGteCondition"></a>
+
 `MessagesGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -2448,6 +2698,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.twilio.types.MessagesSearchFilter`
     :   The type of the None singleton.
+
+<a id="MessagesInCondition"></a>
 
 `MessagesInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -2468,6 +2720,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.twilio.types.MessagesInFilter`
     :   The type of the None singleton.
+
+<a id="MessagesInFilter"></a>
 
 `MessagesInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -2523,6 +2777,8 @@ Classes
     `to: list[str]`
     :   The phone number or recipient ID the message was sent to
 
+<a id="MessagesKeywordCondition"></a>
+
 `MessagesKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -2535,6 +2791,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.twilio.types.MessagesStringFilter`
     :   The type of the None singleton.
 
+<a id="MessagesLikeCondition"></a>
+
 `MessagesLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -2546,6 +2804,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.twilio.types.MessagesStringFilter`
     :   The type of the None singleton.
+
+<a id="MessagesListParams"></a>
 
 `MessagesListParams(*args, **kwargs)`
 :   Parameters for messages.list operation
@@ -2562,6 +2822,8 @@ Classes
     `page_size: int`
     :   The type of the None singleton.
 
+<a id="MessagesLtCondition"></a>
+
 `MessagesLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -2573,6 +2835,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.twilio.types.MessagesSearchFilter`
     :   The type of the None singleton.
+
+<a id="MessagesLteCondition"></a>
 
 `MessagesLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -2586,6 +2850,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.twilio.types.MessagesSearchFilter`
     :   The type of the None singleton.
 
+<a id="MessagesNeqCondition"></a>
+
 `MessagesNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -2597,6 +2863,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.twilio.types.MessagesSearchFilter`
     :   The type of the None singleton.
+
+<a id="MessagesNotCondition"></a>
 
 `MessagesNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -2618,6 +2886,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.twilio.types.MessagesEqCondition | airbyte_agent_sdk.connectors.twilio.types.MessagesNeqCondition | airbyte_agent_sdk.connectors.twilio.types.MessagesGtCondition | airbyte_agent_sdk.connectors.twilio.types.MessagesGteCondition | airbyte_agent_sdk.connectors.twilio.types.MessagesLtCondition | airbyte_agent_sdk.connectors.twilio.types.MessagesLteCondition | airbyte_agent_sdk.connectors.twilio.types.MessagesInCondition | airbyte_agent_sdk.connectors.twilio.types.MessagesLikeCondition | airbyte_agent_sdk.connectors.twilio.types.MessagesFuzzyCondition | airbyte_agent_sdk.connectors.twilio.types.MessagesKeywordCondition | airbyte_agent_sdk.connectors.twilio.types.MessagesContainsCondition | airbyte_agent_sdk.connectors.twilio.types.MessagesNotCondition | airbyte_agent_sdk.connectors.twilio.types.MessagesAndCondition | airbyte_agent_sdk.connectors.twilio.types.MessagesOrCondition | airbyte_agent_sdk.connectors.twilio.types.MessagesAnyCondition`
     :   The type of the None singleton.
 
+<a id="MessagesOrCondition"></a>
+
 `MessagesOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -2637,6 +2907,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.twilio.types.MessagesEqCondition | airbyte_agent_sdk.connectors.twilio.types.MessagesNeqCondition | airbyte_agent_sdk.connectors.twilio.types.MessagesGtCondition | airbyte_agent_sdk.connectors.twilio.types.MessagesGteCondition | airbyte_agent_sdk.connectors.twilio.types.MessagesLtCondition | airbyte_agent_sdk.connectors.twilio.types.MessagesLteCondition | airbyte_agent_sdk.connectors.twilio.types.MessagesInCondition | airbyte_agent_sdk.connectors.twilio.types.MessagesLikeCondition | airbyte_agent_sdk.connectors.twilio.types.MessagesFuzzyCondition | airbyte_agent_sdk.connectors.twilio.types.MessagesKeywordCondition | airbyte_agent_sdk.connectors.twilio.types.MessagesContainsCondition | airbyte_agent_sdk.connectors.twilio.types.MessagesNotCondition | airbyte_agent_sdk.connectors.twilio.types.MessagesAndCondition | airbyte_agent_sdk.connectors.twilio.types.MessagesOrCondition | airbyte_agent_sdk.connectors.twilio.types.MessagesAnyCondition]`
     :   The type of the None singleton.
+
+<a id="MessagesSearchFilter"></a>
 
 `MessagesSearchFilter(*args, **kwargs)`
 :   Available fields for filtering messages search queries.
@@ -2692,6 +2964,8 @@ Classes
     `to: str | None`
     :   The phone number or recipient ID the message was sent to
 
+<a id="MessagesSearchQuery"></a>
+
 `MessagesSearchQuery(*args, **kwargs)`
 :   Search query for messages entity.
 
@@ -2706,6 +2980,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.twilio.types.MessagesSortFilter]`
     :   The type of the None singleton.
+
+<a id="MessagesSortFilter"></a>
 
 `MessagesSortFilter(*args, **kwargs)`
 :   Available fields for sorting messages search results.
@@ -2761,6 +3037,8 @@ Classes
     `to: Literal['asc', 'desc']`
     :   The phone number or recipient ID the message was sent to
 
+<a id="MessagesStringFilter"></a>
+
 `MessagesStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -2815,6 +3093,8 @@ Classes
     `to: str`
     :   The phone number or recipient ID the message was sent to
 
+<a id="OutgoingCallerIdsAndCondition"></a>
+
 `OutgoingCallerIdsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -2835,6 +3115,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.twilio.types.OutgoingCallerIdsEqCondition | airbyte_agent_sdk.connectors.twilio.types.OutgoingCallerIdsNeqCondition | airbyte_agent_sdk.connectors.twilio.types.OutgoingCallerIdsGtCondition | airbyte_agent_sdk.connectors.twilio.types.OutgoingCallerIdsGteCondition | airbyte_agent_sdk.connectors.twilio.types.OutgoingCallerIdsLtCondition | airbyte_agent_sdk.connectors.twilio.types.OutgoingCallerIdsLteCondition | airbyte_agent_sdk.connectors.twilio.types.OutgoingCallerIdsInCondition | airbyte_agent_sdk.connectors.twilio.types.OutgoingCallerIdsLikeCondition | airbyte_agent_sdk.connectors.twilio.types.OutgoingCallerIdsFuzzyCondition | airbyte_agent_sdk.connectors.twilio.types.OutgoingCallerIdsKeywordCondition | airbyte_agent_sdk.connectors.twilio.types.OutgoingCallerIdsContainsCondition | airbyte_agent_sdk.connectors.twilio.types.OutgoingCallerIdsNotCondition | airbyte_agent_sdk.connectors.twilio.types.OutgoingCallerIdsAndCondition | airbyte_agent_sdk.connectors.twilio.types.OutgoingCallerIdsOrCondition | airbyte_agent_sdk.connectors.twilio.types.OutgoingCallerIdsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="OutgoingCallerIdsAnyCondition"></a>
+
 `OutgoingCallerIdsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -2854,6 +3136,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.twilio.types.OutgoingCallerIdsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="OutgoingCallerIdsAnyValueFilter"></a>
 
 `OutgoingCallerIdsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -2882,6 +3166,8 @@ Classes
     `sid: Any`
     :   The unique identifier
 
+<a id="OutgoingCallerIdsContainsCondition"></a>
+
 `OutgoingCallerIdsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -2893,6 +3179,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.twilio.types.OutgoingCallerIdsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="OutgoingCallerIdsEqCondition"></a>
 
 `OutgoingCallerIdsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -2906,6 +3194,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.twilio.types.OutgoingCallerIdsSearchFilter`
     :   The type of the None singleton.
 
+<a id="OutgoingCallerIdsFuzzyCondition"></a>
+
 `OutgoingCallerIdsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -2917,6 +3207,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.twilio.types.OutgoingCallerIdsStringFilter`
     :   The type of the None singleton.
+
+<a id="OutgoingCallerIdsGetParams"></a>
 
 `OutgoingCallerIdsGetParams(*args, **kwargs)`
 :   Parameters for outgoing_caller_ids.get operation
@@ -2933,6 +3225,8 @@ Classes
     `sid: str`
     :   The type of the None singleton.
 
+<a id="OutgoingCallerIdsGtCondition"></a>
+
 `OutgoingCallerIdsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -2945,6 +3239,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.twilio.types.OutgoingCallerIdsSearchFilter`
     :   The type of the None singleton.
 
+<a id="OutgoingCallerIdsGteCondition"></a>
+
 `OutgoingCallerIdsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -2956,6 +3252,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.twilio.types.OutgoingCallerIdsSearchFilter`
     :   The type of the None singleton.
+
+<a id="OutgoingCallerIdsInCondition"></a>
 
 `OutgoingCallerIdsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -2976,6 +3274,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.twilio.types.OutgoingCallerIdsInFilter`
     :   The type of the None singleton.
+
+<a id="OutgoingCallerIdsInFilter"></a>
 
 `OutgoingCallerIdsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -3004,6 +3304,8 @@ Classes
     `sid: list[str]`
     :   The unique identifier
 
+<a id="OutgoingCallerIdsKeywordCondition"></a>
+
 `OutgoingCallerIdsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -3016,6 +3318,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.twilio.types.OutgoingCallerIdsStringFilter`
     :   The type of the None singleton.
 
+<a id="OutgoingCallerIdsLikeCondition"></a>
+
 `OutgoingCallerIdsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -3027,6 +3331,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.twilio.types.OutgoingCallerIdsStringFilter`
     :   The type of the None singleton.
+
+<a id="OutgoingCallerIdsListParams"></a>
 
 `OutgoingCallerIdsListParams(*args, **kwargs)`
 :   Parameters for outgoing_caller_ids.list operation
@@ -3043,6 +3349,8 @@ Classes
     `page_size: int`
     :   The type of the None singleton.
 
+<a id="OutgoingCallerIdsLtCondition"></a>
+
 `OutgoingCallerIdsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -3054,6 +3362,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.twilio.types.OutgoingCallerIdsSearchFilter`
     :   The type of the None singleton.
+
+<a id="OutgoingCallerIdsLteCondition"></a>
 
 `OutgoingCallerIdsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -3067,6 +3377,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.twilio.types.OutgoingCallerIdsSearchFilter`
     :   The type of the None singleton.
 
+<a id="OutgoingCallerIdsNeqCondition"></a>
+
 `OutgoingCallerIdsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -3078,6 +3390,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.twilio.types.OutgoingCallerIdsSearchFilter`
     :   The type of the None singleton.
+
+<a id="OutgoingCallerIdsNotCondition"></a>
 
 `OutgoingCallerIdsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -3099,6 +3413,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.twilio.types.OutgoingCallerIdsEqCondition | airbyte_agent_sdk.connectors.twilio.types.OutgoingCallerIdsNeqCondition | airbyte_agent_sdk.connectors.twilio.types.OutgoingCallerIdsGtCondition | airbyte_agent_sdk.connectors.twilio.types.OutgoingCallerIdsGteCondition | airbyte_agent_sdk.connectors.twilio.types.OutgoingCallerIdsLtCondition | airbyte_agent_sdk.connectors.twilio.types.OutgoingCallerIdsLteCondition | airbyte_agent_sdk.connectors.twilio.types.OutgoingCallerIdsInCondition | airbyte_agent_sdk.connectors.twilio.types.OutgoingCallerIdsLikeCondition | airbyte_agent_sdk.connectors.twilio.types.OutgoingCallerIdsFuzzyCondition | airbyte_agent_sdk.connectors.twilio.types.OutgoingCallerIdsKeywordCondition | airbyte_agent_sdk.connectors.twilio.types.OutgoingCallerIdsContainsCondition | airbyte_agent_sdk.connectors.twilio.types.OutgoingCallerIdsNotCondition | airbyte_agent_sdk.connectors.twilio.types.OutgoingCallerIdsAndCondition | airbyte_agent_sdk.connectors.twilio.types.OutgoingCallerIdsOrCondition | airbyte_agent_sdk.connectors.twilio.types.OutgoingCallerIdsAnyCondition`
     :   The type of the None singleton.
 
+<a id="OutgoingCallerIdsOrCondition"></a>
+
 `OutgoingCallerIdsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -3118,6 +3434,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.twilio.types.OutgoingCallerIdsEqCondition | airbyte_agent_sdk.connectors.twilio.types.OutgoingCallerIdsNeqCondition | airbyte_agent_sdk.connectors.twilio.types.OutgoingCallerIdsGtCondition | airbyte_agent_sdk.connectors.twilio.types.OutgoingCallerIdsGteCondition | airbyte_agent_sdk.connectors.twilio.types.OutgoingCallerIdsLtCondition | airbyte_agent_sdk.connectors.twilio.types.OutgoingCallerIdsLteCondition | airbyte_agent_sdk.connectors.twilio.types.OutgoingCallerIdsInCondition | airbyte_agent_sdk.connectors.twilio.types.OutgoingCallerIdsLikeCondition | airbyte_agent_sdk.connectors.twilio.types.OutgoingCallerIdsFuzzyCondition | airbyte_agent_sdk.connectors.twilio.types.OutgoingCallerIdsKeywordCondition | airbyte_agent_sdk.connectors.twilio.types.OutgoingCallerIdsContainsCondition | airbyte_agent_sdk.connectors.twilio.types.OutgoingCallerIdsNotCondition | airbyte_agent_sdk.connectors.twilio.types.OutgoingCallerIdsAndCondition | airbyte_agent_sdk.connectors.twilio.types.OutgoingCallerIdsOrCondition | airbyte_agent_sdk.connectors.twilio.types.OutgoingCallerIdsAnyCondition]`
     :   The type of the None singleton.
+
+<a id="OutgoingCallerIdsSearchFilter"></a>
 
 `OutgoingCallerIdsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering outgoing_caller_ids search queries.
@@ -3146,6 +3464,8 @@ Classes
     `sid: str | None`
     :   The unique identifier
 
+<a id="OutgoingCallerIdsSearchQuery"></a>
+
 `OutgoingCallerIdsSearchQuery(*args, **kwargs)`
 :   Search query for outgoing_caller_ids entity.
 
@@ -3160,6 +3480,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.twilio.types.OutgoingCallerIdsSortFilter]`
     :   The type of the None singleton.
+
+<a id="OutgoingCallerIdsSortFilter"></a>
 
 `OutgoingCallerIdsSortFilter(*args, **kwargs)`
 :   Available fields for sorting outgoing_caller_ids search results.
@@ -3188,6 +3510,8 @@ Classes
     `sid: Literal['asc', 'desc']`
     :   The unique identifier
 
+<a id="OutgoingCallerIdsStringFilter"></a>
+
 `OutgoingCallerIdsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -3215,6 +3539,8 @@ Classes
     `sid: str`
     :   The unique identifier
 
+<a id="QueuesAndCondition"></a>
+
 `QueuesAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -3235,6 +3561,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.twilio.types.QueuesEqCondition | airbyte_agent_sdk.connectors.twilio.types.QueuesNeqCondition | airbyte_agent_sdk.connectors.twilio.types.QueuesGtCondition | airbyte_agent_sdk.connectors.twilio.types.QueuesGteCondition | airbyte_agent_sdk.connectors.twilio.types.QueuesLtCondition | airbyte_agent_sdk.connectors.twilio.types.QueuesLteCondition | airbyte_agent_sdk.connectors.twilio.types.QueuesInCondition | airbyte_agent_sdk.connectors.twilio.types.QueuesLikeCondition | airbyte_agent_sdk.connectors.twilio.types.QueuesFuzzyCondition | airbyte_agent_sdk.connectors.twilio.types.QueuesKeywordCondition | airbyte_agent_sdk.connectors.twilio.types.QueuesContainsCondition | airbyte_agent_sdk.connectors.twilio.types.QueuesNotCondition | airbyte_agent_sdk.connectors.twilio.types.QueuesAndCondition | airbyte_agent_sdk.connectors.twilio.types.QueuesOrCondition | airbyte_agent_sdk.connectors.twilio.types.QueuesAnyCondition]`
     :   The type of the None singleton.
 
+<a id="QueuesAnyCondition"></a>
+
 `QueuesAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -3254,6 +3582,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.twilio.types.QueuesAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="QueuesAnyValueFilter"></a>
 
 `QueuesAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -3288,6 +3618,8 @@ Classes
     `sid: Any`
     :   The unique identifier for the queue
 
+<a id="QueuesContainsCondition"></a>
+
 `QueuesContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -3299,6 +3631,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.twilio.types.QueuesAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="QueuesEqCondition"></a>
 
 `QueuesEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -3312,6 +3646,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.twilio.types.QueuesSearchFilter`
     :   The type of the None singleton.
 
+<a id="QueuesFuzzyCondition"></a>
+
 `QueuesFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -3323,6 +3659,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.twilio.types.QueuesStringFilter`
     :   The type of the None singleton.
+
+<a id="QueuesGetParams"></a>
 
 `QueuesGetParams(*args, **kwargs)`
 :   Parameters for queues.get operation
@@ -3339,6 +3677,8 @@ Classes
     `sid: str`
     :   The type of the None singleton.
 
+<a id="QueuesGtCondition"></a>
+
 `QueuesGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -3351,6 +3691,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.twilio.types.QueuesSearchFilter`
     :   The type of the None singleton.
 
+<a id="QueuesGteCondition"></a>
+
 `QueuesGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -3362,6 +3704,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.twilio.types.QueuesSearchFilter`
     :   The type of the None singleton.
+
+<a id="QueuesInCondition"></a>
 
 `QueuesInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -3382,6 +3726,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.twilio.types.QueuesInFilter`
     :   The type of the None singleton.
+
+<a id="QueuesInFilter"></a>
 
 `QueuesInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -3416,6 +3762,8 @@ Classes
     `sid: list[str]`
     :   The unique identifier for the queue
 
+<a id="QueuesKeywordCondition"></a>
+
 `QueuesKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -3428,6 +3776,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.twilio.types.QueuesStringFilter`
     :   The type of the None singleton.
 
+<a id="QueuesLikeCondition"></a>
+
 `QueuesLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -3439,6 +3789,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.twilio.types.QueuesStringFilter`
     :   The type of the None singleton.
+
+<a id="QueuesListParams"></a>
 
 `QueuesListParams(*args, **kwargs)`
 :   Parameters for queues.list operation
@@ -3455,6 +3807,8 @@ Classes
     `page_size: int`
     :   The type of the None singleton.
 
+<a id="QueuesLtCondition"></a>
+
 `QueuesLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -3466,6 +3820,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.twilio.types.QueuesSearchFilter`
     :   The type of the None singleton.
+
+<a id="QueuesLteCondition"></a>
 
 `QueuesLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -3479,6 +3835,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.twilio.types.QueuesSearchFilter`
     :   The type of the None singleton.
 
+<a id="QueuesNeqCondition"></a>
+
 `QueuesNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -3490,6 +3848,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.twilio.types.QueuesSearchFilter`
     :   The type of the None singleton.
+
+<a id="QueuesNotCondition"></a>
 
 `QueuesNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -3511,6 +3871,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.twilio.types.QueuesEqCondition | airbyte_agent_sdk.connectors.twilio.types.QueuesNeqCondition | airbyte_agent_sdk.connectors.twilio.types.QueuesGtCondition | airbyte_agent_sdk.connectors.twilio.types.QueuesGteCondition | airbyte_agent_sdk.connectors.twilio.types.QueuesLtCondition | airbyte_agent_sdk.connectors.twilio.types.QueuesLteCondition | airbyte_agent_sdk.connectors.twilio.types.QueuesInCondition | airbyte_agent_sdk.connectors.twilio.types.QueuesLikeCondition | airbyte_agent_sdk.connectors.twilio.types.QueuesFuzzyCondition | airbyte_agent_sdk.connectors.twilio.types.QueuesKeywordCondition | airbyte_agent_sdk.connectors.twilio.types.QueuesContainsCondition | airbyte_agent_sdk.connectors.twilio.types.QueuesNotCondition | airbyte_agent_sdk.connectors.twilio.types.QueuesAndCondition | airbyte_agent_sdk.connectors.twilio.types.QueuesOrCondition | airbyte_agent_sdk.connectors.twilio.types.QueuesAnyCondition`
     :   The type of the None singleton.
 
+<a id="QueuesOrCondition"></a>
+
 `QueuesOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -3530,6 +3892,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.twilio.types.QueuesEqCondition | airbyte_agent_sdk.connectors.twilio.types.QueuesNeqCondition | airbyte_agent_sdk.connectors.twilio.types.QueuesGtCondition | airbyte_agent_sdk.connectors.twilio.types.QueuesGteCondition | airbyte_agent_sdk.connectors.twilio.types.QueuesLtCondition | airbyte_agent_sdk.connectors.twilio.types.QueuesLteCondition | airbyte_agent_sdk.connectors.twilio.types.QueuesInCondition | airbyte_agent_sdk.connectors.twilio.types.QueuesLikeCondition | airbyte_agent_sdk.connectors.twilio.types.QueuesFuzzyCondition | airbyte_agent_sdk.connectors.twilio.types.QueuesKeywordCondition | airbyte_agent_sdk.connectors.twilio.types.QueuesContainsCondition | airbyte_agent_sdk.connectors.twilio.types.QueuesNotCondition | airbyte_agent_sdk.connectors.twilio.types.QueuesAndCondition | airbyte_agent_sdk.connectors.twilio.types.QueuesOrCondition | airbyte_agent_sdk.connectors.twilio.types.QueuesAnyCondition]`
     :   The type of the None singleton.
+
+<a id="QueuesSearchFilter"></a>
 
 `QueuesSearchFilter(*args, **kwargs)`
 :   Available fields for filtering queues search queries.
@@ -3564,6 +3928,8 @@ Classes
     `sid: str | None`
     :   The unique identifier for the queue
 
+<a id="QueuesSearchQuery"></a>
+
 `QueuesSearchQuery(*args, **kwargs)`
 :   Search query for queues entity.
 
@@ -3578,6 +3944,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.twilio.types.QueuesSortFilter]`
     :   The type of the None singleton.
+
+<a id="QueuesSortFilter"></a>
 
 `QueuesSortFilter(*args, **kwargs)`
 :   Available fields for sorting queues search results.
@@ -3612,6 +3980,8 @@ Classes
     `sid: Literal['asc', 'desc']`
     :   The unique identifier for the queue
 
+<a id="QueuesStringFilter"></a>
+
 `QueuesStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -3645,6 +4015,8 @@ Classes
     `sid: str`
     :   The unique identifier for the queue
 
+<a id="RecordingsAndCondition"></a>
+
 `RecordingsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -3665,6 +4037,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.twilio.types.RecordingsEqCondition | airbyte_agent_sdk.connectors.twilio.types.RecordingsNeqCondition | airbyte_agent_sdk.connectors.twilio.types.RecordingsGtCondition | airbyte_agent_sdk.connectors.twilio.types.RecordingsGteCondition | airbyte_agent_sdk.connectors.twilio.types.RecordingsLtCondition | airbyte_agent_sdk.connectors.twilio.types.RecordingsLteCondition | airbyte_agent_sdk.connectors.twilio.types.RecordingsInCondition | airbyte_agent_sdk.connectors.twilio.types.RecordingsLikeCondition | airbyte_agent_sdk.connectors.twilio.types.RecordingsFuzzyCondition | airbyte_agent_sdk.connectors.twilio.types.RecordingsKeywordCondition | airbyte_agent_sdk.connectors.twilio.types.RecordingsContainsCondition | airbyte_agent_sdk.connectors.twilio.types.RecordingsNotCondition | airbyte_agent_sdk.connectors.twilio.types.RecordingsAndCondition | airbyte_agent_sdk.connectors.twilio.types.RecordingsOrCondition | airbyte_agent_sdk.connectors.twilio.types.RecordingsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="RecordingsAnyCondition"></a>
+
 `RecordingsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -3684,6 +4058,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.twilio.types.RecordingsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="RecordingsAnyValueFilter"></a>
 
 `RecordingsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -3724,6 +4100,8 @@ Classes
     `status: Any`
     :   The status of the recording
 
+<a id="RecordingsContainsCondition"></a>
+
 `RecordingsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -3735,6 +4113,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.twilio.types.RecordingsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="RecordingsEqCondition"></a>
 
 `RecordingsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -3748,6 +4128,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.twilio.types.RecordingsSearchFilter`
     :   The type of the None singleton.
 
+<a id="RecordingsFuzzyCondition"></a>
+
 `RecordingsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -3759,6 +4141,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.twilio.types.RecordingsStringFilter`
     :   The type of the None singleton.
+
+<a id="RecordingsGetParams"></a>
 
 `RecordingsGetParams(*args, **kwargs)`
 :   Parameters for recordings.get operation
@@ -3775,6 +4159,8 @@ Classes
     `sid: str`
     :   The type of the None singleton.
 
+<a id="RecordingsGtCondition"></a>
+
 `RecordingsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -3787,6 +4173,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.twilio.types.RecordingsSearchFilter`
     :   The type of the None singleton.
 
+<a id="RecordingsGteCondition"></a>
+
 `RecordingsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -3798,6 +4186,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.twilio.types.RecordingsSearchFilter`
     :   The type of the None singleton.
+
+<a id="RecordingsInCondition"></a>
 
 `RecordingsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -3818,6 +4208,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.twilio.types.RecordingsInFilter`
     :   The type of the None singleton.
+
+<a id="RecordingsInFilter"></a>
 
 `RecordingsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -3858,6 +4250,8 @@ Classes
     `status: list[str]`
     :   The status of the recording
 
+<a id="RecordingsKeywordCondition"></a>
+
 `RecordingsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -3870,6 +4264,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.twilio.types.RecordingsStringFilter`
     :   The type of the None singleton.
 
+<a id="RecordingsLikeCondition"></a>
+
 `RecordingsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -3881,6 +4277,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.twilio.types.RecordingsStringFilter`
     :   The type of the None singleton.
+
+<a id="RecordingsListParams"></a>
 
 `RecordingsListParams(*args, **kwargs)`
 :   Parameters for recordings.list operation
@@ -3897,6 +4295,8 @@ Classes
     `page_size: int`
     :   The type of the None singleton.
 
+<a id="RecordingsLtCondition"></a>
+
 `RecordingsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -3908,6 +4308,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.twilio.types.RecordingsSearchFilter`
     :   The type of the None singleton.
+
+<a id="RecordingsLteCondition"></a>
 
 `RecordingsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -3921,6 +4323,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.twilio.types.RecordingsSearchFilter`
     :   The type of the None singleton.
 
+<a id="RecordingsNeqCondition"></a>
+
 `RecordingsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -3932,6 +4336,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.twilio.types.RecordingsSearchFilter`
     :   The type of the None singleton.
+
+<a id="RecordingsNotCondition"></a>
 
 `RecordingsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -3953,6 +4359,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.twilio.types.RecordingsEqCondition | airbyte_agent_sdk.connectors.twilio.types.RecordingsNeqCondition | airbyte_agent_sdk.connectors.twilio.types.RecordingsGtCondition | airbyte_agent_sdk.connectors.twilio.types.RecordingsGteCondition | airbyte_agent_sdk.connectors.twilio.types.RecordingsLtCondition | airbyte_agent_sdk.connectors.twilio.types.RecordingsLteCondition | airbyte_agent_sdk.connectors.twilio.types.RecordingsInCondition | airbyte_agent_sdk.connectors.twilio.types.RecordingsLikeCondition | airbyte_agent_sdk.connectors.twilio.types.RecordingsFuzzyCondition | airbyte_agent_sdk.connectors.twilio.types.RecordingsKeywordCondition | airbyte_agent_sdk.connectors.twilio.types.RecordingsContainsCondition | airbyte_agent_sdk.connectors.twilio.types.RecordingsNotCondition | airbyte_agent_sdk.connectors.twilio.types.RecordingsAndCondition | airbyte_agent_sdk.connectors.twilio.types.RecordingsOrCondition | airbyte_agent_sdk.connectors.twilio.types.RecordingsAnyCondition`
     :   The type of the None singleton.
 
+<a id="RecordingsOrCondition"></a>
+
 `RecordingsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -3972,6 +4380,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.twilio.types.RecordingsEqCondition | airbyte_agent_sdk.connectors.twilio.types.RecordingsNeqCondition | airbyte_agent_sdk.connectors.twilio.types.RecordingsGtCondition | airbyte_agent_sdk.connectors.twilio.types.RecordingsGteCondition | airbyte_agent_sdk.connectors.twilio.types.RecordingsLtCondition | airbyte_agent_sdk.connectors.twilio.types.RecordingsLteCondition | airbyte_agent_sdk.connectors.twilio.types.RecordingsInCondition | airbyte_agent_sdk.connectors.twilio.types.RecordingsLikeCondition | airbyte_agent_sdk.connectors.twilio.types.RecordingsFuzzyCondition | airbyte_agent_sdk.connectors.twilio.types.RecordingsKeywordCondition | airbyte_agent_sdk.connectors.twilio.types.RecordingsContainsCondition | airbyte_agent_sdk.connectors.twilio.types.RecordingsNotCondition | airbyte_agent_sdk.connectors.twilio.types.RecordingsAndCondition | airbyte_agent_sdk.connectors.twilio.types.RecordingsOrCondition | airbyte_agent_sdk.connectors.twilio.types.RecordingsAnyCondition]`
     :   The type of the None singleton.
+
+<a id="RecordingsSearchFilter"></a>
 
 `RecordingsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering recordings search queries.
@@ -4012,6 +4422,8 @@ Classes
     `status: str | None`
     :   The status of the recording
 
+<a id="RecordingsSearchQuery"></a>
+
 `RecordingsSearchQuery(*args, **kwargs)`
 :   Search query for recordings entity.
 
@@ -4026,6 +4438,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.twilio.types.RecordingsSortFilter]`
     :   The type of the None singleton.
+
+<a id="RecordingsSortFilter"></a>
 
 `RecordingsSortFilter(*args, **kwargs)`
 :   Available fields for sorting recordings search results.
@@ -4066,6 +4480,8 @@ Classes
     `status: Literal['asc', 'desc']`
     :   The status of the recording
 
+<a id="RecordingsStringFilter"></a>
+
 `RecordingsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -4105,6 +4521,8 @@ Classes
     `status: str`
     :   The status of the recording
 
+<a id="TranscriptionsAndCondition"></a>
+
 `TranscriptionsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -4125,6 +4543,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.twilio.types.TranscriptionsEqCondition | airbyte_agent_sdk.connectors.twilio.types.TranscriptionsNeqCondition | airbyte_agent_sdk.connectors.twilio.types.TranscriptionsGtCondition | airbyte_agent_sdk.connectors.twilio.types.TranscriptionsGteCondition | airbyte_agent_sdk.connectors.twilio.types.TranscriptionsLtCondition | airbyte_agent_sdk.connectors.twilio.types.TranscriptionsLteCondition | airbyte_agent_sdk.connectors.twilio.types.TranscriptionsInCondition | airbyte_agent_sdk.connectors.twilio.types.TranscriptionsLikeCondition | airbyte_agent_sdk.connectors.twilio.types.TranscriptionsFuzzyCondition | airbyte_agent_sdk.connectors.twilio.types.TranscriptionsKeywordCondition | airbyte_agent_sdk.connectors.twilio.types.TranscriptionsContainsCondition | airbyte_agent_sdk.connectors.twilio.types.TranscriptionsNotCondition | airbyte_agent_sdk.connectors.twilio.types.TranscriptionsAndCondition | airbyte_agent_sdk.connectors.twilio.types.TranscriptionsOrCondition | airbyte_agent_sdk.connectors.twilio.types.TranscriptionsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="TranscriptionsAnyCondition"></a>
+
 `TranscriptionsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -4144,6 +4564,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.twilio.types.TranscriptionsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="TranscriptionsAnyValueFilter"></a>
 
 `TranscriptionsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -4181,6 +4603,8 @@ Classes
     `status: Any`
     :   The status of the transcription
 
+<a id="TranscriptionsContainsCondition"></a>
+
 `TranscriptionsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -4192,6 +4616,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.twilio.types.TranscriptionsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="TranscriptionsEqCondition"></a>
 
 `TranscriptionsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -4205,6 +4631,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.twilio.types.TranscriptionsSearchFilter`
     :   The type of the None singleton.
 
+<a id="TranscriptionsFuzzyCondition"></a>
+
 `TranscriptionsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -4216,6 +4644,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.twilio.types.TranscriptionsStringFilter`
     :   The type of the None singleton.
+
+<a id="TranscriptionsGetParams"></a>
 
 `TranscriptionsGetParams(*args, **kwargs)`
 :   Parameters for transcriptions.get operation
@@ -4232,6 +4662,8 @@ Classes
     `sid: str`
     :   The type of the None singleton.
 
+<a id="TranscriptionsGtCondition"></a>
+
 `TranscriptionsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -4244,6 +4676,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.twilio.types.TranscriptionsSearchFilter`
     :   The type of the None singleton.
 
+<a id="TranscriptionsGteCondition"></a>
+
 `TranscriptionsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -4255,6 +4689,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.twilio.types.TranscriptionsSearchFilter`
     :   The type of the None singleton.
+
+<a id="TranscriptionsInCondition"></a>
 
 `TranscriptionsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -4275,6 +4711,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.twilio.types.TranscriptionsInFilter`
     :   The type of the None singleton.
+
+<a id="TranscriptionsInFilter"></a>
 
 `TranscriptionsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -4312,6 +4750,8 @@ Classes
     `status: list[str]`
     :   The status of the transcription
 
+<a id="TranscriptionsKeywordCondition"></a>
+
 `TranscriptionsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -4324,6 +4764,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.twilio.types.TranscriptionsStringFilter`
     :   The type of the None singleton.
 
+<a id="TranscriptionsLikeCondition"></a>
+
 `TranscriptionsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -4335,6 +4777,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.twilio.types.TranscriptionsStringFilter`
     :   The type of the None singleton.
+
+<a id="TranscriptionsListParams"></a>
 
 `TranscriptionsListParams(*args, **kwargs)`
 :   Parameters for transcriptions.list operation
@@ -4351,6 +4795,8 @@ Classes
     `page_size: int`
     :   The type of the None singleton.
 
+<a id="TranscriptionsLtCondition"></a>
+
 `TranscriptionsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -4362,6 +4808,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.twilio.types.TranscriptionsSearchFilter`
     :   The type of the None singleton.
+
+<a id="TranscriptionsLteCondition"></a>
 
 `TranscriptionsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -4375,6 +4823,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.twilio.types.TranscriptionsSearchFilter`
     :   The type of the None singleton.
 
+<a id="TranscriptionsNeqCondition"></a>
+
 `TranscriptionsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -4386,6 +4836,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.twilio.types.TranscriptionsSearchFilter`
     :   The type of the None singleton.
+
+<a id="TranscriptionsNotCondition"></a>
 
 `TranscriptionsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -4407,6 +4859,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.twilio.types.TranscriptionsEqCondition | airbyte_agent_sdk.connectors.twilio.types.TranscriptionsNeqCondition | airbyte_agent_sdk.connectors.twilio.types.TranscriptionsGtCondition | airbyte_agent_sdk.connectors.twilio.types.TranscriptionsGteCondition | airbyte_agent_sdk.connectors.twilio.types.TranscriptionsLtCondition | airbyte_agent_sdk.connectors.twilio.types.TranscriptionsLteCondition | airbyte_agent_sdk.connectors.twilio.types.TranscriptionsInCondition | airbyte_agent_sdk.connectors.twilio.types.TranscriptionsLikeCondition | airbyte_agent_sdk.connectors.twilio.types.TranscriptionsFuzzyCondition | airbyte_agent_sdk.connectors.twilio.types.TranscriptionsKeywordCondition | airbyte_agent_sdk.connectors.twilio.types.TranscriptionsContainsCondition | airbyte_agent_sdk.connectors.twilio.types.TranscriptionsNotCondition | airbyte_agent_sdk.connectors.twilio.types.TranscriptionsAndCondition | airbyte_agent_sdk.connectors.twilio.types.TranscriptionsOrCondition | airbyte_agent_sdk.connectors.twilio.types.TranscriptionsAnyCondition`
     :   The type of the None singleton.
 
+<a id="TranscriptionsOrCondition"></a>
+
 `TranscriptionsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -4426,6 +4880,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.twilio.types.TranscriptionsEqCondition | airbyte_agent_sdk.connectors.twilio.types.TranscriptionsNeqCondition | airbyte_agent_sdk.connectors.twilio.types.TranscriptionsGtCondition | airbyte_agent_sdk.connectors.twilio.types.TranscriptionsGteCondition | airbyte_agent_sdk.connectors.twilio.types.TranscriptionsLtCondition | airbyte_agent_sdk.connectors.twilio.types.TranscriptionsLteCondition | airbyte_agent_sdk.connectors.twilio.types.TranscriptionsInCondition | airbyte_agent_sdk.connectors.twilio.types.TranscriptionsLikeCondition | airbyte_agent_sdk.connectors.twilio.types.TranscriptionsFuzzyCondition | airbyte_agent_sdk.connectors.twilio.types.TranscriptionsKeywordCondition | airbyte_agent_sdk.connectors.twilio.types.TranscriptionsContainsCondition | airbyte_agent_sdk.connectors.twilio.types.TranscriptionsNotCondition | airbyte_agent_sdk.connectors.twilio.types.TranscriptionsAndCondition | airbyte_agent_sdk.connectors.twilio.types.TranscriptionsOrCondition | airbyte_agent_sdk.connectors.twilio.types.TranscriptionsAnyCondition]`
     :   The type of the None singleton.
+
+<a id="TranscriptionsSearchFilter"></a>
 
 `TranscriptionsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering transcriptions search queries.
@@ -4463,6 +4919,8 @@ Classes
     `status: str | None`
     :   The status of the transcription
 
+<a id="TranscriptionsSearchQuery"></a>
+
 `TranscriptionsSearchQuery(*args, **kwargs)`
 :   Search query for transcriptions entity.
 
@@ -4477,6 +4935,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.twilio.types.TranscriptionsSortFilter]`
     :   The type of the None singleton.
+
+<a id="TranscriptionsSortFilter"></a>
 
 `TranscriptionsSortFilter(*args, **kwargs)`
 :   Available fields for sorting transcriptions search results.
@@ -4514,6 +4974,8 @@ Classes
     `status: Literal['asc', 'desc']`
     :   The status of the transcription
 
+<a id="TranscriptionsStringFilter"></a>
+
 `TranscriptionsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -4550,6 +5012,8 @@ Classes
     `status: str`
     :   The status of the transcription
 
+<a id="UsageRecordsAndCondition"></a>
+
 `UsageRecordsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -4570,6 +5034,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.twilio.types.UsageRecordsEqCondition | airbyte_agent_sdk.connectors.twilio.types.UsageRecordsNeqCondition | airbyte_agent_sdk.connectors.twilio.types.UsageRecordsGtCondition | airbyte_agent_sdk.connectors.twilio.types.UsageRecordsGteCondition | airbyte_agent_sdk.connectors.twilio.types.UsageRecordsLtCondition | airbyte_agent_sdk.connectors.twilio.types.UsageRecordsLteCondition | airbyte_agent_sdk.connectors.twilio.types.UsageRecordsInCondition | airbyte_agent_sdk.connectors.twilio.types.UsageRecordsLikeCondition | airbyte_agent_sdk.connectors.twilio.types.UsageRecordsFuzzyCondition | airbyte_agent_sdk.connectors.twilio.types.UsageRecordsKeywordCondition | airbyte_agent_sdk.connectors.twilio.types.UsageRecordsContainsCondition | airbyte_agent_sdk.connectors.twilio.types.UsageRecordsNotCondition | airbyte_agent_sdk.connectors.twilio.types.UsageRecordsAndCondition | airbyte_agent_sdk.connectors.twilio.types.UsageRecordsOrCondition | airbyte_agent_sdk.connectors.twilio.types.UsageRecordsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="UsageRecordsAnyCondition"></a>
+
 `UsageRecordsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -4589,6 +5055,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.twilio.types.UsageRecordsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="UsageRecordsAnyValueFilter"></a>
 
 `UsageRecordsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -4632,6 +5100,8 @@ Classes
     `usage_unit: Any`
     :   The unit of measurement for usage
 
+<a id="UsageRecordsContainsCondition"></a>
+
 `UsageRecordsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -4643,6 +5113,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.twilio.types.UsageRecordsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="UsageRecordsEqCondition"></a>
 
 `UsageRecordsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -4656,6 +5128,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.twilio.types.UsageRecordsSearchFilter`
     :   The type of the None singleton.
 
+<a id="UsageRecordsFuzzyCondition"></a>
+
 `UsageRecordsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -4667,6 +5141,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.twilio.types.UsageRecordsStringFilter`
     :   The type of the None singleton.
+
+<a id="UsageRecordsGtCondition"></a>
 
 `UsageRecordsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
@@ -4680,6 +5156,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.twilio.types.UsageRecordsSearchFilter`
     :   The type of the None singleton.
 
+<a id="UsageRecordsGteCondition"></a>
+
 `UsageRecordsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -4691,6 +5169,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.twilio.types.UsageRecordsSearchFilter`
     :   The type of the None singleton.
+
+<a id="UsageRecordsInCondition"></a>
 
 `UsageRecordsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -4711,6 +5191,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.twilio.types.UsageRecordsInFilter`
     :   The type of the None singleton.
+
+<a id="UsageRecordsInFilter"></a>
 
 `UsageRecordsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -4754,6 +5236,8 @@ Classes
     `usage_unit: list[str]`
     :   The unit of measurement for usage
 
+<a id="UsageRecordsKeywordCondition"></a>
+
 `UsageRecordsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -4766,6 +5250,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.twilio.types.UsageRecordsStringFilter`
     :   The type of the None singleton.
 
+<a id="UsageRecordsLikeCondition"></a>
+
 `UsageRecordsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -4777,6 +5263,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.twilio.types.UsageRecordsStringFilter`
     :   The type of the None singleton.
+
+<a id="UsageRecordsListParams"></a>
 
 `UsageRecordsListParams(*args, **kwargs)`
 :   Parameters for usage_records.list operation
@@ -4793,6 +5281,8 @@ Classes
     `page_size: int`
     :   The type of the None singleton.
 
+<a id="UsageRecordsLtCondition"></a>
+
 `UsageRecordsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -4804,6 +5294,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.twilio.types.UsageRecordsSearchFilter`
     :   The type of the None singleton.
+
+<a id="UsageRecordsLteCondition"></a>
 
 `UsageRecordsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -4817,6 +5309,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.twilio.types.UsageRecordsSearchFilter`
     :   The type of the None singleton.
 
+<a id="UsageRecordsNeqCondition"></a>
+
 `UsageRecordsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -4828,6 +5322,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.twilio.types.UsageRecordsSearchFilter`
     :   The type of the None singleton.
+
+<a id="UsageRecordsNotCondition"></a>
 
 `UsageRecordsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -4849,6 +5345,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.twilio.types.UsageRecordsEqCondition | airbyte_agent_sdk.connectors.twilio.types.UsageRecordsNeqCondition | airbyte_agent_sdk.connectors.twilio.types.UsageRecordsGtCondition | airbyte_agent_sdk.connectors.twilio.types.UsageRecordsGteCondition | airbyte_agent_sdk.connectors.twilio.types.UsageRecordsLtCondition | airbyte_agent_sdk.connectors.twilio.types.UsageRecordsLteCondition | airbyte_agent_sdk.connectors.twilio.types.UsageRecordsInCondition | airbyte_agent_sdk.connectors.twilio.types.UsageRecordsLikeCondition | airbyte_agent_sdk.connectors.twilio.types.UsageRecordsFuzzyCondition | airbyte_agent_sdk.connectors.twilio.types.UsageRecordsKeywordCondition | airbyte_agent_sdk.connectors.twilio.types.UsageRecordsContainsCondition | airbyte_agent_sdk.connectors.twilio.types.UsageRecordsNotCondition | airbyte_agent_sdk.connectors.twilio.types.UsageRecordsAndCondition | airbyte_agent_sdk.connectors.twilio.types.UsageRecordsOrCondition | airbyte_agent_sdk.connectors.twilio.types.UsageRecordsAnyCondition`
     :   The type of the None singleton.
 
+<a id="UsageRecordsOrCondition"></a>
+
 `UsageRecordsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -4868,6 +5366,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.twilio.types.UsageRecordsEqCondition | airbyte_agent_sdk.connectors.twilio.types.UsageRecordsNeqCondition | airbyte_agent_sdk.connectors.twilio.types.UsageRecordsGtCondition | airbyte_agent_sdk.connectors.twilio.types.UsageRecordsGteCondition | airbyte_agent_sdk.connectors.twilio.types.UsageRecordsLtCondition | airbyte_agent_sdk.connectors.twilio.types.UsageRecordsLteCondition | airbyte_agent_sdk.connectors.twilio.types.UsageRecordsInCondition | airbyte_agent_sdk.connectors.twilio.types.UsageRecordsLikeCondition | airbyte_agent_sdk.connectors.twilio.types.UsageRecordsFuzzyCondition | airbyte_agent_sdk.connectors.twilio.types.UsageRecordsKeywordCondition | airbyte_agent_sdk.connectors.twilio.types.UsageRecordsContainsCondition | airbyte_agent_sdk.connectors.twilio.types.UsageRecordsNotCondition | airbyte_agent_sdk.connectors.twilio.types.UsageRecordsAndCondition | airbyte_agent_sdk.connectors.twilio.types.UsageRecordsOrCondition | airbyte_agent_sdk.connectors.twilio.types.UsageRecordsAnyCondition]`
     :   The type of the None singleton.
+
+<a id="UsageRecordsSearchFilter"></a>
 
 `UsageRecordsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering usage_records search queries.
@@ -4911,6 +5411,8 @@ Classes
     `usage_unit: str | None`
     :   The unit of measurement for usage
 
+<a id="UsageRecordsSearchQuery"></a>
+
 `UsageRecordsSearchQuery(*args, **kwargs)`
 :   Search query for usage_records entity.
 
@@ -4925,6 +5427,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.twilio.types.UsageRecordsSortFilter]`
     :   The type of the None singleton.
+
+<a id="UsageRecordsSortFilter"></a>
 
 `UsageRecordsSortFilter(*args, **kwargs)`
 :   Available fields for sorting usage_records search results.
@@ -4967,6 +5471,8 @@ Classes
 
     `usage_unit: Literal['asc', 'desc']`
     :   The unit of measurement for usage
+
+<a id="UsageRecordsStringFilter"></a>
 
 `UsageRecordsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/typeform/connector.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/typeform/connector.md
@@ -10,6 +10,8 @@ Typeform connector.
 Classes
 -------
 
+<a id="FormsQuery"></a>
+
 `FormsQuery(connector: TypeformConnector)`
 :   Query class for Forms entity operations.
     
@@ -74,6 +76,8 @@ Classes
         Returns:
             FormsListResult
 
+<a id="ImagesQuery"></a>
+
 `ImagesQuery(connector: TypeformConnector)`
 :   Query class for Images entity operations.
     
@@ -116,6 +120,8 @@ Classes
         
         Returns:
             ImagesListResult
+
+<a id="ResponsesQuery"></a>
 
 `ResponsesQuery(connector: TypeformConnector)`
 :   Query class for Responses entity operations.
@@ -176,6 +182,8 @@ Classes
         Returns:
             ResponsesListResult
 
+<a id="ThemesQuery"></a>
+
 `ThemesQuery(connector: TypeformConnector)`
 :   Query class for Themes entity operations.
     
@@ -227,6 +235,8 @@ Classes
         
         Returns:
             ThemesListResult
+
+<a id="TypeformConnector"></a>
 
 `TypeformConnector(auth_config: TypeformAuthConfig | AirbyteAuthConfig | BaseModel | None = None, on_token_refresh: Any | None = None)`
 :   Type-safe Typeform API connector.
@@ -428,6 +438,8 @@ Classes
             for entity in entities:
                 print(f"\{entity['entity_name']\}: \{entity['available_actions']\}")
 
+<a id="WebhooksQuery"></a>
+
 `WebhooksQuery(connector: TypeformConnector)`
 :   Query class for Webhooks entity operations.
     
@@ -474,6 +486,8 @@ Classes
         
         Returns:
             WebhooksListResult
+
+<a id="WorkspacesQuery"></a>
 
 `WorkspacesQuery(connector: TypeformConnector)`
 :   Query class for Workspaces entity operations.

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/typeform/index.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/typeform/index.md
@@ -19,6 +19,8 @@ Sub-modules
 Classes
 -------
 
+<a id="AirbyteAuthConfig"></a>
+
 `AirbyteAuthConfig(**data: Any)`
 :   Authentication configuration for Airbyte hosted mode execution.
     
@@ -87,6 +89,8 @@ Classes
     `workspace_name: str | None`
     :   The type of the None singleton.
 
+<a id="AirbyteSearchMeta"></a>
+
 `AirbyteSearchMeta(**data: Any)`
 :   Pagination metadata for search responses.
     
@@ -114,6 +118,8 @@ Classes
 
     `took_ms: int | None`
     :   Time taken to execute the search in milliseconds.
+
+<a id="AirbyteSearchResult"></a>
 
 `AirbyteSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -150,6 +156,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="FormsSearchResult"></a>
+
 `FormsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -165,6 +173,8 @@ Classes
     * airbyte_agent_sdk.connectors.typeform.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="ImagesSearchResult"></a>
 
 `ImagesSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -182,6 +192,8 @@ Classes
     * pydantic.main.BaseModel
     * typing.Generic
 
+<a id="ResponsesSearchResult"></a>
+
 `ResponsesSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -197,6 +209,8 @@ Classes
     * airbyte_agent_sdk.connectors.typeform.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="ThemesSearchResult"></a>
 
 `ThemesSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -214,6 +228,8 @@ Classes
     * pydantic.main.BaseModel
     * typing.Generic
 
+<a id="WebhooksSearchResult"></a>
+
 `WebhooksSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -230,6 +246,8 @@ Classes
     * pydantic.main.BaseModel
     * typing.Generic
 
+<a id="WorkspacesSearchResult"></a>
+
 `WorkspacesSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -245,6 +263,8 @@ Classes
     * airbyte_agent_sdk.connectors.typeform.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="FormsSearchData"></a>
 
 `FormsSearchData(**data: Any)`
 :   Search result data for forms entity.
@@ -307,6 +327,8 @@ Classes
     `workspace: dict[str, typing.Any] | None`
     :   Workspace details where the form belongs
 
+<a id="ImagesSearchData"></a>
+
 `ImagesSearchData(**data: Any)`
 :   Search result data for images entity.
     
@@ -349,6 +371,8 @@ Classes
 
     `width: int | None`
     :   Width of the image in pixels
+
+<a id="ResponsesSearchData"></a>
 
 `ResponsesSearchData(**data: Any)`
 :   Search result data for responses entity.
@@ -405,6 +429,8 @@ Classes
     `variables: list[typing.Any] | None`
     :   Variables associated with the response
 
+<a id="ThemesSearchData"></a>
+
 `ThemesSearchData(**data: Any)`
 :   Search result data for themes entity.
     
@@ -460,6 +486,8 @@ Classes
     `visibility: str | None`
     :   Visibility setting of the theme
 
+<a id="TypeformAuthConfig"></a>
+
 `TypeformAuthConfig(**data: Any)`
 :   Access Token Authentication
     
@@ -481,6 +509,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="TypeformConnector"></a>
 
 `TypeformConnector(auth_config: TypeformAuthConfig | AirbyteAuthConfig | BaseModel | None = None, on_token_refresh: Any | None = None)`
 :   Type-safe Typeform API connector.
@@ -682,6 +712,8 @@ Classes
             for entity in entities:
                 print(f"\{entity['entity_name']\}: \{entity['available_actions']\}")
 
+<a id="TypeformReplicationConfig"></a>
+
 `TypeformReplicationConfig(**data: Any)`
 :   Replication Configuration - Settings for data replication from Typeform
     
@@ -703,6 +735,8 @@ Classes
 
     `start_date: str`
     :   UTC date and time in the format YYYY-MM-DDT00:00:00Z from which to start replicating response data.
+
+<a id="WebhooksSearchData"></a>
 
 `WebhooksSearchData(**data: Any)`
 :   Search result data for webhooks entity.
@@ -746,6 +780,8 @@ Classes
 
     `verify_ssl: bool | None`
     :   Whether SSL verification is enforced
+
+<a id="WorkspacesSearchData"></a>
 
 `WorkspacesSearchData(**data: Any)`
 :   Search result data for workspaces entity.

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/typeform/models.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/typeform/models.md
@@ -13,6 +13,8 @@ and response envelope types.
 Classes
 -------
 
+<a id="AirbyteSearchMeta"></a>
+
 `AirbyteSearchMeta(**data: Any)`
 :   Pagination metadata for search responses.
     
@@ -40,6 +42,8 @@ Classes
 
     `took_ms: int | None`
     :   Time taken to execute the search in milliseconds.
+
+<a id="AirbyteSearchResult"></a>
 
 `AirbyteSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -97,6 +101,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="FormsSearchResult"></a>
+
 `FormsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -133,6 +139,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="ImagesSearchResult"></a>
 
 `ImagesSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -171,6 +179,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="ResponsesSearchResult"></a>
+
 `ResponsesSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -207,6 +217,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="ThemesSearchResult"></a>
 
 `ThemesSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -245,6 +257,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="WebhooksSearchResult"></a>
+
 `WebhooksSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -282,6 +296,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="WorkspacesSearchResult"></a>
+
 `WorkspacesSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -297,6 +313,8 @@ Classes
     * airbyte_agent_sdk.connectors.typeform.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="Form"></a>
 
 `Form(**data: Any)`
 :   A Typeform form with its fields, settings, and logic
@@ -362,6 +380,8 @@ Classes
     `workspace: airbyte_agent_sdk.connectors.typeform.models.FormWorkspace | Any | None`
     :   The type of the None singleton.
 
+<a id="FormFieldsItem"></a>
+
 `FormFieldsItem(**data: Any)`
 :   Nested schema for Form.fields_item
     
@@ -405,6 +425,8 @@ Classes
     `validations: airbyte_agent_sdk.connectors.typeform.models.FormFieldsItemValidations | Any | None`
     :   The type of the None singleton.
 
+<a id="FormFieldsItemAttachment"></a>
+
 `FormFieldsItemAttachment(**data: Any)`
 :   Nested schema for FormFieldsItem.attachment
     
@@ -429,6 +451,8 @@ Classes
 
     `type_: str | Any | None`
     :   The type of the None singleton.
+
+<a id="FormFieldsItemLayout"></a>
 
 `FormFieldsItemLayout(**data: Any)`
 :   Nested schema for FormFieldsItem.layout
@@ -461,6 +485,8 @@ Classes
     `type_: str | Any | None`
     :   The type of the None singleton.
 
+<a id="FormFieldsItemLayoutAttachment"></a>
+
 `FormFieldsItemLayoutAttachment(**data: Any)`
 :   Nested schema for FormFieldsItemLayout.attachment
     
@@ -488,6 +514,8 @@ Classes
 
     `type_: str | Any | None`
     :   The type of the None singleton.
+
+<a id="FormFieldsItemLayoutProperties"></a>
 
 `FormFieldsItemLayoutProperties(**data: Any)`
 :   Nested schema for FormFieldsItemLayout.properties
@@ -517,6 +545,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="FormFieldsItemLayoutPropertiesFocalPoint"></a>
+
 `FormFieldsItemLayoutPropertiesFocalPoint(**data: Any)`
 :   Nested schema for FormFieldsItemLayoutProperties.focal_point
     
@@ -541,6 +571,8 @@ Classes
 
     `y: float | Any | None`
     :   The type of the None singleton.
+
+<a id="FormFieldsItemProperties"></a>
 
 `FormFieldsItemProperties(**data: Any)`
 :   Nested schema for FormFieldsItem.properties
@@ -576,6 +608,8 @@ Classes
     `vertical_alignment: bool | Any | None`
     :   The type of the None singleton.
 
+<a id="FormFieldsItemPropertiesChoicesItem"></a>
+
 `FormFieldsItemPropertiesChoicesItem(**data: Any)`
 :   Nested schema for FormFieldsItemProperties.choices_item
     
@@ -604,6 +638,8 @@ Classes
     `ref: str | Any | None`
     :   The type of the None singleton.
 
+<a id="FormFieldsItemValidations"></a>
+
 `FormFieldsItemValidations(**data: Any)`
 :   Nested schema for FormFieldsItem.validations
     
@@ -626,6 +662,8 @@ Classes
     `required: bool | Any | None`
     :   The type of the None singleton.
 
+<a id="FormLinks"></a>
+
 `FormLinks(**data: Any)`
 :   Links to related resources
     
@@ -647,6 +685,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="FormLogicItem"></a>
 
 `FormLogicItem(**data: Any)`
 :   Nested schema for Form.logic_item
@@ -676,6 +716,8 @@ Classes
     `type_: str | Any | None`
     :   The type of the None singleton.
 
+<a id="FormLogicItemActionsItem"></a>
+
 `FormLogicItemActionsItem(**data: Any)`
 :   Nested schema for FormLogicItem.actions_item
     
@@ -704,6 +746,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="FormLogicItemActionsItemCondition"></a>
+
 `FormLogicItemActionsItemCondition(**data: Any)`
 :   Nested schema for FormLogicItemActionsItem.condition
     
@@ -729,6 +773,8 @@ Classes
     `vars: list[airbyte_agent_sdk.connectors.typeform.models.FormLogicItemActionsItemConditionVarsItem | None] | Any | None`
     :   The type of the None singleton.
 
+<a id="FormLogicItemActionsItemConditionVarsItem"></a>
+
 `FormLogicItemActionsItemConditionVarsItem(**data: Any)`
 :   Nested schema for FormLogicItemActionsItemCondition.vars_item
     
@@ -753,6 +799,8 @@ Classes
 
     `value: str | Any | None`
     :   The type of the None singleton.
+
+<a id="FormLogicItemActionsItemDetails"></a>
 
 `FormLogicItemActionsItemDetails(**data: Any)`
 :   Nested schema for FormLogicItemActionsItem.details
@@ -782,6 +830,8 @@ Classes
     `value: airbyte_agent_sdk.connectors.typeform.models.FormLogicItemActionsItemDetailsValue | Any | None`
     :   The type of the None singleton.
 
+<a id="FormLogicItemActionsItemDetailsTarget"></a>
+
 `FormLogicItemActionsItemDetailsTarget(**data: Any)`
 :   Nested schema for FormLogicItemActionsItemDetails.target
     
@@ -806,6 +856,8 @@ Classes
 
     `value: str | Any | None`
     :   The type of the None singleton.
+
+<a id="FormLogicItemActionsItemDetailsTo"></a>
 
 `FormLogicItemActionsItemDetailsTo(**data: Any)`
 :   Nested schema for FormLogicItemActionsItemDetails.to
@@ -832,6 +884,8 @@ Classes
     `value: str | Any | None`
     :   The type of the None singleton.
 
+<a id="FormLogicItemActionsItemDetailsValue"></a>
+
 `FormLogicItemActionsItemDetailsValue(**data: Any)`
 :   Nested schema for FormLogicItemActionsItemDetails.value
     
@@ -857,6 +911,8 @@ Classes
     `value: str | Any | None`
     :   The type of the None singleton.
 
+<a id="FormSelf"></a>
+
 `FormSelf(**data: Any)`
 :   Self-referential link to this form
     
@@ -878,6 +934,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="FormSettings"></a>
 
 `FormSettings(**data: Any)`
 :   Settings and configurations for the form
@@ -949,6 +1007,8 @@ Classes
     `show_typeform_branding: bool | Any | None`
     :   The type of the None singleton.
 
+<a id="FormSettingsCapabilities"></a>
+
 `FormSettingsCapabilities(**data: Any)`
 :   Nested schema for FormSettings.capabilities
     
@@ -970,6 +1030,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="FormSettingsCapabilitiesE2eEncryption"></a>
 
 `FormSettingsCapabilitiesE2eEncryption(**data: Any)`
 :   Nested schema for FormSettingsCapabilities.e2e_encryption
@@ -995,6 +1057,8 @@ Classes
 
     `modifiable: bool | Any | None`
     :   The type of the None singleton.
+
+<a id="FormSettingsCuiSettings"></a>
 
 `FormSettingsCuiSettings(**data: Any)`
 :   Nested schema for FormSettings.cui_settings
@@ -1023,6 +1087,8 @@ Classes
 
     `typing_emulation_speed: str | Any | None`
     :   The type of the None singleton.
+
+<a id="FormSettingsMeta"></a>
 
 `FormSettingsMeta(**data: Any)`
 :   Meta information
@@ -1055,6 +1121,8 @@ Classes
     `title: str | Any | None`
     :   The type of the None singleton.
 
+<a id="FormSettingsMetaImage"></a>
+
 `FormSettingsMetaImage(**data: Any)`
 :   Nested schema for FormSettingsMeta.image
     
@@ -1076,6 +1144,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="FormSettingsNotifications"></a>
 
 `FormSettingsNotifications(**data: Any)`
 :   Nested schema for FormSettings.notifications
@@ -1101,6 +1171,8 @@ Classes
 
     `self: airbyte_agent_sdk.connectors.typeform.models.FormSettingsNotificationsSelf | Any | None`
     :   The type of the None singleton.
+
+<a id="FormSettingsNotificationsRespondent"></a>
 
 `FormSettingsNotificationsRespondent(**data: Any)`
 :   Nested schema for FormSettingsNotifications.respondent
@@ -1136,6 +1208,8 @@ Classes
     `subject: str | Any | None`
     :   The type of the None singleton.
 
+<a id="FormSettingsNotificationsSelf"></a>
+
 `FormSettingsNotificationsSelf(**data: Any)`
 :   Nested schema for FormSettingsNotifications.self
     
@@ -1169,6 +1243,8 @@ Classes
 
     `subject: str | Any | None`
     :   The type of the None singleton.
+
+<a id="FormThankyouScreensItem"></a>
 
 `FormThankyouScreensItem(**data: Any)`
 :   Nested schema for Form.thankyou_screens_item
@@ -1207,6 +1283,8 @@ Classes
     `title: str | Any | None`
     :   The type of the None singleton.
 
+<a id="FormThankyouScreensItemAttachment"></a>
+
 `FormThankyouScreensItemAttachment(**data: Any)`
 :   Nested schema for FormThankyouScreensItem.attachment
     
@@ -1231,6 +1309,8 @@ Classes
 
     `type_: str | Any | None`
     :   The type of the None singleton.
+
+<a id="FormThankyouScreensItemLayout"></a>
 
 `FormThankyouScreensItemLayout(**data: Any)`
 :   Nested schema for FormThankyouScreensItem.layout
@@ -1263,6 +1343,8 @@ Classes
     `type_: str | Any | None`
     :   The type of the None singleton.
 
+<a id="FormThankyouScreensItemLayoutAttachment"></a>
+
 `FormThankyouScreensItemLayoutAttachment(**data: Any)`
 :   Nested schema for FormThankyouScreensItemLayout.attachment
     
@@ -1290,6 +1372,8 @@ Classes
 
     `type_: str | Any | None`
     :   The type of the None singleton.
+
+<a id="FormThankyouScreensItemLayoutProperties"></a>
 
 `FormThankyouScreensItemLayoutProperties(**data: Any)`
 :   Nested schema for FormThankyouScreensItemLayout.properties
@@ -1319,6 +1403,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="FormThankyouScreensItemLayoutPropertiesFocalPoint"></a>
+
 `FormThankyouScreensItemLayoutPropertiesFocalPoint(**data: Any)`
 :   Nested schema for FormThankyouScreensItemLayoutProperties.focal_point
     
@@ -1343,6 +1429,8 @@ Classes
 
     `y: float | Any | None`
     :   The type of the None singleton.
+
+<a id="FormThankyouScreensItemProperties"></a>
 
 `FormThankyouScreensItemProperties(**data: Any)`
 :   Nested schema for FormThankyouScreensItem.properties
@@ -1378,6 +1466,8 @@ Classes
     `show_button: bool | Any | None`
     :   The type of the None singleton.
 
+<a id="FormTheme"></a>
+
 `FormTheme(**data: Any)`
 :   Theme settings for the form
     
@@ -1399,6 +1489,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="FormWelcomeScreensItem"></a>
 
 `FormWelcomeScreensItem(**data: Any)`
 :   Nested schema for Form.welcome_screens_item
@@ -1437,6 +1529,8 @@ Classes
     `title: str | Any | None`
     :   The type of the None singleton.
 
+<a id="FormWelcomeScreensItemAttachment"></a>
+
 `FormWelcomeScreensItemAttachment(**data: Any)`
 :   Nested schema for FormWelcomeScreensItem.attachment
     
@@ -1461,6 +1555,8 @@ Classes
 
     `type_: str | Any | None`
     :   The type of the None singleton.
+
+<a id="FormWelcomeScreensItemLayout"></a>
 
 `FormWelcomeScreensItemLayout(**data: Any)`
 :   Nested schema for FormWelcomeScreensItem.layout
@@ -1493,6 +1589,8 @@ Classes
     `type_: str | Any | None`
     :   The type of the None singleton.
 
+<a id="FormWelcomeScreensItemLayoutAttachment"></a>
+
 `FormWelcomeScreensItemLayoutAttachment(**data: Any)`
 :   Nested schema for FormWelcomeScreensItemLayout.attachment
     
@@ -1520,6 +1618,8 @@ Classes
 
     `type_: str | Any | None`
     :   The type of the None singleton.
+
+<a id="FormWelcomeScreensItemLayoutProperties"></a>
 
 `FormWelcomeScreensItemLayoutProperties(**data: Any)`
 :   Nested schema for FormWelcomeScreensItemLayout.properties
@@ -1549,6 +1649,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="FormWelcomeScreensItemLayoutPropertiesFocalPoint"></a>
+
 `FormWelcomeScreensItemLayoutPropertiesFocalPoint(**data: Any)`
 :   Nested schema for FormWelcomeScreensItemLayoutProperties.focal_point
     
@@ -1573,6 +1675,8 @@ Classes
 
     `y: float | Any | None`
     :   The type of the None singleton.
+
+<a id="FormWelcomeScreensItemProperties"></a>
 
 `FormWelcomeScreensItemProperties(**data: Any)`
 :   Nested schema for FormWelcomeScreensItem.properties
@@ -1608,6 +1712,8 @@ Classes
     `show_button: bool | Any | None`
     :   The type of the None singleton.
 
+<a id="FormWorkspace"></a>
+
 `FormWorkspace(**data: Any)`
 :   Workspace details where the form belongs
     
@@ -1629,6 +1735,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="FormsList"></a>
 
 `FormsList(**data: Any)`
 :   Paginated list of forms
@@ -1658,6 +1766,8 @@ Classes
     `total_items: int | Any | None`
     :   The type of the None singleton.
 
+<a id="FormsListResultMeta"></a>
+
 `FormsListResultMeta(**data: Any)`
 :   Metadata for forms.Action.LIST operation
     
@@ -1682,6 +1792,8 @@ Classes
 
     `total_items: int | Any | None`
     :   The type of the None singleton.
+
+<a id="FormsSearchData"></a>
 
 `FormsSearchData(**data: Any)`
 :   Search result data for forms entity.
@@ -1744,6 +1856,8 @@ Classes
     `workspace: dict[str, typing.Any] | None`
     :   Workspace details where the form belongs
 
+<a id="Image"></a>
+
 `Image(**data: Any)`
 :   An image in the account
     
@@ -1790,6 +1904,8 @@ Classes
     `width: int | Any | None`
     :   The type of the None singleton.
 
+<a id="ImagesSearchData"></a>
+
 `ImagesSearchData(**data: Any)`
 :   Search result data for images entity.
     
@@ -1832,6 +1948,8 @@ Classes
 
     `width: int | None`
     :   Width of the image in pixels
+
+<a id="Response"></a>
 
 `Response(**data: Any)`
 :   A single form response/submission
@@ -1887,6 +2005,8 @@ Classes
 
     `variables: list[airbyte_agent_sdk.connectors.typeform.models.ResponseVariablesItem | None] | Any | None`
     :   The type of the None singleton.
+
+<a id="ResponseAnswersItem"></a>
 
 `ResponseAnswersItem(**data: Any)`
 :   Nested schema for Response.answers_item
@@ -1946,6 +2066,8 @@ Classes
     `url: str | Any | None`
     :   The type of the None singleton.
 
+<a id="ResponseAnswersItemChoice"></a>
+
 `ResponseAnswersItemChoice(**data: Any)`
 :   Nested schema for ResponseAnswersItem.choice
     
@@ -1971,6 +2093,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="ResponseAnswersItemChoices"></a>
+
 `ResponseAnswersItemChoices(**data: Any)`
 :   Nested schema for ResponseAnswersItem.choices
     
@@ -1995,6 +2119,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="ResponseAnswersItemField"></a>
 
 `ResponseAnswersItemField(**data: Any)`
 :   Nested schema for ResponseAnswersItem.field
@@ -2023,6 +2149,8 @@ Classes
 
     `type_: str | Any | None`
     :   The type of the None singleton.
+
+<a id="ResponseAnswersItemPayment"></a>
 
 `ResponseAnswersItemPayment(**data: Any)`
 :   Nested schema for ResponseAnswersItem.payment
@@ -2055,6 +2183,8 @@ Classes
     `success: bool | Any | None`
     :   The type of the None singleton.
 
+<a id="ResponseCalculated"></a>
+
 `ResponseCalculated(**data: Any)`
 :   Calculated data related to the response
     
@@ -2076,6 +2206,8 @@ Classes
 
     `score: int | Any | None`
     :   The type of the None singleton.
+
+<a id="ResponseMetadata"></a>
 
 `ResponseMetadata(**data: Any)`
 :   Metadata related to the response
@@ -2108,6 +2240,8 @@ Classes
     `user_agent: str | Any | None`
     :   The type of the None singleton.
 
+<a id="ResponseVariablesItem"></a>
+
 `ResponseVariablesItem(**data: Any)`
 :   Nested schema for Response.variables_item
     
@@ -2139,6 +2273,8 @@ Classes
     `type_: str | Any | None`
     :   The type of the None singleton.
 
+<a id="ResponsesList"></a>
+
 `ResponsesList(**data: Any)`
 :   Paginated list of responses
     
@@ -2167,6 +2303,8 @@ Classes
     `total_items: int | Any | None`
     :   The type of the None singleton.
 
+<a id="ResponsesListResultMeta"></a>
+
 `ResponsesListResultMeta(**data: Any)`
 :   Metadata for responses.Action.LIST operation
     
@@ -2191,6 +2329,8 @@ Classes
 
     `total_items: int | Any | None`
     :   The type of the None singleton.
+
+<a id="ResponsesSearchData"></a>
 
 `ResponsesSearchData(**data: Any)`
 :   Search result data for responses entity.
@@ -2247,6 +2387,8 @@ Classes
     `variables: list[typing.Any] | None`
     :   Variables associated with the response
 
+<a id="Theme"></a>
+
 `Theme(**data: Any)`
 :   A theme used for styling forms
     
@@ -2302,6 +2444,8 @@ Classes
     `visibility: str | Any | None`
     :   The type of the None singleton.
 
+<a id="ThemeBackground"></a>
+
 `ThemeBackground(**data: Any)`
 :   Background settings
     
@@ -2329,6 +2473,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="ThemeColors"></a>
 
 `ThemeColors(**data: Any)`
 :   Color settings
@@ -2361,6 +2507,8 @@ Classes
     `question: str | Any | None`
     :   Color of question text
 
+<a id="ThemeFields"></a>
+
 `ThemeFields(**data: Any)`
 :   Field display settings
     
@@ -2386,6 +2534,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="ThemeScreens"></a>
+
 `ThemeScreens(**data: Any)`
 :   Screen display settings
     
@@ -2410,6 +2560,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="ThemesList"></a>
 
 `ThemesList(**data: Any)`
 :   Paginated list of themes
@@ -2439,6 +2591,8 @@ Classes
     `total_items: int | Any | None`
     :   The type of the None singleton.
 
+<a id="ThemesListResultMeta"></a>
+
 `ThemesListResultMeta(**data: Any)`
 :   Metadata for themes.Action.LIST operation
     
@@ -2463,6 +2617,8 @@ Classes
 
     `total_items: int | Any | None`
     :   The type of the None singleton.
+
+<a id="ThemesSearchData"></a>
 
 `ThemesSearchData(**data: Any)`
 :   Search result data for themes entity.
@@ -2519,6 +2675,8 @@ Classes
     `visibility: str | None`
     :   Visibility setting of the theme
 
+<a id="TypeformAuthConfig"></a>
+
 `TypeformAuthConfig(**data: Any)`
 :   Access Token Authentication
     
@@ -2540,6 +2698,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="TypeformCheckResult"></a>
 
 `TypeformCheckResult(**data: Any)`
 :   Result of a health check operation.
@@ -2574,6 +2734,8 @@ Classes
     `status: str`
     :   Health check status: 'healthy' or 'unhealthy'.
 
+<a id="TypeformExecuteResult"></a>
+
 `TypeformExecuteResult(**data: Any)`
 :   Response envelope with data only.
     
@@ -2604,6 +2766,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="TypeformExecuteResultWithMeta"></a>
 
 `TypeformExecuteResultWithMeta(**data: Any)`
 :   Response envelope with data and metadata.
@@ -2659,6 +2823,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="FormsListResult"></a>
+
 `FormsListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -2701,6 +2867,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="ResponsesListResult"></a>
 
 `ResponsesListResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -2745,6 +2913,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="ThemesListResult"></a>
+
 `ThemesListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -2788,6 +2958,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="WorkspacesListResult"></a>
+
 `WorkspacesListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -2830,6 +3002,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="ImagesListResult"></a>
+
 `ImagesListResult(**data: Any)`
 :   Response envelope with data only.
     
@@ -2871,6 +3045,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="WebhooksListResult"></a>
+
 `WebhooksListResult(**data: Any)`
 :   Response envelope with data only.
     
@@ -2888,6 +3064,8 @@ Classes
     * airbyte_agent_sdk.connectors.typeform.models.TypeformExecuteResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="TypeformReplicationConfig"></a>
 
 `TypeformReplicationConfig(**data: Any)`
 :   Replication Configuration - Settings for data replication from Typeform
@@ -2910,6 +3088,8 @@ Classes
 
     `start_date: str`
     :   UTC date and time in the format YYYY-MM-DDT00:00:00Z from which to start replicating response data.
+
+<a id="Webhook"></a>
 
 `Webhook(**data: Any)`
 :   A webhook configured for a form
@@ -2954,6 +3134,8 @@ Classes
     `verify_ssl: bool | Any | None`
     :   The type of the None singleton.
 
+<a id="WebhooksList"></a>
+
 `WebhooksList(**data: Any)`
 :   List of webhooks
     
@@ -2975,6 +3157,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="WebhooksSearchData"></a>
 
 `WebhooksSearchData(**data: Any)`
 :   Search result data for webhooks entity.
@@ -3019,6 +3203,8 @@ Classes
     `verify_ssl: bool | None`
     :   Whether SSL verification is enforced
 
+<a id="Workspace"></a>
+
 `Workspace(**data: Any)`
 :   A workspace containing forms
     
@@ -3059,6 +3245,8 @@ Classes
     `shared: bool | Any | None`
     :   The type of the None singleton.
 
+<a id="WorkspaceForms"></a>
+
 `WorkspaceForms(**data: Any)`
 :   Information about forms in the workspace
     
@@ -3084,6 +3272,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="WorkspaceSelf"></a>
+
 `WorkspaceSelf(**data: Any)`
 :   Self-referential link
     
@@ -3105,6 +3295,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="WorkspacesList"></a>
 
 `WorkspacesList(**data: Any)`
 :   Paginated list of workspaces
@@ -3134,6 +3326,8 @@ Classes
     `total_items: int | Any | None`
     :   The type of the None singleton.
 
+<a id="WorkspacesListResultMeta"></a>
+
 `WorkspacesListResultMeta(**data: Any)`
 :   Metadata for workspaces.Action.LIST operation
     
@@ -3158,6 +3352,8 @@ Classes
 
     `total_items: int | Any | None`
     :   The type of the None singleton.
+
+<a id="WorkspacesSearchData"></a>
 
 `WorkspacesSearchData(**data: Any)`
 :   Search result data for workspaces entity.

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/typeform/types.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/typeform/types.md
@@ -10,6 +10,8 @@ Type definitions for typeform connector.
 Classes
 -------
 
+<a id="AirbyteSearchParams"></a>
+
 `AirbyteSearchParams(*args, **kwargs)`
 :   Parameters for Airbyte cache search operations (generic, use entity-specific query types for better type hints).
 
@@ -31,6 +33,8 @@ Classes
     `query: dict[str, typing.Any]`
     :   The type of the None singleton.
 
+<a id="FormsAndCondition"></a>
+
 `FormsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -51,6 +55,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.typeform.types.FormsEqCondition | airbyte_agent_sdk.connectors.typeform.types.FormsNeqCondition | airbyte_agent_sdk.connectors.typeform.types.FormsGtCondition | airbyte_agent_sdk.connectors.typeform.types.FormsGteCondition | airbyte_agent_sdk.connectors.typeform.types.FormsLtCondition | airbyte_agent_sdk.connectors.typeform.types.FormsLteCondition | airbyte_agent_sdk.connectors.typeform.types.FormsInCondition | airbyte_agent_sdk.connectors.typeform.types.FormsLikeCondition | airbyte_agent_sdk.connectors.typeform.types.FormsFuzzyCondition | airbyte_agent_sdk.connectors.typeform.types.FormsKeywordCondition | airbyte_agent_sdk.connectors.typeform.types.FormsContainsCondition | airbyte_agent_sdk.connectors.typeform.types.FormsNotCondition | airbyte_agent_sdk.connectors.typeform.types.FormsAndCondition | airbyte_agent_sdk.connectors.typeform.types.FormsOrCondition | airbyte_agent_sdk.connectors.typeform.types.FormsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="FormsAnyCondition"></a>
+
 `FormsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -70,6 +76,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.typeform.types.FormsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="FormsAnyValueFilter"></a>
 
 `FormsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -122,6 +130,8 @@ Classes
     `workspace: Any`
     :   Workspace details where the form belongs
 
+<a id="FormsContainsCondition"></a>
+
 `FormsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -133,6 +143,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.typeform.types.FormsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="FormsEqCondition"></a>
 
 `FormsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -146,6 +158,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.typeform.types.FormsSearchFilter`
     :   The type of the None singleton.
 
+<a id="FormsFuzzyCondition"></a>
+
 `FormsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -157,6 +171,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.typeform.types.FormsStringFilter`
     :   The type of the None singleton.
+
+<a id="FormsGetParams"></a>
 
 `FormsGetParams(*args, **kwargs)`
 :   Parameters for forms.get operation
@@ -170,6 +186,8 @@ Classes
     `form_id: str`
     :   The type of the None singleton.
 
+<a id="FormsGtCondition"></a>
+
 `FormsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -182,6 +200,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.typeform.types.FormsSearchFilter`
     :   The type of the None singleton.
 
+<a id="FormsGteCondition"></a>
+
 `FormsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -193,6 +213,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.typeform.types.FormsSearchFilter`
     :   The type of the None singleton.
+
+<a id="FormsInCondition"></a>
 
 `FormsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -213,6 +235,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.typeform.types.FormsInFilter`
     :   The type of the None singleton.
+
+<a id="FormsInFilter"></a>
 
 `FormsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -265,6 +289,8 @@ Classes
     `workspace: list[dict[str, typing.Any]]`
     :   Workspace details where the form belongs
 
+<a id="FormsKeywordCondition"></a>
+
 `FormsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -277,6 +303,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.typeform.types.FormsStringFilter`
     :   The type of the None singleton.
 
+<a id="FormsLikeCondition"></a>
+
 `FormsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -288,6 +316,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.typeform.types.FormsStringFilter`
     :   The type of the None singleton.
+
+<a id="FormsListParams"></a>
 
 `FormsListParams(*args, **kwargs)`
 :   Parameters for forms.list operation
@@ -304,6 +334,8 @@ Classes
     `page_size: int`
     :   The type of the None singleton.
 
+<a id="FormsLtCondition"></a>
+
 `FormsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -315,6 +347,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.typeform.types.FormsSearchFilter`
     :   The type of the None singleton.
+
+<a id="FormsLteCondition"></a>
 
 `FormsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -328,6 +362,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.typeform.types.FormsSearchFilter`
     :   The type of the None singleton.
 
+<a id="FormsNeqCondition"></a>
+
 `FormsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -339,6 +375,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.typeform.types.FormsSearchFilter`
     :   The type of the None singleton.
+
+<a id="FormsNotCondition"></a>
 
 `FormsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -360,6 +398,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.typeform.types.FormsEqCondition | airbyte_agent_sdk.connectors.typeform.types.FormsNeqCondition | airbyte_agent_sdk.connectors.typeform.types.FormsGtCondition | airbyte_agent_sdk.connectors.typeform.types.FormsGteCondition | airbyte_agent_sdk.connectors.typeform.types.FormsLtCondition | airbyte_agent_sdk.connectors.typeform.types.FormsLteCondition | airbyte_agent_sdk.connectors.typeform.types.FormsInCondition | airbyte_agent_sdk.connectors.typeform.types.FormsLikeCondition | airbyte_agent_sdk.connectors.typeform.types.FormsFuzzyCondition | airbyte_agent_sdk.connectors.typeform.types.FormsKeywordCondition | airbyte_agent_sdk.connectors.typeform.types.FormsContainsCondition | airbyte_agent_sdk.connectors.typeform.types.FormsNotCondition | airbyte_agent_sdk.connectors.typeform.types.FormsAndCondition | airbyte_agent_sdk.connectors.typeform.types.FormsOrCondition | airbyte_agent_sdk.connectors.typeform.types.FormsAnyCondition`
     :   The type of the None singleton.
 
+<a id="FormsOrCondition"></a>
+
 `FormsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -379,6 +419,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.typeform.types.FormsEqCondition | airbyte_agent_sdk.connectors.typeform.types.FormsNeqCondition | airbyte_agent_sdk.connectors.typeform.types.FormsGtCondition | airbyte_agent_sdk.connectors.typeform.types.FormsGteCondition | airbyte_agent_sdk.connectors.typeform.types.FormsLtCondition | airbyte_agent_sdk.connectors.typeform.types.FormsLteCondition | airbyte_agent_sdk.connectors.typeform.types.FormsInCondition | airbyte_agent_sdk.connectors.typeform.types.FormsLikeCondition | airbyte_agent_sdk.connectors.typeform.types.FormsFuzzyCondition | airbyte_agent_sdk.connectors.typeform.types.FormsKeywordCondition | airbyte_agent_sdk.connectors.typeform.types.FormsContainsCondition | airbyte_agent_sdk.connectors.typeform.types.FormsNotCondition | airbyte_agent_sdk.connectors.typeform.types.FormsAndCondition | airbyte_agent_sdk.connectors.typeform.types.FormsOrCondition | airbyte_agent_sdk.connectors.typeform.types.FormsAnyCondition]`
     :   The type of the None singleton.
+
+<a id="FormsSearchFilter"></a>
 
 `FormsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering forms search queries.
@@ -431,6 +473,8 @@ Classes
     `workspace: dict[str, typing.Any] | None`
     :   Workspace details where the form belongs
 
+<a id="FormsSearchQuery"></a>
+
 `FormsSearchQuery(*args, **kwargs)`
 :   Search query for forms entity.
 
@@ -445,6 +489,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.typeform.types.FormsSortFilter]`
     :   The type of the None singleton.
+
+<a id="FormsSortFilter"></a>
 
 `FormsSortFilter(*args, **kwargs)`
 :   Available fields for sorting forms search results.
@@ -497,6 +543,8 @@ Classes
     `workspace: Literal['asc', 'desc']`
     :   Workspace details where the form belongs
 
+<a id="FormsStringFilter"></a>
+
 `FormsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -548,6 +596,8 @@ Classes
     `workspace: str`
     :   Workspace details where the form belongs
 
+<a id="ImagesAndCondition"></a>
+
 `ImagesAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -568,6 +618,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.typeform.types.ImagesEqCondition | airbyte_agent_sdk.connectors.typeform.types.ImagesNeqCondition | airbyte_agent_sdk.connectors.typeform.types.ImagesGtCondition | airbyte_agent_sdk.connectors.typeform.types.ImagesGteCondition | airbyte_agent_sdk.connectors.typeform.types.ImagesLtCondition | airbyte_agent_sdk.connectors.typeform.types.ImagesLteCondition | airbyte_agent_sdk.connectors.typeform.types.ImagesInCondition | airbyte_agent_sdk.connectors.typeform.types.ImagesLikeCondition | airbyte_agent_sdk.connectors.typeform.types.ImagesFuzzyCondition | airbyte_agent_sdk.connectors.typeform.types.ImagesKeywordCondition | airbyte_agent_sdk.connectors.typeform.types.ImagesContainsCondition | airbyte_agent_sdk.connectors.typeform.types.ImagesNotCondition | airbyte_agent_sdk.connectors.typeform.types.ImagesAndCondition | airbyte_agent_sdk.connectors.typeform.types.ImagesOrCondition | airbyte_agent_sdk.connectors.typeform.types.ImagesAnyCondition]`
     :   The type of the None singleton.
 
+<a id="ImagesAnyCondition"></a>
+
 `ImagesAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -587,6 +639,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.typeform.types.ImagesAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="ImagesAnyValueFilter"></a>
 
 `ImagesAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -621,6 +675,8 @@ Classes
     `width: Any`
     :   Width of the image in pixels
 
+<a id="ImagesContainsCondition"></a>
+
 `ImagesContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -632,6 +688,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.typeform.types.ImagesAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="ImagesEqCondition"></a>
 
 `ImagesEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -645,6 +703,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.typeform.types.ImagesSearchFilter`
     :   The type of the None singleton.
 
+<a id="ImagesFuzzyCondition"></a>
+
 `ImagesFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -656,6 +716,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.typeform.types.ImagesStringFilter`
     :   The type of the None singleton.
+
+<a id="ImagesGtCondition"></a>
 
 `ImagesGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
@@ -669,6 +731,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.typeform.types.ImagesSearchFilter`
     :   The type of the None singleton.
 
+<a id="ImagesGteCondition"></a>
+
 `ImagesGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -680,6 +744,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.typeform.types.ImagesSearchFilter`
     :   The type of the None singleton.
+
+<a id="ImagesInCondition"></a>
 
 `ImagesInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -700,6 +766,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.typeform.types.ImagesInFilter`
     :   The type of the None singleton.
+
+<a id="ImagesInFilter"></a>
 
 `ImagesInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -734,6 +802,8 @@ Classes
     `width: list[int]`
     :   Width of the image in pixels
 
+<a id="ImagesKeywordCondition"></a>
+
 `ImagesKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -745,6 +815,8 @@ Classes
 
     `keyword: airbyte_agent_sdk.connectors.typeform.types.ImagesStringFilter`
     :   The type of the None singleton.
+
+<a id="ImagesLikeCondition"></a>
 
 `ImagesLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
@@ -758,12 +830,16 @@ Classes
     `like: airbyte_agent_sdk.connectors.typeform.types.ImagesStringFilter`
     :   The type of the None singleton.
 
+<a id="ImagesListParams"></a>
+
 `ImagesListParams(*args, **kwargs)`
 :   Parameters for images.list operation
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="ImagesLtCondition"></a>
 
 `ImagesLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
@@ -777,6 +853,8 @@ Classes
     `lt: airbyte_agent_sdk.connectors.typeform.types.ImagesSearchFilter`
     :   The type of the None singleton.
 
+<a id="ImagesLteCondition"></a>
+
 `ImagesLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
 
@@ -789,6 +867,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.typeform.types.ImagesSearchFilter`
     :   The type of the None singleton.
 
+<a id="ImagesNeqCondition"></a>
+
 `ImagesNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -800,6 +880,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.typeform.types.ImagesSearchFilter`
     :   The type of the None singleton.
+
+<a id="ImagesNotCondition"></a>
 
 `ImagesNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -821,6 +903,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.typeform.types.ImagesEqCondition | airbyte_agent_sdk.connectors.typeform.types.ImagesNeqCondition | airbyte_agent_sdk.connectors.typeform.types.ImagesGtCondition | airbyte_agent_sdk.connectors.typeform.types.ImagesGteCondition | airbyte_agent_sdk.connectors.typeform.types.ImagesLtCondition | airbyte_agent_sdk.connectors.typeform.types.ImagesLteCondition | airbyte_agent_sdk.connectors.typeform.types.ImagesInCondition | airbyte_agent_sdk.connectors.typeform.types.ImagesLikeCondition | airbyte_agent_sdk.connectors.typeform.types.ImagesFuzzyCondition | airbyte_agent_sdk.connectors.typeform.types.ImagesKeywordCondition | airbyte_agent_sdk.connectors.typeform.types.ImagesContainsCondition | airbyte_agent_sdk.connectors.typeform.types.ImagesNotCondition | airbyte_agent_sdk.connectors.typeform.types.ImagesAndCondition | airbyte_agent_sdk.connectors.typeform.types.ImagesOrCondition | airbyte_agent_sdk.connectors.typeform.types.ImagesAnyCondition`
     :   The type of the None singleton.
 
+<a id="ImagesOrCondition"></a>
+
 `ImagesOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -840,6 +924,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.typeform.types.ImagesEqCondition | airbyte_agent_sdk.connectors.typeform.types.ImagesNeqCondition | airbyte_agent_sdk.connectors.typeform.types.ImagesGtCondition | airbyte_agent_sdk.connectors.typeform.types.ImagesGteCondition | airbyte_agent_sdk.connectors.typeform.types.ImagesLtCondition | airbyte_agent_sdk.connectors.typeform.types.ImagesLteCondition | airbyte_agent_sdk.connectors.typeform.types.ImagesInCondition | airbyte_agent_sdk.connectors.typeform.types.ImagesLikeCondition | airbyte_agent_sdk.connectors.typeform.types.ImagesFuzzyCondition | airbyte_agent_sdk.connectors.typeform.types.ImagesKeywordCondition | airbyte_agent_sdk.connectors.typeform.types.ImagesContainsCondition | airbyte_agent_sdk.connectors.typeform.types.ImagesNotCondition | airbyte_agent_sdk.connectors.typeform.types.ImagesAndCondition | airbyte_agent_sdk.connectors.typeform.types.ImagesOrCondition | airbyte_agent_sdk.connectors.typeform.types.ImagesAnyCondition]`
     :   The type of the None singleton.
+
+<a id="ImagesSearchFilter"></a>
 
 `ImagesSearchFilter(*args, **kwargs)`
 :   Available fields for filtering images search queries.
@@ -874,6 +960,8 @@ Classes
     `width: int | None`
     :   Width of the image in pixels
 
+<a id="ImagesSearchQuery"></a>
+
 `ImagesSearchQuery(*args, **kwargs)`
 :   Search query for images entity.
 
@@ -888,6 +976,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.typeform.types.ImagesSortFilter]`
     :   The type of the None singleton.
+
+<a id="ImagesSortFilter"></a>
 
 `ImagesSortFilter(*args, **kwargs)`
 :   Available fields for sorting images search results.
@@ -922,6 +1012,8 @@ Classes
     `width: Literal['asc', 'desc']`
     :   Width of the image in pixels
 
+<a id="ImagesStringFilter"></a>
+
 `ImagesStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -955,6 +1047,8 @@ Classes
     `width: str`
     :   Width of the image in pixels
 
+<a id="ResponsesAndCondition"></a>
+
 `ResponsesAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -975,6 +1069,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.typeform.types.ResponsesEqCondition | airbyte_agent_sdk.connectors.typeform.types.ResponsesNeqCondition | airbyte_agent_sdk.connectors.typeform.types.ResponsesGtCondition | airbyte_agent_sdk.connectors.typeform.types.ResponsesGteCondition | airbyte_agent_sdk.connectors.typeform.types.ResponsesLtCondition | airbyte_agent_sdk.connectors.typeform.types.ResponsesLteCondition | airbyte_agent_sdk.connectors.typeform.types.ResponsesInCondition | airbyte_agent_sdk.connectors.typeform.types.ResponsesLikeCondition | airbyte_agent_sdk.connectors.typeform.types.ResponsesFuzzyCondition | airbyte_agent_sdk.connectors.typeform.types.ResponsesKeywordCondition | airbyte_agent_sdk.connectors.typeform.types.ResponsesContainsCondition | airbyte_agent_sdk.connectors.typeform.types.ResponsesNotCondition | airbyte_agent_sdk.connectors.typeform.types.ResponsesAndCondition | airbyte_agent_sdk.connectors.typeform.types.ResponsesOrCondition | airbyte_agent_sdk.connectors.typeform.types.ResponsesAnyCondition]`
     :   The type of the None singleton.
 
+<a id="ResponsesAnyCondition"></a>
+
 `ResponsesAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -994,6 +1090,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.typeform.types.ResponsesAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="ResponsesAnyValueFilter"></a>
 
 `ResponsesAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -1040,6 +1138,8 @@ Classes
     `variables: Any`
     :   Variables associated with the response
 
+<a id="ResponsesContainsCondition"></a>
+
 `ResponsesContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -1051,6 +1151,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.typeform.types.ResponsesAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="ResponsesEqCondition"></a>
 
 `ResponsesEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -1064,6 +1166,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.typeform.types.ResponsesSearchFilter`
     :   The type of the None singleton.
 
+<a id="ResponsesFuzzyCondition"></a>
+
 `ResponsesFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -1075,6 +1179,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.typeform.types.ResponsesStringFilter`
     :   The type of the None singleton.
+
+<a id="ResponsesGtCondition"></a>
 
 `ResponsesGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
@@ -1088,6 +1194,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.typeform.types.ResponsesSearchFilter`
     :   The type of the None singleton.
 
+<a id="ResponsesGteCondition"></a>
+
 `ResponsesGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -1099,6 +1207,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.typeform.types.ResponsesSearchFilter`
     :   The type of the None singleton.
+
+<a id="ResponsesInCondition"></a>
 
 `ResponsesInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -1119,6 +1229,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.typeform.types.ResponsesInFilter`
     :   The type of the None singleton.
+
+<a id="ResponsesInFilter"></a>
 
 `ResponsesInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -1165,6 +1277,8 @@ Classes
     `variables: list[list[typing.Any]]`
     :   Variables associated with the response
 
+<a id="ResponsesKeywordCondition"></a>
+
 `ResponsesKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -1177,6 +1291,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.typeform.types.ResponsesStringFilter`
     :   The type of the None singleton.
 
+<a id="ResponsesLikeCondition"></a>
+
 `ResponsesLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -1188,6 +1304,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.typeform.types.ResponsesStringFilter`
     :   The type of the None singleton.
+
+<a id="ResponsesListParams"></a>
 
 `ResponsesListParams(*args, **kwargs)`
 :   Parameters for responses.list operation
@@ -1225,6 +1343,8 @@ Classes
     `until: str`
     :   The type of the None singleton.
 
+<a id="ResponsesLtCondition"></a>
+
 `ResponsesLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -1236,6 +1356,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.typeform.types.ResponsesSearchFilter`
     :   The type of the None singleton.
+
+<a id="ResponsesLteCondition"></a>
 
 `ResponsesLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -1249,6 +1371,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.typeform.types.ResponsesSearchFilter`
     :   The type of the None singleton.
 
+<a id="ResponsesNeqCondition"></a>
+
 `ResponsesNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -1260,6 +1384,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.typeform.types.ResponsesSearchFilter`
     :   The type of the None singleton.
+
+<a id="ResponsesNotCondition"></a>
 
 `ResponsesNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -1281,6 +1407,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.typeform.types.ResponsesEqCondition | airbyte_agent_sdk.connectors.typeform.types.ResponsesNeqCondition | airbyte_agent_sdk.connectors.typeform.types.ResponsesGtCondition | airbyte_agent_sdk.connectors.typeform.types.ResponsesGteCondition | airbyte_agent_sdk.connectors.typeform.types.ResponsesLtCondition | airbyte_agent_sdk.connectors.typeform.types.ResponsesLteCondition | airbyte_agent_sdk.connectors.typeform.types.ResponsesInCondition | airbyte_agent_sdk.connectors.typeform.types.ResponsesLikeCondition | airbyte_agent_sdk.connectors.typeform.types.ResponsesFuzzyCondition | airbyte_agent_sdk.connectors.typeform.types.ResponsesKeywordCondition | airbyte_agent_sdk.connectors.typeform.types.ResponsesContainsCondition | airbyte_agent_sdk.connectors.typeform.types.ResponsesNotCondition | airbyte_agent_sdk.connectors.typeform.types.ResponsesAndCondition | airbyte_agent_sdk.connectors.typeform.types.ResponsesOrCondition | airbyte_agent_sdk.connectors.typeform.types.ResponsesAnyCondition`
     :   The type of the None singleton.
 
+<a id="ResponsesOrCondition"></a>
+
 `ResponsesOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1300,6 +1428,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.typeform.types.ResponsesEqCondition | airbyte_agent_sdk.connectors.typeform.types.ResponsesNeqCondition | airbyte_agent_sdk.connectors.typeform.types.ResponsesGtCondition | airbyte_agent_sdk.connectors.typeform.types.ResponsesGteCondition | airbyte_agent_sdk.connectors.typeform.types.ResponsesLtCondition | airbyte_agent_sdk.connectors.typeform.types.ResponsesLteCondition | airbyte_agent_sdk.connectors.typeform.types.ResponsesInCondition | airbyte_agent_sdk.connectors.typeform.types.ResponsesLikeCondition | airbyte_agent_sdk.connectors.typeform.types.ResponsesFuzzyCondition | airbyte_agent_sdk.connectors.typeform.types.ResponsesKeywordCondition | airbyte_agent_sdk.connectors.typeform.types.ResponsesContainsCondition | airbyte_agent_sdk.connectors.typeform.types.ResponsesNotCondition | airbyte_agent_sdk.connectors.typeform.types.ResponsesAndCondition | airbyte_agent_sdk.connectors.typeform.types.ResponsesOrCondition | airbyte_agent_sdk.connectors.typeform.types.ResponsesAnyCondition]`
     :   The type of the None singleton.
+
+<a id="ResponsesSearchFilter"></a>
 
 `ResponsesSearchFilter(*args, **kwargs)`
 :   Available fields for filtering responses search queries.
@@ -1346,6 +1476,8 @@ Classes
     `variables: list[typing.Any] | None`
     :   Variables associated with the response
 
+<a id="ResponsesSearchQuery"></a>
+
 `ResponsesSearchQuery(*args, **kwargs)`
 :   Search query for responses entity.
 
@@ -1360,6 +1492,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.typeform.types.ResponsesSortFilter]`
     :   The type of the None singleton.
+
+<a id="ResponsesSortFilter"></a>
 
 `ResponsesSortFilter(*args, **kwargs)`
 :   Available fields for sorting responses search results.
@@ -1406,6 +1540,8 @@ Classes
     `variables: Literal['asc', 'desc']`
     :   Variables associated with the response
 
+<a id="ResponsesStringFilter"></a>
+
 `ResponsesStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -1451,6 +1587,8 @@ Classes
     `variables: str`
     :   Variables associated with the response
 
+<a id="ThemesAndCondition"></a>
+
 `ThemesAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1471,6 +1609,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.typeform.types.ThemesEqCondition | airbyte_agent_sdk.connectors.typeform.types.ThemesNeqCondition | airbyte_agent_sdk.connectors.typeform.types.ThemesGtCondition | airbyte_agent_sdk.connectors.typeform.types.ThemesGteCondition | airbyte_agent_sdk.connectors.typeform.types.ThemesLtCondition | airbyte_agent_sdk.connectors.typeform.types.ThemesLteCondition | airbyte_agent_sdk.connectors.typeform.types.ThemesInCondition | airbyte_agent_sdk.connectors.typeform.types.ThemesLikeCondition | airbyte_agent_sdk.connectors.typeform.types.ThemesFuzzyCondition | airbyte_agent_sdk.connectors.typeform.types.ThemesKeywordCondition | airbyte_agent_sdk.connectors.typeform.types.ThemesContainsCondition | airbyte_agent_sdk.connectors.typeform.types.ThemesNotCondition | airbyte_agent_sdk.connectors.typeform.types.ThemesAndCondition | airbyte_agent_sdk.connectors.typeform.types.ThemesOrCondition | airbyte_agent_sdk.connectors.typeform.types.ThemesAnyCondition]`
     :   The type of the None singleton.
 
+<a id="ThemesAnyCondition"></a>
+
 `ThemesAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1490,6 +1630,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.typeform.types.ThemesAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="ThemesAnyValueFilter"></a>
 
 `ThemesAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -1536,6 +1678,8 @@ Classes
     `visibility: Any`
     :   Visibility setting of the theme
 
+<a id="ThemesContainsCondition"></a>
+
 `ThemesContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -1547,6 +1691,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.typeform.types.ThemesAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="ThemesEqCondition"></a>
 
 `ThemesEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -1560,6 +1706,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.typeform.types.ThemesSearchFilter`
     :   The type of the None singleton.
 
+<a id="ThemesFuzzyCondition"></a>
+
 `ThemesFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -1571,6 +1719,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.typeform.types.ThemesStringFilter`
     :   The type of the None singleton.
+
+<a id="ThemesGtCondition"></a>
 
 `ThemesGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
@@ -1584,6 +1734,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.typeform.types.ThemesSearchFilter`
     :   The type of the None singleton.
 
+<a id="ThemesGteCondition"></a>
+
 `ThemesGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -1595,6 +1747,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.typeform.types.ThemesSearchFilter`
     :   The type of the None singleton.
+
+<a id="ThemesInCondition"></a>
 
 `ThemesInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -1615,6 +1769,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.typeform.types.ThemesInFilter`
     :   The type of the None singleton.
+
+<a id="ThemesInFilter"></a>
 
 `ThemesInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -1661,6 +1817,8 @@ Classes
     `visibility: list[str]`
     :   Visibility setting of the theme
 
+<a id="ThemesKeywordCondition"></a>
+
 `ThemesKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -1673,6 +1831,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.typeform.types.ThemesStringFilter`
     :   The type of the None singleton.
 
+<a id="ThemesLikeCondition"></a>
+
 `ThemesLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -1684,6 +1844,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.typeform.types.ThemesStringFilter`
     :   The type of the None singleton.
+
+<a id="ThemesListParams"></a>
 
 `ThemesListParams(*args, **kwargs)`
 :   Parameters for themes.list operation
@@ -1700,6 +1862,8 @@ Classes
     `page_size: int`
     :   The type of the None singleton.
 
+<a id="ThemesLtCondition"></a>
+
 `ThemesLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -1711,6 +1875,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.typeform.types.ThemesSearchFilter`
     :   The type of the None singleton.
+
+<a id="ThemesLteCondition"></a>
 
 `ThemesLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -1724,6 +1890,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.typeform.types.ThemesSearchFilter`
     :   The type of the None singleton.
 
+<a id="ThemesNeqCondition"></a>
+
 `ThemesNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -1735,6 +1903,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.typeform.types.ThemesSearchFilter`
     :   The type of the None singleton.
+
+<a id="ThemesNotCondition"></a>
 
 `ThemesNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -1756,6 +1926,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.typeform.types.ThemesEqCondition | airbyte_agent_sdk.connectors.typeform.types.ThemesNeqCondition | airbyte_agent_sdk.connectors.typeform.types.ThemesGtCondition | airbyte_agent_sdk.connectors.typeform.types.ThemesGteCondition | airbyte_agent_sdk.connectors.typeform.types.ThemesLtCondition | airbyte_agent_sdk.connectors.typeform.types.ThemesLteCondition | airbyte_agent_sdk.connectors.typeform.types.ThemesInCondition | airbyte_agent_sdk.connectors.typeform.types.ThemesLikeCondition | airbyte_agent_sdk.connectors.typeform.types.ThemesFuzzyCondition | airbyte_agent_sdk.connectors.typeform.types.ThemesKeywordCondition | airbyte_agent_sdk.connectors.typeform.types.ThemesContainsCondition | airbyte_agent_sdk.connectors.typeform.types.ThemesNotCondition | airbyte_agent_sdk.connectors.typeform.types.ThemesAndCondition | airbyte_agent_sdk.connectors.typeform.types.ThemesOrCondition | airbyte_agent_sdk.connectors.typeform.types.ThemesAnyCondition`
     :   The type of the None singleton.
 
+<a id="ThemesOrCondition"></a>
+
 `ThemesOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1775,6 +1947,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.typeform.types.ThemesEqCondition | airbyte_agent_sdk.connectors.typeform.types.ThemesNeqCondition | airbyte_agent_sdk.connectors.typeform.types.ThemesGtCondition | airbyte_agent_sdk.connectors.typeform.types.ThemesGteCondition | airbyte_agent_sdk.connectors.typeform.types.ThemesLtCondition | airbyte_agent_sdk.connectors.typeform.types.ThemesLteCondition | airbyte_agent_sdk.connectors.typeform.types.ThemesInCondition | airbyte_agent_sdk.connectors.typeform.types.ThemesLikeCondition | airbyte_agent_sdk.connectors.typeform.types.ThemesFuzzyCondition | airbyte_agent_sdk.connectors.typeform.types.ThemesKeywordCondition | airbyte_agent_sdk.connectors.typeform.types.ThemesContainsCondition | airbyte_agent_sdk.connectors.typeform.types.ThemesNotCondition | airbyte_agent_sdk.connectors.typeform.types.ThemesAndCondition | airbyte_agent_sdk.connectors.typeform.types.ThemesOrCondition | airbyte_agent_sdk.connectors.typeform.types.ThemesAnyCondition]`
     :   The type of the None singleton.
+
+<a id="ThemesSearchFilter"></a>
 
 `ThemesSearchFilter(*args, **kwargs)`
 :   Available fields for filtering themes search queries.
@@ -1821,6 +1995,8 @@ Classes
     `visibility: str | None`
     :   Visibility setting of the theme
 
+<a id="ThemesSearchQuery"></a>
+
 `ThemesSearchQuery(*args, **kwargs)`
 :   Search query for themes entity.
 
@@ -1835,6 +2011,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.typeform.types.ThemesSortFilter]`
     :   The type of the None singleton.
+
+<a id="ThemesSortFilter"></a>
 
 `ThemesSortFilter(*args, **kwargs)`
 :   Available fields for sorting themes search results.
@@ -1881,6 +2059,8 @@ Classes
     `visibility: Literal['asc', 'desc']`
     :   Visibility setting of the theme
 
+<a id="ThemesStringFilter"></a>
+
 `ThemesStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -1926,6 +2106,8 @@ Classes
     `visibility: str`
     :   Visibility setting of the theme
 
+<a id="WebhooksAndCondition"></a>
+
 `WebhooksAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1946,6 +2128,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.typeform.types.WebhooksEqCondition | airbyte_agent_sdk.connectors.typeform.types.WebhooksNeqCondition | airbyte_agent_sdk.connectors.typeform.types.WebhooksGtCondition | airbyte_agent_sdk.connectors.typeform.types.WebhooksGteCondition | airbyte_agent_sdk.connectors.typeform.types.WebhooksLtCondition | airbyte_agent_sdk.connectors.typeform.types.WebhooksLteCondition | airbyte_agent_sdk.connectors.typeform.types.WebhooksInCondition | airbyte_agent_sdk.connectors.typeform.types.WebhooksLikeCondition | airbyte_agent_sdk.connectors.typeform.types.WebhooksFuzzyCondition | airbyte_agent_sdk.connectors.typeform.types.WebhooksKeywordCondition | airbyte_agent_sdk.connectors.typeform.types.WebhooksContainsCondition | airbyte_agent_sdk.connectors.typeform.types.WebhooksNotCondition | airbyte_agent_sdk.connectors.typeform.types.WebhooksAndCondition | airbyte_agent_sdk.connectors.typeform.types.WebhooksOrCondition | airbyte_agent_sdk.connectors.typeform.types.WebhooksAnyCondition]`
     :   The type of the None singleton.
 
+<a id="WebhooksAnyCondition"></a>
+
 `WebhooksAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1965,6 +2149,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.typeform.types.WebhooksAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="WebhooksAnyValueFilter"></a>
 
 `WebhooksAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -1999,6 +2185,8 @@ Classes
     `verify_ssl: Any`
     :   Whether SSL verification is enforced
 
+<a id="WebhooksContainsCondition"></a>
+
 `WebhooksContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -2010,6 +2198,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.typeform.types.WebhooksAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="WebhooksEqCondition"></a>
 
 `WebhooksEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -2023,6 +2213,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.typeform.types.WebhooksSearchFilter`
     :   The type of the None singleton.
 
+<a id="WebhooksFuzzyCondition"></a>
+
 `WebhooksFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -2034,6 +2226,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.typeform.types.WebhooksStringFilter`
     :   The type of the None singleton.
+
+<a id="WebhooksGtCondition"></a>
 
 `WebhooksGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
@@ -2047,6 +2241,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.typeform.types.WebhooksSearchFilter`
     :   The type of the None singleton.
 
+<a id="WebhooksGteCondition"></a>
+
 `WebhooksGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -2058,6 +2254,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.typeform.types.WebhooksSearchFilter`
     :   The type of the None singleton.
+
+<a id="WebhooksInCondition"></a>
 
 `WebhooksInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -2078,6 +2276,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.typeform.types.WebhooksInFilter`
     :   The type of the None singleton.
+
+<a id="WebhooksInFilter"></a>
 
 `WebhooksInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -2112,6 +2312,8 @@ Classes
     `verify_ssl: list[bool]`
     :   Whether SSL verification is enforced
 
+<a id="WebhooksKeywordCondition"></a>
+
 `WebhooksKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -2123,6 +2325,8 @@ Classes
 
     `keyword: airbyte_agent_sdk.connectors.typeform.types.WebhooksStringFilter`
     :   The type of the None singleton.
+
+<a id="WebhooksLikeCondition"></a>
 
 `WebhooksLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
@@ -2136,6 +2340,8 @@ Classes
     `like: airbyte_agent_sdk.connectors.typeform.types.WebhooksStringFilter`
     :   The type of the None singleton.
 
+<a id="WebhooksListParams"></a>
+
 `WebhooksListParams(*args, **kwargs)`
 :   Parameters for webhooks.list operation
 
@@ -2147,6 +2353,8 @@ Classes
 
     `form_id: str`
     :   The type of the None singleton.
+
+<a id="WebhooksLtCondition"></a>
 
 `WebhooksLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
@@ -2160,6 +2368,8 @@ Classes
     `lt: airbyte_agent_sdk.connectors.typeform.types.WebhooksSearchFilter`
     :   The type of the None singleton.
 
+<a id="WebhooksLteCondition"></a>
+
 `WebhooksLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
 
@@ -2172,6 +2382,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.typeform.types.WebhooksSearchFilter`
     :   The type of the None singleton.
 
+<a id="WebhooksNeqCondition"></a>
+
 `WebhooksNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -2183,6 +2395,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.typeform.types.WebhooksSearchFilter`
     :   The type of the None singleton.
+
+<a id="WebhooksNotCondition"></a>
 
 `WebhooksNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -2204,6 +2418,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.typeform.types.WebhooksEqCondition | airbyte_agent_sdk.connectors.typeform.types.WebhooksNeqCondition | airbyte_agent_sdk.connectors.typeform.types.WebhooksGtCondition | airbyte_agent_sdk.connectors.typeform.types.WebhooksGteCondition | airbyte_agent_sdk.connectors.typeform.types.WebhooksLtCondition | airbyte_agent_sdk.connectors.typeform.types.WebhooksLteCondition | airbyte_agent_sdk.connectors.typeform.types.WebhooksInCondition | airbyte_agent_sdk.connectors.typeform.types.WebhooksLikeCondition | airbyte_agent_sdk.connectors.typeform.types.WebhooksFuzzyCondition | airbyte_agent_sdk.connectors.typeform.types.WebhooksKeywordCondition | airbyte_agent_sdk.connectors.typeform.types.WebhooksContainsCondition | airbyte_agent_sdk.connectors.typeform.types.WebhooksNotCondition | airbyte_agent_sdk.connectors.typeform.types.WebhooksAndCondition | airbyte_agent_sdk.connectors.typeform.types.WebhooksOrCondition | airbyte_agent_sdk.connectors.typeform.types.WebhooksAnyCondition`
     :   The type of the None singleton.
 
+<a id="WebhooksOrCondition"></a>
+
 `WebhooksOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -2223,6 +2439,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.typeform.types.WebhooksEqCondition | airbyte_agent_sdk.connectors.typeform.types.WebhooksNeqCondition | airbyte_agent_sdk.connectors.typeform.types.WebhooksGtCondition | airbyte_agent_sdk.connectors.typeform.types.WebhooksGteCondition | airbyte_agent_sdk.connectors.typeform.types.WebhooksLtCondition | airbyte_agent_sdk.connectors.typeform.types.WebhooksLteCondition | airbyte_agent_sdk.connectors.typeform.types.WebhooksInCondition | airbyte_agent_sdk.connectors.typeform.types.WebhooksLikeCondition | airbyte_agent_sdk.connectors.typeform.types.WebhooksFuzzyCondition | airbyte_agent_sdk.connectors.typeform.types.WebhooksKeywordCondition | airbyte_agent_sdk.connectors.typeform.types.WebhooksContainsCondition | airbyte_agent_sdk.connectors.typeform.types.WebhooksNotCondition | airbyte_agent_sdk.connectors.typeform.types.WebhooksAndCondition | airbyte_agent_sdk.connectors.typeform.types.WebhooksOrCondition | airbyte_agent_sdk.connectors.typeform.types.WebhooksAnyCondition]`
     :   The type of the None singleton.
+
+<a id="WebhooksSearchFilter"></a>
 
 `WebhooksSearchFilter(*args, **kwargs)`
 :   Available fields for filtering webhooks search queries.
@@ -2257,6 +2475,8 @@ Classes
     `verify_ssl: bool | None`
     :   Whether SSL verification is enforced
 
+<a id="WebhooksSearchQuery"></a>
+
 `WebhooksSearchQuery(*args, **kwargs)`
 :   Search query for webhooks entity.
 
@@ -2271,6 +2491,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.typeform.types.WebhooksSortFilter]`
     :   The type of the None singleton.
+
+<a id="WebhooksSortFilter"></a>
 
 `WebhooksSortFilter(*args, **kwargs)`
 :   Available fields for sorting webhooks search results.
@@ -2305,6 +2527,8 @@ Classes
     `verify_ssl: Literal['asc', 'desc']`
     :   Whether SSL verification is enforced
 
+<a id="WebhooksStringFilter"></a>
+
 `WebhooksStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -2338,6 +2562,8 @@ Classes
     `verify_ssl: str`
     :   Whether SSL verification is enforced
 
+<a id="WorkspacesAndCondition"></a>
+
 `WorkspacesAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -2358,6 +2584,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.typeform.types.WorkspacesEqCondition | airbyte_agent_sdk.connectors.typeform.types.WorkspacesNeqCondition | airbyte_agent_sdk.connectors.typeform.types.WorkspacesGtCondition | airbyte_agent_sdk.connectors.typeform.types.WorkspacesGteCondition | airbyte_agent_sdk.connectors.typeform.types.WorkspacesLtCondition | airbyte_agent_sdk.connectors.typeform.types.WorkspacesLteCondition | airbyte_agent_sdk.connectors.typeform.types.WorkspacesInCondition | airbyte_agent_sdk.connectors.typeform.types.WorkspacesLikeCondition | airbyte_agent_sdk.connectors.typeform.types.WorkspacesFuzzyCondition | airbyte_agent_sdk.connectors.typeform.types.WorkspacesKeywordCondition | airbyte_agent_sdk.connectors.typeform.types.WorkspacesContainsCondition | airbyte_agent_sdk.connectors.typeform.types.WorkspacesNotCondition | airbyte_agent_sdk.connectors.typeform.types.WorkspacesAndCondition | airbyte_agent_sdk.connectors.typeform.types.WorkspacesOrCondition | airbyte_agent_sdk.connectors.typeform.types.WorkspacesAnyCondition]`
     :   The type of the None singleton.
 
+<a id="WorkspacesAnyCondition"></a>
+
 `WorkspacesAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -2377,6 +2605,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.typeform.types.WorkspacesAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="WorkspacesAnyValueFilter"></a>
 
 `WorkspacesAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -2408,6 +2638,8 @@ Classes
     `shared: Any`
     :   Whether this workspace is shared
 
+<a id="WorkspacesContainsCondition"></a>
+
 `WorkspacesContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -2419,6 +2651,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.typeform.types.WorkspacesAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="WorkspacesEqCondition"></a>
 
 `WorkspacesEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -2432,6 +2666,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.typeform.types.WorkspacesSearchFilter`
     :   The type of the None singleton.
 
+<a id="WorkspacesFuzzyCondition"></a>
+
 `WorkspacesFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -2443,6 +2679,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.typeform.types.WorkspacesStringFilter`
     :   The type of the None singleton.
+
+<a id="WorkspacesGtCondition"></a>
 
 `WorkspacesGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
@@ -2456,6 +2694,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.typeform.types.WorkspacesSearchFilter`
     :   The type of the None singleton.
 
+<a id="WorkspacesGteCondition"></a>
+
 `WorkspacesGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -2467,6 +2707,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.typeform.types.WorkspacesSearchFilter`
     :   The type of the None singleton.
+
+<a id="WorkspacesInCondition"></a>
 
 `WorkspacesInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -2487,6 +2729,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.typeform.types.WorkspacesInFilter`
     :   The type of the None singleton.
+
+<a id="WorkspacesInFilter"></a>
 
 `WorkspacesInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -2518,6 +2762,8 @@ Classes
     `shared: list[bool]`
     :   Whether this workspace is shared
 
+<a id="WorkspacesKeywordCondition"></a>
+
 `WorkspacesKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -2530,6 +2776,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.typeform.types.WorkspacesStringFilter`
     :   The type of the None singleton.
 
+<a id="WorkspacesLikeCondition"></a>
+
 `WorkspacesLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -2541,6 +2789,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.typeform.types.WorkspacesStringFilter`
     :   The type of the None singleton.
+
+<a id="WorkspacesListParams"></a>
 
 `WorkspacesListParams(*args, **kwargs)`
 :   Parameters for workspaces.list operation
@@ -2557,6 +2807,8 @@ Classes
     `page_size: int`
     :   The type of the None singleton.
 
+<a id="WorkspacesLtCondition"></a>
+
 `WorkspacesLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -2568,6 +2820,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.typeform.types.WorkspacesSearchFilter`
     :   The type of the None singleton.
+
+<a id="WorkspacesLteCondition"></a>
 
 `WorkspacesLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -2581,6 +2835,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.typeform.types.WorkspacesSearchFilter`
     :   The type of the None singleton.
 
+<a id="WorkspacesNeqCondition"></a>
+
 `WorkspacesNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -2592,6 +2848,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.typeform.types.WorkspacesSearchFilter`
     :   The type of the None singleton.
+
+<a id="WorkspacesNotCondition"></a>
 
 `WorkspacesNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -2613,6 +2871,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.typeform.types.WorkspacesEqCondition | airbyte_agent_sdk.connectors.typeform.types.WorkspacesNeqCondition | airbyte_agent_sdk.connectors.typeform.types.WorkspacesGtCondition | airbyte_agent_sdk.connectors.typeform.types.WorkspacesGteCondition | airbyte_agent_sdk.connectors.typeform.types.WorkspacesLtCondition | airbyte_agent_sdk.connectors.typeform.types.WorkspacesLteCondition | airbyte_agent_sdk.connectors.typeform.types.WorkspacesInCondition | airbyte_agent_sdk.connectors.typeform.types.WorkspacesLikeCondition | airbyte_agent_sdk.connectors.typeform.types.WorkspacesFuzzyCondition | airbyte_agent_sdk.connectors.typeform.types.WorkspacesKeywordCondition | airbyte_agent_sdk.connectors.typeform.types.WorkspacesContainsCondition | airbyte_agent_sdk.connectors.typeform.types.WorkspacesNotCondition | airbyte_agent_sdk.connectors.typeform.types.WorkspacesAndCondition | airbyte_agent_sdk.connectors.typeform.types.WorkspacesOrCondition | airbyte_agent_sdk.connectors.typeform.types.WorkspacesAnyCondition`
     :   The type of the None singleton.
 
+<a id="WorkspacesOrCondition"></a>
+
 `WorkspacesOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -2632,6 +2892,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.typeform.types.WorkspacesEqCondition | airbyte_agent_sdk.connectors.typeform.types.WorkspacesNeqCondition | airbyte_agent_sdk.connectors.typeform.types.WorkspacesGtCondition | airbyte_agent_sdk.connectors.typeform.types.WorkspacesGteCondition | airbyte_agent_sdk.connectors.typeform.types.WorkspacesLtCondition | airbyte_agent_sdk.connectors.typeform.types.WorkspacesLteCondition | airbyte_agent_sdk.connectors.typeform.types.WorkspacesInCondition | airbyte_agent_sdk.connectors.typeform.types.WorkspacesLikeCondition | airbyte_agent_sdk.connectors.typeform.types.WorkspacesFuzzyCondition | airbyte_agent_sdk.connectors.typeform.types.WorkspacesKeywordCondition | airbyte_agent_sdk.connectors.typeform.types.WorkspacesContainsCondition | airbyte_agent_sdk.connectors.typeform.types.WorkspacesNotCondition | airbyte_agent_sdk.connectors.typeform.types.WorkspacesAndCondition | airbyte_agent_sdk.connectors.typeform.types.WorkspacesOrCondition | airbyte_agent_sdk.connectors.typeform.types.WorkspacesAnyCondition]`
     :   The type of the None singleton.
+
+<a id="WorkspacesSearchFilter"></a>
 
 `WorkspacesSearchFilter(*args, **kwargs)`
 :   Available fields for filtering workspaces search queries.
@@ -2663,6 +2925,8 @@ Classes
     `shared: bool | None`
     :   Whether this workspace is shared
 
+<a id="WorkspacesSearchQuery"></a>
+
 `WorkspacesSearchQuery(*args, **kwargs)`
 :   Search query for workspaces entity.
 
@@ -2677,6 +2941,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.typeform.types.WorkspacesSortFilter]`
     :   The type of the None singleton.
+
+<a id="WorkspacesSortFilter"></a>
 
 `WorkspacesSortFilter(*args, **kwargs)`
 :   Available fields for sorting workspaces search results.
@@ -2707,6 +2973,8 @@ Classes
 
     `shared: Literal['asc', 'desc']`
     :   Whether this workspace is shared
+
+<a id="WorkspacesStringFilter"></a>
 
 `WorkspacesStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/woocommerce/connector.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/woocommerce/connector.md
@@ -10,6 +10,8 @@ Woocommerce connector.
 Classes
 -------
 
+<a id="CouponsQuery"></a>
+
 `CouponsQuery(connector: WoocommerceConnector)`
 :   Query class for Coupons entity operations.
     
@@ -95,6 +97,8 @@ Classes
         Returns:
             CouponsListResult
 
+<a id="CustomersQuery"></a>
+
 `CustomersQuery(connector: WoocommerceConnector)`
 :   Query class for Customers entity operations.
     
@@ -165,6 +169,8 @@ Classes
         Returns:
             CustomersListResult
 
+<a id="OrderNotesQuery"></a>
+
 `OrderNotesQuery(connector: WoocommerceConnector)`
 :   Query class for OrderNotes entity operations.
     
@@ -220,6 +226,8 @@ Classes
         
         Returns:
             OrderNotesListResult
+
+<a id="OrdersQuery"></a>
 
 `OrdersQuery(connector: WoocommerceConnector)`
 :   Query class for Orders entity operations.
@@ -322,6 +330,8 @@ Classes
         Returns:
             OrdersListResult
 
+<a id="PaymentGatewaysQuery"></a>
+
 `PaymentGatewaysQuery(connector: WoocommerceConnector)`
 :   Query class for PaymentGateways entity operations.
     
@@ -375,6 +385,8 @@ Classes
         
         Returns:
             PaymentGatewaysListResult
+
+<a id="ProductAttributesQuery"></a>
 
 `ProductAttributesQuery(connector: WoocommerceConnector)`
 :   Query class for ProductAttributes entity operations.
@@ -431,6 +443,8 @@ Classes
         
         Returns:
             ProductAttributesListResult
+
+<a id="ProductCategoriesQuery"></a>
 
 `ProductCategoriesQuery(connector: WoocommerceConnector)`
 :   Query class for ProductCategories entity operations.
@@ -498,6 +512,8 @@ Classes
         Returns:
             ProductCategoriesListResult
 
+<a id="ProductReviewsQuery"></a>
+
 `ProductReviewsQuery(connector: WoocommerceConnector)`
 :   Query class for ProductReviews entity operations.
     
@@ -563,6 +579,8 @@ Classes
         Returns:
             ProductReviewsListResult
 
+<a id="ProductTagsQuery"></a>
+
 `ProductTagsQuery(connector: WoocommerceConnector)`
 :   Query class for ProductTags entity operations.
     
@@ -623,6 +641,8 @@ Classes
         
         Returns:
             ProductTagsListResult
+
+<a id="ProductVariationsQuery"></a>
 
 `ProductVariationsQuery(connector: WoocommerceConnector)`
 :   Query class for ProductVariations entity operations.
@@ -723,6 +743,8 @@ Classes
         
         Returns:
             ProductVariationsListResult
+
+<a id="ProductsQuery"></a>
 
 `ProductsQuery(connector: WoocommerceConnector)`
 :   Query class for Products entity operations.
@@ -855,6 +877,8 @@ Classes
         Returns:
             ProductsListResult
 
+<a id="RefundsQuery"></a>
+
 `RefundsQuery(connector: WoocommerceConnector)`
 :   Query class for Refunds entity operations.
     
@@ -916,6 +940,8 @@ Classes
         Returns:
             RefundsListResult
 
+<a id="ShippingMethodsQuery"></a>
+
 `ShippingMethodsQuery(connector: WoocommerceConnector)`
 :   Query class for ShippingMethods entity operations.
     
@@ -963,6 +989,8 @@ Classes
         
         Returns:
             ShippingMethodsListResult
+
+<a id="ShippingZonesQuery"></a>
 
 `ShippingZonesQuery(connector: WoocommerceConnector)`
 :   Query class for ShippingZones entity operations.
@@ -1012,6 +1040,8 @@ Classes
         Returns:
             ShippingZonesListResult
 
+<a id="TaxClassesQuery"></a>
+
 `TaxClassesQuery(connector: WoocommerceConnector)`
 :   Query class for TaxClasses entity operations.
     
@@ -1048,6 +1078,8 @@ Classes
         
         Returns:
             TaxClassesListResult
+
+<a id="TaxRatesQuery"></a>
 
 `TaxRatesQuery(connector: WoocommerceConnector)`
 :   Query class for TaxRates entity operations.
@@ -1115,6 +1147,8 @@ Classes
         
         Returns:
             TaxRatesListResult
+
+<a id="WoocommerceConnector"></a>
 
 `WoocommerceConnector(auth_config: WoocommerceAuthConfig | AirbyteAuthConfig | BaseModel | None = None, on_token_refresh: Any | None = None, shop: str | None = None)`
 :   Type-safe Woocommerce API connector.

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/woocommerce/index.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/woocommerce/index.md
@@ -19,6 +19,8 @@ Sub-modules
 Classes
 -------
 
+<a id="AirbyteAuthConfig"></a>
+
 `AirbyteAuthConfig(**data: Any)`
 :   Authentication configuration for Airbyte hosted mode execution.
     
@@ -87,6 +89,8 @@ Classes
     `workspace_name: str | None`
     :   The type of the None singleton.
 
+<a id="AirbyteSearchMeta"></a>
+
 `AirbyteSearchMeta(**data: Any)`
 :   Pagination metadata for search responses.
     
@@ -114,6 +118,8 @@ Classes
 
     `took_ms: int | None`
     :   Time taken to execute the search in milliseconds.
+
+<a id="AirbyteSearchResult"></a>
 
 `AirbyteSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -160,6 +166,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="CouponsSearchResult"></a>
+
 `CouponsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -175,6 +183,8 @@ Classes
     * airbyte_agent_sdk.connectors.woocommerce.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="CustomersSearchResult"></a>
 
 `CustomersSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -192,6 +202,8 @@ Classes
     * pydantic.main.BaseModel
     * typing.Generic
 
+<a id="OrderNotesSearchResult"></a>
+
 `OrderNotesSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -207,6 +219,8 @@ Classes
     * airbyte_agent_sdk.connectors.woocommerce.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="OrdersSearchResult"></a>
 
 `OrdersSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -224,6 +238,8 @@ Classes
     * pydantic.main.BaseModel
     * typing.Generic
 
+<a id="PaymentGatewaysSearchResult"></a>
+
 `PaymentGatewaysSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -239,6 +255,8 @@ Classes
     * airbyte_agent_sdk.connectors.woocommerce.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="ProductAttributesSearchResult"></a>
 
 `ProductAttributesSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -256,6 +274,8 @@ Classes
     * pydantic.main.BaseModel
     * typing.Generic
 
+<a id="ProductCategoriesSearchResult"></a>
+
 `ProductCategoriesSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -271,6 +291,8 @@ Classes
     * airbyte_agent_sdk.connectors.woocommerce.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="ProductReviewsSearchResult"></a>
 
 `ProductReviewsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -288,6 +310,8 @@ Classes
     * pydantic.main.BaseModel
     * typing.Generic
 
+<a id="ProductTagsSearchResult"></a>
+
 `ProductTagsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -303,6 +327,8 @@ Classes
     * airbyte_agent_sdk.connectors.woocommerce.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="ProductVariationsSearchResult"></a>
 
 `ProductVariationsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -320,6 +346,8 @@ Classes
     * pydantic.main.BaseModel
     * typing.Generic
 
+<a id="ProductsSearchResult"></a>
+
 `ProductsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -335,6 +363,8 @@ Classes
     * airbyte_agent_sdk.connectors.woocommerce.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="RefundsSearchResult"></a>
 
 `RefundsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -352,6 +382,8 @@ Classes
     * pydantic.main.BaseModel
     * typing.Generic
 
+<a id="ShippingMethodsSearchResult"></a>
+
 `ShippingMethodsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -367,6 +399,8 @@ Classes
     * airbyte_agent_sdk.connectors.woocommerce.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="ShippingZonesSearchResult"></a>
 
 `ShippingZonesSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -384,6 +418,8 @@ Classes
     * pydantic.main.BaseModel
     * typing.Generic
 
+<a id="TaxClassesSearchResult"></a>
+
 `TaxClassesSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -400,6 +436,8 @@ Classes
     * pydantic.main.BaseModel
     * typing.Generic
 
+<a id="TaxRatesSearchResult"></a>
+
 `TaxRatesSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -415,6 +453,8 @@ Classes
     * airbyte_agent_sdk.connectors.woocommerce.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="CouponsSearchData"></a>
 
 `CouponsSearchData(**data: Any)`
 :   Search result data for coupons entity.
@@ -516,6 +556,8 @@ Classes
     `used_by: list[typing.Any] | None`
     :   Users who have used the coupon
 
+<a id="CustomersSearchData"></a>
+
 `CustomersSearchData(**data: Any)`
 :   Search result data for customers entity.
     
@@ -580,6 +622,8 @@ Classes
     `username: str | None`
     :   Customer login name
 
+<a id="OrderNotesSearchData"></a>
+
 `OrderNotesSearchData(**data: Any)`
 :   Search result data for order_notes entity.
     
@@ -613,6 +657,8 @@ Classes
 
     `note: str | None`
     :   Order note content
+
+<a id="OrdersSearchData"></a>
 
 `OrdersSearchData(**data: Any)`
 :   Search result data for orders entity.
@@ -756,6 +802,8 @@ Classes
     `version: str | None`
     :   Version of WooCommerce which last updated the order
 
+<a id="PaymentGatewaysSearchData"></a>
+
 `PaymentGatewaysSearchData(**data: Any)`
 :   Search result data for payment_gateways entity.
     
@@ -802,6 +850,8 @@ Classes
     `title: str | None`
     :   Payment gateway title on checkout
 
+<a id="ProductAttributesSearchData"></a>
+
 `ProductAttributesSearchData(**data: Any)`
 :   Search result data for product_attributes entity.
     
@@ -838,6 +888,8 @@ Classes
 
     `type_: str | None`
     :   Type of attribute
+
+<a id="ProductCategoriesSearchData"></a>
 
 `ProductCategoriesSearchData(**data: Any)`
 :   Search result data for product_categories entity.
@@ -884,6 +936,8 @@ Classes
 
     `slug: str | None`
     :   An alphanumeric identifier
+
+<a id="ProductReviewsSearchData"></a>
 
 `ProductReviewsSearchData(**data: Any)`
 :   Search result data for product_reviews entity.
@@ -934,6 +988,8 @@ Classes
     `verified: bool | None`
     :   Shows if the reviewer bought the product
 
+<a id="ProductTagsSearchData"></a>
+
 `ProductTagsSearchData(**data: Any)`
 :   Search result data for product_tags entity.
     
@@ -967,6 +1023,8 @@ Classes
 
     `slug: str | None`
     :   Alphanumeric identifier
+
+<a id="ProductVariationsSearchData"></a>
 
 `ProductVariationsSearchData(**data: Any)`
 :   Search result data for product_variations entity.
@@ -1103,6 +1161,8 @@ Classes
 
     `weight: str | None`
     :   Variation weight
+
+<a id="ProductsSearchData"></a>
 
 `ProductsSearchData(**data: Any)`
 :   Search result data for products entity.
@@ -1315,6 +1375,8 @@ Classes
     `weight: str | None`
     :   Product weight
 
+<a id="RefundsSearchData"></a>
+
 `RefundsSearchData(**data: Any)`
 :   Search result data for refunds entity.
     
@@ -1361,6 +1423,8 @@ Classes
     `refunded_payment: bool | None`
     :   If the payment was refunded via the API
 
+<a id="ShippingMethodsSearchData"></a>
+
 `ShippingMethodsSearchData(**data: Any)`
 :   Search result data for shipping_methods entity.
     
@@ -1388,6 +1452,8 @@ Classes
 
     `title: str | None`
     :   Shipping method title
+
+<a id="ShippingZonesSearchData"></a>
 
 `ShippingZonesSearchData(**data: Any)`
 :   Search result data for shipping_zones entity.
@@ -1417,6 +1483,8 @@ Classes
     `order: int | None`
     :   Shipping zone order
 
+<a id="TaxClassesSearchData"></a>
+
 `TaxClassesSearchData(**data: Any)`
 :   Search result data for tax_classes entity.
     
@@ -1441,6 +1509,8 @@ Classes
 
     `slug: str | None`
     :   Unique identifier
+
+<a id="TaxRatesSearchData"></a>
 
 `TaxRatesSearchData(**data: Any)`
 :   Search result data for tax_rates entity.
@@ -1503,6 +1573,8 @@ Classes
     `state: str | None`
     :   State code
 
+<a id="WoocommerceAuthConfig"></a>
+
 `WoocommerceAuthConfig(**data: Any)`
 :   WooCommerce API Key Authentication
     
@@ -1527,6 +1599,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="WoocommerceConnector"></a>
 
 `WoocommerceConnector(auth_config: WoocommerceAuthConfig | AirbyteAuthConfig | BaseModel | None = None, on_token_refresh: Any | None = None, shop: str | None = None)`
 :   Type-safe Woocommerce API connector.
@@ -1727,6 +1801,8 @@ Classes
             entities = connector.list_entities()
             for entity in entities:
                 print(f"\{entity['entity_name']\}: \{entity['available_actions']\}")
+
+<a id="WoocommerceReplicationConfig"></a>
 
 `WoocommerceReplicationConfig(**data: Any)`
 :   Replication Configuration - Settings for data replication from WooCommerce.

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/woocommerce/models.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/woocommerce/models.md
@@ -13,6 +13,8 @@ and response envelope types.
 Classes
 -------
 
+<a id="AirbyteSearchMeta"></a>
+
 `AirbyteSearchMeta(**data: Any)`
 :   Pagination metadata for search responses.
     
@@ -40,6 +42,8 @@ Classes
 
     `took_ms: int | None`
     :   Time taken to execute the search in milliseconds.
+
+<a id="AirbyteSearchResult"></a>
 
 `AirbyteSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -107,6 +111,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="CouponsSearchResult"></a>
+
 `CouponsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -143,6 +149,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="CustomersSearchResult"></a>
 
 `CustomersSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -181,6 +189,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="OrderNotesSearchResult"></a>
+
 `OrderNotesSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -217,6 +227,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="OrdersSearchResult"></a>
 
 `OrdersSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -255,6 +267,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="PaymentGatewaysSearchResult"></a>
+
 `PaymentGatewaysSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -291,6 +305,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="ProductAttributesSearchResult"></a>
 
 `ProductAttributesSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -329,6 +345,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="ProductCategoriesSearchResult"></a>
+
 `ProductCategoriesSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -365,6 +383,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="ProductReviewsSearchResult"></a>
 
 `ProductReviewsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -403,6 +423,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="ProductTagsSearchResult"></a>
+
 `ProductTagsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -439,6 +461,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="ProductVariationsSearchResult"></a>
 
 `ProductVariationsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -477,6 +501,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="ProductsSearchResult"></a>
+
 `ProductsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -513,6 +539,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="RefundsSearchResult"></a>
 
 `RefundsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -551,6 +579,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="ShippingMethodsSearchResult"></a>
+
 `ShippingMethodsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -587,6 +617,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="ShippingZonesSearchResult"></a>
 
 `ShippingZonesSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -625,6 +657,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="TaxClassesSearchResult"></a>
+
 `TaxClassesSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -662,6 +696,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="TaxRatesSearchResult"></a>
+
 `TaxRatesSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -677,6 +713,8 @@ Classes
     * airbyte_agent_sdk.connectors.woocommerce.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="Coupon"></a>
 
 `Coupon(**data: Any)`
 :   Coupon type definition
@@ -781,6 +819,8 @@ Classes
     `used_by: list[str | None] | Any | None`
     :   The type of the None singleton.
 
+<a id="CouponMetaDataItem"></a>
+
 `CouponMetaDataItem(**data: Any)`
 :   Nested schema for Coupon.meta_data_item
     
@@ -809,6 +849,8 @@ Classes
     `value: Any`
     :   The type of the None singleton.
 
+<a id="CouponsListResultMeta"></a>
+
 `CouponsListResultMeta(**data: Any)`
 :   Metadata for coupons.Action.LIST operation
     
@@ -830,6 +872,8 @@ Classes
 
     `next: str | Any | None`
     :   The type of the None singleton.
+
+<a id="CouponsSearchData"></a>
 
 `CouponsSearchData(**data: Any)`
 :   Search result data for coupons entity.
@@ -931,6 +975,8 @@ Classes
     `used_by: list[typing.Any] | None`
     :   Users who have used the coupon
 
+<a id="Customer"></a>
+
 `Customer(**data: Any)`
 :   Customer type definition
     
@@ -995,6 +1041,8 @@ Classes
     `username: str | Any | None`
     :   The type of the None singleton.
 
+<a id="CustomerBilling"></a>
+
 `CustomerBilling(**data: Any)`
 :   List of billing address data
     
@@ -1047,6 +1095,8 @@ Classes
     `state: str | Any | None`
     :   The type of the None singleton.
 
+<a id="CustomerMetaDataItem"></a>
+
 `CustomerMetaDataItem(**data: Any)`
 :   Nested schema for Customer.meta_data_item
     
@@ -1074,6 +1124,8 @@ Classes
 
     `value: str | Any | None`
     :   The type of the None singleton.
+
+<a id="CustomerShipping"></a>
 
 `CustomerShipping(**data: Any)`
 :   List of shipping address data
@@ -1121,6 +1173,8 @@ Classes
     `state: str | Any | None`
     :   The type of the None singleton.
 
+<a id="CustomersListResultMeta"></a>
+
 `CustomersListResultMeta(**data: Any)`
 :   Metadata for customers.Action.LIST operation
     
@@ -1142,6 +1196,8 @@ Classes
 
     `next: str | Any | None`
     :   The type of the None singleton.
+
+<a id="CustomersSearchData"></a>
 
 `CustomersSearchData(**data: Any)`
 :   Search result data for customers entity.
@@ -1206,6 +1262,8 @@ Classes
 
     `username: str | None`
     :   Customer login name
+
+<a id="Order"></a>
 
 `Order(**data: Any)`
 :   Order type definition
@@ -1364,6 +1422,8 @@ Classes
     `version: str | Any | None`
     :   The type of the None singleton.
 
+<a id="OrderBilling"></a>
+
 `OrderBilling(**data: Any)`
 :   Billing address
     
@@ -1416,6 +1476,8 @@ Classes
     `state: str | Any | None`
     :   The type of the None singleton.
 
+<a id="OrderCouponLinesItem"></a>
+
 `OrderCouponLinesItem(**data: Any)`
 :   Nested schema for Order.coupon_lines_item
     
@@ -1450,6 +1512,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="OrderCouponLinesItemMetaDataItem"></a>
+
 `OrderCouponLinesItemMetaDataItem(**data: Any)`
 :   Nested schema for OrderCouponLinesItem.meta_data_item
     
@@ -1477,6 +1541,8 @@ Classes
 
     `value: Any`
     :   The type of the None singleton.
+
+<a id="OrderFeeLinesItem"></a>
 
 `OrderFeeLinesItem(**data: Any)`
 :   Nested schema for Order.fee_lines_item
@@ -1521,6 +1587,8 @@ Classes
     `total_tax: str | Any | None`
     :   The type of the None singleton.
 
+<a id="OrderFeeLinesItemMetaDataItem"></a>
+
 `OrderFeeLinesItemMetaDataItem(**data: Any)`
 :   Nested schema for OrderFeeLinesItem.meta_data_item
     
@@ -1549,6 +1617,8 @@ Classes
     `value: Any`
     :   The type of the None singleton.
 
+<a id="OrderFeeLinesItemTaxesItem"></a>
+
 `OrderFeeLinesItemTaxesItem(**data: Any)`
 :   Nested schema for OrderFeeLinesItem.taxes_item
     
@@ -1576,6 +1646,8 @@ Classes
 
     `total: str | Any | None`
     :   The type of the None singleton.
+
+<a id="OrderLineItemsItem"></a>
 
 `OrderLineItemsItem(**data: Any)`
 :   Nested schema for Order.line_items_item
@@ -1644,6 +1716,8 @@ Classes
     `variation_id: int | Any | None`
     :   The type of the None singleton.
 
+<a id="OrderLineItemsItemImage"></a>
+
 `OrderLineItemsItemImage(**data: Any)`
 :   Nested schema for OrderLineItemsItem.image
     
@@ -1668,6 +1742,8 @@ Classes
 
     `src: str | Any | None`
     :   The type of the None singleton.
+
+<a id="OrderLineItemsItemMetaDataItem"></a>
 
 `OrderLineItemsItemMetaDataItem(**data: Any)`
 :   Nested schema for OrderLineItemsItem.meta_data_item
@@ -1703,6 +1779,8 @@ Classes
     `value: Any`
     :   The type of the None singleton.
 
+<a id="OrderLineItemsItemTaxesItem"></a>
+
 `OrderLineItemsItemTaxesItem(**data: Any)`
 :   Nested schema for OrderLineItemsItem.taxes_item
     
@@ -1731,6 +1809,8 @@ Classes
     `total: str | Any | None`
     :   The type of the None singleton.
 
+<a id="OrderMetaDataItem"></a>
+
 `OrderMetaDataItem(**data: Any)`
 :   Nested schema for Order.meta_data_item
     
@@ -1758,6 +1838,8 @@ Classes
 
     `value: Any`
     :   The type of the None singleton.
+
+<a id="OrderNote"></a>
 
 `OrderNote(**data: Any)`
 :   OrderNote type definition
@@ -1796,6 +1878,8 @@ Classes
     `note: str | Any | None`
     :   The type of the None singleton.
 
+<a id="OrderNotesListResultMeta"></a>
+
 `OrderNotesListResultMeta(**data: Any)`
 :   Metadata for order_notes.Action.LIST operation
     
@@ -1817,6 +1901,8 @@ Classes
 
     `next: str | Any | None`
     :   The type of the None singleton.
+
+<a id="OrderNotesSearchData"></a>
 
 `OrderNotesSearchData(**data: Any)`
 :   Search result data for order_notes entity.
@@ -1852,6 +1938,8 @@ Classes
     `note: str | None`
     :   Order note content
 
+<a id="OrderRefundsItem"></a>
+
 `OrderRefundsItem(**data: Any)`
 :   Nested schema for Order.refunds_item
     
@@ -1879,6 +1967,8 @@ Classes
 
     `total: str | Any | None`
     :   The type of the None singleton.
+
+<a id="OrderShipping"></a>
 
 `OrderShipping(**data: Any)`
 :   Shipping address
@@ -1926,6 +2016,8 @@ Classes
     `state: str | Any | None`
     :   The type of the None singleton.
 
+<a id="OrderShippingLinesItem"></a>
+
 `OrderShippingLinesItem(**data: Any)`
 :   Nested schema for Order.shipping_lines_item
     
@@ -1966,6 +2058,8 @@ Classes
     `total_tax: str | Any | None`
     :   The type of the None singleton.
 
+<a id="OrderShippingLinesItemMetaDataItem"></a>
+
 `OrderShippingLinesItemMetaDataItem(**data: Any)`
 :   Nested schema for OrderShippingLinesItem.meta_data_item
     
@@ -1994,6 +2088,8 @@ Classes
     `value: Any`
     :   The type of the None singleton.
 
+<a id="OrderShippingLinesItemTaxesItem"></a>
+
 `OrderShippingLinesItemTaxesItem(**data: Any)`
 :   Nested schema for OrderShippingLinesItem.taxes_item
     
@@ -2021,6 +2117,8 @@ Classes
 
     `total: str | Any | None`
     :   The type of the None singleton.
+
+<a id="OrderTaxLinesItem"></a>
 
 `OrderTaxLinesItem(**data: Any)`
 :   Nested schema for Order.tax_lines_item
@@ -2065,6 +2163,8 @@ Classes
     `tax_total: str | Any | None`
     :   The type of the None singleton.
 
+<a id="OrderTaxLinesItemMetaDataItem"></a>
+
 `OrderTaxLinesItemMetaDataItem(**data: Any)`
 :   Nested schema for OrderTaxLinesItem.meta_data_item
     
@@ -2093,6 +2193,8 @@ Classes
     `value: Any`
     :   The type of the None singleton.
 
+<a id="OrdersListResultMeta"></a>
+
 `OrdersListResultMeta(**data: Any)`
 :   Metadata for orders.Action.LIST operation
     
@@ -2114,6 +2216,8 @@ Classes
 
     `next: str | Any | None`
     :   The type of the None singleton.
+
+<a id="OrdersSearchData"></a>
 
 `OrdersSearchData(**data: Any)`
 :   Search result data for orders entity.
@@ -2257,6 +2361,8 @@ Classes
     `version: str | None`
     :   Version of WooCommerce which last updated the order
 
+<a id="PaymentGateway"></a>
+
 `PaymentGateway(**data: Any)`
 :   PaymentGateway type definition
     
@@ -2321,6 +2427,8 @@ Classes
     `title: str | Any | None`
     :   The type of the None singleton.
 
+<a id="PaymentGatewaysListResultMeta"></a>
+
 `PaymentGatewaysListResultMeta(**data: Any)`
 :   Metadata for payment_gateways.Action.LIST operation
     
@@ -2342,6 +2450,8 @@ Classes
 
     `next: str | Any | None`
     :   The type of the None singleton.
+
+<a id="PaymentGatewaysSearchData"></a>
 
 `PaymentGatewaysSearchData(**data: Any)`
 :   Search result data for payment_gateways entity.
@@ -2388,6 +2498,8 @@ Classes
 
     `title: str | None`
     :   Payment gateway title on checkout
+
+<a id="Product"></a>
 
 `Product(**data: Any)`
 :   Product type definition
@@ -2618,6 +2730,8 @@ Classes
     `weight: str | Any | None`
     :   The type of the None singleton.
 
+<a id="ProductAttribute"></a>
+
 `ProductAttribute(**data: Any)`
 :   ProductAttribute type definition
     
@@ -2654,6 +2768,8 @@ Classes
 
     `type_: str | Any | None`
     :   The type of the None singleton.
+
+<a id="ProductAttributesItem"></a>
 
 `ProductAttributesItem(**data: Any)`
 :   Nested schema for Product.attributes_item
@@ -2692,6 +2808,8 @@ Classes
     `visible: bool | Any | None`
     :   The type of the None singleton.
 
+<a id="ProductAttributesListResultMeta"></a>
+
 `ProductAttributesListResultMeta(**data: Any)`
 :   Metadata for product_attributes.Action.LIST operation
     
@@ -2713,6 +2831,8 @@ Classes
 
     `next: str | Any | None`
     :   The type of the None singleton.
+
+<a id="ProductAttributesSearchData"></a>
 
 `ProductAttributesSearchData(**data: Any)`
 :   Search result data for product_attributes entity.
@@ -2751,6 +2871,8 @@ Classes
     `type_: str | None`
     :   Type of attribute
 
+<a id="ProductCategoriesItem"></a>
+
 `ProductCategoriesItem(**data: Any)`
 :   Nested schema for Product.categories_item
     
@@ -2779,6 +2901,8 @@ Classes
     `slug: str | Any | None`
     :   The type of the None singleton.
 
+<a id="ProductCategoriesListResultMeta"></a>
+
 `ProductCategoriesListResultMeta(**data: Any)`
 :   Metadata for product_categories.Action.LIST operation
     
@@ -2800,6 +2924,8 @@ Classes
 
     `next: str | Any | None`
     :   The type of the None singleton.
+
+<a id="ProductCategoriesSearchData"></a>
 
 `ProductCategoriesSearchData(**data: Any)`
 :   Search result data for product_categories entity.
@@ -2847,6 +2973,8 @@ Classes
     `slug: str | None`
     :   An alphanumeric identifier
 
+<a id="ProductCategory"></a>
+
 `ProductCategory(**data: Any)`
 :   ProductCategory type definition
     
@@ -2893,6 +3021,8 @@ Classes
     `slug: str | Any | None`
     :   The type of the None singleton.
 
+<a id="ProductCategoryImage"></a>
+
 `ProductCategoryImage(**data: Any)`
 :   Image data
     
@@ -2936,6 +3066,8 @@ Classes
     `src: str | Any | None`
     :   The type of the None singleton.
 
+<a id="ProductDefaultAttributesItem"></a>
+
 `ProductDefaultAttributesItem(**data: Any)`
 :   Nested schema for Product.default_attributes_item
     
@@ -2963,6 +3095,8 @@ Classes
 
     `option: str | Any | None`
     :   The type of the None singleton.
+
+<a id="ProductDimensions"></a>
 
 `ProductDimensions(**data: Any)`
 :   Product dimensions
@@ -2992,6 +3126,8 @@ Classes
     `width: str | Any | None`
     :   The type of the None singleton.
 
+<a id="ProductDownloadsItem"></a>
+
 `ProductDownloadsItem(**data: Any)`
 :   Nested schema for Product.downloads_item
     
@@ -3019,6 +3155,8 @@ Classes
 
     `name: str | Any | None`
     :   The type of the None singleton.
+
+<a id="ProductImagesItem"></a>
 
 `ProductImagesItem(**data: Any)`
 :   Nested schema for Product.images_item
@@ -3063,6 +3201,8 @@ Classes
     `src: str | Any | None`
     :   The type of the None singleton.
 
+<a id="ProductMetaDataItem"></a>
+
 `ProductMetaDataItem(**data: Any)`
 :   Nested schema for Product.meta_data_item
     
@@ -3090,6 +3230,8 @@ Classes
 
     `value: Any`
     :   The type of the None singleton.
+
+<a id="ProductReview"></a>
 
 `ProductReview(**data: Any)`
 :   ProductReview type definition
@@ -3149,6 +3291,8 @@ Classes
     `verified: bool | Any | None`
     :   The type of the None singleton.
 
+<a id="ProductReviewsListResultMeta"></a>
+
 `ProductReviewsListResultMeta(**data: Any)`
 :   Metadata for product_reviews.Action.LIST operation
     
@@ -3170,6 +3314,8 @@ Classes
 
     `next: str | Any | None`
     :   The type of the None singleton.
+
+<a id="ProductReviewsSearchData"></a>
 
 `ProductReviewsSearchData(**data: Any)`
 :   Search result data for product_reviews entity.
@@ -3220,6 +3366,8 @@ Classes
     `verified: bool | None`
     :   Shows if the reviewer bought the product
 
+<a id="ProductTag"></a>
+
 `ProductTag(**data: Any)`
 :   ProductTag type definition
     
@@ -3254,6 +3402,8 @@ Classes
     `slug: str | Any | None`
     :   The type of the None singleton.
 
+<a id="ProductTagsItem"></a>
+
 `ProductTagsItem(**data: Any)`
 :   Nested schema for Product.tags_item
     
@@ -3282,6 +3432,8 @@ Classes
     `slug: str | Any | None`
     :   The type of the None singleton.
 
+<a id="ProductTagsListResultMeta"></a>
+
 `ProductTagsListResultMeta(**data: Any)`
 :   Metadata for product_tags.Action.LIST operation
     
@@ -3303,6 +3455,8 @@ Classes
 
     `next: str | Any | None`
     :   The type of the None singleton.
+
+<a id="ProductTagsSearchData"></a>
 
 `ProductTagsSearchData(**data: Any)`
 :   Search result data for product_tags entity.
@@ -3337,6 +3491,8 @@ Classes
 
     `slug: str | None`
     :   Alphanumeric identifier
+
+<a id="ProductVariation"></a>
 
 `ProductVariation(**data: Any)`
 :   ProductVariation type definition
@@ -3489,6 +3645,8 @@ Classes
     `weight: str | Any | None`
     :   The type of the None singleton.
 
+<a id="ProductVariationAttributesItem"></a>
+
 `ProductVariationAttributesItem(**data: Any)`
 :   Nested schema for ProductVariation.attributes_item
     
@@ -3516,6 +3674,8 @@ Classes
 
     `option: str | Any | None`
     :   The type of the None singleton.
+
+<a id="ProductVariationDimensions"></a>
 
 `ProductVariationDimensions(**data: Any)`
 :   Variation dimensions
@@ -3545,6 +3705,8 @@ Classes
     `width: str | Any | None`
     :   The type of the None singleton.
 
+<a id="ProductVariationDownloadsItem"></a>
+
 `ProductVariationDownloadsItem(**data: Any)`
 :   Nested schema for ProductVariation.downloads_item
     
@@ -3572,6 +3734,8 @@ Classes
 
     `name: str | Any | None`
     :   The type of the None singleton.
+
+<a id="ProductVariationImage"></a>
 
 `ProductVariationImage(**data: Any)`
 :   Variation image data
@@ -3616,6 +3780,8 @@ Classes
     `src: str | Any | None`
     :   The type of the None singleton.
 
+<a id="ProductVariationMetaDataItem"></a>
+
 `ProductVariationMetaDataItem(**data: Any)`
 :   Nested schema for ProductVariation.meta_data_item
     
@@ -3644,6 +3810,8 @@ Classes
     `value: Any`
     :   The type of the None singleton.
 
+<a id="ProductVariationsListResultMeta"></a>
+
 `ProductVariationsListResultMeta(**data: Any)`
 :   Metadata for product_variations.Action.LIST operation
     
@@ -3665,6 +3833,8 @@ Classes
 
     `next: str | Any | None`
     :   The type of the None singleton.
+
+<a id="ProductVariationsSearchData"></a>
 
 `ProductVariationsSearchData(**data: Any)`
 :   Search result data for product_variations entity.
@@ -3802,6 +3972,8 @@ Classes
     `weight: str | None`
     :   Variation weight
 
+<a id="ProductsListResultMeta"></a>
+
 `ProductsListResultMeta(**data: Any)`
 :   Metadata for products.Action.LIST operation
     
@@ -3823,6 +3995,8 @@ Classes
 
     `next: str | Any | None`
     :   The type of the None singleton.
+
+<a id="ProductsSearchData"></a>
 
 `ProductsSearchData(**data: Any)`
 :   Search result data for products entity.
@@ -4035,6 +4209,8 @@ Classes
     `weight: str | None`
     :   Product weight
 
+<a id="Refund"></a>
+
 `Refund(**data: Any)`
 :   Refund type definition
     
@@ -4090,6 +4266,8 @@ Classes
     `tax_lines: list[airbyte_agent_sdk.connectors.woocommerce.models.RefundTaxLinesItem] | Any | None`
     :   The type of the None singleton.
 
+<a id="RefundFeeLinesItem"></a>
+
 `RefundFeeLinesItem(**data: Any)`
 :   Nested schema for Refund.fee_lines_item
     
@@ -4126,6 +4304,8 @@ Classes
 
     `total_tax: str | Any | None`
     :   The type of the None singleton.
+
+<a id="RefundLineItemsItem"></a>
 
 `RefundLineItemsItem(**data: Any)`
 :   Nested schema for Refund.line_items_item
@@ -4188,6 +4368,8 @@ Classes
     `variation_id: int | Any | None`
     :   The type of the None singleton.
 
+<a id="RefundLineItemsItemMetaDataItem"></a>
+
 `RefundLineItemsItemMetaDataItem(**data: Any)`
 :   Nested schema for RefundLineItemsItem.meta_data_item
     
@@ -4215,6 +4397,8 @@ Classes
 
     `value: Any`
     :   The type of the None singleton.
+
+<a id="RefundLineItemsItemTaxesItem"></a>
 
 `RefundLineItemsItemTaxesItem(**data: Any)`
 :   Nested schema for RefundLineItemsItem.taxes_item
@@ -4244,6 +4428,8 @@ Classes
     `total: str | Any | None`
     :   The type of the None singleton.
 
+<a id="RefundMetaDataItem"></a>
+
 `RefundMetaDataItem(**data: Any)`
 :   Nested schema for Refund.meta_data_item
     
@@ -4271,6 +4457,8 @@ Classes
 
     `value: Any`
     :   The type of the None singleton.
+
+<a id="RefundShippingLinesItem"></a>
 
 `RefundShippingLinesItem(**data: Any)`
 :   Nested schema for Refund.shipping_lines_item
@@ -4305,6 +4493,8 @@ Classes
 
     `total_tax: str | Any | None`
     :   The type of the None singleton.
+
+<a id="RefundTaxLinesItem"></a>
 
 `RefundTaxLinesItem(**data: Any)`
 :   Nested schema for Refund.tax_lines_item
@@ -4346,6 +4536,8 @@ Classes
     `tax_total: str | Any | None`
     :   The type of the None singleton.
 
+<a id="RefundsListResultMeta"></a>
+
 `RefundsListResultMeta(**data: Any)`
 :   Metadata for refunds.Action.LIST operation
     
@@ -4367,6 +4559,8 @@ Classes
 
     `next: str | Any | None`
     :   The type of the None singleton.
+
+<a id="RefundsSearchData"></a>
 
 `RefundsSearchData(**data: Any)`
 :   Search result data for refunds entity.
@@ -4414,6 +4608,8 @@ Classes
     `refunded_payment: bool | None`
     :   If the payment was refunded via the API
 
+<a id="ShippingMethod"></a>
+
 `ShippingMethod(**data: Any)`
 :   ShippingMethod type definition
     
@@ -4442,6 +4638,8 @@ Classes
     `title: str | Any | None`
     :   The type of the None singleton.
 
+<a id="ShippingMethodsListResultMeta"></a>
+
 `ShippingMethodsListResultMeta(**data: Any)`
 :   Metadata for shipping_methods.Action.LIST operation
     
@@ -4463,6 +4661,8 @@ Classes
 
     `next: str | Any | None`
     :   The type of the None singleton.
+
+<a id="ShippingMethodsSearchData"></a>
 
 `ShippingMethodsSearchData(**data: Any)`
 :   Search result data for shipping_methods entity.
@@ -4492,6 +4692,8 @@ Classes
     `title: str | None`
     :   Shipping method title
 
+<a id="ShippingZone"></a>
+
 `ShippingZone(**data: Any)`
 :   ShippingZone type definition
     
@@ -4520,6 +4722,8 @@ Classes
     `order: int | Any | None`
     :   The type of the None singleton.
 
+<a id="ShippingZonesListResultMeta"></a>
+
 `ShippingZonesListResultMeta(**data: Any)`
 :   Metadata for shipping_zones.Action.LIST operation
     
@@ -4541,6 +4745,8 @@ Classes
 
     `next: str | Any | None`
     :   The type of the None singleton.
+
+<a id="ShippingZonesSearchData"></a>
 
 `ShippingZonesSearchData(**data: Any)`
 :   Search result data for shipping_zones entity.
@@ -4570,6 +4776,8 @@ Classes
     `order: int | None`
     :   Shipping zone order
 
+<a id="TaxClass"></a>
+
 `TaxClass(**data: Any)`
 :   TaxClass type definition
     
@@ -4595,6 +4803,8 @@ Classes
     `slug: str | Any | None`
     :   The type of the None singleton.
 
+<a id="TaxClassesListResultMeta"></a>
+
 `TaxClassesListResultMeta(**data: Any)`
 :   Metadata for tax_classes.Action.LIST operation
     
@@ -4616,6 +4826,8 @@ Classes
 
     `next: str | Any | None`
     :   The type of the None singleton.
+
+<a id="TaxClassesSearchData"></a>
 
 `TaxClassesSearchData(**data: Any)`
 :   Search result data for tax_classes entity.
@@ -4641,6 +4853,8 @@ Classes
 
     `slug: str | None`
     :   Unique identifier
+
+<a id="TaxRate"></a>
 
 `TaxRate(**data: Any)`
 :   TaxRate type definition
@@ -4703,6 +4917,8 @@ Classes
     `state: str | Any | None`
     :   The type of the None singleton.
 
+<a id="TaxRatesListResultMeta"></a>
+
 `TaxRatesListResultMeta(**data: Any)`
 :   Metadata for tax_rates.Action.LIST operation
     
@@ -4724,6 +4940,8 @@ Classes
 
     `next: str | Any | None`
     :   The type of the None singleton.
+
+<a id="TaxRatesSearchData"></a>
 
 `TaxRatesSearchData(**data: Any)`
 :   Search result data for tax_rates entity.
@@ -4786,6 +5004,8 @@ Classes
     `state: str | None`
     :   State code
 
+<a id="WoocommerceAuthConfig"></a>
+
 `WoocommerceAuthConfig(**data: Any)`
 :   WooCommerce API Key Authentication
     
@@ -4810,6 +5030,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="WoocommerceCheckResult"></a>
 
 `WoocommerceCheckResult(**data: Any)`
 :   Result of a health check operation.
@@ -4844,6 +5066,8 @@ Classes
     `status: str`
     :   Health check status: 'healthy' or 'unhealthy'.
 
+<a id="WoocommerceExecuteResult"></a>
+
 `WoocommerceExecuteResult(**data: Any)`
 :   Response envelope with data only.
     
@@ -4872,6 +5096,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="WoocommerceExecuteResultWithMeta"></a>
 
 `WoocommerceExecuteResultWithMeta(**data: Any)`
 :   Response envelope with data and metadata.
@@ -4939,6 +5165,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="CouponsListResult"></a>
+
 `CouponsListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -4981,6 +5209,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="CustomersListResult"></a>
 
 `CustomersListResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -5025,6 +5255,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="OrderNotesListResult"></a>
+
 `OrderNotesListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -5067,6 +5299,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="OrdersListResult"></a>
 
 `OrdersListResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -5111,6 +5345,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="PaymentGatewaysListResult"></a>
+
 `PaymentGatewaysListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -5153,6 +5389,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="ProductAttributesListResult"></a>
 
 `ProductAttributesListResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -5197,6 +5435,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="ProductCategoriesListResult"></a>
+
 `ProductCategoriesListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -5239,6 +5479,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="ProductReviewsListResult"></a>
 
 `ProductReviewsListResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -5283,6 +5525,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="ProductTagsListResult"></a>
+
 `ProductTagsListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -5325,6 +5569,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="ProductVariationsListResult"></a>
 
 `ProductVariationsListResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -5369,6 +5615,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="ProductsListResult"></a>
+
 `ProductsListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -5411,6 +5659,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="RefundsListResult"></a>
 
 `RefundsListResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -5455,6 +5705,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="ShippingMethodsListResult"></a>
+
 `ShippingMethodsListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -5497,6 +5749,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="ShippingZonesListResult"></a>
 
 `ShippingZonesListResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -5541,6 +5795,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="TaxClassesListResult"></a>
+
 `TaxClassesListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -5584,6 +5840,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="TaxRatesListResult"></a>
+
 `TaxRatesListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -5602,6 +5860,8 @@ Classes
     * airbyte_agent_sdk.connectors.woocommerce.models.WoocommerceExecuteResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="WoocommerceReplicationConfig"></a>
 
 `WoocommerceReplicationConfig(**data: Any)`
 :   Replication Configuration - Settings for data replication from WooCommerce.

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/woocommerce/types.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/woocommerce/types.md
@@ -10,6 +10,8 @@ Type definitions for woocommerce connector.
 Classes
 -------
 
+<a id="AirbyteSearchParams"></a>
+
 `AirbyteSearchParams(*args, **kwargs)`
 :   Parameters for Airbyte cache search operations (generic, use entity-specific query types for better type hints).
 
@@ -31,6 +33,8 @@ Classes
     `query: dict[str, typing.Any]`
     :   The type of the None singleton.
 
+<a id="CouponsAndCondition"></a>
+
 `CouponsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -51,6 +55,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.woocommerce.types.CouponsEqCondition | airbyte_agent_sdk.connectors.woocommerce.types.CouponsNeqCondition | airbyte_agent_sdk.connectors.woocommerce.types.CouponsGtCondition | airbyte_agent_sdk.connectors.woocommerce.types.CouponsGteCondition | airbyte_agent_sdk.connectors.woocommerce.types.CouponsLtCondition | airbyte_agent_sdk.connectors.woocommerce.types.CouponsLteCondition | airbyte_agent_sdk.connectors.woocommerce.types.CouponsInCondition | airbyte_agent_sdk.connectors.woocommerce.types.CouponsLikeCondition | airbyte_agent_sdk.connectors.woocommerce.types.CouponsFuzzyCondition | airbyte_agent_sdk.connectors.woocommerce.types.CouponsKeywordCondition | airbyte_agent_sdk.connectors.woocommerce.types.CouponsContainsCondition | airbyte_agent_sdk.connectors.woocommerce.types.CouponsNotCondition | airbyte_agent_sdk.connectors.woocommerce.types.CouponsAndCondition | airbyte_agent_sdk.connectors.woocommerce.types.CouponsOrCondition | airbyte_agent_sdk.connectors.woocommerce.types.CouponsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="CouponsAnyCondition"></a>
+
 `CouponsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -70,6 +76,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.woocommerce.types.CouponsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="CouponsAnyValueFilter"></a>
 
 `CouponsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -161,6 +169,8 @@ Classes
     `used_by: Any`
     :   Users who have used the coupon
 
+<a id="CouponsContainsCondition"></a>
+
 `CouponsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -172,6 +182,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.woocommerce.types.CouponsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="CouponsEqCondition"></a>
 
 `CouponsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -185,6 +197,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.woocommerce.types.CouponsSearchFilter`
     :   The type of the None singleton.
 
+<a id="CouponsFuzzyCondition"></a>
+
 `CouponsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -196,6 +210,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.woocommerce.types.CouponsStringFilter`
     :   The type of the None singleton.
+
+<a id="CouponsGetParams"></a>
 
 `CouponsGetParams(*args, **kwargs)`
 :   Parameters for coupons.get operation
@@ -209,6 +225,8 @@ Classes
     `id: str`
     :   The type of the None singleton.
 
+<a id="CouponsGtCondition"></a>
+
 `CouponsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -221,6 +239,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.woocommerce.types.CouponsSearchFilter`
     :   The type of the None singleton.
 
+<a id="CouponsGteCondition"></a>
+
 `CouponsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -232,6 +252,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.woocommerce.types.CouponsSearchFilter`
     :   The type of the None singleton.
+
+<a id="CouponsInCondition"></a>
 
 `CouponsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -252,6 +274,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.woocommerce.types.CouponsInFilter`
     :   The type of the None singleton.
+
+<a id="CouponsInFilter"></a>
 
 `CouponsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -343,6 +367,8 @@ Classes
     `used_by: list[list[typing.Any]]`
     :   Users who have used the coupon
 
+<a id="CouponsKeywordCondition"></a>
+
 `CouponsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -355,6 +381,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.woocommerce.types.CouponsStringFilter`
     :   The type of the None singleton.
 
+<a id="CouponsLikeCondition"></a>
+
 `CouponsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -366,6 +394,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.woocommerce.types.CouponsStringFilter`
     :   The type of the None singleton.
+
+<a id="CouponsListParams"></a>
 
 `CouponsListParams(*args, **kwargs)`
 :   Parameters for coupons.list operation
@@ -406,6 +436,8 @@ Classes
     `search: str`
     :   The type of the None singleton.
 
+<a id="CouponsLtCondition"></a>
+
 `CouponsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -417,6 +449,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.woocommerce.types.CouponsSearchFilter`
     :   The type of the None singleton.
+
+<a id="CouponsLteCondition"></a>
 
 `CouponsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -430,6 +464,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.woocommerce.types.CouponsSearchFilter`
     :   The type of the None singleton.
 
+<a id="CouponsNeqCondition"></a>
+
 `CouponsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -441,6 +477,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.woocommerce.types.CouponsSearchFilter`
     :   The type of the None singleton.
+
+<a id="CouponsNotCondition"></a>
 
 `CouponsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -462,6 +500,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.woocommerce.types.CouponsEqCondition | airbyte_agent_sdk.connectors.woocommerce.types.CouponsNeqCondition | airbyte_agent_sdk.connectors.woocommerce.types.CouponsGtCondition | airbyte_agent_sdk.connectors.woocommerce.types.CouponsGteCondition | airbyte_agent_sdk.connectors.woocommerce.types.CouponsLtCondition | airbyte_agent_sdk.connectors.woocommerce.types.CouponsLteCondition | airbyte_agent_sdk.connectors.woocommerce.types.CouponsInCondition | airbyte_agent_sdk.connectors.woocommerce.types.CouponsLikeCondition | airbyte_agent_sdk.connectors.woocommerce.types.CouponsFuzzyCondition | airbyte_agent_sdk.connectors.woocommerce.types.CouponsKeywordCondition | airbyte_agent_sdk.connectors.woocommerce.types.CouponsContainsCondition | airbyte_agent_sdk.connectors.woocommerce.types.CouponsNotCondition | airbyte_agent_sdk.connectors.woocommerce.types.CouponsAndCondition | airbyte_agent_sdk.connectors.woocommerce.types.CouponsOrCondition | airbyte_agent_sdk.connectors.woocommerce.types.CouponsAnyCondition`
     :   The type of the None singleton.
 
+<a id="CouponsOrCondition"></a>
+
 `CouponsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -481,6 +521,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.woocommerce.types.CouponsEqCondition | airbyte_agent_sdk.connectors.woocommerce.types.CouponsNeqCondition | airbyte_agent_sdk.connectors.woocommerce.types.CouponsGtCondition | airbyte_agent_sdk.connectors.woocommerce.types.CouponsGteCondition | airbyte_agent_sdk.connectors.woocommerce.types.CouponsLtCondition | airbyte_agent_sdk.connectors.woocommerce.types.CouponsLteCondition | airbyte_agent_sdk.connectors.woocommerce.types.CouponsInCondition | airbyte_agent_sdk.connectors.woocommerce.types.CouponsLikeCondition | airbyte_agent_sdk.connectors.woocommerce.types.CouponsFuzzyCondition | airbyte_agent_sdk.connectors.woocommerce.types.CouponsKeywordCondition | airbyte_agent_sdk.connectors.woocommerce.types.CouponsContainsCondition | airbyte_agent_sdk.connectors.woocommerce.types.CouponsNotCondition | airbyte_agent_sdk.connectors.woocommerce.types.CouponsAndCondition | airbyte_agent_sdk.connectors.woocommerce.types.CouponsOrCondition | airbyte_agent_sdk.connectors.woocommerce.types.CouponsAnyCondition]`
     :   The type of the None singleton.
+
+<a id="CouponsSearchFilter"></a>
 
 `CouponsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering coupons search queries.
@@ -572,6 +614,8 @@ Classes
     `used_by: list[typing.Any] | None`
     :   Users who have used the coupon
 
+<a id="CouponsSearchQuery"></a>
+
 `CouponsSearchQuery(*args, **kwargs)`
 :   Search query for coupons entity.
 
@@ -586,6 +630,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.woocommerce.types.CouponsSortFilter]`
     :   The type of the None singleton.
+
+<a id="CouponsSortFilter"></a>
 
 `CouponsSortFilter(*args, **kwargs)`
 :   Available fields for sorting coupons search results.
@@ -677,6 +723,8 @@ Classes
     `used_by: Literal['asc', 'desc']`
     :   Users who have used the coupon
 
+<a id="CouponsStringFilter"></a>
+
 `CouponsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -767,6 +815,8 @@ Classes
     `used_by: str`
     :   Users who have used the coupon
 
+<a id="CustomersAndCondition"></a>
+
 `CustomersAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -787,6 +837,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.woocommerce.types.CustomersEqCondition | airbyte_agent_sdk.connectors.woocommerce.types.CustomersNeqCondition | airbyte_agent_sdk.connectors.woocommerce.types.CustomersGtCondition | airbyte_agent_sdk.connectors.woocommerce.types.CustomersGteCondition | airbyte_agent_sdk.connectors.woocommerce.types.CustomersLtCondition | airbyte_agent_sdk.connectors.woocommerce.types.CustomersLteCondition | airbyte_agent_sdk.connectors.woocommerce.types.CustomersInCondition | airbyte_agent_sdk.connectors.woocommerce.types.CustomersLikeCondition | airbyte_agent_sdk.connectors.woocommerce.types.CustomersFuzzyCondition | airbyte_agent_sdk.connectors.woocommerce.types.CustomersKeywordCondition | airbyte_agent_sdk.connectors.woocommerce.types.CustomersContainsCondition | airbyte_agent_sdk.connectors.woocommerce.types.CustomersNotCondition | airbyte_agent_sdk.connectors.woocommerce.types.CustomersAndCondition | airbyte_agent_sdk.connectors.woocommerce.types.CustomersOrCondition | airbyte_agent_sdk.connectors.woocommerce.types.CustomersAnyCondition]`
     :   The type of the None singleton.
 
+<a id="CustomersAnyCondition"></a>
+
 `CustomersAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -806,6 +858,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.woocommerce.types.CustomersAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="CustomersAnyValueFilter"></a>
 
 `CustomersAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -861,6 +915,8 @@ Classes
     `username: Any`
     :   Customer login name
 
+<a id="CustomersContainsCondition"></a>
+
 `CustomersContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -872,6 +928,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.woocommerce.types.CustomersAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="CustomersEqCondition"></a>
 
 `CustomersEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -885,6 +943,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.woocommerce.types.CustomersSearchFilter`
     :   The type of the None singleton.
 
+<a id="CustomersFuzzyCondition"></a>
+
 `CustomersFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -896,6 +956,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.woocommerce.types.CustomersStringFilter`
     :   The type of the None singleton.
+
+<a id="CustomersGetParams"></a>
 
 `CustomersGetParams(*args, **kwargs)`
 :   Parameters for customers.get operation
@@ -909,6 +971,8 @@ Classes
     `id: str`
     :   The type of the None singleton.
 
+<a id="CustomersGtCondition"></a>
+
 `CustomersGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -921,6 +985,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.woocommerce.types.CustomersSearchFilter`
     :   The type of the None singleton.
 
+<a id="CustomersGteCondition"></a>
+
 `CustomersGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -932,6 +998,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.woocommerce.types.CustomersSearchFilter`
     :   The type of the None singleton.
+
+<a id="CustomersInCondition"></a>
 
 `CustomersInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -952,6 +1020,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.woocommerce.types.CustomersInFilter`
     :   The type of the None singleton.
+
+<a id="CustomersInFilter"></a>
 
 `CustomersInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -1007,6 +1077,8 @@ Classes
     `username: list[str]`
     :   Customer login name
 
+<a id="CustomersKeywordCondition"></a>
+
 `CustomersKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -1019,6 +1091,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.woocommerce.types.CustomersStringFilter`
     :   The type of the None singleton.
 
+<a id="CustomersLikeCondition"></a>
+
 `CustomersLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -1030,6 +1104,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.woocommerce.types.CustomersStringFilter`
     :   The type of the None singleton.
+
+<a id="CustomersListParams"></a>
 
 `CustomersListParams(*args, **kwargs)`
 :   Parameters for customers.list operation
@@ -1061,6 +1137,8 @@ Classes
     `search: str`
     :   The type of the None singleton.
 
+<a id="CustomersLtCondition"></a>
+
 `CustomersLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -1072,6 +1150,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.woocommerce.types.CustomersSearchFilter`
     :   The type of the None singleton.
+
+<a id="CustomersLteCondition"></a>
 
 `CustomersLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -1085,6 +1165,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.woocommerce.types.CustomersSearchFilter`
     :   The type of the None singleton.
 
+<a id="CustomersNeqCondition"></a>
+
 `CustomersNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -1096,6 +1178,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.woocommerce.types.CustomersSearchFilter`
     :   The type of the None singleton.
+
+<a id="CustomersNotCondition"></a>
 
 `CustomersNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -1117,6 +1201,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.woocommerce.types.CustomersEqCondition | airbyte_agent_sdk.connectors.woocommerce.types.CustomersNeqCondition | airbyte_agent_sdk.connectors.woocommerce.types.CustomersGtCondition | airbyte_agent_sdk.connectors.woocommerce.types.CustomersGteCondition | airbyte_agent_sdk.connectors.woocommerce.types.CustomersLtCondition | airbyte_agent_sdk.connectors.woocommerce.types.CustomersLteCondition | airbyte_agent_sdk.connectors.woocommerce.types.CustomersInCondition | airbyte_agent_sdk.connectors.woocommerce.types.CustomersLikeCondition | airbyte_agent_sdk.connectors.woocommerce.types.CustomersFuzzyCondition | airbyte_agent_sdk.connectors.woocommerce.types.CustomersKeywordCondition | airbyte_agent_sdk.connectors.woocommerce.types.CustomersContainsCondition | airbyte_agent_sdk.connectors.woocommerce.types.CustomersNotCondition | airbyte_agent_sdk.connectors.woocommerce.types.CustomersAndCondition | airbyte_agent_sdk.connectors.woocommerce.types.CustomersOrCondition | airbyte_agent_sdk.connectors.woocommerce.types.CustomersAnyCondition`
     :   The type of the None singleton.
 
+<a id="CustomersOrCondition"></a>
+
 `CustomersOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1136,6 +1222,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.woocommerce.types.CustomersEqCondition | airbyte_agent_sdk.connectors.woocommerce.types.CustomersNeqCondition | airbyte_agent_sdk.connectors.woocommerce.types.CustomersGtCondition | airbyte_agent_sdk.connectors.woocommerce.types.CustomersGteCondition | airbyte_agent_sdk.connectors.woocommerce.types.CustomersLtCondition | airbyte_agent_sdk.connectors.woocommerce.types.CustomersLteCondition | airbyte_agent_sdk.connectors.woocommerce.types.CustomersInCondition | airbyte_agent_sdk.connectors.woocommerce.types.CustomersLikeCondition | airbyte_agent_sdk.connectors.woocommerce.types.CustomersFuzzyCondition | airbyte_agent_sdk.connectors.woocommerce.types.CustomersKeywordCondition | airbyte_agent_sdk.connectors.woocommerce.types.CustomersContainsCondition | airbyte_agent_sdk.connectors.woocommerce.types.CustomersNotCondition | airbyte_agent_sdk.connectors.woocommerce.types.CustomersAndCondition | airbyte_agent_sdk.connectors.woocommerce.types.CustomersOrCondition | airbyte_agent_sdk.connectors.woocommerce.types.CustomersAnyCondition]`
     :   The type of the None singleton.
+
+<a id="CustomersSearchFilter"></a>
 
 `CustomersSearchFilter(*args, **kwargs)`
 :   Available fields for filtering customers search queries.
@@ -1191,6 +1279,8 @@ Classes
     `username: str | None`
     :   Customer login name
 
+<a id="CustomersSearchQuery"></a>
+
 `CustomersSearchQuery(*args, **kwargs)`
 :   Search query for customers entity.
 
@@ -1205,6 +1295,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.woocommerce.types.CustomersSortFilter]`
     :   The type of the None singleton.
+
+<a id="CustomersSortFilter"></a>
 
 `CustomersSortFilter(*args, **kwargs)`
 :   Available fields for sorting customers search results.
@@ -1260,6 +1352,8 @@ Classes
     `username: Literal['asc', 'desc']`
     :   Customer login name
 
+<a id="CustomersStringFilter"></a>
+
 `CustomersStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -1314,6 +1408,8 @@ Classes
     `username: str`
     :   Customer login name
 
+<a id="OrderNotesAndCondition"></a>
+
 `OrderNotesAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1334,6 +1430,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.woocommerce.types.OrderNotesEqCondition | airbyte_agent_sdk.connectors.woocommerce.types.OrderNotesNeqCondition | airbyte_agent_sdk.connectors.woocommerce.types.OrderNotesGtCondition | airbyte_agent_sdk.connectors.woocommerce.types.OrderNotesGteCondition | airbyte_agent_sdk.connectors.woocommerce.types.OrderNotesLtCondition | airbyte_agent_sdk.connectors.woocommerce.types.OrderNotesLteCondition | airbyte_agent_sdk.connectors.woocommerce.types.OrderNotesInCondition | airbyte_agent_sdk.connectors.woocommerce.types.OrderNotesLikeCondition | airbyte_agent_sdk.connectors.woocommerce.types.OrderNotesFuzzyCondition | airbyte_agent_sdk.connectors.woocommerce.types.OrderNotesKeywordCondition | airbyte_agent_sdk.connectors.woocommerce.types.OrderNotesContainsCondition | airbyte_agent_sdk.connectors.woocommerce.types.OrderNotesNotCondition | airbyte_agent_sdk.connectors.woocommerce.types.OrderNotesAndCondition | airbyte_agent_sdk.connectors.woocommerce.types.OrderNotesOrCondition | airbyte_agent_sdk.connectors.woocommerce.types.OrderNotesAnyCondition]`
     :   The type of the None singleton.
 
+<a id="OrderNotesAnyCondition"></a>
+
 `OrderNotesAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1353,6 +1451,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.woocommerce.types.OrderNotesAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="OrderNotesAnyValueFilter"></a>
 
 `OrderNotesAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -1378,6 +1478,8 @@ Classes
     `note: Any`
     :   Order note content
 
+<a id="OrderNotesContainsCondition"></a>
+
 `OrderNotesContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -1389,6 +1491,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.woocommerce.types.OrderNotesAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="OrderNotesEqCondition"></a>
 
 `OrderNotesEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -1402,6 +1506,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.woocommerce.types.OrderNotesSearchFilter`
     :   The type of the None singleton.
 
+<a id="OrderNotesFuzzyCondition"></a>
+
 `OrderNotesFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -1413,6 +1519,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.woocommerce.types.OrderNotesStringFilter`
     :   The type of the None singleton.
+
+<a id="OrderNotesGetParams"></a>
 
 `OrderNotesGetParams(*args, **kwargs)`
 :   Parameters for order_notes.get operation
@@ -1429,6 +1537,8 @@ Classes
     `order_id: str`
     :   The type of the None singleton.
 
+<a id="OrderNotesGtCondition"></a>
+
 `OrderNotesGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -1441,6 +1551,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.woocommerce.types.OrderNotesSearchFilter`
     :   The type of the None singleton.
 
+<a id="OrderNotesGteCondition"></a>
+
 `OrderNotesGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -1452,6 +1564,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.woocommerce.types.OrderNotesSearchFilter`
     :   The type of the None singleton.
+
+<a id="OrderNotesInCondition"></a>
 
 `OrderNotesInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -1472,6 +1586,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.woocommerce.types.OrderNotesInFilter`
     :   The type of the None singleton.
+
+<a id="OrderNotesInFilter"></a>
 
 `OrderNotesInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -1497,6 +1613,8 @@ Classes
     `note: list[str]`
     :   Order note content
 
+<a id="OrderNotesKeywordCondition"></a>
+
 `OrderNotesKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -1509,6 +1627,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.woocommerce.types.OrderNotesStringFilter`
     :   The type of the None singleton.
 
+<a id="OrderNotesLikeCondition"></a>
+
 `OrderNotesLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -1520,6 +1640,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.woocommerce.types.OrderNotesStringFilter`
     :   The type of the None singleton.
+
+<a id="OrderNotesListParams"></a>
 
 `OrderNotesListParams(*args, **kwargs)`
 :   Parameters for order_notes.list operation
@@ -1536,6 +1658,8 @@ Classes
     `type: str`
     :   The type of the None singleton.
 
+<a id="OrderNotesLtCondition"></a>
+
 `OrderNotesLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -1547,6 +1671,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.woocommerce.types.OrderNotesSearchFilter`
     :   The type of the None singleton.
+
+<a id="OrderNotesLteCondition"></a>
 
 `OrderNotesLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -1560,6 +1686,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.woocommerce.types.OrderNotesSearchFilter`
     :   The type of the None singleton.
 
+<a id="OrderNotesNeqCondition"></a>
+
 `OrderNotesNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -1571,6 +1699,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.woocommerce.types.OrderNotesSearchFilter`
     :   The type of the None singleton.
+
+<a id="OrderNotesNotCondition"></a>
 
 `OrderNotesNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -1592,6 +1722,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.woocommerce.types.OrderNotesEqCondition | airbyte_agent_sdk.connectors.woocommerce.types.OrderNotesNeqCondition | airbyte_agent_sdk.connectors.woocommerce.types.OrderNotesGtCondition | airbyte_agent_sdk.connectors.woocommerce.types.OrderNotesGteCondition | airbyte_agent_sdk.connectors.woocommerce.types.OrderNotesLtCondition | airbyte_agent_sdk.connectors.woocommerce.types.OrderNotesLteCondition | airbyte_agent_sdk.connectors.woocommerce.types.OrderNotesInCondition | airbyte_agent_sdk.connectors.woocommerce.types.OrderNotesLikeCondition | airbyte_agent_sdk.connectors.woocommerce.types.OrderNotesFuzzyCondition | airbyte_agent_sdk.connectors.woocommerce.types.OrderNotesKeywordCondition | airbyte_agent_sdk.connectors.woocommerce.types.OrderNotesContainsCondition | airbyte_agent_sdk.connectors.woocommerce.types.OrderNotesNotCondition | airbyte_agent_sdk.connectors.woocommerce.types.OrderNotesAndCondition | airbyte_agent_sdk.connectors.woocommerce.types.OrderNotesOrCondition | airbyte_agent_sdk.connectors.woocommerce.types.OrderNotesAnyCondition`
     :   The type of the None singleton.
 
+<a id="OrderNotesOrCondition"></a>
+
 `OrderNotesOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1611,6 +1743,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.woocommerce.types.OrderNotesEqCondition | airbyte_agent_sdk.connectors.woocommerce.types.OrderNotesNeqCondition | airbyte_agent_sdk.connectors.woocommerce.types.OrderNotesGtCondition | airbyte_agent_sdk.connectors.woocommerce.types.OrderNotesGteCondition | airbyte_agent_sdk.connectors.woocommerce.types.OrderNotesLtCondition | airbyte_agent_sdk.connectors.woocommerce.types.OrderNotesLteCondition | airbyte_agent_sdk.connectors.woocommerce.types.OrderNotesInCondition | airbyte_agent_sdk.connectors.woocommerce.types.OrderNotesLikeCondition | airbyte_agent_sdk.connectors.woocommerce.types.OrderNotesFuzzyCondition | airbyte_agent_sdk.connectors.woocommerce.types.OrderNotesKeywordCondition | airbyte_agent_sdk.connectors.woocommerce.types.OrderNotesContainsCondition | airbyte_agent_sdk.connectors.woocommerce.types.OrderNotesNotCondition | airbyte_agent_sdk.connectors.woocommerce.types.OrderNotesAndCondition | airbyte_agent_sdk.connectors.woocommerce.types.OrderNotesOrCondition | airbyte_agent_sdk.connectors.woocommerce.types.OrderNotesAnyCondition]`
     :   The type of the None singleton.
+
+<a id="OrderNotesSearchFilter"></a>
 
 `OrderNotesSearchFilter(*args, **kwargs)`
 :   Available fields for filtering order_notes search queries.
@@ -1636,6 +1770,8 @@ Classes
     `note: str | None`
     :   Order note content
 
+<a id="OrderNotesSearchQuery"></a>
+
 `OrderNotesSearchQuery(*args, **kwargs)`
 :   Search query for order_notes entity.
 
@@ -1650,6 +1786,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.woocommerce.types.OrderNotesSortFilter]`
     :   The type of the None singleton.
+
+<a id="OrderNotesSortFilter"></a>
 
 `OrderNotesSortFilter(*args, **kwargs)`
 :   Available fields for sorting order_notes search results.
@@ -1675,6 +1813,8 @@ Classes
     `note: Literal['asc', 'desc']`
     :   Order note content
 
+<a id="OrderNotesStringFilter"></a>
+
 `OrderNotesStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -1699,6 +1839,8 @@ Classes
     `note: str`
     :   Order note content
 
+<a id="OrdersAndCondition"></a>
+
 `OrdersAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1719,6 +1861,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.woocommerce.types.OrdersEqCondition | airbyte_agent_sdk.connectors.woocommerce.types.OrdersNeqCondition | airbyte_agent_sdk.connectors.woocommerce.types.OrdersGtCondition | airbyte_agent_sdk.connectors.woocommerce.types.OrdersGteCondition | airbyte_agent_sdk.connectors.woocommerce.types.OrdersLtCondition | airbyte_agent_sdk.connectors.woocommerce.types.OrdersLteCondition | airbyte_agent_sdk.connectors.woocommerce.types.OrdersInCondition | airbyte_agent_sdk.connectors.woocommerce.types.OrdersLikeCondition | airbyte_agent_sdk.connectors.woocommerce.types.OrdersFuzzyCondition | airbyte_agent_sdk.connectors.woocommerce.types.OrdersKeywordCondition | airbyte_agent_sdk.connectors.woocommerce.types.OrdersContainsCondition | airbyte_agent_sdk.connectors.woocommerce.types.OrdersNotCondition | airbyte_agent_sdk.connectors.woocommerce.types.OrdersAndCondition | airbyte_agent_sdk.connectors.woocommerce.types.OrdersOrCondition | airbyte_agent_sdk.connectors.woocommerce.types.OrdersAnyCondition]`
     :   The type of the None singleton.
 
+<a id="OrdersAnyCondition"></a>
+
 `OrdersAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1738,6 +1882,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.woocommerce.types.OrdersAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="OrdersAnyValueFilter"></a>
 
 `OrdersAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -1871,6 +2017,8 @@ Classes
     `version: Any`
     :   Version of WooCommerce which last updated the order
 
+<a id="OrdersContainsCondition"></a>
+
 `OrdersContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -1882,6 +2030,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.woocommerce.types.OrdersAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="OrdersEqCondition"></a>
 
 `OrdersEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -1895,6 +2045,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.woocommerce.types.OrdersSearchFilter`
     :   The type of the None singleton.
 
+<a id="OrdersFuzzyCondition"></a>
+
 `OrdersFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -1906,6 +2058,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.woocommerce.types.OrdersStringFilter`
     :   The type of the None singleton.
+
+<a id="OrdersGetParams"></a>
 
 `OrdersGetParams(*args, **kwargs)`
 :   Parameters for orders.get operation
@@ -1919,6 +2073,8 @@ Classes
     `id: str`
     :   The type of the None singleton.
 
+<a id="OrdersGtCondition"></a>
+
 `OrdersGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -1931,6 +2087,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.woocommerce.types.OrdersSearchFilter`
     :   The type of the None singleton.
 
+<a id="OrdersGteCondition"></a>
+
 `OrdersGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -1942,6 +2100,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.woocommerce.types.OrdersSearchFilter`
     :   The type of the None singleton.
+
+<a id="OrdersInCondition"></a>
 
 `OrdersInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -1962,6 +2122,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.woocommerce.types.OrdersInFilter`
     :   The type of the None singleton.
+
+<a id="OrdersInFilter"></a>
 
 `OrdersInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -2095,6 +2257,8 @@ Classes
     `version: list[str]`
     :   Version of WooCommerce which last updated the order
 
+<a id="OrdersKeywordCondition"></a>
+
 `OrdersKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -2107,6 +2271,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.woocommerce.types.OrdersStringFilter`
     :   The type of the None singleton.
 
+<a id="OrdersLikeCondition"></a>
+
 `OrdersLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -2118,6 +2284,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.woocommerce.types.OrdersStringFilter`
     :   The type of the None singleton.
+
+<a id="OrdersListParams"></a>
 
 `OrdersListParams(*args, **kwargs)`
 :   Parameters for orders.list operation
@@ -2164,6 +2332,8 @@ Classes
     `status: str`
     :   The type of the None singleton.
 
+<a id="OrdersLtCondition"></a>
+
 `OrdersLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -2175,6 +2345,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.woocommerce.types.OrdersSearchFilter`
     :   The type of the None singleton.
+
+<a id="OrdersLteCondition"></a>
 
 `OrdersLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -2188,6 +2360,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.woocommerce.types.OrdersSearchFilter`
     :   The type of the None singleton.
 
+<a id="OrdersNeqCondition"></a>
+
 `OrdersNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -2199,6 +2373,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.woocommerce.types.OrdersSearchFilter`
     :   The type of the None singleton.
+
+<a id="OrdersNotCondition"></a>
 
 `OrdersNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -2220,6 +2396,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.woocommerce.types.OrdersEqCondition | airbyte_agent_sdk.connectors.woocommerce.types.OrdersNeqCondition | airbyte_agent_sdk.connectors.woocommerce.types.OrdersGtCondition | airbyte_agent_sdk.connectors.woocommerce.types.OrdersGteCondition | airbyte_agent_sdk.connectors.woocommerce.types.OrdersLtCondition | airbyte_agent_sdk.connectors.woocommerce.types.OrdersLteCondition | airbyte_agent_sdk.connectors.woocommerce.types.OrdersInCondition | airbyte_agent_sdk.connectors.woocommerce.types.OrdersLikeCondition | airbyte_agent_sdk.connectors.woocommerce.types.OrdersFuzzyCondition | airbyte_agent_sdk.connectors.woocommerce.types.OrdersKeywordCondition | airbyte_agent_sdk.connectors.woocommerce.types.OrdersContainsCondition | airbyte_agent_sdk.connectors.woocommerce.types.OrdersNotCondition | airbyte_agent_sdk.connectors.woocommerce.types.OrdersAndCondition | airbyte_agent_sdk.connectors.woocommerce.types.OrdersOrCondition | airbyte_agent_sdk.connectors.woocommerce.types.OrdersAnyCondition`
     :   The type of the None singleton.
 
+<a id="OrdersOrCondition"></a>
+
 `OrdersOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -2239,6 +2417,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.woocommerce.types.OrdersEqCondition | airbyte_agent_sdk.connectors.woocommerce.types.OrdersNeqCondition | airbyte_agent_sdk.connectors.woocommerce.types.OrdersGtCondition | airbyte_agent_sdk.connectors.woocommerce.types.OrdersGteCondition | airbyte_agent_sdk.connectors.woocommerce.types.OrdersLtCondition | airbyte_agent_sdk.connectors.woocommerce.types.OrdersLteCondition | airbyte_agent_sdk.connectors.woocommerce.types.OrdersInCondition | airbyte_agent_sdk.connectors.woocommerce.types.OrdersLikeCondition | airbyte_agent_sdk.connectors.woocommerce.types.OrdersFuzzyCondition | airbyte_agent_sdk.connectors.woocommerce.types.OrdersKeywordCondition | airbyte_agent_sdk.connectors.woocommerce.types.OrdersContainsCondition | airbyte_agent_sdk.connectors.woocommerce.types.OrdersNotCondition | airbyte_agent_sdk.connectors.woocommerce.types.OrdersAndCondition | airbyte_agent_sdk.connectors.woocommerce.types.OrdersOrCondition | airbyte_agent_sdk.connectors.woocommerce.types.OrdersAnyCondition]`
     :   The type of the None singleton.
+
+<a id="OrdersSearchFilter"></a>
 
 `OrdersSearchFilter(*args, **kwargs)`
 :   Available fields for filtering orders search queries.
@@ -2372,6 +2552,8 @@ Classes
     `version: str | None`
     :   Version of WooCommerce which last updated the order
 
+<a id="OrdersSearchQuery"></a>
+
 `OrdersSearchQuery(*args, **kwargs)`
 :   Search query for orders entity.
 
@@ -2386,6 +2568,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.woocommerce.types.OrdersSortFilter]`
     :   The type of the None singleton.
+
+<a id="OrdersSortFilter"></a>
 
 `OrdersSortFilter(*args, **kwargs)`
 :   Available fields for sorting orders search results.
@@ -2519,6 +2703,8 @@ Classes
     `version: Literal['asc', 'desc']`
     :   Version of WooCommerce which last updated the order
 
+<a id="OrdersStringFilter"></a>
+
 `OrdersStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -2651,6 +2837,8 @@ Classes
     `version: str`
     :   Version of WooCommerce which last updated the order
 
+<a id="PaymentGatewaysAndCondition"></a>
+
 `PaymentGatewaysAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -2671,6 +2859,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.woocommerce.types.PaymentGatewaysEqCondition | airbyte_agent_sdk.connectors.woocommerce.types.PaymentGatewaysNeqCondition | airbyte_agent_sdk.connectors.woocommerce.types.PaymentGatewaysGtCondition | airbyte_agent_sdk.connectors.woocommerce.types.PaymentGatewaysGteCondition | airbyte_agent_sdk.connectors.woocommerce.types.PaymentGatewaysLtCondition | airbyte_agent_sdk.connectors.woocommerce.types.PaymentGatewaysLteCondition | airbyte_agent_sdk.connectors.woocommerce.types.PaymentGatewaysInCondition | airbyte_agent_sdk.connectors.woocommerce.types.PaymentGatewaysLikeCondition | airbyte_agent_sdk.connectors.woocommerce.types.PaymentGatewaysFuzzyCondition | airbyte_agent_sdk.connectors.woocommerce.types.PaymentGatewaysKeywordCondition | airbyte_agent_sdk.connectors.woocommerce.types.PaymentGatewaysContainsCondition | airbyte_agent_sdk.connectors.woocommerce.types.PaymentGatewaysNotCondition | airbyte_agent_sdk.connectors.woocommerce.types.PaymentGatewaysAndCondition | airbyte_agent_sdk.connectors.woocommerce.types.PaymentGatewaysOrCondition | airbyte_agent_sdk.connectors.woocommerce.types.PaymentGatewaysAnyCondition]`
     :   The type of the None singleton.
 
+<a id="PaymentGatewaysAnyCondition"></a>
+
 `PaymentGatewaysAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -2690,6 +2880,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.woocommerce.types.PaymentGatewaysAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="PaymentGatewaysAnyValueFilter"></a>
 
 `PaymentGatewaysAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -2727,6 +2919,8 @@ Classes
     `title: Any`
     :   Payment gateway title on checkout
 
+<a id="PaymentGatewaysContainsCondition"></a>
+
 `PaymentGatewaysContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -2738,6 +2932,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.woocommerce.types.PaymentGatewaysAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="PaymentGatewaysEqCondition"></a>
 
 `PaymentGatewaysEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -2751,6 +2947,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.woocommerce.types.PaymentGatewaysSearchFilter`
     :   The type of the None singleton.
 
+<a id="PaymentGatewaysFuzzyCondition"></a>
+
 `PaymentGatewaysFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -2762,6 +2960,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.woocommerce.types.PaymentGatewaysStringFilter`
     :   The type of the None singleton.
+
+<a id="PaymentGatewaysGetParams"></a>
 
 `PaymentGatewaysGetParams(*args, **kwargs)`
 :   Parameters for payment_gateways.get operation
@@ -2775,6 +2975,8 @@ Classes
     `id: str`
     :   The type of the None singleton.
 
+<a id="PaymentGatewaysGtCondition"></a>
+
 `PaymentGatewaysGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -2787,6 +2989,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.woocommerce.types.PaymentGatewaysSearchFilter`
     :   The type of the None singleton.
 
+<a id="PaymentGatewaysGteCondition"></a>
+
 `PaymentGatewaysGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -2798,6 +3002,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.woocommerce.types.PaymentGatewaysSearchFilter`
     :   The type of the None singleton.
+
+<a id="PaymentGatewaysInCondition"></a>
 
 `PaymentGatewaysInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -2818,6 +3024,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.woocommerce.types.PaymentGatewaysInFilter`
     :   The type of the None singleton.
+
+<a id="PaymentGatewaysInFilter"></a>
 
 `PaymentGatewaysInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -2855,6 +3063,8 @@ Classes
     `title: list[str]`
     :   Payment gateway title on checkout
 
+<a id="PaymentGatewaysKeywordCondition"></a>
+
 `PaymentGatewaysKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -2866,6 +3076,8 @@ Classes
 
     `keyword: airbyte_agent_sdk.connectors.woocommerce.types.PaymentGatewaysStringFilter`
     :   The type of the None singleton.
+
+<a id="PaymentGatewaysLikeCondition"></a>
 
 `PaymentGatewaysLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
@@ -2879,12 +3091,16 @@ Classes
     `like: airbyte_agent_sdk.connectors.woocommerce.types.PaymentGatewaysStringFilter`
     :   The type of the None singleton.
 
+<a id="PaymentGatewaysListParams"></a>
+
 `PaymentGatewaysListParams(*args, **kwargs)`
 :   Parameters for payment_gateways.list operation
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="PaymentGatewaysLtCondition"></a>
 
 `PaymentGatewaysLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
@@ -2898,6 +3114,8 @@ Classes
     `lt: airbyte_agent_sdk.connectors.woocommerce.types.PaymentGatewaysSearchFilter`
     :   The type of the None singleton.
 
+<a id="PaymentGatewaysLteCondition"></a>
+
 `PaymentGatewaysLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
 
@@ -2910,6 +3128,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.woocommerce.types.PaymentGatewaysSearchFilter`
     :   The type of the None singleton.
 
+<a id="PaymentGatewaysNeqCondition"></a>
+
 `PaymentGatewaysNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -2921,6 +3141,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.woocommerce.types.PaymentGatewaysSearchFilter`
     :   The type of the None singleton.
+
+<a id="PaymentGatewaysNotCondition"></a>
 
 `PaymentGatewaysNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -2942,6 +3164,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.woocommerce.types.PaymentGatewaysEqCondition | airbyte_agent_sdk.connectors.woocommerce.types.PaymentGatewaysNeqCondition | airbyte_agent_sdk.connectors.woocommerce.types.PaymentGatewaysGtCondition | airbyte_agent_sdk.connectors.woocommerce.types.PaymentGatewaysGteCondition | airbyte_agent_sdk.connectors.woocommerce.types.PaymentGatewaysLtCondition | airbyte_agent_sdk.connectors.woocommerce.types.PaymentGatewaysLteCondition | airbyte_agent_sdk.connectors.woocommerce.types.PaymentGatewaysInCondition | airbyte_agent_sdk.connectors.woocommerce.types.PaymentGatewaysLikeCondition | airbyte_agent_sdk.connectors.woocommerce.types.PaymentGatewaysFuzzyCondition | airbyte_agent_sdk.connectors.woocommerce.types.PaymentGatewaysKeywordCondition | airbyte_agent_sdk.connectors.woocommerce.types.PaymentGatewaysContainsCondition | airbyte_agent_sdk.connectors.woocommerce.types.PaymentGatewaysNotCondition | airbyte_agent_sdk.connectors.woocommerce.types.PaymentGatewaysAndCondition | airbyte_agent_sdk.connectors.woocommerce.types.PaymentGatewaysOrCondition | airbyte_agent_sdk.connectors.woocommerce.types.PaymentGatewaysAnyCondition`
     :   The type of the None singleton.
 
+<a id="PaymentGatewaysOrCondition"></a>
+
 `PaymentGatewaysOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -2961,6 +3185,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.woocommerce.types.PaymentGatewaysEqCondition | airbyte_agent_sdk.connectors.woocommerce.types.PaymentGatewaysNeqCondition | airbyte_agent_sdk.connectors.woocommerce.types.PaymentGatewaysGtCondition | airbyte_agent_sdk.connectors.woocommerce.types.PaymentGatewaysGteCondition | airbyte_agent_sdk.connectors.woocommerce.types.PaymentGatewaysLtCondition | airbyte_agent_sdk.connectors.woocommerce.types.PaymentGatewaysLteCondition | airbyte_agent_sdk.connectors.woocommerce.types.PaymentGatewaysInCondition | airbyte_agent_sdk.connectors.woocommerce.types.PaymentGatewaysLikeCondition | airbyte_agent_sdk.connectors.woocommerce.types.PaymentGatewaysFuzzyCondition | airbyte_agent_sdk.connectors.woocommerce.types.PaymentGatewaysKeywordCondition | airbyte_agent_sdk.connectors.woocommerce.types.PaymentGatewaysContainsCondition | airbyte_agent_sdk.connectors.woocommerce.types.PaymentGatewaysNotCondition | airbyte_agent_sdk.connectors.woocommerce.types.PaymentGatewaysAndCondition | airbyte_agent_sdk.connectors.woocommerce.types.PaymentGatewaysOrCondition | airbyte_agent_sdk.connectors.woocommerce.types.PaymentGatewaysAnyCondition]`
     :   The type of the None singleton.
+
+<a id="PaymentGatewaysSearchFilter"></a>
 
 `PaymentGatewaysSearchFilter(*args, **kwargs)`
 :   Available fields for filtering payment_gateways search queries.
@@ -2998,6 +3224,8 @@ Classes
     `title: str | None`
     :   Payment gateway title on checkout
 
+<a id="PaymentGatewaysSearchQuery"></a>
+
 `PaymentGatewaysSearchQuery(*args, **kwargs)`
 :   Search query for payment_gateways entity.
 
@@ -3012,6 +3240,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.woocommerce.types.PaymentGatewaysSortFilter]`
     :   The type of the None singleton.
+
+<a id="PaymentGatewaysSortFilter"></a>
 
 `PaymentGatewaysSortFilter(*args, **kwargs)`
 :   Available fields for sorting payment_gateways search results.
@@ -3049,6 +3279,8 @@ Classes
     `title: Literal['asc', 'desc']`
     :   Payment gateway title on checkout
 
+<a id="PaymentGatewaysStringFilter"></a>
+
 `PaymentGatewaysStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -3085,6 +3317,8 @@ Classes
     `title: str`
     :   Payment gateway title on checkout
 
+<a id="ProductAttributesAndCondition"></a>
+
 `ProductAttributesAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -3105,6 +3339,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.woocommerce.types.ProductAttributesEqCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductAttributesNeqCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductAttributesGtCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductAttributesGteCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductAttributesLtCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductAttributesLteCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductAttributesInCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductAttributesLikeCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductAttributesFuzzyCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductAttributesKeywordCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductAttributesContainsCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductAttributesNotCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductAttributesAndCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductAttributesOrCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductAttributesAnyCondition]`
     :   The type of the None singleton.
 
+<a id="ProductAttributesAnyCondition"></a>
+
 `ProductAttributesAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -3124,6 +3360,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.woocommerce.types.ProductAttributesAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="ProductAttributesAnyValueFilter"></a>
 
 `ProductAttributesAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -3152,6 +3390,8 @@ Classes
     `type_: Any`
     :   Type of attribute
 
+<a id="ProductAttributesContainsCondition"></a>
+
 `ProductAttributesContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -3163,6 +3403,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.woocommerce.types.ProductAttributesAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="ProductAttributesEqCondition"></a>
 
 `ProductAttributesEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -3176,6 +3418,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.woocommerce.types.ProductAttributesSearchFilter`
     :   The type of the None singleton.
 
+<a id="ProductAttributesFuzzyCondition"></a>
+
 `ProductAttributesFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -3187,6 +3431,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.woocommerce.types.ProductAttributesStringFilter`
     :   The type of the None singleton.
+
+<a id="ProductAttributesGetParams"></a>
 
 `ProductAttributesGetParams(*args, **kwargs)`
 :   Parameters for product_attributes.get operation
@@ -3200,6 +3446,8 @@ Classes
     `id: str`
     :   The type of the None singleton.
 
+<a id="ProductAttributesGtCondition"></a>
+
 `ProductAttributesGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -3212,6 +3460,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.woocommerce.types.ProductAttributesSearchFilter`
     :   The type of the None singleton.
 
+<a id="ProductAttributesGteCondition"></a>
+
 `ProductAttributesGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -3223,6 +3473,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.woocommerce.types.ProductAttributesSearchFilter`
     :   The type of the None singleton.
+
+<a id="ProductAttributesInCondition"></a>
 
 `ProductAttributesInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -3243,6 +3495,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.woocommerce.types.ProductAttributesInFilter`
     :   The type of the None singleton.
+
+<a id="ProductAttributesInFilter"></a>
 
 `ProductAttributesInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -3271,6 +3525,8 @@ Classes
     `type_: list[str]`
     :   Type of attribute
 
+<a id="ProductAttributesKeywordCondition"></a>
+
 `ProductAttributesKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -3283,6 +3539,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.woocommerce.types.ProductAttributesStringFilter`
     :   The type of the None singleton.
 
+<a id="ProductAttributesLikeCondition"></a>
+
 `ProductAttributesLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -3294,6 +3552,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.woocommerce.types.ProductAttributesStringFilter`
     :   The type of the None singleton.
+
+<a id="ProductAttributesListParams"></a>
 
 `ProductAttributesListParams(*args, **kwargs)`
 :   Parameters for product_attributes.list operation
@@ -3310,6 +3570,8 @@ Classes
     `per_page: int`
     :   The type of the None singleton.
 
+<a id="ProductAttributesLtCondition"></a>
+
 `ProductAttributesLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -3321,6 +3583,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.woocommerce.types.ProductAttributesSearchFilter`
     :   The type of the None singleton.
+
+<a id="ProductAttributesLteCondition"></a>
 
 `ProductAttributesLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -3334,6 +3598,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.woocommerce.types.ProductAttributesSearchFilter`
     :   The type of the None singleton.
 
+<a id="ProductAttributesNeqCondition"></a>
+
 `ProductAttributesNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -3345,6 +3611,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.woocommerce.types.ProductAttributesSearchFilter`
     :   The type of the None singleton.
+
+<a id="ProductAttributesNotCondition"></a>
 
 `ProductAttributesNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -3366,6 +3634,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.woocommerce.types.ProductAttributesEqCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductAttributesNeqCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductAttributesGtCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductAttributesGteCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductAttributesLtCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductAttributesLteCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductAttributesInCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductAttributesLikeCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductAttributesFuzzyCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductAttributesKeywordCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductAttributesContainsCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductAttributesNotCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductAttributesAndCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductAttributesOrCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductAttributesAnyCondition`
     :   The type of the None singleton.
 
+<a id="ProductAttributesOrCondition"></a>
+
 `ProductAttributesOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -3385,6 +3655,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.woocommerce.types.ProductAttributesEqCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductAttributesNeqCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductAttributesGtCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductAttributesGteCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductAttributesLtCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductAttributesLteCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductAttributesInCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductAttributesLikeCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductAttributesFuzzyCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductAttributesKeywordCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductAttributesContainsCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductAttributesNotCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductAttributesAndCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductAttributesOrCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductAttributesAnyCondition]`
     :   The type of the None singleton.
+
+<a id="ProductAttributesSearchFilter"></a>
 
 `ProductAttributesSearchFilter(*args, **kwargs)`
 :   Available fields for filtering product_attributes search queries.
@@ -3413,6 +3685,8 @@ Classes
     `type_: str | None`
     :   Type of attribute
 
+<a id="ProductAttributesSearchQuery"></a>
+
 `ProductAttributesSearchQuery(*args, **kwargs)`
 :   Search query for product_attributes entity.
 
@@ -3427,6 +3701,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.woocommerce.types.ProductAttributesSortFilter]`
     :   The type of the None singleton.
+
+<a id="ProductAttributesSortFilter"></a>
 
 `ProductAttributesSortFilter(*args, **kwargs)`
 :   Available fields for sorting product_attributes search results.
@@ -3455,6 +3731,8 @@ Classes
     `type_: Literal['asc', 'desc']`
     :   Type of attribute
 
+<a id="ProductAttributesStringFilter"></a>
+
 `ProductAttributesStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -3482,6 +3760,8 @@ Classes
     `type_: str`
     :   Type of attribute
 
+<a id="ProductCategoriesAndCondition"></a>
+
 `ProductCategoriesAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -3502,6 +3782,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.woocommerce.types.ProductCategoriesEqCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductCategoriesNeqCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductCategoriesGtCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductCategoriesGteCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductCategoriesLtCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductCategoriesLteCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductCategoriesInCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductCategoriesLikeCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductCategoriesFuzzyCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductCategoriesKeywordCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductCategoriesContainsCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductCategoriesNotCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductCategoriesAndCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductCategoriesOrCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductCategoriesAnyCondition]`
     :   The type of the None singleton.
 
+<a id="ProductCategoriesAnyCondition"></a>
+
 `ProductCategoriesAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -3521,6 +3803,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.woocommerce.types.ProductCategoriesAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="ProductCategoriesAnyValueFilter"></a>
 
 `ProductCategoriesAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -3558,6 +3842,8 @@ Classes
     `slug: Any`
     :   An alphanumeric identifier
 
+<a id="ProductCategoriesContainsCondition"></a>
+
 `ProductCategoriesContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -3569,6 +3855,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.woocommerce.types.ProductCategoriesAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="ProductCategoriesEqCondition"></a>
 
 `ProductCategoriesEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -3582,6 +3870,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.woocommerce.types.ProductCategoriesSearchFilter`
     :   The type of the None singleton.
 
+<a id="ProductCategoriesFuzzyCondition"></a>
+
 `ProductCategoriesFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -3593,6 +3883,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.woocommerce.types.ProductCategoriesStringFilter`
     :   The type of the None singleton.
+
+<a id="ProductCategoriesGetParams"></a>
 
 `ProductCategoriesGetParams(*args, **kwargs)`
 :   Parameters for product_categories.get operation
@@ -3606,6 +3898,8 @@ Classes
     `id: str`
     :   The type of the None singleton.
 
+<a id="ProductCategoriesGtCondition"></a>
+
 `ProductCategoriesGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -3618,6 +3912,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.woocommerce.types.ProductCategoriesSearchFilter`
     :   The type of the None singleton.
 
+<a id="ProductCategoriesGteCondition"></a>
+
 `ProductCategoriesGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -3629,6 +3925,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.woocommerce.types.ProductCategoriesSearchFilter`
     :   The type of the None singleton.
+
+<a id="ProductCategoriesInCondition"></a>
 
 `ProductCategoriesInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -3649,6 +3947,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.woocommerce.types.ProductCategoriesInFilter`
     :   The type of the None singleton.
+
+<a id="ProductCategoriesInFilter"></a>
 
 `ProductCategoriesInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -3686,6 +3986,8 @@ Classes
     `slug: list[str]`
     :   An alphanumeric identifier
 
+<a id="ProductCategoriesKeywordCondition"></a>
+
 `ProductCategoriesKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -3698,6 +4000,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.woocommerce.types.ProductCategoriesStringFilter`
     :   The type of the None singleton.
 
+<a id="ProductCategoriesLikeCondition"></a>
+
 `ProductCategoriesLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -3709,6 +4013,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.woocommerce.types.ProductCategoriesStringFilter`
     :   The type of the None singleton.
+
+<a id="ProductCategoriesListParams"></a>
 
 `ProductCategoriesListParams(*args, **kwargs)`
 :   Parameters for product_categories.list operation
@@ -3746,6 +4052,8 @@ Classes
     `slug: str`
     :   The type of the None singleton.
 
+<a id="ProductCategoriesLtCondition"></a>
+
 `ProductCategoriesLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -3757,6 +4065,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.woocommerce.types.ProductCategoriesSearchFilter`
     :   The type of the None singleton.
+
+<a id="ProductCategoriesLteCondition"></a>
 
 `ProductCategoriesLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -3770,6 +4080,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.woocommerce.types.ProductCategoriesSearchFilter`
     :   The type of the None singleton.
 
+<a id="ProductCategoriesNeqCondition"></a>
+
 `ProductCategoriesNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -3781,6 +4093,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.woocommerce.types.ProductCategoriesSearchFilter`
     :   The type of the None singleton.
+
+<a id="ProductCategoriesNotCondition"></a>
 
 `ProductCategoriesNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -3802,6 +4116,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.woocommerce.types.ProductCategoriesEqCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductCategoriesNeqCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductCategoriesGtCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductCategoriesGteCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductCategoriesLtCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductCategoriesLteCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductCategoriesInCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductCategoriesLikeCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductCategoriesFuzzyCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductCategoriesKeywordCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductCategoriesContainsCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductCategoriesNotCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductCategoriesAndCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductCategoriesOrCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductCategoriesAnyCondition`
     :   The type of the None singleton.
 
+<a id="ProductCategoriesOrCondition"></a>
+
 `ProductCategoriesOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -3821,6 +4137,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.woocommerce.types.ProductCategoriesEqCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductCategoriesNeqCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductCategoriesGtCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductCategoriesGteCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductCategoriesLtCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductCategoriesLteCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductCategoriesInCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductCategoriesLikeCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductCategoriesFuzzyCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductCategoriesKeywordCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductCategoriesContainsCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductCategoriesNotCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductCategoriesAndCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductCategoriesOrCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductCategoriesAnyCondition]`
     :   The type of the None singleton.
+
+<a id="ProductCategoriesSearchFilter"></a>
 
 `ProductCategoriesSearchFilter(*args, **kwargs)`
 :   Available fields for filtering product_categories search queries.
@@ -3858,6 +4176,8 @@ Classes
     `slug: str | None`
     :   An alphanumeric identifier
 
+<a id="ProductCategoriesSearchQuery"></a>
+
 `ProductCategoriesSearchQuery(*args, **kwargs)`
 :   Search query for product_categories entity.
 
@@ -3872,6 +4192,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.woocommerce.types.ProductCategoriesSortFilter]`
     :   The type of the None singleton.
+
+<a id="ProductCategoriesSortFilter"></a>
 
 `ProductCategoriesSortFilter(*args, **kwargs)`
 :   Available fields for sorting product_categories search results.
@@ -3909,6 +4231,8 @@ Classes
     `slug: Literal['asc', 'desc']`
     :   An alphanumeric identifier
 
+<a id="ProductCategoriesStringFilter"></a>
+
 `ProductCategoriesStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -3945,6 +4269,8 @@ Classes
     `slug: str`
     :   An alphanumeric identifier
 
+<a id="ProductReviewsAndCondition"></a>
+
 `ProductReviewsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -3965,6 +4291,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.woocommerce.types.ProductReviewsEqCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductReviewsNeqCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductReviewsGtCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductReviewsGteCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductReviewsLtCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductReviewsLteCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductReviewsInCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductReviewsLikeCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductReviewsFuzzyCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductReviewsKeywordCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductReviewsContainsCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductReviewsNotCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductReviewsAndCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductReviewsOrCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductReviewsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="ProductReviewsAnyCondition"></a>
+
 `ProductReviewsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -3984,6 +4312,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.woocommerce.types.ProductReviewsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="ProductReviewsAnyValueFilter"></a>
 
 `ProductReviewsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -4024,6 +4354,8 @@ Classes
     `verified: Any`
     :   Shows if the reviewer bought the product
 
+<a id="ProductReviewsContainsCondition"></a>
+
 `ProductReviewsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -4035,6 +4367,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.woocommerce.types.ProductReviewsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="ProductReviewsEqCondition"></a>
 
 `ProductReviewsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -4048,6 +4382,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.woocommerce.types.ProductReviewsSearchFilter`
     :   The type of the None singleton.
 
+<a id="ProductReviewsFuzzyCondition"></a>
+
 `ProductReviewsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -4059,6 +4395,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.woocommerce.types.ProductReviewsStringFilter`
     :   The type of the None singleton.
+
+<a id="ProductReviewsGetParams"></a>
 
 `ProductReviewsGetParams(*args, **kwargs)`
 :   Parameters for product_reviews.get operation
@@ -4072,6 +4410,8 @@ Classes
     `id: str`
     :   The type of the None singleton.
 
+<a id="ProductReviewsGtCondition"></a>
+
 `ProductReviewsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -4084,6 +4424,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.woocommerce.types.ProductReviewsSearchFilter`
     :   The type of the None singleton.
 
+<a id="ProductReviewsGteCondition"></a>
+
 `ProductReviewsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -4095,6 +4437,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.woocommerce.types.ProductReviewsSearchFilter`
     :   The type of the None singleton.
+
+<a id="ProductReviewsInCondition"></a>
 
 `ProductReviewsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -4115,6 +4459,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.woocommerce.types.ProductReviewsInFilter`
     :   The type of the None singleton.
+
+<a id="ProductReviewsInFilter"></a>
 
 `ProductReviewsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -4155,6 +4501,8 @@ Classes
     `verified: list[bool]`
     :   Shows if the reviewer bought the product
 
+<a id="ProductReviewsKeywordCondition"></a>
+
 `ProductReviewsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -4167,6 +4515,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.woocommerce.types.ProductReviewsStringFilter`
     :   The type of the None singleton.
 
+<a id="ProductReviewsLikeCondition"></a>
+
 `ProductReviewsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -4178,6 +4528,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.woocommerce.types.ProductReviewsStringFilter`
     :   The type of the None singleton.
+
+<a id="ProductReviewsListParams"></a>
 
 `ProductReviewsListParams(*args, **kwargs)`
 :   Parameters for product_reviews.list operation
@@ -4209,6 +4561,8 @@ Classes
     `status: str`
     :   The type of the None singleton.
 
+<a id="ProductReviewsLtCondition"></a>
+
 `ProductReviewsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -4220,6 +4574,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.woocommerce.types.ProductReviewsSearchFilter`
     :   The type of the None singleton.
+
+<a id="ProductReviewsLteCondition"></a>
 
 `ProductReviewsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -4233,6 +4589,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.woocommerce.types.ProductReviewsSearchFilter`
     :   The type of the None singleton.
 
+<a id="ProductReviewsNeqCondition"></a>
+
 `ProductReviewsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -4244,6 +4602,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.woocommerce.types.ProductReviewsSearchFilter`
     :   The type of the None singleton.
+
+<a id="ProductReviewsNotCondition"></a>
 
 `ProductReviewsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -4265,6 +4625,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.woocommerce.types.ProductReviewsEqCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductReviewsNeqCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductReviewsGtCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductReviewsGteCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductReviewsLtCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductReviewsLteCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductReviewsInCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductReviewsLikeCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductReviewsFuzzyCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductReviewsKeywordCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductReviewsContainsCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductReviewsNotCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductReviewsAndCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductReviewsOrCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductReviewsAnyCondition`
     :   The type of the None singleton.
 
+<a id="ProductReviewsOrCondition"></a>
+
 `ProductReviewsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -4284,6 +4646,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.woocommerce.types.ProductReviewsEqCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductReviewsNeqCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductReviewsGtCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductReviewsGteCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductReviewsLtCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductReviewsLteCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductReviewsInCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductReviewsLikeCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductReviewsFuzzyCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductReviewsKeywordCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductReviewsContainsCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductReviewsNotCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductReviewsAndCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductReviewsOrCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductReviewsAnyCondition]`
     :   The type of the None singleton.
+
+<a id="ProductReviewsSearchFilter"></a>
 
 `ProductReviewsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering product_reviews search queries.
@@ -4324,6 +4688,8 @@ Classes
     `verified: bool | None`
     :   Shows if the reviewer bought the product
 
+<a id="ProductReviewsSearchQuery"></a>
+
 `ProductReviewsSearchQuery(*args, **kwargs)`
 :   Search query for product_reviews entity.
 
@@ -4338,6 +4704,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.woocommerce.types.ProductReviewsSortFilter]`
     :   The type of the None singleton.
+
+<a id="ProductReviewsSortFilter"></a>
 
 `ProductReviewsSortFilter(*args, **kwargs)`
 :   Available fields for sorting product_reviews search results.
@@ -4378,6 +4746,8 @@ Classes
     `verified: Literal['asc', 'desc']`
     :   Shows if the reviewer bought the product
 
+<a id="ProductReviewsStringFilter"></a>
+
 `ProductReviewsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -4417,6 +4787,8 @@ Classes
     `verified: str`
     :   Shows if the reviewer bought the product
 
+<a id="ProductTagsAndCondition"></a>
+
 `ProductTagsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -4437,6 +4809,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.woocommerce.types.ProductTagsEqCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductTagsNeqCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductTagsGtCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductTagsGteCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductTagsLtCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductTagsLteCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductTagsInCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductTagsLikeCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductTagsFuzzyCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductTagsKeywordCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductTagsContainsCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductTagsNotCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductTagsAndCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductTagsOrCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductTagsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="ProductTagsAnyCondition"></a>
+
 `ProductTagsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -4456,6 +4830,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.woocommerce.types.ProductTagsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="ProductTagsAnyValueFilter"></a>
 
 `ProductTagsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -4481,6 +4857,8 @@ Classes
     `slug: Any`
     :   Alphanumeric identifier
 
+<a id="ProductTagsContainsCondition"></a>
+
 `ProductTagsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -4492,6 +4870,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.woocommerce.types.ProductTagsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="ProductTagsEqCondition"></a>
 
 `ProductTagsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -4505,6 +4885,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.woocommerce.types.ProductTagsSearchFilter`
     :   The type of the None singleton.
 
+<a id="ProductTagsFuzzyCondition"></a>
+
 `ProductTagsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -4516,6 +4898,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.woocommerce.types.ProductTagsStringFilter`
     :   The type of the None singleton.
+
+<a id="ProductTagsGetParams"></a>
 
 `ProductTagsGetParams(*args, **kwargs)`
 :   Parameters for product_tags.get operation
@@ -4529,6 +4913,8 @@ Classes
     `id: str`
     :   The type of the None singleton.
 
+<a id="ProductTagsGtCondition"></a>
+
 `ProductTagsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -4541,6 +4927,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.woocommerce.types.ProductTagsSearchFilter`
     :   The type of the None singleton.
 
+<a id="ProductTagsGteCondition"></a>
+
 `ProductTagsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -4552,6 +4940,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.woocommerce.types.ProductTagsSearchFilter`
     :   The type of the None singleton.
+
+<a id="ProductTagsInCondition"></a>
 
 `ProductTagsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -4572,6 +4962,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.woocommerce.types.ProductTagsInFilter`
     :   The type of the None singleton.
+
+<a id="ProductTagsInFilter"></a>
 
 `ProductTagsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -4597,6 +4989,8 @@ Classes
     `slug: list[str]`
     :   Alphanumeric identifier
 
+<a id="ProductTagsKeywordCondition"></a>
+
 `ProductTagsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -4609,6 +5003,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.woocommerce.types.ProductTagsStringFilter`
     :   The type of the None singleton.
 
+<a id="ProductTagsLikeCondition"></a>
+
 `ProductTagsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -4620,6 +5016,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.woocommerce.types.ProductTagsStringFilter`
     :   The type of the None singleton.
+
+<a id="ProductTagsListParams"></a>
 
 `ProductTagsListParams(*args, **kwargs)`
 :   Parameters for product_tags.list operation
@@ -4654,6 +5052,8 @@ Classes
     `slug: str`
     :   The type of the None singleton.
 
+<a id="ProductTagsLtCondition"></a>
+
 `ProductTagsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -4665,6 +5065,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.woocommerce.types.ProductTagsSearchFilter`
     :   The type of the None singleton.
+
+<a id="ProductTagsLteCondition"></a>
 
 `ProductTagsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -4678,6 +5080,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.woocommerce.types.ProductTagsSearchFilter`
     :   The type of the None singleton.
 
+<a id="ProductTagsNeqCondition"></a>
+
 `ProductTagsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -4689,6 +5093,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.woocommerce.types.ProductTagsSearchFilter`
     :   The type of the None singleton.
+
+<a id="ProductTagsNotCondition"></a>
 
 `ProductTagsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -4710,6 +5116,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.woocommerce.types.ProductTagsEqCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductTagsNeqCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductTagsGtCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductTagsGteCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductTagsLtCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductTagsLteCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductTagsInCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductTagsLikeCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductTagsFuzzyCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductTagsKeywordCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductTagsContainsCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductTagsNotCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductTagsAndCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductTagsOrCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductTagsAnyCondition`
     :   The type of the None singleton.
 
+<a id="ProductTagsOrCondition"></a>
+
 `ProductTagsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -4729,6 +5137,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.woocommerce.types.ProductTagsEqCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductTagsNeqCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductTagsGtCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductTagsGteCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductTagsLtCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductTagsLteCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductTagsInCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductTagsLikeCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductTagsFuzzyCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductTagsKeywordCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductTagsContainsCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductTagsNotCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductTagsAndCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductTagsOrCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductTagsAnyCondition]`
     :   The type of the None singleton.
+
+<a id="ProductTagsSearchFilter"></a>
 
 `ProductTagsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering product_tags search queries.
@@ -4754,6 +5164,8 @@ Classes
     `slug: str | None`
     :   Alphanumeric identifier
 
+<a id="ProductTagsSearchQuery"></a>
+
 `ProductTagsSearchQuery(*args, **kwargs)`
 :   Search query for product_tags entity.
 
@@ -4768,6 +5180,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.woocommerce.types.ProductTagsSortFilter]`
     :   The type of the None singleton.
+
+<a id="ProductTagsSortFilter"></a>
 
 `ProductTagsSortFilter(*args, **kwargs)`
 :   Available fields for sorting product_tags search results.
@@ -4793,6 +5207,8 @@ Classes
     `slug: Literal['asc', 'desc']`
     :   Alphanumeric identifier
 
+<a id="ProductTagsStringFilter"></a>
+
 `ProductTagsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -4817,6 +5233,8 @@ Classes
     `slug: str`
     :   Alphanumeric identifier
 
+<a id="ProductVariationsAndCondition"></a>
+
 `ProductVariationsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -4837,6 +5255,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.woocommerce.types.ProductVariationsEqCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductVariationsNeqCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductVariationsGtCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductVariationsGteCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductVariationsLtCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductVariationsLteCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductVariationsInCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductVariationsLikeCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductVariationsFuzzyCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductVariationsKeywordCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductVariationsContainsCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductVariationsNotCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductVariationsAndCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductVariationsOrCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductVariationsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="ProductVariationsAnyCondition"></a>
+
 `ProductVariationsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -4856,6 +5276,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.woocommerce.types.ProductVariationsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="ProductVariationsAnyValueFilter"></a>
 
 `ProductVariationsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -4983,6 +5405,8 @@ Classes
     `weight: Any`
     :   Variation weight
 
+<a id="ProductVariationsContainsCondition"></a>
+
 `ProductVariationsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -4994,6 +5418,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.woocommerce.types.ProductVariationsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="ProductVariationsEqCondition"></a>
 
 `ProductVariationsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -5007,6 +5433,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.woocommerce.types.ProductVariationsSearchFilter`
     :   The type of the None singleton.
 
+<a id="ProductVariationsFuzzyCondition"></a>
+
 `ProductVariationsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -5018,6 +5446,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.woocommerce.types.ProductVariationsStringFilter`
     :   The type of the None singleton.
+
+<a id="ProductVariationsGetParams"></a>
 
 `ProductVariationsGetParams(*args, **kwargs)`
 :   Parameters for product_variations.get operation
@@ -5034,6 +5464,8 @@ Classes
     `product_id: str`
     :   The type of the None singleton.
 
+<a id="ProductVariationsGtCondition"></a>
+
 `ProductVariationsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -5046,6 +5478,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.woocommerce.types.ProductVariationsSearchFilter`
     :   The type of the None singleton.
 
+<a id="ProductVariationsGteCondition"></a>
+
 `ProductVariationsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -5057,6 +5491,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.woocommerce.types.ProductVariationsSearchFilter`
     :   The type of the None singleton.
+
+<a id="ProductVariationsInCondition"></a>
 
 `ProductVariationsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -5077,6 +5513,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.woocommerce.types.ProductVariationsInFilter`
     :   The type of the None singleton.
+
+<a id="ProductVariationsInFilter"></a>
 
 `ProductVariationsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -5204,6 +5642,8 @@ Classes
     `weight: list[str]`
     :   Variation weight
 
+<a id="ProductVariationsKeywordCondition"></a>
+
 `ProductVariationsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -5216,6 +5656,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.woocommerce.types.ProductVariationsStringFilter`
     :   The type of the None singleton.
 
+<a id="ProductVariationsLikeCondition"></a>
+
 `ProductVariationsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -5227,6 +5669,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.woocommerce.types.ProductVariationsStringFilter`
     :   The type of the None singleton.
+
+<a id="ProductVariationsListParams"></a>
 
 `ProductVariationsListParams(*args, **kwargs)`
 :   Parameters for product_variations.list operation
@@ -5273,6 +5717,8 @@ Classes
     `stock_status: str`
     :   The type of the None singleton.
 
+<a id="ProductVariationsLtCondition"></a>
+
 `ProductVariationsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -5284,6 +5730,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.woocommerce.types.ProductVariationsSearchFilter`
     :   The type of the None singleton.
+
+<a id="ProductVariationsLteCondition"></a>
 
 `ProductVariationsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -5297,6 +5745,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.woocommerce.types.ProductVariationsSearchFilter`
     :   The type of the None singleton.
 
+<a id="ProductVariationsNeqCondition"></a>
+
 `ProductVariationsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -5308,6 +5758,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.woocommerce.types.ProductVariationsSearchFilter`
     :   The type of the None singleton.
+
+<a id="ProductVariationsNotCondition"></a>
 
 `ProductVariationsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -5329,6 +5781,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.woocommerce.types.ProductVariationsEqCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductVariationsNeqCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductVariationsGtCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductVariationsGteCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductVariationsLtCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductVariationsLteCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductVariationsInCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductVariationsLikeCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductVariationsFuzzyCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductVariationsKeywordCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductVariationsContainsCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductVariationsNotCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductVariationsAndCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductVariationsOrCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductVariationsAnyCondition`
     :   The type of the None singleton.
 
+<a id="ProductVariationsOrCondition"></a>
+
 `ProductVariationsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -5348,6 +5802,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.woocommerce.types.ProductVariationsEqCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductVariationsNeqCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductVariationsGtCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductVariationsGteCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductVariationsLtCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductVariationsLteCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductVariationsInCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductVariationsLikeCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductVariationsFuzzyCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductVariationsKeywordCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductVariationsContainsCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductVariationsNotCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductVariationsAndCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductVariationsOrCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductVariationsAnyCondition]`
     :   The type of the None singleton.
+
+<a id="ProductVariationsSearchFilter"></a>
 
 `ProductVariationsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering product_variations search queries.
@@ -5475,6 +5931,8 @@ Classes
     `weight: str | None`
     :   Variation weight
 
+<a id="ProductVariationsSearchQuery"></a>
+
 `ProductVariationsSearchQuery(*args, **kwargs)`
 :   Search query for product_variations entity.
 
@@ -5489,6 +5947,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.woocommerce.types.ProductVariationsSortFilter]`
     :   The type of the None singleton.
+
+<a id="ProductVariationsSortFilter"></a>
 
 `ProductVariationsSortFilter(*args, **kwargs)`
 :   Available fields for sorting product_variations search results.
@@ -5616,6 +6076,8 @@ Classes
     `weight: Literal['asc', 'desc']`
     :   Variation weight
 
+<a id="ProductVariationsStringFilter"></a>
+
 `ProductVariationsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -5742,6 +6204,8 @@ Classes
     `weight: str`
     :   Variation weight
 
+<a id="ProductsAndCondition"></a>
+
 `ProductsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -5762,6 +6226,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.woocommerce.types.ProductsEqCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductsNeqCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductsGtCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductsGteCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductsLtCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductsLteCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductsInCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductsLikeCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductsFuzzyCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductsKeywordCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductsContainsCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductsNotCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductsAndCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductsOrCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="ProductsAnyCondition"></a>
+
 `ProductsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -5781,6 +6247,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.woocommerce.types.ProductsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="ProductsAnyValueFilter"></a>
 
 `ProductsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -5983,6 +6451,8 @@ Classes
     `weight: Any`
     :   Product weight
 
+<a id="ProductsContainsCondition"></a>
+
 `ProductsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -5994,6 +6464,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.woocommerce.types.ProductsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="ProductsEqCondition"></a>
 
 `ProductsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -6007,6 +6479,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.woocommerce.types.ProductsSearchFilter`
     :   The type of the None singleton.
 
+<a id="ProductsFuzzyCondition"></a>
+
 `ProductsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -6018,6 +6492,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.woocommerce.types.ProductsStringFilter`
     :   The type of the None singleton.
+
+<a id="ProductsGetParams"></a>
 
 `ProductsGetParams(*args, **kwargs)`
 :   Parameters for products.get operation
@@ -6031,6 +6507,8 @@ Classes
     `id: str`
     :   The type of the None singleton.
 
+<a id="ProductsGtCondition"></a>
+
 `ProductsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -6043,6 +6521,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.woocommerce.types.ProductsSearchFilter`
     :   The type of the None singleton.
 
+<a id="ProductsGteCondition"></a>
+
 `ProductsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -6054,6 +6534,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.woocommerce.types.ProductsSearchFilter`
     :   The type of the None singleton.
+
+<a id="ProductsInCondition"></a>
 
 `ProductsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -6074,6 +6556,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.woocommerce.types.ProductsInFilter`
     :   The type of the None singleton.
+
+<a id="ProductsInFilter"></a>
 
 `ProductsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -6276,6 +6760,8 @@ Classes
     `weight: list[str]`
     :   Product weight
 
+<a id="ProductsKeywordCondition"></a>
+
 `ProductsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -6288,6 +6774,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.woocommerce.types.ProductsStringFilter`
     :   The type of the None singleton.
 
+<a id="ProductsLikeCondition"></a>
+
 `ProductsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -6299,6 +6787,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.woocommerce.types.ProductsStringFilter`
     :   The type of the None singleton.
+
+<a id="ProductsListParams"></a>
 
 `ProductsListParams(*args, **kwargs)`
 :   Parameters for products.list operation
@@ -6366,6 +6856,8 @@ Classes
     `type: str`
     :   The type of the None singleton.
 
+<a id="ProductsLtCondition"></a>
+
 `ProductsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -6377,6 +6869,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.woocommerce.types.ProductsSearchFilter`
     :   The type of the None singleton.
+
+<a id="ProductsLteCondition"></a>
 
 `ProductsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -6390,6 +6884,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.woocommerce.types.ProductsSearchFilter`
     :   The type of the None singleton.
 
+<a id="ProductsNeqCondition"></a>
+
 `ProductsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -6401,6 +6897,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.woocommerce.types.ProductsSearchFilter`
     :   The type of the None singleton.
+
+<a id="ProductsNotCondition"></a>
 
 `ProductsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -6422,6 +6920,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.woocommerce.types.ProductsEqCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductsNeqCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductsGtCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductsGteCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductsLtCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductsLteCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductsInCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductsLikeCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductsFuzzyCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductsKeywordCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductsContainsCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductsNotCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductsAndCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductsOrCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductsAnyCondition`
     :   The type of the None singleton.
 
+<a id="ProductsOrCondition"></a>
+
 `ProductsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -6441,6 +6941,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.woocommerce.types.ProductsEqCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductsNeqCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductsGtCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductsGteCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductsLtCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductsLteCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductsInCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductsLikeCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductsFuzzyCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductsKeywordCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductsContainsCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductsNotCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductsAndCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductsOrCondition | airbyte_agent_sdk.connectors.woocommerce.types.ProductsAnyCondition]`
     :   The type of the None singleton.
+
+<a id="ProductsSearchFilter"></a>
 
 `ProductsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering products search queries.
@@ -6643,6 +7145,8 @@ Classes
     `weight: str | None`
     :   Product weight
 
+<a id="ProductsSearchQuery"></a>
+
 `ProductsSearchQuery(*args, **kwargs)`
 :   Search query for products entity.
 
@@ -6657,6 +7161,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.woocommerce.types.ProductsSortFilter]`
     :   The type of the None singleton.
+
+<a id="ProductsSortFilter"></a>
 
 `ProductsSortFilter(*args, **kwargs)`
 :   Available fields for sorting products search results.
@@ -6859,6 +7365,8 @@ Classes
     `weight: Literal['asc', 'desc']`
     :   Product weight
 
+<a id="ProductsStringFilter"></a>
+
 `ProductsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -7060,6 +7568,8 @@ Classes
     `weight: str`
     :   Product weight
 
+<a id="RefundsAndCondition"></a>
+
 `RefundsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -7080,6 +7590,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.woocommerce.types.RefundsEqCondition | airbyte_agent_sdk.connectors.woocommerce.types.RefundsNeqCondition | airbyte_agent_sdk.connectors.woocommerce.types.RefundsGtCondition | airbyte_agent_sdk.connectors.woocommerce.types.RefundsGteCondition | airbyte_agent_sdk.connectors.woocommerce.types.RefundsLtCondition | airbyte_agent_sdk.connectors.woocommerce.types.RefundsLteCondition | airbyte_agent_sdk.connectors.woocommerce.types.RefundsInCondition | airbyte_agent_sdk.connectors.woocommerce.types.RefundsLikeCondition | airbyte_agent_sdk.connectors.woocommerce.types.RefundsFuzzyCondition | airbyte_agent_sdk.connectors.woocommerce.types.RefundsKeywordCondition | airbyte_agent_sdk.connectors.woocommerce.types.RefundsContainsCondition | airbyte_agent_sdk.connectors.woocommerce.types.RefundsNotCondition | airbyte_agent_sdk.connectors.woocommerce.types.RefundsAndCondition | airbyte_agent_sdk.connectors.woocommerce.types.RefundsOrCondition | airbyte_agent_sdk.connectors.woocommerce.types.RefundsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="RefundsAnyCondition"></a>
+
 `RefundsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -7099,6 +7611,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.woocommerce.types.RefundsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="RefundsAnyValueFilter"></a>
 
 `RefundsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -7136,6 +7650,8 @@ Classes
     `refunded_payment: Any`
     :   If the payment was refunded via the API
 
+<a id="RefundsContainsCondition"></a>
+
 `RefundsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -7147,6 +7663,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.woocommerce.types.RefundsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="RefundsEqCondition"></a>
 
 `RefundsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -7160,6 +7678,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.woocommerce.types.RefundsSearchFilter`
     :   The type of the None singleton.
 
+<a id="RefundsFuzzyCondition"></a>
+
 `RefundsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -7171,6 +7691,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.woocommerce.types.RefundsStringFilter`
     :   The type of the None singleton.
+
+<a id="RefundsGetParams"></a>
 
 `RefundsGetParams(*args, **kwargs)`
 :   Parameters for refunds.get operation
@@ -7187,6 +7709,8 @@ Classes
     `order_id: str`
     :   The type of the None singleton.
 
+<a id="RefundsGtCondition"></a>
+
 `RefundsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -7199,6 +7723,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.woocommerce.types.RefundsSearchFilter`
     :   The type of the None singleton.
 
+<a id="RefundsGteCondition"></a>
+
 `RefundsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -7210,6 +7736,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.woocommerce.types.RefundsSearchFilter`
     :   The type of the None singleton.
+
+<a id="RefundsInCondition"></a>
 
 `RefundsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -7230,6 +7758,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.woocommerce.types.RefundsInFilter`
     :   The type of the None singleton.
+
+<a id="RefundsInFilter"></a>
 
 `RefundsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -7267,6 +7797,8 @@ Classes
     `refunded_payment: list[bool]`
     :   If the payment was refunded via the API
 
+<a id="RefundsKeywordCondition"></a>
+
 `RefundsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -7279,6 +7811,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.woocommerce.types.RefundsStringFilter`
     :   The type of the None singleton.
 
+<a id="RefundsLikeCondition"></a>
+
 `RefundsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -7290,6 +7824,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.woocommerce.types.RefundsStringFilter`
     :   The type of the None singleton.
+
+<a id="RefundsListParams"></a>
 
 `RefundsListParams(*args, **kwargs)`
 :   Parameters for refunds.list operation
@@ -7309,6 +7845,8 @@ Classes
     `per_page: int`
     :   The type of the None singleton.
 
+<a id="RefundsLtCondition"></a>
+
 `RefundsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -7320,6 +7858,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.woocommerce.types.RefundsSearchFilter`
     :   The type of the None singleton.
+
+<a id="RefundsLteCondition"></a>
 
 `RefundsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -7333,6 +7873,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.woocommerce.types.RefundsSearchFilter`
     :   The type of the None singleton.
 
+<a id="RefundsNeqCondition"></a>
+
 `RefundsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -7344,6 +7886,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.woocommerce.types.RefundsSearchFilter`
     :   The type of the None singleton.
+
+<a id="RefundsNotCondition"></a>
 
 `RefundsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -7365,6 +7909,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.woocommerce.types.RefundsEqCondition | airbyte_agent_sdk.connectors.woocommerce.types.RefundsNeqCondition | airbyte_agent_sdk.connectors.woocommerce.types.RefundsGtCondition | airbyte_agent_sdk.connectors.woocommerce.types.RefundsGteCondition | airbyte_agent_sdk.connectors.woocommerce.types.RefundsLtCondition | airbyte_agent_sdk.connectors.woocommerce.types.RefundsLteCondition | airbyte_agent_sdk.connectors.woocommerce.types.RefundsInCondition | airbyte_agent_sdk.connectors.woocommerce.types.RefundsLikeCondition | airbyte_agent_sdk.connectors.woocommerce.types.RefundsFuzzyCondition | airbyte_agent_sdk.connectors.woocommerce.types.RefundsKeywordCondition | airbyte_agent_sdk.connectors.woocommerce.types.RefundsContainsCondition | airbyte_agent_sdk.connectors.woocommerce.types.RefundsNotCondition | airbyte_agent_sdk.connectors.woocommerce.types.RefundsAndCondition | airbyte_agent_sdk.connectors.woocommerce.types.RefundsOrCondition | airbyte_agent_sdk.connectors.woocommerce.types.RefundsAnyCondition`
     :   The type of the None singleton.
 
+<a id="RefundsOrCondition"></a>
+
 `RefundsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -7384,6 +7930,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.woocommerce.types.RefundsEqCondition | airbyte_agent_sdk.connectors.woocommerce.types.RefundsNeqCondition | airbyte_agent_sdk.connectors.woocommerce.types.RefundsGtCondition | airbyte_agent_sdk.connectors.woocommerce.types.RefundsGteCondition | airbyte_agent_sdk.connectors.woocommerce.types.RefundsLtCondition | airbyte_agent_sdk.connectors.woocommerce.types.RefundsLteCondition | airbyte_agent_sdk.connectors.woocommerce.types.RefundsInCondition | airbyte_agent_sdk.connectors.woocommerce.types.RefundsLikeCondition | airbyte_agent_sdk.connectors.woocommerce.types.RefundsFuzzyCondition | airbyte_agent_sdk.connectors.woocommerce.types.RefundsKeywordCondition | airbyte_agent_sdk.connectors.woocommerce.types.RefundsContainsCondition | airbyte_agent_sdk.connectors.woocommerce.types.RefundsNotCondition | airbyte_agent_sdk.connectors.woocommerce.types.RefundsAndCondition | airbyte_agent_sdk.connectors.woocommerce.types.RefundsOrCondition | airbyte_agent_sdk.connectors.woocommerce.types.RefundsAnyCondition]`
     :   The type of the None singleton.
+
+<a id="RefundsSearchFilter"></a>
 
 `RefundsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering refunds search queries.
@@ -7421,6 +7969,8 @@ Classes
     `refunded_payment: bool | None`
     :   If the payment was refunded via the API
 
+<a id="RefundsSearchQuery"></a>
+
 `RefundsSearchQuery(*args, **kwargs)`
 :   Search query for refunds entity.
 
@@ -7435,6 +7985,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.woocommerce.types.RefundsSortFilter]`
     :   The type of the None singleton.
+
+<a id="RefundsSortFilter"></a>
 
 `RefundsSortFilter(*args, **kwargs)`
 :   Available fields for sorting refunds search results.
@@ -7472,6 +8024,8 @@ Classes
     `refunded_payment: Literal['asc', 'desc']`
     :   If the payment was refunded via the API
 
+<a id="RefundsStringFilter"></a>
+
 `RefundsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -7508,6 +8062,8 @@ Classes
     `refunded_payment: str`
     :   If the payment was refunded via the API
 
+<a id="ShippingMethodsAndCondition"></a>
+
 `ShippingMethodsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -7527,6 +8083,8 @@ Classes
 
     `and: list[airbyte_agent_sdk.connectors.woocommerce.types.ShippingMethodsEqCondition | airbyte_agent_sdk.connectors.woocommerce.types.ShippingMethodsNeqCondition | airbyte_agent_sdk.connectors.woocommerce.types.ShippingMethodsGtCondition | airbyte_agent_sdk.connectors.woocommerce.types.ShippingMethodsGteCondition | airbyte_agent_sdk.connectors.woocommerce.types.ShippingMethodsLtCondition | airbyte_agent_sdk.connectors.woocommerce.types.ShippingMethodsLteCondition | airbyte_agent_sdk.connectors.woocommerce.types.ShippingMethodsInCondition | airbyte_agent_sdk.connectors.woocommerce.types.ShippingMethodsLikeCondition | airbyte_agent_sdk.connectors.woocommerce.types.ShippingMethodsFuzzyCondition | airbyte_agent_sdk.connectors.woocommerce.types.ShippingMethodsKeywordCondition | airbyte_agent_sdk.connectors.woocommerce.types.ShippingMethodsContainsCondition | airbyte_agent_sdk.connectors.woocommerce.types.ShippingMethodsNotCondition | airbyte_agent_sdk.connectors.woocommerce.types.ShippingMethodsAndCondition | airbyte_agent_sdk.connectors.woocommerce.types.ShippingMethodsOrCondition | airbyte_agent_sdk.connectors.woocommerce.types.ShippingMethodsAnyCondition]`
     :   The type of the None singleton.
+
+<a id="ShippingMethodsAnyCondition"></a>
 
 `ShippingMethodsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -7548,6 +8106,8 @@ Classes
     `any: airbyte_agent_sdk.connectors.woocommerce.types.ShippingMethodsAnyValueFilter`
     :   The type of the None singleton.
 
+<a id="ShippingMethodsAnyValueFilter"></a>
+
 `ShippingMethodsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
 
@@ -7566,6 +8126,8 @@ Classes
     `title: Any`
     :   Shipping method title
 
+<a id="ShippingMethodsContainsCondition"></a>
+
 `ShippingMethodsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -7577,6 +8139,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.woocommerce.types.ShippingMethodsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="ShippingMethodsEqCondition"></a>
 
 `ShippingMethodsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -7590,6 +8154,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.woocommerce.types.ShippingMethodsSearchFilter`
     :   The type of the None singleton.
 
+<a id="ShippingMethodsFuzzyCondition"></a>
+
 `ShippingMethodsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -7601,6 +8167,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.woocommerce.types.ShippingMethodsStringFilter`
     :   The type of the None singleton.
+
+<a id="ShippingMethodsGetParams"></a>
 
 `ShippingMethodsGetParams(*args, **kwargs)`
 :   Parameters for shipping_methods.get operation
@@ -7614,6 +8182,8 @@ Classes
     `id: str`
     :   The type of the None singleton.
 
+<a id="ShippingMethodsGtCondition"></a>
+
 `ShippingMethodsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -7626,6 +8196,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.woocommerce.types.ShippingMethodsSearchFilter`
     :   The type of the None singleton.
 
+<a id="ShippingMethodsGteCondition"></a>
+
 `ShippingMethodsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -7637,6 +8209,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.woocommerce.types.ShippingMethodsSearchFilter`
     :   The type of the None singleton.
+
+<a id="ShippingMethodsInCondition"></a>
 
 `ShippingMethodsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -7658,6 +8232,8 @@ Classes
     `in: airbyte_agent_sdk.connectors.woocommerce.types.ShippingMethodsInFilter`
     :   The type of the None singleton.
 
+<a id="ShippingMethodsInFilter"></a>
+
 `ShippingMethodsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
 
@@ -7676,6 +8252,8 @@ Classes
     `title: list[str]`
     :   Shipping method title
 
+<a id="ShippingMethodsKeywordCondition"></a>
+
 `ShippingMethodsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -7687,6 +8265,8 @@ Classes
 
     `keyword: airbyte_agent_sdk.connectors.woocommerce.types.ShippingMethodsStringFilter`
     :   The type of the None singleton.
+
+<a id="ShippingMethodsLikeCondition"></a>
 
 `ShippingMethodsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
@@ -7700,12 +8280,16 @@ Classes
     `like: airbyte_agent_sdk.connectors.woocommerce.types.ShippingMethodsStringFilter`
     :   The type of the None singleton.
 
+<a id="ShippingMethodsListParams"></a>
+
 `ShippingMethodsListParams(*args, **kwargs)`
 :   Parameters for shipping_methods.list operation
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="ShippingMethodsLtCondition"></a>
 
 `ShippingMethodsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
@@ -7719,6 +8303,8 @@ Classes
     `lt: airbyte_agent_sdk.connectors.woocommerce.types.ShippingMethodsSearchFilter`
     :   The type of the None singleton.
 
+<a id="ShippingMethodsLteCondition"></a>
+
 `ShippingMethodsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
 
@@ -7731,6 +8317,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.woocommerce.types.ShippingMethodsSearchFilter`
     :   The type of the None singleton.
 
+<a id="ShippingMethodsNeqCondition"></a>
+
 `ShippingMethodsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -7742,6 +8330,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.woocommerce.types.ShippingMethodsSearchFilter`
     :   The type of the None singleton.
+
+<a id="ShippingMethodsNotCondition"></a>
 
 `ShippingMethodsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -7763,6 +8353,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.woocommerce.types.ShippingMethodsEqCondition | airbyte_agent_sdk.connectors.woocommerce.types.ShippingMethodsNeqCondition | airbyte_agent_sdk.connectors.woocommerce.types.ShippingMethodsGtCondition | airbyte_agent_sdk.connectors.woocommerce.types.ShippingMethodsGteCondition | airbyte_agent_sdk.connectors.woocommerce.types.ShippingMethodsLtCondition | airbyte_agent_sdk.connectors.woocommerce.types.ShippingMethodsLteCondition | airbyte_agent_sdk.connectors.woocommerce.types.ShippingMethodsInCondition | airbyte_agent_sdk.connectors.woocommerce.types.ShippingMethodsLikeCondition | airbyte_agent_sdk.connectors.woocommerce.types.ShippingMethodsFuzzyCondition | airbyte_agent_sdk.connectors.woocommerce.types.ShippingMethodsKeywordCondition | airbyte_agent_sdk.connectors.woocommerce.types.ShippingMethodsContainsCondition | airbyte_agent_sdk.connectors.woocommerce.types.ShippingMethodsNotCondition | airbyte_agent_sdk.connectors.woocommerce.types.ShippingMethodsAndCondition | airbyte_agent_sdk.connectors.woocommerce.types.ShippingMethodsOrCondition | airbyte_agent_sdk.connectors.woocommerce.types.ShippingMethodsAnyCondition`
     :   The type of the None singleton.
 
+<a id="ShippingMethodsOrCondition"></a>
+
 `ShippingMethodsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -7783,6 +8375,8 @@ Classes
     `or: list[airbyte_agent_sdk.connectors.woocommerce.types.ShippingMethodsEqCondition | airbyte_agent_sdk.connectors.woocommerce.types.ShippingMethodsNeqCondition | airbyte_agent_sdk.connectors.woocommerce.types.ShippingMethodsGtCondition | airbyte_agent_sdk.connectors.woocommerce.types.ShippingMethodsGteCondition | airbyte_agent_sdk.connectors.woocommerce.types.ShippingMethodsLtCondition | airbyte_agent_sdk.connectors.woocommerce.types.ShippingMethodsLteCondition | airbyte_agent_sdk.connectors.woocommerce.types.ShippingMethodsInCondition | airbyte_agent_sdk.connectors.woocommerce.types.ShippingMethodsLikeCondition | airbyte_agent_sdk.connectors.woocommerce.types.ShippingMethodsFuzzyCondition | airbyte_agent_sdk.connectors.woocommerce.types.ShippingMethodsKeywordCondition | airbyte_agent_sdk.connectors.woocommerce.types.ShippingMethodsContainsCondition | airbyte_agent_sdk.connectors.woocommerce.types.ShippingMethodsNotCondition | airbyte_agent_sdk.connectors.woocommerce.types.ShippingMethodsAndCondition | airbyte_agent_sdk.connectors.woocommerce.types.ShippingMethodsOrCondition | airbyte_agent_sdk.connectors.woocommerce.types.ShippingMethodsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="ShippingMethodsSearchFilter"></a>
+
 `ShippingMethodsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering shipping_methods search queries.
 
@@ -7801,6 +8395,8 @@ Classes
     `title: str | None`
     :   Shipping method title
 
+<a id="ShippingMethodsSearchQuery"></a>
+
 `ShippingMethodsSearchQuery(*args, **kwargs)`
 :   Search query for shipping_methods entity.
 
@@ -7815,6 +8411,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.woocommerce.types.ShippingMethodsSortFilter]`
     :   The type of the None singleton.
+
+<a id="ShippingMethodsSortFilter"></a>
 
 `ShippingMethodsSortFilter(*args, **kwargs)`
 :   Available fields for sorting shipping_methods search results.
@@ -7834,6 +8432,8 @@ Classes
     `title: Literal['asc', 'desc']`
     :   Shipping method title
 
+<a id="ShippingMethodsStringFilter"></a>
+
 `ShippingMethodsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -7851,6 +8451,8 @@ Classes
 
     `title: str`
     :   Shipping method title
+
+<a id="ShippingZonesAndCondition"></a>
 
 `ShippingZonesAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -7872,6 +8474,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.woocommerce.types.ShippingZonesEqCondition | airbyte_agent_sdk.connectors.woocommerce.types.ShippingZonesNeqCondition | airbyte_agent_sdk.connectors.woocommerce.types.ShippingZonesGtCondition | airbyte_agent_sdk.connectors.woocommerce.types.ShippingZonesGteCondition | airbyte_agent_sdk.connectors.woocommerce.types.ShippingZonesLtCondition | airbyte_agent_sdk.connectors.woocommerce.types.ShippingZonesLteCondition | airbyte_agent_sdk.connectors.woocommerce.types.ShippingZonesInCondition | airbyte_agent_sdk.connectors.woocommerce.types.ShippingZonesLikeCondition | airbyte_agent_sdk.connectors.woocommerce.types.ShippingZonesFuzzyCondition | airbyte_agent_sdk.connectors.woocommerce.types.ShippingZonesKeywordCondition | airbyte_agent_sdk.connectors.woocommerce.types.ShippingZonesContainsCondition | airbyte_agent_sdk.connectors.woocommerce.types.ShippingZonesNotCondition | airbyte_agent_sdk.connectors.woocommerce.types.ShippingZonesAndCondition | airbyte_agent_sdk.connectors.woocommerce.types.ShippingZonesOrCondition | airbyte_agent_sdk.connectors.woocommerce.types.ShippingZonesAnyCondition]`
     :   The type of the None singleton.
 
+<a id="ShippingZonesAnyCondition"></a>
+
 `ShippingZonesAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -7892,6 +8496,8 @@ Classes
     `any: airbyte_agent_sdk.connectors.woocommerce.types.ShippingZonesAnyValueFilter`
     :   The type of the None singleton.
 
+<a id="ShippingZonesAnyValueFilter"></a>
+
 `ShippingZonesAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
 
@@ -7910,6 +8516,8 @@ Classes
     `order: Any`
     :   Shipping zone order
 
+<a id="ShippingZonesContainsCondition"></a>
+
 `ShippingZonesContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -7921,6 +8529,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.woocommerce.types.ShippingZonesAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="ShippingZonesEqCondition"></a>
 
 `ShippingZonesEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -7934,6 +8544,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.woocommerce.types.ShippingZonesSearchFilter`
     :   The type of the None singleton.
 
+<a id="ShippingZonesFuzzyCondition"></a>
+
 `ShippingZonesFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -7945,6 +8557,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.woocommerce.types.ShippingZonesStringFilter`
     :   The type of the None singleton.
+
+<a id="ShippingZonesGetParams"></a>
 
 `ShippingZonesGetParams(*args, **kwargs)`
 :   Parameters for shipping_zones.get operation
@@ -7958,6 +8572,8 @@ Classes
     `id: str`
     :   The type of the None singleton.
 
+<a id="ShippingZonesGtCondition"></a>
+
 `ShippingZonesGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -7970,6 +8586,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.woocommerce.types.ShippingZonesSearchFilter`
     :   The type of the None singleton.
 
+<a id="ShippingZonesGteCondition"></a>
+
 `ShippingZonesGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -7981,6 +8599,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.woocommerce.types.ShippingZonesSearchFilter`
     :   The type of the None singleton.
+
+<a id="ShippingZonesInCondition"></a>
 
 `ShippingZonesInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -8002,6 +8622,8 @@ Classes
     `in: airbyte_agent_sdk.connectors.woocommerce.types.ShippingZonesInFilter`
     :   The type of the None singleton.
 
+<a id="ShippingZonesInFilter"></a>
+
 `ShippingZonesInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
 
@@ -8020,6 +8642,8 @@ Classes
     `order: list[int]`
     :   Shipping zone order
 
+<a id="ShippingZonesKeywordCondition"></a>
+
 `ShippingZonesKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -8031,6 +8655,8 @@ Classes
 
     `keyword: airbyte_agent_sdk.connectors.woocommerce.types.ShippingZonesStringFilter`
     :   The type of the None singleton.
+
+<a id="ShippingZonesLikeCondition"></a>
 
 `ShippingZonesLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
@@ -8044,12 +8670,16 @@ Classes
     `like: airbyte_agent_sdk.connectors.woocommerce.types.ShippingZonesStringFilter`
     :   The type of the None singleton.
 
+<a id="ShippingZonesListParams"></a>
+
 `ShippingZonesListParams(*args, **kwargs)`
 :   Parameters for shipping_zones.list operation
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="ShippingZonesLtCondition"></a>
 
 `ShippingZonesLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
@@ -8063,6 +8693,8 @@ Classes
     `lt: airbyte_agent_sdk.connectors.woocommerce.types.ShippingZonesSearchFilter`
     :   The type of the None singleton.
 
+<a id="ShippingZonesLteCondition"></a>
+
 `ShippingZonesLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
 
@@ -8075,6 +8707,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.woocommerce.types.ShippingZonesSearchFilter`
     :   The type of the None singleton.
 
+<a id="ShippingZonesNeqCondition"></a>
+
 `ShippingZonesNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -8086,6 +8720,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.woocommerce.types.ShippingZonesSearchFilter`
     :   The type of the None singleton.
+
+<a id="ShippingZonesNotCondition"></a>
 
 `ShippingZonesNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -8107,6 +8743,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.woocommerce.types.ShippingZonesEqCondition | airbyte_agent_sdk.connectors.woocommerce.types.ShippingZonesNeqCondition | airbyte_agent_sdk.connectors.woocommerce.types.ShippingZonesGtCondition | airbyte_agent_sdk.connectors.woocommerce.types.ShippingZonesGteCondition | airbyte_agent_sdk.connectors.woocommerce.types.ShippingZonesLtCondition | airbyte_agent_sdk.connectors.woocommerce.types.ShippingZonesLteCondition | airbyte_agent_sdk.connectors.woocommerce.types.ShippingZonesInCondition | airbyte_agent_sdk.connectors.woocommerce.types.ShippingZonesLikeCondition | airbyte_agent_sdk.connectors.woocommerce.types.ShippingZonesFuzzyCondition | airbyte_agent_sdk.connectors.woocommerce.types.ShippingZonesKeywordCondition | airbyte_agent_sdk.connectors.woocommerce.types.ShippingZonesContainsCondition | airbyte_agent_sdk.connectors.woocommerce.types.ShippingZonesNotCondition | airbyte_agent_sdk.connectors.woocommerce.types.ShippingZonesAndCondition | airbyte_agent_sdk.connectors.woocommerce.types.ShippingZonesOrCondition | airbyte_agent_sdk.connectors.woocommerce.types.ShippingZonesAnyCondition`
     :   The type of the None singleton.
 
+<a id="ShippingZonesOrCondition"></a>
+
 `ShippingZonesOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -8127,6 +8765,8 @@ Classes
     `or: list[airbyte_agent_sdk.connectors.woocommerce.types.ShippingZonesEqCondition | airbyte_agent_sdk.connectors.woocommerce.types.ShippingZonesNeqCondition | airbyte_agent_sdk.connectors.woocommerce.types.ShippingZonesGtCondition | airbyte_agent_sdk.connectors.woocommerce.types.ShippingZonesGteCondition | airbyte_agent_sdk.connectors.woocommerce.types.ShippingZonesLtCondition | airbyte_agent_sdk.connectors.woocommerce.types.ShippingZonesLteCondition | airbyte_agent_sdk.connectors.woocommerce.types.ShippingZonesInCondition | airbyte_agent_sdk.connectors.woocommerce.types.ShippingZonesLikeCondition | airbyte_agent_sdk.connectors.woocommerce.types.ShippingZonesFuzzyCondition | airbyte_agent_sdk.connectors.woocommerce.types.ShippingZonesKeywordCondition | airbyte_agent_sdk.connectors.woocommerce.types.ShippingZonesContainsCondition | airbyte_agent_sdk.connectors.woocommerce.types.ShippingZonesNotCondition | airbyte_agent_sdk.connectors.woocommerce.types.ShippingZonesAndCondition | airbyte_agent_sdk.connectors.woocommerce.types.ShippingZonesOrCondition | airbyte_agent_sdk.connectors.woocommerce.types.ShippingZonesAnyCondition]`
     :   The type of the None singleton.
 
+<a id="ShippingZonesSearchFilter"></a>
+
 `ShippingZonesSearchFilter(*args, **kwargs)`
 :   Available fields for filtering shipping_zones search queries.
 
@@ -8145,6 +8785,8 @@ Classes
     `order: int | None`
     :   Shipping zone order
 
+<a id="ShippingZonesSearchQuery"></a>
+
 `ShippingZonesSearchQuery(*args, **kwargs)`
 :   Search query for shipping_zones entity.
 
@@ -8159,6 +8801,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.woocommerce.types.ShippingZonesSortFilter]`
     :   The type of the None singleton.
+
+<a id="ShippingZonesSortFilter"></a>
 
 `ShippingZonesSortFilter(*args, **kwargs)`
 :   Available fields for sorting shipping_zones search results.
@@ -8178,6 +8822,8 @@ Classes
     `order: Literal['asc', 'desc']`
     :   Shipping zone order
 
+<a id="ShippingZonesStringFilter"></a>
+
 `ShippingZonesStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -8195,6 +8841,8 @@ Classes
 
     `order: str`
     :   Shipping zone order
+
+<a id="TaxClassesAndCondition"></a>
 
 `TaxClassesAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -8216,6 +8864,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.woocommerce.types.TaxClassesEqCondition | airbyte_agent_sdk.connectors.woocommerce.types.TaxClassesNeqCondition | airbyte_agent_sdk.connectors.woocommerce.types.TaxClassesGtCondition | airbyte_agent_sdk.connectors.woocommerce.types.TaxClassesGteCondition | airbyte_agent_sdk.connectors.woocommerce.types.TaxClassesLtCondition | airbyte_agent_sdk.connectors.woocommerce.types.TaxClassesLteCondition | airbyte_agent_sdk.connectors.woocommerce.types.TaxClassesInCondition | airbyte_agent_sdk.connectors.woocommerce.types.TaxClassesLikeCondition | airbyte_agent_sdk.connectors.woocommerce.types.TaxClassesFuzzyCondition | airbyte_agent_sdk.connectors.woocommerce.types.TaxClassesKeywordCondition | airbyte_agent_sdk.connectors.woocommerce.types.TaxClassesContainsCondition | airbyte_agent_sdk.connectors.woocommerce.types.TaxClassesNotCondition | airbyte_agent_sdk.connectors.woocommerce.types.TaxClassesAndCondition | airbyte_agent_sdk.connectors.woocommerce.types.TaxClassesOrCondition | airbyte_agent_sdk.connectors.woocommerce.types.TaxClassesAnyCondition]`
     :   The type of the None singleton.
 
+<a id="TaxClassesAnyCondition"></a>
+
 `TaxClassesAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -8236,6 +8886,8 @@ Classes
     `any: airbyte_agent_sdk.connectors.woocommerce.types.TaxClassesAnyValueFilter`
     :   The type of the None singleton.
 
+<a id="TaxClassesAnyValueFilter"></a>
+
 `TaxClassesAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
 
@@ -8251,6 +8903,8 @@ Classes
     `slug: Any`
     :   Unique identifier
 
+<a id="TaxClassesContainsCondition"></a>
+
 `TaxClassesContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -8262,6 +8916,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.woocommerce.types.TaxClassesAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="TaxClassesEqCondition"></a>
 
 `TaxClassesEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -8275,6 +8931,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.woocommerce.types.TaxClassesSearchFilter`
     :   The type of the None singleton.
 
+<a id="TaxClassesFuzzyCondition"></a>
+
 `TaxClassesFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -8286,6 +8944,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.woocommerce.types.TaxClassesStringFilter`
     :   The type of the None singleton.
+
+<a id="TaxClassesGtCondition"></a>
 
 `TaxClassesGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
@@ -8299,6 +8959,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.woocommerce.types.TaxClassesSearchFilter`
     :   The type of the None singleton.
 
+<a id="TaxClassesGteCondition"></a>
+
 `TaxClassesGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -8310,6 +8972,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.woocommerce.types.TaxClassesSearchFilter`
     :   The type of the None singleton.
+
+<a id="TaxClassesInCondition"></a>
 
 `TaxClassesInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -8331,6 +8995,8 @@ Classes
     `in: airbyte_agent_sdk.connectors.woocommerce.types.TaxClassesInFilter`
     :   The type of the None singleton.
 
+<a id="TaxClassesInFilter"></a>
+
 `TaxClassesInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
 
@@ -8346,6 +9012,8 @@ Classes
     `slug: list[str]`
     :   Unique identifier
 
+<a id="TaxClassesKeywordCondition"></a>
+
 `TaxClassesKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -8357,6 +9025,8 @@ Classes
 
     `keyword: airbyte_agent_sdk.connectors.woocommerce.types.TaxClassesStringFilter`
     :   The type of the None singleton.
+
+<a id="TaxClassesLikeCondition"></a>
 
 `TaxClassesLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
@@ -8370,12 +9040,16 @@ Classes
     `like: airbyte_agent_sdk.connectors.woocommerce.types.TaxClassesStringFilter`
     :   The type of the None singleton.
 
+<a id="TaxClassesListParams"></a>
+
 `TaxClassesListParams(*args, **kwargs)`
 :   Parameters for tax_classes.list operation
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="TaxClassesLtCondition"></a>
 
 `TaxClassesLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
@@ -8389,6 +9063,8 @@ Classes
     `lt: airbyte_agent_sdk.connectors.woocommerce.types.TaxClassesSearchFilter`
     :   The type of the None singleton.
 
+<a id="TaxClassesLteCondition"></a>
+
 `TaxClassesLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
 
@@ -8401,6 +9077,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.woocommerce.types.TaxClassesSearchFilter`
     :   The type of the None singleton.
 
+<a id="TaxClassesNeqCondition"></a>
+
 `TaxClassesNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -8412,6 +9090,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.woocommerce.types.TaxClassesSearchFilter`
     :   The type of the None singleton.
+
+<a id="TaxClassesNotCondition"></a>
 
 `TaxClassesNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -8433,6 +9113,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.woocommerce.types.TaxClassesEqCondition | airbyte_agent_sdk.connectors.woocommerce.types.TaxClassesNeqCondition | airbyte_agent_sdk.connectors.woocommerce.types.TaxClassesGtCondition | airbyte_agent_sdk.connectors.woocommerce.types.TaxClassesGteCondition | airbyte_agent_sdk.connectors.woocommerce.types.TaxClassesLtCondition | airbyte_agent_sdk.connectors.woocommerce.types.TaxClassesLteCondition | airbyte_agent_sdk.connectors.woocommerce.types.TaxClassesInCondition | airbyte_agent_sdk.connectors.woocommerce.types.TaxClassesLikeCondition | airbyte_agent_sdk.connectors.woocommerce.types.TaxClassesFuzzyCondition | airbyte_agent_sdk.connectors.woocommerce.types.TaxClassesKeywordCondition | airbyte_agent_sdk.connectors.woocommerce.types.TaxClassesContainsCondition | airbyte_agent_sdk.connectors.woocommerce.types.TaxClassesNotCondition | airbyte_agent_sdk.connectors.woocommerce.types.TaxClassesAndCondition | airbyte_agent_sdk.connectors.woocommerce.types.TaxClassesOrCondition | airbyte_agent_sdk.connectors.woocommerce.types.TaxClassesAnyCondition`
     :   The type of the None singleton.
 
+<a id="TaxClassesOrCondition"></a>
+
 `TaxClassesOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -8453,6 +9135,8 @@ Classes
     `or: list[airbyte_agent_sdk.connectors.woocommerce.types.TaxClassesEqCondition | airbyte_agent_sdk.connectors.woocommerce.types.TaxClassesNeqCondition | airbyte_agent_sdk.connectors.woocommerce.types.TaxClassesGtCondition | airbyte_agent_sdk.connectors.woocommerce.types.TaxClassesGteCondition | airbyte_agent_sdk.connectors.woocommerce.types.TaxClassesLtCondition | airbyte_agent_sdk.connectors.woocommerce.types.TaxClassesLteCondition | airbyte_agent_sdk.connectors.woocommerce.types.TaxClassesInCondition | airbyte_agent_sdk.connectors.woocommerce.types.TaxClassesLikeCondition | airbyte_agent_sdk.connectors.woocommerce.types.TaxClassesFuzzyCondition | airbyte_agent_sdk.connectors.woocommerce.types.TaxClassesKeywordCondition | airbyte_agent_sdk.connectors.woocommerce.types.TaxClassesContainsCondition | airbyte_agent_sdk.connectors.woocommerce.types.TaxClassesNotCondition | airbyte_agent_sdk.connectors.woocommerce.types.TaxClassesAndCondition | airbyte_agent_sdk.connectors.woocommerce.types.TaxClassesOrCondition | airbyte_agent_sdk.connectors.woocommerce.types.TaxClassesAnyCondition]`
     :   The type of the None singleton.
 
+<a id="TaxClassesSearchFilter"></a>
+
 `TaxClassesSearchFilter(*args, **kwargs)`
 :   Available fields for filtering tax_classes search queries.
 
@@ -8467,6 +9151,8 @@ Classes
 
     `slug: str | None`
     :   Unique identifier
+
+<a id="TaxClassesSearchQuery"></a>
 
 `TaxClassesSearchQuery(*args, **kwargs)`
 :   Search query for tax_classes entity.
@@ -8483,6 +9169,8 @@ Classes
     `sort: list[airbyte_agent_sdk.connectors.woocommerce.types.TaxClassesSortFilter]`
     :   The type of the None singleton.
 
+<a id="TaxClassesSortFilter"></a>
+
 `TaxClassesSortFilter(*args, **kwargs)`
 :   Available fields for sorting tax_classes search results.
 
@@ -8498,6 +9186,8 @@ Classes
     `slug: Literal['asc', 'desc']`
     :   Unique identifier
 
+<a id="TaxClassesStringFilter"></a>
+
 `TaxClassesStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -8512,6 +9202,8 @@ Classes
 
     `slug: str`
     :   Unique identifier
+
+<a id="TaxRatesAndCondition"></a>
 
 `TaxRatesAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -8533,6 +9225,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.woocommerce.types.TaxRatesEqCondition | airbyte_agent_sdk.connectors.woocommerce.types.TaxRatesNeqCondition | airbyte_agent_sdk.connectors.woocommerce.types.TaxRatesGtCondition | airbyte_agent_sdk.connectors.woocommerce.types.TaxRatesGteCondition | airbyte_agent_sdk.connectors.woocommerce.types.TaxRatesLtCondition | airbyte_agent_sdk.connectors.woocommerce.types.TaxRatesLteCondition | airbyte_agent_sdk.connectors.woocommerce.types.TaxRatesInCondition | airbyte_agent_sdk.connectors.woocommerce.types.TaxRatesLikeCondition | airbyte_agent_sdk.connectors.woocommerce.types.TaxRatesFuzzyCondition | airbyte_agent_sdk.connectors.woocommerce.types.TaxRatesKeywordCondition | airbyte_agent_sdk.connectors.woocommerce.types.TaxRatesContainsCondition | airbyte_agent_sdk.connectors.woocommerce.types.TaxRatesNotCondition | airbyte_agent_sdk.connectors.woocommerce.types.TaxRatesAndCondition | airbyte_agent_sdk.connectors.woocommerce.types.TaxRatesOrCondition | airbyte_agent_sdk.connectors.woocommerce.types.TaxRatesAnyCondition]`
     :   The type of the None singleton.
 
+<a id="TaxRatesAnyCondition"></a>
+
 `TaxRatesAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -8552,6 +9246,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.woocommerce.types.TaxRatesAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="TaxRatesAnyValueFilter"></a>
 
 `TaxRatesAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -8604,6 +9300,8 @@ Classes
     `state: Any`
     :   State code
 
+<a id="TaxRatesContainsCondition"></a>
+
 `TaxRatesContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -8615,6 +9313,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.woocommerce.types.TaxRatesAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="TaxRatesEqCondition"></a>
 
 `TaxRatesEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -8628,6 +9328,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.woocommerce.types.TaxRatesSearchFilter`
     :   The type of the None singleton.
 
+<a id="TaxRatesFuzzyCondition"></a>
+
 `TaxRatesFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -8639,6 +9341,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.woocommerce.types.TaxRatesStringFilter`
     :   The type of the None singleton.
+
+<a id="TaxRatesGetParams"></a>
 
 `TaxRatesGetParams(*args, **kwargs)`
 :   Parameters for tax_rates.get operation
@@ -8652,6 +9356,8 @@ Classes
     `id: str`
     :   The type of the None singleton.
 
+<a id="TaxRatesGtCondition"></a>
+
 `TaxRatesGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -8664,6 +9370,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.woocommerce.types.TaxRatesSearchFilter`
     :   The type of the None singleton.
 
+<a id="TaxRatesGteCondition"></a>
+
 `TaxRatesGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -8675,6 +9383,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.woocommerce.types.TaxRatesSearchFilter`
     :   The type of the None singleton.
+
+<a id="TaxRatesInCondition"></a>
 
 `TaxRatesInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -8695,6 +9405,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.woocommerce.types.TaxRatesInFilter`
     :   The type of the None singleton.
+
+<a id="TaxRatesInFilter"></a>
 
 `TaxRatesInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -8747,6 +9459,8 @@ Classes
     `state: list[str]`
     :   State code
 
+<a id="TaxRatesKeywordCondition"></a>
+
 `TaxRatesKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -8759,6 +9473,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.woocommerce.types.TaxRatesStringFilter`
     :   The type of the None singleton.
 
+<a id="TaxRatesLikeCondition"></a>
+
 `TaxRatesLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -8770,6 +9486,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.woocommerce.types.TaxRatesStringFilter`
     :   The type of the None singleton.
+
+<a id="TaxRatesListParams"></a>
 
 `TaxRatesListParams(*args, **kwargs)`
 :   Parameters for tax_rates.list operation
@@ -8795,6 +9513,8 @@ Classes
     `per_page: int`
     :   The type of the None singleton.
 
+<a id="TaxRatesLtCondition"></a>
+
 `TaxRatesLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -8806,6 +9526,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.woocommerce.types.TaxRatesSearchFilter`
     :   The type of the None singleton.
+
+<a id="TaxRatesLteCondition"></a>
 
 `TaxRatesLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -8819,6 +9541,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.woocommerce.types.TaxRatesSearchFilter`
     :   The type of the None singleton.
 
+<a id="TaxRatesNeqCondition"></a>
+
 `TaxRatesNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -8830,6 +9554,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.woocommerce.types.TaxRatesSearchFilter`
     :   The type of the None singleton.
+
+<a id="TaxRatesNotCondition"></a>
 
 `TaxRatesNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -8851,6 +9577,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.woocommerce.types.TaxRatesEqCondition | airbyte_agent_sdk.connectors.woocommerce.types.TaxRatesNeqCondition | airbyte_agent_sdk.connectors.woocommerce.types.TaxRatesGtCondition | airbyte_agent_sdk.connectors.woocommerce.types.TaxRatesGteCondition | airbyte_agent_sdk.connectors.woocommerce.types.TaxRatesLtCondition | airbyte_agent_sdk.connectors.woocommerce.types.TaxRatesLteCondition | airbyte_agent_sdk.connectors.woocommerce.types.TaxRatesInCondition | airbyte_agent_sdk.connectors.woocommerce.types.TaxRatesLikeCondition | airbyte_agent_sdk.connectors.woocommerce.types.TaxRatesFuzzyCondition | airbyte_agent_sdk.connectors.woocommerce.types.TaxRatesKeywordCondition | airbyte_agent_sdk.connectors.woocommerce.types.TaxRatesContainsCondition | airbyte_agent_sdk.connectors.woocommerce.types.TaxRatesNotCondition | airbyte_agent_sdk.connectors.woocommerce.types.TaxRatesAndCondition | airbyte_agent_sdk.connectors.woocommerce.types.TaxRatesOrCondition | airbyte_agent_sdk.connectors.woocommerce.types.TaxRatesAnyCondition`
     :   The type of the None singleton.
 
+<a id="TaxRatesOrCondition"></a>
+
 `TaxRatesOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -8870,6 +9598,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.woocommerce.types.TaxRatesEqCondition | airbyte_agent_sdk.connectors.woocommerce.types.TaxRatesNeqCondition | airbyte_agent_sdk.connectors.woocommerce.types.TaxRatesGtCondition | airbyte_agent_sdk.connectors.woocommerce.types.TaxRatesGteCondition | airbyte_agent_sdk.connectors.woocommerce.types.TaxRatesLtCondition | airbyte_agent_sdk.connectors.woocommerce.types.TaxRatesLteCondition | airbyte_agent_sdk.connectors.woocommerce.types.TaxRatesInCondition | airbyte_agent_sdk.connectors.woocommerce.types.TaxRatesLikeCondition | airbyte_agent_sdk.connectors.woocommerce.types.TaxRatesFuzzyCondition | airbyte_agent_sdk.connectors.woocommerce.types.TaxRatesKeywordCondition | airbyte_agent_sdk.connectors.woocommerce.types.TaxRatesContainsCondition | airbyte_agent_sdk.connectors.woocommerce.types.TaxRatesNotCondition | airbyte_agent_sdk.connectors.woocommerce.types.TaxRatesAndCondition | airbyte_agent_sdk.connectors.woocommerce.types.TaxRatesOrCondition | airbyte_agent_sdk.connectors.woocommerce.types.TaxRatesAnyCondition]`
     :   The type of the None singleton.
+
+<a id="TaxRatesSearchFilter"></a>
 
 `TaxRatesSearchFilter(*args, **kwargs)`
 :   Available fields for filtering tax_rates search queries.
@@ -8922,6 +9652,8 @@ Classes
     `state: str | None`
     :   State code
 
+<a id="TaxRatesSearchQuery"></a>
+
 `TaxRatesSearchQuery(*args, **kwargs)`
 :   Search query for tax_rates entity.
 
@@ -8936,6 +9668,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.woocommerce.types.TaxRatesSortFilter]`
     :   The type of the None singleton.
+
+<a id="TaxRatesSortFilter"></a>
 
 `TaxRatesSortFilter(*args, **kwargs)`
 :   Available fields for sorting tax_rates search results.
@@ -8987,6 +9721,8 @@ Classes
 
     `state: Literal['asc', 'desc']`
     :   State code
+
+<a id="TaxRatesStringFilter"></a>
 
 `TaxRatesStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/zendesk_chat/connector.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/zendesk_chat/connector.md
@@ -10,6 +10,8 @@ Zendesk-Chat connector.
 Classes
 -------
 
+<a id="AccountsQuery"></a>
+
 `AccountsQuery(connector: ZendeskChatConnector)`
 :   Query class for Accounts entity operations.
     
@@ -22,6 +24,8 @@ Classes
         
         Returns:
             Account
+
+<a id="AgentTimelineQuery"></a>
 
 `AgentTimelineQuery(connector: ZendeskChatConnector)`
 :   Query class for AgentTimeline entity operations.
@@ -41,6 +45,8 @@ Classes
         
         Returns:
             AgentTimelineListResult
+
+<a id="AgentsQuery"></a>
 
 `AgentsQuery(connector: ZendeskChatConnector)`
 :   Query class for Agents entity operations.
@@ -101,6 +107,8 @@ Classes
         Returns:
             AgentsListResult
 
+<a id="BansQuery"></a>
+
 `BansQuery(connector: ZendeskChatConnector)`
 :   Query class for Bans entity operations.
     
@@ -128,6 +136,8 @@ Classes
         
         Returns:
             BansListResult
+
+<a id="ChatsQuery"></a>
 
 `ChatsQuery(connector: ZendeskChatConnector)`
 :   Query class for Chats entity operations.
@@ -189,6 +199,8 @@ Classes
         Returns:
             ChatsListResult
 
+<a id="DepartmentsQuery"></a>
+
 `DepartmentsQuery(connector: ZendeskChatConnector)`
 :   Query class for Departments entity operations.
     
@@ -238,6 +250,8 @@ Classes
         Returns:
             DepartmentsListResult
 
+<a id="GoalsQuery"></a>
+
 `GoalsQuery(connector: ZendeskChatConnector)`
 :   Query class for Goals entity operations.
     
@@ -260,6 +274,8 @@ Classes
         
         Returns:
             GoalsListResult
+
+<a id="RolesQuery"></a>
 
 `RolesQuery(connector: ZendeskChatConnector)`
 :   Query class for Roles entity operations.
@@ -284,6 +300,8 @@ Classes
         Returns:
             RolesListResult
 
+<a id="RoutingSettingsQuery"></a>
+
 `RoutingSettingsQuery(connector: ZendeskChatConnector)`
 :   Query class for RoutingSettings entity operations.
     
@@ -296,6 +314,8 @@ Classes
         
         Returns:
             RoutingSettings
+
+<a id="ShortcutsQuery"></a>
 
 `ShortcutsQuery(connector: ZendeskChatConnector)`
 :   Query class for Shortcuts entity operations.
@@ -346,6 +366,8 @@ Classes
         Returns:
             ShortcutsListResult
 
+<a id="SkillsQuery"></a>
+
 `SkillsQuery(connector: ZendeskChatConnector)`
 :   Query class for Skills entity operations.
     
@@ -368,6 +390,8 @@ Classes
         
         Returns:
             SkillsListResult
+
+<a id="TriggersQuery"></a>
 
 `TriggersQuery(connector: ZendeskChatConnector)`
 :   Query class for Triggers entity operations.
@@ -406,6 +430,8 @@ Classes
         
         Returns:
             TriggersListResult
+
+<a id="ZendeskChatConnector"></a>
 
 `ZendeskChatConnector(auth_config: ZendeskChatAuthConfig | AirbyteAuthConfig | BaseModel | None = None, on_token_refresh: Any | None = None, subdomain: str | None = None)`
 :   Type-safe Zendesk-Chat API connector.

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/zendesk_chat/index.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/zendesk_chat/index.md
@@ -19,6 +19,8 @@ Sub-modules
 Classes
 -------
 
+<a id="AgentsSearchData"></a>
+
 `AgentsSearchData(**data: Any)`
 :   Search result data for agents entity.
     
@@ -64,6 +66,8 @@ Classes
 
     `role_id: int | None`
     :   Agent role ID
+
+<a id="AirbyteAuthConfig"></a>
 
 `AirbyteAuthConfig(**data: Any)`
 :   Authentication configuration for Airbyte hosted mode execution.
@@ -133,6 +137,8 @@ Classes
     `workspace_name: str | None`
     :   The type of the None singleton.
 
+<a id="AirbyteSearchMeta"></a>
+
 `AirbyteSearchMeta(**data: Any)`
 :   Pagination metadata for search responses.
     
@@ -160,6 +166,8 @@ Classes
 
     `took_ms: int | None`
     :   Time taken to execute the search in milliseconds.
+
+<a id="AirbyteSearchResult"></a>
 
 `AirbyteSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -195,6 +203,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="AgentsSearchResult"></a>
+
 `AgentsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -210,6 +220,8 @@ Classes
     * airbyte_agent_sdk.connectors.zendesk_chat.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="ChatsSearchResult"></a>
 
 `ChatsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -227,6 +239,8 @@ Classes
     * pydantic.main.BaseModel
     * typing.Generic
 
+<a id="DepartmentsSearchResult"></a>
+
 `DepartmentsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -242,6 +256,8 @@ Classes
     * airbyte_agent_sdk.connectors.zendesk_chat.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="ShortcutsSearchResult"></a>
 
 `ShortcutsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -259,6 +275,8 @@ Classes
     * pydantic.main.BaseModel
     * typing.Generic
 
+<a id="TriggersSearchResult"></a>
+
 `TriggersSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -274,6 +292,8 @@ Classes
     * airbyte_agent_sdk.connectors.zendesk_chat.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="ChatsSearchData"></a>
 
 `ChatsSearchData(**data: Any)`
 :   Search result data for chats entity.
@@ -321,6 +341,8 @@ Classes
     `update_timestamp: str | None`
     :   Last update timestamp
 
+<a id="DepartmentsSearchData"></a>
+
 `DepartmentsSearchData(**data: Any)`
 :   Search result data for departments entity.
     
@@ -351,6 +373,8 @@ Classes
 
     `name: str | None`
     :   Department name
+
+<a id="ShortcutsSearchData"></a>
 
 `ShortcutsSearchData(**data: Any)`
 :   Search result data for shortcuts entity.
@@ -383,6 +407,8 @@ Classes
     `tags: list[typing.Any] | None`
     :   Tags applied when shortcut is used
 
+<a id="TriggersSearchData"></a>
+
 `TriggersSearchData(**data: Any)`
 :   Search result data for triggers entity.
     
@@ -411,6 +437,8 @@ Classes
     `name: str | None`
     :   Trigger name
 
+<a id="ZendeskChatAuthConfig"></a>
+
 `ZendeskChatAuthConfig(**data: Any)`
 :   OAuth 2.0 Access Token - Authenticate using an OAuth 2.0 access token from Zendesk
     
@@ -432,6 +460,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="ZendeskChatConnector"></a>
 
 `ZendeskChatConnector(auth_config: ZendeskChatAuthConfig | AirbyteAuthConfig | BaseModel | None = None, on_token_refresh: Any | None = None, subdomain: str | None = None)`
 :   Type-safe Zendesk-Chat API connector.
@@ -632,6 +662,8 @@ Classes
             entities = connector.list_entities()
             for entity in entities:
                 print(f"\{entity['entity_name']\}: \{entity['available_actions']\}")
+
+<a id="ZendeskChatReplicationConfig"></a>
 
 `ZendeskChatReplicationConfig(**data: Any)`
 :   Replication Configuration - Settings for data replication from Zendesk Chat.

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/zendesk_chat/models.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/zendesk_chat/models.md
@@ -13,6 +13,8 @@ and response envelope types.
 Classes
 -------
 
+<a id="Account"></a>
+
 `Account(**data: Any)`
 :   Zendesk Chat account information
     
@@ -46,6 +48,8 @@ Classes
 
     `status: str | Any | None`
     :   The type of the None singleton.
+
+<a id="Agent"></a>
 
 `Agent(**data: Any)`
 :   Zendesk Chat agent
@@ -111,6 +115,8 @@ Classes
     `skills: list[int] | Any | None`
     :   The type of the None singleton.
 
+<a id="AgentRoles"></a>
+
 `AgentRoles(**data: Any)`
 :   Agent role flags
     
@@ -135,6 +141,8 @@ Classes
 
     `owner: bool | Any | None`
     :   The type of the None singleton.
+
+<a id="AgentTimeline"></a>
 
 `AgentTimeline(**data: Any)`
 :   Agent activity timeline entry
@@ -170,6 +178,8 @@ Classes
     `status: str | Any | None`
     :   The type of the None singleton.
 
+<a id="AgentTimelineListResultMeta"></a>
+
 `AgentTimelineListResultMeta(**data: Any)`
 :   Metadata for agent_timeline.Action.LIST operation
     
@@ -194,6 +204,8 @@ Classes
 
     `next_page: str | Any | None`
     :   The type of the None singleton.
+
+<a id="AgentsSearchData"></a>
 
 `AgentsSearchData(**data: Any)`
 :   Search result data for agents entity.
@@ -241,6 +253,8 @@ Classes
     `role_id: int | None`
     :   Agent role ID
 
+<a id="AirbyteSearchMeta"></a>
+
 `AirbyteSearchMeta(**data: Any)`
 :   Pagination metadata for search responses.
     
@@ -268,6 +282,8 @@ Classes
 
     `took_ms: int | None`
     :   Time taken to execute the search in milliseconds.
+
+<a id="AirbyteSearchResult"></a>
 
 `AirbyteSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -324,6 +340,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="AgentsSearchResult"></a>
+
 `AgentsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -360,6 +378,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="ChatsSearchResult"></a>
 
 `ChatsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -398,6 +418,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="DepartmentsSearchResult"></a>
+
 `DepartmentsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -434,6 +456,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="ShortcutsSearchResult"></a>
 
 `ShortcutsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -472,6 +496,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="TriggersSearchResult"></a>
+
 `TriggersSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -487,6 +513,8 @@ Classes
     * airbyte_agent_sdk.connectors.zendesk_chat.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="Ban"></a>
 
 `Ban(**data: Any)`
 :   Banned visitor
@@ -527,6 +555,8 @@ Classes
 
     `visitor_name: str | Any | None`
     :   The type of the None singleton.
+
+<a id="Billing"></a>
 
 `Billing(**data: Any)`
 :   Account billing information
@@ -585,6 +615,8 @@ Classes
 
     `state: str | Any | None`
     :   The type of the None singleton.
+
+<a id="Chat"></a>
 
 `Chat(**data: Any)`
 :   Chat conversation transcript
@@ -689,6 +721,8 @@ Classes
     `zendesk_ticket_id: int | Any | None`
     :   The type of the None singleton.
 
+<a id="ChatConversion"></a>
+
 `ChatConversion(**data: Any)`
 :   ChatConversion type definition
     
@@ -722,6 +756,8 @@ Classes
 
     `timestamp: str | Any | None`
     :   The type of the None singleton.
+
+<a id="ChatEngagement"></a>
 
 `ChatEngagement(**data: Any)`
 :   ChatEngagement type definition
@@ -790,6 +826,8 @@ Classes
     `timestamp: str | Any | None`
     :   The type of the None singleton.
 
+<a id="ChatHistoryItem"></a>
+
 `ChatHistoryItem(**data: Any)`
 :   ChatHistoryItem type definition
     
@@ -851,6 +889,8 @@ Classes
     `type_: str | Any | None`
     :   The type of the None singleton.
 
+<a id="ChatSession"></a>
+
 `ChatSession(**data: Any)`
 :   ChatSession type definition
     
@@ -903,6 +943,8 @@ Classes
     `user_agent: str | Any | None`
     :   The type of the None singleton.
 
+<a id="ChatsListResultMeta"></a>
+
 `ChatsListResultMeta(**data: Any)`
 :   Metadata for chats.Action.LIST operation
     
@@ -927,6 +969,8 @@ Classes
 
     `next_page: str | Any | None`
     :   The type of the None singleton.
+
+<a id="ChatsSearchData"></a>
 
 `ChatsSearchData(**data: Any)`
 :   Search result data for chats entity.
@@ -974,6 +1018,8 @@ Classes
     `update_timestamp: str | None`
     :   Last update timestamp
 
+<a id="ConversionAttribution"></a>
+
 `ConversionAttribution(**data: Any)`
 :   ConversionAttribution type definition
     
@@ -1007,6 +1053,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="Department"></a>
 
 `Department(**data: Any)`
 :   Department type definition
@@ -1045,6 +1093,8 @@ Classes
     `settings: Any`
     :   The type of the None singleton.
 
+<a id="DepartmentSettings"></a>
+
 `DepartmentSettings(**data: Any)`
 :   DepartmentSettings type definition
     
@@ -1066,6 +1116,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="DepartmentsSearchData"></a>
 
 `DepartmentsSearchData(**data: Any)`
 :   Search result data for departments entity.
@@ -1097,6 +1149,8 @@ Classes
 
     `name: str | None`
     :   Department name
+
+<a id="Goal"></a>
 
 `Goal(**data: Any)`
 :   Goal type definition
@@ -1141,6 +1195,8 @@ Classes
     `settings: dict[str, typing.Any] | Any | None`
     :   The type of the None singleton.
 
+<a id="MessageCount"></a>
+
 `MessageCount(**data: Any)`
 :   MessageCount type definition
     
@@ -1168,6 +1224,8 @@ Classes
 
     `visitor: int | Any | None`
     :   The type of the None singleton.
+
+<a id="Plan"></a>
 
 `Plan(**data: Any)`
 :   Account plan details
@@ -1272,6 +1330,8 @@ Classes
     `widget_customization: str | Any | None`
     :   The type of the None singleton.
 
+<a id="ResponseTime"></a>
+
 `ResponseTime(**data: Any)`
 :   ResponseTime type definition
     
@@ -1299,6 +1359,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="Role"></a>
 
 `Role(**data: Any)`
 :   Role type definition
@@ -1337,6 +1399,8 @@ Classes
     `permissions: dict[str, typing.Any] | Any | None`
     :   The type of the None singleton.
 
+<a id="RoutingSettings"></a>
+
 `RoutingSettings(**data: Any)`
 :   RoutingSettings type definition
     
@@ -1373,6 +1437,8 @@ Classes
 
     `skill_routing: dict[str, typing.Any] | Any | None`
     :   The type of the None singleton.
+
+<a id="Shortcut"></a>
 
 `Shortcut(**data: Any)`
 :   Shortcut type definition
@@ -1417,6 +1483,8 @@ Classes
     `tags: list[str] | Any | None`
     :   The type of the None singleton.
 
+<a id="ShortcutsSearchData"></a>
+
 `ShortcutsSearchData(**data: Any)`
 :   Search result data for shortcuts entity.
     
@@ -1447,6 +1515,8 @@ Classes
 
     `tags: list[typing.Any] | None`
     :   Tags applied when shortcut is used
+
+<a id="Skill"></a>
 
 `Skill(**data: Any)`
 :   Skill type definition
@@ -1481,6 +1551,8 @@ Classes
 
     `name: str | Any | None`
     :   The type of the None singleton.
+
+<a id="Trigger"></a>
 
 `Trigger(**data: Any)`
 :   Trigger type definition
@@ -1528,6 +1600,8 @@ Classes
     `run_once: bool | Any | None`
     :   The type of the None singleton.
 
+<a id="TriggersSearchData"></a>
+
 `TriggersSearchData(**data: Any)`
 :   Search result data for triggers entity.
     
@@ -1555,6 +1629,8 @@ Classes
 
     `name: str | None`
     :   Trigger name
+
+<a id="Visitor"></a>
 
 `Visitor(**data: Any)`
 :   Visitor type definition
@@ -1590,6 +1666,8 @@ Classes
     `phone: str | Any | None`
     :   The type of the None singleton.
 
+<a id="WebpathItem"></a>
+
 `WebpathItem(**data: Any)`
 :   WebpathItem type definition
     
@@ -1615,6 +1693,8 @@ Classes
     `timestamp: str | Any | None`
     :   The type of the None singleton.
 
+<a id="ZendeskChatAuthConfig"></a>
+
 `ZendeskChatAuthConfig(**data: Any)`
 :   OAuth 2.0 Access Token - Authenticate using an OAuth 2.0 access token from Zendesk
     
@@ -1636,6 +1716,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="ZendeskChatCheckResult"></a>
 
 `ZendeskChatCheckResult(**data: Any)`
 :   Result of a health check operation.
@@ -1669,6 +1751,8 @@ Classes
 
     `status: str`
     :   Health check status: 'healthy' or 'unhealthy'.
+
+<a id="ZendeskChatExecuteResult"></a>
 
 `ZendeskChatExecuteResult(**data: Any)`
 :   Response envelope with data only.
@@ -1706,6 +1790,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="ZendeskChatExecuteResultWithMeta"></a>
 
 `ZendeskChatExecuteResultWithMeta(**data: Any)`
 :   Response envelope with data and metadata.
@@ -1759,6 +1845,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="AgentTimelineListResult"></a>
+
 `AgentTimelineListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -1802,6 +1890,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="ChatsListResult"></a>
+
 `ChatsListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -1844,6 +1934,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="BansListResult"></a>
+
 `BansListResult(**data: Any)`
 :   Response envelope with data only.
     
@@ -1884,6 +1976,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="AgentsListResult"></a>
 
 `AgentsListResult(**data: Any)`
 :   Response envelope with data only.
@@ -1926,6 +2020,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="DepartmentsListResult"></a>
+
 `DepartmentsListResult(**data: Any)`
 :   Response envelope with data only.
     
@@ -1966,6 +2062,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="GoalsListResult"></a>
 
 `GoalsListResult(**data: Any)`
 :   Response envelope with data only.
@@ -2008,6 +2106,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="RolesListResult"></a>
+
 `RolesListResult(**data: Any)`
 :   Response envelope with data only.
     
@@ -2048,6 +2148,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="ShortcutsListResult"></a>
 
 `ShortcutsListResult(**data: Any)`
 :   Response envelope with data only.
@@ -2090,6 +2192,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="SkillsListResult"></a>
+
 `SkillsListResult(**data: Any)`
 :   Response envelope with data only.
     
@@ -2131,6 +2235,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="TriggersListResult"></a>
+
 `TriggersListResult(**data: Any)`
 :   Response envelope with data only.
     
@@ -2148,6 +2254,8 @@ Classes
     * airbyte_agent_sdk.connectors.zendesk_chat.models.ZendeskChatExecuteResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="ZendeskChatReplicationConfig"></a>
 
 `ZendeskChatReplicationConfig(**data: Any)`
 :   Replication Configuration - Settings for data replication from Zendesk Chat.

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/zendesk_chat/types.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/zendesk_chat/types.md
@@ -10,12 +10,16 @@ Type definitions for zendesk-chat connector.
 Classes
 -------
 
+<a id="AccountsGetParams"></a>
+
 `AccountsGetParams(*args, **kwargs)`
 :   Parameters for accounts.get operation
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="AgentTimelineListParams"></a>
 
 `AgentTimelineListParams(*args, **kwargs)`
 :   Parameters for agent_timeline.list operation
@@ -34,6 +38,8 @@ Classes
 
     `start_time: int`
     :   The type of the None singleton.
+
+<a id="AgentsAndCondition"></a>
 
 `AgentsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -55,6 +61,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.zendesk_chat.types.AgentsEqCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.AgentsNeqCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.AgentsGtCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.AgentsGteCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.AgentsLtCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.AgentsLteCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.AgentsInCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.AgentsLikeCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.AgentsFuzzyCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.AgentsKeywordCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.AgentsContainsCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.AgentsNotCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.AgentsAndCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.AgentsOrCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.AgentsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="AgentsAnyCondition"></a>
+
 `AgentsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -74,6 +82,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.zendesk_chat.types.AgentsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="AgentsAnyValueFilter"></a>
 
 `AgentsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -111,6 +121,8 @@ Classes
     `role_id: Any`
     :   Agent role ID
 
+<a id="AgentsContainsCondition"></a>
+
 `AgentsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -122,6 +134,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.zendesk_chat.types.AgentsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="AgentsEqCondition"></a>
 
 `AgentsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -135,6 +149,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.zendesk_chat.types.AgentsSearchFilter`
     :   The type of the None singleton.
 
+<a id="AgentsFuzzyCondition"></a>
+
 `AgentsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -146,6 +162,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.zendesk_chat.types.AgentsStringFilter`
     :   The type of the None singleton.
+
+<a id="AgentsGetParams"></a>
 
 `AgentsGetParams(*args, **kwargs)`
 :   Parameters for agents.get operation
@@ -159,6 +177,8 @@ Classes
     `agent_id: str`
     :   The type of the None singleton.
 
+<a id="AgentsGtCondition"></a>
+
 `AgentsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -171,6 +191,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.zendesk_chat.types.AgentsSearchFilter`
     :   The type of the None singleton.
 
+<a id="AgentsGteCondition"></a>
+
 `AgentsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -182,6 +204,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.zendesk_chat.types.AgentsSearchFilter`
     :   The type of the None singleton.
+
+<a id="AgentsInCondition"></a>
 
 `AgentsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -202,6 +226,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.zendesk_chat.types.AgentsInFilter`
     :   The type of the None singleton.
+
+<a id="AgentsInFilter"></a>
 
 `AgentsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -239,6 +265,8 @@ Classes
     `role_id: list[int]`
     :   Agent role ID
 
+<a id="AgentsKeywordCondition"></a>
+
 `AgentsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -251,6 +279,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.zendesk_chat.types.AgentsStringFilter`
     :   The type of the None singleton.
 
+<a id="AgentsLikeCondition"></a>
+
 `AgentsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -262,6 +292,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.zendesk_chat.types.AgentsStringFilter`
     :   The type of the None singleton.
+
+<a id="AgentsListParams"></a>
 
 `AgentsListParams(*args, **kwargs)`
 :   Parameters for agents.list operation
@@ -278,6 +310,8 @@ Classes
     `since_id: int`
     :   The type of the None singleton.
 
+<a id="AgentsLtCondition"></a>
+
 `AgentsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -289,6 +323,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.zendesk_chat.types.AgentsSearchFilter`
     :   The type of the None singleton.
+
+<a id="AgentsLteCondition"></a>
 
 `AgentsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -302,6 +338,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.zendesk_chat.types.AgentsSearchFilter`
     :   The type of the None singleton.
 
+<a id="AgentsNeqCondition"></a>
+
 `AgentsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -313,6 +351,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.zendesk_chat.types.AgentsSearchFilter`
     :   The type of the None singleton.
+
+<a id="AgentsNotCondition"></a>
 
 `AgentsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -334,6 +374,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.zendesk_chat.types.AgentsEqCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.AgentsNeqCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.AgentsGtCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.AgentsGteCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.AgentsLtCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.AgentsLteCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.AgentsInCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.AgentsLikeCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.AgentsFuzzyCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.AgentsKeywordCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.AgentsContainsCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.AgentsNotCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.AgentsAndCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.AgentsOrCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.AgentsAnyCondition`
     :   The type of the None singleton.
 
+<a id="AgentsOrCondition"></a>
+
 `AgentsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -353,6 +395,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.zendesk_chat.types.AgentsEqCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.AgentsNeqCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.AgentsGtCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.AgentsGteCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.AgentsLtCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.AgentsLteCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.AgentsInCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.AgentsLikeCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.AgentsFuzzyCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.AgentsKeywordCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.AgentsContainsCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.AgentsNotCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.AgentsAndCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.AgentsOrCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.AgentsAnyCondition]`
     :   The type of the None singleton.
+
+<a id="AgentsSearchFilter"></a>
 
 `AgentsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering agents search queries.
@@ -390,6 +434,8 @@ Classes
     `role_id: int | None`
     :   Agent role ID
 
+<a id="AgentsSearchQuery"></a>
+
 `AgentsSearchQuery(*args, **kwargs)`
 :   Search query for agents entity.
 
@@ -404,6 +450,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.zendesk_chat.types.AgentsSortFilter]`
     :   The type of the None singleton.
+
+<a id="AgentsSortFilter"></a>
 
 `AgentsSortFilter(*args, **kwargs)`
 :   Available fields for sorting agents search results.
@@ -441,6 +489,8 @@ Classes
     `role_id: Literal['asc', 'desc']`
     :   Agent role ID
 
+<a id="AgentsStringFilter"></a>
+
 `AgentsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -477,6 +527,8 @@ Classes
     `role_id: str`
     :   Agent role ID
 
+<a id="AirbyteSearchParams"></a>
+
 `AirbyteSearchParams(*args, **kwargs)`
 :   Parameters for Airbyte cache search operations (generic, use entity-specific query types for better type hints).
 
@@ -498,6 +550,8 @@ Classes
     `query: dict[str, typing.Any]`
     :   The type of the None singleton.
 
+<a id="BansGetParams"></a>
+
 `BansGetParams(*args, **kwargs)`
 :   Parameters for bans.get operation
 
@@ -509,6 +563,8 @@ Classes
 
     `ban_id: str`
     :   The type of the None singleton.
+
+<a id="BansListParams"></a>
 
 `BansListParams(*args, **kwargs)`
 :   Parameters for bans.list operation
@@ -524,6 +580,8 @@ Classes
 
     `since_id: int`
     :   The type of the None singleton.
+
+<a id="ChatsAndCondition"></a>
 
 `ChatsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -545,6 +603,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.zendesk_chat.types.ChatsEqCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.ChatsNeqCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.ChatsGtCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.ChatsGteCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.ChatsLtCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.ChatsLteCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.ChatsInCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.ChatsLikeCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.ChatsFuzzyCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.ChatsKeywordCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.ChatsContainsCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.ChatsNotCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.ChatsAndCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.ChatsOrCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.ChatsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="ChatsAnyCondition"></a>
+
 `ChatsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -564,6 +624,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.zendesk_chat.types.ChatsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="ChatsAnyValueFilter"></a>
 
 `ChatsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -601,6 +663,8 @@ Classes
     `update_timestamp: Any`
     :   Last update timestamp
 
+<a id="ChatsContainsCondition"></a>
+
 `ChatsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -612,6 +676,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.zendesk_chat.types.ChatsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="ChatsEqCondition"></a>
 
 `ChatsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -625,6 +691,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.zendesk_chat.types.ChatsSearchFilter`
     :   The type of the None singleton.
 
+<a id="ChatsFuzzyCondition"></a>
+
 `ChatsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -636,6 +704,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.zendesk_chat.types.ChatsStringFilter`
     :   The type of the None singleton.
+
+<a id="ChatsGetParams"></a>
 
 `ChatsGetParams(*args, **kwargs)`
 :   Parameters for chats.get operation
@@ -649,6 +719,8 @@ Classes
     `chat_id: str`
     :   The type of the None singleton.
 
+<a id="ChatsGtCondition"></a>
+
 `ChatsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -661,6 +733,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.zendesk_chat.types.ChatsSearchFilter`
     :   The type of the None singleton.
 
+<a id="ChatsGteCondition"></a>
+
 `ChatsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -672,6 +746,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.zendesk_chat.types.ChatsSearchFilter`
     :   The type of the None singleton.
+
+<a id="ChatsInCondition"></a>
 
 `ChatsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -692,6 +768,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.zendesk_chat.types.ChatsInFilter`
     :   The type of the None singleton.
+
+<a id="ChatsInFilter"></a>
 
 `ChatsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -729,6 +807,8 @@ Classes
     `update_timestamp: list[str]`
     :   Last update timestamp
 
+<a id="ChatsKeywordCondition"></a>
+
 `ChatsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -741,6 +821,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.zendesk_chat.types.ChatsStringFilter`
     :   The type of the None singleton.
 
+<a id="ChatsLikeCondition"></a>
+
 `ChatsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -752,6 +834,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.zendesk_chat.types.ChatsStringFilter`
     :   The type of the None singleton.
+
+<a id="ChatsListParams"></a>
 
 `ChatsListParams(*args, **kwargs)`
 :   Parameters for chats.list operation
@@ -771,6 +855,8 @@ Classes
     `start_time: int`
     :   The type of the None singleton.
 
+<a id="ChatsLtCondition"></a>
+
 `ChatsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -782,6 +868,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.zendesk_chat.types.ChatsSearchFilter`
     :   The type of the None singleton.
+
+<a id="ChatsLteCondition"></a>
 
 `ChatsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -795,6 +883,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.zendesk_chat.types.ChatsSearchFilter`
     :   The type of the None singleton.
 
+<a id="ChatsNeqCondition"></a>
+
 `ChatsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -806,6 +896,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.zendesk_chat.types.ChatsSearchFilter`
     :   The type of the None singleton.
+
+<a id="ChatsNotCondition"></a>
 
 `ChatsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -827,6 +919,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.zendesk_chat.types.ChatsEqCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.ChatsNeqCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.ChatsGtCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.ChatsGteCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.ChatsLtCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.ChatsLteCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.ChatsInCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.ChatsLikeCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.ChatsFuzzyCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.ChatsKeywordCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.ChatsContainsCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.ChatsNotCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.ChatsAndCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.ChatsOrCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.ChatsAnyCondition`
     :   The type of the None singleton.
 
+<a id="ChatsOrCondition"></a>
+
 `ChatsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -846,6 +940,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.zendesk_chat.types.ChatsEqCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.ChatsNeqCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.ChatsGtCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.ChatsGteCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.ChatsLtCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.ChatsLteCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.ChatsInCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.ChatsLikeCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.ChatsFuzzyCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.ChatsKeywordCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.ChatsContainsCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.ChatsNotCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.ChatsAndCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.ChatsOrCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.ChatsAnyCondition]`
     :   The type of the None singleton.
+
+<a id="ChatsSearchFilter"></a>
 
 `ChatsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering chats search queries.
@@ -883,6 +979,8 @@ Classes
     `update_timestamp: str | None`
     :   Last update timestamp
 
+<a id="ChatsSearchQuery"></a>
+
 `ChatsSearchQuery(*args, **kwargs)`
 :   Search query for chats entity.
 
@@ -897,6 +995,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.zendesk_chat.types.ChatsSortFilter]`
     :   The type of the None singleton.
+
+<a id="ChatsSortFilter"></a>
 
 `ChatsSortFilter(*args, **kwargs)`
 :   Available fields for sorting chats search results.
@@ -934,6 +1034,8 @@ Classes
     `update_timestamp: Literal['asc', 'desc']`
     :   Last update timestamp
 
+<a id="ChatsStringFilter"></a>
+
 `ChatsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -970,6 +1072,8 @@ Classes
     `update_timestamp: str`
     :   Last update timestamp
 
+<a id="DepartmentsAndCondition"></a>
+
 `DepartmentsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -990,6 +1094,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.zendesk_chat.types.DepartmentsEqCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.DepartmentsNeqCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.DepartmentsGtCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.DepartmentsGteCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.DepartmentsLtCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.DepartmentsLteCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.DepartmentsInCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.DepartmentsLikeCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.DepartmentsFuzzyCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.DepartmentsKeywordCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.DepartmentsContainsCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.DepartmentsNotCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.DepartmentsAndCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.DepartmentsOrCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.DepartmentsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="DepartmentsAnyCondition"></a>
+
 `DepartmentsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1009,6 +1115,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.zendesk_chat.types.DepartmentsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="DepartmentsAnyValueFilter"></a>
 
 `DepartmentsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -1031,6 +1139,8 @@ Classes
     `name: Any`
     :   Department name
 
+<a id="DepartmentsContainsCondition"></a>
+
 `DepartmentsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -1042,6 +1152,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.zendesk_chat.types.DepartmentsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="DepartmentsEqCondition"></a>
 
 `DepartmentsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -1055,6 +1167,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.zendesk_chat.types.DepartmentsSearchFilter`
     :   The type of the None singleton.
 
+<a id="DepartmentsFuzzyCondition"></a>
+
 `DepartmentsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -1066,6 +1180,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.zendesk_chat.types.DepartmentsStringFilter`
     :   The type of the None singleton.
+
+<a id="DepartmentsGetParams"></a>
 
 `DepartmentsGetParams(*args, **kwargs)`
 :   Parameters for departments.get operation
@@ -1079,6 +1195,8 @@ Classes
     `department_id: str`
     :   The type of the None singleton.
 
+<a id="DepartmentsGtCondition"></a>
+
 `DepartmentsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -1091,6 +1209,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.zendesk_chat.types.DepartmentsSearchFilter`
     :   The type of the None singleton.
 
+<a id="DepartmentsGteCondition"></a>
+
 `DepartmentsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -1102,6 +1222,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.zendesk_chat.types.DepartmentsSearchFilter`
     :   The type of the None singleton.
+
+<a id="DepartmentsInCondition"></a>
 
 `DepartmentsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -1122,6 +1244,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.zendesk_chat.types.DepartmentsInFilter`
     :   The type of the None singleton.
+
+<a id="DepartmentsInFilter"></a>
 
 `DepartmentsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -1144,6 +1268,8 @@ Classes
     `name: list[str]`
     :   Department name
 
+<a id="DepartmentsKeywordCondition"></a>
+
 `DepartmentsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -1155,6 +1281,8 @@ Classes
 
     `keyword: airbyte_agent_sdk.connectors.zendesk_chat.types.DepartmentsStringFilter`
     :   The type of the None singleton.
+
+<a id="DepartmentsLikeCondition"></a>
 
 `DepartmentsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
@@ -1168,12 +1296,16 @@ Classes
     `like: airbyte_agent_sdk.connectors.zendesk_chat.types.DepartmentsStringFilter`
     :   The type of the None singleton.
 
+<a id="DepartmentsListParams"></a>
+
 `DepartmentsListParams(*args, **kwargs)`
 :   Parameters for departments.list operation
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="DepartmentsLtCondition"></a>
 
 `DepartmentsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
@@ -1187,6 +1319,8 @@ Classes
     `lt: airbyte_agent_sdk.connectors.zendesk_chat.types.DepartmentsSearchFilter`
     :   The type of the None singleton.
 
+<a id="DepartmentsLteCondition"></a>
+
 `DepartmentsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
 
@@ -1199,6 +1333,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.zendesk_chat.types.DepartmentsSearchFilter`
     :   The type of the None singleton.
 
+<a id="DepartmentsNeqCondition"></a>
+
 `DepartmentsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -1210,6 +1346,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.zendesk_chat.types.DepartmentsSearchFilter`
     :   The type of the None singleton.
+
+<a id="DepartmentsNotCondition"></a>
 
 `DepartmentsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -1231,6 +1369,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.zendesk_chat.types.DepartmentsEqCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.DepartmentsNeqCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.DepartmentsGtCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.DepartmentsGteCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.DepartmentsLtCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.DepartmentsLteCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.DepartmentsInCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.DepartmentsLikeCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.DepartmentsFuzzyCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.DepartmentsKeywordCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.DepartmentsContainsCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.DepartmentsNotCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.DepartmentsAndCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.DepartmentsOrCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.DepartmentsAnyCondition`
     :   The type of the None singleton.
 
+<a id="DepartmentsOrCondition"></a>
+
 `DepartmentsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1250,6 +1390,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.zendesk_chat.types.DepartmentsEqCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.DepartmentsNeqCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.DepartmentsGtCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.DepartmentsGteCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.DepartmentsLtCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.DepartmentsLteCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.DepartmentsInCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.DepartmentsLikeCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.DepartmentsFuzzyCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.DepartmentsKeywordCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.DepartmentsContainsCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.DepartmentsNotCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.DepartmentsAndCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.DepartmentsOrCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.DepartmentsAnyCondition]`
     :   The type of the None singleton.
+
+<a id="DepartmentsSearchFilter"></a>
 
 `DepartmentsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering departments search queries.
@@ -1272,6 +1414,8 @@ Classes
     `name: str | None`
     :   Department name
 
+<a id="DepartmentsSearchQuery"></a>
+
 `DepartmentsSearchQuery(*args, **kwargs)`
 :   Search query for departments entity.
 
@@ -1286,6 +1430,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.zendesk_chat.types.DepartmentsSortFilter]`
     :   The type of the None singleton.
+
+<a id="DepartmentsSortFilter"></a>
 
 `DepartmentsSortFilter(*args, **kwargs)`
 :   Available fields for sorting departments search results.
@@ -1308,6 +1454,8 @@ Classes
     `name: Literal['asc', 'desc']`
     :   Department name
 
+<a id="DepartmentsStringFilter"></a>
+
 `DepartmentsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -1329,6 +1477,8 @@ Classes
     `name: str`
     :   Department name
 
+<a id="GoalsGetParams"></a>
+
 `GoalsGetParams(*args, **kwargs)`
 :   Parameters for goals.get operation
 
@@ -1341,12 +1491,16 @@ Classes
     `goal_id: str`
     :   The type of the None singleton.
 
+<a id="GoalsListParams"></a>
+
 `GoalsListParams(*args, **kwargs)`
 :   Parameters for goals.list operation
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="RolesGetParams"></a>
 
 `RolesGetParams(*args, **kwargs)`
 :   Parameters for roles.get operation
@@ -1360,6 +1514,8 @@ Classes
     `role_id: str`
     :   The type of the None singleton.
 
+<a id="RolesListParams"></a>
+
 `RolesListParams(*args, **kwargs)`
 :   Parameters for roles.list operation
 
@@ -1367,12 +1523,16 @@ Classes
 
     * builtins.dict
 
+<a id="RoutingSettingsGetParams"></a>
+
 `RoutingSettingsGetParams(*args, **kwargs)`
 :   Parameters for routing_settings.get operation
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="ShortcutsAndCondition"></a>
 
 `ShortcutsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -1394,6 +1554,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.zendesk_chat.types.ShortcutsEqCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.ShortcutsNeqCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.ShortcutsGtCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.ShortcutsGteCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.ShortcutsLtCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.ShortcutsLteCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.ShortcutsInCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.ShortcutsLikeCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.ShortcutsFuzzyCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.ShortcutsKeywordCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.ShortcutsContainsCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.ShortcutsNotCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.ShortcutsAndCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.ShortcutsOrCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.ShortcutsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="ShortcutsAnyCondition"></a>
+
 `ShortcutsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1413,6 +1575,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.zendesk_chat.types.ShortcutsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="ShortcutsAnyValueFilter"></a>
 
 `ShortcutsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -1435,6 +1599,8 @@ Classes
     `tags: Any`
     :   Tags applied when shortcut is used
 
+<a id="ShortcutsContainsCondition"></a>
+
 `ShortcutsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -1446,6 +1612,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.zendesk_chat.types.ShortcutsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="ShortcutsEqCondition"></a>
 
 `ShortcutsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -1459,6 +1627,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.zendesk_chat.types.ShortcutsSearchFilter`
     :   The type of the None singleton.
 
+<a id="ShortcutsFuzzyCondition"></a>
+
 `ShortcutsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -1470,6 +1640,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.zendesk_chat.types.ShortcutsStringFilter`
     :   The type of the None singleton.
+
+<a id="ShortcutsGetParams"></a>
 
 `ShortcutsGetParams(*args, **kwargs)`
 :   Parameters for shortcuts.get operation
@@ -1483,6 +1655,8 @@ Classes
     `shortcut_id: str`
     :   The type of the None singleton.
 
+<a id="ShortcutsGtCondition"></a>
+
 `ShortcutsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -1495,6 +1669,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.zendesk_chat.types.ShortcutsSearchFilter`
     :   The type of the None singleton.
 
+<a id="ShortcutsGteCondition"></a>
+
 `ShortcutsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -1506,6 +1682,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.zendesk_chat.types.ShortcutsSearchFilter`
     :   The type of the None singleton.
+
+<a id="ShortcutsInCondition"></a>
 
 `ShortcutsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -1526,6 +1704,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.zendesk_chat.types.ShortcutsInFilter`
     :   The type of the None singleton.
+
+<a id="ShortcutsInFilter"></a>
 
 `ShortcutsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -1548,6 +1728,8 @@ Classes
     `tags: list[list[typing.Any]]`
     :   Tags applied when shortcut is used
 
+<a id="ShortcutsKeywordCondition"></a>
+
 `ShortcutsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -1559,6 +1741,8 @@ Classes
 
     `keyword: airbyte_agent_sdk.connectors.zendesk_chat.types.ShortcutsStringFilter`
     :   The type of the None singleton.
+
+<a id="ShortcutsLikeCondition"></a>
 
 `ShortcutsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
@@ -1572,12 +1756,16 @@ Classes
     `like: airbyte_agent_sdk.connectors.zendesk_chat.types.ShortcutsStringFilter`
     :   The type of the None singleton.
 
+<a id="ShortcutsListParams"></a>
+
 `ShortcutsListParams(*args, **kwargs)`
 :   Parameters for shortcuts.list operation
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="ShortcutsLtCondition"></a>
 
 `ShortcutsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
@@ -1591,6 +1779,8 @@ Classes
     `lt: airbyte_agent_sdk.connectors.zendesk_chat.types.ShortcutsSearchFilter`
     :   The type of the None singleton.
 
+<a id="ShortcutsLteCondition"></a>
+
 `ShortcutsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
 
@@ -1603,6 +1793,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.zendesk_chat.types.ShortcutsSearchFilter`
     :   The type of the None singleton.
 
+<a id="ShortcutsNeqCondition"></a>
+
 `ShortcutsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -1614,6 +1806,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.zendesk_chat.types.ShortcutsSearchFilter`
     :   The type of the None singleton.
+
+<a id="ShortcutsNotCondition"></a>
 
 `ShortcutsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -1635,6 +1829,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.zendesk_chat.types.ShortcutsEqCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.ShortcutsNeqCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.ShortcutsGtCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.ShortcutsGteCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.ShortcutsLtCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.ShortcutsLteCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.ShortcutsInCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.ShortcutsLikeCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.ShortcutsFuzzyCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.ShortcutsKeywordCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.ShortcutsContainsCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.ShortcutsNotCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.ShortcutsAndCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.ShortcutsOrCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.ShortcutsAnyCondition`
     :   The type of the None singleton.
 
+<a id="ShortcutsOrCondition"></a>
+
 `ShortcutsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1654,6 +1850,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.zendesk_chat.types.ShortcutsEqCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.ShortcutsNeqCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.ShortcutsGtCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.ShortcutsGteCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.ShortcutsLtCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.ShortcutsLteCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.ShortcutsInCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.ShortcutsLikeCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.ShortcutsFuzzyCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.ShortcutsKeywordCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.ShortcutsContainsCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.ShortcutsNotCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.ShortcutsAndCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.ShortcutsOrCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.ShortcutsAnyCondition]`
     :   The type of the None singleton.
+
+<a id="ShortcutsSearchFilter"></a>
 
 `ShortcutsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering shortcuts search queries.
@@ -1676,6 +1874,8 @@ Classes
     `tags: list[typing.Any] | None`
     :   Tags applied when shortcut is used
 
+<a id="ShortcutsSearchQuery"></a>
+
 `ShortcutsSearchQuery(*args, **kwargs)`
 :   Search query for shortcuts entity.
 
@@ -1690,6 +1890,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.zendesk_chat.types.ShortcutsSortFilter]`
     :   The type of the None singleton.
+
+<a id="ShortcutsSortFilter"></a>
 
 `ShortcutsSortFilter(*args, **kwargs)`
 :   Available fields for sorting shortcuts search results.
@@ -1712,6 +1914,8 @@ Classes
     `tags: Literal['asc', 'desc']`
     :   Tags applied when shortcut is used
 
+<a id="ShortcutsStringFilter"></a>
+
 `ShortcutsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -1733,6 +1937,8 @@ Classes
     `tags: str`
     :   Tags applied when shortcut is used
 
+<a id="SkillsGetParams"></a>
+
 `SkillsGetParams(*args, **kwargs)`
 :   Parameters for skills.get operation
 
@@ -1745,12 +1951,16 @@ Classes
     `skill_id: str`
     :   The type of the None singleton.
 
+<a id="SkillsListParams"></a>
+
 `SkillsListParams(*args, **kwargs)`
 :   Parameters for skills.list operation
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="TriggersAndCondition"></a>
 
 `TriggersAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -1772,6 +1982,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.zendesk_chat.types.TriggersEqCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.TriggersNeqCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.TriggersGtCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.TriggersGteCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.TriggersLtCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.TriggersLteCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.TriggersInCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.TriggersLikeCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.TriggersFuzzyCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.TriggersKeywordCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.TriggersContainsCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.TriggersNotCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.TriggersAndCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.TriggersOrCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.TriggersAnyCondition]`
     :   The type of the None singleton.
 
+<a id="TriggersAnyCondition"></a>
+
 `TriggersAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1792,6 +2004,8 @@ Classes
     `any: airbyte_agent_sdk.connectors.zendesk_chat.types.TriggersAnyValueFilter`
     :   The type of the None singleton.
 
+<a id="TriggersAnyValueFilter"></a>
+
 `TriggersAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
 
@@ -1810,6 +2024,8 @@ Classes
     `name: Any`
     :   Trigger name
 
+<a id="TriggersContainsCondition"></a>
+
 `TriggersContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -1821,6 +2037,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.zendesk_chat.types.TriggersAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="TriggersEqCondition"></a>
 
 `TriggersEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -1834,6 +2052,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.zendesk_chat.types.TriggersSearchFilter`
     :   The type of the None singleton.
 
+<a id="TriggersFuzzyCondition"></a>
+
 `TriggersFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -1845,6 +2065,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.zendesk_chat.types.TriggersStringFilter`
     :   The type of the None singleton.
+
+<a id="TriggersGtCondition"></a>
 
 `TriggersGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
@@ -1858,6 +2080,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.zendesk_chat.types.TriggersSearchFilter`
     :   The type of the None singleton.
 
+<a id="TriggersGteCondition"></a>
+
 `TriggersGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -1869,6 +2093,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.zendesk_chat.types.TriggersSearchFilter`
     :   The type of the None singleton.
+
+<a id="TriggersInCondition"></a>
 
 `TriggersInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -1890,6 +2116,8 @@ Classes
     `in: airbyte_agent_sdk.connectors.zendesk_chat.types.TriggersInFilter`
     :   The type of the None singleton.
 
+<a id="TriggersInFilter"></a>
+
 `TriggersInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
 
@@ -1908,6 +2136,8 @@ Classes
     `name: list[str]`
     :   Trigger name
 
+<a id="TriggersKeywordCondition"></a>
+
 `TriggersKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -1919,6 +2149,8 @@ Classes
 
     `keyword: airbyte_agent_sdk.connectors.zendesk_chat.types.TriggersStringFilter`
     :   The type of the None singleton.
+
+<a id="TriggersLikeCondition"></a>
 
 `TriggersLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
@@ -1932,12 +2164,16 @@ Classes
     `like: airbyte_agent_sdk.connectors.zendesk_chat.types.TriggersStringFilter`
     :   The type of the None singleton.
 
+<a id="TriggersListParams"></a>
+
 `TriggersListParams(*args, **kwargs)`
 :   Parameters for triggers.list operation
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="TriggersLtCondition"></a>
 
 `TriggersLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
@@ -1951,6 +2187,8 @@ Classes
     `lt: airbyte_agent_sdk.connectors.zendesk_chat.types.TriggersSearchFilter`
     :   The type of the None singleton.
 
+<a id="TriggersLteCondition"></a>
+
 `TriggersLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
 
@@ -1963,6 +2201,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.zendesk_chat.types.TriggersSearchFilter`
     :   The type of the None singleton.
 
+<a id="TriggersNeqCondition"></a>
+
 `TriggersNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -1974,6 +2214,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.zendesk_chat.types.TriggersSearchFilter`
     :   The type of the None singleton.
+
+<a id="TriggersNotCondition"></a>
 
 `TriggersNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -1995,6 +2237,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.zendesk_chat.types.TriggersEqCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.TriggersNeqCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.TriggersGtCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.TriggersGteCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.TriggersLtCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.TriggersLteCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.TriggersInCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.TriggersLikeCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.TriggersFuzzyCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.TriggersKeywordCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.TriggersContainsCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.TriggersNotCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.TriggersAndCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.TriggersOrCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.TriggersAnyCondition`
     :   The type of the None singleton.
 
+<a id="TriggersOrCondition"></a>
+
 `TriggersOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -2015,6 +2259,8 @@ Classes
     `or: list[airbyte_agent_sdk.connectors.zendesk_chat.types.TriggersEqCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.TriggersNeqCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.TriggersGtCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.TriggersGteCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.TriggersLtCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.TriggersLteCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.TriggersInCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.TriggersLikeCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.TriggersFuzzyCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.TriggersKeywordCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.TriggersContainsCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.TriggersNotCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.TriggersAndCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.TriggersOrCondition | airbyte_agent_sdk.connectors.zendesk_chat.types.TriggersAnyCondition]`
     :   The type of the None singleton.
 
+<a id="TriggersSearchFilter"></a>
+
 `TriggersSearchFilter(*args, **kwargs)`
 :   Available fields for filtering triggers search queries.
 
@@ -2033,6 +2279,8 @@ Classes
     `name: str | None`
     :   Trigger name
 
+<a id="TriggersSearchQuery"></a>
+
 `TriggersSearchQuery(*args, **kwargs)`
 :   Search query for triggers entity.
 
@@ -2047,6 +2295,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.zendesk_chat.types.TriggersSortFilter]`
     :   The type of the None singleton.
+
+<a id="TriggersSortFilter"></a>
 
 `TriggersSortFilter(*args, **kwargs)`
 :   Available fields for sorting triggers search results.
@@ -2065,6 +2315,8 @@ Classes
 
     `name: Literal['asc', 'desc']`
     :   Trigger name
+
+<a id="TriggersStringFilter"></a>
 
 `TriggersStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/zendesk_support/connector.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/zendesk_support/connector.md
@@ -10,6 +10,8 @@ Zendesk-Support connector.
 Classes
 -------
 
+<a id="ArticleAttachmentsQuery"></a>
+
 `ArticleAttachmentsQuery(connector: ZendeskSupportConnector)`
 :   Query class for ArticleAttachments entity operations.
     
@@ -65,6 +67,8 @@ Classes
         Returns:
             ArticleAttachmentsListResult
 
+<a id="ArticlesQuery"></a>
+
 `ArticlesQuery(connector: ZendeskSupportConnector)`
 :   Query class for Articles entity operations.
     
@@ -94,6 +98,8 @@ Classes
         
         Returns:
             ArticlesListResult
+
+<a id="AttachmentsQuery"></a>
 
 `AttachmentsQuery(connector: ZendeskSupportConnector)`
 :   Query class for Attachments entity operations.
@@ -135,6 +141,8 @@ Classes
         Returns:
             Attachment
 
+<a id="AutomationsQuery"></a>
+
 `AutomationsQuery(connector: ZendeskSupportConnector)`
 :   Query class for Automations entity operations.
     
@@ -165,6 +173,8 @@ Classes
         
         Returns:
             AutomationsListResult
+
+<a id="BrandsQuery"></a>
 
 `BrandsQuery(connector: ZendeskSupportConnector)`
 :   Query class for Brands entity operations.
@@ -232,6 +242,8 @@ Classes
         Returns:
             BrandsListResult
 
+<a id="DeletedTicketsQuery"></a>
+
 `DeletedTicketsQuery(connector: ZendeskSupportConnector)`
 :   Query class for DeletedTickets entity operations.
     
@@ -280,6 +292,8 @@ Classes
         Returns:
             DeletedTicketsListResult
 
+<a id="GroupMembershipsQuery"></a>
+
 `GroupMembershipsQuery(connector: ZendeskSupportConnector)`
 :   Query class for GroupMemberships entity operations.
     
@@ -297,6 +311,8 @@ Classes
         
         Returns:
             GroupMembershipsListResult
+
+<a id="GroupsQuery"></a>
 
 `GroupsQuery(connector: ZendeskSupportConnector)`
 :   Query class for Groups entity operations.
@@ -358,6 +374,8 @@ Classes
         Returns:
             GroupsListResult
 
+<a id="MacrosQuery"></a>
+
 `MacrosQuery(connector: ZendeskSupportConnector)`
 :   Query class for Macros entity operations.
     
@@ -393,6 +411,8 @@ Classes
         Returns:
             MacrosListResult
 
+<a id="OrganizationMembershipsQuery"></a>
+
 `OrganizationMembershipsQuery(connector: ZendeskSupportConnector)`
 :   Query class for OrganizationMemberships entity operations.
     
@@ -410,6 +430,8 @@ Classes
         
         Returns:
             OrganizationMembershipsListResult
+
+<a id="OrganizationsQuery"></a>
 
 `OrganizationsQuery(connector: ZendeskSupportConnector)`
 :   Query class for Organizations entity operations.
@@ -476,6 +498,8 @@ Classes
         Returns:
             OrganizationsListResult
 
+<a id="SatisfactionRatingsQuery"></a>
+
 `SatisfactionRatingsQuery(connector: ZendeskSupportConnector)`
 :   Query class for SatisfactionRatings entity operations.
     
@@ -541,6 +565,8 @@ Classes
         Returns:
             SatisfactionRatingsListResult
 
+<a id="SlaPoliciesQuery"></a>
+
 `SlaPoliciesQuery(connector: ZendeskSupportConnector)`
 :   Query class for SlaPolicies entity operations.
     
@@ -568,6 +594,8 @@ Classes
         
         Returns:
             SlaPoliciesListResult
+
+<a id="TagsQuery"></a>
 
 `TagsQuery(connector: ZendeskSupportConnector)`
 :   Query class for Tags entity operations.
@@ -610,6 +638,8 @@ Classes
         
         Returns:
             TagsListResult
+
+<a id="TicketAuditsQuery"></a>
 
 `TicketAuditsQuery(connector: ZendeskSupportConnector)`
 :   Query class for TicketAudits entity operations.
@@ -659,6 +689,8 @@ Classes
         
         Returns:
             TicketAuditsListResult
+
+<a id="TicketCommentsQuery"></a>
 
 `TicketCommentsQuery(connector: ZendeskSupportConnector)`
 :   Query class for TicketComments entity operations.
@@ -719,6 +751,8 @@ Classes
         
         Returns:
             TicketCommentsListResult
+
+<a id="TicketFieldsQuery"></a>
 
 `TicketFieldsQuery(connector: ZendeskSupportConnector)`
 :   Query class for TicketFields entity operations.
@@ -798,6 +832,8 @@ Classes
         Returns:
             TicketFieldsListResult
 
+<a id="TicketFormsQuery"></a>
+
 `TicketFormsQuery(connector: ZendeskSupportConnector)`
 :   Query class for TicketForms entity operations.
     
@@ -866,6 +902,8 @@ Classes
         
         Returns:
             TicketFormsListResult
+
+<a id="TicketMetricsQuery"></a>
 
 `TicketMetricsQuery(connector: ZendeskSupportConnector)`
 :   Query class for TicketMetrics entity operations.
@@ -936,6 +974,8 @@ Classes
         
         Returns:
             TicketMetricsListResult
+
+<a id="TicketsQuery"></a>
 
 `TicketsQuery(connector: ZendeskSupportConnector)`
 :   Query class for Tickets entity operations.
@@ -1031,6 +1071,8 @@ Classes
         Returns:
             TicketsListResult
 
+<a id="TriggersQuery"></a>
+
 `TriggersQuery(connector: ZendeskSupportConnector)`
 :   Query class for Triggers entity operations.
     
@@ -1062,6 +1104,8 @@ Classes
         
         Returns:
             TriggersListResult
+
+<a id="UsersQuery"></a>
 
 `UsersQuery(connector: ZendeskSupportConnector)`
 :   Query class for Users entity operations.
@@ -1154,6 +1198,8 @@ Classes
         Returns:
             UsersListResult
 
+<a id="ViewsQuery"></a>
+
 `ViewsQuery(connector: ZendeskSupportConnector)`
 :   Query class for Views entity operations.
     
@@ -1186,6 +1232,8 @@ Classes
         
         Returns:
             ViewsListResult
+
+<a id="ZendeskSupportConnector"></a>
 
 `ZendeskSupportConnector(auth_config: ZendeskSupportAuthConfig | AirbyteAuthConfig | BaseModel | None = None, on_token_refresh: Any | None = None, subdomain: str | None = None)`
 :   Type-safe Zendesk-Support API connector.

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/zendesk_support/index.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/zendesk_support/index.md
@@ -19,6 +19,8 @@ Sub-modules
 Classes
 -------
 
+<a id="AirbyteAuthConfig"></a>
+
 `AirbyteAuthConfig(**data: Any)`
 :   Authentication configuration for Airbyte hosted mode execution.
     
@@ -87,6 +89,8 @@ Classes
     `workspace_name: str | None`
     :   The type of the None singleton.
 
+<a id="AirbyteSearchMeta"></a>
+
 `AirbyteSearchMeta(**data: Any)`
 :   Pagination metadata for search responses.
     
@@ -114,6 +118,8 @@ Classes
 
     `took_ms: int | None`
     :   Time taken to execute the search in milliseconds.
+
+<a id="AirbyteSearchResult"></a>
 
 `AirbyteSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -157,6 +163,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="BrandsSearchResult"></a>
+
 `BrandsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -172,6 +180,8 @@ Classes
     * airbyte_agent_sdk.connectors.zendesk_support.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="DeletedTicketsSearchResult"></a>
 
 `DeletedTicketsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -189,6 +199,8 @@ Classes
     * pydantic.main.BaseModel
     * typing.Generic
 
+<a id="GroupsSearchResult"></a>
+
 `GroupsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -204,6 +216,8 @@ Classes
     * airbyte_agent_sdk.connectors.zendesk_support.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="OrganizationsSearchResult"></a>
 
 `OrganizationsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -221,6 +235,8 @@ Classes
     * pydantic.main.BaseModel
     * typing.Generic
 
+<a id="SatisfactionRatingsSearchResult"></a>
+
 `SatisfactionRatingsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -236,6 +252,8 @@ Classes
     * airbyte_agent_sdk.connectors.zendesk_support.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="TagsSearchResult"></a>
 
 `TagsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -253,6 +271,8 @@ Classes
     * pydantic.main.BaseModel
     * typing.Generic
 
+<a id="TicketAuditsSearchResult"></a>
+
 `TicketAuditsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -268,6 +288,8 @@ Classes
     * airbyte_agent_sdk.connectors.zendesk_support.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="TicketCommentsSearchResult"></a>
 
 `TicketCommentsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -285,6 +307,8 @@ Classes
     * pydantic.main.BaseModel
     * typing.Generic
 
+<a id="TicketFieldsSearchResult"></a>
+
 `TicketFieldsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -300,6 +324,8 @@ Classes
     * airbyte_agent_sdk.connectors.zendesk_support.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="TicketFormsSearchResult"></a>
 
 `TicketFormsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -317,6 +343,8 @@ Classes
     * pydantic.main.BaseModel
     * typing.Generic
 
+<a id="TicketMetricsSearchResult"></a>
+
 `TicketMetricsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -332,6 +360,8 @@ Classes
     * airbyte_agent_sdk.connectors.zendesk_support.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="TicketsSearchResult"></a>
 
 `TicketsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -349,6 +379,8 @@ Classes
     * pydantic.main.BaseModel
     * typing.Generic
 
+<a id="UsersSearchResult"></a>
+
 `UsersSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -364,6 +396,8 @@ Classes
     * airbyte_agent_sdk.connectors.zendesk_support.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="BrandsSearchData"></a>
 
 `BrandsSearchData(**data: Any)`
 :   Search result data for brands entity.
@@ -432,6 +466,8 @@ Classes
     `url: str | None`
     :   The API URL for accessing this brand resource
 
+<a id="DeletedTicketsSearchData"></a>
+
 `DeletedTicketsSearchData(**data: Any)`
 :   Search result data for deleted_tickets entity.
     
@@ -468,6 +504,8 @@ Classes
 
     `subject: str | None`
     :   The subject or title of the deleted ticket
+
+<a id="GroupsSearchData"></a>
 
 `GroupsSearchData(**data: Any)`
 :   Search result data for groups entity.
@@ -514,6 +552,8 @@ Classes
 
     `url: str | None`
     :   The API URL of the group
+
+<a id="OrganizationsSearchData"></a>
 
 `OrganizationsSearchData(**data: Any)`
 :   Search result data for organizations entity.
@@ -579,6 +619,8 @@ Classes
     `url: str | None`
     :   The API URL of this organization
 
+<a id="SatisfactionRatingsSearchData"></a>
+
 `SatisfactionRatingsSearchData(**data: Any)`
 :   Search result data for satisfaction_ratings entity.
     
@@ -634,6 +676,8 @@ Classes
     `url: str | None`
     :   The API URL of this satisfaction rating resource
 
+<a id="TagsSearchData"></a>
+
 `TagsSearchData(**data: Any)`
 :   Search result data for tags entity.
     
@@ -658,6 +702,8 @@ Classes
 
     `name: str | None`
     :   The tag name string used to label and categorize resources
+
+<a id="TicketAuditsSearchData"></a>
 
 `TicketAuditsSearchData(**data: Any)`
 :   Search result data for ticket_audits entity.
@@ -701,6 +747,8 @@ Classes
 
     `via: dict[str, typing.Any] | None`
     :   Describes how the audit was created, providing context about the creation source
+
+<a id="TicketCommentsSearchData"></a>
 
 `TicketCommentsSearchData(**data: Any)`
 :   Search result data for ticket_comments entity.
@@ -771,6 +819,8 @@ Classes
 
     `via_reference_id: int | None`
     :   Reference identifier for the channel through which the comment was created
+
+<a id="TicketFieldsSearchData"></a>
 
 `TicketFieldsSearchData(**data: Any)`
 :   Search result data for ticket_fields entity.
@@ -872,6 +922,8 @@ Classes
     `visible_in_portal: bool | None`
     :   Whether this field is visible to end users in Help Center
 
+<a id="TicketFormsSearchData"></a>
+
 `TicketFormsSearchData(**data: Any)`
 :   Search result data for ticket_forms entity.
     
@@ -941,6 +993,8 @@ Classes
 
     `url: str | None`
     :   URL of the ticket form
+
+<a id="TicketMetricsSearchData"></a>
 
 `TicketMetricsSearchData(**data: Any)`
 :   Search result data for ticket_metrics entity.
@@ -1050,6 +1104,8 @@ Classes
 
     `url: str | None`
     :   The API url of the ticket metric
+
+<a id="TicketsSearchData"></a>
 
 `TicketsSearchData(**data: Any)`
 :   Search result data for tickets entity.
@@ -1193,6 +1249,8 @@ Classes
     `via: dict[str, typing.Any] | None`
     :   Object describing the channel and method through which the ticket was created
 
+<a id="UsersSearchData"></a>
+
 `UsersSearchData(**data: Any)`
 :   Search result data for users entity.
     
@@ -1328,6 +1386,8 @@ Classes
 
     `verified: bool | None`
     :   Indicates if the user's identity has been verified
+
+<a id="ZendeskSupportConnector"></a>
 
 `ZendeskSupportConnector(auth_config: ZendeskSupportAuthConfig | AirbyteAuthConfig | BaseModel | None = None, on_token_refresh: Any | None = None, subdomain: str | None = None)`
 :   Type-safe Zendesk-Support API connector.

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/zendesk_support/models.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/zendesk_support/models.md
@@ -13,6 +13,8 @@ and response envelope types.
 Classes
 -------
 
+<a id="AirbyteSearchMeta"></a>
+
 `AirbyteSearchMeta(**data: Any)`
 :   Pagination metadata for search responses.
     
@@ -40,6 +42,8 @@ Classes
 
     `took_ms: int | None`
     :   Time taken to execute the search in milliseconds.
+
+<a id="AirbyteSearchResult"></a>
 
 `AirbyteSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -104,6 +108,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="BrandsSearchResult"></a>
+
 `BrandsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -140,6 +146,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="DeletedTicketsSearchResult"></a>
 
 `DeletedTicketsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -178,6 +186,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="GroupsSearchResult"></a>
+
 `GroupsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -214,6 +224,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="OrganizationsSearchResult"></a>
 
 `OrganizationsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -252,6 +264,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="SatisfactionRatingsSearchResult"></a>
+
 `SatisfactionRatingsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -288,6 +302,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="TagsSearchResult"></a>
 
 `TagsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -326,6 +342,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="TicketAuditsSearchResult"></a>
+
 `TicketAuditsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -362,6 +380,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="TicketCommentsSearchResult"></a>
 
 `TicketCommentsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -400,6 +420,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="TicketFieldsSearchResult"></a>
+
 `TicketFieldsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -436,6 +458,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="TicketFormsSearchResult"></a>
 
 `TicketFormsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -474,6 +498,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="TicketMetricsSearchResult"></a>
+
 `TicketMetricsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -510,6 +536,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="TicketsSearchResult"></a>
 
 `TicketsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -548,6 +576,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="UsersSearchResult"></a>
+
 `UsersSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -563,6 +593,8 @@ Classes
     * airbyte_agent_sdk.connectors.zendesk_support.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="Article"></a>
 
 `Article(**data: Any)`
 :   Help Center article object
@@ -631,6 +663,8 @@ Classes
     `vote_sum: int | Any`
     :   The type of the None singleton.
 
+<a id="ArticleAttachment"></a>
+
 `ArticleAttachment(**data: Any)`
 :   Article attachment object
     
@@ -680,6 +714,8 @@ Classes
     `url: str | Any`
     :   The type of the None singleton.
 
+<a id="ArticleAttachmentsListResultMeta"></a>
+
 `ArticleAttachmentsListResultMeta(**data: Any)`
 :   Metadata for article_attachments.Action.LIST operation
     
@@ -708,6 +744,8 @@ Classes
     `previous_page: str | Any | None`
     :   The type of the None singleton.
 
+<a id="ArticlesListResultMeta"></a>
+
 `ArticlesListResultMeta(**data: Any)`
 :   Metadata for articles.Action.LIST operation
     
@@ -735,6 +773,8 @@ Classes
 
     `previous_page: str | Any | None`
     :   The type of the None singleton.
+
+<a id="Attachment"></a>
 
 `Attachment(**data: Any)`
 :   Zendesk Support attachment object
@@ -797,6 +837,8 @@ Classes
     `width: int | Any | None`
     :   The type of the None singleton.
 
+<a id="Automation"></a>
+
 `Automation(**data: Any)`
 :   Zendesk Support automation object
     
@@ -846,6 +888,8 @@ Classes
     `url: str | Any`
     :   The type of the None singleton.
 
+<a id="AutomationsListResultMeta"></a>
+
 `AutomationsListResultMeta(**data: Any)`
 :   Metadata for automations.Action.LIST operation
     
@@ -873,6 +917,8 @@ Classes
 
     `previous_page: str | Any | None`
     :   The type of the None singleton.
+
+<a id="Brand"></a>
 
 `Brand(**data: Any)`
 :   Zendesk Support brand object
@@ -941,6 +987,8 @@ Classes
     `url: str | Any`
     :   The type of the None singleton.
 
+<a id="BrandsListResultMeta"></a>
+
 `BrandsListResultMeta(**data: Any)`
 :   Metadata for brands.Action.LIST operation
     
@@ -968,6 +1016,8 @@ Classes
 
     `previous_page: str | Any | None`
     :   The type of the None singleton.
+
+<a id="BrandsSearchData"></a>
 
 `BrandsSearchData(**data: Any)`
 :   Search result data for brands entity.
@@ -1036,6 +1086,8 @@ Classes
     `url: str | None`
     :   The API URL for accessing this brand resource
 
+<a id="DeletedTicket"></a>
+
 `DeletedTicket(**data: Any)`
 :   Zendesk Support deleted ticket object
     
@@ -1073,6 +1125,8 @@ Classes
     `subject: str | Any | None`
     :   The type of the None singleton.
 
+<a id="DeletedTicketActor"></a>
+
 `DeletedTicketActor(**data: Any)`
 :   The user who performed the deletion action
     
@@ -1097,6 +1151,8 @@ Classes
 
     `name: str | Any | None`
     :   The name of the user
+
+<a id="DeletedTicketsListResultMeta"></a>
 
 `DeletedTicketsListResultMeta(**data: Any)`
 :   Metadata for deleted_tickets.Action.LIST operation
@@ -1125,6 +1181,8 @@ Classes
 
     `previous_page: str | Any | None`
     :   The type of the None singleton.
+
+<a id="DeletedTicketsSearchData"></a>
 
 `DeletedTicketsSearchData(**data: Any)`
 :   Search result data for deleted_tickets entity.
@@ -1162,6 +1220,8 @@ Classes
 
     `subject: str | None`
     :   The subject or title of the deleted ticket
+
+<a id="Group"></a>
 
 `Group(**data: Any)`
 :   Zendesk Support group object
@@ -1209,6 +1269,8 @@ Classes
     `url: str | Any`
     :   The type of the None singleton.
 
+<a id="GroupMembership"></a>
+
 `GroupMembership(**data: Any)`
 :   Zendesk Support group membership object
     
@@ -1249,6 +1311,8 @@ Classes
     `user_id: int | Any`
     :   The type of the None singleton.
 
+<a id="GroupMembershipsListResultMeta"></a>
+
 `GroupMembershipsListResultMeta(**data: Any)`
 :   Metadata for group_memberships.Action.LIST operation
     
@@ -1277,6 +1341,8 @@ Classes
     `previous_page: str | Any | None`
     :   The type of the None singleton.
 
+<a id="GroupsListResultMeta"></a>
+
 `GroupsListResultMeta(**data: Any)`
 :   Metadata for groups.Action.LIST operation
     
@@ -1304,6 +1370,8 @@ Classes
 
     `previous_page: str | Any | None`
     :   The type of the None singleton.
+
+<a id="GroupsSearchData"></a>
 
 `GroupsSearchData(**data: Any)`
 :   Search result data for groups entity.
@@ -1350,6 +1418,8 @@ Classes
 
     `url: str | None`
     :   The API URL of the group
+
+<a id="Macro"></a>
 
 `Macro(**data: Any)`
 :   Zendesk Support macro object
@@ -1403,6 +1473,8 @@ Classes
     `url: str | Any`
     :   The type of the None singleton.
 
+<a id="MacrosListResultMeta"></a>
+
 `MacrosListResultMeta(**data: Any)`
 :   Metadata for macros.Action.LIST operation
     
@@ -1430,6 +1502,8 @@ Classes
 
     `previous_page: str | Any | None`
     :   The type of the None singleton.
+
+<a id="Organization"></a>
 
 `Organization(**data: Any)`
 :   Zendesk Support organization object
@@ -1492,6 +1566,8 @@ Classes
     `url: str | Any`
     :   The type of the None singleton.
 
+<a id="OrganizationMembership"></a>
+
 `OrganizationMembership(**data: Any)`
 :   Zendesk Support organization membership object
     
@@ -1538,6 +1614,8 @@ Classes
     `view_tickets: bool | Any`
     :   The type of the None singleton.
 
+<a id="OrganizationMembershipsListResultMeta"></a>
+
 `OrganizationMembershipsListResultMeta(**data: Any)`
 :   Metadata for organization_memberships.Action.LIST operation
     
@@ -1566,6 +1644,8 @@ Classes
     `previous_page: str | Any | None`
     :   The type of the None singleton.
 
+<a id="OrganizationsListResultMeta"></a>
+
 `OrganizationsListResultMeta(**data: Any)`
 :   Metadata for organizations.Action.LIST operation
     
@@ -1593,6 +1673,8 @@ Classes
 
     `previous_page: str | Any | None`
     :   The type of the None singleton.
+
+<a id="OrganizationsSearchData"></a>
 
 `OrganizationsSearchData(**data: Any)`
 :   Search result data for organizations entity.
@@ -1658,6 +1740,8 @@ Classes
     `url: str | None`
     :   The API URL of this organization
 
+<a id="SLAPolicy"></a>
+
 `SLAPolicy(**data: Any)`
 :   Zendesk Support SLA policy object
     
@@ -1703,6 +1787,8 @@ Classes
 
     `url: str | Any`
     :   The type of the None singleton.
+
+<a id="SatisfactionRating"></a>
 
 `SatisfactionRating(**data: Any)`
 :   Zendesk Support satisfaction rating object
@@ -1762,6 +1848,8 @@ Classes
     `url: str | Any`
     :   The type of the None singleton.
 
+<a id="SatisfactionRatingsListResultMeta"></a>
+
 `SatisfactionRatingsListResultMeta(**data: Any)`
 :   Metadata for satisfaction_ratings.Action.LIST operation
     
@@ -1789,6 +1877,8 @@ Classes
 
     `previous_page: str | Any | None`
     :   The type of the None singleton.
+
+<a id="SatisfactionRatingsSearchData"></a>
 
 `SatisfactionRatingsSearchData(**data: Any)`
 :   Search result data for satisfaction_ratings entity.
@@ -1845,6 +1935,8 @@ Classes
     `url: str | None`
     :   The API URL of this satisfaction rating resource
 
+<a id="SlaPoliciesListResultMeta"></a>
+
 `SlaPoliciesListResultMeta(**data: Any)`
 :   Metadata for sla_policies.Action.LIST operation
     
@@ -1873,6 +1965,8 @@ Classes
     `previous_page: str | Any | None`
     :   The type of the None singleton.
 
+<a id="Tag"></a>
+
 `Tag(**data: Any)`
 :   Zendesk Support tag object
     
@@ -1897,6 +1991,8 @@ Classes
 
     `name: str | Any`
     :   The type of the None singleton.
+
+<a id="TagsListResultMeta"></a>
 
 `TagsListResultMeta(**data: Any)`
 :   Metadata for tags.Action.LIST operation
@@ -1926,6 +2022,8 @@ Classes
     `previous_page: str | Any | None`
     :   The type of the None singleton.
 
+<a id="TagsSearchData"></a>
+
 `TagsSearchData(**data: Any)`
 :   Search result data for tags entity.
     
@@ -1950,6 +2048,8 @@ Classes
 
     `name: str | None`
     :   The tag name string used to label and categorize resources
+
+<a id="Ticket"></a>
 
 `Ticket(**data: Any)`
 :   Zendesk Support ticket object
@@ -2090,6 +2190,8 @@ Classes
     `via: dict[str, typing.Any] | Any`
     :   The type of the None singleton.
 
+<a id="TicketAudit"></a>
+
 `TicketAudit(**data: Any)`
 :   Zendesk Support ticket audit object
     
@@ -2130,6 +2232,8 @@ Classes
     `via: dict[str, typing.Any] | Any`
     :   The type of the None singleton.
 
+<a id="TicketAuditsListResultMeta"></a>
+
 `TicketAuditsListResultMeta(**data: Any)`
 :   Metadata for ticket_audits.Action.LIST operation
     
@@ -2157,6 +2261,8 @@ Classes
 
     `previous_page: str | Any | None`
     :   The type of the None singleton.
+
+<a id="TicketAuditsSearchData"></a>
 
 `TicketAuditsSearchData(**data: Any)`
 :   Search result data for ticket_audits entity.
@@ -2200,6 +2306,8 @@ Classes
 
     `via: dict[str, typing.Any] | None`
     :   Describes how the audit was created, providing context about the creation source
+
+<a id="TicketComment"></a>
 
 `TicketComment(**data: Any)`
 :   Zendesk Support ticket comment object
@@ -2256,6 +2364,8 @@ Classes
     `via: dict[str, typing.Any] | Any`
     :   The type of the None singleton.
 
+<a id="TicketCommentsListResultMeta"></a>
+
 `TicketCommentsListResultMeta(**data: Any)`
 :   Metadata for ticket_comments.Action.LIST operation
     
@@ -2283,6 +2393,8 @@ Classes
 
     `previous_page: str | Any | None`
     :   The type of the None singleton.
+
+<a id="TicketCommentsSearchData"></a>
 
 `TicketCommentsSearchData(**data: Any)`
 :   Search result data for ticket_comments entity.
@@ -2353,6 +2465,8 @@ Classes
 
     `via_reference_id: int | None`
     :   Reference identifier for the channel through which the comment was created
+
+<a id="TicketField"></a>
 
 `TicketField(**data: Any)`
 :   Zendesk Support ticket field object
@@ -2448,6 +2562,8 @@ Classes
     `visible_in_portal: bool | Any`
     :   The type of the None singleton.
 
+<a id="TicketFieldsListResultMeta"></a>
+
 `TicketFieldsListResultMeta(**data: Any)`
 :   Metadata for ticket_fields.Action.LIST operation
     
@@ -2475,6 +2591,8 @@ Classes
 
     `previous_page: str | Any | None`
     :   The type of the None singleton.
+
+<a id="TicketFieldsSearchData"></a>
 
 `TicketFieldsSearchData(**data: Any)`
 :   Search result data for ticket_fields entity.
@@ -2576,6 +2694,8 @@ Classes
     `visible_in_portal: bool | None`
     :   Whether this field is visible to end users in Help Center
 
+<a id="TicketForm"></a>
+
 `TicketForm(**data: Any)`
 :   Zendesk Support ticket form object
     
@@ -2646,6 +2766,8 @@ Classes
     `url: str | Any`
     :   The type of the None singleton.
 
+<a id="TicketFormsListResultMeta"></a>
+
 `TicketFormsListResultMeta(**data: Any)`
 :   Metadata for ticket_forms.Action.LIST operation
     
@@ -2673,6 +2795,8 @@ Classes
 
     `previous_page: str | Any | None`
     :   The type of the None singleton.
+
+<a id="TicketFormsSearchData"></a>
 
 `TicketFormsSearchData(**data: Any)`
 :   Search result data for ticket_forms entity.
@@ -2743,6 +2867,8 @@ Classes
 
     `url: str | None`
     :   URL of the ticket form
+
+<a id="TicketMetric"></a>
 
 `TicketMetric(**data: Any)`
 :   Zendesk Support ticket metric object
@@ -2829,6 +2955,8 @@ Classes
     `url: str | Any`
     :   The type of the None singleton.
 
+<a id="TicketMetricsListResultMeta"></a>
+
 `TicketMetricsListResultMeta(**data: Any)`
 :   Metadata for ticket_metrics.Action.LIST operation
     
@@ -2856,6 +2984,8 @@ Classes
 
     `previous_page: str | Any | None`
     :   The type of the None singleton.
+
+<a id="TicketMetricsSearchData"></a>
 
 `TicketMetricsSearchData(**data: Any)`
 :   Search result data for ticket_metrics entity.
@@ -2966,6 +3096,8 @@ Classes
     `url: str | None`
     :   The API url of the ticket metric
 
+<a id="TicketsListResultMeta"></a>
+
 `TicketsListResultMeta(**data: Any)`
 :   Metadata for tickets.Action.LIST operation
     
@@ -2993,6 +3125,8 @@ Classes
 
     `previous_page: str | Any | None`
     :   The type of the None singleton.
+
+<a id="TicketsSearchData"></a>
 
 `TicketsSearchData(**data: Any)`
 :   Search result data for tickets entity.
@@ -3136,6 +3270,8 @@ Classes
     `via: dict[str, typing.Any] | None`
     :   Object describing the channel and method through which the ticket was created
 
+<a id="Trigger"></a>
+
 `Trigger(**data: Any)`
 :   Zendesk Support trigger object
     
@@ -3191,6 +3327,8 @@ Classes
     `url: str | Any`
     :   The type of the None singleton.
 
+<a id="TriggersListResultMeta"></a>
+
 `TriggersListResultMeta(**data: Any)`
 :   Metadata for triggers.Action.LIST operation
     
@@ -3218,6 +3356,8 @@ Classes
 
     `previous_page: str | Any | None`
     :   The type of the None singleton.
+
+<a id="User"></a>
 
 `User(**data: Any)`
 :   Zendesk Support user object
@@ -3352,6 +3492,8 @@ Classes
     `verified: bool | Any`
     :   The type of the None singleton.
 
+<a id="UsersListResultMeta"></a>
+
 `UsersListResultMeta(**data: Any)`
 :   Metadata for users.Action.LIST operation
     
@@ -3379,6 +3521,8 @@ Classes
 
     `previous_page: str | Any | None`
     :   The type of the None singleton.
+
+<a id="UsersSearchData"></a>
 
 `UsersSearchData(**data: Any)`
 :   Search result data for users entity.
@@ -3516,6 +3660,8 @@ Classes
     `verified: bool | None`
     :   Indicates if the user's identity has been verified
 
+<a id="View"></a>
+
 `View(**data: Any)`
 :   Zendesk Support view object
     
@@ -3571,6 +3717,8 @@ Classes
     `url: str | Any`
     :   The type of the None singleton.
 
+<a id="ViewsListResultMeta"></a>
+
 `ViewsListResultMeta(**data: Any)`
 :   Metadata for views.Action.LIST operation
     
@@ -3599,6 +3747,8 @@ Classes
     `previous_page: str | Any | None`
     :   The type of the None singleton.
 
+<a id="ZendeskSupportApiTokenAuthConfig"></a>
+
 `ZendeskSupportApiTokenAuthConfig(**data: Any)`
 :   API Token - Authenticate using email and API token
     
@@ -3623,6 +3773,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="ZendeskSupportCheckResult"></a>
 
 `ZendeskSupportCheckResult(**data: Any)`
 :   Result of a health check operation.
@@ -3657,6 +3809,8 @@ Classes
     `status: str`
     :   Health check status: 'healthy' or 'unhealthy'.
 
+<a id="ZendeskSupportExecuteResult"></a>
+
 `ZendeskSupportExecuteResult(**data: Any)`
 :   Response envelope with data only.
     
@@ -3685,6 +3839,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="ZendeskSupportExecuteResultWithMeta"></a>
 
 `ZendeskSupportExecuteResultWithMeta(**data: Any)`
 :   Response envelope with data and metadata.
@@ -3758,6 +3914,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="ArticleAttachmentsListResult"></a>
+
 `ArticleAttachmentsListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -3800,6 +3958,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="ArticlesListResult"></a>
 
 `ArticlesListResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -3844,6 +4004,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="AutomationsListResult"></a>
+
 `AutomationsListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -3886,6 +4048,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="BrandsListResult"></a>
 
 `BrandsListResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -3930,6 +4094,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="DeletedTicketsListResult"></a>
+
 `DeletedTicketsListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -3972,6 +4138,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="GroupMembershipsListResult"></a>
 
 `GroupMembershipsListResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -4016,6 +4184,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="GroupsListResult"></a>
+
 `GroupsListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -4058,6 +4228,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="MacrosListResult"></a>
 
 `MacrosListResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -4102,6 +4274,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="OrganizationMembershipsListResult"></a>
+
 `OrganizationMembershipsListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -4144,6 +4318,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="OrganizationsListResult"></a>
 
 `OrganizationsListResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -4188,6 +4364,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="SlaPoliciesListResult"></a>
+
 `SlaPoliciesListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -4230,6 +4408,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="SatisfactionRatingsListResult"></a>
 
 `SatisfactionRatingsListResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -4274,6 +4454,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="TagsListResult"></a>
+
 `TagsListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -4316,6 +4498,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="TicketAuditsListResult"></a>
 
 `TicketAuditsListResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -4360,6 +4544,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="TicketCommentsListResult"></a>
+
 `TicketCommentsListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -4402,6 +4588,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="TicketFieldsListResult"></a>
 
 `TicketFieldsListResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -4446,6 +4634,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="TicketFormsListResult"></a>
+
 `TicketFormsListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -4488,6 +4678,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="TicketMetricsListResult"></a>
 
 `TicketMetricsListResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -4532,6 +4724,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="TicketsListResult"></a>
+
 `TicketsListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -4574,6 +4768,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="TriggersListResult"></a>
 
 `TriggersListResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -4618,6 +4814,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="UsersListResult"></a>
+
 `UsersListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -4661,6 +4859,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="ViewsListResult"></a>
+
 `ViewsListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -4679,6 +4879,8 @@ Classes
     * airbyte_agent_sdk.connectors.zendesk_support.models.ZendeskSupportExecuteResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="ZendeskSupportOauth20AuthConfig"></a>
 
 `ZendeskSupportOauth20AuthConfig(**data: Any)`
 :   OAuth 2.0 - Zendesk OAuth 2.0 authentication

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/zendesk_support/types.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/zendesk_support/types.md
@@ -10,6 +10,8 @@ Type definitions for zendesk-support connector.
 Classes
 -------
 
+<a id="AirbyteSearchParams"></a>
+
 `AirbyteSearchParams(*args, **kwargs)`
 :   Parameters for Airbyte cache search operations (generic, use entity-specific query types for better type hints).
 
@@ -31,6 +33,8 @@ Classes
     `query: dict[str, typing.Any]`
     :   The type of the None singleton.
 
+<a id="ArticleAttachmentsDownloadParams"></a>
+
 `ArticleAttachmentsDownloadParams(*args, **kwargs)`
 :   Parameters for article_attachments.download operation
 
@@ -49,6 +53,8 @@ Classes
     `range_header: str`
     :   The type of the None singleton.
 
+<a id="ArticleAttachmentsGetParams"></a>
+
 `ArticleAttachmentsGetParams(*args, **kwargs)`
 :   Parameters for article_attachments.get operation
 
@@ -63,6 +69,8 @@ Classes
 
     `attachment_id: str`
     :   The type of the None singleton.
+
+<a id="ArticleAttachmentsListParams"></a>
 
 `ArticleAttachmentsListParams(*args, **kwargs)`
 :   Parameters for article_attachments.list operation
@@ -82,6 +90,8 @@ Classes
     `per_page: int`
     :   The type of the None singleton.
 
+<a id="ArticlesGetParams"></a>
+
 `ArticlesGetParams(*args, **kwargs)`
 :   Parameters for articles.get operation
 
@@ -93,6 +103,8 @@ Classes
 
     `id: str`
     :   The type of the None singleton.
+
+<a id="ArticlesListParams"></a>
 
 `ArticlesListParams(*args, **kwargs)`
 :   Parameters for articles.list operation
@@ -115,6 +127,8 @@ Classes
     `sort_order: str`
     :   The type of the None singleton.
 
+<a id="AttachmentsDownloadParams"></a>
+
 `AttachmentsDownloadParams(*args, **kwargs)`
 :   Parameters for attachments.download operation
 
@@ -130,6 +144,8 @@ Classes
     `range_header: str`
     :   The type of the None singleton.
 
+<a id="AttachmentsGetParams"></a>
+
 `AttachmentsGetParams(*args, **kwargs)`
 :   Parameters for attachments.get operation
 
@@ -142,6 +158,8 @@ Classes
     `attachment_id: str`
     :   The type of the None singleton.
 
+<a id="AutomationsGetParams"></a>
+
 `AutomationsGetParams(*args, **kwargs)`
 :   Parameters for automations.get operation
 
@@ -153,6 +171,8 @@ Classes
 
     `automation_id: str`
     :   The type of the None singleton.
+
+<a id="AutomationsListParams"></a>
 
 `AutomationsListParams(*args, **kwargs)`
 :   Parameters for automations.list operation
@@ -178,6 +198,8 @@ Classes
     `sort_order: str`
     :   The type of the None singleton.
 
+<a id="BrandsAndCondition"></a>
+
 `BrandsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -198,6 +220,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.zendesk_support.types.BrandsEqCondition | airbyte_agent_sdk.connectors.zendesk_support.types.BrandsNeqCondition | airbyte_agent_sdk.connectors.zendesk_support.types.BrandsGtCondition | airbyte_agent_sdk.connectors.zendesk_support.types.BrandsGteCondition | airbyte_agent_sdk.connectors.zendesk_support.types.BrandsLtCondition | airbyte_agent_sdk.connectors.zendesk_support.types.BrandsLteCondition | airbyte_agent_sdk.connectors.zendesk_support.types.BrandsInCondition | airbyte_agent_sdk.connectors.zendesk_support.types.BrandsLikeCondition | airbyte_agent_sdk.connectors.zendesk_support.types.BrandsFuzzyCondition | airbyte_agent_sdk.connectors.zendesk_support.types.BrandsKeywordCondition | airbyte_agent_sdk.connectors.zendesk_support.types.BrandsContainsCondition | airbyte_agent_sdk.connectors.zendesk_support.types.BrandsNotCondition | airbyte_agent_sdk.connectors.zendesk_support.types.BrandsAndCondition | airbyte_agent_sdk.connectors.zendesk_support.types.BrandsOrCondition | airbyte_agent_sdk.connectors.zendesk_support.types.BrandsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="BrandsAnyCondition"></a>
+
 `BrandsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -217,6 +241,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.zendesk_support.types.BrandsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="BrandsAnyValueFilter"></a>
 
 `BrandsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -275,6 +301,8 @@ Classes
     `url: Any`
     :   The API URL for accessing this brand resource
 
+<a id="BrandsContainsCondition"></a>
+
 `BrandsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -286,6 +314,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.zendesk_support.types.BrandsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="BrandsEqCondition"></a>
 
 `BrandsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -299,6 +329,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.zendesk_support.types.BrandsSearchFilter`
     :   The type of the None singleton.
 
+<a id="BrandsFuzzyCondition"></a>
+
 `BrandsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -310,6 +342,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.zendesk_support.types.BrandsStringFilter`
     :   The type of the None singleton.
+
+<a id="BrandsGetParams"></a>
 
 `BrandsGetParams(*args, **kwargs)`
 :   Parameters for brands.get operation
@@ -323,6 +357,8 @@ Classes
     `brand_id: str`
     :   The type of the None singleton.
 
+<a id="BrandsGtCondition"></a>
+
 `BrandsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -335,6 +371,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.zendesk_support.types.BrandsSearchFilter`
     :   The type of the None singleton.
 
+<a id="BrandsGteCondition"></a>
+
 `BrandsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -346,6 +384,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.zendesk_support.types.BrandsSearchFilter`
     :   The type of the None singleton.
+
+<a id="BrandsInCondition"></a>
 
 `BrandsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -366,6 +406,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.zendesk_support.types.BrandsInFilter`
     :   The type of the None singleton.
+
+<a id="BrandsInFilter"></a>
 
 `BrandsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -424,6 +466,8 @@ Classes
     `url: list[str]`
     :   The API URL for accessing this brand resource
 
+<a id="BrandsKeywordCondition"></a>
+
 `BrandsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -436,6 +480,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.zendesk_support.types.BrandsStringFilter`
     :   The type of the None singleton.
 
+<a id="BrandsLikeCondition"></a>
+
 `BrandsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -447,6 +493,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.zendesk_support.types.BrandsStringFilter`
     :   The type of the None singleton.
+
+<a id="BrandsListParams"></a>
 
 `BrandsListParams(*args, **kwargs)`
 :   Parameters for brands.list operation
@@ -463,6 +511,8 @@ Classes
     `per_page: int`
     :   The type of the None singleton.
 
+<a id="BrandsLtCondition"></a>
+
 `BrandsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -474,6 +524,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.zendesk_support.types.BrandsSearchFilter`
     :   The type of the None singleton.
+
+<a id="BrandsLteCondition"></a>
 
 `BrandsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -487,6 +539,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.zendesk_support.types.BrandsSearchFilter`
     :   The type of the None singleton.
 
+<a id="BrandsNeqCondition"></a>
+
 `BrandsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -498,6 +552,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.zendesk_support.types.BrandsSearchFilter`
     :   The type of the None singleton.
+
+<a id="BrandsNotCondition"></a>
 
 `BrandsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -519,6 +575,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.zendesk_support.types.BrandsEqCondition | airbyte_agent_sdk.connectors.zendesk_support.types.BrandsNeqCondition | airbyte_agent_sdk.connectors.zendesk_support.types.BrandsGtCondition | airbyte_agent_sdk.connectors.zendesk_support.types.BrandsGteCondition | airbyte_agent_sdk.connectors.zendesk_support.types.BrandsLtCondition | airbyte_agent_sdk.connectors.zendesk_support.types.BrandsLteCondition | airbyte_agent_sdk.connectors.zendesk_support.types.BrandsInCondition | airbyte_agent_sdk.connectors.zendesk_support.types.BrandsLikeCondition | airbyte_agent_sdk.connectors.zendesk_support.types.BrandsFuzzyCondition | airbyte_agent_sdk.connectors.zendesk_support.types.BrandsKeywordCondition | airbyte_agent_sdk.connectors.zendesk_support.types.BrandsContainsCondition | airbyte_agent_sdk.connectors.zendesk_support.types.BrandsNotCondition | airbyte_agent_sdk.connectors.zendesk_support.types.BrandsAndCondition | airbyte_agent_sdk.connectors.zendesk_support.types.BrandsOrCondition | airbyte_agent_sdk.connectors.zendesk_support.types.BrandsAnyCondition`
     :   The type of the None singleton.
 
+<a id="BrandsOrCondition"></a>
+
 `BrandsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -538,6 +596,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.zendesk_support.types.BrandsEqCondition | airbyte_agent_sdk.connectors.zendesk_support.types.BrandsNeqCondition | airbyte_agent_sdk.connectors.zendesk_support.types.BrandsGtCondition | airbyte_agent_sdk.connectors.zendesk_support.types.BrandsGteCondition | airbyte_agent_sdk.connectors.zendesk_support.types.BrandsLtCondition | airbyte_agent_sdk.connectors.zendesk_support.types.BrandsLteCondition | airbyte_agent_sdk.connectors.zendesk_support.types.BrandsInCondition | airbyte_agent_sdk.connectors.zendesk_support.types.BrandsLikeCondition | airbyte_agent_sdk.connectors.zendesk_support.types.BrandsFuzzyCondition | airbyte_agent_sdk.connectors.zendesk_support.types.BrandsKeywordCondition | airbyte_agent_sdk.connectors.zendesk_support.types.BrandsContainsCondition | airbyte_agent_sdk.connectors.zendesk_support.types.BrandsNotCondition | airbyte_agent_sdk.connectors.zendesk_support.types.BrandsAndCondition | airbyte_agent_sdk.connectors.zendesk_support.types.BrandsOrCondition | airbyte_agent_sdk.connectors.zendesk_support.types.BrandsAnyCondition]`
     :   The type of the None singleton.
+
+<a id="BrandsSearchFilter"></a>
 
 `BrandsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering brands search queries.
@@ -596,6 +656,8 @@ Classes
     `url: str | None`
     :   The API URL for accessing this brand resource
 
+<a id="BrandsSearchQuery"></a>
+
 `BrandsSearchQuery(*args, **kwargs)`
 :   Search query for brands entity.
 
@@ -610,6 +672,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.zendesk_support.types.BrandsSortFilter]`
     :   The type of the None singleton.
+
+<a id="BrandsSortFilter"></a>
 
 `BrandsSortFilter(*args, **kwargs)`
 :   Available fields for sorting brands search results.
@@ -668,6 +732,8 @@ Classes
     `url: Literal['asc', 'desc']`
     :   The API URL for accessing this brand resource
 
+<a id="BrandsStringFilter"></a>
+
 `BrandsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -725,6 +791,8 @@ Classes
     `url: str`
     :   The API URL for accessing this brand resource
 
+<a id="DeletedTicketsAndCondition"></a>
+
 `DeletedTicketsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -745,6 +813,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.zendesk_support.types.DeletedTicketsEqCondition | airbyte_agent_sdk.connectors.zendesk_support.types.DeletedTicketsNeqCondition | airbyte_agent_sdk.connectors.zendesk_support.types.DeletedTicketsGtCondition | airbyte_agent_sdk.connectors.zendesk_support.types.DeletedTicketsGteCondition | airbyte_agent_sdk.connectors.zendesk_support.types.DeletedTicketsLtCondition | airbyte_agent_sdk.connectors.zendesk_support.types.DeletedTicketsLteCondition | airbyte_agent_sdk.connectors.zendesk_support.types.DeletedTicketsInCondition | airbyte_agent_sdk.connectors.zendesk_support.types.DeletedTicketsLikeCondition | airbyte_agent_sdk.connectors.zendesk_support.types.DeletedTicketsFuzzyCondition | airbyte_agent_sdk.connectors.zendesk_support.types.DeletedTicketsKeywordCondition | airbyte_agent_sdk.connectors.zendesk_support.types.DeletedTicketsContainsCondition | airbyte_agent_sdk.connectors.zendesk_support.types.DeletedTicketsNotCondition | airbyte_agent_sdk.connectors.zendesk_support.types.DeletedTicketsAndCondition | airbyte_agent_sdk.connectors.zendesk_support.types.DeletedTicketsOrCondition | airbyte_agent_sdk.connectors.zendesk_support.types.DeletedTicketsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="DeletedTicketsAnyCondition"></a>
+
 `DeletedTicketsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -764,6 +834,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.zendesk_support.types.DeletedTicketsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="DeletedTicketsAnyValueFilter"></a>
 
 `DeletedTicketsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -792,6 +864,8 @@ Classes
     `subject: Any`
     :   The subject or title of the deleted ticket
 
+<a id="DeletedTicketsContainsCondition"></a>
+
 `DeletedTicketsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -803,6 +877,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.zendesk_support.types.DeletedTicketsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="DeletedTicketsEqCondition"></a>
 
 `DeletedTicketsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -816,6 +892,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.zendesk_support.types.DeletedTicketsSearchFilter`
     :   The type of the None singleton.
 
+<a id="DeletedTicketsFuzzyCondition"></a>
+
 `DeletedTicketsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -827,6 +905,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.zendesk_support.types.DeletedTicketsStringFilter`
     :   The type of the None singleton.
+
+<a id="DeletedTicketsGtCondition"></a>
 
 `DeletedTicketsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
@@ -840,6 +920,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.zendesk_support.types.DeletedTicketsSearchFilter`
     :   The type of the None singleton.
 
+<a id="DeletedTicketsGteCondition"></a>
+
 `DeletedTicketsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -851,6 +933,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.zendesk_support.types.DeletedTicketsSearchFilter`
     :   The type of the None singleton.
+
+<a id="DeletedTicketsInCondition"></a>
 
 `DeletedTicketsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -871,6 +955,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.zendesk_support.types.DeletedTicketsInFilter`
     :   The type of the None singleton.
+
+<a id="DeletedTicketsInFilter"></a>
 
 `DeletedTicketsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -899,6 +985,8 @@ Classes
     `subject: list[str]`
     :   The subject or title of the deleted ticket
 
+<a id="DeletedTicketsKeywordCondition"></a>
+
 `DeletedTicketsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -911,6 +999,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.zendesk_support.types.DeletedTicketsStringFilter`
     :   The type of the None singleton.
 
+<a id="DeletedTicketsLikeCondition"></a>
+
 `DeletedTicketsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -922,6 +1012,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.zendesk_support.types.DeletedTicketsStringFilter`
     :   The type of the None singleton.
+
+<a id="DeletedTicketsListParams"></a>
 
 `DeletedTicketsListParams(*args, **kwargs)`
 :   Parameters for deleted_tickets.list operation
@@ -944,6 +1036,8 @@ Classes
     `sort_order: str`
     :   The type of the None singleton.
 
+<a id="DeletedTicketsLtCondition"></a>
+
 `DeletedTicketsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -955,6 +1049,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.zendesk_support.types.DeletedTicketsSearchFilter`
     :   The type of the None singleton.
+
+<a id="DeletedTicketsLteCondition"></a>
 
 `DeletedTicketsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -968,6 +1064,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.zendesk_support.types.DeletedTicketsSearchFilter`
     :   The type of the None singleton.
 
+<a id="DeletedTicketsNeqCondition"></a>
+
 `DeletedTicketsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -979,6 +1077,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.zendesk_support.types.DeletedTicketsSearchFilter`
     :   The type of the None singleton.
+
+<a id="DeletedTicketsNotCondition"></a>
 
 `DeletedTicketsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -1000,6 +1100,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.zendesk_support.types.DeletedTicketsEqCondition | airbyte_agent_sdk.connectors.zendesk_support.types.DeletedTicketsNeqCondition | airbyte_agent_sdk.connectors.zendesk_support.types.DeletedTicketsGtCondition | airbyte_agent_sdk.connectors.zendesk_support.types.DeletedTicketsGteCondition | airbyte_agent_sdk.connectors.zendesk_support.types.DeletedTicketsLtCondition | airbyte_agent_sdk.connectors.zendesk_support.types.DeletedTicketsLteCondition | airbyte_agent_sdk.connectors.zendesk_support.types.DeletedTicketsInCondition | airbyte_agent_sdk.connectors.zendesk_support.types.DeletedTicketsLikeCondition | airbyte_agent_sdk.connectors.zendesk_support.types.DeletedTicketsFuzzyCondition | airbyte_agent_sdk.connectors.zendesk_support.types.DeletedTicketsKeywordCondition | airbyte_agent_sdk.connectors.zendesk_support.types.DeletedTicketsContainsCondition | airbyte_agent_sdk.connectors.zendesk_support.types.DeletedTicketsNotCondition | airbyte_agent_sdk.connectors.zendesk_support.types.DeletedTicketsAndCondition | airbyte_agent_sdk.connectors.zendesk_support.types.DeletedTicketsOrCondition | airbyte_agent_sdk.connectors.zendesk_support.types.DeletedTicketsAnyCondition`
     :   The type of the None singleton.
 
+<a id="DeletedTicketsOrCondition"></a>
+
 `DeletedTicketsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1019,6 +1121,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.zendesk_support.types.DeletedTicketsEqCondition | airbyte_agent_sdk.connectors.zendesk_support.types.DeletedTicketsNeqCondition | airbyte_agent_sdk.connectors.zendesk_support.types.DeletedTicketsGtCondition | airbyte_agent_sdk.connectors.zendesk_support.types.DeletedTicketsGteCondition | airbyte_agent_sdk.connectors.zendesk_support.types.DeletedTicketsLtCondition | airbyte_agent_sdk.connectors.zendesk_support.types.DeletedTicketsLteCondition | airbyte_agent_sdk.connectors.zendesk_support.types.DeletedTicketsInCondition | airbyte_agent_sdk.connectors.zendesk_support.types.DeletedTicketsLikeCondition | airbyte_agent_sdk.connectors.zendesk_support.types.DeletedTicketsFuzzyCondition | airbyte_agent_sdk.connectors.zendesk_support.types.DeletedTicketsKeywordCondition | airbyte_agent_sdk.connectors.zendesk_support.types.DeletedTicketsContainsCondition | airbyte_agent_sdk.connectors.zendesk_support.types.DeletedTicketsNotCondition | airbyte_agent_sdk.connectors.zendesk_support.types.DeletedTicketsAndCondition | airbyte_agent_sdk.connectors.zendesk_support.types.DeletedTicketsOrCondition | airbyte_agent_sdk.connectors.zendesk_support.types.DeletedTicketsAnyCondition]`
     :   The type of the None singleton.
+
+<a id="DeletedTicketsSearchFilter"></a>
 
 `DeletedTicketsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering deleted_tickets search queries.
@@ -1047,6 +1151,8 @@ Classes
     `subject: str | None`
     :   The subject or title of the deleted ticket
 
+<a id="DeletedTicketsSearchQuery"></a>
+
 `DeletedTicketsSearchQuery(*args, **kwargs)`
 :   Search query for deleted_tickets entity.
 
@@ -1061,6 +1167,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.zendesk_support.types.DeletedTicketsSortFilter]`
     :   The type of the None singleton.
+
+<a id="DeletedTicketsSortFilter"></a>
 
 `DeletedTicketsSortFilter(*args, **kwargs)`
 :   Available fields for sorting deleted_tickets search results.
@@ -1089,6 +1197,8 @@ Classes
     `subject: Literal['asc', 'desc']`
     :   The subject or title of the deleted ticket
 
+<a id="DeletedTicketsStringFilter"></a>
+
 `DeletedTicketsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -1116,6 +1226,8 @@ Classes
     `subject: str`
     :   The subject or title of the deleted ticket
 
+<a id="GroupMembershipsListParams"></a>
+
 `GroupMembershipsListParams(*args, **kwargs)`
 :   Parameters for group_memberships.list operation
 
@@ -1130,6 +1242,8 @@ Classes
 
     `per_page: int`
     :   The type of the None singleton.
+
+<a id="GroupsAndCondition"></a>
 
 `GroupsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -1151,6 +1265,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.zendesk_support.types.GroupsEqCondition | airbyte_agent_sdk.connectors.zendesk_support.types.GroupsNeqCondition | airbyte_agent_sdk.connectors.zendesk_support.types.GroupsGtCondition | airbyte_agent_sdk.connectors.zendesk_support.types.GroupsGteCondition | airbyte_agent_sdk.connectors.zendesk_support.types.GroupsLtCondition | airbyte_agent_sdk.connectors.zendesk_support.types.GroupsLteCondition | airbyte_agent_sdk.connectors.zendesk_support.types.GroupsInCondition | airbyte_agent_sdk.connectors.zendesk_support.types.GroupsLikeCondition | airbyte_agent_sdk.connectors.zendesk_support.types.GroupsFuzzyCondition | airbyte_agent_sdk.connectors.zendesk_support.types.GroupsKeywordCondition | airbyte_agent_sdk.connectors.zendesk_support.types.GroupsContainsCondition | airbyte_agent_sdk.connectors.zendesk_support.types.GroupsNotCondition | airbyte_agent_sdk.connectors.zendesk_support.types.GroupsAndCondition | airbyte_agent_sdk.connectors.zendesk_support.types.GroupsOrCondition | airbyte_agent_sdk.connectors.zendesk_support.types.GroupsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="GroupsAnyCondition"></a>
+
 `GroupsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1170,6 +1286,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.zendesk_support.types.GroupsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="GroupsAnyValueFilter"></a>
 
 `GroupsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -1207,6 +1325,8 @@ Classes
     `url: Any`
     :   The API URL of the group
 
+<a id="GroupsContainsCondition"></a>
+
 `GroupsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -1218,6 +1338,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.zendesk_support.types.GroupsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="GroupsEqCondition"></a>
 
 `GroupsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -1231,6 +1353,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.zendesk_support.types.GroupsSearchFilter`
     :   The type of the None singleton.
 
+<a id="GroupsFuzzyCondition"></a>
+
 `GroupsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -1242,6 +1366,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.zendesk_support.types.GroupsStringFilter`
     :   The type of the None singleton.
+
+<a id="GroupsGetParams"></a>
 
 `GroupsGetParams(*args, **kwargs)`
 :   Parameters for groups.get operation
@@ -1255,6 +1381,8 @@ Classes
     `group_id: str`
     :   The type of the None singleton.
 
+<a id="GroupsGtCondition"></a>
+
 `GroupsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -1267,6 +1395,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.zendesk_support.types.GroupsSearchFilter`
     :   The type of the None singleton.
 
+<a id="GroupsGteCondition"></a>
+
 `GroupsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -1278,6 +1408,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.zendesk_support.types.GroupsSearchFilter`
     :   The type of the None singleton.
+
+<a id="GroupsInCondition"></a>
 
 `GroupsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -1298,6 +1430,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.zendesk_support.types.GroupsInFilter`
     :   The type of the None singleton.
+
+<a id="GroupsInFilter"></a>
 
 `GroupsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -1335,6 +1469,8 @@ Classes
     `url: list[str]`
     :   The API URL of the group
 
+<a id="GroupsKeywordCondition"></a>
+
 `GroupsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -1347,6 +1483,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.zendesk_support.types.GroupsStringFilter`
     :   The type of the None singleton.
 
+<a id="GroupsLikeCondition"></a>
+
 `GroupsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -1358,6 +1496,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.zendesk_support.types.GroupsStringFilter`
     :   The type of the None singleton.
+
+<a id="GroupsListParams"></a>
 
 `GroupsListParams(*args, **kwargs)`
 :   Parameters for groups.list operation
@@ -1377,6 +1517,8 @@ Classes
     `per_page: int`
     :   The type of the None singleton.
 
+<a id="GroupsLtCondition"></a>
+
 `GroupsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -1388,6 +1530,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.zendesk_support.types.GroupsSearchFilter`
     :   The type of the None singleton.
+
+<a id="GroupsLteCondition"></a>
 
 `GroupsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -1401,6 +1545,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.zendesk_support.types.GroupsSearchFilter`
     :   The type of the None singleton.
 
+<a id="GroupsNeqCondition"></a>
+
 `GroupsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -1412,6 +1558,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.zendesk_support.types.GroupsSearchFilter`
     :   The type of the None singleton.
+
+<a id="GroupsNotCondition"></a>
 
 `GroupsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -1433,6 +1581,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.zendesk_support.types.GroupsEqCondition | airbyte_agent_sdk.connectors.zendesk_support.types.GroupsNeqCondition | airbyte_agent_sdk.connectors.zendesk_support.types.GroupsGtCondition | airbyte_agent_sdk.connectors.zendesk_support.types.GroupsGteCondition | airbyte_agent_sdk.connectors.zendesk_support.types.GroupsLtCondition | airbyte_agent_sdk.connectors.zendesk_support.types.GroupsLteCondition | airbyte_agent_sdk.connectors.zendesk_support.types.GroupsInCondition | airbyte_agent_sdk.connectors.zendesk_support.types.GroupsLikeCondition | airbyte_agent_sdk.connectors.zendesk_support.types.GroupsFuzzyCondition | airbyte_agent_sdk.connectors.zendesk_support.types.GroupsKeywordCondition | airbyte_agent_sdk.connectors.zendesk_support.types.GroupsContainsCondition | airbyte_agent_sdk.connectors.zendesk_support.types.GroupsNotCondition | airbyte_agent_sdk.connectors.zendesk_support.types.GroupsAndCondition | airbyte_agent_sdk.connectors.zendesk_support.types.GroupsOrCondition | airbyte_agent_sdk.connectors.zendesk_support.types.GroupsAnyCondition`
     :   The type of the None singleton.
 
+<a id="GroupsOrCondition"></a>
+
 `GroupsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1452,6 +1602,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.zendesk_support.types.GroupsEqCondition | airbyte_agent_sdk.connectors.zendesk_support.types.GroupsNeqCondition | airbyte_agent_sdk.connectors.zendesk_support.types.GroupsGtCondition | airbyte_agent_sdk.connectors.zendesk_support.types.GroupsGteCondition | airbyte_agent_sdk.connectors.zendesk_support.types.GroupsLtCondition | airbyte_agent_sdk.connectors.zendesk_support.types.GroupsLteCondition | airbyte_agent_sdk.connectors.zendesk_support.types.GroupsInCondition | airbyte_agent_sdk.connectors.zendesk_support.types.GroupsLikeCondition | airbyte_agent_sdk.connectors.zendesk_support.types.GroupsFuzzyCondition | airbyte_agent_sdk.connectors.zendesk_support.types.GroupsKeywordCondition | airbyte_agent_sdk.connectors.zendesk_support.types.GroupsContainsCondition | airbyte_agent_sdk.connectors.zendesk_support.types.GroupsNotCondition | airbyte_agent_sdk.connectors.zendesk_support.types.GroupsAndCondition | airbyte_agent_sdk.connectors.zendesk_support.types.GroupsOrCondition | airbyte_agent_sdk.connectors.zendesk_support.types.GroupsAnyCondition]`
     :   The type of the None singleton.
+
+<a id="GroupsSearchFilter"></a>
 
 `GroupsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering groups search queries.
@@ -1489,6 +1641,8 @@ Classes
     `url: str | None`
     :   The API URL of the group
 
+<a id="GroupsSearchQuery"></a>
+
 `GroupsSearchQuery(*args, **kwargs)`
 :   Search query for groups entity.
 
@@ -1503,6 +1657,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.zendesk_support.types.GroupsSortFilter]`
     :   The type of the None singleton.
+
+<a id="GroupsSortFilter"></a>
 
 `GroupsSortFilter(*args, **kwargs)`
 :   Available fields for sorting groups search results.
@@ -1540,6 +1696,8 @@ Classes
     `url: Literal['asc', 'desc']`
     :   The API URL of the group
 
+<a id="GroupsStringFilter"></a>
+
 `GroupsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -1576,6 +1734,8 @@ Classes
     `url: str`
     :   The API URL of the group
 
+<a id="MacrosGetParams"></a>
+
 `MacrosGetParams(*args, **kwargs)`
 :   Parameters for macros.get operation
 
@@ -1587,6 +1747,8 @@ Classes
 
     `macro_id: str`
     :   The type of the None singleton.
+
+<a id="MacrosListParams"></a>
 
 `MacrosListParams(*args, **kwargs)`
 :   Parameters for macros.list operation
@@ -1624,6 +1786,8 @@ Classes
     `sort_order: str`
     :   The type of the None singleton.
 
+<a id="OrganizationMembershipsListParams"></a>
+
 `OrganizationMembershipsListParams(*args, **kwargs)`
 :   Parameters for organization_memberships.list operation
 
@@ -1638,6 +1802,8 @@ Classes
 
     `per_page: int`
     :   The type of the None singleton.
+
+<a id="OrganizationsAndCondition"></a>
 
 `OrganizationsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -1659,6 +1825,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.zendesk_support.types.OrganizationsEqCondition | airbyte_agent_sdk.connectors.zendesk_support.types.OrganizationsNeqCondition | airbyte_agent_sdk.connectors.zendesk_support.types.OrganizationsGtCondition | airbyte_agent_sdk.connectors.zendesk_support.types.OrganizationsGteCondition | airbyte_agent_sdk.connectors.zendesk_support.types.OrganizationsLtCondition | airbyte_agent_sdk.connectors.zendesk_support.types.OrganizationsLteCondition | airbyte_agent_sdk.connectors.zendesk_support.types.OrganizationsInCondition | airbyte_agent_sdk.connectors.zendesk_support.types.OrganizationsLikeCondition | airbyte_agent_sdk.connectors.zendesk_support.types.OrganizationsFuzzyCondition | airbyte_agent_sdk.connectors.zendesk_support.types.OrganizationsKeywordCondition | airbyte_agent_sdk.connectors.zendesk_support.types.OrganizationsContainsCondition | airbyte_agent_sdk.connectors.zendesk_support.types.OrganizationsNotCondition | airbyte_agent_sdk.connectors.zendesk_support.types.OrganizationsAndCondition | airbyte_agent_sdk.connectors.zendesk_support.types.OrganizationsOrCondition | airbyte_agent_sdk.connectors.zendesk_support.types.OrganizationsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="OrganizationsAnyCondition"></a>
+
 `OrganizationsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1678,6 +1846,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.zendesk_support.types.OrganizationsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="OrganizationsAnyValueFilter"></a>
 
 `OrganizationsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -1733,6 +1903,8 @@ Classes
     `url: Any`
     :   The API URL of this organization
 
+<a id="OrganizationsContainsCondition"></a>
+
 `OrganizationsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -1744,6 +1916,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.zendesk_support.types.OrganizationsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="OrganizationsEqCondition"></a>
 
 `OrganizationsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -1757,6 +1931,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.zendesk_support.types.OrganizationsSearchFilter`
     :   The type of the None singleton.
 
+<a id="OrganizationsFuzzyCondition"></a>
+
 `OrganizationsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -1768,6 +1944,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.zendesk_support.types.OrganizationsStringFilter`
     :   The type of the None singleton.
+
+<a id="OrganizationsGetParams"></a>
 
 `OrganizationsGetParams(*args, **kwargs)`
 :   Parameters for organizations.get operation
@@ -1781,6 +1959,8 @@ Classes
     `organization_id: str`
     :   The type of the None singleton.
 
+<a id="OrganizationsGtCondition"></a>
+
 `OrganizationsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -1793,6 +1973,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.zendesk_support.types.OrganizationsSearchFilter`
     :   The type of the None singleton.
 
+<a id="OrganizationsGteCondition"></a>
+
 `OrganizationsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -1804,6 +1986,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.zendesk_support.types.OrganizationsSearchFilter`
     :   The type of the None singleton.
+
+<a id="OrganizationsInCondition"></a>
 
 `OrganizationsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -1824,6 +2008,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.zendesk_support.types.OrganizationsInFilter`
     :   The type of the None singleton.
+
+<a id="OrganizationsInFilter"></a>
 
 `OrganizationsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -1879,6 +2065,8 @@ Classes
     `url: list[str]`
     :   The API URL of this organization
 
+<a id="OrganizationsKeywordCondition"></a>
+
 `OrganizationsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -1891,6 +2079,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.zendesk_support.types.OrganizationsStringFilter`
     :   The type of the None singleton.
 
+<a id="OrganizationsLikeCondition"></a>
+
 `OrganizationsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -1902,6 +2092,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.zendesk_support.types.OrganizationsStringFilter`
     :   The type of the None singleton.
+
+<a id="OrganizationsListParams"></a>
 
 `OrganizationsListParams(*args, **kwargs)`
 :   Parameters for organizations.list operation
@@ -1918,6 +2110,8 @@ Classes
     `per_page: int`
     :   The type of the None singleton.
 
+<a id="OrganizationsLtCondition"></a>
+
 `OrganizationsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -1929,6 +2123,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.zendesk_support.types.OrganizationsSearchFilter`
     :   The type of the None singleton.
+
+<a id="OrganizationsLteCondition"></a>
 
 `OrganizationsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -1942,6 +2138,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.zendesk_support.types.OrganizationsSearchFilter`
     :   The type of the None singleton.
 
+<a id="OrganizationsNeqCondition"></a>
+
 `OrganizationsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -1953,6 +2151,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.zendesk_support.types.OrganizationsSearchFilter`
     :   The type of the None singleton.
+
+<a id="OrganizationsNotCondition"></a>
 
 `OrganizationsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -1974,6 +2174,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.zendesk_support.types.OrganizationsEqCondition | airbyte_agent_sdk.connectors.zendesk_support.types.OrganizationsNeqCondition | airbyte_agent_sdk.connectors.zendesk_support.types.OrganizationsGtCondition | airbyte_agent_sdk.connectors.zendesk_support.types.OrganizationsGteCondition | airbyte_agent_sdk.connectors.zendesk_support.types.OrganizationsLtCondition | airbyte_agent_sdk.connectors.zendesk_support.types.OrganizationsLteCondition | airbyte_agent_sdk.connectors.zendesk_support.types.OrganizationsInCondition | airbyte_agent_sdk.connectors.zendesk_support.types.OrganizationsLikeCondition | airbyte_agent_sdk.connectors.zendesk_support.types.OrganizationsFuzzyCondition | airbyte_agent_sdk.connectors.zendesk_support.types.OrganizationsKeywordCondition | airbyte_agent_sdk.connectors.zendesk_support.types.OrganizationsContainsCondition | airbyte_agent_sdk.connectors.zendesk_support.types.OrganizationsNotCondition | airbyte_agent_sdk.connectors.zendesk_support.types.OrganizationsAndCondition | airbyte_agent_sdk.connectors.zendesk_support.types.OrganizationsOrCondition | airbyte_agent_sdk.connectors.zendesk_support.types.OrganizationsAnyCondition`
     :   The type of the None singleton.
 
+<a id="OrganizationsOrCondition"></a>
+
 `OrganizationsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1993,6 +2195,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.zendesk_support.types.OrganizationsEqCondition | airbyte_agent_sdk.connectors.zendesk_support.types.OrganizationsNeqCondition | airbyte_agent_sdk.connectors.zendesk_support.types.OrganizationsGtCondition | airbyte_agent_sdk.connectors.zendesk_support.types.OrganizationsGteCondition | airbyte_agent_sdk.connectors.zendesk_support.types.OrganizationsLtCondition | airbyte_agent_sdk.connectors.zendesk_support.types.OrganizationsLteCondition | airbyte_agent_sdk.connectors.zendesk_support.types.OrganizationsInCondition | airbyte_agent_sdk.connectors.zendesk_support.types.OrganizationsLikeCondition | airbyte_agent_sdk.connectors.zendesk_support.types.OrganizationsFuzzyCondition | airbyte_agent_sdk.connectors.zendesk_support.types.OrganizationsKeywordCondition | airbyte_agent_sdk.connectors.zendesk_support.types.OrganizationsContainsCondition | airbyte_agent_sdk.connectors.zendesk_support.types.OrganizationsNotCondition | airbyte_agent_sdk.connectors.zendesk_support.types.OrganizationsAndCondition | airbyte_agent_sdk.connectors.zendesk_support.types.OrganizationsOrCondition | airbyte_agent_sdk.connectors.zendesk_support.types.OrganizationsAnyCondition]`
     :   The type of the None singleton.
+
+<a id="OrganizationsSearchFilter"></a>
 
 `OrganizationsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering organizations search queries.
@@ -2048,6 +2252,8 @@ Classes
     `url: str | None`
     :   The API URL of this organization
 
+<a id="OrganizationsSearchQuery"></a>
+
 `OrganizationsSearchQuery(*args, **kwargs)`
 :   Search query for organizations entity.
 
@@ -2062,6 +2268,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.zendesk_support.types.OrganizationsSortFilter]`
     :   The type of the None singleton.
+
+<a id="OrganizationsSortFilter"></a>
 
 `OrganizationsSortFilter(*args, **kwargs)`
 :   Available fields for sorting organizations search results.
@@ -2117,6 +2325,8 @@ Classes
     `url: Literal['asc', 'desc']`
     :   The API URL of this organization
 
+<a id="OrganizationsStringFilter"></a>
+
 `OrganizationsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -2171,6 +2381,8 @@ Classes
     `url: str`
     :   The API URL of this organization
 
+<a id="SatisfactionRatingsAndCondition"></a>
+
 `SatisfactionRatingsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -2191,6 +2403,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.zendesk_support.types.SatisfactionRatingsEqCondition | airbyte_agent_sdk.connectors.zendesk_support.types.SatisfactionRatingsNeqCondition | airbyte_agent_sdk.connectors.zendesk_support.types.SatisfactionRatingsGtCondition | airbyte_agent_sdk.connectors.zendesk_support.types.SatisfactionRatingsGteCondition | airbyte_agent_sdk.connectors.zendesk_support.types.SatisfactionRatingsLtCondition | airbyte_agent_sdk.connectors.zendesk_support.types.SatisfactionRatingsLteCondition | airbyte_agent_sdk.connectors.zendesk_support.types.SatisfactionRatingsInCondition | airbyte_agent_sdk.connectors.zendesk_support.types.SatisfactionRatingsLikeCondition | airbyte_agent_sdk.connectors.zendesk_support.types.SatisfactionRatingsFuzzyCondition | airbyte_agent_sdk.connectors.zendesk_support.types.SatisfactionRatingsKeywordCondition | airbyte_agent_sdk.connectors.zendesk_support.types.SatisfactionRatingsContainsCondition | airbyte_agent_sdk.connectors.zendesk_support.types.SatisfactionRatingsNotCondition | airbyte_agent_sdk.connectors.zendesk_support.types.SatisfactionRatingsAndCondition | airbyte_agent_sdk.connectors.zendesk_support.types.SatisfactionRatingsOrCondition | airbyte_agent_sdk.connectors.zendesk_support.types.SatisfactionRatingsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="SatisfactionRatingsAnyCondition"></a>
+
 `SatisfactionRatingsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -2210,6 +2424,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.zendesk_support.types.SatisfactionRatingsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="SatisfactionRatingsAnyValueFilter"></a>
 
 `SatisfactionRatingsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -2256,6 +2472,8 @@ Classes
     `url: Any`
     :   The API URL of this satisfaction rating resource
 
+<a id="SatisfactionRatingsContainsCondition"></a>
+
 `SatisfactionRatingsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -2267,6 +2485,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.zendesk_support.types.SatisfactionRatingsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="SatisfactionRatingsEqCondition"></a>
 
 `SatisfactionRatingsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -2280,6 +2500,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.zendesk_support.types.SatisfactionRatingsSearchFilter`
     :   The type of the None singleton.
 
+<a id="SatisfactionRatingsFuzzyCondition"></a>
+
 `SatisfactionRatingsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -2291,6 +2513,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.zendesk_support.types.SatisfactionRatingsStringFilter`
     :   The type of the None singleton.
+
+<a id="SatisfactionRatingsGetParams"></a>
 
 `SatisfactionRatingsGetParams(*args, **kwargs)`
 :   Parameters for satisfaction_ratings.get operation
@@ -2304,6 +2528,8 @@ Classes
     `satisfaction_rating_id: str`
     :   The type of the None singleton.
 
+<a id="SatisfactionRatingsGtCondition"></a>
+
 `SatisfactionRatingsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -2316,6 +2542,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.zendesk_support.types.SatisfactionRatingsSearchFilter`
     :   The type of the None singleton.
 
+<a id="SatisfactionRatingsGteCondition"></a>
+
 `SatisfactionRatingsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -2327,6 +2555,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.zendesk_support.types.SatisfactionRatingsSearchFilter`
     :   The type of the None singleton.
+
+<a id="SatisfactionRatingsInCondition"></a>
 
 `SatisfactionRatingsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -2347,6 +2577,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.zendesk_support.types.SatisfactionRatingsInFilter`
     :   The type of the None singleton.
+
+<a id="SatisfactionRatingsInFilter"></a>
 
 `SatisfactionRatingsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -2393,6 +2625,8 @@ Classes
     `url: list[str]`
     :   The API URL of this satisfaction rating resource
 
+<a id="SatisfactionRatingsKeywordCondition"></a>
+
 `SatisfactionRatingsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -2405,6 +2639,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.zendesk_support.types.SatisfactionRatingsStringFilter`
     :   The type of the None singleton.
 
+<a id="SatisfactionRatingsLikeCondition"></a>
+
 `SatisfactionRatingsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -2416,6 +2652,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.zendesk_support.types.SatisfactionRatingsStringFilter`
     :   The type of the None singleton.
+
+<a id="SatisfactionRatingsListParams"></a>
 
 `SatisfactionRatingsListParams(*args, **kwargs)`
 :   Parameters for satisfaction_ratings.list operation
@@ -2441,6 +2679,8 @@ Classes
     `start_time: int`
     :   The type of the None singleton.
 
+<a id="SatisfactionRatingsLtCondition"></a>
+
 `SatisfactionRatingsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -2452,6 +2692,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.zendesk_support.types.SatisfactionRatingsSearchFilter`
     :   The type of the None singleton.
+
+<a id="SatisfactionRatingsLteCondition"></a>
 
 `SatisfactionRatingsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -2465,6 +2707,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.zendesk_support.types.SatisfactionRatingsSearchFilter`
     :   The type of the None singleton.
 
+<a id="SatisfactionRatingsNeqCondition"></a>
+
 `SatisfactionRatingsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -2476,6 +2720,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.zendesk_support.types.SatisfactionRatingsSearchFilter`
     :   The type of the None singleton.
+
+<a id="SatisfactionRatingsNotCondition"></a>
 
 `SatisfactionRatingsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -2497,6 +2743,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.zendesk_support.types.SatisfactionRatingsEqCondition | airbyte_agent_sdk.connectors.zendesk_support.types.SatisfactionRatingsNeqCondition | airbyte_agent_sdk.connectors.zendesk_support.types.SatisfactionRatingsGtCondition | airbyte_agent_sdk.connectors.zendesk_support.types.SatisfactionRatingsGteCondition | airbyte_agent_sdk.connectors.zendesk_support.types.SatisfactionRatingsLtCondition | airbyte_agent_sdk.connectors.zendesk_support.types.SatisfactionRatingsLteCondition | airbyte_agent_sdk.connectors.zendesk_support.types.SatisfactionRatingsInCondition | airbyte_agent_sdk.connectors.zendesk_support.types.SatisfactionRatingsLikeCondition | airbyte_agent_sdk.connectors.zendesk_support.types.SatisfactionRatingsFuzzyCondition | airbyte_agent_sdk.connectors.zendesk_support.types.SatisfactionRatingsKeywordCondition | airbyte_agent_sdk.connectors.zendesk_support.types.SatisfactionRatingsContainsCondition | airbyte_agent_sdk.connectors.zendesk_support.types.SatisfactionRatingsNotCondition | airbyte_agent_sdk.connectors.zendesk_support.types.SatisfactionRatingsAndCondition | airbyte_agent_sdk.connectors.zendesk_support.types.SatisfactionRatingsOrCondition | airbyte_agent_sdk.connectors.zendesk_support.types.SatisfactionRatingsAnyCondition`
     :   The type of the None singleton.
 
+<a id="SatisfactionRatingsOrCondition"></a>
+
 `SatisfactionRatingsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -2516,6 +2764,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.zendesk_support.types.SatisfactionRatingsEqCondition | airbyte_agent_sdk.connectors.zendesk_support.types.SatisfactionRatingsNeqCondition | airbyte_agent_sdk.connectors.zendesk_support.types.SatisfactionRatingsGtCondition | airbyte_agent_sdk.connectors.zendesk_support.types.SatisfactionRatingsGteCondition | airbyte_agent_sdk.connectors.zendesk_support.types.SatisfactionRatingsLtCondition | airbyte_agent_sdk.connectors.zendesk_support.types.SatisfactionRatingsLteCondition | airbyte_agent_sdk.connectors.zendesk_support.types.SatisfactionRatingsInCondition | airbyte_agent_sdk.connectors.zendesk_support.types.SatisfactionRatingsLikeCondition | airbyte_agent_sdk.connectors.zendesk_support.types.SatisfactionRatingsFuzzyCondition | airbyte_agent_sdk.connectors.zendesk_support.types.SatisfactionRatingsKeywordCondition | airbyte_agent_sdk.connectors.zendesk_support.types.SatisfactionRatingsContainsCondition | airbyte_agent_sdk.connectors.zendesk_support.types.SatisfactionRatingsNotCondition | airbyte_agent_sdk.connectors.zendesk_support.types.SatisfactionRatingsAndCondition | airbyte_agent_sdk.connectors.zendesk_support.types.SatisfactionRatingsOrCondition | airbyte_agent_sdk.connectors.zendesk_support.types.SatisfactionRatingsAnyCondition]`
     :   The type of the None singleton.
+
+<a id="SatisfactionRatingsSearchFilter"></a>
 
 `SatisfactionRatingsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering satisfaction_ratings search queries.
@@ -2562,6 +2812,8 @@ Classes
     `url: str | None`
     :   The API URL of this satisfaction rating resource
 
+<a id="SatisfactionRatingsSearchQuery"></a>
+
 `SatisfactionRatingsSearchQuery(*args, **kwargs)`
 :   Search query for satisfaction_ratings entity.
 
@@ -2576,6 +2828,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.zendesk_support.types.SatisfactionRatingsSortFilter]`
     :   The type of the None singleton.
+
+<a id="SatisfactionRatingsSortFilter"></a>
 
 `SatisfactionRatingsSortFilter(*args, **kwargs)`
 :   Available fields for sorting satisfaction_ratings search results.
@@ -2622,6 +2876,8 @@ Classes
     `url: Literal['asc', 'desc']`
     :   The API URL of this satisfaction rating resource
 
+<a id="SatisfactionRatingsStringFilter"></a>
+
 `SatisfactionRatingsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -2667,6 +2923,8 @@ Classes
     `url: str`
     :   The API URL of this satisfaction rating resource
 
+<a id="SlaPoliciesGetParams"></a>
+
 `SlaPoliciesGetParams(*args, **kwargs)`
 :   Parameters for sla_policies.get operation
 
@@ -2678,6 +2936,8 @@ Classes
 
     `sla_policy_id: str`
     :   The type of the None singleton.
+
+<a id="SlaPoliciesListParams"></a>
 
 `SlaPoliciesListParams(*args, **kwargs)`
 :   Parameters for sla_policies.list operation
@@ -2693,6 +2953,8 @@ Classes
 
     `per_page: int`
     :   The type of the None singleton.
+
+<a id="TagsAndCondition"></a>
 
 `TagsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -2714,6 +2976,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.zendesk_support.types.TagsEqCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TagsNeqCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TagsGtCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TagsGteCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TagsLtCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TagsLteCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TagsInCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TagsLikeCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TagsFuzzyCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TagsKeywordCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TagsContainsCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TagsNotCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TagsAndCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TagsOrCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TagsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="TagsAnyCondition"></a>
+
 `TagsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -2734,6 +2998,8 @@ Classes
     `any: airbyte_agent_sdk.connectors.zendesk_support.types.TagsAnyValueFilter`
     :   The type of the None singleton.
 
+<a id="TagsAnyValueFilter"></a>
+
 `TagsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
 
@@ -2749,6 +3015,8 @@ Classes
     `name: Any`
     :   The tag name string used to label and categorize resources
 
+<a id="TagsContainsCondition"></a>
+
 `TagsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -2760,6 +3028,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.zendesk_support.types.TagsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="TagsEqCondition"></a>
 
 `TagsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -2773,6 +3043,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.zendesk_support.types.TagsSearchFilter`
     :   The type of the None singleton.
 
+<a id="TagsFuzzyCondition"></a>
+
 `TagsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -2784,6 +3056,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.zendesk_support.types.TagsStringFilter`
     :   The type of the None singleton.
+
+<a id="TagsGtCondition"></a>
 
 `TagsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
@@ -2797,6 +3071,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.zendesk_support.types.TagsSearchFilter`
     :   The type of the None singleton.
 
+<a id="TagsGteCondition"></a>
+
 `TagsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -2808,6 +3084,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.zendesk_support.types.TagsSearchFilter`
     :   The type of the None singleton.
+
+<a id="TagsInCondition"></a>
 
 `TagsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -2829,6 +3107,8 @@ Classes
     `in: airbyte_agent_sdk.connectors.zendesk_support.types.TagsInFilter`
     :   The type of the None singleton.
 
+<a id="TagsInFilter"></a>
+
 `TagsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
 
@@ -2844,6 +3124,8 @@ Classes
     `name: list[str]`
     :   The tag name string used to label and categorize resources
 
+<a id="TagsKeywordCondition"></a>
+
 `TagsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -2856,6 +3138,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.zendesk_support.types.TagsStringFilter`
     :   The type of the None singleton.
 
+<a id="TagsLikeCondition"></a>
+
 `TagsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -2867,6 +3151,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.zendesk_support.types.TagsStringFilter`
     :   The type of the None singleton.
+
+<a id="TagsListParams"></a>
 
 `TagsListParams(*args, **kwargs)`
 :   Parameters for tags.list operation
@@ -2883,6 +3169,8 @@ Classes
     `per_page: int`
     :   The type of the None singleton.
 
+<a id="TagsLtCondition"></a>
+
 `TagsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -2894,6 +3182,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.zendesk_support.types.TagsSearchFilter`
     :   The type of the None singleton.
+
+<a id="TagsLteCondition"></a>
 
 `TagsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -2907,6 +3197,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.zendesk_support.types.TagsSearchFilter`
     :   The type of the None singleton.
 
+<a id="TagsNeqCondition"></a>
+
 `TagsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -2918,6 +3210,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.zendesk_support.types.TagsSearchFilter`
     :   The type of the None singleton.
+
+<a id="TagsNotCondition"></a>
 
 `TagsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -2939,6 +3233,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.zendesk_support.types.TagsEqCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TagsNeqCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TagsGtCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TagsGteCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TagsLtCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TagsLteCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TagsInCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TagsLikeCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TagsFuzzyCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TagsKeywordCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TagsContainsCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TagsNotCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TagsAndCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TagsOrCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TagsAnyCondition`
     :   The type of the None singleton.
 
+<a id="TagsOrCondition"></a>
+
 `TagsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -2959,6 +3255,8 @@ Classes
     `or: list[airbyte_agent_sdk.connectors.zendesk_support.types.TagsEqCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TagsNeqCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TagsGtCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TagsGteCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TagsLtCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TagsLteCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TagsInCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TagsLikeCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TagsFuzzyCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TagsKeywordCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TagsContainsCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TagsNotCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TagsAndCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TagsOrCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TagsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="TagsSearchFilter"></a>
+
 `TagsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering tags search queries.
 
@@ -2973,6 +3271,8 @@ Classes
 
     `name: str | None`
     :   The tag name string used to label and categorize resources
+
+<a id="TagsSearchQuery"></a>
 
 `TagsSearchQuery(*args, **kwargs)`
 :   Search query for tags entity.
@@ -2989,6 +3289,8 @@ Classes
     `sort: list[airbyte_agent_sdk.connectors.zendesk_support.types.TagsSortFilter]`
     :   The type of the None singleton.
 
+<a id="TagsSortFilter"></a>
+
 `TagsSortFilter(*args, **kwargs)`
 :   Available fields for sorting tags search results.
 
@@ -3004,6 +3306,8 @@ Classes
     `name: Literal['asc', 'desc']`
     :   The tag name string used to label and categorize resources
 
+<a id="TagsStringFilter"></a>
+
 `TagsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -3018,6 +3322,8 @@ Classes
 
     `name: str`
     :   The tag name string used to label and categorize resources
+
+<a id="TicketAuditsAndCondition"></a>
 
 `TicketAuditsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -3039,6 +3345,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.zendesk_support.types.TicketAuditsEqCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketAuditsNeqCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketAuditsGtCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketAuditsGteCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketAuditsLtCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketAuditsLteCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketAuditsInCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketAuditsLikeCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketAuditsFuzzyCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketAuditsKeywordCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketAuditsContainsCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketAuditsNotCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketAuditsAndCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketAuditsOrCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketAuditsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="TicketAuditsAnyCondition"></a>
+
 `TicketAuditsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -3058,6 +3366,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.zendesk_support.types.TicketAuditsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="TicketAuditsAnyValueFilter"></a>
 
 `TicketAuditsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -3092,6 +3402,8 @@ Classes
     `via: Any`
     :   Describes how the audit was created, providing context about the creation source
 
+<a id="TicketAuditsContainsCondition"></a>
+
 `TicketAuditsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -3103,6 +3415,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.zendesk_support.types.TicketAuditsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="TicketAuditsEqCondition"></a>
 
 `TicketAuditsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -3116,6 +3430,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.zendesk_support.types.TicketAuditsSearchFilter`
     :   The type of the None singleton.
 
+<a id="TicketAuditsFuzzyCondition"></a>
+
 `TicketAuditsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -3127,6 +3443,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.zendesk_support.types.TicketAuditsStringFilter`
     :   The type of the None singleton.
+
+<a id="TicketAuditsGtCondition"></a>
 
 `TicketAuditsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
@@ -3140,6 +3458,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.zendesk_support.types.TicketAuditsSearchFilter`
     :   The type of the None singleton.
 
+<a id="TicketAuditsGteCondition"></a>
+
 `TicketAuditsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -3151,6 +3471,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.zendesk_support.types.TicketAuditsSearchFilter`
     :   The type of the None singleton.
+
+<a id="TicketAuditsInCondition"></a>
 
 `TicketAuditsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -3171,6 +3493,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.zendesk_support.types.TicketAuditsInFilter`
     :   The type of the None singleton.
+
+<a id="TicketAuditsInFilter"></a>
 
 `TicketAuditsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -3205,6 +3529,8 @@ Classes
     `via: list[dict[str, typing.Any]]`
     :   Describes how the audit was created, providing context about the creation source
 
+<a id="TicketAuditsKeywordCondition"></a>
+
 `TicketAuditsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -3217,6 +3543,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.zendesk_support.types.TicketAuditsStringFilter`
     :   The type of the None singleton.
 
+<a id="TicketAuditsLikeCondition"></a>
+
 `TicketAuditsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -3228,6 +3556,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.zendesk_support.types.TicketAuditsStringFilter`
     :   The type of the None singleton.
+
+<a id="TicketAuditsListParams"></a>
 
 `TicketAuditsListParams(*args, **kwargs)`
 :   Parameters for ticket_audits.list operation
@@ -3247,6 +3577,8 @@ Classes
     `ticket_id: str`
     :   The type of the None singleton.
 
+<a id="TicketAuditsLtCondition"></a>
+
 `TicketAuditsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -3258,6 +3590,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.zendesk_support.types.TicketAuditsSearchFilter`
     :   The type of the None singleton.
+
+<a id="TicketAuditsLteCondition"></a>
 
 `TicketAuditsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -3271,6 +3605,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.zendesk_support.types.TicketAuditsSearchFilter`
     :   The type of the None singleton.
 
+<a id="TicketAuditsNeqCondition"></a>
+
 `TicketAuditsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -3282,6 +3618,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.zendesk_support.types.TicketAuditsSearchFilter`
     :   The type of the None singleton.
+
+<a id="TicketAuditsNotCondition"></a>
 
 `TicketAuditsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -3303,6 +3641,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.zendesk_support.types.TicketAuditsEqCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketAuditsNeqCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketAuditsGtCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketAuditsGteCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketAuditsLtCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketAuditsLteCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketAuditsInCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketAuditsLikeCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketAuditsFuzzyCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketAuditsKeywordCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketAuditsContainsCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketAuditsNotCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketAuditsAndCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketAuditsOrCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketAuditsAnyCondition`
     :   The type of the None singleton.
 
+<a id="TicketAuditsOrCondition"></a>
+
 `TicketAuditsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -3322,6 +3662,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.zendesk_support.types.TicketAuditsEqCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketAuditsNeqCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketAuditsGtCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketAuditsGteCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketAuditsLtCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketAuditsLteCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketAuditsInCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketAuditsLikeCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketAuditsFuzzyCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketAuditsKeywordCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketAuditsContainsCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketAuditsNotCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketAuditsAndCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketAuditsOrCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketAuditsAnyCondition]`
     :   The type of the None singleton.
+
+<a id="TicketAuditsSearchFilter"></a>
 
 `TicketAuditsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering ticket_audits search queries.
@@ -3356,6 +3698,8 @@ Classes
     `via: dict[str, typing.Any] | None`
     :   Describes how the audit was created, providing context about the creation source
 
+<a id="TicketAuditsSearchQuery"></a>
+
 `TicketAuditsSearchQuery(*args, **kwargs)`
 :   Search query for ticket_audits entity.
 
@@ -3370,6 +3714,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.zendesk_support.types.TicketAuditsSortFilter]`
     :   The type of the None singleton.
+
+<a id="TicketAuditsSortFilter"></a>
 
 `TicketAuditsSortFilter(*args, **kwargs)`
 :   Available fields for sorting ticket_audits search results.
@@ -3404,6 +3750,8 @@ Classes
     `via: Literal['asc', 'desc']`
     :   Describes how the audit was created, providing context about the creation source
 
+<a id="TicketAuditsStringFilter"></a>
+
 `TicketAuditsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -3437,6 +3785,8 @@ Classes
     `via: str`
     :   Describes how the audit was created, providing context about the creation source
 
+<a id="TicketCommentsAndCondition"></a>
+
 `TicketCommentsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -3457,6 +3807,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.zendesk_support.types.TicketCommentsEqCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketCommentsNeqCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketCommentsGtCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketCommentsGteCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketCommentsLtCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketCommentsLteCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketCommentsInCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketCommentsLikeCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketCommentsFuzzyCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketCommentsKeywordCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketCommentsContainsCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketCommentsNotCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketCommentsAndCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketCommentsOrCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketCommentsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="TicketCommentsAnyCondition"></a>
+
 `TicketCommentsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -3476,6 +3828,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.zendesk_support.types.TicketCommentsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="TicketCommentsAnyValueFilter"></a>
 
 `TicketCommentsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -3537,6 +3891,8 @@ Classes
     `via_reference_id: Any`
     :   Reference identifier for the channel through which the comment was created
 
+<a id="TicketCommentsContainsCondition"></a>
+
 `TicketCommentsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -3548,6 +3904,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.zendesk_support.types.TicketCommentsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="TicketCommentsEqCondition"></a>
 
 `TicketCommentsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -3561,6 +3919,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.zendesk_support.types.TicketCommentsSearchFilter`
     :   The type of the None singleton.
 
+<a id="TicketCommentsFuzzyCondition"></a>
+
 `TicketCommentsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -3572,6 +3932,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.zendesk_support.types.TicketCommentsStringFilter`
     :   The type of the None singleton.
+
+<a id="TicketCommentsGtCondition"></a>
 
 `TicketCommentsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
@@ -3585,6 +3947,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.zendesk_support.types.TicketCommentsSearchFilter`
     :   The type of the None singleton.
 
+<a id="TicketCommentsGteCondition"></a>
+
 `TicketCommentsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -3596,6 +3960,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.zendesk_support.types.TicketCommentsSearchFilter`
     :   The type of the None singleton.
+
+<a id="TicketCommentsInCondition"></a>
 
 `TicketCommentsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -3616,6 +3982,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.zendesk_support.types.TicketCommentsInFilter`
     :   The type of the None singleton.
+
+<a id="TicketCommentsInFilter"></a>
 
 `TicketCommentsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -3677,6 +4045,8 @@ Classes
     `via_reference_id: list[int]`
     :   Reference identifier for the channel through which the comment was created
 
+<a id="TicketCommentsKeywordCondition"></a>
+
 `TicketCommentsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -3689,6 +4059,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.zendesk_support.types.TicketCommentsStringFilter`
     :   The type of the None singleton.
 
+<a id="TicketCommentsLikeCondition"></a>
+
 `TicketCommentsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -3700,6 +4072,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.zendesk_support.types.TicketCommentsStringFilter`
     :   The type of the None singleton.
+
+<a id="TicketCommentsListParams"></a>
 
 `TicketCommentsListParams(*args, **kwargs)`
 :   Parameters for ticket_comments.list operation
@@ -3725,6 +4099,8 @@ Classes
     `ticket_id: str`
     :   The type of the None singleton.
 
+<a id="TicketCommentsLtCondition"></a>
+
 `TicketCommentsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -3736,6 +4112,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.zendesk_support.types.TicketCommentsSearchFilter`
     :   The type of the None singleton.
+
+<a id="TicketCommentsLteCondition"></a>
 
 `TicketCommentsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -3749,6 +4127,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.zendesk_support.types.TicketCommentsSearchFilter`
     :   The type of the None singleton.
 
+<a id="TicketCommentsNeqCondition"></a>
+
 `TicketCommentsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -3760,6 +4140,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.zendesk_support.types.TicketCommentsSearchFilter`
     :   The type of the None singleton.
+
+<a id="TicketCommentsNotCondition"></a>
 
 `TicketCommentsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -3781,6 +4163,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.zendesk_support.types.TicketCommentsEqCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketCommentsNeqCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketCommentsGtCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketCommentsGteCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketCommentsLtCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketCommentsLteCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketCommentsInCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketCommentsLikeCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketCommentsFuzzyCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketCommentsKeywordCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketCommentsContainsCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketCommentsNotCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketCommentsAndCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketCommentsOrCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketCommentsAnyCondition`
     :   The type of the None singleton.
 
+<a id="TicketCommentsOrCondition"></a>
+
 `TicketCommentsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -3800,6 +4184,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.zendesk_support.types.TicketCommentsEqCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketCommentsNeqCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketCommentsGtCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketCommentsGteCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketCommentsLtCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketCommentsLteCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketCommentsInCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketCommentsLikeCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketCommentsFuzzyCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketCommentsKeywordCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketCommentsContainsCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketCommentsNotCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketCommentsAndCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketCommentsOrCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketCommentsAnyCondition]`
     :   The type of the None singleton.
+
+<a id="TicketCommentsSearchFilter"></a>
 
 `TicketCommentsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering ticket_comments search queries.
@@ -3861,6 +4247,8 @@ Classes
     `via_reference_id: int | None`
     :   Reference identifier for the channel through which the comment was created
 
+<a id="TicketCommentsSearchQuery"></a>
+
 `TicketCommentsSearchQuery(*args, **kwargs)`
 :   Search query for ticket_comments entity.
 
@@ -3875,6 +4263,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.zendesk_support.types.TicketCommentsSortFilter]`
     :   The type of the None singleton.
+
+<a id="TicketCommentsSortFilter"></a>
 
 `TicketCommentsSortFilter(*args, **kwargs)`
 :   Available fields for sorting ticket_comments search results.
@@ -3936,6 +4326,8 @@ Classes
     `via_reference_id: Literal['asc', 'desc']`
     :   Reference identifier for the channel through which the comment was created
 
+<a id="TicketCommentsStringFilter"></a>
+
 `TicketCommentsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -3996,6 +4388,8 @@ Classes
     `via_reference_id: str`
     :   Reference identifier for the channel through which the comment was created
 
+<a id="TicketFieldsAndCondition"></a>
+
 `TicketFieldsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -4016,6 +4410,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.zendesk_support.types.TicketFieldsEqCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketFieldsNeqCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketFieldsGtCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketFieldsGteCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketFieldsLtCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketFieldsLteCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketFieldsInCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketFieldsLikeCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketFieldsFuzzyCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketFieldsKeywordCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketFieldsContainsCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketFieldsNotCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketFieldsAndCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketFieldsOrCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketFieldsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="TicketFieldsAnyCondition"></a>
+
 `TicketFieldsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -4035,6 +4431,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.zendesk_support.types.TicketFieldsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="TicketFieldsAnyValueFilter"></a>
 
 `TicketFieldsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -4126,6 +4524,8 @@ Classes
     `visible_in_portal: Any`
     :   Whether this field is visible to end users in Help Center
 
+<a id="TicketFieldsContainsCondition"></a>
+
 `TicketFieldsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -4137,6 +4537,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.zendesk_support.types.TicketFieldsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="TicketFieldsEqCondition"></a>
 
 `TicketFieldsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -4150,6 +4552,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.zendesk_support.types.TicketFieldsSearchFilter`
     :   The type of the None singleton.
 
+<a id="TicketFieldsFuzzyCondition"></a>
+
 `TicketFieldsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -4161,6 +4565,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.zendesk_support.types.TicketFieldsStringFilter`
     :   The type of the None singleton.
+
+<a id="TicketFieldsGetParams"></a>
 
 `TicketFieldsGetParams(*args, **kwargs)`
 :   Parameters for ticket_fields.get operation
@@ -4174,6 +4580,8 @@ Classes
     `ticket_field_id: str`
     :   The type of the None singleton.
 
+<a id="TicketFieldsGtCondition"></a>
+
 `TicketFieldsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -4186,6 +4594,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.zendesk_support.types.TicketFieldsSearchFilter`
     :   The type of the None singleton.
 
+<a id="TicketFieldsGteCondition"></a>
+
 `TicketFieldsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -4197,6 +4607,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.zendesk_support.types.TicketFieldsSearchFilter`
     :   The type of the None singleton.
+
+<a id="TicketFieldsInCondition"></a>
 
 `TicketFieldsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -4217,6 +4629,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.zendesk_support.types.TicketFieldsInFilter`
     :   The type of the None singleton.
+
+<a id="TicketFieldsInFilter"></a>
 
 `TicketFieldsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -4308,6 +4722,8 @@ Classes
     `visible_in_portal: list[bool]`
     :   Whether this field is visible to end users in Help Center
 
+<a id="TicketFieldsKeywordCondition"></a>
+
 `TicketFieldsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -4320,6 +4736,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.zendesk_support.types.TicketFieldsStringFilter`
     :   The type of the None singleton.
 
+<a id="TicketFieldsLikeCondition"></a>
+
 `TicketFieldsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -4331,6 +4749,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.zendesk_support.types.TicketFieldsStringFilter`
     :   The type of the None singleton.
+
+<a id="TicketFieldsListParams"></a>
 
 `TicketFieldsListParams(*args, **kwargs)`
 :   Parameters for ticket_fields.list operation
@@ -4350,6 +4770,8 @@ Classes
     `per_page: int`
     :   The type of the None singleton.
 
+<a id="TicketFieldsLtCondition"></a>
+
 `TicketFieldsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -4361,6 +4783,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.zendesk_support.types.TicketFieldsSearchFilter`
     :   The type of the None singleton.
+
+<a id="TicketFieldsLteCondition"></a>
 
 `TicketFieldsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -4374,6 +4798,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.zendesk_support.types.TicketFieldsSearchFilter`
     :   The type of the None singleton.
 
+<a id="TicketFieldsNeqCondition"></a>
+
 `TicketFieldsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -4385,6 +4811,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.zendesk_support.types.TicketFieldsSearchFilter`
     :   The type of the None singleton.
+
+<a id="TicketFieldsNotCondition"></a>
 
 `TicketFieldsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -4406,6 +4834,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.zendesk_support.types.TicketFieldsEqCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketFieldsNeqCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketFieldsGtCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketFieldsGteCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketFieldsLtCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketFieldsLteCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketFieldsInCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketFieldsLikeCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketFieldsFuzzyCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketFieldsKeywordCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketFieldsContainsCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketFieldsNotCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketFieldsAndCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketFieldsOrCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketFieldsAnyCondition`
     :   The type of the None singleton.
 
+<a id="TicketFieldsOrCondition"></a>
+
 `TicketFieldsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -4425,6 +4855,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.zendesk_support.types.TicketFieldsEqCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketFieldsNeqCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketFieldsGtCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketFieldsGteCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketFieldsLtCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketFieldsLteCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketFieldsInCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketFieldsLikeCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketFieldsFuzzyCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketFieldsKeywordCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketFieldsContainsCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketFieldsNotCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketFieldsAndCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketFieldsOrCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketFieldsAnyCondition]`
     :   The type of the None singleton.
+
+<a id="TicketFieldsSearchFilter"></a>
 
 `TicketFieldsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering ticket_fields search queries.
@@ -4516,6 +4948,8 @@ Classes
     `visible_in_portal: bool | None`
     :   Whether this field is visible to end users in Help Center
 
+<a id="TicketFieldsSearchQuery"></a>
+
 `TicketFieldsSearchQuery(*args, **kwargs)`
 :   Search query for ticket_fields entity.
 
@@ -4530,6 +4964,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.zendesk_support.types.TicketFieldsSortFilter]`
     :   The type of the None singleton.
+
+<a id="TicketFieldsSortFilter"></a>
 
 `TicketFieldsSortFilter(*args, **kwargs)`
 :   Available fields for sorting ticket_fields search results.
@@ -4621,6 +5057,8 @@ Classes
     `visible_in_portal: Literal['asc', 'desc']`
     :   Whether this field is visible to end users in Help Center
 
+<a id="TicketFieldsStringFilter"></a>
+
 `TicketFieldsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -4711,6 +5149,8 @@ Classes
     `visible_in_portal: str`
     :   Whether this field is visible to end users in Help Center
 
+<a id="TicketFormsAndCondition"></a>
+
 `TicketFormsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -4731,6 +5171,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.zendesk_support.types.TicketFormsEqCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketFormsNeqCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketFormsGtCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketFormsGteCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketFormsLtCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketFormsLteCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketFormsInCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketFormsLikeCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketFormsFuzzyCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketFormsKeywordCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketFormsContainsCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketFormsNotCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketFormsAndCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketFormsOrCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketFormsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="TicketFormsAnyCondition"></a>
+
 `TicketFormsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -4750,6 +5192,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.zendesk_support.types.TicketFormsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="TicketFormsAnyValueFilter"></a>
 
 `TicketFormsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -4811,6 +5255,8 @@ Classes
     `url: Any`
     :   URL of the ticket form
 
+<a id="TicketFormsContainsCondition"></a>
+
 `TicketFormsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -4822,6 +5268,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.zendesk_support.types.TicketFormsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="TicketFormsEqCondition"></a>
 
 `TicketFormsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -4835,6 +5283,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.zendesk_support.types.TicketFormsSearchFilter`
     :   The type of the None singleton.
 
+<a id="TicketFormsFuzzyCondition"></a>
+
 `TicketFormsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -4846,6 +5296,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.zendesk_support.types.TicketFormsStringFilter`
     :   The type of the None singleton.
+
+<a id="TicketFormsGetParams"></a>
 
 `TicketFormsGetParams(*args, **kwargs)`
 :   Parameters for ticket_forms.get operation
@@ -4859,6 +5311,8 @@ Classes
     `ticket_form_id: str`
     :   The type of the None singleton.
 
+<a id="TicketFormsGtCondition"></a>
+
 `TicketFormsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -4871,6 +5325,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.zendesk_support.types.TicketFormsSearchFilter`
     :   The type of the None singleton.
 
+<a id="TicketFormsGteCondition"></a>
+
 `TicketFormsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -4882,6 +5338,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.zendesk_support.types.TicketFormsSearchFilter`
     :   The type of the None singleton.
+
+<a id="TicketFormsInCondition"></a>
 
 `TicketFormsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -4902,6 +5360,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.zendesk_support.types.TicketFormsInFilter`
     :   The type of the None singleton.
+
+<a id="TicketFormsInFilter"></a>
 
 `TicketFormsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -4963,6 +5423,8 @@ Classes
     `url: list[str]`
     :   URL of the ticket form
 
+<a id="TicketFormsKeywordCondition"></a>
+
 `TicketFormsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -4975,6 +5437,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.zendesk_support.types.TicketFormsStringFilter`
     :   The type of the None singleton.
 
+<a id="TicketFormsLikeCondition"></a>
+
 `TicketFormsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -4986,6 +5450,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.zendesk_support.types.TicketFormsStringFilter`
     :   The type of the None singleton.
+
+<a id="TicketFormsListParams"></a>
 
 `TicketFormsListParams(*args, **kwargs)`
 :   Parameters for ticket_forms.list operation
@@ -5008,6 +5474,8 @@ Classes
     `per_page: int`
     :   The type of the None singleton.
 
+<a id="TicketFormsLtCondition"></a>
+
 `TicketFormsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -5019,6 +5487,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.zendesk_support.types.TicketFormsSearchFilter`
     :   The type of the None singleton.
+
+<a id="TicketFormsLteCondition"></a>
 
 `TicketFormsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -5032,6 +5502,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.zendesk_support.types.TicketFormsSearchFilter`
     :   The type of the None singleton.
 
+<a id="TicketFormsNeqCondition"></a>
+
 `TicketFormsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -5043,6 +5515,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.zendesk_support.types.TicketFormsSearchFilter`
     :   The type of the None singleton.
+
+<a id="TicketFormsNotCondition"></a>
 
 `TicketFormsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -5064,6 +5538,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.zendesk_support.types.TicketFormsEqCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketFormsNeqCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketFormsGtCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketFormsGteCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketFormsLtCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketFormsLteCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketFormsInCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketFormsLikeCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketFormsFuzzyCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketFormsKeywordCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketFormsContainsCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketFormsNotCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketFormsAndCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketFormsOrCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketFormsAnyCondition`
     :   The type of the None singleton.
 
+<a id="TicketFormsOrCondition"></a>
+
 `TicketFormsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -5083,6 +5559,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.zendesk_support.types.TicketFormsEqCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketFormsNeqCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketFormsGtCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketFormsGteCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketFormsLtCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketFormsLteCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketFormsInCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketFormsLikeCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketFormsFuzzyCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketFormsKeywordCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketFormsContainsCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketFormsNotCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketFormsAndCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketFormsOrCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketFormsAnyCondition]`
     :   The type of the None singleton.
+
+<a id="TicketFormsSearchFilter"></a>
 
 `TicketFormsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering ticket_forms search queries.
@@ -5144,6 +5622,8 @@ Classes
     `url: str | None`
     :   URL of the ticket form
 
+<a id="TicketFormsSearchQuery"></a>
+
 `TicketFormsSearchQuery(*args, **kwargs)`
 :   Search query for ticket_forms entity.
 
@@ -5158,6 +5638,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.zendesk_support.types.TicketFormsSortFilter]`
     :   The type of the None singleton.
+
+<a id="TicketFormsSortFilter"></a>
 
 `TicketFormsSortFilter(*args, **kwargs)`
 :   Available fields for sorting ticket_forms search results.
@@ -5219,6 +5701,8 @@ Classes
     `url: Literal['asc', 'desc']`
     :   URL of the ticket form
 
+<a id="TicketFormsStringFilter"></a>
+
 `TicketFormsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -5279,6 +5763,8 @@ Classes
     `url: str`
     :   URL of the ticket form
 
+<a id="TicketMetricsAndCondition"></a>
+
 `TicketMetricsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -5299,6 +5785,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.zendesk_support.types.TicketMetricsEqCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketMetricsNeqCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketMetricsGtCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketMetricsGteCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketMetricsLtCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketMetricsLteCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketMetricsInCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketMetricsLikeCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketMetricsFuzzyCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketMetricsKeywordCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketMetricsContainsCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketMetricsNotCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketMetricsAndCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketMetricsOrCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketMetricsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="TicketMetricsAnyCondition"></a>
+
 `TicketMetricsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -5318,6 +5806,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.zendesk_support.types.TicketMetricsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="TicketMetricsAnyValueFilter"></a>
 
 `TicketMetricsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -5418,6 +5908,8 @@ Classes
     `url: Any`
     :   The API url of the ticket metric
 
+<a id="TicketMetricsContainsCondition"></a>
+
 `TicketMetricsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -5429,6 +5921,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.zendesk_support.types.TicketMetricsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="TicketMetricsEqCondition"></a>
 
 `TicketMetricsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -5442,6 +5936,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.zendesk_support.types.TicketMetricsSearchFilter`
     :   The type of the None singleton.
 
+<a id="TicketMetricsFuzzyCondition"></a>
+
 `TicketMetricsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -5453,6 +5949,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.zendesk_support.types.TicketMetricsStringFilter`
     :   The type of the None singleton.
+
+<a id="TicketMetricsGtCondition"></a>
 
 `TicketMetricsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
@@ -5466,6 +5964,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.zendesk_support.types.TicketMetricsSearchFilter`
     :   The type of the None singleton.
 
+<a id="TicketMetricsGteCondition"></a>
+
 `TicketMetricsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -5477,6 +5977,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.zendesk_support.types.TicketMetricsSearchFilter`
     :   The type of the None singleton.
+
+<a id="TicketMetricsInCondition"></a>
 
 `TicketMetricsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -5497,6 +5999,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.zendesk_support.types.TicketMetricsInFilter`
     :   The type of the None singleton.
+
+<a id="TicketMetricsInFilter"></a>
 
 `TicketMetricsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -5597,6 +6101,8 @@ Classes
     `url: list[str]`
     :   The API url of the ticket metric
 
+<a id="TicketMetricsKeywordCondition"></a>
+
 `TicketMetricsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -5609,6 +6115,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.zendesk_support.types.TicketMetricsStringFilter`
     :   The type of the None singleton.
 
+<a id="TicketMetricsLikeCondition"></a>
+
 `TicketMetricsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -5620,6 +6128,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.zendesk_support.types.TicketMetricsStringFilter`
     :   The type of the None singleton.
+
+<a id="TicketMetricsListParams"></a>
 
 `TicketMetricsListParams(*args, **kwargs)`
 :   Parameters for ticket_metrics.list operation
@@ -5636,6 +6146,8 @@ Classes
     `per_page: int`
     :   The type of the None singleton.
 
+<a id="TicketMetricsLtCondition"></a>
+
 `TicketMetricsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -5647,6 +6159,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.zendesk_support.types.TicketMetricsSearchFilter`
     :   The type of the None singleton.
+
+<a id="TicketMetricsLteCondition"></a>
 
 `TicketMetricsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -5660,6 +6174,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.zendesk_support.types.TicketMetricsSearchFilter`
     :   The type of the None singleton.
 
+<a id="TicketMetricsNeqCondition"></a>
+
 `TicketMetricsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -5671,6 +6187,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.zendesk_support.types.TicketMetricsSearchFilter`
     :   The type of the None singleton.
+
+<a id="TicketMetricsNotCondition"></a>
 
 `TicketMetricsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -5692,6 +6210,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.zendesk_support.types.TicketMetricsEqCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketMetricsNeqCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketMetricsGtCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketMetricsGteCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketMetricsLtCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketMetricsLteCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketMetricsInCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketMetricsLikeCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketMetricsFuzzyCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketMetricsKeywordCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketMetricsContainsCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketMetricsNotCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketMetricsAndCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketMetricsOrCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketMetricsAnyCondition`
     :   The type of the None singleton.
 
+<a id="TicketMetricsOrCondition"></a>
+
 `TicketMetricsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -5711,6 +6231,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.zendesk_support.types.TicketMetricsEqCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketMetricsNeqCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketMetricsGtCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketMetricsGteCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketMetricsLtCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketMetricsLteCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketMetricsInCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketMetricsLikeCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketMetricsFuzzyCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketMetricsKeywordCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketMetricsContainsCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketMetricsNotCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketMetricsAndCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketMetricsOrCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketMetricsAnyCondition]`
     :   The type of the None singleton.
+
+<a id="TicketMetricsSearchFilter"></a>
 
 `TicketMetricsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering ticket_metrics search queries.
@@ -5811,6 +6333,8 @@ Classes
     `url: str | None`
     :   The API url of the ticket metric
 
+<a id="TicketMetricsSearchQuery"></a>
+
 `TicketMetricsSearchQuery(*args, **kwargs)`
 :   Search query for ticket_metrics entity.
 
@@ -5825,6 +6349,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.zendesk_support.types.TicketMetricsSortFilter]`
     :   The type of the None singleton.
+
+<a id="TicketMetricsSortFilter"></a>
 
 `TicketMetricsSortFilter(*args, **kwargs)`
 :   Available fields for sorting ticket_metrics search results.
@@ -5925,6 +6451,8 @@ Classes
     `url: Literal['asc', 'desc']`
     :   The API url of the ticket metric
 
+<a id="TicketMetricsStringFilter"></a>
+
 `TicketMetricsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -6024,6 +6552,8 @@ Classes
     `url: str`
     :   The API url of the ticket metric
 
+<a id="TicketsAndCondition"></a>
+
 `TicketsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -6044,6 +6574,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.zendesk_support.types.TicketsEqCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketsNeqCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketsGtCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketsGteCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketsLtCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketsLteCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketsInCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketsLikeCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketsFuzzyCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketsKeywordCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketsContainsCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketsNotCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketsAndCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketsOrCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="TicketsAnyCondition"></a>
+
 `TicketsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -6063,6 +6595,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.zendesk_support.types.TicketsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="TicketsAnyValueFilter"></a>
 
 `TicketsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -6196,6 +6730,8 @@ Classes
     `via: Any`
     :   Object describing the channel and method through which the ticket was created
 
+<a id="TicketsContainsCondition"></a>
+
 `TicketsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -6207,6 +6743,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.zendesk_support.types.TicketsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="TicketsEqCondition"></a>
 
 `TicketsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -6220,6 +6758,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.zendesk_support.types.TicketsSearchFilter`
     :   The type of the None singleton.
 
+<a id="TicketsFuzzyCondition"></a>
+
 `TicketsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -6231,6 +6771,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.zendesk_support.types.TicketsStringFilter`
     :   The type of the None singleton.
+
+<a id="TicketsGetParams"></a>
 
 `TicketsGetParams(*args, **kwargs)`
 :   Parameters for tickets.get operation
@@ -6244,6 +6786,8 @@ Classes
     `ticket_id: str`
     :   The type of the None singleton.
 
+<a id="TicketsGtCondition"></a>
+
 `TicketsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -6256,6 +6800,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.zendesk_support.types.TicketsSearchFilter`
     :   The type of the None singleton.
 
+<a id="TicketsGteCondition"></a>
+
 `TicketsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -6267,6 +6813,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.zendesk_support.types.TicketsSearchFilter`
     :   The type of the None singleton.
+
+<a id="TicketsInCondition"></a>
 
 `TicketsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -6287,6 +6835,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.zendesk_support.types.TicketsInFilter`
     :   The type of the None singleton.
+
+<a id="TicketsInFilter"></a>
 
 `TicketsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -6420,6 +6970,8 @@ Classes
     `via: list[dict[str, typing.Any]]`
     :   Object describing the channel and method through which the ticket was created
 
+<a id="TicketsKeywordCondition"></a>
+
 `TicketsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -6432,6 +6984,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.zendesk_support.types.TicketsStringFilter`
     :   The type of the None singleton.
 
+<a id="TicketsLikeCondition"></a>
+
 `TicketsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -6443,6 +6997,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.zendesk_support.types.TicketsStringFilter`
     :   The type of the None singleton.
+
+<a id="TicketsListParams"></a>
 
 `TicketsListParams(*args, **kwargs)`
 :   Parameters for tickets.list operation
@@ -6468,6 +7024,8 @@ Classes
     `sort_order: str`
     :   The type of the None singleton.
 
+<a id="TicketsLtCondition"></a>
+
 `TicketsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -6479,6 +7037,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.zendesk_support.types.TicketsSearchFilter`
     :   The type of the None singleton.
+
+<a id="TicketsLteCondition"></a>
 
 `TicketsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -6492,6 +7052,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.zendesk_support.types.TicketsSearchFilter`
     :   The type of the None singleton.
 
+<a id="TicketsNeqCondition"></a>
+
 `TicketsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -6503,6 +7065,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.zendesk_support.types.TicketsSearchFilter`
     :   The type of the None singleton.
+
+<a id="TicketsNotCondition"></a>
 
 `TicketsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -6524,6 +7088,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.zendesk_support.types.TicketsEqCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketsNeqCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketsGtCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketsGteCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketsLtCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketsLteCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketsInCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketsLikeCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketsFuzzyCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketsKeywordCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketsContainsCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketsNotCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketsAndCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketsOrCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketsAnyCondition`
     :   The type of the None singleton.
 
+<a id="TicketsOrCondition"></a>
+
 `TicketsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -6543,6 +7109,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.zendesk_support.types.TicketsEqCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketsNeqCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketsGtCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketsGteCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketsLtCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketsLteCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketsInCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketsLikeCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketsFuzzyCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketsKeywordCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketsContainsCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketsNotCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketsAndCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketsOrCondition | airbyte_agent_sdk.connectors.zendesk_support.types.TicketsAnyCondition]`
     :   The type of the None singleton.
+
+<a id="TicketsSearchFilter"></a>
 
 `TicketsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering tickets search queries.
@@ -6676,6 +7244,8 @@ Classes
     `via: dict[str, typing.Any] | None`
     :   Object describing the channel and method through which the ticket was created
 
+<a id="TicketsSearchQuery"></a>
+
 `TicketsSearchQuery(*args, **kwargs)`
 :   Search query for tickets entity.
 
@@ -6690,6 +7260,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.zendesk_support.types.TicketsSortFilter]`
     :   The type of the None singleton.
+
+<a id="TicketsSortFilter"></a>
 
 `TicketsSortFilter(*args, **kwargs)`
 :   Available fields for sorting tickets search results.
@@ -6823,6 +7395,8 @@ Classes
     `via: Literal['asc', 'desc']`
     :   Object describing the channel and method through which the ticket was created
 
+<a id="TicketsStringFilter"></a>
+
 `TicketsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -6955,6 +7529,8 @@ Classes
     `via: str`
     :   Object describing the channel and method through which the ticket was created
 
+<a id="TriggersGetParams"></a>
+
 `TriggersGetParams(*args, **kwargs)`
 :   Parameters for triggers.get operation
 
@@ -6966,6 +7542,8 @@ Classes
 
     `trigger_id: str`
     :   The type of the None singleton.
+
+<a id="TriggersListParams"></a>
 
 `TriggersListParams(*args, **kwargs)`
 :   Parameters for triggers.list operation
@@ -6994,6 +7572,8 @@ Classes
     `sort_order: str`
     :   The type of the None singleton.
 
+<a id="UsersAndCondition"></a>
+
 `UsersAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -7014,6 +7594,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.zendesk_support.types.UsersEqCondition | airbyte_agent_sdk.connectors.zendesk_support.types.UsersNeqCondition | airbyte_agent_sdk.connectors.zendesk_support.types.UsersGtCondition | airbyte_agent_sdk.connectors.zendesk_support.types.UsersGteCondition | airbyte_agent_sdk.connectors.zendesk_support.types.UsersLtCondition | airbyte_agent_sdk.connectors.zendesk_support.types.UsersLteCondition | airbyte_agent_sdk.connectors.zendesk_support.types.UsersInCondition | airbyte_agent_sdk.connectors.zendesk_support.types.UsersLikeCondition | airbyte_agent_sdk.connectors.zendesk_support.types.UsersFuzzyCondition | airbyte_agent_sdk.connectors.zendesk_support.types.UsersKeywordCondition | airbyte_agent_sdk.connectors.zendesk_support.types.UsersContainsCondition | airbyte_agent_sdk.connectors.zendesk_support.types.UsersNotCondition | airbyte_agent_sdk.connectors.zendesk_support.types.UsersAndCondition | airbyte_agent_sdk.connectors.zendesk_support.types.UsersOrCondition | airbyte_agent_sdk.connectors.zendesk_support.types.UsersAnyCondition]`
     :   The type of the None singleton.
 
+<a id="UsersAnyCondition"></a>
+
 `UsersAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -7033,6 +7615,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.zendesk_support.types.UsersAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="UsersAnyValueFilter"></a>
 
 `UsersAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -7160,6 +7744,8 @@ Classes
     `verified: Any`
     :   Indicates if the user's identity has been verified
 
+<a id="UsersContainsCondition"></a>
+
 `UsersContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -7171,6 +7757,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.zendesk_support.types.UsersAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="UsersEqCondition"></a>
 
 `UsersEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -7184,6 +7772,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.zendesk_support.types.UsersSearchFilter`
     :   The type of the None singleton.
 
+<a id="UsersFuzzyCondition"></a>
+
 `UsersFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -7195,6 +7785,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.zendesk_support.types.UsersStringFilter`
     :   The type of the None singleton.
+
+<a id="UsersGetParams"></a>
 
 `UsersGetParams(*args, **kwargs)`
 :   Parameters for users.get operation
@@ -7208,6 +7800,8 @@ Classes
     `user_id: str`
     :   The type of the None singleton.
 
+<a id="UsersGtCondition"></a>
+
 `UsersGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -7220,6 +7814,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.zendesk_support.types.UsersSearchFilter`
     :   The type of the None singleton.
 
+<a id="UsersGteCondition"></a>
+
 `UsersGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -7231,6 +7827,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.zendesk_support.types.UsersSearchFilter`
     :   The type of the None singleton.
+
+<a id="UsersInCondition"></a>
 
 `UsersInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -7251,6 +7849,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.zendesk_support.types.UsersInFilter`
     :   The type of the None singleton.
+
+<a id="UsersInFilter"></a>
 
 `UsersInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -7378,6 +7978,8 @@ Classes
     `verified: list[bool]`
     :   Indicates if the user's identity has been verified
 
+<a id="UsersKeywordCondition"></a>
+
 `UsersKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -7390,6 +7992,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.zendesk_support.types.UsersStringFilter`
     :   The type of the None singleton.
 
+<a id="UsersLikeCondition"></a>
+
 `UsersLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -7401,6 +8005,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.zendesk_support.types.UsersStringFilter`
     :   The type of the None singleton.
+
+<a id="UsersListParams"></a>
 
 `UsersListParams(*args, **kwargs)`
 :   Parameters for users.list operation
@@ -7423,6 +8029,8 @@ Classes
     `role: str`
     :   The type of the None singleton.
 
+<a id="UsersLtCondition"></a>
+
 `UsersLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -7434,6 +8042,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.zendesk_support.types.UsersSearchFilter`
     :   The type of the None singleton.
+
+<a id="UsersLteCondition"></a>
 
 `UsersLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -7447,6 +8057,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.zendesk_support.types.UsersSearchFilter`
     :   The type of the None singleton.
 
+<a id="UsersNeqCondition"></a>
+
 `UsersNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -7458,6 +8070,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.zendesk_support.types.UsersSearchFilter`
     :   The type of the None singleton.
+
+<a id="UsersNotCondition"></a>
 
 `UsersNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -7479,6 +8093,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.zendesk_support.types.UsersEqCondition | airbyte_agent_sdk.connectors.zendesk_support.types.UsersNeqCondition | airbyte_agent_sdk.connectors.zendesk_support.types.UsersGtCondition | airbyte_agent_sdk.connectors.zendesk_support.types.UsersGteCondition | airbyte_agent_sdk.connectors.zendesk_support.types.UsersLtCondition | airbyte_agent_sdk.connectors.zendesk_support.types.UsersLteCondition | airbyte_agent_sdk.connectors.zendesk_support.types.UsersInCondition | airbyte_agent_sdk.connectors.zendesk_support.types.UsersLikeCondition | airbyte_agent_sdk.connectors.zendesk_support.types.UsersFuzzyCondition | airbyte_agent_sdk.connectors.zendesk_support.types.UsersKeywordCondition | airbyte_agent_sdk.connectors.zendesk_support.types.UsersContainsCondition | airbyte_agent_sdk.connectors.zendesk_support.types.UsersNotCondition | airbyte_agent_sdk.connectors.zendesk_support.types.UsersAndCondition | airbyte_agent_sdk.connectors.zendesk_support.types.UsersOrCondition | airbyte_agent_sdk.connectors.zendesk_support.types.UsersAnyCondition`
     :   The type of the None singleton.
 
+<a id="UsersOrCondition"></a>
+
 `UsersOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -7498,6 +8114,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.zendesk_support.types.UsersEqCondition | airbyte_agent_sdk.connectors.zendesk_support.types.UsersNeqCondition | airbyte_agent_sdk.connectors.zendesk_support.types.UsersGtCondition | airbyte_agent_sdk.connectors.zendesk_support.types.UsersGteCondition | airbyte_agent_sdk.connectors.zendesk_support.types.UsersLtCondition | airbyte_agent_sdk.connectors.zendesk_support.types.UsersLteCondition | airbyte_agent_sdk.connectors.zendesk_support.types.UsersInCondition | airbyte_agent_sdk.connectors.zendesk_support.types.UsersLikeCondition | airbyte_agent_sdk.connectors.zendesk_support.types.UsersFuzzyCondition | airbyte_agent_sdk.connectors.zendesk_support.types.UsersKeywordCondition | airbyte_agent_sdk.connectors.zendesk_support.types.UsersContainsCondition | airbyte_agent_sdk.connectors.zendesk_support.types.UsersNotCondition | airbyte_agent_sdk.connectors.zendesk_support.types.UsersAndCondition | airbyte_agent_sdk.connectors.zendesk_support.types.UsersOrCondition | airbyte_agent_sdk.connectors.zendesk_support.types.UsersAnyCondition]`
     :   The type of the None singleton.
+
+<a id="UsersSearchFilter"></a>
 
 `UsersSearchFilter(*args, **kwargs)`
 :   Available fields for filtering users search queries.
@@ -7625,6 +8243,8 @@ Classes
     `verified: bool | None`
     :   Indicates if the user's identity has been verified
 
+<a id="UsersSearchQuery"></a>
+
 `UsersSearchQuery(*args, **kwargs)`
 :   Search query for users entity.
 
@@ -7639,6 +8259,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.zendesk_support.types.UsersSortFilter]`
     :   The type of the None singleton.
+
+<a id="UsersSortFilter"></a>
 
 `UsersSortFilter(*args, **kwargs)`
 :   Available fields for sorting users search results.
@@ -7766,6 +8388,8 @@ Classes
     `verified: Literal['asc', 'desc']`
     :   Indicates if the user's identity has been verified
 
+<a id="UsersStringFilter"></a>
+
 `UsersStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -7892,6 +8516,8 @@ Classes
     `verified: str`
     :   Indicates if the user's identity has been verified
 
+<a id="ViewsGetParams"></a>
+
 `ViewsGetParams(*args, **kwargs)`
 :   Parameters for views.get operation
 
@@ -7903,6 +8529,8 @@ Classes
 
     `view_id: str`
     :   The type of the None singleton.
+
+<a id="ViewsListParams"></a>
 
 `ViewsListParams(*args, **kwargs)`
 :   Parameters for views.list operation

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/zendesk_talk/connector.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/zendesk_talk/connector.md
@@ -10,6 +10,8 @@ Zendesk-Talk connector.
 Classes
 -------
 
+<a id="AccountOverviewQuery"></a>
+
 `AccountOverviewQuery(connector: ZendeskTalkConnector)`
 :   Query class for AccountOverview entity operations.
     
@@ -68,6 +70,8 @@ Classes
         Returns:
             AccountOverviewListResult
 
+<a id="AddressesQuery"></a>
+
 `AddressesQuery(connector: ZendeskTalkConnector)`
 :   Query class for Addresses entity operations.
     
@@ -121,6 +125,8 @@ Classes
         
         Returns:
             AddressesListResult
+
+<a id="AgentsActivityQuery"></a>
 
 `AgentsActivityQuery(connector: ZendeskTalkConnector)`
 :   Query class for AgentsActivity entity operations.
@@ -183,6 +189,8 @@ Classes
         Returns:
             AgentsActivityListResult
 
+<a id="AgentsOverviewQuery"></a>
+
 `AgentsOverviewQuery(connector: ZendeskTalkConnector)`
 :   Query class for AgentsOverview entity operations.
     
@@ -240,6 +248,8 @@ Classes
         
         Returns:
             AgentsOverviewListResult
+
+<a id="CallLegsQuery"></a>
 
 `CallLegsQuery(connector: ZendeskTalkConnector)`
 :   Query class for CallLegs entity operations.
@@ -304,6 +314,8 @@ Classes
         
         Returns:
             CallLegsListResult
+
+<a id="CallsQuery"></a>
 
 `CallsQuery(connector: ZendeskTalkConnector)`
 :   Query class for Calls entity operations.
@@ -385,6 +397,8 @@ Classes
         Returns:
             CallsListResult
 
+<a id="CurrentQueueActivityQuery"></a>
+
 `CurrentQueueActivityQuery(connector: ZendeskTalkConnector)`
 :   Query class for CurrentQueueActivity entity operations.
     
@@ -426,6 +440,8 @@ Classes
         
         Returns:
             CurrentQueueActivityListResult
+
+<a id="GreetingCategoriesQuery"></a>
 
 `GreetingCategoriesQuery(connector: ZendeskTalkConnector)`
 :   Query class for GreetingCategories entity operations.
@@ -473,6 +489,8 @@ Classes
         
         Returns:
             GreetingCategoriesListResult
+
+<a id="GreetingsQuery"></a>
 
 `GreetingsQuery(connector: ZendeskTalkConnector)`
 :   Query class for Greetings entity operations.
@@ -532,6 +550,8 @@ Classes
         Returns:
             GreetingsListResult
 
+<a id="IvrsQuery"></a>
+
 `IvrsQuery(connector: ZendeskTalkConnector)`
 :   Query class for Ivrs entity operations.
     
@@ -581,6 +601,8 @@ Classes
         
         Returns:
             IvrsListResult
+
+<a id="PhoneNumbersQuery"></a>
 
 `PhoneNumbersQuery(connector: ZendeskTalkConnector)`
 :   Query class for PhoneNumbers entity operations.
@@ -656,6 +678,8 @@ Classes
         
         Returns:
             PhoneNumbersListResult
+
+<a id="ZendeskTalkConnector"></a>
 
 `ZendeskTalkConnector(auth_config: ZendeskTalkAuthConfig | AirbyteAuthConfig | BaseModel | None = None, on_token_refresh: Any | None = None, subdomain: str | None = None)`
 :   Type-safe Zendesk-Talk API connector.

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/zendesk_talk/index.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/zendesk_talk/index.md
@@ -19,6 +19,8 @@ Sub-modules
 Classes
 -------
 
+<a id="AccountOverviewSearchData"></a>
+
 `AccountOverviewSearchData(**data: Any)`
 :   Search result data for account_overview entity.
     
@@ -107,6 +109,8 @@ Classes
     `total_wrap_up_time: int | None`
     :   Total wrap-up time
 
+<a id="AddressesSearchData"></a>
+
 `AddressesSearchData(**data: Any)`
 :   Search result data for addresses entity.
     
@@ -152,6 +156,8 @@ Classes
 
     `zip: str | None`
     :   Zip code of the address
+
+<a id="AgentsActivitySearchData"></a>
 
 `AgentsActivitySearchData(**data: Any)`
 :   Search result data for agents_activity entity.
@@ -250,6 +256,8 @@ Classes
     `via: str | None`
     :   Channel the agent is registered on
 
+<a id="AgentsOverviewSearchData"></a>
+
 `AgentsOverviewSearchData(**data: Any)`
 :   Search result data for agents_overview entity.
     
@@ -338,6 +346,8 @@ Classes
     `total_wrap_up_time: int | None`
     :   Total wrap-up time
 
+<a id="AirbyteAuthConfig"></a>
+
 `AirbyteAuthConfig(**data: Any)`
 :   Authentication configuration for Airbyte hosted mode execution.
     
@@ -406,6 +416,8 @@ Classes
     `workspace_name: str | None`
     :   The type of the None singleton.
 
+<a id="AirbyteSearchMeta"></a>
+
 `AirbyteSearchMeta(**data: Any)`
 :   Pagination metadata for search responses.
     
@@ -433,6 +445,8 @@ Classes
 
     `took_ms: int | None`
     :   Time taken to execute the search in milliseconds.
+
+<a id="AirbyteSearchResult"></a>
 
 `AirbyteSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -474,6 +488,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="AccountOverviewSearchResult"></a>
+
 `AccountOverviewSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -489,6 +505,8 @@ Classes
     * airbyte_agent_sdk.connectors.zendesk_talk.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="AddressesSearchResult"></a>
 
 `AddressesSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -506,6 +524,8 @@ Classes
     * pydantic.main.BaseModel
     * typing.Generic
 
+<a id="AgentsActivitySearchResult"></a>
+
 `AgentsActivitySearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -521,6 +541,8 @@ Classes
     * airbyte_agent_sdk.connectors.zendesk_talk.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="AgentsOverviewSearchResult"></a>
 
 `AgentsOverviewSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -538,6 +560,8 @@ Classes
     * pydantic.main.BaseModel
     * typing.Generic
 
+<a id="CallLegsSearchResult"></a>
+
 `CallLegsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -553,6 +577,8 @@ Classes
     * airbyte_agent_sdk.connectors.zendesk_talk.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="CallsSearchResult"></a>
 
 `CallsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -570,6 +596,8 @@ Classes
     * pydantic.main.BaseModel
     * typing.Generic
 
+<a id="CurrentQueueActivitySearchResult"></a>
+
 `CurrentQueueActivitySearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -585,6 +613,8 @@ Classes
     * airbyte_agent_sdk.connectors.zendesk_talk.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="GreetingCategoriesSearchResult"></a>
 
 `GreetingCategoriesSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -602,6 +632,8 @@ Classes
     * pydantic.main.BaseModel
     * typing.Generic
 
+<a id="GreetingsSearchResult"></a>
+
 `GreetingsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -617,6 +649,8 @@ Classes
     * airbyte_agent_sdk.connectors.zendesk_talk.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="IvrsSearchResult"></a>
 
 `IvrsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -634,6 +668,8 @@ Classes
     * pydantic.main.BaseModel
     * typing.Generic
 
+<a id="PhoneNumbersSearchResult"></a>
+
 `PhoneNumbersSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -649,6 +685,8 @@ Classes
     * airbyte_agent_sdk.connectors.zendesk_talk.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="CallLegsSearchData"></a>
 
 `CallLegsSearchData(**data: Any)`
 :   Search result data for call_legs entity.
@@ -743,6 +781,8 @@ Classes
 
     `wrap_up_time: int | None`
     :   Wrap-up time in seconds
+
+<a id="CallsSearchData"></a>
 
 `CallsSearchData(**data: Any)`
 :   Search result data for calls entity.
@@ -886,6 +926,8 @@ Classes
     `wrap_up_time: int | None`
     :   Wrap-up time in seconds
 
+<a id="CurrentQueueActivitySearchData"></a>
+
 `CurrentQueueActivitySearchData(**data: Any)`
 :   Search result data for current_queue_activity entity.
     
@@ -926,6 +968,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="GreetingCategoriesSearchData"></a>
+
 `GreetingCategoriesSearchData(**data: Any)`
 :   Search result data for greeting_categories entity.
     
@@ -950,6 +994,8 @@ Classes
 
     `name: str | None`
     :   Name of the greeting category
+
+<a id="GreetingsSearchData"></a>
 
 `GreetingsSearchData(**data: Any)`
 :   Search result data for greetings entity.
@@ -1009,6 +1055,8 @@ Classes
     `upload_id: int | None`
     :   Upload ID associated with the greeting
 
+<a id="IvrsSearchData"></a>
+
 `IvrsSearchData(**data: Any)`
 :   Search result data for ivrs entity.
     
@@ -1042,6 +1090,8 @@ Classes
 
     `phone_number_names: list[typing.Any] | None`
     :   Names of phone numbers configured with this IVR
+
+<a id="PhoneNumbersSearchData"></a>
 
 `PhoneNumbersSearchData(**data: Any)`
 :   Search result data for phone_numbers entity.
@@ -1151,6 +1201,8 @@ Classes
 
     `voice_enabled: bool | None`
     :   Whether voice is enabled
+
+<a id="ZendeskTalkConnector"></a>
 
 `ZendeskTalkConnector(auth_config: ZendeskTalkAuthConfig | AirbyteAuthConfig | BaseModel | None = None, on_token_refresh: Any | None = None, subdomain: str | None = None)`
 :   Type-safe Zendesk-Talk API connector.
@@ -1407,6 +1459,8 @@ Classes
             entities = connector.list_entities()
             for entity in entities:
                 print(f"\{entity['entity_name']\}: \{entity['available_actions']\}")
+
+<a id="ZendeskTalkReplicationConfig"></a>
 
 `ZendeskTalkReplicationConfig(**data: Any)`
 :   Replication Configuration - Settings for data replication from Zendesk Talk.

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/zendesk_talk/models.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/zendesk_talk/models.md
@@ -13,6 +13,8 @@ and response envelope types.
 Classes
 -------
 
+<a id="AccountOverview"></a>
+
 `AccountOverview(**data: Any)`
 :   AccountOverview type definition
     
@@ -101,6 +103,8 @@ Classes
     `total_wrap_up_time: int | Any | None`
     :   The type of the None singleton.
 
+<a id="AccountOverviewResponse"></a>
+
 `AccountOverviewResponse(**data: Any)`
 :   AccountOverviewResponse type definition
     
@@ -122,6 +126,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="AccountOverviewSearchData"></a>
 
 `AccountOverviewSearchData(**data: Any)`
 :   Search result data for account_overview entity.
@@ -211,6 +217,8 @@ Classes
     `total_wrap_up_time: int | None`
     :   Total wrap-up time
 
+<a id="Address"></a>
+
 `Address(**data: Any)`
 :   Address type definition
     
@@ -257,6 +265,8 @@ Classes
     `zip: str | Any | None`
     :   The type of the None singleton.
 
+<a id="AddressWrapper"></a>
+
 `AddressWrapper(**data: Any)`
 :   AddressWrapper type definition
     
@@ -278,6 +288,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="AddressesList"></a>
 
 `AddressesList(**data: Any)`
 :   AddressesList type definition
@@ -310,6 +322,8 @@ Classes
     `previous_page: str | Any | None`
     :   The type of the None singleton.
 
+<a id="AddressesListResultMeta"></a>
+
 `AddressesListResultMeta(**data: Any)`
 :   Metadata for addresses.Action.LIST operation
     
@@ -331,6 +345,8 @@ Classes
 
     `next_page: str | Any | None`
     :   The type of the None singleton.
+
+<a id="AddressesSearchData"></a>
 
 `AddressesSearchData(**data: Any)`
 :   Search result data for addresses entity.
@@ -377,6 +393,8 @@ Classes
 
     `zip: str | None`
     :   Zip code of the address
+
+<a id="AgentActivity"></a>
 
 `AgentActivity(**data: Any)`
 :   AgentActivity type definition
@@ -475,6 +493,8 @@ Classes
     `via: str | Any | None`
     :   The type of the None singleton.
 
+<a id="AgentsActivityList"></a>
+
 `AgentsActivityList(**data: Any)`
 :   AgentsActivityList type definition
     
@@ -506,6 +526,8 @@ Classes
     `previous_page: str | Any | None`
     :   The type of the None singleton.
 
+<a id="AgentsActivityListResultMeta"></a>
+
 `AgentsActivityListResultMeta(**data: Any)`
 :   Metadata for agents_activity.Action.LIST operation
     
@@ -527,6 +549,8 @@ Classes
 
     `next_page: str | Any | None`
     :   The type of the None singleton.
+
+<a id="AgentsActivitySearchData"></a>
 
 `AgentsActivitySearchData(**data: Any)`
 :   Search result data for agents_activity entity.
@@ -625,6 +649,8 @@ Classes
     `via: str | None`
     :   Channel the agent is registered on
 
+<a id="AgentsOverview"></a>
+
 `AgentsOverview(**data: Any)`
 :   AgentsOverview type definition
     
@@ -713,6 +739,8 @@ Classes
     `total_wrap_up_time: int | Any | None`
     :   The type of the None singleton.
 
+<a id="AgentsOverviewResponse"></a>
+
 `AgentsOverviewResponse(**data: Any)`
 :   AgentsOverviewResponse type definition
     
@@ -734,6 +762,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="AgentsOverviewSearchData"></a>
 
 `AgentsOverviewSearchData(**data: Any)`
 :   Search result data for agents_overview entity.
@@ -823,6 +853,8 @@ Classes
     `total_wrap_up_time: int | None`
     :   Total wrap-up time
 
+<a id="AirbyteSearchMeta"></a>
+
 `AirbyteSearchMeta(**data: Any)`
 :   Pagination metadata for search responses.
     
@@ -850,6 +882,8 @@ Classes
 
     `took_ms: int | None`
     :   Time taken to execute the search in milliseconds.
+
+<a id="AirbyteSearchResult"></a>
 
 `AirbyteSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -912,6 +946,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="AccountOverviewSearchResult"></a>
+
 `AccountOverviewSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -948,6 +984,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="AddressesSearchResult"></a>
 
 `AddressesSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -986,6 +1024,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="AgentsActivitySearchResult"></a>
+
 `AgentsActivitySearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -1022,6 +1062,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="AgentsOverviewSearchResult"></a>
 
 `AgentsOverviewSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -1060,6 +1102,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="CallLegsSearchResult"></a>
+
 `CallLegsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -1096,6 +1140,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="CallsSearchResult"></a>
 
 `CallsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -1134,6 +1180,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="CurrentQueueActivitySearchResult"></a>
+
 `CurrentQueueActivitySearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -1170,6 +1218,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="GreetingCategoriesSearchResult"></a>
 
 `GreetingCategoriesSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -1208,6 +1258,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="GreetingsSearchResult"></a>
+
 `GreetingsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -1244,6 +1296,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="IvrsSearchResult"></a>
 
 `IvrsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -1282,6 +1336,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="PhoneNumbersSearchResult"></a>
+
 `PhoneNumbersSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -1297,6 +1353,8 @@ Classes
     * airbyte_agent_sdk.connectors.zendesk_talk.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="Call"></a>
 
 `Call(**data: Any)`
 :   Call type definition
@@ -1461,6 +1519,8 @@ Classes
     `wrap_up_time: int | Any | None`
     :   The type of the None singleton.
 
+<a id="CallLeg"></a>
+
 `CallLeg(**data: Any)`
 :   CallLeg type definition
     
@@ -1555,6 +1615,8 @@ Classes
     `wrap_up_time: int | Any | None`
     :   The type of the None singleton.
 
+<a id="CallLegsList"></a>
+
 `CallLegsList(**data: Any)`
 :   CallLegsList type definition
     
@@ -1586,6 +1648,8 @@ Classes
     `next_page: str | Any | None`
     :   The type of the None singleton.
 
+<a id="CallLegsListResultMeta"></a>
+
 `CallLegsListResultMeta(**data: Any)`
 :   Metadata for call_legs.Action.LIST operation
     
@@ -1610,6 +1674,8 @@ Classes
 
     `next_page: str | Any | None`
     :   The type of the None singleton.
+
+<a id="CallLegsSearchData"></a>
 
 `CallLegsSearchData(**data: Any)`
 :   Search result data for call_legs entity.
@@ -1705,6 +1771,8 @@ Classes
     `wrap_up_time: int | None`
     :   Wrap-up time in seconds
 
+<a id="CallsList"></a>
+
 `CallsList(**data: Any)`
 :   CallsList type definition
     
@@ -1736,6 +1804,8 @@ Classes
     `next_page: str | Any | None`
     :   The type of the None singleton.
 
+<a id="CallsListResultMeta"></a>
+
 `CallsListResultMeta(**data: Any)`
 :   Metadata for calls.Action.LIST operation
     
@@ -1760,6 +1830,8 @@ Classes
 
     `next_page: str | Any | None`
     :   The type of the None singleton.
+
+<a id="CallsSearchData"></a>
 
 `CallsSearchData(**data: Any)`
 :   Search result data for calls entity.
@@ -1903,6 +1975,8 @@ Classes
     `wrap_up_time: int | None`
     :   Wrap-up time in seconds
 
+<a id="CurrentQueueActivity"></a>
+
 `CurrentQueueActivity(**data: Any)`
 :   CurrentQueueActivity type definition
     
@@ -1946,6 +2020,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="CurrentQueueActivityResponse"></a>
+
 `CurrentQueueActivityResponse(**data: Any)`
 :   CurrentQueueActivityResponse type definition
     
@@ -1967,6 +2043,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="CurrentQueueActivitySearchData"></a>
 
 `CurrentQueueActivitySearchData(**data: Any)`
 :   Search result data for current_queue_activity entity.
@@ -2007,6 +2085,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="Greeting"></a>
 
 `Greeting(**data: Any)`
 :   Greeting type definition
@@ -2066,6 +2146,8 @@ Classes
     `upload_id: int | Any | None`
     :   The type of the None singleton.
 
+<a id="GreetingCategoriesList"></a>
+
 `GreetingCategoriesList(**data: Any)`
 :   GreetingCategoriesList type definition
     
@@ -2097,6 +2179,8 @@ Classes
     `previous_page: str | Any | None`
     :   The type of the None singleton.
 
+<a id="GreetingCategoriesListResultMeta"></a>
+
 `GreetingCategoriesListResultMeta(**data: Any)`
 :   Metadata for greeting_categories.Action.LIST operation
     
@@ -2118,6 +2202,8 @@ Classes
 
     `next_page: str | Any | None`
     :   The type of the None singleton.
+
+<a id="GreetingCategoriesSearchData"></a>
 
 `GreetingCategoriesSearchData(**data: Any)`
 :   Search result data for greeting_categories entity.
@@ -2144,6 +2230,8 @@ Classes
     `name: str | None`
     :   Name of the greeting category
 
+<a id="GreetingCategory"></a>
+
 `GreetingCategory(**data: Any)`
 :   GreetingCategory type definition
     
@@ -2169,6 +2257,8 @@ Classes
     `name: str | Any | None`
     :   The type of the None singleton.
 
+<a id="GreetingCategoryWrapper"></a>
+
 `GreetingCategoryWrapper(**data: Any)`
 :   GreetingCategoryWrapper type definition
     
@@ -2191,6 +2281,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="GreetingWrapper"></a>
+
 `GreetingWrapper(**data: Any)`
 :   GreetingWrapper type definition
     
@@ -2212,6 +2304,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="GreetingsList"></a>
 
 `GreetingsList(**data: Any)`
 :   GreetingsList type definition
@@ -2244,6 +2338,8 @@ Classes
     `previous_page: str | Any | None`
     :   The type of the None singleton.
 
+<a id="GreetingsListResultMeta"></a>
+
 `GreetingsListResultMeta(**data: Any)`
 :   Metadata for greetings.Action.LIST operation
     
@@ -2265,6 +2361,8 @@ Classes
 
     `next_page: str | Any | None`
     :   The type of the None singleton.
+
+<a id="GreetingsSearchData"></a>
 
 `GreetingsSearchData(**data: Any)`
 :   Search result data for greetings entity.
@@ -2324,6 +2422,8 @@ Classes
     `upload_id: int | None`
     :   Upload ID associated with the greeting
 
+<a id="Ivr"></a>
+
 `Ivr(**data: Any)`
 :   Ivr type definition
     
@@ -2358,6 +2458,8 @@ Classes
     `phone_number_names: list[typing.Any] | Any | None`
     :   The type of the None singleton.
 
+<a id="IvrMenusItem"></a>
+
 `IvrMenusItem(**data: Any)`
 :   Nested schema for Ivr.menus_item
     
@@ -2391,6 +2493,8 @@ Classes
 
     `routes: list[airbyte_agent_sdk.connectors.zendesk_talk.models.IvrMenusItemRoutesItem] | Any | None`
     :   The type of the None singleton.
+
+<a id="IvrMenusItemRoutesItem"></a>
 
 `IvrMenusItemRoutesItem(**data: Any)`
 :   Nested schema for IvrMenusItem.routes_item
@@ -2432,6 +2536,8 @@ Classes
     `overflow_options: list[typing.Any] | Any | None`
     :   The type of the None singleton.
 
+<a id="IvrWrapper"></a>
+
 `IvrWrapper(**data: Any)`
 :   IvrWrapper type definition
     
@@ -2453,6 +2559,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="IvrsList"></a>
 
 `IvrsList(**data: Any)`
 :   IvrsList type definition
@@ -2485,6 +2593,8 @@ Classes
     `previous_page: str | Any | None`
     :   The type of the None singleton.
 
+<a id="IvrsListResultMeta"></a>
+
 `IvrsListResultMeta(**data: Any)`
 :   Metadata for ivrs.Action.LIST operation
     
@@ -2506,6 +2616,8 @@ Classes
 
     `next_page: str | Any | None`
     :   The type of the None singleton.
+
+<a id="IvrsSearchData"></a>
 
 `IvrsSearchData(**data: Any)`
 :   Search result data for ivrs entity.
@@ -2540,6 +2652,8 @@ Classes
 
     `phone_number_names: list[typing.Any] | None`
     :   Names of phone numbers configured with this IVR
+
+<a id="PhoneNumber"></a>
 
 `PhoneNumber(**data: Any)`
 :   PhoneNumber type definition
@@ -2653,6 +2767,8 @@ Classes
     `voice_enabled: bool | Any | None`
     :   The type of the None singleton.
 
+<a id="PhoneNumberCapabilities"></a>
+
 `PhoneNumberCapabilities(**data: Any)`
 :   Phone number capabilities (sms, mms, voice)
     
@@ -2684,6 +2800,8 @@ Classes
     `voice: bool | Any | None`
     :   The type of the None singleton.
 
+<a id="PhoneNumberWrapper"></a>
+
 `PhoneNumberWrapper(**data: Any)`
 :   PhoneNumberWrapper type definition
     
@@ -2705,6 +2823,8 @@ Classes
 
     `phone_number: airbyte_agent_sdk.connectors.zendesk_talk.models.PhoneNumber | Any`
     :   The type of the None singleton.
+
+<a id="PhoneNumbersList"></a>
 
 `PhoneNumbersList(**data: Any)`
 :   PhoneNumbersList type definition
@@ -2737,6 +2857,8 @@ Classes
     `previous_page: str | Any | None`
     :   The type of the None singleton.
 
+<a id="PhoneNumbersListResultMeta"></a>
+
 `PhoneNumbersListResultMeta(**data: Any)`
 :   Metadata for phone_numbers.Action.LIST operation
     
@@ -2758,6 +2880,8 @@ Classes
 
     `next_page: str | Any | None`
     :   The type of the None singleton.
+
+<a id="PhoneNumbersSearchData"></a>
 
 `PhoneNumbersSearchData(**data: Any)`
 :   Search result data for phone_numbers entity.
@@ -2868,6 +2992,8 @@ Classes
     `voice_enabled: bool | None`
     :   Whether voice is enabled
 
+<a id="ZendeskTalkApiTokenAuthConfig"></a>
+
 `ZendeskTalkApiTokenAuthConfig(**data: Any)`
 :   API Token - Authenticate using email and API token
     
@@ -2892,6 +3018,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="ZendeskTalkCheckResult"></a>
 
 `ZendeskTalkCheckResult(**data: Any)`
 :   Result of a health check operation.
@@ -2926,6 +3054,8 @@ Classes
     `status: str`
     :   Health check status: 'healthy' or 'unhealthy'.
 
+<a id="ZendeskTalkExecuteResult"></a>
+
 `ZendeskTalkExecuteResult(**data: Any)`
 :   Response envelope with data only.
     
@@ -2957,6 +3087,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="ZendeskTalkExecuteResultWithMeta"></a>
 
 `ZendeskTalkExecuteResultWithMeta(**data: Any)`
 :   Response envelope with data and metadata.
@@ -3016,6 +3148,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="AddressesListResult"></a>
+
 `AddressesListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -3058,6 +3192,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="AgentsActivityListResult"></a>
 
 `AgentsActivityListResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -3102,6 +3238,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="CallLegsListResult"></a>
+
 `CallLegsListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -3144,6 +3282,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="CallsListResult"></a>
 
 `CallsListResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -3188,6 +3328,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="GreetingCategoriesListResult"></a>
+
 `GreetingCategoriesListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -3230,6 +3372,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="GreetingsListResult"></a>
 
 `GreetingsListResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -3274,6 +3418,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="IvrsListResult"></a>
+
 `IvrsListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -3317,6 +3463,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="PhoneNumbersListResult"></a>
+
 `PhoneNumbersListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -3359,6 +3507,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="AccountOverviewListResult"></a>
+
 `AccountOverviewListResult(**data: Any)`
 :   Response envelope with data only.
     
@@ -3399,6 +3549,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="AgentsOverviewListResult"></a>
 
 `AgentsOverviewListResult(**data: Any)`
 :   Response envelope with data only.
@@ -3441,6 +3593,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="CurrentQueueActivityListResult"></a>
+
 `CurrentQueueActivityListResult(**data: Any)`
 :   Response envelope with data only.
     
@@ -3458,6 +3612,8 @@ Classes
     * airbyte_agent_sdk.connectors.zendesk_talk.models.ZendeskTalkExecuteResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="ZendeskTalkOauth20AuthConfig"></a>
 
 `ZendeskTalkOauth20AuthConfig(**data: Any)`
 :   OAuth 2.0 - Zendesk OAuth 2.0 authentication
@@ -3489,6 +3645,8 @@ Classes
 
     `refresh_token: str | None`
     :   OAuth 2.0 refresh token (optional)
+
+<a id="ZendeskTalkReplicationConfig"></a>
 
 `ZendeskTalkReplicationConfig(**data: Any)`
 :   Replication Configuration - Settings for data replication from Zendesk Talk.

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/zendesk_talk/types.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/zendesk_talk/types.md
@@ -10,6 +10,8 @@ Type definitions for zendesk-talk connector.
 Classes
 -------
 
+<a id="AccountOverviewAndCondition"></a>
+
 `AccountOverviewAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -30,6 +32,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.zendesk_talk.types.AccountOverviewEqCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.AccountOverviewNeqCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.AccountOverviewGtCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.AccountOverviewGteCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.AccountOverviewLtCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.AccountOverviewLteCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.AccountOverviewInCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.AccountOverviewLikeCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.AccountOverviewFuzzyCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.AccountOverviewKeywordCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.AccountOverviewContainsCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.AccountOverviewNotCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.AccountOverviewAndCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.AccountOverviewOrCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.AccountOverviewAnyCondition]`
     :   The type of the None singleton.
 
+<a id="AccountOverviewAnyCondition"></a>
+
 `AccountOverviewAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -49,6 +53,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.zendesk_talk.types.AccountOverviewAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="AccountOverviewAnyValueFilter"></a>
 
 `AccountOverviewAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -128,6 +134,8 @@ Classes
     `total_wrap_up_time: Any`
     :   Total wrap-up time
 
+<a id="AccountOverviewContainsCondition"></a>
+
 `AccountOverviewContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -139,6 +147,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.zendesk_talk.types.AccountOverviewAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="AccountOverviewEqCondition"></a>
 
 `AccountOverviewEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -152,6 +162,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.zendesk_talk.types.AccountOverviewSearchFilter`
     :   The type of the None singleton.
 
+<a id="AccountOverviewFuzzyCondition"></a>
+
 `AccountOverviewFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -163,6 +175,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.zendesk_talk.types.AccountOverviewStringFilter`
     :   The type of the None singleton.
+
+<a id="AccountOverviewGtCondition"></a>
 
 `AccountOverviewGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
@@ -176,6 +190,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.zendesk_talk.types.AccountOverviewSearchFilter`
     :   The type of the None singleton.
 
+<a id="AccountOverviewGteCondition"></a>
+
 `AccountOverviewGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -187,6 +203,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.zendesk_talk.types.AccountOverviewSearchFilter`
     :   The type of the None singleton.
+
+<a id="AccountOverviewInCondition"></a>
 
 `AccountOverviewInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -207,6 +225,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.zendesk_talk.types.AccountOverviewInFilter`
     :   The type of the None singleton.
+
+<a id="AccountOverviewInFilter"></a>
 
 `AccountOverviewInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -286,6 +306,8 @@ Classes
     `total_wrap_up_time: list[int]`
     :   Total wrap-up time
 
+<a id="AccountOverviewKeywordCondition"></a>
+
 `AccountOverviewKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -297,6 +319,8 @@ Classes
 
     `keyword: airbyte_agent_sdk.connectors.zendesk_talk.types.AccountOverviewStringFilter`
     :   The type of the None singleton.
+
+<a id="AccountOverviewLikeCondition"></a>
 
 `AccountOverviewLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
@@ -310,12 +334,16 @@ Classes
     `like: airbyte_agent_sdk.connectors.zendesk_talk.types.AccountOverviewStringFilter`
     :   The type of the None singleton.
 
+<a id="AccountOverviewListParams"></a>
+
 `AccountOverviewListParams(*args, **kwargs)`
 :   Parameters for account_overview.list operation
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="AccountOverviewLtCondition"></a>
 
 `AccountOverviewLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
@@ -329,6 +357,8 @@ Classes
     `lt: airbyte_agent_sdk.connectors.zendesk_talk.types.AccountOverviewSearchFilter`
     :   The type of the None singleton.
 
+<a id="AccountOverviewLteCondition"></a>
+
 `AccountOverviewLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
 
@@ -341,6 +371,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.zendesk_talk.types.AccountOverviewSearchFilter`
     :   The type of the None singleton.
 
+<a id="AccountOverviewNeqCondition"></a>
+
 `AccountOverviewNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -352,6 +384,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.zendesk_talk.types.AccountOverviewSearchFilter`
     :   The type of the None singleton.
+
+<a id="AccountOverviewNotCondition"></a>
 
 `AccountOverviewNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -373,6 +407,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.zendesk_talk.types.AccountOverviewEqCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.AccountOverviewNeqCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.AccountOverviewGtCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.AccountOverviewGteCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.AccountOverviewLtCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.AccountOverviewLteCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.AccountOverviewInCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.AccountOverviewLikeCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.AccountOverviewFuzzyCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.AccountOverviewKeywordCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.AccountOverviewContainsCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.AccountOverviewNotCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.AccountOverviewAndCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.AccountOverviewOrCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.AccountOverviewAnyCondition`
     :   The type of the None singleton.
 
+<a id="AccountOverviewOrCondition"></a>
+
 `AccountOverviewOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -392,6 +428,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.zendesk_talk.types.AccountOverviewEqCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.AccountOverviewNeqCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.AccountOverviewGtCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.AccountOverviewGteCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.AccountOverviewLtCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.AccountOverviewLteCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.AccountOverviewInCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.AccountOverviewLikeCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.AccountOverviewFuzzyCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.AccountOverviewKeywordCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.AccountOverviewContainsCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.AccountOverviewNotCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.AccountOverviewAndCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.AccountOverviewOrCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.AccountOverviewAnyCondition]`
     :   The type of the None singleton.
+
+<a id="AccountOverviewSearchFilter"></a>
 
 `AccountOverviewSearchFilter(*args, **kwargs)`
 :   Available fields for filtering account_overview search queries.
@@ -471,6 +509,8 @@ Classes
     `total_wrap_up_time: int | None`
     :   Total wrap-up time
 
+<a id="AccountOverviewSearchQuery"></a>
+
 `AccountOverviewSearchQuery(*args, **kwargs)`
 :   Search query for account_overview entity.
 
@@ -485,6 +525,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.zendesk_talk.types.AccountOverviewSortFilter]`
     :   The type of the None singleton.
+
+<a id="AccountOverviewSortFilter"></a>
 
 `AccountOverviewSortFilter(*args, **kwargs)`
 :   Available fields for sorting account_overview search results.
@@ -564,6 +606,8 @@ Classes
     `total_wrap_up_time: Literal['asc', 'desc']`
     :   Total wrap-up time
 
+<a id="AccountOverviewStringFilter"></a>
+
 `AccountOverviewStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -642,6 +686,8 @@ Classes
     `total_wrap_up_time: str`
     :   Total wrap-up time
 
+<a id="AddressesAndCondition"></a>
+
 `AddressesAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -662,6 +708,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.zendesk_talk.types.AddressesEqCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.AddressesNeqCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.AddressesGtCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.AddressesGteCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.AddressesLtCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.AddressesLteCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.AddressesInCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.AddressesLikeCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.AddressesFuzzyCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.AddressesKeywordCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.AddressesContainsCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.AddressesNotCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.AddressesAndCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.AddressesOrCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.AddressesAnyCondition]`
     :   The type of the None singleton.
 
+<a id="AddressesAnyCondition"></a>
+
 `AddressesAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -681,6 +729,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.zendesk_talk.types.AddressesAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="AddressesAnyValueFilter"></a>
 
 `AddressesAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -718,6 +768,8 @@ Classes
     `zip: Any`
     :   Zip code of the address
 
+<a id="AddressesContainsCondition"></a>
+
 `AddressesContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -729,6 +781,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.zendesk_talk.types.AddressesAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="AddressesEqCondition"></a>
 
 `AddressesEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -742,6 +796,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.zendesk_talk.types.AddressesSearchFilter`
     :   The type of the None singleton.
 
+<a id="AddressesFuzzyCondition"></a>
+
 `AddressesFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -753,6 +809,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.zendesk_talk.types.AddressesStringFilter`
     :   The type of the None singleton.
+
+<a id="AddressesGetParams"></a>
 
 `AddressesGetParams(*args, **kwargs)`
 :   Parameters for addresses.get operation
@@ -766,6 +824,8 @@ Classes
     `address_id: str`
     :   The type of the None singleton.
 
+<a id="AddressesGtCondition"></a>
+
 `AddressesGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -778,6 +838,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.zendesk_talk.types.AddressesSearchFilter`
     :   The type of the None singleton.
 
+<a id="AddressesGteCondition"></a>
+
 `AddressesGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -789,6 +851,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.zendesk_talk.types.AddressesSearchFilter`
     :   The type of the None singleton.
+
+<a id="AddressesInCondition"></a>
 
 `AddressesInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -809,6 +873,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.zendesk_talk.types.AddressesInFilter`
     :   The type of the None singleton.
+
+<a id="AddressesInFilter"></a>
 
 `AddressesInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -846,6 +912,8 @@ Classes
     `zip: list[str]`
     :   Zip code of the address
 
+<a id="AddressesKeywordCondition"></a>
+
 `AddressesKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -857,6 +925,8 @@ Classes
 
     `keyword: airbyte_agent_sdk.connectors.zendesk_talk.types.AddressesStringFilter`
     :   The type of the None singleton.
+
+<a id="AddressesLikeCondition"></a>
 
 `AddressesLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
@@ -870,12 +940,16 @@ Classes
     `like: airbyte_agent_sdk.connectors.zendesk_talk.types.AddressesStringFilter`
     :   The type of the None singleton.
 
+<a id="AddressesListParams"></a>
+
 `AddressesListParams(*args, **kwargs)`
 :   Parameters for addresses.list operation
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="AddressesLtCondition"></a>
 
 `AddressesLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
@@ -889,6 +963,8 @@ Classes
     `lt: airbyte_agent_sdk.connectors.zendesk_talk.types.AddressesSearchFilter`
     :   The type of the None singleton.
 
+<a id="AddressesLteCondition"></a>
+
 `AddressesLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
 
@@ -901,6 +977,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.zendesk_talk.types.AddressesSearchFilter`
     :   The type of the None singleton.
 
+<a id="AddressesNeqCondition"></a>
+
 `AddressesNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -912,6 +990,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.zendesk_talk.types.AddressesSearchFilter`
     :   The type of the None singleton.
+
+<a id="AddressesNotCondition"></a>
 
 `AddressesNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -933,6 +1013,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.zendesk_talk.types.AddressesEqCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.AddressesNeqCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.AddressesGtCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.AddressesGteCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.AddressesLtCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.AddressesLteCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.AddressesInCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.AddressesLikeCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.AddressesFuzzyCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.AddressesKeywordCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.AddressesContainsCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.AddressesNotCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.AddressesAndCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.AddressesOrCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.AddressesAnyCondition`
     :   The type of the None singleton.
 
+<a id="AddressesOrCondition"></a>
+
 `AddressesOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -952,6 +1034,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.zendesk_talk.types.AddressesEqCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.AddressesNeqCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.AddressesGtCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.AddressesGteCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.AddressesLtCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.AddressesLteCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.AddressesInCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.AddressesLikeCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.AddressesFuzzyCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.AddressesKeywordCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.AddressesContainsCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.AddressesNotCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.AddressesAndCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.AddressesOrCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.AddressesAnyCondition]`
     :   The type of the None singleton.
+
+<a id="AddressesSearchFilter"></a>
 
 `AddressesSearchFilter(*args, **kwargs)`
 :   Available fields for filtering addresses search queries.
@@ -989,6 +1073,8 @@ Classes
     `zip: str | None`
     :   Zip code of the address
 
+<a id="AddressesSearchQuery"></a>
+
 `AddressesSearchQuery(*args, **kwargs)`
 :   Search query for addresses entity.
 
@@ -1003,6 +1089,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.zendesk_talk.types.AddressesSortFilter]`
     :   The type of the None singleton.
+
+<a id="AddressesSortFilter"></a>
 
 `AddressesSortFilter(*args, **kwargs)`
 :   Available fields for sorting addresses search results.
@@ -1040,6 +1128,8 @@ Classes
     `zip: Literal['asc', 'desc']`
     :   Zip code of the address
 
+<a id="AddressesStringFilter"></a>
+
 `AddressesStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -1076,6 +1166,8 @@ Classes
     `zip: str`
     :   Zip code of the address
 
+<a id="AgentsActivityAndCondition"></a>
+
 `AgentsActivityAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1096,6 +1188,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.zendesk_talk.types.AgentsActivityEqCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.AgentsActivityNeqCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.AgentsActivityGtCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.AgentsActivityGteCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.AgentsActivityLtCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.AgentsActivityLteCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.AgentsActivityInCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.AgentsActivityLikeCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.AgentsActivityFuzzyCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.AgentsActivityKeywordCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.AgentsActivityContainsCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.AgentsActivityNotCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.AgentsActivityAndCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.AgentsActivityOrCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.AgentsActivityAnyCondition]`
     :   The type of the None singleton.
 
+<a id="AgentsActivityAnyCondition"></a>
+
 `AgentsActivityAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1115,6 +1209,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.zendesk_talk.types.AgentsActivityAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="AgentsActivityAnyValueFilter"></a>
 
 `AgentsActivityAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -1203,6 +1299,8 @@ Classes
     `via: Any`
     :   Channel the agent is registered on
 
+<a id="AgentsActivityContainsCondition"></a>
+
 `AgentsActivityContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -1214,6 +1312,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.zendesk_talk.types.AgentsActivityAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="AgentsActivityEqCondition"></a>
 
 `AgentsActivityEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -1227,6 +1327,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.zendesk_talk.types.AgentsActivitySearchFilter`
     :   The type of the None singleton.
 
+<a id="AgentsActivityFuzzyCondition"></a>
+
 `AgentsActivityFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -1238,6 +1340,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.zendesk_talk.types.AgentsActivityStringFilter`
     :   The type of the None singleton.
+
+<a id="AgentsActivityGtCondition"></a>
 
 `AgentsActivityGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
@@ -1251,6 +1355,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.zendesk_talk.types.AgentsActivitySearchFilter`
     :   The type of the None singleton.
 
+<a id="AgentsActivityGteCondition"></a>
+
 `AgentsActivityGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -1262,6 +1368,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.zendesk_talk.types.AgentsActivitySearchFilter`
     :   The type of the None singleton.
+
+<a id="AgentsActivityInCondition"></a>
 
 `AgentsActivityInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -1282,6 +1390,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.zendesk_talk.types.AgentsActivityInFilter`
     :   The type of the None singleton.
+
+<a id="AgentsActivityInFilter"></a>
 
 `AgentsActivityInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -1370,6 +1480,8 @@ Classes
     `via: list[str]`
     :   Channel the agent is registered on
 
+<a id="AgentsActivityKeywordCondition"></a>
+
 `AgentsActivityKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -1381,6 +1493,8 @@ Classes
 
     `keyword: airbyte_agent_sdk.connectors.zendesk_talk.types.AgentsActivityStringFilter`
     :   The type of the None singleton.
+
+<a id="AgentsActivityLikeCondition"></a>
 
 `AgentsActivityLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
@@ -1394,12 +1508,16 @@ Classes
     `like: airbyte_agent_sdk.connectors.zendesk_talk.types.AgentsActivityStringFilter`
     :   The type of the None singleton.
 
+<a id="AgentsActivityListParams"></a>
+
 `AgentsActivityListParams(*args, **kwargs)`
 :   Parameters for agents_activity.list operation
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="AgentsActivityLtCondition"></a>
 
 `AgentsActivityLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
@@ -1413,6 +1531,8 @@ Classes
     `lt: airbyte_agent_sdk.connectors.zendesk_talk.types.AgentsActivitySearchFilter`
     :   The type of the None singleton.
 
+<a id="AgentsActivityLteCondition"></a>
+
 `AgentsActivityLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
 
@@ -1425,6 +1545,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.zendesk_talk.types.AgentsActivitySearchFilter`
     :   The type of the None singleton.
 
+<a id="AgentsActivityNeqCondition"></a>
+
 `AgentsActivityNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -1436,6 +1558,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.zendesk_talk.types.AgentsActivitySearchFilter`
     :   The type of the None singleton.
+
+<a id="AgentsActivityNotCondition"></a>
 
 `AgentsActivityNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -1457,6 +1581,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.zendesk_talk.types.AgentsActivityEqCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.AgentsActivityNeqCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.AgentsActivityGtCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.AgentsActivityGteCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.AgentsActivityLtCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.AgentsActivityLteCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.AgentsActivityInCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.AgentsActivityLikeCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.AgentsActivityFuzzyCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.AgentsActivityKeywordCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.AgentsActivityContainsCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.AgentsActivityNotCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.AgentsActivityAndCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.AgentsActivityOrCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.AgentsActivityAnyCondition`
     :   The type of the None singleton.
 
+<a id="AgentsActivityOrCondition"></a>
+
 `AgentsActivityOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1476,6 +1602,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.zendesk_talk.types.AgentsActivityEqCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.AgentsActivityNeqCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.AgentsActivityGtCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.AgentsActivityGteCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.AgentsActivityLtCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.AgentsActivityLteCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.AgentsActivityInCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.AgentsActivityLikeCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.AgentsActivityFuzzyCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.AgentsActivityKeywordCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.AgentsActivityContainsCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.AgentsActivityNotCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.AgentsActivityAndCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.AgentsActivityOrCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.AgentsActivityAnyCondition]`
     :   The type of the None singleton.
+
+<a id="AgentsActivitySearchFilter"></a>
 
 `AgentsActivitySearchFilter(*args, **kwargs)`
 :   Available fields for filtering agents_activity search queries.
@@ -1564,6 +1692,8 @@ Classes
     `via: str | None`
     :   Channel the agent is registered on
 
+<a id="AgentsActivitySearchQuery"></a>
+
 `AgentsActivitySearchQuery(*args, **kwargs)`
 :   Search query for agents_activity entity.
 
@@ -1578,6 +1708,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.zendesk_talk.types.AgentsActivitySortFilter]`
     :   The type of the None singleton.
+
+<a id="AgentsActivitySortFilter"></a>
 
 `AgentsActivitySortFilter(*args, **kwargs)`
 :   Available fields for sorting agents_activity search results.
@@ -1666,6 +1798,8 @@ Classes
     `via: Literal['asc', 'desc']`
     :   Channel the agent is registered on
 
+<a id="AgentsActivityStringFilter"></a>
+
 `AgentsActivityStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -1753,6 +1887,8 @@ Classes
     `via: str`
     :   Channel the agent is registered on
 
+<a id="AgentsOverviewAndCondition"></a>
+
 `AgentsOverviewAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1773,6 +1909,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.zendesk_talk.types.AgentsOverviewEqCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.AgentsOverviewNeqCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.AgentsOverviewGtCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.AgentsOverviewGteCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.AgentsOverviewLtCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.AgentsOverviewLteCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.AgentsOverviewInCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.AgentsOverviewLikeCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.AgentsOverviewFuzzyCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.AgentsOverviewKeywordCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.AgentsOverviewContainsCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.AgentsOverviewNotCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.AgentsOverviewAndCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.AgentsOverviewOrCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.AgentsOverviewAnyCondition]`
     :   The type of the None singleton.
 
+<a id="AgentsOverviewAnyCondition"></a>
+
 `AgentsOverviewAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1792,6 +1930,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.zendesk_talk.types.AgentsOverviewAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="AgentsOverviewAnyValueFilter"></a>
 
 `AgentsOverviewAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -1871,6 +2011,8 @@ Classes
     `total_wrap_up_time: Any`
     :   Total wrap-up time
 
+<a id="AgentsOverviewContainsCondition"></a>
+
 `AgentsOverviewContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -1882,6 +2024,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.zendesk_talk.types.AgentsOverviewAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="AgentsOverviewEqCondition"></a>
 
 `AgentsOverviewEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -1895,6 +2039,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.zendesk_talk.types.AgentsOverviewSearchFilter`
     :   The type of the None singleton.
 
+<a id="AgentsOverviewFuzzyCondition"></a>
+
 `AgentsOverviewFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -1906,6 +2052,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.zendesk_talk.types.AgentsOverviewStringFilter`
     :   The type of the None singleton.
+
+<a id="AgentsOverviewGtCondition"></a>
 
 `AgentsOverviewGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
@@ -1919,6 +2067,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.zendesk_talk.types.AgentsOverviewSearchFilter`
     :   The type of the None singleton.
 
+<a id="AgentsOverviewGteCondition"></a>
+
 `AgentsOverviewGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -1930,6 +2080,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.zendesk_talk.types.AgentsOverviewSearchFilter`
     :   The type of the None singleton.
+
+<a id="AgentsOverviewInCondition"></a>
 
 `AgentsOverviewInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -1950,6 +2102,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.zendesk_talk.types.AgentsOverviewInFilter`
     :   The type of the None singleton.
+
+<a id="AgentsOverviewInFilter"></a>
 
 `AgentsOverviewInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -2029,6 +2183,8 @@ Classes
     `total_wrap_up_time: list[int]`
     :   Total wrap-up time
 
+<a id="AgentsOverviewKeywordCondition"></a>
+
 `AgentsOverviewKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -2040,6 +2196,8 @@ Classes
 
     `keyword: airbyte_agent_sdk.connectors.zendesk_talk.types.AgentsOverviewStringFilter`
     :   The type of the None singleton.
+
+<a id="AgentsOverviewLikeCondition"></a>
 
 `AgentsOverviewLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
@@ -2053,12 +2211,16 @@ Classes
     `like: airbyte_agent_sdk.connectors.zendesk_talk.types.AgentsOverviewStringFilter`
     :   The type of the None singleton.
 
+<a id="AgentsOverviewListParams"></a>
+
 `AgentsOverviewListParams(*args, **kwargs)`
 :   Parameters for agents_overview.list operation
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="AgentsOverviewLtCondition"></a>
 
 `AgentsOverviewLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
@@ -2072,6 +2234,8 @@ Classes
     `lt: airbyte_agent_sdk.connectors.zendesk_talk.types.AgentsOverviewSearchFilter`
     :   The type of the None singleton.
 
+<a id="AgentsOverviewLteCondition"></a>
+
 `AgentsOverviewLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
 
@@ -2084,6 +2248,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.zendesk_talk.types.AgentsOverviewSearchFilter`
     :   The type of the None singleton.
 
+<a id="AgentsOverviewNeqCondition"></a>
+
 `AgentsOverviewNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -2095,6 +2261,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.zendesk_talk.types.AgentsOverviewSearchFilter`
     :   The type of the None singleton.
+
+<a id="AgentsOverviewNotCondition"></a>
 
 `AgentsOverviewNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -2116,6 +2284,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.zendesk_talk.types.AgentsOverviewEqCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.AgentsOverviewNeqCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.AgentsOverviewGtCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.AgentsOverviewGteCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.AgentsOverviewLtCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.AgentsOverviewLteCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.AgentsOverviewInCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.AgentsOverviewLikeCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.AgentsOverviewFuzzyCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.AgentsOverviewKeywordCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.AgentsOverviewContainsCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.AgentsOverviewNotCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.AgentsOverviewAndCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.AgentsOverviewOrCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.AgentsOverviewAnyCondition`
     :   The type of the None singleton.
 
+<a id="AgentsOverviewOrCondition"></a>
+
 `AgentsOverviewOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -2135,6 +2305,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.zendesk_talk.types.AgentsOverviewEqCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.AgentsOverviewNeqCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.AgentsOverviewGtCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.AgentsOverviewGteCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.AgentsOverviewLtCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.AgentsOverviewLteCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.AgentsOverviewInCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.AgentsOverviewLikeCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.AgentsOverviewFuzzyCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.AgentsOverviewKeywordCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.AgentsOverviewContainsCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.AgentsOverviewNotCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.AgentsOverviewAndCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.AgentsOverviewOrCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.AgentsOverviewAnyCondition]`
     :   The type of the None singleton.
+
+<a id="AgentsOverviewSearchFilter"></a>
 
 `AgentsOverviewSearchFilter(*args, **kwargs)`
 :   Available fields for filtering agents_overview search queries.
@@ -2214,6 +2386,8 @@ Classes
     `total_wrap_up_time: int | None`
     :   Total wrap-up time
 
+<a id="AgentsOverviewSearchQuery"></a>
+
 `AgentsOverviewSearchQuery(*args, **kwargs)`
 :   Search query for agents_overview entity.
 
@@ -2228,6 +2402,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.zendesk_talk.types.AgentsOverviewSortFilter]`
     :   The type of the None singleton.
+
+<a id="AgentsOverviewSortFilter"></a>
 
 `AgentsOverviewSortFilter(*args, **kwargs)`
 :   Available fields for sorting agents_overview search results.
@@ -2307,6 +2483,8 @@ Classes
     `total_wrap_up_time: Literal['asc', 'desc']`
     :   Total wrap-up time
 
+<a id="AgentsOverviewStringFilter"></a>
+
 `AgentsOverviewStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -2385,6 +2563,8 @@ Classes
     `total_wrap_up_time: str`
     :   Total wrap-up time
 
+<a id="AirbyteSearchParams"></a>
+
 `AirbyteSearchParams(*args, **kwargs)`
 :   Parameters for Airbyte cache search operations (generic, use entity-specific query types for better type hints).
 
@@ -2406,6 +2586,8 @@ Classes
     `query: dict[str, typing.Any]`
     :   The type of the None singleton.
 
+<a id="CallLegsAndCondition"></a>
+
 `CallLegsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -2426,6 +2608,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.zendesk_talk.types.CallLegsEqCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.CallLegsNeqCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.CallLegsGtCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.CallLegsGteCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.CallLegsLtCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.CallLegsLteCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.CallLegsInCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.CallLegsLikeCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.CallLegsFuzzyCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.CallLegsKeywordCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.CallLegsContainsCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.CallLegsNotCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.CallLegsAndCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.CallLegsOrCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.CallLegsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="CallLegsAnyCondition"></a>
+
 `CallLegsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -2445,6 +2629,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.zendesk_talk.types.CallLegsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="CallLegsAnyValueFilter"></a>
 
 `CallLegsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -2530,6 +2716,8 @@ Classes
     `wrap_up_time: Any`
     :   Wrap-up time in seconds
 
+<a id="CallLegsContainsCondition"></a>
+
 `CallLegsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -2541,6 +2729,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.zendesk_talk.types.CallLegsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="CallLegsEqCondition"></a>
 
 `CallLegsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -2554,6 +2744,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.zendesk_talk.types.CallLegsSearchFilter`
     :   The type of the None singleton.
 
+<a id="CallLegsFuzzyCondition"></a>
+
 `CallLegsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -2565,6 +2757,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.zendesk_talk.types.CallLegsStringFilter`
     :   The type of the None singleton.
+
+<a id="CallLegsGtCondition"></a>
 
 `CallLegsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
@@ -2578,6 +2772,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.zendesk_talk.types.CallLegsSearchFilter`
     :   The type of the None singleton.
 
+<a id="CallLegsGteCondition"></a>
+
 `CallLegsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -2589,6 +2785,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.zendesk_talk.types.CallLegsSearchFilter`
     :   The type of the None singleton.
+
+<a id="CallLegsInCondition"></a>
 
 `CallLegsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -2609,6 +2807,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.zendesk_talk.types.CallLegsInFilter`
     :   The type of the None singleton.
+
+<a id="CallLegsInFilter"></a>
 
 `CallLegsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -2694,6 +2894,8 @@ Classes
     `wrap_up_time: list[int]`
     :   Wrap-up time in seconds
 
+<a id="CallLegsKeywordCondition"></a>
+
 `CallLegsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -2705,6 +2907,8 @@ Classes
 
     `keyword: airbyte_agent_sdk.connectors.zendesk_talk.types.CallLegsStringFilter`
     :   The type of the None singleton.
+
+<a id="CallLegsLikeCondition"></a>
 
 `CallLegsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
@@ -2718,6 +2922,8 @@ Classes
     `like: airbyte_agent_sdk.connectors.zendesk_talk.types.CallLegsStringFilter`
     :   The type of the None singleton.
 
+<a id="CallLegsListParams"></a>
+
 `CallLegsListParams(*args, **kwargs)`
 :   Parameters for call_legs.list operation
 
@@ -2729,6 +2935,8 @@ Classes
 
     `start_time: int`
     :   The type of the None singleton.
+
+<a id="CallLegsLtCondition"></a>
 
 `CallLegsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
@@ -2742,6 +2950,8 @@ Classes
     `lt: airbyte_agent_sdk.connectors.zendesk_talk.types.CallLegsSearchFilter`
     :   The type of the None singleton.
 
+<a id="CallLegsLteCondition"></a>
+
 `CallLegsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
 
@@ -2754,6 +2964,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.zendesk_talk.types.CallLegsSearchFilter`
     :   The type of the None singleton.
 
+<a id="CallLegsNeqCondition"></a>
+
 `CallLegsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -2765,6 +2977,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.zendesk_talk.types.CallLegsSearchFilter`
     :   The type of the None singleton.
+
+<a id="CallLegsNotCondition"></a>
 
 `CallLegsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -2786,6 +3000,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.zendesk_talk.types.CallLegsEqCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.CallLegsNeqCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.CallLegsGtCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.CallLegsGteCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.CallLegsLtCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.CallLegsLteCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.CallLegsInCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.CallLegsLikeCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.CallLegsFuzzyCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.CallLegsKeywordCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.CallLegsContainsCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.CallLegsNotCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.CallLegsAndCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.CallLegsOrCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.CallLegsAnyCondition`
     :   The type of the None singleton.
 
+<a id="CallLegsOrCondition"></a>
+
 `CallLegsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -2805,6 +3021,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.zendesk_talk.types.CallLegsEqCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.CallLegsNeqCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.CallLegsGtCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.CallLegsGteCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.CallLegsLtCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.CallLegsLteCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.CallLegsInCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.CallLegsLikeCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.CallLegsFuzzyCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.CallLegsKeywordCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.CallLegsContainsCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.CallLegsNotCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.CallLegsAndCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.CallLegsOrCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.CallLegsAnyCondition]`
     :   The type of the None singleton.
+
+<a id="CallLegsSearchFilter"></a>
 
 `CallLegsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering call_legs search queries.
@@ -2890,6 +3108,8 @@ Classes
     `wrap_up_time: int | None`
     :   Wrap-up time in seconds
 
+<a id="CallLegsSearchQuery"></a>
+
 `CallLegsSearchQuery(*args, **kwargs)`
 :   Search query for call_legs entity.
 
@@ -2904,6 +3124,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.zendesk_talk.types.CallLegsSortFilter]`
     :   The type of the None singleton.
+
+<a id="CallLegsSortFilter"></a>
 
 `CallLegsSortFilter(*args, **kwargs)`
 :   Available fields for sorting call_legs search results.
@@ -2989,6 +3211,8 @@ Classes
     `wrap_up_time: Literal['asc', 'desc']`
     :   Wrap-up time in seconds
 
+<a id="CallLegsStringFilter"></a>
+
 `CallLegsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -3073,6 +3297,8 @@ Classes
     `wrap_up_time: str`
     :   Wrap-up time in seconds
 
+<a id="CallsAndCondition"></a>
+
 `CallsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -3093,6 +3319,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.zendesk_talk.types.CallsEqCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.CallsNeqCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.CallsGtCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.CallsGteCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.CallsLtCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.CallsLteCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.CallsInCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.CallsLikeCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.CallsFuzzyCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.CallsKeywordCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.CallsContainsCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.CallsNotCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.CallsAndCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.CallsOrCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.CallsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="CallsAnyCondition"></a>
+
 `CallsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -3112,6 +3340,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.zendesk_talk.types.CallsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="CallsAnyValueFilter"></a>
 
 `CallsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -3245,6 +3475,8 @@ Classes
     `wrap_up_time: Any`
     :   Wrap-up time in seconds
 
+<a id="CallsContainsCondition"></a>
+
 `CallsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -3256,6 +3488,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.zendesk_talk.types.CallsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="CallsEqCondition"></a>
 
 `CallsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -3269,6 +3503,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.zendesk_talk.types.CallsSearchFilter`
     :   The type of the None singleton.
 
+<a id="CallsFuzzyCondition"></a>
+
 `CallsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -3280,6 +3516,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.zendesk_talk.types.CallsStringFilter`
     :   The type of the None singleton.
+
+<a id="CallsGtCondition"></a>
 
 `CallsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
@@ -3293,6 +3531,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.zendesk_talk.types.CallsSearchFilter`
     :   The type of the None singleton.
 
+<a id="CallsGteCondition"></a>
+
 `CallsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -3304,6 +3544,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.zendesk_talk.types.CallsSearchFilter`
     :   The type of the None singleton.
+
+<a id="CallsInCondition"></a>
 
 `CallsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -3324,6 +3566,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.zendesk_talk.types.CallsInFilter`
     :   The type of the None singleton.
+
+<a id="CallsInFilter"></a>
 
 `CallsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -3457,6 +3701,8 @@ Classes
     `wrap_up_time: list[int]`
     :   Wrap-up time in seconds
 
+<a id="CallsKeywordCondition"></a>
+
 `CallsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -3468,6 +3714,8 @@ Classes
 
     `keyword: airbyte_agent_sdk.connectors.zendesk_talk.types.CallsStringFilter`
     :   The type of the None singleton.
+
+<a id="CallsLikeCondition"></a>
 
 `CallsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
@@ -3481,6 +3729,8 @@ Classes
     `like: airbyte_agent_sdk.connectors.zendesk_talk.types.CallsStringFilter`
     :   The type of the None singleton.
 
+<a id="CallsListParams"></a>
+
 `CallsListParams(*args, **kwargs)`
 :   Parameters for calls.list operation
 
@@ -3492,6 +3742,8 @@ Classes
 
     `start_time: int`
     :   The type of the None singleton.
+
+<a id="CallsLtCondition"></a>
 
 `CallsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
@@ -3505,6 +3757,8 @@ Classes
     `lt: airbyte_agent_sdk.connectors.zendesk_talk.types.CallsSearchFilter`
     :   The type of the None singleton.
 
+<a id="CallsLteCondition"></a>
+
 `CallsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
 
@@ -3517,6 +3771,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.zendesk_talk.types.CallsSearchFilter`
     :   The type of the None singleton.
 
+<a id="CallsNeqCondition"></a>
+
 `CallsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -3528,6 +3784,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.zendesk_talk.types.CallsSearchFilter`
     :   The type of the None singleton.
+
+<a id="CallsNotCondition"></a>
 
 `CallsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -3549,6 +3807,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.zendesk_talk.types.CallsEqCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.CallsNeqCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.CallsGtCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.CallsGteCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.CallsLtCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.CallsLteCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.CallsInCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.CallsLikeCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.CallsFuzzyCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.CallsKeywordCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.CallsContainsCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.CallsNotCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.CallsAndCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.CallsOrCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.CallsAnyCondition`
     :   The type of the None singleton.
 
+<a id="CallsOrCondition"></a>
+
 `CallsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -3568,6 +3828,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.zendesk_talk.types.CallsEqCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.CallsNeqCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.CallsGtCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.CallsGteCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.CallsLtCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.CallsLteCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.CallsInCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.CallsLikeCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.CallsFuzzyCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.CallsKeywordCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.CallsContainsCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.CallsNotCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.CallsAndCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.CallsOrCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.CallsAnyCondition]`
     :   The type of the None singleton.
+
+<a id="CallsSearchFilter"></a>
 
 `CallsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering calls search queries.
@@ -3701,6 +3963,8 @@ Classes
     `wrap_up_time: int | None`
     :   Wrap-up time in seconds
 
+<a id="CallsSearchQuery"></a>
+
 `CallsSearchQuery(*args, **kwargs)`
 :   Search query for calls entity.
 
@@ -3715,6 +3979,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.zendesk_talk.types.CallsSortFilter]`
     :   The type of the None singleton.
+
+<a id="CallsSortFilter"></a>
 
 `CallsSortFilter(*args, **kwargs)`
 :   Available fields for sorting calls search results.
@@ -3848,6 +4114,8 @@ Classes
     `wrap_up_time: Literal['asc', 'desc']`
     :   Wrap-up time in seconds
 
+<a id="CallsStringFilter"></a>
+
 `CallsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -3980,6 +4248,8 @@ Classes
     `wrap_up_time: str`
     :   Wrap-up time in seconds
 
+<a id="CurrentQueueActivityAndCondition"></a>
+
 `CurrentQueueActivityAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -4000,6 +4270,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.zendesk_talk.types.CurrentQueueActivityEqCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.CurrentQueueActivityNeqCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.CurrentQueueActivityGtCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.CurrentQueueActivityGteCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.CurrentQueueActivityLtCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.CurrentQueueActivityLteCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.CurrentQueueActivityInCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.CurrentQueueActivityLikeCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.CurrentQueueActivityFuzzyCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.CurrentQueueActivityKeywordCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.CurrentQueueActivityContainsCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.CurrentQueueActivityNotCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.CurrentQueueActivityAndCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.CurrentQueueActivityOrCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.CurrentQueueActivityAnyCondition]`
     :   The type of the None singleton.
 
+<a id="CurrentQueueActivityAnyCondition"></a>
+
 `CurrentQueueActivityAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -4019,6 +4291,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.zendesk_talk.types.CurrentQueueActivityAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="CurrentQueueActivityAnyValueFilter"></a>
 
 `CurrentQueueActivityAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -4050,6 +4324,8 @@ Classes
     `longest_wait_time: Any`
     :   Longest wait time for any caller (seconds)
 
+<a id="CurrentQueueActivityContainsCondition"></a>
+
 `CurrentQueueActivityContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -4061,6 +4337,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.zendesk_talk.types.CurrentQueueActivityAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="CurrentQueueActivityEqCondition"></a>
 
 `CurrentQueueActivityEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -4074,6 +4352,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.zendesk_talk.types.CurrentQueueActivitySearchFilter`
     :   The type of the None singleton.
 
+<a id="CurrentQueueActivityFuzzyCondition"></a>
+
 `CurrentQueueActivityFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -4085,6 +4365,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.zendesk_talk.types.CurrentQueueActivityStringFilter`
     :   The type of the None singleton.
+
+<a id="CurrentQueueActivityGtCondition"></a>
 
 `CurrentQueueActivityGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
@@ -4098,6 +4380,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.zendesk_talk.types.CurrentQueueActivitySearchFilter`
     :   The type of the None singleton.
 
+<a id="CurrentQueueActivityGteCondition"></a>
+
 `CurrentQueueActivityGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -4109,6 +4393,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.zendesk_talk.types.CurrentQueueActivitySearchFilter`
     :   The type of the None singleton.
+
+<a id="CurrentQueueActivityInCondition"></a>
 
 `CurrentQueueActivityInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -4129,6 +4415,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.zendesk_talk.types.CurrentQueueActivityInFilter`
     :   The type of the None singleton.
+
+<a id="CurrentQueueActivityInFilter"></a>
 
 `CurrentQueueActivityInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -4160,6 +4448,8 @@ Classes
     `longest_wait_time: list[int]`
     :   Longest wait time for any caller (seconds)
 
+<a id="CurrentQueueActivityKeywordCondition"></a>
+
 `CurrentQueueActivityKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -4171,6 +4461,8 @@ Classes
 
     `keyword: airbyte_agent_sdk.connectors.zendesk_talk.types.CurrentQueueActivityStringFilter`
     :   The type of the None singleton.
+
+<a id="CurrentQueueActivityLikeCondition"></a>
 
 `CurrentQueueActivityLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
@@ -4184,12 +4476,16 @@ Classes
     `like: airbyte_agent_sdk.connectors.zendesk_talk.types.CurrentQueueActivityStringFilter`
     :   The type of the None singleton.
 
+<a id="CurrentQueueActivityListParams"></a>
+
 `CurrentQueueActivityListParams(*args, **kwargs)`
 :   Parameters for current_queue_activity.list operation
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="CurrentQueueActivityLtCondition"></a>
 
 `CurrentQueueActivityLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
@@ -4203,6 +4499,8 @@ Classes
     `lt: airbyte_agent_sdk.connectors.zendesk_talk.types.CurrentQueueActivitySearchFilter`
     :   The type of the None singleton.
 
+<a id="CurrentQueueActivityLteCondition"></a>
+
 `CurrentQueueActivityLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
 
@@ -4215,6 +4513,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.zendesk_talk.types.CurrentQueueActivitySearchFilter`
     :   The type of the None singleton.
 
+<a id="CurrentQueueActivityNeqCondition"></a>
+
 `CurrentQueueActivityNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -4226,6 +4526,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.zendesk_talk.types.CurrentQueueActivitySearchFilter`
     :   The type of the None singleton.
+
+<a id="CurrentQueueActivityNotCondition"></a>
 
 `CurrentQueueActivityNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -4247,6 +4549,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.zendesk_talk.types.CurrentQueueActivityEqCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.CurrentQueueActivityNeqCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.CurrentQueueActivityGtCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.CurrentQueueActivityGteCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.CurrentQueueActivityLtCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.CurrentQueueActivityLteCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.CurrentQueueActivityInCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.CurrentQueueActivityLikeCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.CurrentQueueActivityFuzzyCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.CurrentQueueActivityKeywordCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.CurrentQueueActivityContainsCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.CurrentQueueActivityNotCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.CurrentQueueActivityAndCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.CurrentQueueActivityOrCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.CurrentQueueActivityAnyCondition`
     :   The type of the None singleton.
 
+<a id="CurrentQueueActivityOrCondition"></a>
+
 `CurrentQueueActivityOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -4266,6 +4570,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.zendesk_talk.types.CurrentQueueActivityEqCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.CurrentQueueActivityNeqCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.CurrentQueueActivityGtCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.CurrentQueueActivityGteCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.CurrentQueueActivityLtCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.CurrentQueueActivityLteCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.CurrentQueueActivityInCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.CurrentQueueActivityLikeCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.CurrentQueueActivityFuzzyCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.CurrentQueueActivityKeywordCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.CurrentQueueActivityContainsCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.CurrentQueueActivityNotCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.CurrentQueueActivityAndCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.CurrentQueueActivityOrCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.CurrentQueueActivityAnyCondition]`
     :   The type of the None singleton.
+
+<a id="CurrentQueueActivitySearchFilter"></a>
 
 `CurrentQueueActivitySearchFilter(*args, **kwargs)`
 :   Available fields for filtering current_queue_activity search queries.
@@ -4297,6 +4603,8 @@ Classes
     `longest_wait_time: int | None`
     :   Longest wait time for any caller (seconds)
 
+<a id="CurrentQueueActivitySearchQuery"></a>
+
 `CurrentQueueActivitySearchQuery(*args, **kwargs)`
 :   Search query for current_queue_activity entity.
 
@@ -4311,6 +4619,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.zendesk_talk.types.CurrentQueueActivitySortFilter]`
     :   The type of the None singleton.
+
+<a id="CurrentQueueActivitySortFilter"></a>
 
 `CurrentQueueActivitySortFilter(*args, **kwargs)`
 :   Available fields for sorting current_queue_activity search results.
@@ -4342,6 +4652,8 @@ Classes
     `longest_wait_time: Literal['asc', 'desc']`
     :   Longest wait time for any caller (seconds)
 
+<a id="CurrentQueueActivityStringFilter"></a>
+
 `CurrentQueueActivityStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -4372,6 +4684,8 @@ Classes
     `longest_wait_time: str`
     :   Longest wait time for any caller (seconds)
 
+<a id="GreetingCategoriesAndCondition"></a>
+
 `GreetingCategoriesAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -4391,6 +4705,8 @@ Classes
 
     `and: list[airbyte_agent_sdk.connectors.zendesk_talk.types.GreetingCategoriesEqCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.GreetingCategoriesNeqCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.GreetingCategoriesGtCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.GreetingCategoriesGteCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.GreetingCategoriesLtCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.GreetingCategoriesLteCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.GreetingCategoriesInCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.GreetingCategoriesLikeCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.GreetingCategoriesFuzzyCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.GreetingCategoriesKeywordCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.GreetingCategoriesContainsCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.GreetingCategoriesNotCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.GreetingCategoriesAndCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.GreetingCategoriesOrCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.GreetingCategoriesAnyCondition]`
     :   The type of the None singleton.
+
+<a id="GreetingCategoriesAnyCondition"></a>
 
 `GreetingCategoriesAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -4412,6 +4728,8 @@ Classes
     `any: airbyte_agent_sdk.connectors.zendesk_talk.types.GreetingCategoriesAnyValueFilter`
     :   The type of the None singleton.
 
+<a id="GreetingCategoriesAnyValueFilter"></a>
+
 `GreetingCategoriesAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
 
@@ -4427,6 +4745,8 @@ Classes
     `name: Any`
     :   Name of the greeting category
 
+<a id="GreetingCategoriesContainsCondition"></a>
+
 `GreetingCategoriesContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -4438,6 +4758,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.zendesk_talk.types.GreetingCategoriesAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="GreetingCategoriesEqCondition"></a>
 
 `GreetingCategoriesEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -4451,6 +4773,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.zendesk_talk.types.GreetingCategoriesSearchFilter`
     :   The type of the None singleton.
 
+<a id="GreetingCategoriesFuzzyCondition"></a>
+
 `GreetingCategoriesFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -4462,6 +4786,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.zendesk_talk.types.GreetingCategoriesStringFilter`
     :   The type of the None singleton.
+
+<a id="GreetingCategoriesGetParams"></a>
 
 `GreetingCategoriesGetParams(*args, **kwargs)`
 :   Parameters for greeting_categories.get operation
@@ -4475,6 +4801,8 @@ Classes
     `greeting_category_id: str`
     :   The type of the None singleton.
 
+<a id="GreetingCategoriesGtCondition"></a>
+
 `GreetingCategoriesGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -4487,6 +4815,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.zendesk_talk.types.GreetingCategoriesSearchFilter`
     :   The type of the None singleton.
 
+<a id="GreetingCategoriesGteCondition"></a>
+
 `GreetingCategoriesGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -4498,6 +4828,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.zendesk_talk.types.GreetingCategoriesSearchFilter`
     :   The type of the None singleton.
+
+<a id="GreetingCategoriesInCondition"></a>
 
 `GreetingCategoriesInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -4519,6 +4851,8 @@ Classes
     `in: airbyte_agent_sdk.connectors.zendesk_talk.types.GreetingCategoriesInFilter`
     :   The type of the None singleton.
 
+<a id="GreetingCategoriesInFilter"></a>
+
 `GreetingCategoriesInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
 
@@ -4534,6 +4868,8 @@ Classes
     `name: list[str]`
     :   Name of the greeting category
 
+<a id="GreetingCategoriesKeywordCondition"></a>
+
 `GreetingCategoriesKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -4545,6 +4881,8 @@ Classes
 
     `keyword: airbyte_agent_sdk.connectors.zendesk_talk.types.GreetingCategoriesStringFilter`
     :   The type of the None singleton.
+
+<a id="GreetingCategoriesLikeCondition"></a>
 
 `GreetingCategoriesLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
@@ -4558,12 +4896,16 @@ Classes
     `like: airbyte_agent_sdk.connectors.zendesk_talk.types.GreetingCategoriesStringFilter`
     :   The type of the None singleton.
 
+<a id="GreetingCategoriesListParams"></a>
+
 `GreetingCategoriesListParams(*args, **kwargs)`
 :   Parameters for greeting_categories.list operation
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="GreetingCategoriesLtCondition"></a>
 
 `GreetingCategoriesLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
@@ -4577,6 +4919,8 @@ Classes
     `lt: airbyte_agent_sdk.connectors.zendesk_talk.types.GreetingCategoriesSearchFilter`
     :   The type of the None singleton.
 
+<a id="GreetingCategoriesLteCondition"></a>
+
 `GreetingCategoriesLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
 
@@ -4589,6 +4933,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.zendesk_talk.types.GreetingCategoriesSearchFilter`
     :   The type of the None singleton.
 
+<a id="GreetingCategoriesNeqCondition"></a>
+
 `GreetingCategoriesNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -4600,6 +4946,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.zendesk_talk.types.GreetingCategoriesSearchFilter`
     :   The type of the None singleton.
+
+<a id="GreetingCategoriesNotCondition"></a>
 
 `GreetingCategoriesNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -4621,6 +4969,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.zendesk_talk.types.GreetingCategoriesEqCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.GreetingCategoriesNeqCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.GreetingCategoriesGtCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.GreetingCategoriesGteCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.GreetingCategoriesLtCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.GreetingCategoriesLteCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.GreetingCategoriesInCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.GreetingCategoriesLikeCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.GreetingCategoriesFuzzyCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.GreetingCategoriesKeywordCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.GreetingCategoriesContainsCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.GreetingCategoriesNotCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.GreetingCategoriesAndCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.GreetingCategoriesOrCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.GreetingCategoriesAnyCondition`
     :   The type of the None singleton.
 
+<a id="GreetingCategoriesOrCondition"></a>
+
 `GreetingCategoriesOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -4641,6 +4991,8 @@ Classes
     `or: list[airbyte_agent_sdk.connectors.zendesk_talk.types.GreetingCategoriesEqCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.GreetingCategoriesNeqCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.GreetingCategoriesGtCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.GreetingCategoriesGteCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.GreetingCategoriesLtCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.GreetingCategoriesLteCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.GreetingCategoriesInCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.GreetingCategoriesLikeCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.GreetingCategoriesFuzzyCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.GreetingCategoriesKeywordCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.GreetingCategoriesContainsCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.GreetingCategoriesNotCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.GreetingCategoriesAndCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.GreetingCategoriesOrCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.GreetingCategoriesAnyCondition]`
     :   The type of the None singleton.
 
+<a id="GreetingCategoriesSearchFilter"></a>
+
 `GreetingCategoriesSearchFilter(*args, **kwargs)`
 :   Available fields for filtering greeting_categories search queries.
 
@@ -4655,6 +5007,8 @@ Classes
 
     `name: str | None`
     :   Name of the greeting category
+
+<a id="GreetingCategoriesSearchQuery"></a>
 
 `GreetingCategoriesSearchQuery(*args, **kwargs)`
 :   Search query for greeting_categories entity.
@@ -4671,6 +5025,8 @@ Classes
     `sort: list[airbyte_agent_sdk.connectors.zendesk_talk.types.GreetingCategoriesSortFilter]`
     :   The type of the None singleton.
 
+<a id="GreetingCategoriesSortFilter"></a>
+
 `GreetingCategoriesSortFilter(*args, **kwargs)`
 :   Available fields for sorting greeting_categories search results.
 
@@ -4686,6 +5042,8 @@ Classes
     `name: Literal['asc', 'desc']`
     :   Name of the greeting category
 
+<a id="GreetingCategoriesStringFilter"></a>
+
 `GreetingCategoriesStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -4700,6 +5058,8 @@ Classes
 
     `name: str`
     :   Name of the greeting category
+
+<a id="GreetingsAndCondition"></a>
 
 `GreetingsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -4721,6 +5081,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.zendesk_talk.types.GreetingsEqCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.GreetingsNeqCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.GreetingsGtCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.GreetingsGteCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.GreetingsLtCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.GreetingsLteCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.GreetingsInCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.GreetingsLikeCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.GreetingsFuzzyCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.GreetingsKeywordCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.GreetingsContainsCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.GreetingsNotCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.GreetingsAndCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.GreetingsOrCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.GreetingsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="GreetingsAnyCondition"></a>
+
 `GreetingsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -4740,6 +5102,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.zendesk_talk.types.GreetingsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="GreetingsAnyValueFilter"></a>
 
 `GreetingsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -4789,6 +5153,8 @@ Classes
     `upload_id: Any`
     :   Upload ID associated with the greeting
 
+<a id="GreetingsContainsCondition"></a>
+
 `GreetingsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -4800,6 +5166,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.zendesk_talk.types.GreetingsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="GreetingsEqCondition"></a>
 
 `GreetingsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -4813,6 +5181,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.zendesk_talk.types.GreetingsSearchFilter`
     :   The type of the None singleton.
 
+<a id="GreetingsFuzzyCondition"></a>
+
 `GreetingsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -4824,6 +5194,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.zendesk_talk.types.GreetingsStringFilter`
     :   The type of the None singleton.
+
+<a id="GreetingsGetParams"></a>
 
 `GreetingsGetParams(*args, **kwargs)`
 :   Parameters for greetings.get operation
@@ -4837,6 +5209,8 @@ Classes
     `greeting_id: str`
     :   The type of the None singleton.
 
+<a id="GreetingsGtCondition"></a>
+
 `GreetingsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -4849,6 +5223,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.zendesk_talk.types.GreetingsSearchFilter`
     :   The type of the None singleton.
 
+<a id="GreetingsGteCondition"></a>
+
 `GreetingsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -4860,6 +5236,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.zendesk_talk.types.GreetingsSearchFilter`
     :   The type of the None singleton.
+
+<a id="GreetingsInCondition"></a>
 
 `GreetingsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -4880,6 +5258,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.zendesk_talk.types.GreetingsInFilter`
     :   The type of the None singleton.
+
+<a id="GreetingsInFilter"></a>
 
 `GreetingsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -4929,6 +5309,8 @@ Classes
     `upload_id: list[int]`
     :   Upload ID associated with the greeting
 
+<a id="GreetingsKeywordCondition"></a>
+
 `GreetingsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -4940,6 +5322,8 @@ Classes
 
     `keyword: airbyte_agent_sdk.connectors.zendesk_talk.types.GreetingsStringFilter`
     :   The type of the None singleton.
+
+<a id="GreetingsLikeCondition"></a>
 
 `GreetingsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
@@ -4953,12 +5337,16 @@ Classes
     `like: airbyte_agent_sdk.connectors.zendesk_talk.types.GreetingsStringFilter`
     :   The type of the None singleton.
 
+<a id="GreetingsListParams"></a>
+
 `GreetingsListParams(*args, **kwargs)`
 :   Parameters for greetings.list operation
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="GreetingsLtCondition"></a>
 
 `GreetingsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
@@ -4972,6 +5360,8 @@ Classes
     `lt: airbyte_agent_sdk.connectors.zendesk_talk.types.GreetingsSearchFilter`
     :   The type of the None singleton.
 
+<a id="GreetingsLteCondition"></a>
+
 `GreetingsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
 
@@ -4984,6 +5374,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.zendesk_talk.types.GreetingsSearchFilter`
     :   The type of the None singleton.
 
+<a id="GreetingsNeqCondition"></a>
+
 `GreetingsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -4995,6 +5387,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.zendesk_talk.types.GreetingsSearchFilter`
     :   The type of the None singleton.
+
+<a id="GreetingsNotCondition"></a>
 
 `GreetingsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -5016,6 +5410,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.zendesk_talk.types.GreetingsEqCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.GreetingsNeqCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.GreetingsGtCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.GreetingsGteCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.GreetingsLtCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.GreetingsLteCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.GreetingsInCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.GreetingsLikeCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.GreetingsFuzzyCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.GreetingsKeywordCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.GreetingsContainsCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.GreetingsNotCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.GreetingsAndCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.GreetingsOrCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.GreetingsAnyCondition`
     :   The type of the None singleton.
 
+<a id="GreetingsOrCondition"></a>
+
 `GreetingsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -5035,6 +5431,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.zendesk_talk.types.GreetingsEqCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.GreetingsNeqCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.GreetingsGtCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.GreetingsGteCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.GreetingsLtCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.GreetingsLteCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.GreetingsInCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.GreetingsLikeCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.GreetingsFuzzyCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.GreetingsKeywordCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.GreetingsContainsCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.GreetingsNotCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.GreetingsAndCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.GreetingsOrCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.GreetingsAnyCondition]`
     :   The type of the None singleton.
+
+<a id="GreetingsSearchFilter"></a>
 
 `GreetingsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering greetings search queries.
@@ -5084,6 +5482,8 @@ Classes
     `upload_id: int | None`
     :   Upload ID associated with the greeting
 
+<a id="GreetingsSearchQuery"></a>
+
 `GreetingsSearchQuery(*args, **kwargs)`
 :   Search query for greetings entity.
 
@@ -5098,6 +5498,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.zendesk_talk.types.GreetingsSortFilter]`
     :   The type of the None singleton.
+
+<a id="GreetingsSortFilter"></a>
 
 `GreetingsSortFilter(*args, **kwargs)`
 :   Available fields for sorting greetings search results.
@@ -5147,6 +5549,8 @@ Classes
     `upload_id: Literal['asc', 'desc']`
     :   Upload ID associated with the greeting
 
+<a id="GreetingsStringFilter"></a>
+
 `GreetingsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -5195,6 +5599,8 @@ Classes
     `upload_id: str`
     :   Upload ID associated with the greeting
 
+<a id="IvrsAndCondition"></a>
+
 `IvrsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -5215,6 +5621,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.zendesk_talk.types.IvrsEqCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.IvrsNeqCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.IvrsGtCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.IvrsGteCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.IvrsLtCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.IvrsLteCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.IvrsInCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.IvrsLikeCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.IvrsFuzzyCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.IvrsKeywordCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.IvrsContainsCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.IvrsNotCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.IvrsAndCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.IvrsOrCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.IvrsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="IvrsAnyCondition"></a>
+
 `IvrsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -5234,6 +5642,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.zendesk_talk.types.IvrsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="IvrsAnyValueFilter"></a>
 
 `IvrsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -5259,6 +5669,8 @@ Classes
     `phone_number_names: Any`
     :   Names of phone numbers configured with this IVR
 
+<a id="IvrsContainsCondition"></a>
+
 `IvrsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -5270,6 +5682,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.zendesk_talk.types.IvrsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="IvrsEqCondition"></a>
 
 `IvrsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -5283,6 +5697,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.zendesk_talk.types.IvrsSearchFilter`
     :   The type of the None singleton.
 
+<a id="IvrsFuzzyCondition"></a>
+
 `IvrsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -5294,6 +5710,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.zendesk_talk.types.IvrsStringFilter`
     :   The type of the None singleton.
+
+<a id="IvrsGetParams"></a>
 
 `IvrsGetParams(*args, **kwargs)`
 :   Parameters for ivrs.get operation
@@ -5307,6 +5725,8 @@ Classes
     `ivr_id: str`
     :   The type of the None singleton.
 
+<a id="IvrsGtCondition"></a>
+
 `IvrsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -5319,6 +5739,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.zendesk_talk.types.IvrsSearchFilter`
     :   The type of the None singleton.
 
+<a id="IvrsGteCondition"></a>
+
 `IvrsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -5330,6 +5752,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.zendesk_talk.types.IvrsSearchFilter`
     :   The type of the None singleton.
+
+<a id="IvrsInCondition"></a>
 
 `IvrsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -5350,6 +5774,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.zendesk_talk.types.IvrsInFilter`
     :   The type of the None singleton.
+
+<a id="IvrsInFilter"></a>
 
 `IvrsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -5375,6 +5801,8 @@ Classes
     `phone_number_names: list[list[typing.Any]]`
     :   Names of phone numbers configured with this IVR
 
+<a id="IvrsKeywordCondition"></a>
+
 `IvrsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -5386,6 +5814,8 @@ Classes
 
     `keyword: airbyte_agent_sdk.connectors.zendesk_talk.types.IvrsStringFilter`
     :   The type of the None singleton.
+
+<a id="IvrsLikeCondition"></a>
 
 `IvrsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
@@ -5399,12 +5829,16 @@ Classes
     `like: airbyte_agent_sdk.connectors.zendesk_talk.types.IvrsStringFilter`
     :   The type of the None singleton.
 
+<a id="IvrsListParams"></a>
+
 `IvrsListParams(*args, **kwargs)`
 :   Parameters for ivrs.list operation
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="IvrsLtCondition"></a>
 
 `IvrsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
@@ -5418,6 +5852,8 @@ Classes
     `lt: airbyte_agent_sdk.connectors.zendesk_talk.types.IvrsSearchFilter`
     :   The type of the None singleton.
 
+<a id="IvrsLteCondition"></a>
+
 `IvrsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
 
@@ -5430,6 +5866,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.zendesk_talk.types.IvrsSearchFilter`
     :   The type of the None singleton.
 
+<a id="IvrsNeqCondition"></a>
+
 `IvrsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -5441,6 +5879,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.zendesk_talk.types.IvrsSearchFilter`
     :   The type of the None singleton.
+
+<a id="IvrsNotCondition"></a>
 
 `IvrsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -5462,6 +5902,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.zendesk_talk.types.IvrsEqCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.IvrsNeqCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.IvrsGtCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.IvrsGteCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.IvrsLtCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.IvrsLteCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.IvrsInCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.IvrsLikeCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.IvrsFuzzyCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.IvrsKeywordCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.IvrsContainsCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.IvrsNotCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.IvrsAndCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.IvrsOrCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.IvrsAnyCondition`
     :   The type of the None singleton.
 
+<a id="IvrsOrCondition"></a>
+
 `IvrsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -5481,6 +5923,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.zendesk_talk.types.IvrsEqCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.IvrsNeqCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.IvrsGtCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.IvrsGteCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.IvrsLtCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.IvrsLteCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.IvrsInCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.IvrsLikeCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.IvrsFuzzyCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.IvrsKeywordCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.IvrsContainsCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.IvrsNotCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.IvrsAndCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.IvrsOrCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.IvrsAnyCondition]`
     :   The type of the None singleton.
+
+<a id="IvrsSearchFilter"></a>
 
 `IvrsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering ivrs search queries.
@@ -5506,6 +5950,8 @@ Classes
     `phone_number_names: list[typing.Any] | None`
     :   Names of phone numbers configured with this IVR
 
+<a id="IvrsSearchQuery"></a>
+
 `IvrsSearchQuery(*args, **kwargs)`
 :   Search query for ivrs entity.
 
@@ -5520,6 +5966,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.zendesk_talk.types.IvrsSortFilter]`
     :   The type of the None singleton.
+
+<a id="IvrsSortFilter"></a>
 
 `IvrsSortFilter(*args, **kwargs)`
 :   Available fields for sorting ivrs search results.
@@ -5545,6 +5993,8 @@ Classes
     `phone_number_names: Literal['asc', 'desc']`
     :   Names of phone numbers configured with this IVR
 
+<a id="IvrsStringFilter"></a>
+
 `IvrsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -5569,6 +6019,8 @@ Classes
     `phone_number_names: str`
     :   Names of phone numbers configured with this IVR
 
+<a id="PhoneNumbersAndCondition"></a>
+
 `PhoneNumbersAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -5589,6 +6041,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.zendesk_talk.types.PhoneNumbersEqCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.PhoneNumbersNeqCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.PhoneNumbersGtCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.PhoneNumbersGteCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.PhoneNumbersLtCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.PhoneNumbersLteCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.PhoneNumbersInCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.PhoneNumbersLikeCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.PhoneNumbersFuzzyCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.PhoneNumbersKeywordCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.PhoneNumbersContainsCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.PhoneNumbersNotCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.PhoneNumbersAndCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.PhoneNumbersOrCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.PhoneNumbersAnyCondition]`
     :   The type of the None singleton.
 
+<a id="PhoneNumbersAnyCondition"></a>
+
 `PhoneNumbersAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -5608,6 +6062,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.zendesk_talk.types.PhoneNumbersAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="PhoneNumbersAnyValueFilter"></a>
 
 `PhoneNumbersAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -5708,6 +6164,8 @@ Classes
     `voice_enabled: Any`
     :   Whether voice is enabled
 
+<a id="PhoneNumbersContainsCondition"></a>
+
 `PhoneNumbersContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -5719,6 +6177,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.zendesk_talk.types.PhoneNumbersAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="PhoneNumbersEqCondition"></a>
 
 `PhoneNumbersEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -5732,6 +6192,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.zendesk_talk.types.PhoneNumbersSearchFilter`
     :   The type of the None singleton.
 
+<a id="PhoneNumbersFuzzyCondition"></a>
+
 `PhoneNumbersFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -5743,6 +6205,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.zendesk_talk.types.PhoneNumbersStringFilter`
     :   The type of the None singleton.
+
+<a id="PhoneNumbersGetParams"></a>
 
 `PhoneNumbersGetParams(*args, **kwargs)`
 :   Parameters for phone_numbers.get operation
@@ -5756,6 +6220,8 @@ Classes
     `phone_number_id: str`
     :   The type of the None singleton.
 
+<a id="PhoneNumbersGtCondition"></a>
+
 `PhoneNumbersGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -5768,6 +6234,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.zendesk_talk.types.PhoneNumbersSearchFilter`
     :   The type of the None singleton.
 
+<a id="PhoneNumbersGteCondition"></a>
+
 `PhoneNumbersGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -5779,6 +6247,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.zendesk_talk.types.PhoneNumbersSearchFilter`
     :   The type of the None singleton.
+
+<a id="PhoneNumbersInCondition"></a>
 
 `PhoneNumbersInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -5799,6 +6269,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.zendesk_talk.types.PhoneNumbersInFilter`
     :   The type of the None singleton.
+
+<a id="PhoneNumbersInFilter"></a>
 
 `PhoneNumbersInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -5899,6 +6371,8 @@ Classes
     `voice_enabled: list[bool]`
     :   Whether voice is enabled
 
+<a id="PhoneNumbersKeywordCondition"></a>
+
 `PhoneNumbersKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -5910,6 +6384,8 @@ Classes
 
     `keyword: airbyte_agent_sdk.connectors.zendesk_talk.types.PhoneNumbersStringFilter`
     :   The type of the None singleton.
+
+<a id="PhoneNumbersLikeCondition"></a>
 
 `PhoneNumbersLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
@@ -5923,12 +6399,16 @@ Classes
     `like: airbyte_agent_sdk.connectors.zendesk_talk.types.PhoneNumbersStringFilter`
     :   The type of the None singleton.
 
+<a id="PhoneNumbersListParams"></a>
+
 `PhoneNumbersListParams(*args, **kwargs)`
 :   Parameters for phone_numbers.list operation
 
     ### Ancestors (in MRO)
 
     * builtins.dict
+
+<a id="PhoneNumbersLtCondition"></a>
 
 `PhoneNumbersLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
@@ -5942,6 +6422,8 @@ Classes
     `lt: airbyte_agent_sdk.connectors.zendesk_talk.types.PhoneNumbersSearchFilter`
     :   The type of the None singleton.
 
+<a id="PhoneNumbersLteCondition"></a>
+
 `PhoneNumbersLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
 
@@ -5954,6 +6436,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.zendesk_talk.types.PhoneNumbersSearchFilter`
     :   The type of the None singleton.
 
+<a id="PhoneNumbersNeqCondition"></a>
+
 `PhoneNumbersNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -5965,6 +6449,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.zendesk_talk.types.PhoneNumbersSearchFilter`
     :   The type of the None singleton.
+
+<a id="PhoneNumbersNotCondition"></a>
 
 `PhoneNumbersNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -5986,6 +6472,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.zendesk_talk.types.PhoneNumbersEqCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.PhoneNumbersNeqCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.PhoneNumbersGtCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.PhoneNumbersGteCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.PhoneNumbersLtCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.PhoneNumbersLteCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.PhoneNumbersInCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.PhoneNumbersLikeCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.PhoneNumbersFuzzyCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.PhoneNumbersKeywordCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.PhoneNumbersContainsCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.PhoneNumbersNotCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.PhoneNumbersAndCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.PhoneNumbersOrCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.PhoneNumbersAnyCondition`
     :   The type of the None singleton.
 
+<a id="PhoneNumbersOrCondition"></a>
+
 `PhoneNumbersOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -6005,6 +6493,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.zendesk_talk.types.PhoneNumbersEqCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.PhoneNumbersNeqCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.PhoneNumbersGtCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.PhoneNumbersGteCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.PhoneNumbersLtCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.PhoneNumbersLteCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.PhoneNumbersInCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.PhoneNumbersLikeCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.PhoneNumbersFuzzyCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.PhoneNumbersKeywordCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.PhoneNumbersContainsCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.PhoneNumbersNotCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.PhoneNumbersAndCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.PhoneNumbersOrCondition | airbyte_agent_sdk.connectors.zendesk_talk.types.PhoneNumbersAnyCondition]`
     :   The type of the None singleton.
+
+<a id="PhoneNumbersSearchFilter"></a>
 
 `PhoneNumbersSearchFilter(*args, **kwargs)`
 :   Available fields for filtering phone_numbers search queries.
@@ -6105,6 +6595,8 @@ Classes
     `voice_enabled: bool | None`
     :   Whether voice is enabled
 
+<a id="PhoneNumbersSearchQuery"></a>
+
 `PhoneNumbersSearchQuery(*args, **kwargs)`
 :   Search query for phone_numbers entity.
 
@@ -6119,6 +6611,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.zendesk_talk.types.PhoneNumbersSortFilter]`
     :   The type of the None singleton.
+
+<a id="PhoneNumbersSortFilter"></a>
 
 `PhoneNumbersSortFilter(*args, **kwargs)`
 :   Available fields for sorting phone_numbers search results.
@@ -6218,6 +6712,8 @@ Classes
 
     `voice_enabled: Literal['asc', 'desc']`
     :   Whether voice is enabled
+
+<a id="PhoneNumbersStringFilter"></a>
 
 `PhoneNumbersStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/zoho_crm/connector.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/zoho_crm/connector.md
@@ -10,6 +10,8 @@ Zoho-Crm connector.
 Classes
 -------
 
+<a id="AccountsQuery"></a>
+
 `AccountsQuery(connector: ZohoCrmConnector)`
 :   Query class for Accounts entity operations.
     
@@ -80,6 +82,8 @@ Classes
         Returns:
             AccountsListResult
 
+<a id="CallsQuery"></a>
+
 `CallsQuery(connector: ZohoCrmConnector)`
 :   Query class for Calls entity operations.
     
@@ -145,6 +149,8 @@ Classes
         
         Returns:
             CallsListResult
+
+<a id="CampaignsQuery"></a>
 
 `CampaignsQuery(connector: ZohoCrmConnector)`
 :   Query class for Campaigns entity operations.
@@ -212,6 +218,8 @@ Classes
         
         Returns:
             CampaignsListResult
+
+<a id="ContactsQuery"></a>
 
 `ContactsQuery(connector: ZohoCrmConnector)`
 :   Query class for Contacts entity operations.
@@ -283,6 +291,8 @@ Classes
         Returns:
             ContactsListResult
 
+<a id="DealsQuery"></a>
+
 `DealsQuery(connector: ZohoCrmConnector)`
 :   Query class for Deals entity operations.
     
@@ -348,6 +358,8 @@ Classes
         Returns:
             DealsListResult
 
+<a id="EventsQuery"></a>
+
 `EventsQuery(connector: ZohoCrmConnector)`
 :   Query class for Events entity operations.
     
@@ -409,6 +421,8 @@ Classes
         
         Returns:
             EventsListResult
+
+<a id="InvoicesQuery"></a>
 
 `InvoicesQuery(connector: ZohoCrmConnector)`
 :   Query class for Invoices entity operations.
@@ -479,6 +493,8 @@ Classes
         
         Returns:
             InvoicesListResult
+
+<a id="LeadsQuery"></a>
 
 `LeadsQuery(connector: ZohoCrmConnector)`
 :   Query class for Leads entity operations.
@@ -555,6 +571,8 @@ Classes
         Returns:
             LeadsListResult
 
+<a id="ProductsQuery"></a>
+
 `ProductsQuery(connector: ZohoCrmConnector)`
 :   Query class for Products entity operations.
     
@@ -624,6 +642,8 @@ Classes
         Returns:
             ProductsListResult
 
+<a id="QuotesQuery"></a>
+
 `QuotesQuery(connector: ZohoCrmConnector)`
 :   Query class for Quotes entity operations.
     
@@ -691,6 +711,8 @@ Classes
         Returns:
             QuotesListResult
 
+<a id="TasksQuery"></a>
+
 `TasksQuery(connector: ZohoCrmConnector)`
 :   Query class for Tasks entity operations.
     
@@ -753,6 +775,8 @@ Classes
         
         Returns:
             TasksListResult
+
+<a id="ZohoCrmConnector"></a>
 
 `ZohoCrmConnector(auth_config: ZohoCrmAuthConfig | AirbyteAuthConfig | BaseModel | None = None, on_token_refresh: Any | None = None, dc_region: str | None = None)`
 :   Type-safe Zoho-Crm API connector.

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/zoho_crm/index.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/zoho_crm/index.md
@@ -19,6 +19,8 @@ Sub-modules
 Classes
 -------
 
+<a id="AccountsSearchData"></a>
+
 `AccountsSearchData(**data: Any)`
 :   Search result data for accounts entity.
     
@@ -89,6 +91,8 @@ Classes
     `website: str | None`
     :   Account website URL
 
+<a id="AirbyteAuthConfig"></a>
+
 `AirbyteAuthConfig(**data: Any)`
 :   Authentication configuration for Airbyte hosted mode execution.
     
@@ -157,6 +161,8 @@ Classes
     `workspace_name: str | None`
     :   The type of the None singleton.
 
+<a id="AirbyteSearchMeta"></a>
+
 `AirbyteSearchMeta(**data: Any)`
 :   Pagination metadata for search responses.
     
@@ -184,6 +190,8 @@ Classes
 
     `took_ms: int | None`
     :   Time taken to execute the search in milliseconds.
+
+<a id="AirbyteSearchResult"></a>
 
 `AirbyteSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -225,6 +233,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="AccountsSearchResult"></a>
+
 `AccountsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -240,6 +250,8 @@ Classes
     * airbyte_agent_sdk.connectors.zoho_crm.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="CallsSearchResult"></a>
 
 `CallsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -257,6 +269,8 @@ Classes
     * pydantic.main.BaseModel
     * typing.Generic
 
+<a id="CampaignsSearchResult"></a>
+
 `CampaignsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -272,6 +286,8 @@ Classes
     * airbyte_agent_sdk.connectors.zoho_crm.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="ContactsSearchResult"></a>
 
 `ContactsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -289,6 +305,8 @@ Classes
     * pydantic.main.BaseModel
     * typing.Generic
 
+<a id="DealsSearchResult"></a>
+
 `DealsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -304,6 +322,8 @@ Classes
     * airbyte_agent_sdk.connectors.zoho_crm.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="EventsSearchResult"></a>
 
 `EventsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -321,6 +341,8 @@ Classes
     * pydantic.main.BaseModel
     * typing.Generic
 
+<a id="InvoicesSearchResult"></a>
+
 `InvoicesSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -336,6 +358,8 @@ Classes
     * airbyte_agent_sdk.connectors.zoho_crm.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="LeadsSearchResult"></a>
 
 `LeadsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -353,6 +377,8 @@ Classes
     * pydantic.main.BaseModel
     * typing.Generic
 
+<a id="ProductsSearchResult"></a>
+
 `ProductsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -368,6 +394,8 @@ Classes
     * airbyte_agent_sdk.connectors.zoho_crm.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="QuotesSearchResult"></a>
 
 `QuotesSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -385,6 +413,8 @@ Classes
     * pydantic.main.BaseModel
     * typing.Generic
 
+<a id="TasksSearchResult"></a>
+
 `TasksSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -400,6 +430,8 @@ Classes
     * airbyte_agent_sdk.connectors.zoho_crm.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="CallsSearchData"></a>
 
 `CallsSearchData(**data: Any)`
 :   Search result data for calls entity.
@@ -458,6 +490,8 @@ Classes
 
     `subject: str | None`
     :   Subject of the call
+
+<a id="CampaignsSearchData"></a>
 
 `CampaignsSearchData(**data: Any)`
 :   Search result data for campaigns entity.
@@ -519,6 +553,8 @@ Classes
 
     `type_: str | None`
     :   Type of campaign (e.g., Email, Webinar, Conference)
+
+<a id="ContactsSearchData"></a>
 
 `ContactsSearchData(**data: Any)`
 :   Search result data for contacts entity.
@@ -590,6 +626,8 @@ Classes
     `title: str | None`
     :   Contact's job title
 
+<a id="DealsSearchData"></a>
+
 `DealsSearchData(**data: Any)`
 :   Search result data for deals entity.
     
@@ -645,6 +683,8 @@ Classes
     `type_: str | None`
     :   Type of deal (e.g., New Business, Existing Business)
 
+<a id="EventsSearchData"></a>
+
 `EventsSearchData(**data: Any)`
 :   Search result data for events entity.
     
@@ -690,6 +730,8 @@ Classes
 
     `start_date_time: str | None`
     :   Event start date and time
+
+<a id="InvoicesSearchData"></a>
 
 `InvoicesSearchData(**data: Any)`
 :   Search result data for invoices entity.
@@ -760,6 +802,8 @@ Classes
 
     `terms_and_conditions: str | None`
     :   Terms and conditions text
+
+<a id="LeadsSearchData"></a>
 
 `LeadsSearchData(**data: Any)`
 :   Search result data for leads entity.
@@ -846,6 +890,8 @@ Classes
     `website: str | None`
     :   Lead's website URL
 
+<a id="ProductsSearchData"></a>
+
 `ProductsSearchData(**data: Any)`
 :   Search result data for products entity.
     
@@ -913,6 +959,8 @@ Classes
     `unit_price: float | None`
     :   Unit price of the product
 
+<a id="QuotesSearchData"></a>
+
 `QuotesSearchData(**data: Any)`
 :   Search result data for quotes entity.
     
@@ -974,6 +1022,8 @@ Classes
     `valid_till: str | None`
     :   Date until which the quote is valid
 
+<a id="TasksSearchData"></a>
+
 `TasksSearchData(**data: Any)`
 :   Search result data for tasks entity.
     
@@ -1023,6 +1073,8 @@ Classes
     `subject: str | None`
     :   Subject or title of the task
 
+<a id="ZohoCrmAuthConfig"></a>
+
 `ZohoCrmAuthConfig(**data: Any)`
 :   Zoho CRM OAuth 2.0
     
@@ -1050,6 +1102,8 @@ Classes
 
     `refresh_token: str`
     :   OAuth 2.0 Refresh Token (does not expire)
+
+<a id="ZohoCrmConnector"></a>
 
 `ZohoCrmConnector(auth_config: ZohoCrmAuthConfig | AirbyteAuthConfig | BaseModel | None = None, on_token_refresh: Any | None = None, dc_region: str | None = None)`
 :   Type-safe Zoho-Crm API connector.

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/zoho_crm/models.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/zoho_crm/models.md
@@ -13,6 +13,8 @@ and response envelope types.
 Classes
 -------
 
+<a id="Account"></a>
+
 `Account(**data: Any)`
 :   Zoho CRM account (company) object
     
@@ -128,6 +130,8 @@ Classes
     `website: str | Any | None`
     :   The type of the None singleton.
 
+<a id="AccountsList"></a>
+
 `AccountsList(**data: Any)`
 :   Paginated list of accounts
     
@@ -153,6 +157,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="AccountsListResultMeta"></a>
+
 `AccountsListResultMeta(**data: Any)`
 :   Metadata for accounts.Action.LIST operation
     
@@ -177,6 +183,8 @@ Classes
 
     `page: int | Any`
     :   The type of the None singleton.
+
+<a id="AccountsSearchData"></a>
 
 `AccountsSearchData(**data: Any)`
 :   Search result data for accounts entity.
@@ -248,6 +256,8 @@ Classes
     `website: str | None`
     :   Account website URL
 
+<a id="AirbyteSearchMeta"></a>
+
 `AirbyteSearchMeta(**data: Any)`
 :   Pagination metadata for search responses.
     
@@ -275,6 +285,8 @@ Classes
 
     `took_ms: int | None`
     :   Time taken to execute the search in milliseconds.
+
+<a id="AirbyteSearchResult"></a>
 
 `AirbyteSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -337,6 +349,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="AccountsSearchResult"></a>
+
 `AccountsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -373,6 +387,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="CallsSearchResult"></a>
 
 `CallsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -411,6 +427,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="CampaignsSearchResult"></a>
+
 `CampaignsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -447,6 +465,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="ContactsSearchResult"></a>
 
 `ContactsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -485,6 +505,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="DealsSearchResult"></a>
+
 `DealsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -521,6 +543,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="EventsSearchResult"></a>
 
 `EventsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -559,6 +583,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="InvoicesSearchResult"></a>
+
 `InvoicesSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -595,6 +621,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="LeadsSearchResult"></a>
 
 `LeadsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -633,6 +661,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="ProductsSearchResult"></a>
+
 `ProductsSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -669,6 +699,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="QuotesSearchResult"></a>
 
 `QuotesSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
@@ -707,6 +739,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="TasksSearchResult"></a>
+
 `TasksSearchResult(**data: Any)`
 :   Result from Airbyte cache search operations with typed records.
     
@@ -722,6 +756,8 @@ Classes
     * airbyte_agent_sdk.connectors.zoho_crm.models.AirbyteSearchResult
     * pydantic.main.BaseModel
     * typing.Generic
+
+<a id="Call"></a>
 
 `Call(**data: Any)`
 :   Zoho CRM call object
@@ -799,6 +835,8 @@ Classes
     `who_id: Any`
     :   The type of the None singleton.
 
+<a id="CallsList"></a>
+
 `CallsList(**data: Any)`
 :   Paginated list of calls
     
@@ -824,6 +862,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="CallsListResultMeta"></a>
+
 `CallsListResultMeta(**data: Any)`
 :   Metadata for calls.Action.LIST operation
     
@@ -848,6 +888,8 @@ Classes
 
     `page: int | Any`
     :   The type of the None singleton.
+
+<a id="CallsSearchData"></a>
 
 `CallsSearchData(**data: Any)`
 :   Search result data for calls entity.
@@ -906,6 +948,8 @@ Classes
 
     `subject: str | None`
     :   Subject of the call
+
+<a id="Campaign"></a>
 
 `Campaign(**data: Any)`
 :   Zoho CRM campaign object
@@ -980,6 +1024,8 @@ Classes
     `type_: str | Any | None`
     :   The type of the None singleton.
 
+<a id="CampaignsList"></a>
+
 `CampaignsList(**data: Any)`
 :   Paginated list of campaigns
     
@@ -1005,6 +1051,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="CampaignsListResultMeta"></a>
+
 `CampaignsListResultMeta(**data: Any)`
 :   Metadata for campaigns.Action.LIST operation
     
@@ -1029,6 +1077,8 @@ Classes
 
     `page: int | Any`
     :   The type of the None singleton.
+
+<a id="CampaignsSearchData"></a>
 
 `CampaignsSearchData(**data: Any)`
 :   Search result data for campaigns entity.
@@ -1090,6 +1140,8 @@ Classes
 
     `type_: str | None`
     :   Type of campaign (e.g., Email, Webinar, Conference)
+
+<a id="Contact"></a>
 
 `Contact(**data: Any)`
 :   Zoho CRM contact object
@@ -1200,6 +1252,8 @@ Classes
     `title: str | Any | None`
     :   The type of the None singleton.
 
+<a id="ContactsList"></a>
+
 `ContactsList(**data: Any)`
 :   Paginated list of contacts
     
@@ -1225,6 +1279,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="ContactsListResultMeta"></a>
+
 `ContactsListResultMeta(**data: Any)`
 :   Metadata for contacts.Action.LIST operation
     
@@ -1249,6 +1305,8 @@ Classes
 
     `page: int | Any`
     :   The type of the None singleton.
+
+<a id="ContactsSearchData"></a>
 
 `ContactsSearchData(**data: Any)`
 :   Search result data for contacts entity.
@@ -1320,6 +1378,8 @@ Classes
     `title: str | None`
     :   Contact's job title
 
+<a id="CreatedBy"></a>
+
 `CreatedBy(**data: Any)`
 :   User who created the record
     
@@ -1347,6 +1407,8 @@ Classes
 
     `name: str | Any`
     :   The type of the None singleton.
+
+<a id="Deal"></a>
 
 `Deal(**data: Any)`
 :   Zoho CRM deal (opportunity) object
@@ -1427,6 +1489,8 @@ Classes
     `type_: str | Any | None`
     :   The type of the None singleton.
 
+<a id="DealPipeline"></a>
+
 `DealPipeline(**data: Any)`
 :   Sales pipeline reference
     
@@ -1451,6 +1515,8 @@ Classes
 
     `name: str | Any`
     :   The type of the None singleton.
+
+<a id="DealsList"></a>
 
 `DealsList(**data: Any)`
 :   Paginated list of deals
@@ -1477,6 +1543,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="DealsListResultMeta"></a>
+
 `DealsListResultMeta(**data: Any)`
 :   Metadata for deals.Action.LIST operation
     
@@ -1501,6 +1569,8 @@ Classes
 
     `page: int | Any`
     :   The type of the None singleton.
+
+<a id="DealsSearchData"></a>
 
 `DealsSearchData(**data: Any)`
 :   Search result data for deals entity.
@@ -1556,6 +1626,8 @@ Classes
 
     `type_: str | None`
     :   Type of deal (e.g., New Business, Existing Business)
+
+<a id="Event"></a>
 
 `Event(**data: Any)`
 :   Zoho CRM event (meeting/calendar) object
@@ -1630,6 +1702,8 @@ Classes
     `who_id: Any`
     :   The type of the None singleton.
 
+<a id="EventParticipantsItem"></a>
+
 `EventParticipantsItem(**data: Any)`
 :   Nested schema for Event.Participants_item
     
@@ -1667,6 +1741,8 @@ Classes
     `type_: str | Any`
     :   The type of the None singleton.
 
+<a id="EventsList"></a>
+
 `EventsList(**data: Any)`
 :   Paginated list of events
     
@@ -1692,6 +1768,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="EventsListResultMeta"></a>
+
 `EventsListResultMeta(**data: Any)`
 :   Metadata for events.Action.LIST operation
     
@@ -1716,6 +1794,8 @@ Classes
 
     `page: int | Any`
     :   The type of the None singleton.
+
+<a id="EventsSearchData"></a>
 
 `EventsSearchData(**data: Any)`
 :   Search result data for events entity.
@@ -1762,6 +1842,8 @@ Classes
 
     `start_date_time: str | None`
     :   Event start date and time
+
+<a id="Invoice"></a>
 
 `Invoice(**data: Any)`
 :   Zoho CRM invoice object
@@ -1887,6 +1969,8 @@ Classes
     `terms_and_conditions: str | Any | None`
     :   The type of the None singleton.
 
+<a id="InvoicesList"></a>
+
 `InvoicesList(**data: Any)`
 :   Paginated list of invoices
     
@@ -1912,6 +1996,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="InvoicesListResultMeta"></a>
+
 `InvoicesListResultMeta(**data: Any)`
 :   Metadata for invoices.Action.LIST operation
     
@@ -1936,6 +2022,8 @@ Classes
 
     `page: int | Any`
     :   The type of the None singleton.
+
+<a id="InvoicesSearchData"></a>
 
 `InvoicesSearchData(**data: Any)`
 :   Search result data for invoices entity.
@@ -2006,6 +2094,8 @@ Classes
 
     `terms_and_conditions: str | None`
     :   Terms and conditions text
+
+<a id="Lead"></a>
 
 `Lead(**data: Any)`
 :   Zoho CRM lead object
@@ -2116,6 +2206,8 @@ Classes
     `zip_code: str | Any | None`
     :   The type of the None singleton.
 
+<a id="LeadsList"></a>
+
 `LeadsList(**data: Any)`
 :   Paginated list of leads
     
@@ -2141,6 +2233,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="LeadsListResultMeta"></a>
+
 `LeadsListResultMeta(**data: Any)`
 :   Metadata for leads.Action.LIST operation
     
@@ -2165,6 +2259,8 @@ Classes
 
     `page: int | Any`
     :   The type of the None singleton.
+
+<a id="LeadsSearchData"></a>
 
 `LeadsSearchData(**data: Any)`
 :   Search result data for leads entity.
@@ -2251,6 +2347,8 @@ Classes
     `website: str | None`
     :   Lead's website URL
 
+<a id="LookupRef"></a>
+
 `LookupRef(**data: Any)`
 :   Lookup reference to another record
     
@@ -2275,6 +2373,8 @@ Classes
 
     `name: str | Any`
     :   The type of the None singleton.
+
+<a id="ModifiedBy"></a>
 
 `ModifiedBy(**data: Any)`
 :   User who last modified the record
@@ -2304,6 +2404,8 @@ Classes
     `name: str | Any`
     :   The type of the None singleton.
 
+<a id="Owner"></a>
+
 `Owner(**data: Any)`
 :   Record owner reference
     
@@ -2331,6 +2433,8 @@ Classes
 
     `name: str | Any`
     :   The type of the None singleton.
+
+<a id="PaginationInfo"></a>
 
 `PaginationInfo(**data: Any)`
 :   Pagination metadata
@@ -2368,6 +2472,8 @@ Classes
 
     `sort_order: str | Any`
     :   The type of the None singleton.
+
+<a id="Product"></a>
 
 `Product(**data: Any)`
 :   Zoho CRM product object
@@ -2466,6 +2572,8 @@ Classes
     `vendor_name: Any`
     :   The type of the None singleton.
 
+<a id="ProductsList"></a>
+
 `ProductsList(**data: Any)`
 :   Paginated list of products
     
@@ -2491,6 +2599,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="ProductsListResultMeta"></a>
+
 `ProductsListResultMeta(**data: Any)`
 :   Metadata for products.Action.LIST operation
     
@@ -2515,6 +2625,8 @@ Classes
 
     `page: int | Any`
     :   The type of the None singleton.
+
+<a id="ProductsSearchData"></a>
 
 `ProductsSearchData(**data: Any)`
 :   Search result data for products entity.
@@ -2582,6 +2694,8 @@ Classes
 
     `unit_price: float | None`
     :   Unit price of the product
+
+<a id="Quote"></a>
 
 `Quote(**data: Any)`
 :   Zoho CRM quote object
@@ -2695,6 +2809,8 @@ Classes
     `valid_till: str | Any | None`
     :   The type of the None singleton.
 
+<a id="QuotesList"></a>
+
 `QuotesList(**data: Any)`
 :   Paginated list of quotes
     
@@ -2720,6 +2836,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="QuotesListResultMeta"></a>
+
 `QuotesListResultMeta(**data: Any)`
 :   Metadata for quotes.Action.LIST operation
     
@@ -2744,6 +2862,8 @@ Classes
 
     `page: int | Any`
     :   The type of the None singleton.
+
+<a id="QuotesSearchData"></a>
 
 `QuotesSearchData(**data: Any)`
 :   Search result data for quotes entity.
@@ -2805,6 +2925,8 @@ Classes
 
     `valid_till: str | None`
     :   Date until which the quote is valid
+
+<a id="Task"></a>
 
 `Task(**data: Any)`
 :   Zoho CRM task object
@@ -2879,6 +3001,8 @@ Classes
     `who_id: Any`
     :   The type of the None singleton.
 
+<a id="TasksList"></a>
+
 `TasksList(**data: Any)`
 :   Paginated list of tasks
     
@@ -2904,6 +3028,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="TasksListResultMeta"></a>
+
 `TasksListResultMeta(**data: Any)`
 :   Metadata for tasks.Action.LIST operation
     
@@ -2928,6 +3054,8 @@ Classes
 
     `page: int | Any`
     :   The type of the None singleton.
+
+<a id="TasksSearchData"></a>
 
 `TasksSearchData(**data: Any)`
 :   Search result data for tasks entity.
@@ -2978,6 +3106,8 @@ Classes
     `subject: str | None`
     :   Subject or title of the task
 
+<a id="ZohoCrmAuthConfig"></a>
+
 `ZohoCrmAuthConfig(**data: Any)`
 :   Zoho CRM OAuth 2.0
     
@@ -3005,6 +3135,8 @@ Classes
 
     `refresh_token: str`
     :   OAuth 2.0 Refresh Token (does not expire)
+
+<a id="ZohoCrmCheckResult"></a>
 
 `ZohoCrmCheckResult(**data: Any)`
 :   Result of a health check operation.
@@ -3039,6 +3171,8 @@ Classes
     `status: str`
     :   Health check status: 'healthy' or 'unhealthy'.
 
+<a id="ZohoCrmExecuteResult"></a>
+
 `ZohoCrmExecuteResult(**data: Any)`
 :   Response envelope with data only.
     
@@ -3067,6 +3201,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="ZohoCrmExecuteResultWithMeta"></a>
 
 `ZohoCrmExecuteResultWithMeta(**data: Any)`
 :   Response envelope with data and metadata.
@@ -3129,6 +3265,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="AccountsListResult"></a>
+
 `AccountsListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -3171,6 +3309,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="CallsListResult"></a>
 
 `CallsListResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -3215,6 +3355,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="CampaignsListResult"></a>
+
 `CampaignsListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -3257,6 +3399,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="ContactsListResult"></a>
 
 `ContactsListResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -3301,6 +3445,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="DealsListResult"></a>
+
 `DealsListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -3343,6 +3489,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="EventsListResult"></a>
 
 `EventsListResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -3387,6 +3535,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="InvoicesListResult"></a>
+
 `InvoicesListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -3429,6 +3579,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="LeadsListResult"></a>
 
 `LeadsListResult(**data: Any)`
 :   Response envelope with data and metadata.
@@ -3473,6 +3625,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="ProductsListResult"></a>
+
 `ProductsListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -3516,6 +3670,8 @@ Classes
     `model_config`
     :   The type of the None singleton.
 
+<a id="QuotesListResult"></a>
+
 `QuotesListResult(**data: Any)`
 :   Response envelope with data and metadata.
     
@@ -3558,6 +3714,8 @@ Classes
 
     `model_config`
     :   The type of the None singleton.
+
+<a id="TasksListResult"></a>
 
 `TasksListResult(**data: Any)`
 :   Response envelope with data and metadata.

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/zoho_crm/types.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/zoho_crm/types.md
@@ -10,6 +10,8 @@ Type definitions for zoho-crm connector.
 Classes
 -------
 
+<a id="AccountsAndCondition"></a>
+
 `AccountsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -30,6 +32,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.zoho_crm.types.AccountsEqCondition | airbyte_agent_sdk.connectors.zoho_crm.types.AccountsNeqCondition | airbyte_agent_sdk.connectors.zoho_crm.types.AccountsGtCondition | airbyte_agent_sdk.connectors.zoho_crm.types.AccountsGteCondition | airbyte_agent_sdk.connectors.zoho_crm.types.AccountsLtCondition | airbyte_agent_sdk.connectors.zoho_crm.types.AccountsLteCondition | airbyte_agent_sdk.connectors.zoho_crm.types.AccountsInCondition | airbyte_agent_sdk.connectors.zoho_crm.types.AccountsLikeCondition | airbyte_agent_sdk.connectors.zoho_crm.types.AccountsFuzzyCondition | airbyte_agent_sdk.connectors.zoho_crm.types.AccountsKeywordCondition | airbyte_agent_sdk.connectors.zoho_crm.types.AccountsContainsCondition | airbyte_agent_sdk.connectors.zoho_crm.types.AccountsNotCondition | airbyte_agent_sdk.connectors.zoho_crm.types.AccountsAndCondition | airbyte_agent_sdk.connectors.zoho_crm.types.AccountsOrCondition | airbyte_agent_sdk.connectors.zoho_crm.types.AccountsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="AccountsAnyCondition"></a>
+
 `AccountsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -49,6 +53,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.zoho_crm.types.AccountsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="AccountsAnyValueFilter"></a>
 
 `AccountsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -110,6 +116,8 @@ Classes
     `website: Any`
     :   Account website URL
 
+<a id="AccountsContainsCondition"></a>
+
 `AccountsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -121,6 +129,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.zoho_crm.types.AccountsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="AccountsEqCondition"></a>
 
 `AccountsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -134,6 +144,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.zoho_crm.types.AccountsSearchFilter`
     :   The type of the None singleton.
 
+<a id="AccountsFuzzyCondition"></a>
+
 `AccountsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -145,6 +157,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.zoho_crm.types.AccountsStringFilter`
     :   The type of the None singleton.
+
+<a id="AccountsGetParams"></a>
 
 `AccountsGetParams(*args, **kwargs)`
 :   Parameters for accounts.get operation
@@ -158,6 +172,8 @@ Classes
     `id: str`
     :   The type of the None singleton.
 
+<a id="AccountsGtCondition"></a>
+
 `AccountsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -170,6 +186,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.zoho_crm.types.AccountsSearchFilter`
     :   The type of the None singleton.
 
+<a id="AccountsGteCondition"></a>
+
 `AccountsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -181,6 +199,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.zoho_crm.types.AccountsSearchFilter`
     :   The type of the None singleton.
+
+<a id="AccountsInCondition"></a>
 
 `AccountsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -201,6 +221,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.zoho_crm.types.AccountsInFilter`
     :   The type of the None singleton.
+
+<a id="AccountsInFilter"></a>
 
 `AccountsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -262,6 +284,8 @@ Classes
     `website: list[str]`
     :   Account website URL
 
+<a id="AccountsKeywordCondition"></a>
+
 `AccountsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -274,6 +298,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.zoho_crm.types.AccountsStringFilter`
     :   The type of the None singleton.
 
+<a id="AccountsLikeCondition"></a>
+
 `AccountsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -285,6 +311,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.zoho_crm.types.AccountsStringFilter`
     :   The type of the None singleton.
+
+<a id="AccountsListParams"></a>
 
 `AccountsListParams(*args, **kwargs)`
 :   Parameters for accounts.list operation
@@ -310,6 +338,8 @@ Classes
     `sort_order: str`
     :   The type of the None singleton.
 
+<a id="AccountsLtCondition"></a>
+
 `AccountsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -321,6 +351,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.zoho_crm.types.AccountsSearchFilter`
     :   The type of the None singleton.
+
+<a id="AccountsLteCondition"></a>
 
 `AccountsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -334,6 +366,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.zoho_crm.types.AccountsSearchFilter`
     :   The type of the None singleton.
 
+<a id="AccountsNeqCondition"></a>
+
 `AccountsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -345,6 +379,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.zoho_crm.types.AccountsSearchFilter`
     :   The type of the None singleton.
+
+<a id="AccountsNotCondition"></a>
 
 `AccountsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -366,6 +402,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.zoho_crm.types.AccountsEqCondition | airbyte_agent_sdk.connectors.zoho_crm.types.AccountsNeqCondition | airbyte_agent_sdk.connectors.zoho_crm.types.AccountsGtCondition | airbyte_agent_sdk.connectors.zoho_crm.types.AccountsGteCondition | airbyte_agent_sdk.connectors.zoho_crm.types.AccountsLtCondition | airbyte_agent_sdk.connectors.zoho_crm.types.AccountsLteCondition | airbyte_agent_sdk.connectors.zoho_crm.types.AccountsInCondition | airbyte_agent_sdk.connectors.zoho_crm.types.AccountsLikeCondition | airbyte_agent_sdk.connectors.zoho_crm.types.AccountsFuzzyCondition | airbyte_agent_sdk.connectors.zoho_crm.types.AccountsKeywordCondition | airbyte_agent_sdk.connectors.zoho_crm.types.AccountsContainsCondition | airbyte_agent_sdk.connectors.zoho_crm.types.AccountsNotCondition | airbyte_agent_sdk.connectors.zoho_crm.types.AccountsAndCondition | airbyte_agent_sdk.connectors.zoho_crm.types.AccountsOrCondition | airbyte_agent_sdk.connectors.zoho_crm.types.AccountsAnyCondition`
     :   The type of the None singleton.
 
+<a id="AccountsOrCondition"></a>
+
 `AccountsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -385,6 +423,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.zoho_crm.types.AccountsEqCondition | airbyte_agent_sdk.connectors.zoho_crm.types.AccountsNeqCondition | airbyte_agent_sdk.connectors.zoho_crm.types.AccountsGtCondition | airbyte_agent_sdk.connectors.zoho_crm.types.AccountsGteCondition | airbyte_agent_sdk.connectors.zoho_crm.types.AccountsLtCondition | airbyte_agent_sdk.connectors.zoho_crm.types.AccountsLteCondition | airbyte_agent_sdk.connectors.zoho_crm.types.AccountsInCondition | airbyte_agent_sdk.connectors.zoho_crm.types.AccountsLikeCondition | airbyte_agent_sdk.connectors.zoho_crm.types.AccountsFuzzyCondition | airbyte_agent_sdk.connectors.zoho_crm.types.AccountsKeywordCondition | airbyte_agent_sdk.connectors.zoho_crm.types.AccountsContainsCondition | airbyte_agent_sdk.connectors.zoho_crm.types.AccountsNotCondition | airbyte_agent_sdk.connectors.zoho_crm.types.AccountsAndCondition | airbyte_agent_sdk.connectors.zoho_crm.types.AccountsOrCondition | airbyte_agent_sdk.connectors.zoho_crm.types.AccountsAnyCondition]`
     :   The type of the None singleton.
+
+<a id="AccountsSearchFilter"></a>
 
 `AccountsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering accounts search queries.
@@ -446,6 +486,8 @@ Classes
     `website: str | None`
     :   Account website URL
 
+<a id="AccountsSearchQuery"></a>
+
 `AccountsSearchQuery(*args, **kwargs)`
 :   Search query for accounts entity.
 
@@ -460,6 +502,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.zoho_crm.types.AccountsSortFilter]`
     :   The type of the None singleton.
+
+<a id="AccountsSortFilter"></a>
 
 `AccountsSortFilter(*args, **kwargs)`
 :   Available fields for sorting accounts search results.
@@ -521,6 +565,8 @@ Classes
     `website: Literal['asc', 'desc']`
     :   Account website URL
 
+<a id="AccountsStringFilter"></a>
+
 `AccountsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -581,6 +627,8 @@ Classes
     `website: str`
     :   Account website URL
 
+<a id="AirbyteSearchParams"></a>
+
 `AirbyteSearchParams(*args, **kwargs)`
 :   Parameters for Airbyte cache search operations (generic, use entity-specific query types for better type hints).
 
@@ -602,6 +650,8 @@ Classes
     `query: dict[str, typing.Any]`
     :   The type of the None singleton.
 
+<a id="CallsAndCondition"></a>
+
 `CallsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -622,6 +672,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.zoho_crm.types.CallsEqCondition | airbyte_agent_sdk.connectors.zoho_crm.types.CallsNeqCondition | airbyte_agent_sdk.connectors.zoho_crm.types.CallsGtCondition | airbyte_agent_sdk.connectors.zoho_crm.types.CallsGteCondition | airbyte_agent_sdk.connectors.zoho_crm.types.CallsLtCondition | airbyte_agent_sdk.connectors.zoho_crm.types.CallsLteCondition | airbyte_agent_sdk.connectors.zoho_crm.types.CallsInCondition | airbyte_agent_sdk.connectors.zoho_crm.types.CallsLikeCondition | airbyte_agent_sdk.connectors.zoho_crm.types.CallsFuzzyCondition | airbyte_agent_sdk.connectors.zoho_crm.types.CallsKeywordCondition | airbyte_agent_sdk.connectors.zoho_crm.types.CallsContainsCondition | airbyte_agent_sdk.connectors.zoho_crm.types.CallsNotCondition | airbyte_agent_sdk.connectors.zoho_crm.types.CallsAndCondition | airbyte_agent_sdk.connectors.zoho_crm.types.CallsOrCondition | airbyte_agent_sdk.connectors.zoho_crm.types.CallsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="CallsAnyCondition"></a>
+
 `CallsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -641,6 +693,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.zoho_crm.types.CallsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="CallsAnyValueFilter"></a>
 
 `CallsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -690,6 +744,8 @@ Classes
     `subject: Any`
     :   Subject of the call
 
+<a id="CallsContainsCondition"></a>
+
 `CallsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -701,6 +757,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.zoho_crm.types.CallsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="CallsEqCondition"></a>
 
 `CallsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -714,6 +772,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.zoho_crm.types.CallsSearchFilter`
     :   The type of the None singleton.
 
+<a id="CallsFuzzyCondition"></a>
+
 `CallsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -725,6 +785,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.zoho_crm.types.CallsStringFilter`
     :   The type of the None singleton.
+
+<a id="CallsGetParams"></a>
 
 `CallsGetParams(*args, **kwargs)`
 :   Parameters for calls.get operation
@@ -738,6 +800,8 @@ Classes
     `id: str`
     :   The type of the None singleton.
 
+<a id="CallsGtCondition"></a>
+
 `CallsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -750,6 +814,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.zoho_crm.types.CallsSearchFilter`
     :   The type of the None singleton.
 
+<a id="CallsGteCondition"></a>
+
 `CallsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -761,6 +827,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.zoho_crm.types.CallsSearchFilter`
     :   The type of the None singleton.
+
+<a id="CallsInCondition"></a>
 
 `CallsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -781,6 +849,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.zoho_crm.types.CallsInFilter`
     :   The type of the None singleton.
+
+<a id="CallsInFilter"></a>
 
 `CallsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -830,6 +900,8 @@ Classes
     `subject: list[str]`
     :   Subject of the call
 
+<a id="CallsKeywordCondition"></a>
+
 `CallsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -842,6 +914,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.zoho_crm.types.CallsStringFilter`
     :   The type of the None singleton.
 
+<a id="CallsLikeCondition"></a>
+
 `CallsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -853,6 +927,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.zoho_crm.types.CallsStringFilter`
     :   The type of the None singleton.
+
+<a id="CallsListParams"></a>
 
 `CallsListParams(*args, **kwargs)`
 :   Parameters for calls.list operation
@@ -878,6 +954,8 @@ Classes
     `sort_order: str`
     :   The type of the None singleton.
 
+<a id="CallsLtCondition"></a>
+
 `CallsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -889,6 +967,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.zoho_crm.types.CallsSearchFilter`
     :   The type of the None singleton.
+
+<a id="CallsLteCondition"></a>
 
 `CallsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -902,6 +982,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.zoho_crm.types.CallsSearchFilter`
     :   The type of the None singleton.
 
+<a id="CallsNeqCondition"></a>
+
 `CallsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -913,6 +995,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.zoho_crm.types.CallsSearchFilter`
     :   The type of the None singleton.
+
+<a id="CallsNotCondition"></a>
 
 `CallsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -934,6 +1018,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.zoho_crm.types.CallsEqCondition | airbyte_agent_sdk.connectors.zoho_crm.types.CallsNeqCondition | airbyte_agent_sdk.connectors.zoho_crm.types.CallsGtCondition | airbyte_agent_sdk.connectors.zoho_crm.types.CallsGteCondition | airbyte_agent_sdk.connectors.zoho_crm.types.CallsLtCondition | airbyte_agent_sdk.connectors.zoho_crm.types.CallsLteCondition | airbyte_agent_sdk.connectors.zoho_crm.types.CallsInCondition | airbyte_agent_sdk.connectors.zoho_crm.types.CallsLikeCondition | airbyte_agent_sdk.connectors.zoho_crm.types.CallsFuzzyCondition | airbyte_agent_sdk.connectors.zoho_crm.types.CallsKeywordCondition | airbyte_agent_sdk.connectors.zoho_crm.types.CallsContainsCondition | airbyte_agent_sdk.connectors.zoho_crm.types.CallsNotCondition | airbyte_agent_sdk.connectors.zoho_crm.types.CallsAndCondition | airbyte_agent_sdk.connectors.zoho_crm.types.CallsOrCondition | airbyte_agent_sdk.connectors.zoho_crm.types.CallsAnyCondition`
     :   The type of the None singleton.
 
+<a id="CallsOrCondition"></a>
+
 `CallsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -953,6 +1039,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.zoho_crm.types.CallsEqCondition | airbyte_agent_sdk.connectors.zoho_crm.types.CallsNeqCondition | airbyte_agent_sdk.connectors.zoho_crm.types.CallsGtCondition | airbyte_agent_sdk.connectors.zoho_crm.types.CallsGteCondition | airbyte_agent_sdk.connectors.zoho_crm.types.CallsLtCondition | airbyte_agent_sdk.connectors.zoho_crm.types.CallsLteCondition | airbyte_agent_sdk.connectors.zoho_crm.types.CallsInCondition | airbyte_agent_sdk.connectors.zoho_crm.types.CallsLikeCondition | airbyte_agent_sdk.connectors.zoho_crm.types.CallsFuzzyCondition | airbyte_agent_sdk.connectors.zoho_crm.types.CallsKeywordCondition | airbyte_agent_sdk.connectors.zoho_crm.types.CallsContainsCondition | airbyte_agent_sdk.connectors.zoho_crm.types.CallsNotCondition | airbyte_agent_sdk.connectors.zoho_crm.types.CallsAndCondition | airbyte_agent_sdk.connectors.zoho_crm.types.CallsOrCondition | airbyte_agent_sdk.connectors.zoho_crm.types.CallsAnyCondition]`
     :   The type of the None singleton.
+
+<a id="CallsSearchFilter"></a>
 
 `CallsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering calls search queries.
@@ -1002,6 +1090,8 @@ Classes
     `subject: str | None`
     :   Subject of the call
 
+<a id="CallsSearchQuery"></a>
+
 `CallsSearchQuery(*args, **kwargs)`
 :   Search query for calls entity.
 
@@ -1016,6 +1106,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.zoho_crm.types.CallsSortFilter]`
     :   The type of the None singleton.
+
+<a id="CallsSortFilter"></a>
 
 `CallsSortFilter(*args, **kwargs)`
 :   Available fields for sorting calls search results.
@@ -1065,6 +1157,8 @@ Classes
     `subject: Literal['asc', 'desc']`
     :   Subject of the call
 
+<a id="CallsStringFilter"></a>
+
 `CallsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -1113,6 +1207,8 @@ Classes
     `subject: str`
     :   Subject of the call
 
+<a id="CampaignsAndCondition"></a>
+
 `CampaignsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1133,6 +1229,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.zoho_crm.types.CampaignsEqCondition | airbyte_agent_sdk.connectors.zoho_crm.types.CampaignsNeqCondition | airbyte_agent_sdk.connectors.zoho_crm.types.CampaignsGtCondition | airbyte_agent_sdk.connectors.zoho_crm.types.CampaignsGteCondition | airbyte_agent_sdk.connectors.zoho_crm.types.CampaignsLtCondition | airbyte_agent_sdk.connectors.zoho_crm.types.CampaignsLteCondition | airbyte_agent_sdk.connectors.zoho_crm.types.CampaignsInCondition | airbyte_agent_sdk.connectors.zoho_crm.types.CampaignsLikeCondition | airbyte_agent_sdk.connectors.zoho_crm.types.CampaignsFuzzyCondition | airbyte_agent_sdk.connectors.zoho_crm.types.CampaignsKeywordCondition | airbyte_agent_sdk.connectors.zoho_crm.types.CampaignsContainsCondition | airbyte_agent_sdk.connectors.zoho_crm.types.CampaignsNotCondition | airbyte_agent_sdk.connectors.zoho_crm.types.CampaignsAndCondition | airbyte_agent_sdk.connectors.zoho_crm.types.CampaignsOrCondition | airbyte_agent_sdk.connectors.zoho_crm.types.CampaignsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="CampaignsAnyCondition"></a>
+
 `CampaignsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1152,6 +1250,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.zoho_crm.types.CampaignsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="CampaignsAnyValueFilter"></a>
 
 `CampaignsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -1204,6 +1304,8 @@ Classes
     `type_: Any`
     :   Type of campaign (e.g., Email, Webinar, Conference)
 
+<a id="CampaignsContainsCondition"></a>
+
 `CampaignsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -1215,6 +1317,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.zoho_crm.types.CampaignsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="CampaignsEqCondition"></a>
 
 `CampaignsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -1228,6 +1332,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.zoho_crm.types.CampaignsSearchFilter`
     :   The type of the None singleton.
 
+<a id="CampaignsFuzzyCondition"></a>
+
 `CampaignsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -1239,6 +1345,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.zoho_crm.types.CampaignsStringFilter`
     :   The type of the None singleton.
+
+<a id="CampaignsGetParams"></a>
 
 `CampaignsGetParams(*args, **kwargs)`
 :   Parameters for campaigns.get operation
@@ -1252,6 +1360,8 @@ Classes
     `id: str`
     :   The type of the None singleton.
 
+<a id="CampaignsGtCondition"></a>
+
 `CampaignsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -1264,6 +1374,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.zoho_crm.types.CampaignsSearchFilter`
     :   The type of the None singleton.
 
+<a id="CampaignsGteCondition"></a>
+
 `CampaignsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -1275,6 +1387,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.zoho_crm.types.CampaignsSearchFilter`
     :   The type of the None singleton.
+
+<a id="CampaignsInCondition"></a>
 
 `CampaignsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -1295,6 +1409,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.zoho_crm.types.CampaignsInFilter`
     :   The type of the None singleton.
+
+<a id="CampaignsInFilter"></a>
 
 `CampaignsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -1347,6 +1463,8 @@ Classes
     `type_: list[str]`
     :   Type of campaign (e.g., Email, Webinar, Conference)
 
+<a id="CampaignsKeywordCondition"></a>
+
 `CampaignsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -1359,6 +1477,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.zoho_crm.types.CampaignsStringFilter`
     :   The type of the None singleton.
 
+<a id="CampaignsLikeCondition"></a>
+
 `CampaignsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -1370,6 +1490,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.zoho_crm.types.CampaignsStringFilter`
     :   The type of the None singleton.
+
+<a id="CampaignsListParams"></a>
 
 `CampaignsListParams(*args, **kwargs)`
 :   Parameters for campaigns.list operation
@@ -1395,6 +1517,8 @@ Classes
     `sort_order: str`
     :   The type of the None singleton.
 
+<a id="CampaignsLtCondition"></a>
+
 `CampaignsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -1406,6 +1530,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.zoho_crm.types.CampaignsSearchFilter`
     :   The type of the None singleton.
+
+<a id="CampaignsLteCondition"></a>
 
 `CampaignsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -1419,6 +1545,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.zoho_crm.types.CampaignsSearchFilter`
     :   The type of the None singleton.
 
+<a id="CampaignsNeqCondition"></a>
+
 `CampaignsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -1430,6 +1558,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.zoho_crm.types.CampaignsSearchFilter`
     :   The type of the None singleton.
+
+<a id="CampaignsNotCondition"></a>
 
 `CampaignsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -1451,6 +1581,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.zoho_crm.types.CampaignsEqCondition | airbyte_agent_sdk.connectors.zoho_crm.types.CampaignsNeqCondition | airbyte_agent_sdk.connectors.zoho_crm.types.CampaignsGtCondition | airbyte_agent_sdk.connectors.zoho_crm.types.CampaignsGteCondition | airbyte_agent_sdk.connectors.zoho_crm.types.CampaignsLtCondition | airbyte_agent_sdk.connectors.zoho_crm.types.CampaignsLteCondition | airbyte_agent_sdk.connectors.zoho_crm.types.CampaignsInCondition | airbyte_agent_sdk.connectors.zoho_crm.types.CampaignsLikeCondition | airbyte_agent_sdk.connectors.zoho_crm.types.CampaignsFuzzyCondition | airbyte_agent_sdk.connectors.zoho_crm.types.CampaignsKeywordCondition | airbyte_agent_sdk.connectors.zoho_crm.types.CampaignsContainsCondition | airbyte_agent_sdk.connectors.zoho_crm.types.CampaignsNotCondition | airbyte_agent_sdk.connectors.zoho_crm.types.CampaignsAndCondition | airbyte_agent_sdk.connectors.zoho_crm.types.CampaignsOrCondition | airbyte_agent_sdk.connectors.zoho_crm.types.CampaignsAnyCondition`
     :   The type of the None singleton.
 
+<a id="CampaignsOrCondition"></a>
+
 `CampaignsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1470,6 +1602,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.zoho_crm.types.CampaignsEqCondition | airbyte_agent_sdk.connectors.zoho_crm.types.CampaignsNeqCondition | airbyte_agent_sdk.connectors.zoho_crm.types.CampaignsGtCondition | airbyte_agent_sdk.connectors.zoho_crm.types.CampaignsGteCondition | airbyte_agent_sdk.connectors.zoho_crm.types.CampaignsLtCondition | airbyte_agent_sdk.connectors.zoho_crm.types.CampaignsLteCondition | airbyte_agent_sdk.connectors.zoho_crm.types.CampaignsInCondition | airbyte_agent_sdk.connectors.zoho_crm.types.CampaignsLikeCondition | airbyte_agent_sdk.connectors.zoho_crm.types.CampaignsFuzzyCondition | airbyte_agent_sdk.connectors.zoho_crm.types.CampaignsKeywordCondition | airbyte_agent_sdk.connectors.zoho_crm.types.CampaignsContainsCondition | airbyte_agent_sdk.connectors.zoho_crm.types.CampaignsNotCondition | airbyte_agent_sdk.connectors.zoho_crm.types.CampaignsAndCondition | airbyte_agent_sdk.connectors.zoho_crm.types.CampaignsOrCondition | airbyte_agent_sdk.connectors.zoho_crm.types.CampaignsAnyCondition]`
     :   The type of the None singleton.
+
+<a id="CampaignsSearchFilter"></a>
 
 `CampaignsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering campaigns search queries.
@@ -1522,6 +1656,8 @@ Classes
     `type_: str | None`
     :   Type of campaign (e.g., Email, Webinar, Conference)
 
+<a id="CampaignsSearchQuery"></a>
+
 `CampaignsSearchQuery(*args, **kwargs)`
 :   Search query for campaigns entity.
 
@@ -1536,6 +1672,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.zoho_crm.types.CampaignsSortFilter]`
     :   The type of the None singleton.
+
+<a id="CampaignsSortFilter"></a>
 
 `CampaignsSortFilter(*args, **kwargs)`
 :   Available fields for sorting campaigns search results.
@@ -1588,6 +1726,8 @@ Classes
     `type_: Literal['asc', 'desc']`
     :   Type of campaign (e.g., Email, Webinar, Conference)
 
+<a id="CampaignsStringFilter"></a>
+
 `CampaignsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -1639,6 +1779,8 @@ Classes
     `type_: str`
     :   Type of campaign (e.g., Email, Webinar, Conference)
 
+<a id="ContactsAndCondition"></a>
+
 `ContactsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1659,6 +1801,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.zoho_crm.types.ContactsEqCondition | airbyte_agent_sdk.connectors.zoho_crm.types.ContactsNeqCondition | airbyte_agent_sdk.connectors.zoho_crm.types.ContactsGtCondition | airbyte_agent_sdk.connectors.zoho_crm.types.ContactsGteCondition | airbyte_agent_sdk.connectors.zoho_crm.types.ContactsLtCondition | airbyte_agent_sdk.connectors.zoho_crm.types.ContactsLteCondition | airbyte_agent_sdk.connectors.zoho_crm.types.ContactsInCondition | airbyte_agent_sdk.connectors.zoho_crm.types.ContactsLikeCondition | airbyte_agent_sdk.connectors.zoho_crm.types.ContactsFuzzyCondition | airbyte_agent_sdk.connectors.zoho_crm.types.ContactsKeywordCondition | airbyte_agent_sdk.connectors.zoho_crm.types.ContactsContainsCondition | airbyte_agent_sdk.connectors.zoho_crm.types.ContactsNotCondition | airbyte_agent_sdk.connectors.zoho_crm.types.ContactsAndCondition | airbyte_agent_sdk.connectors.zoho_crm.types.ContactsOrCondition | airbyte_agent_sdk.connectors.zoho_crm.types.ContactsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="ContactsAnyCondition"></a>
+
 `ContactsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -1678,6 +1822,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.zoho_crm.types.ContactsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="ContactsAnyValueFilter"></a>
 
 `ContactsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -1739,6 +1885,8 @@ Classes
     `title: Any`
     :   Contact's job title
 
+<a id="ContactsContainsCondition"></a>
+
 `ContactsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -1750,6 +1898,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.zoho_crm.types.ContactsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="ContactsEqCondition"></a>
 
 `ContactsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -1763,6 +1913,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.zoho_crm.types.ContactsSearchFilter`
     :   The type of the None singleton.
 
+<a id="ContactsFuzzyCondition"></a>
+
 `ContactsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -1774,6 +1926,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.zoho_crm.types.ContactsStringFilter`
     :   The type of the None singleton.
+
+<a id="ContactsGetParams"></a>
 
 `ContactsGetParams(*args, **kwargs)`
 :   Parameters for contacts.get operation
@@ -1787,6 +1941,8 @@ Classes
     `id: str`
     :   The type of the None singleton.
 
+<a id="ContactsGtCondition"></a>
+
 `ContactsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -1799,6 +1955,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.zoho_crm.types.ContactsSearchFilter`
     :   The type of the None singleton.
 
+<a id="ContactsGteCondition"></a>
+
 `ContactsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -1810,6 +1968,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.zoho_crm.types.ContactsSearchFilter`
     :   The type of the None singleton.
+
+<a id="ContactsInCondition"></a>
 
 `ContactsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -1830,6 +1990,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.zoho_crm.types.ContactsInFilter`
     :   The type of the None singleton.
+
+<a id="ContactsInFilter"></a>
 
 `ContactsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -1891,6 +2053,8 @@ Classes
     `title: list[str]`
     :   Contact's job title
 
+<a id="ContactsKeywordCondition"></a>
+
 `ContactsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -1903,6 +2067,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.zoho_crm.types.ContactsStringFilter`
     :   The type of the None singleton.
 
+<a id="ContactsLikeCondition"></a>
+
 `ContactsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -1914,6 +2080,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.zoho_crm.types.ContactsStringFilter`
     :   The type of the None singleton.
+
+<a id="ContactsListParams"></a>
 
 `ContactsListParams(*args, **kwargs)`
 :   Parameters for contacts.list operation
@@ -1939,6 +2107,8 @@ Classes
     `sort_order: str`
     :   The type of the None singleton.
 
+<a id="ContactsLtCondition"></a>
+
 `ContactsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -1950,6 +2120,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.zoho_crm.types.ContactsSearchFilter`
     :   The type of the None singleton.
+
+<a id="ContactsLteCondition"></a>
 
 `ContactsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -1963,6 +2135,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.zoho_crm.types.ContactsSearchFilter`
     :   The type of the None singleton.
 
+<a id="ContactsNeqCondition"></a>
+
 `ContactsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -1974,6 +2148,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.zoho_crm.types.ContactsSearchFilter`
     :   The type of the None singleton.
+
+<a id="ContactsNotCondition"></a>
 
 `ContactsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -1995,6 +2171,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.zoho_crm.types.ContactsEqCondition | airbyte_agent_sdk.connectors.zoho_crm.types.ContactsNeqCondition | airbyte_agent_sdk.connectors.zoho_crm.types.ContactsGtCondition | airbyte_agent_sdk.connectors.zoho_crm.types.ContactsGteCondition | airbyte_agent_sdk.connectors.zoho_crm.types.ContactsLtCondition | airbyte_agent_sdk.connectors.zoho_crm.types.ContactsLteCondition | airbyte_agent_sdk.connectors.zoho_crm.types.ContactsInCondition | airbyte_agent_sdk.connectors.zoho_crm.types.ContactsLikeCondition | airbyte_agent_sdk.connectors.zoho_crm.types.ContactsFuzzyCondition | airbyte_agent_sdk.connectors.zoho_crm.types.ContactsKeywordCondition | airbyte_agent_sdk.connectors.zoho_crm.types.ContactsContainsCondition | airbyte_agent_sdk.connectors.zoho_crm.types.ContactsNotCondition | airbyte_agent_sdk.connectors.zoho_crm.types.ContactsAndCondition | airbyte_agent_sdk.connectors.zoho_crm.types.ContactsOrCondition | airbyte_agent_sdk.connectors.zoho_crm.types.ContactsAnyCondition`
     :   The type of the None singleton.
 
+<a id="ContactsOrCondition"></a>
+
 `ContactsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -2014,6 +2192,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.zoho_crm.types.ContactsEqCondition | airbyte_agent_sdk.connectors.zoho_crm.types.ContactsNeqCondition | airbyte_agent_sdk.connectors.zoho_crm.types.ContactsGtCondition | airbyte_agent_sdk.connectors.zoho_crm.types.ContactsGteCondition | airbyte_agent_sdk.connectors.zoho_crm.types.ContactsLtCondition | airbyte_agent_sdk.connectors.zoho_crm.types.ContactsLteCondition | airbyte_agent_sdk.connectors.zoho_crm.types.ContactsInCondition | airbyte_agent_sdk.connectors.zoho_crm.types.ContactsLikeCondition | airbyte_agent_sdk.connectors.zoho_crm.types.ContactsFuzzyCondition | airbyte_agent_sdk.connectors.zoho_crm.types.ContactsKeywordCondition | airbyte_agent_sdk.connectors.zoho_crm.types.ContactsContainsCondition | airbyte_agent_sdk.connectors.zoho_crm.types.ContactsNotCondition | airbyte_agent_sdk.connectors.zoho_crm.types.ContactsAndCondition | airbyte_agent_sdk.connectors.zoho_crm.types.ContactsOrCondition | airbyte_agent_sdk.connectors.zoho_crm.types.ContactsAnyCondition]`
     :   The type of the None singleton.
+
+<a id="ContactsSearchFilter"></a>
 
 `ContactsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering contacts search queries.
@@ -2075,6 +2255,8 @@ Classes
     `title: str | None`
     :   Contact's job title
 
+<a id="ContactsSearchQuery"></a>
+
 `ContactsSearchQuery(*args, **kwargs)`
 :   Search query for contacts entity.
 
@@ -2089,6 +2271,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.zoho_crm.types.ContactsSortFilter]`
     :   The type of the None singleton.
+
+<a id="ContactsSortFilter"></a>
 
 `ContactsSortFilter(*args, **kwargs)`
 :   Available fields for sorting contacts search results.
@@ -2150,6 +2334,8 @@ Classes
     `title: Literal['asc', 'desc']`
     :   Contact's job title
 
+<a id="ContactsStringFilter"></a>
+
 `ContactsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -2210,6 +2396,8 @@ Classes
     `title: str`
     :   Contact's job title
 
+<a id="DealsAndCondition"></a>
+
 `DealsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -2230,6 +2418,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.zoho_crm.types.DealsEqCondition | airbyte_agent_sdk.connectors.zoho_crm.types.DealsNeqCondition | airbyte_agent_sdk.connectors.zoho_crm.types.DealsGtCondition | airbyte_agent_sdk.connectors.zoho_crm.types.DealsGteCondition | airbyte_agent_sdk.connectors.zoho_crm.types.DealsLtCondition | airbyte_agent_sdk.connectors.zoho_crm.types.DealsLteCondition | airbyte_agent_sdk.connectors.zoho_crm.types.DealsInCondition | airbyte_agent_sdk.connectors.zoho_crm.types.DealsLikeCondition | airbyte_agent_sdk.connectors.zoho_crm.types.DealsFuzzyCondition | airbyte_agent_sdk.connectors.zoho_crm.types.DealsKeywordCondition | airbyte_agent_sdk.connectors.zoho_crm.types.DealsContainsCondition | airbyte_agent_sdk.connectors.zoho_crm.types.DealsNotCondition | airbyte_agent_sdk.connectors.zoho_crm.types.DealsAndCondition | airbyte_agent_sdk.connectors.zoho_crm.types.DealsOrCondition | airbyte_agent_sdk.connectors.zoho_crm.types.DealsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="DealsAnyCondition"></a>
+
 `DealsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -2249,6 +2439,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.zoho_crm.types.DealsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="DealsAnyValueFilter"></a>
 
 `DealsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -2295,6 +2487,8 @@ Classes
     `type_: Any`
     :   Type of deal (e.g., New Business, Existing Business)
 
+<a id="DealsContainsCondition"></a>
+
 `DealsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -2306,6 +2500,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.zoho_crm.types.DealsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="DealsEqCondition"></a>
 
 `DealsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -2319,6 +2515,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.zoho_crm.types.DealsSearchFilter`
     :   The type of the None singleton.
 
+<a id="DealsFuzzyCondition"></a>
+
 `DealsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -2330,6 +2528,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.zoho_crm.types.DealsStringFilter`
     :   The type of the None singleton.
+
+<a id="DealsGetParams"></a>
 
 `DealsGetParams(*args, **kwargs)`
 :   Parameters for deals.get operation
@@ -2343,6 +2543,8 @@ Classes
     `id: str`
     :   The type of the None singleton.
 
+<a id="DealsGtCondition"></a>
+
 `DealsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -2355,6 +2557,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.zoho_crm.types.DealsSearchFilter`
     :   The type of the None singleton.
 
+<a id="DealsGteCondition"></a>
+
 `DealsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -2366,6 +2570,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.zoho_crm.types.DealsSearchFilter`
     :   The type of the None singleton.
+
+<a id="DealsInCondition"></a>
 
 `DealsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -2386,6 +2592,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.zoho_crm.types.DealsInFilter`
     :   The type of the None singleton.
+
+<a id="DealsInFilter"></a>
 
 `DealsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -2432,6 +2640,8 @@ Classes
     `type_: list[str]`
     :   Type of deal (e.g., New Business, Existing Business)
 
+<a id="DealsKeywordCondition"></a>
+
 `DealsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -2444,6 +2654,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.zoho_crm.types.DealsStringFilter`
     :   The type of the None singleton.
 
+<a id="DealsLikeCondition"></a>
+
 `DealsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -2455,6 +2667,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.zoho_crm.types.DealsStringFilter`
     :   The type of the None singleton.
+
+<a id="DealsListParams"></a>
 
 `DealsListParams(*args, **kwargs)`
 :   Parameters for deals.list operation
@@ -2480,6 +2694,8 @@ Classes
     `sort_order: str`
     :   The type of the None singleton.
 
+<a id="DealsLtCondition"></a>
+
 `DealsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -2491,6 +2707,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.zoho_crm.types.DealsSearchFilter`
     :   The type of the None singleton.
+
+<a id="DealsLteCondition"></a>
 
 `DealsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -2504,6 +2722,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.zoho_crm.types.DealsSearchFilter`
     :   The type of the None singleton.
 
+<a id="DealsNeqCondition"></a>
+
 `DealsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -2515,6 +2735,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.zoho_crm.types.DealsSearchFilter`
     :   The type of the None singleton.
+
+<a id="DealsNotCondition"></a>
 
 `DealsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -2536,6 +2758,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.zoho_crm.types.DealsEqCondition | airbyte_agent_sdk.connectors.zoho_crm.types.DealsNeqCondition | airbyte_agent_sdk.connectors.zoho_crm.types.DealsGtCondition | airbyte_agent_sdk.connectors.zoho_crm.types.DealsGteCondition | airbyte_agent_sdk.connectors.zoho_crm.types.DealsLtCondition | airbyte_agent_sdk.connectors.zoho_crm.types.DealsLteCondition | airbyte_agent_sdk.connectors.zoho_crm.types.DealsInCondition | airbyte_agent_sdk.connectors.zoho_crm.types.DealsLikeCondition | airbyte_agent_sdk.connectors.zoho_crm.types.DealsFuzzyCondition | airbyte_agent_sdk.connectors.zoho_crm.types.DealsKeywordCondition | airbyte_agent_sdk.connectors.zoho_crm.types.DealsContainsCondition | airbyte_agent_sdk.connectors.zoho_crm.types.DealsNotCondition | airbyte_agent_sdk.connectors.zoho_crm.types.DealsAndCondition | airbyte_agent_sdk.connectors.zoho_crm.types.DealsOrCondition | airbyte_agent_sdk.connectors.zoho_crm.types.DealsAnyCondition`
     :   The type of the None singleton.
 
+<a id="DealsOrCondition"></a>
+
 `DealsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -2555,6 +2779,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.zoho_crm.types.DealsEqCondition | airbyte_agent_sdk.connectors.zoho_crm.types.DealsNeqCondition | airbyte_agent_sdk.connectors.zoho_crm.types.DealsGtCondition | airbyte_agent_sdk.connectors.zoho_crm.types.DealsGteCondition | airbyte_agent_sdk.connectors.zoho_crm.types.DealsLtCondition | airbyte_agent_sdk.connectors.zoho_crm.types.DealsLteCondition | airbyte_agent_sdk.connectors.zoho_crm.types.DealsInCondition | airbyte_agent_sdk.connectors.zoho_crm.types.DealsLikeCondition | airbyte_agent_sdk.connectors.zoho_crm.types.DealsFuzzyCondition | airbyte_agent_sdk.connectors.zoho_crm.types.DealsKeywordCondition | airbyte_agent_sdk.connectors.zoho_crm.types.DealsContainsCondition | airbyte_agent_sdk.connectors.zoho_crm.types.DealsNotCondition | airbyte_agent_sdk.connectors.zoho_crm.types.DealsAndCondition | airbyte_agent_sdk.connectors.zoho_crm.types.DealsOrCondition | airbyte_agent_sdk.connectors.zoho_crm.types.DealsAnyCondition]`
     :   The type of the None singleton.
+
+<a id="DealsSearchFilter"></a>
 
 `DealsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering deals search queries.
@@ -2601,6 +2827,8 @@ Classes
     `type_: str | None`
     :   Type of deal (e.g., New Business, Existing Business)
 
+<a id="DealsSearchQuery"></a>
+
 `DealsSearchQuery(*args, **kwargs)`
 :   Search query for deals entity.
 
@@ -2615,6 +2843,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.zoho_crm.types.DealsSortFilter]`
     :   The type of the None singleton.
+
+<a id="DealsSortFilter"></a>
 
 `DealsSortFilter(*args, **kwargs)`
 :   Available fields for sorting deals search results.
@@ -2661,6 +2891,8 @@ Classes
     `type_: Literal['asc', 'desc']`
     :   Type of deal (e.g., New Business, Existing Business)
 
+<a id="DealsStringFilter"></a>
+
 `DealsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -2706,6 +2938,8 @@ Classes
     `type_: str`
     :   Type of deal (e.g., New Business, Existing Business)
 
+<a id="EventsAndCondition"></a>
+
 `EventsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -2726,6 +2960,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.zoho_crm.types.EventsEqCondition | airbyte_agent_sdk.connectors.zoho_crm.types.EventsNeqCondition | airbyte_agent_sdk.connectors.zoho_crm.types.EventsGtCondition | airbyte_agent_sdk.connectors.zoho_crm.types.EventsGteCondition | airbyte_agent_sdk.connectors.zoho_crm.types.EventsLtCondition | airbyte_agent_sdk.connectors.zoho_crm.types.EventsLteCondition | airbyte_agent_sdk.connectors.zoho_crm.types.EventsInCondition | airbyte_agent_sdk.connectors.zoho_crm.types.EventsLikeCondition | airbyte_agent_sdk.connectors.zoho_crm.types.EventsFuzzyCondition | airbyte_agent_sdk.connectors.zoho_crm.types.EventsKeywordCondition | airbyte_agent_sdk.connectors.zoho_crm.types.EventsContainsCondition | airbyte_agent_sdk.connectors.zoho_crm.types.EventsNotCondition | airbyte_agent_sdk.connectors.zoho_crm.types.EventsAndCondition | airbyte_agent_sdk.connectors.zoho_crm.types.EventsOrCondition | airbyte_agent_sdk.connectors.zoho_crm.types.EventsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="EventsAnyCondition"></a>
+
 `EventsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -2745,6 +2981,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.zoho_crm.types.EventsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="EventsAnyValueFilter"></a>
 
 `EventsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -2782,6 +3020,8 @@ Classes
     `start_date_time: Any`
     :   Event start date and time
 
+<a id="EventsContainsCondition"></a>
+
 `EventsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -2793,6 +3033,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.zoho_crm.types.EventsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="EventsEqCondition"></a>
 
 `EventsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -2806,6 +3048,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.zoho_crm.types.EventsSearchFilter`
     :   The type of the None singleton.
 
+<a id="EventsFuzzyCondition"></a>
+
 `EventsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -2817,6 +3061,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.zoho_crm.types.EventsStringFilter`
     :   The type of the None singleton.
+
+<a id="EventsGetParams"></a>
 
 `EventsGetParams(*args, **kwargs)`
 :   Parameters for events.get operation
@@ -2830,6 +3076,8 @@ Classes
     `id: str`
     :   The type of the None singleton.
 
+<a id="EventsGtCondition"></a>
+
 `EventsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -2842,6 +3090,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.zoho_crm.types.EventsSearchFilter`
     :   The type of the None singleton.
 
+<a id="EventsGteCondition"></a>
+
 `EventsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -2853,6 +3103,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.zoho_crm.types.EventsSearchFilter`
     :   The type of the None singleton.
+
+<a id="EventsInCondition"></a>
 
 `EventsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -2873,6 +3125,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.zoho_crm.types.EventsInFilter`
     :   The type of the None singleton.
+
+<a id="EventsInFilter"></a>
 
 `EventsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -2910,6 +3164,8 @@ Classes
     `start_date_time: list[str]`
     :   Event start date and time
 
+<a id="EventsKeywordCondition"></a>
+
 `EventsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -2922,6 +3178,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.zoho_crm.types.EventsStringFilter`
     :   The type of the None singleton.
 
+<a id="EventsLikeCondition"></a>
+
 `EventsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -2933,6 +3191,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.zoho_crm.types.EventsStringFilter`
     :   The type of the None singleton.
+
+<a id="EventsListParams"></a>
 
 `EventsListParams(*args, **kwargs)`
 :   Parameters for events.list operation
@@ -2958,6 +3218,8 @@ Classes
     `sort_order: str`
     :   The type of the None singleton.
 
+<a id="EventsLtCondition"></a>
+
 `EventsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -2969,6 +3231,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.zoho_crm.types.EventsSearchFilter`
     :   The type of the None singleton.
+
+<a id="EventsLteCondition"></a>
 
 `EventsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -2982,6 +3246,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.zoho_crm.types.EventsSearchFilter`
     :   The type of the None singleton.
 
+<a id="EventsNeqCondition"></a>
+
 `EventsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -2993,6 +3259,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.zoho_crm.types.EventsSearchFilter`
     :   The type of the None singleton.
+
+<a id="EventsNotCondition"></a>
 
 `EventsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -3014,6 +3282,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.zoho_crm.types.EventsEqCondition | airbyte_agent_sdk.connectors.zoho_crm.types.EventsNeqCondition | airbyte_agent_sdk.connectors.zoho_crm.types.EventsGtCondition | airbyte_agent_sdk.connectors.zoho_crm.types.EventsGteCondition | airbyte_agent_sdk.connectors.zoho_crm.types.EventsLtCondition | airbyte_agent_sdk.connectors.zoho_crm.types.EventsLteCondition | airbyte_agent_sdk.connectors.zoho_crm.types.EventsInCondition | airbyte_agent_sdk.connectors.zoho_crm.types.EventsLikeCondition | airbyte_agent_sdk.connectors.zoho_crm.types.EventsFuzzyCondition | airbyte_agent_sdk.connectors.zoho_crm.types.EventsKeywordCondition | airbyte_agent_sdk.connectors.zoho_crm.types.EventsContainsCondition | airbyte_agent_sdk.connectors.zoho_crm.types.EventsNotCondition | airbyte_agent_sdk.connectors.zoho_crm.types.EventsAndCondition | airbyte_agent_sdk.connectors.zoho_crm.types.EventsOrCondition | airbyte_agent_sdk.connectors.zoho_crm.types.EventsAnyCondition`
     :   The type of the None singleton.
 
+<a id="EventsOrCondition"></a>
+
 `EventsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -3033,6 +3303,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.zoho_crm.types.EventsEqCondition | airbyte_agent_sdk.connectors.zoho_crm.types.EventsNeqCondition | airbyte_agent_sdk.connectors.zoho_crm.types.EventsGtCondition | airbyte_agent_sdk.connectors.zoho_crm.types.EventsGteCondition | airbyte_agent_sdk.connectors.zoho_crm.types.EventsLtCondition | airbyte_agent_sdk.connectors.zoho_crm.types.EventsLteCondition | airbyte_agent_sdk.connectors.zoho_crm.types.EventsInCondition | airbyte_agent_sdk.connectors.zoho_crm.types.EventsLikeCondition | airbyte_agent_sdk.connectors.zoho_crm.types.EventsFuzzyCondition | airbyte_agent_sdk.connectors.zoho_crm.types.EventsKeywordCondition | airbyte_agent_sdk.connectors.zoho_crm.types.EventsContainsCondition | airbyte_agent_sdk.connectors.zoho_crm.types.EventsNotCondition | airbyte_agent_sdk.connectors.zoho_crm.types.EventsAndCondition | airbyte_agent_sdk.connectors.zoho_crm.types.EventsOrCondition | airbyte_agent_sdk.connectors.zoho_crm.types.EventsAnyCondition]`
     :   The type of the None singleton.
+
+<a id="EventsSearchFilter"></a>
 
 `EventsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering events search queries.
@@ -3070,6 +3342,8 @@ Classes
     `start_date_time: str | None`
     :   Event start date and time
 
+<a id="EventsSearchQuery"></a>
+
 `EventsSearchQuery(*args, **kwargs)`
 :   Search query for events entity.
 
@@ -3084,6 +3358,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.zoho_crm.types.EventsSortFilter]`
     :   The type of the None singleton.
+
+<a id="EventsSortFilter"></a>
 
 `EventsSortFilter(*args, **kwargs)`
 :   Available fields for sorting events search results.
@@ -3121,6 +3397,8 @@ Classes
     `start_date_time: Literal['asc', 'desc']`
     :   Event start date and time
 
+<a id="EventsStringFilter"></a>
+
 `EventsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -3157,6 +3435,8 @@ Classes
     `start_date_time: str`
     :   Event start date and time
 
+<a id="InvoicesAndCondition"></a>
+
 `InvoicesAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -3177,6 +3457,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.zoho_crm.types.InvoicesEqCondition | airbyte_agent_sdk.connectors.zoho_crm.types.InvoicesNeqCondition | airbyte_agent_sdk.connectors.zoho_crm.types.InvoicesGtCondition | airbyte_agent_sdk.connectors.zoho_crm.types.InvoicesGteCondition | airbyte_agent_sdk.connectors.zoho_crm.types.InvoicesLtCondition | airbyte_agent_sdk.connectors.zoho_crm.types.InvoicesLteCondition | airbyte_agent_sdk.connectors.zoho_crm.types.InvoicesInCondition | airbyte_agent_sdk.connectors.zoho_crm.types.InvoicesLikeCondition | airbyte_agent_sdk.connectors.zoho_crm.types.InvoicesFuzzyCondition | airbyte_agent_sdk.connectors.zoho_crm.types.InvoicesKeywordCondition | airbyte_agent_sdk.connectors.zoho_crm.types.InvoicesContainsCondition | airbyte_agent_sdk.connectors.zoho_crm.types.InvoicesNotCondition | airbyte_agent_sdk.connectors.zoho_crm.types.InvoicesAndCondition | airbyte_agent_sdk.connectors.zoho_crm.types.InvoicesOrCondition | airbyte_agent_sdk.connectors.zoho_crm.types.InvoicesAnyCondition]`
     :   The type of the None singleton.
 
+<a id="InvoicesAnyCondition"></a>
+
 `InvoicesAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -3196,6 +3478,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.zoho_crm.types.InvoicesAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="InvoicesAnyValueFilter"></a>
 
 `InvoicesAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -3257,6 +3541,8 @@ Classes
     `terms_and_conditions: Any`
     :   Terms and conditions text
 
+<a id="InvoicesContainsCondition"></a>
+
 `InvoicesContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -3268,6 +3554,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.zoho_crm.types.InvoicesAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="InvoicesEqCondition"></a>
 
 `InvoicesEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -3281,6 +3569,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.zoho_crm.types.InvoicesSearchFilter`
     :   The type of the None singleton.
 
+<a id="InvoicesFuzzyCondition"></a>
+
 `InvoicesFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -3292,6 +3582,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.zoho_crm.types.InvoicesStringFilter`
     :   The type of the None singleton.
+
+<a id="InvoicesGetParams"></a>
 
 `InvoicesGetParams(*args, **kwargs)`
 :   Parameters for invoices.get operation
@@ -3305,6 +3597,8 @@ Classes
     `id: str`
     :   The type of the None singleton.
 
+<a id="InvoicesGtCondition"></a>
+
 `InvoicesGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -3317,6 +3611,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.zoho_crm.types.InvoicesSearchFilter`
     :   The type of the None singleton.
 
+<a id="InvoicesGteCondition"></a>
+
 `InvoicesGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -3328,6 +3624,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.zoho_crm.types.InvoicesSearchFilter`
     :   The type of the None singleton.
+
+<a id="InvoicesInCondition"></a>
 
 `InvoicesInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -3348,6 +3646,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.zoho_crm.types.InvoicesInFilter`
     :   The type of the None singleton.
+
+<a id="InvoicesInFilter"></a>
 
 `InvoicesInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -3409,6 +3709,8 @@ Classes
     `terms_and_conditions: list[str]`
     :   Terms and conditions text
 
+<a id="InvoicesKeywordCondition"></a>
+
 `InvoicesKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -3421,6 +3723,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.zoho_crm.types.InvoicesStringFilter`
     :   The type of the None singleton.
 
+<a id="InvoicesLikeCondition"></a>
+
 `InvoicesLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -3432,6 +3736,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.zoho_crm.types.InvoicesStringFilter`
     :   The type of the None singleton.
+
+<a id="InvoicesListParams"></a>
 
 `InvoicesListParams(*args, **kwargs)`
 :   Parameters for invoices.list operation
@@ -3457,6 +3763,8 @@ Classes
     `sort_order: str`
     :   The type of the None singleton.
 
+<a id="InvoicesLtCondition"></a>
+
 `InvoicesLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -3468,6 +3776,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.zoho_crm.types.InvoicesSearchFilter`
     :   The type of the None singleton.
+
+<a id="InvoicesLteCondition"></a>
 
 `InvoicesLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -3481,6 +3791,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.zoho_crm.types.InvoicesSearchFilter`
     :   The type of the None singleton.
 
+<a id="InvoicesNeqCondition"></a>
+
 `InvoicesNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -3492,6 +3804,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.zoho_crm.types.InvoicesSearchFilter`
     :   The type of the None singleton.
+
+<a id="InvoicesNotCondition"></a>
 
 `InvoicesNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -3513,6 +3827,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.zoho_crm.types.InvoicesEqCondition | airbyte_agent_sdk.connectors.zoho_crm.types.InvoicesNeqCondition | airbyte_agent_sdk.connectors.zoho_crm.types.InvoicesGtCondition | airbyte_agent_sdk.connectors.zoho_crm.types.InvoicesGteCondition | airbyte_agent_sdk.connectors.zoho_crm.types.InvoicesLtCondition | airbyte_agent_sdk.connectors.zoho_crm.types.InvoicesLteCondition | airbyte_agent_sdk.connectors.zoho_crm.types.InvoicesInCondition | airbyte_agent_sdk.connectors.zoho_crm.types.InvoicesLikeCondition | airbyte_agent_sdk.connectors.zoho_crm.types.InvoicesFuzzyCondition | airbyte_agent_sdk.connectors.zoho_crm.types.InvoicesKeywordCondition | airbyte_agent_sdk.connectors.zoho_crm.types.InvoicesContainsCondition | airbyte_agent_sdk.connectors.zoho_crm.types.InvoicesNotCondition | airbyte_agent_sdk.connectors.zoho_crm.types.InvoicesAndCondition | airbyte_agent_sdk.connectors.zoho_crm.types.InvoicesOrCondition | airbyte_agent_sdk.connectors.zoho_crm.types.InvoicesAnyCondition`
     :   The type of the None singleton.
 
+<a id="InvoicesOrCondition"></a>
+
 `InvoicesOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -3532,6 +3848,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.zoho_crm.types.InvoicesEqCondition | airbyte_agent_sdk.connectors.zoho_crm.types.InvoicesNeqCondition | airbyte_agent_sdk.connectors.zoho_crm.types.InvoicesGtCondition | airbyte_agent_sdk.connectors.zoho_crm.types.InvoicesGteCondition | airbyte_agent_sdk.connectors.zoho_crm.types.InvoicesLtCondition | airbyte_agent_sdk.connectors.zoho_crm.types.InvoicesLteCondition | airbyte_agent_sdk.connectors.zoho_crm.types.InvoicesInCondition | airbyte_agent_sdk.connectors.zoho_crm.types.InvoicesLikeCondition | airbyte_agent_sdk.connectors.zoho_crm.types.InvoicesFuzzyCondition | airbyte_agent_sdk.connectors.zoho_crm.types.InvoicesKeywordCondition | airbyte_agent_sdk.connectors.zoho_crm.types.InvoicesContainsCondition | airbyte_agent_sdk.connectors.zoho_crm.types.InvoicesNotCondition | airbyte_agent_sdk.connectors.zoho_crm.types.InvoicesAndCondition | airbyte_agent_sdk.connectors.zoho_crm.types.InvoicesOrCondition | airbyte_agent_sdk.connectors.zoho_crm.types.InvoicesAnyCondition]`
     :   The type of the None singleton.
+
+<a id="InvoicesSearchFilter"></a>
 
 `InvoicesSearchFilter(*args, **kwargs)`
 :   Available fields for filtering invoices search queries.
@@ -3593,6 +3911,8 @@ Classes
     `terms_and_conditions: str | None`
     :   Terms and conditions text
 
+<a id="InvoicesSearchQuery"></a>
+
 `InvoicesSearchQuery(*args, **kwargs)`
 :   Search query for invoices entity.
 
@@ -3607,6 +3927,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.zoho_crm.types.InvoicesSortFilter]`
     :   The type of the None singleton.
+
+<a id="InvoicesSortFilter"></a>
 
 `InvoicesSortFilter(*args, **kwargs)`
 :   Available fields for sorting invoices search results.
@@ -3668,6 +3990,8 @@ Classes
     `terms_and_conditions: Literal['asc', 'desc']`
     :   Terms and conditions text
 
+<a id="InvoicesStringFilter"></a>
+
 `InvoicesStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -3728,6 +4052,8 @@ Classes
     `terms_and_conditions: str`
     :   Terms and conditions text
 
+<a id="LeadsAndCondition"></a>
+
 `LeadsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -3748,6 +4074,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.zoho_crm.types.LeadsEqCondition | airbyte_agent_sdk.connectors.zoho_crm.types.LeadsNeqCondition | airbyte_agent_sdk.connectors.zoho_crm.types.LeadsGtCondition | airbyte_agent_sdk.connectors.zoho_crm.types.LeadsGteCondition | airbyte_agent_sdk.connectors.zoho_crm.types.LeadsLtCondition | airbyte_agent_sdk.connectors.zoho_crm.types.LeadsLteCondition | airbyte_agent_sdk.connectors.zoho_crm.types.LeadsInCondition | airbyte_agent_sdk.connectors.zoho_crm.types.LeadsLikeCondition | airbyte_agent_sdk.connectors.zoho_crm.types.LeadsFuzzyCondition | airbyte_agent_sdk.connectors.zoho_crm.types.LeadsKeywordCondition | airbyte_agent_sdk.connectors.zoho_crm.types.LeadsContainsCondition | airbyte_agent_sdk.connectors.zoho_crm.types.LeadsNotCondition | airbyte_agent_sdk.connectors.zoho_crm.types.LeadsAndCondition | airbyte_agent_sdk.connectors.zoho_crm.types.LeadsOrCondition | airbyte_agent_sdk.connectors.zoho_crm.types.LeadsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="LeadsAnyCondition"></a>
+
 `LeadsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -3767,6 +4095,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.zoho_crm.types.LeadsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="LeadsAnyValueFilter"></a>
 
 `LeadsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -3843,6 +4173,8 @@ Classes
     `website: Any`
     :   Lead's website URL
 
+<a id="LeadsContainsCondition"></a>
+
 `LeadsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -3854,6 +4186,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.zoho_crm.types.LeadsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="LeadsEqCondition"></a>
 
 `LeadsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -3867,6 +4201,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.zoho_crm.types.LeadsSearchFilter`
     :   The type of the None singleton.
 
+<a id="LeadsFuzzyCondition"></a>
+
 `LeadsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -3878,6 +4214,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.zoho_crm.types.LeadsStringFilter`
     :   The type of the None singleton.
+
+<a id="LeadsGetParams"></a>
 
 `LeadsGetParams(*args, **kwargs)`
 :   Parameters for leads.get operation
@@ -3891,6 +4229,8 @@ Classes
     `id: str`
     :   The type of the None singleton.
 
+<a id="LeadsGtCondition"></a>
+
 `LeadsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -3903,6 +4243,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.zoho_crm.types.LeadsSearchFilter`
     :   The type of the None singleton.
 
+<a id="LeadsGteCondition"></a>
+
 `LeadsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -3914,6 +4256,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.zoho_crm.types.LeadsSearchFilter`
     :   The type of the None singleton.
+
+<a id="LeadsInCondition"></a>
 
 `LeadsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -3934,6 +4278,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.zoho_crm.types.LeadsInFilter`
     :   The type of the None singleton.
+
+<a id="LeadsInFilter"></a>
 
 `LeadsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -4010,6 +4356,8 @@ Classes
     `website: list[str]`
     :   Lead's website URL
 
+<a id="LeadsKeywordCondition"></a>
+
 `LeadsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -4022,6 +4370,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.zoho_crm.types.LeadsStringFilter`
     :   The type of the None singleton.
 
+<a id="LeadsLikeCondition"></a>
+
 `LeadsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -4033,6 +4383,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.zoho_crm.types.LeadsStringFilter`
     :   The type of the None singleton.
+
+<a id="LeadsListParams"></a>
 
 `LeadsListParams(*args, **kwargs)`
 :   Parameters for leads.list operation
@@ -4058,6 +4410,8 @@ Classes
     `sort_order: str`
     :   The type of the None singleton.
 
+<a id="LeadsLtCondition"></a>
+
 `LeadsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -4069,6 +4423,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.zoho_crm.types.LeadsSearchFilter`
     :   The type of the None singleton.
+
+<a id="LeadsLteCondition"></a>
 
 `LeadsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -4082,6 +4438,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.zoho_crm.types.LeadsSearchFilter`
     :   The type of the None singleton.
 
+<a id="LeadsNeqCondition"></a>
+
 `LeadsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -4093,6 +4451,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.zoho_crm.types.LeadsSearchFilter`
     :   The type of the None singleton.
+
+<a id="LeadsNotCondition"></a>
 
 `LeadsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -4114,6 +4474,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.zoho_crm.types.LeadsEqCondition | airbyte_agent_sdk.connectors.zoho_crm.types.LeadsNeqCondition | airbyte_agent_sdk.connectors.zoho_crm.types.LeadsGtCondition | airbyte_agent_sdk.connectors.zoho_crm.types.LeadsGteCondition | airbyte_agent_sdk.connectors.zoho_crm.types.LeadsLtCondition | airbyte_agent_sdk.connectors.zoho_crm.types.LeadsLteCondition | airbyte_agent_sdk.connectors.zoho_crm.types.LeadsInCondition | airbyte_agent_sdk.connectors.zoho_crm.types.LeadsLikeCondition | airbyte_agent_sdk.connectors.zoho_crm.types.LeadsFuzzyCondition | airbyte_agent_sdk.connectors.zoho_crm.types.LeadsKeywordCondition | airbyte_agent_sdk.connectors.zoho_crm.types.LeadsContainsCondition | airbyte_agent_sdk.connectors.zoho_crm.types.LeadsNotCondition | airbyte_agent_sdk.connectors.zoho_crm.types.LeadsAndCondition | airbyte_agent_sdk.connectors.zoho_crm.types.LeadsOrCondition | airbyte_agent_sdk.connectors.zoho_crm.types.LeadsAnyCondition`
     :   The type of the None singleton.
 
+<a id="LeadsOrCondition"></a>
+
 `LeadsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -4133,6 +4495,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.zoho_crm.types.LeadsEqCondition | airbyte_agent_sdk.connectors.zoho_crm.types.LeadsNeqCondition | airbyte_agent_sdk.connectors.zoho_crm.types.LeadsGtCondition | airbyte_agent_sdk.connectors.zoho_crm.types.LeadsGteCondition | airbyte_agent_sdk.connectors.zoho_crm.types.LeadsLtCondition | airbyte_agent_sdk.connectors.zoho_crm.types.LeadsLteCondition | airbyte_agent_sdk.connectors.zoho_crm.types.LeadsInCondition | airbyte_agent_sdk.connectors.zoho_crm.types.LeadsLikeCondition | airbyte_agent_sdk.connectors.zoho_crm.types.LeadsFuzzyCondition | airbyte_agent_sdk.connectors.zoho_crm.types.LeadsKeywordCondition | airbyte_agent_sdk.connectors.zoho_crm.types.LeadsContainsCondition | airbyte_agent_sdk.connectors.zoho_crm.types.LeadsNotCondition | airbyte_agent_sdk.connectors.zoho_crm.types.LeadsAndCondition | airbyte_agent_sdk.connectors.zoho_crm.types.LeadsOrCondition | airbyte_agent_sdk.connectors.zoho_crm.types.LeadsAnyCondition]`
     :   The type of the None singleton.
+
+<a id="LeadsSearchFilter"></a>
 
 `LeadsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering leads search queries.
@@ -4209,6 +4573,8 @@ Classes
     `website: str | None`
     :   Lead's website URL
 
+<a id="LeadsSearchQuery"></a>
+
 `LeadsSearchQuery(*args, **kwargs)`
 :   Search query for leads entity.
 
@@ -4223,6 +4589,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.zoho_crm.types.LeadsSortFilter]`
     :   The type of the None singleton.
+
+<a id="LeadsSortFilter"></a>
 
 `LeadsSortFilter(*args, **kwargs)`
 :   Available fields for sorting leads search results.
@@ -4299,6 +4667,8 @@ Classes
     `website: Literal['asc', 'desc']`
     :   Lead's website URL
 
+<a id="LeadsStringFilter"></a>
+
 `LeadsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -4374,6 +4744,8 @@ Classes
     `website: str`
     :   Lead's website URL
 
+<a id="ProductsAndCondition"></a>
+
 `ProductsAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -4394,6 +4766,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.zoho_crm.types.ProductsEqCondition | airbyte_agent_sdk.connectors.zoho_crm.types.ProductsNeqCondition | airbyte_agent_sdk.connectors.zoho_crm.types.ProductsGtCondition | airbyte_agent_sdk.connectors.zoho_crm.types.ProductsGteCondition | airbyte_agent_sdk.connectors.zoho_crm.types.ProductsLtCondition | airbyte_agent_sdk.connectors.zoho_crm.types.ProductsLteCondition | airbyte_agent_sdk.connectors.zoho_crm.types.ProductsInCondition | airbyte_agent_sdk.connectors.zoho_crm.types.ProductsLikeCondition | airbyte_agent_sdk.connectors.zoho_crm.types.ProductsFuzzyCondition | airbyte_agent_sdk.connectors.zoho_crm.types.ProductsKeywordCondition | airbyte_agent_sdk.connectors.zoho_crm.types.ProductsContainsCondition | airbyte_agent_sdk.connectors.zoho_crm.types.ProductsNotCondition | airbyte_agent_sdk.connectors.zoho_crm.types.ProductsAndCondition | airbyte_agent_sdk.connectors.zoho_crm.types.ProductsOrCondition | airbyte_agent_sdk.connectors.zoho_crm.types.ProductsAnyCondition]`
     :   The type of the None singleton.
 
+<a id="ProductsAnyCondition"></a>
+
 `ProductsAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -4413,6 +4787,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.zoho_crm.types.ProductsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="ProductsAnyValueFilter"></a>
 
 `ProductsAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -4471,6 +4847,8 @@ Classes
     `unit_price: Any`
     :   Unit price of the product
 
+<a id="ProductsContainsCondition"></a>
+
 `ProductsContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -4482,6 +4860,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.zoho_crm.types.ProductsAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="ProductsEqCondition"></a>
 
 `ProductsEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -4495,6 +4875,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.zoho_crm.types.ProductsSearchFilter`
     :   The type of the None singleton.
 
+<a id="ProductsFuzzyCondition"></a>
+
 `ProductsFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -4506,6 +4888,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.zoho_crm.types.ProductsStringFilter`
     :   The type of the None singleton.
+
+<a id="ProductsGetParams"></a>
 
 `ProductsGetParams(*args, **kwargs)`
 :   Parameters for products.get operation
@@ -4519,6 +4903,8 @@ Classes
     `id: str`
     :   The type of the None singleton.
 
+<a id="ProductsGtCondition"></a>
+
 `ProductsGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -4531,6 +4917,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.zoho_crm.types.ProductsSearchFilter`
     :   The type of the None singleton.
 
+<a id="ProductsGteCondition"></a>
+
 `ProductsGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -4542,6 +4930,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.zoho_crm.types.ProductsSearchFilter`
     :   The type of the None singleton.
+
+<a id="ProductsInCondition"></a>
 
 `ProductsInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -4562,6 +4952,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.zoho_crm.types.ProductsInFilter`
     :   The type of the None singleton.
+
+<a id="ProductsInFilter"></a>
 
 `ProductsInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -4620,6 +5012,8 @@ Classes
     `unit_price: list[float]`
     :   Unit price of the product
 
+<a id="ProductsKeywordCondition"></a>
+
 `ProductsKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -4632,6 +5026,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.zoho_crm.types.ProductsStringFilter`
     :   The type of the None singleton.
 
+<a id="ProductsLikeCondition"></a>
+
 `ProductsLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -4643,6 +5039,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.zoho_crm.types.ProductsStringFilter`
     :   The type of the None singleton.
+
+<a id="ProductsListParams"></a>
 
 `ProductsListParams(*args, **kwargs)`
 :   Parameters for products.list operation
@@ -4668,6 +5066,8 @@ Classes
     `sort_order: str`
     :   The type of the None singleton.
 
+<a id="ProductsLtCondition"></a>
+
 `ProductsLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -4679,6 +5079,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.zoho_crm.types.ProductsSearchFilter`
     :   The type of the None singleton.
+
+<a id="ProductsLteCondition"></a>
 
 `ProductsLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -4692,6 +5094,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.zoho_crm.types.ProductsSearchFilter`
     :   The type of the None singleton.
 
+<a id="ProductsNeqCondition"></a>
+
 `ProductsNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -4703,6 +5107,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.zoho_crm.types.ProductsSearchFilter`
     :   The type of the None singleton.
+
+<a id="ProductsNotCondition"></a>
 
 `ProductsNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -4724,6 +5130,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.zoho_crm.types.ProductsEqCondition | airbyte_agent_sdk.connectors.zoho_crm.types.ProductsNeqCondition | airbyte_agent_sdk.connectors.zoho_crm.types.ProductsGtCondition | airbyte_agent_sdk.connectors.zoho_crm.types.ProductsGteCondition | airbyte_agent_sdk.connectors.zoho_crm.types.ProductsLtCondition | airbyte_agent_sdk.connectors.zoho_crm.types.ProductsLteCondition | airbyte_agent_sdk.connectors.zoho_crm.types.ProductsInCondition | airbyte_agent_sdk.connectors.zoho_crm.types.ProductsLikeCondition | airbyte_agent_sdk.connectors.zoho_crm.types.ProductsFuzzyCondition | airbyte_agent_sdk.connectors.zoho_crm.types.ProductsKeywordCondition | airbyte_agent_sdk.connectors.zoho_crm.types.ProductsContainsCondition | airbyte_agent_sdk.connectors.zoho_crm.types.ProductsNotCondition | airbyte_agent_sdk.connectors.zoho_crm.types.ProductsAndCondition | airbyte_agent_sdk.connectors.zoho_crm.types.ProductsOrCondition | airbyte_agent_sdk.connectors.zoho_crm.types.ProductsAnyCondition`
     :   The type of the None singleton.
 
+<a id="ProductsOrCondition"></a>
+
 `ProductsOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -4743,6 +5151,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.zoho_crm.types.ProductsEqCondition | airbyte_agent_sdk.connectors.zoho_crm.types.ProductsNeqCondition | airbyte_agent_sdk.connectors.zoho_crm.types.ProductsGtCondition | airbyte_agent_sdk.connectors.zoho_crm.types.ProductsGteCondition | airbyte_agent_sdk.connectors.zoho_crm.types.ProductsLtCondition | airbyte_agent_sdk.connectors.zoho_crm.types.ProductsLteCondition | airbyte_agent_sdk.connectors.zoho_crm.types.ProductsInCondition | airbyte_agent_sdk.connectors.zoho_crm.types.ProductsLikeCondition | airbyte_agent_sdk.connectors.zoho_crm.types.ProductsFuzzyCondition | airbyte_agent_sdk.connectors.zoho_crm.types.ProductsKeywordCondition | airbyte_agent_sdk.connectors.zoho_crm.types.ProductsContainsCondition | airbyte_agent_sdk.connectors.zoho_crm.types.ProductsNotCondition | airbyte_agent_sdk.connectors.zoho_crm.types.ProductsAndCondition | airbyte_agent_sdk.connectors.zoho_crm.types.ProductsOrCondition | airbyte_agent_sdk.connectors.zoho_crm.types.ProductsAnyCondition]`
     :   The type of the None singleton.
+
+<a id="ProductsSearchFilter"></a>
 
 `ProductsSearchFilter(*args, **kwargs)`
 :   Available fields for filtering products search queries.
@@ -4801,6 +5211,8 @@ Classes
     `unit_price: float | None`
     :   Unit price of the product
 
+<a id="ProductsSearchQuery"></a>
+
 `ProductsSearchQuery(*args, **kwargs)`
 :   Search query for products entity.
 
@@ -4815,6 +5227,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.zoho_crm.types.ProductsSortFilter]`
     :   The type of the None singleton.
+
+<a id="ProductsSortFilter"></a>
 
 `ProductsSortFilter(*args, **kwargs)`
 :   Available fields for sorting products search results.
@@ -4873,6 +5287,8 @@ Classes
     `unit_price: Literal['asc', 'desc']`
     :   Unit price of the product
 
+<a id="ProductsStringFilter"></a>
+
 `ProductsStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -4930,6 +5346,8 @@ Classes
     `unit_price: str`
     :   Unit price of the product
 
+<a id="QuotesAndCondition"></a>
+
 `QuotesAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -4950,6 +5368,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.zoho_crm.types.QuotesEqCondition | airbyte_agent_sdk.connectors.zoho_crm.types.QuotesNeqCondition | airbyte_agent_sdk.connectors.zoho_crm.types.QuotesGtCondition | airbyte_agent_sdk.connectors.zoho_crm.types.QuotesGteCondition | airbyte_agent_sdk.connectors.zoho_crm.types.QuotesLtCondition | airbyte_agent_sdk.connectors.zoho_crm.types.QuotesLteCondition | airbyte_agent_sdk.connectors.zoho_crm.types.QuotesInCondition | airbyte_agent_sdk.connectors.zoho_crm.types.QuotesLikeCondition | airbyte_agent_sdk.connectors.zoho_crm.types.QuotesFuzzyCondition | airbyte_agent_sdk.connectors.zoho_crm.types.QuotesKeywordCondition | airbyte_agent_sdk.connectors.zoho_crm.types.QuotesContainsCondition | airbyte_agent_sdk.connectors.zoho_crm.types.QuotesNotCondition | airbyte_agent_sdk.connectors.zoho_crm.types.QuotesAndCondition | airbyte_agent_sdk.connectors.zoho_crm.types.QuotesOrCondition | airbyte_agent_sdk.connectors.zoho_crm.types.QuotesAnyCondition]`
     :   The type of the None singleton.
 
+<a id="QuotesAnyCondition"></a>
+
 `QuotesAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -4969,6 +5389,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.zoho_crm.types.QuotesAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="QuotesAnyValueFilter"></a>
 
 `QuotesAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -5021,6 +5443,8 @@ Classes
     `valid_till: Any`
     :   Date until which the quote is valid
 
+<a id="QuotesContainsCondition"></a>
+
 `QuotesContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -5032,6 +5456,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.zoho_crm.types.QuotesAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="QuotesEqCondition"></a>
 
 `QuotesEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -5045,6 +5471,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.zoho_crm.types.QuotesSearchFilter`
     :   The type of the None singleton.
 
+<a id="QuotesFuzzyCondition"></a>
+
 `QuotesFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -5056,6 +5484,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.zoho_crm.types.QuotesStringFilter`
     :   The type of the None singleton.
+
+<a id="QuotesGetParams"></a>
 
 `QuotesGetParams(*args, **kwargs)`
 :   Parameters for quotes.get operation
@@ -5069,6 +5499,8 @@ Classes
     `id: str`
     :   The type of the None singleton.
 
+<a id="QuotesGtCondition"></a>
+
 `QuotesGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -5081,6 +5513,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.zoho_crm.types.QuotesSearchFilter`
     :   The type of the None singleton.
 
+<a id="QuotesGteCondition"></a>
+
 `QuotesGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -5092,6 +5526,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.zoho_crm.types.QuotesSearchFilter`
     :   The type of the None singleton.
+
+<a id="QuotesInCondition"></a>
 
 `QuotesInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -5112,6 +5548,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.zoho_crm.types.QuotesInFilter`
     :   The type of the None singleton.
+
+<a id="QuotesInFilter"></a>
 
 `QuotesInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -5164,6 +5602,8 @@ Classes
     `valid_till: list[str]`
     :   Date until which the quote is valid
 
+<a id="QuotesKeywordCondition"></a>
+
 `QuotesKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -5176,6 +5616,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.zoho_crm.types.QuotesStringFilter`
     :   The type of the None singleton.
 
+<a id="QuotesLikeCondition"></a>
+
 `QuotesLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -5187,6 +5629,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.zoho_crm.types.QuotesStringFilter`
     :   The type of the None singleton.
+
+<a id="QuotesListParams"></a>
 
 `QuotesListParams(*args, **kwargs)`
 :   Parameters for quotes.list operation
@@ -5212,6 +5656,8 @@ Classes
     `sort_order: str`
     :   The type of the None singleton.
 
+<a id="QuotesLtCondition"></a>
+
 `QuotesLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -5223,6 +5669,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.zoho_crm.types.QuotesSearchFilter`
     :   The type of the None singleton.
+
+<a id="QuotesLteCondition"></a>
 
 `QuotesLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -5236,6 +5684,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.zoho_crm.types.QuotesSearchFilter`
     :   The type of the None singleton.
 
+<a id="QuotesNeqCondition"></a>
+
 `QuotesNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -5247,6 +5697,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.zoho_crm.types.QuotesSearchFilter`
     :   The type of the None singleton.
+
+<a id="QuotesNotCondition"></a>
 
 `QuotesNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -5268,6 +5720,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.zoho_crm.types.QuotesEqCondition | airbyte_agent_sdk.connectors.zoho_crm.types.QuotesNeqCondition | airbyte_agent_sdk.connectors.zoho_crm.types.QuotesGtCondition | airbyte_agent_sdk.connectors.zoho_crm.types.QuotesGteCondition | airbyte_agent_sdk.connectors.zoho_crm.types.QuotesLtCondition | airbyte_agent_sdk.connectors.zoho_crm.types.QuotesLteCondition | airbyte_agent_sdk.connectors.zoho_crm.types.QuotesInCondition | airbyte_agent_sdk.connectors.zoho_crm.types.QuotesLikeCondition | airbyte_agent_sdk.connectors.zoho_crm.types.QuotesFuzzyCondition | airbyte_agent_sdk.connectors.zoho_crm.types.QuotesKeywordCondition | airbyte_agent_sdk.connectors.zoho_crm.types.QuotesContainsCondition | airbyte_agent_sdk.connectors.zoho_crm.types.QuotesNotCondition | airbyte_agent_sdk.connectors.zoho_crm.types.QuotesAndCondition | airbyte_agent_sdk.connectors.zoho_crm.types.QuotesOrCondition | airbyte_agent_sdk.connectors.zoho_crm.types.QuotesAnyCondition`
     :   The type of the None singleton.
 
+<a id="QuotesOrCondition"></a>
+
 `QuotesOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -5287,6 +5741,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.zoho_crm.types.QuotesEqCondition | airbyte_agent_sdk.connectors.zoho_crm.types.QuotesNeqCondition | airbyte_agent_sdk.connectors.zoho_crm.types.QuotesGtCondition | airbyte_agent_sdk.connectors.zoho_crm.types.QuotesGteCondition | airbyte_agent_sdk.connectors.zoho_crm.types.QuotesLtCondition | airbyte_agent_sdk.connectors.zoho_crm.types.QuotesLteCondition | airbyte_agent_sdk.connectors.zoho_crm.types.QuotesInCondition | airbyte_agent_sdk.connectors.zoho_crm.types.QuotesLikeCondition | airbyte_agent_sdk.connectors.zoho_crm.types.QuotesFuzzyCondition | airbyte_agent_sdk.connectors.zoho_crm.types.QuotesKeywordCondition | airbyte_agent_sdk.connectors.zoho_crm.types.QuotesContainsCondition | airbyte_agent_sdk.connectors.zoho_crm.types.QuotesNotCondition | airbyte_agent_sdk.connectors.zoho_crm.types.QuotesAndCondition | airbyte_agent_sdk.connectors.zoho_crm.types.QuotesOrCondition | airbyte_agent_sdk.connectors.zoho_crm.types.QuotesAnyCondition]`
     :   The type of the None singleton.
+
+<a id="QuotesSearchFilter"></a>
 
 `QuotesSearchFilter(*args, **kwargs)`
 :   Available fields for filtering quotes search queries.
@@ -5339,6 +5795,8 @@ Classes
     `valid_till: str | None`
     :   Date until which the quote is valid
 
+<a id="QuotesSearchQuery"></a>
+
 `QuotesSearchQuery(*args, **kwargs)`
 :   Search query for quotes entity.
 
@@ -5353,6 +5811,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.zoho_crm.types.QuotesSortFilter]`
     :   The type of the None singleton.
+
+<a id="QuotesSortFilter"></a>
 
 `QuotesSortFilter(*args, **kwargs)`
 :   Available fields for sorting quotes search results.
@@ -5405,6 +5865,8 @@ Classes
     `valid_till: Literal['asc', 'desc']`
     :   Date until which the quote is valid
 
+<a id="QuotesStringFilter"></a>
+
 `QuotesStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).
 
@@ -5456,6 +5918,8 @@ Classes
     `valid_till: str`
     :   Date until which the quote is valid
 
+<a id="TasksAndCondition"></a>
+
 `TasksAndCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -5476,6 +5940,8 @@ Classes
     `and: list[airbyte_agent_sdk.connectors.zoho_crm.types.TasksEqCondition | airbyte_agent_sdk.connectors.zoho_crm.types.TasksNeqCondition | airbyte_agent_sdk.connectors.zoho_crm.types.TasksGtCondition | airbyte_agent_sdk.connectors.zoho_crm.types.TasksGteCondition | airbyte_agent_sdk.connectors.zoho_crm.types.TasksLtCondition | airbyte_agent_sdk.connectors.zoho_crm.types.TasksLteCondition | airbyte_agent_sdk.connectors.zoho_crm.types.TasksInCondition | airbyte_agent_sdk.connectors.zoho_crm.types.TasksLikeCondition | airbyte_agent_sdk.connectors.zoho_crm.types.TasksFuzzyCondition | airbyte_agent_sdk.connectors.zoho_crm.types.TasksKeywordCondition | airbyte_agent_sdk.connectors.zoho_crm.types.TasksContainsCondition | airbyte_agent_sdk.connectors.zoho_crm.types.TasksNotCondition | airbyte_agent_sdk.connectors.zoho_crm.types.TasksAndCondition | airbyte_agent_sdk.connectors.zoho_crm.types.TasksOrCondition | airbyte_agent_sdk.connectors.zoho_crm.types.TasksAnyCondition]`
     :   The type of the None singleton.
 
+<a id="TasksAnyCondition"></a>
+
 `TasksAnyCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -5495,6 +5961,8 @@ Classes
 
     `any: airbyte_agent_sdk.connectors.zoho_crm.types.TasksAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="TasksAnyValueFilter"></a>
 
 `TasksAnyValueFilter(*args, **kwargs)`
 :   Available fields with Any value type. Used for 'contains' and 'any' conditions.
@@ -5535,6 +6003,8 @@ Classes
     `subject: Any`
     :   Subject or title of the task
 
+<a id="TasksContainsCondition"></a>
+
 `TasksContainsCondition(*args, **kwargs)`
 :   Check if value exists in array field. Example: \{"contains": \{"tags": "premium"\}\}
 
@@ -5546,6 +6016,8 @@ Classes
 
     `contains: airbyte_agent_sdk.connectors.zoho_crm.types.TasksAnyValueFilter`
     :   The type of the None singleton.
+
+<a id="TasksEqCondition"></a>
 
 `TasksEqCondition(*args, **kwargs)`
 :   Equal to: field equals value.
@@ -5559,6 +6031,8 @@ Classes
     `eq: airbyte_agent_sdk.connectors.zoho_crm.types.TasksSearchFilter`
     :   The type of the None singleton.
 
+<a id="TasksFuzzyCondition"></a>
+
 `TasksFuzzyCondition(*args, **kwargs)`
 :   Ordered word text match (case-insensitive).
 
@@ -5570,6 +6044,8 @@ Classes
 
     `fuzzy: airbyte_agent_sdk.connectors.zoho_crm.types.TasksStringFilter`
     :   The type of the None singleton.
+
+<a id="TasksGetParams"></a>
 
 `TasksGetParams(*args, **kwargs)`
 :   Parameters for tasks.get operation
@@ -5583,6 +6059,8 @@ Classes
     `id: str`
     :   The type of the None singleton.
 
+<a id="TasksGtCondition"></a>
+
 `TasksGtCondition(*args, **kwargs)`
 :   Greater than: field > value.
 
@@ -5595,6 +6073,8 @@ Classes
     `gt: airbyte_agent_sdk.connectors.zoho_crm.types.TasksSearchFilter`
     :   The type of the None singleton.
 
+<a id="TasksGteCondition"></a>
+
 `TasksGteCondition(*args, **kwargs)`
 :   Greater than or equal: field >= value.
 
@@ -5606,6 +6086,8 @@ Classes
 
     `gte: airbyte_agent_sdk.connectors.zoho_crm.types.TasksSearchFilter`
     :   The type of the None singleton.
+
+<a id="TasksInCondition"></a>
 
 `TasksInCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -5626,6 +6108,8 @@ Classes
 
     `in: airbyte_agent_sdk.connectors.zoho_crm.types.TasksInFilter`
     :   The type of the None singleton.
+
+<a id="TasksInFilter"></a>
 
 `TasksInFilter(*args, **kwargs)`
 :   Available fields for 'in' condition (values are lists).
@@ -5666,6 +6150,8 @@ Classes
     `subject: list[str]`
     :   Subject or title of the task
 
+<a id="TasksKeywordCondition"></a>
+
 `TasksKeywordCondition(*args, **kwargs)`
 :   Keyword text match (any word present).
 
@@ -5678,6 +6164,8 @@ Classes
     `keyword: airbyte_agent_sdk.connectors.zoho_crm.types.TasksStringFilter`
     :   The type of the None singleton.
 
+<a id="TasksLikeCondition"></a>
+
 `TasksLikeCondition(*args, **kwargs)`
 :   Partial string match with % wildcards.
 
@@ -5689,6 +6177,8 @@ Classes
 
     `like: airbyte_agent_sdk.connectors.zoho_crm.types.TasksStringFilter`
     :   The type of the None singleton.
+
+<a id="TasksListParams"></a>
 
 `TasksListParams(*args, **kwargs)`
 :   Parameters for tasks.list operation
@@ -5714,6 +6204,8 @@ Classes
     `sort_order: str`
     :   The type of the None singleton.
 
+<a id="TasksLtCondition"></a>
+
 `TasksLtCondition(*args, **kwargs)`
 :   Less than: field &lt; value.
 
@@ -5725,6 +6217,8 @@ Classes
 
     `lt: airbyte_agent_sdk.connectors.zoho_crm.types.TasksSearchFilter`
     :   The type of the None singleton.
+
+<a id="TasksLteCondition"></a>
 
 `TasksLteCondition(*args, **kwargs)`
 :   Less than or equal: field &lt;= value.
@@ -5738,6 +6232,8 @@ Classes
     `lte: airbyte_agent_sdk.connectors.zoho_crm.types.TasksSearchFilter`
     :   The type of the None singleton.
 
+<a id="TasksNeqCondition"></a>
+
 `TasksNeqCondition(*args, **kwargs)`
 :   Not equal to: field does not equal value.
 
@@ -5749,6 +6245,8 @@ Classes
 
     `neq: airbyte_agent_sdk.connectors.zoho_crm.types.TasksSearchFilter`
     :   The type of the None singleton.
+
+<a id="TasksNotCondition"></a>
 
 `TasksNotCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
@@ -5770,6 +6268,8 @@ Classes
     `not: airbyte_agent_sdk.connectors.zoho_crm.types.TasksEqCondition | airbyte_agent_sdk.connectors.zoho_crm.types.TasksNeqCondition | airbyte_agent_sdk.connectors.zoho_crm.types.TasksGtCondition | airbyte_agent_sdk.connectors.zoho_crm.types.TasksGteCondition | airbyte_agent_sdk.connectors.zoho_crm.types.TasksLtCondition | airbyte_agent_sdk.connectors.zoho_crm.types.TasksLteCondition | airbyte_agent_sdk.connectors.zoho_crm.types.TasksInCondition | airbyte_agent_sdk.connectors.zoho_crm.types.TasksLikeCondition | airbyte_agent_sdk.connectors.zoho_crm.types.TasksFuzzyCondition | airbyte_agent_sdk.connectors.zoho_crm.types.TasksKeywordCondition | airbyte_agent_sdk.connectors.zoho_crm.types.TasksContainsCondition | airbyte_agent_sdk.connectors.zoho_crm.types.TasksNotCondition | airbyte_agent_sdk.connectors.zoho_crm.types.TasksAndCondition | airbyte_agent_sdk.connectors.zoho_crm.types.TasksOrCondition | airbyte_agent_sdk.connectors.zoho_crm.types.TasksAnyCondition`
     :   The type of the None singleton.
 
+<a id="TasksOrCondition"></a>
+
 `TasksOrCondition(*args, **kwargs)`
 :   dict() -> new empty dictionary
     dict(mapping) -> new dictionary initialized from a mapping object's
@@ -5789,6 +6289,8 @@ Classes
 
     `or: list[airbyte_agent_sdk.connectors.zoho_crm.types.TasksEqCondition | airbyte_agent_sdk.connectors.zoho_crm.types.TasksNeqCondition | airbyte_agent_sdk.connectors.zoho_crm.types.TasksGtCondition | airbyte_agent_sdk.connectors.zoho_crm.types.TasksGteCondition | airbyte_agent_sdk.connectors.zoho_crm.types.TasksLtCondition | airbyte_agent_sdk.connectors.zoho_crm.types.TasksLteCondition | airbyte_agent_sdk.connectors.zoho_crm.types.TasksInCondition | airbyte_agent_sdk.connectors.zoho_crm.types.TasksLikeCondition | airbyte_agent_sdk.connectors.zoho_crm.types.TasksFuzzyCondition | airbyte_agent_sdk.connectors.zoho_crm.types.TasksKeywordCondition | airbyte_agent_sdk.connectors.zoho_crm.types.TasksContainsCondition | airbyte_agent_sdk.connectors.zoho_crm.types.TasksNotCondition | airbyte_agent_sdk.connectors.zoho_crm.types.TasksAndCondition | airbyte_agent_sdk.connectors.zoho_crm.types.TasksOrCondition | airbyte_agent_sdk.connectors.zoho_crm.types.TasksAnyCondition]`
     :   The type of the None singleton.
+
+<a id="TasksSearchFilter"></a>
 
 `TasksSearchFilter(*args, **kwargs)`
 :   Available fields for filtering tasks search queries.
@@ -5829,6 +6331,8 @@ Classes
     `subject: str | None`
     :   Subject or title of the task
 
+<a id="TasksSearchQuery"></a>
+
 `TasksSearchQuery(*args, **kwargs)`
 :   Search query for tasks entity.
 
@@ -5843,6 +6347,8 @@ Classes
 
     `sort: list[airbyte_agent_sdk.connectors.zoho_crm.types.TasksSortFilter]`
     :   The type of the None singleton.
+
+<a id="TasksSortFilter"></a>
 
 `TasksSortFilter(*args, **kwargs)`
 :   Available fields for sorting tasks search results.
@@ -5882,6 +6388,8 @@ Classes
 
     `subject: Literal['asc', 'desc']`
     :   Subject or title of the task
+
+<a id="TasksStringFilter"></a>
 
 `TasksStringFilter(*args, **kwargs)`
 :   String fields for text search conditions (like, fuzzy, keyword).

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/executor/hosted_executor.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/executor/hosted_executor.md
@@ -10,6 +10,8 @@ Hosted executor for proxying operations through the cloud API.
 Classes
 -------
 
+<a id="HostedExecutor"></a>
+
 `HostedExecutor(airbyte_client_id: str, airbyte_client_secret: str, connector_id: str | None = None, workspace_name: str | None = None, connector_definition_id: str | None = None, organization_id: str | None = None, model: Any | None = None)`
 :   Executor that proxies execution through the Airbyte Cloud API.
     

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/executor/index.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/executor/index.md
@@ -16,6 +16,8 @@ Sub-modules
 Classes
 -------
 
+<a id="ActionNotSupportedError"></a>
+
 `ActionNotSupportedError(*args, **kwargs)`
 :   Raised when an action is not supported for an entity.
 
@@ -26,6 +28,8 @@ Classes
     * builtins.Exception
     * builtins.BaseException
 
+<a id="EntityNotFoundError"></a>
+
 `EntityNotFoundError(*args, **kwargs)`
 :   Raised when an entity is not found in the connector.
 
@@ -35,6 +39,8 @@ Classes
     * airbyte_agent_sdk.errors.AirbyteError
     * builtins.Exception
     * builtins.BaseException
+
+<a id="ExecutionConfig"></a>
 
 `ExecutionConfig(entity: str, action: str, *, params: dict[str, Any] | None = None)`
 :   Configuration for connector execution.
@@ -68,6 +74,8 @@ Classes
 
     `params: dict[str, typing.Any] | None`
     :   The type of the None singleton.
+
+<a id="ExecutionResult"></a>
 
 `ExecutionResult(success: bool, data: dict[str, Any] | AsyncIterator[bytes], error: str | None = None, meta: dict[str, Any] | None = None)`
 :   Result of a connector execution.
@@ -120,6 +128,8 @@ Classes
     `success: bool`
     :   The type of the None singleton.
 
+<a id="ExecutorError"></a>
+
 `ExecutorError(*args, **kwargs)`
 :   Base exception for executor errors.
 
@@ -135,6 +145,8 @@ Classes
     * airbyte_agent_sdk.executor.models.EntityNotFoundError
     * airbyte_agent_sdk.executor.models.InvalidParameterError
     * airbyte_agent_sdk.executor.models.MissingParameterError
+
+<a id="ExecutorProtocol"></a>
 
 `ExecutorProtocol(*args, **kwargs)`
 :   Protocol for connector execution.
@@ -196,6 +208,8 @@ Classes
         
             Execution errors (entity not found, invalid operation) are returned
             in ExecutionResult.error instead of being raised.
+
+<a id="HostedExecutor"></a>
 
 `HostedExecutor(airbyte_client_id: str, airbyte_client_secret: str, connector_id: str | None = None, workspace_name: str | None = None, connector_definition_id: str | None = None, organization_id: str | None = None, model: Any | None = None)`
 :   Executor that proxies execution through the Airbyte Cloud API.
@@ -338,6 +352,8 @@ Classes
             # Shorthand form:
             result = await executor.execute("customers", "list", params=\{"limit": 10\})
 
+<a id="InvalidParameterError"></a>
+
 `InvalidParameterError(*args, **kwargs)`
 :   Raised when a parameter has an invalid type or value.
 
@@ -347,6 +363,8 @@ Classes
     * airbyte_agent_sdk.errors.AirbyteError
     * builtins.Exception
     * builtins.BaseException
+
+<a id="LocalExecutor"></a>
 
 `LocalExecutor(config_path: str | None = None, model: ConnectorModel | None = None, secrets: dict[str, SecretStr] | None = None, auth_config: dict[str, SecretStr] | None = None, auth_scheme: str | None = None, enable_logging: bool = False, log_file: str | None = None, execution_context: str | None = None, max_connections: int = 100, max_keepalive_connections: int = 20, max_logs: int | None = 10000, config_values: dict[str, str] | None = None, on_token_refresh: TokenRefreshCallback = None, retry_config: RetryConfig | None = None)`
 :   Async executor for Entity×Action operations with direct HTTP execution.
@@ -463,6 +481,8 @@ Classes
                 ("Customer", "get", \{"id": "cus_123"\}),
                 ("attachments", "download", \{"id": "att_456"\}),
             ])
+
+<a id="MissingParameterError"></a>
 
 `MissingParameterError(*args, **kwargs)`
 :   Raised when a required parameter is missing.

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/executor/local_executor.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/executor/local_executor.md
@@ -10,6 +10,8 @@ Local executor for direct HTTP execution of connector operations.
 Classes
 -------
 
+<a id="LocalExecutor"></a>
+
 `LocalExecutor(config_path: str | None = None, model: ConnectorModel | None = None, secrets: dict[str, SecretStr] | None = None, auth_config: dict[str, SecretStr] | None = None, auth_scheme: str | None = None, enable_logging: bool = False, log_file: str | None = None, execution_context: str | None = None, max_connections: int = 100, max_keepalive_connections: int = 20, max_logs: int | None = 10000, config_values: dict[str, str] | None = None, on_token_refresh: TokenRefreshCallback = None, retry_config: RetryConfig | None = None)`
 :   Async executor for Entity×Action operations with direct HTTP execution.
     
@@ -126,6 +128,8 @@ Classes
                 ("attachments", "download", \{"id": "att_456"\}),
             ])
 
+<a id="ParamResolutionError"></a>
+
 `ParamResolutionError(*args, **kwargs)`
 :   Raised when a path parameter cannot be resolved for entity probing.
     
@@ -143,6 +147,8 @@ Classes
 
     * builtins.Exception
     * builtins.BaseException
+
+<a id="ParentProbeError"></a>
 
 `ParentProbeError(message: str, status_code: int | None = None)`
 :   Raised when a parent entity's LIST probe fails during param resolution.

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/executor/models.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/executor/models.md
@@ -10,6 +10,8 @@ Data models and protocols for executor implementations.
 Functions
 ---------
 
+<a id="find_check_operation"></a>
+
 `find_check_operation(model: Any) ‑> tuple[str, typing.Any, dict[str, typing.Any]] | None`
 :   Find the best operation for a health check from a ConnectorModel.
     
@@ -24,6 +26,8 @@ Functions
         Tuple of (entity_name, action, params) or None if no suitable operation found.
         For list operations, params includes \{"limit": 1\} to minimize data transfer.
 
+<a id="has_required_params"></a>
+
 `has_required_params(endpoint: Any) ‑> bool`
 :   Check if an endpoint has required parameters without defaults.
     
@@ -34,6 +38,8 @@ Functions
 Classes
 -------
 
+<a id="ActionNotSupportedError"></a>
+
 `ActionNotSupportedError(*args, **kwargs)`
 :   Raised when an action is not supported for an entity.
 
@@ -43,6 +49,8 @@ Classes
     * airbyte_agent_sdk.errors.AirbyteError
     * builtins.Exception
     * builtins.BaseException
+
+<a id="AskResult"></a>
 
 `AskResult(outcome: str, outcome_reason: str | None = None, answer: str | None = None, results: list[AskToolCallResult] = <factory>, query_id: str | None = None, execution_metadata: dict[str, Any] = <factory>)`
 :   Result of a workspace-level natural language query.
@@ -76,6 +84,8 @@ Classes
     `results: list[airbyte_agent_sdk.executor.models.AskToolCallResult]`
     :   The type of the None singleton.
 
+<a id="AskToolCallResult"></a>
+
 `AskToolCallResult(source_id: str | None = None, entity: str | None = None, action: str | None = None, params: dict[str, Any] = <factory>, status: str | None = None, data: Any = None, connector_metadata: Any = None, execution_time_ms: int | None = None)`
 :   A single tool call result from a structured query.
     
@@ -106,6 +116,8 @@ Classes
 
     `status: str | None`
     :   The type of the None singleton.
+
+<a id="AutomationInfo"></a>
 
 `AutomationInfo(id: str, workflow_id: str, workspace_id: str, enabled: bool, trigger_type: str, cron_expression: str | None = None, timezone: str = 'UTC', completion_webhook_url: str | None = None, trigger_webhook_url: str | None = None, created_at: str | None = None, updated_at: str | None = None)`
 :   An automation attached to a workflow.
@@ -145,6 +157,8 @@ Classes
     `workspace_id: str`
     :   The type of the None singleton.
 
+<a id="ConnectorInfo"></a>
+
 `ConnectorInfo(id: str, name: str, connector_type: str | None = None, created_at: str | None = None, updated_at: str | None = None)`
 :   A connector instance in a workspace.
 
@@ -165,6 +179,8 @@ Classes
     `updated_at: str | None`
     :   The type of the None singleton.
 
+<a id="EntityNotFoundError"></a>
+
 `EntityNotFoundError(*args, **kwargs)`
 :   Raised when an entity is not found in the connector.
 
@@ -174,6 +190,8 @@ Classes
     * airbyte_agent_sdk.errors.AirbyteError
     * builtins.Exception
     * builtins.BaseException
+
+<a id="ExecutionConfig"></a>
 
 `ExecutionConfig(entity: str, action: str, *, params: dict[str, Any] | None = None)`
 :   Configuration for connector execution.
@@ -207,6 +225,8 @@ Classes
 
     `params: dict[str, typing.Any] | None`
     :   The type of the None singleton.
+
+<a id="ExecutionResult"></a>
 
 `ExecutionResult(success: bool, data: dict[str, Any] | AsyncIterator[bytes], error: str | None = None, meta: dict[str, Any] | None = None)`
 :   Result of a connector execution.
@@ -259,6 +279,8 @@ Classes
     `success: bool`
     :   The type of the None singleton.
 
+<a id="ExecutorError"></a>
+
 `ExecutorError(*args, **kwargs)`
 :   Base exception for executor errors.
 
@@ -274,6 +296,8 @@ Classes
     * airbyte_agent_sdk.executor.models.EntityNotFoundError
     * airbyte_agent_sdk.executor.models.InvalidParameterError
     * airbyte_agent_sdk.executor.models.MissingParameterError
+
+<a id="ExecutorProtocol"></a>
 
 `ExecutorProtocol(*args, **kwargs)`
 :   Protocol for connector execution.
@@ -336,6 +360,8 @@ Classes
             Execution errors (entity not found, invalid operation) are returned
             in ExecutionResult.error instead of being raised.
 
+<a id="InvalidParameterError"></a>
+
 `InvalidParameterError(*args, **kwargs)`
 :   Raised when a parameter has an invalid type or value.
 
@@ -346,6 +372,8 @@ Classes
     * builtins.Exception
     * builtins.BaseException
 
+<a id="MissingParameterError"></a>
+
 `MissingParameterError(*args, **kwargs)`
 :   Raised when a required parameter is missing.
 
@@ -355,6 +383,8 @@ Classes
     * airbyte_agent_sdk.errors.AirbyteError
     * builtins.Exception
     * builtins.BaseException
+
+<a id="StandardExecuteResult"></a>
 
 `StandardExecuteResult(data: dict[str, Any], metadata: dict[str, Any] | None = None)`
 :   Result from standard operation handlers (GET, LIST, CREATE, UPDATE, DELETE, etc.).
@@ -380,6 +410,8 @@ Classes
 
     `metadata: dict[str, typing.Any] | None`
     :   The type of the None singleton.
+
+<a id="WorkflowInfo"></a>
 
 `WorkflowInfo(id: str, name: str, workspace_id: str, created_at: str | None = None, updated_at: str | None = None)`
 :   A workflow in a workspace.

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/http_client.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/http_client.md
@@ -10,6 +10,8 @@ Async HTTP client with connection pooling, auth injection, metrics, and retry su
 Classes
 -------
 
+<a id="HTTPClient"></a>
+
 `HTTPClient(base_url: str, auth_config: AuthConfig, secrets: dict[str, SecretStr | str], config_values: dict[str, str] | None = None, client: HTTPClientProtocol | None = None, logger: Any | None = None, max_connections: int = 100, max_keepalive_connections: int = 20, timeout: float = 30.0, connect_timeout: float | None = None, read_timeout: float | None = None, on_token_refresh: TokenRefreshCallback = None, retry_config: RetryConfig | None = None)`
 :   Async HTTP client for making API requests with authentication and connection pooling.
     
@@ -81,6 +83,8 @@ Classes
             TimeoutError: If request times out (after all retries if configured)
             NetworkError: If network error occurs (after all retries if configured)
             HTTPClientError: For other client errors
+
+<a id="HTTPMetrics"></a>
 
 `HTTPMetrics()`
 :   Metrics collector for HTTP requests.

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/index.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/index.md
@@ -132,6 +132,8 @@ Sub-modules
 Functions
 ---------
 
+<a id="ask"></a>
+
 `ask(prompt: str, *, client_id: str | None = None, client_secret: str | None = None, workspace_name: str | None = None, organization_id: str | None = None) ‑> airbyte_agent_sdk.executor.models.AskResult`
 :   Ask a natural-language question across all connectors in a workspace.
     
@@ -177,6 +179,8 @@ Functions
     See also:
         [`ask_sync`](#ask_sync) — blocking wrapper for scripts and notebooks.
 
+<a id="ask_sync"></a>
+
 `ask_sync(prompt: str, *, client_id: str | None = None, client_secret: str | None = None, workspace_name: str | None = None, organization_id: str | None = None) ‑> airbyte_agent_sdk.executor.models.AskResult`
 :   Blocking variant of [`ask`](#ask). Works in scripts and notebooks.
     
@@ -215,11 +219,15 @@ Functions
     See also:
         [`ask`](#ask) — the async version for use in async applications.
 
+<a id="configure"></a>
+
 `configure(*, client_id: str, client_secret: str, organization_id: str | None = None, workspace_name: str = 'default') ‑> None`
 :   Set global SDK credentials. These are used as defaults by connect(), Workspace, and ask().
     
     Calling configure() again overwrites the previous configuration.
     Explicit kwargs passed to connect()/Workspace()/ask() always take priority.
+
+<a id="connect"></a>
 
 `connect(connector_name: str, *, client_id: str | None = None, client_secret: str | None = None, workspace_name: str | None = None, connector_id: str | None = None, organization_id: str | None = None, auth_config: AirbyteAuthConfig | None = None) ‑> StripeConnector | HostedExecutor`
 :   Create a typed connector or `HostedExecutor` for a connector by name.
@@ -283,8 +291,12 @@ Functions
         See the module-level `## Errors` section for a compound `try`/`except`
         pattern that catches both SDK-defined and hosted-path errors.
 
+<a id="list_connectors"></a>
+
 `list_connectors() ‑> list[str]`
 :   Return a sorted list of all available connector names.
+
+<a id="save_download"></a>
 
 `save_download(download_iterator: AsyncIterator[bytes], path: str | Path, *, overwrite: bool = False) ‑> pathlib._local.Path`
 :   Save a download iterator to a file.
@@ -316,6 +328,8 @@ Functions
 Classes
 -------
 
+<a id="ActionNotSupportedError"></a>
+
 `ActionNotSupportedError(*args, **kwargs)`
 :   Raised when an action is not supported for an entity.
 
@@ -325,6 +339,8 @@ Classes
     * airbyte_agent_sdk.errors.AirbyteError
     * builtins.Exception
     * builtins.BaseException
+
+<a id="AirbyteAuthConfig"></a>
 
 `AirbyteAuthConfig(**data: Any)`
 :   Authentication configuration for Airbyte hosted mode execution.
@@ -394,6 +410,8 @@ Classes
     `workspace_name: str | None`
     :   The type of the None singleton.
 
+<a id="AirbyteError"></a>
+
 `AirbyteError(*args, **kwargs)`
 :   Root of the SDK exception hierarchy.
     
@@ -433,6 +451,8 @@ Classes
     * airbyte_agent_sdk.executor.models.ExecutorError
     * airbyte_agent_sdk.http.exceptions.HTTPClientError
 
+<a id="AskResult"></a>
+
 `AskResult(outcome: str, outcome_reason: str | None = None, answer: str | None = None, results: list[AskToolCallResult] = <factory>, query_id: str | None = None, execution_metadata: dict[str, Any] = <factory>)`
 :   Result of a workspace-level natural language query.
     
@@ -465,6 +485,8 @@ Classes
     `results: list[airbyte_agent_sdk.executor.models.AskToolCallResult]`
     :   The type of the None singleton.
 
+<a id="AuthenticationError"></a>
+
 `AuthenticationError(message: str, status_code: int = 401, response: HTTPResponse | None = None)`
 :   Raised when authentication credentials are missing or invalid (401, 403).
     
@@ -482,6 +504,8 @@ Classes
     * airbyte_agent_sdk.errors.AirbyteError
     * builtins.Exception
     * builtins.BaseException
+
+<a id="AutomationInfo"></a>
 
 `AutomationInfo(id: str, workflow_id: str, workspace_id: str, enabled: bool, trigger_type: str, cron_expression: str | None = None, timezone: str = 'UTC', completion_webhook_url: str | None = None, trigger_webhook_url: str | None = None, created_at: str | None = None, updated_at: str | None = None)`
 :   An automation attached to a workflow.
@@ -521,6 +545,8 @@ Classes
     `workspace_id: str`
     :   The type of the None singleton.
 
+<a id="ConnectorInfo"></a>
+
 `ConnectorInfo(id: str, name: str, connector_type: str | None = None, created_at: str | None = None, updated_at: str | None = None)`
 :   A connector instance in a workspace.
 
@@ -540,6 +566,8 @@ Classes
 
     `updated_at: str | None`
     :   The type of the None singleton.
+
+<a id="ConnectorValidationError"></a>
 
 `ConnectorValidationError(message: str, status_code: int = 400, response: HTTPResponse | None = None)`
 :   Raised when a connector request fails client-side or server-side validation.
@@ -565,6 +593,8 @@ Classes
     * builtins.Exception
     * builtins.BaseException
 
+<a id="EntityNotFoundError"></a>
+
 `EntityNotFoundError(*args, **kwargs)`
 :   Raised when an entity is not found in the connector.
 
@@ -574,6 +604,8 @@ Classes
     * airbyte_agent_sdk.errors.AirbyteError
     * builtins.Exception
     * builtins.BaseException
+
+<a id="ExecutionConfig"></a>
 
 `ExecutionConfig(entity: str, action: str, *, params: dict[str, Any] | None = None)`
 :   Configuration for connector execution.
@@ -607,6 +639,8 @@ Classes
 
     `params: dict[str, typing.Any] | None`
     :   The type of the None singleton.
+
+<a id="ExecutionResult"></a>
 
 `ExecutionResult(success: bool, data: dict[str, Any] | AsyncIterator[bytes], error: str | None = None, meta: dict[str, Any] | None = None)`
 :   Result of a connector execution.
@@ -659,6 +693,8 @@ Classes
     `success: bool`
     :   The type of the None singleton.
 
+<a id="ExecutorError"></a>
+
 `ExecutorError(*args, **kwargs)`
 :   Base exception for executor errors.
 
@@ -675,6 +711,8 @@ Classes
     * airbyte_agent_sdk.executor.models.InvalidParameterError
     * airbyte_agent_sdk.executor.models.MissingParameterError
 
+<a id="HTTPClientError"></a>
+
 `HTTPClientError(*args, **kwargs)`
 :   Base exception for HTTP client errors.
 
@@ -689,6 +727,8 @@ Classes
     * airbyte_agent_sdk.http.exceptions.HTTPStatusError
     * airbyte_agent_sdk.http.exceptions.NetworkError
     * airbyte_agent_sdk.http.exceptions.TimeoutError
+
+<a id="HTTPStatusError"></a>
 
 `HTTPStatusError(status_code: int, message: str, response: HTTPResponse | None = None)`
 :   Raised when an HTTP response has a 4xx or 5xx status code.
@@ -715,6 +755,8 @@ Classes
     * airbyte_agent_sdk.http.exceptions.AuthenticationError
     * airbyte_agent_sdk.http.exceptions.ConnectorValidationError
     * airbyte_agent_sdk.http.exceptions.RateLimitError
+
+<a id="HostedExecutor"></a>
 
 `HostedExecutor(airbyte_client_id: str, airbyte_client_secret: str, connector_id: str | None = None, workspace_name: str | None = None, connector_definition_id: str | None = None, organization_id: str | None = None, model: Any | None = None)`
 :   Executor that proxies execution through the Airbyte Cloud API.
@@ -857,6 +899,8 @@ Classes
             # Shorthand form:
             result = await executor.execute("customers", "list", params=\{"limit": 10\})
 
+<a id="InvalidParameterError"></a>
+
 `InvalidParameterError(*args, **kwargs)`
 :   Raised when a parameter has an invalid type or value.
 
@@ -867,6 +911,8 @@ Classes
     * builtins.Exception
     * builtins.BaseException
 
+<a id="MissingParameterError"></a>
+
 `MissingParameterError(*args, **kwargs)`
 :   Raised when a required parameter is missing.
 
@@ -876,6 +922,8 @@ Classes
     * airbyte_agent_sdk.errors.AirbyteError
     * builtins.Exception
     * builtins.BaseException
+
+<a id="NetworkError"></a>
 
 `NetworkError(message: str, original_error: Exception | None = None)`
 :   Raised when network connection fails.
@@ -896,6 +944,8 @@ Classes
     * builtins.Exception
     * builtins.BaseException
 
+<a id="RateLimitError"></a>
+
 `RateLimitError(message: str, retry_after: int | None = None, response: HTTPResponse | None = None)`
 :   Raised when API rate limit is exceeded (429 response).
     
@@ -913,6 +963,8 @@ Classes
     * airbyte_agent_sdk.errors.AirbyteError
     * builtins.Exception
     * builtins.BaseException
+
+<a id="TimeoutError"></a>
 
 `TimeoutError(message: str, timeout_type: str | None = None, original_error: Exception | None = None)`
 :   Raised when a request times out.
@@ -939,6 +991,8 @@ Classes
     * builtins.Exception
     * builtins.BaseException
 
+<a id="WorkflowInfo"></a>
+
 `WorkflowInfo(id: str, name: str, workspace_id: str, created_at: str | None = None, updated_at: str | None = None)`
 :   A workflow in a workspace.
 
@@ -958,6 +1012,8 @@ Classes
 
     `workspace_id: str`
     :   The type of the None singleton.
+
+<a id="Workspace"></a>
 
 `Workspace(*, client_id: str | None = None, client_secret: str | None = None, workspace_name: str | None = None, organization_id: str | None = None)`
 :   Top-level entry point for Airbyte hosted-mode workspace operations.

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/types.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/types.md
@@ -10,6 +10,8 @@ Type definitions for Airbyte SDK.
 Classes
 -------
 
+<a id="Action"></a>
+
 `Action(*args, **kwds)`
 :   Supported actions for Entity operations.
     
@@ -51,6 +53,8 @@ Classes
 
     `UPDATE`
     :   The type of the None singleton.
+
+<a id="AirbyteAuthConfig"></a>
 
 `AirbyteAuthConfig(**data: Any)`
 :   Authentication configuration for Airbyte hosted mode execution.
@@ -120,6 +124,8 @@ Classes
     `workspace_name: str | None`
     :   The type of the None singleton.
 
+<a id="AuthConfig"></a>
+
 `AuthConfig(**data: Any)`
 :   Authentication configuration supporting single or multiple auth methods.
     
@@ -183,6 +189,8 @@ Classes
         Returns:
             True if multiple auth options are available, False for single-auth
 
+<a id="AuthOption"></a>
+
 `AuthOption(**data: Any)`
 :   A single authentication option in a multi-auth connector.
     
@@ -226,6 +234,8 @@ Classes
     `user_config_spec: airbyte_agent_sdk.schema.security.AuthConfigSpec | None`
     :   The type of the None singleton.
 
+<a id="AuthType"></a>
+
 `AuthType(*args, **kwds)`
 :   Supported authentication types.
 
@@ -250,6 +260,8 @@ Classes
 
     `OAUTH2`
     :   The type of the None singleton.
+
+<a id="ConnectorModel"></a>
 
 `ConnectorModel(**data: Any)`
 :   Complete connector model loaded from YAML definition.
@@ -309,6 +321,8 @@ Classes
     `version: str`
     :   The type of the None singleton.
 
+<a id="ContentType"></a>
+
 `ContentType(*args, **kwds)`
 :   Supported content types for request bodies.
 
@@ -330,6 +344,8 @@ Classes
 
     `MULTIPART_RELATED`
     :   The type of the None singleton.
+
+<a id="EndpointDefinition"></a>
 
 `EndpointDefinition(**data: Any)`
 :   Definition of an API endpoint.
@@ -431,6 +447,8 @@ Classes
     `upload_file_param: str | None`
     :   The type of the None singleton.
 
+<a id="EntityDefinition"></a>
+
 `EntityDefinition(**data: Any)`
 :   Definition of an API entity.
     
@@ -470,6 +488,8 @@ Classes
 
     `stream_name: str | None`
     :   The type of the None singleton.
+
+<a id="ParameterLocation"></a>
 
 `ParameterLocation(*args, **kwds)`
 :   Location of operation parameters.

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/utils.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/utils.md
@@ -10,6 +10,8 @@ Utility functions for working with connectors.
 Functions
 ---------
 
+<a id="find_matching_auth_options"></a>
+
 `find_matching_auth_options(provided_keys: set[str], auth_options: list[AuthOption]) ‑> list[AuthOption]`
 :   Find auth options that match the provided credential keys.
     
@@ -27,6 +29,8 @@ Functions
     Returns:
         List of AuthOption that match the provided keys
 
+<a id="infer_auth_scheme_name"></a>
+
 `infer_auth_scheme_name(provided_keys: set[str], auth_options: list[AuthOption]) ‑> str | None`
 :   Infer the auth scheme name from provided credential keys.
     
@@ -39,6 +43,8 @@ Functions
     
     Returns:
         The scheme_name if exactly one match, None otherwise
+
+<a id="save_download"></a>
 
 `save_download(download_iterator: AsyncIterator[bytes], path: str | Path, *, overwrite: bool = False) ‑> pathlib._local.Path`
 :   Save a download iterator to a file.

--- a/docs/ai-agents/reference/sdk/airbyte_agent_sdk/workspace.md
+++ b/docs/ai-agents/reference/sdk/airbyte_agent_sdk/workspace.md
@@ -10,13 +10,15 @@ Workspace — top-level entry point for hosted-mode workspace operations.
 Classes
 -------
 
+<a id="Workspace"></a>
+
 `Workspace(*, client_id: str | None = None, client_secret: str | None = None, workspace_name: str | None = None, organization_id: str | None = None)`
 :   Top-level entry point for Airbyte hosted-mode workspace operations.
     
     Provides workspace-level methods: `ask`, list/create/delete connectors,
     get a connector executor, and workflow/automation CRUD. Use `Workspace`
     when you want to operate against a whole workspace (many connectors,
-    workflows, automations); use [`connect()`](#connect) when you already
+    workflows, automations); use [`connect()`](index.md#connect) when you already
     know which connector you want to execute.
     
     Example:


### PR DESCRIPTION
## What

Fixes broken cross-reference links in the auto-generated SDK reference docs (`docs/ai-agents/reference/sdk/`).

pdoc3 generates same-page anchor links (`#SymbolName`) that assume every symbol lives on a single HTML page. In Docusaurus, each module gets its own page, so these links either have no matching target (definition lists don't create heading anchors) or point to a non-existent anchor on the wrong page (e.g. `workspace.md` linking to `#connect` when `connect()` is documented in `index.md`).

## How

Adds a "Resolve pdoc3 Cross-References" post-processing step to the `agent-sdk-docs-generate` workflow (between frontmatter insertion and MDX sanitization) that:

1. Builds a symbol index by scanning all generated `.md` files for function/class definitions.
2. Inserts `<a id="SymbolName"></a>` HTML anchors before each definition so same-page `#anchor` links have valid targets.
3. Rewrites cross-page `#anchor` links to relative Markdown file paths (e.g. `index.md#connect`) so inter-module references navigate to the correct page.

Also applies the fix to the existing seeded SDK reference docs so the branch reflects the improvement immediately.

## Review guide

1. `.github/workflows/agent-sdk-docs-generate.yml` — the new "Resolve pdoc3 Cross-References" step
2. `docs/ai-agents/reference/sdk/` — the fixed generated docs (anchor tags added, cross-page links resolved)

## User Impact

SDK reference docs links that previously did nothing now navigate to the correct symbol definition, either on the same page or across pages.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚


Link to Devin session: https://app.devin.ai/sessions/da0f467888454ef187491d81baa6e95d
Requested by: @ian-at-airbyte