### PR TITLE
docs: remove links to retired glossary.airbyte.com

### DIFF
--- a/docs/platform/using-airbyte/core-concepts/readme.md
+++ b/docs/platform/using-airbyte/core-concepts/readme.md
@@ -111,6 +111,4 @@ A workspace is a grouping of sources, destinations, connections, and other confi
 
 Organizations let you collaborate with team members and share workspaces across your team.
 
-## Glossary of Terms
 
-You can find a extended list of [Airbyte specific terms](https://glossary.airbyte.com/term/airbyte-glossary-of-terms/), [data engineering concepts](https://glossary.airbyte.com/term/data-engineering-concepts) or many [other data related terms](https://glossary.airbyte.com/).


### PR DESCRIPTION
## What

`glossary.airbyte.com` is being shut down. The platform Core Concepts page links to three URLs on that domain, all of which will stop resolving (or 301 to `docs.airbyte.com` root, which doesn't host equivalents of those pages). This PR removes the trailing "Glossary of Terms" section that contains those links.

The 5 versioned copies under `docusaurus/platform_versioned_docs/version-{1.6,1.7,1.8,2.0,2.1}/using-airbyte/core-concepts/readme.md` are intentionally left untouched, per the repo policy that historical/versioned documentation should not be modified unless it breaks the Docusaurus build.

## How

Deleted the three-line "Glossary of Terms" section at the bottom of `docs/platform/using-airbyte/core-concepts/readme.md`.

## Review guide

1. `docs/platform/using-airbyte/core-concepts/readme.md` — confirm the section removed only contained references to `glossary.airbyte.com` and nothing else of value.

## User Impact

Users browsing Core Concepts in the next published platform docs will no longer see a "Glossary of Terms" section pointing at the retired site. No other pages reference `glossary.airbyte.com` outside of versioned docs.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚
- [ ] NO ❌

Link to Devin session: https://app.devin.ai/sessions/45834cef3aca42cd945f7d27da2edfd4
Requested by: @davinchia