### PR TITLE
chore(source-gong): increase default_concurrency from 4 to 5 (1.2.0-rc.2)

### DIFF
--- a/airbyte-integrations/connectors/source-gong/manifest.yaml
+++ b/airbyte-integrations/connectors/source-gong/manifest.yaml
@@ -455,7 +455,7 @@ streams:
 
 concurrency_level:
   type: ConcurrencyLevel
-  default_concurrency: 4
+  default_concurrency: 5
 
 spec:
   type: Spec

--- a/airbyte-integrations/connectors/source-gong/metadata.yaml
+++ b/airbyte-integrations/connectors/source-gong/metadata.yaml
@@ -7,7 +7,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 32382e40-3b49-4b99-9c5c-4076501914e7
-  dockerImageTag: 1.2.0-rc.1
+  dockerImageTag: 1.2.0-rc.2
   dockerRepository: airbyte/source-gong
   documentationUrl: https://docs.airbyte.com/integrations/sources/gong
   githubIssueLabel: source-gong

--- a/docs/integrations/sources/gong.md
+++ b/docs/integrations/sources/gong.md
@@ -82,6 +82,7 @@ The call transcripts stream fetches transcripts one call at a time as a substrea
 
 | Version | Date       | Pull Request                                             | Subject                                                                         |
 | :------ | :--------- | :------------------------------------------------------- | :------------------------------------------------------------------------------ |
+| 1.2.0-rc.2 | 2026-04-28 | [77049](https://github.com/airbytehq/airbyte/pull/77049) | Increase default_concurrency from 4 to 5 based on Phase 1 health check results |
 | 1.2.0-rc.1 | 2026-04-27 | [77049](https://github.com/airbytehq/airbyte/pull/77049) | Add concurrency support with default_concurrency=4; enable progressive rollout |
 | 1.1.0 | 2026-04-20 | [76454](https://github.com/airbytehq/airbyte/pull/76454) | Filter out private calls (`isPrivate: true`) from `calls` and `extensiveCalls` streams per Gong API listing requirements |
 | 1.1.1 | 2026-04-21 | [76593](https://github.com/airbytehq/airbyte/pull/76593) | Update dependencies |


### PR DESCRIPTION
## What\nIncrease `default_concurrency` from 4 to 5 for source-gong as part of the concurrency tuning progressive rollout.\n\nPhase 1 health check (24h monitoring) passed with excellent results:\n- **0% failure rate** across 19 reporting actors on RC 1.2.0-rc.1\n- **9 connections faster** (up to 54% improvement)\n- **9 connections similar** (within -10% to +20%)\n- **1 minor regression** (+43%, but small absolute change: 14s → 20s)\n\nApproved by Sophie Cui to increase concurrency.\n\nRelated: https://github.com/airbytehq/airbyte/pull/77049 (Phase 1 PR)\n\n## How\n- `manifest.yaml`: Changed `default_concurrency` from 4 to 5\n- `metadata.yaml`: Bumped version from `1.2.0-rc.1` to `1.2.0-rc.2`\n- `docs/integrations/sources/gong.md`: Added changelog entry for 1.2.0-rc.2\n\n## Review guide\n1. `airbyte-integrations/connectors/source-gong/manifest.yaml` — concurrency bump\n2. `airbyte-integrations/connectors/source-gong/metadata.yaml` — version bump\n3. `docs/integrations/sources/gong.md` — changelog entry\n\n## User Impact\nTier 2 actors pinned to the RC will see `default_concurrency=5` after the new RC is published and rollout progressed. No breaking changes.\n\n## Can this PR be safely reverted and rolled back?\n- [x] YES 💚"

Link to Devin session: https://app.devin.ai/sessions/07dae43bde7b44e1994cda9e4a29473b
Requested by: @sophiecuiy