### PR TITLE
docs(source-asana): document incremental stream considerations

### DIFF
--- a/airbyte-integrations/connectors/source-asana/CONTRIBUTING.md
+++ b/airbyte-integrations/connectors/source-asana/CONTRIBUTING.md
@@ -1,0 +1,15 @@
+# Contributing to source-asana
+
+For general guidance on contributing to Airbyte connectors, see the [Connector Development documentation](https://docs.airbyte.com/connector-development/).
+
+## Incremental Stream Considerations
+
+The Asana API supports `modified_since` filtering on tasks and other endpoints. The connector is a Python CDK connector. PR airbytehq/airbyte#76838 (in flight) adds incremental sync for the `tasks` stream and performs inert-flag cleanup.
+
+**Connector type:** Python CDK
+
+**Analysis status:** Pure Python CDK connector. PR airbytehq/airbyte#76838 is in flight for `tasks` stream incremental. Full stream-by-stream analysis requires Python code review.
+
+### Deferred streams
+
+- **All streams deferred for Python code review:** This connector defines its streams in Python code rather than declarative manifest YAML. A full stream-by-stream incremental analysis table (per the standard CONTRIBUTING.md schema) should be added by a future agent after reviewing the Python stream definitions, their `cursor_field` properties, and the API endpoints they call.


### PR DESCRIPTION
## What

Adds `CONTRIBUTING.md` with "Incremental Stream Considerations" for source-asana (pure Python CDK connector).

Requested by @aaronsteers.

## How

- Documents Asana API `modified_since` filtering support
- Notes PR airbytehq/airbyte#76838 in flight for `tasks` stream incremental + inert-flag cleanup
- Defers full stream-by-stream analysis to Python code review

## Review guide

1. `airbyte-integrations/connectors/source-asana/CONTRIBUTING.md`

## User Impact

Documentation-only. No user-facing impact.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

---
Devin session: https://app.devin.ai/sessions/688f2cad835448718118edf76a6bf581