### PR TITLE
chore(source-gong): add concurrency support and enable progressive rollout

### DIFF
--- a/airbyte-integrations/connectors/source-gong/manifest.yaml
+++ b/airbyte-integrations/connectors/source-gong/manifest.yaml
@@ -453,6 +453,10 @@ streams:
   - $ref: "#/definitions/streams/answeredScorecards"
   - $ref: "#/definitions/streams/callTranscripts"
 
+concurrency_level:
+  type: ConcurrencyLevel
+  default_concurrency: 4
+
 spec:
   type: Spec
   connection_specification:

--- a/airbyte-integrations/connectors/source-gong/metadata.yaml
+++ b/airbyte-integrations/connectors/source-gong/metadata.yaml
@@ -7,7 +7,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 32382e40-3b49-4b99-9c5c-4076501914e7
-  dockerImageTag: 1.1.1
+  dockerImageTag: 1.2.0
   dockerRepository: airbyte/source-gong
   documentationUrl: https://docs.airbyte.com/integrations/sources/gong
   githubIssueLabel: source-gong
@@ -36,6 +36,8 @@ data:
           - scopeType: stream
             impactedScopes:
               - "extensiveCalls"
+    rolloutConfiguration:
+      enableProgressiveRollout: true
   releaseStage: alpha
   remoteRegistries:
     pypi:

--- a/airbyte-integrations/connectors/source-gong/metadata.yaml
+++ b/airbyte-integrations/connectors/source-gong/metadata.yaml
@@ -7,7 +7,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 32382e40-3b49-4b99-9c5c-4076501914e7
-  dockerImageTag: 1.2.0-rc.0
+  dockerImageTag: 1.2.0-rc.1
   dockerRepository: airbyte/source-gong
   documentationUrl: https://docs.airbyte.com/integrations/sources/gong
   githubIssueLabel: source-gong

--- a/airbyte-integrations/connectors/source-gong/metadata.yaml
+++ b/airbyte-integrations/connectors/source-gong/metadata.yaml
@@ -7,7 +7,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 32382e40-3b49-4b99-9c5c-4076501914e7
-  dockerImageTag: 1.2.0
+  dockerImageTag: 1.2.0-rc.0
   dockerRepository: airbyte/source-gong
   documentationUrl: https://docs.airbyte.com/integrations/sources/gong
   githubIssueLabel: source-gong

--- a/docs/integrations/sources/gong.md
+++ b/docs/integrations/sources/gong.md
@@ -82,7 +82,7 @@ The call transcripts stream fetches transcripts one call at a time as a substrea
 
 | Version | Date       | Pull Request                                             | Subject                                                                         |
 | :------ | :--------- | :------------------------------------------------------- | :------------------------------------------------------------------------------ |
-| 1.2.0 | 2026-04-27 | [PR_NUMBER](https://github.com/airbytehq/airbyte/pull/PR_NUMBER) | Add concurrency support with default_concurrency=4; enable progressive rollout |
+| 1.2.0 | 2026-04-27 | [77049](https://github.com/airbytehq/airbyte/pull/77049) | Add concurrency support with default_concurrency=4; enable progressive rollout |
 | 1.1.0 | 2026-04-20 | [76454](https://github.com/airbytehq/airbyte/pull/76454) | Filter out private calls (`isPrivate: true`) from `calls` and `extensiveCalls` streams per Gong API listing requirements |
 | 1.1.1 | 2026-04-21 | [76593](https://github.com/airbytehq/airbyte/pull/76593) | Update dependencies |
 | 1.1.0 | 2026-04-16 | [PR_NUMBER](https://github.com/airbytehq/airbyte/pull/PR_NUMBER) | Filter out private calls (`isPrivate: true`) from `calls` and `extensiveCalls` streams per Gong API listing requirements |

--- a/docs/integrations/sources/gong.md
+++ b/docs/integrations/sources/gong.md
@@ -82,7 +82,7 @@ The call transcripts stream fetches transcripts one call at a time as a substrea
 
 | Version | Date       | Pull Request                                             | Subject                                                                         |
 | :------ | :--------- | :------------------------------------------------------- | :------------------------------------------------------------------------------ |
-| 1.2.0-rc.0 | 2026-04-27 | [77049](https://github.com/airbytehq/airbyte/pull/77049) | Add concurrency support with default_concurrency=4; enable progressive rollout |
+| 1.2.0-rc.1 | 2026-04-27 | [77049](https://github.com/airbytehq/airbyte/pull/77049) | Add concurrency support with default_concurrency=4; enable progressive rollout |
 | 1.1.0 | 2026-04-20 | [76454](https://github.com/airbytehq/airbyte/pull/76454) | Filter out private calls (`isPrivate: true`) from `calls` and `extensiveCalls` streams per Gong API listing requirements |
 | 1.1.1 | 2026-04-21 | [76593](https://github.com/airbytehq/airbyte/pull/76593) | Update dependencies |
 | 1.1.0 | 2026-04-16 | [PR_NUMBER](https://github.com/airbytehq/airbyte/pull/PR_NUMBER) | Filter out private calls (`isPrivate: true`) from `calls` and `extensiveCalls` streams per Gong API listing requirements |

--- a/docs/integrations/sources/gong.md
+++ b/docs/integrations/sources/gong.md
@@ -82,6 +82,7 @@ The call transcripts stream fetches transcripts one call at a time as a substrea
 
 | Version | Date       | Pull Request                                             | Subject                                                                         |
 | :------ | :--------- | :------------------------------------------------------- | :------------------------------------------------------------------------------ |
+| 1.2.0 | 2026-04-27 | [PR_NUMBER](https://github.com/airbytehq/airbyte/pull/PR_NUMBER) | Add concurrency support with default_concurrency=4; enable progressive rollout |
 | 1.1.0 | 2026-04-20 | [76454](https://github.com/airbytehq/airbyte/pull/76454) | Filter out private calls (`isPrivate: true`) from `calls` and `extensiveCalls` streams per Gong API listing requirements |
 | 1.1.1 | 2026-04-21 | [76593](https://github.com/airbytehq/airbyte/pull/76593) | Update dependencies |
 | 1.1.0 | 2026-04-16 | [PR_NUMBER](https://github.com/airbytehq/airbyte/pull/PR_NUMBER) | Filter out private calls (`isPrivate: true`) from `calls` and `extensiveCalls` streams per Gong API listing requirements |

--- a/docs/integrations/sources/gong.md
+++ b/docs/integrations/sources/gong.md
@@ -82,7 +82,7 @@ The call transcripts stream fetches transcripts one call at a time as a substrea
 
 | Version | Date       | Pull Request                                             | Subject                                                                         |
 | :------ | :--------- | :------------------------------------------------------- | :------------------------------------------------------------------------------ |
-| 1.2.0 | 2026-04-27 | [77049](https://github.com/airbytehq/airbyte/pull/77049) | Add concurrency support with default_concurrency=4; enable progressive rollout |
+| 1.2.0-rc.0 | 2026-04-27 | [77049](https://github.com/airbytehq/airbyte/pull/77049) | Add concurrency support with default_concurrency=4; enable progressive rollout |
 | 1.1.0 | 2026-04-20 | [76454](https://github.com/airbytehq/airbyte/pull/76454) | Filter out private calls (`isPrivate: true`) from `calls` and `extensiveCalls` streams per Gong API listing requirements |
 | 1.1.1 | 2026-04-21 | [76593](https://github.com/airbytehq/airbyte/pull/76593) | Update dependencies |
 | 1.1.0 | 2026-04-16 | [PR_NUMBER](https://github.com/airbytehq/airbyte/pull/PR_NUMBER) | Filter out private calls (`isPrivate: true`) from `calls` and `extensiveCalls` streams per Gong API listing requirements |


### PR DESCRIPTION
## What

Add concurrency support to `source-gong` and enable progressive rollout. This is part of the connector concurrency tuning initiative to improve sync performance.

## How

- **manifest.yaml**: Added `concurrency_level` block with `default_concurrency: 4`
- **metadata.yaml**: Bumped version to `1.2.0-rc.1`, added `rolloutConfiguration.enableProgressiveRollout: true`
- **docs/integrations/sources/gong.md**: Added changelog entry for `1.2.0-rc.1`

## Review guide

1. `airbyte-integrations/connectors/source-gong/manifest.yaml` — new `concurrency_level` block between `streams` and `spec`
2. `airbyte-integrations/connectors/source-gong/metadata.yaml` — version bump + rollout config
3. `docs/integrations/sources/gong.md` — changelog entry

### Phase 0 Research Summary
- **Gong API rate limits**: 3 requests/second, 10,000 requests/day (single-tier → Path A)
- **Starting concurrency**: 4 (special case: `floor(3/4) = 0 ≤ 2` → override to 4)
- **Step size**: 1
- **Eligible Tier 2 actors**: 28 (20 selected for tuning cohort)
- **Baseline sync durations**: 14s–151s on version 1.1.1
- **Baseline row volumes**: 86–980 rows per sync
- **No existing HTTP API budget** in manifest

## User Impact

No user-facing impact during progressive rollout — only Tier 2 connections in the tuning cohort will receive the RC version. Performance improvements expected once tuning is validated and GA version is released.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

[Devin session](https://app.devin.ai/sessions/07dae43bde7b44e1994cda9e4a29473b)

Requested by: @sophiecuiy