### PR TITLE
docs(source-pylon): document incremental stream considerations

### DIFF
--- a/airbyte-integrations/connectors/source-pylon/CONTRIBUTING.md
+++ b/airbyte-integrations/connectors/source-pylon/CONTRIBUTING.md
@@ -1,0 +1,30 @@
+# Contributing to source-pylon
+
+For general guidance on contributing to Airbyte connectors, see the [Connector Development documentation](https://docs.airbyte.com/connector-development/).
+
+## Incremental Stream Considerations
+
+The Pylon API supports cursor-based pagination on list endpoints. The `issues` stream already uses `DatetimeBasedCursor` with `updated_at` filtering. The remaining FR parent streams are config-style lookups (accounts, contacts, tags, teams, users, custom_fields, etc.) that do not expose date-based filtering parameters.
+
+| Stream | Volume Tier | Relationship | Cursor Field | API Incremental Support | Current Status | Notes |
+|---|---|---|---|---|---|---|
+| accounts | small | top-level parent | none | none | deferred_no_api_support | Config-style; no date filter |
+| activity_types | small | top-level parent | none | none | deferred_no_api_support | Config-style lookup |
+| contacts | medium | top-level parent | none | none | deferred_no_api_support | No documented date filter on list endpoint |
+| custom_fields | small | top-level parent | none | none | deferred_no_api_support | Config-style lookup |
+| issue_statuses | small | top-level parent | none | none | deferred_no_api_support | Config-style lookup |
+| issues | medium | top-level parent | created_at | created_at | incremental |  |
+| knowledge_bases | small | top-level parent | none | none | deferred_no_api_support | Config-style lookup |
+| tags | small | top-level parent | none | none | deferred_no_api_support | Config-style lookup |
+| teams | small | top-level parent | none | none | deferred_no_api_support | Config-style lookup |
+| ticket_forms | small | top-level parent | none | none | deferred_no_api_support | Config-style lookup |
+| user_roles | small | top-level parent | none | none | deferred_no_api_support | Config-style lookup |
+| users | small | top-level parent | none | none | deferred_no_api_support | Config-style lookup |
+| issue_messages | medium | child | none | none | deferred_child |  |
+| issue_threads | medium | child | none | none | deferred_child |  |
+| knowledge_base_articles | medium | child | none | none | deferred_child |  |
+
+### Deferred streams
+
+- **No API date filter (11 streams):** `accounts`, `activity_types`, `contacts`, `custom_fields`, `issue_statuses`, `knowledge_bases`, `tags`, `teams`, `ticket_forms`, `user_roles`, `users` — these endpoints do not expose date-based filtering. A future agent should verify via live API probing whether undocumented filter parameters are accepted.
+- **Child streams (3 streams):** `issue_messages`, `issue_threads`, `knowledge_base_articles` — partitioned via `SubstreamPartitionRouter`. A follow-up session should evaluate incremental support.


### PR DESCRIPTION
## What

Adds `CONTRIBUTING.md` with "Incremental Stream Considerations" section for source-pylon. Documents all streams, their incremental eligibility, and deferral reasons.

Requested by @aaronsteers.

## How

- Created `CONTRIBUTING.md` with stream-by-stream analysis table
- 11 FR parent streams are config-style lookups (accounts, tags, teams, users, custom_fields, etc.) without date filtering
- `issues` stream already uses `DatetimeBasedCursor` with `updated_at`

## Review guide

1. `airbyte-integrations/connectors/source-pylon/CONTRIBUTING.md`

## User Impact

Documentation-only change. No user-facing impact.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

---
Devin session: https://app.devin.ai/sessions/688f2cad835448718118edf76a6bf581