### PR TITLE
feat(source-incident-io): add incremental sync support for incidents stream

### DIFF
--- a/airbyte-integrations/connectors/source-incident-io/CONTRIBUTING.md
+++ b/airbyte-integrations/connectors/source-incident-io/CONTRIBUTING.md
@@ -1,0 +1,33 @@
+# Contributing to source-incident-io
+
+For general guidance on contributing to Airbyte connectors, see the [Connector Development documentation](https://docs.airbyte.com/connector-development/).
+
+## Incremental Stream Considerations
+
+The incident.io API v2 supports date-based filtering on a limited set of endpoints. The `/v2/incidents` endpoint supports `updated_at[gte]` and `updated_at[lte]` query parameters ([API reference](https://docs.incident.io/api-reference/incidents-v2/list)). The `/v2/alerts` endpoint only supports `created_at` filtering, not `updated_at`. Most other list endpoints (actions, follow-ups, custom_fields, etc.) do not expose any date-based filtering.
+
+All streams in this connector are top-level (no parent/child SubstreamPartitionRouter relationships). The connector uses cursor-based pagination via the `pagination_meta.after` field.
+
+| Stream | Volume Tier | Relationship | Cursor Field | API Incremental Support | Current Status | Notes |
+|---|---|---|---|---|---|---|
+| incidents | xlarge | top-level parent | updated_at | updated_at | in_scope_this_pr | [API ref](https://docs.incident.io/api-reference/incidents-v2/list) — supports `updated_at[gte]` |
+| alerts | large | top-level parent | updated_at | created_at_only | deferred_no_api_support | Only `created_at` filter, not `updated_at` — insufficient for mutable resource |
+| escalations | large | top-level parent | updated_at | none | deferred_no_api_support | No date-based filter on list endpoint |
+| actions | medium | top-level parent | updated_at | none | deferred_no_api_support | No date-based filter on list endpoint |
+| follow-ups | medium | top-level parent | updated_at | none | deferred_no_api_support | No date-based filter on list endpoint |
+| incident_updates | medium | top-level parent | none | none | deferred_no_api_support | No updated_at field; append-only log |
+| catalog_types | small | top-level parent | updated_at | none | deferred_no_api_support | Config-style stream, low volume |
+| custom_fields | small | top-level parent | updated_at | none | deferred_no_api_support | Config-style stream, low volume |
+| incident_roles | small | top-level parent | updated_at | none | deferred_no_api_support | Config-style stream, low volume |
+| incident_timestamps | small | top-level parent | none | none | not_applicable | Config-style stream, no updated_at |
+| incident_statuses | small | top-level parent | updated_at | none | deferred_no_api_support | Config-style stream, low volume |
+| workflows | small | top-level parent | none | none | deferred_no_api_support | No updated_at field |
+| users | small | top-level parent | none | none | deferred_no_api_support | No updated_at field or date filter |
+| severities | small | top-level parent | updated_at | none | deferred_no_api_support | Config-style stream, low volume |
+| schedules | small | top-level parent | updated_at | none | deferred_no_api_support | Config-style stream, low volume |
+
+### Deferred streams
+
+- **No API date filter (10 streams):** `alerts`, `escalations`, `actions`, `follow-ups`, `catalog_types`, `custom_fields`, `incident_roles`, `incident_statuses`, `severities`, `schedules` — these streams have `updated_at` on the record but the incident.io API does not expose an `updated_at`-based filter on their list endpoints. The `alerts` endpoint supports `created_at` filtering only, which is insufficient for a mutable resource. A future agent should verify via live API probing whether undocumented `updated_at` filter parameters are accepted.
+- **No cursor field (3 streams):** `incident_timestamps`, `workflows`, `users` — no `updated_at` field on the record schema.
+- **Append-only (1 stream):** `incident_updates` — log-style entries without `updated_at`; could potentially use `created_at` for append-only incremental in the future.

--- a/airbyte-integrations/connectors/source-incident-io/manifest.yaml
+++ b/airbyte-integrations/connectors/source-incident-io/manifest.yaml
@@ -349,6 +349,21 @@ definitions:
             page_size: 100
             cursor_value: "{{ response.get('pagination_meta', {}).get('after') }}"
             stop_condition: "{{ response.get('pagination_meta', {}).get('after') is none }}"
+      incremental_sync:
+        type: DatetimeBasedCursor
+        cursor_field: updated_at
+        cursor_datetime_formats:
+          - "%Y-%m-%dT%H:%M:%S.%fZ"
+          - "%Y-%m-%dT%H:%M:%SZ"
+        datetime_format: "%Y-%m-%dT%H:%M:%SZ"
+        start_datetime:
+          type: MinMaxDatetime
+          datetime: "{{ config.get('start_date', '2020-01-01T00:00:00Z') }}"
+          datetime_format: "%Y-%m-%dT%H:%M:%SZ"
+        start_time_option:
+          type: RequestOption
+          field_name: "updated_at[gte]"
+          inject_into: request_parameter
       schema_loader:
         type: InlineSchemaLoader
         schema:
@@ -464,6 +479,17 @@ spec:
         title: API Key
         airbyte_secret: true
         order: 0
+      start_date:
+        type: string
+        title: Start Date
+        description: >-
+          UTC date and time in the format YYYY-MM-DDTHH:MM:SSZ. Data with an
+          updated_at value equal to or later than this will be replicated. If
+          not set, all data will be replicated.
+        pattern: "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$"
+        examples:
+          - "2020-01-01T00:00:00Z"
+        order: 1
     additionalProperties: true
 
 metadata:


### PR DESCRIPTION
## What

Adds incremental sync support to the `incidents` stream in source-incident-io. The incident.io v2 API supports `updated_at[gte]` filtering on the `/v2/incidents` endpoint ([API reference](https://docs.incident.io/api-reference/incidents-v2/list)).

Also adds a `CONTRIBUTING.md` with an "Incremental Stream Considerations" section documenting all 15 streams, their incremental eligibility, and deferral reasons.

Requested by @aaronsteers.

## How

- Added `incremental_sync` block with `DatetimeBasedCursor` to the `incidents` stream definition in `manifest.yaml`, using `cursor_field: updated_at` and `updated_at[gte]` request parameter.
- Added optional `start_date` config parameter to the spec.
- Created `CONTRIBUTING.md` with stream-by-stream analysis table.

### Streams addressed
- `incidents` — changed from full-refresh to incremental (cursor: `updated_at`, filter: `updated_at[gte]`)

### Deferred streams
- `alerts` — only supports `created_at` filtering, insufficient for mutable resource
- 10 other streams have `updated_at` fields but no API date filter
- 3 streams lack an `updated_at` field entirely

## Review guide

1. `airbyte-integrations/connectors/source-incident-io/manifest.yaml` — incremental_sync block + start_date spec
2. `airbyte-integrations/connectors/source-incident-io/CONTRIBUTING.md` — new file

## User Impact

Users can now configure incremental syncs for the `incidents` stream, reducing sync time and API rate-limit pressure.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

---
Devin session: https://app.devin.ai/sessions/688f2cad835448718118edf76a6bf581