### PR TITLE
ci(release-notes): add daily Sonar release notes workflow

### DIFF
--- a/.github/workflows/daily-sonar-release-notes.yml
+++ b/.github/workflows/daily-sonar-release-notes.yml
@@ -6,6 +6,9 @@ on:
     - cron: "0 14 * * 1-5"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   generate-release-notes:
     name: Generate Airbyte Agents release notes

--- a/.github/workflows/daily-sonar-release-notes.yml
+++ b/.github/workflows/daily-sonar-release-notes.yml
@@ -1,0 +1,26 @@
+name: Daily Sonar Release Notes
+
+on:
+  schedule:
+    # Run at 14:00 UTC on weekdays (6:00 AM PST / 7:00 AM PDT)
+    - cron: "0 14 * * 1-5"
+  workflow_dispatch:
+
+jobs:
+  generate-release-notes:
+    name: Generate Airbyte Agents release notes
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Trigger Devin session
+        uses: aaronsteers/devin-action@main
+        with:
+          devin-token: ${{ secrets.DEVIN_AI_API_KEY }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          playbook-macro: "!sonar_release_notes"
+          api-version: v3
+          org-id: ${{ vars.DEVIN_AI_ORG_ID }}
+          tags: |
+            area/documentation
+            team/documentation
+            sonar-release-notes


### PR DESCRIPTION
## What
Adds a scheduled GitHub Actions workflow that triggers a Devin session daily at 6 AM PST (14:00 UTC) on weekdays to generate Airbyte Agents release notes from merged PRs in the sonar repository.

Resolves: [AGENTIC-955](https://linear.app/airbyteio/issue/AGENTIC-955/automate-daily-release-notes)

Requested by @ian-at-airbyte.

## How
The workflow (`.github/workflows/daily-sonar-release-notes.yml`) uses `aaronsteers/devin-action@main` with the `!sonar_release_notes` playbook macro. The playbook and skill that power it live in `airbytehq/ai-skills`.

The Devin session will:
1. Clone sonar and collect the previous day's merged PRs
2. Categorize changes (Web app, MCP server, Python SDK, API, Connectors, Other)
3. Write release notes and insert them into `docs/release_notes/agents/readme.md`
4. Create a draft PR with branch `sonar-release-notes-for-YYYY-MM-DD` and assign `ian-at-airbyte` as reviewer

## Review guide
1. `.github/workflows/daily-sonar-release-notes.yml` — the only file changed

## User Impact
Daily draft PRs with Agents release notes will appear for review. No user-facing impact until the draft PR is manually reviewed and merged.

## Can this PR be safely reverted and rolled back?
- [x] YES 💚

---
[Devin session](https://app.devin.ai/sessions/6ed78aad6a544d348fe9e6ddd1e79e2f)