### PR TITLE
fix(docs): add description to System architecture category card on Core concepts page

### DIFF
--- a/docs/ai-agents/concepts/architecture/_category_.json
+++ b/docs/ai-agents/concepts/architecture/_category_.json
@@ -1,0 +1,3 @@
+{
+  "description": "How the platform is organized. Covers the four interfaces, the resource hierarchy of organizations, workspaces, and connectors, and the execution model that routes agent requests."
+}


### PR DESCRIPTION
## What

The System architecture card on the [Core concepts](https://docs.airbyte.com/ai-agents/concepts) page shows "3 items" instead of a description, unlike the other cards which display descriptive text. This is the same Docusaurus limitation addressed in https://github.com/airbytehq/airbyte/pull/77535.

Reported by @katmarkham.

## How

Added a `_category_.json` file to the `docs/ai-agents/concepts/architecture/` directory with a `description` field. The swizzled `DocCard` component (from PR https://github.com/airbytehq/airbyte/pull/77535) already renders `item.description` when available, so this one-file addition is all that's needed.

## Review guide

1. `docs/ai-agents/concepts/architecture/_category_.json` — new category metadata file

## User Impact

The System architecture card on the Core concepts page now shows a descriptive tagline instead of "3 items", consistent with the other cards on the page.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚
- [ ] NO ❌

Link to Devin session: https://app.devin.ai/sessions/6a93d07c72d4408480caf2916d6af9ad