### PR TITLE
docs(ai-agents): remove inaccurate credential rotation references

### DIFF
--- a/docs/ai-agents/concepts/architecture/connectors-and-credentials.md
+++ b/docs/ai-agents/concepts/architecture/connectors-and-credentials.md
@@ -80,7 +80,6 @@ Credentials you add through one interface are available to all of them. A connec
 - Platform tokens are short-lived by design. Application tokens expire after 15 minutes; scoped tokens expire after 20 minutes.
 - Airbyte stores connector credentials server-side and never returns them in API responses after creation.
 - Never expose platform credentials or tokens in client-side code. Keep them in your backend.
-- Rotate platform credentials periodically from the [Profile page](https://app.airbyte.ai/profile).
 
 ## Related topics
 

--- a/docs/ai-agents/interfaces/sdk/authenticate.md
+++ b/docs/ai-agents/interfaces/sdk/authenticate.md
@@ -115,4 +115,3 @@ If you belong to a single organization, you can omit `organization_id`.
 
 - Never commit `AIRBYTE_CLIENT_ID` or `AIRBYTE_CLIENT_SECRET` to version control. Use a `.env` file and add it to `.gitignore`.
 - Keep Airbyte credentials server-side. The SDK is designed for backend use.
-- Rotate credentials periodically from the [Profile page](https://app.airbyte.ai/profile).


### PR DESCRIPTION
## What

Two docs pages advised users to "rotate credentials periodically from the Profile page," but no rotation functionality exists in the UI or backend. This removes those misleading lines.

## How

Deleted the rotation bullet from the Security sections of:
- `docs/ai-agents/interfaces/sdk/authenticate.md`
- `docs/ai-agents/concepts/architecture/connectors-and-credentials.md`

## Review guide

1. `docs/ai-agents/interfaces/sdk/authenticate.md`
2. `docs/ai-agents/concepts/architecture/connectors-and-credentials.md`

## User Impact

Users are no longer told to rotate credentials via a feature that doesn't exist.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Link to Devin session: https://app.devin.ai/sessions/b069fd4066b04c968e5ba99652c357f2
Requested by: @ian-at-airbyte