### PR TITLE
docs(ai-agents): rename execute action `search` to `context_store_search`

### DIFF
--- a/docs/ai-agents/interfaces/api/execute.md
+++ b/docs/ai-agents/interfaces/api/execute.md
@@ -46,7 +46,7 @@ The request body contains three fields:
 | Field | Type | Description |
 | ----- | ---- | ----------- |
 | `entity` | `string` | The entity to operate on, such as `users`, `calls`, or `issues`. |
-| `action` | `string` | The action to perform, such as `list`, `get`, or `search`. |
+| `action` | `string` | The action to perform, such as `list`, `get`, or `context_store_search`. |
 | `params` | `object` | Parameters for the action. The required parameters depend on the entity and action. |
 
 ### Example: List issues
@@ -85,8 +85,8 @@ curl -X POST 'https://api.airbyte.ai/api/v1/integrations/connectors/<connector_i
 
 This example searches for records using filter conditions.
 
-:::note `search` reads from the [Context Store](../../concepts/context-store)
-The `search` action reads from Airbyte's pre-indexed Context Store, not the live third-party API. The store is always on and Airbyte populates it per connector after the connector is created. If you call `search` while the connector's Context Store still shows `Loading` or `Building Preview` on the Connectors page, the call returns an error at runtime. Wait for the status to reach `Preview` or `Ready`, or use `list`/`get` against the live API until it does.
+:::note `context_store_search` reads from the [Context Store](../../concepts/context-store)
+The `context_store_search` action reads from Airbyte's pre-indexed Context Store, not the live third-party API. The store is always on and Airbyte populates it per connector after the connector is created. If you call `context_store_search` while the connector's Context Store still shows `Loading` or `Building Preview` on the Connectors page, the call returns an error at runtime. Wait for the status to reach `Preview` or `Ready`, or use `list`/`get` against the live API until it does.
 :::
 
 ```bash title="Request"
@@ -95,13 +95,15 @@ curl -X POST 'https://api.airbyte.ai/api/v1/integrations/connectors/<connector_i
   --header 'Content-Type: application/json' \
   --data '{
     "entity": "users",
-    "action": "search",
+    "action": "context_store_search",
     "params": {
       "query": {"filter": {"eq": {"active": true}}},
       "limit": 100
     }
   }'
 ```
+
+Some connectors also expose an `api_search` action that calls the third-party platform's live search endpoint instead of the Context Store. Check the [connector's reference page](/ai-agents/connectors) to see whether your connector supports it.
 
 ## Download files
 
@@ -198,7 +200,7 @@ Every execute response uses the same top-level envelope. The connector's records
 }
 ```
 
-- `result` is whatever the operation returns: an array for `list` and `search`, a single object for `get`, or a byte stream for `download`.
+- `result` is whatever the operation returns: an array for `list` and `context_store_search`, a single object for `get`, or a byte stream for `download`.
 - `connector_metadata` surfaces pagination state. The exact key names depend on the connector; expect `has_next_page` and `end_cursor`.
 - `execution_metadata` always includes `connector_instance_id` and `execution_time_ms`.
 

--- a/docs/ai-agents/interfaces/sdk/execute.md
+++ b/docs/ai-agents/interfaces/sdk/execute.md
@@ -28,7 +28,7 @@ asyncio.run(main())
 ```
 
 - `entity` is the resource, such as `issues`, `repositories`, or `pull_requests`.
-- `action` is one of the connector's supported actions, such as `list` or `get`. Some connectors support additional actions like `search` or `download`; check the connector's reference page.
+- `action` is one of the connector's supported actions, such as `list` or `get`. Some connectors support additional actions like `context_store_search`, `api_search`, or `download`; check the connector's reference page.
 - `params` contains action-specific arguments. The exact keys are connector- and entity-specific. GitHub's `issues.list` accepts `per_page`, for example, while other connectors paginate via `cursor`. Use [`list_entities()`](#introspection) to discover the parameters a connector supports at runtime.
 - Always wrap the call in `try`/`finally` and `await connector.close()` once you're done to release the underlying HTTP client.
 
@@ -130,7 +130,7 @@ async def github_execute(entity: str, action: str, params: dict | None = None):
     """Execute GitHub operations.
 
     `entity` must be a simple name such as `issues`, `repositories`, or `pull_requests`.
-    `action` must be `list`, `get`, or `search`.
+    `action` must be `list`, `get`, or `context_store_search`.
     Pass owner and repo info in the `params` dict, for example:
     `params={"owner": "airbytehq", "repo": "airbyte"}`.
     """


### PR DESCRIPTION
## What

Fixes [AGENTIC-1425](https://linear.app/airbyteio/issue/AGENTIC-1425/fix-incorrect-execute-api-docs-search-operation-name).

The execute API and SDK reference pages used the literal action name `search`, but the server-accepted name is `context_store_search`. The server's `HostedAction` enum (`backend/app/core/types.py`) only defines `context_store_search`, `api_search`, and the lifecycle actions; a plain `search` action does not exist and would fail at runtime.

## How

Two docs pages updated, no code changes:

- `docs/ai-agents/interfaces/api/execute.md` — 5 literal `search` → `context_store_search` swaps (actions table, the `:::note` admonition title and body, the example request body, the response-format prose) plus a one-line note that some connectors also expose `api_search` for live upstream search.
- `docs/ai-agents/interfaces/sdk/execute.md` — 2 literal `search` → `context_store_search` swaps (the supported-actions bullet now mentions both `context_store_search` and `api_search`; the custom-docstring example renamed to `context_store_search`).

The descriptive H3 heading `### Example: Search with filters` is left as natural-language prose. Full `api_search` documentation (concept paragraph, dedicated example, cross-linking) is tracked separately in [AGENTIC-1426](https://linear.app/airbyteio/issue/AGENTIC-1426/document-api-search-action-in-execute-api-and-sdk-docs).

## Review guide

1. `docs/ai-agents/interfaces/api/execute.md`
2. `docs/ai-agents/interfaces/sdk/execute.md`

## User Impact

Readers copying the example request body into curl will now use the correct action name and won't get a runtime error. The new `api_search` mention also helps readers who actually want live-API search find the right action on connectors that expose it (Stripe, GitHub).

## Can this PR be safely reverted and rolled back?

- [x] YES 💚
- [ ] NO ❌

Link to Devin session: https://app.devin.ai/sessions/ca509124c3234d75947eb7763bfa9165
Requested by: @ian-at-airbyte