### PR TITLE
fix(docs): add description to Skills category card on Developer Quickstart page

### DIFF
--- a/docs/ai-agents/get-started/developer-quickstart/skills/_category_.json
+++ b/docs/ai-agents/get-started/developer-quickstart/skills/_category_.json
@@ -1,0 +1,3 @@
+{
+  "description": "Install pre-packaged instructions into a coding agent so it can generate working code against Airbyte connectors."
+}


### PR DESCRIPTION
## What

The Skills card on the [Developer Quickstart](https://docs.airbyte.com/ai-agents/get-started/developer-quickstart/) page renders "3 items" instead of a descriptive tagline, unlike the other cards (Pydantic AI, LangChain, FastMCP) which show descriptions.

This is the same issue fixed in #77535 for the Developer Quickstart card itself — the swizzled `DocCard` component already prefers `item.description` over the item count, but the Skills category directory was missing a `_category_.json` file to supply that description.

## How

Added `_category_.json` to `docs/ai-agents/get-started/developer-quickstart/skills/` with a `description` field. The existing swizzled `DocCard` component (from #77535) picks this up automatically via `item.description ?? categoryItemsPlural(item.items.length)`.

## Review guide

1. `docs/ai-agents/get-started/developer-quickstart/skills/_category_.json` — new file (only change)

## User Impact

The Skills card on the Developer Quickstart page now shows a descriptive tagline ("Install pre-packaged instructions into a coding agent so it can generate working code against Airbyte connectors.") instead of "3 items", consistent with the other cards on the page.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚
- [ ] NO ❌

Link to Devin session: https://app.devin.ai/sessions/a888e009911b4c0882b71a12bc3ac21f
Requested by: @katmarkham