### PR TITLE
fix: mainline fast date time coercion

### DIFF
--- a/airbyte-cdk/bulk/core/load/changelog.md
+++ b/airbyte-cdk/bulk/core/load/changelog.md
@@ -9,6 +9,7 @@ The Load CDK provides functionality for destination connectors including stream-
 
 | Version | Date       | Pull Request                                                   | Subject                                                                                         |
 |---------|------------|----------------------------------------------------------------|-------------------------------------------------------------------------------------------------|
+| 1.0.11  | 2026-04-28 |                                                                | Mainline fast timestamp coercion. Fast date time coercion is now the only path. |
 | 1.0.10  | 2026-04-23 | [#76966](https://github.com/airbytehq/airbyte/pull/76966/)     | Bump bulk-cdk-core-base from 1.0.1 to 1.0.3: picks up fix to use AIRBYTE_EDITION env var instead of DEPLOYMENT_MODE for cloud feature flag (base 1.0.3). |
 | 1.0.9   | 2026-04-15 | [#76246](https://github.com/airbytehq/airbyte/pull/76246)      | Perf: fix timestamp coercion using exception-as-control-flow. Use ethlo/itu for ISO-8601 fast path (~25x faster), JDK TemporalQueries fallback for exotic formats. Eliminates ~56% destination CPU on timestamp-heavy workloads. |
 | 1.0.8   | 2026-04-14 | [#74728](https://github.com/airbytehq/airbyte/pull/74728)      | Fix OAuthAuthenticator to track token expiry via `expires_in` and refresh expired tokens. |

--- a/airbyte-cdk/bulk/core/load/changelog.md
+++ b/airbyte-cdk/bulk/core/load/changelog.md
@@ -9,7 +9,7 @@ The Load CDK provides functionality for destination connectors including stream-
 
 | Version | Date       | Pull Request                                                   | Subject                                                                                         |
 |---------|------------|----------------------------------------------------------------|-------------------------------------------------------------------------------------------------|
-| 1.0.11  | 2026-04-28 |                                                                | Mainline fast timestamp coercion. Fast date time coercion is now the only path. |
+| 1.0.11  | 2026-04-28 | [#77539](https://github.com/airbytehq/airbyte/pull/77539)      | Mainline fast timestamp coercion. Fast date time coercion is now the only path. |
 | 1.0.10  | 2026-04-23 | [#76966](https://github.com/airbytehq/airbyte/pull/76966/)     | Bump bulk-cdk-core-base from 1.0.1 to 1.0.3: picks up fix to use AIRBYTE_EDITION env var instead of DEPLOYMENT_MODE for cloud feature flag (base 1.0.3). |
 | 1.0.9   | 2026-04-15 | [#76246](https://github.com/airbytehq/airbyte/pull/76246)      | Perf: fix timestamp coercion using exception-as-control-flow. Use ethlo/itu for ISO-8601 fast path (~25x faster), JDK TemporalQueries fallback for exotic formats. Eliminates ~56% destination CPU on timestamp-heavy workloads. |
 | 1.0.8   | 2026-04-14 | [#74728](https://github.com/airbytehq/airbyte/pull/74728)      | Fix OAuthAuthenticator to track token expiry via `expires_in` and refresh expired tokens. |

--- a/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/data/AirbyteValueCoercer.kt
+++ b/airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/data/AirbyteValueCoercer.kt
@@ -9,7 +9,6 @@ import com.ethlo.time.ParseConfig
 import io.airbyte.cdk.load.data.TemporalFormatters.DATE_TIME_FORMATTER
 import io.airbyte.cdk.load.data.json.JsonToAirbyteValue
 import io.airbyte.cdk.load.util.serializeToString
-import io.micronaut.context.annotation.Property
 import jakarta.inject.Singleton
 import java.math.BigDecimal
 import java.math.BigInteger
@@ -30,20 +29,12 @@ import java.time.temporal.TemporalQueries
  * [AirbyteValue]. In particular, this class will parse temporal types, and performs some
  * common-sense conversions among numeric types, as well as upcasting any value to StringValue.
  *
- * The [useFastTimestampParsing] flag controls timestamp parsing behavior:
- * - When false (default): uses the original try-ZonedDateTime/catch-fallback-to-LocalDateTime
- * pattern. Safe but slow due to exception-as-control-flow.
- * - When true: uses ethlo/itu for fast ISO-8601 parsing (~25x faster) with a JDK TemporalQueries
- * fallback for exotic formats. No exceptions on the hot path.
- *
- * Destinations opt in via the Micronaut property
- * `airbyte.destination.core.coercion.use-fast-timestamp-parsing`.
+ * Timestamp parsing uses ethlo/itu for fast ISO-8601 parsing with a JDK TemporalQueries fallback
+ * for exotic formats. Time parsing uses a single parse + TemporalQueries check. Both avoid
+ * exception-as-control-flow.
  */
 @Singleton
-class AirbyteValueCoercer(
-    @Property(name = "airbyte.destination.core.coercion.use-fast-timestamp-parsing")
-    private val useFastTimestampParsing: Boolean = false,
-) {
+class AirbyteValueCoercer {
     fun coerce(
         value: AirbyteValue,
         type: AirbyteType,
@@ -147,26 +138,17 @@ class AirbyteValueCoercer(
             is TimeWithTimezoneValue -> value
             else ->
                 requireType<StringValue, TimeWithTimezoneValue>(value) {
+                    // Single parse + temporal query to detect timezone, avoiding the old
+                    // try-OffsetTime.parse/catch-fallback-to-LocalTime pattern.
+                    val parsed = TemporalFormatters.TIME_FORMATTER.parse(it.value)
+                    val offset = parsed.query(TemporalQueries.offset())
                     val ot =
-                        if (useFastTimestampParsing) {
-                            // Single parse + temporal query to detect timezone, avoiding the
-                            // try-OffsetTime.parse/catch-fallback-to-LocalTime pattern.
-                            val parsed = TemporalFormatters.TIME_FORMATTER.parse(it.value)
-                            val offset = parsed.query(TemporalQueries.offset())
-                            if (offset != null) {
-                                // Has timezone offset (e.g. "12:00:00+01:00") — use it directly
-                                OffsetTime.from(parsed)
-                            } else {
-                                // No timezone (e.g. "12:00:00") — assume UTC
-                                LocalTime.from(parsed).atOffset(ZoneOffset.UTC)
-                            }
+                        if (offset != null) {
+                            // Has timezone offset (e.g. "12:00:00+01:00") — use it directly
+                            OffsetTime.from(parsed)
                         } else {
-                            try {
-                                OffsetTime.parse(it.value, TemporalFormatters.TIME_FORMATTER)
-                            } catch (_: Exception) {
-                                LocalTime.parse(it.value, TemporalFormatters.TIME_FORMATTER)
-                                    .atOffset(ZoneOffset.UTC)
-                            }
+                            // No timezone (e.g. "12:00:00") — assume UTC
+                            LocalTime.from(parsed).atOffset(ZoneOffset.UTC)
                         }
                     TimeWithTimezoneValue(ot)
                 }
@@ -201,28 +183,12 @@ class AirbyteValueCoercer(
                 }
         }
 
-    private fun offsetDateTime(it: StringValue): OffsetDateTime {
-        return if (useFastTimestampParsing) {
-            offsetDateTimeFast(it.value)
-        } else {
-            offsetDateTimeLegacy(it.value)
-        }
-    }
-
-    /** Legacy path: try ZonedDateTime.parse, catch, fall back to LocalDateTime.parse. */
-    private fun offsetDateTimeLegacy(s: String): OffsetDateTime {
-        return try {
-            ZonedDateTime.parse(s, DATE_TIME_FORMATTER).toOffsetDateTime()
-        } catch (e: Exception) {
-            LocalDateTime.parse(s, DATE_TIME_FORMATTER).atOffset(ZoneOffset.UTC)
-        }
-    }
-
     /**
-     * Fast path: uses ethlo/itu for ISO-8601 (~25x faster, no exceptions), with a JDK
-     * TemporalQueries fallback for non-ISO formats.
+     * Parses a timestamp string into an OffsetDateTime. Uses ethlo/itu for ISO-8601 formats (~25x
+     * faster than JDK), with a JDK TemporalQueries fallback for non-ISO formats.
      */
-    private fun offsetDateTimeFast(s: String): OffsetDateTime {
+    private fun offsetDateTime(it: StringValue): OffsetDateTime {
+        val s = it.value
         if (looksLikeIso8601(s)) {
             // Fast path: ITU handles ISO-8601/RFC-3339 ~25x faster than JDK DateTimeFormatter,
             // and determines with/without timezone via position-based parsing (no exceptions).

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/data/AirbyteValueCoercerTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/data/AirbyteValueCoercerTest.kt
@@ -4,7 +4,6 @@
 
 // Test cases ported from legacy-task-loader's AirbyteValueDeepCoercingMapperTest.kt,
 // adapted to call AirbyteValueCoercer.coerce() directly with hardcoded expected values.
-// All tests run against both legacy (flag=false) and fast (flag=true) implementations.
 
 package io.airbyte.cdk.load.data
 
@@ -26,74 +25,63 @@ import org.junit.jupiter.params.provider.MethodSource
 // Formatting disabled — breaking up timestamp creation across lines makes it much harder to read
 class AirbyteValueCoercerTest {
 
-    private val legacyCoercer = AirbyteValueCoercer(useFastTimestampParsing = false)
-    private val fastCoercer = AirbyteValueCoercer(useFastTimestampParsing = true)
+    private val coercer = AirbyteValueCoercer()
 
     @ParameterizedTest(name = "{0}")
     @MethodSource("timestampWithTimezoneArgs")
     fun testCoerceTimestampWithTimezone(input: String, expected: AirbyteValue) {
-        assertEquals(expected, legacyCoercer.coerce(StringValue(input), TimestampTypeWithTimezone))
-        assertEquals(expected, fastCoercer.coerce(StringValue(input), TimestampTypeWithTimezone))
+        assertEquals(expected, coercer.coerce(StringValue(input), TimestampTypeWithTimezone))
     }
 
     @ParameterizedTest(name = "{0}")
     @MethodSource("timestampWithoutTimezoneArgs")
     fun testCoerceTimestampWithoutTimezone(input: String, expected: AirbyteValue) {
-        assertEquals(expected, legacyCoercer.coerce(StringValue(input), TimestampTypeWithoutTimezone))
-        assertEquals(expected, fastCoercer.coerce(StringValue(input), TimestampTypeWithoutTimezone))
+        assertEquals(expected, coercer.coerce(StringValue(input), TimestampTypeWithoutTimezone))
     }
 
     @ParameterizedTest(name = "{0}")
     @MethodSource("timeWithTimezoneArgs")
     fun testCoerceTimeWithTimezone(input: String, expected: AirbyteValue) {
-        assertEquals(expected, legacyCoercer.coerce(StringValue(input), TimeTypeWithTimezone))
-        assertEquals(expected, fastCoercer.coerce(StringValue(input), TimeTypeWithTimezone))
+        assertEquals(expected, coercer.coerce(StringValue(input), TimeTypeWithTimezone))
     }
 
     @ParameterizedTest(name = "{0}")
     @MethodSource("timeWithoutTimezoneArgs")
     fun testCoerceTimeWithoutTimezone(input: String, expected: AirbyteValue) {
-        assertEquals(expected, legacyCoercer.coerce(StringValue(input), TimeTypeWithoutTimezone))
-        assertEquals(expected, fastCoercer.coerce(StringValue(input), TimeTypeWithoutTimezone))
+        assertEquals(expected, coercer.coerce(StringValue(input), TimeTypeWithoutTimezone))
     }
 
     @ParameterizedTest(name = "{0}")
     @MethodSource("dateArgs")
     fun testCoerceDate(input: String, expected: AirbyteValue) {
-        assertEquals(expected, legacyCoercer.coerce(StringValue(input), DateType))
-        assertEquals(expected, fastCoercer.coerce(StringValue(input), DateType))
+        assertEquals(expected, coercer.coerce(StringValue(input), DateType))
     }
 
     @Test
     fun testCoerceNullValue() {
-        assertEquals(NullValue, legacyCoercer.coerce(NullValue, TimestampTypeWithTimezone))
-        assertEquals(NullValue, fastCoercer.coerce(NullValue, TimestampTypeWithTimezone))
+        assertEquals(NullValue, coercer.coerce(NullValue, TimestampTypeWithTimezone))
     }
 
     @Test
     fun testCoerceAlreadyTypedTimestamp() {
         val value: AirbyteValue = TimestampWithTimezoneValue(OffsetDateTime.of(2024, 1, 23, 1, 23, 45, 0, ZoneOffset.UTC))
-        assertEquals(value, legacyCoercer.coerce(value, TimestampTypeWithTimezone))
-        assertEquals(value, fastCoercer.coerce(value, TimestampTypeWithTimezone))
+        assertEquals(value, coercer.coerce(value, TimestampTypeWithTimezone))
     }
 
     @Test
     fun testCoerceAlreadyTypedTime() {
         val value: AirbyteValue = TimeWithTimezoneValue(OffsetTime.of(1, 23, 45, 0, ZoneOffset.UTC))
-        assertEquals(value, legacyCoercer.coerce(value, TimeTypeWithTimezone))
-        assertEquals(value, fastCoercer.coerce(value, TimeTypeWithTimezone))
+        assertEquals(value, coercer.coerce(value, TimeTypeWithTimezone))
     }
 
     @Test
     fun testCoerceWrongTypeReturnsNull() {
-        assertNull(legacyCoercer.coerce(IntegerValue(12345), TimestampTypeWithTimezone))
-        assertNull(fastCoercer.coerce(IntegerValue(12345), TimestampTypeWithTimezone))
+        assertNull(coercer.coerce(IntegerValue(12345), TimestampTypeWithTimezone))
     }
 
     @Test
     fun testCoerceInvalidStringReturnsNull() {
-        assertNull(legacyCoercer.coerce(StringValue("not-a-timestamp"), TimestampTypeWithTimezone))
-        assertNull(fastCoercer.coerce(StringValue("not-a-timestamp"), TimestampTypeWithTimezone))
+        assertNull(coercer.coerce(StringValue("not-a-timestamp"), TimestampTypeWithTimezone))
     }
 
     companion object {

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/dataflow/transform/medium/JsonRecordConversionTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/dataflow/transform/medium/JsonRecordConversionTest.kt
@@ -51,7 +51,7 @@ class JsonRecordConversionTest {
                 valueCoercer,
                 validationResultHandler,
                 jsonConverterConfig,
-                AirbyteValueCoercer(useFastTimestampParsing = true),
+                AirbyteValueCoercer(),
             )
     }
 

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/message/DestinationMessageTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/message/DestinationMessageTest.kt
@@ -50,7 +50,7 @@ import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
 
 internal class DestinationMessageTest {
-    private val coercer = AirbyteValueCoercer(useFastTimestampParsing = true)
+    private val coercer = AirbyteValueCoercer()
     private val uuidGenerator = UUIDGenerator()
 
     private fun factory(

--- a/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/message/DestinationRecordRawTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/message/DestinationRecordRawTest.kt
@@ -21,7 +21,7 @@ import org.junit.jupiter.api.Test
 
 class DestinationRecordRawTest {
 
-    private val coercer = AirbyteValueCoercer(useFastTimestampParsing = true)
+    private val coercer = AirbyteValueCoercer()
 
     // Create a schema with various field types for testing
     private val recordSchema =

--- a/airbyte-cdk/bulk/core/load/version.properties
+++ b/airbyte-cdk/bulk/core/load/version.properties
@@ -1,1 +1,1 @@
-version=1.0.10
+version=1.0.11


### PR DESCRIPTION
## Note:
Connector compatability failures are expected — they still reference the removed useFastTimestampParsing parameter and will be fixed when they bump CDK. This is a pain point of the compatability tests.

The vercel failure is also expected — that is broken for some reason.

## What
Mainline fast timestamp coercion — remove the `useFastTimestampParsing` feature flag and make the fast path the only path for all destinations.
## How
- Remove `useFastTimestampParsing` constructor parameter, `@Property` annotation, and legacy code paths from `AirbyteValueCoercer`
- Remove `legacyCoercer` and duplicate assertions from `AirbyteValueCoercerTest`
## Recommended reading order
1. `AirbyteValueCoercer.kt`
2. `AirbyteValueCoercerTest.kt`
## User Impact
Fast timestamp coercion is now enabled for all dataflow destinations by default.
## Can this PR be safely reverted and rolled back?
- [x] YES
- [ ] NO