### PR TITLE
docs(ai-agents): reorder Developer Quickstart nav items

### DIFF
--- a/docs/ai-agents/get-started/developer-quickstart/skills/claude-code.md
+++ b/docs/ai-agents/get-started/developer-quickstart/skills/claude-code.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 2
+sidebar_position: 1
 sidebar_label: Claude Code
 ---
 

--- a/docs/ai-agents/get-started/developer-quickstart/skills/codex.md
+++ b/docs/ai-agents/get-started/developer-quickstart/skills/codex.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 3
+sidebar_position: 2
 sidebar_label: Codex
 ---
 

--- a/docs/ai-agents/get-started/developer-quickstart/skills/lovable.md
+++ b/docs/ai-agents/get-started/developer-quickstart/skills/lovable.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 1
+sidebar_position: 3
 sidebar_label: Lovable
 ---
 

--- a/docs/ai-agents/get-started/developer-quickstart/skills/readme.md
+++ b/docs/ai-agents/get-started/developer-quickstart/skills/readme.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 3
+sidebar_position: 4
 sidebar_label: Skills
 ---
 

--- a/docs/ai-agents/get-started/developer-quickstart/tutorial-fastmcp.md
+++ b/docs/ai-agents/get-started/developer-quickstart/tutorial-fastmcp.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: "FastMCP"
-sidebar_position: 3
+sidebar_position: 1
 ---
 
 import Tabs from '@theme/Tabs';

--- a/docs/ai-agents/get-started/developer-quickstart/tutorial-pydantic.md
+++ b/docs/ai-agents/get-started/developer-quickstart/tutorial-pydantic.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: "Pydantic AI"
-sidebar_position: 1
+sidebar_position: 3
 ---
 
 # Agent connector tutorial: Pydantic AI


### PR DESCRIPTION
## What

Reorders the left navigation under Airbyte Agents > Developer Quickstart to match the requested order.

Requested by @katmarkham.

## How

Updated `sidebar_position` frontmatter values in six files:

**Developer Quickstart items:**
1. FastMCP (was 3 → now 1)
2. LangChain (stays 2)
3. Pydantic AI (was 1 → now 3)
4. Skills (was 3 → now 4)

**Skills sub-items:**
1. Claude Code (was 2 → now 1)
2. Codex (was 3 → now 2)
3. Lovable (was 1 → now 3)

## Review guide

1. `docs/ai-agents/get-started/developer-quickstart/tutorial-fastmcp.md`
2. `docs/ai-agents/get-started/developer-quickstart/tutorial-pydantic.md`
3. `docs/ai-agents/get-started/developer-quickstart/skills/readme.md`
4. `docs/ai-agents/get-started/developer-quickstart/skills/claude-code.md`
5. `docs/ai-agents/get-started/developer-quickstart/skills/codex.md`
6. `docs/ai-agents/get-started/developer-quickstart/skills/lovable.md`

## User Impact

The sidebar navigation order under Developer Quickstart will change to: FastMCP, LangChain, Pydantic AI, Skills (Claude Code, Codex, Lovable).

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Link to Devin session: https://app.devin.ai/sessions/c87e56c19a584c0fbec4ed9db00a40be