### PR TITLE
chore(source-airtable): add API deprecation guidelines URL to external docs

### DIFF
--- a/airbyte-integrations/connectors/source-airtable/metadata.yaml
+++ b/airbyte-integrations/connectors/source-airtable/metadata.yaml
@@ -22,6 +22,9 @@ data:
       url: https://community.airtable.com/development-apis-11
     - title: OAuth refference
       url: https://airtable.com/developers/web/api/oauth-reference#authorization-request
+    - title: API Deprecation Guidelines
+      url: https://support.airtable.com/docs/airtable-api-deprecation-guidelines
+      type: api_deprecations
   resourceRequirements:
     jobSpecific:
       - jobType: check_connection


### PR DESCRIPTION
## What

Adds Airtable's official [API Deprecation Guidelines](https://support.airtable.com/docs/airtable-api-deprecation-guidelines) page to the `source-airtable` connector's `externalDocumentationUrls` in `metadata.yaml` as an `api_deprecations` type URL.

This was identified during routine API deprecation monitoring for the Airtable API family. The deprecation guidelines page documents Airtable's policy on breaking changes (12-month advance notice for Web API) and is useful for future deprecation monitoring runs.

Resolves https://github.com/airbytehq/oncall/issues/10427

- https://github.com/airbytehq/oncall/issues/10427

Requested by: @DanyloGL

## How

Added a new entry to the `externalDocumentationUrls` list in `metadata.yaml`:
```yaml
- title: API Deprecation Guidelines
  url: https://support.airtable.com/docs/airtable-api-deprecation-guidelines
  type: api_deprecations
```

## Review guide

1. `airbyte-integrations/connectors/source-airtable/metadata.yaml`

## User Impact

No user-facing impact. This is a metadata-only change that improves deprecation monitoring coverage.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Link to Devin session: https://app.devin.ai/sessions/9a6ac9f21f254c5281fd4e1ce5f87744