### PR TITLE
fix(source-zendesk-chat): hide Start Date from connector setup page

### DIFF
--- a/airbyte-integrations/connectors/source-zendesk-chat/manifest.yaml
+++ b/airbyte-integrations/connectors/source-zendesk-chat/manifest.yaml
@@ -574,7 +574,6 @@ spec:
     type: object
     $schema: http://json-schema.org/draft-07/schema#
     required:
-      - start_date
       - subdomain
     properties:
       start_date:
@@ -583,11 +582,13 @@ spec:
           The date from which you'd like to replicate data for Zendesk Chat API,
           in the format YYYY-MM-DDT00:00:00Z.
         title: Start Date
+        default: "2021-01-01T00:00:00Z"
         examples:
           - "2021-02-01T00:00:00Z"
         pattern: ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$
         format: date-time
         order: 0
+        airbyte_hidden: true
       subdomain:
         type: string
         description: >-

--- a/airbyte-integrations/connectors/source-zendesk-chat/metadata.yaml
+++ b/airbyte-integrations/connectors/source-zendesk-chat/metadata.yaml
@@ -10,7 +10,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 40d24d0f-b8f9-4fe0-9e6c-b06c0f3f45e4
-  dockerImageTag: 1.3.11
+  dockerImageTag: 1.3.12
   dockerRepository: airbyte/source-zendesk-chat
   documentationUrl: https://docs.airbyte.com/integrations/sources/zendesk-chat
   externalDocumentationUrls:


### PR DESCRIPTION
## What

Remove the Start Date field from the "Add Connector" setup page in ADP for the Zendesk Chat connector, for both OAuth and "Access Token" authentication methods.

Requested by @jimruppert.

## How

- Removed `start_date` from the `required` array in the connector spec
- Added `airbyte_hidden: true` to the `start_date` property so it no longer renders on the setup form
- Added a `default` value of `"2021-01-01T00:00:00Z"` so existing incremental sync logic continues to work when no user-provided value is present
- Bumped connector version from 1.3.11 to 1.3.12

## Review guide

1. `airbyte-integrations/connectors/source-zendesk-chat/manifest.yaml` — spec changes
2. `airbyte-integrations/connectors/source-zendesk-chat/metadata.yaml` — version bump

## User Impact

The Start Date field will no longer appear on the Zendesk Chat connector setup page in ADP. Existing connections with a configured start_date will continue to use their stored value. New connections will default to `2021-01-01T00:00:00Z`.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

---
[Devin session](https://app.devin.ai/sessions/a2ac4aba0fc74493a85dfe8660178a5b)