### PR TITLE
docs(ai-agents): remove Context Store toggle references; rename Credentials page to Connectors page

### DIFF
--- a/docs/ai-agents/concepts/architecture/connectors-and-credentials.md
+++ b/docs/ai-agents/concepts/architecture/connectors-and-credentials.md
@@ -36,7 +36,7 @@ A typical connector lifecycle looks like this:
 
 1. **Add credentials** — Provide the third-party service's credentials through the [web app](../../interfaces/ui/add-connector), [API](../../interfaces/api/add-connector), or [SDK](../../interfaces/sdk/add-connector). Airbyte stores the credentials and returns a connector ID.
 2. **Execute operations** — Make tool calls against the connector. Each call targets an entity and an action. See [Execute operations (API)](../../interfaces/api/execute) or [Execute operations (SDK)](../../interfaces/sdk/execute).
-3. **Use the Context Store** — The [Context Store](../context-store) is enabled by default and replicates and indexes a subset of your connector data. This powers fast search operations without hitting the upstream API.
+3. **Use the Context Store** — The [Context Store](../context-store) is always on and automatically replicates and indexes a subset of your connector data. This powers fast search operations without hitting the upstream API.
 
 ## Entities and actions {#entities-and-actions}
 

--- a/docs/ai-agents/concepts/architecture/organizations.md
+++ b/docs/ai-agents/concepts/architecture/organizations.md
@@ -12,7 +12,7 @@ Each organization has:
 
 - **Platform API credentials** — A `client_id`, `client_secret`, and `organization_id` that authenticate programmatic access through the [API](../../interfaces/api), [SDK](../../interfaces/sdk), and [MCP server](../../interfaces/mcp). Find these on the [Profile page](https://app.airbyte.ai/profile).
 - **Workspaces** — Every organization starts with a `default` [workspace](./workspaces), which is all most people need. If you need to isolate credentials across tenants or teams, you can create additional workspaces.
-- **Context Store configuration** — The [Context Store](../context-store) is enabled by default and operates at the organization level. You can turn it on or off from the Credentials page.
+- **Context Store** — The [Context Store](../context-store) is enabled by default and operates at the organization level. It is always on and requires no configuration.
 - **Billing** — Plans, payment methods, usage limits, and invoices live at the organization level. See [Billing and pricing](../../admin/billing).
 - **Users** — People who can sign in and interact with the organization through the [web app](../../interfaces/ui).
 

--- a/docs/ai-agents/concepts/context-store.md
+++ b/docs/ai-agents/concepts/context-store.md
@@ -20,7 +20,7 @@ Working this way causes a variety of problems:
 
 The result is a query that takes substantial time and resources to process, a degraded experience, and inflated costs.
 
-The Context Store solves this problem by making key fields available to your agents in Airbyte-managed storage. When you turn it on, Airbyte replicates a curated subset of the entities in your agent connectors into the store and keeps it up to date. Agents then answer these kinds of questions with fast, indexed searches instead of live API crawls.
+The Context Store solves this problem by making key fields available to your agents in Airbyte-managed storage. Airbyte replicates a curated subset of the entities in your agent connectors into the store and keeps it up to date. Agents then answer these kinds of questions with fast, indexed searches instead of live API crawls.
 
 ## What's in the Context Store
 
@@ -32,32 +32,17 @@ Each connected source has its own isolated store. Airbyte curates the store for 
 
 For the list of entities each connector contributes, see [Agent connectors](../connectors).
 
-## Who can configure the Context Store
+## Who manages the Context Store
 
-The Context Store is an organization-level setting. Only organization administrators see the **Manage Context Store** button and can turn the store on or off. End users who run Chats and Automations see the benefits of the store but don't configure it.
-
-## Turn on the Context Store
-
-1. In the Airbyte Agents web app, click **Credentials** in the left sidebar.
-
-2. At the top of the Credentials page, click **Manage Context Store**.
-
-3. In the slide-out, turn on **Enable Context Store**.
-
-When you turn on the Context Store:
-
-- **Storage begins automatically.** Airbyte starts copying data from each agent connector in your workspace into the store.
-- **Search becomes available.** As soon as a connector has enough data, its entities are available to agents through the search action.
-
-You can continue using Airbyte while the store populates. First-time population takes longer for connectors with large datasets.
+The Context Store is enabled by default for every organization and operates at the organization level. Organization administrators can view Context Store status and monitor population progress from the Connectors page in the web app.
 
 ## Check Context Store status
 
-You can check Context Store status in two places on the **Credentials** page: per connector and per entity.
+You can check Context Store status in two places on the **Connectors** page: per connector and per entity.
 
 ### Per-connector status
 
-Each credential in the Credentials list shows a status badge when the Context Store is on for its workspace.
+Each connector in the Connectors list shows a status badge.
 
 - **Ready.** The store is populated and fully available for search.
 - **Preview.** The first population is still in progress, but some data is already searchable.
@@ -68,7 +53,7 @@ Ready and Preview are both usable states for agents. Preview means newer records
 
 ### Per-entity status
 
-Click the status badge on a credential to open a detailed view for that connector. The view lists every entity Airbyte populates for the connector, along with:
+Click the status badge on a connector to open a detailed view. The view lists every entity Airbyte populates for the connector, along with:
 
 - **Entity.** The entity name, for example `contacts`, `deals`, or `products`.
 - **Status.** `Ready`, `Preview`, `Building Preview`, `Initializing`, or `Updating`.
@@ -76,16 +61,6 @@ Click the status badge on a credential to open a detailed view for that connecto
 - **Last Synced** or **Last Updated.** The most recent time Airbyte refreshed that entity.
 
 Use this view to confirm which entities are ready to query and which are still populating.
-
-## Turn off the Context Store
-
-1. In the Airbyte Agents web app, click **Credentials** in the left sidebar.
-
-2. At the top of the Credentials page, click **Manage Context Store**.
-
-3. In the slide-out, turn off **Enable Context Store**.
-
-When you turn off the Context Store, Airbyte removes the replicated data from the store. Agents can no longer use the search action until you turn the store back on and Airbyte repopulates it.
 
 ## How agents use the Context Store
 
@@ -108,22 +83,18 @@ When the Context Store populates data for a connector, Airbyte runs an initial b
 
 During the backfill, Airbyte makes data available to agents progressively. You don't have to wait for the backfill to finish before agents can search. An entity in **Preview** status already has partial data that agents can query. As the backfill continues, more records become searchable until the entity reaches **Ready** status.
 
-The per-entity detail view on the Credentials page shows record counts and timestamps so you can track backfill progress.
+The per-entity detail view on the Connectors page shows record counts and timestamps so you can track backfill progress.
 
 ## When to use the Context Store
 
-Turn the Context Store on when:
+The Context Store is always on and requires no configuration. It benefits most workflows by default:
 
-- You want agents to search across large amounts of connector data with predictable latency.
-- You want prompts like "find all X where Y" to run as a single search instead of a live API crawl.
-- You want consistent search behavior across connectors, including connectors whose APIs don't offer their own search endpoint.
+- Agents can search across large amounts of connector data with predictable latency.
+- Prompts like "find all X where Y" run as a single search instead of a live API crawl.
+- Search behavior is consistent across connectors, including connectors whose APIs don't offer their own search endpoint.
 
-You may want to skip the Context Store when:
-
-- You already maintain your own copy of the relevant data and prefer to expose it through your own tools.
-- You only need to read or write a small number of records at a time and don't need to search across a dataset.
+If you already maintain your own copy of the relevant data and prefer to expose it through your own tools, or if you only need to read or write a small number of records at a time and don't need to search across a dataset, agents still fall back to direct API requests automatically.
 
 ## Limitations
 
-- All agent connectors and interfaces can use the Context Store and always try to do so unless you turn it off.
-- Turning the Context Store off and on again triggers a fresh population. Repopulating can take a long time if your system contains substantial amounts of data. Plan for this if you rely on search-heavy prompts.
+- All agent connectors and interfaces can use the Context Store. Agents prefer it for search operations whenever the entity is available in the store.

--- a/docs/ai-agents/get-started/choose-how-to-use.md
+++ b/docs/ai-agents/get-started/choose-how-to-use.md
@@ -34,7 +34,7 @@ Two primary surfaces:
 - **[Chats](../interfaces/ui/chats)** — Interactive conversations with an agent. Ask a question, iterate on the answer, and explore your data in real time.
 - **[Automations](../interfaces/ui/automations)** — Agent tasks that run on a schedule, on a webhook, or on demand. Use Automations when you need the same work to happen repeatedly without a person in the loop.
 
-**Get started:** Sign up at [app.airbyte.ai](https://app.airbyte.ai), add a connector on the Credentials page, and open New Chat.
+**Get started:** Sign up at [app.airbyte.ai](https://app.airbyte.ai), add a connector on the Connectors page, and open New Chat.
 
 ## MCP server
 

--- a/docs/ai-agents/get-started/developer-quickstart/readme.md
+++ b/docs/ai-agents/get-started/developer-quickstart/readme.md
@@ -48,7 +48,7 @@ Both paths share a few common requirements.
 
 - **An Airbyte Agents account.** Sign up for free at [app.airbyte.ai](https://app.airbyte.ai).
 - **API credentials.** Copy your `AIRBYTE_CLIENT_ID` and `AIRBYTE_CLIENT_SECRET` from the [Profile page](https://app.airbyte.ai/profile) in the Airbyte Agents web app. See [Manage your user profile](../../admin/profile) for details.
-- **A connector.** Add at least one connector to your workspace from the [Credentials page](https://app.airbyte.ai/credentials) in the web app. The tutorials use GitHub, but any connector works.
+- **A connector.** Add at least one connector to your workspace from the [Connectors page](https://app.airbyte.ai/connectors) in the web app. The tutorials use GitHub, but any connector works.
 - **Python 3.13+ and uv** (for tutorials). Skills have their own prerequisites listed on each skill page.
 
 import DocCardList from '@theme/DocCardList';

--- a/docs/ai-agents/interfaces/api/execute.md
+++ b/docs/ai-agents/interfaces/api/execute.md
@@ -85,7 +85,7 @@ curl -X POST 'https://api.airbyte.ai/api/v1/integrations/connectors/<connector_i
 This example searches for records using filter conditions.
 
 :::note `search` reads from the [Context Store](../../concepts/context-store)
-The `search` action reads from Airbyte's pre-indexed Context Store, not the live third-party API. The store is enabled by default in new organizations, and Airbyte populates it per connector after the connector is created. If you call `search` while the connector's Context Store still shows `Loading` or `Building Preview` on the Credentials page, the call returns an error at runtime. Wait for the status to reach `Preview` or `Ready`, or use `list`/`get` against the live API until it does.
+The `search` action reads from Airbyte's pre-indexed Context Store, not the live third-party API. The store is always on and Airbyte populates it per connector after the connector is created. If you call `search` while the connector's Context Store still shows `Loading` or `Building Preview` on the Connectors page, the call returns an error at runtime. Wait for the status to reach `Preview` or `Ready`, or use `list`/`get` against the live API until it does.
 :::
 
 ```bash title="Request"

--- a/docs/ai-agents/interfaces/ui/add-connector.md
+++ b/docs/ai-agents/interfaces/ui/add-connector.md
@@ -4,7 +4,7 @@ sidebar_position: 3
 
 # Add a connector
 
-Before an Airbyte agent can read from or write to a data source, someone has to authenticate that source for the workspace. In the web app, that happens on the **Credentials** page. Adding a connector means picking a workspace, picking a data source, and completing an authentication flow once; after that, every interface you use—Chats, Automations, the SDK, the API, and the MCP server—can use the resulting connector.
+Before an Airbyte agent can read from or write to a data source, someone has to authenticate that source for the workspace. In the web app, that happens on the **Connectors** page. Adding a connector means picking a workspace, picking a data source, and completing an authentication flow once; after that, every interface you use—Chats, Automations, the SDK, the API, and the MCP server—can use the resulting connector.
 
 This page walks through adding connectors end-to-end: where to add them, how to add them from inside a chat or the Automation Builder, how workspaces and multiple connectors fit together, and how to update or remove connectors you've already added.
 
@@ -30,13 +30,13 @@ A workspace can hold as many connectors as you need:
 
 Each Chat or Automation runs in one workspace at a time and sees only the connectors in that workspace. If you can't find a connector you expect, check that you're in the right workspace.
 
-## Add a connector from the Credentials page
+## Add a connector from the Connectors page
 
-The Credentials page is the primary place to add, view, and manage connectors for every workspace in your organization. This is the right flow when you're setting up a new workspace, onboarding a data source before you need it, or adding a second account for a connector type you already use.
+The Connectors page is the primary place to add, view, and manage connectors for every workspace in your organization. This is the right flow when you're setting up a new workspace, onboarding a data source before you need it, or adding a second account for a connector type you already use.
 
-1. Click **Credentials** in the left sidebar.
+1. Click **Connectors** in the left sidebar.
 
-2. Click **Add Credential** in the top right. A slide-out panel opens.
+2. Click **Add Connector** in the top right. A slide-out panel opens.
 
 3. Under **Select Workspace**, pick the workspace the connector should belong to. To create a new workspace on the fly, click **+ Add new workspace** and give it a name.
 
@@ -46,7 +46,7 @@ The Credentials page is the primary place to add, view, and manage connectors fo
 
 6. When authentication finishes, the dialog closes and a **Credential Added** confirmation appears in the slide-out. From there you can click **Add Another Credential** to add more, or **Chat with your Agent** to jump straight into a Chat that uses the new connector.
 
-The new connector appears immediately in the Credentials table and in the **Available context** list on the Chat and Automation landing pages. You don't need to reload other tabs.
+The new connector appears immediately in the Connectors list and in the **Available context** list on the Chat and Automation landing pages. You don't need to reload other tabs.
 
 ## OAuth versus access tokens {#oauth-vs-tokens}
 
@@ -77,7 +77,7 @@ You don't have to add connectors up front. If you start a Chat and the agent rea
 
 When this happens, the agent's message includes one or more connector tiles next to its reply. Each tile shows the connector's logo, name, and current status. To authenticate:
 
-1. Click the tile for the connector you want to connect. The authentication module opens in a dialog, the same flow the Credentials page uses.
+1. Click the tile for the connector you want to connect. The authentication module opens in a dialog, the same flow the Connectors page uses.
 
 2. Complete the OAuth or API-key flow. When it finishes, the tile flips to a success state.
 
@@ -85,9 +85,9 @@ When this happens, the agent's message includes one or more connector tiles next
 
 4. Once you've handled the tiles you care about, the agent picks up the new connectors automatically and continues its response.
 
-Anything you add through this inline flow is saved to the workspace the Chat is running in, just like credentials added from the Credentials page. It's visible afterward in the Credentials table and usable by other Chats and Automations in the same workspace.
+Anything you add through this inline flow is saved to the workspace the Chat is running in, just like connectors added from the Connectors page. It's visible afterward in the Connectors list and usable by other Chats and Automations in the same workspace.
 
-If you'd rather not add a connector inline—for example, because you want to pick a different workspace, or because you need to finish authentication elsewhere first—you can also open the **Credentials** page in another tab, add the connector there, then come back to the Chat. Send the agent a short message like "try again" and it re-reads the available context and picks up the new connector on its next turn.
+If you'd rather not add a connector inline—for example, because you want to pick a different workspace, or because you need to finish authentication elsewhere first—you can also open the **Connectors** page in another tab, add the connector there, then come back to the Chat. Send the agent a short message like "try again" and it re-reads the available context and picks up the new connector on its next turn.
 
 ## Add a connector from the Automation Builder
 
@@ -97,11 +97,11 @@ The fastest path is to tell the Automation Builder Agent what you want and let i
 
 You can also ask the Automation Builder Agent to change which connectors the automation uses. Sending a message like "use the Salesforce connector instead" or "add HubSpot" tells it to update the automation's [**Context**](./automations#properties) to match. Airbyte blocks direct edits to the Context list in the Properties panel on purpose, so that the prompt and the connectors it relies on stay in sync.
 
-If you prefer, you can still pre-authenticate everything from the Credentials page first, then open the Automation Builder with the connectors already in place. That path is often faster when you already know exactly which sources the automation needs.
+If you prefer, you can still pre-authenticate everything from the Connectors page first, then open the Automation Builder with the connectors already in place. That path is often faster when you already know exactly which sources the automation needs.
 
 ## Manage existing connectors
 
-The Credentials page also shows every connector that's already been added across every workspace. Use it to audit what's authenticated, see how much each connector is being used, and retire ones you no longer need.
+The Connectors page also shows every connector that's already been added across every workspace. Use it to audit what's authenticated, see how much each connector is being used, and retire ones you no longer need.
 
 - **Filter the list**. Use the **All workspaces** and **All connectors** filters at the top of the table to narrow the list by workspace or connector type.
 

--- a/docs/ai-agents/interfaces/ui/chats.md
+++ b/docs/ai-agents/interfaces/ui/chats.md
@@ -41,7 +41,7 @@ Two places surface the context the agent has.
 
 ### Add new context
 
-To give the agent more to work with, connect another source. Open the **Credentials** page from the sidebar, connect the new source, and authenticate it. The new connector is immediately available in any chat you open afterward.
+To give the agent more to work with, connect another source. Open the **Connectors** page from the sidebar, connect the new source, and authenticate it. The new connector is immediately available in any chat you open afterward.
 
 If you're in the middle of a chat and realize the agent needs a connector it doesn't have, connect the source in another tab, then return to the chat and ask the agent to try again. The agent picks up the new connector automatically on its next message.
 

--- a/docs/ai-agents/interfaces/ui/readme.md
+++ b/docs/ai-agents/interfaces/ui/readme.md
@@ -17,12 +17,12 @@ The web app has two primary surfaces for working with an Airbyte agent.
 
 Every Chat and Automation runs against the connectors you've authenticated in your workspace. Manage connectors from the **Credentials** page in the sidebar. For the catalog of available connectors, see [Agent connectors](../../connectors).
 
-## Set up connectors and context
+## Set up connectors
 
-Administrators can add connectors and configure the Context Store from the web app.
+Administrators can add connectors from the web app.
 
 - [**Add a connector**](./add-connector): Authenticate data sources so agents in Chats, Automations, and every other interface can use them.
-- [**Context Store**](../../concepts/context-store): Configure the searchable replica of select entities from your connected data sources that powers grounded answers and large-scale analytics.
+- [**Context Store**](../../concepts/context-store): The searchable replica of select entities from your connected data sources that powers grounded answers and large-scale analytics. The Context Store is always on and requires no configuration.
 
 ## Related administration
 

--- a/docs/ai-agents/interfaces/ui/readme.md
+++ b/docs/ai-agents/interfaces/ui/readme.md
@@ -15,7 +15,7 @@ The web app has two primary surfaces for working with an Airbyte agent.
 - [**Chats**](./chats): Interactive conversations with an Airbyte agent. Ask a question, iterate on the answer, and explore your data in natural language. Chats are the fastest way to get a one-off answer or prototype an idea.
 - [**Automations**](./automations): Agent tasks that run without a person in the loop. Trigger an Automation manually, on a schedule, or from a webhook. Use Automations when you need the same work to happen repeatedly and reliably.
 
-Every Chat and Automation runs against the connectors you've authenticated in your workspace. Manage connectors from the **Credentials** page in the sidebar. For the catalog of available connectors, see [Agent connectors](../../connectors).
+Every Chat and Automation runs against the connectors you've authenticated in your workspace. Manage connectors from the **Connectors** page in the sidebar. For the catalog of available connectors, see [Agent connectors](../../connectors).
 
 ## Set up connectors
 


### PR DESCRIPTION
## What

Two documentation updates for the AI Agents docs:

1. **Context Store is always on.** The Context Store can no longer be toggled off by users. Several pages still described how to turn it on/off and referenced a toggle that no longer exists.
2. **Credentials page → Connectors page.** The UI page formerly called "Credentials" is now "Connectors". All page-level references are updated. References to credential *objects* (API keys, OAuth tokens) are unchanged.

Related Slack thread: https://airbytehq-team.slack.com/archives/C07N1EGSM8E/p1777430392828989

## How

**Context Store changes (commit 1):**
- `context-store.md` — Removed the "Turn on" and "Turn off" sections entirely. Rewrote "Who can configure" → "Who manages" to state it's always on. Rewrote "When to use" and "Limitations" to remove toggle language.
- `organizations.md` — Removed "You can turn it on or off from the Credentials page."
- `connectors-and-credentials.md` — "enabled by default" → "always on and automatically"
- `execute.md` — "enabled by default in new organizations" → "always on"
- `ui/readme.md` — Removed "Configure" language for the Context Store

**Credentials → Connectors rename (commit 2):**
- `add-connector.md` — "Credentials page" → "Connectors page", "Add Credential" → "Add Connector", "Credentials table" → "Connectors list" (9 replacements)
- `chats.md` — "Credentials page" → "Connectors page"
- `choose-how-to-use.md` — "Credentials page" → "Connectors page"
- `developer-quickstart/readme.md` — "Credentials page" → "Connectors page" (including URL)
- `ui/readme.md` — "Credentials page" → "Connectors page"

## Review guide

1. `docs/ai-agents/concepts/context-store.md` — main Context Store changes
2. `docs/ai-agents/concepts/architecture/organizations.md`
3. `docs/ai-agents/concepts/architecture/connectors-and-credentials.md`
4. `docs/ai-agents/interfaces/api/execute.md`
5. `docs/ai-agents/interfaces/ui/readme.md`
6. `docs/ai-agents/interfaces/ui/add-connector.md` — main rename changes
7. `docs/ai-agents/interfaces/ui/chats.md`
8. `docs/ai-agents/get-started/choose-how-to-use.md`
9. `docs/ai-agents/get-started/developer-quickstart/readme.md`

## User Impact

Documentation now accurately reflects the current product: the Context Store is always on, and the page is called "Connectors" instead of "Credentials".

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Link to Devin session: https://app.devin.ai/sessions/124ae2c306ff45829a13ff609379436c
Requested by: @ian-at-airbyte