### PR TITLE
docs(source-youtube-analytics): add YouTube API ToS disclosure section

### DIFF
--- a/docs/integrations/sources/youtube-analytics.md
+++ b/docs/integrations/sources/youtube-analytics.md
@@ -79,6 +79,14 @@ The YouTube Analytics source connector supports the following [sync modes](https
 - [playlist_province_a2](https://developers.google.com/youtube/reporting/v1/reports/channel_reports#playlist-province)
 - [playlist_traffic_source_a2](https://developers.google.com/youtube/reporting/v1/reports/channel_reports#playlist-traffic-sources)
 
+## YouTube API Services usage disclosure
+
+This connector uses [YouTube API Services](https://developers.google.com/youtube/analytics) to retrieve data from YouTube. By using this connector, you agree to be bound by the [YouTube Terms of Service](https://www.youtube.com/t/terms).
+
+YouTube API Services are provided by Google. For information about how Google handles data, review the [Google Privacy Policy](https://www.google.com/policies/privacy).
+
+When using OAuth 2.0 authentication, this connector accesses authorized user data. You can revoke the connector's access to your Google account at any time through the [Google security settings page](https://myaccount.google.com/connections?filters=3,4&hl=en). To delete stored data that was previously synced, remove the relevant connection in your Airbyte workspace or delete the data from your configured destination.
+
 ## Performance considerations
 
 The YouTube Reporting API has the following quota limits:


### PR DESCRIPTION
## What
Adds a YouTube API Services usage disclosure section to the `source-youtube-analytics` connector documentation, addressing ToS compliance requirements (policies III.A.1, III.A.2b, III.A.2c, III.A.2h). This mirrors the disclosure already added to `source-youtube-data` in #75185, but references `https://developers.google.com/youtube/analytics` instead of the Data API.

## How
- Added a new **YouTube API Services usage disclosure** section to `youtube-analytics.md` between the Supported Streams and Performance considerations sections, addressing:
  - **III.A.1** — states users agree to be bound by the YouTube Terms of Service
  - **III.A.2b** — discloses that the connector uses YouTube API Services
  - **III.A.2c** — references and links to the Google Privacy Policy
  - **III.A.2h** — explains how to revoke access via Google security settings and delete stored data

## Review guide
1. `docs/integrations/sources/youtube-analytics.md` — new "YouTube API Services usage disclosure" section

## User Impact
The connector documentation will now include a YouTube API Services usage disclosure section with links to the YouTube ToS, Google Privacy Policy, and Google security settings for revoking access.

## Can this PR be safely reverted and rolled back?
- [x] YES 💚

Link to Devin session: https://app.devin.ai/sessions/4f2757573feb47bab31076fca44d870d
Requested by: @DanyloGL