### PR TITLE
docs(ai-agents): move Research Preview label from web app to Automations only

### DIFF
--- a/docs/ai-agents/get-started/choose-how-to-use.md
+++ b/docs/ai-agents/get-started/choose-how-to-use.md
@@ -20,7 +20,7 @@ flowchart TD
 
     click MCP "#mcp-server"
     click SDK "#python-sdk"
-    click WEB "#web-app-research-preview"
+    click WEB "#web-app"
     click API "#http-api"
 ```
 
@@ -48,7 +48,7 @@ uv add airbyte-agent-sdk
 - [LangChain tutorial](developer-quickstart/tutorial-langchain)
 - [FastMCP tutorial](developer-quickstart/tutorial-fastmcp)
 
-## Web app (Research Preview)
+## Web app
 
 **Best for:** Non-developers, operations teams, and anyone who wants to explore Airbyte Agents without writing code.
 

--- a/docs/ai-agents/interfaces/ui/_category_.json
+++ b/docs/ai-agents/interfaces/ui/_category_.json
@@ -1,4 +1,4 @@
 {
-  "label": "Web app (Research Preview)",
+  "label": "Web app",
   "description": "Talk to an Airbyte-hosted agent in Chats, or define Automations that run on a schedule or webhook."
 }

--- a/docs/ai-agents/interfaces/ui/automations.md
+++ b/docs/ai-agents/interfaces/ui/automations.md
@@ -5,6 +5,10 @@ sidebar_position: 2
 
 # Automations
 
+:::info Research Preview
+Automations are currently in Research Preview. Features, interfaces, and behavior may change as the product evolves.
+:::
+
 An Automation is an agent task that runs on its own, without a human in the loop. You describe what you want done once, pick how you want to trigger it (manually, on a schedule, or from a webhook), and Airbyte runs the task every time the trigger fires. Automations are the right choice when you need the same work to happen repeatedly, reliably, and without someone sitting at a keyboard.
 
 To open Automations, click **Automations** in the left sidebar.

--- a/docs/ai-agents/interfaces/ui/readme.md
+++ b/docs/ai-agents/interfaces/ui/readme.md
@@ -5,10 +5,6 @@ sidebar_position: 1
 
 # Web app
 
-:::info Research Preview
-The Airbyte Agents web app is currently in Research Preview. Features, interfaces, and behavior may change as the product evolves.
-:::
-
 The Airbyte Agents web app at [app.airbyte.ai](https://app.airbyte.ai) is the fastest way to use Airbyte Agents without writing code. Describe what you want in natural language, and Airbyte picks the right connectors, makes the necessary tool calls, and replies with an answer grounded in your data.
 
 Use the web app when you want Airbyte itself to be your agent. For Python agents you build yourself, use the [SDK](../sdk). For agents in any other language, use the [API](../api). For agents that already speak Model Context Protocol, use the [MCP server](../mcp).

--- a/docusaurus/src/components/AiAgentsHome/QuickInstall.jsx
+++ b/docusaurus/src/components/AiAgentsHome/QuickInstall.jsx
@@ -101,7 +101,7 @@ const TABS = [
   },
   {
     id: "webapp",
-    label: "Web app (research preview)",
+    label: "Web app",
     command: null,
     description:
       "Chat with an AI agent and build automations in your web browser. No code, nothing to install.",


### PR DESCRIPTION
## What
Removes the "Research Preview" label from the web app across the ai-agents public docs and moves it to Automations only.

## How
- `QuickInstall.jsx`: Changed tab label from "Web app (research preview)" to "Web app"
- `interfaces/ui/_category_.json`: Changed sidebar label from "Web app (Research Preview)" to "Web app"
- `interfaces/ui/readme.md`: Removed the Research Preview info admonition from the Web app overview page
- `interfaces/ui/automations.md`: Added a Research Preview info admonition to the Automations page

## Review guide
1. `docusaurus/src/components/AiAgentsHome/QuickInstall.jsx`
2. `docs/ai-agents/interfaces/ui/_category_.json`
3. `docs/ai-agents/interfaces/ui/readme.md`
4. `docs/ai-agents/interfaces/ui/automations.md`

## User Impact
The public docs sidebar and pages no longer label the entire web app as "Research Preview" — only Automations carries that label now.

## Can this PR be safely reverted and rolled back?
- [x] YES

Link to Devin session: https://app.devin.ai/sessions/ae00c22b560a45afbcb55a60464380ff
Requested by: @ian-at-airbyte
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/airbytehq/airbyte/pull/77699" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
