### PR TITLE
docs(ai-agents): update Individual plan AO allotment from 1,000 to 5,000

### DIFF
--- a/docs/ai-agents/admin/billing.md
+++ b/docs/ai-agents/admin/billing.md
@@ -159,7 +159,7 @@ A plan to explore Airbyte Agents and prototype agents.
 A plan for personal use and daily work.
 
 - $29 per month.
-- 1,000 AOs per month.
+- 5,000 AOs per month.
 - No daily limit.
 - Overage AOs are available.
 - Context Store refreshes hourly.


### PR DESCRIPTION
Updates documentation to reflect that Individual plan now gets 5000 AOs.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/airbytehq/airbyte/pull/77701" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
