### PR TITLE
docs(source-cal-com): fix API key URL in spec and docs (0.0.49)

### DIFF
--- a/airbyte-integrations/connectors/source-cal-com/manifest.yaml
+++ b/airbyte-integrations/connectors/source-cal-com/manifest.yaml
@@ -229,7 +229,7 @@ spec:
         title: orgId
       api_key:
         type: string
-        description: API key to use. Find it at https://cal.com/account
+        description: API key to use. Find it at https://app.cal.com/settings/developer/api-keys
         name: api_key
         order: 1
         title: API Key

--- a/airbyte-integrations/connectors/source-cal-com/metadata.yaml
+++ b/airbyte-integrations/connectors/source-cal-com/metadata.yaml
@@ -17,7 +17,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 3db8a652-88f7-41ee-91a3-2f745322d9ae
-  dockerImageTag: 0.0.48
+  dockerImageTag: 0.0.49
   dockerRepository: airbyte/source-cal-com
   githubIssueLabel: source-cal-com
   icon: icon.svg

--- a/docs/integrations/sources/cal-com.md
+++ b/docs/integrations/sources/cal-com.md
@@ -25,7 +25,7 @@ The Cal.com connector enables seamless data synchronization between Cal.com’s 
 
 | Version          | Date              | Pull Request | Subject        |
 |------------------|-------------------|--------------|----------------|
-| 0.0.49 | 2026-05-06 | [PR_NUMBER](https://github.com/airbytehq/airbyte/pull/PR_NUMBER) | Fix API key URL in spec and docs |
+| 0.0.49 | 2026-05-06 | [77794](https://github.com/airbytehq/airbyte/pull/77794) | Fix API key URL in spec and docs |
 | 0.0.48 | 2026-04-28 | [77188](https://github.com/airbytehq/airbyte/pull/77188) | Update dependencies |
 | 0.0.47 | 2026-04-21 | [76540](https://github.com/airbytehq/airbyte/pull/76540) | Update dependencies |
 | 0.0.46 | 2026-03-31 | [75684](https://github.com/airbytehq/airbyte/pull/75684) | Update dependencies |

--- a/docs/integrations/sources/cal-com.md
+++ b/docs/integrations/sources/cal-com.md
@@ -6,7 +6,7 @@ The Cal.com connector enables seamless data synchronization between Cal.com’s 
 | Input | Type | Description | Default Value |
 |-------|------|-------------|---------------|
 | `orgId` | `string` | Organization ID.  |  |
-| `api_key` | `string` | API Key. API key to use. Find it at https://cal.com/account |  |
+| `api_key` | `string` | API Key. API key to use. Find it at https://app.cal.com/settings/developer/api-keys |  |
 
 ## Streams
 | Stream Name | Primary Key | Pagination | Supports Full Sync | Supports Incremental |
@@ -25,6 +25,7 @@ The Cal.com connector enables seamless data synchronization between Cal.com’s 
 
 | Version          | Date              | Pull Request | Subject        |
 |------------------|-------------------|--------------|----------------|
+| 0.0.49 | 2026-05-06 | [PR_NUMBER](https://github.com/airbytehq/airbyte/pull/PR_NUMBER) | Fix API key URL in spec and docs |
 | 0.0.48 | 2026-04-28 | [77188](https://github.com/airbytehq/airbyte/pull/77188) | Update dependencies |
 | 0.0.47 | 2026-04-21 | [76540](https://github.com/airbytehq/airbyte/pull/76540) | Update dependencies |
 | 0.0.46 | 2026-03-31 | [75684](https://github.com/airbytehq/airbyte/pull/75684) | Update dependencies |


### PR DESCRIPTION
## What

The Cal.com connector spec and docs pointed users to `https://cal.com/account` to find their API key. That URL no longer serves Cal.com's API-key page — it currently resolves to an unrelated user profile (a `/account` username). Anyone following the existing instructions lands on a stranger's booking page instead of their API settings.

This PR updates both references to the correct location: `https://app.cal.com/settings/developer/api-keys`.

<img width="2291" height="998" alt="image" src="https://github.com/user-attachments/assets/0b25c664-4a0a-48a0-8095-42deb658eb72" />


## Changes

- `airbyte-integrations/connectors/source-cal-com/manifest.yaml` — update `api_key` description URL in the spec
- `docs/integrations/sources/cal-com.md` — update the matching URL in the input table; add changelog row for `0.0.49`
- `airbyte-integrations/connectors/source-cal-com/metadata.yaml` — bump `dockerImageTag` from `0.0.48` to `0.0.49`

No code/behavior changes — text only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)