### PR TITLE
docs(ai-agents): rename "Airbyte Agents SDK" to "Airbyte Agent SDK"

### DIFF
--- a/docs/ai-agents/admin/sessions.md
+++ b/docs/ai-agents/admin/sessions.md
@@ -59,7 +59,7 @@ Airbyte also processes tool calls from these sources, but doesn't log them as se
 
 - **[MCP](../interfaces/mcp/readme.md)**: Tool calls from agents connected through the Model Context Protocol.
 - **[API](../reference/api/readme.md)**: Direct calls to the Airbyte Agents API.
-- **[SDK](../interfaces/sdk/readme.md)**: Calls made from an agent built with the Airbyte Agents SDK.
+- **[SDK](../interfaces/sdk/readme.md)**: Calls made from an agent built with the Airbyte Agent SDK.
 
 These tool calls still consume AOs and appear in your [Usage panel](./billing.md#monitor-usage), but they don't have a corresponding Sessions row. To review them, open the Usage panel on the Billing page and filter by the **MCP**, **API**, or **SDK** source.
 

--- a/docs/ai-agents/concepts/agent-operations.md
+++ b/docs/ai-agents/concepts/agent-operations.md
@@ -25,7 +25,7 @@ Any interaction with an agent consumes AOs. The source of the interaction determ
 | **Automation Builder Chat** | A conversation inside the Automation Builder while designing an automation. | Yes | Yes |
 | **MCP** | Tool calls from agents connected through the Model Context Protocol. | No | Yes |
 | **API** | Direct calls to the Airbyte Agents API. | No | Yes |
-| **SDK** | Calls from an agent built with the Airbyte Agents SDK. | No | Yes |
+| **SDK** | Calls from an agent built with the Airbyte Agent SDK. | No | Yes |
 
 Sources tracked as sessions appear on the [Sessions](../admin/sessions.md) page, where you can review the full conversation and tool calls. Sources that aren't tracked as sessions still consume AOs and appear in the [Usage panel](../admin/billing.md#monitor-usage) on the Billing page.
 

--- a/docs/ai-agents/get-started/developer-quickstart/tutorial-fastmcp.md
+++ b/docs/ai-agents/get-started/developer-quickstart/tutorial-fastmcp.md
@@ -64,7 +64,7 @@ my-mcp-agent/
 
     This command installs:
 
-    - `airbyte-agent-sdk`: The Airbyte Agents Python SDK, which ships every connector as a typed submodule.
+    - `airbyte-agent-sdk`: The Airbyte Agent SDK, which ships every connector as a typed submodule.
     - `fastmcp`: A Python framework for building MCP servers with minimal boilerplate.
     - `python-dotenv`: A library you can use to load environment variables from a `.env` file.
 

--- a/docs/ai-agents/get-started/developer-quickstart/tutorial-langchain.md
+++ b/docs/ai-agents/get-started/developer-quickstart/tutorial-langchain.md
@@ -65,7 +65,7 @@ You create `.env` and `uv.lock` files in later steps, so don't worry about them 
 
     This command installs:
 
-    - `airbyte-agent-sdk`: The Airbyte Agents Python SDK, which ships every connector as a typed submodule.
+    - `airbyte-agent-sdk`: The Airbyte Agent SDK, which ships every connector as a typed submodule.
     - `langchain`: The LangChain framework core.
     - `langchain-openai`: LangChain's OpenAI integration for chat models.
     - `langgraph`: The LangGraph agent runtime, which provides a `create_react_agent` function for building tool-calling agents.

--- a/docs/ai-agents/get-started/developer-quickstart/tutorial-pydantic.md
+++ b/docs/ai-agents/get-started/developer-quickstart/tutorial-pydantic.md
@@ -65,7 +65,7 @@ You create `.env` and `uv.lock` files in later steps, so don't worry about them 
 
     This command installs:
 
-    - `airbyte-agent-sdk`: The Airbyte Agents Python SDK, which ships every connector as a typed submodule.
+    - `airbyte-agent-sdk`: The Airbyte Agent SDK, which ships every connector as a typed submodule.
 
     - `pydantic-ai`: The AI agent framework, which includes support for [multiple LLM providers](https://pydantic.dev/docs/ai/models/overview) including OpenAI, Anthropic, and Google.
 

--- a/docs/ai-agents/interfaces/sdk/readme.md
+++ b/docs/ai-agents/interfaces/sdk/readme.md
@@ -8,7 +8,7 @@ import SdkVsApi from '@site/static/_ai-agents-sdk-vs-api.md';
 
 # SDK
 
-The Airbyte Agents Python SDK (`airbyte_agent_sdk`) is the Python entry point to Airbyte Agents. With one install you get typed connectors, automatic credential handling, direct execution, and patterns for exposing connectors as tools to AI agent frameworks.
+The Airbyte Agent SDK (`airbyte_agent_sdk`) is the Python entry point to Airbyte Agents. With one install you get typed connectors, automatic credential handling, direct execution, and patterns for exposing connectors as tools to AI agent frameworks.
 
 This section walks through authenticate, add a connector, and execute operations. Deeper class and method signatures live in the [SDK reference](/ai-agents/reference/sdk).
 

--- a/docs/ai-agents/reference/readme.md
+++ b/docs/ai-agents/reference/readme.md
@@ -11,6 +11,6 @@ Reference documentation for Airbyte Agents.
 
 <CardWithIcon title="API reference" description="Browse endpoints, request and response schemas, and authentication requirements for the Airbyte Agent API." ctaText="API reference" ctaLink="/ai-agents/reference/api/" icon="fa-cloud" />
 
-<CardWithIcon title="SDK reference" description="Reference for the Airbyte Agents Python SDK. Classes, methods, and type signatures for airbyte_agent_sdk." ctaText="SDK reference" ctaLink="/ai-agents/reference/sdk/" icon="fa-python" />
+<CardWithIcon title="SDK reference" description="Reference for the Airbyte Agent SDK. Classes, methods, and type signatures for airbyte_agent_sdk." ctaText="SDK reference" ctaLink="/ai-agents/reference/sdk/" icon="fa-python" />
 
 </Grid>

--- a/docs/ai-agents/reference/sdk/readme.md
+++ b/docs/ai-agents/reference/sdk/readme.md
@@ -4,6 +4,6 @@ sidebar_position: 1
 
 # SDK reference
 
-Complete reference for the Airbyte Agents Python SDK (`airbyte_agent_sdk`). For a guided introduction, authentication, and example code, see the [SDK interface](/ai-agents/interfaces/sdk) documentation.
+Complete reference for the Airbyte Agent SDK (`airbyte_agent_sdk`). For a guided introduction, authentication, and example code, see the [SDK interface](/ai-agents/interfaces/sdk) documentation.
 
 The reference pages below are automatically generated from the SDK's source docstrings. Browse the modules in the sidebar to explore classes, methods, and type signatures.


### PR DESCRIPTION
## What

Standardizes SDK naming across all AI Agents docs. Replaces "Airbyte Agents Python SDK" and "Airbyte Agents SDK" with "Airbyte Agent SDK" (singular "Agent").

## How

Simple find-and-replace across 7 files (8 occurrences total) under `docs/ai-agents/`:
- `reference/readme.md`
- `reference/sdk/readme.md`
- `interfaces/sdk/readme.md`
- `get-started/developer-quickstart/tutorial-langchain.md`
- `get-started/developer-quickstart/tutorial-fastmcp.md`
- `get-started/developer-quickstart/tutorial-pydantic.md`
- `admin/sessions.md`
- `concepts/agent-operations.md`

## Review guide

All changes are single-line string replacements — no structural or logic changes.

## User Impact

Users will see the consistent name "Airbyte Agent SDK" across all AI Agents documentation pages.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚
- [ ] NO ❌

Link to Devin session: https://app.devin.ai/sessions/b4f19a6c6c964d51acdb3e58eacbbc55
Requested by: @katmarkham