### PR TITLE
docs(source-linear): document incremental stream considerations

### DIFF
--- a/airbyte-integrations/connectors/source-linear/CONTRIBUTING.md
+++ b/airbyte-integrations/connectors/source-linear/CONTRIBUTING.md
@@ -1,0 +1,30 @@
+# Contributing to source-linear
+
+For general guidance on contributing to Airbyte connectors, see the [Connector Development documentation](https://docs.airbyte.com/connector-development/).
+
+## Incremental Stream Considerations
+
+The Linear GraphQL API supports `updatedAt` filtering via `filter: { updatedAt: { gte: ... } }` on most entity types, which the connector uses extensively — 12 streams are already incremental (added in PR airbytehq/airbyte#76429). The remaining 4 FR parent streams are config-style lookups (`customer_statuses`, `customer_tiers`, `project_statuses`) and `issue_relations` which lacks a documented `updatedAt` filter in the GraphQL schema.
+
+| Stream | Volume Tier | Relationship | Cursor Field | API Incremental Support | Current Status | Notes |
+|---|---|---|---|---|---|---|
+| attachments | medium | top-level parent | unknown | unknown | incremental |  |
+| comments | medium | top-level parent | unknown | unknown | incremental |  |
+| customer_needs | medium | top-level parent | unknown | unknown | incremental |  |
+| customer_statuses | small | top-level parent | none | none | deferred_no_api_support | Config-style enum lookup; no `updatedAt` filter |
+| customer_tiers | small | top-level parent | none | none | deferred_no_api_support | Config-style enum lookup; no `updatedAt` filter |
+| customers | medium | top-level parent | unknown | unknown | incremental |  |
+| cycles | medium | top-level parent | unknown | unknown | incremental |  |
+| issue_labels | medium | top-level parent | unknown | unknown | incremental |  |
+| issue_relations | medium | top-level parent | none | none | deferred_no_api_support | No documented `updatedAt` filter in GraphQL schema. Verify via introspection. |
+| issues | medium | top-level parent | unknown | unknown | incremental |  |
+| project_milestones | medium | top-level parent | unknown | unknown | incremental |  |
+| project_statuses | small | top-level parent | none | none | deferred_no_api_support | Config-style enum lookup; no `updatedAt` filter |
+| projects | medium | top-level parent | unknown | unknown | incremental |  |
+| teams | medium | top-level parent | unknown | unknown | incremental |  |
+| users | medium | top-level parent | unknown | unknown | incremental |  |
+| workflow_states | medium | top-level parent | unknown | unknown | incremental |  |
+
+### Deferred streams
+
+- **No API date filter (4 streams):** `customer_statuses`, `customer_tiers`, `issue_relations`, `project_statuses` — these endpoints do not expose date-based filtering. A future agent should verify via live API probing whether undocumented filter parameters are accepted.


### PR DESCRIPTION
## What

Adds `CONTRIBUTING.md` with "Incremental Stream Considerations" section for source-linear. Documents all 16 streams, noting 12 already-incremental streams (added in airbytehq/airbyte#76429) and 4 remaining FR parents.

Requested by @aaronsteers.

## How

- Created `CONTRIBUTING.md` with stream-by-stream analysis table
- 4 FR parent streams are config-style lookups (`customer_statuses`, `customer_tiers`, `project_statuses`) and `issue_relations` which lacks `updatedAt` filter in GraphQL schema
- 12 existing incremental streams (from merged PR airbytehq/airbyte#76429) documented

## Review guide

1. `airbyte-integrations/connectors/source-linear/CONTRIBUTING.md`

## User Impact

Documentation-only change. No user-facing impact.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

---
Devin session: https://app.devin.ai/sessions/688f2cad835448718118edf76a6bf581