### PR TITLE
docs(community): reposition community and support docs to reflect both products

### DIFF
--- a/docs/community/README.md
+++ b/docs/community/README.md
@@ -2,6 +2,6 @@ import DocCardList from '@theme/DocCardList';
 
 # Community & support
 
-Welcome to the Airbyte community. This section contains resources for getting support, contributing to Airbyte, and understanding Airbyte's community guidelines.
+Welcome to the Airbyte community. Whether you use Airbyte for data replication, Airbyte Agents, or both, this section contains resources for getting support, contributing to Airbyte, and understanding Airbyte's community guidelines.
 
 <DocCardList />

--- a/docs/community/contributing-to-airbyte/README.md
+++ b/docs/community/contributing-to-airbyte/README.md
@@ -4,7 +4,9 @@ description: "We love contributions to Airbyte, big or small."
 
 # Contributing to Airbyte
 
-Thank you for your interest in contributing! Contributions are very welcome. We appreciate first time contributors and we are happy help you get started. Join our [community Slack](https://slack.airbyte.io) and feel free to reach out with questions in [`#dev-and-contribuions` channel](https://airbytehq.slack.com/archives/C054V9JFTC6).
+Thank you for your interest in contributing! Airbyte accepts community contributions to its open-source data replication connectors in the [`airbyte`](https://github.com/airbytehq/airbyte) repository. Airbyte Agents is a separate closed-source product and does not accept community code contributions.
+
+We appreciate first-time contributors and are happy to help you get started. Join our [community Slack](https://slack.airbyte.io) and feel free to reach out with questions in [`#dev-and-contribuions` channel](https://airbytehq.slack.com/archives/C054V9JFTC6).
 
 If you're interacting in Slack, codebases, mailing lists, events, or any other Airbyte activity, you must follow the [Code of Conduct](/community/code-of-conduct). Please review it before getting started.
 
@@ -30,7 +32,8 @@ Airbyte is revamping its core Java destinations codebase. We're not reviewing/ac
 
 ### Contributions we don't accept
 
-- Platform contributions. In mid-2025, Airbyte stopping accepting community contributions to the Airbyte platform. Continue reporting issues through GitHub so we can investigate and prioritize fixes and improvements.
+- Platform contributions. In mid-2025, Airbyte stopped accepting community contributions to the Airbyte platform. Continue reporting issues through GitHub so we can investigate and prioritize fixes and improvements.
+- Airbyte Agents contributions. Airbyte Agents is closed-source. For bugs or feature requests related to Airbyte Agents, use the [support center](https://support.airbyte.com/hc/en-us/requests/new).
 
 ### Standard contribution workflow
 

--- a/docs/community/contributing-to-airbyte/README.md
+++ b/docs/community/contributing-to-airbyte/README.md
@@ -33,6 +33,7 @@ Airbyte is revamping its core Java destinations codebase. We're not reviewing/ac
 ### Contributions we don't accept
 
 - Data replication platform contributions: in mid-2025, Airbyte stopped accepting community contributions to the data replication platform. Continue reporting issues through GitHub so we can investigate and prioritize fixes and improvements.
+- Contributions to destination connectors. We only accept contributions to source connectors.
 - Airbyte Agents contributions: for bugs or feature requests related to Airbyte Agents, if you're a paid customer, use the [Support Center](https://support.airbyte.com/hc/en-us/requests/new), and if you're a free user, use the [`#airbyte-agents`](https://airbytehq.slack.com/archives/C0B1CUSEQKT) channel in Slack.
 
 ### Standard contribution workflow

--- a/docs/community/contributing-to-airbyte/README.md
+++ b/docs/community/contributing-to-airbyte/README.md
@@ -32,7 +32,7 @@ Airbyte is revamping its core Java destinations codebase. We're not reviewing/ac
 
 ### Contributions we don't accept
 
-- Platform contributions. In mid-2025, Airbyte stopped accepting community contributions to the Airbyte platform. Continue reporting issues through GitHub so we can investigate and prioritize fixes and improvements.
+- Platform contributions. In mid-2025, Airbyte stopped accepting community contributions to the data replication platform. Continue reporting issues through GitHub so we can investigate and prioritize fixes and improvements.
 - Airbyte Agents contributions. Airbyte Agents is closed-source. For bugs or feature requests related to Airbyte Agents, use the [support center](https://support.airbyte.com/hc/en-us/requests/new).
 
 ### Standard contribution workflow

--- a/docs/community/contributing-to-airbyte/README.md
+++ b/docs/community/contributing-to-airbyte/README.md
@@ -6,7 +6,7 @@ description: "We love contributions to Airbyte, big or small."
 
 Thank you for your interest in contributing! Airbyte accepts community contributions to its open-source data replication connectors in the [`airbyte`](https://github.com/airbytehq/airbyte) repository. Airbyte Agents does not accept community code contributions.
 
-We appreciate first-time contributors and are happy to help you get started. Join our [community Slack](https://slack.airbyte.io) and feel free to reach out with questions in [`#help-connector-development` channel](https://airbytehq.slack.com/archives/C027KKE4BCZ).
+We appreciate first-time contributors and are happy to help you get started. Join our [Airbyte Community Slack](https://slack.airbyte.io) and feel free to reach out with questions in [`#help-connector-development` channel](https://airbytehq.slack.com/archives/C027KKE4BCZ).
 
 If you're interacting in Slack, codebases, mailing lists, events, or any other Airbyte activity, you must follow the [Code of Conduct](/community/code-of-conduct). Please review it before getting started.
 
@@ -33,7 +33,7 @@ Airbyte is revamping its core Java destinations codebase. We're not reviewing/ac
 ### Contributions we don't accept
 
 - Data replication platform contributions: in mid-2025, Airbyte stopped accepting community contributions to the data replication platform. Continue reporting issues through GitHub so we can investigate and prioritize fixes and improvements.
-- Airbyte Agents contributions: for bugs or feature requests related to Airbyte Agents, if you're a paid customer, use the [support center](https://support.airbyte.com/hc/en-us/requests/new), and if you're a free user, use the [`#airbyte-agents`](https://airbytehq.slack.com/archives/C0B1CUSEQKT) channel in Slack.
+- Airbyte Agents contributions: for bugs or feature requests related to Airbyte Agents, if you're a paid customer, use the [Support Center](https://support.airbyte.com/hc/en-us/requests/new), and if you're a free user, use the [`#airbyte-agents`](https://airbytehq.slack.com/archives/C0B1CUSEQKT) channel in Slack.
 
 ### Standard contribution workflow
 

--- a/docs/community/contributing-to-airbyte/README.md
+++ b/docs/community/contributing-to-airbyte/README.md
@@ -4,9 +4,9 @@ description: "We love contributions to Airbyte, big or small."
 
 # Contributing to Airbyte
 
-Thank you for your interest in contributing! Airbyte accepts community contributions to its open-source data replication connectors in the [`airbyte`](https://github.com/airbytehq/airbyte) repository. Airbyte Agents is a separate closed-source product and does not accept community code contributions.
+Thank you for your interest in contributing! Airbyte accepts community contributions to its open-source data replication connectors in the [`airbyte`](https://github.com/airbytehq/airbyte) repository. Airbyte Agents does not accept community code contributions.
 
-We appreciate first-time contributors and are happy to help you get started. Join our [community Slack](https://slack.airbyte.io) and feel free to reach out with questions in [`#dev-and-contribuions` channel](https://airbytehq.slack.com/archives/C054V9JFTC6).
+We appreciate first-time contributors and are happy to help you get started. Join our [community Slack](https://slack.airbyte.io) and feel free to reach out with questions in [`#help-connector-development` channel](https://airbytehq.slack.com/archives/C027KKE4BCZ).
 
 If you're interacting in Slack, codebases, mailing lists, events, or any other Airbyte activity, you must follow the [Code of Conduct](/community/code-of-conduct). Please review it before getting started.
 
@@ -32,8 +32,8 @@ Airbyte is revamping its core Java destinations codebase. We're not reviewing/ac
 
 ### Contributions we don't accept
 
-- Platform contributions. In mid-2025, Airbyte stopped accepting community contributions to the data replication platform. Continue reporting issues through GitHub so we can investigate and prioritize fixes and improvements.
-- Airbyte Agents contributions. Airbyte Agents is closed-source. For bugs or feature requests related to Airbyte Agents, use the [support center](https://support.airbyte.com/hc/en-us/requests/new).
+- Data replication platform contributions: in mid-2025, Airbyte stopped accepting community contributions to the data replication platform. Continue reporting issues through GitHub so we can investigate and prioritize fixes and improvements.
+- Airbyte Agents contributions: for bugs or feature requests related to Airbyte Agents, if you're a paid customer, use the [support center](https://support.airbyte.com/hc/en-us/requests/new), and if you're a free user, use the [`#airbyte-agents`](https://airbytehq.slack.com/archives/C0B1CUSEQKT) channel in Slack.
 
 ### Standard contribution workflow
 

--- a/docs/community/contributing-to-airbyte/issues-and-requests.md
+++ b/docs/community/contributing-to-airbyte/issues-and-requests.md
@@ -1,21 +1,29 @@
 # Issues and feature requests
 
-If you're an enterprise customer, discuss your needs with support or another Airbyte representative. For all other requests, see these options.
+If you're an enterprise or paid customer, discuss your needs with support or another Airbyte representative. For all other requests, see these options.
 
 ## Report a bug
 
-Bug reports help make Airbyte better for everyone. Airbyte provides templates for reporting bugs to make it clear what information maintainers need.
+### Data replication
+
+Bug reports help make Airbyte better for everyone. Airbyte provides templates for reporting data replication bugs to make it clear what information maintainers need.
 
 1. To avoid duplicate reports, check if the bug was [already reported](https://github.com/airbytehq/airbyte/issues?q=is%3Aissue+is%3Aopen+label%3Atype%2Fbug).
 
 2. Submit a [bug report](https://github.com/airbytehq/airbyte/issues/new/choose) in GitHub.
 
+### Airbyte Agents
+
+For bugs related to Airbyte Agents, create a ticket in the [support center](https://support.airbyte.com/hc/en-us/requests/new). Airbyte Agents is closed-source, so GitHub issues are not used for Agents bug reports.
+
 ## Request a new feature or connector
 
-[Starting a Github Discussion](https://github.com/airbytehq/airbyte/discussions) is the best way to request new things.
+[Starting a Github Discussion](https://github.com/airbytehq/airbyte/discussions) is the best way to request new data replication features or connectors.
 
 Requesting new features [or connectors](https://github.com/airbytehq/airbyte/discussions/categories/new-connector-request) is an essential way to contribute. Your input helps Airbyte understand your needs and priorities, enabling the team to enhance the capabilities and versatility of Airbyte.
 
+For Airbyte Agents feature requests, use the [support center](https://support.airbyte.com/hc/en-us/requests/new).
+
 ## Report a security issue
 
-**Do not** create a public GitHub issue. If you've found a security issue, email us directly at [security@airbyte.io](mailto:security@airbyte.io).
+**Do not** create a public GitHub issue. If you've found a security issue in any Airbyte product, email us directly at [security@airbyte.io](mailto:security@airbyte.io).

--- a/docs/community/contributing-to-airbyte/issues-and-requests.md
+++ b/docs/community/contributing-to-airbyte/issues-and-requests.md
@@ -14,7 +14,7 @@ Bug reports help make Airbyte better for everyone. Airbyte provides templates fo
 
 ### Airbyte Agents
 
-For bugs related to Airbyte Agents, create a ticket in the [support center](https://support.airbyte.com/hc/en-us/requests/new).
+For bugs related to Airbyte Agents, create a ticket in the [support center](https://support.airbyte.com/hc/en-us/requests/new) or use the [`#airbyte-agents`](https://airbytehq.slack.com/archives/C0B1CUSEQKT) channel in Slack.
 
 ## Request a new feature or connector
 

--- a/docs/community/contributing-to-airbyte/issues-and-requests.md
+++ b/docs/community/contributing-to-airbyte/issues-and-requests.md
@@ -1,6 +1,6 @@
 # Issues and feature requests
 
-If you're an enterprise or paid customer, discuss your needs with support or another Airbyte representative. For all other requests, see these options.
+If you're a paid customer, discuss your needs with support or another Airbyte representative. For all other requests, see these options.
 
 ## Report a bug
 
@@ -14,13 +14,17 @@ Bug reports help make Airbyte better for everyone. Airbyte provides templates fo
 
 ### Airbyte Agents
 
-For bugs related to Airbyte Agents, create a ticket in the [support center](https://support.airbyte.com/hc/en-us/requests/new). Airbyte Agents is closed-source, so GitHub issues are not used for Agents bug reports.
+For bugs related to Airbyte Agents, create a ticket in the [support center](https://support.airbyte.com/hc/en-us/requests/new).
 
 ## Request a new feature or connector
+
+### Data replication
 
 [Starting a Github Discussion](https://github.com/airbytehq/airbyte/discussions) is the best way to request new data replication features or connectors.
 
 Requesting new features [or connectors](https://github.com/airbytehq/airbyte/discussions/categories/new-connector-request) is an essential way to contribute. Your input helps Airbyte understand your needs and priorities, enabling the team to enhance the capabilities and versatility of Airbyte.
+
+### Airbyte Agents
 
 For Airbyte Agents feature requests, use the [support center](https://support.airbyte.com/hc/en-us/requests/new).
 

--- a/docs/community/contributing-to-airbyte/issues-and-requests.md
+++ b/docs/community/contributing-to-airbyte/issues-and-requests.md
@@ -14,7 +14,7 @@ Bug reports help make Airbyte better for everyone. Airbyte provides templates fo
 
 ### Airbyte Agents
 
-For bugs related to Airbyte Agents, create a ticket in the [support center](https://support.airbyte.com/hc/en-us/requests/new) or use the [`#airbyte-agents`](https://airbytehq.slack.com/archives/C0B1CUSEQKT) channel in Slack.
+For bugs related to Airbyte Agents, create a ticket in the [Support Center](https://support.airbyte.com/hc/en-us/requests/new) or use the [`#airbyte-agents`](https://airbytehq.slack.com/archives/C0B1CUSEQKT) channel in Slack.
 
 ## Request a new feature or connector
 
@@ -26,7 +26,7 @@ Requesting new features [or connectors](https://github.com/airbytehq/airbyte/dis
 
 ### Airbyte Agents
 
-For Airbyte Agents feature requests, use the [support center](https://support.airbyte.com/hc/en-us/requests/new).
+For Airbyte Agents feature requests, use the [Support Center](https://support.airbyte.com/hc/en-us/requests/new).
 
 ## Report a security issue
 

--- a/docs/community/contributing-to-airbyte/issues-and-requests.md
+++ b/docs/community/contributing-to-airbyte/issues-and-requests.md
@@ -1,6 +1,6 @@
 # Issues and feature requests
 
-If you're a paid customer, discuss your needs with support or another Airbyte representative. For all other requests, see these options.
+If you're a paid customer, discuss your needs with support or another Airbyte representative. For all other requests, see these options:
 
 ## Report a bug
 

--- a/docs/community/getting-support.md
+++ b/docs/community/getting-support.md
@@ -13,17 +13,27 @@ Airbyte offers support for both Data Replication and Airbyte Agents. If you can'
 **For additional help, create a ticket in Airbyte's [support center](https://support.airbyte.com/hc/en-us/requests/new).** Support agents are available 7 AM to 7 PM Eastern time. Response times may vary according to your plan and SLAs.
 
 - For account or billing inquiries, [contact sales](https://airbyte.com/talk-to-sales).
-- Sign up for Airbyte with your company email address. Airbyte doesn't support personal accounts.
+- Sign up for Airbyte Cloud with your company email address. Airbyte Cloud doesn't support personal accounts.
 
 ### Core (open source)
 
-Core users don't have access to paid support but can use [community resources](#community-resources). If you need personalized help, consider upgrading to one of Airbyte's [paid plans](https://www.airbyte.com/pricing).
+Core users don't have access to paid support but can use the [Community Slack](#community-slack). If you need personalized help, consider upgrading to one of Airbyte's [paid plans](https://www.airbyte.com/pricing).
 
 ### Connector support levels
 
 Connector support depends on the connector's certification status. See [Connector Support Levels](/integrations/connector-support-levels) for details.
 
 If you don't see a connector you need, submit a [connector request](https://airbyte.com/connector-requests).
+
+### GitHub discussions
+
+[GitHub discussions](https://github.com/airbytehq/airbyte/discussions) are a great way to propose, vote on, and discuss data replication improvements.
+
+### Report an issue
+
+If you've found a bug or issue with Airbyte or its documentation, [create an issue](https://github.com/airbytehq/airbyte/issues/new/choose) on GitHub.
+
+Check the [issue list](https://github.com/airbytehq/airbyte/issues) first in case the issue has already been reported.
 
 ## Airbyte Agents
 
@@ -34,31 +44,17 @@ If you don't see a connector you need, submit a [connector request](https://airb
 ### Support by plan
 
 - **Free**: AI and community support.
-- **Individual / Team**: Standard human support, in addition to AI and community support. Create a ticket in the [support center](https://support.airbyte.com/hc/en-us/requests/new).
+- **Individual / Team**: Standard human support, in addition to AI and community support. The in-app support bot can create a ticket for you, or you can create your own in the [support center](https://support.airbyte.com/hc/en-us/requests/new).
 - **Custom**: Dedicated human support.
 
 For full details on Agents plans, see [Billing and pricing](/ai-agents/admin/billing).
 
-## Community resources
-
-These resources are available to all Airbyte users regardless of product or plan.
-
-### Community Slack
+## Community Slack
 
 [Join the Slack community](https://slack.airbyte.com) for help from other users and Airbyte team members. Popular channels include:
 
 - Data Replication: `#ask-ai`, `#ask-community-for-troubleshooting`
 - Airbyte Agents: `#airbyte-agents`, `#airbyte-agents-ask-ai`
-
-### GitHub discussions
-
-[GitHub discussions](https://github.com/airbytehq/airbyte/discussions) are a great way to propose, vote on, and discuss Airbyte improvements.
-
-### Report an issue
-
-If you've found a bug or issue with Airbyte or its documentation, [create an issue](https://github.com/airbytehq/airbyte/issues/new/choose) on GitHub. If you're willing to work on this issue yourself, please indicate this.
-
-Check the [issue list](https://github.com/airbytehq/airbyte/issues) first in case the issue has already been reported.
 
 ## Questions about contributions
 

--- a/docs/community/getting-support.md
+++ b/docs/community/getting-support.md
@@ -8,9 +8,9 @@ Airbyte offers support for both Data Replication and Airbyte Agents. If you can'
 
 **The in-app support bot is available 24/7 for Airbyte Cloud and Enterprise customers.** Look for the chat button in the bottom-right corner of the screen. The bot can help answer questions about your workspace, connections, and common troubleshooting scenarios. It has context about your current workspace, making it easier to get relevant assistance immediately. The bot can also create support tickets for the Airbyte support team if further help is needed.
 
-### Support center
+### Support Center
 
-**For additional help, create a ticket in Airbyte's [support center](https://support.airbyte.com/hc/en-us/requests/new).** Support agents are available 7 AM to 7 PM Eastern time. Response times may vary according to your plan and SLAs.
+**For additional help, create a ticket in Airbyte's [Support Center](https://support.airbyte.com/hc/en-us/requests/new).** Support agents are available 7 AM to 7 PM Eastern time. Response times may vary according to your plan and SLAs.
 
 - For account or billing inquiries, [contact sales](https://airbyte.com/talk-to-sales).
 - Sign up for Airbyte Cloud with your company email address. Airbyte Cloud doesn't support personal accounts.
@@ -21,7 +21,7 @@ Core users don't have access to paid support but can use the [Community Slack](#
 
 ### Connector support levels
 
-Connector support depends on the connector's certification status. See [Connector Support Levels](/integrations/connector-support-levels) for details.
+Connector support depends on the connector's support level. See [Connector Support Levels](/integrations/connector-support-levels) for details.
 
 If you don't see a connector you need, submit a [connector request](https://airbyte.com/connector-requests).
 
@@ -44,7 +44,7 @@ Check the [issue list](https://github.com/airbytehq/airbyte/issues) first in cas
 ### Support by plan
 
 - **Free**: AI and [community](#community-slack) support.
-- **Individual / Team**: Standard human support, in addition to AI and community support. The in-app support bot can create a ticket for you, or you can create your own in the [support center](https://support.airbyte.com/hc/en-us/requests/new).
+- **Individual / Team**: Standard human support, in addition to AI and community support. The in-app support bot can create a ticket for you, or you can create your own in the [Support Center](https://support.airbyte.com/hc/en-us/requests/new).
 - **Custom**: Dedicated human support.
 
 For full details on Agents plans, see [Billing and pricing](/ai-agents/admin/billing).

--- a/docs/community/getting-support.md
+++ b/docs/community/getting-support.md
@@ -1,34 +1,45 @@
----
-products: all
----
-
 # Get support
 
-If you can't find an answer to your question in the docs, Airbyte has different support options.
+Airbyte offers support for both its data replication platform and Airbyte Agents. If you can't find an answer to your question in the docs, use one of the following options.
 
-## For Airbyte Enterprise and Cloud
+## Support center
 
-### In-app support agent
+**For support with any Airbyte product, create a ticket in Airbyte's [support center](https://support.airbyte.com/hc/en-us/requests/new).** Support agents are available 7 AM to 7 PM Eastern time. Response times may vary according to your plan and SLAs.
 
-**The in-app support agent is available 24/7 for Airbyte Enterprise and Cloud customers, and can help with basic troubleshooting anytime.**
+- For account or billing inquiries, [contact sales](https://airbyte.com/talk-to-sales).
+- Sign up for Airbyte with your company email address. Airbyte doesn't support personal accounts.
 
-Airbyte Cloud includes an AI-powered support agent accessible directly within the app. Look for the chat button in the bottom-right corner of the screen. The support agent can help answer questions about your workspace, connections, and common troubleshooting scenarios. It has context about your current workspace, making it easier to get relevant assistance immediately. The agent can also create Zendesk tickets with additional connection information for the Airbyte support team if further help is needed.
+## In-app support agent
 
-### Support center
+Both Airbyte Cloud (data replication) and Airbyte Agents include an AI-powered support agent accessible directly within each app. Look for the chat button in the bottom-right corner of the screen. The support agent can help answer questions about your workspace, troubleshoot common scenarios, and create support tickets if further help is needed.
 
-- **For support with any part of Airbyte, create an issue in Airbyte's [support center](https://support.airbyte.com/hc/en-us/requests/new)**. Agents are available 7 AM to 7 PM Eastern time. Response times may vary according to your plan and SLAs.
-- For account or credit-related inquiries, [contact sales](https://airbyte.com/talk-to-sales).
-- If you don't see a connector you need, submit a [connector request](https://airbyte.com/connector-requests).
+## Data replication
 
-Please sign up for Airbyte with your company email address. We don't support personal accounts.
+### Plans and support availability
 
-## For Airbyte Core
+Airbyte offers several data replication plans, from Core (free, open-source) to Enterprise. Paid plans include access to the [support center](https://support.airbyte.com/hc/en-us/requests/new) and the in-app support agent. Core users have access to community resources.
 
-Airbyte Core users don't have access to paid support, but you still have community support options. If you need personalized help, consider upgrading to one of Airbyte's [paid plans](https://www.airbyte.com/pricing).
+If you need personalized help with Core, consider upgrading to one of Airbyte's [paid plans](https://www.airbyte.com/pricing).
+
+### Connector support levels
+
+Data replication connector support depends on the connector's certification status. See [Connector Support Levels](/integrations/connector-support-levels) for details.
+
+If you don't see a data replication connector you need, submit a [connector request](https://airbyte.com/connector-requests).
+
+## Airbyte Agents
+
+Airbyte Agents support depends on your plan. Free plan users have access to AI and community support. Individual and Team plan users also receive standard human support. Custom plan users receive dedicated human support.
+
+For full details on Agents plans and support availability, see [Billing and pricing](/ai-agents/admin/billing).
+
+## Community resources
+
+These resources are available to all Airbyte users regardless of product or plan.
 
 ### Community Slack
 
-[Join the Slack community](https://slack.airbyte.com/?_gl=1*1h8mjfe*_gcl_au*MTc4MjAxMDQzOS4xNjgyOTczMDYy*_ga*MTc1OTkyOTYzNi4xNjQxMjQyMjA0*_ga_HDBMVFQGBH*MTY4Nzg4OTQ4MC4zMjUuMS4xNjg3ODkwMjE1LjAuMC4w&_ga=2.58571491.813788522.1687789276-1759929636.1641242204) for help from other open sources users and Airbyte team members. Popular channels are `#ask-ai` and `#ask-community-for-troubleshooting`.
+[Join the Slack community](https://slack.airbyte.com) for help from other users and Airbyte team members. Popular channels are `#ask-ai` and `#ask-community-for-troubleshooting`.
 
 ### GitHub discussions
 
@@ -36,17 +47,13 @@ Airbyte Core users don't have access to paid support, but you still have communi
 
 ### Report an issue
 
-If you've found a bug or issue with Airbyte or its documentation, [create an issue](https://github.com/airbytehq/airbyte/issues/new/choose). If you're willing to work on this issue yourself, please indicate this.
+If you've found a bug or issue with Airbyte or its documentation, [create an issue](https://github.com/airbytehq/airbyte/issues/new/choose) on GitHub. If you're willing to work on this issue yourself, please indicate this.
 
-Please check the [issue list](https://github.com/airbytehq/airbyte/issues) first in case the issue has already been reported. If it has, feel free to comment on that issue to provide more details about your experience.
+Check the [issue list](https://github.com/airbytehq/airbyte/issues) first in case the issue has already been reported.
 
 ### Public roadmap
 
-To stay updated on Airbyte's future plans, take a look at [our roadmap](https://github.com/orgs/airbytehq/projects/37/views/1). Airbyte updates this every few weeks with initiatives that are of interest to the community.
-
-## Connector support depends on support level
-
-Connector support depends on the certification status of the connector. See [Connector Support Levels](/integrations/connector-support-levels) if you have any questions on support provided for one of your connectors.
+To stay updated on Airbyte's future plans, take a look at [the roadmap](https://github.com/orgs/airbytehq/projects/37/views/1). Airbyte updates this every few weeks with initiatives that are of interest to the community.
 
 ## Questions about contributions
 
@@ -62,7 +69,7 @@ Submitting a pull request for review?
 
 The team tries its best to assist, and always tries to do the right thing for Airbyte users. That said, there are some things the team doesn't support:
 
-- Questions/troubleshooting with forked versions of Airbyte
+- Questions or troubleshooting with forked versions of Airbyte
 - Configuring using Octavia CLI
 - Creating and configuring custom transformation using dbt
 - Curating unique documentation and training materials

--- a/docs/community/getting-support.md
+++ b/docs/community/getting-support.md
@@ -13,7 +13,7 @@ Airbyte offers support for both Data Replication and Airbyte Agents. If you can'
 **For additional help, create a ticket in Airbyte's [Support Center](https://support.airbyte.com/hc/en-us/requests/new).** Support agents are available 7 AM to 7 PM Eastern time. Response times may vary according to your plan and SLAs.
 
 - For account or billing inquiries, [contact sales](https://airbyte.com/talk-to-sales).
-- Sign up for Airbyte Cloud with your company email address. Airbyte Cloud doesn't support personal accounts.
+- We suggest signing up for Airbyte with your company email address, and not a personal one.
 
 ### Core (open source)
 

--- a/docs/community/getting-support.md
+++ b/docs/community/getting-support.md
@@ -1,12 +1,12 @@
 # Get support
 
-Airbyte offers support for both Data Replication and Airbyte Agents. If you can't find an answer to your question in the docs, use one of the following options.
+Airbyte offers support for both Data Replication and Airbyte Agents. If you can't find an answer to your question in the docs, use one of the following options:
 
 ## Data Replication
 
-### In-app support bot
+### In-app support agent bot
 
-**The in-app support bot is available 24/7 for Airbyte Cloud and Enterprise customers.** Look for the chat button in the bottom-right corner of the screen. The bot can help answer questions about your workspace, connections, and common troubleshooting scenarios. It has context about your current workspace, making it easier to get relevant assistance immediately. The bot can also create support tickets for the Airbyte support team if further help is needed.
+**The in-app support agent bot is available 24/7 for Airbyte Cloud and Enterprise customers.** Look for the chat button in the bottom-right corner of the screen. The bot can help answer questions about your workspace, connections, and common troubleshooting scenarios. It has context about your current workspace, making it easier to get relevant assistance immediately. The bot can also create support tickets for the Airbyte support team if further help is needed.
 
 ### Support Center
 
@@ -37,17 +37,17 @@ Check the [issue list](https://github.com/airbytehq/airbyte/issues) first in cas
 
 ## Airbyte Agents
 
-### In-app support bot
+### In-app support agent bot
 
-**The in-app support bot is available 24/7 for all Airbyte Agents users.** Look for the chat button in the bottom-right corner of the screen. The bot can help answer questions about your organization, troubleshoot common scenarios, and create support tickets if further help is needed.
+**The in-app support agent bot is available 24/7 for all Airbyte Agents users.** Look for the chat button in the bottom-right corner of the screen. The bot can help answer questions about your organization, troubleshoot common scenarios, and create support tickets if further help is needed.
 
 ### Support by plan
 
 - **Free**: AI and [community](#community-slack) support.
-- **Individual / Team**: Standard human support, in addition to AI and community support. The in-app support bot can create a ticket for you, or you can create your own in the [Support Center](https://support.airbyte.com/hc/en-us/requests/new).
+- **Individual / Team**: Standard human support, in addition to AI and community support. The in-app support agent bot can create a ticket for you, or you can create your own in the [Support Center](https://support.airbyte.com/hc/en-us/requests/new).
 - **Custom**: Dedicated human support.
 
-For full details on Agents plans, see [Billing and pricing](/ai-agents/admin/billing).
+For full details on Airbyte Agents plans, see [Billing and pricing](/ai-agents/admin/billing).
 
 ## Community Slack
 

--- a/docs/community/getting-support.md
+++ b/docs/community/getting-support.md
@@ -1,37 +1,43 @@
 # Get support
 
-Airbyte offers support for both its data replication platform and Airbyte Agents. If you can't find an answer to your question in the docs, use one of the following options.
+Airbyte offers support for both Data Replication and Airbyte Agents. If you can't find an answer to your question in the docs, use one of the following options.
 
-## Support center
+## Data Replication
 
-**For support with any Airbyte product, create a ticket in Airbyte's [support center](https://support.airbyte.com/hc/en-us/requests/new).** Support agents are available 7 AM to 7 PM Eastern time. Response times may vary according to your plan and SLAs.
+### In-app support bot
+
+**The in-app support bot is available 24/7 for Airbyte Cloud and Enterprise customers.** Look for the chat button in the bottom-right corner of the screen. The bot can help answer questions about your workspace, connections, and common troubleshooting scenarios. It has context about your current workspace, making it easier to get relevant assistance immediately. The bot can also create support tickets for the Airbyte support team if further help is needed.
+
+### Support center
+
+**For additional help, create a ticket in Airbyte's [support center](https://support.airbyte.com/hc/en-us/requests/new).** Support agents are available 7 AM to 7 PM Eastern time. Response times may vary according to your plan and SLAs.
 
 - For account or billing inquiries, [contact sales](https://airbyte.com/talk-to-sales).
 - Sign up for Airbyte with your company email address. Airbyte doesn't support personal accounts.
 
-## In-app support agent
+### Core (open source)
 
-Both Airbyte Cloud (data replication) and Airbyte Agents include an AI-powered support agent accessible directly within each app. Look for the chat button in the bottom-right corner of the screen. The support agent can help answer questions about your workspace, troubleshoot common scenarios, and create support tickets if further help is needed.
-
-## Data replication
-
-### Plans and support availability
-
-Airbyte offers several data replication plans, from Core (free, open-source) to Enterprise. Paid plans include access to the [support center](https://support.airbyte.com/hc/en-us/requests/new) and the in-app support agent. Core users have access to community resources.
-
-If you need personalized help with Core, consider upgrading to one of Airbyte's [paid plans](https://www.airbyte.com/pricing).
+Core users don't have access to paid support but can use [community resources](#community-resources). If you need personalized help, consider upgrading to one of Airbyte's [paid plans](https://www.airbyte.com/pricing).
 
 ### Connector support levels
 
-Data replication connector support depends on the connector's certification status. See [Connector Support Levels](/integrations/connector-support-levels) for details.
+Connector support depends on the connector's certification status. See [Connector Support Levels](/integrations/connector-support-levels) for details.
 
-If you don't see a data replication connector you need, submit a [connector request](https://airbyte.com/connector-requests).
+If you don't see a connector you need, submit a [connector request](https://airbyte.com/connector-requests).
 
 ## Airbyte Agents
 
-Airbyte Agents support depends on your plan. Free plan users have access to AI and community support. Individual and Team plan users also receive standard human support. Custom plan users receive dedicated human support.
+### In-app support bot
 
-For full details on Agents plans and support availability, see [Billing and pricing](/ai-agents/admin/billing).
+**The in-app support bot is available 24/7 for all Airbyte Agents users.** Look for the chat button in the bottom-right corner of the screen. The bot can help answer questions about your workspace, troubleshoot common scenarios, and create support tickets if further help is needed.
+
+### Support by plan
+
+- **Free**: AI and community support.
+- **Individual / Team**: Standard human support, in addition to AI and community support. Create a ticket in the [support center](https://support.airbyte.com/hc/en-us/requests/new).
+- **Custom**: Dedicated human support.
+
+For full details on Agents plans, see [Billing and pricing](/ai-agents/admin/billing).
 
 ## Community resources
 
@@ -39,7 +45,10 @@ These resources are available to all Airbyte users regardless of product or plan
 
 ### Community Slack
 
-[Join the Slack community](https://slack.airbyte.com) for help from other users and Airbyte team members. Popular channels are `#ask-ai` and `#ask-community-for-troubleshooting`.
+[Join the Slack community](https://slack.airbyte.com) for help from other users and Airbyte team members. Popular channels include:
+
+- Data Replication: `#ask-ai`, `#ask-community-for-troubleshooting`
+- Airbyte Agents: `#airbyte-agents`, `#airbyte-agents-ask-ai`
 
 ### GitHub discussions
 
@@ -50,10 +59,6 @@ These resources are available to all Airbyte users regardless of product or plan
 If you've found a bug or issue with Airbyte or its documentation, [create an issue](https://github.com/airbytehq/airbyte/issues/new/choose) on GitHub. If you're willing to work on this issue yourself, please indicate this.
 
 Check the [issue list](https://github.com/airbytehq/airbyte/issues) first in case the issue has already been reported.
-
-### Public roadmap
-
-To stay updated on Airbyte's future plans, take a look at [the roadmap](https://github.com/orgs/airbytehq/projects/37/views/1). Airbyte updates this every few weeks with initiatives that are of interest to the community.
 
 ## Questions about contributions
 

--- a/docs/community/getting-support.md
+++ b/docs/community/getting-support.md
@@ -39,11 +39,11 @@ Check the [issue list](https://github.com/airbytehq/airbyte/issues) first in cas
 
 ### In-app support bot
 
-**The in-app support bot is available 24/7 for all Airbyte Agents users.** Look for the chat button in the bottom-right corner of the screen. The bot can help answer questions about your workspace, troubleshoot common scenarios, and create support tickets if further help is needed.
+**The in-app support bot is available 24/7 for all Airbyte Agents users.** Look for the chat button in the bottom-right corner of the screen. The bot can help answer questions about your organization, troubleshoot common scenarios, and create support tickets if further help is needed.
 
 ### Support by plan
 
-- **Free**: AI and community support.
+- **Free**: AI and [community](#community-slack) support.
 - **Individual / Team**: Standard human support, in addition to AI and community support. The in-app support bot can create a ticket for you, or you can create your own in the [support center](https://support.airbyte.com/hc/en-us/requests/new).
 - **Custom**: Dedicated human support.
 

--- a/docs/community/licenses/README.md
+++ b/docs/community/licenses/README.md
@@ -4,7 +4,7 @@
 
 **Airbyte Protocol** is open sourced and available under the [MIT License](https://opensource.org/license/mit/).
 
-**Airbyte Cloud & Airbyte Enterprise** are both closed source and require a commercial license from Airbyte.
+**Airbyte Cloud, Airbyte Enterprise, and Airbyte Agents** are closed source and require a commercial license from Airbyte.
 
 ## Questions and examples
 

--- a/docs/community/licenses/README.md
+++ b/docs/community/licenses/README.md
@@ -4,7 +4,7 @@
 
 **Airbyte Protocol** is open sourced and available under the [MIT License](https://opensource.org/license/mit/).
 
-**Airbyte Cloud, Airbyte Enterprise, and Airbyte Agents** are closed source and require a commercial license from Airbyte.
+**Airbyte Cloud, Airbyte Enterprise, and Airbyte Agents** require a commercial license from Airbyte.
 
 ## Questions and examples
 


### PR DESCRIPTION
## What

Repositions the Community & Support documentation to reflect both Airbyte product families: data replication and Airbyte Agents.

Currently, every page in the community docs instance assumes the reader uses only the data replication product. There is no mention of Airbyte Agents, no guidance on how Agents users get support, and no clarity about which products accept contributions.

Resolves [AGENTIC-923](https://linear.app/airbyteio/issue/AGENTIC-923/reposition-community-support-docs-to-reflect-both-products).

## How

Content-only changes across 5 markdown files (no config or code changes):

1. **`docs/community/getting-support.md`** — Restructured into cross-product page: shared support center and in-app agent sections, product-specific sections for data replication and Agents, and a unified community resources section. Removed `products: all` frontmatter since the page now serves both product families.
2. **`docs/community/contributing-to-airbyte/README.md`** — Added intro clarifying contributions target the `airbyte` repo (data replication connectors). Added Airbyte Agents to the \"Contributions we don't accept\" list with a link to the support center. Fixed typo (\"stopping\" → \"stopped\").
3. **`docs/community/contributing-to-airbyte/issues-and-requests.md`** — Split bug reporting into Data replication (GitHub) and Airbyte Agents (support center) subsections. Added Agents feature request guidance.
4. **`docs/community/README.md`** — Updated intro to acknowledge both product families.
5. **`docs/community/licenses/README.md`** — Added Airbyte Agents to the closed-source products list.

## Review guide

1. `docs/community/getting-support.md` — most substantial change
2. `docs/community/contributing-to-airbyte/README.md`
3. `docs/community/contributing-to-airbyte/issues-and-requests.md`
4. `docs/community/README.md`
5. `docs/community/licenses/README.md`

## User Impact

Airbyte Agents users visiting the Community & Support docs will now find relevant support information, understand where to report bugs, and see that Agents is acknowledged as a product alongside data replication.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Link to Devin session: https://app.devin.ai/sessions/a93558e374694cf69c69f4bc9ce76c0b
Requested by: @ian-at-airbyte