### PR TITLE
fix(source-harvest): set Content-Type on OAuth access token request

### DIFF
--- a/airbyte-integrations/connectors/source-harvest/manifest.yaml
+++ b/airbyte-integrations/connectors/source-harvest/manifest.yaml
@@ -2819,6 +2819,8 @@ spec:
       oauth_connector_input_specification:
         consent_url: "https://id.getharvest.com/oauth2/authorize?{{client_id_param}}&{{redirect_uri_param}}&{{state_param}}&response_type=code"
         access_token_url: "https://id.getharvest.com/api/v2/oauth2/token"
+        access_token_headers:
+          Content-Type: "application/x-www-form-urlencoded"
         access_token_params:
           grant_type: "authorization_code"
           code: "{{ auth_code_value }}"

--- a/airbyte-integrations/connectors/source-harvest/metadata.yaml
+++ b/airbyte-integrations/connectors/source-harvest/metadata.yaml
@@ -10,7 +10,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: fe2b4084-3386-4d3b-9ad6-308f61a6f1e6
-  dockerImageTag: 1.2.37
+  dockerImageTag: 1.2.38
   dockerRepository: airbyte/source-harvest
   documentationUrl: https://docs.airbyte.com/integrations/sources/harvest
   externalDocumentationUrls:

--- a/docs/integrations/sources/harvest.md
+++ b/docs/integrations/sources/harvest.md
@@ -108,6 +108,7 @@ This connector uses Harvest's granular permission model. If your credentials lac
 
 | Version | Date       | Pull Request                                             | Subject                                                                                                                                                                |
 |:--------|:-----------|:---------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 1.2.38 | 2026-05-06 | [77821](https://github.com/airbytehq/airbyte/pull/77821) | Set `Content-Type: application/x-www-form-urlencoded` on OAuth access token request |
 | 1.2.37 | 2026-05-05 | [77778](https://github.com/airbytehq/airbyte/pull/77778) | Reorder spec fields so `credentials` appears before `account_id` and `replication_start_date` |
 | 1.2.36 | 2026-05-04 | [76217](https://github.com/airbytehq/airbyte/pull/76217) | Declare OAuth2 flow inline via `advanced_auth` and `oauthConnectorInputSpecification` |
 | 1.2.35 | 2026-04-28 | [75371](https://github.com/airbytehq/airbyte/pull/75371) | Update dependencies |


### PR DESCRIPTION
## Summary
- Adds `access_token_headers.Content-Type: application/x-www-form-urlencoded` to the source-harvest manifest's `oauth_connector_input_specification`.
- Bumps `dockerImageTag` to `1.2.38` and adds a docs changelog entry.

## Why
The advanced_auth block added in #76217 wires up the platform's `DeclarativeOAuthFlow` for Harvest, but omits `access_token_headers`. In `DeclarativeOAuthFlow.getRequestContentType`, when `access_token_params` is set without `access_token_headers`, the request content type defaults to `application/json` (`oss/airbyte-oauth/.../DeclarativeOAuthFlow.kt:206`).

Harvest's token endpoint at `https://id.getharvest.com/api/v2/oauth2/token` is a standard OAuth2 endpoint that only parses `application/x-www-form-urlencoded`. When it receives a JSON body it sees no form fields and returns:

```
{"error":"invalid_request","error_description":"client_id, client_secret, grant_type required."}
```

The platform then tries to extract `access_token` from that error response, fails, and surfaces:

```
Internal Server Error: java.io.IOException: Missing 'access_token' field in the `OAuth Output`. Expected fields: [access_token, refresh_token].
```

Setting the header makes `getRequestContentType` return `URL_ENCODED`, which routes through the form-encoded body publisher (`BaseOAuth2Flow.kt:381-385`).

## Prior art
Every other connector that uses declarative OAuth with `access_token_params` ships `access_token_headers.Content-Type: application/x-www-form-urlencoded` in the same commit that introduces the block. #76217 is the outlier:

| Connector | PR introducing the block |
|---|---|
| source-linkedin-ads | #75583 |
| source-slack | #75197 |
| source-mailchimp | #75576 |
| source-hubspot | #75574 |
| source-intercom | #75575 |

`source-notion`, `source-gong`, and `source-ticktick` also set the same `Content-Type` (alongside an additional `Authorization: Basic …` header).

## Test plan
- [ ] OAuth flow completes end-to-end against Harvest with the dev image of this branch
- [ ] Existing `liveTests` (`harvest_config_oauth_dev_null`) still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)