### PR TITLE
docs: fix kubectl secret key casing for data plane client ID/secret

### DIFF
--- a/docs/platform/enterprise-flex/data-plane.md
+++ b/docs/platform/enterprise-flex/data-plane.md
@@ -252,8 +252,8 @@ You can also use `kubectl` to create the secret directly from the command-line t
 ```bash
 kubectl create secret generic airbyte-config-secrets \
   --from-literal=license-key='' \
-  --from-literal=data_plane_client_id='' \
-  --from-literal=data_plane_client_secret='' \
+  --from-literal=DATA_PLANE_CLIENT_ID='' \
+  --from-literal=DATA_PLANE_CLIENT_SECRET='' \
   --from-literal=s3-access-key-id='' \
   --from-literal=s3-secret-access-key='' \
   --from-literal=aws-secret-manager-access-key-id='' \

--- a/docs/platform/enterprise-setup/multi-region.md
+++ b/docs/platform/enterprise-setup/multi-region.md
@@ -310,8 +310,8 @@ You can also use `kubectl` to create the secret directly from the command-line t
 ```bash
 kubectl create secret generic airbyte-config-secrets \
   --from-literal=license-key='' \
-  --from-literal=data_plane_client_id='' \
-  --from-literal=data_plane_client_secret='' \
+  --from-literal=DATA_PLANE_CLIENT_ID='' \
+  --from-literal=DATA_PLANE_CLIENT_SECRET='' \
   --from-literal=s3-access-key-id='' \
   --from-literal=s3-secret-access-key='' \
   --from-literal=aws-secret-manager-access-key-id='' \
@@ -355,8 +355,8 @@ You can also use `kubectl` to create the secret directly from the command-line t
 ```bash
 kubectl create secret generic airbyte-config-secrets \
   --from-literal=license-key='' \
-  --from-literal=data_plane_client_id='' \
-  --from-literal=data_plane_client_secret='' \
+  --from-literal=DATA_PLANE_CLIENT_ID='' \
+  --from-literal=DATA_PLANE_CLIENT_SECRET='' \
   --from-literal=s3-access-key-id='' \
   --from-literal=s3-secret-access-key='' \
   --from-literal=aws-secret-manager-access-key-id='' \

--- a/docusaurus/platform_versioned_docs/version-1.6/enterprise-setup/multi-region.md
+++ b/docusaurus/platform_versioned_docs/version-1.6/enterprise-setup/multi-region.md
@@ -294,8 +294,8 @@ You can also use `kubectl` to create the secret directly from the command-line t
 ```bash
 kubectl create secret generic airbyte-config-secrets \
   --from-literal=license-key='' \
-  --from-literal=data_plane_client_id='' \
-  --from-literal=data_plane_client_secret='' \
+  --from-literal=DATA_PLANE_CLIENT_ID='' \
+  --from-literal=DATA_PLANE_CLIENT_SECRET='' \
   --from-literal=s3-access-key-id='' \
   --from-literal=s3-secret-access-key='' \
   --from-literal=aws-secret-manager-access-key-id='' \
@@ -339,8 +339,8 @@ You can also use `kubectl` to create the secret directly from the command-line t
 ```bash
 kubectl create secret generic airbyte-config-secrets \
   --from-literal=license-key='' \
-  --from-literal=data_plane_client_id='' \
-  --from-literal=data_plane_client_secret='' \
+  --from-literal=DATA_PLANE_CLIENT_ID='' \
+  --from-literal=DATA_PLANE_CLIENT_SECRET='' \
   --from-literal=s3-access-key-id='' \
   --from-literal=s3-secret-access-key='' \
   --from-literal=aws-secret-manager-access-key-id='' \

--- a/docusaurus/platform_versioned_docs/version-1.7/enterprise-setup/multi-region.md
+++ b/docusaurus/platform_versioned_docs/version-1.7/enterprise-setup/multi-region.md
@@ -312,8 +312,8 @@ You can also use `kubectl` to create the secret directly from the command-line t
 ```bash
 kubectl create secret generic airbyte-config-secrets \
   --from-literal=license-key='' \
-  --from-literal=data_plane_client_id='' \
-  --from-literal=data_plane_client_secret='' \
+  --from-literal=DATA_PLANE_CLIENT_ID='' \
+  --from-literal=DATA_PLANE_CLIENT_SECRET='' \
   --from-literal=s3-access-key-id='' \
   --from-literal=s3-secret-access-key='' \
   --from-literal=aws-secret-manager-access-key-id='' \
@@ -357,8 +357,8 @@ You can also use `kubectl` to create the secret directly from the command-line t
 ```bash
 kubectl create secret generic airbyte-config-secrets \
   --from-literal=license-key='' \
-  --from-literal=data_plane_client_id='' \
-  --from-literal=data_plane_client_secret='' \
+  --from-literal=DATA_PLANE_CLIENT_ID='' \
+  --from-literal=DATA_PLANE_CLIENT_SECRET='' \
   --from-literal=s3-access-key-id='' \
   --from-literal=s3-secret-access-key='' \
   --from-literal=aws-secret-manager-access-key-id='' \

--- a/docusaurus/platform_versioned_docs/version-1.8/enterprise-setup/multi-region.md
+++ b/docusaurus/platform_versioned_docs/version-1.8/enterprise-setup/multi-region.md
@@ -312,8 +312,8 @@ You can also use `kubectl` to create the secret directly from the command-line t
 ```bash
 kubectl create secret generic airbyte-config-secrets \
   --from-literal=license-key='' \
-  --from-literal=data_plane_client_id='' \
-  --from-literal=data_plane_client_secret='' \
+  --from-literal=DATA_PLANE_CLIENT_ID='' \
+  --from-literal=DATA_PLANE_CLIENT_SECRET='' \
   --from-literal=s3-access-key-id='' \
   --from-literal=s3-secret-access-key='' \
   --from-literal=aws-secret-manager-access-key-id='' \
@@ -357,8 +357,8 @@ You can also use `kubectl` to create the secret directly from the command-line t
 ```bash
 kubectl create secret generic airbyte-config-secrets \
   --from-literal=license-key='' \
-  --from-literal=data_plane_client_id='' \
-  --from-literal=data_plane_client_secret='' \
+  --from-literal=DATA_PLANE_CLIENT_ID='' \
+  --from-literal=DATA_PLANE_CLIENT_SECRET='' \
   --from-literal=s3-access-key-id='' \
   --from-literal=s3-secret-access-key='' \
   --from-literal=aws-secret-manager-access-key-id='' \

--- a/docusaurus/platform_versioned_docs/version-2.0/enterprise-flex/data-plane.md
+++ b/docusaurus/platform_versioned_docs/version-2.0/enterprise-flex/data-plane.md
@@ -243,8 +243,8 @@ You can also use `kubectl` to create the secret directly from the command-line t
 ```bash
 kubectl create secret generic airbyte-config-secrets \
   --from-literal=license-key='' \
-  --from-literal=data_plane_client_id='' \
-  --from-literal=data_plane_client_secret='' \
+  --from-literal=DATA_PLANE_CLIENT_ID='' \
+  --from-literal=DATA_PLANE_CLIENT_SECRET='' \
   --from-literal=s3-access-key-id='' \
   --from-literal=s3-secret-access-key='' \
   --from-literal=aws-secret-manager-access-key-id='' \

--- a/docusaurus/platform_versioned_docs/version-2.0/enterprise-setup/multi-region.md
+++ b/docusaurus/platform_versioned_docs/version-2.0/enterprise-setup/multi-region.md
@@ -310,8 +310,8 @@ You can also use `kubectl` to create the secret directly from the command-line t
 ```bash
 kubectl create secret generic airbyte-config-secrets \
   --from-literal=license-key='' \
-  --from-literal=data_plane_client_id='' \
-  --from-literal=data_plane_client_secret='' \
+  --from-literal=DATA_PLANE_CLIENT_ID='' \
+  --from-literal=DATA_PLANE_CLIENT_SECRET='' \
   --from-literal=s3-access-key-id='' \
   --from-literal=s3-secret-access-key='' \
   --from-literal=aws-secret-manager-access-key-id='' \
@@ -355,8 +355,8 @@ You can also use `kubectl` to create the secret directly from the command-line t
 ```bash
 kubectl create secret generic airbyte-config-secrets \
   --from-literal=license-key='' \
-  --from-literal=data_plane_client_id='' \
-  --from-literal=data_plane_client_secret='' \
+  --from-literal=DATA_PLANE_CLIENT_ID='' \
+  --from-literal=DATA_PLANE_CLIENT_SECRET='' \
   --from-literal=s3-access-key-id='' \
   --from-literal=s3-secret-access-key='' \
   --from-literal=aws-secret-manager-access-key-id='' \

--- a/docusaurus/platform_versioned_docs/version-2.1/enterprise-flex/data-plane.md
+++ b/docusaurus/platform_versioned_docs/version-2.1/enterprise-flex/data-plane.md
@@ -252,8 +252,8 @@ You can also use `kubectl` to create the secret directly from the command-line t
 ```bash
 kubectl create secret generic airbyte-config-secrets \
   --from-literal=license-key='' \
-  --from-literal=data_plane_client_id='' \
-  --from-literal=data_plane_client_secret='' \
+  --from-literal=DATA_PLANE_CLIENT_ID='' \
+  --from-literal=DATA_PLANE_CLIENT_SECRET='' \
   --from-literal=s3-access-key-id='' \
   --from-literal=s3-secret-access-key='' \
   --from-literal=aws-secret-manager-access-key-id='' \

--- a/docusaurus/platform_versioned_docs/version-2.1/enterprise-setup/multi-region.md
+++ b/docusaurus/platform_versioned_docs/version-2.1/enterprise-setup/multi-region.md
@@ -310,8 +310,8 @@ You can also use `kubectl` to create the secret directly from the command-line t
 ```bash
 kubectl create secret generic airbyte-config-secrets \
   --from-literal=license-key='' \
-  --from-literal=data_plane_client_id='' \
-  --from-literal=data_plane_client_secret='' \
+  --from-literal=DATA_PLANE_CLIENT_ID='' \
+  --from-literal=DATA_PLANE_CLIENT_SECRET='' \
   --from-literal=s3-access-key-id='' \
   --from-literal=s3-secret-access-key='' \
   --from-literal=aws-secret-manager-access-key-id='' \
@@ -355,8 +355,8 @@ You can also use `kubectl` to create the secret directly from the command-line t
 ```bash
 kubectl create secret generic airbyte-config-secrets \
   --from-literal=license-key='' \
-  --from-literal=data_plane_client_id='' \
-  --from-literal=data_plane_client_secret='' \
+  --from-literal=DATA_PLANE_CLIENT_ID='' \
+  --from-literal=DATA_PLANE_CLIENT_SECRET='' \
   --from-literal=s3-access-key-id='' \
   --from-literal=s3-secret-access-key='' \
   --from-literal=aws-secret-manager-access-key-id='' \


### PR DESCRIPTION
## What

The `kubectl create secret` commands in the data plane and multi-region docs used lowercase `data_plane_client_id` / `data_plane_client_secret`, while the YAML manifest and `values.yaml` examples reference `DATA_PLANE_CLIENT_ID` / `DATA_PLANE_CLIENT_SECRET` (uppercase). This mismatch would cause the data plane to fail to authenticate with the control plane.

Fixes the casing in the `kubectl` commands to match the manifest across all affected docs.

Requested by @lleadbet.

## How

Changed `--from-literal=data_plane_client_id` → `--from-literal=DATA_PLANE_CLIENT_ID` and `--from-literal=data_plane_client_secret` → `--from-literal=DATA_PLANE_CLIENT_SECRET` in the `kubectl` commands in:
- `docs/platform/enterprise-flex/data-plane.md`
- `docs/platform/enterprise-setup/multi-region.md`
- All versioned copies (v1.6, v1.7, v1.8, v2.0, v2.1)

## Review guide
1. `docs/platform/enterprise-flex/data-plane.md`
2. `docs/platform/enterprise-setup/multi-region.md`
3. Versioned docs under `docusaurus/platform_versioned_docs/`

## User Impact

Users following the `kubectl` command to create secrets will now create keys that match the manifest and `values.yaml`, preventing authentication failures when deploying a data plane.

## Can this PR be safely reverted and rolled back?
- [x] YES 💚

---
[Devin session](https://app.devin.ai/sessions/1b9314b9bf0247ddac3ff618d610b801)