### PR TITLE
chore(zendesk): update external documentation URLs

### DIFF
--- a/airbyte-integrations/connectors/source-zendesk-chat/metadata.yaml
+++ b/airbyte-integrations/connectors/source-zendesk-chat/metadata.yaml
@@ -19,6 +19,18 @@ data:
     - title: Changelog
       url: https://developer.zendesk.com/api-reference/changelog/changelog/
       type: api_release_history
+    - title: Zendesk Chat API
+      url: https://developer.zendesk.com/api-reference/live-chat/chat-api/introduction/
+      type: api_reference
+    - title: Zendesk Chat OAuth
+      url: https://developer.zendesk.com/api-reference/live-chat/chat-api/oauth/
+      type: authentication_guide
+    - title: Zendesk OAuth token expiration
+      url: https://support.zendesk.com/hc/en-us/articles/10212201463962-Announcing-the-required-expiration-of-global-OAuth-access-and-refresh-tokens
+      type: api_deprecations
+    - title: Zopim Chat REST API domain deprecation
+      url: https://support.zendesk.com/hc/en-us/articles/7827476398362-Deprecating-the-Zopim-Chat-REST-API-domain
+      type: api_deprecations
   githubIssueLabel: source-zendesk-chat
   icon: zendesk-chat.svg
   license: ELv2

--- a/airbyte-integrations/connectors/source-zendesk-talk/metadata.yaml
+++ b/airbyte-integrations/connectors/source-zendesk-talk/metadata.yaml
@@ -20,6 +20,15 @@ data:
     - title: Changelog
       url: https://developer.zendesk.com/api-reference/changelog/changelog/
       type: api_release_history
+    - title: Zendesk Talk API
+      url: https://developer.zendesk.com/api-reference/voice/talk-api/introduction/
+      type: api_reference
+    - title: Zendesk OAuth authentication
+      url: https://support.zendesk.com/hc/en-us/articles/4408845965210-Using-OAuth-authentication-with-your-application
+      type: authentication_guide
+    - title: Zendesk OAuth token expiration
+      url: https://support.zendesk.com/hc/en-us/articles/10212201463962-Announcing-the-required-expiration-of-global-OAuth-access-and-refresh-tokens
+      type: api_deprecations
   githubIssueLabel: source-zendesk-talk
   icon: zendesk-talk.svg
   license: ELv2


### PR DESCRIPTION
## What
Updates `source-zendesk-chat` and `source-zendesk-talk` metadata with Zendesk API reference, OAuth/authentication, and deprecation URLs found during the Zendesk API deprecation monitoring run.

No stale URLs were removed; the existing Developer Updates and Changelog URLs are still live.

Resolves https://github.com/airbytehq/oncall/issues/10426
Resolves https://github.com/airbytehq/oncall/issues/10443

- https://github.com/airbytehq/oncall/issues/11261
- https://github.com/airbytehq/oncall/issues/11782

## How
Adds higher-priority `externalDocumentationUrls` entries using the existing metadata schema types:

- `api_reference` for Zendesk Chat and Talk API docs
- `authentication_guide` for Zendesk OAuth/authentication docs
- `api_deprecations` for Zendesk OAuth token expiration and Zopim Chat REST API domain deprecation docs

## Review guide
1. `airbyte-integrations/connectors/source-zendesk-chat/metadata.yaml`
2. `airbyte-integrations/connectors/source-zendesk-talk/metadata.yaml`

## User Impact
Future API deprecation monitoring runs have direct access to the relevant Zendesk reference, auth, and deprecation pages from connector metadata. Connector runtime behavior is unchanged.

## Can this PR be safely reverted and rolled back?
- [x] YES 💚

---
[Devin session](https://app.devin.ai/sessions/6f460eb2433942a58e5a38037a50f4cd)

Requested by: @DanyloGL