### PR TITLE
docs(ai-agents): fix ChatGPT tab button label from "Create" to "Create App"

### DIFF
--- a/docs/ai-agents/interfaces/mcp/readme.md
+++ b/docs/ai-agents/interfaces/mcp/readme.md
@@ -196,7 +196,7 @@ On Business, Enterprise, and Education plans, you must be a workspace owner or a
 
 4. Go back to **Settings** > **Apps & Connectors**.
 
-5. Click **Create**. This button only appears when Developer Mode is enabled.
+5. Click **Create App**. This button only appears when Developer Mode is enabled.
 
 6. Enter the connector details:
 


### PR DESCRIPTION
## What

Fixes the button label in step 5 of the ChatGPT tab on the [MCP server docs page](https://docs.airbyte.com/ai-agents/interfaces/mcp). The button in ChatGPT's UI is called "Create App", not "Create".

## How

Updated step 5 text from `Click **Create**` to `Click **Create App**` in `docs/ai-agents/interfaces/mcp/readme.md`.

## Review guide

1. `docs/ai-agents/interfaces/mcp/readme.md` — single word change on line 199

## User Impact

Docs now match the actual ChatGPT UI button label, reducing confusion for users following the setup instructions.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Link to Devin session: https://app.devin.ai/sessions/bf2d2de9eb344b58b10b8918e2f0216e
Requested by: @katmarkham