### PR TITLE
fix(docs): add description to Web app, SDK, and API category cards on Interfaces page

### DIFF
--- a/docs/ai-agents/interfaces/api/_category_.json
+++ b/docs/ai-agents/interfaces/api/_category_.json
@@ -1,0 +1,4 @@
+{
+  "label": "API",
+  "description": "Manage connectors, tokens, and operations from any language or backend service."
+}

--- a/docs/ai-agents/interfaces/sdk/_category_.json
+++ b/docs/ai-agents/interfaces/sdk/_category_.json
@@ -1,0 +1,4 @@
+{
+  "label": "SDK",
+  "description": "Build, authenticate, and execute agent connectors directly in your Python applications."
+}

--- a/docs/ai-agents/interfaces/ui/_category_.json
+++ b/docs/ai-agents/interfaces/ui/_category_.json
@@ -1,0 +1,4 @@
+{
+  "label": "Web app",
+  "description": "Talk to an Airbyte-hosted agent in Chats, or define Automations that run on a schedule or webhook."
+}

--- a/docs/ai-agents/interfaces/ui/_category_.json
+++ b/docs/ai-agents/interfaces/ui/_category_.json
@@ -1,4 +1,4 @@
 {
-  "label": "Web app",
+  "label": "Web app (Research Preview)",
   "description": "Talk to an Airbyte-hosted agent in Chats, or define Automations that run on a schedule or webhook."
 }

--- a/docs/ai-agents/interfaces/ui/readme.md
+++ b/docs/ai-agents/interfaces/ui/readme.md
@@ -4,6 +4,10 @@ sidebar_position: 1
 
 # Web app
 
+:::info Research Preview
+The Airbyte Agents web app is currently in Research Preview. Features, interfaces, and behavior may change as the product evolves.
+:::
+
 The Airbyte Agents web app at [app.airbyte.ai](https://app.airbyte.ai) is the fastest way to use Airbyte Agents without writing code. Describe what you want in natural language, and Airbyte picks the right connectors, makes the necessary tool calls, and replies with an answer grounded in your data.
 
 Use the web app when you want Airbyte itself to be your agent. For Python agents you build yourself, use the [SDK](../sdk). For agents in any other language, use the [API](../api). For agents that already speak Model Context Protocol, use the [MCP server](../mcp).


### PR DESCRIPTION
## What

The Web app, SDK, and API cards on the [Interfaces](https://docs.airbyte.com/ai-agents/interfaces) page render item counts (e.g., "3 items", "4 items") instead of descriptive taglines. This is the same Docusaurus limitation fixed in #77535, where `DocCard` ignores the `description` field on category sidebar items unless a `_category_.json` provides one.

Reported by @katmarkham.

## How

Added `_category_.json` files with `description` fields to each of the three affected category directories:

1. `docs/ai-agents/interfaces/ui/_category_.json` — "Talk to an Airbyte-hosted agent in Chats, or define Automations that run on a schedule or webhook."
2. `docs/ai-agents/interfaces/sdk/_category_.json` — "Build, authenticate, and execute agent connectors directly in your Python applications."
3. `docs/ai-agents/interfaces/api/_category_.json` — "Manage connectors, tokens, and operations from any language or backend service."

The swizzled `DocCard` component from #77535 already checks `item.description` first and falls back to the item count, so no component changes are needed.

## Review guide

1. `docs/ai-agents/interfaces/ui/_category_.json`
2. `docs/ai-agents/interfaces/sdk/_category_.json`
3. `docs/ai-agents/interfaces/api/_category_.json`

## User Impact

The Web app, SDK, and API cards on the Interfaces page now show descriptive taglines consistent with the MCP server card, instead of generic item counts.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚
- [ ] NO ❌

Link to Devin session: https://app.devin.ai/sessions/db393a993d874a0ab096531732e2ed9f
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/airbytehq/airbyte/pull/77572" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
