### PR TITLE
fix(docs): convert time zone UTC paragraph to warning admonition

### DIFF
--- a/docs/ai-agents/concepts/time-zones.md
+++ b/docs/ai-agents/concepts/time-zones.md
@@ -27,7 +27,9 @@ All timestamps are UTC on the backend, and every interface that reads or writes 
 - **SDK**: The Python SDK returns the same UTC ISO 8601 strings through its response models.
 - **MCP server**: Tools that return timestamps return them in UTC. The `current_datetime` tool, which an agent calls to resolve relative dates like "today" or "last week," returns the current UTC time.
 
+:::warning
 If you pass a timestamp into a connector action—for example, as a date filter on a list query—use UTC. The agent doing the calling is responsible for any time zone conversion before it hands the value to the platform.
+:::
 
 ## Scheduling Automations
 


### PR DESCRIPTION
## What
Converts the UTC timestamp guidance paragraph on the [Time zones](https://docs.airbyte.com/ai-agents/concepts/time-zones) page into a `:::warning` admonition so it stands out visually for readers.

## How
Wrapped the paragraph in a Docusaurus `:::warning` block in `docs/ai-agents/concepts/time-zones.md`.

## Review guide
1. `docs/ai-agents/concepts/time-zones.md`

## User Impact
The UTC timestamp guidance is now rendered as a warning callout instead of plain body text, making it more noticeable.

## Can this PR be safely reverted and rolled back?
- [x] YES 💚
- [ ] NO ❌

Link to Devin session: https://app.devin.ai/sessions/8666168118a0435294a09c376dbde932
Requested by: @katmarkham