### PR TITLE
docs: remove glossary.airbyte.com references from core-concepts pages

### DIFF
--- a/docs/platform/using-airbyte/core-concepts/readme.md
+++ b/docs/platform/using-airbyte/core-concepts/readme.md
@@ -110,7 +110,3 @@ A workspace is a grouping of sources, destinations, connections, and other confi
 ## Organization
 
 Organizations let you collaborate with team members and share workspaces across your team.
-
-## Glossary of Terms
-
-You can find a extended list of [Airbyte specific terms](https://glossary.airbyte.com/term/airbyte-glossary-of-terms/), [data engineering concepts](https://glossary.airbyte.com/term/data-engineering-concepts) or many [other data related terms](https://glossary.airbyte.com/).

--- a/docusaurus/platform_versioned_docs/version-1.6/using-airbyte/core-concepts/readme.md
+++ b/docusaurus/platform_versioned_docs/version-1.6/using-airbyte/core-concepts/readme.md
@@ -110,7 +110,3 @@ A workspace is a grouping of sources, destinations, connections, and other confi
 ## Organization
 
 Organizations let you collaborate with team members and share workspaces across your team.
-
-## Glossary of Terms
-
-You can find a extended list of [Airbyte specific terms](https://glossary.airbyte.com/term/airbyte-glossary-of-terms/), [data engineering concepts](https://glossary.airbyte.com/term/data-engineering-concepts) or many [other data related terms](https://glossary.airbyte.com/).

--- a/docusaurus/platform_versioned_docs/version-1.7/using-airbyte/core-concepts/readme.md
+++ b/docusaurus/platform_versioned_docs/version-1.7/using-airbyte/core-concepts/readme.md
@@ -110,7 +110,3 @@ A workspace is a grouping of sources, destinations, connections, and other confi
 ## Organization
 
 Organizations let you collaborate with team members and share workspaces across your team.
-
-## Glossary of Terms
-
-You can find a extended list of [Airbyte specific terms](https://glossary.airbyte.com/term/airbyte-glossary-of-terms/), [data engineering concepts](https://glossary.airbyte.com/term/data-engineering-concepts) or many [other data related terms](https://glossary.airbyte.com/).

--- a/docusaurus/platform_versioned_docs/version-1.8/using-airbyte/core-concepts/readme.md
+++ b/docusaurus/platform_versioned_docs/version-1.8/using-airbyte/core-concepts/readme.md
@@ -110,7 +110,3 @@ A workspace is a grouping of sources, destinations, connections, and other confi
 ## Organization
 
 Organizations let you collaborate with team members and share workspaces across your team.
-
-## Glossary of Terms
-
-You can find a extended list of [Airbyte specific terms](https://glossary.airbyte.com/term/airbyte-glossary-of-terms/), [data engineering concepts](https://glossary.airbyte.com/term/data-engineering-concepts) or many [other data related terms](https://glossary.airbyte.com/).

--- a/docusaurus/platform_versioned_docs/version-2.0/using-airbyte/core-concepts/readme.md
+++ b/docusaurus/platform_versioned_docs/version-2.0/using-airbyte/core-concepts/readme.md
@@ -110,7 +110,3 @@ A workspace is a grouping of sources, destinations, connections, and other confi
 ## Organization
 
 Organizations let you collaborate with team members and share workspaces across your team.
-
-## Glossary of Terms
-
-You can find a extended list of [Airbyte specific terms](https://glossary.airbyte.com/term/airbyte-glossary-of-terms/), [data engineering concepts](https://glossary.airbyte.com/term/data-engineering-concepts) or many [other data related terms](https://glossary.airbyte.com/).

--- a/docusaurus/platform_versioned_docs/version-2.1/using-airbyte/core-concepts/readme.md
+++ b/docusaurus/platform_versioned_docs/version-2.1/using-airbyte/core-concepts/readme.md
@@ -110,7 +110,3 @@ A workspace is a grouping of sources, destinations, connections, and other confi
 ## Organization
 
 Organizations let you collaborate with team members and share workspaces across your team.
-
-## Glossary of Terms
-
-You can find a extended list of [Airbyte specific terms](https://glossary.airbyte.com/term/airbyte-glossary-of-terms/), [data engineering concepts](https://glossary.airbyte.com/term/data-engineering-concepts) or many [other data related terms](https://glossary.airbyte.com/).


### PR DESCRIPTION
## What

Removes all references to `glossary.airbyte.com` from the core-concepts documentation pages. The glossary site is being retired.

## How

Removed the "Glossary of Terms" section (heading + link paragraph) from the core-concepts `readme.md` in:
- `docs/platform/using-airbyte/core-concepts/readme.md`
- `docusaurus/platform_versioned_docs/version-1.6/using-airbyte/core-concepts/readme.md`
- `docusaurus/platform_versioned_docs/version-1.7/using-airbyte/core-concepts/readme.md`
- `docusaurus/platform_versioned_docs/version-1.8/using-airbyte/core-concepts/readme.md`
- `docusaurus/platform_versioned_docs/version-2.0/using-airbyte/core-concepts/readme.md`
- `docusaurus/platform_versioned_docs/version-2.1/using-airbyte/core-concepts/readme.md`

## Review guide

All 6 files have the same change: deletion of the trailing "Glossary of Terms" section.

## User Impact

Users will no longer see broken links to the retired glossary.airbyte.com site in the core-concepts docs.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Requested by @davinchia.

---
[Devin session](https://app.devin.ai/sessions/9c260e1913eb4e02b74d2ed88701eae0)