### PR TITLE
chore(source-amazon-seller-partner): restore HTTPAPIBudget and ship 5.7.4

### DIFF
--- a/airbyte-integrations/connectors/source-amazon-seller-partner/manifest.yaml
+++ b/airbyte-integrations/connectors/source-amazon-seller-partner/manifest.yaml
@@ -285,7 +285,7 @@ spec:
         title: Number of Workers
         description: The number of workers to use for the connector when syncing concurrently.
         type: integer
-        default: 4
+        default: 2
         minimum: 2
         maximum: 10
         order: 14
@@ -3186,68 +3186,68 @@ definitions:
           - path: ["dataEndTime"]
             value: "{{ format_datetime(stream_slice['end_time'], '%Y-%m-%d') }}"
 
-# api_budget:
-#   type: HTTPAPIBudget
-#   policies:
-#     - type: MovingWindowCallRatePolicy
-#       rates:
-#         - limit: 1 # burst: 0.0167 calls per second
-#           interval: PT1M
-#       matchers:
-#         - method: GET
-#           url_path_pattern: "orders/v0/orders(\\?.*)?$" # matches '/orders' (exact or with trailing slash/extra)
-#     - type: MovingWindowCallRatePolicy
-#       rates:
-#         - limit: 1 # burst: 0.5 call per second
-#           interval: PT2S
-#       matchers:
-#         - method: GET
-#           url_path_pattern: "orders/v0/orders/[^/]+/orderItems(\\?.*)?$" # matches /orderItems
-#
-#     # SP-API Reports v2021-06-30
-#
-#     # 1) Create report  (POST /reports/2021-06-30/reports)
-#     #   Default: ~0.0167 rps (≈1/min), burst 15
-#     - type: MovingWindowCallRatePolicy
-#       rates:
-#         - limit: 1
-#           interval: PT1M
-#       matchers:
-#         - method: POST
-#           url_path_pattern: "reports/2021-06-30/reports$"
-#
-#     # 2) Poll report status  (GET /reports/2021-06-30/reports/{reportId})
-#     #   Default: 2 rps, burst 15
-#     - type: MovingWindowCallRatePolicy
-#       rates:
-#         - limit: 2
-#           interval: PT1S
-#       matchers:
-#         - method: GET
-#           url_path_pattern: "reports/2021-06-30/reports/[^/]+$"
-#
-#     # 3) Get report document metadata  (GET /reports/2021-06-30/documents/{documentId})
-#     #   Default: ~0.0167 rps (≈1/min), burst 15
-#     - type: MovingWindowCallRatePolicy
-#       rates:
-#         - limit: 1
-#           interval: PT1M
-#       matchers:
-#         - method: GET
-#           url_path_pattern: "reports/2021-06-30/documents/[^/]+$"
-#
-#     # SP-API Finances v0
-#     # ListFinancialEvents: Rate 0.5 rps, Burst 30
-#     - type: MovingWindowCallRatePolicy
-#       rates:
-#         - limit: 1
-#           interval: PT2S
-#       matchers:
-#         - method: GET
-#           url_path_pattern: "finances/v0/financialEvents(\\?.*)?$"
-#
-#   # Other API budget settings:
-#   status_codes_for_ratelimit_hit: [429]
+api_budget:
+  type: HTTPAPIBudget
+  policies:
+    - type: MovingWindowCallRatePolicy
+      rates:
+        - limit: 1 # burst: 0.0167 calls per second
+          interval: PT1M
+      matchers:
+        - method: GET
+          url_path_pattern: "orders/v0/orders(\\?.*)?$" # matches '/orders' (exact or with trailing slash/extra)
+    - type: MovingWindowCallRatePolicy
+      rates:
+        - limit: 1 # burst: 0.5 call per second
+          interval: PT2S
+      matchers:
+        - method: GET
+          url_path_pattern: "orders/v0/orders/[^/]+/orderItems(\\?.*)?$" # matches /orderItems
+
+    # SP-API Reports v2021-06-30
+
+    # 1) Create report  (POST /reports/2021-06-30/reports)
+    #   Default: ~0.0167 rps (≈1/min), burst 15
+    - type: MovingWindowCallRatePolicy
+      rates:
+        - limit: 1
+          interval: PT1M
+      matchers:
+        - method: POST
+          url_path_pattern: "reports/2021-06-30/reports$"
+
+    # 2) Poll report status  (GET /reports/2021-06-30/reports/{reportId})
+    #   Default: 2 rps, burst 15
+    - type: MovingWindowCallRatePolicy
+      rates:
+        - limit: 2
+          interval: PT1S
+      matchers:
+        - method: GET
+          url_path_pattern: "reports/2021-06-30/reports/[^/]+$"
+
+    # 3) Get report document metadata  (GET /reports/2021-06-30/documents/{documentId})
+    #   Default: ~0.0167 rps (≈1/min), burst 15
+    - type: MovingWindowCallRatePolicy
+      rates:
+        - limit: 1
+          interval: PT1M
+      matchers:
+        - method: GET
+          url_path_pattern: "reports/2021-06-30/documents/[^/]+$"
+
+    # SP-API Finances v0
+    # ListFinancialEvents: Rate 0.5 rps, Burst 30
+    - type: MovingWindowCallRatePolicy
+      rates:
+        - limit: 1
+          interval: PT2S
+      matchers:
+        - method: GET
+          url_path_pattern: "finances/v0/financialEvents(\\?.*)?$"
+
+  # Other API budget settings:
+  status_codes_for_ratelimit_hit: [429]
 
 streams:
   # REST Streams
@@ -3311,7 +3311,7 @@ streams:
 
 concurrency_level:
   type: ConcurrencyLevel
-  default_concurrency: "{{ config.get('num_workers', 4) }}"
+  default_concurrency: "{{ config.get('num_workers', 2) }}"
   max_concurrency: 10
 max_concurrent_async_job_count: "{{ config.get('max_async_job_count', 2) }}"
 

--- a/airbyte-integrations/connectors/source-amazon-seller-partner/metadata.yaml
+++ b/airbyte-integrations/connectors/source-amazon-seller-partner/metadata.yaml
@@ -15,7 +15,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: e55879a8-0ef8-4557-abcf-ab34c53ec460
-  dockerImageTag: 5.7.4-rc.1
+  dockerImageTag: 5.7.4
   dockerRepository: airbyte/source-amazon-seller-partner
   documentationUrl: https://docs.airbyte.com/integrations/sources/amazon-seller-partner
   erdUrl: https://dbdocs.io/airbyteio/source-amazon-seller-partner?view=relationships
@@ -42,7 +42,7 @@ data:
       - ListFinancialEventGroups
   releases:
     rolloutConfiguration:
-      enableProgressiveRollout: true
+      enableProgressiveRollout: false
     breakingChanges:
       2.0.0:
         message: "Deprecated FBA reports will be removed permanently from Cloud and Brand Analytics Reports will be removed temporarily. Updates on Brand Analytics Reports can be tracked here: [#32353](https://github.com/airbytehq/airbyte/issues/32353)"

--- a/docs/integrations/sources/amazon-seller-partner.md
+++ b/docs/integrations/sources/amazon-seller-partner.md
@@ -299,7 +299,7 @@ You may also combine this with a smaller **Financial Events Step Size** (e.g., 1
 
 | Version    | Date       | Pull Request                                              | Subject                                                                                                                                                                             |
 |:-----------|:-----------|:----------------------------------------------------------|:------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| 5.7.4 | 2026-04-28 | [*PR_NUMBER_PLACEHOLDER*](https://github.com/airbytehq/airbyte/pull/*PR_NUMBER_PLACEHOLDER*) | Restore HTTPAPIBudget that was temporarily commented out in 5.7.4-rc.1; revert default_concurrency back to 2. Concurrency tuning rollout was canceled and is being deferred. |
+| 5.7.4 | 2026-04-28 | [77521](https://github.com/airbytehq/airbyte/pull/77521) | Restore HTTPAPIBudget that was temporarily commented out in 5.7.4-rc.1; revert default_concurrency back to 2. Concurrency tuning rollout was canceled and is being deferred. |
 | 5.7.4-rc.1 | 2026-04-23 | [76955](https://github.com/airbytehq/airbyte/pull/76955) | Concurrency tuning iteration 1: bump default_concurrency from 2 to 4 and temporarily comment out HTTPAPIBudget to measure empirical concurrency ceiling. |
 | 5.7.3 | 2026-04-21 | [76494](https://github.com/airbytehq/airbyte/pull/76494) | Update dependencies |
 | 5.7.2 | 2026-04-13 | [75143](https://github.com/airbytehq/airbyte/pull/75143) | Fix incorrect URL path for GET_V2_SETTLEMENT_REPORT_DATA_FLAT_FILE stream — add missing `/reports/` segment |

--- a/docs/integrations/sources/amazon-seller-partner.md
+++ b/docs/integrations/sources/amazon-seller-partner.md
@@ -299,7 +299,8 @@ You may also combine this with a smaller **Financial Events Step Size** (e.g., 1
 
 | Version    | Date       | Pull Request                                              | Subject                                                                                                                                                                             |
 |:-----------|:-----------|:----------------------------------------------------------|:------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| 5.7.4-rc.1 | 2026-04-23 | [*PR_NUMBER_PLACEHOLDER*](https://github.com/airbytehq/airbyte/pull/*PR_NUMBER_PLACEHOLDER*) | Concurrency tuning iteration 1: bump default_concurrency from 2 to 4 and temporarily comment out HTTPAPIBudget to measure empirical concurrency ceiling. |
+| 5.7.4 | 2026-04-28 | [*PR_NUMBER_PLACEHOLDER*](https://github.com/airbytehq/airbyte/pull/*PR_NUMBER_PLACEHOLDER*) | Restore HTTPAPIBudget that was temporarily commented out in 5.7.4-rc.1; revert default_concurrency back to 2. Concurrency tuning rollout was canceled and is being deferred. |
+| 5.7.4-rc.1 | 2026-04-23 | [76955](https://github.com/airbytehq/airbyte/pull/76955) | Concurrency tuning iteration 1: bump default_concurrency from 2 to 4 and temporarily comment out HTTPAPIBudget to measure empirical concurrency ceiling. |
 | 5.7.3 | 2026-04-21 | [76494](https://github.com/airbytehq/airbyte/pull/76494) | Update dependencies |
 | 5.7.2 | 2026-04-13 | [75143](https://github.com/airbytehq/airbyte/pull/75143) | Fix incorrect URL path for GET_V2_SETTLEMENT_REPORT_DATA_FLAT_FILE stream — add missing `/reports/` segment |
 | 5.7.1 | 2026-04-08 | [76031](https://github.com/airbytehq/airbyte/pull/76031) | Deprecate non-functional `wait_to_avoid_fatal_errors` config option (hidden from UI) |


### PR DESCRIPTION
## What

Reverts the manifest changes from PR #76955 (`5.7.4-rc.1`) and ships as plain GA `5.7.4`. The concurrency tuning rollout that was started against `5.7.4-rc.1` has been canceled and tuning is being deferred.

Net effect of merging this PR vs. master: the connector behavior matches the prior stable `5.7.3` release, with the version bumped to `5.7.4`.

## How

- `manifest.yaml`: uncomment HTTPAPIBudget (6 `MovingWindowCallRatePolicy` policies are active again).
- `manifest.yaml`: revert `num_workers` default from 4 → 2.
- `manifest.yaml`: revert `default_concurrency` Jinja fallback from 4 → 2.
- `metadata.yaml`: bump `dockerImageTag` `5.7.4-rc.1` → `5.7.4`.
- `metadata.yaml`: `enableProgressiveRollout` true → false (no progressive rollout — straight GA).
- `docs/integrations/sources/amazon-seller-partner.md`: changelog entry for `5.7.4` documenting the revert.

After this PR merges, `manifest.yaml` is byte-identical to the pre-#76955 state and `metadata.yaml` differs only in `dockerImageTag` (`5.7.3` → `5.7.4`).

Rollout `2339d486-6f4e-4afe-83d2-dc4a26feb284` (17 TIER_2 actors pinned to `5.7.4-rc.1`) was canceled with `retain_pins_on_cancellation=False`. The async `finalize_rollout.yml` workflow will unpin those actors back to the GA default.

## Review guide

1. `airbyte-integrations/connectors/source-amazon-seller-partner/manifest.yaml`
2. `airbyte-integrations/connectors/source-amazon-seller-partner/metadata.yaml`
3. `docs/integrations/sources/amazon-seller-partner.md`

## User Impact

Users on `5.7.4-rc.1` (the pinned 17 TIER_2 actors) will return to the same behavior as `5.7.3`: `default_concurrency=2` with the HTTPAPIBudget enforcing per-endpoint rate limits. Users already on `5.7.3` see no change other than the version number.

## Can this PR be safely reverted and rolled back?
- [x] YES 💚
- [ ] NO ❌

Link to Devin session: https://app.devin.ai/sessions/eb2ea3f67f5f4abea5dfa13d12e77ad2
Requested by: @sophiecuiy