### PR TITLE
docs(ai-agents): add plan frontmatter to all hand-written docs pages

### DIFF
--- a/docs/ai-agents/README.md
+++ b/docs/ai-agents/README.md
@@ -1,4 +1,5 @@
 ---
+plan: all
 sidebar_position: 1
 ---
 

--- a/docs/ai-agents/admin/readme.md
+++ b/docs/ai-agents/admin/readme.md
@@ -1,4 +1,5 @@
 ---
+plan: all
 sidebar_position: 7
 ---
 

--- a/docs/ai-agents/admin/sessions.md
+++ b/docs/ai-agents/admin/sessions.md
@@ -1,3 +1,7 @@
+---
+plan: all
+---
+
 # Review sessions
 
 The Sessions page shows a read-only history of every agent interaction in your workspace, along with token usage and the tools each interaction used. Use it to audit what your agents did, troubleshoot unexpected results, and understand what's driving your [agent operations (AOs)](../concepts/agent-operations.md).

--- a/docs/ai-agents/admin/tool-calls.md
+++ b/docs/ai-agents/admin/tool-calls.md
@@ -1,3 +1,7 @@
+---
+plan: all
+---
+
 # Review tool calls
 
 Airbyte Agents logs every tool call your agents make. Review this log to understand what your agents are doing, troubleshoot failures, and investigate unexpected activity or cost spikes.

--- a/docs/ai-agents/concepts/agent-operations.md
+++ b/docs/ai-agents/concepts/agent-operations.md
@@ -1,4 +1,5 @@
 ---
+plan: all
 sidebar_position: 1
 ---
 

--- a/docs/ai-agents/concepts/architecture/connectors-and-credentials.md
+++ b/docs/ai-agents/concepts/architecture/connectors-and-credentials.md
@@ -1,4 +1,5 @@
 ---
+plan: all
 sidebar_position: 3
 ---
 

--- a/docs/ai-agents/concepts/architecture/organizations.md
+++ b/docs/ai-agents/concepts/architecture/organizations.md
@@ -1,4 +1,5 @@
 ---
+plan: all
 sidebar_position: 1
 ---
 

--- a/docs/ai-agents/concepts/architecture/readme.md
+++ b/docs/ai-agents/concepts/architecture/readme.md
@@ -1,4 +1,5 @@
 ---
+plan: all
 sidebar_position: 3
 ---
 

--- a/docs/ai-agents/concepts/architecture/workspaces.md
+++ b/docs/ai-agents/concepts/architecture/workspaces.md
@@ -1,4 +1,5 @@
 ---
+plan: all
 sidebar_position: 2
 ---
 

--- a/docs/ai-agents/concepts/connect-unify-act.md
+++ b/docs/ai-agents/concepts/connect-unify-act.md
@@ -1,4 +1,5 @@
 ---
+plan: all
 sidebar_position: 0
 ---
 

--- a/docs/ai-agents/concepts/context-store.md
+++ b/docs/ai-agents/concepts/context-store.md
@@ -1,4 +1,5 @@
 ---
+plan: all
 sidebar_position: 2
 ---
 

--- a/docs/ai-agents/concepts/readme.md
+++ b/docs/ai-agents/concepts/readme.md
@@ -1,4 +1,5 @@
 ---
+plan: all
 sidebar_position: 3
 ---
 

--- a/docs/ai-agents/concepts/time-zones.md
+++ b/docs/ai-agents/concepts/time-zones.md
@@ -1,4 +1,5 @@
 ---
+plan: all
 sidebar_position: 3
 ---
 

--- a/docs/ai-agents/get-started/choose-how-to-use.md
+++ b/docs/ai-agents/get-started/choose-how-to-use.md
@@ -1,4 +1,5 @@
 ---
+plan: all
 sidebar_position: 2
 sidebar_label: Choose how to use Airbyte Agents
 ---

--- a/docs/ai-agents/get-started/developer-quickstart/readme.md
+++ b/docs/ai-agents/get-started/developer-quickstart/readme.md
@@ -1,4 +1,5 @@
 ---
+plan: all
 sidebar_position: 3
 sidebar_label: Developer Quickstart
 ---

--- a/docs/ai-agents/get-started/developer-quickstart/skills/claude-code.md
+++ b/docs/ai-agents/get-started/developer-quickstart/skills/claude-code.md
@@ -1,4 +1,5 @@
 ---
+plan: all
 sidebar_position: 1
 sidebar_label: Claude Code
 ---

--- a/docs/ai-agents/get-started/developer-quickstart/skills/codex.md
+++ b/docs/ai-agents/get-started/developer-quickstart/skills/codex.md
@@ -1,4 +1,5 @@
 ---
+plan: all
 sidebar_position: 2
 sidebar_label: Codex
 ---

--- a/docs/ai-agents/get-started/developer-quickstart/skills/lovable.md
+++ b/docs/ai-agents/get-started/developer-quickstart/skills/lovable.md
@@ -1,4 +1,5 @@
 ---
+plan: all
 sidebar_position: 3
 sidebar_label: Lovable
 ---

--- a/docs/ai-agents/get-started/developer-quickstart/skills/readme.md
+++ b/docs/ai-agents/get-started/developer-quickstart/skills/readme.md
@@ -1,4 +1,5 @@
 ---
+plan: all
 sidebar_position: 4
 sidebar_label: Skills
 ---

--- a/docs/ai-agents/get-started/developer-quickstart/tutorial-fastmcp.md
+++ b/docs/ai-agents/get-started/developer-quickstart/tutorial-fastmcp.md
@@ -1,4 +1,5 @@
 ---
+plan: all
 sidebar_label: "FastMCP"
 sidebar_position: 1
 ---

--- a/docs/ai-agents/get-started/developer-quickstart/tutorial-langchain.md
+++ b/docs/ai-agents/get-started/developer-quickstart/tutorial-langchain.md
@@ -1,4 +1,5 @@
 ---
+plan: all
 sidebar_label: "LangChain"
 sidebar_position: 2
 ---

--- a/docs/ai-agents/get-started/developer-quickstart/tutorial-pydantic.md
+++ b/docs/ai-agents/get-started/developer-quickstart/tutorial-pydantic.md
@@ -1,4 +1,5 @@
 ---
+plan: all
 sidebar_label: "Pydantic AI"
 sidebar_position: 3
 ---

--- a/docs/ai-agents/get-started/readme.md
+++ b/docs/ai-agents/get-started/readme.md
@@ -1,4 +1,5 @@
 ---
+plan: all
 sidebar_position: 2
 ---
 

--- a/docs/ai-agents/get-started/what-is-airbyte-agents.md
+++ b/docs/ai-agents/get-started/what-is-airbyte-agents.md
@@ -1,4 +1,5 @@
 ---
+plan: all
 sidebar_position: 1
 sidebar_label: What is Airbyte Agents?
 ---

--- a/docs/ai-agents/interfaces/api/add-connector.md
+++ b/docs/ai-agents/interfaces/api/add-connector.md
@@ -1,4 +1,5 @@
 ---
+plan: all
 sidebar_position: 2
 ---
 

--- a/docs/ai-agents/interfaces/api/authentication/readme.md
+++ b/docs/ai-agents/interfaces/api/authentication/readme.md
@@ -1,4 +1,5 @@
 ---
+plan: all
 sidebar_position: 1
 ---
 

--- a/docs/ai-agents/interfaces/api/execute.md
+++ b/docs/ai-agents/interfaces/api/execute.md
@@ -1,4 +1,5 @@
 ---
+plan: all
 sidebar_position: 3
 ---
 

--- a/docs/ai-agents/interfaces/api/readme.md
+++ b/docs/ai-agents/interfaces/api/readme.md
@@ -1,4 +1,5 @@
 ---
+plan: all
 sidebar_position: 3
 ---
 

--- a/docs/ai-agents/interfaces/api/workspaces.md
+++ b/docs/ai-agents/interfaces/api/workspaces.md
@@ -1,4 +1,5 @@
 ---
+plan: team, custom
 sidebar_position: 4
 ---
 

--- a/docs/ai-agents/interfaces/mcp/readme.md
+++ b/docs/ai-agents/interfaces/mcp/readme.md
@@ -1,4 +1,5 @@
 ---
+plan: all
 sidebar_position: 6
 ---
 

--- a/docs/ai-agents/interfaces/readme.md
+++ b/docs/ai-agents/interfaces/readme.md
@@ -1,4 +1,5 @@
 ---
+plan: all
 sidebar_position: 4
 ---
 

--- a/docs/ai-agents/interfaces/sdk/add-connector.md
+++ b/docs/ai-agents/interfaces/sdk/add-connector.md
@@ -1,4 +1,5 @@
 ---
+plan: all
 sidebar_position: 2
 ---
 

--- a/docs/ai-agents/interfaces/sdk/authenticate.md
+++ b/docs/ai-agents/interfaces/sdk/authenticate.md
@@ -1,4 +1,5 @@
 ---
+plan: all
 sidebar_position: 1
 ---
 

--- a/docs/ai-agents/interfaces/sdk/execute.md
+++ b/docs/ai-agents/interfaces/sdk/execute.md
@@ -1,4 +1,5 @@
 ---
+plan: all
 sidebar_position: 3
 ---
 

--- a/docs/ai-agents/interfaces/sdk/readme.md
+++ b/docs/ai-agents/interfaces/sdk/readme.md
@@ -1,4 +1,5 @@
 ---
+plan: all
 sidebar_position: 2
 ---
 

--- a/docs/ai-agents/interfaces/sdk/workspaces.md
+++ b/docs/ai-agents/interfaces/sdk/workspaces.md
@@ -1,4 +1,5 @@
 ---
+plan: team, custom
 sidebar_position: 4
 ---
 

--- a/docs/ai-agents/interfaces/ui/add-connector.md
+++ b/docs/ai-agents/interfaces/ui/add-connector.md
@@ -1,4 +1,5 @@
 ---
+plan: all
 sidebar_position: 3
 ---
 

--- a/docs/ai-agents/interfaces/ui/automations.md
+++ b/docs/ai-agents/interfaces/ui/automations.md
@@ -1,4 +1,5 @@
 ---
+plan: all
 sidebar_position: 2
 ---
 

--- a/docs/ai-agents/interfaces/ui/chats.md
+++ b/docs/ai-agents/interfaces/ui/chats.md
@@ -1,4 +1,5 @@
 ---
+plan: all
 sidebar_position: 1
 ---
 

--- a/docs/ai-agents/interfaces/ui/readme.md
+++ b/docs/ai-agents/interfaces/ui/readme.md
@@ -1,4 +1,5 @@
 ---
+plan: all
 sidebar_position: 1
 ---
 

--- a/docs/ai-agents/reference/api/readme.md
+++ b/docs/ai-agents/reference/api/readme.md
@@ -1,4 +1,5 @@
 ---
+plan: all
 sidebar_position: 1
 ---
 

--- a/docs/ai-agents/reference/readme.md
+++ b/docs/ai-agents/reference/readme.md
@@ -1,4 +1,5 @@
 ---
+plan: all
 sidebar_position: 6
 ---
 

--- a/docusaurus/src/components/PlanInformation.jsx
+++ b/docusaurus/src/components/PlanInformation.jsx
@@ -53,7 +53,7 @@ export const PlanInformation = ({ plans }) => {
         Custom
       </Badge>
       <a
-        href="https://airbyte.com/product/ai-agents"
+        href="https://airbyte.com/ai"
         target="_blank"
         className={styles.helpIcon}
       >


### PR DESCRIPTION
## What

Add supported plan indicators to ai-agents docs pages. This adds `plan:` frontmatter to all hand-written content pages so the `PlanInformation` component renders plan badges below each page's heading. Also fixes the "Compare plans" URL in the component.

Requested by @ian-at-airbyte.

## How

- Added `plan: all` to 40 hand-written docs pages (get-started, concepts, interfaces, admin, reference landing pages).
- Added `plan: team, custom` to the 2 workspace management pages (`interfaces/sdk/workspaces.md` and `interfaces/api/workspaces.md`) since multi-workspace is a Team+ feature.
- Fixed the "Compare plans" link in `PlanInformation.jsx` from `https://airbyte.com/product/ai-agents` to `https://airbyte.com/ai`.
- Skipped autogenerated pages (connector AUTH/README/REFERENCE, SDK reference docs).
- Skipped draft pages (authentication module, build your own OAuth, recipes).
- `admin/billing.md` and `admin/profile.md` already had `plan: all` and were left unchanged.

## Review guide

1. `docusaurus/src/components/PlanInformation.jsx` — URL fix
2. All other changes are a single `plan: <value>` line inserted into YAML frontmatter:
   - `interfaces/sdk/workspaces.md` and `interfaces/api/workspaces.md` → `plan: team, custom`
   - Everything else → `plan: all`

## User Impact

Plan availability badges now appear on all hand-written ai-agents docs pages, giving users a clear signal of which plans support each feature. The "Compare plans" link now points to the correct page.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Link to Devin session: https://app.devin.ai/sessions/5b89cee257b04839a32149824d75a7ba
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/airbytehq/airbyte/pull/77611" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
