### PR TITLE
feat(source-ashby): add metadata-driven smoke-test scenario and 1Password CI creds

### DIFF
--- a/.github/workflows/connector-ci-checks.yml
+++ b/.github/workflows/connector-ci-checks.yml
@@ -127,10 +127,9 @@ jobs:
     env:
       GCP_GSM_CREDENTIALS: ${{ secrets.GCP_GSM_CREDENTIALS }}
       GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID || vars.GCP_PROJECT_ID }}
-      # 1Password-backed credentials for connectors that declare a `smokeTests`
-      # suite in `metadata.yaml`. Required only when `${secret-ref:...}` sigils
-      # are present; legacy GSM-fetched connectors are unaffected.
-      AIRBYTE_TEST_CREDS_PROVIDER: 1pass
+      # Forks can opt into 1Password-backed smoke-test credentials by setting
+      # `AIRBYTE_TEST_CREDS_PROVIDER=1pass` and `OP_SERVICE_ACCOUNT_TOKEN` in their
+      # repository vars/secrets, and optionally overriding the default vault name:
       AIRBYTE_TEST_CREDS_1PASS_VAULT_NAME: ${{ vars.AIRBYTE_TEST_CREDS_1PASS_VAULT_NAME || 'connector-integration-test-creds' }}
       OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
       DD_TAGS: "connector.name:${{ matrix.connector }}"
@@ -226,10 +225,9 @@ jobs:
     env:
       GCP_GSM_CREDENTIALS: ${{ secrets.GCP_GSM_CREDENTIALS }}
       GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID || vars.GCP_PROJECT_ID }}
-      # 1Password-backed credentials for connectors that declare a `smokeTests`
-      # suite in `metadata.yaml`. Required only when `${secret-ref:...}` sigils
-      # are present; legacy GSM-fetched connectors are unaffected.
-      AIRBYTE_TEST_CREDS_PROVIDER: 1pass
+      # Forks can opt into 1Password-backed smoke-test credentials by setting
+      # `AIRBYTE_TEST_CREDS_PROVIDER=1pass` and `OP_SERVICE_ACCOUNT_TOKEN` in their
+      # repository vars/secrets, and optionally overriding the default vault name:
       AIRBYTE_TEST_CREDS_1PASS_VAULT_NAME: ${{ vars.AIRBYTE_TEST_CREDS_1PASS_VAULT_NAME || 'connector-integration-test-creds' }}
       OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
 

--- a/.github/workflows/connector-ci-checks.yml
+++ b/.github/workflows/connector-ci-checks.yml
@@ -128,10 +128,10 @@ jobs:
       GCP_GSM_CREDENTIALS: ${{ secrets.GCP_GSM_CREDENTIALS }}
       GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID || vars.GCP_PROJECT_ID }}
       # Forks can opt into 1Password-backed smoke-test credentials by setting
-      # `AIRBYTE_TEST_CREDS_PROVIDER=1pass` and `OP_SERVICE_ACCOUNT_TOKEN` in their
-      # repository vars/secrets, and optionally overriding the default vault name:
+      # `AIRBYTE_TEST_CREDS_PROVIDER=1pass` and `AIRBYTE_TEST_CREDS_1PASS_SERVICE_TOKEN`
+      # in their repository vars/secrets, and optionally overriding the default vault name:
       AIRBYTE_TEST_CREDS_1PASS_VAULT_NAME: ${{ vars.AIRBYTE_TEST_CREDS_1PASS_VAULT_NAME || 'connector-integration-test-creds' }}
-      OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+      AIRBYTE_TEST_CREDS_1PASS_SERVICE_TOKEN: ${{ secrets.AIRBYTE_TEST_CREDS_1PASS_SERVICE_TOKEN }}
       DD_TAGS: "connector.name:${{ matrix.connector }}"
       DOCKER_API_VERSION: "1.44"
 
@@ -226,10 +226,10 @@ jobs:
       GCP_GSM_CREDENTIALS: ${{ secrets.GCP_GSM_CREDENTIALS }}
       GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID || vars.GCP_PROJECT_ID }}
       # Forks can opt into 1Password-backed smoke-test credentials by setting
-      # `AIRBYTE_TEST_CREDS_PROVIDER=1pass` and `OP_SERVICE_ACCOUNT_TOKEN` in their
-      # repository vars/secrets, and optionally overriding the default vault name:
+      # `AIRBYTE_TEST_CREDS_PROVIDER=1pass` and `AIRBYTE_TEST_CREDS_1PASS_SERVICE_TOKEN`
+      # in their repository vars/secrets, and optionally overriding the default vault name:
       AIRBYTE_TEST_CREDS_1PASS_VAULT_NAME: ${{ vars.AIRBYTE_TEST_CREDS_1PASS_VAULT_NAME || 'connector-integration-test-creds' }}
-      OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+      AIRBYTE_TEST_CREDS_1PASS_SERVICE_TOKEN: ${{ secrets.AIRBYTE_TEST_CREDS_1PASS_SERVICE_TOKEN }}
 
     strategy:
       matrix: ${{ fromJson(needs.generate-matrix.outputs.non-jvm-connectors-matrix) }}

--- a/.github/workflows/connector-ci-checks.yml
+++ b/.github/workflows/connector-ci-checks.yml
@@ -127,6 +127,12 @@ jobs:
     env:
       GCP_GSM_CREDENTIALS: ${{ secrets.GCP_GSM_CREDENTIALS }}
       GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID || vars.GCP_PROJECT_ID }}
+      # 1Password-backed credentials for connectors that declare a `smokeTests`
+      # suite in `metadata.yaml`. Required only when `${secret-ref:...}` sigils
+      # are present; legacy GSM-fetched connectors are unaffected.
+      AIRBYTE_TEST_CREDS_PROVIDER: 1pass
+      AIRBYTE_TEST_CREDS_1PASS_VAULT_NAME: ${{ vars.AIRBYTE_TEST_CREDS_1PASS_VAULT_NAME || 'connector-integration-test-creds' }}
+      OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
       DD_TAGS: "connector.name:${{ matrix.connector }}"
       DOCKER_API_VERSION: "1.44"
 
@@ -220,6 +226,12 @@ jobs:
     env:
       GCP_GSM_CREDENTIALS: ${{ secrets.GCP_GSM_CREDENTIALS }}
       GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID || vars.GCP_PROJECT_ID }}
+      # 1Password-backed credentials for connectors that declare a `smokeTests`
+      # suite in `metadata.yaml`. Required only when `${secret-ref:...}` sigils
+      # are present; legacy GSM-fetched connectors are unaffected.
+      AIRBYTE_TEST_CREDS_PROVIDER: 1pass
+      AIRBYTE_TEST_CREDS_1PASS_VAULT_NAME: ${{ vars.AIRBYTE_TEST_CREDS_1PASS_VAULT_NAME || 'connector-integration-test-creds' }}
+      OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
 
     strategy:
       matrix: ${{ fromJson(needs.generate-matrix.outputs.non-jvm-connectors-matrix) }}

--- a/airbyte-integrations/connectors/source-ashby/metadata.yaml
+++ b/airbyte-integrations/connectors/source-ashby/metadata.yaml
@@ -36,6 +36,12 @@ data:
   supportLevel: community
   connectorTestSuitesOptions:
     - suite: unitTests
+    - suite: smokeTests
+      scenarios:
+        - name: default
+          configSettings:
+            api_key: "${secret-ref:ashby/test-credentials-api_key/api_key}"
+            start_date: "${relative-date:-P30D}"
   connectorBuildOptions:
     baseImage: docker.io/airbyte/source-declarative-manifest:7.17.2@sha256:1bfcca53335b2669b02414180fe9ad96b0abd9c95d6cbf50089c1d881fc07801
   externalDocumentationUrls:


### PR DESCRIPTION
## What

First concrete consumer of the new `metadata.yaml` smoke-test dialect (proposed in airbytehq/airbyte-connector-models#42 and consumed in airbytehq/airbyte-python-cdk#999) plus the CI plumbing that exposes 1Password-backed credentials to the connector test jobs.

Two changes, intentionally combined per request:

1. **`airbyte-integrations/connectors/source-ashby/metadata.yaml`** — adds a `smokeTests` suite with one `default` scenario:

   ```yaml
   - suite: smokeTests
     scenarios:
       - name: default
         configSettings:
           api_key: "${secret-ref:ashby/test-credentials-api_key/api_key}"
           start_date: "${relative-date:-P30D}"
   ```

   The `secret-ref` sigil uses the literal 1Password section name (`test-credentials-api_key`) — no prefix-stripping. The `relative-date` sigil renders to an RFC 3339 timestamp anchored at today's UTC midnight (e.g. `2026-03-22T00:00:00Z`).

2. **`.github/workflows/connector-ci-checks.yml`** — adds three env vars to both `jvm-connectors-test` and `non-jvm-connectors-test` jobs:

   ```yaml
   AIRBYTE_TEST_CREDS_PROVIDER: 1pass
   AIRBYTE_TEST_CREDS_1PASS_VAULT_NAME: ${{ vars.AIRBYTE_TEST_CREDS_1PASS_VAULT_NAME || 'connector-integration-test-creds' }}
   OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
   ```

   The vault name is overridable via repo `vars` and falls back to the existing default. These env vars are required **only when** a `${secret-ref:...}` sigil actually appears in `configSettings`; legacy GSM-fetched connectors are unaffected.

## How

- **metadata.yaml** — additive; the existing `connectorTestSuitesOptions` already lists `unitTests`, this just appends `smokeTests`. No spec, dockerImageTag, or other connector-runtime fields are touched.
- **connector-ci-checks.yml** — env vars are added alongside the existing `GCP_GSM_CREDENTIALS` / `GCP_PROJECT_ID` block, with an inline comment explaining the `smokeTests` opt-in semantics. Missing org-level secrets resolve to empty strings, which is fine — the CDK only validates the provider env vars when a sigil is actually present.

## Review guide

1. `airbyte-integrations/connectors/source-ashby/metadata.yaml` — confirm 3-segment sigil shape and literal section name.
2. `.github/workflows/connector-ci-checks.yml` — two near-identical env blocks (jvm + non-jvm jobs).

## User Impact

None today. This PR is structurally complete but functionally inert until two follow-ups land:

- airbytehq/airbyte-python-cdk#999 — scenario loader that resolves the sigils at test-collection time.
- airbytehq/airbyte-ops-mcp follow-up — per-section `.env.<literal-section>` writer that the CDK reads.

Once those land, `airbyte-ci connectors test --name=source-ashby` will auto-discover the smoke-test scenario, fetch creds from 1Password (vault `connector-integration-test-creds`, item `ashby`, section `test-credentials-api_key`), and run a check/spec/read against a fresh `start_date = today - 30 days` configuration.

Legacy GSM-based credential fetching for any other connector is **not** affected by this change.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

The metadata.yaml addition is additive (no existing scenarios consume it yet). The workflow env vars only matter for connectors that opt in via a `smokeTests` block, so reverting just removes plumbing that nothing in production reads today.


Link to Devin session: https://app.devin.ai/sessions/5c2ccf537b70486b9e6fbc974d26063e
Requested by: @aaronsteers