### PR TITLE
fix(docs): add missing Font Awesome icons to CardWithIcon component

### DIFF
--- a/docusaurus/src/components/Card/Card.jsx
+++ b/docusaurus/src/components/Card/Card.jsx
@@ -1,10 +1,15 @@
 import {
   faArrowRight,
+  faBook,
   faCloud,
   faDownload,
+  faGear,
+  faLightbulb,
   faLock,
   faPlug,
+  faPuzzlePiece,
   faRobot,
+  faRocket,
 } from "@fortawesome/free-solid-svg-icons";
 import { faPython } from "@fortawesome/free-brands-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
@@ -12,12 +17,17 @@ import styles from "./Card.module.css";
 import { CloudIcon, EnterpriseIcon, OssIcon } from "./CustomIcons";
 
 const FA_ICONS = {
+  "fa-book": faBook,
   "fa-cloud": faCloud,
   "fa-download": faDownload,
+  "fa-gear": faGear,
+  "fa-lightbulb": faLightbulb,
   "fa-lock": faLock,
   "fa-plug": faPlug,
+  "fa-puzzle-piece": faPuzzlePiece,
   "fa-python": faPython,
   "fa-robot": faRobot,
+  "fa-rocket": faRocket,
 };
 
 const CUSTOM_ICONS = {


### PR DESCRIPTION
## What

The icons on the [Airbyte Agents landing page](https://docs.airbyte.com/ai-agents/) are not rendering. Five of the six `CardWithIcon` icons (`fa-rocket`, `fa-lightbulb`, `fa-puzzle-piece`, `fa-book`, `fa-gear`) are missing from the `FA_ICONS` map in `Card.jsx`, so only `fa-plug` (Interfaces card) renders.

Requested by @katmarkham.

## How

Added the five missing Font Awesome icon imports (`faBook`, `faGear`, `faLightbulb`, `faPuzzlePiece`, `faRocket`) from `@fortawesome/free-solid-svg-icons` and registered them in the `FA_ICONS` lookup map in `docusaurus/src/components/Card/Card.jsx`.

## Review guide

1. `docusaurus/src/components/Card/Card.jsx` — the only file changed

## User Impact

All six icons on the Airbyte Agents docs landing page will render correctly.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

---
[Devin session](https://app.devin.ai/sessions/b31934d3b5c74eb7a57cc4a190ecafc8)