### PR TITLE
chore(source-clickup-api): add concurrency support for concurrency tuning

### DIFF
--- a/airbyte-integrations/connectors/source-clickup-api/manifest.yaml
+++ b/airbyte-integrations/connectors/source-clickup-api/manifest.yaml
@@ -9671,21 +9671,8 @@ spec:
 
 concurrency_level:
   type: ConcurrencyLevel
-  default_concurrency: 41
-  max_concurrency: 60
-
-api_budget:
-  type: HTTPAPIBudget
-  policies:
-    - type: MovingWindowCallRatePolicy
-      rates:
-        - limit: 10000
-          interval: PT1M
-      matchers: []
-  ratelimit_reset_header: X-RateLimit-Reset
-  ratelimit_remaining_header: X-RateLimit-Remaining
-  status_codes_for_ratelimit_hit:
-    - 429
+  default_concurrency: 4
+  max_concurrency: 10
 
 metadata:
   autoImportSchema:

--- a/airbyte-integrations/connectors/source-clickup-api/manifest.yaml
+++ b/airbyte-integrations/connectors/source-clickup-api/manifest.yaml
@@ -9668,6 +9668,25 @@ spec:
         title: Include Closed Tasks
         default: false
     additionalProperties: true
+
+concurrency_level:
+  type: ConcurrencyLevel
+  default_concurrency: 41
+  max_concurrency: 60
+
+api_budget:
+  type: HTTPAPIBudget
+  policies:
+    - type: MovingWindowCallRatePolicy
+      rates:
+        - limit: 10000
+          interval: PT1M
+      matchers: []
+  ratelimit_reset_header: X-RateLimit-Reset
+  ratelimit_remaining_header: X-RateLimit-Remaining
+  status_codes_for_ratelimit_hit:
+    - 429
+
 metadata:
   autoImportSchema:
     user: false

--- a/airbyte-integrations/connectors/source-clickup-api/metadata.yaml
+++ b/airbyte-integrations/connectors/source-clickup-api/metadata.yaml
@@ -5,7 +5,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 311a7a27-3fb5-4f7e-8265-5e4afe258b66
-  dockerImageTag: 0.3.46
+  dockerImageTag: 0.3.47
   dockerRepository: airbyte/source-clickup-api
   githubIssueLabel: source-clickup-api
   icon: clickup.svg
@@ -22,6 +22,9 @@ data:
       enabled: true
   releaseDate: 2023-02-10
   releaseStage: alpha
+  releases:
+    rolloutConfiguration:
+      enableProgressiveRollout: true
   documentationUrl: https://docs.airbyte.com/integrations/sources/clickup-api
   tags:
     - cdk:low-code

--- a/docs/integrations/sources/clickup-api.md
+++ b/docs/integrations/sources/clickup-api.md
@@ -57,7 +57,7 @@ Here are some optional fields:
 
 | Version | Date       | Pull Request                                             | Subject                           |
 | :------ | :--------- | :------------------------------------------------------- | :-------------------------------- |
-| 0.3.47 | 2026-04-27 | [TBD](https://github.com/airbytehq/airbyte/pull/TBD) | Add concurrency support and Enterprise-tier API budget for concurrency tuning |
+| 0.3.47 | 2026-04-27 | [77050](https://github.com/airbytehq/airbyte/pull/77050) | Add concurrency support and Enterprise-tier API budget for concurrency tuning |
 | 0.3.46 | 2026-04-21 | [76539](https://github.com/airbytehq/airbyte/pull/76539) | Update dependencies |
 | 0.3.45 | 2026-03-31 | [75750](https://github.com/airbytehq/airbyte/pull/75750) | Update dependencies |
 | 0.3.44 | 2026-03-17 | [75076](https://github.com/airbytehq/airbyte/pull/75076) | Update dependencies |

--- a/docs/integrations/sources/clickup-api.md
+++ b/docs/integrations/sources/clickup-api.md
@@ -57,6 +57,7 @@ Here are some optional fields:
 
 | Version | Date       | Pull Request                                             | Subject                           |
 | :------ | :--------- | :------------------------------------------------------- | :-------------------------------- |
+| 0.3.47 | 2026-04-27 | [TBD](https://github.com/airbytehq/airbyte/pull/TBD) | Add concurrency support and Enterprise-tier API budget for concurrency tuning |
 | 0.3.46 | 2026-04-21 | [76539](https://github.com/airbytehq/airbyte/pull/76539) | Update dependencies |
 | 0.3.45 | 2026-03-31 | [75750](https://github.com/airbytehq/airbyte/pull/75750) | Update dependencies |
 | 0.3.44 | 2026-03-17 | [75076](https://github.com/airbytehq/airbyte/pull/75076) | Update dependencies |


### PR DESCRIPTION
## What

Add concurrency tuning infrastructure for `source-clickup-api` as part of the [Connector Concurrency Tuning & Rollout](https://github.com/airbytehq/airbyte-internal-issues/issues/15262) initiative. This enables parallel stream processing for ClickUp API connections.

Requested by @sophicue.

## How

1. **`manifest.yaml`** — Added `concurrency_level` block:
   - `default_concurrency: 4` (Path A, calculated from lowest tier: Free/Business at 100 req/min = 1.67 req/sec; `floor(1.67/4) = 0 ≤ 2` → special case override to c=4, step=1)
   - `max_concurrency: 10`

2. **`metadata.yaml`** — Version bump 0.3.46 → 0.3.47, enabled progressive rollout (`enableProgressiveRollout: true`)

3. **`docs/integrations/sources/clickup-api.md`** — Changelog entry

**Path A rationale:** ClickUp has tiered rate limits (Free/Business: 100 req/min, Business Plus: 1,000 req/min, Enterprise: 10,000 req/min), but `max_rate_limit` in the formula refers to the max across endpoints within the lowest tier, not across tiers. Since ClickUp has no per-endpoint differences, `max_rate_limit = 100 req/min`. No API budget is shipped for Path A — rate limiting is handled by ClickUp's API directly (429 responses).

## Review guide

1. `airbyte-integrations/connectors/source-clickup-api/manifest.yaml` — `concurrency_level` block added after `spec` section
2. `airbyte-integrations/connectors/source-clickup-api/metadata.yaml` — version bump + rollout config
3. `docs/integrations/sources/clickup-api.md` — changelog

## User Impact

- Enables concurrent stream processing for ClickUp connections (up to 4 parallel streams by default, max 10)
- No breaking changes; connections without concurrency support will continue to work sequentially

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Link to Devin session: https://app.devin.ai/sessions/80a759df6c0849348ac4807229c1f357
Requested by: @sophiecuiy