### PR TITLE
feat(source-confluence): add concurrency_level for parallel stream reads (1.1.0-rc.1)

### DIFF
--- a/airbyte-integrations/connectors/source-confluence/manifest.yaml
+++ b/airbyte-integrations/connectors/source-confluence/manifest.yaml
@@ -2,6 +2,11 @@ version: 6.41.5
 
 type: DeclarativeSource
 
+concurrency_level:
+  type: ConcurrencyLevel
+  default_concurrency: "{{ config.get('num_workers', 10) }}"
+  max_concurrency: 25
+
 check:
   type: CheckStream
   stream_names:
@@ -243,6 +248,17 @@ spec:
         description: Your Confluence domain name
         order: 2
         title: Domain name
+      num_workers:
+        type: integer
+        title: Concurrent Workers
+        minimum: 1
+        maximum: 25
+        default: 10
+        order: 3
+        description: >-
+          The number of concurrent workers to use for syncing data. Increasing
+          this may improve sync speed for large Confluence instances but could
+          trigger rate limiting.
     additionalProperties: true
 
 metadata:

--- a/airbyte-integrations/connectors/source-confluence/metadata.yaml
+++ b/airbyte-integrations/connectors/source-confluence/metadata.yaml
@@ -10,7 +10,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: cf40a7f8-71f8-45ce-a7fa-fca053e4028c
-  dockerImageTag: 1.0.21
+  dockerImageTag: 1.1.0-rc.1
   dockerRepository: airbyte/source-confluence
   documentationUrl: https://docs.airbyte.com/integrations/sources/confluence
   githubIssueLabel: source-confluence
@@ -27,6 +27,8 @@ data:
       enabled: true
     oss:
       enabled: true
+  rolloutConfiguration:
+    enableProgressiveRollout: true
   releaseDate: 2021-11-05
   releaseStage: beta
   remoteRegistries:

--- a/docs/integrations/sources/confluence.md
+++ b/docs/integrations/sources/confluence.md
@@ -63,6 +63,7 @@ The Confluence connector should not run into Confluence API limitations under no
 
 | Version | Date       | Pull Request                                             | Subject                                                                         |
 | :------ | :--------- | :------------------------------------------------------- | :------------------------------------------------------------------------------ |
+| 1.1.0-rc.1 | 2026-04-27 | | Add concurrency support for parallel stream reads |
 | 1.0.21 | 2025-12-19 | [70941](https://github.com/airbytehq/airbyte/pull/70941) | Update dependencies |
 | 1.0.20 | 2025-11-25 | [69919](https://github.com/airbytehq/airbyte/pull/69919) | Update dependencies |
 | 1.0.19 | 2025-10-29 | [66333](https://github.com/airbytehq/airbyte/pull/66333) | Update dependencies |


### PR DESCRIPTION
## What

Adds `concurrency_level` configuration to `source-confluence` to enable concurrent stream reads, as part of the concurrency tuning epic ([airbytehq/airbyte-internal-issues#15262](https://github.com/airbytehq/airbyte-internal-issues/issues/15262)).

This is the first RC for concurrency tuning of this connector. Requested by @sophiecuiy.

## How

1. **`manifest.yaml`**: Added `concurrency_level` block with `default_concurrency: 10` (configurable via `num_workers` spec field) and `max_concurrency: 25`. Added `num_workers` integer field to the connector spec (min 1, max 25, default 10).
2. **`metadata.yaml`**: Bumped version from `1.0.21` → `1.1.0-rc.1`, added `rolloutConfiguration.enableProgressiveRollout: true`.
3. **`confluence.md`**: Added changelog entry for `1.1.0-rc.1`.

**Rate limit research summary:**
- source-confluence uses `BasicHttpAuthenticator` (email + API token)
- Atlassian's points-based hourly quotas do NOT apply to API token traffic
- Only burst rate limits apply: 100 RPS (GET) per endpoint per tenant
- Burst limits are identical across all Confluence editions (no tier differentiation)
- Decision: *Path A* (single-tier, empirical tuning)

**Concurrency rationale:**
- The connector has 5 streams (audit, blog_posts, group, pages, space) with no sub-stream partitioning
- Effective max parallelism is 5 (one per stream), so starting at 10 provides 2x headroom
- No explicit `api_budget` included initially — the CDK's built-in 429 retry/backoff handles burst rate limiting reactively (same approach used successfully for source-typeform)

**Starting values:** `default_concurrency = 10`, `step = 6` (for progressive tuning)

## Review guide

1. `airbyte-integrations/connectors/source-confluence/manifest.yaml` — `concurrency_level` block at top + `num_workers` spec field
2. `airbyte-integrations/connectors/source-confluence/metadata.yaml` — version bump + progressive rollout flag
3. `docs/integrations/sources/confluence.md` — changelog entry

## User Impact

Users will benefit from faster sync times as all 5 streams can now read in parallel. The `num_workers` spec field allows users to tune concurrency if needed.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

---
[Devin session](https://app.devin.ai/sessions/4a9b7be76c7b4815b1a4587438b2324a)