### PR TITLE
chore(source-granola): set default_concurrency=4 for concurrency tuning (0.2.0-rc.1)

### DIFF
--- a/airbyte-integrations/connectors/source-granola/manifest.yaml
+++ b/airbyte-integrations/connectors/source-granola/manifest.yaml
@@ -6,6 +6,10 @@ description: >-
   Granola is an AI-powered meeting notes tool. This connector reads meeting
   notes from your Granola workspace using the Granola Enterprise API.
 
+concurrency_level:
+  type: ConcurrencyLevel
+  default_concurrency: 4
+
 check:
   type: CheckStream
   stream_names:

--- a/airbyte-integrations/connectors/source-granola/metadata.yaml
+++ b/airbyte-integrations/connectors/source-granola/metadata.yaml
@@ -7,7 +7,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 9023923c-002f-4131-9554-3ebdf56540a4
-  dockerImageTag: 0.1.3
+  dockerImageTag: 0.2.0-rc.1
   dockerRepository: airbyte/source-granola
   documentationUrl: https://docs.airbyte.com/integrations/sources/granola
   githubIssueLabel: source-granola
@@ -16,8 +16,10 @@ data:
   registryOverrides:
     cloud:
       enabled: true
+      dockerImageTag: 0.1.3
     oss:
       enabled: true
+      dockerImageTag: 0.1.3
   releaseStage: alpha
   remoteRegistries:
     pypi:
@@ -45,4 +47,7 @@ data:
     - title: Granola Enterprise API documentation
       url: https://docs.granola.ai/introduction
       type: api_reference
+  releases:
+    rolloutConfiguration:
+      enableProgressiveRollout: true
 metadataSpecVersion: "1.0"

--- a/docs/integrations/sources/granola.md
+++ b/docs/integrations/sources/granola.md
@@ -103,6 +103,7 @@ The connector handles rate limiting automatically by retrying requests when a `4
 
 | Version | Date       | Pull Request | Subject         |
 | :------ | :--------- | :----------- | :-------------- |
+| 0.2.0-rc.1 | 2026-04-27 | [*PR_NUMBER_PLACEHOLDER*](https://github.com/airbytehq/airbyte/pull/*PR_NUMBER_PLACEHOLDER*) | set default_concurrency=4 for concurrency tuning iteration 1 (Path A, max_rate_limit=5 req/s) |
 | 0.1.3 | 2026-04-21 | [76632](https://github.com/airbytehq/airbyte/pull/76632) | Update dependencies |
 | 0.1.2 | 2026-03-31 | [75737](https://github.com/airbytehq/airbyte/pull/75737) | Update dependencies |
 | 0.1.1 | 2026-03-24 | [75353](https://github.com/airbytehq/airbyte/pull/75353) | Update dependencies |


### PR DESCRIPTION
## What

Concurrency tuning Phase 1 for source-granola. This is the first RC (0.2.0-rc.1) in a progressive rollout to tune concurrency for this connector.

**Rate-limit research:**
- Granola API: 5 requests/second sustained (single tier, no per-endpoint differentiation)
- Source: https://docs.granola.ai/introduction changelog (v1.0.0, Feb 2026)

**Tuning path:** Path A (single-tier rate limit — tune empirically without shipping rate-limit config)

**Starting concurrency:** 4 (special case override: `floor(5/4)=1` which is ≤ 2, so override to 4)
**Step size:** 1

**Eligible actors:** 11 Tier 2 actors with recent successful syncs (all US, no Tier 0/1 actors exist)

Requested by @sophiecuiy as part of the connector concurrency tuning initiative.

## How

1. Added `concurrency_level` block to `manifest.yaml` with `default_concurrency: 4`
2. Bumped version from 0.1.3 to 0.2.0-rc.1 (RC for progressive rollout)
3. Added `releases.rolloutConfiguration.enableProgressiveRollout: true` to `metadata.yaml`
4. Cloud/OSS registry overrides pinned to stable 0.1.3

## Review guide

1. `airbyte-integrations/connectors/source-granola/manifest.yaml` — new `concurrency_level` block
2. `airbyte-integrations/connectors/source-granola/metadata.yaml` — version bump + rollout config
3. `docs/integrations/sources/granola.md` — changelog entry

## User Impact

No immediate user impact. The RC version will be progressively rolled out to a subset of Tier 2 connections for performance validation before general release. Stable version (0.1.3) remains pinned for cloud/OSS.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Link to Devin session: https://app.devin.ai/sessions/d78f9b087fdc48e58bea13476997498e