### PR TITLE
docs(source-gmail): document incremental stream considerations

### DIFF
--- a/airbyte-integrations/connectors/source-gmail/CONTRIBUTING.md
+++ b/airbyte-integrations/connectors/source-gmail/CONTRIBUTING.md
@@ -1,0 +1,23 @@
+# Contributing to source-gmail
+
+For general guidance on contributing to Airbyte connectors, see the [Connector Development documentation](https://docs.airbyte.com/connector-development/).
+
+## Incremental Stream Considerations
+
+The Gmail API uses a query-based filtering system (`q` parameter) that supports date ranges via `after:` and `before:` operators. However, these filter by internal date (similar to created_at), not by modification time. Messages and threads are mutable (labels change, read status), making `created_at`-style filtering insufficient. The `profile`, `drafts`, and `labels` streams are small config-style endpoints.
+
+| Stream | Volume Tier | Relationship | Cursor Field | API Incremental Support | Current Status | Notes |
+|---|---|---|---|---|---|---|
+| drafts | small | top-level parent | none | none | deferred_no_api_support | No date filter; relatively small set per user |
+| labels | small | top-level parent | none | none | deferred_no_api_support | Config-style lookup, typically <100 labels |
+| messages | xlarge | top-level parent | none | created_at_only | deferred_no_api_support | Gmail q parameter supports after:/before: but filters by internalDate (received), not modification time |
+| profile | small | top-level parent | none | none | deferred_no_api_support | Singleton user profile endpoint |
+| threads | xlarge | top-level parent | none | created_at_only | deferred_no_api_support | Same limitation as messages — q parameter filters by date received |
+| labels_details | medium | child | none | none | deferred_child |  |
+| messages_details | medium | child | none | none | deferred_child |  |
+| threads_details | medium | child | none | none | deferred_child |  |
+
+### Deferred streams
+
+- **No API date filter (5 streams):** `drafts`, `labels`, `messages`, `profile`, `threads` — these streams do not have a documented date-based filter on their list endpoints. A future agent should verify via live API probing whether undocumented filter parameters are accepted.
+- **Child streams (3 streams):** `labels_details`, `messages_details`, `threads_details` — partitioned via `SubstreamPartitionRouter`. A follow-up session should evaluate whether these can be made incremental independently or via `incremental_dependency`.


### PR DESCRIPTION
## What

Adds `CONTRIBUTING.md` with "Incremental Stream Considerations" section for source-gmail. Documents all streams, their incremental eligibility, and deferral reasons.

Requested by @aaronsteers.

## How

- Created `CONTRIBUTING.md` with stream-by-stream analysis table
- `messages` and `threads` deferred — Gmail `q` parameter supports `after:`/`before:` but filters by `internalDate` (received time), not modification time. Since messages are mutable (labels, read status), `created_at_only` is insufficient.
- `profile`, `drafts`, `labels` deferred — small config-style endpoints without date filtering

## Review guide

1. `airbyte-integrations/connectors/source-gmail/CONTRIBUTING.md`

## User Impact

Documentation-only change. No user-facing impact.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

---
Devin session: https://app.devin.ai/sessions/688f2cad835448718118edf76a6bf581