### PR TITLE
docs(ai-agents): update SDK page copy and fix Add a connector card

### DIFF
--- a/docs/ai-agents/interfaces/sdk/add-connector.md
+++ b/docs/ai-agents/interfaces/sdk/add-connector.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 2
+description: "Create, list, get, and delete connectors — stored credentials for third-party services."
 ---
 
 # Add a connector

--- a/docs/ai-agents/interfaces/sdk/add-connector.md
+++ b/docs/ai-agents/interfaces/sdk/add-connector.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 2
-description: "Create, list, get, and delete connectors — stored credentials for third-party services."
+description: "Create, list, get, and delete connectors for third-party services."
 ---
 
 # Add a connector

--- a/docs/ai-agents/interfaces/sdk/readme.md
+++ b/docs/ai-agents/interfaces/sdk/readme.md
@@ -7,9 +7,9 @@ import SdkVsApi from '@site/static/_ai-agents-sdk-vs-api.md';
 
 # SDK
 
-The Airbyte Agents Python SDK (`airbyte_agent_sdk`) is the Python front door to Airbyte Agents. With one install you get typed connectors, automatic credential handling, direct execution, and patterns for exposing connectors as tools to AI agent frameworks.
+The Airbyte Agents Python SDK (`airbyte_agent_sdk`) is the Python entry point to Airbyte Agents. With one install you get typed connectors, automatic credential handling, direct execution, and patterns for exposing connectors as tools to AI agent frameworks.
 
-This section walks through the three operations most apps need: authenticate, add a connector, and execute operations. Deeper class and method signatures live in the [SDK reference](/ai-agents/reference/sdk).
+This section walks through authenticate, add a connector, and execute operations. Deeper class and method signatures live in the [SDK reference](/ai-agents/reference/sdk).
 
 ## Choose your interface
 

--- a/docusaurus/static/_ai-agents-sdk-vs-api.md
+++ b/docusaurus/static/_ai-agents-sdk-vs-api.md
@@ -3,4 +3,4 @@ You can use Airbyte Agents programmatically two ways:
 - [**SDK**](/ai-agents/interfaces/sdk): a typed Python library. Best for Python apps, notebooks, scripts, and AI agents.
 - [**API**](/ai-agents/interfaces/api): an HTTP API. Best for non-Python backends and languages the SDK doesn't cover.
 
-Most Airbyte Agents operations are available through both interfaces. Where the SDK can't do something directly, use the API. Pages in the SDK section flag this explicitly.
+Most Airbyte Agents operations are available through both interfaces. Where the SDK can't do something directly, use the API as noted explicitly in docs.


### PR DESCRIPTION
## What

Copy edits to the [SDK overview page](https://docs.airbyte.com/ai-agents/interfaces/sdk) requested by @katmarkham.

## How

1. Changed "front door" → "entry point" in the SDK intro sentence.
2. Shortened the operations sentence (removed "the three operations most apps need:").
3. Reworded the SDK-vs-API fallback sentence to "use the API as noted explicitly in docs."
4. Added a `description` frontmatter field to `add-connector.md` so the DocCardList card renders a real description instead of the `<!--` HTML comment that was leaking through.

## Review guide

1. `docs/ai-agents/interfaces/sdk/readme.md` — edits 1 and 2
2. `docusaurus/static/_ai-agents-sdk-vs-api.md` — edit 3
3. `docs/ai-agents/interfaces/sdk/add-connector.md` — edit 4 (frontmatter description)

## User Impact

Corrects copy on the published SDK docs page and fixes a broken card preview.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

---
[Devin session](https://app.devin.ai/sessions/f03759a5282643f3bc9cbcbc382c2aa8)

> [!IMPORTANT]
> ⚡ **Auto-merge enabled.**
> 
> _This PR is set to merge automatically when all requirements are met._