### PR TITLE
docs: clarify incremental_dependency semantics, inert-flag rule, and verification

### DIFF
--- a/docs/platform/connector-development/config-based/understanding-the-yaml-file/incremental-syncs.md
+++ b/docs/platform/connector-development/config-based/understanding-the-yaml-file/incremental-syncs.md
@@ -112,6 +112,7 @@ The default state format is **per partition with fallback to global**, but there
   ```
 
 #### Incremental Dependency
+
 - **Description**: This option allows the parent stream to be read incrementally, ensuring that only new data is synced.
 - **Requirement**: The API must ensure that the parent record's cursor is updated whenever child records are added or updated. If this requirement is not met, child records added to older parent records will be lost.
 - **When to Use**: Use this option if the parent stream is incremental, the child stream has its own incremental cursor, and you want to read the parent with state. The parent state is updated after processing all the child records for the parent record.

--- a/docs/platform/connector-development/config-based/understanding-the-yaml-file/incremental-syncs.md
+++ b/docs/platform/connector-development/config-based/understanding-the-yaml-file/incremental-syncs.md
@@ -87,13 +87,13 @@ incremental_sync:
     inject_into: "request_parameter"
 ```
 
-### Nested Streams
+## Incremental Support for Child Streams
 
 Nested streams, subresources, or streams that depend on other streams can be implemented using a [`SubstreamPartitionRouter`](#SubstreamPartitionRouter)
 
 The default state format is **per partition with fallback to global**, but there are options to enhance efficiency depending on your use case: **incremental_dependency** and **global_substream_cursor**. Here's when and how to use each option, with examples:
 
-#### Per Partition with Fallback to Global (Default)
+### Per Partition with Fallback to Global (Default)
 - **Description**: This is the default state format, where each partition has its own cursor. However, when the number of records in the parent sync exceeds two times the set limit, the cursor automatically falls back to a global state to manage efficiency and scalability.
 - **Limitation**: The per partition state has a limit of 10,000 partitions. Once this limit is exceeded, the global cursor takes over, aggregating the state across partitions to avoid inefficiencies.
 - **When to Use**: Use this as the default option for most cases. It provides the flexibility of managing partitions while preventing performance degradation when large numbers of records are involved.
@@ -111,7 +111,7 @@ The default state format is **per partition with fallback to global**, but there
   }
   ```
 
-#### Incremental Dependency
+### Incremental Dependency
 
 - **Description**: This option allows the parent stream to be read incrementally, ensuring that only new data is synced.
 - **Requirement**: The API must ensure that the parent record's cursor is updated whenever child records are added or updated. If this requirement is not met, child records added to older parent records will be lost.
@@ -130,11 +130,11 @@ The default state format is **per partition with fallback to global**, but there
   }
   ```
 
-##### When `incremental_dependency` has no effect
+#### When `incremental_dependency` has no effect
 
 `incremental_dependency: true` is a runtime optimization on the partition router. It is not the same thing as declaring the child stream incremental. Specifically, it has no effect unless the child stream itself defines an `incremental_sync` block. If the child has no own cursor, the CDK assigns it a `FinalStateCursor`, which never persists `parent_state`. As a result, every sync re-reads the parent from `start_datetime` and the flag is silently inert. To activate the optimization for a child without its own cursor, give the child stream an `incremental_sync` block (typically derived from a parent timestamp), or use a base stream class that supplies a per-partition cursor.
 
-##### Verifying the parent-cursor-bump assumption
+#### Verifying the parent-cursor-bump assumption
 
 The "Requirement" above is load-bearing. Before shipping `incremental_dependency: true`, verify empirically that every mutation of a child resource bumps the parent's cursor field. API behavior is per-resource and varies even within a single API. To check:
 
@@ -146,7 +146,7 @@ Common false negatives to watch for: no-op mutations (e.g., adding the same watc
 
 If any child mutation does not bump the parent cursor, exclude that child from `incremental_dependency: true` (route it through a non-incremental parent copy) or give the child its own incremental cursor.
 
-#### Global Substream Cursor
+### Global Substream Cursor
 
 - **Description**: This option uses a single global cursor for all partitions, significantly reducing the state size. It enforces a minimal lookback window based on the previous sync's duration to avoid losing records added or updated during the sync. Since the global cursor is already part of the per partition with fallback to global approach, it should only be used cautiously for custom connectors with exceptionally large parent streams to avoid managing state per partition.
 - **When to Use**: Use this option cautiously for custom connectors where the number of partitions in the parent stream is extremely high (e.g., millions of records per sync). The global cursor avoids the inefficiency of managing state per partition but sacrifices some granularity, which may not be suitable for every use case.

--- a/docs/platform/connector-development/config-based/understanding-the-yaml-file/incremental-syncs.md
+++ b/docs/platform/connector-development/config-based/understanding-the-yaml-file/incremental-syncs.md
@@ -137,7 +137,7 @@ The default state format is **per partition with fallback to global**, but there
 
 #### The parent-cursor-bump assumption
 
-For `incremental_dependency: true` to be safe, the API needs to update the parent record's cursor field whenever a child resource is created, updated, or deleted. If a child mutation does not advance the parent's cursor, that child record is added to a parent the partition router will skip on subsequent warm syncs — so the new child is never observed, even though the sync itself completes successfully.
+For `incremental_dependency: true` to be safe, the API needs to update the parent record's cursor field whenever a child resource is created, updated, or deleted. If a child mutation does not advance the parent's cursor, that child record is added to a parent the partition router will skip on subsequent warm syncs — so the new child is never observed, even though the sync itself completes successfully. When a particular child mutation does not bump the parent cursor, two options preserve correctness: route that child through a non-incremental parent copy, or give the child its own incremental cursor.
 
 API behavior here is per-resource and frequently varies within a single API, so this assumption typically benefits from empirical verification before shipping. A typical confirmation pass looks like:
 
@@ -146,8 +146,6 @@ API behavior here is per-resource and frequently varies within a single API, so 
 3. Re-fetch the parent and compare the cursor field. If it did not advance, that child operation is unsafe under `incremental_dependency: true`: children added to an unchanged parent are not re-iterated on warm syncs.
 
 A few common false negatives are worth being aware of: no-op mutations (such as adding the same watcher twice), parent re-fetches that hit a cache, idempotent endpoints that return success without actually writing, and APIs that expose more than one timestamp where only one of them is the cursor. A positive write that produces a real state change tends to be the most reliable signal.
-
-When a particular child mutation does not bump the parent cursor, two options preserve correctness: route that child through a non-incremental parent copy, or give the child its own incremental cursor.
 
 ### Global Substream Cursor
 

--- a/docs/platform/connector-development/config-based/understanding-the-yaml-file/incremental-syncs.md
+++ b/docs/platform/connector-development/config-based/understanding-the-yaml-file/incremental-syncs.md
@@ -89,11 +89,12 @@ incremental_sync:
 
 ## Incremental Support for Child Streams
 
-Nested streams, subresources, or streams that depend on other streams can be implemented using a [`SubstreamPartitionRouter`](#SubstreamPartitionRouter)
+Nested streams, subresources, or streams that depend on other streams can be implemented using a [`SubstreamPartitionRouter`](./partition-router.md#substreampartitionrouter).
 
 The default state format is **per partition with fallback to global**, but there are options to enhance efficiency depending on your use case: **incremental_dependency** and **global_substream_cursor**. Here's when and how to use each option, with examples:
 
 ### Per Partition with Fallback to Global (Default)
+
 - **Description**: This is the default state format, where each partition has its own cursor. However, when the number of records in the parent sync exceeds two times the set limit, the cursor automatically falls back to a global state to manage efficiency and scalability.
 - **Limitation**: The per partition state has a limit of 10,000 partitions. Once this limit is exceeded, the global cursor takes over, aggregating the state across partitions to avoid inefficiencies.
 - **When to Use**: Use this as the default option for most cases. It provides the flexibility of managing partitions while preventing performance degradation when large numbers of records are involved.
@@ -159,7 +160,7 @@ If any child mutation does not bump the parent cursor, exclude that child from `
   ```
 
 ### Summary
-Summary
+
 - **Per Partition with Fallback to Global (Default)**: Best for managing scalability and optimizing state size. Starts with per partition cursors, and automatically falls back to a global cursor if the number of records in the parent sync exceeds two times the partition limit.
 - **Incremental Dependency**: Use for incremental parent streams with a dependent child cursor. Ensure the API updates the parent cursor when child records are added or updated.
 - **Global Substream Cursor**: Use cautiously for custom connectors with very large parent streams. Avoids per partition state management but sacrifices some granularity.

--- a/docs/platform/connector-development/config-based/understanding-the-yaml-file/incremental-syncs.md
+++ b/docs/platform/connector-development/config-based/understanding-the-yaml-file/incremental-syncs.md
@@ -110,6 +110,7 @@ The default state format is **per partition with fallback to global**, but there
       "use_global_cursor": false
   }
   ```
+
 #### Incremental Dependency
 - **Description**: This option allows the parent stream to be read incrementally, ensuring that only new data is synced.
 - **Requirement**: The API must ensure that the parent record's cursor is updated whenever child records are added or updated. If this requirement is not met, child records added to older parent records will be lost.

--- a/docs/platform/connector-development/config-based/understanding-the-yaml-file/incremental-syncs.md
+++ b/docs/platform/connector-development/config-based/understanding-the-yaml-file/incremental-syncs.md
@@ -113,7 +113,7 @@ The default state format is **per partition with fallback to global**, but there
 #### Incremental Dependency
 - **Description**: This option allows the parent stream to be read incrementally, ensuring that only new data is synced.
 - **Requirement**: The API must ensure that the parent record's cursor is updated whenever child records are added or updated. If this requirement is not met, child records added to older parent records will be lost.
-- **When to Use**: Use this option if the parent stream is incremental and you want to read it with the state. The parent state is updated after processing all the child records for the parent record.
+- **When to Use**: Use this option if the parent stream is incremental, the child stream has its own incremental cursor, and you want to read the parent with state. The parent state is updated after processing all the child records for the parent record.
 - **Example State**:
   ```json
   {
@@ -126,6 +126,22 @@ The default state format is **per partition with fallback to global**, but there
     ]
   }
   ```
+
+##### When `incremental_dependency` has no effect
+
+`incremental_dependency: true` is a runtime optimization on the partition router. It is not the same thing as declaring the child stream incremental. Specifically, it has no effect unless the child stream itself defines an `incremental_sync` block. If the child has no own cursor, the CDK assigns it a `FinalStateCursor`, which never persists `parent_state`. As a result, every sync re-reads the parent from `start_datetime` and the flag is silently inert. To activate the optimization for a child without its own cursor, give the child stream an `incremental_sync` block (typically derived from a parent timestamp), or use a base stream class that supplies a per-partition cursor.
+
+##### Verifying the parent-cursor-bump assumption
+
+The "Requirement" above is load-bearing. Before shipping `incremental_dependency: true`, verify empirically that every mutation of a child resource bumps the parent's cursor field. API behavior is per-resource and varies even within a single API. To check:
+
+1. Capture the parent record's cursor field (e.g., `updated_at`).
+2. Perform each kind of child mutation the connector exposes (create, update, delete, plus any side-effecting endpoints like state transitions, votes, or watchers).
+3. Re-fetch the parent and compare the cursor field. If it did not advance, that child operation is unsafe under `incremental_dependency: true` — children added to an unchanged parent will not be re-iterated on warm syncs and will be permanently missed.
+
+Common false negatives to watch for: no-op mutations (e.g., adding the same watcher twice), parent re-fetches that hit a cache, idempotent endpoints that return success without writing, and APIs that expose more than one timestamp where only one of them is the cursor. Always perform a positive write that produces a real state change.
+
+If any child mutation does not bump the parent cursor, exclude that child from `incremental_dependency: true` (route it through a non-incremental parent copy) or give the child its own incremental cursor.
 
 #### Global Substream Cursor
 - **Description**: This option uses a single global cursor for all partitions, significantly reducing the state size. It enforces a minimal lookback window based on the previous sync's duration to avoid losing records added or updated during the sync. Since the global cursor is already part of the per partition with fallback to global approach, it should only be used cautiously for custom connectors with exceptionally large parent streams to avoid managing state per partition.

--- a/docs/platform/connector-development/config-based/understanding-the-yaml-file/incremental-syncs.md
+++ b/docs/platform/connector-development/config-based/understanding-the-yaml-file/incremental-syncs.md
@@ -117,6 +117,7 @@ The default state format is **per partition with fallback to global**, but there
 - **Requirement**: The API must ensure that the parent record's cursor is updated whenever child records are added or updated. If this requirement is not met, child records added to older parent records will be lost.
 - **When to Use**: Use this option if the parent stream is incremental, the child stream has its own incremental cursor, and you want to read the parent with state. The parent state is updated after processing all the child records for the parent record.
 - **Example State**:
+
   ```json
   {
     "parent_state": {

--- a/docs/platform/connector-development/config-based/understanding-the-yaml-file/incremental-syncs.md
+++ b/docs/platform/connector-development/config-based/understanding-the-yaml-file/incremental-syncs.md
@@ -133,19 +133,21 @@ The default state format is **per partition with fallback to global**, but there
 
 #### When `incremental_dependency` has no effect
 
-`incremental_dependency: true` is a runtime optimization on the partition router. It is not the same thing as declaring the child stream incremental. Specifically, it has no effect unless the child stream itself defines an `incremental_sync` block. If the child has no own cursor, the CDK assigns it a `FinalStateCursor`, which never persists `parent_state`. As a result, every sync re-reads the parent from `start_datetime` and the flag is silently inert. To activate the optimization for a child without its own cursor, give the child stream an `incremental_sync` block (typically derived from a parent timestamp), or use a base stream class that supplies a per-partition cursor.
+`incremental_dependency: true` is a runtime optimization on the partition router rather than a declaration that the child stream is incremental. It only takes effect when the child stream itself defines an `incremental_sync` block. When the child has no cursor of its own, the CDK assigns it a `FinalStateCursor`, which never persists `parent_state`; in that case every sync re-reads the parent from `start_datetime` and the flag has no observable effect. The optimization becomes active once the child stream gains its own incremental cursor — typically one derived from a parent timestamp — or once the child uses a base stream class that supplies a per-partition cursor.
 
-#### Verifying the parent-cursor-bump assumption
+#### The parent-cursor-bump assumption
 
-The "Requirement" above is load-bearing. Before shipping `incremental_dependency: true`, verify empirically that every mutation of a child resource bumps the parent's cursor field. API behavior is per-resource and varies even within a single API. To check:
+For `incremental_dependency: true` to be safe, the API needs to update the parent record's cursor field whenever a child resource is created, updated, or deleted. If a child mutation does not advance the parent's cursor, that child record is added to a parent the partition router will skip on subsequent warm syncs — so the new child is never observed, even though the sync itself completes successfully.
 
-1. Capture the parent record's cursor field (e.g., `updated_at`).
-2. Perform each kind of child mutation the connector exposes (create, update, delete, plus any side-effecting endpoints like state transitions, votes, or watchers).
-3. Re-fetch the parent and compare the cursor field. If it did not advance, that child operation is unsafe under `incremental_dependency: true` — children added to an unchanged parent will not be re-iterated on warm syncs and will be permanently missed.
+API behavior here is per-resource and frequently varies within a single API, so this assumption typically benefits from empirical verification before shipping. A typical confirmation pass looks like:
 
-Common false negatives to watch for: no-op mutations (e.g., adding the same watcher twice), parent re-fetches that hit a cache, idempotent endpoints that return success without writing, and APIs that expose more than one timestamp where only one of them is the cursor. Always perform a positive write that produces a real state change.
+1. Capture the parent record's cursor field (for example, `updated_at`).
+2. Perform each kind of child mutation the connector exposes — including create, update, delete, and any side-effecting endpoints such as state transitions, votes, or watchers.
+3. Re-fetch the parent and compare the cursor field. If it did not advance, that child operation is unsafe under `incremental_dependency: true`: children added to an unchanged parent are not re-iterated on warm syncs.
 
-If any child mutation does not bump the parent cursor, exclude that child from `incremental_dependency: true` (route it through a non-incremental parent copy) or give the child its own incremental cursor.
+A few common false negatives are worth being aware of: no-op mutations (such as adding the same watcher twice), parent re-fetches that hit a cache, idempotent endpoints that return success without actually writing, and APIs that expose more than one timestamp where only one of them is the cursor. A positive write that produces a real state change tends to be the most reliable signal.
+
+When a particular child mutation does not bump the parent cursor, two options preserve correctness: route that child through a non-incremental parent copy, or give the child its own incremental cursor.
 
 ### Global Substream Cursor
 

--- a/docs/platform/connector-development/config-based/understanding-the-yaml-file/incremental-syncs.md
+++ b/docs/platform/connector-development/config-based/understanding-the-yaml-file/incremental-syncs.md
@@ -139,7 +139,7 @@ The intent is to avoid re-iterating every parent on every sync when the parent s
 
 #### The parent-cursor-bump assumption
 
-For `incremental_dependency: true` to be safe, the API needs to update the parent record's cursor field whenever a child resource is created, updated, or deleted. If a child mutation does not advance the parent's cursor, that child record is added to a parent the partition router will skip on subsequent warm syncs — so the new child is never observed, even though the sync itself completes successfully. When a particular child mutation does not bump the parent cursor, two options preserve correctness: route that child through a non-incremental parent copy, or give the child its own incremental cursor.
+For `incremental_dependency: true` to be safe, the API needs to update the parent record's cursor field whenever a child resource is created, updated, or deleted. If a child mutation does not advance the parent's cursor, that child record is added to a parent the partition router will skip on subsequent warm syncs — so the new child is never observed, even though the sync itself completes successfully. When a particular child mutation does not bump the parent cursor, disable `incremental_dependency` on that child's `SubstreamPartitionRouter`. Without the flag, the partition router re-iterates the parent stream from `start_date` on every sync, so children added to parents whose cursor was never advanced are still observed.
 
 API behavior here is per-resource and frequently varies within a single API, so this assumption typically benefits from empirical verification before shipping. A typical confirmation pass looks like:
 

--- a/docs/platform/connector-development/config-based/understanding-the-yaml-file/incremental-syncs.md
+++ b/docs/platform/connector-development/config-based/understanding-the-yaml-file/incremental-syncs.md
@@ -114,10 +114,12 @@ The default state format is **per partition with fallback to global**, but there
 
 ### Incremental Dependency
 
-- **Description**: This option allows the parent stream to be read incrementally, ensuring that only new data is synced.
-- **Requirement**: The API must ensure that the parent record's cursor is updated whenever child records are added or updated. If this requirement is not met, child records added to older parent records will be lost.
-- **When to Use**: Use this option if the parent stream is incremental, the child stream has its own incremental cursor, and you want to read the parent with state. The parent state is updated after processing all the child records for the parent record.
-- **Example State**:
+`incremental_dependency: true` on a `SubstreamPartitionRouter` tells the parent stream to be read with state during warm syncs. On the first sync it iterates all parents, the same as it would without the flag. On subsequent syncs it persists the parent's cursor as `parent_state` inside the child stream's state, and the partition router uses that to iterate only parent partitions whose cursor has advanced since the last sync. For each parent the router visits, the child stream re-fetches its records.
+
+The intent is to avoid re-iterating every parent on every sync when the parent set is large.
+
+- **When to use**: the parent stream has its own `incremental_sync` block, the child stream has its own incremental cursor (see [When `incremental_dependency` has no effect](#when-incremental_dependency-has-no-effect) below), and the API satisfies [the parent-cursor-bump assumption](#the-parent-cursor-bump-assumption) below.
+- **Example state**:
 
   ```json
   {

--- a/docs/platform/connector-development/config-based/understanding-the-yaml-file/incremental-syncs.md
+++ b/docs/platform/connector-development/config-based/understanding-the-yaml-file/incremental-syncs.md
@@ -147,6 +147,7 @@ Common false negatives to watch for: no-op mutations (e.g., adding the same watc
 If any child mutation does not bump the parent cursor, exclude that child from `incremental_dependency: true` (route it through a non-incremental parent copy) or give the child its own incremental cursor.
 
 #### Global Substream Cursor
+
 - **Description**: This option uses a single global cursor for all partitions, significantly reducing the state size. It enforces a minimal lookback window based on the previous sync's duration to avoid losing records added or updated during the sync. Since the global cursor is already part of the per partition with fallback to global approach, it should only be used cautiously for custom connectors with exceptionally large parent streams to avoid managing state per partition.
 - **When to Use**: Use this option cautiously for custom connectors where the number of partitions in the parent stream is extremely high (e.g., millions of records per sync). The global cursor avoids the inefficiency of managing state per partition but sacrifices some granularity, which may not be suitable for every use case.
 - **Operational Detail**: The global cursor is updated only at the end of the sync. If the sync fails, only the parent state is updated, provided that the incremental dependency is enabled. The global cursor ensures that records are captured through a lookback window, even if they were added during the sync.

--- a/docs/platform/connector-development/config-based/understanding-the-yaml-file/partition-router.md
+++ b/docs/platform/connector-development/config-based/understanding-the-yaml-file/partition-router.md
@@ -149,6 +149,10 @@ retriever:
         incremental_dependency: true
 ```
 
+:::warning Verification required for `incremental_dependency`
+`incremental_dependency: true` is a runtime optimization on the partition router and is not equivalent to declaring the child stream incremental. It only takes effect when the child stream has its own `incremental_sync` block, and it relies on the assumption that every child mutation bumps the parent's cursor field. See [Incremental Dependency](./incremental-syncs.md#incremental-dependency) for the full requirement, the inert-flag rule, and the empirical-verification procedure that must be performed for each child resource before shipping.
+:::
+
 ## Nested streams
 
 Nested streams, subresources, or streams that depend on other streams can be implemented using a [`SubstreamPartitionRouter`](#substreampartitionrouter)

--- a/docs/platform/connector-development/config-based/understanding-the-yaml-file/partition-router.md
+++ b/docs/platform/connector-development/config-based/understanding-the-yaml-file/partition-router.md
@@ -149,8 +149,8 @@ retriever:
         incremental_dependency: true
 ```
 
-:::warning Verification required for `incremental_dependency`
-`incremental_dependency: true` is a runtime optimization on the partition router and is not equivalent to declaring the child stream incremental. It only takes effect when the child stream has its own `incremental_sync` block, and it relies on the assumption that every child mutation bumps the parent's cursor field. See [Incremental Dependency](./incremental-syncs.md#incremental-dependency) for the full requirement, the inert-flag rule, and the empirical-verification procedure that must be performed for each child resource before shipping.
+:::note About `incremental_dependency`
+`incremental_dependency: true` is a runtime optimization on the partition router rather than a declaration that the child stream is incremental. It only takes effect when the child stream has its own `incremental_sync` block, and it depends on the assumption that every child mutation bumps the parent's cursor field. See [Incremental Dependency](./incremental-syncs.md#incremental-dependency) for the case where the flag has no observable effect, and for a verification procedure for each child resource.
 :::
 
 ## Nested streams

--- a/docs/platform/connector-development/connector-builder-ui/partitioning.md
+++ b/docs/platform/connector-development/connector-builder-ui/partitioning.md
@@ -113,12 +113,12 @@ For complex injection requirements that the standard options don't support:
 
 **Lazy Read Pointer**: Enable lazy reading to extract child records during initial parent record processing.
 
-**Incremental Dependency**: When enabled, the parent stream is read with state during warm syncs so that on each subsequent sync only parents whose cursor field has advanced since the last sync are iterated, and the child stream then re-fetches records for that narrowed set of parents. This is a router-level optimization, not a sync-mode declaration, and it has two prerequisites:
+**Incremental Dependency**: When enabled, the parent stream is read with state during warm syncs, so that each subsequent sync iterates only parents whose cursor field has advanced since the last sync and the child stream re-fetches records for that narrowed set. This is a router-level optimization rather than a sync-mode declaration, and it depends on two conditions:
 
-- The child stream must have its own incremental cursor. Without one, the optimization may be silently inert.
-- Every child-resource mutation the API exposes must bump the parent's cursor field. If any child mutation does not bump the parent, those changes will be permanently missed on warm syncs.
+- The child stream needs its own incremental cursor. Without one, the optimization has no observable effect.
+- Every child-resource mutation the API exposes needs to bump the parent's cursor field. If a particular child mutation does not, those changes are not picked up on warm syncs.
 
-API behavior is per-resource and must be verified empirically for each child resource before enabling this option. See the [Incremental Dependency reference](/platform/connector-development/config-based/understanding-the-yaml-file/incremental-syncs#incremental-dependency) for the full requirement, the inert-flag rule, and the verification procedure.
+API behavior here is per-resource and frequently varies within a single API, so this option typically benefits from empirical verification for each child resource before being enabled. See the [Incremental Dependency reference](/platform/connector-development/config-based/understanding-the-yaml-file/incremental-syncs#incremental-dependency) for the case where the flag has no observable effect and a verification procedure.
 
 ## When not to Use Partitioning
 

--- a/docs/platform/connector-development/connector-builder-ui/partitioning.md
+++ b/docs/platform/connector-development/connector-builder-ui/partitioning.md
@@ -113,7 +113,12 @@ For complex injection requirements that the standard options don't support:
 
 **Lazy Read Pointer**: Enable lazy reading to extract child records during initial parent record processing.
 
-**Incremental Dependency**: When enabled, the parent stream is read incrementally based on child stream updates.
+**Incremental Dependency**: When enabled, the parent stream is read with state during warm syncs so that on each subsequent sync only parents whose cursor field has advanced since the last sync are iterated, and the child stream then re-fetches records for that narrowed set of parents. This is a router-level optimization, not a sync-mode declaration, and it has two prerequisites:
+
+- The child stream must have its own incremental cursor. Without one, the optimization is silently inert.
+- Every child-resource mutation the API exposes must bump the parent's cursor field. If any child mutation does not bump the parent, those changes will be permanently missed on warm syncs.
+
+API behavior is per-resource and must be verified empirically for each child resource before enabling this option. See the [Incremental Dependency reference](/platform/connector-development/config-based/understanding-the-yaml-file/incremental-syncs#incremental-dependency) for the full requirement, the inert-flag rule, and the verification procedure.
 
 ## When not to Use Partitioning
 

--- a/docs/platform/connector-development/connector-builder-ui/partitioning.md
+++ b/docs/platform/connector-development/connector-builder-ui/partitioning.md
@@ -115,7 +115,7 @@ For complex injection requirements that the standard options don't support:
 
 **Incremental Dependency**: When enabled, the parent stream is read with state during warm syncs so that on each subsequent sync only parents whose cursor field has advanced since the last sync are iterated, and the child stream then re-fetches records for that narrowed set of parents. This is a router-level optimization, not a sync-mode declaration, and it has two prerequisites:
 
-- The child stream must have its own incremental cursor. Without one, the optimization is silently inert.
+- The child stream must have its own incremental cursor. Without one, the optimization may be silently inert.
 - Every child-resource mutation the API exposes must bump the parent's cursor field. If any child mutation does not bump the parent, those changes will be permanently missed on warm syncs.
 
 API behavior is per-resource and must be verified empirically for each child resource before enabling this option. See the [Incremental Dependency reference](/platform/connector-development/config-based/understanding-the-yaml-file/incremental-syncs#incremental-dependency) for the full requirement, the inert-flag rule, and the verification procedure.


### PR DESCRIPTION
## What

Substantive content updates to the `incremental_dependency` reference documentation. Follow-up to the cosmetic tidying merged in #77039.

The current docs assert "the API must ensure that the parent record's cursor is updated whenever child records are added or updated" but provide no methodology to verify this assumption, and they do not call out that the flag is silently inert when the child stream has no own cursor. This PR fills both gaps and corrects the inverted Builder UI one-liner that prompted the work.

## How

### `docs/platform/connector-development/config-based/understanding-the-yaml-file/incremental-syncs.md`

Inside the existing **Incremental Dependency** subsection:

- Reworded the **When to Use** bullet to make explicit that the child stream must have its own incremental cursor for the option to do anything.
- Added new `##### When incremental_dependency has no effect` subsubsection. Explains the inert-flag rule: a child without its own `incremental_sync` block gets `FinalStateCursor`, which never persists `parent_state`, so the partition router has no parent state to apply on warm syncs. Points to the two ways to activate the optimization (own incremental block on the child, or a base stream class with a per-partition cursor).
- Added new `##### Verifying the parent-cursor-bump assumption` subsubsection. Provides a 3-step procedure (capture cursor → mutate child → re-fetch and compare) plus a list of common false negatives (no-op mutations, cached re-fetches, idempotent endpoints, multi-timestamp APIs). Makes the load-bearing requirement testable.

### `docs/platform/connector-development/config-based/understanding-the-yaml-file/partition-router.md`

Added a `:::warning` admonition immediately after the `SubstreamPartitionRouter` example that uses `incremental_dependency: true`. Sends readers to the full reference in `incremental-syncs.md` so the warning is encountered at the point where they would otherwise copy the example without context.

### `docs/platform/connector-development/connector-builder-ui/partitioning.md`

Replaced the inverted one-liner — *"When enabled, the parent stream is read incrementally based on child stream updates"* — with a corrected statement of cause and effect (parent read with state during warm syncs, child re-fetched for the narrowed set of parents) and the two prerequisites: child has its own cursor, and every child mutation bumps the parent cursor. Links to the YAML reference for the verification procedure.

## Review guide

1. `docs/platform/connector-development/config-based/understanding-the-yaml-file/incremental-syncs.md` — the two new `#####` subsubsections are the primary content addition. The "When to Use" bullet rewording is small but load-bearing.
2. `docs/platform/connector-development/config-based/understanding-the-yaml-file/partition-router.md` — single `:::warning` block, drop-in.
3. `docs/platform/connector-development/connector-builder-ui/partitioning.md` — the **Incremental Dependency** paragraph is rewritten; verify the cause/effect direction reads correctly.

## User Impact

Documentation-only. Connector authors and Builder UI users are now warned at all three relevant entry points (Builder UI Concepts, YAML Components reference, YAML Components partition router) that `incremental_dependency: true` is a runtime optimization, not a sync-mode declaration, and that its safety depends on a per-resource API behavior that must be empirically verified.

This unblocks a decision on follow-up connector PRs (e.g. #76838, #76840) that hit the inert-flag case.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚
- [ ] NO ❌

Link to Devin session: https://app.devin.ai/sessions/45671900dc14438dac24810b5acd36f2
Requested by: @aaronsteers