### PR TITLE
docs(source-gong): document incremental stream considerations

### DIFF
--- a/airbyte-integrations/connectors/source-gong/CONTRIBUTING.md
+++ b/airbyte-integrations/connectors/source-gong/CONTRIBUTING.md
@@ -1,0 +1,20 @@
+# Contributing to source-gong
+
+For general guidance on contributing to Airbyte connectors, see the [Connector Development documentation](https://docs.airbyte.com/connector-development/).
+
+## Incremental Stream Considerations
+
+The Gong API exposes incremental filtering via `fromDateTime` on the calls and scorecards endpoints. The `users` endpoint does not support date-based filtering. Child streams (e.g. `answered_scorecards`) are partitioned via `SubstreamPartitionRouter`.
+
+| Stream | Volume Tier | Relationship | Cursor Field | API Incremental Support | Current Status | Notes |
+|---|---|---|---|---|---|---|
+| answeredScorecards | medium | top-level parent | reviewTime | reviewTime | incremental |  |
+| calls | medium | top-level parent | started | started | incremental |  |
+| extensiveCalls | medium | top-level parent | startdatetime | startdatetime | incremental |  |
+| scorecards | small | top-level parent | none | none | deferred_no_api_support | No date filter on list endpoint; config-style lookup |
+| users | small | top-level parent | none | none | deferred_no_api_support | No date filter on list endpoint |
+| callTranscripts | medium | child | started | started | incremental |  |
+
+### Deferred streams
+
+- **No API date filter (2 streams):** `scorecards`, `users` — these streams do not have a documented date-based filter on their list endpoints. A future agent should verify via live API probing whether undocumented filter parameters are accepted.


### PR DESCRIPTION
## What

Adds `CONTRIBUTING.md` with "Incremental Stream Considerations" section for source-gong. Documents all streams, their incremental eligibility, and deferral reasons.

Requested by @aaronsteers.

## How

- Created `CONTRIBUTING.md` with stream-by-stream analysis table
- `users` and `scorecards` deferred as `deferred_no_api_support` (small config-style lookups without date filtering)
- Existing incremental streams (`calls`, `extensiveCalls`, `answeredScorecards`) documented

## Review guide

1. `airbyte-integrations/connectors/source-gong/CONTRIBUTING.md`

## User Impact

Documentation-only change. No user-facing impact.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

---
Devin session: https://app.devin.ai/sessions/688f2cad835448718118edf76a6bf581