### PR TITLE
fix(docs): use anchor tags for card buttons to support cmd+click

### DIFF
--- a/docusaurus/src/components/Card/Card.jsx
+++ b/docusaurus/src/components/Card/Card.jsx
@@ -30,15 +30,11 @@ const Link = ({ children, href, variant = "primary" }) => {
   const linkClass =
     variant === "secondary" ? styles.cardCtaSecondary : styles.cardCtaPrimary;
 
-  const handleClick = () => {
-    window.location.href = href;
-  };
-
   return (
-    <button className={`${styles.cardCta} ${linkClass}`} onClick={handleClick} role="link">
+    <a className={`${styles.cardCta} ${linkClass}`} href={href}>
       {children}
       <FontAwesomeIcon icon={faArrowRight} />
-    </button>
+    </a>
   );
 };
 


### PR DESCRIPTION
## What

The card CTA buttons on docs landing pages (e.g. https://docs.airbyte.com/ai-agents/) used `<button>` elements with `onClick` handlers that set `window.location.href`. This prevents standard browser behavior like Cmd+Click / Ctrl+Click to open links in a new tab.

Requested by @katmarkham.

## How

Replaced the `<button>` element in the `Link` component (`docusaurus/src/components/Card/Card.jsx`) with an `<a>` tag. This preserves the same styling and navigation behavior while restoring native link semantics — Cmd+Click, middle-click, and right-click → "Open in new tab" all work as expected.

## Review guide

1. `docusaurus/src/components/Card/Card.jsx` — the only changed file

## User Impact

Card buttons on docs landing pages now behave like standard links: left-click navigates normally, Cmd+Click (or Ctrl+Click) opens in a new tab. Affects all pages using the `CardWithIcon` component (ai-agents, platform, reference, academy).

## Can this PR be safely reverted and rolled back?

- [x] YES 💚
- [ ] NO ❌

---
[Devin session](https://app.devin.ai/sessions/f86c82d8408a4729aa569b2e4b693a8a)