### PR TITLE
feat(source-greenhouse): start concurrency tuning at c=4 (0.7.22-rc.1, Path A)

### DIFF
--- a/airbyte-integrations/connectors/source-greenhouse/manifest.yaml
+++ b/airbyte-integrations/connectors/source-greenhouse/manifest.yaml
@@ -1792,6 +1792,19 @@ streams:
   - $ref: "#/definitions/streams/user_roles"
   - $ref: "#/definitions/streams/user_permissions"
 
+# Greenhouse Harvest API documented rate limit (single tier — Path A):
+# - 50 requests per 10 seconds (5 req/sec) for all accounts.
+# - Source: https://developers.greenhouse.io/harvest.html#throttling
+#
+# Starting concurrency follows the connector concurrency tuning playbook:
+# floor(5 / 4) = 1 ≤ 2 triggers the low-rate-limit special case →
+# starting_concurrency = 4, step = 1. Empirical tuning will adjust upward
+# in steps of 1 against the documented 5 req/sec ceiling.
+concurrency_level:
+  type: ConcurrencyLevel
+  default_concurrency: 4
+  max_concurrency: 16
+
 spec:
   type: Spec
   connection_specification:

--- a/airbyte-integrations/connectors/source-greenhouse/metadata.yaml
+++ b/airbyte-integrations/connectors/source-greenhouse/metadata.yaml
@@ -10,7 +10,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 59f1e50a-331f-4f09-b3e8-2e8d4d355f44
-  dockerImageTag: 0.7.21
+  dockerImageTag: 0.7.22-rc.1
   dockerRepository: airbyte/source-greenhouse
   documentationUrl: https://docs.airbyte.com/integrations/sources/greenhouse
   githubIssueLabel: source-greenhouse
@@ -24,7 +24,7 @@ data:
       packageName: airbyte-source-greenhouse
   releases:
     rolloutConfiguration:
-      enableProgressiveRollout: false
+      enableProgressiveRollout: true
   registryOverrides:
     cloud:
       enabled: true

--- a/docs/integrations/sources/greenhouse.md
+++ b/docs/integrations/sources/greenhouse.md
@@ -74,7 +74,7 @@ The Greenhouse connector should not run into Greenhouse API limitations under no
 
 | Version    | Date       | Pull Request                                             | Subject                                                                                                                                                                |
 |:-----------|:-----------|:---------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| 0.7.22-rc.1 | 2026-05-06 | [TBD](https://github.com/airbytehq/airbyte/pull/TBD) | Start concurrency tuning at default_concurrency=4 (Path A) and enable progressive rollout |
+| 0.7.22-rc.1 | 2026-05-06 | [77826](https://github.com/airbytehq/airbyte/pull/77826) | Start concurrency tuning at default_concurrency=4 (Path A) and enable progressive rollout |
 | 0.7.21 | 2026-04-28 | [77287](https://github.com/airbytehq/airbyte/pull/77287) | Update dependencies |
 | 0.7.20 | 2026-04-21 | [76637](https://github.com/airbytehq/airbyte/pull/76637) | Update dependencies |
 | 0.7.19 | 2026-03-31 | [75729](https://github.com/airbytehq/airbyte/pull/75729) | Update dependencies |

--- a/docs/integrations/sources/greenhouse.md
+++ b/docs/integrations/sources/greenhouse.md
@@ -74,6 +74,7 @@ The Greenhouse connector should not run into Greenhouse API limitations under no
 
 | Version    | Date       | Pull Request                                             | Subject                                                                                                                                                                |
 |:-----------|:-----------|:---------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 0.7.22-rc.1 | 2026-05-06 | [TBD](https://github.com/airbytehq/airbyte/pull/TBD) | Start concurrency tuning at default_concurrency=4 (Path A) and enable progressive rollout |
 | 0.7.21 | 2026-04-28 | [77287](https://github.com/airbytehq/airbyte/pull/77287) | Update dependencies |
 | 0.7.20 | 2026-04-21 | [76637](https://github.com/airbytehq/airbyte/pull/76637) | Update dependencies |
 | 0.7.19 | 2026-03-31 | [75729](https://github.com/airbytehq/airbyte/pull/75729) | Update dependencies |


### PR DESCRIPTION
## What

Phase 0 RC for the connector concurrency tuning playbook on `source-greenhouse`. Bumps to `0.7.22-rc.1` and enables progressive rollout.

This RC is intentionally narrow: only the values needed to start tuning land active in the manifest. There is no existing `HTTPAPIBudget` on this connector, so nothing needs to be commented out.

### Active in 0.7.22-rc.1

- `concurrency_level` block added to `manifest.yaml` with `default_concurrency: 4` and `max_concurrency: 16`.
- `metadata.yaml`: `0.7.21` → `0.7.22-rc.1`, `enableProgressiveRollout: false` → `true`.
- Changelog entry in `docs/integrations/sources/greenhouse.md`.

### Design references

- Umbrella concurrency tuning epic: airbytehq/airbyte-internal-issues#11747
- Connector concurrency tuning epic (this rollout sub-epic): airbytehq/airbyte-internal-issues#15262
- Greenhouse Harvest API rate limits: https://developers.greenhouse.io/harvest.html#throttling

### Path A starting math (single-tier API)

- Greenhouse Harvest API documents a single, account-wide rate limit: 50 requests per 10 seconds = 5 req/sec, with no Free / Premium / Enterprise tiering and no per-endpoint differences. This is Path A in the connector concurrency tuning playbook (no tier-aware HTTPAPIBudget needed).
- `floor(5 / 4) = 1 ≤ 2` triggers the low-rate-limit special case → `starting_concurrency = 4`, `step = 1`.
- `max_concurrency = 16` gives 4× headroom from the start, so subsequent step-of-1 RCs do not need to re-touch the manifest ceiling.

### Rollout plan

- Phase 1: pin all 7 eligible Tier-2 actors to `0.7.22-rc.1`, observe for 24 h, then iterate concurrency upward in steps of 1 against the documented 5 req/sec ceiling. End on a pass.
- Phase 2: full 100% Tier-2 rollout of the final tuned RC, 24 h health check.
- Phase 3: Tier-1 rollout (only one eligible actor today), 24 h health check.
- Phase 4 (step 22.5): expose `num_workers` as a user-configurable field in `spec` via a follow-up RC, then promote to GA.

## How

Manifest-only change. No code changes; concurrency tuning is validated empirically by the rollout, not by unit tests.

## Review guide

1. `airbyte-integrations/connectors/source-greenhouse/manifest.yaml`
2. `airbyte-integrations/connectors/source-greenhouse/metadata.yaml`
3. `docs/integrations/sources/greenhouse.md`

## User Impact

While `0.7.22-rc.1` is pinned to a small Tier-2 cohort during tuning, those connections will run with `default_concurrency: 4` (vs. the implicit `1` on `0.7.21`), which should reduce full sync wall time. No config changes are required from users; the documented Greenhouse rate limit is unchanged.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚
- [ ] NO ❌


Link to Devin session: https://app.devin.ai/sessions/d29bbca914074401b056b51c68b85d86
Requested by: @sophiecuiy