### PR TITLE
fix(bulk-cdk): emit CDC meta fields on JDBC streams without a primary key

### DIFF
--- a/airbyte-cdk/bulk/core/extract/changelog.md
+++ b/airbyte-cdk/bulk/core/extract/changelog.md
@@ -9,6 +9,7 @@ The Extract CDK provides functionality for source connectors including schema di
 
 | Version | Date       | Pull Request                                             | Subject                                                                                                                                              |
 |---------|------------|----------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 1.1.7   | 2026-05-04 | [77739](https://github.com/airbytehq/airbyte/pull/77739) | `JdbcAirbyteStreamFactory` emits CDC meta fields (`_ab_cdc_lsn`, `_ab_cdc_updated_at`, `_ab_cdc_deleted_at`) on streams without a primary key.       |
 | 1.1.6   | 2026-04-24 | [76961](https://github.com/airbytehq/airbyte/pull/76961) | `JdbcSourceConfiguration.namespaces` is optional: an empty set means discover across all accessible schemas/catalogs.                                |
 | 1.1.5   | 2026-04-22 | [76898](https://github.com/airbytehq/airbyte/pull/76898) | Catalog validation failure messages now include an actionable remediation sentence.                                                                  |
 | 1.1.4   | 2026-04-20 | [76481](https://github.com/airbytehq/airbyte/pull/76481) | Bump bulk-cdk-core-base to 1.0.3 to pick up AIRBYTE_EDITION feature flag fix.                                                                        |

--- a/airbyte-cdk/bulk/core/extract/version.properties
+++ b/airbyte-cdk/bulk/core/extract/version.properties
@@ -1,1 +1,1 @@
-version=1.1.6
+version=1.1.7

--- a/airbyte-cdk/bulk/toolkits/extract-jdbc/src/main/kotlin/io/airbyte/cdk/discover/JdbcAirbyteStreamFactory.kt
+++ b/airbyte-cdk/bulk/toolkits/extract-jdbc/src/main/kotlin/io/airbyte/cdk/discover/JdbcAirbyteStreamFactory.kt
@@ -34,7 +34,7 @@ interface JdbcAirbyteStreamFactory : AirbyteStreamFactory, MetaFieldDecorator {
             if (isCdc || hasPK) discoveredStream.primaryKeyColumnIDs else emptyList()
         val stream =
             AirbyteStreamFactory.createAirbyteStream(discoveredStream).apply {
-                if (isCdc && hasPK) {
+                if (isCdc) {
                     decorateAirbyteStream(this)
                 }
                 supportedSyncModes = syncModes

--- a/airbyte-cdk/bulk/toolkits/extract-jdbc/src/test/kotlin/io/airbyte/cdk/discover/JdbcAirbyteStreamFactoryTest.kt
+++ b/airbyte-cdk/bulk/toolkits/extract-jdbc/src/test/kotlin/io/airbyte/cdk/discover/JdbcAirbyteStreamFactoryTest.kt
@@ -4,12 +4,14 @@
 
 package io.airbyte.cdk.discover
 
+import com.fasterxml.jackson.databind.node.ObjectNode
 import io.airbyte.cdk.StreamIdentifier
 import io.airbyte.cdk.command.SourceConfiguration
 import io.airbyte.cdk.h2source.H2SourceOperations
 import io.airbyte.cdk.jdbc.BigIntegerFieldType
 import io.airbyte.cdk.jdbc.BooleanFieldType
 import io.airbyte.cdk.jdbc.StringFieldType
+import io.airbyte.protocol.models.v0.AirbyteStream
 import io.airbyte.protocol.models.v0.SyncMode
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeEach
@@ -54,6 +56,11 @@ class JdbcAirbyteStreamFactoryTest {
         )
         Assertions.assertTrue(stream.sourceDefinedCursor)
         Assertions.assertTrue(stream.isResumable)
+        assertHasCdcMetaFields(stream)
+        Assertions.assertEquals(
+            listOf(H2SourceOperations.H2GlobalCursor.id),
+            stream.defaultCursorField
+        )
     }
 
     @Test
@@ -67,6 +74,13 @@ class JdbcAirbyteStreamFactoryTest {
         Assertions.assertEquals(listOf(SyncMode.FULL_REFRESH), stream.supportedSyncModes)
         Assertions.assertFalse(stream.sourceDefinedCursor)
         Assertions.assertFalse(stream.isResumable)
+        // CDC streams without a primary key must still expose the CDC meta fields in their
+        // schema; otherwise destinations whose catalog references the CDC cursor field reject it.
+        assertHasCdcMetaFields(stream)
+        Assertions.assertEquals(
+            listOf(H2SourceOperations.H2GlobalCursor.id),
+            stream.defaultCursorField
+        )
     }
 
     @Test
@@ -83,6 +97,7 @@ class JdbcAirbyteStreamFactoryTest {
         )
         Assertions.assertFalse(stream.sourceDefinedCursor)
         Assertions.assertTrue(stream.isResumable)
+        assertDoesNotHaveCdcMetaFields(stream)
     }
 
     @Test
@@ -98,5 +113,26 @@ class JdbcAirbyteStreamFactoryTest {
         Assertions.assertEquals(listOf(SyncMode.FULL_REFRESH), stream.supportedSyncModes)
         Assertions.assertFalse(stream.sourceDefinedCursor)
         Assertions.assertFalse(stream.isResumable)
+        assertDoesNotHaveCdcMetaFields(stream)
+    }
+
+    private fun assertHasCdcMetaFields(stream: AirbyteStream) {
+        val properties = stream.jsonSchema["properties"] as ObjectNode
+        for (metaField in H2SourceOperations().globalMetaFields) {
+            Assertions.assertTrue(
+                properties.has(metaField.id),
+                "expected schema properties to contain ${metaField.id} but got ${properties.fieldNames().asSequence().toList()}",
+            )
+        }
+    }
+
+    private fun assertDoesNotHaveCdcMetaFields(stream: AirbyteStream) {
+        val properties = stream.jsonSchema["properties"] as ObjectNode
+        for (metaField in H2SourceOperations().globalMetaFields) {
+            Assertions.assertFalse(
+                properties.has(metaField.id),
+                "did not expect schema properties to contain ${metaField.id}",
+            )
+        }
     }
 }


### PR DESCRIPTION
## What

`JdbcAirbyteStreamFactory.create()` previously gated the call to `decorateAirbyteStream()` on `isCdc && hasPK`, which meant CDC streams whose source table had no primary key did not get the CDC meta fields (`_ab_cdc_*`) added to their JSON schema during DISCOVER.

After a connector built on this base class is upgraded across a version that introduces this gating (for source-postgres, that was `3.7.2` → `3.8.0-rc.x`), configured catalogs whose cursor references a CDC meta field (e.g. `_ab_cdc_lsn`) are rejected by the destination's catalog validator (`DestinationCatalog.throwIfInvalidDedupConfig`, added in airbytehq/airbyte#61700) with:

```
ConfigErrorException: For stream <ns>.<table>: The cursor does not exist in the schema: _ab_cdc_lsn
```

The companion connector-side fix for source-postgres is in airbytehq/airbyte#77738.

## How

Drop the `&& hasPK` guard in `JdbcAirbyteStreamFactory.create()` so any CDC stream gets `decorateAirbyteStream()` applied to its schema, regardless of whether the underlying table has a primary key.

Sync-mode logic is unchanged: non-PK CDC streams remain `FULL_REFRESH` only, and `sourceDefinedCursor` / `isResumable` are still gated on `hasPK`. Only the JSON schema gains the three `_ab_cdc_*` fields plus a `defaultCursorField` referencing the CDC cursor.

This benefits other JDBC sources that build on this base (e.g. source-mysql, source-mssql, source-snowflake) once they roll over to the bulk CDK so they don't repeat the same regression.

## Review guide

1. `airbyte-cdk/bulk/toolkits/extract-jdbc/src/main/kotlin/io/airbyte/cdk/discover/JdbcAirbyteStreamFactory.kt` — single-line guard change.
2. `airbyte-cdk/bulk/toolkits/extract-jdbc/src/test/kotlin/io/airbyte/cdk/discover/JdbcAirbyteStreamFactoryTest.kt` — extends the four existing tests to assert that CDC streams (with or without a PK) carry the CDC meta fields and `defaultCursorField`, and that non-CDC streams do not. The new assertions in `testCreate_withCdcAndWithoutPK` are the regression guard.

Tests pass locally (`./gradlew :airbyte-cdk:bulk:toolkits:bulk-cdk-toolkit-extract-jdbc:test --tests JdbcAirbyteStreamFactoryTest`).

## User Impact

No user-visible change for non-CDC sources. For JDBC CDC sources adopting this base class, non-PK streams will (re)gain the `_ab_cdc_lsn` / `_ab_cdc_updated_at` / `_ab_cdc_deleted_at` fields in their discovered schema, matching the behavior they had before the introduction of the `&& hasPK` guard.

Reported by Matt Bayley while debugging an Airbyte Cloud connection that started failing after the source was upgraded from source-postgres `3.7.2` to `3.8.0-rc.x`.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚
- [ ] NO ❌

Link to Devin session: https://app.devin.ai/sessions/ff1c38fe2c39410797f2a088c36e6ac7
Requested by: @mwbayley