### PR TITLE
fix(docs): replace literal \\n with &lt;br/&gt; in ai-agents mermaid diagrams

### DIFF
--- a/docs/ai-agents/concepts/architecture/readme.md
+++ b/docs/ai-agents/concepts/architecture/readme.md
@@ -24,7 +24,7 @@ flowchart TB
     end
 
     subgraph platform["Airbyte Agents Platform"]
-        AUTH["Authentication\n& token management"]
+        AUTH["Authentication<br/>& token management"]
         EXEC["Execution engine"]
         CS["Context Store"]
     end

--- a/docs/ai-agents/get-started/choose-how-to-use.md
+++ b/docs/ai-agents/get-started/choose-how-to-use.md
@@ -11,11 +11,11 @@ Use the flowchart below to find the best starting point, then read the section t
 
 ```mermaid
 flowchart TD
-    START(["How do you want to use\nAirbyte Agents?"])
+    START(["How do you want to use<br/>Airbyte Agents?"])
     START -->|"No code needed"| WEB["Web app"]
-    START -->|"I already use Claude,\nCursor, or ChatGPT"| MCP["MCP server"]
-    START -->|"I'm building a\nPython agent"| SDK["Python SDK"]
-    START -->|"Non-Python backend\nor custom admin"| API["HTTP API"]
+    START -->|"I already use Claude,<br/>Cursor, or ChatGPT"| MCP["MCP server"]
+    START -->|"I'm building a<br/>Python agent"| SDK["Python SDK"]
+    START -->|"Non-Python backend<br/>or custom admin"| API["HTTP API"]
 
     click WEB "#web-app"
     click MCP "#mcp-server"

--- a/docs/ai-agents/get-started/developer-quickstart/readme.md
+++ b/docs/ai-agents/get-started/developer-quickstart/readme.md
@@ -9,9 +9,9 @@ This section is for developers who want to build agents that use Airbyte connect
 
 ```mermaid
 flowchart TD
-    START(["I want to build with\nAirbyte Agents"])
+    START(["I want to build with<br/>Airbyte Agents"])
     START -->|"I write the code myself"| TUT["Tutorials"]
-    START -->|"I use a coding agent\n(Claude Code, Codex, Lovable)"| SKILL["Skills"]
+    START -->|"I use a coding agent<br/>(Claude Code, Codex, Lovable)"| SKILL["Skills"]
 
     TUT --> T1["Pydantic AI"]
     TUT --> T2["LangChain"]

--- a/docs/ai-agents/get-started/what-is-airbyte-agents.md
+++ b/docs/ai-agents/get-started/what-is-airbyte-agents.md
@@ -32,7 +32,7 @@ flowchart LR
         C2["Managed auth & credentials"]
     end
     subgraph unify["Unify"]
-        CS["Context Store\n(indexed, searchable)"]
+        CS["Context Store<br/>(indexed, searchable)"]
     end
     subgraph act["Act"]
         A1["Read & search"]


### PR DESCRIPTION
## What

Mermaid diagrams in the ai-agents docs render `\n` as literal text instead of line breaks. For example, `"How do you want to use\nAirbyte Agents?"` displays the backslash-n characters visibly in the diagram nodes and edge labels.

## How

Replaced all `\n` occurrences inside mermaid diagram node labels and edge labels with `<br/>`, which is the standard HTML line break that Mermaid and the `@docusaurus/theme-mermaid` plugin render correctly.

Four files changed:
- `docs/ai-agents/get-started/choose-how-to-use.md` — 4 replacements in flowchart node/edge labels
- `docs/ai-agents/get-started/what-is-airbyte-agents.md` — 1 replacement in subgraph node
- `docs/ai-agents/get-started/developer-quickstart/readme.md` — 2 replacements in flowchart node/edge labels
- `docs/ai-agents/concepts/architecture/readme.md` — 1 replacement in subgraph node

## Review guide

1. `docs/ai-agents/get-started/choose-how-to-use.md`
2. `docs/ai-agents/get-started/what-is-airbyte-agents.md`
3. `docs/ai-agents/get-started/developer-quickstart/readme.md`
4. `docs/ai-agents/concepts/architecture/readme.md`

## User Impact

Mermaid diagrams in the ai-agents documentation now render line breaks correctly instead of showing literal `\n` characters.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚
- [ ] NO ❌

Link to Devin session: https://app.devin.ai/sessions/429df1a07d824276804c3cf03fb67ce2
Requested by: @ian-at-airbyte

> [!IMPORTANT]
> ⚡ **Auto-merge enabled.**
> 
> _This PR is set to merge automatically when all requirements are met._