### PR TITLE
docs(source-zendesk-chat): document incremental stream considerations

### DIFF
--- a/airbyte-integrations/connectors/source-zendesk-chat/CONTRIBUTING.md
+++ b/airbyte-integrations/connectors/source-zendesk-chat/CONTRIBUTING.md
@@ -1,0 +1,26 @@
+# Contributing to source-zendesk-chat
+
+For general guidance on contributing to Airbyte connectors, see the [Connector Development documentation](https://docs.airbyte.com/connector-development/).
+
+## Incremental Stream Considerations
+
+The Zendesk Chat (Zopim) API supports incremental exports for high-volume endpoints (chats, agents, bans, agent_timeline) via the Incremental API. The connector already uses these for incremental streams. The remaining FR parent streams are config-style lookups (accounts, departments, goals, roles, routing_settings, shortcuts, skills, triggers) that do not support date-based filtering.
+
+| Stream | Volume Tier | Relationship | Cursor Field | API Incremental Support | Current Status | Notes |
+|---|---|---|---|---|---|---|
+| accounts | small | top-level parent | none | none | deferred_no_api_support | Singleton account config |
+| agent_timeline | medium | top-level parent | start_time | start_time | incremental |  |
+| agents | medium | top-level parent | id | id | incremental |  |
+| bans | medium | top-level parent | id | id | incremental |  |
+| chats | medium | top-level parent | update_timestamp | update_timestamp | incremental |  |
+| departments | small | top-level parent | none | none | deferred_no_api_support | Config-style lookup |
+| goals | small | top-level parent | none | none | deferred_no_api_support | Config-style lookup |
+| roles | small | top-level parent | none | none | deferred_no_api_support | Config-style lookup |
+| routing_settings | small | top-level parent | none | none | deferred_no_api_support | Singleton config endpoint |
+| shortcuts | small | top-level parent | none | none | deferred_no_api_support | Config-style lookup |
+| skills | small | top-level parent | none | none | deferred_no_api_support | Config-style lookup |
+| triggers | small | top-level parent | none | none | deferred_no_api_support | Config-style lookup |
+
+### Deferred streams
+
+- **No API date filter (8 streams):** `accounts`, `departments`, `goals`, `roles`, `routing_settings`, `shortcuts`, `skills`, `triggers` — these endpoints do not expose date-based filtering. A future agent should verify via live API probing whether undocumented filter parameters are accepted.


### PR DESCRIPTION
## What

Adds `CONTRIBUTING.md` with "Incremental Stream Considerations" section for source-zendesk-chat. Documents all streams, their incremental eligibility, and deferral reasons.

Requested by @aaronsteers.

## How

- Created `CONTRIBUTING.md` with stream-by-stream analysis table
- All 8 FR parent streams are config-style lookups (accounts, departments, goals, roles, routing_settings, shortcuts, skills, triggers) without date filtering
- Existing incremental streams (chats, agents, bans, agent_timeline) use Zendesk Incremental API

## Review guide

1. `airbyte-integrations/connectors/source-zendesk-chat/CONTRIBUTING.md`

## User Impact

Documentation-only change. No user-facing impact.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

---
Devin session: https://app.devin.ai/sessions/688f2cad835448718118edf76a6bf581