### PR TITLE
ci: replace snap install yq with direct binary download

### DIFF
--- a/.github/actions/connector-image-build-push/action.yml
+++ b/.github/actions/connector-image-build-push/action.yml
@@ -80,7 +80,7 @@ runs:
       shell: bash
       run: |
         uv tool install poethepoet
-        sudo snap install yq
+        sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 && sudo chmod +x /usr/local/bin/yq
 
     - name: Validate inputs and resolve variables
       id: vars

--- a/.github/workflows/auto-upgrade-certified-connectors-cdk.yml
+++ b/.github/workflows/auto-upgrade-certified-connectors-cdk.yml
@@ -26,7 +26,7 @@ jobs:
           submodules: true
 
       - name: Install yq
-        run: sudo snap install yq
+        run: sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 && sudo chmod +x /usr/local/bin/yq
 
       - name: List certified connectors
         id: list-connectors
@@ -70,7 +70,7 @@ jobs:
           submodules: true
 
       - name: Install yq
-        run: sudo snap install yq
+        run: sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 && sudo chmod +x /usr/local/bin/yq
 
       - name: Setup Java
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0

--- a/.github/workflows/cdk-destination-connector-compatibility-test.yml
+++ b/.github/workflows/cdk-destination-connector-compatibility-test.yml
@@ -22,7 +22,7 @@ jobs:
           submodules: true # Needed for when airbyte-enterprise calls this workflow
 
       - name: Install yq
-        run: sudo snap install yq
+        run: sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 && sudo chmod +x /usr/local/bin/yq
 
       - name: Generate Destination Connector Matrix
         id: generate-matrix

--- a/.github/workflows/cdk-source-connector-compatibility-test.yml
+++ b/.github/workflows/cdk-source-connector-compatibility-test.yml
@@ -22,7 +22,7 @@ jobs:
           submodules: true # Needed for when airbyte-enterprise calls this workflow
 
       - name: Install yq
-        run: sudo snap install yq
+        run: sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 && sudo chmod +x /usr/local/bin/yq
 
       - name: Generate Source Connector Matrix
         id: generate-matrix


### PR DESCRIPTION
## What

The snap store has been unreachable from GitHub Actions runners all day, causing **all** connector pre-release publish workflows to fail with:

```
error: unable to contact snap store
```

Affected connectors today (8+ failed runs):
- `source-google-ads` (PR #77663) — 4 failures
- `source-airtable` (PR #76071)
- `source-snapchat-marketing` (PR #76214)
- `source-linear` (PR #77578)
- `source-microsoft-dataverse` (PR #77565)

Requested by @agarctfi.

## How

Replace `sudo snap install yq` with a direct binary download from the [mikefarah/yq GitHub releases](https://github.com/mikefarah/yq/releases) in all 5 occurrences:

1. `.github/actions/connector-image-build-push/action.yml` — used by the publish workflow
2. `.github/workflows/auto-upgrade-certified-connectors-cdk.yml` (2 occurrences)
3. `.github/workflows/cdk-source-connector-compatibility-test.yml`
4. `.github/workflows/cdk-destination-connector-compatibility-test.yml`

The new install method (`wget` from GitHub releases) does not depend on the snap store and is a common pattern for installing `yq` in CI.

## Review guide

1. `.github/actions/connector-image-build-push/action.yml` — line 83
2. `.github/workflows/auto-upgrade-certified-connectors-cdk.yml` — lines 29, 73
3. `.github/workflows/cdk-source-connector-compatibility-test.yml` — line 25
4. `.github/workflows/cdk-destination-connector-compatibility-test.yml` — line 25

## User Impact

Unblocks all connector pre-release publish workflows that are currently failing due to the snap store outage.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚
- [ ] NO ❌

---
[Devin session](https://app.devin.ai/sessions/7dacd5af5df24271a94993719f66b814)