### PR TITLE
docs(ai-agents): address bug bash feedback for Agent Operations page

### DIFF
--- a/docs/ai-agents/concepts/agent-operations.md
+++ b/docs/ai-agents/concepts/agent-operations.md
@@ -14,7 +14,7 @@ Airbyte derives AOs from a combination of two factors:
 
 Simple tasks typically make fewer tool calls and require less reasoning, so they consume fewer AOs. Complex tasks that span multiple connectors, require iterative lookups, or produce long responses consume more.
 
-Airbyte does not expose the exact formula that converts tool calls and reasoning into AOs. Use the [Usage panel](../admin/billing.md#monitor-usage) on the Billing page to monitor your consumption.
+Airbyte does not expose the exact formula that converts tool calls and reasoning into AOs. Use the [Usage chart](../admin/billing.md#monitor-usage) on the Billing page to monitor your consumption.
 
 ## What produces agent operations
 
@@ -29,7 +29,7 @@ Any interaction with an agent consumes AOs. The source of the interaction determ
 | **API** | Direct calls to the Airbyte Agents API. | No | Yes |
 | **SDK** | Calls from an agent built with the Airbyte Agents SDK. | No | Yes |
 
-Sources tracked as sessions appear on the [Sessions](../admin/sessions.md) page, where you can review the full conversation and tool calls. Sources that aren't tracked as sessions still consume AOs and appear in the [Usage panel](../admin/billing.md#monitor-usage) on the Billing page. To inspect individual tool calls from MCP, API, or SDK usage, use the [Review tool calls](../admin/tool-calls.md) page.
+Sources tracked as sessions appear on the [Sessions](../admin/sessions.md) page, where you can review the full conversation and tool calls. Sources that aren't tracked as sessions still consume AOs and appear in the [Usage panel](../admin/billing.md#monitor-usage) on the Billing page. To inspect individual tool calls from MCP, API, or SDK usage, use the [Tool calls](../admin/tool-calls.md) page.
 
 ## How AOs relate to billing
 

--- a/docs/ai-agents/concepts/agent-operations.md
+++ b/docs/ai-agents/concepts/agent-operations.md
@@ -5,14 +5,16 @@ sidebar_position: 1
 
 # Agent operations
 
-An agent operation (AO) is the unit of work in Airbyte Agents. Every time an agent processes a prompt, reasons about data, or calls a tool, it consumes AOs. AOs measure the processing intensity of a task, not just the number of requests.
+An Agent Operation (AO) is the unit of work in Airbyte Agents. Every time an agent processes a prompt, reasons about data, or calls a tool through Airbyte's hosted platform, it consumes AOs. AOs measure the processing intensity of a task, not just the number of requests. Connector calls made locally through the open-source SDK do not consume AOs.
 
 Airbyte derives AOs from a combination of two factors:
 
 - **Tool calls.** Each action an agent takes against a connector counts as a tool call. Listing records, fetching a single record, searching the Context Store, and writing data back to a source are all tool calls.
-- **Token usage.** The input and output tokens an agent consumes while reasoning about your prompt contribute to the AO count.
+- **Reasoning.** The input and output tokens an agent consumes while reasoning about your prompt contribute to the AO count.
 
-Simple tasks typically make fewer tool calls and use fewer tokens, so they consume fewer AOs. Complex reasoning tasks that span multiple connectors, require iterative lookups, or produce long responses consume more.
+Simple tasks typically make fewer tool calls and require less reasoning, so they consume fewer AOs. Complex tasks that span multiple connectors, require iterative lookups, or produce long responses consume more.
+
+Airbyte does not expose the exact formula that converts tool calls and reasoning into AOs. Use the [Usage panel](../admin/billing.md#monitor-usage) on the Billing page to monitor your consumption.
 
 ## What produces agent operations
 
@@ -27,7 +29,7 @@ Any interaction with an agent consumes AOs. The source of the interaction determ
 | **API** | Direct calls to the Airbyte Agents API. | No | Yes |
 | **SDK** | Calls from an agent built with the Airbyte Agents SDK. | No | Yes |
 
-Sources tracked as sessions appear on the [Sessions](../admin/sessions.md) page, where you can review the full conversation and tool calls. Sources that aren't tracked as sessions still consume AOs and appear in the [Usage panel](../admin/billing.md#monitor-usage) on the Billing page.
+Sources tracked as sessions appear on the [Sessions](../admin/sessions.md) page, where you can review the full conversation and tool calls. Sources that aren't tracked as sessions still consume AOs and appear in the [Usage panel](../admin/billing.md#monitor-usage) on the Billing page. To inspect individual tool calls from MCP, API, or SDK usage, use the [Review tool calls](../admin/tool-calls.md) page.
 
 ## How AOs relate to billing
 


### PR DESCRIPTION
## What

Addresses bug bash feedback items from [AGENTIC-1393](https://linear.app/airbyteio/issue/AGENTIC-1393/bug-bash-items-for-agent-operations-page) for the Agent Operations documentation page.

Requested by @ian-at-airbyte.

## How

Five changes to `docs/ai-agents/concepts/agent-operations.md`:

1. **Scope AOs to hosted execution** — Added "through Airbyte's hosted platform" qualifier and a sentence clarifying that local open-source SDK calls do not consume AOs.
2. **Reframe "Token usage" as "Reasoning"** — Renamed the bullet heading from "Token usage" to "Reasoning" so the framing leads with what the agent is doing, not the internal metric.
3. **Transparency note on AO formula** — Added a paragraph stating the exact conversion formula is not exposed and pointing readers to the Usage panel.
4. **Capitalize "Agent Operation"** — Capitalized as a proper noun in prose. Already covered by the existing Vale `accept.txt` pattern `[Aa]gent(ic)? [Oo]peration(s)?`.
5. **Pointer to Review tool calls page** — Updated the paragraph below the sources table to direct MCP/API/SDK users to the Review tool calls page.

## Review guide

1. `docs/ai-agents/concepts/agent-operations.md` — the only file changed.

## User Impact

Clearer documentation for users trying to understand what Agent Operations are, what consumes them, and how to monitor usage. Explicitly scopes AOs to hosted platform usage so open-source SDK users aren't confused.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

---
[Devin session](https://app.devin.ai/sessions/a069cfea4a2d4cc78834c38dbe9b4ef4)