### PR TITLE
feat(source-zendesk-support): activate tier-aware HTTPAPIBudget and step concurrency to c=5 (5.2.7-rc.2)

### DIFF
--- a/airbyte-integrations/connectors/source-zendesk-support/manifest.yaml
+++ b/airbyte-integrations/connectors/source-zendesk-support/manifest.yaml
@@ -7,11 +7,10 @@ check:
   stream_names:
     - tags
 
-# HTTPAPIBudget is intentionally COMMENTED OUT during the connector concurrency
-# tuning rollout (Phase 1-3). Active proactive throttling skews the concurrency
-# signal we are measuring. The full tier-aware policy below will be uncommented
-# at GA step 22.5, at which point users on any documented Zendesk plan will get
-# proactive throttling scoped to their account's actual per-minute limit.
+# Tier-aware HTTPAPIBudget. The per-minute limit is interpolated from the
+# user-selectable `subscription_tier` spec field so the connector throttles
+# at the rate that actually applies to the account's Zendesk plan, defaulting
+# to the lowest documented tier for unconfigured accounts.
 #
 # Tier -> per-minute limit (Zendesk Support / Suite, see
 # https://developer.zendesk.com/api-reference/introduction/rate-limits/):
@@ -21,20 +20,23 @@ check:
 #   enterprise              -> 700  req/min (Support Enterprise, Suite Enterprise)
 #   high_volume_api_add_on  -> 2500 req/min (any plan with the High Volume API add-on, or Suite Enterprise Plus)
 #
-# The endpoint-specific policies (incremental, search/export, deleted_tickets)
-# preserve the previous behavior of this connector. They are tier-independent
-# per the Zendesk endpoint rate-limit docs and are also commented out during
-# tuning so the budget cannot interfere with the concurrency signal.
-#
-# api_budget:
-#   type: HTTPAPIBudget
-#   policies:
-#     - type: MovingWindowCallRatePolicy
-#       rates:
-#         - limit: "{{ ({'essential': 10, 'team': 200, 'professional': 400, 'enterprise': 700, 'high_volume_api_add_on': 2500}).get(config.get('subscription_tier') or 'essential', 10) | int }}"
-#           interval: PT1M
-#       matchers: []
-#
+# The previous endpoint-specific policies (incremental 10/min, search/export
+# 100/min, deleted_tickets 10/min) are kept here as commented YAML for
+# reference. They are tier-independent per the Zendesk endpoint rate-limit
+# docs but are intentionally not enforced because the tier-level budget above
+# already covers all endpoints at the lowest tier (every endpoint cap is
+# bounded by the account's tier cap).
+api_budget:
+  type: HTTPAPIBudget
+  policies:
+    - type: MovingWindowCallRatePolicy
+      rates:
+        - limit: "{{ ({'essential': 10, 'team': 200, 'professional': 400, 'enterprise': 700, 'high_volume_api_add_on': 2500}).get(config.get('subscription_tier') or 'essential', 10) | int }}"
+          interval: PT1M
+      matchers: []
+  status_codes_for_ratelimit_hit: [429]
+
+# Endpoint-specific policies (kept for reference, not enforced):
 #     - type: MovingWindowCallRatePolicy
 #       rates:
 #         - limit: 10
@@ -55,7 +57,6 @@ check:
 #           interval: PT1M
 #       matchers:
 #         - url_path_pattern: "^/api/v2/deleted_tickets$"
-#   status_codes_for_ratelimit_hit: [429]
 
 definitions:
   bearer_authenticator:
@@ -1410,13 +1411,15 @@ streams:
 # - High Volume API add-on: 2500 req/min (41.7 req/sec)
 #
 # Default concurrency is tuned to be safe for the LOWEST documented tier
-# (Path B, scope #3 of the connector concurrency tuning playbook):
-#   floor(0.17 / 4) = 0  -> low-rate-limit special case ->
-#   starting_concurrency = 4, step = 1
+# (Path B, scope #3 of the connector concurrency tuning playbook). The
+# low-rate-limit special case (floor(0.17 / 4) = 0) sets starting_concurrency
+# = 4, step = 1; the live tier-aware HTTPAPIBudget above caps the actual
+# request rate per the account's plan. Phase 1 at c=4 was clean (0 failures,
+# wall-time matched or beat the 5.2.6 baseline) so this RC steps to c=5.
 # Customers on higher tiers can raise `num_workers` to fully exploit their plan.
 concurrency_level:
   type: ConcurrencyLevel
-  default_concurrency: "{{ config.get('num_workers', 4) }}"
+  default_concurrency: "{{ config.get('num_workers', 5) }}"
   max_concurrency: 40
 
 spec:
@@ -1609,14 +1612,14 @@ spec:
         title: Number of concurrent threads
         minimum: 1
         maximum: 40
-        default: 4
+        default: 5
         examples:
           - 1
           - 2
-          - 4
+          - 5
           - 10
         description: >-
-          The number of worker threads to use for the sync. The default of 4
+          The number of worker threads to use for the sync. The default of 5
           is tuned to be safe for the lowest documented Zendesk plan; users on
           higher plans (Team 200 req/min, Professional 400 req/min, Enterprise
           700 req/min, High Volume API add-on 2500 req/min) can raise this

--- a/airbyte-integrations/connectors/source-zendesk-support/metadata.yaml
+++ b/airbyte-integrations/connectors/source-zendesk-support/metadata.yaml
@@ -11,7 +11,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 79c1aa37-dae3-42ae-b333-d1c105477715
-  dockerImageTag: 5.2.7-rc.1
+  dockerImageTag: 5.2.7-rc.2
   dockerRepository: airbyte/source-zendesk-support
   documentationUrl: https://docs.airbyte.com/integrations/sources/zendesk-support
   githubIssueLabel: source-zendesk-support

--- a/docs/integrations/sources/zendesk-support.md
+++ b/docs/integrations/sources/zendesk-support.md
@@ -220,7 +220,7 @@ The `tickets` stream uses Zendesk's [Export Search Results](https://developer.ze
 
 | Version     | Date       | Pull Request                                             | Subject                                                                                                                                                                                                                            |
 |:------------|:-----------|:---------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| 5.2.7-rc.2 | 2026-04-28 | [TODO_PR](https://github.com/airbytehq/airbyte/pull/TODO_PR) | Activate the tier-aware HTTP API budget driven by `subscription_tier` and raise default concurrency from 4 to 5 |
+| 5.2.7-rc.2 | 2026-04-28 | [77548](https://github.com/airbytehq/airbyte/pull/77548) | Activate the tier-aware HTTP API budget driven by `subscription_tier` and raise default concurrency from 4 to 5 |
 | 5.2.7-rc.1 | 2026-04-23 | [76953](https://github.com/airbytehq/airbyte/pull/76953) | Add `subscription_tier` config field, comment out the existing HTTP API budget for concurrency tuning, raise default concurrency from 3 to 4, and enable progressive rollout |
 | 5.2.6 | 2026-04-22 | [76153](https://github.com/airbytehq/airbyte/pull/76153) | Fix sync crash when the Zendesk API returns responses without cursor pagination keys (for example, on single-page results) |
 | 5.2.5 | 2026-04-21 | [74696](https://github.com/airbytehq/airbyte/pull/74696) | Update dependencies |

--- a/docs/integrations/sources/zendesk-support.md
+++ b/docs/integrations/sources/zendesk-support.md
@@ -220,6 +220,7 @@ The `tickets` stream uses Zendesk's [Export Search Results](https://developer.ze
 
 | Version     | Date       | Pull Request                                             | Subject                                                                                                                                                                                                                            |
 |:------------|:-----------|:---------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 5.2.7-rc.2 | 2026-04-28 | [TODO_PR](https://github.com/airbytehq/airbyte/pull/TODO_PR) | Activate the tier-aware HTTP API budget driven by `subscription_tier` and raise default concurrency from 4 to 5 |
 | 5.2.7-rc.1 | 2026-04-23 | [76953](https://github.com/airbytehq/airbyte/pull/76953) | Add `subscription_tier` config field, comment out the existing HTTP API budget for concurrency tuning, raise default concurrency from 3 to 4, and enable progressive rollout |
 | 5.2.6 | 2026-04-22 | [76153](https://github.com/airbytehq/airbyte/pull/76153) | Fix sync crash when the Zendesk API returns responses without cursor pagination keys (for example, on single-page results) |
 | 5.2.5 | 2026-04-21 | [74696](https://github.com/airbytehq/airbyte/pull/74696) | Update dependencies |


### PR DESCRIPTION
## What

Phase 1 iteration 2 of the connector concurrency tuning rollout for `source-zendesk-support`. Tracking issue: airbytehq/airbyte-internal-issues#15330. Phase 1 health-check report: https://github.com/airbytehq/airbyte-internal-issues/issues/15330#issuecomment-4339823274.

Phase 1 RC https://github.com/airbytehq/airbyte/pull/76953 (5.2.7-rc.1, c=4) ran for 24h pinned to 28 Tier-2 actors. Result was clean: 0 concurrency-attributable failures across 257 successful syncs, median per-actor wall-time delta -0.5%, mean -10.6%, with -83% to -89% wall-time wins on the long-running cohorts. This PR steps to c=5 and activates the tier-aware HTTPAPIBudget per scope #5 (Zendesk-specific deviation: keep the budget *live* during tuning, accepting that the tuned concurrency is "concurrency tuned within current budget envelope" rather than against raw API capacity, to avoid account-level throttling risk).

## How

`airbyte-integrations/connectors/source-zendesk-support/manifest.yaml`:
- Uncomment the tier-aware `HTTPAPIBudget`. Single `MovingWindowCallRatePolicy` whose `limit` is Jinja-interpolated from `config.subscription_tier` via the full tier->limit map (essential 10, team 200, professional 400, enterprise 700, high_volume_api_add_on 2500 req/min). `status_codes_for_ratelimit_hit: [429]`. `subscription_tier` defaults to `essential` so unconfigured accounts get the safest rate limit; users on higher plans opt in via the spec field.
- The previous endpoint-specific policies (`incremental` 10/min, `search/export` 100/min, `deleted_tickets` 10/min) stay as commented YAML for reference; they are not enforced because at the lowest tier every endpoint is bounded by the account's tier cap.
- `concurrency_level.default_concurrency` fallback `num_workers` default: 4 -> 5.
- `spec.num_workers.default`: 4 -> 5 (description and examples updated).

`airbyte-integrations/connectors/source-zendesk-support/metadata.yaml`:
- `dockerImageTag`: 5.2.7-rc.1 -> 5.2.7-rc.2. `enableProgressiveRollout` stays true.

`docs/integrations/sources/zendesk-support.md`:
- Add 5.2.7-rc.2 changelog entry above 5.2.7-rc.1.

## Review guide

1. `airbyte-integrations/connectors/source-zendesk-support/manifest.yaml` (api_budget block, concurrency_level, num_workers spec field)
2. `airbyte-integrations/connectors/source-zendesk-support/metadata.yaml` (version)
3. `docs/integrations/sources/zendesk-support.md` (changelog)

## User Impact

- During the rollout: the 28 pinned Tier-2 actors will sync with c=5 and the tier-aware budget enforced. Default `subscription_tier=essential` (10 req/min) is the most conservative setting and matches existing Zendesk account-level throttling behaviour.
- After GA: users on higher plans should set `subscription_tier` to their actual plan to fully exploit their per-minute budget. Users on any plan can override `num_workers` to tune concurrency.
- No spec changes that require reconfiguration; both new spec fields have safe defaults.

## Can this PR be safely reverted and rolled back?

- [x] YES :green_heart:

Link to Devin session: https://app.devin.ai/sessions/601372f1623e423b9b564378694678ec
Requested by: @sophiecuiy