### PR TITLE
chore(destination-dev-null): 🚫 DO NOT MERGE — force-fail every record (0.9.4-rc.1 pre-release only)

### DIFF
--- a/airbyte-integrations/connectors/destination-dev-null/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-dev-null/metadata.yaml
@@ -16,7 +16,7 @@ data:
     - suite: integrationTests
   connectorType: destination
   definitionId: a7bcc9d8-13b3-4e49-b80d-d020b90045e3
-  dockerImageTag: 0.9.3
+  dockerImageTag: 0.9.4-rc.1
   dockerRepository: airbyte/destination-dev-null
   documentationUrl: https://docs.airbyte.com/integrations/destinations/dev-null
   githubIssueLabel: destination-dev-null

--- a/airbyte-integrations/connectors/destination-dev-null/src/main/kotlin/io/airbyte/integrations/destination/dev_null/DevNullAggregate.kt
+++ b/airbyte-integrations/connectors/destination-dev-null/src/main/kotlin/io/airbyte/integrations/destination/dev_null/DevNullAggregate.kt
@@ -77,14 +77,30 @@ class LoggingAggregate(
 }
 
 class SilentAggregate : Aggregate {
+    private val log = KotlinLogging.logger {}
+    private var recordCount: Long = 0L
+
     override fun accept(record: RecordDTO) {
-        /* Do nothing - silently discard */
+        // DO NOT MERGE: pre-release force-fail injection used to investigate an
+        // orchestrator race that drops connector-emitted ERROR trace messages.
+        // See https://github.com/airbytehq/airbyte/pull/77746 for the source-side
+        // analogue + investigation notes.
+        if (recordCount >= 0) {
+            val message =
+                "destination-dev-null pre-release force-fail injection. DO NOT MERGE."
+            log.info { message }
+            throw ForceFailError(message)
+        }
+        recordCount++
     }
 
     override suspend fun flush() {
         /* Do nothing - dev-null doesn't persist data */
     }
 }
+
+/** Custom exception raised by the pre-release force-fail injection. DO NOT MERGE. */
+class ForceFailError(message: String) : RuntimeException(message)
 
 class ThrottledAggregate(private val millisPerRecord: Long) : Aggregate {
     override fun accept(record: RecordDTO) {

--- a/airbyte-integrations/connectors/destination-dev-null/src/main/kotlin/io/airbyte/integrations/destination/dev_null/DevNullAggregate.kt
+++ b/airbyte-integrations/connectors/destination-dev-null/src/main/kotlin/io/airbyte/integrations/destination/dev_null/DevNullAggregate.kt
@@ -86,8 +86,7 @@ class SilentAggregate : Aggregate {
         // See https://github.com/airbytehq/airbyte/pull/77746 for the source-side
         // analogue + investigation notes.
         if (recordCount >= 0) {
-            val message =
-                "destination-dev-null pre-release force-fail injection. DO NOT MERGE."
+            val message = "destination-dev-null pre-release force-fail injection. DO NOT MERGE."
             log.info { message }
             throw ForceFailError(message)
         }

--- a/docs/integrations/destinations/dev-null.md
+++ b/docs/integrations/destinations/dev-null.md
@@ -53,6 +53,7 @@ The self-managed and Cloud variants have the same version number starting from v
 
 | Version     | Date       | Pull Request                                             | Subject                                                                                      |
 |:------------|:-----------|:---------------------------------------------------------|:---------------------------------------------------------------------------------------------|
+| 0.9.4-rc.1 | 2026-05-04 |  | DO NOT MERGE — pre-release force-fail injection for orchestrator trace-loss investigation |
 | 0.9.3 | 2026-02-04 | [72856](https://github.com/airbytehq/airbyte/pull/72856) | Upgrade CDK to 0.2.8 |
 | 0.9.2 | 2026-01-21 | [72291](https://github.com/airbytehq/airbyte/pull/72291) | Upgrade CDK to 0.2.0 |
 | 0.9.1 | 2026-01-21 | [72226](https://github.com/airbytehq/airbyte/pull/72226) | No-op version bump to test release cycle |


### PR DESCRIPTION
## What

🚫 **DO NOT MERGE.** Pre-release-only force-fail injection on `destination-dev-null` for empirical investigation of an orchestrator trace-loss race. Companion to the source-side PR https://github.com/airbytehq/airbyte/pull/77746 — that PR identified the race on the source side; this one is the destination-side equivalent.

## How

Modifies `SilentAggregate.accept(record)` to throw a `ForceFailError(RuntimeException)` on every record, regardless of `test_destination_type`. Because `DevNullSpecificationCloud` only exposes `SILENT` (the cloud variant doesn't expose `FAILING` at all), this is the only path that lets us produce a destination-side failure on a cloud-pinned actor.

- `airbyte-integrations/connectors/destination-dev-null/src/main/kotlin/io/airbyte/integrations/destination/dev_null/DevNullAggregate.kt`
  - `SilentAggregate.accept` now throws `ForceFailError("destination-dev-null pre-release force-fail injection. DO NOT MERGE.")` on every record.
  - New `ForceFailError(RuntimeException)` class (mirrors the `ForceFailError(RuntimeError)` in `source-zendesk-support`'s pre-release).
- `airbyte-integrations/connectors/destination-dev-null/metadata.yaml` — bump `dockerImageTag: 0.9.3` → `0.9.4-rc.1`.
- `docs/integrations/destinations/dev-null.md` — changelog entry for `0.9.4-rc.1`.

## Review guide

1. `DevNullAggregate.kt:79-103` — `SilentAggregate` now always throws.
2. `metadata.yaml` — version bump.
3. `docs/integrations/destinations/dev-null.md` — changelog.

## User Impact

🚫 None — this image is **never** intended to ship to OSS or to be used outside the Devin AI sandbox cloud workspace. The pre-release will be pinned via `set_cloud_connector_version_override` to a single test actor in `@devin-ai-sandbox`, and unpinned + reverted as soon as the destination-side race investigation is complete.

If this image were ever installed by mistake: every record sent to a `dev-null` destination would fail with a `RuntimeException`, every sync would fail.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚 — never merge it. Close instead.


Link to Devin session: https://app.devin.ai/sessions/3eec5220ed86495e94563caa4b5da5f4
Requested by: @pedroslopez