### PR TITLE
fix(source-s3): pass config credentials to STS client for IAM role assumption

### DIFF
--- a/airbyte-integrations/connectors/source-s3/metadata.yaml
+++ b/airbyte-integrations/connectors/source-s3/metadata.yaml
@@ -10,7 +10,7 @@ data:
   connectorSubtype: file
   connectorType: source
   definitionId: 69589781-7828-43c5-9f63-8925b1c1ccc2
-  dockerImageTag: 4.15.3
+  dockerImageTag: 4.15.4
   dockerRepository: airbyte/source-s3
   documentationUrl: https://docs.airbyte.com/integrations/sources/s3
   externalDocumentationUrls:

--- a/airbyte-integrations/connectors/source-s3/pyproject.toml
+++ b/airbyte-integrations/connectors/source-s3/pyproject.toml
@@ -3,7 +3,7 @@ requires = [ "poetry-core>=1.0.0",]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
-version = "4.15.3"
+version = "4.15.4"
 name = "source-s3"
 description = "Source implementation for S3."
 authors = [ "Airbyte <contact@airbyte.io>",]

--- a/airbyte-integrations/connectors/source-s3/source_s3/v4/stream_reader.py
+++ b/airbyte-integrations/connectors/source-s3/source_s3/v4/stream_reader.py
@@ -100,7 +100,11 @@ class SourceS3StreamReader(AbstractFileBasedStreamReader):
         """
 
         def refresh():
-            client = boto3.client("sts")
+            client = boto3.client(
+                "sts",
+                aws_access_key_id=self.config.aws_access_key_id,
+                aws_secret_access_key=self.config.aws_secret_access_key,
+            )
             if AWS_EXTERNAL_ID:
                 role = client.assume_role(
                     RoleArn=self.config.role_arn,

--- a/airbyte-integrations/connectors/source-s3/unit_tests/v4/test_stream_reader.py
+++ b/airbyte-integrations/connectors/source-s3/unit_tests/v4/test_stream_reader.py
@@ -331,6 +331,40 @@ def test_get_iam_s3_client(boto3_client_mock):
     assert s3_client is not None
 
 
+@mock_sts
+@patch("source_s3.v4.stream_reader.boto3.client")
+def test_get_iam_s3_client_passes_credentials_to_sts(boto3_client_mock):
+    """Verify that user-provided AWS credentials are forwarded to the STS client
+    so that assume_role works in environments without instance profiles."""
+    boto3_client_mock.return_value.assume_role.return_value = {
+        "Credentials": {
+            "AccessKeyId": "assumed_access_key_id",
+            "SecretAccessKey": "assumed_secret_access_key",
+            "SessionToken": "assumed_session_token",
+            "Expiration": datetime.now(),
+        }
+    }
+
+    reader = SourceS3StreamReader()
+    reader.config = Config(
+        bucket="test",
+        aws_access_key_id="config_access_key",
+        aws_secret_access_key="config_secret_key",
+        role_arn="arn:aws:iam::123456789012:role/my-role",
+        streams=[],
+        endpoint=None,
+    )
+
+    with Stubber(reader.s3_client):
+        reader._get_iam_s3_client({})
+
+    # The first boto3.client() call should be for "sts" with the config credentials
+    first_call = boto3_client_mock.call_args_list[0]
+    assert first_call[0][0] == "sts"
+    assert first_call[1]["aws_access_key_id"] == "config_access_key"
+    assert first_call[1]["aws_secret_access_key"] == "config_secret_key"
+
+
 @pytest.mark.parametrize(
     "start_date, last_modified_date, expected_result",
     (


### PR DESCRIPTION
## What

Fixes `NoCredentialsError` when using the S3 source connector with IAM role assumption (`role_arn`) in environments that don't have instance profiles or AWS environment variables set.

When a user provides `aws_access_key_id` and `aws_secret_access_key` alongside a `role_arn`, the STS client used for `AssumeRole` was created without any credentials (`boto3.client("sts")`), causing the call to fail with:

```
botocore.exceptions.NoCredentialsError: Unable to locate credentials
```

## How

Pass `self.config.aws_access_key_id` and `self.config.aws_secret_access_key` to the `boto3.client("sts", ...)` call inside `_get_iam_s3_client`. When the values are `None` (e.g., running on EC2 with an instance profile), boto3 falls back to the default credential chain — so this change is fully backwards-compatible.

Added a unit test that verifies the config credentials are forwarded to the STS client.

## Review guide

1. `airbyte-integrations/connectors/source-s3/source_s3/v4/stream_reader.py` — the fix (3-line change in `_get_iam_s3_client`)
2. `airbyte-integrations/connectors/source-s3/unit_tests/v4/test_stream_reader.py` — new test `test_get_iam_s3_client_passes_credentials_to_sts`

## User Impact

Users who provide AWS access keys + a role ARN in the S3 source config will now be able to successfully authenticate via IAM role assumption. Previously this combination always failed with `NoCredentialsError` unless the environment had ambient AWS credentials (instance profile, env vars, etc.).

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Link to Devin session: https://app.devin.ai/sessions/415fed60677043b08170f3d1049d0d6e
Requested by: @rwask
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/airbytehq/airbyte/pull/77574" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
