### PR TITLE
chore(source-github): fix stale GitHub API changelog URL in metadata

### DIFF
--- a/airbyte-integrations/connectors/source-github/metadata.yaml
+++ b/airbyte-integrations/connectors/source-github/metadata.yaml
@@ -92,7 +92,7 @@ data:
       url: https://docs.github.com/en/rest/about-the-rest-api/api-versions
       type: api_release_history
     - title: GitHub API changelog
-      url: https://github.blog/changelog/label/api/
+      url: https://github.blog/changelog/
       type: api_release_history
     - title: GitHub authentication
       url: https://docs.github.com/en/rest/overview/authenticating-to-the-rest-api


### PR DESCRIPTION
## What

Fixes a stale external documentation URL in the `source-github` connector's `metadata.yaml`. The GitHub API changelog URL `https://github.blog/changelog/label/api/` returns a 404 error because GitHub changed their changelog from URL-based label filtering to in-page tag filtering.

Resolves https://github.com/airbytehq/oncall/issues/12092

- https://github.com/airbytehq/oncall/issues/12092

## How

Updated the stale URL in `externalDocumentationUrls` from `https://github.blog/changelog/label/api/` to `https://github.blog/changelog/`, which is the correct entry point for the GitHub changelog.

## Review guide

1. `airbyte-integrations/connectors/source-github/metadata.yaml` — single URL change on line 95

## User Impact

No user-facing impact. This is a metadata-only change that fixes a stale documentation URL used by internal tooling for API deprecation monitoring.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Requested by @DanyloGL via API Deprecation Monitoring playbook.

Link to Devin session: https://app.devin.ai/sessions/68a5b53aff744e3694832ad5238534d2