### PR TITLE
feat(destination-redshift-v2): add write layer, value coercer, and dataflow components

### DIFF
--- a/airbyte-integrations/connectors/destination-redshift-v2/src/main/kotlin/io/airbyte/integrations/destination/redshift2/client/RedshiftAirbyteClient.kt
+++ b/airbyte-integrations/connectors/destination-redshift-v2/src/main/kotlin/io/airbyte/integrations/destination/redshift2/client/RedshiftAirbyteClient.kt
@@ -172,6 +172,19 @@ class RedshiftAirbyteClient(
         return TableSchema(userColumns)
     }
 
+    /**
+     * Returns the column names of the given table in ordinal order (matching the physical column
+     * layout)
+     */
+    fun describeTable(tableName: TableName): List<String> =
+        executeQuery(sqlGenerator.getTableSchema(tableName)) { rs ->
+            val columns = mutableListOf<String>()
+            while (rs.next()) {
+                columns.add(rs.getString(COLUMN_NAME_COLUMN))
+            }
+            columns
+        }
+
     override fun computeSchema(
         stream: DestinationStream,
         columnNameMapping: ColumnNameMapping

--- a/airbyte-integrations/connectors/destination-redshift-v2/src/main/kotlin/io/airbyte/integrations/destination/redshift2/config/RedshiftBeanFactory.kt
+++ b/airbyte-integrations/connectors/destination-redshift-v2/src/main/kotlin/io/airbyte/integrations/destination/redshift2/config/RedshiftBeanFactory.kt
@@ -8,6 +8,9 @@ import com.amazonaws.services.s3.AmazonS3
 import com.zaxxer.hikari.HikariDataSource
 import io.airbyte.cdk.Operation
 import io.airbyte.cdk.command.ConfigurationSpecificationSupplier
+import io.airbyte.cdk.load.dataflow.config.model.AggregatePublishingConfig
+import io.airbyte.cdk.load.table.DefaultTempTableNameGenerator
+import io.airbyte.cdk.load.table.TempTableNameGenerator
 import io.airbyte.integrations.destination.redshift2.connect.RedshiftConnect
 import io.airbyte.integrations.destination.redshift2.connect.S3Connect
 import io.micronaut.context.annotation.Factory
@@ -40,4 +43,22 @@ class RedshiftBeanFactory {
     fun s3Client(s3Connect: S3Connect): AmazonS3 {
         return s3Connect.createS3Client()
     }
+
+    /** Generates deterministic temp table names for staging during dedup/truncate syncs. */
+    @Singleton
+    fun tempTableNameGenerator(): TempTableNameGenerator = DefaultTempTableNameGenerator()
+
+    /**
+     * Configures aggregate publishing thresholds for the CDK dataflow pipeline.
+     *
+     * Redshift loads data via S3 staging + COPY, which has fixed per-invocation overhead. Larger
+     * batches amortize this cost better. 200 MB per aggregate with 1 GB total across all streams
+     * balances throughput against memory usage.
+     */
+    @Singleton
+    fun aggregatePublishingConfig(): AggregatePublishingConfig =
+        AggregatePublishingConfig(
+            maxEstBytesPerAgg = 200_000_000L,
+            maxEstBytesAllAggregates = 1_000_000_000L,
+        )
 }

--- a/airbyte-integrations/connectors/destination-redshift-v2/src/main/kotlin/io/airbyte/integrations/destination/redshift2/dataflow/RedshiftAggregate.kt
+++ b/airbyte-integrations/connectors/destination-redshift-v2/src/main/kotlin/io/airbyte/integrations/destination/redshift2/dataflow/RedshiftAggregate.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2026 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.integrations.destination.redshift2.dataflow
+
+import io.airbyte.cdk.load.dataflow.aggregate.Aggregate
+import io.airbyte.cdk.load.dataflow.transform.RecordDTO
+import io.airbyte.integrations.destination.redshift2.write.load.RedshiftInsertBuffer
+
+class RedshiftAggregate(
+    private val buffer: RedshiftInsertBuffer,
+) : Aggregate {
+
+    override fun accept(record: RecordDTO) {
+        buffer.accumulate(record.fields)
+    }
+
+    override suspend fun flush() {
+        buffer.flush()
+    }
+}

--- a/airbyte-integrations/connectors/destination-redshift-v2/src/main/kotlin/io/airbyte/integrations/destination/redshift2/dataflow/RedshiftAggregateFactory.kt
+++ b/airbyte-integrations/connectors/destination-redshift-v2/src/main/kotlin/io/airbyte/integrations/destination/redshift2/dataflow/RedshiftAggregateFactory.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2026 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.integrations.destination.redshift2.dataflow
+
+import io.airbyte.cdk.load.dataflow.aggregate.Aggregate
+import io.airbyte.cdk.load.dataflow.aggregate.AggregateFactory
+import io.airbyte.cdk.load.dataflow.aggregate.StoreKey
+import io.airbyte.cdk.load.table.directload.DirectLoadTableExecutionConfig
+import io.airbyte.cdk.load.write.StreamStateStore
+import io.airbyte.integrations.destination.redshift2.client.RedshiftAirbyteClient
+import io.airbyte.integrations.destination.redshift2.config.RedshiftConfiguration
+import io.airbyte.integrations.destination.redshift2.write.load.RedshiftInsertBuffer
+import jakarta.inject.Singleton
+
+/** Factory for creating [RedshiftAggregate] instances, one per stream */
+@Singleton
+class RedshiftAggregateFactory(
+    private val redshiftClient: RedshiftAirbyteClient,
+    private val streamStateStore: StreamStateStore<DirectLoadTableExecutionConfig>,
+    private val redshiftConfiguration: RedshiftConfiguration,
+) : AggregateFactory {
+
+    override fun create(key: StoreKey): Aggregate {
+        val tableName = streamStateStore.get(key)!!.tableName
+        val columns = redshiftClient.describeTable(tableName)
+        val buffer =
+            RedshiftInsertBuffer(
+                tableName = tableName,
+                columns = columns,
+                redshiftClient = redshiftClient,
+                configuration = redshiftConfiguration,
+            )
+        return RedshiftAggregate(buffer = buffer)
+    }
+}

--- a/airbyte-integrations/connectors/destination-redshift-v2/src/main/kotlin/io/airbyte/integrations/destination/redshift2/schema/RedshiftTableSchemaMapper.kt
+++ b/airbyte-integrations/connectors/destination-redshift-v2/src/main/kotlin/io/airbyte/integrations/destination/redshift2/schema/RedshiftTableSchemaMapper.kt
@@ -65,6 +65,7 @@ class RedshiftTableSchemaMapper(
                 TimeTypeWithoutTimezone -> RedshiftDataType.TIME.typeName
                 TimestampTypeWithTimezone -> RedshiftDataType.TIMESTAMPTZ.typeName
                 TimestampTypeWithoutTimezone -> RedshiftDataType.TIMESTAMP.typeName
+                is UnionType -> RedshiftDataType.VARCHAR.typeName
 
                 // Semi-structured types (all map to Redshift SUPER)
                 is ArrayType,
@@ -72,7 +73,6 @@ class RedshiftTableSchemaMapper(
                 is ObjectType,
                 ObjectTypeWithEmptySchema,
                 ObjectTypeWithoutSchema,
-                is UnionType,
                 is UnknownType -> RedshiftDataType.SUPER.typeName
             }
 

--- a/airbyte-integrations/connectors/destination-redshift-v2/src/main/kotlin/io/airbyte/integrations/destination/redshift2/write/RedshiftWriter.kt
+++ b/airbyte-integrations/connectors/destination-redshift-v2/src/main/kotlin/io/airbyte/integrations/destination/redshift2/write/RedshiftWriter.kt
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) 2026 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.integrations.destination.redshift2.write
+
+import io.airbyte.cdk.SystemErrorException
+import io.airbyte.cdk.load.command.Dedupe
+import io.airbyte.cdk.load.command.DestinationCatalog
+import io.airbyte.cdk.load.command.DestinationStream
+import io.airbyte.cdk.load.table.ColumnNameMapping
+import io.airbyte.cdk.load.table.DatabaseInitialStatusGatherer
+import io.airbyte.cdk.load.table.TempTableNameGenerator
+import io.airbyte.cdk.load.table.directload.DirectLoadInitialStatus
+import io.airbyte.cdk.load.table.directload.DirectLoadTableAppendStreamLoader
+import io.airbyte.cdk.load.table.directload.DirectLoadTableAppendTruncateStreamLoader
+import io.airbyte.cdk.load.table.directload.DirectLoadTableDedupStreamLoader
+import io.airbyte.cdk.load.table.directload.DirectLoadTableDedupTruncateStreamLoader
+import io.airbyte.cdk.load.table.directload.DirectLoadTableExecutionConfig
+import io.airbyte.cdk.load.write.DestinationWriter
+import io.airbyte.cdk.load.write.StreamLoader
+import io.airbyte.cdk.load.write.StreamStateStore
+import io.airbyte.integrations.destination.redshift2.client.RedshiftAirbyteClient
+import io.github.oshai.kotlinlogging.KotlinLogging
+import jakarta.inject.Singleton
+
+private val log = KotlinLogging.logger {}
+
+/** Top-level orchestrator for Redshift destination syncs */
+@Singleton
+class RedshiftWriter(
+    private val catalog: DestinationCatalog,
+    private val stateGatherer: DatabaseInitialStatusGatherer<DirectLoadInitialStatus>,
+    private val streamStateStore: StreamStateStore<DirectLoadTableExecutionConfig>,
+    private val redshiftClient: RedshiftAirbyteClient,
+    private val tempTableNameGenerator: TempTableNameGenerator,
+) : DestinationWriter {
+
+    private lateinit var initialStatuses: Map<DestinationStream, DirectLoadInitialStatus>
+
+    override suspend fun setup() {
+        // Create namespaces for all final tables
+        val namespaces =
+            catalog.streams
+                .flatMap { listOfNotNull(it.tableSchema.tableNames.finalTableName?.namespace) }
+                .toSet()
+
+        namespaces.forEach { redshiftClient.createNamespace(it) }
+
+        initialStatuses = stateGatherer.gatherInitialStatus()
+    }
+
+    override fun createStreamLoader(stream: DestinationStream): StreamLoader {
+        val initialStatus = initialStatuses[stream]!!
+        val realTableName = stream.tableSchema.tableNames.finalTableName!!
+        val tempTableName = tempTableNameGenerator.generate(realTableName)
+        val columnNameMapping =
+            ColumnNameMapping(stream.tableSchema.columnSchema.inputToFinalColumnNames)
+        val useDedupe = stream.tableSchema.importType is Dedupe
+
+        log.info {
+            "Creating stream loader for ${realTableName.namespace}.${realTableName.name}: " +
+                "mode=${if (useDedupe) "dedupe" else "append"}, " +
+                "minGenId=${stream.minimumGenerationId}, genId=${stream.generationId}"
+        }
+
+        return when (stream.minimumGenerationId) {
+            0L ->
+                when {
+                    useDedupe ->
+                        DirectLoadTableDedupStreamLoader(
+                            stream,
+                            initialStatus,
+                            realTableName = realTableName,
+                            tempTableName = tempTableName,
+                            columnNameMapping,
+                            redshiftClient,
+                            redshiftClient,
+                            streamStateStore,
+                        )
+                    else ->
+                        DirectLoadTableAppendStreamLoader(
+                            stream,
+                            initialStatus,
+                            realTableName = realTableName,
+                            tempTableName = tempTableName,
+                            columnNameMapping,
+                            redshiftClient,
+                            redshiftClient,
+                            streamStateStore,
+                        )
+                }
+            stream.generationId ->
+                when {
+                    useDedupe ->
+                        DirectLoadTableDedupTruncateStreamLoader(
+                            stream,
+                            initialStatus,
+                            realTableName = realTableName,
+                            tempTableName = tempTableName,
+                            columnNameMapping,
+                            redshiftClient,
+                            redshiftClient,
+                            streamStateStore,
+                            tempTableNameGenerator,
+                        )
+                    else ->
+                        DirectLoadTableAppendTruncateStreamLoader(
+                            stream,
+                            initialStatus,
+                            realTableName = realTableName,
+                            tempTableName = tempTableName,
+                            columnNameMapping,
+                            redshiftClient,
+                            redshiftClient,
+                            streamStateStore,
+                        )
+                }
+            else ->
+                throw SystemErrorException(
+                    "Cannot execute a hybrid refresh - " +
+                        "current generation ${stream.generationId}; " +
+                        "minimum generation ${stream.minimumGenerationId}"
+                )
+        }
+    }
+}

--- a/airbyte-integrations/connectors/destination-redshift-v2/src/main/kotlin/io/airbyte/integrations/destination/redshift2/write/load/RedshiftInsertBuffer.kt
+++ b/airbyte-integrations/connectors/destination-redshift-v2/src/main/kotlin/io/airbyte/integrations/destination/redshift2/write/load/RedshiftInsertBuffer.kt
@@ -1,0 +1,270 @@
+/*
+ * Copyright (c) 2026 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.integrations.destination.redshift2.write.load
+
+import com.amazonaws.services.s3.model.ObjectMetadata
+import io.airbyte.cdk.load.data.AirbyteValue
+import io.airbyte.cdk.load.schema.model.TableName
+import io.airbyte.integrations.destination.redshift2.client.RedshiftAirbyteClient
+import io.airbyte.integrations.destination.redshift2.config.RedshiftConfiguration
+import io.github.oshai.kotlinlogging.KotlinLogging
+import java.io.ByteArrayOutputStream
+import java.io.OutputStreamWriter
+import java.nio.charset.StandardCharsets
+import java.text.SimpleDateFormat
+import java.time.Instant
+import java.util.TimeZone
+import java.util.UUID
+import java.util.zip.GZIPOutputStream
+import org.apache.commons.csv.CSVFormat
+import org.apache.commons.csv.CSVPrinter
+
+private val logger = KotlinLogging.logger {}
+
+internal val CSV_FORMAT: CSVFormat = CSVFormat.DEFAULT
+internal const val DEFAULT_FLUSH_LIMIT = 1_000_000
+private const val STAGING_FILE_EXTENSION = ".csv.gz"
+private const val DATE_FORMAT = "yyyy_MM_dd"
+private const val UTC = "UTC"
+
+/** Regex matching extended placeholders like `{date:yyyy_MM}` or `{timestamp:millis}`. */
+private val EXTENDED_PLACEHOLDER_PATTERN = Regex("""\{(date:.+?|timestamp:.+?)\}""")
+
+/**
+ * Buffers records into a gzip-compressed CSV file and flushes them to Redshift via S3 staging.
+ *
+ * The loading pipeline works as follows:
+ * 1. Records are accumulated into an in-memory gzip-compressed CSV buffer
+ * 2. On [flush], the buffer is uploaded to S3 as a `.csv.gz` file
+ * 3. A Redshift `COPY` command loads the data from S3 into the target table
+ * 4. The staging S3 object is optionally deleted (based on [purgeStagingData])
+ */
+class RedshiftInsertBuffer(
+    private val tableName: TableName,
+    val columns: List<String>,
+    private val redshiftClient: RedshiftAirbyteClient,
+    private val configuration: RedshiftConfiguration,
+    private val flushLimit: Int = DEFAULT_FLUSH_LIMIT,
+) {
+
+    private val formatter = RedshiftSchemaRecordFormatter(columns)
+    private val s3Config = configuration.uploadingMethod!!
+    private val purgeStagingData: Boolean = s3Config.purgeStagingData ?: true
+
+    /** In-memory byte buffer backing the gzip CSV output. */
+    private var byteBuffer: ByteArrayOutputStream? = null
+    private var gzipOutputStream: GZIPOutputStream? = null
+    private var csvPrinter: CSVPrinter? = null
+
+    internal var recordCount = 0
+    private var partNumber = 0
+
+    /**
+     * Adds a record to the current CSV batch.
+     *
+     * On the first call, initializes the gzip CSV buffer and writes a header row containing column
+     * names. Subsequent calls format the record and append it as a CSV row. The CSV printer is
+     * flushed every [flushLimit] records to manage memory.
+     */
+    fun accumulate(recordFields: Map<String, AirbyteValue>) {
+        if (byteBuffer == null) {
+            initializeBuffer()
+        }
+
+        csvPrinter!!.printRecord(formatter.format(recordFields))
+        recordCount++
+
+        if (recordCount % flushLimit == 0) {
+            csvPrinter!!.flush()
+        }
+    }
+
+    /**
+     * Flushes the buffered CSV data to Redshift via S3 staging.
+     *
+     * Steps:
+     * 1. Finalize and close the gzip CSV buffer
+     * 2. Upload the compressed bytes to S3
+     * 3. Execute Redshift COPY to load the data from S3
+     * 4. Optionally delete the S3 staging file
+     * 5. Reset internal state for the next batch
+     */
+    suspend fun flush() {
+        val buffer = byteBuffer
+        if (buffer == null) {
+            logger.warn { "No data to flush for ${tableName.namespace}.${tableName.name}" }
+            return
+        }
+
+        try {
+            // Step 1: Finalize the gzip CSV
+            csvPrinter?.flush()
+            csvPrinter?.close()
+            gzipOutputStream?.finish()
+            gzipOutputStream?.close()
+
+            val csvBytes = buffer.toByteArray()
+            val s3Key = buildStagingS3Key()
+            val s3Path = "s3://${s3Config.s3BucketName}/$s3Key"
+
+            logger.info {
+                "Uploading $recordCount record(s) (${csvBytes.size} bytes compressed) " +
+                    "for ${tableName.namespace}.${tableName.name} to $s3Path"
+            }
+
+            // Step 2: Upload to S3
+            val metadata =
+                ObjectMetadata().apply {
+                    contentLength = csvBytes.size.toLong()
+                    contentType = "application/gzip"
+                }
+            redshiftClient.uploadToS3(s3Config.s3BucketName, s3Key, csvBytes, metadata)
+
+            // Step 3: Execute COPY
+            redshiftClient.copyFromS3(
+                tableName = tableName,
+                s3Path = s3Path,
+                accessKeyId = s3Config.accessKeyId,
+                secretAccessKey = s3Config.secretAccessKey,
+                region = s3Config.s3BucketRegion!!,
+            )
+
+            logger.info {
+                "Loaded $recordCount row(s) into ${tableName.namespace}.${tableName.name}"
+            }
+
+            // Step 4: Cleanup S3 staging file
+            if (purgeStagingData) {
+                redshiftClient.deleteFromS3(s3Config.s3BucketName, s3Key)
+                logger.debug { "Purged staging file: $s3Key" }
+            }
+        } catch (e: Exception) {
+            logger.error(e) {
+                "Failed to flush $recordCount record(s) for " +
+                    "${tableName.namespace}.${tableName.name}"
+            }
+            throw e
+        } finally {
+            // Step 5: Reset state
+            resetState()
+        }
+    }
+
+    /**
+     * Initializes the in-memory gzip CSV buffer and writes the header row.
+     *
+     * The header row contains all column names in the table's ordinal order. Redshift's COPY
+     * command skips it via `IGNOREHEADER 1`.
+     */
+    private fun initializeBuffer() {
+        byteBuffer = ByteArrayOutputStream()
+        gzipOutputStream = GZIPOutputStream(byteBuffer)
+        csvPrinter =
+            CSVPrinter(OutputStreamWriter(gzipOutputStream!!, StandardCharsets.UTF_8), CSV_FORMAT)
+        csvPrinter!!.printRecord(columns)
+    }
+
+    /**
+     * Builds the S3 key for the staging file, respecting the configured bucket path prefix.
+     *
+     * The key is composed of two parts:
+     * - **Directory**: `{bucketPath}/{namespace}/{tableName}/` (always hardcoded)
+     * - **Filename**: resolved from [S3StagingConfiguration.fileNamePattern] if set, otherwise
+     * falls back to a default `{timestamp}_{uuid}.csv.gz` format.
+     *
+     * Supported filename pattern tokens (matching v1 parity):
+     * - `{date}` — UTC date formatted as `yyyy_MM_dd`
+     * - `{date:<format>}` — UTC date with a custom [SimpleDateFormat] pattern
+     * - `{timestamp}` — epoch milliseconds
+     * - `{timestamp:millis}` — epoch milliseconds (explicit)
+     * - `{timestamp:micro}` — epoch microseconds
+     * - `{sync_id}` — value of `WORKER_JOB_ID` environment variable
+     * - `{format_extension}` — `.csv.gz`
+     * - `{part_number}` — monotonically increasing part counter per buffer instance
+     *
+     * If the resolved filename does not end with `.csv.gz`, the extension is appended automatically
+     * so that Redshift's COPY command can detect the compression format.
+     */
+    internal fun buildStagingS3Key(): String {
+        val prefix =
+            s3Config.s3BucketPath?.let { path ->
+                val trimmed = path.trimEnd('/')
+                if (trimmed.isNotEmpty()) "$trimmed/" else ""
+            }
+                ?: ""
+        val directory = "${prefix}${tableName.namespace}/${tableName.name}/"
+        val fileName = resolveFileName()
+        partNumber++
+        return "$directory$fileName"
+    }
+
+    /**
+     * Resolves the staging filename.
+     *
+     * If [S3StagingConfiguration.fileNamePattern] is null or blank, returns a default filename
+     * using timestamp and a short UUID for uniqueness. Otherwise, resolves the pattern by
+     * substituting supported `{token}` placeholders — matching the behavior of the legacy
+     * [S3FilenameTemplateManager] used by Redshift v1.
+     */
+    private fun resolveFileName(): String {
+        val pattern = s3Config.fileNamePattern
+        if (pattern.isNullOrBlank()) {
+            val timestamp = Instant.now().toEpochMilli()
+            val uniqueId = UUID.randomUUID().toString().replace("-", "").take(8)
+            return "${timestamp}_$uniqueId$STAGING_FILE_EXTENSION"
+        }
+
+        val millis = Instant.now().toEpochMilli()
+        var resolved = pattern.trim().replace(" ", "_")
+
+        // Step 1: Resolve extended placeholders ({date:<format>}, {timestamp:millis|micro})
+        resolved =
+            EXTENDED_PLACEHOLDER_PATTERN.replace(resolved) { match ->
+                val parts = match.groupValues[1].split(":", limit = 2)
+                when (parts[0].lowercase()) {
+                    "date" -> {
+                        val fmt =
+                            SimpleDateFormat(parts[1]).apply {
+                                timeZone = TimeZone.getTimeZone(UTC)
+                            }
+                        fmt.format(millis)
+                    }
+                    "timestamp" ->
+                        when (parts[1]) {
+                            "millis" -> millis.toString()
+                            "micro" -> (millis * 1000).toString()
+                            else -> match.value
+                        }
+                    else -> match.value
+                }
+            }
+
+        // Step 2: Resolve standard placeholders
+        val defaultDateFmt =
+            SimpleDateFormat(DATE_FORMAT).apply { timeZone = TimeZone.getTimeZone(UTC) }
+        resolved =
+            resolved
+                .replace("{date}", defaultDateFmt.format(millis))
+                .replace("{timestamp}", millis.toString())
+                .replace("{sync_id}", System.getenv("WORKER_JOB_ID") ?: "")
+                .replace("{format_extension}", STAGING_FILE_EXTENSION)
+                .replace("{part_number}", partNumber.toString())
+
+        // Step 3: Ensure the file has the correct extension for Redshift COPY
+        if (!resolved.endsWith(STAGING_FILE_EXTENSION)) {
+            resolved += STAGING_FILE_EXTENSION
+        }
+
+        return resolved
+    }
+
+    /** Resets all internal state for the next batch. */
+    private fun resetState() {
+        csvPrinter = null
+        gzipOutputStream = null
+        byteBuffer = null
+        recordCount = 0
+    }
+}

--- a/airbyte-integrations/connectors/destination-redshift-v2/src/main/kotlin/io/airbyte/integrations/destination/redshift2/write/load/RedshiftRecordFormatter.kt
+++ b/airbyte-integrations/connectors/destination-redshift-v2/src/main/kotlin/io/airbyte/integrations/destination/redshift2/write/load/RedshiftRecordFormatter.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2026 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.integrations.destination.redshift2.write.load
+
+import io.airbyte.cdk.load.data.AirbyteValue
+import io.airbyte.cdk.load.data.csv.toCsvValue
+
+class RedshiftSchemaRecordFormatter(
+    private val columns: List<String>,
+) {
+    /**
+     * Converts a record into a list of CSV values in column order. Columns not present in the
+     * record produce an empty string, which Redshift interprets as NULL for the corresponding
+     * column type.
+     */
+    fun format(record: Map<String, AirbyteValue>): List<Any> =
+        columns.map { columnName ->
+            if (record.containsKey(columnName)) record[columnName].toCsvValue() else ""
+        }
+}

--- a/airbyte-integrations/connectors/destination-redshift-v2/src/main/kotlin/io/airbyte/integrations/destination/redshift2/write/transform/RedshiftValueCoercer.kt
+++ b/airbyte-integrations/connectors/destination-redshift-v2/src/main/kotlin/io/airbyte/integrations/destination/redshift2/write/transform/RedshiftValueCoercer.kt
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2026 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.integrations.destination.redshift2.write.transform
+
+import io.airbyte.cdk.load.data.ArrayValue
+import io.airbyte.cdk.load.data.EnrichedAirbyteValue
+import io.airbyte.cdk.load.data.IntegerValue
+import io.airbyte.cdk.load.data.NullValue
+import io.airbyte.cdk.load.data.NumberValue
+import io.airbyte.cdk.load.data.ObjectValue
+import io.airbyte.cdk.load.data.StringValue
+import io.airbyte.cdk.load.data.UnionType
+import io.airbyte.cdk.load.data.csv.toCsvValue
+import io.airbyte.cdk.load.dataflow.transform.ValidationResult
+import io.airbyte.cdk.load.dataflow.transform.ValueCoercer
+import io.airbyte.cdk.load.util.serializeToString
+import io.airbyte.protocol.models.v0.AirbyteRecordMessageMetaChange
+import jakarta.inject.Singleton
+import java.math.BigDecimal
+import java.math.BigInteger
+
+/*
+ * Redshift-specific data type limits.
+ * See https://docs.aws.amazon.com/redshift/latest/dg/c_Supported_data_types.html
+ */
+
+internal val BIGINT_MAX = BigInteger("9223372036854775807")
+internal val BIGINT_MIN = BigInteger("-9223372036854775808")
+internal val BIGINT_RANGE = BIGINT_MIN..BIGINT_MAX
+internal val NUMERIC_MAX = BigDecimal("1E131072")
+internal val NUMERIC_MIN = BigDecimal("-1E131072")
+internal const val SUPER_LIMIT_BYTES = 16 * 1024 * 1024
+
+/**
+ * Validates and transforms values to conform to Redshift's data type constraints. The CDK calls
+ * coercer methods in order: [representAs] -> [map] -> [validate].
+ *
+ * Key Redshift-specific limits enforced:
+ * - **BIGINT**: int64 range (-2^63 to 2^63-1)
+ * - **SUPER**: 16 MB maximum per value (for JSON objects/arrays)
+ */
+@Singleton
+class RedshiftValueCoercer : ValueCoercer {
+
+    /**
+     * Serializes Union typed values to JSON strings for storage in VARCHAR columns.
+     *
+     * Union types are mapped to `varchar(65535)` columns. Values must be serialized to a JSON
+     * string representation so they can be stored. [NullValue]s pass through unchanged.
+     */
+    override fun map(value: EnrichedAirbyteValue): EnrichedAirbyteValue {
+        if (value.type is UnionType && value.abValue !is NullValue) {
+            value.abValue = StringValue(value.abValue.serializeToString())
+        }
+        return value
+    }
+
+    /**
+     * Validates values against Redshift's data type constraints.
+     *
+     * Returns [ValidationResult.ShouldNullify] for values that exceed Redshift limits, or
+     * [ValidationResult.Valid] for values that are safe to load.
+     */
+    override fun validate(value: EnrichedAirbyteValue): ValidationResult =
+        when (val abValue = value.abValue) {
+            is IntegerValue -> {
+                if (abValue.value !in BIGINT_RANGE) {
+                    ValidationResult.ShouldNullify(
+                        AirbyteRecordMessageMetaChange.Reason.DESTINATION_FIELD_SIZE_LIMITATION
+                    )
+                } else {
+                    ValidationResult.Valid
+                }
+            }
+            is NumberValue -> {
+                if (abValue.value < NUMERIC_MIN || abValue.value > NUMERIC_MAX) {
+                    ValidationResult.ShouldNullify(
+                        AirbyteRecordMessageMetaChange.Reason.DESTINATION_FIELD_SIZE_LIMITATION
+                    )
+                } else {
+                    ValidationResult.Valid
+                }
+            }
+            is ArrayValue,
+            is ObjectValue -> {
+                if (!isSuperValid(abValue.toCsvValue().toString())) {
+                    ValidationResult.ShouldNullify(
+                        AirbyteRecordMessageMetaChange.Reason.DESTINATION_FIELD_SIZE_LIMITATION
+                    )
+                } else {
+                    ValidationResult.Valid
+                }
+            }
+            else -> ValidationResult.Valid
+        }
+}
+
+/** Checks whether a serialized SUPER value fits within Redshift's 16 MB limit. */
+internal fun isSuperValid(s: String): Boolean = s.length <= SUPER_LIMIT_BYTES

--- a/airbyte-integrations/connectors/destination-redshift-v2/src/test/kotlin/io/airbyte/integrations/destination/redshift2/dataflow/RedshiftAggregateFactoryTest.kt
+++ b/airbyte-integrations/connectors/destination-redshift-v2/src/test/kotlin/io/airbyte/integrations/destination/redshift2/dataflow/RedshiftAggregateFactoryTest.kt
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2026 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.integrations.destination.redshift2.dataflow
+
+import io.airbyte.cdk.load.command.DestinationStream
+import io.airbyte.cdk.load.schema.model.TableName
+import io.airbyte.cdk.load.table.directload.DirectLoadTableExecutionConfig
+import io.airbyte.cdk.load.write.StreamStateStore
+import io.airbyte.integrations.destination.redshift2.client.RedshiftAirbyteClient
+import io.airbyte.integrations.destination.redshift2.config.RedshiftConfiguration
+import io.airbyte.integrations.destination.redshift2.config.S3StagingConfiguration
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.junit5.MockKExtension
+import io.mockk.verify
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+
+@ExtendWith(MockKExtension::class)
+internal class RedshiftAggregateFactoryTest {
+
+    @MockK lateinit var redshiftClient: RedshiftAirbyteClient
+    @MockK lateinit var streamStateStore: StreamStateStore<DirectLoadTableExecutionConfig>
+
+    private val tableName = TableName(namespace = "my_schema", name = "my_table")
+    private val storeKey = DestinationStream.Descriptor("my_namespace", "my_stream")
+
+    private val s3Config =
+        S3StagingConfiguration(
+            s3BucketName = "test-bucket",
+            s3BucketRegion = "us-east-1",
+            accessKeyId = "AKID",
+            secretAccessKey = "SECRET",
+        )
+
+    private val configuration =
+        RedshiftConfiguration(
+            host = "redshift.example.com",
+            port = 5439,
+            database = "mydb",
+            schema = "public",
+            username = "admin",
+            password = "secret",
+            jdbcUrlParams = null,
+            uploadingMethod = s3Config,
+            tunnelMethod = null,
+        )
+
+    private lateinit var factory: RedshiftAggregateFactory
+
+    @BeforeEach
+    fun setUp() {
+        factory = RedshiftAggregateFactory(redshiftClient, streamStateStore, configuration)
+    }
+
+    @Test
+    fun `create resolves table name from stream state store`() {
+        val executionConfig = DirectLoadTableExecutionConfig(tableName = tableName)
+        every { streamStateStore.get(storeKey) } returns executionConfig
+        every { redshiftClient.describeTable(tableName) } returns
+            listOf(
+                "_airbyte_raw_id",
+                "_airbyte_extracted_at",
+                "_airbyte_meta",
+                "_airbyte_generation_id",
+                "col1"
+            )
+
+        val aggregate = factory.create(storeKey)
+
+        assertNotNull(aggregate)
+        assertTrue(aggregate is RedshiftAggregate)
+        verify { streamStateStore.get(storeKey) }
+        verify { redshiftClient.describeTable(tableName) }
+    }
+
+    @Test
+    fun `create calls describeTable with correct table name`() {
+        val executionConfig = DirectLoadTableExecutionConfig(tableName = tableName)
+        every { streamStateStore.get(storeKey) } returns executionConfig
+        every { redshiftClient.describeTable(tableName) } returns listOf("id", "name")
+
+        factory.create(storeKey)
+
+        verify(exactly = 1) { redshiftClient.describeTable(tableName) }
+    }
+
+    @Test
+    fun `create produces distinct aggregates per invocation`() {
+        val executionConfig = DirectLoadTableExecutionConfig(tableName = tableName)
+        every { streamStateStore.get(storeKey) } returns executionConfig
+        every { redshiftClient.describeTable(tableName) } returns listOf("id")
+
+        val agg1 = factory.create(storeKey)
+        val agg2 = factory.create(storeKey)
+
+        // Each invocation should produce a fresh aggregate with its own buffer
+        assertTrue(agg1 !== agg2, "Factory should produce distinct aggregate instances")
+    }
+}

--- a/airbyte-integrations/connectors/destination-redshift-v2/src/test/kotlin/io/airbyte/integrations/destination/redshift2/schema/RedshiftTableSchemaMapperTest.kt
+++ b/airbyte-integrations/connectors/destination-redshift-v2/src/test/kotlin/io/airbyte/integrations/destination/redshift2/schema/RedshiftTableSchemaMapperTest.kt
@@ -207,7 +207,7 @@ class RedshiftTableSchemaMapperTest {
                         UnionType(setOf(StringType, IntegerType), isLegacyUnion = false),
                         true,
                     ),
-                    "super",
+                    "varchar(65535)",
                 ),
                 Arguments.of(
                     FieldType(

--- a/airbyte-integrations/connectors/destination-redshift-v2/src/test/kotlin/io/airbyte/integrations/destination/redshift2/write/load/RedshiftInsertBufferTest.kt
+++ b/airbyte-integrations/connectors/destination-redshift-v2/src/test/kotlin/io/airbyte/integrations/destination/redshift2/write/load/RedshiftInsertBufferTest.kt
@@ -1,0 +1,499 @@
+/*
+ * Copyright (c) 2026 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.integrations.destination.redshift2.write.load
+
+import com.amazonaws.services.s3.model.ObjectMetadata
+import io.airbyte.cdk.load.data.IntegerValue
+import io.airbyte.cdk.load.data.StringValue
+import io.airbyte.cdk.load.schema.model.TableName
+import io.airbyte.integrations.destination.redshift2.client.RedshiftAirbyteClient
+import io.airbyte.integrations.destination.redshift2.config.RedshiftConfiguration
+import io.airbyte.integrations.destination.redshift2.config.S3StagingConfiguration
+import io.mockk.Runs
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.coVerifyOrder
+import io.mockk.impl.annotations.MockK
+import io.mockk.junit5.MockKExtension
+import io.mockk.just
+import io.mockk.slot
+import java.math.BigInteger
+import java.text.SimpleDateFormat
+import java.util.TimeZone
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+
+@ExtendWith(MockKExtension::class)
+internal class RedshiftInsertBufferTest {
+
+    @MockK lateinit var redshiftClient: RedshiftAirbyteClient
+
+    private val tableName = TableName(namespace = "test_schema", name = "test_table")
+    private val columns =
+        listOf(
+            "_airbyte_raw_id",
+            "_airbyte_extracted_at",
+            "_airbyte_meta",
+            "_airbyte_generation_id",
+            "name"
+        )
+
+    private val s3Config =
+        S3StagingConfiguration(
+            s3BucketName = "my-bucket",
+            s3BucketPath = "staging/data",
+            s3BucketRegion = "us-west-2",
+            accessKeyId = "AKID",
+            secretAccessKey = "SECRET",
+            purgeStagingData = true,
+        )
+
+    private val configuration =
+        RedshiftConfiguration(
+            host = "redshift.example.com",
+            port = 5439,
+            database = "mydb",
+            schema = "public",
+            username = "admin",
+            password = "secret",
+            jdbcUrlParams = null,
+            uploadingMethod = s3Config,
+            tunnelMethod = null,
+        )
+
+    private lateinit var buffer: RedshiftInsertBuffer
+
+    @BeforeEach
+    fun setUp() {
+        coEvery { redshiftClient.uploadToS3(any(), any(), any(), any()) } just Runs
+        coEvery { redshiftClient.copyFromS3(any(), any(), any(), any(), any()) } just Runs
+        coEvery { redshiftClient.deleteFromS3(any(), any()) } just Runs
+
+        buffer = RedshiftInsertBuffer(tableName, columns, redshiftClient, configuration)
+    }
+
+    @Test
+    fun `accumulate and flush uploads to S3 and executes COPY`() = runTest {
+        val record =
+            mapOf(
+                "_airbyte_raw_id" to StringValue("uuid-1"),
+                "_airbyte_extracted_at" to StringValue("2026-01-01T00:00:00Z"),
+                "_airbyte_meta" to StringValue("{}"),
+                "_airbyte_generation_id" to IntegerValue(BigInteger.ZERO),
+                "name" to StringValue("Alice"),
+            )
+
+        buffer.accumulate(record)
+        assertEquals(1, buffer.recordCount)
+
+        buffer.flush()
+
+        // Verify the full pipeline: upload -> COPY -> cleanup
+        coVerifyOrder {
+            redshiftClient.uploadToS3(eq("my-bucket"), any(), any(), any())
+            redshiftClient.copyFromS3(
+                tableName = eq(tableName),
+                s3Path = match { it.startsWith("s3://my-bucket/staging/data/") },
+                accessKeyId = eq("AKID"),
+                secretAccessKey = eq("SECRET"),
+                region = eq("us-west-2"),
+            )
+            redshiftClient.deleteFromS3(eq("my-bucket"), any())
+        }
+
+        // State is reset after flush
+        assertEquals(0, buffer.recordCount)
+    }
+
+    @Test
+    fun `flush with no data is a no-op`() = runTest {
+        buffer.flush()
+
+        coVerify(exactly = 0) { redshiftClient.uploadToS3(any(), any(), any(), any()) }
+        coVerify(exactly = 0) { redshiftClient.copyFromS3(any(), any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `uploaded data is valid gzip CSV with header`() = runTest {
+        val record =
+            mapOf(
+                "_airbyte_raw_id" to StringValue("id-1"),
+                "_airbyte_extracted_at" to StringValue("2026-04-01T12:00:00Z"),
+                "_airbyte_meta" to StringValue("{}"),
+                "_airbyte_generation_id" to IntegerValue(BigInteger.ONE),
+                "name" to StringValue("Bob"),
+            )
+
+        buffer.accumulate(record)
+        buffer.flush()
+
+        val dataSlot = slot<ByteArray>()
+        coVerify { redshiftClient.uploadToS3(any(), any(), capture(dataSlot), any()) }
+
+        // Decompress and verify CSV content
+        val csvContent =
+            java.util.zip
+                .GZIPInputStream(java.io.ByteArrayInputStream(dataSlot.captured))
+                .bufferedReader()
+                .readText()
+
+        val lines = csvContent.trim().split("\n")
+        assertEquals(2, lines.size, "Expected header + 1 data row")
+
+        // Header row matches column names
+        val header = lines[0]
+        assertTrue(header.contains("_airbyte_raw_id"), "Header should contain _airbyte_raw_id")
+        assertTrue(header.contains("name"), "Header should contain 'name'")
+
+        // Data row has the right values
+        val dataRow = lines[1]
+        assertTrue(dataRow.contains("id-1"), "Data should contain raw_id value")
+        assertTrue(dataRow.contains("Bob"), "Data should contain name value")
+    }
+
+    @Test
+    fun `S3 key includes bucket path and table info`() = runTest {
+        val record = mapOf("_airbyte_raw_id" to StringValue("x"), "name" to StringValue("y"))
+
+        buffer.accumulate(record)
+        buffer.flush()
+
+        val keySlot = slot<String>()
+        coVerify { redshiftClient.uploadToS3(any(), capture(keySlot), any(), any()) }
+
+        val key = keySlot.captured
+        assertTrue(key.startsWith("staging/data/"), "Key should start with bucket path")
+        assertTrue(key.contains("test_schema/"), "Key should contain namespace")
+        assertTrue(key.contains("test_table/"), "Key should contain table name")
+        assertTrue(key.endsWith(".csv.gz"), "Key should end with .csv.gz")
+    }
+
+    @Test
+    fun `S3 key handles null bucket path`() = runTest {
+        val noPrefixConfig = s3Config.copy(s3BucketPath = null)
+        val noPrefixConfiguration = configuration.copy(uploadingMethod = noPrefixConfig)
+        val bufferNoPrefix =
+            RedshiftInsertBuffer(tableName, columns, redshiftClient, noPrefixConfiguration)
+
+        bufferNoPrefix.accumulate(
+            mapOf("_airbyte_raw_id" to StringValue("x"), "name" to StringValue("y"))
+        )
+        bufferNoPrefix.flush()
+
+        val keySlot = slot<String>()
+        coVerify { redshiftClient.uploadToS3(any(), capture(keySlot), any(), any()) }
+
+        val key = keySlot.captured
+        assertTrue(key.startsWith("test_schema/"), "Key without prefix should start with namespace")
+    }
+
+    @Test
+    fun `purge staging data is skipped when disabled`() = runTest {
+        val noPurgeConfig = s3Config.copy(purgeStagingData = false)
+        val noPurgeConfiguration = configuration.copy(uploadingMethod = noPurgeConfig)
+        val noPurgeBuffer =
+            RedshiftInsertBuffer(tableName, columns, redshiftClient, noPurgeConfiguration)
+
+        noPurgeBuffer.accumulate(
+            mapOf("_airbyte_raw_id" to StringValue("x"), "name" to StringValue("y"))
+        )
+        noPurgeBuffer.flush()
+
+        coVerify(exactly = 1) { redshiftClient.uploadToS3(any(), any(), any(), any()) }
+        coVerify(exactly = 1) { redshiftClient.copyFromS3(any(), any(), any(), any(), any()) }
+        coVerify(exactly = 0) { redshiftClient.deleteFromS3(any(), any()) }
+    }
+
+    @Test
+    fun `multiple accumulate calls batch into single flush`() = runTest {
+        repeat(5) { i ->
+            buffer.accumulate(
+                mapOf(
+                    "_airbyte_raw_id" to StringValue("id-$i"),
+                    "name" to StringValue("name-$i"),
+                )
+            )
+        }
+        assertEquals(5, buffer.recordCount)
+
+        buffer.flush()
+
+        // Single upload + COPY for all 5 records
+        coVerify(exactly = 1) { redshiftClient.uploadToS3(any(), any(), any(), any()) }
+        coVerify(exactly = 1) { redshiftClient.copyFromS3(any(), any(), any(), any(), any()) }
+
+        assertEquals(0, buffer.recordCount)
+    }
+
+    @Test
+    fun `upload metadata has correct content type and length`() = runTest {
+        buffer.accumulate(mapOf("_airbyte_raw_id" to StringValue("x"), "name" to StringValue("y")))
+        buffer.flush()
+
+        val metadataSlot = slot<ObjectMetadata>()
+        coVerify { redshiftClient.uploadToS3(any(), any(), any(), capture(metadataSlot)) }
+
+        assertEquals("application/gzip", metadataSlot.captured.contentType)
+        assertTrue(metadataSlot.captured.contentLength > 0)
+    }
+
+    @Test
+    fun `buffer can be reused after flush`() = runTest {
+        buffer.accumulate(mapOf("_airbyte_raw_id" to StringValue("batch1")))
+        buffer.flush()
+
+        buffer.accumulate(mapOf("_airbyte_raw_id" to StringValue("batch2")))
+        buffer.flush()
+
+        coVerify(exactly = 2) { redshiftClient.uploadToS3(any(), any(), any(), any()) }
+        coVerify(exactly = 2) { redshiftClient.copyFromS3(any(), any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `flush propagates exceptions from copyFromS3`() = runTest {
+        coEvery { redshiftClient.copyFromS3(any(), any(), any(), any(), any()) } throws
+            RuntimeException("COPY failed")
+
+        buffer.accumulate(mapOf("_airbyte_raw_id" to StringValue("x")))
+
+        val exception = org.junit.jupiter.api.assertThrows<RuntimeException> { buffer.flush() }
+        assertEquals("COPY failed", exception.message)
+
+        // State is reset even after error
+        assertEquals(0, buffer.recordCount)
+    }
+
+    @Test
+    fun `default region used when s3BucketRegion is null`() = runTest {
+        val noRegionConfig = s3Config.copy(s3BucketRegion = null)
+        val noRegionConfiguration = configuration.copy(uploadingMethod = noRegionConfig)
+        val noRegionBuffer =
+            RedshiftInsertBuffer(tableName, columns, redshiftClient, noRegionConfiguration)
+
+        noRegionBuffer.accumulate(mapOf("_airbyte_raw_id" to StringValue("x")))
+        noRegionBuffer.flush()
+
+        coVerify {
+            redshiftClient.copyFromS3(
+                tableName = any(),
+                s3Path = any(),
+                accessKeyId = any(),
+                secretAccessKey = any(),
+                region = eq("us-east-1"),
+            )
+        }
+    }
+
+    // ================================================================
+    // fileNamePattern tests
+    // ================================================================
+
+    @Test
+    fun `null fileNamePattern uses default timestamp_uuid format`() {
+        // s3Config already has fileNamePattern = null (default)
+        val buf = RedshiftInsertBuffer(tableName, columns, redshiftClient, configuration)
+        val key = buf.buildStagingS3Key()
+
+        assertTrue(key.startsWith("staging/data/test_schema/test_table/"), "Directory prefix")
+        assertTrue(key.endsWith(".csv.gz"), "Extension")
+        // Default format: {timestamp}_{8-char-uuid}.csv.gz
+        val fileName = key.substringAfterLast("/")
+        assertTrue(
+            fileName.matches(Regex("""\d+_[a-f0-9]{8}\.csv\.gz""")),
+            "Default format: $fileName"
+        )
+    }
+
+    @Test
+    fun `blank fileNamePattern uses default format`() {
+        val blankPatternConfig = s3Config.copy(fileNamePattern = "   ")
+        val blankConfiguration = configuration.copy(uploadingMethod = blankPatternConfig)
+        val buf = RedshiftInsertBuffer(tableName, columns, redshiftClient, blankConfiguration)
+        val key = buf.buildStagingS3Key()
+
+        val fileName = key.substringAfterLast("/")
+        assertTrue(
+            fileName.matches(Regex("""\d+_[a-f0-9]{8}\.csv\.gz""")),
+            "Default format for blank: $fileName"
+        )
+    }
+
+    @Test
+    fun `fileNamePattern with date token resolves to yyyy_MM_dd`() {
+        val patternConfig = s3Config.copy(fileNamePattern = "{date}")
+        val patternConfiguration = configuration.copy(uploadingMethod = patternConfig)
+        val buf = RedshiftInsertBuffer(tableName, columns, redshiftClient, patternConfiguration)
+        val key = buf.buildStagingS3Key()
+
+        val fileName = key.substringAfterLast("/")
+        // Should be like 2026_04_28.csv.gz (auto-appended extension)
+        assertTrue(
+            fileName.matches(Regex("""\d{4}_\d{2}_\d{2}\.csv\.gz""")),
+            "Date format: $fileName"
+        )
+    }
+
+    @Test
+    fun `fileNamePattern with timestamp token resolves to epoch millis`() {
+        val patternConfig = s3Config.copy(fileNamePattern = "{timestamp}{format_extension}")
+        val patternConfiguration = configuration.copy(uploadingMethod = patternConfig)
+        val buf = RedshiftInsertBuffer(tableName, columns, redshiftClient, patternConfiguration)
+
+        val before = System.currentTimeMillis()
+        val key = buf.buildStagingS3Key()
+        val after = System.currentTimeMillis()
+
+        val fileName = key.substringAfterLast("/")
+        assertTrue(fileName.endsWith(".csv.gz"), "Extension present: $fileName")
+        val timestampStr = fileName.removeSuffix(".csv.gz")
+        val timestamp = timestampStr.toLong()
+        assertTrue(timestamp in before..after, "Timestamp in range: $timestamp")
+    }
+
+    @Test
+    fun `fileNamePattern with format_extension does not double-append`() {
+        val patternConfig = s3Config.copy(fileNamePattern = "data_{date}{format_extension}")
+        val patternConfiguration = configuration.copy(uploadingMethod = patternConfig)
+        val buf = RedshiftInsertBuffer(tableName, columns, redshiftClient, patternConfiguration)
+        val key = buf.buildStagingS3Key()
+
+        val fileName = key.substringAfterLast("/")
+        // Should NOT have .csv.gz.csv.gz
+        assertFalse(fileName.endsWith(".csv.gz.csv.gz"), "No double extension: $fileName")
+        assertTrue(fileName.endsWith(".csv.gz"), "Ends with extension: $fileName")
+        assertTrue(fileName.startsWith("data_"), "Starts with prefix: $fileName")
+    }
+
+    @Test
+    fun `fileNamePattern without format_extension auto-appends csv gz`() {
+        val patternConfig = s3Config.copy(fileNamePattern = "myfile_{date}_{timestamp}")
+        val patternConfiguration = configuration.copy(uploadingMethod = patternConfig)
+        val buf = RedshiftInsertBuffer(tableName, columns, redshiftClient, patternConfiguration)
+        val key = buf.buildStagingS3Key()
+
+        val fileName = key.substringAfterLast("/")
+        assertTrue(fileName.endsWith(".csv.gz"), "Auto-appended extension: $fileName")
+        assertTrue(fileName.startsWith("myfile_"), "Prefix preserved: $fileName")
+    }
+
+    @Test
+    fun `fileNamePattern with part_number increments across flushes`() {
+        val patternConfig = s3Config.copy(fileNamePattern = "part_{part_number}{format_extension}")
+        val patternConfiguration = configuration.copy(uploadingMethod = patternConfig)
+        val buf = RedshiftInsertBuffer(tableName, columns, redshiftClient, patternConfiguration)
+
+        val key1 = buf.buildStagingS3Key()
+        val key2 = buf.buildStagingS3Key()
+        val key3 = buf.buildStagingS3Key()
+
+        val fileName1 = key1.substringAfterLast("/")
+        val fileName2 = key2.substringAfterLast("/")
+        val fileName3 = key3.substringAfterLast("/")
+
+        assertEquals("part_0.csv.gz", fileName1)
+        assertEquals("part_1.csv.gz", fileName2)
+        assertEquals("part_2.csv.gz", fileName3)
+    }
+
+    @Test
+    fun `fileNamePattern with extended date format`() {
+        val patternConfig =
+            s3Config.copy(fileNamePattern = "{date:yyyy_MM}_{part_number}{format_extension}")
+        val patternConfiguration = configuration.copy(uploadingMethod = patternConfig)
+        val buf = RedshiftInsertBuffer(tableName, columns, redshiftClient, patternConfiguration)
+        val key = buf.buildStagingS3Key()
+
+        val fileName = key.substringAfterLast("/")
+        // Should be like 2026_04_0.csv.gz
+        assertTrue(
+            fileName.matches(Regex("""\d{4}_\d{2}_\d+\.csv\.gz""")),
+            "Extended date format: $fileName"
+        )
+    }
+
+    @Test
+    fun `fileNamePattern with timestamp millis extended placeholder`() {
+        val patternConfig = s3Config.copy(fileNamePattern = "{timestamp:millis}{format_extension}")
+        val patternConfiguration = configuration.copy(uploadingMethod = patternConfig)
+        val buf = RedshiftInsertBuffer(tableName, columns, redshiftClient, patternConfiguration)
+
+        val before = System.currentTimeMillis()
+        val key = buf.buildStagingS3Key()
+        val after = System.currentTimeMillis()
+
+        val fileName = key.substringAfterLast("/")
+        val timestampStr = fileName.removeSuffix(".csv.gz")
+        val timestamp = timestampStr.toLong()
+        assertTrue(timestamp in before..after, "Millis timestamp in range: $timestamp")
+    }
+
+    @Test
+    fun `fileNamePattern with timestamp micro extended placeholder`() {
+        val patternConfig = s3Config.copy(fileNamePattern = "{timestamp:micro}{format_extension}")
+        val patternConfiguration = configuration.copy(uploadingMethod = patternConfig)
+        val buf = RedshiftInsertBuffer(tableName, columns, redshiftClient, patternConfiguration)
+
+        val beforeMicro = System.currentTimeMillis() * 1000
+        val key = buf.buildStagingS3Key()
+        val afterMicro = System.currentTimeMillis() * 1000
+
+        val fileName = key.substringAfterLast("/")
+        val microStr = fileName.removeSuffix(".csv.gz")
+        val micro = microStr.toLong()
+        assertTrue(micro in beforeMicro..afterMicro, "Micro timestamp in range: $micro")
+    }
+
+    @Test
+    fun `fileNamePattern with spaces are replaced by underscores`() {
+        val patternConfig = s3Config.copy(fileNamePattern = "my file {date}")
+        val patternConfiguration = configuration.copy(uploadingMethod = patternConfig)
+        val buf = RedshiftInsertBuffer(tableName, columns, redshiftClient, patternConfiguration)
+        val key = buf.buildStagingS3Key()
+
+        val fileName = key.substringAfterLast("/")
+        assertFalse(fileName.contains(" "), "No spaces: $fileName")
+        assertTrue(fileName.startsWith("my_file_"), "Spaces replaced: $fileName")
+    }
+
+    @Test
+    fun `fileNamePattern directory path is always preserved`() {
+        val patternConfig =
+            s3Config.copy(fileNamePattern = "{date}_{part_number}{format_extension}")
+        val patternConfiguration = configuration.copy(uploadingMethod = patternConfig)
+        val buf = RedshiftInsertBuffer(tableName, columns, redshiftClient, patternConfiguration)
+        val key = buf.buildStagingS3Key()
+
+        // Directory path should still be {bucketPath}/{namespace}/{tableName}/
+        assertTrue(
+            key.startsWith("staging/data/test_schema/test_table/"),
+            "Directory unchanged: $key"
+        )
+    }
+
+    @Test
+    fun `fileNamePattern with all standard tokens combined`() {
+        val patternConfig =
+            s3Config.copy(fileNamePattern = "{date}_{timestamp}_{part_number}{format_extension}")
+        val patternConfiguration = configuration.copy(uploadingMethod = patternConfig)
+        val buf = RedshiftInsertBuffer(tableName, columns, redshiftClient, patternConfiguration)
+
+        val before = System.currentTimeMillis()
+        val key = buf.buildStagingS3Key()
+
+        val fileName = key.substringAfterLast("/")
+        assertTrue(fileName.endsWith(".csv.gz"), "Extension: $fileName")
+
+        val dateFmt =
+            SimpleDateFormat("yyyy_MM_dd").apply { timeZone = TimeZone.getTimeZone("UTC") }
+        val todayDate = dateFmt.format(before)
+        assertTrue(fileName.startsWith(todayDate), "Starts with today's date: $fileName")
+        assertTrue(fileName.contains("_0.csv.gz"), "Contains part_number 0: $fileName")
+    }
+}

--- a/airbyte-integrations/connectors/destination-redshift-v2/src/test/kotlin/io/airbyte/integrations/destination/redshift2/write/load/RedshiftRecordFormatterTest.kt
+++ b/airbyte-integrations/connectors/destination-redshift-v2/src/test/kotlin/io/airbyte/integrations/destination/redshift2/write/load/RedshiftRecordFormatterTest.kt
@@ -1,0 +1,144 @@
+/*
+ * Copyright (c) 2026 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.integrations.destination.redshift2.write.load
+
+import io.airbyte.cdk.load.data.ArrayValue
+import io.airbyte.cdk.load.data.BooleanValue
+import io.airbyte.cdk.load.data.IntegerValue
+import io.airbyte.cdk.load.data.NullValue
+import io.airbyte.cdk.load.data.NumberValue
+import io.airbyte.cdk.load.data.ObjectValue
+import io.airbyte.cdk.load.data.StringValue
+import java.math.BigDecimal
+import java.math.BigInteger
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+internal class RedshiftRecordFormatterTest {
+
+    @Test
+    fun `format produces values in column order`() {
+        val columns = listOf("_airbyte_raw_id", "_airbyte_extracted_at", "name", "age")
+        val formatter = RedshiftSchemaRecordFormatter(columns)
+
+        val record =
+            mapOf(
+                "_airbyte_raw_id" to StringValue("abc-123"),
+                "_airbyte_extracted_at" to StringValue("2026-01-01T00:00:00Z"),
+                "name" to StringValue("Alice"),
+                "age" to IntegerValue(BigInteger.valueOf(30)),
+            )
+
+        val result = formatter.format(record)
+
+        assertEquals(4, result.size)
+        assertEquals("abc-123", result[0])
+        assertEquals("2026-01-01T00:00:00Z", result[1])
+        assertEquals("Alice", result[2])
+        assertEquals(BigInteger.valueOf(30), result[3])
+    }
+
+    @Test
+    fun `format returns empty string for missing columns`() {
+        val columns = listOf("id", "name", "missing_col")
+        val formatter = RedshiftSchemaRecordFormatter(columns)
+
+        val record =
+            mapOf(
+                "id" to IntegerValue(BigInteger.ONE),
+                "name" to StringValue("Bob"),
+            )
+
+        val result = formatter.format(record)
+
+        assertEquals(3, result.size)
+        assertEquals(BigInteger.ONE, result[0])
+        assertEquals("Bob", result[1])
+        assertEquals("", result[2])
+    }
+
+    @Test
+    fun `format handles null values via toCsvValue`() {
+        val columns = listOf("col_a", "col_b")
+        val formatter = RedshiftSchemaRecordFormatter(columns)
+
+        val record =
+            mapOf(
+                "col_a" to NullValue,
+                "col_b" to StringValue("present"),
+            )
+
+        val result = formatter.format(record)
+
+        assertEquals(2, result.size)
+        assertEquals("", result[0]) // NullValue -> empty string via toCsvValue
+        assertEquals("present", result[1])
+    }
+
+    @Test
+    fun `format serializes objects and arrays as JSON strings`() {
+        val columns = listOf("json_obj", "json_arr")
+        val formatter = RedshiftSchemaRecordFormatter(columns)
+
+        val record =
+            mapOf(
+                "json_obj" to ObjectValue(linkedMapOf("key" to StringValue("value"))),
+                "json_arr" to
+                    ArrayValue(listOf(IntegerValue(BigInteger.ONE), IntegerValue(BigInteger.TWO))),
+            )
+
+        val result = formatter.format(record)
+
+        assertEquals(2, result.size)
+        // ObjectValue and ArrayValue are serialized to JSON strings by toCsvValue
+        assertEquals("""{"key":"value"}""", result[0])
+        assertEquals("[1,2]", result[1])
+    }
+
+    @Test
+    fun `format handles boolean and number types`() {
+        val columns = listOf("is_active", "price")
+        val formatter = RedshiftSchemaRecordFormatter(columns)
+
+        val record =
+            mapOf(
+                "is_active" to BooleanValue(true),
+                "price" to NumberValue(BigDecimal("19.99")),
+            )
+
+        val result = formatter.format(record)
+
+        assertEquals(2, result.size)
+        assertEquals(true, result[0])
+        assertEquals(BigDecimal("19.99"), result[1])
+    }
+
+    @Test
+    fun `format with empty record returns all empty strings`() {
+        val columns = listOf("a", "b", "c")
+        val formatter = RedshiftSchemaRecordFormatter(columns)
+
+        val result = formatter.format(emptyMap())
+
+        assertEquals(listOf("", "", ""), result)
+    }
+
+    @Test
+    fun `format ignores extra fields not in column list`() {
+        val columns = listOf("id")
+        val formatter = RedshiftSchemaRecordFormatter(columns)
+
+        val record =
+            mapOf(
+                "id" to IntegerValue(BigInteger.ONE),
+                "extra_field" to StringValue("should be ignored"),
+            )
+
+        val result = formatter.format(record)
+
+        assertEquals(1, result.size)
+        assertEquals(BigInteger.ONE, result[0])
+    }
+}

--- a/airbyte-integrations/connectors/destination-redshift-v2/src/test/kotlin/io/airbyte/integrations/destination/redshift2/write/transform/RedshiftValueCoercerTest.kt
+++ b/airbyte-integrations/connectors/destination-redshift-v2/src/test/kotlin/io/airbyte/integrations/destination/redshift2/write/transform/RedshiftValueCoercerTest.kt
@@ -1,0 +1,316 @@
+/*
+ * Copyright (c) 2026 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.integrations.destination.redshift2.write.transform
+
+import com.fasterxml.jackson.databind.node.NullNode
+import io.airbyte.cdk.load.data.AirbyteValue
+import io.airbyte.cdk.load.data.ArrayType
+import io.airbyte.cdk.load.data.ArrayValue
+import io.airbyte.cdk.load.data.BooleanValue
+import io.airbyte.cdk.load.data.EnrichedAirbyteValue
+import io.airbyte.cdk.load.data.FieldType
+import io.airbyte.cdk.load.data.IntegerType
+import io.airbyte.cdk.load.data.IntegerValue
+import io.airbyte.cdk.load.data.NullValue
+import io.airbyte.cdk.load.data.NumberType
+import io.airbyte.cdk.load.data.NumberValue
+import io.airbyte.cdk.load.data.ObjectType
+import io.airbyte.cdk.load.data.ObjectValue
+import io.airbyte.cdk.load.data.StringType
+import io.airbyte.cdk.load.data.StringValue
+import io.airbyte.cdk.load.data.UnionType
+import io.airbyte.cdk.load.data.UnknownType
+import io.airbyte.cdk.load.dataflow.transform.ValidationResult
+import io.airbyte.protocol.models.v0.AirbyteRecordMessageMetaChange
+import java.math.BigDecimal
+import java.math.BigInteger
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+internal class RedshiftValueCoercerTest {
+
+    private lateinit var coercer: RedshiftValueCoercer
+
+    @BeforeEach
+    fun setUp() {
+        coercer = RedshiftValueCoercer()
+    }
+
+    // ================================================================
+    // map() tests
+    // ================================================================
+
+    @Test
+    fun `map passes through non-union types unchanged`() {
+        val value = StringValue("hello")
+        val enriched = enriched(value, StringType)
+
+        val result = coercer.map(enriched)
+
+        assertEquals(value, result.abValue)
+    }
+
+    @Test
+    fun `map serializes union type values to string`() {
+        val value = ObjectValue(linkedMapOf("key" to StringValue("val")))
+        val enriched =
+            enriched(value, UnionType(options = setOf(StringType), isLegacyUnion = false))
+
+        val result = coercer.map(enriched)
+
+        assertTrue(result.abValue is StringValue)
+        assertEquals(StringType, result.abValue.airbyteType)
+    }
+
+    @Test
+    fun `map passes through unknown type values unchanged`() {
+        val value = IntegerValue(42)
+        val enriched = enriched(value, UnknownType(schema = NullNode.instance))
+
+        val result = coercer.map(enriched)
+
+        assertEquals(value, result.abValue)
+    }
+
+    @Test
+    fun `map serializes legacy union type values to string`() {
+        val value = ObjectValue(linkedMapOf("key" to StringValue("val")))
+        val enriched = enriched(value, UnionType(options = setOf(StringType), isLegacyUnion = true))
+
+        val result = coercer.map(enriched)
+
+        assertTrue(result.abValue is StringValue)
+    }
+
+    @Test
+    fun `map preserves NullValue for union types`() {
+        val enriched =
+            enriched(NullValue, UnionType(options = setOf(StringType), isLegacyUnion = false))
+
+        val result = coercer.map(enriched)
+
+        assertEquals(NullValue, result.abValue)
+    }
+
+    // ================================================================
+    // validate() — Integer (BIGINT) tests
+    // ================================================================
+
+    @Test
+    fun `validate accepts valid integer`() {
+        val result = coercer.validate(enriched(IntegerValue(10000.toBigInteger()), IntegerType))
+        assertEquals(ValidationResult.Valid, result)
+    }
+
+    @Test
+    fun `validate accepts integer at BIGINT_MAX boundary`() {
+        val result = coercer.validate(enriched(IntegerValue(BIGINT_MAX), IntegerType))
+        assertEquals(ValidationResult.Valid, result)
+    }
+
+    @Test
+    fun `validate accepts integer at BIGINT_MIN boundary`() {
+        val result = coercer.validate(enriched(IntegerValue(BIGINT_MIN), IntegerType))
+        assertEquals(ValidationResult.Valid, result)
+    }
+
+    @Test
+    fun `validate nullifies integer above BIGINT_MAX`() {
+        val result =
+            coercer.validate(enriched(IntegerValue(BIGINT_MAX + BigInteger.ONE), IntegerType))
+        assertShouldNullify(result)
+    }
+
+    @Test
+    fun `validate nullifies integer below BIGINT_MIN`() {
+        val result =
+            coercer.validate(enriched(IntegerValue(BIGINT_MIN - BigInteger.ONE), IntegerType))
+        assertShouldNullify(result)
+    }
+
+    @Test
+    fun `validate accepts zero integer`() {
+        val result = coercer.validate(enriched(IntegerValue(BigInteger.ZERO), IntegerType))
+        assertEquals(ValidationResult.Valid, result)
+    }
+
+    // ================================================================
+    // validate() — Number (NUMERIC) tests
+    // ================================================================
+
+    @Test
+    fun `validate accepts valid number`() {
+        val result = coercer.validate(enriched(NumberValue(BigDecimal("10000.123")), NumberType))
+        assertEquals(ValidationResult.Valid, result)
+    }
+
+    @Test
+    fun `validate nullifies number exceeding maximum`() {
+        val result =
+            coercer.validate(
+                enriched(NumberValue(NUMERIC_MAX.multiply(BigDecimal.TEN)), NumberType)
+            )
+        assertShouldNullify(result)
+    }
+
+    @Test
+    fun `validate nullifies number below minimum`() {
+        val result =
+            coercer.validate(
+                enriched(NumberValue(NUMERIC_MIN.multiply(BigDecimal.TEN)), NumberType)
+            )
+        assertShouldNullify(result)
+    }
+
+    @Test
+    fun `validate accepts zero number`() {
+        val result = coercer.validate(enriched(NumberValue(BigDecimal.ZERO), NumberType))
+        assertEquals(ValidationResult.Valid, result)
+    }
+
+    @Test
+    fun `validate accepts very small positive number`() {
+        val result =
+            coercer.validate(enriched(NumberValue(BigDecimal("0.000000000001")), NumberType))
+        assertEquals(ValidationResult.Valid, result)
+    }
+
+    @Test
+    fun `validate accepts scientific notation number`() {
+        val result = coercer.validate(enriched(NumberValue(BigDecimal("1.23E-10")), NumberType))
+        assertEquals(ValidationResult.Valid, result)
+    }
+
+    // ================================================================
+    // validate() — Object/Array (SUPER 16MB) tests
+    // ================================================================
+
+    @Test
+    fun `validate accepts small object`() {
+        val obj =
+            ObjectValue(
+                linkedMapOf(
+                    "foo" to IntegerValue(1),
+                    "bar" to IntegerValue(2),
+                )
+            )
+        val result =
+            coercer.validate(
+                enriched(
+                    obj,
+                    ObjectType(
+                        properties = linkedMapOf(),
+                        additionalProperties = true,
+                        required = emptyList(),
+                    ),
+                )
+            )
+        assertEquals(ValidationResult.Valid, result)
+    }
+
+    @Test
+    fun `validate accepts small array`() {
+        val arr = ArrayValue(listOf(IntegerValue(1), IntegerValue(2), IntegerValue(3)))
+        val result = coercer.validate(enriched(arr, ArrayType(FieldType(IntegerType, false))))
+        assertEquals(ValidationResult.Valid, result)
+    }
+
+    @Test
+    fun `validate accepts deeply nested object`() {
+        val deepObj =
+            ObjectValue(
+                linkedMapOf<String, AirbyteValue>(
+                    "l1" to
+                        ObjectValue(
+                            linkedMapOf<String, AirbyteValue>(
+                                "l2" to
+                                    ObjectValue(
+                                        linkedMapOf<String, AirbyteValue>(
+                                            "l3" to StringValue("deep"),
+                                        )
+                                    ),
+                            )
+                        ),
+                )
+            )
+        val result =
+            coercer.validate(
+                enriched(
+                    deepObj,
+                    ObjectType(
+                        properties = linkedMapOf(),
+                        additionalProperties = true,
+                        required = emptyList(),
+                    ),
+                )
+            )
+        assertEquals(ValidationResult.Valid, result)
+    }
+
+    @Test
+    fun `validate accepts large array under SUPER limit`() {
+        val largeArray = ArrayValue((1..1000).map { IntegerValue(it.toBigInteger()) })
+        val result =
+            coercer.validate(enriched(largeArray, ArrayType(FieldType(IntegerType, false))))
+        assertEquals(ValidationResult.Valid, result)
+    }
+
+    // ================================================================
+    // isSuperValid() — boundary tests
+    // ================================================================
+
+    @Test
+    fun `isSuperValid accepts string at SUPER character limit`() {
+        assertTrue(isSuperValid("a".repeat(SUPER_LIMIT_BYTES)))
+    }
+
+    @Test
+    fun `isSuperValid rejects string exceeding SUPER character limit`() {
+        assertEquals(false, isSuperValid("a".repeat(SUPER_LIMIT_BYTES + 1)))
+    }
+
+    // ================================================================
+    // validate() — Other types
+    // ================================================================
+
+    @Test
+    fun `validate accepts NullValue`() {
+        val result = coercer.validate(enriched(NullValue, StringType))
+        assertEquals(ValidationResult.Valid, result)
+    }
+
+    @Test
+    fun `validate accepts BooleanValue`() {
+        val result =
+            coercer.validate(enriched(BooleanValue(true), io.airbyte.cdk.load.data.BooleanType))
+        assertEquals(ValidationResult.Valid, result)
+    }
+
+    // ================================================================
+    // Helpers
+    // ================================================================
+
+    private fun enriched(
+        value: AirbyteValue,
+        type: io.airbyte.cdk.load.data.AirbyteType,
+    ): EnrichedAirbyteValue =
+        EnrichedAirbyteValue(
+            abValue = value,
+            type = type,
+            name = "test_field",
+            changes = mutableListOf(),
+            airbyteMetaField = null,
+        )
+
+    private fun assertShouldNullify(result: ValidationResult) {
+        assertEquals(ValidationResult.ShouldNullify::class, result::class)
+        assertEquals(
+            AirbyteRecordMessageMetaChange.Reason.DESTINATION_FIELD_SIZE_LIMITATION,
+            (result as ValidationResult.ShouldNullify).reason,
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- **Write layer**: `RedshiftWriter`, `RedshiftInsertBuffer`, `RedshiftRecordFormatter` for S3-staged CSV data loading via COPY
- **Value coercer**: `RedshiftValueCoercer` validates BIGINT range, NUMERIC range, and SUPER 16MB size limits; serializes `UnionType` values to JSON strings for VARCHAR storage
- **Dataflow integration**: `RedshiftAggregate` and `RedshiftAggregateFactory` wire into the CDK dataflow pipeline
- **Client enhancement**: Added `describeTable()` to `RedshiftAirbyteClient` for column introspection
- **Bean configuration**: Added `tempTableNameGenerator` and `aggregatePublishingConfig` beans to `RedshiftBeanFactory`
- **Type mapping refinement**: `UnionType` now maps to `VARCHAR(65535)` instead of `SUPER` (values are serialized to JSON strings by the coercer, aligning with ClickHouse's approach)

## Key Design Decisions
- **UnionType → VARCHAR**: Both legacy and non-legacy unions map to VARCHAR. The coercer serializes union values to JSON strings, making VARCHAR the natural storage type.
- **Simplified coercer**: Removed timestamp range checks (Redshift COPY handles out-of-range timestamps), removed VARCHAR size validation and null byte stripping (let Redshift handle string constraints), and simplified SUPER size check to use `s.length` instead of exact UTF-8 byte counting.
- **UnknownType passthrough**: `UnknownType` values pass through the coercer unchanged (they go to SUPER columns which handle any JSON natively).

## Testing
- Comprehensive unit tests for `RedshiftValueCoercer` (map + validate), `RedshiftTableSchemaMapper` (type mapping), `RedshiftInsertBuffer`, `RedshiftRecordFormatter`, `RedshiftAggregateFactory`
- `isSuperValid()` boundary tests at 16M character limit