### PR TITLE
fix(source-harvest): show authentication mechanism before account ID and start date in spec

### DIFF
--- a/airbyte-integrations/connectors/source-harvest/manifest.yaml
+++ b/airbyte-integrations/connectors/source-harvest/manifest.yaml
@@ -2721,7 +2721,7 @@ spec:
         description: >-
           Harvest account ID. Required for all Harvest requests in pair with
           Personal Access Token
-        order: 0
+        order: 1
         title: Account ID
         airbyte_secret: true
       replication_start_date:
@@ -2729,7 +2729,7 @@ spec:
         description: >-
           UTC date and time in the format 2017-01-25T00:00:00Z. Any data before
           this date will not be replicated.
-        order: 1
+        order: 2
         title: Start Date
         format: date-time
         pattern: ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$
@@ -2740,7 +2740,7 @@ spec:
         description: >-
           UTC date and time in the format 2017-01-25T00:00:00Z. Any data after
           this date will not be replicated.
-        order: 2
+        order: 3
         title: End Date
         format: date-time
         pattern: ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$
@@ -2795,7 +2795,7 @@ spec:
                 const: Token
                 order: 0
             additionalProperties: true
-        order: 3
+        order: 0
         title: Authentication mechanism
       num_workers:
         type: integer

--- a/airbyte-integrations/connectors/source-harvest/metadata.yaml
+++ b/airbyte-integrations/connectors/source-harvest/metadata.yaml
@@ -10,7 +10,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: fe2b4084-3386-4d3b-9ad6-308f61a6f1e6
-  dockerImageTag: 1.2.36
+  dockerImageTag: 1.2.37
   dockerRepository: airbyte/source-harvest
   documentationUrl: https://docs.airbyte.com/integrations/sources/harvest
   externalDocumentationUrls:

--- a/docs/integrations/sources/harvest.md
+++ b/docs/integrations/sources/harvest.md
@@ -108,6 +108,7 @@ This connector uses Harvest's granular permission model. If your credentials lac
 
 | Version | Date       | Pull Request                                             | Subject                                                                                                                                                                |
 |:--------|:-----------|:---------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 1.2.37 | 2026-05-05 | [76900](https://github.com/airbytehq/airbyte/pull/76900) | Reorder spec fields so `credentials` appears before `account_id` and `replication_start_date` |
 | 1.2.36 | 2026-05-04 | [76217](https://github.com/airbytehq/airbyte/pull/76217) | Declare OAuth2 flow inline via `advanced_auth` and `oauthConnectorInputSpecification` |
 | 1.2.35 | 2026-04-28 | [75371](https://github.com/airbytehq/airbyte/pull/75371) | Update dependencies |
 | 1.2.34 | 2026-04-21 | [76845](https://github.com/airbytehq/airbyte/pull/76845) | Bump SDM base image to stable 7.17.2 |


### PR DESCRIPTION
## What

On the Harvest connector setup page, the **Authentication mechanism** field currently appears after **Account ID** and **Start Date**. This change reorders the spec fields so authentication is shown first.

## How

Updated `order` properties on the user-facing spec fields in `airbyte-integrations/connectors/source-harvest/manifest.yaml`:

- `credentials` (Authentication mechanism): `3` → `0`
- `account_id` (Account ID): `0` → `1`
- `replication_start_date` (Start Date): `1` → `2`
- `replication_end_date` (End Date, hidden): `2` → `3`
- `num_workers`: unchanged at `4`

Bumped `dockerImageTag` to `1.2.37` and added a changelog entry.

## Review guide

1. `airbyte-integrations/connectors/source-harvest/manifest.yaml` — `order` values on spec fields under `connection_specification.properties`.
2. `airbyte-integrations/connectors/source-harvest/metadata.yaml` — version bump.
3. `docs/integrations/sources/harvest.md` — changelog entry.

## User Impact

When configuring Harvest in any UI driven by the connector spec (Airbyte Cloud, Airbyte Agents, OSS), users will see the **Authentication mechanism** field before **Account ID** and **Start Date**, matching the natural order in which credentials are typically chosen first.

No behavior change beyond field ordering. No streams, schemas, or auth flows are affected.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚
- [ ] NO ❌


Link to Devin session: https://app.devin.ai/sessions/271ce7b1061a45758c456f3b567bc2c1
Requested by: @sophiecuiy

> [!IMPORTANT]
> ⚡ **Auto-merge enabled.**
> 
> _This PR is set to merge automatically when all requirements are met._