### PR TITLE
docs(enterprise-flex): use consistent SCREAMING_SNAKE_CASE for kubectl secret keys

### DIFF
--- a/docs/platform/enterprise-flex/data-plane.md
+++ b/docs/platform/enterprise-flex/data-plane.md
@@ -251,13 +251,12 @@ You can also use `kubectl` to create the secret directly from the command-line t
 
 ```bash
 kubectl create secret generic airbyte-config-secrets \
-  --from-literal=license-key='' \
   --from-literal=DATA_PLANE_CLIENT_ID='' \
   --from-literal=DATA_PLANE_CLIENT_SECRET='' \
-  --from-literal=s3-access-key-id='' \
-  --from-literal=s3-secret-access-key='' \
-  --from-literal=aws-secret-manager-access-key-id='' \
-  --from-literal=aws-secret-manager-secret-access-key='' \
+  --from-literal=S3_ACCESS_KEY_ID='' \
+  --from-literal=S3_SECRET_ACCESS_KEY='' \
+  --from-literal=AWS_SECRET_MANAGER_ACCESS_KEY_ID='' \
+  --from-literal=AWS_SECRET_MANAGER_SECRET_ACCESS_KEY='' \
   --namespace airbyte
 ```
 


### PR DESCRIPTION
## What

Fixes inconsistent casing of Kubernetes Secret keys in the [Enterprise Flex data plane deployment guide](https://docs.airbyte.com/platform/enterprise-flex/data-plane#step-3).

In step 3 ("Configure Kubernetes Secrets"), the YAML manifest example and the values.yaml references in step 4 already use `SCREAMING_SNAKE_CASE` (e.g. `DATA_PLANE_CLIENT_ID`, `S3_ACCESS_KEY_ID`, `AWS_SECRET_MANAGER_ACCESS_KEY_ID`), but the equivalent `kubectl create secret generic` command mixed `SCREAMING_SNAKE_CASE` and `kebab-case`. Following the snippet as written would have created Secret keys (`s3-access-key-id`, `aws-secret-manager-access-key-id`, etc.) that don't match the keys the values.yaml in step 4 expects, leaving the data plane unable to read its credentials.

It also dropped the `--from-literal=license-key=''` line, which is not part of the YAML manifest above and not referenced anywhere in the Flex `values.yaml` example — Enterprise Flex customers don't manage their own control-plane license key.

## How

In `docs/platform/enterprise-flex/data-plane.md`, the `kubectl create secret generic airbyte-config-secrets` snippet now uses `SCREAMING_SNAKE_CASE` for all six keys, matching:

- the `stringData:` block of the example Secret manifest immediately above it, and
- the `clientIdSecretKey` / `clientSecretSecretKey` / `accessKeyIdSecretKey` / `secretAccessKeySecretKey` references in the step-4 `values.yaml` (and the Helm chart's defaults, e.g. `DATAPLANE_CLIENT_ID`, `AWS_SECRET_MANAGER_ACCESS_KEY_ID`, `AWS_SECRET_MANAGER_SECRET_ACCESS_KEY` in `oss/charts/v2/airbyte-data-plane` and `oss/charts/v2/airbyte`).

`SCREAMING_SNAKE_CASE` is a Kubernetes-valid Secret key format (Secret keys must match `[-._a-zA-Z0-9]+`) and is the conventional shape for keys that are mounted as environment variables, which is how the Helm chart consumes these values.

## Review guide

1. `docs/platform/enterprise-flex/data-plane.md` — diff is a single block in step 3 ("Configure Kubernetes Secrets") under the AWS tab.

## User Impact

Customers copy-pasting the `kubectl create secret generic` command from the Flex data plane guide will now produce a Secret whose keys actually match the references in their `values.yaml`, so the Helm-deployed data plane can authenticate with the control plane and read its S3 / AWS Secret Manager credentials on the first try. No code changes; documentation only.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚
- [ ] NO ❌


Link to Devin session: https://app.devin.ai/sessions/a44feccb894a461882c876d25acbb709
Requested by: @ian-at-airbyte