### PR TITLE
docs: fix markdownlint errors in docs-airbyte-agents branch

### DIFF
--- a/docs/ai-agents/concepts/connect-unify-act.md
+++ b/docs/ai-agents/concepts/connect-unify-act.md
@@ -37,7 +37,7 @@ The result is that agents reason over unified, searchable context rather than ra
 
 With context in hand, agents execute operations against connected systems in real time. Every connector exposes a uniform interface:
 
-```
+```text
 execute(entity, action, params)
 ```
 

--- a/docs/ai-agents/interfaces/api/authentication-module.md
+++ b/docs/ai-agents/interfaces/api/authentication-module.md
@@ -192,7 +192,7 @@ Pass an `onEvent` callback to receive notifications when users complete actions 
 The `data` field contains the full source object with the following top-level properties:
 
 | Field | Description |
-|-------|-------------|
+| ----- | ----------- |
 | `id` | Unique identifier for the created or updated source. |
 | `name` | Display name assigned to the source (e.g., `"GitHub - <uuid>"`). |
 | `source_template` | The template used to create this source, including the connector's `source_definition_id`, `user_config_spec`, and `mode` (`DIRECT` or `REPLICATION`). |

--- a/docs/ai-agents/interfaces/api/authentication/build-your-own.md
+++ b/docs/ai-agents/interfaces/api/authentication/build-your-own.md
@@ -92,7 +92,7 @@ Requires a bearer token.
 ### Request body
 
 | Field | Type | Required | Description |
-|-------|------|----------|-------------|
+| ----- | ---- | -------- | ----------- |
 | `connector_type` | string | Yes | Connector display name, case-insensitive on letters but otherwise spelled exactly as it appears in the [connector catalog](../../../connectors) (spaces included). For example, `hubspot`, `Salesforce`, `Facebook Marketing`. Snake-case forms like `facebook_marketing` return `404`. |
 | `configuration` | object | Yes | Your OAuth app credentials (client_id, client_secret, etc.). |
 
@@ -233,7 +233,7 @@ Requires a bearer token or scoped token.
 ### Request body
 
 | Field | Type | Required | Description |
-|-------|------|----------|-------------|
+| ----- | ---- | -------- | ----------- |
 | `workspace_name` | string | Yes | Your workspace identifier. Maps to a workspace in Airbyte. |
 | `connector_type` | string | Yes* | Connector display name, case-insensitive on letters but otherwise spelled exactly as it appears in the [connector catalog](../../../connectors) (spaces included). For example, `hubspot`, `Salesforce`, `Facebook Marketing`. Snake-case forms like `facebook_marketing` return `404`. |
 | `redirect_url` | string | Yes | Your callback URL. After OAuth consent, Airbyte auto-creates the connector and redirects the user here with `?connector_id=<value>`. |

--- a/docs/ai-agents/interfaces/api/execute.md
+++ b/docs/ai-agents/interfaces/api/execute.md
@@ -43,7 +43,7 @@ curl -X POST 'https://api.airbyte.ai/api/v1/integrations/connectors/<connector_i
 The request body contains three fields:
 
 | Field | Type | Description |
-|-------|------|-------------|
+| ----- | ---- | ----------- |
 | `entity` | `string` | The entity to operate on, such as `users`, `calls`, or `issues`. |
 | `action` | `string` | The action to perform, such as `list`, `get`, or `search`. |
 | `params` | `object` | Parameters for the action. The required parameters depend on the entity and action. |

--- a/docs/ai-agents/interfaces/api/workspaces.md
+++ b/docs/ai-agents/interfaces/api/workspaces.md
@@ -28,7 +28,6 @@ publicly. Revisit when autocreate is consistent across endpoints and/or
 rename rejects reuse of the old name.
 -->
 
-
 ## Create a new workspace
 
 You don't create workspaces directly. Airbyte creates one automatically the first time you mint a [scoped token](./authentication#scoped-token) against a new `workspace_name`. Use any stable string that makes sense in your app — for example, an internal tenant ID or team slug.
@@ -40,7 +39,6 @@ is the canonical way to create a workspace, and the paragraph above
 already routes readers through that path, so we don't need to call out
 the asymmetry publicly. Revisit when autocreate is consistent.
 -->
-
 
 ## Manage workspaces
 

--- a/docs/ai-agents/interfaces/mcp/readme.md
+++ b/docs/ai-agents/interfaces/mcp/readme.md
@@ -86,7 +86,7 @@ Add the MCP server to your Cursor app.
 
 Add the MCP server to Visual Studio Code. Airbyte Agents provides a one-click install button for both the stable and Insiders builds. If you prefer to configure VS Code manually, use the Command Palette or edit `mcp.json` directly.
 
-#### Option 1: One-click install from Airbyte Agents (recommended)
+### Option 1: One-click install from Airbyte Agents (recommended)
 
 1. Sign into [app.airbyte.ai](https://app.airbyte.ai).
 
@@ -104,7 +104,7 @@ Add the MCP server to Visual Studio Code. Airbyte Agents provides a one-click in
 If VS Code isn't installed, the click lands on the `vscode.dev` help page instead of opening a blank tab. Install VS Code and try the button again.
 :::
 
-#### Option 2: Add the server from the Command Palette
+### Option 2: Add the server from the Command Palette
 
 1. In VS Code, open the Command Palette with ⇧⌘P (macOS) or Ctrl+Shift+P (Windows, Linux).
 
@@ -120,7 +120,7 @@ If VS Code isn't installed, the click lands on the `vscode.dev` help page instea
 
 7. The MCP server's tools are now available in Copilot Chat.
 
-#### Option 3: Edit `mcp.json` directly
+### Option 3: Edit `mcp.json` directly
 
 Run **MCP: Open User Configuration** from the Command Palette to open your user `mcp.json` file, or create `.vscode/mcp.json` in your workspace, and add:
 

--- a/docs/ai-agents/interfaces/sdk/workspaces.md
+++ b/docs/ai-agents/interfaces/sdk/workspaces.md
@@ -78,8 +78,6 @@ this, which is why we don't surface the quirk in the public narrative.
 Revisit when autocreate is consistent across endpoints.
 -->
 
-
-
 ## Operations that require the API
 
 The SDK doesn't expose every workspace operation. If you need to do any of the following, use the [API](../api/workspaces) instead:

--- a/docs/ai-agents/interfaces/ui/add-connector.md
+++ b/docs/ai-agents/interfaces/ui/add-connector.md
@@ -50,7 +50,6 @@ The new connector appears immediately in the Credentials table and in the **Avai
 
 ## OAuth versus access tokens {#oauth-vs-tokens}
 
-
 ### OAuth
 
 In an OAuth flow, the third-party service asks you to authorize Airbyte to act on your behalf. For connectors that publish OAuth scope metadata, the entity picker shows **Read** and **Write** columns, and you can select access per entity. Your selections map to the narrowest set of OAuth scopes that covers what you chose, and the third-party service enforces those scopes on every request the connector makes.

--- a/docs/integrations/destinations/bigquery-migrations.md
+++ b/docs/integrations/destinations/bigquery-migrations.md
@@ -14,7 +14,7 @@ If you interact with both the raw _and_ final tables, this usecase will no longe
 
 ## Upgrading to 2.0.0
 
-This version introduces [Destinations V2](/release_notes/self-managed/upgrading_to_destinations_v2/#what-is-destinations-v2), which provides better error handling, incremental delivery of data for large syncs, and improved final table structures. To review the breaking changes, and how to upgrade, see [here](/release_notes/self-managed/upgrading_to_destinations_v2/#quick-start-to-upgrading). These changes will likely require updates to downstream dbt / SQL models, which we walk through [here](/release_notes/self-managed/upgrading_to_destinations_v2/#updating-downstream-transformations). Selecting `Upgrade` will upgrade **all** connections using this destination at their next sync. You can manually sync existing connections prior to the next scheduled sync to start the upgrade early.
+This version introduces [Destinations V2](/release_notes/self-managed/upgrading_to_destinations_v2/#what-is-destinations-v2), which provides better error handling, incremental delivery of data for large syncs, and improved final table structures. To review the breaking changes, and how to upgrade, see the [quick start to upgrading](/release_notes/self-managed/upgrading_to_destinations_v2/#quick-start-to-upgrading). These changes will likely require updates to downstream dbt / SQL models, which we walk through in the [downstream transformations guide](/release_notes/self-managed/upgrading_to_destinations_v2/#updating-downstream-transformations). Selecting `Upgrade` will upgrade **all** connections using this destination at their next sync. You can manually sync existing connections prior to the next scheduled sync to start the upgrade early.
 
 Worthy of specific mention, this version includes:
 
@@ -23,4 +23,4 @@ Worthy of specific mention, this version includes:
 - Removal of sub-tables for nested properties
 - Removal of SCD tables
 
-Learn more about what's new in Destinations V2 [here](/platform/using-airbyte/core-concepts/typing-deduping).
+Learn more about what's new in Destinations V2 in the [Typing & Deduping guide](/platform/using-airbyte/core-concepts/typing-deduping).

--- a/docs/integrations/destinations/databricks-migrations.md
+++ b/docs/integrations/destinations/databricks-migrations.md
@@ -6,6 +6,7 @@ This version adds an `_airbyte_generation_id` column to the raw and final tables
 For now, these values will always be set to 0 - they will be used by the upcoming refreshes feature.
 
 There is no automated upgrade process. After selecting `Upgrade`, you should:
+
 1. `DROP` any raw/final tables created using a 2.x sync
 1. Clear (reset) your connection to resync all your data
 
@@ -14,7 +15,7 @@ There is no automated upgrade process. After selecting `Upgrade`, you should:
 More to come. this is a preview release.
 
 This version introduces [Destinations V2](/release_notes/self-managed/upgrading_to_destinations_v2/#what-is-destinations-v2), which provides better error handling, incremental delivery of data for large syncs, and improved final table structures.
-To review the breaking changes, and how to upgrade, see [here](/release_notes/self-managed/upgrading_to_destinations_v2/#quick-start-to-upgrading). These changes will likely require updates to downstream dbt / SQL models, which we walk through [here](/release_notes/self-managed/upgrading_to_destinations_v2/#updating-downstream-transformations).
+To review the breaking changes, and how to upgrade, see the [quick start to upgrading](/release_notes/self-managed/upgrading_to_destinations_v2/#quick-start-to-upgrading). These changes will likely require updates to downstream dbt / SQL models, which we walk through in the [downstream transformations guide](/release_notes/self-managed/upgrading_to_destinations_v2/#updating-downstream-transformations).
 Selecting `Upgrade` will upgrade **all** connections using this destination at their next sync. You can manually sync existing connections prior to the next scheduled sync to start the upgrade early.
 
 Worthy of specific mention, this version includes:
@@ -24,4 +25,4 @@ Worthy of specific mention, this version includes:
 - Removal of sub-tables for nested properties
 - Removal of SCD tables
 
-Learn more about what's new in Destinations V2 [here](/platform/using-airbyte/core-concepts/typing-deduping).
+Learn more about what's new in Destinations V2 in the [Typing & Deduping guide](/platform/using-airbyte/core-concepts/typing-deduping).

--- a/docs/integrations/destinations/motherduck.md
+++ b/docs/integrations/destinations/motherduck.md
@@ -10,7 +10,7 @@ For file-based DBs, data is written to `/tmp/airbyte_local` by default. To chang
 
 This destination implements [Destinations V2](/release_notes/self-managed/upgrading_to_destinations_v2/#what-is-destinations-v2), which provides improved final table structures. It's a new version of the existing DuckDB destination and works both with DuckDB and MotherDuck.
 
-Learn more about what's new in Destinations V2 [here](/platform/using-airbyte/core-concepts/typing-deduping). Note that [data generations](/platform/operator-guides/refreshes#data-generations) are not currently supported.
+Learn more about what's new in Destinations V2 in the [Typing & Deduping guide](/platform/using-airbyte/core-concepts/typing-deduping). Note that [data generations](/platform/operator-guides/refreshes#data-generations) are not currently supported.
 
 ## Supported sync modes
 
@@ -73,8 +73,8 @@ This destination supports [namespaces](https://docs.airbyte.com/platform/using-a
 <details>
   <summary>Expand to review</summary>
 
-| Version | Date       | Pull Request                                             | Subject                                                                                                                   |
-| :------ | :--------- | :------------------------------------------------------- | :------------------------------------------------------------------------------------------------------------------------ |
+| Version | Date | Pull Request | Subject |
+| :------ | :--- | :----------- | :------ |
 | 0.2.3 | 2026-03-31 | [75645](https://github.com/airbytehq/airbyte/pull/75645) | Bump version to force registry update for supportLevel change to certified |
 | 0.2.2 | 2025-02-02 | [70438](https://github.com/airbytehq/airbyte/pull/70438) | Fix for camelCase columns being `NULL` |
 | 0.2.1 | 2025-12-19 | [70999](https://github.com/airbytehq/airbyte/pull/70999) | Fix for empty STRUCTs |
@@ -86,7 +86,7 @@ This destination supports [namespaces](https://docs.airbyte.com/platform/using-a
 | 0.1.22 | 2025-07-22 | [63714](https://github.com/airbytehq/airbyte/pull/63714) | fix(destination-motherduck): handle special characters in stream name when creating tables |
 | 0.1.21 | 2025-07-22 | [63709](https://github.com/airbytehq/airbyte/pull/63709) | fix: resolve error "Can't find the home directory at '/nonexistent'" [#63710](https://github.com/airbytehq/airbyte/issues/63710) |
 | 0.1.20 | 2025-07-06 | [62133](https://github.com/airbytehq/airbyte/pull/62133) | fix: when `primary_key` is not defined in the catalog, use `source_defined_primary_key` if available |
-| n/a    | 2025-06-27 | [48673](https://github.com/airbytehq/airbyte/pull/48673) | Update dependencies |
+| n/a | 2025-06-27 | [48673](https://github.com/airbytehq/airbyte/pull/48673) | Update dependencies |
 | 0.1.19 | 2025-05-25 | [60905](https://github.com/airbytehq/airbyte/pull/60905) | Allow unicode characters in database/table names |
 | 0.1.18 | 2025-03-01 | [54737](https://github.com/airbytehq/airbyte/pull/54737) | Update airbyte-cdk to ^6.0.0 in destination-motherduck |
 | 0.1.17 | 2024-12-26 | [50425](https://github.com/airbytehq/airbyte/pull/50425) | Fix bug overwrite write method not saving all batches |

--- a/docs/integrations/destinations/mysql-migrations.md
+++ b/docs/integrations/destinations/mysql-migrations.md
@@ -2,7 +2,7 @@
 
 ## Upgrading to 1.0.0
 
-This version introduces [Destinations V2](/release_notes/self-managed/upgrading_to_destinations_v2/#what-is-destinations-v2), which provides better error handling and improved final table structures. To review the breaking changes, and how to upgrade, see [here](/release_notes/self-managed/upgrading_to_destinations_v2/#quick-start-to-upgrading). These changes will likely require updates to downstream dbt / SQL models, which we walk through [here](/release_notes/self-managed/upgrading_to_destinations_v2/#updating-downstream-transformations). Selecting `Upgrade` will upgrade **all** connections using this destination at their next sync. You can manually sync existing connections prior to the next scheduled sync to start the upgrade early.
+This version introduces [Destinations V2](/release_notes/self-managed/upgrading_to_destinations_v2/#what-is-destinations-v2), which provides better error handling and improved final table structures. To review the breaking changes, and how to upgrade, see the [quick start to upgrading](/release_notes/self-managed/upgrading_to_destinations_v2/#quick-start-to-upgrading). These changes will likely require updates to downstream dbt / SQL models, which we walk through in the [downstream transformations guide](/release_notes/self-managed/upgrading_to_destinations_v2/#updating-downstream-transformations). Selecting `Upgrade` will upgrade **all** connections using this destination at their next sync. You can manually sync existing connections prior to the next scheduled sync to start the upgrade early.
 
 Worthy of specific mention, this version includes:
 
@@ -11,4 +11,4 @@ Worthy of specific mention, this version includes:
 - Removal of sub-tables for nested properties
 - Removal of SCD tables
 
-Learn more about what's new in Destinations V2 [here](/platform/using-airbyte/core-concepts/typing-deduping).
+Learn more about what's new in Destinations V2 in the [Typing & Deduping guide](/platform/using-airbyte/core-concepts/typing-deduping).

--- a/docs/integrations/destinations/postgres-migrations.md
+++ b/docs/integrations/destinations/postgres-migrations.md
@@ -40,7 +40,7 @@ Only remove raw tables after you have verified that all your workflows are worki
 
 ## Upgrading to 2.0.0
 
-This version introduces [Destinations V2](/release_notes/self-managed/upgrading_to_destinations_v2/#what-is-destinations-v2), which provides better error handling, incremental delivery of data for large syncs, and improved final table structures. To review the breaking changes, and how to upgrade, see [here](/release_notes/self-managed/upgrading_to_destinations_v2/#quick-start-to-upgrading). These changes will likely require updates to downstream dbt / SQL models, which we walk through [here](/release_notes/self-managed/upgrading_to_destinations_v2/#updating-downstream-transformations). Selecting `Upgrade` will upgrade **all** connections using this destination at their next sync. You can manually sync existing connections prior to the next scheduled sync to start the upgrade early.
+This version introduces [Destinations V2](/release_notes/self-managed/upgrading_to_destinations_v2/#what-is-destinations-v2), which provides better error handling, incremental delivery of data for large syncs, and improved final table structures. To review the breaking changes, and how to upgrade, see the [quick start to upgrading](/release_notes/self-managed/upgrading_to_destinations_v2/#quick-start-to-upgrading). These changes will likely require updates to downstream dbt / SQL models, which we walk through in the [downstream transformations guide](/release_notes/self-managed/upgrading_to_destinations_v2/#updating-downstream-transformations). Selecting `Upgrade` will upgrade **all** connections using this destination at their next sync. You can manually sync existing connections prior to the next scheduled sync to start the upgrade early.
 
 Worthy of specific mention, this version includes:
 
@@ -50,4 +50,4 @@ Worthy of specific mention, this version includes:
 - Removal of SCD tables
 - Preserving [upper case column names](https://docs.airbyte.com/release_notes/upgrading_to_destinations_v2/#destinations-v2-implementation-differences)
 
-Learn more about what's new in Destinations V2 [here](/platform/using-airbyte/core-concepts/typing-deduping).
+Learn more about what's new in Destinations V2 in the [Typing & Deduping guide](/platform/using-airbyte/core-concepts/typing-deduping).

--- a/docs/integrations/destinations/redshift-migrations.md
+++ b/docs/integrations/destinations/redshift-migrations.md
@@ -4,8 +4,8 @@
 
 This version removes support for standard inserts. Although this loading method is easier to set up than S3 staging, it has two major disadvantages:
 
-* Standard inserts is significantly slower
-* Standard inserts is significantly more expensive
+- Standard inserts is significantly slower
+- Standard inserts is significantly more expensive
 
 [Redshift's documentation](https://docs.aws.amazon.com/redshift/latest/dg/r_INSERT_30.html#r_INSERT_30_usage_notes) states:
 > We strongly encourage you to use the COPY command to load large amounts of data. Using individual INSERT statements to populate a table might be prohibitively slow.
@@ -14,13 +14,13 @@ See our [Redshift docs](https://docs.airbyte.com/integrations/destinations/redsh
 
 ## Upgrading to 2.0.0
 
-This version introduces [Destinations V2](/release_notes/self-managed/upgrading_to_destinations_v2/#what-is-destinations-v2), which provides better error handling, incremental delivery of data for large syncs, and improved final table structures. To review the breaking changes, and how to upgrade, see [here](/release_notes/self-managed/upgrading_to_destinations_v2/#quick-start-to-upgrading). These changes will likely require updates to downstream dbt / SQL models, which we walk through [here](/release_notes/self-managed/upgrading_to_destinations_v2/#updating-downstream-transformations). Selecting `Upgrade` will upgrade **all** connections using this destination at their next sync. You can manually sync existing connections prior to the next scheduled sync to start the upgrade early.
+This version introduces [Destinations V2](/release_notes/self-managed/upgrading_to_destinations_v2/#what-is-destinations-v2), which provides better error handling, incremental delivery of data for large syncs, and improved final table structures. To review the breaking changes, and how to upgrade, see the [quick start to upgrading](/release_notes/self-managed/upgrading_to_destinations_v2/#quick-start-to-upgrading). These changes will likely require updates to downstream dbt / SQL models, which we walk through in the [downstream transformations guide](/release_notes/self-managed/upgrading_to_destinations_v2/#updating-downstream-transformations). Selecting `Upgrade` will upgrade **all** connections using this destination at their next sync. You can manually sync existing connections prior to the next scheduled sync to start the upgrade early.
 
 Worthy of specific mention, this version includes:
 
-* Per-record error handling
-* Clearer table structure
-* Removal of sub-tables for nested properties
-* Removal of SCD tables
+- Per-record error handling
+- Clearer table structure
+- Removal of sub-tables for nested properties
+- Removal of SCD tables
 
-Learn more about what's new in Destinations V2 [here](/platform/using-airbyte/core-concepts/typing-deduping).
+Learn more about what's new in Destinations V2 in the [Typing & Deduping guide](/platform/using-airbyte/core-concepts/typing-deduping).

--- a/docs/integrations/destinations/snowflake-migrations.md
+++ b/docs/integrations/destinations/snowflake-migrations.md
@@ -16,7 +16,7 @@ If you interact with both the raw _and_ final tables, this usecase will no longe
 
 ## Upgrading to 3.0.0
 
-This version introduces [Destinations V2](/release_notes/self-managed/upgrading_to_destinations_v2/#what-is-destinations-v2), which provides better error handling, incremental delivery of data for large syncs, and improved final table structures. To review the breaking changes, and how to upgrade, see [here](/release_notes/self-managed/upgrading_to_destinations_v2/#quick-start-to-upgrading). These changes will likely require updates to downstream dbt / SQL models, which we walk through [here](/release_notes/self-managed/upgrading_to_destinations_v2/#updating-downstream-transformations). Selecting `Upgrade` will upgrade **all** connections using this destination at their next sync. You can manually sync existing connections prior to the next scheduled sync to start the upgrade early.
+This version introduces [Destinations V2](/release_notes/self-managed/upgrading_to_destinations_v2/#what-is-destinations-v2), which provides better error handling, incremental delivery of data for large syncs, and improved final table structures. To review the breaking changes, and how to upgrade, see the [quick start to upgrading](/release_notes/self-managed/upgrading_to_destinations_v2/#quick-start-to-upgrading). These changes will likely require updates to downstream dbt / SQL models, which we walk through in the [downstream transformations guide](/release_notes/self-managed/upgrading_to_destinations_v2/#updating-downstream-transformations). Selecting `Upgrade` will upgrade **all** connections using this destination at their next sync. You can manually sync existing connections prior to the next scheduled sync to start the upgrade early.
 
 Worthy of specific mention, this version includes:
 
@@ -25,7 +25,7 @@ Worthy of specific mention, this version includes:
 - Removal of sub-tables for nested properties
 - Removal of SCD tables
 
-Learn more about what's new in Destinations V2 [here](/platform/using-airbyte/core-concepts/typing-deduping).
+Learn more about what's new in Destinations V2 in the [Typing & Deduping guide](/platform/using-airbyte/core-concepts/typing-deduping).
 
 ## Upgrading to 2.0.0
 

--- a/docs/integrations/destinations/teradata-migrations.md
+++ b/docs/integrations/destinations/teradata-migrations.md
@@ -2,16 +2,14 @@
 
 ## Upgrading to 1.0.0
 
-This version introduces [Destinations V2](/release_notes/self-managed/upgrading_to_destinations_v2/#what-is-destinations-v2), which provides better error handling, incremental delivery of data for large syncs, and final table generation. To review the breaking changes, and how to upgrade, see [here](/release_notes/self-managed/upgrading_to_destinations_v2/#quick-start-to-upgrading). These changes will likely require updates to downstream dbt / SQL models, which we walk through [here](/release_notes/self-managed/upgrading_to_destinations_v2/#updating-downstream-transformations). Selecting `Upgrade` will upgrade **all** connections using this destination at their next sync. You can manually sync existing connections prior to the next scheduled sync to start the upgrade early.
+This version introduces [Destinations V2](/release_notes/self-managed/upgrading_to_destinations_v2/#what-is-destinations-v2), which provides better error handling, incremental delivery of data for large syncs, and final table generation. To review the breaking changes, and how to upgrade, see the [quick start to upgrading](/release_notes/self-managed/upgrading_to_destinations_v2/#quick-start-to-upgrading). These changes will likely require updates to downstream dbt / SQL models, which we walk through in the [downstream transformations guide](/release_notes/self-managed/upgrading_to_destinations_v2/#updating-downstream-transformations). Selecting `Upgrade` will upgrade **all** connections using this destination at their next sync. You can manually sync existing connections prior to the next scheduled sync to start the upgrade early.
 
 Worthy of specific mention, this version includes:
 
 - Final table generation
 - Per-record error handling
 
-Learn more about what's new in Destinations V2 [here](/platform/using-airbyte/core-concepts/typing-deduping).
-
-
+Learn more about what's new in Destinations V2 in the [Typing & Deduping guide](/platform/using-airbyte/core-concepts/typing-deduping).
 
 ### Changes to RAW table structure
 
@@ -32,9 +30,4 @@ V2 Raw Table Columns
 
 [Refer to this guide for more details](https://docs.airbyte.com/understanding-airbyte/airbyte-metadata-fields)
 
-
-
-The migration process will take care of Raw table update from OLD format to V2 format. Following the successful migration of v1 raw tables to v2, the v1 raw tables will be dropped. 
-
-
-
+The migration process will take care of Raw table update from OLD format to V2 format. Following the successful migration of v1 raw tables to v2, the v1 raw tables will be dropped.

--- a/docs/platform/using-airbyte/core-concepts/typing-deduping.md
+++ b/docs/platform/using-airbyte/core-concepts/typing-deduping.md
@@ -10,7 +10,6 @@ products: all
 With Direct Loads, there is no intermediate table result containing the raw JSON blob. Instead, top-level fields are typed during time of insert, and there is only a single destination table maintained per stream.
 :::
 
-
 This page refers to new functionality added by
 [Destinations V2](/release_notes/self-managed/upgrading_to_destinations_v2/). Typing and deduping is the default
 method of transforming datasets within data warehouse and database destinations after they've been
@@ -88,26 +87,26 @@ Consider the following [source schema](/integrations/sources/faker) for stream `
 
 The data from one stream will now be mapped to one table in your schema as below:
 
-#### Final Destination Table Name: _public.users_
+### Final Destination Table Name: _public.users_
 
-| _(note, not in actual table)_                | \_airbyte_raw_id | \_airbyte_extracted_at | \_airbyte_meta                                                 | id  | first_name | age  | address                                   |
-| -------------------------------------------- | ---------------- | ---------------------- | -------------------------------------------------------------- | --- | ---------- | ---- | ----------------------------------------- |
-| Successful typing and de-duping ⟶            | xxx-xxx-xxx      | 2022-01-01 12:00:00    | `{}`                                                           | 1   | sarah      | 39   | `{ city: “San Francisco”, zip: “94131” }` |
-| Failed typing that didn’t break other rows ⟶ | yyy-yyy-yyy      | 2022-01-01 12:00:00    | `{ changes: {"field": "age", "change": "NULLED", "reason": "DESTINATION_TYPECAST_ERROR"}}` | 2   | evan       | NULL | `{ city: “Menlo Park”, zip: “94002” }`    |
-| Not-yet-typed ⟶                              |                  |                        |                                                                |     |            |      |                                           |
+| _(note, not in actual table)_ | \_airbyte_raw_id | \_airbyte_extracted_at | \_airbyte_meta | id | first_name | age | address |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| Successful typing and de-duping ⟶ | xxx-xxx-xxx | 2022-01-01 12:00:00 | `{}` | 1 | sarah | 39 | `{ city: "San Francisco", zip: "94131" }` |
+| Failed typing that didn't break other rows ⟶ | yyy-yyy-yyy | 2022-01-01 12:00:00 | `{ changes: {"field": "age", "change": "NULLED", "reason": "DESTINATION_TYPECAST_ERROR"}}` | 2 | evan | NULL | `{ city: "Menlo Park", zip: "94002" }` |
+| Not-yet-typed ⟶ | | | | | | | |
 
 In legacy normalization, columns of
 [Airbyte type](/platform/understanding-airbyte/supported-data-types/#the-types) `Object` in the Destination
 were "unnested" into separate tables. In this example, with Destinations V2, the previously unnested
 `public.users_address` table with columns `city` and `zip` will no longer be generated.
 
-#### Raw Destination Table Name: _airbyte_internal.raw_public\_\_users_ (`airbyte_internal.raw_{namespace}__{stream}`)
+### Raw Destination Table Name: _airbyte_internal.raw_public\_\_users_ (`airbyte_internal.raw_{namespace}__{stream}`)
 
-| _(note, not in actual table)_                | \_airbyte_raw_id | \_airbyte_data﻿                                                                             | \_airbyte_loaded_at  | \_airbyte_extracted_at |
-| -------------------------------------------- | ---------------- | ------------------------------------------------------------------------------------------- | -------------------- | ---------------------- |
-| Successful typing and de-duping ⟶            | xxx-xxx-xxx      | `{ id: 1, first_name: “sarah”, age: 39, address: { city: “San Francisco”, zip: “94131” } }` | 2022-01-01 12:00:001 | 2022-01-01 12:00:00﻿   |
-| Failed typing that didn’t break other rows ⟶ | yyy-yyy-yyy      | `{ id: 2, first_name: “evan”, age: “fish”, address: { city: “Menlo Park”, zip: “94002” } }` | 2022-01-01 12:00:001 | 2022-01-01 12:00:00﻿   |
-| Not-yet-typed ⟶                              | zzz-zzz-zzz      | `{ id: 3, first_name: “edward”, age: 35, address: { city: “Sunnyvale”, zip: “94003” } }`    | NULL                 | 2022-01-01 13:00:00﻿   |
+| _(note, not in actual table)_ | \_airbyte_raw_id | \_airbyte_data | \_airbyte_loaded_at | \_airbyte_extracted_at |
+| --- | --- | --- | --- | --- |
+| Successful typing and de-duping ⟶ | xxx-xxx-xxx | `{ id: 1, first_name: "sarah", age: 39, address: { city: "San Francisco", zip: "94131" } }` | 2022-01-01 12:00:001 | 2022-01-01 12:00:00 |
+| Failed typing that didn't break other rows ⟶ | yyy-yyy-yyy | `{ id: 2, first_name: "evan", age: "fish", address: { city: "Menlo Park", zip: "94002" } }` | 2022-01-01 12:00:001 | 2022-01-01 12:00:00 |
+| Not-yet-typed ⟶ | zzz-zzz-zzz | `{ id: 3, first_name: "edward", age: 35, address: { city: "Sunnyvale", zip: "94003" } }` | NULL | 2022-01-01 13:00:00 |
 
 You also now see the following changes in Airbyte-provided columns:
 

--- a/docs/release_notes/self-managed/aug_2024.md
+++ b/docs/release_notes/self-managed/aug_2024.md
@@ -5,10 +5,10 @@
 This page includes new features and improvements to the Airbyte Cloud and Airbyte Open Source platforms.
 
 ## ✨ Highlights
+
 Destination S3 ([v1.0.0](https://github.com/airbytehq/airbyte/pull/42409)) was released! Experience faster sync speeds, checkpointing, and modernization to our Destinations V2 framework, along with many bug fixes around Avro and Parquet file formats.
 
-Databricks destination ([v3.1.0](https://github.com/airbytehq/airbyte/pull/40692)) was also released with several new features, including typing & deduping, refreshes, and resumable full refresh! We are actively looking for beta testers. Please reach out to us [here](https://github.com/airbytehq/airbyte/discussions/43997) with your feedback.
-
+Databricks destination ([v3.1.0](https://github.com/airbytehq/airbyte/pull/40692)) was also released with several new features, including typing & deduping, refreshes, and resumable full refresh! We are actively looking for beta testers. Please reach out to us in the [Databricks beta discussion](https://github.com/airbytehq/airbyte/discussions/43997) with your feedback.
 
 ## Platform Releases
 
@@ -33,6 +33,6 @@ We also released a few notable improvements for our connectors:
 
 ## Announcements
 
-- To ensure adherence to security best practices, Airbyte is migrating all connectors to [non-root versions](https://github.com/airbytehq/airbyte/discussions/44924). It is highly recommended that you upgrade your platform version to [v0.63.9](https://github.com/airbytehq/airbyte-platform/releases/tag/v0.63.9) or later before October 2024 to ensure your syncs continue to succeed. 
+- To ensure adherence to security best practices, Airbyte is migrating all connectors to [non-root versions](https://github.com/airbytehq/airbyte/discussions/44924). It is highly recommended that you upgrade your platform version to [v0.63.9](https://github.com/airbytehq/airbyte-platform/releases/tag/v0.63.9) or later before October 2024 to ensure your syncs continue to succeed.
 
 <!-- - As we prepare to deprecate Docker Compose, we published a [migration guide](../../using-airbyte/getting-started/oss-quickstart#migrating-from-docker-compose-optional) for those migrating from Docker Compose to abctl. -->

--- a/docs/release_notes/self-managed/january_2023.md
+++ b/docs/release_notes/self-managed/january_2023.md
@@ -21,7 +21,7 @@ This page includes new features and improvements to the Airbyte Cloud and Airbyt
   - Added ability to convert from YAML manifest to UI form values. [#21142](https://github.com/airbytehq/airbyte/pull/21142)
   - Improved the Connector Builder’s conversion of YAML manifest to UI form values by resolving references and options in the manifest. The Connector Builder Server API has been updated with a new endpoint for resolving the manifest, which is now utilized by the conversion function. [#21898](https://github.com/airbytehq/airbyte/pull/21898)
 
-# Bugs
+## Bugs
 
 - Fixed an issue where the checkboxes in the stream table would collapse and updated icons to match the new design. [#21108](https://github.com/airbytehq/airbyte/pull/21108)
 - Fixed issues with non-breaking schema changes by adding an i18n string, ensuring supported options are rendered, and fixing a custom styling issue when resizing. [#20625](https://github.com/airbytehq/airbyte/pull/20625)

--- a/docs/release_notes/self-managed/july_2024.md
+++ b/docs/release_notes/self-managed/july_2024.md
@@ -6,25 +6,23 @@ This page includes new features and improvements to the Airbyte Cloud and Airbyt
 
 ## ✨ Highlights
 
-[Native authentication](https://github.com/airbytehq/airbyte/issues/41634) by email and password is available in Airbyte OSS so that any instance of Airbyte is secure by default. The newest version of `abctl` (v0.11.0) now generates the credentials randomly and you can use `abctl local credentials` to retrieve them. See our [quickstart docs](/platform/using-airbyte/getting-started/oss-quickstart) for more details. For more detailed documentation about authentication, see our docs [here](/platform/deploying-airbyte/integrations/authentication).
+[Native authentication](https://github.com/airbytehq/airbyte/issues/41634) by email and password is available in Airbyte OSS so that any instance of Airbyte is secure by default. The newest version of `abctl` (v0.11.0) now generates the credentials randomly and you can use `abctl local credentials` to retrieve them. See our [quickstart docs](/platform/using-airbyte/getting-started/oss-quickstart) for more details. For more detailed documentation about authentication, see the [authentication docs](/platform/deploying-airbyte/integrations/authentication).
 
 We have also released rate limited messaging, providing users more transparency into what's going on with their syncs. When a source is rate limited, it can not only tell the platform but also include a timestamp when the API is expected to be available again to resume extracting records. This is used to tell users the connection is being rate limited, and if the timestamp is provided we include a countdown to when Airbyte will start syncing again.
 
 ![Rate Limited Status](./assets/rate_limited.png)
 
-
 ## Platform Releases
 
 - [Workloads](https://github.com/airbytehq/airbyte/discussions/42947) have been released with Airbyte Helm Chart `0.390.0`, which provides a more scalable and reliable architecture to run sync jobs by separating scheduling and orchestration from data movement tasks. This improvement unlocks more automated management of workloads by managing job spikes and enables horizonal scaling (for Cloud and Enterprise users). Read more about the Workloads feature in our [docs](/platform/understanding-airbyte/jobs) or [blog post](https://airbyte.com/blog/introducing-workloads-how-airbyte-1-0-orchestrates-data-movement-jobs).
-  
+
 - Managing and obtaining API keys is now consistent across all our products. We have brought our API portal in-house and API keys can now be generated and found in the “Applications” page of our UI. Along with this, the Terraform provider and Java/Python SDKs have been updated to automatically retrieve tokens between each action, so that users don’t need to worry about fetching tokens themselves.
 
 - The progress of active syncs is now reported every 10 seconds for increased visibility and tracking (available in OSS v.0.63.5)
 
 - Schema discovery is now always run as a part of the sync for Airbyte Cloud. This ensures we always run the sync with the latest schema, which ensures the auto-propagation and backfill features works as expected. This will be released to Self-Managed users in the coming weeks.
 
-- Community Connectors are now found in the Marketplace. In the UI, we now show three tabs on the source/destination selection page: Airbyte Connectors (formerly "certified"), Marketplace (formerly "community"), and Custom. Connectors in the Marketplace tab now also contain success rate and usage metric info to help users understand how the connector is used. 
-
+- Community Connectors are now found in the Marketplace. In the UI, we now show three tabs on the source/destination selection page: Airbyte Connectors (formerly "certified"), Marketplace (formerly "community"), and Custom. Connectors in the Marketplace tab now also contain success rate and usage metric info to help users understand how the connector is used.
 
 ## Connector Improvements
 
@@ -32,7 +30,7 @@ We also released a few notable improvements for our connectors:
 
 - MySQL has been enhanced to ensure large historical syncs are successful. During an initial sync, Airbyte now gracefully consumes WAL and acknowledges logs periodically to ensure disk space is freed in a timely manner.
 
-- Source S3 has become faster! With CDK 2.0, the protocol now uses Pydantic V2 and removes the serialization of each record. As connectors are updated to the new CDK version, additional connectors will see varying levels of speed improvements. 
+- Source S3 has become faster! With CDK 2.0, the protocol now uses Pydantic V2 and removes the serialization of each record. As connectors are updated to the new CDK version, additional connectors will see varying levels of speed improvements.
 
 - Destination Redshift (v3.3.0) and Snowflake (v3.11.0) support [Refreshes](/platform/operator-guides/refreshes), which reduces data downtime when resyncing historical data. They join BigQuery in also supporting [Resumable Full Refresh](https://airbyte.com/blog/resumable-full-refresh-building-resilient-systems-for-syncing-data), which ensures the success of large Full Refresh syncs.
 
@@ -44,8 +42,6 @@ We also released a few notable improvements for our connectors:
 
 - pyAirbyte now integrates with Apache Arrow and supports Pydantic 2.0 and CDK 2.0! Pydantic 2.0 support was a frequently-requested feature for PyAirbyte users and the benefit for users is (1) improved performance, and (2) improved compatibility with modern Python tools.
 
-
 ## Announcements
-
 
 - As we prepare to deprecate Docker Compose, we published a [migration guide](https://airbyte.com/blog/understand-and-troubleshoot-your-migration-to-abctl) for those migrating from Docker Compose to abctl.

--- a/docs/release_notes/self-managed/june_2024.md
+++ b/docs/release_notes/self-managed/june_2024.md
@@ -6,7 +6,7 @@ This page includes new features and improvements to the Airbyte Cloud and Airbyt
 
 ## ✨ Highlights
 
-Airbyte added [Refresh](/platform/operator-guides/refreshes) support for our BigQuery destination, which brings an improved experience to resyncing all of your data again. This enables data to never be deleted from final tables during a historical resyncing of data. More certified destinations will support Refresh in the coming weeks. 
+Airbyte added [Refresh](/platform/operator-guides/refreshes) support for our BigQuery destination, which brings an improved experience to resyncing all of your data again. This enables data to never be deleted from final tables during a historical resyncing of data. More certified destinations will support Refresh in the coming weeks.
 
 Users can now monitor the incremental progress of syncs on the Connection Status page. The sync progress feature displays record counts and sync duration for each stream during a sync, as well as which streams are syncing and when a connection sync is actively running. The Connection Status Page also now shows counts from the last time each enabled stream synced. Lastly, each stream individually displays stream status, which helps users troubleshoot by indicating exactly which streams are erroring.
 
@@ -14,7 +14,7 @@ Users can now monitor the incremental progress of syncs on the Connection Status
 
 ## Platform Releases
 
-- (Cloud, Cloud Teams, and Self-Managed Enterprise only) Connections now display both per stream status and tracking of records moved for recent syncs to aid with troubleshooting. 
+- (Cloud, Cloud Teams, and Self-Managed Enterprise only) Connections now display both per stream status and tracking of records moved for recent syncs to aid with troubleshooting.
 
 ![Connection Graph](./assets/connection-stream-status-graph.png)
 
@@ -35,8 +35,7 @@ We also released a few notable improvements for our connectors:
 - Our connector docs now contain Connector Quality Metric indicators. Icons display additional information targeted to help users understand the health of a connector. Sync Success Rate and Usage Rate are now scored 1-3 to better curate the Connector Catalog experience. We’ve also added how recently the connector and its CDK dependency have been updated.
 
 ## Announcements
-We announced we will formally deprecate support for Docker Compose deployments in favor of Kubernetes, and welcome beta testers [here](https://github.com/airbytehq/airbyte/discussions/40599) who want migration assistance. You can use [`abctl`](https://github.com/airbytehq/abctl) for local deployments starting today.
 
-Airbyte is planning to deprecate the Configuration API later this year, and we are looking for feedback on endpoints or data enhancements to improve the Airbyte API [here](https://github.com/airbytehq/airbyte/discussions/39433).
+We announced we will formally deprecate support for Docker Compose deployments in favor of Kubernetes, and welcome beta testers in the [migration discussion](https://github.com/airbytehq/airbyte/discussions/40599) who want migration assistance. You can use [`abctl`](https://github.com/airbytehq/abctl) for local deployments starting today.
 
-
+Airbyte is planning to deprecate the Configuration API later this year, and we are looking for feedback on endpoints or data enhancements to improve the Airbyte API in the [API feedback discussion](https://github.com/airbytehq/airbyte/discussions/39433).

--- a/docs/release_notes/self-managed/may_2024.md
+++ b/docs/release_notes/self-managed/may_2024.md
@@ -10,7 +10,6 @@ Our certified database sources (Mongo,  MySQL, MSSQL and Postgres) are now [resi
 
 We expanded on our AI offering by releasing a new [Snowflake Cortex](/integrations/destinations/snowflake-cortex) destination to support users who prefer to use Snowflake as a vector store and utilize the LLM capabilities of Snowflake Cortex functions.
 
-
 ## Platform Releases
 
 - We are now resilient to changes when a connector changes its defined primary key. This can occur during major version updates to a connector or when there are upstream adjustments to a source-defined primary key. Airbyte will gracefully recognize the change in the primary key and ask to update the connection before syncing again.

--- a/docs/release_notes/self-managed/november_2022.md
+++ b/docs/release_notes/self-managed/november_2022.md
@@ -16,7 +16,7 @@ This page includes new features and improvements to the Airbyte Cloud and Airbyt
 - Improved the Airbyte Protocol by introducing Airbyte Protocol v1 [#19846](https://github.com/airbytehq/airbyte/pull/19846), which defines a set of [well-known data types](https://github.com/airbytehq/airbyte/blob/5813700927cfc690d2bffcec28f5286e59ac0122/docs/understanding-airbyte/supported-data-types.md). [#17486](https://github.com/airbytehq/airbyte/pull/17486)
   - These replace existing JSON Schema primitive types.
   - They provide out-of-the-box validation and enforce specific formatting on some data types, like timestamps.
-  - Non-primitive types, like `object`, `array`, and ` oneOf`, still use raw JSON Schema types.
+  - Non-primitive types, like `object`, `array`, and `oneOf`, still use raw JSON Schema types.
   - These well-known types mostly correspond with the existing Airbyte data types, aside from a few differences:
     - `BinaryData` is the only new type, which is used in places that previously produced a `Base64` string.
     - `TimestampWithTimezone`, `TimestampWithoutTimezone`, `TimeWithTimezone`, and `TimeWithoutTimezone` have been in use for some time, so we made them official.

--- a/docs/release_notes/self-managed/upgrading_to_destinations_v2.md
+++ b/docs/release_notes/self-managed/upgrading_to_destinations_v2.md
@@ -64,7 +64,7 @@ Whenever possible, we've taken this opportunity to use the best data type for st
 If any of the above concerns are applicable to your existing setup, we recommend [Upgrading Connections One by One with Dual-Writing](#upgrading-connections-one-by-one-with-dual-writing) for a more controlled upgrade process
 :::
 
-After upgrading the out-of-date destination to a [Destinations V2 compatible version](#destinations-v2-effective-versions), the following will occur at the next sync **for each connection** sending data to the updated destination:
+After upgrading the out-of-date destination to a [Destinations V2 compatible version](#destinations-v2-compatible-versions), the following will occur at the next sync **for each connection** sending data to the updated destination:
 
 1. Existing raw tables replicated to this destination will be copied to a new `airbyte_internal` schema.
 2. The new raw tables will be updated to the new Destinations V2 format.
@@ -93,13 +93,13 @@ Dual writing is a method employed during upgrades where new incoming data is wri
 
 #### Steps to Follow for All Sync Modes
 
-1. **[Open Source]** Update the default destination version for your workspace to a [Destinations V2 compatible version](#destinations-v2-effective-versions). This sets the default version for any newly created destination. All existing syncs will remain on their current version.
+1. **[Open Source]** Update the default destination version for your workspace to a [Destinations V2 compatible version](#destinations-v2-compatible-versions). This sets the default version for any newly created destination. All existing syncs will remain on their current version.
 
-![Upgrade your default destination version](assets/airbyte_version_upgrade.png)
+   ![Upgrade your default destination version](assets/airbyte_version_upgrade.png)
 
 2. Create and configure a new destination connecting to the same database as your existing destination except for `Default Schema`, which you should update to a new value to avoid collisions.
 
-![Create a new destination](assets/airbyte_dual_destinations.png)
+   ![Create a new destination](assets/airbyte_dual_destinations.png)
 
 3. Create a new connection leveraging your existing source and the newly created destination. Match the settings of your pre-existing connection.
 4. If the streams you are looking to replicate are in **full refresh** mode, enabling the connection will now provide a parallel copy of the data in the updated format for testing. If any of the streams in the connection are in an **incremental** sync mode, follow the steps below before enabling the connection.
@@ -110,24 +110,24 @@ These steps allow you to dual-write for connections incrementally syncing data w
 
 1. Copy the raw data you've already replicated to the new schema being used by your newly created connection. You need to do this for every stream in the connection with an incremental sync mode. Sample SQL you can run in your data warehouse:
 
-<Tabs>
-  <TabItem value="bigquery" label="BigQuery" default>
-    <BigQueryMigrationGenerator />
-  </TabItem>
-  <TabItem value="snowflake" label="Snowflake">
-    <SnowflakeMigrationGenerator />
-  </TabItem>
-  <TabItem value="redshift" label="Redshift">
-    <RedshiftMigrationGenerator />
-  </TabItem>
-  <TabItem value="postgres" label="Postgres">
-    <PostgresMigrationGenerator />
-  </TabItem>
-</Tabs>
+   <Tabs>
+     <TabItem value="bigquery" label="BigQuery" default>
+       <BigQueryMigrationGenerator />
+     </TabItem>
+     <TabItem value="snowflake" label="Snowflake">
+       <SnowflakeMigrationGenerator />
+     </TabItem>
+     <TabItem value="redshift" label="Redshift">
+       <RedshiftMigrationGenerator />
+     </TabItem>
+     <TabItem value="postgres" label="Postgres">
+       <PostgresMigrationGenerator />
+     </TabItem>
+   </Tabs>
 
 2. Navigate to the existing connection you are duplicating, and navigate to the `Settings` tab. Open the `Advanced` settings to see the connection state (which manages incremental syncs). Copy the state to your clipboard.
 
-![img.png](assets/airbyte_connection_update_state.png)
+   ![img.png](assets/airbyte_connection_update_state.png)
 
 3. Go to your newly created connection, replace the state with the copied contents in the previous step, then click `Update State`. This will ensure historical data is not replicated again.
 4. Enabling the connection will now provide a parallel copy of all streams in the updated format.
@@ -148,7 +148,7 @@ If you have written downstream transformations directly from the output of raw t
 
 - Multiple column names are being updated (from `airbyte_ab_id` to `airbyte_raw_id`, and `airbyte_emitted_at` to `airbyte_extracted_at`).
 - The location of raw tables will from now on default to an `airbyte_internal` schema in your destination.
-- When you upgrade to a [Destinations V2 compatible version](#destinations-v2-effective-versions) of your destination, we will leave a copy of your existing raw tables as they are, and new syncs will work from a new copy we make in the new `airbyte_internal` schema. Although existing downstream dashboards will go stale, they will not be broken.
+- When you upgrade to a [Destinations V2 compatible version](#destinations-v2-compatible-versions) of your destination, we will leave a copy of your existing raw tables as they are, and new syncs will work from a new copy we make in the new `airbyte_internal` schema. Although existing downstream dashboards will go stale, they will not be broken.
 - You can dual write by following the [steps above](#upgrading-connections-one-by-one-with-dual-writing) and copying your raw data to the schema of your newly created connection.
 
 We may make further changes to raw tables in the future, as these tables are intended to be a staging ground for Airbyte to optimize the performance of your syncs. We cannot guarantee the same level of stability as for final tables in your destination schema, nor will features like error handling be implemented in the raw tables.
@@ -203,7 +203,7 @@ In addition to the changes which apply for all destinations described above, the
 #### [Object and array properties](https://docs.airbyte.com/understanding-airbyte/supported-data-types/#the-types) are properly stored as JSON columns
 
 Previously, we had used TEXT, which made querying sub-properties more difficult.
-In certain cases, numbers within sub-properties with long decimal values will need to be converted to float representations due to a _quirk_ of Bigquery. Learn more [here](https://github.com/airbytehq/airbyte/issues/29594).
+In certain cases, numbers within sub-properties with long decimal values will need to be converted to float representations due to a _quirk_ of Bigquery. Learn more in the [BigQuery float precision issue](https://github.com/airbytehq/airbyte/issues/29594).
 
 ### Snowflake
 
@@ -247,18 +247,18 @@ _This section is targeted towards analysts updating downstream models after you'
 
 See here for a [breakdown of changes](#breakdown-of-breaking-changes). Your models will often require updates for the following changes:
 
-#### Column Name Changes
+### Column Name Changes
 
 1. `_airbyte_emitted_at_` and `_airbyte_extracted_at` are exactly the same, only the column name changed. You can replace all instances of `_airbyte_emitted_at` with `_airbyte_extracted_at`.
 2. `_airbyte_ab_id` and `_airbyte_raw_id` are exactly the same, only the column name changed. You can replace all instances of `_airbyte_ab_id` with `_airbyte_raw_id`.
 3. Since `_airbyte_normalized_at` is no longer in the final table. We now recommend using `_airbyte_extracted_at` instead.
 
-#### Data Type Changes
+### Data Type Changes
 
 You'll get data type errors in downstream models where previously `string` columns are now JSON. In BigQuery, nested JSON values originating from API sources were previously delivered in type `string`. These are now delivered in type `JSON`.
 
 Example: In dbt, you may now get errors with functions such as `regexp_replace`. You can attempt prepending these with `json_extract_array(...)` or `to_json_string(...)` where appropriate.
 
-#### Stale Tables
+### Stale Tables
 
 Unnested tables (e.g. `public.users_address`) do not get deleted during the migration, and are no longer updated. Your downstream models will not throw errors until you drop these tables. Until then, dashboards reliant on these tables will be stale.

--- a/docs/release_notes/self-managed/v-1.0.md
+++ b/docs/release_notes/self-managed/v-1.0.md
@@ -6,13 +6,13 @@ Moving forward, Airbyte will release official new platform versions on a monthly
 
 ## Ease of deployment
 
-- [`abctl`](https://github.com/airbytehq/abctl/releases) is the easiest, quickest way to get started with Airbyte Self-managed. See our [quickstart docs](/platform/using-airbyte/getting-started/oss-quickstart) for more details. 
+- [`abctl`](https://github.com/airbytehq/abctl/releases) is the easiest, quickest way to get started with Airbyte Self-managed. See our [quickstart docs](/platform/using-airbyte/getting-started/oss-quickstart) for more details.
 
-- [Native authentication](/platform/deploying-airbyte/integrations/authentication) by email and password is available so that any instance of Airbyte is secure by default. 
+- [Native authentication](/platform/deploying-airbyte/integrations/authentication) by email and password is available so that any instance of Airbyte is secure by default.
 
 ## Proven Reliability
 
-- [Automatic detection of dropped records](https://airbyte.com/blog/automatic-detection-of-dropped-records) ensures data is passed without fail through the Airbyte platform. 
+- [Automatic detection of dropped records](https://airbyte.com/blog/automatic-detection-of-dropped-records) ensures data is passed without fail through the Airbyte platform.
 
 - Enhanced our [notification suite](https://airbyte.com/blog/airbyte-notifications-and-webhooks-effortless-etl-jobs-monitoring) to enable webhook integrations and added more contextual information about sync failures or schema changes.
 
@@ -24,7 +24,7 @@ Moving forward, Airbyte will release official new platform versions on a monthly
 
 ## Resiliency at Scale
 
-- [Refreshes](/platform/operator-guides/refreshes) bring an improved experience to resyncing all of your data again. This enables data to never be deleted from final tables during a historical resyncing of data. 
+- [Refreshes](/platform/operator-guides/refreshes) bring an improved experience to resyncing all of your data again. This enables data to never be deleted from final tables during a historical resyncing of data.
 
 - [Resumable Full Refresh](https://airbyte.com/blog/resumable-full-refresh-building-resilient-systems-for-syncing-data) allows for large streams syncing in Full Refresh to sync without failures.
 
@@ -35,11 +35,12 @@ Moving forward, Airbyte will release official new platform versions on a monthly
 - [Workloads](/platform/understanding-airbyte/jobs#workloads) provide a more scalable and reliable architecture to run sync jobs by separating scheduling and orchestration from data movement tasks. This [improvement](https://airbyte.com/blog/introducing-workloads-how-airbyte-1-0-orchestrates-data-movement-jobs) unlocks more automated management of workloads by managing job spikes and enables horizontal scaling (for Cloud and Enterprise users).
 
 ## Tackling the long-tail of connectors
-- We launched our connector Marketplace for our community-maintained connectors. [Automated testing](https://airbyte.com/blog/how-we-test-airbyte-and-marketplace-connectors) ensures our connectors stay high quality, and most connectors have been migrated to low/no-code. 
+
+- We launched our connector Marketplace for our community-maintained connectors. [Automated testing](https://airbyte.com/blog/how-we-test-airbyte-and-marketplace-connectors) ensures our connectors stay high quality, and most connectors have been migrated to low/no-code.
 
 - The [Connector Builder](https://airbyte.com/blog/maintaining-hundreds-of-api-connectors-with-the-low-code-cdk-and-connector-builder) seamlessly switches between UI and YAML modes, supports custom components, and contains extensive testing and error handling.
 
-- AI Assist now builds connectors from scratch for you with just a link to the API docs. 
+- AI Assist now builds connectors from scratch for you with just a link to the API docs.
 
 - Anyone can now contribute new connectors directly from the builder to add a new connector directly to Airbyte's Marketplace. Additionally, connectors can be forked directly from the UI for faster edits, ensuring our connectors stay up-to-date.
 
@@ -55,6 +56,6 @@ Self-Managed Enterprise extends on Airbyte 1.0 by introducing new classes of fun
 
 ## Announcements
 
-- To ensure adherence to security best practices, Airbyte is migrating all connectors to [non-root versions](https://github.com/airbytehq/airbyte/discussions/44924). It is highly recommended that you upgrade your platform version to [v0.63.9](https://github.com/airbytehq/airbyte-platform/releases/tag/v0.63.9) or later before October 2024 to ensure your syncs continue to succeed. 
+- To ensure adherence to security best practices, Airbyte is migrating all connectors to [non-root versions](https://github.com/airbytehq/airbyte/discussions/44924). It is highly recommended that you upgrade your platform version to [v0.63.9](https://github.com/airbytehq/airbyte-platform/releases/tag/v0.63.9) or later before October 2024 to ensure your syncs continue to succeed.
 
 - Docker Compose deployments have been deprecated. See the [migration guide](/platform/deploying-airbyte/migrating-from-docker-compose) for information on transitioning to `abctl`.

--- a/docs/release_notes/self-managed/v-1.1.md
+++ b/docs/release_notes/self-managed/v-1.1.md
@@ -5,20 +5,24 @@ The 1.1.0 release includes the following enhancements and bug fixes.
 ## 🚀 Features
 
 ## Platform Releases
+
 - Adds field hashing for Self-Managed Enterprise
-- Adds the [Connection Timeline](/platform/cloud/managing-airbyte-cloud/review-connection-timeline), replacing the Job History for a connection. For assistance with the migration of existing jobs to the new timeline events, follow our [guide](https://github.com/airbytehq/airbyte/discussions/46319). 
+- Adds the [Connection Timeline](/platform/cloud/managing-airbyte-cloud/review-connection-timeline), replacing the Job History for a connection. For assistance with the migration of existing jobs to the new timeline events, follow our [guide](https://github.com/airbytehq/airbyte/discussions/46319).
 
 - Redesigned the schema tab to improve the selection & deselection of streams and fields. Sync modes, cursor fields, and primary keys are also selected here.
 
 ![Schema Tab](./assets/new-schema-tab.png)
 
-- Custom Docker-based connectors can now be renamed and deleted 
+- Custom Docker-based connectors can now be renamed and deleted
 
 ## Support Experience
-- Diagnostics can be downloaded through the Organization Settings page, which will export a JSON file to facilitate sharing with Support. This JSON file includes relevant infrastructure and connection information.  (Self-Managed Enterprise only) 
+
+- Diagnostics can be downloaded through the Organization Settings page, which will export a JSON file to facilitate sharing with Support. This JSON file includes relevant infrastructure and connection information.  (Self-Managed Enterprise only)
 
 ## Billing & Licenses
+
 - Self-Managed Enterprise users can now view directly in the UI when the license is expiring.
 
 ## Changelog
+
 See the [Full Changelog](https://github.com/airbytehq/airbyte/releases)

--- a/docs/release_notes/self-managed/v-1.2.md
+++ b/docs/release_notes/self-managed/v-1.2.md
@@ -16,7 +16,7 @@ global:
     registry: my-registry.foo.com/
 ```
 
-- **XML Support in the Connector Builder**: Airbyte now supports custom API connectors built via the Airbyte Connector Builder which return responses as XML format. 
+- **XML Support in the Connector Builder**: Airbyte now supports custom API connectors built via the Airbyte Connector Builder which return responses as XML format.
 
 ![xml-builder](./assets/1.2-xml-builder.png)
 

--- a/docs/release_notes/self-managed/v-1.4.md
+++ b/docs/release_notes/self-managed/v-1.4.md
@@ -8,7 +8,7 @@ Platform changes improve Airbyte for everyone with a self-managed instance.
 
 ### Configure the schema refresh rate
 
-At the start of a sync, Airbyte occasionally re-runs schema discovery to detect changes in your source, such as new fields or a change in column type. But running schema discovery has a performance cost, and may not always be necessary before every sync. 
+At the start of a sync, Airbyte occasionally re-runs schema discovery to detect changes in your source, such as new fields or a change in column type. But running schema discovery has a performance cost, and may not always be necessary before every sync.
 
 You may now use a new toggle, `DISCOVER_REFRESH_WINDOW_MINUTES`, to set the minimum number of minutes Airbyte will wait to refresh the schema for your sources. By setting a larger number, you run automatic schema detection less frequently, which can result in gains in sync performance. The default configuration in Airbyte Open Source is `1440`, which refreshes schemas every 24 hours. The lowest interval you can set is `1`, which refreshes schemas before every sync.
 
@@ -54,7 +54,7 @@ Airbyte handles the parts of the OAuth flow that once required a separate web se
 
 1. Create your OAuth application for a given data source.
 2. Input your Client ID and Client Secret in Airbyte while setting up a connection.
-3. Click the authenticate button. 
+3. Click the authenticate button.
 
 Airgapped instances support this new flow. The redirect is handled by your web browser and not the Airbyte server.
 
@@ -66,6 +66,6 @@ Airgapped instances support this new flow. The redirect is handled by your web b
 
 - **Canceled syncs do not rerun until the next scheduled sync**: If you previously cancelled an in-progress sync, and the next sync as configured in the connection frequency was behind schedule, Airbyte would immediately start a new sync. In practice, many users had to choose to ‘Cancel Sync’ twice in a row to stop moving data.  Airbyte now automatically waits until the next scheduled sync to move data.
 
-- **Reduce rate limit errors from the `airbyte-cron` service**: We fixed an [issue](https://github.com/airbytehq/airbyte/issues/30691) reported by the community that caused excessive rate limit errors on the `airbyte-cron` pod when users scheduled connections using the Airbyte CRON capability. 
+- **Reduce rate limit errors from the `airbyte-cron` service**: We fixed an [issue](https://github.com/airbytehq/airbyte/issues/30691) reported by the community that caused excessive rate limit errors on the `airbyte-cron` pod when users scheduled connections using the Airbyte CRON capability.
 
 - **Autorecovery for hanging connections**: Airbyte now packages a service to detect connections blocked by the unlikely event that a sync becomes stuck, and remains in a perpetual ‘in-progress’ state without moving data. This heartbeat service will detect syncs that are hanging, and automatically create a new job attempt.

--- a/docs/release_notes/self-managed/v-1.5.md
+++ b/docs/release_notes/self-managed/v-1.5.md
@@ -43,7 +43,7 @@ These changes bring new capabilities to Airbyte's Self-Managed Enterprise custom
 
 We introduced mappings in the API in version 1.3, and it's now available in Airbyte's user interface, too. Use mappings to hash, encrypt, and rename fields, and filter rows. You set up mappings on each stream, ensuring your source data arrives in your destination in a more meaningful way. [**Learn more >**](/platform/using-airbyte/mappings)
 
-![](../../platform/using-airbyte/images/mappings.png)
+![Mappings in the Airbyte UI](../../platform/using-airbyte/images/mappings.png)
 
 ### OpenTelemetry (OTel) metrics monitoring
 
@@ -68,7 +68,7 @@ global:
 
 ### Resource allocation on connectors
 
-In Self-Managed Enterprise, you can now define resource allocations for individual connectors as part of that connector's configuration, both in the user interface and the API. 
+In Self-Managed Enterprise, you can now define resource allocations for individual connectors as part of that connector's configuration, both in the user interface and the API.
 
 Airbyte's default CPU and memory allocations aren't always appropriate for every situation, and different connectors have different resource requirements. This can make it challenging to run a large number of concurrent syncs. Historically, you had to tweak a number of variables to configure this. Now, you can set CPU and memory allocation when you set up a source or destination, and it applies to all connections using that connector. [**Learn more >**](/platform/operator-guides/configuring-connector-resources)
 

--- a/docusaurus/platform_versioned_docs/version-1.6/using-airbyte/core-concepts/typing-deduping.md
+++ b/docusaurus/platform_versioned_docs/version-1.6/using-airbyte/core-concepts/typing-deduping.md
@@ -81,26 +81,26 @@ Consider the following [source schema](/integrations/sources/faker) for stream `
 
 The data from one stream will now be mapped to one table in your schema as below:
 
-#### Final Destination Table Name: _public.users_
+### Final Destination Table Name: _public.users_
 
-| _(note, not in actual table)_                | \_airbyte_raw_id | \_airbyte_extracted_at | \_airbyte_meta                                                                             | id  | first_name | age  | address                                   |
-| -------------------------------------------- | ---------------- | ---------------------- | ------------------------------------------------------------------------------------------ | --- | ---------- | ---- | ----------------------------------------- |
-| Successful typing and de-duping ⟶            | xxx-xxx-xxx      | 2022-01-01 12:00:00    | `{}`                                                                                       | 1   | sarah      | 39   | `{ city: “San Francisco”, zip: “94131” }` |
-| Failed typing that didn’t break other rows ⟶ | yyy-yyy-yyy      | 2022-01-01 12:00:00    | `{ changes: {"field": "age", "change": "NULLED", "reason": "DESTINATION_TYPECAST_ERROR"}}` | 2   | evan       | NULL | `{ city: “Menlo Park”, zip: “94002” }`    |
-| Not-yet-typed ⟶                              |                  |                        |                                                                                            |     |            |      |                                           |
+| _(note, not in actual table)_ | \_airbyte_raw_id | \_airbyte_extracted_at | \_airbyte_meta | id | first_name | age | address |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| Successful typing and de-duping ⟶ | xxx-xxx-xxx | 2022-01-01 12:00:00 | `{}` | 1 | sarah | 39 | `{ city: "San Francisco", zip: "94131" }` |
+| Failed typing that didn't break other rows ⟶ | yyy-yyy-yyy | 2022-01-01 12:00:00 | `{ changes: {"field": "age", "change": "NULLED", "reason": "DESTINATION_TYPECAST_ERROR"}}` | 2 | evan | NULL | `{ city: "Menlo Park", zip: "94002" }` |
+| Not-yet-typed ⟶ | | | | | | | |
 
 In legacy normalization, columns of
 [Airbyte type](/platform/understanding-airbyte/supported-data-types/#the-types) `Object` in the Destination
 were "unnested" into separate tables. In this example, with Destinations V2, the previously unnested
 `public.users_address` table with columns `city` and `zip` will no longer be generated.
 
-#### Raw Destination Table Name: _airbyte_internal.raw_public\_\_users_ (`airbyte_internal.raw_{namespace}__{stream}`)
+### Raw Destination Table Name: _airbyte_internal.raw_public\_\_users_ (`airbyte_internal.raw_{namespace}__{stream}`)
 
-| _(note, not in actual table)_                | \_airbyte_raw_id | \_airbyte_data﻿                                                                             | \_airbyte_loaded_at  | \_airbyte_extracted_at |
-| -------------------------------------------- | ---------------- | ------------------------------------------------------------------------------------------- | -------------------- | ---------------------- |
-| Successful typing and de-duping ⟶            | xxx-xxx-xxx      | `{ id: 1, first_name: “sarah”, age: 39, address: { city: “San Francisco”, zip: “94131” } }` | 2022-01-01 12:00:001 | 2022-01-01 12:00:00﻿   |
-| Failed typing that didn’t break other rows ⟶ | yyy-yyy-yyy      | `{ id: 2, first_name: “evan”, age: “fish”, address: { city: “Menlo Park”, zip: “94002” } }` | 2022-01-01 12:00:001 | 2022-01-01 12:00:00﻿   |
-| Not-yet-typed ⟶                              | zzz-zzz-zzz      | `{ id: 3, first_name: “edward”, age: 35, address: { city: “Sunnyvale”, zip: “94003” } }`    | NULL                 | 2022-01-01 13:00:00﻿   |
+| _(note, not in actual table)_ | \_airbyte_raw_id | \_airbyte_data | \_airbyte_loaded_at | \_airbyte_extracted_at |
+| --- | --- | --- | --- | --- |
+| Successful typing and de-duping ⟶ | xxx-xxx-xxx | `{ id: 1, first_name: "sarah", age: 39, address: { city: "San Francisco", zip: "94131" } }` | 2022-01-01 12:00:001 | 2022-01-01 12:00:00 |
+| Failed typing that didn't break other rows ⟶ | yyy-yyy-yyy | `{ id: 2, first_name: "evan", age: "fish", address: { city: "Menlo Park", zip: "94002" } }` | 2022-01-01 12:00:001 | 2022-01-01 12:00:00 |
+| Not-yet-typed ⟶ | zzz-zzz-zzz | `{ id: 3, first_name: "edward", age: 35, address: { city: "Sunnyvale", zip: "94003" } }` | NULL | 2022-01-01 13:00:00 |
 
 You also now see the following changes in Airbyte-provided columns:
 

--- a/docusaurus/platform_versioned_docs/version-1.7/using-airbyte/core-concepts/typing-deduping.md
+++ b/docusaurus/platform_versioned_docs/version-1.7/using-airbyte/core-concepts/typing-deduping.md
@@ -10,7 +10,6 @@ products: all
 With Direct Loads, there is no intermediate table result containing the raw JSON blob. Instead, top-level fields are typed during time of insert, and there is only a single destination table maintained per stream.
 :::
 
-
 This page refers to new functionality added by
 [Destinations V2](/release_notes/self-managed/upgrading_to_destinations_v2/). Typing and deduping is the default
 method of transforming datasets within data warehouse and database destinations after they've been
@@ -88,26 +87,26 @@ Consider the following [source schema](/integrations/sources/faker) for stream `
 
 The data from one stream will now be mapped to one table in your schema as below:
 
-#### Final Destination Table Name: _public.users_
+### Final Destination Table Name: _public.users_
 
-| _(note, not in actual table)_                | \_airbyte_raw_id | \_airbyte_extracted_at | \_airbyte_meta                                                 | id  | first_name | age  | address                                   |
-| -------------------------------------------- | ---------------- | ---------------------- | -------------------------------------------------------------- | --- | ---------- | ---- | ----------------------------------------- |
-| Successful typing and de-duping ⟶            | xxx-xxx-xxx      | 2022-01-01 12:00:00    | `{}`                                                           | 1   | sarah      | 39   | `{ city: “San Francisco”, zip: “94131” }` |
-| Failed typing that didn’t break other rows ⟶ | yyy-yyy-yyy      | 2022-01-01 12:00:00    | `{ changes: {"field": "age", "change": "NULLED", "reason": "DESTINATION_TYPECAST_ERROR"}}` | 2   | evan       | NULL | `{ city: “Menlo Park”, zip: “94002” }`    |
-| Not-yet-typed ⟶                              |                  |                        |                                                                |     |            |      |                                           |
+| _(note, not in actual table)_ | \_airbyte_raw_id | \_airbyte_extracted_at | \_airbyte_meta | id | first_name | age | address |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| Successful typing and de-duping ⟶ | xxx-xxx-xxx | 2022-01-01 12:00:00 | `{}` | 1 | sarah | 39 | `{ city: "San Francisco", zip: "94131" }` |
+| Failed typing that didn't break other rows ⟶ | yyy-yyy-yyy | 2022-01-01 12:00:00 | `{ changes: {"field": "age", "change": "NULLED", "reason": "DESTINATION_TYPECAST_ERROR"}}` | 2 | evan | NULL | `{ city: "Menlo Park", zip: "94002" }` |
+| Not-yet-typed ⟶ | | | | | | | |
 
 In legacy normalization, columns of
 [Airbyte type](/platform/understanding-airbyte/supported-data-types/#the-types) `Object` in the Destination
 were "unnested" into separate tables. In this example, with Destinations V2, the previously unnested
 `public.users_address` table with columns `city` and `zip` will no longer be generated.
 
-#### Raw Destination Table Name: _airbyte_internal.raw_public\_\_users_ (`airbyte_internal.raw_{namespace}__{stream}`)
+### Raw Destination Table Name: _airbyte_internal.raw_public\_\_users_ (`airbyte_internal.raw_{namespace}__{stream}`)
 
-| _(note, not in actual table)_                | \_airbyte_raw_id | \_airbyte_data﻿                                                                             | \_airbyte_loaded_at  | \_airbyte_extracted_at |
-| -------------------------------------------- | ---------------- | ------------------------------------------------------------------------------------------- | -------------------- | ---------------------- |
-| Successful typing and de-duping ⟶            | xxx-xxx-xxx      | `{ id: 1, first_name: “sarah”, age: 39, address: { city: “San Francisco”, zip: “94131” } }` | 2022-01-01 12:00:001 | 2022-01-01 12:00:00﻿   |
-| Failed typing that didn’t break other rows ⟶ | yyy-yyy-yyy      | `{ id: 2, first_name: “evan”, age: “fish”, address: { city: “Menlo Park”, zip: “94002” } }` | 2022-01-01 12:00:001 | 2022-01-01 12:00:00﻿   |
-| Not-yet-typed ⟶                              | zzz-zzz-zzz      | `{ id: 3, first_name: “edward”, age: 35, address: { city: “Sunnyvale”, zip: “94003” } }`    | NULL                 | 2022-01-01 13:00:00﻿   |
+| _(note, not in actual table)_ | \_airbyte_raw_id | \_airbyte_data | \_airbyte_loaded_at | \_airbyte_extracted_at |
+| --- | --- | --- | --- | --- |
+| Successful typing and de-duping ⟶ | xxx-xxx-xxx | `{ id: 1, first_name: "sarah", age: 39, address: { city: "San Francisco", zip: "94131" } }` | 2022-01-01 12:00:001 | 2022-01-01 12:00:00 |
+| Failed typing that didn't break other rows ⟶ | yyy-yyy-yyy | `{ id: 2, first_name: "evan", age: "fish", address: { city: "Menlo Park", zip: "94002" } }` | 2022-01-01 12:00:001 | 2022-01-01 12:00:00 |
+| Not-yet-typed ⟶ | zzz-zzz-zzz | `{ id: 3, first_name: "edward", age: 35, address: { city: "Sunnyvale", zip: "94003" } }` | NULL | 2022-01-01 13:00:00 |
 
 You also now see the following changes in Airbyte-provided columns:
 

--- a/docusaurus/platform_versioned_docs/version-1.8/using-airbyte/core-concepts/typing-deduping.md
+++ b/docusaurus/platform_versioned_docs/version-1.8/using-airbyte/core-concepts/typing-deduping.md
@@ -10,7 +10,6 @@ products: all
 With Direct Loads, there is no intermediate table result containing the raw JSON blob. Instead, top-level fields are typed during time of insert, and there is only a single destination table maintained per stream.
 :::
 
-
 This page refers to new functionality added by
 [Destinations V2](/release_notes/self-managed/upgrading_to_destinations_v2/). Typing and deduping is the default
 method of transforming datasets within data warehouse and database destinations after they've been
@@ -88,26 +87,26 @@ Consider the following [source schema](/integrations/sources/faker) for stream `
 
 The data from one stream will now be mapped to one table in your schema as below:
 
-#### Final Destination Table Name: _public.users_
+### Final Destination Table Name: _public.users_
 
-| _(note, not in actual table)_                | \_airbyte_raw_id | \_airbyte_extracted_at | \_airbyte_meta                                                 | id  | first_name | age  | address                                   |
-| -------------------------------------------- | ---------------- | ---------------------- | -------------------------------------------------------------- | --- | ---------- | ---- | ----------------------------------------- |
-| Successful typing and de-duping ⟶            | xxx-xxx-xxx      | 2022-01-01 12:00:00    | `{}`                                                           | 1   | sarah      | 39   | `{ city: “San Francisco”, zip: “94131” }` |
-| Failed typing that didn’t break other rows ⟶ | yyy-yyy-yyy      | 2022-01-01 12:00:00    | `{ changes: {"field": "age", "change": "NULLED", "reason": "DESTINATION_TYPECAST_ERROR"}}` | 2   | evan       | NULL | `{ city: “Menlo Park”, zip: “94002” }`    |
-| Not-yet-typed ⟶                              |                  |                        |                                                                |     |            |      |                                           |
+| _(note, not in actual table)_ | \_airbyte_raw_id | \_airbyte_extracted_at | \_airbyte_meta | id | first_name | age | address |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| Successful typing and de-duping ⟶ | xxx-xxx-xxx | 2022-01-01 12:00:00 | `{}` | 1 | sarah | 39 | `{ city: "San Francisco", zip: "94131" }` |
+| Failed typing that didn't break other rows ⟶ | yyy-yyy-yyy | 2022-01-01 12:00:00 | `{ changes: {"field": "age", "change": "NULLED", "reason": "DESTINATION_TYPECAST_ERROR"}}` | 2 | evan | NULL | `{ city: "Menlo Park", zip: "94002" }` |
+| Not-yet-typed ⟶ | | | | | | | |
 
 In legacy normalization, columns of
 [Airbyte type](/platform/understanding-airbyte/supported-data-types/#the-types) `Object` in the Destination
 were "unnested" into separate tables. In this example, with Destinations V2, the previously unnested
 `public.users_address` table with columns `city` and `zip` will no longer be generated.
 
-#### Raw Destination Table Name: _airbyte_internal.raw_public\_\_users_ (`airbyte_internal.raw_{namespace}__{stream}`)
+### Raw Destination Table Name: _airbyte_internal.raw_public\_\_users_ (`airbyte_internal.raw_{namespace}__{stream}`)
 
-| _(note, not in actual table)_                | \_airbyte_raw_id | \_airbyte_data﻿                                                                             | \_airbyte_loaded_at  | \_airbyte_extracted_at |
-| -------------------------------------------- | ---------------- | ------------------------------------------------------------------------------------------- | -------------------- | ---------------------- |
-| Successful typing and de-duping ⟶            | xxx-xxx-xxx      | `{ id: 1, first_name: “sarah”, age: 39, address: { city: “San Francisco”, zip: “94131” } }` | 2022-01-01 12:00:001 | 2022-01-01 12:00:00﻿   |
-| Failed typing that didn’t break other rows ⟶ | yyy-yyy-yyy      | `{ id: 2, first_name: “evan”, age: “fish”, address: { city: “Menlo Park”, zip: “94002” } }` | 2022-01-01 12:00:001 | 2022-01-01 12:00:00﻿   |
-| Not-yet-typed ⟶                              | zzz-zzz-zzz      | `{ id: 3, first_name: “edward”, age: 35, address: { city: “Sunnyvale”, zip: “94003” } }`    | NULL                 | 2022-01-01 13:00:00﻿   |
+| _(note, not in actual table)_ | \_airbyte_raw_id | \_airbyte_data | \_airbyte_loaded_at | \_airbyte_extracted_at |
+| --- | --- | --- | --- | --- |
+| Successful typing and de-duping ⟶ | xxx-xxx-xxx | `{ id: 1, first_name: "sarah", age: 39, address: { city: "San Francisco", zip: "94131" } }` | 2022-01-01 12:00:001 | 2022-01-01 12:00:00 |
+| Failed typing that didn't break other rows ⟶ | yyy-yyy-yyy | `{ id: 2, first_name: "evan", age: "fish", address: { city: "Menlo Park", zip: "94002" } }` | 2022-01-01 12:00:001 | 2022-01-01 12:00:00 |
+| Not-yet-typed ⟶ | zzz-zzz-zzz | `{ id: 3, first_name: "edward", age: 35, address: { city: "Sunnyvale", zip: "94003" } }` | NULL | 2022-01-01 13:00:00 |
 
 You also now see the following changes in Airbyte-provided columns:
 

--- a/docusaurus/platform_versioned_docs/version-2.0/using-airbyte/core-concepts/typing-deduping.md
+++ b/docusaurus/platform_versioned_docs/version-2.0/using-airbyte/core-concepts/typing-deduping.md
@@ -10,7 +10,6 @@ products: all
 With Direct Loads, there is no intermediate table result containing the raw JSON blob. Instead, top-level fields are typed during time of insert, and there is only a single destination table maintained per stream.
 :::
 
-
 This page refers to new functionality added by
 [Destinations V2](/release_notes/self-managed/upgrading_to_destinations_v2/). Typing and deduping is the default
 method of transforming datasets within data warehouse and database destinations after they've been
@@ -88,26 +87,26 @@ Consider the following [source schema](/integrations/sources/faker) for stream `
 
 The data from one stream will now be mapped to one table in your schema as below:
 
-#### Final Destination Table Name: _public.users_
+### Final Destination Table Name: _public.users_
 
-| _(note, not in actual table)_                | \_airbyte_raw_id | \_airbyte_extracted_at | \_airbyte_meta                                                 | id  | first_name | age  | address                                   |
-| -------------------------------------------- | ---------------- | ---------------------- | -------------------------------------------------------------- | --- | ---------- | ---- | ----------------------------------------- |
-| Successful typing and de-duping ⟶            | xxx-xxx-xxx      | 2022-01-01 12:00:00    | `{}`                                                           | 1   | sarah      | 39   | `{ city: “San Francisco”, zip: “94131” }` |
-| Failed typing that didn’t break other rows ⟶ | yyy-yyy-yyy      | 2022-01-01 12:00:00    | `{ changes: {"field": "age", "change": "NULLED", "reason": "DESTINATION_TYPECAST_ERROR"}}` | 2   | evan       | NULL | `{ city: “Menlo Park”, zip: “94002” }`    |
-| Not-yet-typed ⟶                              |                  |                        |                                                                |     |            |      |                                           |
+| _(note, not in actual table)_ | \_airbyte_raw_id | \_airbyte_extracted_at | \_airbyte_meta | id | first_name | age | address |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| Successful typing and de-duping ⟶ | xxx-xxx-xxx | 2022-01-01 12:00:00 | `{}` | 1 | sarah | 39 | `{ city: "San Francisco", zip: "94131" }` |
+| Failed typing that didn't break other rows ⟶ | yyy-yyy-yyy | 2022-01-01 12:00:00 | `{ changes: {"field": "age", "change": "NULLED", "reason": "DESTINATION_TYPECAST_ERROR"}}` | 2 | evan | NULL | `{ city: "Menlo Park", zip: "94002" }` |
+| Not-yet-typed ⟶ | | | | | | | |
 
 In legacy normalization, columns of
 [Airbyte type](/platform/understanding-airbyte/supported-data-types/#the-types) `Object` in the Destination
 were "unnested" into separate tables. In this example, with Destinations V2, the previously unnested
 `public.users_address` table with columns `city` and `zip` will no longer be generated.
 
-#### Raw Destination Table Name: _airbyte_internal.raw_public\_\_users_ (`airbyte_internal.raw_{namespace}__{stream}`)
+### Raw Destination Table Name: _airbyte_internal.raw_public\_\_users_ (`airbyte_internal.raw_{namespace}__{stream}`)
 
-| _(note, not in actual table)_                | \_airbyte_raw_id | \_airbyte_data﻿                                                                             | \_airbyte_loaded_at  | \_airbyte_extracted_at |
-| -------------------------------------------- | ---------------- | ------------------------------------------------------------------------------------------- | -------------------- | ---------------------- |
-| Successful typing and de-duping ⟶            | xxx-xxx-xxx      | `{ id: 1, first_name: “sarah”, age: 39, address: { city: “San Francisco”, zip: “94131” } }` | 2022-01-01 12:00:001 | 2022-01-01 12:00:00﻿   |
-| Failed typing that didn’t break other rows ⟶ | yyy-yyy-yyy      | `{ id: 2, first_name: “evan”, age: “fish”, address: { city: “Menlo Park”, zip: “94002” } }` | 2022-01-01 12:00:001 | 2022-01-01 12:00:00﻿   |
-| Not-yet-typed ⟶                              | zzz-zzz-zzz      | `{ id: 3, first_name: “edward”, age: 35, address: { city: “Sunnyvale”, zip: “94003” } }`    | NULL                 | 2022-01-01 13:00:00﻿   |
+| _(note, not in actual table)_ | \_airbyte_raw_id | \_airbyte_data | \_airbyte_loaded_at | \_airbyte_extracted_at |
+| --- | --- | --- | --- | --- |
+| Successful typing and de-duping ⟶ | xxx-xxx-xxx | `{ id: 1, first_name: "sarah", age: 39, address: { city: "San Francisco", zip: "94131" } }` | 2022-01-01 12:00:001 | 2022-01-01 12:00:00 |
+| Failed typing that didn't break other rows ⟶ | yyy-yyy-yyy | `{ id: 2, first_name: "evan", age: "fish", address: { city: "Menlo Park", zip: "94002" } }` | 2022-01-01 12:00:001 | 2022-01-01 12:00:00 |
+| Not-yet-typed ⟶ | zzz-zzz-zzz | `{ id: 3, first_name: "edward", age: 35, address: { city: "Sunnyvale", zip: "94003" } }` | NULL | 2022-01-01 13:00:00 |
 
 You also now see the following changes in Airbyte-provided columns:
 

--- a/docusaurus/platform_versioned_docs/version-2.1/using-airbyte/core-concepts/typing-deduping.md
+++ b/docusaurus/platform_versioned_docs/version-2.1/using-airbyte/core-concepts/typing-deduping.md
@@ -10,7 +10,6 @@ products: all
 With Direct Loads, there is no intermediate table result containing the raw JSON blob. Instead, top-level fields are typed during time of insert, and there is only a single destination table maintained per stream.
 :::
 
-
 This page refers to new functionality added by
 [Destinations V2](/release_notes/self-managed/upgrading_to_destinations_v2/). Typing and deduping is the default
 method of transforming datasets within data warehouse and database destinations after they've been
@@ -88,26 +87,26 @@ Consider the following [source schema](/integrations/sources/faker) for stream `
 
 The data from one stream will now be mapped to one table in your schema as below:
 
-#### Final Destination Table Name: _public.users_
+### Final Destination Table Name: _public.users_
 
-| _(note, not in actual table)_                | \_airbyte_raw_id | \_airbyte_extracted_at | \_airbyte_meta                                                 | id  | first_name | age  | address                                   |
-| -------------------------------------------- | ---------------- | ---------------------- | -------------------------------------------------------------- | --- | ---------- | ---- | ----------------------------------------- |
-| Successful typing and de-duping ⟶            | xxx-xxx-xxx      | 2022-01-01 12:00:00    | `{}`                                                           | 1   | sarah      | 39   | `{ city: “San Francisco”, zip: “94131” }` |
-| Failed typing that didn’t break other rows ⟶ | yyy-yyy-yyy      | 2022-01-01 12:00:00    | `{ changes: {"field": "age", "change": "NULLED", "reason": "DESTINATION_TYPECAST_ERROR"}}` | 2   | evan       | NULL | `{ city: “Menlo Park”, zip: “94002” }`    |
-| Not-yet-typed ⟶                              |                  |                        |                                                                |     |            |      |                                           |
+| _(note, not in actual table)_ | \_airbyte_raw_id | \_airbyte_extracted_at | \_airbyte_meta | id | first_name | age | address |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| Successful typing and de-duping ⟶ | xxx-xxx-xxx | 2022-01-01 12:00:00 | `{}` | 1 | sarah | 39 | `{ city: "San Francisco", zip: "94131" }` |
+| Failed typing that didn't break other rows ⟶ | yyy-yyy-yyy | 2022-01-01 12:00:00 | `{ changes: {"field": "age", "change": "NULLED", "reason": "DESTINATION_TYPECAST_ERROR"}}` | 2 | evan | NULL | `{ city: "Menlo Park", zip: "94002" }` |
+| Not-yet-typed ⟶ | | | | | | | |
 
 In legacy normalization, columns of
 [Airbyte type](/platform/understanding-airbyte/supported-data-types/#the-types) `Object` in the Destination
 were "unnested" into separate tables. In this example, with Destinations V2, the previously unnested
 `public.users_address` table with columns `city` and `zip` will no longer be generated.
 
-#### Raw Destination Table Name: _airbyte_internal.raw_public\_\_users_ (`airbyte_internal.raw_{namespace}__{stream}`)
+### Raw Destination Table Name: _airbyte_internal.raw_public\_\_users_ (`airbyte_internal.raw_{namespace}__{stream}`)
 
-| _(note, not in actual table)_                | \_airbyte_raw_id | \_airbyte_data﻿                                                                             | \_airbyte_loaded_at  | \_airbyte_extracted_at |
-| -------------------------------------------- | ---------------- | ------------------------------------------------------------------------------------------- | -------------------- | ---------------------- |
-| Successful typing and de-duping ⟶            | xxx-xxx-xxx      | `{ id: 1, first_name: “sarah”, age: 39, address: { city: “San Francisco”, zip: “94131” } }` | 2022-01-01 12:00:001 | 2022-01-01 12:00:00﻿   |
-| Failed typing that didn’t break other rows ⟶ | yyy-yyy-yyy      | `{ id: 2, first_name: “evan”, age: “fish”, address: { city: “Menlo Park”, zip: “94002” } }` | 2022-01-01 12:00:001 | 2022-01-01 12:00:00﻿   |
-| Not-yet-typed ⟶                              | zzz-zzz-zzz      | `{ id: 3, first_name: “edward”, age: 35, address: { city: “Sunnyvale”, zip: “94003” } }`    | NULL                 | 2022-01-01 13:00:00﻿   |
+| _(note, not in actual table)_ | \_airbyte_raw_id | \_airbyte_data | \_airbyte_loaded_at | \_airbyte_extracted_at |
+| --- | --- | --- | --- | --- |
+| Successful typing and de-duping ⟶ | xxx-xxx-xxx | `{ id: 1, first_name: "sarah", age: 39, address: { city: "San Francisco", zip: "94131" } }` | 2022-01-01 12:00:001 | 2022-01-01 12:00:00 |
+| Failed typing that didn't break other rows ⟶ | yyy-yyy-yyy | `{ id: 2, first_name: "evan", age: "fish", address: { city: "Menlo Park", zip: "94002" } }` | 2022-01-01 12:00:001 | 2022-01-01 12:00:00 |
+| Not-yet-typed ⟶ | zzz-zzz-zzz | `{ id: 3, first_name: "edward", age: 35, address: { city: "Sunnyvale", zip: "94003" } }` | NULL | 2022-01-01 13:00:00 |
 
 You also now see the following changes in Airbyte-provided columns:
 


### PR DESCRIPTION
This PR targets the following PR:
- #76447

---

## What

Fix all 222 markdownlint errors across the 49 changed markdown files in the `docs-airbyte-agents` integration branch.

## How

Systematically fixed each category of lint violation:

- **MD004** (6): Convert asterisks to dashes for unordered lists
- **MD009** (21): Remove trailing whitespace
- **MD012** (25): Remove multiple consecutive blank lines
- **MD022** (7): Add blank lines around headings
- **MD025** (1): Fix duplicate top-level heading (h1 -> h2)
- **MD029** (7): Fix ordered list numbering by indenting images/content under list items
- **MD032** (5): Add blank lines around lists
- **MD038** (1): Fix spaces inside code spans
- **MD040** (1): Add language identifier to fenced code block
- **MD045** (1): Add alt text to image
- **MD051** (3): Fix broken link fragments (`#destinations-v2-effective-versions` -> `#destinations-v2-compatible-versions`)
- **MD059** (27): Replace non-descriptive `[here]` links with descriptive text
- **MD060** (109): Fix table column spacing and convert misaligned tables to compact style
- **MD001** (8): Fix heading increment levels (e.g. `####` under `##` -> `###`)

## Review guide

Changes span 34 files across `docs/` and `docusaurus/platform_versioned_docs/`. All changes are whitespace/formatting/link-text only — no content changes.

Key areas:
1. `docs/ai-agents/` - heading levels, table separators, code fence language
2. `docs/integrations/destinations/*-migrations.md` - descriptive link text replacing `[here]`
3. `docs/release_notes/self-managed/` - blanks around headings, trailing spaces, descriptive links
4. `docs/platform/using-airbyte/core-concepts/typing-deduping.md` - heading levels, table compaction
5. `docusaurus/platform_versioned_docs/` - same typing-deduping fixes across versioned docs

## User Impact

Cleaner markdown that passes linting. No user-visible changes since these are formatting-only fixes.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Link to Devin session: https://app.devin.ai/sessions/82a7c12a4eaf4222925048a62028f556
Requested by: @ian-at-airbyte