### PR TITLE
fix(source-microsoft-dataverse): map DateOnly fields to date format instead of date-time

### DIFF
--- a/airbyte-integrations/connectors/source-microsoft-dataverse/metadata.yaml
+++ b/airbyte-integrations/connectors/source-microsoft-dataverse/metadata.yaml
@@ -2,7 +2,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 9220e3de-3b60-4bb2-a46f-046d59ea235a
-  dockerImageTag: 0.1.32
+  dockerImageTag: 0.1.33
   dockerRepository: airbyte/source-microsoft-dataverse
   githubIssueLabel: source-microsoft-dataverse
   icon: microsoftdataverse.svg

--- a/airbyte-integrations/connectors/source-microsoft-dataverse/pyproject.toml
+++ b/airbyte-integrations/connectors/source-microsoft-dataverse/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
-version = "0.1.32"
+version = "0.1.33"
 name = "source-microsoft-dataverse"
 description = "Source implementation for Microsoft Dataverse."
 authors = ["Airbyte <contact@airbyte.io>"]

--- a/airbyte-integrations/connectors/source-microsoft-dataverse/source_microsoft_dataverse/dataverse.py
+++ b/airbyte-integrations/connectors/source-microsoft-dataverse/source_microsoft_dataverse/dataverse.py
@@ -28,6 +28,7 @@ class MicrosoftOauth2Authenticator(Oauth2Authenticator):
 class AirbyteType(Enum):
     String = {"type": ["null", "string"]}
     Boolean = {"type": ["null", "boolean"]}
+    Date = {"type": ["null", "string"], "format": "date"}
     Timestamp = {"type": ["null", "string"], "format": "date-time", "airbyte_type": "timestamp_with_timezone"}
     Integer = {"type": ["null", "integer"]}
     Number = {"type": ["null", "number"]}
@@ -70,7 +71,9 @@ def do_request(config: Mapping[str, Any], path: str):
     )
 
 
-def convert_dataverse_type(dataverse_type: str) -> Optional[dict]:
+def convert_dataverse_type(dataverse_type: str, date_time_behavior: Optional[str] = None) -> Optional[dict]:
+    if dataverse_type == "DateTime" and date_time_behavior == "DateOnly":
+        return AirbyteType.Date.value
     if dataverse_type in DataverseType.__members__:
         enum_type = DataverseType[dataverse_type]
         if enum_type:

--- a/airbyte-integrations/connectors/source-microsoft-dataverse/source_microsoft_dataverse/source.py
+++ b/airbyte-integrations/connectors/source-microsoft-dataverse/source_microsoft_dataverse/source.py
@@ -27,7 +27,14 @@ class SourceMicrosoftDataverse(AbstractSource):
                 dataverse_type = attribute["AttributeType"]
                 if dataverse_type == "Lookup":
                     attribute["LogicalName"] = "_" + attribute["LogicalName"] + "_value"
-                attribute_type = convert_dataverse_type(dataverse_type)
+
+                date_time_behavior = None
+                if dataverse_type == "DateTime":
+                    behavior = attribute.get("DateTimeBehavior")
+                    if behavior:
+                        date_time_behavior = behavior.get("Value")
+
+                attribute_type = convert_dataverse_type(dataverse_type, date_time_behavior)
 
                 if not attribute_type:
                     continue

--- a/airbyte-integrations/connectors/source-microsoft-dataverse/unit_tests/test_dataverse.py
+++ b/airbyte-integrations/connectors/source-microsoft-dataverse/unit_tests/test_dataverse.py
@@ -7,9 +7,18 @@ from source_microsoft_dataverse.dataverse import AirbyteType, convert_dataverse_
 
 
 @pytest.mark.parametrize(
-    "dataverse_type,expected_result",
-    [("String", AirbyteType.String.value), ("Integer", AirbyteType.Integer.value), ("Virtual", None), ("Random", AirbyteType.String.value)],
+    "dataverse_type,date_time_behavior,expected_result",
+    [
+        ("String", None, AirbyteType.String.value),
+        ("Integer", None, AirbyteType.Integer.value),
+        ("Virtual", None, None),
+        ("Random", None, AirbyteType.String.value),
+        ("DateTime", None, AirbyteType.Timestamp.value),
+        ("DateTime", "UserLocal", AirbyteType.Timestamp.value),
+        ("DateTime", "TimeZoneIndependent", AirbyteType.Timestamp.value),
+        ("DateTime", "DateOnly", AirbyteType.Date.value),
+    ],
 )
-def test_convert_dataverse_type(dataverse_type, expected_result):
-    result = convert_dataverse_type(dataverse_type)
+def test_convert_dataverse_type(dataverse_type, date_time_behavior, expected_result):
+    result = convert_dataverse_type(dataverse_type, date_time_behavior)
     assert result == expected_result

--- a/airbyte-integrations/connectors/source-microsoft-dataverse/unit_tests/test_source.py
+++ b/airbyte-integrations/connectors/source-microsoft-dataverse/unit_tests/test_source.py
@@ -111,6 +111,58 @@ def test_discover_incremental(mock_request):
 
 
 @mock.patch("source_microsoft_dataverse.source.do_request")
+def test_discover_date_only_field(mock_request):
+    result_json = json.loads(
+        """
+        {
+            "value": [
+                {
+                    "LogicalName": "stream",
+                    "PrimaryIdAttribute": "primary",
+                    "ChangeTrackingEnabled": false,
+                    "CanChangeTrackingBeEnabled": {
+                        "Value": false
+                    },
+                    "Attributes": [
+                        {
+                            "LogicalName": "date_field",
+                            "AttributeType": "DateTime",
+                            "DateTimeBehavior": {
+                                "Value": "DateOnly"
+                            }
+                        },
+                        {
+                            "LogicalName": "datetime_field",
+                            "AttributeType": "DateTime",
+                            "DateTimeBehavior": {
+                                "Value": "UserLocal"
+                            }
+                        },
+                        {
+                            "LogicalName": "datetime_no_behavior",
+                            "AttributeType": "DateTime"
+                        }
+                    ]
+                }
+            ]
+        }
+    """
+    )
+
+    mock_request.return_value.status.return_value = 200
+    mock_request.return_value.json.return_value = result_json
+
+    source = SourceMicrosoftDataverse()
+    logger_mock, config_mock = MagicMock(), MagicMock()
+
+    catalog = source.discover(logger_mock, config_mock)
+
+    assert catalog.streams[0].json_schema["properties"]["date_field"] == AirbyteType.Date.value
+    assert catalog.streams[0].json_schema["properties"]["datetime_field"] == AirbyteType.Timestamp.value
+    assert catalog.streams[0].json_schema["properties"]["datetime_no_behavior"] == AirbyteType.Timestamp.value
+
+
+@mock.patch("source_microsoft_dataverse.source.do_request")
 def test_discover_full_refresh(mock_request):
     result_json = json.loads(
         """

--- a/docs/integrations/sources/microsoft-dataverse.md
+++ b/docs/integrations/sources/microsoft-dataverse.md
@@ -17,7 +17,7 @@ This source will automatically discover the schema of the Entities of your Datav
 | :----------------- | :------------------------ | :-------------------- |
 | `String`           | `string`                  |                       |
 | `UniqueIdentifier` | `string`                  |                       |
-| `DateTime`         | `timestamp with timezone` |                       |
+| `DateTime`         | `timestamp with timezone` | When `DateTimeBehavior` is `DateOnly`, mapped to `date` instead |
 | `Integer`          | `integer`                 |                       |
 | `BigInt`           | `integer`                 |                       |
 | `Money`            | `number`                  |                       |

--- a/docs/integrations/sources/microsoft-dataverse.md
+++ b/docs/integrations/sources/microsoft-dataverse.md
@@ -64,6 +64,7 @@ https://blog.magnetismsolutions.com/blog/paulnieuwelaar/2021/9/21/setting-up-an-
 
 | Version | Date       | Pull Request                                             | Subject                                                                                |
 | :------ | :--------- | :------------------------------------------------------- | :------------------------------------------------------------------------------------- |
+| 0.1.33 | 2026-04-29 | [77571](https://github.com/airbytehq/airbyte/pull/77571) | Fix DateOnly fields emitting date-time instead of date schema type |
 | 0.1.32 | 2025-05-10 | [60052](https://github.com/airbytehq/airbyte/pull/60052) | Update dependencies |
 | 0.1.31 | 2025-05-03 | [59292](https://github.com/airbytehq/airbyte/pull/59292) | Update dependencies |
 | 0.1.30 | 2025-04-26 | [58830](https://github.com/airbytehq/airbyte/pull/58830) | Update dependencies |


### PR DESCRIPTION
## What

Fixes a bug where Dataverse fields configured with `DateOnly` behavior are declared as `{"type": "string", "format": "date-time"}` in the stream JSON schema. Since Dataverse returns date-only values like `2024-03-15` (no time component), these fail RFC 3339 datetime validation, causing `DESTINATION_SERIALIZATION_ERROR` and nulling the field values in the destination.

Requested by @Airbyte-Support.

## How

1. Added a `Date` type to `AirbyteType` enum: `{"type": ["null", "string"], "format": "date"}`
2. Updated `convert_dataverse_type()` to accept an optional `date_time_behavior` parameter. When `dataverse_type == "DateTime"` and `date_time_behavior == "DateOnly"`, it returns the new `Date` type instead of `Timestamp`.
3. Updated the `discover()` method in `source.py` to extract `DateTimeBehavior.Value` from each DateTime attribute's metadata and pass it to `convert_dataverse_type()`.
4. Updated the data type mapping table in the connector docs.

## Review guide

1. `source_microsoft_dataverse/dataverse.py` — new `Date` AirbyteType + updated `convert_dataverse_type` signature
2. `source_microsoft_dataverse/source.py` — `discover()` now extracts `DateTimeBehavior` from attribute metadata
3. `unit_tests/test_dataverse.py` — parameterized tests for DateTime/DateOnly/UserLocal/TimeZoneIndependent
4. `unit_tests/test_source.py` — new `test_discover_date_only_field` covering all three DateTime behavior variants
5. `docs/integrations/sources/microsoft-dataverse.md` — updated data type mapping table

## User Impact

DateOnly fields from Dataverse will now correctly emit `{"type": "string", "format": "date"}` in the schema, so values like `2024-03-15` will pass validation and sync to the destination without being nulled.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

---
[Devin session](https://app.devin.ai/sessions/ca72658ce0004147aae907b45183fcad)