### PR TITLE
docs(privatelink): rename to Private Links and update for self-serve UI

### DIFF
--- a/docs/platform/enterprise-flex/readme.md
+++ b/docs/platform/enterprise-flex/readme.md
@@ -37,7 +37,7 @@ Enterprise Flex addresses these needs by offering fully managed Cloud workspaces
 
 ### Enterprise Flex versus Pro
 
-Enterprise Flex includes all features that are standard in Pro with the additional capabilities of running self-managed data planes, referencing your own secrets manager, Private Links support, and storing audit logs.
+Enterprise Flex includes all features that are standard in Pro with the additional capabilities of running self-managed data planes, referencing your own secrets manager, PrivateLink support, and storing audit logs.
 
 Any Airbyte Cloud environment can be easily upgraded to Enterprise Flex. To learn more about upgrading to Enterprise Flex, [talk to sales](https://airbyte.com/company/talk-to-sales).
 

--- a/docs/platform/enterprise-flex/readme.md
+++ b/docs/platform/enterprise-flex/readme.md
@@ -37,7 +37,7 @@ Enterprise Flex addresses these needs by offering fully managed Cloud workspaces
 
 ### Enterprise Flex versus Pro
 
-Enterprise Flex includes all features that are standard in Pro with the additional capabilities of running self-managed data planes, referencing your own secrets manager, PrivateLink support, and storing audit logs.
+Enterprise Flex includes all features that are standard in Pro with the additional capabilities of running self-managed data planes, referencing your own secrets manager, Private Links support, and storing audit logs.
 
 Any Airbyte Cloud environment can be easily upgraded to Enterprise Flex. To learn more about upgrading to Enterprise Flex, [talk to sales](https://airbyte.com/company/talk-to-sales).
 

--- a/docs/platform/operating-airbyte/privatelink.md
+++ b/docs/platform/operating-airbyte/privatelink.md
@@ -62,6 +62,8 @@ Airbyte's PrivateLink endpoints are located in `us-east-1` (US) and `eu-west-3` 
 
 Private Links are currently limited to sources and destinations running in AWS. This includes services like Snowflake, Databricks, and PostgreSQL hosted on AWS. If you need to connect to resources outside of AWS, Private Links are not yet available.
 
+Private Links currently support only VPC endpoint services backed by a Network Load Balancer (NLB) that you create and manage in your own AWS account. Airbyte doesn't host the NLB or the underlying service for you.
+
 If you need a PrivateLink for an S3 bucket, [talk to sales](https://airbyte.com/company/talk-to-sales) so we can scope your requirements.
 
 For managed AWS services like RDS or Aurora, additional configuration is required to expose them via AWS PrivateLink. See [Using Private Links with AWS managed services](#using-private-links-with-aws-managed-services) for details.
@@ -131,7 +133,7 @@ Once you accept the request, the connection status changes to **Available** and 
 
 ## Using Private Links with AWS managed services
 
-Managed AWS services like Amazon RDS and Aurora don't natively support VPC endpoint services. To use Private Links with these services, you need to set up additional infrastructure to expose them via a Network Load Balancer.
+Managed AWS services like Amazon RDS and Aurora don't natively support VPC endpoint services. To use Private Links with these services, you need to set up additional infrastructure in your own AWS account to expose them via a Network Load Balancer that you own and manage.
 
 The general approach is almost identical to the steps above. You create an NLB that targets your RDS or Aurora endpoint, then create a VPC endpoint service that points to that NLB.
 

--- a/docs/platform/operating-airbyte/privatelink.md
+++ b/docs/platform/operating-airbyte/privatelink.md
@@ -45,13 +45,13 @@ Airbyte Cloud is multi-tenant cloud software, regardless of whether you use Priv
 
 ### Availability and supported regions
 
-Private Links is currently available for AWS only. Airbyte doesn't support Azure Private Endpoint or Google Cloud Private Service Connect.
+Private Links is currently available for AWS. If you need Private Links for Azure or GCP, [talk to sales](https://airbyte.com/company/talk-to-sales) so we can scope your requirements.
 
-| Cloud provider | Name                            | Available |
-| -------------- | ------------------------------- | --------- |
-| AWS            | PrivateLink                     | Yes       |
-| Azure          | Private Endpoint / Private Link | No        |
-| GCP            | Private Service Connect         | No        |
+| Cloud provider | Name                            | Available                                                  |
+| -------------- | ------------------------------- | ---------------------------------------------------------- |
+| AWS            | PrivateLink                     | Yes                                                        |
+| Azure          | Private Endpoint / Private Link | [Talk to sales](https://airbyte.com/company/talk-to-sales) |
+| GCP            | Private Service Connect         | [Talk to sales](https://airbyte.com/company/talk-to-sales) |
 
 Airbyte maintains AWS PrivateLink infrastructure in the US (`us-east-1`) and EU (`eu-west-3`). Your service can be in any AWS region. Airbyte uses [cross-region PrivateLink](https://aws.amazon.com/blogs/networking-and-content-delivery/introducing-cross-region-connectivity-for-aws-privatelink/) to connect to services outside of these regions, so you don't need to relocate your infrastructure.
 
@@ -61,9 +61,9 @@ Airbyte's PrivateLink endpoints are located in `us-east-1` (US) and `eu-west-3` 
 
 ### Limitations
 
-Private Links are currently limited to sources and destinations running in AWS. This includes services like Snowflake, Databricks, and PostgreSQL hosted on AWS. If you need to connect to resources outside of AWS, Private Links are not an option.
+Private Links are currently limited to sources and destinations running in AWS. This includes services like Snowflake, Databricks, and PostgreSQL hosted on AWS. If you need to connect to resources outside of AWS, Private Links are not yet available.
 
-Support for AWS S3 sources and destinations is in development. If you need a Private Link for an S3 bucket, [talk to sales](https://airbyte.com/company/talk-to-sales) so we can scope your requirements.
+Support for AWS S3 buckets is in development. If you need a PrivateLink for an S3 bucket, [talk to sales](https://airbyte.com/company/talk-to-sales) so we can scope your requirements.
 
 For managed AWS services like RDS or Aurora, additional configuration is required to expose them via AWS PrivateLink. See [Using Private Links with managed services](#using-private-links-with-managed-services) for details.
 

--- a/docs/platform/operating-airbyte/privatelink.md
+++ b/docs/platform/operating-airbyte/privatelink.md
@@ -68,7 +68,7 @@ For managed AWS services like RDS or Aurora, additional configuration is require
 
 ## Prerequisites
 
-Before setting up PrivateLink, ensure you have the following:
+Before setting up a Private Link, ensure you have the following:
 
 - **Airbyte Cloud Private Links add-on enabled**: Private Links is an add-on feature. [Talk to sales](https://airbyte.com/company/talk-to-sales) to enable it for your organization.
 
@@ -86,7 +86,7 @@ Before setting up PrivateLink, ensure you have the following:
   - `elasticloadbalancing:CreateTargetGroup`
   - `elasticloadbalancing:RegisterTargets`
 
-## Set up PrivateLink
+## Set up a Private Link
 
 ### Step 1: Contact Airbyte
 

--- a/docs/platform/operating-airbyte/privatelink.md
+++ b/docs/platform/operating-airbyte/privatelink.md
@@ -1,6 +1,5 @@
 ---
 products: cloud-teams
-sidebar_label: Private Links
 ---
 
 # Private Links
@@ -8,7 +7,7 @@ sidebar_label: Private Links
 Private Links allow Airbyte Cloud to securely connect to your data sources and destinations without using the public internet or exposing IPs. Traffic between Airbyte and your resources stays entirely within your cloud provider's private network, providing enhanced security for organizations with strict network isolation requirements.
 
 :::info
-Private Links is an add-on feature for Airbyte Cloud. To enable Private Links for your organization, [talk to sales](https://airbyte.com/company/talk-to-sales).
+Private Links is an add-on feature for Airbyte Cloud, and requires the Pro plan or above. To enable Private Links for your organization, [talk to sales](https://airbyte.com/company/talk-to-sales).
 :::
 
 ## Why use Private Links
@@ -63,13 +62,13 @@ Airbyte's PrivateLink endpoints are located in `us-east-1` (US) and `eu-west-3` 
 
 Private Links are currently limited to sources and destinations running in AWS. This includes services like Snowflake, Databricks, and PostgreSQL hosted on AWS. If you need to connect to resources outside of AWS, Private Links are not yet available.
 
-Support for AWS S3 buckets is in development. If you need a PrivateLink for an S3 bucket, [talk to sales](https://airbyte.com/company/talk-to-sales) so we can scope your requirements.
+If you need a PrivateLink for an S3 bucket, [talk to sales](https://airbyte.com/company/talk-to-sales) so we can scope your requirements.
 
-For managed AWS services like RDS or Aurora, additional configuration is required to expose them via AWS PrivateLink. See [Using Private Links with managed services](#using-private-links-with-managed-services) for details.
+For managed AWS services like RDS or Aurora, additional configuration is required to expose them via AWS PrivateLink. See [Using Private Links with AWS managed services](#using-private-links-with-aws-managed-services) for details.
 
 ## Prerequisites
 
-Before setting up a Private Link, ensure you have the following:
+Before setting up PrivateLink, ensure you have the following:
 
 - **Airbyte Cloud Private Links add-on enabled**: Private Links is an add-on feature. [Talk to sales](https://airbyte.com/company/talk-to-sales) to enable it for your organization.
 
@@ -87,7 +86,7 @@ Before setting up a Private Link, ensure you have the following:
   - `elasticloadbalancing:CreateTargetGroup`
   - `elasticloadbalancing:RegisterTargets`
 
-## Set up a Private Link
+## Set up PrivateLink
 
 ### Step 1: Contact Airbyte
 
@@ -103,7 +102,7 @@ For a complete overview of sharing services through AWS PrivateLink, see [Share 
 
 3. If your service is in a different region than Airbyte's PrivateLink infrastructure (`us-east-1` for US, `eu-west-3` for EU), enable cross-region support on your VPC endpoint service and add Airbyte's region to the supported regions list. See [Cross-region connectivity](#cross-region-connectivity) for more information.
 
-4. Note your endpoint service name. It follows the format `com.amazonaws.vpce.{region}.vpce-svc-{id}`. You'll provide this to Airbyte in Step 4.
+4. Note your endpoint service name. It follows the format `com.amazonaws.vpce.{region}.vpce-svc-{id}`. You provide this to Airbyte in Step 4.
 
 ### Step 3: Configure permissions for Airbyte
 
@@ -130,7 +129,7 @@ After Airbyte creates the VPC endpoint, the connection appears as **Pending Acce
 
 Once you accept the request, the connection status changes to **Available** and your Private Link is ready to use with your Airbyte connections.
 
-## Using Private Links with managed services
+## Using Private Links with AWS managed services
 
 Managed AWS services like Amazon RDS and Aurora don't natively support VPC endpoint services. To use Private Links with these services, you need to set up additional infrastructure to expose them via a Network Load Balancer.
 

--- a/docs/platform/operating-airbyte/privatelink.md
+++ b/docs/platform/operating-airbyte/privatelink.md
@@ -154,7 +154,7 @@ To set up Snowflake with Private Links:
 
 1. Complete [Step 4: Create the Private Link in Airbyte](#step-4-create-the-private-link-in-airbyte) and [Step 5: Accept the connection request](#step-5-accept-the-connection-request).
 2. Run [`SYSTEM$GET_PRIVATELINK_CONFIG`](https://docs.snowflake.com/en/sql-reference/functions/system_get_privatelink_config) in your Snowflake account.
-3. Reach out to Airbyte and share the output, along with the name of the Private Link you created in Step 4, so Airbyte can complete the DNS configuration.
+3. [Talk to sales](https://airbyte.com/company/talk-to-sales) and share the output, along with the name of the Private Link you created in Step 4, so Airbyte can complete the DNS configuration.
 4. Once Airbyte confirms the DNS is in place, the Private Link is ready for use with your Snowflake connector.
 
 For background on the DNS configuration involved, see [How to configure Route 53 to access Snowflake via PrivateLink](https://community.snowflake.com/s/article/How-to-configure-the-AWS-DNS-service-Route-53-to-access-Snowflake-via-a-PrivateLink) in the Snowflake community documentation.

--- a/docs/platform/operating-airbyte/privatelink.md
+++ b/docs/platform/operating-airbyte/privatelink.md
@@ -1,16 +1,21 @@
 ---
 products: cloud-teams
+sidebar_label: Private Links
 ---
 
-# PrivateLink
+# Private Links
 
-PrivateLink allows Airbyte Cloud to securely connect to your data sources and destinations without using the public internet or exposing IPs. Traffic between Airbyte and your resources stays entirely within your cloud provider's private network, providing enhanced security for organizations with strict network isolation requirements.
+Private Links allow Airbyte Cloud to securely connect to your data sources and destinations without using the public internet or exposing IPs. Traffic between Airbyte and your resources stays entirely within your cloud provider's private network, providing enhanced security for organizations with strict network isolation requirements.
 
-## Why use PrivateLink
+:::info
+Private Links is an add-on feature for Airbyte Cloud. To enable Private Links for your organization, [talk to sales](https://airbyte.com/company/talk-to-sales).
+:::
 
-Most Airbyte customers don't need to use PrivateLink. However, some organizatons maintain a heightened security posture and more comprehensive data protection, but still want to benefit from the simplicity of cloud infrastructure and SaaS. PrivateLink is an excellent choice for organizations that can't expose systems and data to the public internet.
+## Why use Private Links
 
-PrivateLink offers several advantages for security-conscious organizations.
+Most Airbyte customers don't need to use Private Links. However, some organizations maintain a heightened security posture and more comprehensive data protection, but still want to benefit from the simplicity of cloud infrastructure and SaaS. Private Links are an excellent choice for organizations that can't expose systems and data to the public internet.
+
+Private Links offer several advantages for security-conscious organizations.
 
 - **No public IP exposure**: Your data sources and destinations remain private. You don't need to assign public IP addresses or open firewall rules to the internet.
 
@@ -22,23 +27,25 @@ PrivateLink offers several advantages for security-conscious organizations.
 
 ## How it works
 
-With PrivateLink, you create a VPC endpoint service in your cloud provider that exposes your data source or destination. Airbyte then creates a VPC endpoint that connects to your endpoint service, establishing a private network path between Airbyte's infrastructure and your resources.
+With Private Links, you create a VPC endpoint service in your cloud provider that exposes your data source or destination. Airbyte then creates a VPC endpoint that connects to your endpoint service, establishing a private network path between Airbyte's infrastructure and your resources.
 
 When a sync runs, Airbyte routes traffic through this private connection rather than over the public internet. Your resources never need public IP addresses or internet-facing firewall rules. All communication happens within the cloud provider's internal network.
 
-Airbyte maintains dedicated infrastructure for PrivateLink connections, ensuring that only your workspace's sync jobs can access your endpoint.
+Airbyte maintains dedicated infrastructure for Private Links, ensuring that only your workspace's sync jobs can access your endpoint.
 
 ![Network diagram. The relationship of your VPC to Airbyte's. Data from pods flows from the data plane through the VPC without touching the public internet](assets/privatelink.png)
 
 ### Security model
 
-Airbyte's PrivateLink implementation ensures that only sync jobs from your workspace can access your PrivateLink endpoint. Each workspace is assigned a unique security token, and Airbyte's infrastructure enforces network-level isolation so that jobs from other workspaces cannot reach your endpoint, even if they run on shared infrastructure.
+Airbyte's Private Links implementation ensures that only sync jobs from your workspace can access your Private Link endpoint. Each workspace is assigned a unique security token, and Airbyte's infrastructure enforces network-level isolation so that jobs from other workspaces cannot reach your endpoint, even if they run on shared infrastructure.
 
 ### Single tenant or multi tenant
 
-Airbyte Cloud is multi-tenant cloud software, regardless of whether you use PrivateLink. However, PrivateLink can feel like a single-tenant experience due to the lack of a shared public endpoint and strong isolation at your network boundary. With or without PrivateLink, all sync jobs in Airbyte use separate Kubernetes pods. This pod-level isolation further helps ensure data syncs from one organizaton are never exposed to another organizaton. Your syncs never run in their pods, and their syncs never run in your pods.
+Airbyte Cloud is multi-tenant cloud software, regardless of whether you use Private Links. However, Private Links can feel like a single-tenant experience due to the lack of a shared public endpoint and strong isolation at your network boundary. With or without Private Links, all sync jobs in Airbyte use separate Kubernetes pods. This pod-level isolation further helps ensure data syncs from one organization are never exposed to another organization. Your syncs never run in their pods, and their syncs never run in your pods.
 
 ### Availability and supported regions
+
+Private Links is currently available for AWS only. Airbyte doesn't support Azure Private Endpoint or Google Cloud Private Service Connect.
 
 | Cloud provider | Name                            | Available |
 | -------------- | ------------------------------- | --------- |
@@ -46,7 +53,7 @@ Airbyte Cloud is multi-tenant cloud software, regardless of whether you use Priv
 | Azure          | Private Endpoint / Private Link | No        |
 | GCP            | Private Service Connect         | No        |
 
-Airbyte maintains PrivateLink infrastructure in the US (`us-east-1`) and EU (`eu-west-3`). Your service can be in any AWS region. Airbyte uses [cross-region PrivateLink](https://aws.amazon.com/blogs/networking-and-content-delivery/introducing-cross-region-connectivity-for-aws-privatelink/) to connect to services outside of these regions, so you don't need to relocate your infrastructure.
+Airbyte maintains AWS PrivateLink infrastructure in the US (`us-east-1`) and EU (`eu-west-3`). Your service can be in any AWS region. Airbyte uses [cross-region PrivateLink](https://aws.amazon.com/blogs/networking-and-content-delivery/introducing-cross-region-connectivity-for-aws-privatelink/) to connect to services outside of these regions, so you don't need to relocate your infrastructure.
 
 ### Cross-region connectivity
 
@@ -54,15 +61,19 @@ Airbyte's PrivateLink endpoints are located in `us-east-1` (US) and `eu-west-3` 
 
 ### Limitations
 
-PrivateLink connections are limited to sources and destinations running in AWS. This includes services like Snowflake, Databricks, and PostgreSQL hosted on AWS. If you need to connect to resources outside of AWS, PrivateLink is not an option.
+Private Links are currently limited to sources and destinations running in AWS. This includes services like Snowflake, Databricks, and PostgreSQL hosted on AWS. If you need to connect to resources outside of AWS, Private Links are not an option.
 
-For managed AWS services like RDS or Aurora, additional configuration is required to expose them via PrivateLink. See [Using PrivateLink with Managed Services](#using-privatelink-with-managed-services) for details.
+Support for AWS S3 sources and destinations is in development. If you need a Private Link for an S3 bucket, [talk to sales](https://airbyte.com/company/talk-to-sales) so we can scope your requirements.
+
+For managed AWS services like RDS or Aurora, additional configuration is required to expose them via AWS PrivateLink. See [Using Private Links with managed services](#using-private-links-with-managed-services) for details.
 
 ## Prerequisites
 
-Before setting up PrivateLink, ensure you have the following:
+Before setting up a Private Link, ensure you have the following:
 
-- **AWS infrastructure**: Your source or destination must be running in AWS, since PrivateLink is currently AWS-only.
+- **Airbyte Cloud Private Links add-on enabled**: Private Links is an add-on feature. [Talk to sales](https://airbyte.com/company/talk-to-sales) to enable it for your organization.
+
+- **AWS infrastructure**: Your source or destination must be running in AWS, since Private Links is currently AWS-only.
 
 - **Permissions to create VPC endpoint services**: You need IAM permissions to create and configure VPC endpoint services in your AWS account, including:
 
@@ -76,11 +87,11 @@ Before setting up PrivateLink, ensure you have the following:
   - `elasticloadbalancing:CreateTargetGroup`
   - `elasticloadbalancing:RegisterTargets`
 
-## Set up PrivateLink
+## Set up a Private Link
 
 ### Step 1: Contact Airbyte
 
-Before configuring anything, contact Airbyte to discuss your PrivateLink requirements. Airbyte will confirm region availability and provide you with the AWS account ID you'll need to grant access to your endpoint service.
+Before configuring anything, [talk to sales](https://airbyte.com/company/talk-to-sales) to enable the Private Links add-on and discuss your requirements. Airbyte will confirm region availability and provide you with the AWS account ID you'll need to grant access to your endpoint service.
 
 ### Step 2: Create a VPC Endpoint Service
 
@@ -92,7 +103,7 @@ For a complete overview of sharing services through AWS PrivateLink, see [Share 
 
 3. If your service is in a different region than Airbyte's PrivateLink infrastructure (`us-east-1` for US, `eu-west-3` for EU), enable cross-region support on your VPC endpoint service and add Airbyte's region to the supported regions list. See [Cross-region connectivity](#cross-region-connectivity) for more information.
 
-4. Note your endpoint service name. It follows the format `com.amazonaws.vpce.{region}.vpce-svc-{id}`. You provide this to Airbyte in Step 5.
+4. Note your endpoint service name. It follows the format `com.amazonaws.vpce.{region}.vpce-svc-{id}`. You'll provide this to Airbyte in Step 4.
 
 ### Step 3: Configure permissions for Airbyte
 
@@ -100,25 +111,28 @@ Add Airbyte's AWS account as an allowed principal on your endpoint service. This
 
 See [Manage permissions](https://docs.aws.amazon.com/vpc/latest/privatelink/configure-endpoint-service.html#add-remove-permissions) in the AWS documentation for instructions on adding principals to your endpoint service.
 
-### Step 4: Provide your endpoint service name to Airbyte
+### Step 4: Create the Private Link in Airbyte
 
-Share the following with Airbyte:
+Create the Private Link from your Airbyte Cloud workspace settings.
 
-- Your endpoint service name (for example, `com.amazonaws.vpce.us-west-2.vpce-svc-05df72d283c05fbc7`)
-- The AWS region your service is deployed in
-- The type of data source or destination (for example, PostgreSQL, Snowflake, MySQL). Some services, such as Snowflake, require additional DNS configuration on Airbyte's side. Providing the service type up front ensures Airbyte can complete the full setup.
+1. In Airbyte Cloud, go to **Workspace settings** > **Private Links**.
+2. Enter a **Name** for the Private Link (for example, `my-production-link`).
+3. Enter your **Endpoint Service Name** (for example, `com.amazonaws.vpce.us-east-1.vpce-svc-05df72d283c05fbc7`).
+4. Click **Create Private Link**.
 
-Airbyte creates a VPC endpoint that connects to your service.
+Airbyte creates a VPC endpoint that connects to your endpoint service.
+
+If your data source or destination requires additional DNS configuration (for example, Snowflake), share the service type and any required configuration with Airbyte after creating the Private Link. See [Using Private Links with Snowflake](#using-private-links-with-snowflake) for details.
 
 ### Step 5: Accept the connection request
 
-After Airbyte creates the VPC endpoint, the connection appears as **Pending Acceptance** in your AWS console under **VPC > Endpoint Services > Endpoint Connections**. You must accept this connection request before the PrivateLink connection becomes active.
+After Airbyte creates the VPC endpoint, the connection appears as **Pending Acceptance** in your AWS console under **VPC > Endpoint Services > Endpoint Connections**. You must accept this connection request before the Private Link becomes active.
 
-Once you accept the request, the connection status changes to **Available** and your PrivateLink connection is ready to use with your Airbyte connections.
+Once you accept the request, the connection status changes to **Available** and your Private Link is ready to use with your Airbyte connections.
 
-## Using PrivateLink with Managed Services
+## Using Private Links with managed services
 
-Managed AWS services like Amazon RDS and Aurora don't natively support VPC endpoint services. To use PrivateLink with these services, you need to set up additional infrastructure to expose them via a Network Load Balancer.
+Managed AWS services like Amazon RDS and Aurora don't natively support VPC endpoint services. To use Private Links with these services, you need to set up additional infrastructure to expose them via a Network Load Balancer.
 
 The general approach is almost identical to the steps above. You create an NLB that targets your RDS or Aurora endpoint, then create a VPC endpoint service that points to that NLB.
 
@@ -126,24 +140,24 @@ AWS provides a guide for this configuration: [Access Amazon RDS across VPCs usin
 
 When setting up the NLB and related infrastructure, keep the following requirements in mind:
 
-- **NLB scheme must be `internal`**: Do not use `internet-facing`. An internet-facing NLB creates public IPs and is incompatible with PrivateLink.
+- **NLB scheme must be `internal`**: Do not use `internet-facing`. An internet-facing NLB creates public IPs and is incompatible with AWS PrivateLink.
 - **NLB must be in a private subnet**: The subnet's route table must not have a route to an Internet Gateway.
 - **Target group targets must be healthy**: Register the IP address of your RDS or Aurora endpoint in the target group (resolve the DNS endpoint to an IP address using `nslookup`). Verify that targets show as **Healthy** in the AWS console.
 - **Database security group must allow NLB traffic**: Add an inbound rule to your database's security group allowing TCP traffic on the database port from the NLB's subnet CIDR. A self-referencing security group rule alone is not sufficient.
 
-### Using PrivateLink with Snowflake
+### Using Private Links with Snowflake
 
-Snowflake on AWS requires additional DNS configuration to work with PrivateLink, because Airbyte connectors connect using `*.snowflakecomputing.com` domain names.
+Snowflake on AWS requires additional DNS configuration to work with Private Links, because Airbyte connectors connect using `*.snowflakecomputing.com` domain names.
 
-To set up Snowflake with PrivateLink:
+To set up Snowflake with Private Links:
 
 1. Run [`SYSTEM$GET_PRIVATELINK_CONFIG`](https://docs.snowflake.com/en/sql-reference/functions/system_get_privatelink_config) in your Snowflake account and share the output with Airbyte.
-2. Airbyte configures the necessary DNS entries to route Snowflake traffic through the PrivateLink connection.
+2. Airbyte configures the necessary DNS entries to route Snowflake traffic through the Private Link.
 
 For background on the DNS configuration involved, see [How to configure Route 53 to access Snowflake via PrivateLink](https://community.snowflake.com/s/article/How-to-configure-the-AWS-DNS-service-Route-53-to-access-Snowflake-via-a-PrivateLink) in the Snowflake community documentation.
 
 ## IP allowlist (rare)
 
-In most cases, PrivateLink eliminates the need for IP allowlisting since traffic flows through private connections. However, if you have a connection where one side uses PrivateLink and the other side requires IP allowlisting (for example, a public source connecting to a PrivateLink-enabled destination), you may need to allowlist Airbyte's IP addresses for the non-PrivateLink endpoint.
+In most cases, Private Links eliminate the need for IP allowlisting since traffic flows through private connections. However, if you have a connection where one side uses a Private Link and the other side requires IP allowlisting (for example, a public source connecting to a destination behind a Private Link), you may need to allowlist Airbyte's IP addresses for the non-Private Link endpoint.
 
 These IPs are _separate_ from the normal IP allow list for Airbyte Cloud. Airbyte provides the list of IPs for your region on request.

--- a/docs/platform/operating-airbyte/privatelink.md
+++ b/docs/platform/operating-airbyte/privatelink.md
@@ -123,7 +123,7 @@ Create the Private Link from your Airbyte Cloud workspace settings.
 
 Airbyte creates a VPC endpoint that connects to your endpoint service.
 
-If your data source or destination requires additional DNS configuration (for example, Snowflake), share the service type and any required configuration with Airbyte after creating the Private Link. See [Using Private Links with Snowflake](#using-private-links-with-snowflake) for details.
+Snowflake setup isn't fully self-serve. Airbyte handles DNS for Snowflake connectors on its side, so after you create the Private Link in this step and accept the connection request in Step 5, follow [Using Private Links with Snowflake](#using-private-links-with-snowflake) to share the configuration Airbyte needs to finish setup.
 
 ### Step 5: Accept the connection request
 
@@ -148,12 +148,14 @@ When setting up the NLB and related infrastructure, keep the following requireme
 
 ### Using Private Links with Snowflake
 
-Snowflake on AWS requires additional DNS configuration to work with Private Links, because Airbyte connectors connect using `*.snowflakecomputing.com` domain names.
+Snowflake on AWS requires additional DNS configuration to work with Private Links, because Airbyte connectors connect using `*.snowflakecomputing.com` domain names. The Workspace settings UI doesn't provision this DNS, so setting up Snowflake is a two-stage process: you create the Private Link yourself, then Airbyte completes DNS provisioning on its side.
 
 To set up Snowflake with Private Links:
 
-1. Run [`SYSTEM$GET_PRIVATELINK_CONFIG`](https://docs.snowflake.com/en/sql-reference/functions/system_get_privatelink_config) in your Snowflake account and share the output with Airbyte.
-2. Airbyte configures the necessary DNS entries to route Snowflake traffic through the Private Link.
+1. Complete [Step 4: Create the Private Link in Airbyte](#step-4-create-the-private-link-in-airbyte) and [Step 5: Accept the connection request](#step-5-accept-the-connection-request).
+2. Run [`SYSTEM$GET_PRIVATELINK_CONFIG`](https://docs.snowflake.com/en/sql-reference/functions/system_get_privatelink_config) in your Snowflake account.
+3. Reach out to Airbyte and share the output, along with the name of the Private Link you created in Step 4, so Airbyte can complete the DNS configuration.
+4. Once Airbyte confirms the DNS is in place, the Private Link is ready for use with your Snowflake connector.
 
 For background on the DNS configuration involved, see [How to configure Route 53 to access Snowflake via PrivateLink](https://community.snowflake.com/s/article/How-to-configure-the-AWS-DNS-service-Route-53-to-access-Snowflake-via-a-PrivateLink) in the Snowflake community documentation.
 


### PR DESCRIPTION
## What

Updates the [Private Links docs](https://docs.airbyte.com/platform/operating-airbyte/privatelink) (formerly "PrivateLink") per @katmarkham's request:

- Renames the page and most prose to **Private Links** (the Airbyte feature). "PrivateLink" is reserved for places where we are explicitly referring to the AWS service (e.g. _AWS PrivateLink_, _cross-region PrivateLink_).
- Adds an `:::info` admonition at the top making it explicit that **Private Links is an add-on feature** for Airbyte Cloud requiring the **Pro plan or above**, with a [talk to sales](https://airbyte.com/company/talk-to-sales) link.
- Clarifies in the **Availability and supported regions** section that Private Links is **AWS-only** today, and links Azure / GCP rows in the table to talk-to-sales rather than just saying "No".
- Renames **Using Private Links with AWS managed services** to be explicit about scope, and adds a sales link for **AWS S3** support in **Limitations**.
- Rewrites **Step 4** to match the new self-serve **Workspace settings → Private Links** UI that Justin recently shipped (Name + Endpoint Service Name → "Create Private Link"), instead of the old "email the endpoint service name to Airbyte" flow.
- Drive-by: leaves the generic "PrivateLink support" mention in `enterprise-flex/readme.md` as-is per @katmarkham's review (the two AWS-specific occurrences in that page already say "AWS PrivateLink").

The file path (`docs/platform/operating-airbyte/privatelink.md`) and published URL (`/platform/operating-airbyte/privatelink`) are unchanged so existing inbound links keep working. The H1 (`# Private Links`) drives the sidebar label.

The versioned snapshot at `docusaurus/platform_versioned_docs/version-2.1/operating-airbyte/privatelink.md` is intentionally **not** modified — it's a historical version.

## How

Two files updated:

- `docs/platform/operating-airbyte/privatelink.md` — title, intro, all generic feature mentions, Step 4 rewrite, S3 limitation note, "Pro plan or above" admonition.
- `docs/platform/enterprise-flex/readme.md` — single generic mention (initially changed, then reverted per @katmarkham's review).

## Review guide

1. `docs/platform/operating-airbyte/privatelink.md` — main doc rewrite. Pay attention to:
   - Top admonition wording for the add-on / Pro plan / sales callout.
   - The new Step 4 (does it match the production UI from the screenshot?).
   - The S3 limitation wording.
   - Whether the AWS-vs-Airbyte naming split (PrivateLink vs Private Links vs "a Private Link") reads correctly throughout.
2. `docs/platform/enterprise-flex/readme.md` — currently unchanged from `master` after the revert.

## User Impact

Documentation-only. Customers reading the Private Links docs will see:
- The correct product name.
- An upfront callout that this is an add-on requiring the Pro plan and sales engagement.
- Accurate AWS-only scope, with Azure / GCP / S3 paths to talk-to-sales.
- Up-to-date Step 4 matching the new self-serve UI.

No code changes; no runtime impact.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚
- [ ] NO ❌

---

Requested by @katmarkham in [Slack](https://airbytehq-team.slack.com/archives/C08BHPUMEPJ/p1778124001504049?thread_ts=1778124001.504049&cid=C08BHPUMEPJ).

Link to Devin session: https://app.devin.ai/sessions/193ccf0f7a944832ba7a075505c56b27