### PR TITLE
fix(source-amazon-seller-partner): skip FATAL reports when checking for existing reports (5.7.6-rc.2)

### DIFF
--- a/airbyte-integrations/connectors/source-amazon-seller-partner/components.py
+++ b/airbyte-integrations/connectors/source-amazon-seller-partner/components.py
@@ -706,7 +706,7 @@ class ReportCreationRequester(HttpRequester):
 
         FATAL reports are also skipped because they represent permanently failed report
         processing by Amazon. Reusing a FATAL report would cause the CDK's status_mapping
-        (which maps FATAL to ``failed``) to trigger a retry, which would find the same
+        (which maps FATAL to `failed`) to trigger a retry, which would find the same
         FATAL report again, creating an infinite loop.
         """
         reports, get_response = self._fetch_reports(stream_state, stream_slice, report_type, requested_marketplace_ids)

--- a/airbyte-integrations/connectors/source-amazon-seller-partner/components.py
+++ b/airbyte-integrations/connectors/source-amazon-seller-partner/components.py
@@ -572,8 +572,9 @@ class ReportCreationRequester(HttpRequester):
        DONE reports older than `max_done_report_age_hours` (from config, default 0) are skipped
        since their data snapshot may be stale and the report document may have expired. When the
        config value is 0 (default), DONE reports are never reused. Status filtering (e.g.
-       CANCELLED, FATAL) is NOT done here — the manifest's status_mapping is the single source
-       of truth for which statuses are retryable, skippable, or terminal.
+       CANCELLED, FATAL) is done here to prevent reuse of reports that should not be reused.
+       The manifest's status_mapping remains the single source of truth for which statuses
+       are retryable, skippable, or terminal once a report is being polled.
     3. If no suitable report is found, fall through to super().send_request() to create a new one.
     """
 
@@ -702,6 +703,11 @@ class ReportCreationRequester(HttpRequester):
         This acts as a retry mechanism: if the data is now available, the new report will
         succeed; if still no data, the new report will also be CANCELLED and the CDK's
         SKIPPED status mapping will handle it silently.
+
+        FATAL reports are also skipped because they represent permanently failed report
+        processing by Amazon. Reusing a FATAL report would cause the CDK's status_mapping
+        (which maps FATAL to ``failed``) to trigger a retry, which would find the same
+        FATAL report again, creating an infinite loop.
         """
         reports, get_response = self._fetch_reports(stream_state, stream_slice, report_type, requested_marketplace_ids)
         if not reports:
@@ -719,6 +725,13 @@ class ReportCreationRequester(HttpRequester):
                 logger.info(
                     f"Skipping CANCELLED report {report.get('reportId', '')} for {report_type}. "
                     f"A new report will be created to retry in case data is now available."
+                )
+                continue
+
+            if report_status == "FATAL":
+                logger.info(
+                    f"Skipping FATAL report {report.get('reportId', '')} for {report_type}. "
+                    f"A new report will be created instead of reusing a permanently failed one."
                 )
                 continue
 

--- a/airbyte-integrations/connectors/source-amazon-seller-partner/metadata.yaml
+++ b/airbyte-integrations/connectors/source-amazon-seller-partner/metadata.yaml
@@ -15,7 +15,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: e55879a8-0ef8-4557-abcf-ab34c53ec460
-  dockerImageTag: 5.7.6-rc.1
+  dockerImageTag: 5.7.6-rc.2
   dockerRepository: airbyte/source-amazon-seller-partner
   documentationUrl: https://docs.airbyte.com/integrations/sources/amazon-seller-partner
   erdUrl: https://dbdocs.io/airbyteio/source-amazon-seller-partner?view=relationships

--- a/airbyte-integrations/connectors/source-amazon-seller-partner/unit_tests/test_report_creation_requester.py
+++ b/airbyte-integrations/connectors/source-amazon-seller-partner/unit_tests/test_report_creation_requester.py
@@ -233,8 +233,8 @@ class TestFindExistingReport:
 
         assert result is None
 
-    def test_reuses_fatal_report(self):
-        """FATAL reports should be reused — status_mapping handles the behavior."""
+    def test_skips_fatal_report(self):
+        """FATAL reports should be skipped so a new report is created instead of reusing a permanently failed one."""
         requester = _make_requester()
         fatal_report = _make_report(report_id="rpt-fatal", status="FATAL")
         get_response = _make_get_reports_response([fatal_report])
@@ -249,8 +249,7 @@ class TestFindExistingReport:
             requested_marketplace_ids=["ATVPDKIKX0DER"],
         )
 
-        assert result is not None
-        assert result.json()["reportId"] == "rpt-fatal"
+        assert result is None
 
     def test_returns_first_matching_report(self):
         """API returns reports sorted by createdTime desc, so first match is returned."""
@@ -262,12 +261,12 @@ class TestFindExistingReport:
             status="IN_PROGRESS",
             created_time=(now - timedelta(hours=1)).isoformat(),
         )
-        fatal_report = _make_report(
-            report_id="rpt-fatal",
-            status="FATAL",
+        iq_report = _make_report(
+            report_id="rpt-iq",
+            status="IN_QUEUE",
             created_time=(now - timedelta(hours=2)).isoformat(),
         )
-        get_response = _make_get_reports_response([ip_report, fatal_report])
+        get_response = _make_get_reports_response([ip_report, iq_report])
         requester._http_client.send_request.return_value = (None, get_response)
 
         result = requester._find_existing_report(
@@ -297,6 +296,35 @@ class TestFindExistingReport:
             created_time=(now - timedelta(hours=2)).isoformat(),
         )
         get_response = _make_get_reports_response([cancelled_report, ip_report])
+        requester._http_client.send_request.return_value = (None, get_response)
+
+        result = requester._find_existing_report(
+            stream_state=None,
+            stream_slice=None,
+            report_type="GET_AMAZON_FULFILLED_SHIPMENTS_DATA_GENERAL",
+            requested_start="2023-01-01T00:00:00Z",
+            requested_end="2023-01-30T00:00:00Z",
+            requested_marketplace_ids=["ATVPDKIKX0DER"],
+        )
+
+        assert result is not None
+        assert result.json()["reportId"] == "rpt-ip"
+
+    def test_skips_fatal_but_returns_in_progress(self):
+        """When both FATAL and IN_PROGRESS reports exist, FATAL is skipped and IN_PROGRESS is returned."""
+        requester = _make_requester()
+        now = datetime.now(tz=timezone.utc)
+        fatal_report = _make_report(
+            report_id="rpt-fatal",
+            status="FATAL",
+            created_time=(now - timedelta(hours=1)).isoformat(),
+        )
+        ip_report = _make_report(
+            report_id="rpt-ip",
+            status="IN_PROGRESS",
+            created_time=(now - timedelta(hours=2)).isoformat(),
+        )
+        get_response = _make_get_reports_response([fatal_report, ip_report])
         requester._http_client.send_request.return_value = (None, get_response)
 
         result = requester._find_existing_report(
@@ -729,8 +757,8 @@ class TestSendRequest:
         assert result is not None
         assert result.json()["reportId"] == "rpt-new"
 
-    def test_reuses_fatal_report_in_send_request(self):
-        """FATAL reports should be reused — status_mapping handles the behavior."""
+    def test_creates_new_report_when_only_fatal_exists(self):
+        """FATAL reports should be skipped, causing a new report to be created."""
         requester = _make_requester()
         requester._request_body_json.return_value = {
             "reportType": "GET_AMAZON_FULFILLED_SHIPMENTS_DATA_GENERAL",
@@ -742,10 +770,12 @@ class TestSendRequest:
         get_response = _make_get_reports_response([fatal])
         requester._http_client.send_request.return_value = (None, get_response)
 
-        result = requester.send_request(stream_state=None, stream_slice=None)
+        create_response = _create_response(200, {"reportId": "rpt-new"})
+        with patch.object(ReportCreationRequester.__bases__[0], "send_request", return_value=create_response):
+            result = requester.send_request(stream_state=None, stream_slice=None)
 
         assert result is not None
-        assert result.json()["reportId"] == "rpt-fatal"
+        assert result.json()["reportId"] == "rpt-new"
 
     def test_passes_marketplace_ids_to_fetch_reports(self):
         """Verify that send_request passes marketplaceIds from body_json to _fetch_reports."""

--- a/docs/integrations/sources/amazon-seller-partner.md
+++ b/docs/integrations/sources/amazon-seller-partner.md
@@ -326,7 +326,7 @@ You may also combine this with a smaller **Financial Events Step Size** (e.g., 1
 
 | Version    | Date       | Pull Request                                              | Subject                                                                                                                                                                             |
 |:-----------|:-----------|:----------------------------------------------------------|:------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| 5.7.6-rc.2 | 2026-05-06 | [XXXX](https://github.com/airbytehq/airbyte/pull/XXXX) | Skip FATAL reports when checking for existing reports to prevent infinite retry loops |
+| 5.7.6-rc.2 | 2026-05-06 | [77800](https://github.com/airbytehq/airbyte/pull/77800) | Skip FATAL reports when checking for existing reports to prevent infinite retry loops |
 | 5.7.6-rc.1 | 2026-04-28 | [76093](https://github.com/airbytehq/airbyte/pull/76093) | Check for existing reports before creating new ones to avoid hitting Amazon SP-API rate limits |
 | 5.7.5 | 2026-05-04 | [76269](https://github.com/airbytehq/airbyte/pull/76269) | Use 89-day buffer for GET_V2_SETTLEMENT_REPORT_DATA_FLAT_FILE start date to avoid 400 errors caused by network latency near Amazon's 90-day boundary |
 | 5.7.4 | 2026-04-28 | [77521](https://github.com/airbytehq/airbyte/pull/77521) | Restore HTTPAPIBudget that was temporarily commented out in 5.7.4-rc.1; revert default_concurrency back to 2. Concurrency tuning rollout was canceled and is being deferred. |

--- a/docs/integrations/sources/amazon-seller-partner.md
+++ b/docs/integrations/sources/amazon-seller-partner.md
@@ -326,6 +326,7 @@ You may also combine this with a smaller **Financial Events Step Size** (e.g., 1
 
 | Version    | Date       | Pull Request                                              | Subject                                                                                                                                                                             |
 |:-----------|:-----------|:----------------------------------------------------------|:------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 5.7.6-rc.2 | 2026-05-06 | [XXXX](https://github.com/airbytehq/airbyte/pull/XXXX) | Skip FATAL reports when checking for existing reports to prevent infinite retry loops |
 | 5.7.6-rc.1 | 2026-04-28 | [76093](https://github.com/airbytehq/airbyte/pull/76093) | Check for existing reports before creating new ones to avoid hitting Amazon SP-API rate limits |
 | 5.7.5 | 2026-05-04 | [76269](https://github.com/airbytehq/airbyte/pull/76269) | Use 89-day buffer for GET_V2_SETTLEMENT_REPORT_DATA_FLAT_FILE start date to avoid 400 errors caused by network latency near Amazon's 90-day boundary |
 | 5.7.4 | 2026-04-28 | [77521](https://github.com/airbytehq/airbyte/pull/77521) | Restore HTTPAPIBudget that was temporarily commented out in 5.7.4-rc.1; revert default_concurrency back to 2. Concurrency tuning rollout was canceled and is being deferred. |


### PR DESCRIPTION
## What

Fixes [oncall#11837](https://github.com/airbytehq/oncall/issues/11837) — the `ReportCreationRequester` (introduced in [#76093](https://github.com/airbytehq/airbyte/pull/76093)) checks for existing SP-API reports before creating new ones, but it was reusing FATAL reports. Since the manifest's `status_mapping` maps FATAL to `failed`, the CDK retries the job, which finds the same FATAL report again, creating an infinite retry loop.

## How

- Skip FATAL reports in `_find_existing_report()` (same logic as existing CANCELLED skip), so a new report is created instead of reusing a permanently failed one.
- Updated class-level and method-level docstrings to reflect that both CANCELLED and FATAL reports are now filtered.
- Updated unit tests to verify FATAL reports are skipped (not reused).
- Bumped version to `5.7.6-rc.2`.

## Review guide

1. `components.py` — `_find_existing_report()`: added FATAL skip block (mirrors CANCELLED skip), updated docstrings
2. `unit_tests/test_report_creation_requester.py` — updated 3 existing tests and added 1 new test for FATAL skip behavior
3. `metadata.yaml` — version bump `5.7.6-rc.1` → `5.7.6-rc.2`
4. `docs/integrations/sources/amazon-seller-partner.md` — changelog entry

## User Impact

Connections that previously got stuck in an infinite retry loop when Amazon returned a FATAL report status will now correctly skip the failed report and create a new one.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Requested by @darynaishchenko.

Link to Devin session: https://app.devin.ai/sessions/9973291e68ff44a4a18aa3986753f41f