### PR TITLE
docs(ai-agents): fix Context Store page bug bash items

### DIFF
--- a/docs/ai-agents/concepts/context-store.md
+++ b/docs/ai-agents/concepts/context-store.md
@@ -5,7 +5,7 @@ sidebar_position: 2
 
 # Context Store
 
-The Context Store is a managed, searchable replica of select entities from all your connected data sources. Airbyte populates it from the connectors in your workspace and gives agents a fast, consistent way to search your business data in natural language, without hitting the underlying APIs for every request.
+The Context Store is a managed, searchable replica of select entities from all your connected data sources. Airbyte populates it from the connectors in your workspace and gives agents a fast, consistent way to search your business data without hitting the underlying APIs for every request.
 
 Some third-party APIs have search endpoints, but many don't. Without the Context Store, prompts like these force your agent to list, page through, and filter records from the API in real time:
 
@@ -74,17 +74,17 @@ Agents choose between these paths automatically. You don't need to specify which
 
 ## How search works
 
-The Context Store supports structured search with filter operators, field selection, sorting, and cursor-based pagination. Agents translate natural-language prompts into structured queries automatically, so most users don't need to construct queries by hand.
+The Context Store supports structured search with filter operators, field selection, sorting, and cursor-based pagination. The agent translates user intent from natural language into a structured query, so most users don't need to construct queries by hand.
 
-If you build agents with the SDK or API, you can call `context_store_search` directly and pass structured filters. For details on the query model, see the [SDK reference](../reference/sdk/airbyte_agent_sdk) and individual [connector reference pages](../connectors).
+If you build agents with the SDK or API, you can call `context_store_search` directly and pass structured filters. For details on the query model, see the individual [connector reference pages](../connectors), which document the available entities, filter fields, and search parameters for each connector.
 
-## Initial backfill
+## Initial index
 
-When the Context Store populates data for a connector, Airbyte runs an initial backfill. Backfill time depends on the amount of data and third-party API rate limits, and can range from minutes to days.
+When the Context Store populates data for a connector, Airbyte runs an initial index. Indexing time depends on the amount of data and third-party API rate limits, and can range from minutes to days.
 
-During the backfill, Airbyte makes data available to agents progressively. You don't have to wait for the backfill to finish before agents can search. An entity in **Preview** status already has partial data that agents can query. As the backfill continues, more records become searchable until the entity reaches **Ready** status.
+During the initial index, Airbyte makes data available to agents progressively. You don't have to wait for the index to finish before agents can search. An entity in **Preview** status already has partial data that agents can query. As indexing continues, more records become searchable until the entity reaches **Ready** status.
 
-The per-entity detail view on the Connectors page shows record counts and timestamps so you can track backfill progress.
+The per-entity detail view on the Connectors page shows record counts and timestamps so you can track indexing progress.
 
 ## When to use the Context Store
 
@@ -98,4 +98,7 @@ If you already maintain your own copy of the relevant data and prefer to expose 
 
 ## Limitations
 
-- All agent connectors and interfaces can use the Context Store. Agents prefer it for search operations whenever the entity is available in the store.
+- **Data freshness.** The Context Store is not real-time. Airbyte refreshes data on a schedule that depends on your plan, ranging from hourly to daily. See [Billing and pricing](../admin/billing) for refresh cadence by plan.
+- **Curated subset of data.** Not every field or entity from a source is included. Airbyte indexes only the fields and entities that are most useful for search. For the list of indexed entities per connector, see [Agent connectors](../connectors).
+- **Initial indexing delay.** The first time Airbyte populates a connector, the [initial index](#initial-index) can take minutes to days depending on data volume and API rate limits.
+- **Read-only.** The Context Store supports search operations only. Write operations like creating, updating, or deleting records always go through a direct API request.

--- a/docs/ai-agents/concepts/context-store.md
+++ b/docs/ai-agents/concepts/context-store.md
@@ -99,6 +99,6 @@ If you already maintain your own copy of the relevant data and prefer to expose 
 ## Limitations
 
 - **Data freshness.** The Context Store is not real-time. Airbyte refreshes data on a schedule that depends on your plan, ranging from hourly to daily. See [Billing and pricing](../admin/billing) for refresh cadence by plan.
-- **Curated subset of data.** Not every field or entity from a source is included. Airbyte indexes only the fields and entities that are most useful for search. You can see which entities populate the Context Store when selecting entities in the connector authentication widget.
+- **Curated subset of data.** Not every field or entity from a source is included. Airbyte indexes only the fields and entities that are most useful for search. You can see which entities populate the Context Store when selecting entities in the authentication widget.
 - **Initial indexing delay.** The first time Airbyte populates a connector, the [initial index](#initial-index) can take minutes to days depending on data volume and API rate limits.
 - **Read-only.** The Context Store supports search operations only. Write operations like creating, updating, or deleting records always go through a direct API request.

--- a/docs/ai-agents/concepts/context-store.md
+++ b/docs/ai-agents/concepts/context-store.md
@@ -74,7 +74,7 @@ Agents choose between these paths automatically. You don't need to specify which
 
 ## How search works
 
-The Context Store supports structured search with filter operators, field selection, sorting, and cursor-based pagination. The agent translates user intent from natural language into a structured query, so most users don't need to construct queries by hand.
+The Context Store supports structured search with filter operators, field selection, sorting, and cursor-based pagination. The agent translates user intent from natural language into a structured query, so you don't need to construct queries by hand.
 
 If you build agents with the SDK or API, you can call `context_store_search` directly and pass structured filters. For details on the query model, see the individual [connector reference pages](../connectors), which document the available entities, filter fields, and search parameters for each connector.
 
@@ -99,6 +99,6 @@ If you already maintain your own copy of the relevant data and prefer to expose 
 ## Limitations
 
 - **Data freshness.** The Context Store is not real-time. Airbyte refreshes data on a schedule that depends on your plan, ranging from hourly to daily. See [Billing and pricing](../admin/billing) for refresh cadence by plan.
-- **Curated subset of data.** Not every field or entity from a source is included. Airbyte indexes only the fields and entities that are most useful for search. For the list of indexed entities per connector, see [Agent connectors](../connectors).
+- **Curated subset of data.** Not every field or entity from a source is included. Airbyte indexes only the fields and entities that are most useful for search. You can see which entities populate the Context Store when selecting entities in the connector authentication widget.
 - **Initial indexing delay.** The first time Airbyte populates a connector, the [initial index](#initial-index) can take minutes to days depending on data volume and API rate limits.
 - **Read-only.** The Context Store supports search operations only. Write operations like creating, updating, or deleting records always go through a direct API request.


### PR DESCRIPTION
## What

Addresses bug bash feedback for the Context Store documentation page ([AGENTIC-1394](https://linear.app/airbyteio/issue/AGENTIC-1394/bug-bash-items-for-context-store-page)).

## How

All changes are in `docs/ai-agents/concepts/context-store.md`:

1. **Rename "Initial backfill" → "Initial index"** — section header and all body references updated from "backfill" to "index"/"indexing".
2. **Rewrite "Limitations" section** — replaced the single non-limitation bullet with four real limitations: data freshness (with link to billing page), curated subset of data, initial indexing delay, and read-only.
3. **Fix misleading "natural language translation" wording** — changed to "the agent translates user intent from natural language into a structured query" per reviewer feedback.
4. **Fix SDK reference link** — removed the link to the top-level SDK reference index (which has no mention of `context_store_search`) and pointed users to individual connector reference pages instead.
5. **Soften intro paragraph** — removed "in natural language" from the opening sentence to avoid the same misleading implication.

## Review guide

1. `docs/ai-agents/concepts/context-store.md` — only file changed

## User Impact

More accurate and useful Context Store documentation. Users now see real limitations, correct terminology ("initial index" instead of "backfill"), and working links to `context_store_search` documentation.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Requested by @ian-at-airbyte.

Link to Devin session: https://app.devin.ai/sessions/c0a8917b21b4413dbddcd220f4330c50