### PR TITLE
ci: fix `airbyte-ops: command not found` in connector test secret fetch

### DIFF
--- a/.github/workflows/connector-ci-checks.yml
+++ b/.github/workflows/connector-ci-checks.yml
@@ -190,7 +190,7 @@ jobs:
         # Later integration tests will likely fail in this case, but we at least let them run.
         if: matrix.connector && needs.generate-matrix.outputs.creds-available == 'true'
         run: |
-          airbyte-ops secrets fetch ${{ matrix.connector }} \
+          uvx airbyte-internal-ops secrets fetch ${{ matrix.connector }} \
             --print-ci-secrets-masks
 
       - name: Run Unit Tests ${{ needs.generate-matrix.outputs.creds-available == 'false' && '[Non-Blocking (Unprivileged) Test From Fork, pls run `/run-connector-tests`]' || '' }}
@@ -288,7 +288,7 @@ jobs:
         # Later integration tests will likely fail in this case, but we at least let them run.
         if: matrix.connector && env.GCP_PROJECT_ID != ''
         run: |
-          airbyte-ops secrets fetch ${{ matrix.connector }} \
+          uvx airbyte-internal-ops secrets fetch ${{ matrix.connector }} \
             --print-ci-secrets-masks
 
       - name: Run Unit Tests ${{ needs.generate-matrix.outputs.creds-available == 'false' && '[Non-Blocking (Unprivileged) Test From Fork, pls run `/run-connector-tests`]' || '' }}


### PR DESCRIPTION
## What

Fixes a CI regression introduced in #76867 (`9c7f64a49a3`) that breaks the `Fetch connector secrets` step on every PR with `creds-available == 'true'` (i.e. PRs from this org, not forks).

#76867's PR body described the migration as `airbyte-cdk secrets fetch` → `uvx airbyte-internal-ops secrets fetch`, but the diff at the two test-job call sites in `connector-ci-checks.yml` ended up as the bare `airbyte-ops secrets fetch` form. The `airbyte-ops` executable is provisioned by `uv tool install airbyte-internal-ops`, which the `run-qa-checks` (line 444) and `build-and-verify-artifacts` (line 513) jobs do explicitly — but the `jvm-connectors-test` and `non-jvm-connectors-test` jobs do *not*. Result: the step fails with `airbyte-ops: command not found` (exit 127) before the unit / integration tests run.

Concrete failure: e.g. https://github.com/airbytehq/airbyte/pull/77129 — `Test source-ashby Connector` job, exit 127 at the `Fetch connector secrets` step.

## How

Match #76867's stated intent by switching the two test-job call sites to the `uvx` form. `uvx` is self-installing per invocation and is already present in both jobs (`astral-sh/setup-uv` runs earlier). No additional install step needed, no behavioral change beyond getting the right binary on PATH.

## Review guide

1. `.github/workflows/connector-ci-checks.yml` — two-line change at the `jvm-connectors-test` and `non-jvm-connectors-test` `Fetch connector secrets` steps.

## User Impact

Unblocks CI on every PR with `creds-available == 'true'`. No runtime behavior change for connector developers.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚


Link to Devin session: https://app.devin.ai/sessions/5c2ccf537b70486b9e6fbc974d26063e
Requested by: @aaronsteers