### PR TITLE
fix(source-hubspot): use fully qualified names for custom object streams

### DIFF
--- a/airbyte-integrations/connectors/source-hubspot/manifest.yaml
+++ b/airbyte-integrations/connectors/source-hubspot/manifest.yaml
@@ -2286,17 +2286,17 @@ dynamic_streams:
         - type: ComponentMappingDefinition
           field_path:
             - name
-          value: "{{ components_values.name }}"
+          value: "{{ components_values.fullyQualifiedName or 'p_' + components_values.name }}"
         - type: ComponentMappingDefinition
           field_path:
             - full_refresh_stream
             - name
-          value: "{{ components_values.name }}"
+          value: "{{ components_values.fullyQualifiedName or 'p_' + components_values.name }}"
         - type: ComponentMappingDefinition
           field_path:
             - incremental_stream
             - name
-          value: "{{ components_values.name }}"
+          value: "{{ components_values.fullyQualifiedName or 'p_' + components_values.name }}"
         - type: ComponentMappingDefinition
           field_path:
             - $parameters

--- a/airbyte-integrations/connectors/source-hubspot/metadata.yaml
+++ b/airbyte-integrations/connectors/source-hubspot/metadata.yaml
@@ -10,7 +10,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 36c891d9-4bd9-43ac-bad2-10e12756272c
-  dockerImageTag: 6.5.5
+  dockerImageTag: 6.5.6
   dockerRepository: airbyte/source-hubspot
   documentationUrl: https://docs.airbyte.com/integrations/sources/hubspot
   resourceRequirements:

--- a/airbyte-integrations/connectors/source-hubspot/unit_tests/test_source.py
+++ b/airbyte-integrations/connectors/source-hubspot/unit_tests/test_source.py
@@ -118,6 +118,29 @@ def test_streams_ok_with_one_custom_stream(requests_mock, config, mock_dynamic_s
     assert len(streams) == 37
 
 
+def test_custom_object_stream_uses_fully_qualified_name_to_avoid_builtin_collision(requests_mock, config, mock_dynamic_schema_requests):
+    adapter = requests_mock.get(
+        "https://api.hubapi.com/crm/v3/schemas",
+        json={
+            "results": [
+                {
+                    "name": "form_submissions",
+                    "fullyQualifiedName": "p123456_form_submissions",
+                    "properties": {},
+                }
+            ]
+        },
+        status_code=200,
+    )
+
+    stream_names = [stream.name for stream in discover(get_source(config), config).catalog.catalog.streams]
+
+    assert adapter.called
+    assert "form_submissions" in stream_names
+    assert "p123456_form_submissions" in stream_names
+    assert stream_names.count("form_submissions") == 1
+
+
 def test_check_connection_backoff_on_limit_reached(requests_mock, config):
     """Error once, check that we retry and not fail"""
     prop_response = [

--- a/airbyte-integrations/connectors/source-hubspot/unit_tests/test_streams.py
+++ b/airbyte-integrations/connectors/source-hubspot/unit_tests/test_streams.py
@@ -550,7 +550,7 @@ def test_custom_object_stream_doesnt_call_hubspot_to_get_json_schema_if_availabl
 ):
     adapter = requests_mock.register_uri("GET", "/crm/v3/schemas", json={"results": [custom_object_schema]})
     streams = discover(get_source(config), config)
-    json_schema = [s.json_schema for s in streams.catalog.catalog.streams if s.name == "animals"][0]
+    json_schema = [s.json_schema for s in streams.catalog.catalog.streams if s.name == custom_object_schema["fullyQualifiedName"]][0]
 
     assert json_schema == expected_custom_object_json_schema
     # called only once when creating dynamic streams
@@ -563,8 +563,10 @@ def test_get_custom_objects_metadata_success(
     requests_mock.register_uri("GET", "/crm/v3/schemas", json={"results": [custom_object_schema]})
     source_hubspot = get_source(config)
     streams = discover(source_hubspot, config)
-    custom_stream = [s for s in source_hubspot.streams(config) if s.name == "animals"][0]
-    custom_stream_json_schema = [s.json_schema for s in streams.catalog.catalog.streams if s.name == "animals"][0]
+    custom_stream = [s for s in source_hubspot.streams(config) if s.name == custom_object_schema["fullyQualifiedName"]][0]
+    custom_stream_json_schema = [
+        s.json_schema for s in streams.catalog.catalog.streams if s.name == custom_object_schema["fullyQualifiedName"]
+    ][0]
 
     assert custom_stream_json_schema == expected_custom_object_json_schema
     assert custom_stream._stream_partition_generator._partition_factory._retriever._parameters["entity"] == "p19936848_Animal"


### PR DESCRIPTION
Fixes #77525

## What
Fixes a HubSpot discovery failure mode where a custom CRM object can have the same name as a built-in Airbyte stream, producing duplicate catalog streams with the same name and namespace pair.

For example, a custom object named form_submissions can collide with the built-in form_submissions stream and prevent connection creation because the backend cannot disambiguate the streams.

## How
Use HubSpot portal-qualified fullyQualifiedName when naming dynamic custom object streams instead of the non-unique object name.

The same mapping is applied to the StateDelegatingStream wrapper and both delegated custom object implementations, full_refresh_stream and incremental_stream, so the generated stream names stay consistent.

## Review guide
1. airbyte-integrations/connectors/source-hubspot/manifest.yaml
2. airbyte-integrations/connectors/source-hubspot/unit_tests/test_source.py

## User Impact
Custom object streams are discovered with portal-qualified names such as p123456_form_submissions, avoiding collisions with built-in HubSpot streams.

Users already syncing custom object streams may see custom object stream names change after schema refresh and may need to reselect the renamed custom object stream. Built-in streams are unaffected.

## Can this PR be safely reverted and rolled back?
- [x] YES
- [ ] NO

Reverting restores the previous naming behavior, but can reintroduce duplicate stream names for HubSpot accounts with custom objects that collide with built-in stream names.

## Tests
- poetry run pytest test_source.py -k custom_object_stream_uses_fully_qualified_name_to_avoid_builtin_collision
