### PR TITLE
feat(source-google-analytics-data-api): Phase 1 step 2 tuning (2.9.34-rc.1)

### DIFF
--- a/airbyte-integrations/connectors/source-google-analytics-data-api/manifest.yaml
+++ b/airbyte-integrations/connectors/source-google-analytics-data-api/manifest.yaml
@@ -3062,12 +3062,11 @@ spec:
 # https://developers.google.com/analytics/devguides/reporting/data/v1/quotas
 concurrency_level:
   type: ConcurrencyLevel
-  default_concurrency: 4
+  default_concurrency: 5
   max_concurrency: 16
 
-# Original single-policy api_budget (pre-tuning). Commented out during the
-# concurrency tuning rollout so proactive throttling does not skew the signal;
-# replaced at GA by the tier-aware block below.
+# Original single-policy api_budget (pre-tuning). Superseded by the tier-aware
+# block below; kept commented for audit only.
 # api_budget:
 #   type: HTTPAPIBudget
 #   policies:
@@ -3079,17 +3078,17 @@ concurrency_level:
 #         - method: POST
 #           url_path_pattern: "^/v1/properties/[^/]+:(runReport|runPivotReport)$"
 
-# Tier-aware api_budget (Path B). Kept commented during tuning; uncomment at the
-# GA step 22.5 RC to activate. The `subscription_tier` spec field selects the
-# per-property Core rate limit applied locally (Standard 10 req/s, Analytics 360
-# 50 req/s). See https://developers.google.com/analytics/devguides/reporting/data/v1/quotas
-# api_budget:
-#   type: HTTPAPIBudget
-#   policies:
-#     - type: MovingWindowCallRatePolicy
-#       rates:
-#         - limit: "{{ {'Standard Property': 10, 'Analytics 360 Property': 50}[config.get('subscription_tier', 'Standard Property')] }}"
-#           interval: PT1S
-#       matchers:
-#         - method: POST
-#           url_path_pattern: "^/v1/properties/[^/]+:(runReport|runPivotReport)$"
+# Tier-aware api_budget (Path B). Active during tuning and onward. The
+# `subscription_tier` spec field selects the per-property Core rate limit
+# applied locally (Standard 10 req/s, Analytics 360 50 req/s). See
+# https://developers.google.com/analytics/devguides/reporting/data/v1/quotas
+api_budget:
+  type: HTTPAPIBudget
+  policies:
+    - type: MovingWindowCallRatePolicy
+      rates:
+        - limit: "{{ {'Standard Property': 10, 'Analytics 360 Property': 50}[config.get('subscription_tier', 'Standard Property')] }}"
+          interval: PT1S
+      matchers:
+        - method: POST
+          url_path_pattern: "^/v1/properties/[^/]+:(runReport|runPivotReport)$"

--- a/airbyte-integrations/connectors/source-google-analytics-data-api/metadata.yaml
+++ b/airbyte-integrations/connectors/source-google-analytics-data-api/metadata.yaml
@@ -12,7 +12,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 3cc2eafd-84aa-4dca-93af-322d9dfeec1a
-  dockerImageTag: 2.9.33-rc.1
+  dockerImageTag: 2.9.34-rc.1
   dockerRepository: airbyte/source-google-analytics-data-api
   documentationUrl: https://docs.airbyte.com/integrations/sources/google-analytics-data-api
   externalDocumentationUrls:

--- a/docs/integrations/sources/google-analytics-data-api.md
+++ b/docs/integrations/sources/google-analytics-data-api.md
@@ -280,6 +280,7 @@ The Google Analytics connector is subject to Google Analytics Data API quotas. P
 
 | Version        | Date       | Pull Request                                             | Subject                                                                                                                                                                |
 |:---------------|:-----------|:---------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 2.9.34-rc.1 | 2026-04-29 | [PR-pending](https://github.com/airbytehq/airbyte/pull/PR-pending) | Phase 1 step 2: bump `default_concurrency` 4 to 5 and activate the tier-aware `api_budget` (Standard 10 req/s, Analytics 360 50 req/s on opt-in via `subscription_tier`) |
 | 2.9.33-rc.1 | 2026-04-23 | [76956](https://github.com/airbytehq/airbyte/pull/76956) | Add `concurrency_level` (default 4, max 16) and `subscription_tier` spec field (Standard or Analytics 360) for the Path B concurrency tuning rollout (RC); existing and tier-aware `api_budget` kept commented during tuning |
 | 2.9.31 | 2026-04-20 | [76185](https://github.com/airbytehq/airbyte/pull/76185) | Surface the GA4 API error message on 400 and 403 responses, and stop retrying permission errors |
 | 2.9.30 | 2026-04-14 | [76190](https://github.com/airbytehq/airbyte/pull/76190) | Add access_token to extract_output and complete_oauth_output_specification to fix OAuth secretId 422 regression |


### PR DESCRIPTION
## What

Phase 1 step 2 of the connector concurrency tuning rollout for `source-google-analytics-data-api` (tracking issue airbytehq/airbyte-internal-issues#15332). RC `2.9.34-rc.1`.

Two changes to `manifest.yaml`:
1. `default_concurrency`: 4 -> 5.
2. Tier-aware `api_budget` is uncommented and active. Default `subscription_tier` (`Standard Property`) gets a 10 req/s `MovingWindowCallRatePolicy` on `POST /v1/properties/*:runReport` and `runPivotReport`; explicit `Analytics 360 Property` gets 50 req/s. The original single-policy 10 req/s budget stays commented as audit (it is being replaced by the tier-aware version).

This activates the budget while tuning, per the connector-specific scope deviation approved by @sophie.cui. Phase 1 step 1 (`2.9.33-rc.1`, default_concurrency=4) completed Day 1 with 0 failures across 372 RC syncs and no p50 regression vs the stable 2.9.32 baseline.

## How

`manifest.yaml`:
- `concurrency_level.default_concurrency` bumped 4 -> 5. `max_concurrency` stays 16.
- Tier-aware `api_budget` block uncommented. `limit:` interpolates from `config.subscription_tier`: `{'Standard Property': 10, 'Analytics 360 Property': 50}`. Default policy is the lowest-tier 10 req/s for safety.
- Original single-policy `api_budget` block remains commented for audit.

`metadata.yaml`:
- `dockerImageTag` bumped to `2.9.34-rc.1`. `enableProgressiveRollout` stays `true`.

`docs/integrations/sources/google-analytics-data-api.md`:
- Changelog row added.

## Review guide
1. `airbyte-integrations/connectors/source-google-analytics-data-api/manifest.yaml`
2. `airbyte-integrations/connectors/source-google-analytics-data-api/metadata.yaml`
3. `docs/integrations/sources/google-analytics-data-api.md`

## User Impact

For users on the unpinned latest version, no immediate impact: this is an RC, not GA. For the 19 cohort actors that get pinned to `2.9.34-rc.1` after merge:

- Source read-side concurrency raised by 1 (4 -> 5 parallel tasks).
- A local 10 req/s `MovingWindowCallRatePolicy` is now applied to `runReport` and `runPivotReport` for users on the default `Standard Property` tier. With concurrency=5 and a 10 req/s budget, occasional thread queueing on the budget is expected; this is the intended "tune within current budget envelope" behavior. Users on `Analytics 360 Property` get a 50 req/s budget, so concurrency=5 has comfortable headroom.

Per the playbook's HTTP heuristic, the tuned concurrency for this connector is expected to plateau where the local budget caps it (around concurrency 4-6 for Standard tier) rather than approaching `max_concurrency=16`. This is acceptable per the scope owner, since the local budget protects against account-level Google quota throttling that the empirical concurrency loop alone cannot detect.

## Can this PR be safely reverted and rolled back?
- [x] YES 💚
- [ ] NO ❌

The progressive rollout pin is already in place from `2.9.33-rc.1`; rolling back means re-pinning the cohort to the stable 2.9.32 (or another superseded RC) via the existing rollout.

Link to Devin session: https://app.devin.ai/sessions/093480b3778142fbba79803a14468b53
Requested by: @sophiecuiy