### PR TITLE
docs: tidy Concepts/YAML titles, ordering, and add cross-link sections

### DIFF
--- a/docs/platform/connector-development/config-based/understanding-the-yaml-file/authentication.md
+++ b/docs/platform/connector-development/config-based/understanding-the-yaml-file/authentication.md
@@ -287,7 +287,8 @@ authenticator:
 
 For more information see [JwtAuthenticator Reference](https://docs.airbyte.com/connector-development/config-based/understanding-the-yaml-file/reference#/definitions/JwtAuthenticator)
 
-## More readings
+## Related
 
+- *No-Code Connector Builder*: [Authentication](/platform/connector-development/connector-builder-ui/authentication)
 - [Requester](./requester.md)
 - [Request options](./request-options.md)

--- a/docs/platform/connector-development/config-based/understanding-the-yaml-file/error-handling.md
+++ b/docs/platform/connector-development/config-based/understanding-the-yaml-file/error-handling.md
@@ -1,4 +1,4 @@
-# Error handling
+# Error Handling
 
 By default, only server errors (HTTP 5XX) and too many requests (HTTP 429) will be retried up to 5 times with exponential backoff.
 Other HTTP errors will result in a failed read.
@@ -349,6 +349,7 @@ requester:
           - type: "ExponentialBackoffStrategy"
 ```
 
-## More readings
+## Related
 
+- *No-Code Connector Builder*: [Error Handling](/platform/connector-development/connector-builder-ui/error-handling)
 - [Requester](./requester.md)

--- a/docs/platform/connector-development/config-based/understanding-the-yaml-file/file-syncing.md
+++ b/docs/platform/connector-development/config-based/understanding-the-yaml-file/file-syncing.md
@@ -1,4 +1,4 @@
-# File syncing
+# File Syncing
 
 File syncing enables connectors to download and transfer files from API sources when an API endpoint returns a file. This capability supports all common file formats including documents, images, and structured data.
 

--- a/docs/platform/connector-development/config-based/understanding-the-yaml-file/incremental-syncs.md
+++ b/docs/platform/connector-development/config-based/understanding-the-yaml-file/incremental-syncs.md
@@ -1,4 +1,4 @@
-# Incremental Syncs
+# Incremental Sync
 
 An incremental sync is a sync which pulls only the data that has changed since the previous sync (as opposed to all the data available in the data source).
 
@@ -162,7 +162,7 @@ Summary
 
 Choose the option that best fits your data structure and sync requirements to optimize performance and data integrity.
 
-## More readings
+## Related
 
+- *No-Code Connector Builder*: [Incremental Sync](/platform/connector-development/connector-builder-ui/incremental-sync)
 - [Incremental reads](../../cdk-python/incremental-stream.md)
-- Many of the concepts discussed here are described in the [No-Code Connector Builder docs](../../connector-builder-ui/incremental-sync.md) as well, with more examples.

--- a/docs/platform/connector-development/config-based/understanding-the-yaml-file/incremental-syncs.md
+++ b/docs/platform/connector-development/config-based/understanding-the-yaml-file/incremental-syncs.md
@@ -113,7 +113,7 @@ The default state format is **per partition with fallback to global**, but there
 #### Incremental Dependency
 - **Description**: This option allows the parent stream to be read incrementally, ensuring that only new data is synced.
 - **Requirement**: The API must ensure that the parent record's cursor is updated whenever child records are added or updated. If this requirement is not met, child records added to older parent records will be lost.
-- **When to Use**: Use this option if the parent stream is incremental and you want to read it with the state. The parent state is updated after processing all the child records for the parent record.
+- **When to Use**: Use this option if the parent stream is incremental, the child stream has its own incremental cursor, and you want to read the parent with state. The parent state is updated after processing all the child records for the parent record.
 - **Example State**:
   ```json
   {
@@ -126,6 +126,22 @@ The default state format is **per partition with fallback to global**, but there
     ]
   }
   ```
+
+##### When `incremental_dependency` has no effect
+
+`incremental_dependency: true` is a runtime optimization on the partition router. It is not the same thing as declaring the child stream incremental. Specifically, it has no effect unless the child stream itself defines an `incremental_sync` block. If the child has no own cursor, the CDK assigns it a `FinalStateCursor`, which never persists `parent_state`. As a result, every sync re-reads the parent from `start_datetime` and the flag is silently inert. To activate the optimization for a child without its own cursor, give the child stream an `incremental_sync` block (typically derived from a parent timestamp), or use a base stream class that supplies a per-partition cursor.
+
+##### Verifying the parent-cursor-bump assumption
+
+The "Requirement" above is load-bearing. Before shipping `incremental_dependency: true`, verify empirically that every mutation of a child resource bumps the parent's cursor field. API behavior is per-resource and varies even within a single API. To check:
+
+1. Capture the parent record's cursor field (e.g., `updated_at`).
+2. Perform each kind of child mutation the connector exposes (create, update, delete, plus any side-effecting endpoints like state transitions, votes, or watchers).
+3. Re-fetch the parent and compare the cursor field. If it did not advance, that child operation is unsafe under `incremental_dependency: true` — children added to an unchanged parent will not be re-iterated on warm syncs and will be permanently missed.
+
+Common false negatives to watch for: no-op mutations (e.g., adding the same watcher twice), parent re-fetches that hit a cache, idempotent endpoints that return success without writing, and APIs that expose more than one timestamp where only one of them is the cursor. Always perform a positive write that produces a real state change.
+
+If any child mutation does not bump the parent cursor, exclude that child from `incremental_dependency: true` (route it through a non-incremental parent copy) or give the child its own incremental cursor.
 
 #### Global Substream Cursor
 - **Description**: This option uses a single global cursor for all partitions, significantly reducing the state size. It enforces a minimal lookback window based on the previous sync's duration to avoid losing records added or updated during the sync. Since the global cursor is already part of the per partition with fallback to global approach, it should only be used cautiously for custom connectors with exceptionally large parent streams to avoid managing state per partition.

--- a/docs/platform/connector-development/config-based/understanding-the-yaml-file/incremental-syncs.md
+++ b/docs/platform/connector-development/config-based/understanding-the-yaml-file/incremental-syncs.md
@@ -113,7 +113,7 @@ The default state format is **per partition with fallback to global**, but there
 #### Incremental Dependency
 - **Description**: This option allows the parent stream to be read incrementally, ensuring that only new data is synced.
 - **Requirement**: The API must ensure that the parent record's cursor is updated whenever child records are added or updated. If this requirement is not met, child records added to older parent records will be lost.
-- **When to Use**: Use this option if the parent stream is incremental, the child stream has its own incremental cursor, and you want to read the parent with state. The parent state is updated after processing all the child records for the parent record.
+- **When to Use**: Use this option if the parent stream is incremental and you want to read it with the state. The parent state is updated after processing all the child records for the parent record.
 - **Example State**:
   ```json
   {
@@ -126,22 +126,6 @@ The default state format is **per partition with fallback to global**, but there
     ]
   }
   ```
-
-##### When `incremental_dependency` has no effect
-
-`incremental_dependency: true` is a runtime optimization on the partition router. It is not the same thing as declaring the child stream incremental. Specifically, it has no effect unless the child stream itself defines an `incremental_sync` block. If the child has no own cursor, the CDK assigns it a `FinalStateCursor`, which never persists `parent_state`. As a result, every sync re-reads the parent from `start_datetime` and the flag is silently inert. To activate the optimization for a child without its own cursor, give the child stream an `incremental_sync` block (typically derived from a parent timestamp), or use a base stream class that supplies a per-partition cursor.
-
-##### Verifying the parent-cursor-bump assumption
-
-The "Requirement" above is load-bearing. Before shipping `incremental_dependency: true`, verify empirically that every mutation of a child resource bumps the parent's cursor field. API behavior is per-resource and varies even within a single API. To check:
-
-1. Capture the parent record's cursor field (e.g., `updated_at`).
-2. Perform each kind of child mutation the connector exposes (create, update, delete, plus any side-effecting endpoints like state transitions, votes, or watchers).
-3. Re-fetch the parent and compare the cursor field. If it did not advance, that child operation is unsafe under `incremental_dependency: true` — children added to an unchanged parent will not be re-iterated on warm syncs and will be permanently missed.
-
-Common false negatives to watch for: no-op mutations (e.g., adding the same watcher twice), parent re-fetches that hit a cache, idempotent endpoints that return success without writing, and APIs that expose more than one timestamp where only one of them is the cursor. Always perform a positive write that produces a real state change.
-
-If any child mutation does not bump the parent cursor, exclude that child from `incremental_dependency: true` (route it through a non-incremental parent copy) or give the child its own incremental cursor.
 
 #### Global Substream Cursor
 - **Description**: This option uses a single global cursor for all partitions, significantly reducing the state size. It enforces a minimal lookback window based on the previous sync's duration to avoid losing records added or updated during the sync. Since the global cursor is already part of the per partition with fallback to global approach, it should only be used cautiously for custom connectors with exceptionally large parent streams to avoid managing state per partition.

--- a/docs/platform/connector-development/config-based/understanding-the-yaml-file/pagination.md
+++ b/docs/platform/connector-development/config-based/understanding-the-yaml-file/pagination.md
@@ -229,3 +229,7 @@ Assuming the endpoint to fetch data from is `https://cloud.airbyte.com/api/get_d
 the first request will be sent as `https://cloud.airbyte.com/api/get_data`
 Assuming the response's next url is `https://cloud.airbyte.com/api/get_data?page=1&page_size=100`,
 the next request will be sent as `https://cloud.airbyte.com/api/get_data?page=1&page_size=100`
+
+## Related
+
+- *No-Code Connector Builder*: [Pagination](/platform/connector-development/connector-builder-ui/pagination)

--- a/docs/platform/connector-development/config-based/understanding-the-yaml-file/partition-router.md
+++ b/docs/platform/connector-development/config-based/understanding-the-yaml-file/partition-router.md
@@ -149,10 +149,6 @@ retriever:
         incremental_dependency: true
 ```
 
-:::warning Verification required for `incremental_dependency`
-`incremental_dependency: true` is a runtime optimization on the partition router and is not equivalent to declaring the child stream incremental. It only takes effect when the child stream has its own `incremental_sync` block, and it relies on the assumption that every child mutation bumps the parent's cursor field. See [Incremental Dependency](./incremental-syncs.md#incremental-dependency) for the full requirement, the inert-flag rule, and the empirical-verification procedure that must be performed for each child resource before shipping.
-:::
-
 ## Nested streams
 
 Nested streams, subresources, or streams that depend on other streams can be implemented using a [`SubstreamPartitionRouter`](#SubstreamPartitionRouter)

--- a/docs/platform/connector-development/config-based/understanding-the-yaml-file/partition-router.md
+++ b/docs/platform/connector-development/config-based/understanding-the-yaml-file/partition-router.md
@@ -1,4 +1,4 @@
-# Retrieving Records Spread Across Partitions
+# Stream Partitions
 
 In some cases, the data you are replicating is spread across multiple partitions. You can specify a set of parameters to be iterated over and used while requesting all of your data. On each iteration, using the current element being iterated upon, the connector will perform a cycle of requesting data from your source.
 
@@ -148,6 +148,10 @@ retriever:
         partition_field: "repository"
         incremental_dependency: true
 ```
+
+:::warning Verification required for `incremental_dependency`
+`incremental_dependency: true` is a runtime optimization on the partition router and is not equivalent to declaring the child stream incremental. It only takes effect when the child stream has its own `incremental_sync` block, and it relies on the assumption that every child mutation bumps the parent's cursor field. See [Incremental Dependency](./incremental-syncs.md#incremental-dependency) for the full requirement, the inert-flag rule, and the empirical-verification procedure that must be performed for each child resource before shipping.
+:::
 
 ## Nested streams
 

--- a/docs/platform/connector-development/config-based/understanding-the-yaml-file/partition-router.md
+++ b/docs/platform/connector-development/config-based/understanding-the-yaml-file/partition-router.md
@@ -1,4 +1,4 @@
-# Stream Partitions
+# Partitions
 
 In some cases, the data you are replicating is spread across multiple partitions. You can specify a set of parameters to be iterated over and used while requesting all of your data. On each iteration, using the current element being iterated upon, the connector will perform a cycle of requesting data from your source.
 
@@ -157,8 +157,9 @@ retriever:
 
 Nested streams, subresources, or streams that depend on other streams can be implemented using a [`SubstreamPartitionRouter`](#SubstreamPartitionRouter)
 
-## More readings
+## Related
 
+- *No-Code Connector Builder*: [Partitions](/platform/connector-development/connector-builder-ui/partitioning)
 - [Incremental streams](../../cdk-python/incremental-stream.md)
 - [Stream slices](../../cdk-python/stream-slices.md)
 

--- a/docs/platform/connector-development/config-based/understanding-the-yaml-file/partition-router.md
+++ b/docs/platform/connector-development/config-based/understanding-the-yaml-file/partition-router.md
@@ -151,7 +151,7 @@ retriever:
 
 ## Nested streams
 
-Nested streams, subresources, or streams that depend on other streams can be implemented using a [`SubstreamPartitionRouter`](#SubstreamPartitionRouter)
+Nested streams, subresources, or streams that depend on other streams can be implemented using a [`SubstreamPartitionRouter`](#substreampartitionrouter)
 
 ## Related
 

--- a/docs/platform/connector-development/config-based/understanding-the-yaml-file/property-chunking.md
+++ b/docs/platform/connector-development/config-based/understanding-the-yaml-file/property-chunking.md
@@ -1,4 +1,4 @@
-# Property chunking
+# Property Chunking
 
 Property chunking enables connectors to handle APIs with limitations on the number of properties that you can fetch per request. This feature breaks down large property lists into smaller, manageable chunks and merges the results back into complete records. Some connectors require this capability to work with APIs that have property limits.
 

--- a/docs/platform/connector-development/config-based/understanding-the-yaml-file/rate-limit-api-budget.md
+++ b/docs/platform/connector-development/config-based/understanding-the-yaml-file/rate-limit-api-budget.md
@@ -1,4 +1,4 @@
-# Rate limiting (API Budget)
+# Rate Limiting (API Budget)
 
 In order to prevent sending too many requests to the API in a short period of time, you can configure an API Budget. This budget determines the maximum number of calls that can be made within a specified time interval (or intervals). This mechanism is particularly useful for respecting third-party API rate limits and avoiding potential throttling or denial of service.
 

--- a/docs/platform/connector-development/config-based/understanding-the-yaml-file/record-selector.md
+++ b/docs/platform/connector-development/config-based/understanding-the-yaml-file/record-selector.md
@@ -1,4 +1,4 @@
-# Record selector
+# Record Selector
 
 The record selector is responsible for translating an HTTP response into a list of Airbyte records by extracting records from the response and optionally filtering and shaping records based on a heuristic.
 Schema:
@@ -390,3 +390,7 @@ resulting in the following record:
   "path3": "data_to_keep"
 }
 ```
+
+## Related
+
+- *No-Code Connector Builder*: [Record Parsing](/platform/connector-development/connector-builder-ui/record-processing)

--- a/docs/platform/connector-development/config-based/understanding-the-yaml-file/requester.md
+++ b/docs/platform/connector-development/config-based/understanding-the-yaml-file/requester.md
@@ -55,6 +55,7 @@ Other components, such as an `Authenticator` can also set additional request par
 
 Additionally, some stateful components use a `RequestOption` to configure the options and update the value. Example of such components are [Paginators](./pagination.md) and [Partition routers](./partition-router.md).
 
-## More readings
+## Related
 
+- *No-Code Connector Builder*: [Global Configuration](/platform/connector-development/connector-builder-ui/global-configuration)
 - [Request options](./request-options.md)

--- a/docs/platform/connector-development/config-based/understanding-the-yaml-file/yaml-overview.md
+++ b/docs/platform/connector-development/config-based/understanding-the-yaml-file/yaml-overview.md
@@ -1,4 +1,4 @@
-# Understanding the YAML file
+# YAML Components
 
 The low-code framework involves editing a boilerplate [YAML file](../low-code-cdk-overview.md#configuring-the-yaml-file). This section deep dives into the components of the YAML file.
 

--- a/docs/platform/connector-development/connector-builder-ui/async-streams.md
+++ b/docs/platform/connector-development/connector-builder-ui/async-streams.md
@@ -1,4 +1,4 @@
-# Asynchronous Job streams
+# Asynchronous Job Streams
 
 In the Connector Builder UI, you can create two types of streams: **Synchronous Request** and **Asynchronous Job**. Understanding the difference is important for efficiently extracting data from APIs that use asynchronous processing.
 

--- a/docs/platform/connector-development/connector-builder-ui/authentication.md
+++ b/docs/platform/connector-development/connector-builder-ui/authentication.md
@@ -370,3 +370,7 @@ If your connector uses the same API key authentication for both data retrieval a
 ## Custom authentication methods
 
 Some APIs require complex custom authentication schemes involving signing requests or doing multiple requests to authenticate. In these cases, use the [low-code/YAML mode](/platform/connector-development/config-based/low-code-cdk-overview) or [Python CDK](/platform/connector-development/cdk-python/).
+
+## Related
+
+- *YAML Components*: [Authentication](/platform/connector-development/config-based/understanding-the-yaml-file/authentication)

--- a/docs/platform/connector-development/connector-builder-ui/error-handling.md
+++ b/docs/platform/connector-development/connector-builder-ui/error-handling.md
@@ -292,3 +292,7 @@ If your error handler is not working as expected:
 3. **Test with simple conditions**: Start with HTTP status codes before adding complex predicates
 4. **Use custom error messages**: Include response details to understand what's happening
 5. **Check logs**: Review sync logs to see which error handlers are being triggered
+
+## Related
+
+- *YAML Components*: [Error Handling](/platform/connector-development/config-based/understanding-the-yaml-file/error-handling)

--- a/docs/platform/connector-development/connector-builder-ui/global-configuration.md
+++ b/docs/platform/connector-development/connector-builder-ui/global-configuration.md
@@ -88,3 +88,7 @@ Specifies which HTTP response header contains the number of remaining requests a
 Configure which HTTP status codes indicate that a rate limit has been exceeded. The most common is `429 Too Many Requests`, but some APIs use other codes like `420` or `503`.
 
 When these status codes are encountered, the connector will automatically pause requests and retry according to the rate limiting policy.
+
+## Related
+
+- *YAML Components*: [Requester](/platform/connector-development/config-based/understanding-the-yaml-file/requester)

--- a/docs/platform/connector-development/connector-builder-ui/incremental-sync.md
+++ b/docs/platform/connector-development/connector-builder-ui/incremental-sync.md
@@ -1,4 +1,4 @@
-# Incremental sync
+# Incremental Sync
 
 An incremental sync is a sync which pulls only the data that has changed since the previous sync (as opposed to all the data available in the data source).
 

--- a/docs/platform/connector-development/connector-builder-ui/incremental-sync.md
+++ b/docs/platform/connector-development/connector-builder-ui/incremental-sync.md
@@ -199,3 +199,7 @@ To handle these cases, disable injection in the incremental sync form and use th
 
 For example the [Sendgrid API](https://docs.sendgrid.com/api-reference/e-mail-activity/filter-all-messages) requires setting both start and end time in a `query` parameter.
 For this case, you can use the `stream_interval` variable to configure a query parameter with "key" `query` and "value" `last_event_time BETWEEN TIMESTAMP "{{stream_interval.start_time}}" AND TIMESTAMP "{{stream_interval.end_time}}"` to filter down to the right window in time.
+
+## Related
+
+- *YAML Components*: [Incremental Sync](/platform/connector-development/config-based/understanding-the-yaml-file/incremental-syncs)

--- a/docs/platform/connector-development/connector-builder-ui/pagination.md
+++ b/docs/platform/connector-development/connector-builder-ui/pagination.md
@@ -508,3 +508,7 @@ If pagination parameters aren't being sent correctly:
 - **Check parameter names**: Verify that parameter names match what the API expects
 - **Test interpolation**: For interpolated values, ensure the template syntax is correct
 - **Review API documentation**: Confirm the expected parameter format and location
+
+## Related
+
+- *YAML Components*: [Pagination](/platform/connector-development/config-based/understanding-the-yaml-file/pagination)

--- a/docs/platform/connector-development/connector-builder-ui/partitioning.md
+++ b/docs/platform/connector-development/connector-builder-ui/partitioning.md
@@ -113,12 +113,7 @@ For complex injection requirements that the standard options don't support:
 
 **Lazy Read Pointer**: Enable lazy reading to extract child records during initial parent record processing.
 
-**Incremental Dependency**: When enabled, the parent stream is read with state during warm syncs so that on each subsequent sync only parents whose cursor field has advanced since the last sync are iterated, and the child stream then re-fetches records for that narrowed set of parents. This is a router-level optimization, not a sync-mode declaration, and it has two prerequisites:
-
-- The child stream must have its own incremental cursor. Without one, the optimization is silently inert.
-- Every child-resource mutation the API exposes must bump the parent's cursor field. If any child mutation does not bump the parent, those changes will be permanently missed on warm syncs.
-
-API behavior is per-resource and must be verified empirically for each child resource before enabling this option. See the [Incremental Dependency reference](/platform/connector-development/config-based/understanding-the-yaml-file/incremental-syncs#incremental-dependency) for the full requirement, the inert-flag rule, and the verification procedure.
+**Incremental Dependency**: When enabled, the parent stream is read incrementally based on child stream updates.
 
 ## When not to Use Partitioning
 

--- a/docs/platform/connector-development/connector-builder-ui/partitioning.md
+++ b/docs/platform/connector-development/connector-builder-ui/partitioning.md
@@ -113,7 +113,12 @@ For complex injection requirements that the standard options don't support:
 
 **Lazy Read Pointer**: Enable lazy reading to extract child records during initial parent record processing.
 
-**Incremental Dependency**: When enabled, the parent stream is read incrementally based on child stream updates.
+**Incremental Dependency**: When enabled, the parent stream is read with state during warm syncs so that on each subsequent sync only parents whose cursor field has advanced since the last sync are iterated, and the child stream then re-fetches records for that narrowed set of parents. This is a router-level optimization, not a sync-mode declaration, and it has two prerequisites:
+
+- The child stream must have its own incremental cursor. Without one, the optimization is silently inert.
+- Every child-resource mutation the API exposes must bump the parent's cursor field. If any child mutation does not bump the parent, those changes will be permanently missed on warm syncs.
+
+API behavior is per-resource and must be verified empirically for each child resource before enabling this option. See the [Incremental Dependency reference](/platform/connector-development/config-based/understanding-the-yaml-file/incremental-syncs#incremental-dependency) for the full requirement, the inert-flag rule, and the verification procedure.
 
 ## When not to Use Partitioning
 

--- a/docs/platform/connector-development/connector-builder-ui/partitioning.md
+++ b/docs/platform/connector-development/connector-builder-ui/partitioning.md
@@ -1,4 +1,4 @@
-# Partitioning
+# Partitions
 
 Partitioning is required when records of a stream are grouped into subsets that need to be queried separately to extract all records. This is common when APIs require specific parameters (like IDs or categories) to fetch different portions of the data.
 
@@ -127,3 +127,7 @@ Don't use partitioning for:
 - **Time-based incremental sync**: Use the Incremental Sync feature instead
 
 Partitioning is specifically for cases where the API requires different parameter values to access different subsets of the same logical data stream.
+
+## Related
+
+- *YAML Components*: [Partitions](/platform/connector-development/config-based/understanding-the-yaml-file/partition-router)

--- a/docs/platform/connector-development/connector-builder-ui/record-processing.mdx
+++ b/docs/platform/connector-development/connector-builder-ui/record-processing.mdx
@@ -1,4 +1,4 @@
-# Record processing
+# Record Parsing
 
 Connectors built with the connector builder always make HTTP requests, receive the responses and emit records. Besides making the right requests, it's important to properly hand over the records to the system:
 

--- a/docs/platform/connector-development/connector-builder-ui/record-processing.mdx
+++ b/docs/platform/connector-development/connector-builder-ui/record-processing.mdx
@@ -917,3 +917,7 @@ In some cases, the auto-detected schema might not cover all scenarios:
 - **Fields have inconsistent types.** If the same field appears as a string for one record and a number for another, the auto-detected schema may choose too narrow a type. In these cases, manually edit the declared schema to use a broader type such as `["string", "number"]`.
 
 For the common case where the API returns a mix of known and unknown fields, the auto-detected schema combined with Airbyte's schema change management provides the right balance between structured typing and flexibility.
+
+## Related
+
+- *YAML Components*: [Record Selector](/platform/connector-development/config-based/understanding-the-yaml-file/record-selector)

--- a/docusaurus/sidebar-platform.js
+++ b/docusaurus/sidebar-platform.js
@@ -24,6 +24,11 @@ const buildAConnector = {
         "connector-development/connector-builder-ui/ai-assist",
         "connector-development/connector-builder-ui/custom-components",
         {
+          label: "Low-Code CDK Intro",
+          type: "doc",
+          id: "connector-development/config-based/low-code-cdk-overview",
+        },
+        {
           type: "category",
           label: "Concepts",
           items: [
@@ -39,13 +44,8 @@ const buildAConnector = {
           ],
         },
         {
-          label: "Low-Code CDK Intro",
-          type: "doc",
-          id: "connector-development/config-based/low-code-cdk-overview",
-        },
-        {
           type: "category",
-          label: "Understanding the YAML file",
+          label: "YAML Components",
           link: {
             type: "doc",
             id: "connector-development/config-based/understanding-the-yaml-file/yaml-overview",
@@ -64,12 +64,12 @@ const buildAConnector = {
                 "connector-development/config-based/understanding-the-yaml-file/error-handling",
               ],
             },
-            "connector-development/config-based/understanding-the-yaml-file/incremental-syncs",
+            "connector-development/config-based/understanding-the-yaml-file/record-selector",
             "connector-development/config-based/understanding-the-yaml-file/pagination",
+            "connector-development/config-based/understanding-the-yaml-file/incremental-syncs",
             "connector-development/config-based/understanding-the-yaml-file/partition-router",
             "connector-development/config-based/understanding-the-yaml-file/property-chunking",
             "connector-development/config-based/understanding-the-yaml-file/rate-limit-api-budget",
-            "connector-development/config-based/understanding-the-yaml-file/record-selector",
             "connector-development/config-based/understanding-the-yaml-file/file-syncing",
             "connector-development/config-based/understanding-the-yaml-file/reference",
           ],


### PR DESCRIPTION
## What

Cosmetic tidying of the Connector Builder UI ("Concepts") and config-based ("Understanding the YAML file") documentation areas. No content changes — only titles, sidebar ordering, and bottom-of-page cross-link sections.

Substantive content updates about `incremental_dependency` semantics will land in a follow-up PR stacked on top of this branch.

## How

### Sidebar (`docusaurus/sidebar-platform.js`)

- Renamed sidebar category `Understanding the YAML file` → `YAML Components`.
- Reordered top-level entries so `Low-Code CDK Intro` appears above `Concepts`, and `YAML Components` immediately follows `Concepts`.
- Reordered the YAML Components child items to mirror the Concepts order (Record Selector → Pagination → Incremental Sync → Partitions → Property Chunking → Rate Limiting → File Syncing → Reference).

### Title casing and parallelization

YAML Components pages:

- `yaml-overview.md`: `Understanding the YAML file` → `YAML Components`
- `incremental-syncs.md`: `Incremental Syncs` → `Incremental Sync` (singular, parallel to Concepts)
- `error-handling.md`: `Error handling` → `Error Handling`
- `record-selector.md`: `Record selector` → `Record Selector`
- `property-chunking.md`: `Property chunking` → `Property Chunking`
- `rate-limit-api-budget.md`: `Rate limiting (API Budget)` → `Rate Limiting (API Budget)`
- `file-syncing.md`: `File syncing` → `File Syncing`
- `partition-router.md`: `Retrieving Records Spread Across Partitions` → `Partitions` (slug unchanged)

Builder UI ("Concepts") pages:

- `incremental-sync.md`: `Incremental sync` → `Incremental Sync`
- `record-processing.mdx`: `Record processing` → `Record Parsing` (slug unchanged)
- `partitioning.md`: `Partitioning` → `Partitions` (slug unchanged)
- `async-streams.md`: `Asynchronous Job streams` → `Asynchronous Job Streams`

### Cross-link `## Related` sections

Added bottom-of-page `## Related` sections to each matching pair so readers can jump between the Builder UI Concept and the YAML Component:

- Authentication ↔ Authentication
- Pagination ↔ Pagination
- Incremental Sync ↔ Incremental Sync
- Partitions ↔ Partitions
- Error Handling ↔ Error Handling
- Record Parsing ↔ Record Selector (subtly different — Builder UI describes record parsing semantics; YAML page documents the `RecordSelector` component)
- Global Configuration ↔ Requester (subtly different — Builder UI groups Check/Concurrency/Rate Limit settings; YAML page documents the `Requester` component)

Cross-links are bottom-of-page only; no inline links were added.

## Review guide

1. `docusaurus/sidebar-platform.js` — verify category rename and ordering.
2. Spot-check a few pairs of Concepts/YAML pages for matching titles and presence of the `## Related` section at the bottom.
3. All slug paths are unchanged, so no link rot risk for external bookmarks.

## User Impact

Documentation-only. No code changes, no behavior changes, no slug changes. Improves navigability between the two parallel documentation surfaces.

A follow-up PR will be stacked on top of this branch with the substantive `incremental_dependency` content updates (inert-flag rule, verification methodology, fix to the inverted Builder UI one-liner).

## Can this PR be safely reverted and rolled back?

- [x] YES 💚
- [ ] NO ❌

Link to Devin session: https://app.devin.ai/sessions/45671900dc14438dac24810b5acd36f2
Requested by: @aaronsteers