### PR TITLE
chore(source-bing-ads): add SOAP-to-REST migration guide to external documentation URLs

### DIFF
--- a/airbyte-integrations/connectors/source-bing-ads/metadata.yaml
+++ b/airbyte-integrations/connectors/source-bing-ads/metadata.yaml
@@ -26,6 +26,9 @@ data:
     - title: Release notes
       url: https://learn.microsoft.com/en-us/advertising/guides/release-notes?view=bingads-13
       type: api_release_history
+    - title: Migrate to REST API
+      url: https://learn.microsoft.com/en-us/advertising/guides/migrate-to-rest?view=bingads-13
+      type: api_deprecations
   erdUrl: https://dbdocs.io/airbyteio/source-bing-ads?view=relationships
   githubIssueLabel: source-bing-ads
   icon: bingads.svg


### PR DESCRIPTION
## What

Adds Microsoft's official SOAP-to-REST migration guide URL to the `source-bing-ads` connector's `metadata.yaml` external documentation URLs.

Resolves https://github.com/airbytehq/oncall/issues/12093

- https://github.com/airbytehq/oncall/issues/12093

Requested by @DanyloGL as part of API Deprecation Monitoring for the Bing Ads (Microsoft Advertising) API family.

## How

Added a new entry to `externalDocumentationUrls` in `metadata.yaml` with type `api_deprecations`:
- **Title**: Migrate to REST API
- **URL**: https://learn.microsoft.com/en-us/advertising/guides/migrate-to-rest?view=bingads-13
- **Type**: `api_deprecations`

This URL documents Microsoft Advertising's SOAP API retirement timeline:
- **October 1, 2026**: New features available only via REST API
- **January 31, 2027**: SOAP API fully deprecated

The `source-bing-ads` connector already uses REST API endpoints and is not affected by this deprecation. Adding this URL ensures future deprecation monitoring runs have the migration guide readily available.

## Review guide

1. `airbyte-integrations/connectors/source-bing-ads/metadata.yaml` — 3-line addition to `externalDocumentationUrls`

## User Impact

No user impact. This is a metadata-only change that improves deprecation monitoring coverage.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Link to Devin session: https://app.devin.ai/sessions/3e13e4d5bfad43698765dbf87b2767d1