### PR TITLE
chore(source-granola): promote 0.2.0-rc.4 to 0.2.0 GA

### DIFF
--- a/airbyte-integrations/connectors/source-granola/metadata.yaml
+++ b/airbyte-integrations/connectors/source-granola/metadata.yaml
@@ -7,7 +7,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 9023923c-002f-4131-9554-3ebdf56540a4
-  dockerImageTag: 0.2.0-rc.4
+  dockerImageTag: 0.2.0
   dockerRepository: airbyte/source-granola
   documentationUrl: https://docs.airbyte.com/integrations/sources/granola
   githubIssueLabel: source-granola
@@ -16,10 +16,8 @@ data:
   registryOverrides:
     cloud:
       enabled: true
-      dockerImageTag: 0.1.3
     oss:
       enabled: true
-      dockerImageTag: 0.1.3
   releaseStage: alpha
   remoteRegistries:
     pypi:
@@ -49,5 +47,5 @@ data:
       type: api_reference
   releases:
     rolloutConfiguration:
-      enableProgressiveRollout: true
+      enableProgressiveRollout: false
 metadataSpecVersion: "1.0"

--- a/docs/integrations/sources/granola.md
+++ b/docs/integrations/sources/granola.md
@@ -103,6 +103,7 @@ The connector handles rate limiting automatically by retrying requests when a `4
 
 | Version | Date       | Pull Request | Subject         |
 | :------ | :--------- | :----------- | :-------------- |
+| 0.2.0 | 2026-05-07 | [77698](https://github.com/airbytehq/airbyte/pull/77698) | Promote to GA: default_concurrency=5 with HTTP API budget (25 req/5s burst). Validated across 3 tuning iterations and Phase 2 Tier 2 rollout with 0% concurrency-related failures and -7.2% source read duration improvement. |
 | 0.2.0-rc.4 | 2026-05-01 | [77698](https://github.com/airbytehq/airbyte/pull/77698) | Revert default_concurrency from 6 to 5 (optimal value from tuning) and add HTTP API budget matching Granola's documented rate limit (25 req/5s burst) |
 | 0.2.0-rc.3 | 2026-04-28 | [77645](https://github.com/airbytehq/airbyte/pull/77645) | Increase default_concurrency from 5 to 6 for concurrency tuning iteration 3 (final) |
 | 0.2.0-rc.2 | 2026-04-29 | [77551](https://github.com/airbytehq/airbyte/pull/77551) | Increase default_concurrency from 4 to 5 for concurrency tuning iteration 2 |


### PR DESCRIPTION
## What\n\nPromote source-granola `0.2.0-rc.4` to `0.2.0` GA after successful concurrency tuning and Phase 2 Tier 2 rollout.\n\nThis is the culmination of a 3-iteration concurrency tuning process:\n- Iteration 1 (rc.1, c=4): -3.7% source read duration vs stable\n- Iteration 2 (rc.2, c=5): -14.4% vs stable (optimal)\n- Iteration 3 (rc.3, c=6): -7.8% vs stable\n- Phase 2 (rc.4, c=5 + API budget): -7.2% vs stable, 0% concurrency-related failures across 227 syncs\n\nRelated PRs:\n- https://github.com/airbytehq/airbyte/pull/77067 (rc.1)\n- https://github.com/airbytehq/airbyte/pull/77551 (rc.2)\n- https://github.com/airbytehq/airbyte/pull/77645 (rc.3)\n- https://github.com/airbytehq/airbyte/pull/77698 (rc.4)\n\n## How\n\n1. Bumped `dockerImageTag` from `0.2.0-rc.4` to `0.2.0` in `metadata.yaml`\n2. Removed cloud/oss registry overrides that pinned stable to `0.1.3` during rollout\n3. Disabled `enableProgressiveRollout` (GA release, no longer needed)\n4. Added GA changelog entry\n\n## Review guide\n\n1. `airbyte-integrations/connectors/source-granola/metadata.yaml` — version bump, registry override removal, rollout config\n2. `docs/integrations/sources/granola.md` — changelog entry\n\n## User Impact\n\nAll source-granola users will receive `0.2.0` with:\n- `default_concurrency=5` (up from 1 in stable) — approximately 7% faster source reads\n- HTTP API budget matching Granola's documented rate limit (25 req/5s burst) — proactive rate limit protection\n\n## Can this PR be safely reverted and rolled back?\n\n- [x] YES 💚"}
</invoke>

Link to Devin session: https://app.devin.ai/sessions/d78f9b087fdc48e58bea13476997498e
Requested by: @sophiecuiy