### PR TITLE
fix(source-mssql): restore registry enabled flags

### DIFF
--- a/airbyte-integrations/connectors/source-mssql/metadata.yaml
+++ b/airbyte-integrations/connectors/source-mssql/metadata.yaml
@@ -24,6 +24,11 @@ data:
       version: "0.0.2"
       supportedSerialization: ["JSONL", "PROTOBUF"]
       supportedTransport: ["SOCKET", "STDIO"]
+  registryOverrides:
+    cloud:
+      enabled: true
+    oss:
+      enabled: true
   releaseStage: alpha
   supportLevel: certified
   tags:


### PR DESCRIPTION
## What
Restores `registryOverrides.cloud.enabled: true` and `registryOverrides.oss.enabled: true` for `source-mssql`.

Investigation found that `source-mssql` 4.4.6 `metadata.yaml` is published at the public registry path, but `cloud.json` and `oss.json` for 4.4.6 return 404 and `source-mssql` is absent from both compiled registry indexes. The 4.4.6 merge removed the registry enabled flags, and the current registry artifact generation path skips `cloud.json` / `oss.json` when the corresponding `registryOverrides.<registry>.enabled` flag is missing.

## How
Adds back the registry override section with only the enablement flags. This does not re-add the prior `dockerImageTag: 4.4.3` pins, so once artifacts are regenerated/published, 4.4.6 can become the default registry entry.

## Review guide
1. `airbyte-integrations/connectors/source-mssql/metadata.yaml`

## User Impact
`source-mssql` 4.4.6 should be eligible to generate and publish Cloud/OSS registry entries again. Follow-up publish/compile is still needed after merge to populate the missing `cloud.json`/`oss.json` artifacts and compiled indexes.

## Can this PR be safely reverted and rolled back?
- [ ] YES 💚
- [ ] NO ❌

---
[Devin session](https://app.devin.ai/sessions/64751052e0304f2a8bf6490ec3aa8ea7)

Requested by: @aaronsteers