### PR TITLE
fix(source-dynamodb): stop masking reserved_attribute_names (#76947)

### DIFF
--- a/airbyte-integrations/connectors/source-dynamodb/metadata.yaml
+++ b/airbyte-integrations/connectors/source-dynamodb/metadata.yaml
@@ -17,7 +17,7 @@ data:
             type: GSM
   connectorType: source
   definitionId: 50401137-8871-4c5a-abb7-1f5fda35545a
-  dockerImageTag: 0.3.11
+  dockerImageTag: 0.3.12
   dockerRepository: airbyte/source-dynamodb
   documentationUrl: https://docs.airbyte.com/integrations/sources/dynamodb
   githubIssueLabel: source-dynamodb

--- a/airbyte-integrations/connectors/source-dynamodb/src/main/resources/spec.json
+++ b/airbyte-integrations/connectors/source-dynamodb/src/main/resources/spec.json
@@ -107,8 +107,7 @@
       "reserved_attribute_names": {
         "title": "Reserved attribute names",
         "type": "string",
-        "description": "Comma separated reserved attribute names present in your tables",
-        "airbyte_secret": true,
+        "description": "Comma separated reserved attribute names present in your tables. Not a secret — masking this field made connection maintenance harder (issue #76947).",
         "examples": ["name, field_name, field-name"]
       },
       "ignore_missing_read_permissions_tables": {

--- a/airbyte-integrations/connectors/source-dynamodb/src/test/java/io/airbyte/integrations/source/dynamodb/DynamodbSpecTest.java
+++ b/airbyte-integrations/connectors/source-dynamodb/src/test/java/io/airbyte/integrations/source/dynamodb/DynamodbSpecTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2026 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.integrations.source.dynamodb;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.airbyte.commons.json.Jsons;
+import io.airbyte.commons.resources.MoreResources;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Regression test for airbytehq/airbyte#76947.
+ *
+ * The {@code reserved_attribute_names} property was historically declared
+ * with {@code airbyte_secret: true}, which masks its value in the UI on
+ * every connection edit. Maintainers using the connector reported that
+ * they could not see the existing list of reserved attribute names when
+ * adding or removing a single entry, and had to re-type the whole list.
+ *
+ * The field holds attribute names that collide with DynamoDB reserved
+ * keywords (see https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.ExpressionAttributeNames.html).
+ * It contains schema metadata, not credentials, so the secret marking was
+ * incorrect.
+ *
+ * This test pins the property's secret-ness at "false / absent" so a
+ * future edit cannot silently re-introduce the masking.
+ */
+class DynamodbSpecTest {
+
+  @Test
+  void reservedAttributeNamesIsNotASecret() throws Exception {
+    final String specJson = MoreResources.readResource("spec.json");
+    final JsonNode spec = Jsons.deserialize(specJson);
+
+    final JsonNode reservedAttrs = spec
+        .path("connectionSpecification")
+        .path("properties")
+        .path("reserved_attribute_names");
+
+    assertThat(reservedAttrs.isMissingNode())
+        .as("reserved_attribute_names property must exist in spec.json")
+        .isFalse();
+
+    // The property may either omit airbyte_secret entirely (preferred) or
+    // explicitly set it to false. Either is fine; `true` is the regression.
+    final JsonNode airbyteSecret = reservedAttrs.path("airbyte_secret");
+    if (!airbyteSecret.isMissingNode()) {
+      assertThat(airbyteSecret.asBoolean(true))
+          .as("reserved_attribute_names must not be marked as a secret "
+              + "(see airbytehq/airbyte#76947)")
+          .isFalse();
+    }
+  }
+
+}

--- a/airbyte-integrations/connectors/source-dynamodb/src/test/java/io/airbyte/integrations/source/dynamodb/DynamodbSpecTest.java
+++ b/airbyte-integrations/connectors/source-dynamodb/src/test/java/io/airbyte/integrations/source/dynamodb/DynamodbSpecTest.java
@@ -14,19 +14,17 @@ import org.junit.jupiter.api.Test;
 /**
  * Regression test for airbytehq/airbyte#76947.
  *
- * The {@code reserved_attribute_names} property was historically declared
- * with {@code airbyte_secret: true}, which masks its value in the UI on
- * every connection edit. Maintainers using the connector reported that
- * they could not see the existing list of reserved attribute names when
- * adding or removing a single entry, and had to re-type the whole list.
+ * The {@code reserved_attribute_names} property was historically declared with
+ * {@code airbyte_secret: true}, which masks its value in the UI on every connection edit.
+ * Maintainers using the connector reported that they could not see the existing list of reserved
+ * attribute names when adding or removing a single entry, and had to re-type the whole list.
  *
- * The field holds attribute names that collide with DynamoDB reserved
- * keywords (see https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.ExpressionAttributeNames.html).
- * It contains schema metadata, not credentials, so the secret marking was
- * incorrect.
+ * The field holds attribute names that collide with DynamoDB reserved keywords (see
+ * https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.ExpressionAttributeNames.html).
+ * It contains schema metadata, not credentials, so the secret marking was incorrect.
  *
- * This test pins the property's secret-ness at "false / absent" so a
- * future edit cannot silently re-introduce the masking.
+ * This test pins the property's secret-ness at "false / absent" so a future edit cannot silently
+ * re-introduce the masking.
  */
 class DynamodbSpecTest {
 
@@ -35,23 +33,15 @@ class DynamodbSpecTest {
     final String specJson = MoreResources.readResource("spec.json");
     final JsonNode spec = Jsons.deserialize(specJson);
 
-    final JsonNode reservedAttrs = spec
-        .path("connectionSpecification")
-        .path("properties")
-        .path("reserved_attribute_names");
+    final JsonNode reservedAttrs = spec.path("connectionSpecification").path("properties").path("reserved_attribute_names");
 
-    assertThat(reservedAttrs.isMissingNode())
-        .as("reserved_attribute_names property must exist in spec.json")
-        .isFalse();
+    assertThat(reservedAttrs.isMissingNode()).as("reserved_attribute_names property must exist in spec.json").isFalse();
 
     // The property may either omit airbyte_secret entirely (preferred) or
     // explicitly set it to false. Either is fine; `true` is the regression.
     final JsonNode airbyteSecret = reservedAttrs.path("airbyte_secret");
     if (!airbyteSecret.isMissingNode()) {
-      assertThat(airbyteSecret.asBoolean(true))
-          .as("reserved_attribute_names must not be marked as a secret "
-              + "(see airbytehq/airbyte#76947)")
-          .isFalse();
+      assertThat(airbyteSecret.asBoolean(true)).as("reserved_attribute_names must not be marked as a secret (see airbytehq/airbyte#76947)").isFalse();
     }
   }
 

--- a/docs/integrations/sources/dynamodb.md
+++ b/docs/integrations/sources/dynamodb.md
@@ -78,6 +78,7 @@ the underlying role executing the container workload in AWS.
 
 | Version | Date       | Pull Request                                              | Subject                                                              |
 | :------ | :--------- | :-------------------------------------------------------- | :------------------------------------------------------------------- |
+| 0.3.12 | 2026-05-09 | [airbytehq/airbyte#76947](https://github.com/airbytehq/airbyte/issues/76947) | Stop masking `reserved_attribute_names` (was incorrectly marked as secret) |
 | 0.3.11 | 2025-07-10 | [62916](https://github.com/airbytehq/airbyte/pull/62916) | Add gradle docker plugins |
 | 0.3.10 | 2025-06-14 | [61601](https://github.com/airbytehq/airbyte/pull/61601) | fix(source-dynamodb): Replace ListNode with Iterator for lazyness #61600 |
 | 0.3.9 | 2025-02-12 | [53202](https://github.com/airbytehq/airbyte/pull/53202) | fixed IRSA by adding STS to classpath of connector. |


### PR DESCRIPTION
## What

Fixes #76947 — `reserved_attribute_names` in the DynamoDB source spec was incorrectly marked as a secret, masking its value on every connection edit.

## How

`spec.json` line 111 had `"airbyte_secret": true` on `reserved_attribute_names`. That property is a comma-separated list of DynamoDB attribute names that collide with [reserved keywords](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.ExpressionAttributeNames.html) — schema metadata, not credentials — so the secret marking was wrong.

The flag is removed (rather than set to `false`); the rest of the property declaration is untouched.

A new `DynamodbSpecTest` pins the expected non-secret state so a future edit cannot silently re-introduce the masking. The test reads `spec.json` via the standard `MoreResources.readResource` helper used elsewhere in the codebase.

## Review guide

1. `airbyte-integrations/connectors/source-dynamodb/src/main/resources/spec.json` — the actual fix: remove `"airbyte_secret": true` from `reserved_attribute_names`, plus a one-line description note.
2. `airbyte-integrations/connectors/source-dynamodb/src/test/java/io/airbyte/integrations/source/dynamodb/DynamodbSpecTest.java` — new regression test.
3. `airbyte-integrations/connectors/source-dynamodb/metadata.yaml` — `dockerImageTag` 0.3.11 → 0.3.12.
4. `docs/integrations/sources/dynamodb.md` — changelog entry.

## Reproduce BEFORE/AFTER yourself (copy-paste)

```bash
# --- one-time setup ---
git clone https://github.com/airbytehq/airbyte.git /tmp/repro && cd /tmp/repro

# --- BEFORE (origin/master) ---
git checkout origin/master
python3 -c "
import json
spec = json.load(open('airbyte-integrations/connectors/source-dynamodb/src/main/resources/spec.json'))
ra = spec['connectionSpecification']['properties']['reserved_attribute_names']
print('airbyte_secret =', ra.get('airbyte_secret'))
"
# Expected: airbyte_secret = True   ← the bug.

# --- AFTER (this PR) ---
git fetch https://github.com/jbbqqf/airbyte.git feat/76947-dynamodb-reserved-attribute-names-not-secret
git checkout FETCH_HEAD
python3 -c "
import json
spec = json.load(open('airbyte-integrations/connectors/source-dynamodb/src/main/resources/spec.json'))
ra = spec['connectionSpecification']['properties']['reserved_attribute_names']
print('airbyte_secret =', ra.get('airbyte_secret'))
"
# Expected: airbyte_secret = None   ← the property no longer carries the flag.
```

Maintainers can run the new JVM test directly:

```bash
./gradlew :airbyte-integrations:connectors:source-dynamodb:test --tests DynamodbSpecTest
# Expected on this branch: BUILD SUCCESSFUL.
# Expected on origin/master with the test cherry-picked: assertion fails on
#   `reserved_attribute_names must not be marked as a secret`.
```

## What I ran locally

- Static-validated the modified `spec.json` parses clean and no longer has `airbyte_secret` on the property (Python `json.load`, see reproducer above).
- Logically reviewed `DynamodbSpecTest.java` against existing patterns in the repo (`MoreResources.readResource("spec.json")` is the same idiom used in `Db2SourceCertificateAcceptanceTest.java:58` and elsewhere).
- I did **not** run the full `./gradlew :airbyte-integrations:connectors:source-dynamodb:test` suite locally because Airbyte's Gradle build needs Docker + JDK + a primed Gradle cache that wasn't available in this triage environment. Maintainers' CI exercises this on every PR (`connector-ci-checks.yml`), and the test is small + reads only `spec.json` so it has no integration dependencies.

## Edge cases tested

| # | Scenario | Input | Expected | Verified by |
|---|----------|-------|----------|-------------|
| 1 | Default branch state | `spec.json` on `origin/master` | `airbyte_secret == true` (the bug) | Reproducer block, BEFORE step |
| 2 | This PR | `spec.json` on this branch | `airbyte_secret` flag absent (preferred) or `false` | Reproducer block, AFTER step + `DynamodbSpecTest.reservedAttributeNamesIsNotASecret` |
| 3 | Future edit re-adds the flag | hypothetical `airbyte_secret: true` | Test fails | `DynamodbSpecTest` accepts missing-or-false; rejects true |

## User Impact

Users editing an existing DynamoDB connection see the existing `reserved_attribute_names` list in plaintext, which means they can add or remove a single entry without re-typing the whole list. No behavior change at sync time. No state migration needed — the field's value still passes through unchanged; only its UI presentation is affected.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚
- [ ] NO ❌

Pure spec/metadata change. Revert is the inverse three-line diff.

## Risk / blast radius

Touches only `source-dynamodb`. The field is currently masked in storage too (any pre-existing connection's value is encrypted at rest in the secret store). After this change, new edits will store the value as plaintext config. That is the **intended** behavior per the issue — the field doesn't hold secrets — but operators with strict policies should be aware. No automatic data migration is performed; existing connections will continue to round-trip the encrypted value until the user next edits it.

## Release note

```release-note
source-dynamodb: `reserved_attribute_names` is no longer masked as a secret in the UI, so users can see and edit the existing list without re-typing it.
```

---

*PR drafted with assistance from Claude Code as part of an automated triage pass on `airbytehq/airbyte` open issues. The change was reviewed manually against the upstream spec and the AWS DynamoDB reserved-words documentation. The reproducer block above was used during development; it is the same one a reviewer can paste verbatim.*
