### PR TITLE
fix(source-snowflake): switch Field.sql() to DataField.sql() for bulk-cdk SelectColumns API change

### DIFF
--- a/airbyte-integrations/connectors/source-snowflake/metadata.yaml
+++ b/airbyte-integrations/connectors/source-snowflake/metadata.yaml
@@ -8,7 +8,7 @@ data:
   connectorSubtype: database
   connectorType: source
   definitionId: e2d65910-8c8b-40a1-ae7d-ee2416b2bfa2
-  dockerImageTag: 1.0.10
+  dockerImageTag: 1.0.11
   dockerRepository: airbyte/source-snowflake
   documentationUrl: https://docs.airbyte.com/integrations/sources/snowflake
   githubIssueLabel: source-snowflake

--- a/airbyte-integrations/connectors/source-snowflake/src/main/kotlin/io/airbyte/integrations/source/snowflake/SnowflakeSourceOperations.kt
+++ b/airbyte-integrations/connectors/source-snowflake/src/main/kotlin/io/airbyte/integrations/source/snowflake/SnowflakeSourceOperations.kt
@@ -6,7 +6,7 @@ package io.airbyte.integrations.source.snowflake
 
 import com.fasterxml.jackson.databind.node.ObjectNode
 import io.airbyte.cdk.command.OpaqueStateValue
-import io.airbyte.cdk.discover.Field
+import io.airbyte.cdk.discover.DataField
 import io.airbyte.cdk.discover.FieldType
 import io.airbyte.cdk.discover.JdbcAirbyteStreamFactory
 import io.airbyte.cdk.discover.JdbcMetadataQuerier
@@ -149,7 +149,7 @@ class SnowflakeSourceOperations() :
                 is SelectColumnMaxValue -> "MAX(${column.sql()})"
             }
 
-    fun Field.sql(): String = "\"$id\""
+    fun DataField.sql(): String = "\"$id\""
 
     fun FromNode.sql(): String =
         when (this) {

--- a/docs/integrations/sources/snowflake.md
+++ b/docs/integrations/sources/snowflake.md
@@ -212,6 +212,7 @@ To read more, please check the official [Snowflake documentation](https://docs.s
 
 | Version | Date       | Pull Request                                             | Subject                                                                                                                                   |
 |:--------|:-----------|:---------------------------------------------------------|:------------------------------------------------------------------------------------------------------------------------------------------|
+| 1.0.11  | 2026-05-05 | [77760](https://github.com/airbytehq/airbyte/pull/77760) | Update `Field.sql()` extension to `DataField.sql()` to match bulk CDK `SelectColumns` API (no runtime change)                              |
 | 1.0.10  | 2026-03-13 | [74834](https://github.com/airbytehq/airbyte/pull/74834) | Truncate timestamp precision to 6 digits (microseconds) to prevent precision errors in destinations                                       |
 | 1.0.9   | 2025-09-16 | [74081](https://github.com/airbytehq/airbyte/pull/74081) | Security update                                                                                                                           |
 | 1.0.8   | 2025-09-16 | [66311](https://github.com/airbytehq/airbyte/pull/66311) | Change CDK version to 0.1.31                                                                                                              |


### PR DESCRIPTION
## What

`source-snowflake`'s `compileKotlin` task fails against the bulk CDK on master because PR airbytehq/airbyte#75636 (March 31) changed `SelectColumns.columns` from `List<Field>` to `List<DataField>`. The connector still declared `fun Field.sql()`, but the loop calls `it.sql()` on `DataField` items, so the extension never resolved and the connector failed to compile.

This is latent master breakage — the "CDK Source Connector Compatibility Test" only runs on PRs that bump `version.properties`, so the failure has been masked since March 31. It surfaced again on the version-bump PRs airbytehq/airbyte#76943 (the `additionalProperties` CDK fix that needs to ship for the Symend P1 / oncall#12062 / airbytehq/airbyte#76942) and the closed airbytehq/airbyte#77739.

## How

Two one-line changes in `SnowflakeSourceOperations.kt`:

- `import io.airbyte.cdk.discover.Field` → `import io.airbyte.cdk.discover.DataField`
- `fun Field.sql(): String = "\"$id\""` → `fun DataField.sql(): String = "\"$id\""`

Verified locally with `./gradlew :airbyte-integrations:connectors:source-snowflake:compileKotlin` after temporarily setting `cdkVersion=local` to mirror what the CDK Source Connector Compatibility Test does.

`Field` is a deprecated typealias for `EmittedField` (which implements `DataField`). All existing call sites (`SnowflakeSourceMetadataQuerier.kt`, etc.) construct `EmittedField` instances; the rename is purely a parameter-type change for the extension function and does not affect any existing code path.

## Review guide

1. `airbyte-integrations/connectors/source-snowflake/src/main/kotlin/io/airbyte/integrations/source/snowflake/SnowflakeSourceOperations.kt` — the import + extension-function rename.
2. `airbyte-integrations/connectors/source-snowflake/metadata.yaml` — `dockerImageTag` 1.0.10 → 1.0.11.
3. Changelog entry in `docs/integrations/sources/snowflake.md` will be added in a follow-up commit once this PR is created and we have a concrete PR number.

## User Impact

None at runtime — the published 1.0.10 image already runs `EmittedField` instances through this code path; calling an extension function on a subtype works identically. The change is purely a type-signature compile fix.

The bump to 1.0.11 unblocks future bulk CDK upgrades (the next `version.properties` bump will be able to run the compatibility test for source-snowflake without compile failures).

## Can this PR be safely reverted and rolled back?
- [x] YES 💚
- [ ] NO ❌

Link to Devin session: https://app.devin.ai/sessions/edb30a29e90346a09e177f48dca8fc54
Requested by: @aaronsteers