### PR TITLE
ci(autodoc): extract connector name and pass to Devin session

### DIFF
--- a/.github/workflows/autodoc.yml
+++ b/.github/workflows/autodoc.yml
@@ -94,14 +94,28 @@ jobs:
           fi
 
           echo "📋 Found connector metadata file: $METADATA_FILE"
-          echo "✅ Connector change detected - documentation update needed"
+
+          # Extract connector name from path (e.g., "source-slack" from
+          # "airbyte-integrations/connectors/source-slack/metadata.yaml").
+          # This is passed to Devin so it can use a deterministic branch name
+          # (docs/auto/{connector-name}) to prevent duplicate PRs when
+          # multiple commits for the same connector merge in quick succession.
+          CONNECTOR_NAME=$(echo "$METADATA_FILE" | sed 's|airbyte-integrations/connectors/||; s|/metadata\.yaml||')
+          echo "connector_name=$CONNECTOR_NAME" >> $GITHUB_OUTPUT
+
+          echo "✅ Connector change detected ($CONNECTOR_NAME) - documentation update needed"
           echo "connector_changed=true" >> $GITHUB_OUTPUT
 
       # Step 4: Trigger AI documentation update for connector changes
       - name: Start AI documentation update session
         if: steps.check-connector.outputs.connector_changed == 'true'
         env:
-          PROMPT_TEXT: "The commit to review is ${{ github.sha }}. This commit was pushed to master and may contain connector changes that need documentation updates."
+          CONNECTOR_NAME: ${{ steps.check-connector.outputs.connector_name }}
+          PROMPT_TEXT: >-
+            The commit to review is ${{ github.sha }}.
+            The connector is ${{ steps.check-connector.outputs.connector_name }}.
+            This commit was pushed to master and may contain connector changes
+            that need documentation updates.
         uses: aaronsteers/devin-action@main
         with:
           devin-token: ${{ secrets.DEVIN_AI_API_KEY }}
@@ -113,3 +127,4 @@ jobs:
           tags: |
             area/documentation
             team/documentation
+            connector/${{ steps.check-connector.outputs.connector_name }}


### PR DESCRIPTION
## What

Extracts the connector name from the metadata file path in the `autodoc.yml` workflow and passes it explicitly to the Devin session prompt. This complements a playbook change in `airbytehq/ai-skills` that introduces deterministic branch naming (`docs/auto/{connector-name}`) to prevent duplicate documentation PRs.

## How

1. In step 3 ("Check for connector changes"), after finding the `METADATA_FILE`, extract the connector name using `sed` (e.g., `source-slack` from `airbyte-integrations/connectors/source-slack/metadata.yaml`) and output it as `connector_name`.

2. In step 4 ("Start AI documentation update session"), include the connector name in the prompt text so Devin can immediately construct the deterministic branch name without needing to parse the commit diff first. Also adds a `connector/{name}` tag for session traceability.

## Review guide

1. `.github/workflows/autodoc.yml` — all changes in this single file
   - Lines 96-107: Connector name extraction and output
   - Lines 109-130: Updated prompt text and tags

## User Impact

No user-facing impact. This is a CI-only change that improves the reliability of automated connector documentation updates by helping prevent duplicate PRs when multiple commits for the same connector merge in quick succession.

### Context

This was observed in practice with source-slack PRs [#77041](https://github.com/airbytehq/airbyte/pull/77041) and [#77042](https://github.com/airbytehq/airbyte/pull/77042), where two Devin sessions created competing doc-update PRs within 34 minutes of each other. The playbook-side change (in `airbytehq/ai-skills`) instructs Devin to use the deterministic branch name; this workflow-side change ensures the connector name is available upfront in the prompt.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

---

Requested by @ian-at-airbyte.

[Devin session](https://app.devin.ai/sessions/b16c8713faa14887b23a05eae13275b4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/airbytehq/airbyte/pull/77566" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
