### PR TITLE
docs(ai-agents): split VS Code tab into stable and Insiders tabs in MCP docs

### DIFF
--- a/docs/ai-agents/interfaces/mcp/readme.md
+++ b/docs/ai-agents/interfaces/mcp/readme.md
@@ -83,9 +83,9 @@ Add the MCP server to your Cursor app.
 8. Return to Cursor. The MCP server tools are now available.
 
 </TabItem>
-<TabItem value="vscode" label="VS Code">
+<TabItem value="vscode" label="VS Code (stable)">
 
-Add the MCP server to Visual Studio Code. Airbyte Agents provides a one-click install button for both the stable and Insiders builds. If you prefer to configure VS Code manually, use the Command Palette or edit `mcp.json` directly.
+Add the MCP server to Visual Studio Code. You can use a one-click install from the Airbyte Agents web app, or configure VS Code manually with the Command Palette or `mcp.json`.
 
 ### Option 1: One-click install from Airbyte Agents (recommended)
 
@@ -93,7 +93,7 @@ Add the MCP server to Visual Studio Code. Airbyte Agents provides a one-click in
 
 2. In the left sidebar, click **MCP Server**.
 
-3. Select **Add to VS Code**, or **Add to VS Code Insiders** for Insiders builds. A new tab opens at `vscode.dev/redirect` (or `insiders.vscode.dev/redirect`) and hands the install off to VS Code.
+3. Select **Add to VS Code**. A new tab opens at `vscode.dev/redirect` and hands the install off to VS Code.
 
 4. Confirm the install in VS Code. The Airbyte Agent MCP server appears in your MCP server list, pointing at `https://mcp.airbyte.ai/mcp`.
 
@@ -137,6 +137,62 @@ Run **MCP: Open User Configuration** from the Command Palette to open your user 
 ```
 
 Save the file. VS Code detects that the server requires OAuth and opens your browser. Log in with your Airbyte account and grant access.
+
+</TabItem>
+<TabItem value="vscode-insiders" label="VS Code (Insiders)">
+
+Add the MCP server to Visual Studio Code Insiders. You can use a one-click install from the Airbyte Agents web app, or configure VS Code Insiders manually with the Command Palette or `mcp.json`.
+
+### Option 1: One-click install from Airbyte Agents (recommended)
+
+1. Sign into [app.airbyte.ai](https://app.airbyte.ai).
+
+2. In the left sidebar, click **MCP Server**.
+
+3. Select **Add to VS Code Insiders**. A new tab opens at `insiders.vscode.dev/redirect` and hands the install off to VS Code Insiders.
+
+4. Confirm the install in VS Code Insiders. The Airbyte Agent MCP server appears in your MCP server list, pointing at `https://mcp.airbyte.ai/mcp`.
+
+5. VS Code Insiders detects that the server requires OAuth and opens your browser. Log in with your Airbyte account and grant access.
+
+6. Return to VS Code Insiders. The MCP server's tools are now available in Copilot Chat.
+
+:::note
+If VS Code Insiders isn't installed, the click lands on the `insiders.vscode.dev` help page instead of opening a blank tab. Install VS Code Insiders and try the button again.
+:::
+
+### Option 2: Add the server from the Command Palette
+
+1. In VS Code Insiders, open the Command Palette with ⇧⌘P (macOS) or Ctrl+Shift+P (Windows, Linux).
+
+2. Run **MCP: Add Server** and choose **HTTP** as the server type.
+
+3. Enter the server URL: `https://mcp.airbyte.ai/mcp`
+
+4. Enter a server name, such as `Airbyte Agent MCP`.
+
+5. Choose whether to install the server in your user profile (**Global**) or the current workspace.
+
+6. VS Code Insiders detects that the server requires OAuth and opens your browser. Log in with your Airbyte account and grant access.
+
+7. The MCP server's tools are now available in Copilot Chat.
+
+### Option 3: Edit `mcp.json` directly
+
+Run **MCP: Open User Configuration** from the Command Palette to open your user `mcp.json` file, or create `.vscode/mcp.json` in your workspace, and add:
+
+```json
+{
+  "servers": {
+    "Airbyte Agent MCP": {
+      "type": "http",
+      "url": "https://mcp.airbyte.ai/mcp"
+    }
+  }
+}
+```
+
+Save the file. VS Code Insiders detects that the server requires OAuth and opens your browser. Log in with your Airbyte account and grant access.
 
 </TabItem>
 <TabItem value="claude-desktop" label="Claude Desktop">


### PR DESCRIPTION
## What

Splits the single "VS Code" tab in the MCP server docs into two separate tabs — "VS Code (stable)" and "VS Code (Insiders)" — so each variant has its own self-contained setup instructions. Resolves [AGENTIC-1353](https://linear.app/airbyteio/issue/AGENTIC-1353/document-vscode-and-vscode-insiders-as-separate-tabs).

The current layout nests VS Code Insiders as a parenthetical mention inside the VS Code tab, which makes MCP appear to be an Insiders-only feature and confuses readers.

Requested by @ian-at-airbyte.

## How

In `docs/ai-agents/interfaces/mcp/readme.md`:

1. Renamed the existing VS Code `TabItem` label from "VS Code" to "VS Code (stable)" and removed all Insiders references from it.
2. Added a new `TabItem` with value `vscode-insiders` and label "VS Code (Insiders)" immediately after the stable tab.
3. Each tab contains all three setup options (one-click install, Command Palette, mcp.json) with variant-specific wording and URLs (`vscode.dev` vs `insiders.vscode.dev`).

This mirrors how the product UI (sonar sidebar) already presents these as separate menu items.

## Review guide

1. `docs/ai-agents/interfaces/mcp/readme.md` — the only file changed.

## User Impact

Users of VS Code Insiders now see dedicated setup instructions instead of a confusing parenthetical mention nested inside the VS Code tab.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Link to Devin session: https://app.devin.ai/sessions/2af72a0563aa4634b9f4a81dba52b699