### PR TITLE
docs(connector-support-levels): clarify Enterprise connectors are for Enterprise and Pro customers

### DIFF
--- a/docs/integrations/connector-support-levels.md
+++ b/docs/integrations/connector-support-levels.md
@@ -34,7 +34,7 @@ maintenance/upgrades are owned by the customer.
 
 ## Enterprise connectors
 
-**Enterprise** Connectors are premium connectors available exclusively for Self-Managed Enterprise and Pro customers at **an additional cost**. These connectors:
+**Enterprise** Connectors are premium connectors available exclusively for Enterprise and Pro customers at **an additional cost**. These connectors:
 
 - Are built and maintained by the Airbyte team.
 - Provide enhanced capabilities and support for critical enterprise systems.


### PR DESCRIPTION
## What

Updates the "Enterprise connectors" section of the [Connector support levels](https://docs.airbyte.com/integrations/connector-support-levels#enterprise-connectors) page to specify that Enterprise connectors are available to **Enterprise** and **Pro** customers, instead of "Self-Managed Enterprise and Pro" customers.

This addresses internal feedback that the prior wording was too narrow — Enterprise connectors are available to both Enterprise (which includes Cloud Enterprise) and Pro tiers, not just Self-Managed Enterprise.

## How

Single-word edit in `docs/integrations/connector-support-levels.md`:

- Before: "available exclusively for Self-Managed Enterprise and Pro customers"
- After: "available exclusively for Enterprise and Pro customers"

## Review guide

1. `docs/integrations/connector-support-levels.md` — line 37 only

## User Impact

Documentation now correctly reflects which customer tiers can access Enterprise connectors. No code or behavior changes.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚
- [ ] NO ❌


Link to Devin session: https://app.devin.ai/sessions/4469962853af4e99a317929f34752309
Requested by: @ian-at-airbyte