### PR TITLE
chore(source-gong): revert default_concurrency from 5 to 4 (1.2.0-rc.3)

### DIFF
--- a/airbyte-integrations/connectors/source-gong/manifest.yaml
+++ b/airbyte-integrations/connectors/source-gong/manifest.yaml
@@ -455,7 +455,7 @@ streams:
 
 concurrency_level:
   type: ConcurrencyLevel
-  default_concurrency: 5
+  default_concurrency: 4
 
 spec:
   type: Spec

--- a/airbyte-integrations/connectors/source-gong/metadata.yaml
+++ b/airbyte-integrations/connectors/source-gong/metadata.yaml
@@ -7,7 +7,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 32382e40-3b49-4b99-9c5c-4076501914e7
-  dockerImageTag: 1.2.0-rc.2
+  dockerImageTag: 1.2.0-rc.3
   dockerRepository: airbyte/source-gong
   documentationUrl: https://docs.airbyte.com/integrations/sources/gong
   githubIssueLabel: source-gong

--- a/docs/integrations/sources/gong.md
+++ b/docs/integrations/sources/gong.md
@@ -82,6 +82,7 @@ The call transcripts stream fetches transcripts one call at a time as a substrea
 
 | Version | Date       | Pull Request                                             | Subject                                                                         |
 | :------ | :--------- | :------------------------------------------------------- | :------------------------------------------------------------------------------ |
+| 1.2.0-rc.3 | 2026-05-05 | [77049](https://github.com/airbytehq/airbyte/pull/77049) | Revert default_concurrency from 5 to 4 based on Phase 2 results |
 | 1.2.0-rc.2 | 2026-04-28 | [77049](https://github.com/airbytehq/airbyte/pull/77049) | Increase default_concurrency from 4 to 5 based on Phase 1 health check results |
 | 1.2.0-rc.1 | 2026-04-27 | [77049](https://github.com/airbytehq/airbyte/pull/77049) | Add concurrency support with default_concurrency=4; enable progressive rollout |
 | 1.1.0 | 2026-04-20 | [76454](https://github.com/airbytehq/airbyte/pull/76454) | Filter out private calls (`isPrivate: true`) from `calls` and `extensiveCalls` streams per Gong API listing requirements |


### PR DESCRIPTION
## What
Revert `default_concurrency` from 5 back to 4 for source-gong as part of the concurrency tuning rollout.

Phase 2 testing with `concurrency=5` (rc.2) was inconclusive due to limited sync data overlap with baselines and BigQuery data retention issues that nulled `stream_duration_seconds` for rc.1 syncs. Phase 1 (`concurrency=4`) was proven safe with 0% failures and 0 regressions across 19 connections over 24+ hours.

Reverting to the known-good `concurrency=4` to proceed with the next rollout phase.

## How
- `manifest.yaml`: Changed `default_concurrency` from 5 to 4
- `metadata.yaml`: Bumped version from `1.2.0-rc.2` to `1.2.0-rc.3`
- `gong.md`: Added changelog entry for rc.3

## Review guide
1. `airbyte-integrations/connectors/source-gong/manifest.yaml` (line 458)
2. `airbyte-integrations/connectors/source-gong/metadata.yaml` (line 10)
3. `docs/integrations/sources/gong.md` (line 85)

## User Impact
No user impact — this is an RC version used in progressive rollout only.

## Can this PR be safely reverted and rolled back?
- [x] YES 💚

Link to Devin session: https://app.devin.ai/sessions/07dae43bde7b44e1994cda9e4a29473b
Requested by: @sophiecuiy