### PR TITLE
docs(source-confluence): document incremental stream considerations

### DIFF
--- a/airbyte-integrations/connectors/source-confluence/CONTRIBUTING.md
+++ b/airbyte-integrations/connectors/source-confluence/CONTRIBUTING.md
@@ -1,0 +1,19 @@
+# Contributing to source-confluence
+
+For general guidance on contributing to Airbyte connectors, see the [Connector Development documentation](https://docs.airbyte.com/connector-development/).
+
+## Incremental Stream Considerations
+
+The Confluence Cloud REST API uses cursor-based pagination. The `audit` endpoint supports `startDate`/`endDate` filtering but records are append-only (audit logs). The `blog_posts`, `pages`, `group`, and `space` endpoints do not support `updated_at`-style filtering via query parameters.
+
+| Stream | Volume Tier | Relationship | Cursor Field | API Incremental Support | Current Status | Notes |
+|---|---|---|---|---|---|---|
+| audit | medium | top-level parent | none | created_at_only | deferred_no_api_support | Append-only audit log; supports startDate/endDate but records are immutable |
+| blog_posts | medium | top-level parent | none | none | deferred_no_api_support | No date filter on list endpoint; has sort but no filter |
+| group | small | top-level parent | none | none | deferred_no_api_support | Config-style lookup |
+| pages | large | top-level parent | none | none | deferred_no_api_support | No date filter on list endpoint |
+| space | small | top-level parent | none | none | deferred_no_api_support | Config-style lookup |
+
+### Deferred streams
+
+- **No API date filter (5 streams):** `audit`, `blog_posts`, `group`, `pages`, `space` — these streams do not have a documented date-based filter on their list endpoints. A future agent should verify via live API probing whether undocumented filter parameters are accepted.


### PR DESCRIPTION
## What

Adds `CONTRIBUTING.md` with "Incremental Stream Considerations" section for source-confluence. Documents all streams, their incremental eligibility, and deferral reasons.

Requested by @aaronsteers.

## How

- Created `CONTRIBUTING.md` with stream-by-stream analysis table
- `audit` deferred — supports `startDate`/`endDate` but records are append-only (audit logs), making `created_at_only` insufficient for mutable resources
- `blog_posts`, `pages` deferred — no date filter on list endpoints despite being medium/large volume
- `group`, `space` deferred — small config-style lookups without date filtering

## Review guide

1. `airbyte-integrations/connectors/source-confluence/CONTRIBUTING.md`

## User Impact

Documentation-only change. No user-facing impact.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

---
Devin session: https://app.devin.ai/sessions/688f2cad835448718118edf76a6bf581