### PR TITLE
fix(source-twilio): fix usage_records null primary key caused by incorrect start_date schema format

### DIFF
--- a/airbyte-integrations/connectors/source-twilio/manifest.yaml
+++ b/airbyte-integrations/connectors/source-twilio/manifest.yaml
@@ -690,6 +690,11 @@ definitions:
       - end_date
     retriever:
       $ref: "#/definitions/base_stream/retriever"
+      record_selector:
+        $ref: "#/definitions/base_stream/retriever/record_selector"
+        record_filter:
+          type: RecordFilter
+          condition: "{{ record.get('account_sid') is not none and record.get('category') is not none and record.get('start_date') is not none and record.get('end_date') is not none }}"
       requester:
         $ref: "#/definitions/base_requester"
         url: "https://api.twilio.com/2010-04-01/Accounts/{{ stream_partition['account_sid'] }}/Usage/Records/Daily.json"

--- a/airbyte-integrations/connectors/source-twilio/manifest.yaml
+++ b/airbyte-integrations/connectors/source-twilio/manifest.yaml
@@ -690,11 +690,6 @@ definitions:
       - end_date
     retriever:
       $ref: "#/definitions/base_stream/retriever"
-      record_selector:
-        $ref: "#/definitions/base_stream/retriever/record_selector"
-        record_filter:
-          type: RecordFilter
-          condition: "{{ record.get('account_sid') is not none and record.get('category') is not none and record.get('start_date') is not none and record.get('end_date') is not none }}"
       requester:
         $ref: "#/definitions/base_requester"
         url: "https://api.twilio.com/2010-04-01/Accounts/{{ stream_partition['account_sid'] }}/Usage/Records/Daily.json"

--- a/airbyte-integrations/connectors/source-twilio/manifest.yaml
+++ b/airbyte-integrations/connectors/source-twilio/manifest.yaml
@@ -3858,8 +3858,8 @@ schemas:
           - "null"
           - number
       start_date:
-        description: The start date and time of the usage record period.
-        format: date-time
+        description: The start date of the usage record period.
+        format: date
         type:
           - "null"
           - string

--- a/airbyte-integrations/connectors/source-twilio/metadata.yaml
+++ b/airbyte-integrations/connectors/source-twilio/metadata.yaml
@@ -13,7 +13,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: b9dc6155-672e-42ea-b10d-9f1f1fb95ab1
-  dockerImageTag: 0.17.8
+  dockerImageTag: 0.17.9
   dockerRepository: airbyte/source-twilio
   documentationUrl: https://docs.airbyte.com/integrations/sources/twilio
   githubIssueLabel: source-twilio

--- a/airbyte-integrations/connectors/source-twilio/metadata.yaml
+++ b/airbyte-integrations/connectors/source-twilio/metadata.yaml
@@ -13,7 +13,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: b9dc6155-672e-42ea-b10d-9f1f1fb95ab1
-  dockerImageTag: 0.17.9
+  dockerImageTag: 0.17.8
   dockerRepository: airbyte/source-twilio
   documentationUrl: https://docs.airbyte.com/integrations/sources/twilio
   githubIssueLabel: source-twilio

--- a/docs/integrations/sources/twilio.md
+++ b/docs/integrations/sources/twilio.md
@@ -115,6 +115,7 @@ Smaller windows increase the number of API requests and are more likely to be ra
 
 | Version     | Date       | Pull Request                                             | Subject                                                                                                                                                                |
 |:------------|:-----------| :------------------------------------------------------- |:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 0.17.9 | 2026-04-29 | [*PR_NUMBER_PLACEHOLDER*](https://github.com/airbytehq/airbyte/pull/*PR_NUMBER_PLACEHOLDER*) | Filter out usage_records with null primary key fields to prevent Iceberg destination failures |
 | 0.17.8 | 2026-04-28 | [77453](https://github.com/airbytehq/airbyte/pull/77453) | Update dependencies |
 | 0.17.7 | 2026-04-22 | [72494](https://github.com/airbytehq/airbyte/pull/72494) | Add configurable slice step duration (default: 1 month) |
 | 0.17.6 | 2026-04-21 | [76801](https://github.com/airbytehq/airbyte/pull/76801) | Update dependencies |

--- a/docs/integrations/sources/twilio.md
+++ b/docs/integrations/sources/twilio.md
@@ -115,6 +115,7 @@ Smaller windows increase the number of API requests and are more likely to be ra
 
 | Version     | Date       | Pull Request                                             | Subject                                                                                                                                                                |
 |:------------|:-----------| :------------------------------------------------------- |:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 0.17.9 | 2026-04-29 | [](https://github.com/airbytehq/airbyte/pull/) | Filter out usage_records with null primary key fields to prevent Iceberg destination failures |
 | 0.17.8 | 2026-04-28 | [77453](https://github.com/airbytehq/airbyte/pull/77453) | Update dependencies |
 | 0.17.7 | 2026-04-22 | [72494](https://github.com/airbytehq/airbyte/pull/72494) | Add configurable slice step duration (default: 1 month) |
 | 0.17.6 | 2026-04-21 | [76801](https://github.com/airbytehq/airbyte/pull/76801) | Update dependencies |

--- a/docs/integrations/sources/twilio.md
+++ b/docs/integrations/sources/twilio.md
@@ -115,7 +115,7 @@ Smaller windows increase the number of API requests and are more likely to be ra
 
 | Version     | Date       | Pull Request                                             | Subject                                                                                                                                                                |
 |:------------|:-----------| :------------------------------------------------------- |:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| 0.17.9 | 2026-04-29 | [*PR_NUMBER_PLACEHOLDER*](https://github.com/airbytehq/airbyte/pull/*PR_NUMBER_PLACEHOLDER*) | Filter out usage_records with null primary key fields to prevent Iceberg destination failures |
+| 0.17.9 | 2026-04-29 | [77593](https://github.com/airbytehq/airbyte/pull/77593) | Fix usage_records start_date schema format from date-time to date to prevent null primary key in Iceberg destination |
 | 0.17.8 | 2026-04-28 | [77453](https://github.com/airbytehq/airbyte/pull/77453) | Update dependencies |
 | 0.17.7 | 2026-04-22 | [72494](https://github.com/airbytehq/airbyte/pull/72494) | Add configurable slice step duration (default: 1 month) |
 | 0.17.6 | 2026-04-21 | [76801](https://github.com/airbytehq/airbyte/pull/76801) | Update dependencies |

--- a/docs/integrations/sources/twilio.md
+++ b/docs/integrations/sources/twilio.md
@@ -115,7 +115,6 @@ Smaller windows increase the number of API requests and are more likely to be ra
 
 | Version     | Date       | Pull Request                                             | Subject                                                                                                                                                                |
 |:------------|:-----------| :------------------------------------------------------- |:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| 0.17.9 | 2026-04-29 | [](https://github.com/airbytehq/airbyte/pull/) | Filter out usage_records with null primary key fields to prevent Iceberg destination failures |
 | 0.17.8 | 2026-04-28 | [77453](https://github.com/airbytehq/airbyte/pull/77453) | Update dependencies |
 | 0.17.7 | 2026-04-22 | [72494](https://github.com/airbytehq/airbyte/pull/72494) | Add configurable slice step duration (default: 1 month) |
 | 0.17.6 | 2026-04-21 | [76801](https://github.com/airbytehq/airbyte/pull/76801) | Update dependencies |


### PR DESCRIPTION
## What

Fixes the Twilio Context Store replication failure: `Detected null value in primary key. The Iceberg protocol disallows this.`

The `start_date` field in the `usage_records` schema was declared with `format: date-time`, but the Twilio API returns plain dates like `"2020-11-17"`. At the Iceberg destination, `format: date-time` maps to `TimestampTypeWithTimezone`. The coercer tries to parse `"2020-11-17"` as a `ZonedDateTime` (fails — no timezone), falls back to `LocalDateTime.parse` (fails — no time component), catches the exception and returns `null`. The Iceberg writer then detects a null PK on `start_date` and throws the error. The `end_date` field already correctly uses `format: date`.

## How

Changed `start_date` from `format: date-time` to `format: date` in the `usage_records` schema to match the actual API response format.

## Review guide

1. `airbyte-integrations/connectors/source-twilio/manifest.yaml` — `start_date` format fix in the schema section (`#/schemas/usage_records`)

## User Impact

Unblocks Twilio Context Store replication for `usage_records`, which was failing for all records due to the `start_date` type coercion producing nulls.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚


Link to Devin session: https://app.devin.ai/sessions/2b032698388647c0bd2ecd5121273dcd
Requested by: @sophiecuiy