### PR TITLE
ci(auto-merge-cron): allow docs/ai-agents/reference/* in path allowlist

### DIFF
--- a/.github/workflows/auto-merge-cron.yml
+++ b/.github/workflows/auto-merge-cron.yml
@@ -121,6 +121,7 @@ jobs:
               docs/integrations/sources/*) ;;
               docs/integrations/destinations/*) ;;
               docs/ai-agents/connectors/*) ;;
+              docs/ai-agents/reference/*) ;;
               docs/developers/pyairbyte/*) ;;
               docusaurus/src/data/*) ;;
               *) valid=false; echo "::warning::Non-connector file: $file"; break ;;


### PR DESCRIPTION
## What

The `auto-merge-cron` workflow validates that every changed file in a PR matches an allowlist of "connector-only" paths before octavia-bot-admin approves and squash-merges it. The allowlist did not include `docs/ai-agents/reference/*`, so PRs auto-generated by `agent-sdk-docs-generate.yml` (which writes the `airbyte-agent-sdk` API reference under `docs/ai-agents/reference/sdk/...`) are rejected at the path-validation step and never get the auto-approval needed to merge.

Concrete example: PR #77654 has been sitting open for 2 days with all CI green and the `auto-merge` label applied by the workflow itself. The cron logs `::warning::Non-connector file: docs/ai-agents/reference/sdk/...` for every file it sees, sets `valid=false`, and skips the approve/merge steps.

## How

Add `docs/ai-agents/reference/*` to the case statement in `.github/workflows/auto-merge-cron.yml` so files under that subtree pass the path-validation step. The pattern is intentionally broad (the whole `reference/` folder) so future additions like a PyAirbyte SDK reference subdirectory are covered too.

## Review guide

1. `.github/workflows/auto-merge-cron.yml` — one-line addition to the path allowlist.

## User Impact

Auto-generated agent-sdk API reference docs PRs (and any future PRs scoped under `docs/ai-agents/reference/`) will be auto-merged by the cron once CI is green, instead of staling open. No effect on existing connector or PyAirbyte auto-merge behavior.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

---
[Devin session](https://app.devin.ai/sessions/6897d779985642d59705c3ad9dcc3e24)

Requested by: @ian-at-airbyte