### PR TITLE
docs(ai-agents): replace "Connect, Unify, Act" with "Connect, Ask, Act"

### DIFF
--- a/docs/ai-agents/README.md
+++ b/docs/ai-agents/README.md
@@ -19,7 +19,7 @@ Airbyte Agents is a data and context layer for AI agents. It gives your agents r
 
 <CardWithIcon title="Get started" description="New to Airbyte Agents? Learn what the product is, choose the right interface, or jump straight into building." ctaText="Get started" ctaLink="/ai-agents/get-started/" icon="fa-rocket" />
 
-<CardWithIcon title="Core concepts" description="Understand the building blocks: the Connect-Unify-Act model, agent operations, the Context Store, and system architecture." ctaText="Core concepts" ctaLink="/ai-agents/concepts/" icon="fa-lightbulb" />
+<CardWithIcon title="Core concepts" description="Understand the building blocks: the Connect-Ask-Act model, agent operations, the Context Store, and system architecture." ctaText="Core concepts" ctaLink="/ai-agents/concepts/" icon="fa-lightbulb" />
 
 </Grid>
 

--- a/docs/ai-agents/concepts/connect-ask-act.md
+++ b/docs/ai-agents/concepts/connect-ask-act.md
@@ -3,9 +3,9 @@ plan: all
 sidebar_position: 0
 ---
 
-# Connect, Unify, Act
+# Connect, Ask, Act
 
-AI agents need real-time access to business data spread across dozens of systems, but building and maintaining those integrations is expensive and fragile. Airbyte Agents solves this with three layers: **Connect** your agents to any system, **Unify** data from every source into one searchable layer, and let agents **Act** on that data in real time.
+AI agents need real-time access to business data spread across dozens of systems, but building and maintaining those integrations is expensive and fragile. Airbyte Agents solves this with three layers: **Connect** your agents to any system, **Ask** questions across all your data in one searchable layer, and let agents **Act** on that data in real time.
 
 ## Connect
 
@@ -19,9 +19,9 @@ The platform manages the hard parts of connecting to third-party systems:
 
 Connecting a new data source takes minutes, not weeks. You don't build or maintain API wrappers, manage credential storage, or handle token lifecycle.
 
-## Unify
+## Ask
 
-Once your agents are connected, the [Context Store](context-store) indexes and normalizes data from every source into one searchable layer.
+Once your agents are connected, the [Context Store](context-store) unifies and indexes data from every source into a single searchable layer so you can start asking the questions that matter most.
 
 Without the Context Store, an agent that needs to answer a question like "find all open deals over $10,000" has to page through API results, manage rate limits, and accumulate records in its context window. This is slow, expensive, and unreliable. For benchmark data on how the Context Store compares to live API retrieval, see the [airbyte-agents-benchmarks](https://github.com/airbytehq/airbyte-agents-benchmarks) repository.
 
@@ -56,7 +56,7 @@ Airbyte logs every action an agent takes. You can review what happened, when, an
 
 ## How the layers compose
 
-You connect once. Data unifies automatically. Agents act with full context.
+You connect once. Ask across every source instantly. Agents act with full context.
 
 A single connector credential gives an agent the ability to fetch live data, search across an indexed store, and write changes back, all through one consistent interface. Adding a new data source extends every layer at once: the agent can immediately connect, search, and act on the new system.
 

--- a/docs/ai-agents/concepts/readme.md
+++ b/docs/ai-agents/concepts/readme.md
@@ -7,7 +7,7 @@ sidebar_position: 3
 
 This section covers the building blocks of Airbyte Agents: the models, resources, and platform behaviors you work with across every interface.
 
-- [**Connect, Unify, Act**](connect-unify-act): The three-layer model at the heart of the platform. Connect agents to any system through managed connectors, unify data from every source into one searchable layer, and let agents act on that data in real time.
+- [**Connect, Ask, Act**](connect-ask-act): The three-layer model at the heart of the platform. Connect agents to any system through managed connectors, ask questions across all your data in one searchable layer, and let agents act on that data in real time.
 - [**Agent operations**](agent-operations): The unit of work in Airbyte Agents. Learn how tool calls and token usage combine into agent operations, and how AOs relate to your plan's billing.
 - [**Context Store**](context-store): A managed, searchable replica of your connector data. The Context Store gives agents fast, indexed access to business data without live API crawls.
 - [**System architecture**](architecture): How the platform is organized. Covers the four interfaces, the resource hierarchy of organizations, workspaces, and connectors, and the execution model that routes agent requests.

--- a/docs/ai-agents/concepts/readme.md
+++ b/docs/ai-agents/concepts/readme.md
@@ -7,11 +7,11 @@ sidebar_position: 3
 
 This section covers the building blocks of Airbyte Agents: the models, resources, and platform behaviors you work with across every interface.
 
-- [**Connect, Ask, Act**](connect-ask-act): The three-layer model at the heart of the platform. Connect agents to any system through managed connectors, ask questions across all your data in one searchable layer, and let agents act on that data in real time.
-- [**Agent operations**](agent-operations): The unit of work in Airbyte Agents. Learn how tool calls and token usage combine into agent operations, and how AOs relate to your plan's billing.
-- [**Context Store**](context-store): A managed, searchable replica of your connector data. The Context Store gives agents fast, indexed access to business data without live API crawls.
-- [**System architecture**](architecture): How the platform is organized. Covers the four interfaces, the resource hierarchy of organizations, workspaces, and connectors, and the execution model that routes agent requests.
-- [**Time zones**](time-zones): How Airbyte Agents stores, displays, and schedules dates and times across the web app, API, SDK, and MCP server.
+- [**Connect, Ask, Act**](./connect-ask-act.md): The three-layer model at the heart of the platform. Connect agents to any system through managed connectors, ask questions across all your data in one searchable layer, and let agents act on that data in real time.
+- [**Agent operations**](./agent-operations.md): The unit of work in Airbyte Agents. Learn how tool calls and token usage combine into agent operations, and how AOs relate to your plan's billing.
+- [**Context Store**](./context-store.md): A managed, searchable replica of your connector data. The Context Store gives agents fast, indexed access to business data without live API crawls.
+- [**System architecture**](./architecture/readme.md): How the platform is organized. Covers the four interfaces, the resource hierarchy of organizations, workspaces, and connectors, and the execution model that routes agent requests.
+- [**Time zones**](./time-zones.md): How Airbyte Agents stores, displays, and schedules dates and times across the web app, API, SDK, and MCP server.
 
 import DocCardList from '@theme/DocCardList';
 

--- a/docs/ai-agents/get-started/what-is-airbyte-agents.md
+++ b/docs/ai-agents/get-started/what-is-airbyte-agents.md
@@ -24,7 +24,7 @@ Organizations either end up with agents that demo well but fail in production, o
 
 ## How Airbyte Agents works
 
-Airbyte Agents solves this with three layers: Connect, Unify, and Act.
+Airbyte Agents solves this with three layers: Connect, Ask, and Act.
 
 ```mermaid
 flowchart LR
@@ -32,14 +32,14 @@ flowchart LR
         C1["50+ SaaS connectors"]
         C2["Managed auth & credentials"]
     end
-    subgraph unify["Unify"]
+    subgraph ask["Ask"]
         CS["Context Store<br/>(indexed, searchable)"]
     end
     subgraph act["Act"]
         A1["Read & search"]
         A2["Create & update"]
     end
-    connect --> unify --> act
+    connect --> ask --> act
 ```
 
 ### Connect
@@ -52,7 +52,7 @@ The platform handles the hard parts:
 - **Multi-tenancy.** Workspaces isolate connectors and credentials across tenants, teams, or environments.
 - **Open source.** The SDK is a single open source Python package that includes every connector. You can inspect, extend, or run it locally.
 
-### Unify
+### Ask
 
 The [Context Store](../concepts/context-store) indexes and normalizes data from every connected source into one searchable layer.
 

--- a/docusaurus/src/pages/index.js
+++ b/docusaurus/src/pages/index.js
@@ -186,7 +186,7 @@ export default function Home() {
     {
       title: 'Core concepts',
       link: '/ai-agents/concepts/',
-      description: 'Understand the building blocks: the Connect-Unify-Act model, agent operations, the Context Store, and system architecture.',
+      description: 'Understand the building blocks: the Connect-Ask-Act model, agent operations, the Context Store, and system architecture.',
       icon: AIAgentsIcon,
     },
     {

--- a/docusaurus/vercel.json
+++ b/docusaurus/vercel.json
@@ -1095,6 +1095,11 @@
       "source": "/platform/2.1/:path*",
       "destination": "/platform/:path*",
       "statusCode": 301
+    },
+    {
+      "source": "/ai-agents/concepts/connect-unify-act",
+      "destination": "/ai-agents/concepts/connect-ask-act",
+      "statusCode": 301
     }
   ]
 }


### PR DESCRIPTION
## What

Replaces the "Connect, Unify, Act" tagline with "Connect, Ask, Act" across all Airbyte Agents documentation, per [AGENTIC-1416](https://linear.app/airbyteio/issue/AGENTIC-1416/replace-connect-unify-act-with-connect-ask-act).

Requested by @ian-at-airbyte.

## How

- Renamed `docs/ai-agents/concepts/connect-unify-act.md` → `connect-ask-act.md`
- Updated the page heading, intro paragraph, section headings, and Mermaid diagram labels/edges
- Rewrote the opening sentence of the "Ask" section per Ian's direction
- Updated all cross-references in `readme.md`, `README.md`, `what-is-airbyte-agents.md`, and `index.js`
- Added a 301 redirect in `docusaurus/vercel.json` from `/ai-agents/concepts/connect-unify-act` → `/ai-agents/concepts/connect-ask-act`

## Review guide

1. `docs/ai-agents/concepts/connect-ask-act.md` — renamed file, heading + section heading + intro + body changes
2. `docs/ai-agents/get-started/what-is-airbyte-agents.md` — tagline, Mermaid diagram, section heading
3. `docs/ai-agents/concepts/readme.md` — link text + href + description
4. `docs/ai-agents/README.md` — card description
5. `docusaurus/src/pages/index.js` — card description
6. `docusaurus/vercel.json` — new 301 redirect entry

## User Impact

- The published docs will show "Connect, Ask, Act" instead of "Connect, Unify, Act"
- The old URL `/ai-agents/concepts/connect-unify-act` will 301 redirect to the new URL

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Link to Devin session: https://app.devin.ai/sessions/6238511ec03d429c93e9ff5eb7639a65