### PR TITLE
docs(source-facebook-marketing): warn about default status filtering excluding ARCHIVED records

### DIFF
--- a/docs/integrations/sources/facebook-marketing.md
+++ b/docs/integrations/sources/facebook-marketing.md
@@ -426,8 +426,6 @@ To resolve this:
 2. For each of **Campaign Statuses**, **AdSet Statuses**, and **Ad Statuses**, select all statuses you want to include. At minimum, add `ARCHIVED` alongside the active statuses.
 3. Trigger a Full Refresh sync to re-fetch the complete dataset.
 
-Note that `DELETED` records cannot be retrieved through listing endpoints per Facebook's API design. They can only be queried individually by ID.
-
 ### Missing data for 7-day and 28-day view-through attribution windows
 
 Starting January 12, 2026, Meta removed support for the 7-day view-through (`7d_view`) and 28-day view-through (`28d_view`) attribution windows in the Ads Insights API. In v4.1.3, these attribution windows were removed from request parameters for `ads_insights` and Ads Insights Reports streams. In v5.0.0, the `7d_view` and `28d_view` columns were also removed from stream schemas. Data previously returned for these windows is no longer available. For more information, see Meta's [2025 Out-Of-Cycle Changes](https://developers.facebook.com/docs/marketing-api/out-of-cycle-changes/occ-2025/).

--- a/docs/integrations/sources/facebook-marketing.md
+++ b/docs/integrations/sources/facebook-marketing.md
@@ -172,6 +172,12 @@ To ensure reliable performance, you'll need to request "Advanced Access."
 6. (Optional) Multiselect the **Ad Statuses** to include data from Ads for particular statuses.
 </FieldAnchor>
 
+   :::caution Status filtering and missing records
+   When no statuses are selected for Campaign Statuses, AdSet Statuses, or Ad Statuses, the connector relies on the Facebook Marketing API's default behavior, which **excludes records in ARCHIVED and DELETED states**. This means archived campaigns, ad sets, and ads will not appear in your synced data.
+
+   To ensure a complete dataset, explicitly select all statuses you want to include. This is especially important when using Full Refresh sync mode, because previously synced records that have since been archived will not be re-fetched unless you include the ARCHIVED status.
+   :::
+
 <FieldAnchor field="fetch_thumbnail_images">
 7. (Optional) Toggle the **Fetch Thumbnail Images** button to fetch the `thumbnail_url` and store the result in `thumbnail_data_url` for each [Ad Creative](https://developers.facebook.com/docs/marketing-api/creative/).
 </FieldAnchor>
@@ -405,6 +411,22 @@ This response indicates that the Facebook Graph API is refusing a synchronous re
 If the `ad_creatives` stream fails with the error "Please reduce the amount of data you're asking for, then retry your request" and you do not want to disable any fields, you can switch to the `ad_creatives_from_ads` stream instead. This alternative stream fetches the same creative data but retrieves it through the Ads endpoint one creative at a time, which avoids the data-size limitation. The output schema is identical to `ad_creatives`.
 
 Note that `ad_creatives_from_ads` is slower than `ad_creatives` because it makes individual API calls per creative. It also only returns creatives that are associated with ads — orphaned creatives that are not linked to any ad will not be included.
+
+### Missing records in Campaigns, Ad Sets, or Ads streams {#missing-records-status-filtering}
+
+If you notice that some campaigns, ad sets, or ads are missing from your synced data, the most common cause is the status filtering configuration.
+
+The Facebook Marketing API excludes records in `ARCHIVED` and `DELETED` states by default. When the **Campaign Statuses**, **AdSet Statuses**, or **Ad Statuses** fields are left empty in the connector configuration, the connector does not override this default, and archived or deleted records are silently omitted.
+
+This is particularly noticeable after a Full Refresh sync: records that were previously synced when they were active will not reappear if they have since been archived. You can verify this by looking up the missing record IDs directly in the Facebook API. Individual record lookups by ID return data regardless of status, but the listing endpoints the connector uses do not.
+
+To resolve this:
+
+1. Go to **Settings > Source > Facebook Marketing**.
+2. For each of **Campaign Statuses**, **AdSet Statuses**, and **Ad Statuses**, select all statuses you want to include. At minimum, add `ARCHIVED` alongside the active statuses.
+3. Trigger a Full Refresh sync to re-fetch the complete dataset.
+
+Note that `DELETED` records cannot be retrieved through listing endpoints per Facebook's API design. They can only be queried individually by ID.
 
 ### Missing data for 7-day and 28-day view-through attribution windows
 


### PR DESCRIPTION
## What

Adds documentation to the Facebook Marketing source connector warning users that leaving the status filtering fields empty causes the Facebook API to exclude ARCHIVED and DELETED records by default. This addresses a common cause of missing records reported in [oncall#11908](https://github.com/airbytehq/oncall/issues/11908).

## How

Two documentation additions in `docs/integrations/sources/facebook-marketing.md`:

1. **Inline caution admonition** after the Campaign/AdSet/Ad Statuses setup fields — warns that empty status selections rely on Facebook's default behavior which excludes ARCHIVED and DELETED records, and recommends explicitly selecting all desired statuses.

2. **New troubleshooting section** ("Missing records in Campaigns, Ad Sets, or Ads streams") — explains the root cause, how to verify with the Facebook API, and step-by-step resolution instructions.

## Review guide

1. `docs/integrations/sources/facebook-marketing.md` — the only file changed

## User Impact

Users who leave the status fields empty and then run a Full Refresh sync will now see a clear warning explaining that archived records are excluded by default. The new troubleshooting section provides actionable steps to resolve the issue.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Link to Devin session: https://app.devin.ai/sessions/8eb210669c6f49949234c1428133d8cb
Requested by: @darynaishchenko