### PR TITLE
fix(docs): rename Tools to Connectors in sessions page documentation

### DIFF
--- a/docs/ai-agents/admin/sessions.md
+++ b/docs/ai-agents/admin/sessions.md
@@ -1,6 +1,6 @@
 # Review sessions
 
-The Sessions page shows a read-only history of every agent interaction in your workspace, along with token usage and the tools each interaction used. Use it to audit what your agents did, troubleshoot unexpected results, and understand what's driving your [agent operations (AOs)](../concepts/agent-operations.md).
+The Sessions page shows a read-only history of every agent interaction in your workspace, along with token usage and the connectors each interaction used. Use it to audit what your agents did, troubleshoot unexpected results, and understand what's driving your [agent operations (AOs)](../concepts/agent-operations.md).
 
 ## What sessions are
 
@@ -21,7 +21,7 @@ The Sessions table lists the most recent sessions first. Each row represents one
 - **Source**: A descriptive name for the session. For automations, this is the automation's name. For chats, this is the chat's title.
 - **Type**: Whether the session is a [Chat](#chat), an [Automation](#automation), or an **Automation Builder Chat**.
 - **Status**: Notes Active or Deleted. Active chats are resumable.
-- **Tools**: The connectors the agent used during the session. Hover over a connector icon to see its name.
+- **Connectors**: The connectors the agent used during the session. Hover over a connector icon to see its name.
 - **Messages**: The number of messages exchanged in the session. Automation sessions typically have fewer messages than chat sessions, since they don't involve a back-and-forth with a user.
 - **Tool Calls**: The number of tool calls the agent made during the session. Drill into [tool calls](./tool-calls.md) to see individual calls.
 - **Input Tokens**: The total tokens the agent received as input, across every turn in the session.
@@ -31,7 +31,7 @@ The Sessions table lists the most recent sessions first. Each row represents one
     - Click the **View** icon to open the session and see its messages and tool calls.
     - Click the **Chat** icon to jump to the chat or automation the session belongs to.
 
-Use the **Type**, **Status**, and **Tools** filters above the table to narrow the list. The Type filter scopes to chats or automations. The Status filter scopes to Active, which you can resume, or Deleted. The Tools filter scopes to sessions that used one or more specific connectors.
+Use the **Type**, **Status**, and **Connectors** filters above the table to narrow the list. The Type filter scopes to chats or automations. The Status filter scopes to Active, which you can resume, or Deleted. The Connectors filter scopes to sessions that used one or more specific connectors.
 
 ## Session types {#session-types}
 


### PR DESCRIPTION
## What
Updates the ai-agents sessions documentation to reflect the UI rename of the "Tools" column and filter to "Connectors" on the Sessions page.

Companion to https://github.com/airbytehq/sonar/pull/4583.

## How
Updated three references in `docs/ai-agents/admin/sessions.md`:
- Intro paragraph: "the tools each interaction used" → "the connectors each interaction used"
- Column description: `**Tools**` → `**Connectors**`
- Filter description: `**Tools** filters` → `**Connectors** filters`

## Review guide
1. `docs/ai-agents/admin/sessions.md`

## User Impact
Documentation now matches the updated UI labels. No functional changes.

## Can this PR be safely reverted and rolled back?
- [x] YES 💚

Link to Devin session: https://app.devin.ai/sessions/b8014e87c7ad475ea9f0d2c242c3111f
Requested by: @ian-at-airbyte
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/airbytehq/airbyte/pull/77635" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
