### PR TITLE
chore(source-granola): increase default_concurrency from 5 to 6 (iteration 3)

### DIFF
--- a/airbyte-integrations/connectors/source-granola/manifest.yaml
+++ b/airbyte-integrations/connectors/source-granola/manifest.yaml
@@ -8,7 +8,7 @@ description: >-
 
 concurrency_level:
   type: ConcurrencyLevel
-  default_concurrency: 5
+  default_concurrency: 6
 
 check:
   type: CheckStream

--- a/airbyte-integrations/connectors/source-granola/metadata.yaml
+++ b/airbyte-integrations/connectors/source-granola/metadata.yaml
@@ -7,7 +7,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 9023923c-002f-4131-9554-3ebdf56540a4
-  dockerImageTag: 0.2.0-rc.2
+  dockerImageTag: 0.2.0-rc.3
   dockerRepository: airbyte/source-granola
   documentationUrl: https://docs.airbyte.com/integrations/sources/granola
   githubIssueLabel: source-granola

--- a/docs/integrations/sources/granola.md
+++ b/docs/integrations/sources/granola.md
@@ -103,7 +103,7 @@ The connector handles rate limiting automatically by retrying requests when a `4
 
 | Version | Date       | Pull Request | Subject         |
 | :------ | :--------- | :----------- | :-------------- |
-| 0.2.0-rc.3 | 2026-04-28 | [*PR_NUMBER_PLACEHOLDER*](https://github.com/airbytehq/airbyte/pull/*PR_NUMBER_PLACEHOLDER*) | Increase default_concurrency from 5 to 6 for concurrency tuning iteration 3 (final) |
+| 0.2.0-rc.3 | 2026-04-28 | [77645](https://github.com/airbytehq/airbyte/pull/77645) | Increase default_concurrency from 5 to 6 for concurrency tuning iteration 3 (final) |
 | 0.2.0-rc.2 | 2026-04-29 | [77551](https://github.com/airbytehq/airbyte/pull/77551) | Increase default_concurrency from 4 to 5 for concurrency tuning iteration 2 |
 | 0.2.0-rc.1 | 2026-04-27 | [77067](https://github.com/airbytehq/airbyte/pull/77067) | set default_concurrency=4 for concurrency tuning iteration 1 (Path A, max_rate_limit=5 req/s) |
 | 0.1.3 | 2026-04-21 | [76632](https://github.com/airbytehq/airbyte/pull/76632) | Update dependencies |

--- a/docs/integrations/sources/granola.md
+++ b/docs/integrations/sources/granola.md
@@ -103,7 +103,8 @@ The connector handles rate limiting automatically by retrying requests when a `4
 
 | Version | Date       | Pull Request | Subject         |
 | :------ | :--------- | :----------- | :-------------- |
-| 0.2.0-rc.2 | 2026-04-29 | [*PR_NUMBER_PLACEHOLDER*](https://github.com/airbytehq/airbyte/pull/*PR_NUMBER_PLACEHOLDER*) | Increase default_concurrency from 4 to 5 for concurrency tuning iteration 2 |
+| 0.2.0-rc.3 | 2026-04-28 | [*PR_NUMBER_PLACEHOLDER*](https://github.com/airbytehq/airbyte/pull/*PR_NUMBER_PLACEHOLDER*) | Increase default_concurrency from 5 to 6 for concurrency tuning iteration 3 (final) |
+| 0.2.0-rc.2 | 2026-04-29 | [77551](https://github.com/airbytehq/airbyte/pull/77551) | Increase default_concurrency from 4 to 5 for concurrency tuning iteration 2 |
 | 0.2.0-rc.1 | 2026-04-27 | [77067](https://github.com/airbytehq/airbyte/pull/77067) | set default_concurrency=4 for concurrency tuning iteration 1 (Path A, max_rate_limit=5 req/s) |
 | 0.1.3 | 2026-04-21 | [76632](https://github.com/airbytehq/airbyte/pull/76632) | Update dependencies |
 | 0.1.2 | 2026-03-31 | [75737](https://github.com/airbytehq/airbyte/pull/75737) | Update dependencies |


### PR DESCRIPTION
## What

Increases `default_concurrency` from 5 to 6 for source-granola as part of the progressive concurrency tuning rollout (iteration 3, final).

**Context:** This is the third and final iteration of the Path A concurrency tuning for source-granola (single-tier, 5 req/s rate limit). Previous iterations:
- Iteration 1: concurrency=4 (PR #77067) → 0% failures, 11.1% speedup → approved
- Iteration 2: concurrency=5 (PR #77551) → 0% failures, 18.7% speedup → approved
- Iteration 3 (this PR): concurrency=6

Approved by @sophiecui via HITL approval flow.

## How

1. `manifest.yaml`: `default_concurrency: 5` → `default_concurrency: 6`
2. `metadata.yaml`: `dockerImageTag: 0.2.0-rc.2` → `dockerImageTag: 0.2.0-rc.3`
3. `docs/integrations/sources/granola.md`: Added changelog entry for 0.2.0-rc.3; updated rc.2 entry with merged PR number

## Review guide

1. `airbyte-integrations/connectors/source-granola/manifest.yaml` — concurrency bump
2. `airbyte-integrations/connectors/source-granola/metadata.yaml` — version bump
3. `docs/integrations/sources/granola.md` — changelog

## User Impact

No user-facing impact. This RC is only deployed to pinned Tier 2 actors during the progressive rollout. Once the final iteration passes, the concurrency value will be promoted to GA.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Link to Devin session: https://app.devin.ai/sessions/d78f9b087fdc48e58bea13476997498e
Requested by: @sophiecuiy