### PR TITLE
chore(source-granola): increase default_concurrency from 4 to 5 (iteration 2)

### DIFF
--- a/airbyte-integrations/connectors/source-granola/manifest.yaml
+++ b/airbyte-integrations/connectors/source-granola/manifest.yaml
@@ -8,7 +8,7 @@ description: >-
 
 concurrency_level:
   type: ConcurrencyLevel
-  default_concurrency: 4
+  default_concurrency: 5
 
 check:
   type: CheckStream

--- a/airbyte-integrations/connectors/source-granola/metadata.yaml
+++ b/airbyte-integrations/connectors/source-granola/metadata.yaml
@@ -7,7 +7,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 9023923c-002f-4131-9554-3ebdf56540a4
-  dockerImageTag: 0.2.0-rc.1
+  dockerImageTag: 0.2.0-rc.2
   dockerRepository: airbyte/source-granola
   documentationUrl: https://docs.airbyte.com/integrations/sources/granola
   githubIssueLabel: source-granola

--- a/docs/integrations/sources/granola.md
+++ b/docs/integrations/sources/granola.md
@@ -103,7 +103,8 @@ The connector handles rate limiting automatically by retrying requests when a `4
 
 | Version | Date       | Pull Request | Subject         |
 | :------ | :--------- | :----------- | :-------------- |
-| 0.2.0-rc.1 | 2026-04-27 | [*PR_NUMBER_PLACEHOLDER*](https://github.com/airbytehq/airbyte/pull/*PR_NUMBER_PLACEHOLDER*) | set default_concurrency=4 for concurrency tuning iteration 1 (Path A, max_rate_limit=5 req/s) |
+| 0.2.0-rc.2 | 2026-04-29 | [*PR_NUMBER_PLACEHOLDER*](https://github.com/airbytehq/airbyte/pull/*PR_NUMBER_PLACEHOLDER*) | Increase default_concurrency from 4 to 5 for concurrency tuning iteration 2 |
+| 0.2.0-rc.1 | 2026-04-27 | [77067](https://github.com/airbytehq/airbyte/pull/77067) | set default_concurrency=4 for concurrency tuning iteration 1 (Path A, max_rate_limit=5 req/s) |
 | 0.1.3 | 2026-04-21 | [76632](https://github.com/airbytehq/airbyte/pull/76632) | Update dependencies |
 | 0.1.2 | 2026-03-31 | [75737](https://github.com/airbytehq/airbyte/pull/75737) | Update dependencies |
 | 0.1.1 | 2026-03-24 | [75353](https://github.com/airbytehq/airbyte/pull/75353) | Update dependencies |


### PR DESCRIPTION
## What

Concurrency tuning iteration 2 for source-granola. Increases `default_concurrency` from 4 to 5 after successful iteration 1 evaluation.

**Context:**
- Iteration 1 (concurrency=4, RC 0.2.0-rc.1) completed with 0 concurrency-related failures across all 11 Tier 2 actors
- Aggregate sync duration improved 11.1% vs stable baseline
- Source read duration improved or stayed flat for all connections
- Two full-sync-duration regressions (1.87x and 1.36x) were identified as platform overhead variance, not concurrency-related
- Sophie Cui approved the increase: https://airbytehq-team.slack.com/archives/C0AEXV81Q7N/p1777420470897019

**Tuning parameters (Path A):**
- Rate limit: 5 req/s sustained (single tier)
- Previous concurrency: 4
- New concurrency: 5
- Step size: 1

Related: https://github.com/airbytehq/airbyte/pull/77067

## How

1. Updated `manifest.yaml`: `default_concurrency` from 4 to 5
2. Bumped `metadata.yaml`: `dockerImageTag` from `0.2.0-rc.1` to `0.2.0-rc.2`
3. Added changelog entry in `docs/integrations/sources/granola.md`

## Review guide

1. `airbyte-integrations/connectors/source-granola/manifest.yaml` — concurrency value change
2. `airbyte-integrations/connectors/source-granola/metadata.yaml` — version bump
3. `docs/integrations/sources/granola.md` — changelog entry

## User Impact

No user-facing impact. This is an RC version used only for progressive rollout testing with pinned Tier 2 actors.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚\n\n---\n[Devin session](https://app.devin.ai/sessions/d78f9b087fdc48e58bea13476997498e)</pr_template>"

Requested by: @sophiecuiy