### PR TITLE
feat(destination-redshift-v2):  add drop_cascade to config

### DIFF
--- a/airbyte-integrations/connectors/destination-redshift-v2/src/main/kotlin/io/airbyte/integrations/destination/redshift2/client/RedshiftAirbyteClient.kt
+++ b/airbyte-integrations/connectors/destination-redshift-v2/src/main/kotlin/io/airbyte/integrations/destination/redshift2/client/RedshiftAirbyteClient.kt
@@ -349,8 +349,12 @@ class RedshiftAirbyteClient(
                     Failed to modify table because other database objects (such as views \
                     or rules) depend on it. Original error: ${e.message}
 
-                    You can manually drop the dependent views before running the sync, \
-                    then recreate them afterward. To find dependent views, run:
+                    You can enable the 'Drop tables with CASCADE' option in the destination \
+                    configuration to automatically drop dependent objects during sync. \
+                    WARNING: This will delete all data in dependent objects (views, etc.).
+
+                    Alternatively, you can manually drop the dependent views before running \
+                    the sync, then recreate them afterward. To find dependent views, run:
                     SELECT dependent_ns.nspname, dependent_view.relname \
                     FROM pg_depend \
                     JOIN pg_rewrite ON pg_depend.objid = pg_rewrite.oid \

--- a/airbyte-integrations/connectors/destination-redshift-v2/src/main/kotlin/io/airbyte/integrations/destination/redshift2/client/RedshiftAirbyteClient.kt
+++ b/airbyte-integrations/connectors/destination-redshift-v2/src/main/kotlin/io/airbyte/integrations/destination/redshift2/client/RedshiftAirbyteClient.kt
@@ -346,22 +346,22 @@ class RedshiftAirbyteClient(
             ) {
                 val message =
                     """
-                    Failed to modify table because other database objects (such as views \
-                    or rules) depend on it. Original error: ${e.message}
+                    Failed to modify table because other database objects (such as views 
+                    or rules) depend on it. Original error: ${e.message} .
 
-                    You can enable the 'Drop tables with CASCADE' option in the destination \
-                    configuration to automatically drop dependent objects during sync. \
-                    WARNING: This will delete all data in dependent objects (views, etc.).
+                    You can enable the 'Drop tables with CASCADE' option in the destination 
+                    configuration to automatically drop dependent objects during sync. 
+                    WARNING: This will delete all data in dependent objects (views, etc.). 
 
-                    Alternatively, you can manually drop the dependent views before running \
-                    the sync, then recreate them afterward. To find dependent views, run:
-                    SELECT dependent_ns.nspname, dependent_view.relname \
-                    FROM pg_depend \
-                    JOIN pg_rewrite ON pg_depend.objid = pg_rewrite.oid \
-                    JOIN pg_class AS dependent_view \
-                    ON pg_rewrite.ev_class = dependent_view.oid \
-                    JOIN pg_namespace dependent_ns \
-                    ON dependent_view.relnamespace = dependent_ns.oid \
+                    Alternatively, you can manually drop the dependent views before running 
+                    the sync, then recreate them afterward. To find dependent views, run: 
+                    SELECT dependent_ns.nspname, dependent_view.relname 
+                    FROM pg_depend 
+                    JOIN pg_rewrite ON pg_depend.objid = pg_rewrite.oid 
+                    JOIN pg_class AS dependent_view 
+                    ON pg_rewrite.ev_class = dependent_view.oid 
+                    JOIN pg_namespace dependent_ns 
+                    ON dependent_view.relnamespace = dependent_ns.oid 
                     WHERE pg_depend.refobjid = 'your_schema.your_table'::regclass;
                     """.trimIndent()
                 log.error { message }

--- a/airbyte-integrations/connectors/destination-redshift-v2/src/main/kotlin/io/airbyte/integrations/destination/redshift2/client/RedshiftAirbyteClient.kt
+++ b/airbyte-integrations/connectors/destination-redshift-v2/src/main/kotlin/io/airbyte/integrations/destination/redshift2/client/RedshiftAirbyteClient.kt
@@ -312,12 +312,12 @@ class RedshiftAirbyteClient(
      * internal type names used in DDL statements. Verified against a real Redshift cluster.
      *
      * Precision/scale/length are ignored: all varchars normalize to `varchar(65535)` and all
-     * numerics normalize to `numeric(38,9)`
+     * numerics normalize to `decimal(38,9)`
      */
     internal fun normalizeRedshiftType(redshiftType: String): String =
         when (redshiftType) {
             "character varying" -> "varchar(65535)"
-            "numeric" -> "numeric(38,9)"
+            "numeric" -> "decimal(38,9)"
             "timestamp without time zone" -> "timestamp"
             "timestamp with time zone" -> "timestamptz"
             "time without time zone" -> "time"

--- a/airbyte-integrations/connectors/destination-redshift-v2/src/main/kotlin/io/airbyte/integrations/destination/redshift2/config/RedshiftConfiguration.kt
+++ b/airbyte-integrations/connectors/destination-redshift-v2/src/main/kotlin/io/airbyte/integrations/destination/redshift2/config/RedshiftConfiguration.kt
@@ -39,7 +39,7 @@ class RedshiftConfigurationFactory :
             jdbcUrlParams = pojo.jdbcUrlParams,
             uploadingMethod = pojo.uploadingMethod,
             tunnelMethod = pojo.getTunnelMethodValue(),
-            dropCascade = pojo.dropCascade,
+            dropCascade = pojo.dropCascade ?: false,
         )
     }
 }

--- a/airbyte-integrations/connectors/destination-redshift-v2/src/main/kotlin/io/airbyte/integrations/destination/redshift2/config/RedshiftConfiguration.kt
+++ b/airbyte-integrations/connectors/destination-redshift-v2/src/main/kotlin/io/airbyte/integrations/destination/redshift2/config/RedshiftConfiguration.kt
@@ -20,6 +20,7 @@ data class RedshiftConfiguration(
     val jdbcUrlParams: String?,
     val uploadingMethod: S3StagingConfiguration?,
     val tunnelMethod: SshTunnelMethodConfiguration?,
+    val dropCascade: Boolean,
 ) : DestinationConfiguration()
 
 /** Factory for creating RedshiftConfiguration from RedshiftSpecification. */
@@ -38,6 +39,7 @@ class RedshiftConfigurationFactory :
             jdbcUrlParams = pojo.jdbcUrlParams,
             uploadingMethod = pojo.uploadingMethod,
             tunnelMethod = pojo.getTunnelMethodValue(),
+            dropCascade = pojo.dropCascade,
         )
     }
 }

--- a/airbyte-integrations/connectors/destination-redshift-v2/src/main/kotlin/io/airbyte/integrations/destination/redshift2/config/RedshiftSpecification.kt
+++ b/airbyte-integrations/connectors/destination-redshift-v2/src/main/kotlin/io/airbyte/integrations/destination/redshift2/config/RedshiftSpecification.kt
@@ -84,10 +84,20 @@ open class RedshiftSpecification : ConfigurationSpecification() {
     @get:JsonSchemaInject(json = """{"group": "connection", "order": 7}""")
     val jdbcUrlParams: String? = null
 
+    @get:JsonSchemaTitle("Drop tables with CASCADE")
+    @get:JsonPropertyDescription(
+        "Drop tables with CASCADE. WARNING! This will delete all data in all dependent objects " +
+            "(views, etc.). Use with caution. This option is intended for usecases which can " +
+            "easily rebuild the dependent objects."
+    )
+    @get:JsonProperty("drop_cascade")
+    @get:JsonSchemaInject(json = """{"group": "connection", "order": 8, "default": false}""")
+    val dropCascade: Boolean = false
+
     @get:JsonSchemaTitle("Uploading Method")
     @get:JsonPropertyDescription("The way data will be uploaded to Redshift.")
     @get:JsonProperty("uploading_method")
-    @get:JsonSchemaInject(json = """{"group": "connection", "order": 8, "display_type": "radio"}""")
+    @get:JsonSchemaInject(json = """{"group": "connection", "order": 9, "display_type": "radio"}""")
     val uploadingMethod: S3StagingConfiguration? = null
 
     @JsonIgnore
@@ -106,7 +116,7 @@ open class RedshiftSpecification : ConfigurationSpecification() {
     @JsonPropertyDescription(
         "Whether to initiate an SSH tunnel before connecting to the database, and if so, which kind of authentication to use."
     )
-    @JsonSchemaInject(json = """{"group": "connection", "order": 9}""")
+    @JsonSchemaInject(json = """{"group": "connection", "order": 10}""")
     fun getTunnelMethodValue(): SshTunnelMethodConfiguration? =
         tunnelMethodJson ?: tunnelMethod.asSshTunnelMethod()
 }

--- a/airbyte-integrations/connectors/destination-redshift-v2/src/main/kotlin/io/airbyte/integrations/destination/redshift2/config/RedshiftSpecification.kt
+++ b/airbyte-integrations/connectors/destination-redshift-v2/src/main/kotlin/io/airbyte/integrations/destination/redshift2/config/RedshiftSpecification.kt
@@ -84,10 +84,12 @@ open class RedshiftSpecification : ConfigurationSpecification() {
     @get:JsonSchemaInject(json = """{"group": "connection", "order": 7}""")
     val jdbcUrlParams: String? = null
 
-    @get:JsonSchemaTitle("Drop tables with CASCADE. (WARNING! Risk of unrecoverable data loss)")
+    @get:JsonSchemaTitle(
+        "Drop tables and columns with CASCADE. (WARNING! Risk of unrecoverable data loss)"
+    )
     @get:JsonPropertyDescription(
-        "Drop tables with CASCADE. WARNING! This will delete all data in all dependent objects " +
-            "(views, etc.). Use with caution. This option is intended for usecases which can " +
+        "WARNING! This will delete all data in all dependent objects " +
+            "(views, etc.) including during schema evolution of columns. Use with caution. This option is intended for usecases which can " +
             "easily rebuild the dependent objects."
     )
     @get:JsonProperty("drop_cascade")

--- a/airbyte-integrations/connectors/destination-redshift-v2/src/main/kotlin/io/airbyte/integrations/destination/redshift2/config/RedshiftSpecification.kt
+++ b/airbyte-integrations/connectors/destination-redshift-v2/src/main/kotlin/io/airbyte/integrations/destination/redshift2/config/RedshiftSpecification.kt
@@ -84,7 +84,7 @@ open class RedshiftSpecification : ConfigurationSpecification() {
     @get:JsonSchemaInject(json = """{"group": "connection", "order": 7}""")
     val jdbcUrlParams: String? = null
 
-    @get:JsonSchemaTitle("Drop tables with CASCADE")
+    @get:JsonSchemaTitle("Drop tables with CASCADE. (WARNING! Risk of unrecoverable data loss)")
     @get:JsonPropertyDescription(
         "Drop tables with CASCADE. WARNING! This will delete all data in all dependent objects " +
             "(views, etc.). Use with caution. This option is intended for usecases which can " +
@@ -92,7 +92,7 @@ open class RedshiftSpecification : ConfigurationSpecification() {
     )
     @get:JsonProperty("drop_cascade")
     @get:JsonSchemaInject(json = """{"group": "connection", "order": 8, "default": false}""")
-    val dropCascade: Boolean = false
+    val dropCascade: Boolean? = false
 
     @get:JsonSchemaTitle("Uploading Method")
     @get:JsonPropertyDescription("The way data will be uploaded to Redshift.")

--- a/airbyte-integrations/connectors/destination-redshift-v2/src/main/kotlin/io/airbyte/integrations/destination/redshift2/sql/RedshiftDataType.kt
+++ b/airbyte-integrations/connectors/destination-redshift-v2/src/main/kotlin/io/airbyte/integrations/destination/redshift2/sql/RedshiftDataType.kt
@@ -8,7 +8,7 @@ package io.airbyte.integrations.destination.redshift2.sql
 enum class RedshiftDataType(val typeName: String) {
     // Numeric types
     BIGINT("bigint"),
-    NUMERIC("numeric(38,9)"),
+    NUMERIC("decimal(38,9)"),
 
     // String types
     VARCHAR("varchar(65535)"),

--- a/airbyte-integrations/connectors/destination-redshift-v2/src/main/kotlin/io/airbyte/integrations/destination/redshift2/sql/RedshiftSqlGenerator.kt
+++ b/airbyte-integrations/connectors/destination-redshift-v2/src/main/kotlin/io/airbyte/integrations/destination/redshift2/sql/RedshiftSqlGenerator.kt
@@ -14,11 +14,16 @@ import io.airbyte.cdk.load.message.Meta.Companion.COLUMN_NAME_AB_GENERATION_ID
 import io.airbyte.cdk.load.message.Meta.Companion.COLUMN_NAME_AB_META
 import io.airbyte.cdk.load.schema.model.TableName
 import io.airbyte.cdk.load.table.CDC_DELETED_AT_COLUMN
+import io.airbyte.integrations.destination.redshift2.config.RedshiftConfiguration
 import io.airbyte.integrations.destination.redshift2.schema.toRedshiftCompatibleName
 import jakarta.inject.Singleton
 
 @Singleton
-class RedshiftSqlGenerator {
+class RedshiftSqlGenerator(private val config: RedshiftConfiguration) {
+
+    /** Suffix appended to DROP TABLE / DROP COLUMN when cascade mode is enabled. */
+    private val cascadeSuffix: String
+        get() = if (config.dropCascade) " CASCADE" else ""
 
     companion object {
         private val EXTRACTED_AT_COLUMN_NAME = quoteIdentifier(COLUMN_NAME_AB_EXTRACTED_AT)
@@ -83,14 +88,15 @@ class RedshiftSqlGenerator {
                 }
                 .joinToString(",\n    ")
 
+        val tableKeyClauses = getTableKeyClauses(stream)
         val createStatement =
-            "CREATE TABLE IF NOT EXISTS ${getFullyQualifiedName(tableName)} ($columnDeclarations);"
+            "CREATE TABLE IF NOT EXISTS ${getFullyQualifiedName(tableName)} ($columnDeclarations) $tableKeyClauses;"
 
         // Only wrap in a transaction when replacing (DROP + CREATE must be atomic).
         return if (replace) {
             """
                 |BEGIN TRANSACTION;
-                |DROP TABLE IF EXISTS ${getFullyQualifiedName(tableName)};
+                |DROP TABLE IF EXISTS ${getFullyQualifiedName(tableName)}$cascadeSuffix;
                 |$createStatement
                 |COMMIT;
             """.trimMargin()
@@ -100,7 +106,7 @@ class RedshiftSqlGenerator {
     }
 
     fun dropTable(tableName: TableName): String =
-        "DROP TABLE IF EXISTS ${getFullyQualifiedName(tableName)};"
+        "DROP TABLE IF EXISTS ${getFullyQualifiedName(tableName)}$cascadeSuffix;"
 
     fun addColumn(tableName: TableName, columnName: String, columnType: String): String =
         "ALTER TABLE ${getFullyQualifiedName(tableName)} ADD COLUMN ${quoteIdentifier(columnName)} $columnType;"
@@ -153,7 +159,7 @@ class RedshiftSqlGenerator {
     fun overwriteTable(sourceTableName: TableName, targetTableName: TableName): String {
         return """
             |BEGIN TRANSACTION;
-            |DROP TABLE IF EXISTS ${getFullyQualifiedName(targetTableName)};
+            |DROP TABLE IF EXISTS ${getFullyQualifiedName(targetTableName)}$cascadeSuffix;
             |ALTER TABLE ${getFullyQualifiedName(sourceTableName)} RENAME TO ${getName(targetTableName)};
             |COMMIT;
         """.trimMargin()
@@ -421,7 +427,7 @@ class RedshiftSqlGenerator {
 
         // Remove columns
         columnsToRemove.forEach { (name, _) ->
-            clauses.add("ALTER TABLE $fqn DROP COLUMN ${quoteIdentifier(name)};")
+            clauses.add("ALTER TABLE $fqn DROP COLUMN ${quoteIdentifier(name)}$cascadeSuffix;")
         }
 
         // Modify column types via 4-step rename pattern
@@ -489,7 +495,7 @@ class RedshiftSqlGenerator {
                 )
             )
             // Step 4: Drop the original column
-            add("ALTER TABLE $fullyQualifiedTableName DROP COLUMN $quotedName;")
+            add("ALTER TABLE $fullyQualifiedTableName DROP COLUMN $quotedName$cascadeSuffix;")
             // Step 5: Rename temp column to the original name
             add("ALTER TABLE $fullyQualifiedTableName RENAME COLUMN $tempColumn TO $quotedName;")
         }
@@ -582,4 +588,23 @@ class RedshiftSqlGenerator {
 
     private fun getCursorColumnNameQuoted(stream: DestinationStream): String? =
         stream.tableSchema.getCursor().firstOrNull()?.let { quoteIdentifier(it) }
+
+    /**
+     * For dedup streams:
+     * - DISTKEY on the first primary key column (Redshift allows only one DISTKEY column)
+     * - COMPOUND SORTKEY on all primary key columns
+     */
+    private fun getTableKeyClauses(stream: DestinationStream): String {
+        val importType = stream.tableSchema.importType
+        if (importType !is Dedupe) {
+            return ""
+        }
+        val pkColumns = getPrimaryKeysColumnNamesQuoted(stream)
+        if (pkColumns.isEmpty()) {
+            return ""
+        }
+        val distKey = " DISTKEY(${pkColumns.first()})"
+        val sortKey = " COMPOUND SORTKEY(${pkColumns.joinToString(", ")})"
+        return "\n$distKey\n$sortKey"
+    }
 }

--- a/airbyte-integrations/connectors/destination-redshift-v2/src/main/kotlin/io/airbyte/integrations/destination/redshift2/sql/RedshiftSqlGenerator.kt
+++ b/airbyte-integrations/connectors/destination-redshift-v2/src/main/kotlin/io/airbyte/integrations/destination/redshift2/sql/RedshiftSqlGenerator.kt
@@ -88,9 +88,8 @@ class RedshiftSqlGenerator(private val config: RedshiftConfiguration) {
                 }
                 .joinToString(",\n    ")
 
-        val tableKeyClauses = getTableKeyClauses(stream)
         val createStatement =
-            "CREATE TABLE IF NOT EXISTS ${getFullyQualifiedName(tableName)} ($columnDeclarations) $tableKeyClauses;"
+            "CREATE TABLE IF NOT EXISTS ${getFullyQualifiedName(tableName)} ($columnDeclarations);"
 
         // Only wrap in a transaction when replacing (DROP + CREATE must be atomic).
         return if (replace) {
@@ -588,23 +587,4 @@ class RedshiftSqlGenerator(private val config: RedshiftConfiguration) {
 
     private fun getCursorColumnNameQuoted(stream: DestinationStream): String? =
         stream.tableSchema.getCursor().firstOrNull()?.let { quoteIdentifier(it) }
-
-    /**
-     * For dedup streams:
-     * - DISTKEY on the first primary key column (Redshift allows only one DISTKEY column)
-     * - COMPOUND SORTKEY on all primary key columns
-     */
-    private fun getTableKeyClauses(stream: DestinationStream): String {
-        val importType = stream.tableSchema.importType
-        if (importType !is Dedupe) {
-            return ""
-        }
-        val pkColumns = getPrimaryKeysColumnNamesQuoted(stream)
-        if (pkColumns.isEmpty()) {
-            return ""
-        }
-        val distKey = " DISTKEY(${pkColumns.first()})"
-        val sortKey = " COMPOUND SORTKEY(${pkColumns.joinToString(", ")})"
-        return "\n$distKey\n$sortKey"
-    }
 }

--- a/airbyte-integrations/connectors/destination-redshift-v2/src/test-integration/kotlin/io/airbyte/integrations/destination/redshift2/check/RedshiftCheckerTest.kt
+++ b/airbyte-integrations/connectors/destination-redshift-v2/src/test-integration/kotlin/io/airbyte/integrations/destination/redshift2/check/RedshiftCheckerTest.kt
@@ -10,6 +10,7 @@ import io.airbyte.integrations.destination.redshift2.client.RedshiftAirbyteClien
 import io.airbyte.integrations.destination.redshift2.config.RedshiftConfiguration
 import io.airbyte.integrations.destination.redshift2.connect.RedshiftConnect
 import io.airbyte.integrations.destination.redshift2.connect.S3Connect
+import io.airbyte.integrations.destination.redshift2.sql.RedshiftSqlGenerator
 import io.airbyte.integrations.destination.redshift2.write.RedshiftTestConfigProvider
 import io.airbyte.integrations.destination.redshift2.write.RedshiftTestDataSourceProvider
 import javax.sql.DataSource
@@ -29,10 +30,8 @@ class RedshiftCheckerTest {
 
     @BeforeAll
     fun setup() {
-        val spec = mapper.treeToValue(config, RedshiftSpecification::class.java)
-        configuration = RedshiftConfigurationFactory().makeWithoutExceptionHandling(spec)
-        dataSource = RedshiftConnect(configuration).createDataSource()
-        sqlGenerator = RedshiftSqlGenerator(configuration)
+        configuration = RedshiftTestConfigProvider.configFromFile()
+        dataSource = RedshiftTestDataSourceProvider.get()
     }
 
     @Test
@@ -140,7 +139,7 @@ class RedshiftCheckerTest {
         val client =
             RedshiftAirbyteClient(
                 ds,
-                RedshiftTestConfigProvider.sqlGenerator,
+                RedshiftSqlGenerator(config),
                 S3Connect(config).createS3Client(),
             )
         return RedshiftChecker(client, config)

--- a/airbyte-integrations/connectors/destination-redshift-v2/src/test-integration/kotlin/io/airbyte/integrations/destination/redshift2/check/RedshiftCheckerTest.kt
+++ b/airbyte-integrations/connectors/destination-redshift-v2/src/test-integration/kotlin/io/airbyte/integrations/destination/redshift2/check/RedshiftCheckerTest.kt
@@ -42,7 +42,7 @@ class RedshiftCheckerTest {
         val spec = mapper.treeToValue(config, RedshiftSpecification::class.java)
         configuration = RedshiftConfigurationFactory().makeWithoutExceptionHandling(spec)
         dataSource = RedshiftConnect(configuration).createDataSource()
-        sqlGenerator = RedshiftSqlGenerator()
+        sqlGenerator = RedshiftSqlGenerator(configuration)
     }
 
     @Test

--- a/airbyte-integrations/connectors/destination-redshift-v2/src/test-integration/kotlin/io/airbyte/integrations/destination/redshift2/write/RedshiftDataDumper.kt
+++ b/airbyte-integrations/connectors/destination-redshift-v2/src/test-integration/kotlin/io/airbyte/integrations/destination/redshift2/write/RedshiftDataDumper.kt
@@ -17,6 +17,7 @@ import io.airbyte.cdk.load.test.util.OutputRecord
 import io.airbyte.integrations.destination.redshift2.config.RedshiftConfiguration
 import io.airbyte.integrations.destination.redshift2.schema.RedshiftTableSchemaMapper
 import io.airbyte.integrations.destination.redshift2.schema.toRedshiftCompatibleName
+import io.airbyte.integrations.destination.redshift2.sql.RedshiftSqlGenerator
 import java.time.ZoneOffset
 
 private val testObjectMapper: ObjectMapper = ObjectMapper()

--- a/airbyte-integrations/connectors/destination-redshift-v2/src/test-integration/kotlin/io/airbyte/integrations/destination/redshift2/write/RedshiftDataDumper.kt
+++ b/airbyte-integrations/connectors/destination-redshift-v2/src/test-integration/kotlin/io/airbyte/integrations/destination/redshift2/write/RedshiftDataDumper.kt
@@ -56,7 +56,7 @@ class RedshiftDataDumper(
 
             // Use the TableSchemaMapper to get the correct table name
             val tableName = schemaMapper.toFinalTableName(stream.mappedDescriptor)
-            val sqlGenerator = RedshiftSqlGenerator()
+            val sqlGenerator = RedshiftSqlGenerator(config)
             val quotedTableName = sqlGenerator.getFullyQualifiedName(tableName)
             val existsResultSet = statement.executeQuery(sqlGenerator.tableExists(tableName))
             existsResultSet.next()

--- a/airbyte-integrations/connectors/destination-redshift-v2/src/test-integration/kotlin/io/airbyte/integrations/destination/redshift2/write/RedshiftTestConfigProvider.kt
+++ b/airbyte-integrations/connectors/destination-redshift-v2/src/test-integration/kotlin/io/airbyte/integrations/destination/redshift2/write/RedshiftTestConfigProvider.kt
@@ -25,8 +25,8 @@ import software.amazon.awssdk.services.s3.S3Client
  */
 object RedshiftTestConfigProvider {
 
-    /** Shared, stateless SQL generator instance. */
-    val sqlGenerator = RedshiftSqlGenerator()
+    /** Creates a SQL generator instance for the given configuration. */
+    fun sqlGenerator(config: RedshiftConfiguration) = RedshiftSqlGenerator(config)
 
     /** No-op S3 client stub for tests that don't need S3 (schema discovery, regression). */
     val noOpS3Client: S3Client by lazy { S3Client.builder().region(Region.US_EAST_1).build() }
@@ -52,6 +52,6 @@ object RedshiftTestConfigProvider {
     fun airbyteClientFrom(spec: ConfigurationSpecification): RedshiftAirbyteClient {
         val config = configFrom(spec)
         val dataSource = RedshiftConnect(config).createDataSource()
-        return RedshiftAirbyteClient(dataSource, sqlGenerator, noOpS3Client)
+        return RedshiftAirbyteClient(dataSource, sqlGenerator(config), noOpS3Client)
     }
 }

--- a/airbyte-integrations/connectors/destination-redshift-v2/src/test-integration/resources/expected-spec-cloud.json
+++ b/airbyte-integrations/connectors/destination-redshift-v2/src/test-integration/resources/expected-spec-cloud.json
@@ -64,8 +64,8 @@
       },
       "drop_cascade" : {
         "type" : "boolean",
-        "description" : "Drop tables with CASCADE. WARNING! This will delete all data in all dependent objects (views, etc.). Use with caution. This option is intended for usecases which can easily rebuild the dependent objects.",
-        "title" : "Drop tables with CASCADE. (WARNING! Risk of unrecoverable data loss)",
+        "description" : "WARNING! This will delete all data in all dependent objects (views, etc.) including during schema evolution of columns. Use with caution. This option is intended for usecases which can easily rebuild the dependent objects.",
+        "title" : "Drop tables and columns with CASCADE. (WARNING! Risk of unrecoverable data loss)",
         "group" : "connection",
         "order" : 8,
         "default" : false

--- a/airbyte-integrations/connectors/destination-redshift-v2/src/test-integration/resources/expected-spec-cloud.json
+++ b/airbyte-integrations/connectors/destination-redshift-v2/src/test-integration/resources/expected-spec-cloud.json
@@ -62,11 +62,19 @@
         "group" : "connection",
         "order" : 7
       },
+      "drop_cascade" : {
+        "type" : "boolean",
+        "description" : "Drop tables with CASCADE. WARNING! This will delete all data in all dependent objects (views, etc.). Use with caution. This option is intended for usecases which can easily rebuild the dependent objects.",
+        "title" : "Drop tables with CASCADE. (WARNING! Risk of unrecoverable data loss)",
+        "group" : "connection",
+        "order" : 8,
+        "default" : false
+      },
       "uploading_method" : {
         "description" : "The way data will be uploaded to Redshift.",
         "title" : "Uploading Method",
         "group" : "connection",
-        "order" : 8,
+        "order" : 9,
         "display_type" : "radio",
         "type" : "object",
         "additionalProperties" : true,
@@ -213,16 +221,8 @@
         "description" : "Whether to initiate an SSH tunnel before connecting to the database, and if so, which kind of authentication to use.",
         "title" : "SSH Tunnel Method",
         "group" : "connection",
-        "order" : 9,
+        "order" : 10,
         "type" : "object"
-      },
-      "drop_cascade" : {
-        "type" : "boolean",
-        "description" : "Drop tables with CASCADE. WARNING! This will delete all data in all dependent objects (views, etc.). Use with caution. This option is intended for usecases which can easily rebuild the dependent objects.",
-        "title" : "Drop tables with CASCADE. (WARNING! Risk of unrecoverable data loss)",
-        "group" : "tables",
-        "order" : 1,
-        "default" : false
       }
     },
     "required" : [ "host", "port", "username", "password", "database", "schema" ],

--- a/airbyte-integrations/connectors/destination-redshift-v2/src/test-integration/resources/expected-spec-cloud.json
+++ b/airbyte-integrations/connectors/destination-redshift-v2/src/test-integration/resources/expected-spec-cloud.json
@@ -215,6 +215,14 @@
         "group" : "connection",
         "order" : 9,
         "type" : "object"
+      },
+      "drop_cascade" : {
+        "type" : "boolean",
+        "description" : "Drop tables with CASCADE. WARNING! This will delete all data in all dependent objects (views, etc.). Use with caution. This option is intended for usecases which can easily rebuild the dependent objects.",
+        "title" : "Drop tables with CASCADE. (WARNING! Risk of unrecoverable data loss)",
+        "group" : "tables",
+        "order" : 1,
+        "default" : false
       }
     },
     "required" : [ "host", "port", "username", "password", "database", "schema" ],

--- a/airbyte-integrations/connectors/destination-redshift-v2/src/test-integration/resources/expected-spec-oss.json
+++ b/airbyte-integrations/connectors/destination-redshift-v2/src/test-integration/resources/expected-spec-oss.json
@@ -64,8 +64,8 @@
       },
       "drop_cascade" : {
         "type" : "boolean",
-        "description" : "Drop tables with CASCADE. WARNING! This will delete all data in all dependent objects (views, etc.). Use with caution. This option is intended for usecases which can easily rebuild the dependent objects.",
-        "title" : "Drop tables with CASCADE. (WARNING! Risk of unrecoverable data loss)",
+        "description" : "WARNING! This will delete all data in all dependent objects (views, etc.) including during schema evolution of columns. Use with caution. This option is intended for usecases which can easily rebuild the dependent objects.",
+        "title" : "Drop tables and columns with CASCADE. (WARNING! Risk of unrecoverable data loss)",
         "group" : "connection",
         "order" : 8,
         "default" : false

--- a/airbyte-integrations/connectors/destination-redshift-v2/src/test-integration/resources/expected-spec-oss.json
+++ b/airbyte-integrations/connectors/destination-redshift-v2/src/test-integration/resources/expected-spec-oss.json
@@ -62,11 +62,19 @@
         "group" : "connection",
         "order" : 7
       },
+      "drop_cascade" : {
+        "type" : "boolean",
+        "description" : "Drop tables with CASCADE. WARNING! This will delete all data in all dependent objects (views, etc.). Use with caution. This option is intended for usecases which can easily rebuild the dependent objects.",
+        "title" : "Drop tables with CASCADE. (WARNING! Risk of unrecoverable data loss)",
+        "group" : "connection",
+        "order" : 8,
+        "default" : false
+      },
       "uploading_method" : {
         "description" : "The way data will be uploaded to Redshift.",
         "title" : "Uploading Method",
         "group" : "connection",
-        "order" : 8,
+        "order" : 9,
         "display_type" : "radio",
         "type" : "object",
         "additionalProperties" : true,
@@ -213,16 +221,8 @@
         "description" : "Whether to initiate an SSH tunnel before connecting to the database, and if so, which kind of authentication to use.",
         "title" : "SSH Tunnel Method",
         "group" : "connection",
-        "order" : 9,
+        "order" : 10,
         "type" : "object"
-      },
-      "drop_cascade" : {
-        "type" : "boolean",
-        "description" : "Drop tables with CASCADE. WARNING! This will delete all data in all dependent objects (views, etc.). Use with caution. This option is intended for usecases which can easily rebuild the dependent objects.",
-        "title" : "Drop tables with CASCADE. (WARNING! Risk of unrecoverable data loss)",
-        "group" : "tables",
-        "order" : 1,
-        "default" : false
       }
     },
     "required" : [ "host", "port", "username", "password", "database", "schema" ],

--- a/airbyte-integrations/connectors/destination-redshift-v2/src/test-integration/resources/expected-spec-oss.json
+++ b/airbyte-integrations/connectors/destination-redshift-v2/src/test-integration/resources/expected-spec-oss.json
@@ -215,6 +215,14 @@
         "group" : "connection",
         "order" : 9,
         "type" : "object"
+      },
+      "drop_cascade" : {
+        "type" : "boolean",
+        "description" : "Drop tables with CASCADE. WARNING! This will delete all data in all dependent objects (views, etc.). Use with caution. This option is intended for usecases which can easily rebuild the dependent objects.",
+        "title" : "Drop tables with CASCADE. (WARNING! Risk of unrecoverable data loss)",
+        "group" : "tables",
+        "order" : 1,
+        "default" : false
       }
     },
     "required" : [ "host", "port", "username", "password", "database", "schema" ],

--- a/airbyte-integrations/connectors/destination-redshift-v2/src/test-integration/resources/golden_files/RedshiftRegressionTest/schema-regression/column_names/append.json
+++ b/airbyte-integrations/connectors/destination-redshift-v2/src/test-integration/resources/golden_files/RedshiftRegressionTest/schema-regression/column_names/append.json
@@ -1,0 +1,6 @@
+{
+  "tableSchema" : {
+    "columns" : { }
+  },
+  "additionalInfo" : { }
+}

--- a/airbyte-integrations/connectors/destination-redshift-v2/src/test-integration/resources/golden_files/RedshiftRegressionTest/schema-regression/column_names/dedup_colliding_names.json
+++ b/airbyte-integrations/connectors/destination-redshift-v2/src/test-integration/resources/golden_files/RedshiftRegressionTest/schema-regression/column_names/dedup_colliding_names.json
@@ -1,0 +1,6 @@
+{
+  "tableSchema" : {
+    "columns" : { }
+  },
+  "additionalInfo" : { }
+}

--- a/airbyte-integrations/connectors/destination-redshift-v2/src/test-integration/resources/golden_files/RedshiftRegressionTest/schema-regression/column_names/dedup_funky_chars_cursor.json
+++ b/airbyte-integrations/connectors/destination-redshift-v2/src/test-integration/resources/golden_files/RedshiftRegressionTest/schema-regression/column_names/dedup_funky_chars_cursor.json
@@ -1,0 +1,6 @@
+{
+  "tableSchema" : {
+    "columns" : { }
+  },
+  "additionalInfo" : { }
+}

--- a/airbyte-integrations/connectors/destination-redshift-v2/src/test-integration/resources/golden_files/RedshiftRegressionTest/schema-regression/column_names/dedup_funky_chars_pk.json
+++ b/airbyte-integrations/connectors/destination-redshift-v2/src/test-integration/resources/golden_files/RedshiftRegressionTest/schema-regression/column_names/dedup_funky_chars_pk.json
@@ -1,0 +1,6 @@
+{
+  "tableSchema" : {
+    "columns" : { }
+  },
+  "additionalInfo" : { }
+}

--- a/airbyte-integrations/connectors/destination-redshift-v2/src/test-integration/resources/golden_files/RedshiftRegressionTest/schema-regression/column_names/dedup_simple.json
+++ b/airbyte-integrations/connectors/destination-redshift-v2/src/test-integration/resources/golden_files/RedshiftRegressionTest/schema-regression/column_names/dedup_simple.json
@@ -1,0 +1,6 @@
+{
+  "tableSchema" : {
+    "columns" : { }
+  },
+  "additionalInfo" : { }
+}

--- a/airbyte-integrations/connectors/destination-redshift-v2/src/test/kotlin/io/airbyte/integrations/destination/redshift2/check/RedshiftCheckerUnitTest.kt
+++ b/airbyte-integrations/connectors/destination-redshift-v2/src/test/kotlin/io/airbyte/integrations/destination/redshift2/check/RedshiftCheckerUnitTest.kt
@@ -195,6 +195,7 @@ class RedshiftCheckerUnitTest {
                         secretAccessKey = "secret",
                     ),
                 tunnelMethod = null,
+                dropCascade = false,
             )
     }
 

--- a/airbyte-integrations/connectors/destination-redshift-v2/src/test/kotlin/io/airbyte/integrations/destination/redshift2/client/RedshiftAirbyteClientTest.kt
+++ b/airbyte-integrations/connectors/destination-redshift-v2/src/test/kotlin/io/airbyte/integrations/destination/redshift2/client/RedshiftAirbyteClientTest.kt
@@ -566,7 +566,7 @@ internal class RedshiftAirbyteClientTest {
 
     @Test
     fun `normalizeRedshiftType maps numeric`() {
-        assertEquals("numeric(38,9)", client.normalizeRedshiftType("numeric"))
+        assertEquals("decimal(38,9)", client.normalizeRedshiftType("numeric"))
     }
 
     @Test

--- a/airbyte-integrations/connectors/destination-redshift-v2/src/test/kotlin/io/airbyte/integrations/destination/redshift2/client/RedshiftAirbyteClientTest.kt
+++ b/airbyte-integrations/connectors/destination-redshift-v2/src/test/kotlin/io/airbyte/integrations/destination/redshift2/client/RedshiftAirbyteClientTest.kt
@@ -352,6 +352,7 @@ internal class RedshiftAirbyteClientTest {
 
         val thrown = assertThrows<ConfigErrorException> { client.execute("DROP TABLE something") }
         assertTrue(thrown.message!!.contains("other database objects"))
+        assertTrue(thrown.message!!.contains("Drop tables with CASCADE"))
         assertTrue(thrown.message!!.contains("pg_depend"))
     }
 
@@ -362,6 +363,7 @@ internal class RedshiftAirbyteClientTest {
 
         val thrown = assertThrows<ConfigErrorException> { client.execute("ALTER TABLE something") }
         assertTrue(thrown.message!!.contains("other database objects"))
+        assertTrue(thrown.message!!.contains("Drop tables with CASCADE"))
     }
 
     @Test

--- a/airbyte-integrations/connectors/destination-redshift-v2/src/test/kotlin/io/airbyte/integrations/destination/redshift2/config/RedshiftConfigurationFactoryTest.kt
+++ b/airbyte-integrations/connectors/destination-redshift-v2/src/test/kotlin/io/airbyte/integrations/destination/redshift2/config/RedshiftConfigurationFactoryTest.kt
@@ -30,6 +30,7 @@ class RedshiftConfigurationFactoryTest {
         jdbcUrlParams: String? = null,
         hasUploadingMethod: Boolean = false,
         tunnelMethodValue: SshTunnelMethodConfiguration? = SshNoTunnelMethod,
+        dropCascade: Boolean = false,
     ): RedshiftSpecification = mockk {
         every { this@mockk.host } returns host
         every { this@mockk.port } returns port
@@ -40,6 +41,7 @@ class RedshiftConfigurationFactoryTest {
         every { this@mockk.jdbcUrlParams } returns jdbcUrlParams
         every { this@mockk.uploadingMethod } returns if (hasUploadingMethod) mockk() else null
         every { getTunnelMethodValue() } returns tunnelMethodValue
+        every { this@mockk.dropCascade } returns dropCascade
     }
 
     @Test
@@ -55,6 +57,7 @@ class RedshiftConfigurationFactoryTest {
                 jdbcUrlParams = "ssl=true&timeout=30",
                 hasUploadingMethod = true,
                 tunnelMethodValue = SshNoTunnelMethod,
+                dropCascade = true,
             )
 
         val config = factory.makeWithoutExceptionHandling(spec)
@@ -68,6 +71,7 @@ class RedshiftConfigurationFactoryTest {
         assertEquals("ssl=true&timeout=30", config.jdbcUrlParams)
         assertNotNull(config.uploadingMethod)
         assertEquals(SshNoTunnelMethod, config.tunnelMethod)
+        assertEquals(true, config.dropCascade)
     }
 
     @Test
@@ -84,6 +88,7 @@ class RedshiftConfigurationFactoryTest {
         assertNull(config.jdbcUrlParams)
         assertNull(config.uploadingMethod)
         assertNull(config.tunnelMethod)
+        assertEquals(false, config.dropCascade)
     }
 
     @Test
@@ -135,5 +140,6 @@ class RedshiftConfigurationFactoryTest {
 
         assertEquals(5439, config.port)
         assertEquals("public", config.schema)
+        assertEquals(false, config.dropCascade)
     }
 }

--- a/airbyte-integrations/connectors/destination-redshift-v2/src/test/kotlin/io/airbyte/integrations/destination/redshift2/config/RedshiftConfigurationFactoryTest.kt
+++ b/airbyte-integrations/connectors/destination-redshift-v2/src/test/kotlin/io/airbyte/integrations/destination/redshift2/config/RedshiftConfigurationFactoryTest.kt
@@ -30,7 +30,7 @@ class RedshiftConfigurationFactoryTest {
         jdbcUrlParams: String? = null,
         hasUploadingMethod: Boolean = false,
         tunnelMethodValue: SshTunnelMethodConfiguration? = SshNoTunnelMethod,
-        dropCascade: Boolean = false,
+        dropCascade: Boolean? = false,
     ): RedshiftSpecification = mockk {
         every { this@mockk.host } returns host
         every { this@mockk.port } returns port
@@ -130,6 +130,15 @@ class RedshiftConfigurationFactoryTest {
         assertEquals(2222, tunnel.port)
         assertEquals("tunnel-user", tunnel.user)
         assertEquals("tunnel-pass", tunnel.password)
+    }
+
+    @Test
+    fun `dropCascade defaults to false when null`() {
+        val spec = spec(dropCascade = null)
+
+        val config = factory.makeWithoutExceptionHandling(spec)
+
+        assertEquals(false, config.dropCascade)
     }
 
     @Test

--- a/airbyte-integrations/connectors/destination-redshift-v2/src/test/kotlin/io/airbyte/integrations/destination/redshift2/connect/RedshiftConnectTest.kt
+++ b/airbyte-integrations/connectors/destination-redshift-v2/src/test/kotlin/io/airbyte/integrations/destination/redshift2/connect/RedshiftConnectTest.kt
@@ -32,6 +32,7 @@ class RedshiftConnectTest {
             jdbcUrlParams = jdbcUrlParams,
             uploadingMethod = null,
             tunnelMethod = tunnelMethod,
+            dropCascade = false,
         )
 
     @Test

--- a/airbyte-integrations/connectors/destination-redshift-v2/src/test/kotlin/io/airbyte/integrations/destination/redshift2/dataflow/RedshiftAggregateFactoryTest.kt
+++ b/airbyte-integrations/connectors/destination-redshift-v2/src/test/kotlin/io/airbyte/integrations/destination/redshift2/dataflow/RedshiftAggregateFactoryTest.kt
@@ -49,6 +49,7 @@ internal class RedshiftAggregateFactoryTest {
             jdbcUrlParams = null,
             uploadingMethod = s3Config,
             tunnelMethod = null,
+            dropCascade = false,
         )
 
     private lateinit var factory: RedshiftAggregateFactory

--- a/airbyte-integrations/connectors/destination-redshift-v2/src/test/kotlin/io/airbyte/integrations/destination/redshift2/schema/RedshiftTableSchemaMapperTest.kt
+++ b/airbyte-integrations/connectors/destination-redshift-v2/src/test/kotlin/io/airbyte/integrations/destination/redshift2/schema/RedshiftTableSchemaMapperTest.kt
@@ -179,7 +179,7 @@ class RedshiftTableSchemaMapperTest {
                 // Simple types
                 Arguments.of(FieldType(BooleanType, false), "boolean"),
                 Arguments.of(FieldType(IntegerType, true), "bigint"),
-                Arguments.of(FieldType(NumberType, false), "numeric(38,9)"),
+                Arguments.of(FieldType(NumberType, false), "decimal(38,9)"),
                 Arguments.of(FieldType(StringType, true), "varchar(65535)"),
                 // Temporal types
                 Arguments.of(FieldType(DateType, false), "date"),
@@ -214,7 +214,7 @@ class RedshiftTableSchemaMapperTest {
                         UnknownType(com.fasterxml.jackson.databind.node.NullNode.instance),
                         false,
                     ),
-                    "super",
+                    "varchar(65535)",
                 ),
             )
     }

--- a/airbyte-integrations/connectors/destination-redshift-v2/src/test/kotlin/io/airbyte/integrations/destination/redshift2/sql/RedshiftSqlGeneratorTest.kt
+++ b/airbyte-integrations/connectors/destination-redshift-v2/src/test/kotlin/io/airbyte/integrations/destination/redshift2/sql/RedshiftSqlGeneratorTest.kt
@@ -4,6 +4,7 @@
 
 package io.airbyte.integrations.destination.redshift2.sql
 
+import io.airbyte.cdk.load.command.Append
 import io.airbyte.cdk.load.command.Dedupe
 import io.airbyte.cdk.load.command.DestinationStream
 import io.airbyte.cdk.load.component.ColumnType
@@ -14,6 +15,7 @@ import io.airbyte.cdk.load.schema.model.ColumnSchema
 import io.airbyte.cdk.load.schema.model.StreamTableSchema
 import io.airbyte.cdk.load.schema.model.TableName
 import io.airbyte.cdk.load.table.CDC_DELETED_AT_COLUMN
+import io.airbyte.integrations.destination.redshift2.config.RedshiftConfiguration
 import io.mockk.every
 import io.mockk.mockk
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -21,6 +23,7 @@ import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 
@@ -28,9 +31,12 @@ internal class RedshiftSqlGeneratorTest {
 
     private lateinit var sqlGenerator: RedshiftSqlGenerator
 
+    private fun mockConfig(dropCascade: Boolean = false): RedshiftConfiguration =
+        mockk<RedshiftConfiguration> { every { this@mockk.dropCascade } returns dropCascade }
+
     @BeforeEach
     fun setUp() {
-        sqlGenerator = RedshiftSqlGenerator()
+        sqlGenerator = RedshiftSqlGenerator(mockConfig(dropCascade = false))
     }
 
     // ================================================================
@@ -57,6 +63,20 @@ internal class RedshiftSqlGeneratorTest {
                 every { getPrimaryKey() } returns primaryKey
                 every { getCursor() } returns cursor
                 every { importType } returns Dedupe(primaryKey = primaryKey, cursor = cursor)
+            }
+        return mockk<DestinationStream> { every { tableSchema } returns streamTableSchema }
+    }
+
+    private fun mockAppendStream(
+        finalSchema: Map<String, ColumnType>,
+    ): DestinationStream {
+        val columnSchema = ColumnSchema(emptyMap(), emptyMap(), finalSchema)
+        val streamTableSchema =
+            mockk<StreamTableSchema> {
+                every { this@mockk.columnSchema } returns columnSchema
+                every { getPrimaryKey() } returns emptyList()
+                every { getCursor() } returns emptyList()
+                every { importType } returns Append
             }
         return mockk<DestinationStream> { every { tableSchema } returns streamTableSchema }
     }
@@ -141,6 +161,105 @@ internal class RedshiftSqlGeneratorTest {
         assertFalse(sql.contains("BEGIN TRANSACTION;"))
         assertFalse(sql.contains("COMMIT;"))
         assertTrue(sql.contains("CREATE TABLE IF NOT EXISTS"))
+    }
+
+    // ================================================================
+    // DDL: DISTKEY / SORTKEY
+    // ================================================================
+
+    @Test
+    fun `createTable for dedup stream with single PK adds DISTKEY and SORTKEY`() {
+        val finalSchema =
+            mapOf(
+                "id" to ColumnType("bigint", false),
+                "name" to ColumnType("varchar(65535)", true),
+            )
+        val stream =
+            mockStream(
+                finalSchema = finalSchema,
+                primaryKey = listOf(listOf("id")),
+                cursor = listOf("updated_at"),
+            )
+        val tableName = TableName(namespace = "public", name = "users")
+
+        val sql = sqlGenerator.createTable(stream, tableName, replace = false)
+
+        assertTrue(sql.contains("""DISTKEY("id")"""), "Expected DISTKEY on first PK column")
+        assertTrue(
+            sql.contains("""COMPOUND SORTKEY("id")"""),
+            "Expected COMPOUND SORTKEY on PK columns",
+        )
+    }
+
+    @Test
+    fun `createTable for dedup stream with multiple PKs uses first PK as DISTKEY and all PKs as SORTKEY`() {
+        val finalSchema =
+            mapOf(
+                "org_id" to ColumnType("bigint", false),
+                "user_id" to ColumnType("bigint", false),
+                "name" to ColumnType("varchar(65535)", true),
+            )
+        val stream =
+            mockStream(
+                finalSchema = finalSchema,
+                primaryKey = listOf(listOf("org_id"), listOf("user_id")),
+                cursor = listOf("updated_at"),
+            )
+        val tableName = TableName(namespace = "public", name = "org_users")
+
+        val sql = sqlGenerator.createTable(stream, tableName, replace = false)
+
+        assertTrue(
+            sql.contains("""DISTKEY("org_id")"""),
+            "Expected DISTKEY on first PK column",
+        )
+        assertTrue(
+            sql.contains("""COMPOUND SORTKEY("org_id", "user_id")"""),
+            "Expected COMPOUND SORTKEY on all PK columns",
+        )
+    }
+
+    @Test
+    fun `createTable for append stream has no DISTKEY or SORTKEY`() {
+        val finalSchema =
+            mapOf(
+                "id" to ColumnType("bigint", false),
+                "name" to ColumnType("varchar(65535)", true),
+            )
+        val stream = mockAppendStream(finalSchema)
+        val tableName = TableName(namespace = "public", name = "events")
+
+        val sql = sqlGenerator.createTable(stream, tableName, replace = false)
+
+        assertFalse(sql.contains("DISTKEY"), "Append stream should not have DISTKEY")
+        assertFalse(sql.contains("SORTKEY"), "Append stream should not have SORTKEY")
+    }
+
+    @Test
+    fun `createTable for dedup stream with replace preserves DISTKEY and SORTKEY`() {
+        val finalSchema =
+            mapOf(
+                "id" to ColumnType("bigint", false),
+                "name" to ColumnType("varchar(65535)", true),
+            )
+        val stream =
+            mockStream(
+                finalSchema = finalSchema,
+                primaryKey = listOf(listOf("id")),
+                cursor = listOf("updated_at"),
+            )
+        val tableName = TableName(namespace = "public", name = "users")
+
+        val sql = sqlGenerator.createTable(stream, tableName, replace = true)
+
+        assertTrue(sql.contains("BEGIN TRANSACTION;"))
+        assertTrue(sql.contains("DROP TABLE IF EXISTS"))
+        assertTrue(sql.contains("""DISTKEY("id")"""), "Expected DISTKEY in replace mode")
+        assertTrue(
+            sql.contains("""COMPOUND SORTKEY("id")"""),
+            "Expected COMPOUND SORTKEY in replace mode",
+        )
+        assertTrue(sql.contains("COMMIT;"))
     }
 
     @Test
@@ -685,5 +804,129 @@ internal class RedshiftSqlGeneratorTest {
     fun `blank namespace is passed through without defaulting`() {
         val sql = sqlGenerator.dropTable(TableName(namespace = "", name = "tbl"))
         assertEquals("""DROP TABLE IF EXISTS ""."tbl";""", sql)
+    }
+
+    // ================================================================
+    // Drop CASCADE tests
+    // ================================================================
+
+    @Nested
+    inner class DropCascadeTests {
+
+        private lateinit var cascadeGenerator: RedshiftSqlGenerator
+
+        @BeforeEach
+        fun setUp() {
+            cascadeGenerator = RedshiftSqlGenerator(mockConfig(dropCascade = true))
+        }
+
+        @Test
+        fun `dropTable with cascade appends CASCADE`() {
+            val sql = cascadeGenerator.dropTable(TableName(namespace = "ns", name = "tbl"))
+            assertEquals("""DROP TABLE IF EXISTS "ns"."tbl" CASCADE;""", sql)
+        }
+
+        @Test
+        fun `createTable with replace and cascade appends CASCADE to DROP`() {
+            val finalSchema =
+                mapOf(
+                    "id" to ColumnType("bigint", false),
+                    "name" to ColumnType("varchar(65535)", true),
+                )
+            val stream = mockStream(finalSchema)
+            val tableName = TableName(namespace = "public", name = "users")
+
+            val sql = cascadeGenerator.createTable(stream, tableName, replace = true)
+
+            assertTrue(sql.contains("""DROP TABLE IF EXISTS "public"."users" CASCADE;"""))
+            assertTrue(sql.contains("BEGIN TRANSACTION;"))
+            assertTrue(sql.contains("CREATE TABLE IF NOT EXISTS"))
+            assertTrue(sql.contains("COMMIT;"))
+        }
+
+        @Test
+        fun `createTable without replace and cascade does not add CASCADE`() {
+            val finalSchema = mapOf("id" to ColumnType("bigint", false))
+            val stream = mockStream(finalSchema)
+            val tableName = TableName(namespace = "public", name = "users")
+
+            val sql = cascadeGenerator.createTable(stream, tableName, replace = false)
+
+            assertFalse(sql.contains("CASCADE"))
+            assertFalse(sql.contains("DROP TABLE"))
+        }
+
+        @Test
+        fun `overwriteTable with cascade appends CASCADE to DROP`() {
+            val source = TableName(namespace = "ns", name = "tmp")
+            val target = TableName(namespace = "ns", name = "final")
+
+            val sql = cascadeGenerator.overwriteTable(source, target)
+
+            assertTrue(sql.contains("""DROP TABLE IF EXISTS "ns"."final" CASCADE;"""))
+            assertTrue(sql.contains("""ALTER TABLE "ns"."tmp" RENAME TO "final""""))
+        }
+
+        @Test
+        fun `matchSchemas removes columns with CASCADE`() {
+            val tableName = TableName(namespace = "ns", name = "tbl")
+            val sql =
+                cascadeGenerator.matchSchemas(
+                    tableName,
+                    columnsToAdd = emptyMap(),
+                    columnsToRemove = mapOf("old_col" to ColumnType("varchar", true)),
+                    columnsToModify = emptyMap(),
+                )
+
+            assertTrue(sql.contains("""ALTER TABLE "ns"."tbl" DROP COLUMN "old_col" CASCADE;"""))
+        }
+
+        @Test
+        fun `matchSchemas type change drops column with CASCADE`() {
+            val tableName = TableName(namespace = "ns", name = "tbl")
+            val sql =
+                cascadeGenerator.matchSchemas(
+                    tableName,
+                    columnsToAdd = emptyMap(),
+                    columnsToRemove = emptyMap(),
+                    columnsToModify =
+                        mapOf(
+                            "num_col" to
+                                ColumnTypeChange(
+                                    originalType = ColumnType("bigint", false),
+                                    newType = ColumnType("numeric(38,9)", false),
+                                )
+                        ),
+                )
+
+            assertTrue(sql.contains("""DROP COLUMN "num_col" CASCADE;"""))
+            assertTrue(sql.contains("""RENAME COLUMN "_airbyte_tmp_num_col" TO "num_col";"""))
+        }
+
+        @Test
+        fun `upsertTable temp table drop does not use CASCADE even when enabled`() {
+            val finalSchema =
+                mapOf(
+                    "id" to ColumnType("bigint", false),
+                    "name" to ColumnType("varchar(65535)", true),
+                    "updated_at" to ColumnType("timestamptz", true),
+                )
+            val stream =
+                mockStream(
+                    finalSchema = finalSchema,
+                    primaryKey = listOf(listOf("id")),
+                    cursor = listOf("updated_at"),
+                )
+
+            val source = TableName(namespace = "ns", name = "staging")
+            val target = TableName(namespace = "ns", name = "final")
+
+            val sql = cascadeGenerator.upsertTable(stream, source, target)
+
+            // The temp table drop should NOT have CASCADE (temp tables can't have dependent views)
+            val dedup = """"_airbyte_dedup_staging""""
+            assertTrue(sql.contains("DROP TABLE IF EXISTS $dedup;"))
+            assertFalse(sql.contains("DROP TABLE IF EXISTS $dedup CASCADE;"))
+        }
     }
 }

--- a/airbyte-integrations/connectors/destination-redshift-v2/src/test/kotlin/io/airbyte/integrations/destination/redshift2/sql/RedshiftSqlGeneratorTest.kt
+++ b/airbyte-integrations/connectors/destination-redshift-v2/src/test/kotlin/io/airbyte/integrations/destination/redshift2/sql/RedshiftSqlGeneratorTest.kt
@@ -743,13 +743,13 @@ internal class RedshiftSqlGeneratorTest {
                         "num_col" to
                             ColumnTypeChange(
                                 originalType = ColumnType("bigint", false),
-                                newType = ColumnType("numeric(38,9)", false),
+                                newType = ColumnType("decimal(38,9)", false),
                             )
                     ),
             )
 
-        assertTrue(sql.contains("""ADD COLUMN "_airbyte_tmp_num_col" numeric(38,9);"""))
-        assertTrue(sql.contains("""CAST("num_col" AS numeric(38,9))"""))
+        assertTrue(sql.contains("""ADD COLUMN "_airbyte_tmp_num_col" decimal(38,9);"""))
+        assertTrue(sql.contains("""CAST("num_col" AS decimal(38,9))"""))
         assertTrue(sql.contains("""DESTINATION_TYPECAST_ERROR"""))
         assertTrue(sql.contains(""""num_col" IS NOT NULL"""))
         assertTrue(sql.contains(""""_airbyte_tmp_num_col" IS NULL"""))
@@ -894,7 +894,7 @@ internal class RedshiftSqlGeneratorTest {
                             "num_col" to
                                 ColumnTypeChange(
                                     originalType = ColumnType("bigint", false),
-                                    newType = ColumnType("numeric(38,9)", false),
+                                    newType = ColumnType("decimal(38,9)", false),
                                 )
                         ),
                 )

--- a/airbyte-integrations/connectors/destination-redshift-v2/src/test/kotlin/io/airbyte/integrations/destination/redshift2/sql/RedshiftSqlGeneratorTest.kt
+++ b/airbyte-integrations/connectors/destination-redshift-v2/src/test/kotlin/io/airbyte/integrations/destination/redshift2/sql/RedshiftSqlGeneratorTest.kt
@@ -163,12 +163,8 @@ internal class RedshiftSqlGeneratorTest {
         assertTrue(sql.contains("CREATE TABLE IF NOT EXISTS"))
     }
 
-    // ================================================================
-    // DDL: DISTKEY / SORTKEY
-    // ================================================================
-
     @Test
-    fun `createTable for dedup stream with single PK adds DISTKEY and SORTKEY`() {
+    fun `createTable does not include DISTKEY or SORTKEY`() {
         val finalSchema =
             mapOf(
                 "id" to ColumnType("bigint", false),
@@ -184,59 +180,12 @@ internal class RedshiftSqlGeneratorTest {
 
         val sql = sqlGenerator.createTable(stream, tableName, replace = false)
 
-        assertTrue(sql.contains("""DISTKEY("id")"""), "Expected DISTKEY on first PK column")
-        assertTrue(
-            sql.contains("""COMPOUND SORTKEY("id")"""),
-            "Expected COMPOUND SORTKEY on PK columns",
-        )
+        assertFalse(sql.contains("DISTKEY"), "Should not have DISTKEY")
+        assertFalse(sql.contains("SORTKEY"), "Should not have SORTKEY")
     }
 
     @Test
-    fun `createTable for dedup stream with multiple PKs uses first PK as DISTKEY and all PKs as SORTKEY`() {
-        val finalSchema =
-            mapOf(
-                "org_id" to ColumnType("bigint", false),
-                "user_id" to ColumnType("bigint", false),
-                "name" to ColumnType("varchar(65535)", true),
-            )
-        val stream =
-            mockStream(
-                finalSchema = finalSchema,
-                primaryKey = listOf(listOf("org_id"), listOf("user_id")),
-                cursor = listOf("updated_at"),
-            )
-        val tableName = TableName(namespace = "public", name = "org_users")
-
-        val sql = sqlGenerator.createTable(stream, tableName, replace = false)
-
-        assertTrue(
-            sql.contains("""DISTKEY("org_id")"""),
-            "Expected DISTKEY on first PK column",
-        )
-        assertTrue(
-            sql.contains("""COMPOUND SORTKEY("org_id", "user_id")"""),
-            "Expected COMPOUND SORTKEY on all PK columns",
-        )
-    }
-
-    @Test
-    fun `createTable for append stream has no DISTKEY or SORTKEY`() {
-        val finalSchema =
-            mapOf(
-                "id" to ColumnType("bigint", false),
-                "name" to ColumnType("varchar(65535)", true),
-            )
-        val stream = mockAppendStream(finalSchema)
-        val tableName = TableName(namespace = "public", name = "events")
-
-        val sql = sqlGenerator.createTable(stream, tableName, replace = false)
-
-        assertFalse(sql.contains("DISTKEY"), "Append stream should not have DISTKEY")
-        assertFalse(sql.contains("SORTKEY"), "Append stream should not have SORTKEY")
-    }
-
-    @Test
-    fun `createTable for dedup stream with replace preserves DISTKEY and SORTKEY`() {
+    fun `createTable for dedup stream with replace wraps in transaction`() {
         val finalSchema =
             mapOf(
                 "id" to ColumnType("bigint", false),
@@ -254,11 +203,8 @@ internal class RedshiftSqlGeneratorTest {
 
         assertTrue(sql.contains("BEGIN TRANSACTION;"))
         assertTrue(sql.contains("DROP TABLE IF EXISTS"))
-        assertTrue(sql.contains("""DISTKEY("id")"""), "Expected DISTKEY in replace mode")
-        assertTrue(
-            sql.contains("""COMPOUND SORTKEY("id")"""),
-            "Expected COMPOUND SORTKEY in replace mode",
-        )
+        assertFalse(sql.contains("DISTKEY"), "Should not have DISTKEY")
+        assertFalse(sql.contains("SORTKEY"), "Should not have SORTKEY")
         assertTrue(sql.contains("COMMIT;"))
     }
 

--- a/airbyte-integrations/connectors/destination-redshift-v2/src/test/kotlin/io/airbyte/integrations/destination/redshift2/write/load/RedshiftInsertBufferTest.kt
+++ b/airbyte-integrations/connectors/destination-redshift-v2/src/test/kotlin/io/airbyte/integrations/destination/redshift2/write/load/RedshiftInsertBufferTest.kt
@@ -258,27 +258,6 @@ internal class RedshiftInsertBufferTest {
         assertEquals(0, buffer.recordCount)
     }
 
-    @Test
-    fun `default region used when s3BucketRegion is null`() = runTest {
-        val noRegionConfig = s3Config.copy(s3BucketRegion = null)
-        val noRegionConfiguration = configuration.copy(uploadingMethod = noRegionConfig)
-        val noRegionBuffer =
-            RedshiftInsertBuffer(tableName, columns, redshiftClient, noRegionConfiguration)
-
-        noRegionBuffer.accumulate(mapOf("_airbyte_raw_id" to StringValue("x")))
-        noRegionBuffer.flush()
-
-        coVerify {
-            redshiftClient.copyFromS3(
-                tableName = any(),
-                s3Path = any(),
-                accessKeyId = any(),
-                secretAccessKey = any(),
-                region = eq("us-east-1"),
-            )
-        }
-    }
-
     // ================================================================
     // fileNamePattern tests
     // ================================================================

--- a/airbyte-integrations/connectors/destination-redshift-v2/src/test/kotlin/io/airbyte/integrations/destination/redshift2/write/load/RedshiftInsertBufferTest.kt
+++ b/airbyte-integrations/connectors/destination-redshift-v2/src/test/kotlin/io/airbyte/integrations/destination/redshift2/write/load/RedshiftInsertBufferTest.kt
@@ -65,6 +65,7 @@ internal class RedshiftInsertBufferTest {
             jdbcUrlParams = null,
             uploadingMethod = s3Config,
             tunnelMethod = null,
+            dropCascade = false,
         )
 
     private lateinit var buffer: RedshiftInsertBuffer


### PR DESCRIPTION
## Summary

- **`drop_cascade` config option**: Adds a new boolean config field to support `CASCADE` on `DROP TABLE`/`DROP COLUMN`, allowing users with dependent views to use the connector.
- Rename NUMERIC(38,9) to DECIMAL (38,9). Both are same datatype. But renaming to avoid data type conversino when moving from v1 to v2.
