### PR TITLE
docs(ai-agents): remove changelog links from agent connector registry table

### DIFF
--- a/docusaurus/src/components/AgentConnectorRegistry.jsx
+++ b/docusaurus/src/components/AgentConnectorRegistry.jsx
@@ -3,8 +3,6 @@ import styles from "./AgentConnectorRegistry.module.css";
 
 const ICON_BASE_URL =
   "https://connectors.airbyte.com/files/metadata/airbyte";
-const CHANGELOG_BASE_URL =
-  "https://github.com/airbytehq/airbyte-agent-connectors/blob/main/connectors";
 
 const iconStyle = { maxWidth: 25, maxHeight: 25 };
 
@@ -73,15 +71,6 @@ export default function AgentConnectorRegistry() {
                 <span className={styles.linkSeparator}>|</span>
                 <a href={`${connector.href}REFERENCE`} title="API Reference">
                   Reference
-                </a>
-                <span className={styles.linkSeparator}>|</span>
-                <a
-                  href={`${CHANGELOG_BASE_URL}/${connector.slug}/CHANGELOG.md`}
-                  title="Changelog"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  Changelog
                 </a>
               </div>
             </td>


### PR DESCRIPTION
## What

Removes the per-row "Changelog" links (and the `CHANGELOG_BASE_URL` constant they used) from the agent connector docs list rendered by `AgentConnectorRegistry`.

## How

In `docusaurus/src/components/AgentConnectorRegistry.jsx`:
- Drop the `CHANGELOG_BASE_URL` constant.
- Remove the trailing `<span>|</span>` separator and the `<a>` linking to `${CHANGELOG_BASE_URL}/${slug}/CHANGELOG.md` from each row's Links cell.

The remaining links per row are now: Overview, Auth, Reference.

## Review guide

1. `docusaurus/src/components/AgentConnectorRegistry.jsx`

## User Impact

Users browsing the agent connector docs list no longer see a "Changelog" link in the Links column for each connector. No other behavior changes.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚
- [ ] NO ❌


Link to Devin session: https://app.devin.ai/sessions/b22c41977b824e1bb025a4b0e8587c29
Requested by: @ian-at-airbyte