### PR TITLE
chore: update CDK to version with default timestamp parsing.

### DIFF
--- a/airbyte-integrations/connectors/destination-snowflake/gradle.properties
+++ b/airbyte-integrations/connectors/destination-snowflake/gradle.properties
@@ -1,3 +1,3 @@
 testExecutionConcurrency=-1
-cdkVersion=1.0.10
+cdkVersion=1.0.11
 JunitMethodExecutionTimeout=10m

--- a/airbyte-integrations/connectors/destination-snowflake/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-snowflake/metadata.yaml
@@ -32,7 +32,7 @@ data:
   releaseStage: generally_available
   releases:
     rolloutConfiguration:
-      enableProgressiveRollout: true
+      enableProgressiveRollout: false
     breakingChanges:
       2.0.0:
         message: Remove GCS/S3 loading method support.

--- a/airbyte-integrations/connectors/destination-snowflake/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-snowflake/metadata.yaml
@@ -6,7 +6,7 @@ data:
   connectorSubtype: database
   connectorType: destination
   definitionId: 424892c4-daac-4491-b35d-c6688ba547ba
-  dockerImageTag: 4.0.40-rc.1
+  dockerImageTag: 4.0.40
   dockerRepository: airbyte/destination-snowflake
   documentationUrl: https://docs.airbyte.com/integrations/destinations/snowflake
   githubIssueLabel: destination-snowflake

--- a/airbyte-integrations/connectors/destination-snowflake/src/main/resources/application-connector.yml
+++ b/airbyte-integrations/connectors/destination-snowflake/src/main/resources/application-connector.yml
@@ -3,8 +3,6 @@ airbyte:
     core:
       types:
         unions: DEFAULT
-      coercion:
-        use-fast-timestamp-parsing: true
 
 logger:
   levels:


### PR DESCRIPTION
## What
Cuts 4.0.40 release with mainlined fast timestamp parsing

## Also
* bumps CDK and removes extra flag (no behavior change)

## User Impact
Faster timestamp parsing

## Can this PR be safely reverted and rolled back?

- [x] YES 💚
- [ ] NO ❌

> [!IMPORTANT]
> ⚡ **Auto-merge enabled.**
> 
> _This PR is set to merge automatically when all requirements are met._