### PR TITLE
chore(source-gitlab): update external documentation URLs to canonical paths

### DIFF
--- a/airbyte-integrations/connectors/source-gitlab/metadata.yaml
+++ b/airbyte-integrations/connectors/source-gitlab/metadata.yaml
@@ -15,14 +15,14 @@ data:
   documentationUrl: https://docs.airbyte.com/integrations/sources/gitlab
   externalDocumentationUrls:
     - title: Future REST API deprecations and removals
-      url: https://docs.gitlab.com/ee/api/rest/deprecations.html
+      url: https://docs.gitlab.com/api/rest/deprecations/
       type: api_deprecations
+    - title: Deprecations and removals by version
+      url: https://docs.gitlab.com/update/deprecations/
+      type: api_release_history
     - title: API reference
-      url: https://docs.gitlab.com/ee/api/rest/
+      url: https://docs.gitlab.com/api/rest/
       type: api_reference
-    - title: GitLab API OpenAPI specification
-      url: https://docs.gitlab.com/ee/api/openapi/openapi.yaml
-      type: openapi_spec
   githubIssueLabel: source-gitlab
   icon: gitlab.svg
   license: ELv2


### PR DESCRIPTION
## What

Update external documentation URLs in `source-gitlab` metadata to use canonical paths and improve deprecation monitoring coverage.

Resolves https://github.com/airbytehq/oncall/issues/10435

- https://github.com/airbytehq/oncall/issues/10435

## How

- Updated deprecations URL from `/ee/api/rest/deprecations.html` to `/api/rest/deprecations/` (old URL 301-redirects)
- Updated API reference URL from `/ee/api/rest/` to `/api/rest/` (old URL 301-redirects)
- Replaced OpenAPI spec URL (now returns 403, requires GitLab Pages auth) with the GitLab deprecations-by-version page (`/update/deprecations/`) as `api_release_history` type
- Added `api_release_history` type URL for broader deprecation monitoring coverage

## Review guide

1. `airbyte-integrations/connectors/source-gitlab/metadata.yaml`

## User Impact

No user-facing impact. This is a metadata-only change that improves the accuracy of external documentation URLs used for automated deprecation monitoring.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Link to Devin session: https://app.devin.ai/sessions/1fd178dc87c04d08a58df11697868ba7
Requested by: @DanyloGL