### PR TITLE
docs(ai-agents): add interface cards to Get Started page

### DIFF
--- a/docs/ai-agents/get-started/readme.md
+++ b/docs/ai-agents/get-started/readme.md
@@ -12,12 +12,14 @@ New to Airbyte Agents? Start here. Learn what the product is, choose the right i
 
 ## Interfaces
 
-<Grid columns="3">
+<Grid columns="2">
 
 <CardWithIcon title="Web app" description="Talk to an Airbyte-hosted agent in natural language. No code required." ctaText="Web app" ctaLink="/ai-agents/interfaces/ui/" icon="fa-window-maximize" />
 
 <CardWithIcon title="SDK" description="Build and run agent connectors directly in your Python applications." ctaText="SDK" ctaLink="/ai-agents/interfaces/sdk/" icon="fa-python" />
 
 <CardWithIcon title="MCP server" description="Connect MCP-capable agents like Claude, Cursor, and ChatGPT to your data." ctaText="MCP server" ctaLink="/ai-agents/interfaces/mcp/" icon="fa-plug" />
+
+<CardWithIcon title="API" description="Integrate Airbyte Agents into any language or framework over HTTP." ctaText="API" ctaLink="/ai-agents/interfaces/api/" icon="fa-code" />
 
 </Grid>

--- a/docs/ai-agents/get-started/readme.md
+++ b/docs/ai-agents/get-started/readme.md
@@ -9,3 +9,15 @@ import DocCardList from '@theme/DocCardList';
 New to Airbyte Agents? Start here. Learn what the product is, choose the right interface for your use case, or jump straight into building.
 
 <DocCardList />
+
+## Interfaces
+
+<Grid columns="3">
+
+<CardWithIcon title="Web app" description="Talk to an Airbyte-hosted agent in natural language. No code required." ctaText="Web app" ctaLink="/ai-agents/interfaces/ui/" icon="fa-window-maximize" />
+
+<CardWithIcon title="SDK" description="Build and run agent connectors directly in your Python applications." ctaText="SDK" ctaLink="/ai-agents/interfaces/sdk/" icon="fa-python" />
+
+<CardWithIcon title="MCP server" description="Connect MCP-capable agents like Claude, Cursor, and ChatGPT to your data." ctaText="MCP server" ctaLink="/ai-agents/interfaces/mcp/" icon="fa-plug" />
+
+</Grid>

--- a/docusaurus/src/components/Card/Card.jsx
+++ b/docusaurus/src/components/Card/Card.jsx
@@ -10,6 +10,7 @@ import {
   faPuzzlePiece,
   faRobot,
   faRocket,
+  faWindowMaximize,
 } from "@fortawesome/free-solid-svg-icons";
 import { faPython } from "@fortawesome/free-brands-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
@@ -28,6 +29,7 @@ const FA_ICONS = {
   "fa-python": faPython,
   "fa-robot": faRobot,
   "fa-rocket": faRocket,
+  "fa-window-maximize": faWindowMaximize,
 };
 
 const CUSTOM_ICONS = {

--- a/docusaurus/src/components/Card/Card.jsx
+++ b/docusaurus/src/components/Card/Card.jsx
@@ -2,6 +2,7 @@ import {
   faArrowRight,
   faBook,
   faCloud,
+  faCode,
   faDownload,
   faGear,
   faLightbulb,
@@ -20,6 +21,7 @@ import { CloudIcon, EnterpriseIcon, OssIcon } from "./CustomIcons";
 const FA_ICONS = {
   "fa-book": faBook,
   "fa-cloud": faCloud,
+  "fa-code": faCode,
   "fa-download": faDownload,
   "fa-gear": faGear,
   "fa-lightbulb": faLightbulb,


### PR DESCRIPTION
## What

Add four interface cards (Web app, SDK, MCP server, API) to the [Get Started](https://docs.airbyte.com/ai-agents/get-started/) page so users can quickly navigate to interface-specific documentation.

Requested in Slack by @katmarkham.

## How

- Added a new "Interfaces" section with a `<Grid columns="2">` containing four `<CardWithIcon>` components linking to:
  - `/ai-agents/interfaces/ui/` — Web app
  - `/ai-agents/interfaces/sdk/` — SDK
  - `/ai-agents/interfaces/mcp/` — MCP server
  - `/ai-agents/interfaces/api/` — API
- Added `faWindowMaximize` and `faCode` icons to the `CardWithIcon` component's icon map for the Web app and API cards respectively
- Grid uses 2 columns (2×2 layout) which collapses to 1 column at ≤1024px for responsive display

## Review guide
1. `docs/ai-agents/get-started/readme.md` — new Interfaces section with 4 cards
2. `docusaurus/src/components/Card/Card.jsx` — added `fa-window-maximize` and `fa-code` to the icon map

## User Impact
Users visiting the Get Started page now see cards linking directly to the four interface pages, making it easier to discover how to use Airbyte Agents.

## Can this PR be safely reverted and rolled back?
- [x] YES 💚

Link to Devin session: https://app.devin.ai/sessions/7002d3e8c80a49c8bc831783a18bb590