### PR TITLE
ci(workflows): Add progressive rollout gate

### DIFF
--- a/.github/scripts/query-progressive-rollout.uv
+++ b/.github/scripts/query-progressive-rollout.uv
@@ -1,0 +1,252 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.11,<3.13"
+# dependencies = [
+#   "airbyte-internal-ops",
+#   "pyyaml>=6.0,<7.0",
+# ]
+# ///
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+import urllib.request
+from pathlib import Path
+from typing import Mapping
+
+import yaml
+from airbyte_ops_mcp.mcp.prod_db_queries import query_prod_connector_rollouts
+
+
+ACK_MARKER = "ACK: I understand this PR modifies connectors with active progressive rollouts"
+
+
+def mapping_value(mapping: Mapping[str, object], key: str) -> Mapping[str, object]:
+    value = mapping.get(key)
+    if not isinstance(value, Mapping):
+        raise ValueError(f"Metadata field `{key}` must be an object.")
+    return value
+
+
+def string_value(mapping: Mapping[str, object], key: str) -> str:
+    value = mapping.get(key)
+    if not isinstance(value, str) or value == "":
+        raise ValueError(f"Metadata field `{key}` must be a non-empty string.")
+    return value
+
+
+def load_connector_metadata(repo_path: Path, connector: str) -> tuple[str, str, str]:
+    metadata_path = (
+        repo_path / "airbyte-integrations" / "connectors" / connector / "metadata.yaml"
+    )
+    if not metadata_path.exists():
+        raise ValueError(f"Metadata file does not exist for connector `{connector}`.")
+
+    metadata = yaml.safe_load(metadata_path.read_text())
+    if not isinstance(metadata, Mapping):
+        raise ValueError(f"Metadata file is invalid for connector `{connector}`.")
+
+    data = mapping_value(metadata, "data")
+    definition_id = string_value(data, "definitionId")
+    docker_repository = string_value(data, "dockerRepository")
+    docker_image_tag = string_value(data, "dockerImageTag")
+    return definition_id, docker_repository, docker_image_tag
+
+
+def connector_doc_path(repo_path: Path, connector: str) -> Path | None:
+    if connector.startswith("source-"):
+        return (
+            repo_path
+            / "docs"
+            / "integrations"
+            / "sources"
+            / f"{connector.removeprefix('source-')}.md"
+        )
+    if connector.startswith("destination-"):
+        return (
+            repo_path
+            / "docs"
+            / "integrations"
+            / "destinations"
+            / f"{connector.removeprefix('destination-')}.md"
+        )
+    return None
+
+
+def find_rollout_pr_url(repo_path: Path, connector: str, docker_image_tag: str) -> str | None:
+    doc_path = connector_doc_path(repo_path, connector)
+    if doc_path is None or not doc_path.exists():
+        return None
+
+    pr_link_pattern = re.compile(
+        rf"^\|\s*{re.escape(docker_image_tag)}\s*\|.*?\|\s*\[[^\]]+\]\((https://github\.com/airbytehq/airbyte/pull/[0-9]+)\)",
+    )
+    for line in doc_path.read_text().splitlines():
+        match = pr_link_pattern.search(line)
+        if match:
+            return match.group(1)
+    return None
+
+
+def fetch_pr_body(repository: str, pr_number: str, token: str) -> str:
+    if repository == "" or pr_number == "" or token == "":
+        return ""
+
+    request = urllib.request.Request(
+        f"https://api.github.com/repos/{repository}/pulls/{pr_number}",
+        headers={
+            "Accept": "application/vnd.github+json",
+            "Authorization": f"Bearer {token}",
+            "X-GitHub-Api-Version": "2022-11-28",
+        },
+    )
+    with urllib.request.urlopen(request, timeout=30) as response:
+        response_body = response.read().decode("utf-8")
+
+    payload = json.loads(response_body)
+    if not isinstance(payload, Mapping):
+        return ""
+
+    body = payload.get("body")
+    if isinstance(body, str):
+        return body
+    return ""
+
+
+def is_acknowledged(pr_body: str) -> bool:
+    for line in pr_body.splitlines():
+        if re.search(r"^\s*[-*]\s*\[[xX]\]", line) and ACK_MARKER.lower() in line.lower():
+            return True
+    return False
+
+
+def write_result(output_file: Path, result: Mapping[str, object]) -> None:
+    output_file.parent.mkdir(parents=True, exist_ok=True)
+    output_file.write_text(json.dumps(result, indent=2, sort_keys=True))
+
+
+def check_rollouts(args: argparse.Namespace) -> int:
+    connector = args.connector
+    output_file = Path(args.output_file)
+
+    if connector == "":
+        write_result(output_file, {"connector": connector, "status": "no_connector"})
+        return 0
+
+    repo_path = Path(args.repo_path)
+    credentials_available = os.getenv("GCP_PROD_DB_ACCESS_CREDENTIALS", "") != ""
+    is_fork = os.getenv("IS_FORK", "false") == "true"
+    if not credentials_available:
+        result = {
+            "connector": connector,
+            "status": "skipped",
+            "reason": "GCP credentials are unavailable for this pull request.",
+        }
+        write_result(output_file, result)
+        if is_fork:
+            print("::warning::Skipping progressive rollout lookup for forked PR.")
+            return 0
+        print("::error::GCP credentials are unavailable for progressive rollout lookup.")
+        return 1
+
+    definition_id, docker_repository, docker_image_tag = load_connector_metadata(
+        repo_path,
+        connector,
+    )
+    pr_body = fetch_pr_body(
+        os.getenv("GITHUB_REPOSITORY", ""),
+        os.getenv("PR_NUMBER", ""),
+        os.getenv("GITHUB_TOKEN", ""),
+    )
+    acknowledged = is_acknowledged(pr_body)
+
+    rollouts = query_prod_connector_rollouts(
+        actor_definition_id=definition_id,
+        active_only=True,
+        limit=25,
+    )
+    rollout_results: list[dict[str, object]] = []
+    for rollout in rollouts:
+        rollout_results.append(
+            {
+                "rollout_id": rollout.rollout_id,
+                "state": rollout.state,
+                "actor_definition_id": rollout.actor_definition_id,
+                "initial_rollout_pct": rollout.initial_rollout_pct,
+                "current_target_rollout_pct": rollout.current_target_rollout_pct,
+                "final_target_rollout_pct": rollout.final_target_rollout_pct,
+                "has_breaking_changes": rollout.has_breaking_changes,
+                "rollout_strategy": rollout.rollout_strategy,
+                "workflow_run_id": rollout.workflow_run_id,
+                "tag": rollout.tag,
+                "created_at": rollout.created_at.isoformat() if rollout.created_at else None,
+                "updated_at": rollout.updated_at.isoformat() if rollout.updated_at else None,
+                "expires_at": rollout.expires_at.isoformat() if rollout.expires_at else None,
+                "rc_docker_image_tag": rollout.rc_docker_image_tag,
+                "rc_docker_repository": rollout.rc_docker_repository,
+                "initial_docker_image_tag": rollout.initial_docker_image_tag,
+                "initial_docker_repository": rollout.initial_docker_repository,
+                "customer_tier": rollout.customer_tier,
+                "rollout_pr_url": find_rollout_pr_url(
+                    repo_path,
+                    connector,
+                    rollout.rc_docker_image_tag or "",
+                ),
+            }
+        )
+
+    status = "clear"
+    if rollout_results and acknowledged:
+        status = "acknowledged"
+    if rollout_results and not acknowledged:
+        status = "blocked"
+
+    write_result(
+        output_file,
+        {
+            "connector": connector,
+            "status": status,
+            "acknowledged": acknowledged,
+            "definition_id": definition_id,
+            "docker_repository": docker_repository,
+            "docker_image_tag": docker_image_tag,
+            "rollouts": rollout_results,
+        },
+    )
+
+    if status == "blocked":
+        print(f"::error::Active progressive rollout found for {connector}.")
+        return 1
+    if status == "acknowledged":
+        print(f"::warning::Active progressive rollout acknowledged for {connector}.")
+        return 0
+
+    print(f"No active progressive rollout found for {connector}.")
+    return 0
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--connector", required=True)
+    parser.add_argument("--repo-path", required=True)
+    parser.add_argument("--output-file", required=True)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        return check_rollouts(args)
+    except ValueError as error:
+        output_file = Path(args.output_file)
+        write_result(output_file, {"status": "error", "error": str(error)})
+        print(f"::error::{error}")
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/render-progressive-rollout-gate.uv
+++ b/.github/scripts/render-progressive-rollout-gate.uv
@@ -1,0 +1,234 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.11,<3.13"
+# dependencies = []
+# ///
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+import urllib.request
+from pathlib import Path
+from typing import Mapping
+
+
+ACK_LINE = "- [x] ACK: I understand this PR modifies connectors with active progressive rollouts and want to merge anyway."
+ACK_MARKER = "ACK: I understand this PR modifies connectors with active progressive rollouts"
+
+
+def fetch_pr_body(repository: str, pr_number: str, token: str) -> str:
+    if repository == "" or pr_number == "" or token == "":
+        return ""
+
+    request = urllib.request.Request(
+        f"https://api.github.com/repos/{repository}/pulls/{pr_number}",
+        headers={
+            "Accept": "application/vnd.github+json",
+            "Authorization": f"Bearer {token}",
+            "X-GitHub-Api-Version": "2022-11-28",
+        },
+    )
+    with urllib.request.urlopen(request, timeout=30) as response:
+        response_body = response.read().decode("utf-8")
+
+    payload = json.loads(response_body)
+    if not isinstance(payload, Mapping):
+        return ""
+
+    body = payload.get("body")
+    if isinstance(body, str):
+        return body
+    return ""
+
+
+def is_acknowledged(pr_body: str) -> bool:
+    for line in pr_body.splitlines():
+        if re.search(r"^\s*[-*]\s*\[[xX]\]", line) and ACK_MARKER.lower() in line.lower():
+            return True
+    return False
+
+
+def load_result_files(artifacts_dir: Path) -> list[Mapping[str, object]]:
+    results: list[Mapping[str, object]] = []
+    if not artifacts_dir.exists():
+        return results
+
+    for result_file in sorted(artifacts_dir.glob("**/*.json")):
+        result = json.loads(result_file.read_text())
+        if isinstance(result, Mapping):
+            results.append(result)
+    return results
+
+
+def rollout_items(results: list[Mapping[str, object]]) -> list[tuple[Mapping[str, object], Mapping[str, object]]]:
+    items: list[tuple[Mapping[str, object], Mapping[str, object]]] = []
+    for result in results:
+        rollouts = result.get("rollouts")
+        if not isinstance(rollouts, list):
+            continue
+        for rollout in rollouts:
+            if isinstance(rollout, Mapping):
+                items.append((result, rollout))
+    return items
+
+
+def format_value(value: object) -> str:
+    if value is None or value == "":
+        return "unknown"
+    return str(value)
+
+
+def format_comment(
+    results: list[Mapping[str, object]],
+    active_rollouts: list[tuple[Mapping[str, object], Mapping[str, object]]],
+    acknowledged: bool,
+    run_url: str,
+) -> str:
+    lines = [
+        "<!-- progressive-rollout-gate -->",
+        "> **Progressive rollout gate**",
+        ">",
+    ]
+
+    skipped = [result for result in results if result.get("status") == "skipped"]
+
+    if not active_rollouts and not skipped:
+        lines.extend(
+            [
+                "> No active progressive rollouts were found for modified connectors.",
+                ">",
+                f"> [View workflow run]({run_url})",
+                "",
+            ]
+        )
+        return "\n".join(lines)
+
+    if not active_rollouts:
+        lines.extend(
+            [
+                "> No active progressive rollouts were found for modified connectors that could be checked.",
+                ">",
+            ]
+        )
+
+    if active_rollouts and acknowledged:
+        lines.extend(
+            [
+                "> Active progressive rollouts were found, but this PR is acknowledged in the PR description.",
+                "> The check passes with this warning so the PR can merge intentionally.",
+                ">",
+            ]
+        )
+    if active_rollouts and not acknowledged:
+        lines.extend(
+            [
+                "> Active progressive rollouts were found for modified connectors.",
+                "> This check blocks until the rollout finishes or the PR description includes the ACK checkbox.",
+                ">",
+            ]
+        )
+
+    if active_rollouts:
+        lines.append("> **Active rollouts**")
+        lines.append(">")
+    for result, rollout in active_rollouts:
+        connector = format_value(result.get("connector"))
+        rc_repository = format_value(rollout.get("rc_docker_repository"))
+        rc_tag = format_value(rollout.get("rc_docker_image_tag"))
+        initial_tag = format_value(rollout.get("initial_docker_image_tag"))
+        rollout_pr_url = rollout.get("rollout_pr_url")
+        lines.append(f"> - `{connector}`")
+        lines.append(f">   - Rollout ID: `{format_value(rollout.get('rollout_id'))}`")
+        lines.append(f">   - State: `{format_value(rollout.get('state'))}`")
+        lines.append(f">   - RC image: `{rc_repository}:{rc_tag}`")
+        lines.append(f">   - Initial version: `{initial_tag}`")
+        lines.append(
+            f">   - Target: `{format_value(rollout.get('current_target_rollout_pct'))}%` of `{format_value(rollout.get('final_target_rollout_pct'))}%`"
+        )
+        lines.append(f">   - Customer tier: `{format_value(rollout.get('customer_tier'))}`")
+        if isinstance(rollout_pr_url, str) and rollout_pr_url:
+            lines.append(f">   - Rollout PR: {rollout_pr_url}")
+        lines.append(">")
+
+    if skipped:
+        lines.append("> **Skipped lookups**")
+        lines.append(">")
+        for result in skipped:
+            lines.append(f"> - `{format_value(result.get('connector'))}`: {format_value(result.get('reason'))}")
+        lines.append(">")
+        lines.append("> This gate fails because rollout status could not be verified.")
+        lines.append(">")
+
+    lines.extend(
+        [
+            "> **ACK override**",
+            ">",
+            f"> ACK status: `{'acknowledged' if acknowledged else 'not acknowledged'}`",
+            ">",
+            "> To override this gate, add this exact checked item to the PR description:",
+            ">",
+            f"> `{ACK_LINE}`",
+            ">",
+            "> After the rollout completes or after adding the ACK checkbox, re-run this workflow from the Actions run page.",
+            f"> [View workflow run]({run_url})",
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def write_output(name: str, value: str) -> None:
+    github_output = os.getenv("GITHUB_OUTPUT")
+    if github_output is None or github_output == "":
+        print(f"{name}={value}")
+        return
+    output_path = Path(github_output)
+    output_path.write_text(f"{output_path.read_text()}{name}={value}\n")
+
+
+def render(args: argparse.Namespace) -> int:
+    results = load_result_files(Path(args.artifacts_dir))
+    active_rollouts = rollout_items(results)
+    acknowledged = is_acknowledged(
+        fetch_pr_body(
+            os.getenv("GITHUB_REPOSITORY", ""),
+            os.getenv("PR_NUMBER", ""),
+            os.getenv("GITHUB_TOKEN", ""),
+        )
+    )
+    failed_results = [result for result in results if result.get("status") == "error"]
+    skipped_results = [result for result in results if result.get("status") == "skipped"]
+    has_rollouts = len(active_rollouts) > 0
+    matrix_failed = os.getenv("ROLLOUT_MATRIX_RESULT", "") == "failure"
+    result = (
+        "failure"
+        if matrix_failed or failed_results or skipped_results or (has_rollouts and not acknowledged)
+        else "success"
+    )
+
+    run_url = os.getenv("RUN_URL", "")
+    comment_body = format_comment(results, active_rollouts, acknowledged, run_url)
+    comment_body_path = Path(args.comment_body_path)
+    comment_body_path.parent.mkdir(parents=True, exist_ok=True)
+    comment_body_path.write_text(comment_body)
+
+    write_output("has-rollouts", str(has_rollouts).lower())
+    write_output("acked", str(acknowledged).lower())
+    write_output("result", result)
+    write_output("comment-body-path", str(comment_body_path))
+    return 0
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--artifacts-dir", required=True)
+    parser.add_argument("--comment-body-path", required=True)
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    sys.exit(render(parse_args()))

--- a/.github/workflows/connector-ci-checks.yml
+++ b/.github/workflows/connector-ci-checks.yml
@@ -7,6 +7,7 @@ on:
       - synchronize
       - reopened
       - ready_for_review
+      - edited
 
   # Available as a reusable workflow
   # (https://docs.github.com/en/actions/sharing-automations/reusing-workflows)
@@ -42,6 +43,7 @@ permissions:
   contents: read
   checks: write
   pull-requests: write
+  issues: write
 
 jobs:
   generate-matrix:
@@ -479,6 +481,157 @@ jobs:
             echo "Skipping CDK pre-release check for non-Python connector."
           fi
 
+  progressive-rollout-gate:
+    if: github.event.pull_request.draft == false
+    needs: [generate-matrix]
+    strategy:
+      matrix: ${{ fromJson(needs.generate-matrix.outputs.connectors-matrix) }}
+      max-parallel: 10
+      fail-fast: false
+    name: "${{ matrix.connector || 'No-Op' }} Progressive Rollout Gate"
+    runs-on: ubuntu-24.04
+    env:
+      GCP_PROD_DB_ACCESS_CREDENTIALS: ${{ secrets.GCP_GSM_CREDENTIALS }}
+      GITHUB_TOKEN: ${{ github.token }}
+      PR_NUMBER: ${{ inputs.pr || github.event.pull_request.number }}
+      IS_FORK: ${{ github.event.pull_request.head.repo.fork == true }}
+    steps:
+      - name: Checkout Airbyte
+        if: matrix.connector
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: ${{ inputs.repo || github.event.pull_request.head.repo.full_name }}
+          ref: ${{ inputs.gitref || github.head_ref || github.ref_name }}
+          submodules: true # Needed for airbyte-enterprise connectors (no-op otherwise)
+          fetch-depth: 1
+
+      - name: Install uv
+        if: matrix.connector
+        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
+
+      - name: Install Cloud SQL Auth Proxy
+        if: matrix.connector
+        run: |
+          set -euo pipefail
+          curl --fail --show-error --location --output cloud-sql-proxy \
+            https://storage.googleapis.com/cloud-sql-connectors/cloud-sql-proxy/v2.18.3/cloud-sql-proxy.linux.amd64
+          chmod +x cloud-sql-proxy
+          sudo mv cloud-sql-proxy /usr/local/bin/
+          cloud-sql-proxy --version
+
+      - name: Start Cloud SQL Auth Proxy
+        if: matrix.connector
+        env:
+          GCP_PROD_DB_ACCESS_CREDENTIALS: ${{ secrets.GCP_GSM_CREDENTIALS }}
+          USE_CLOUD_SQL_PROXY: "1"
+          DB_PORT: "15432"
+        run: |
+          set -euo pipefail
+          uvx --from=airbyte-internal-ops airbyte-ops cloud db start-proxy --port 15432
+          for i in {1..30}; do
+            if nc -z localhost 15432 2>/dev/null; then
+              echo "Cloud SQL Proxy is ready on port 15432"
+              break
+            fi
+            echo "Waiting for Cloud SQL Proxy... ($i/30)"
+            sleep 1
+          done
+          if ! nc -z localhost 15432 2>/dev/null; then
+            echo "::error::Cloud SQL Proxy failed to start."
+            exit 1
+          fi
+
+      - name: Query progressive rollouts
+        if: matrix.connector
+        id: rollout-query
+        env:
+          USE_CLOUD_SQL_PROXY: "1"
+          DB_PORT: "15432"
+        run: >
+          ./.github/scripts/query-progressive-rollout.uv
+          --connector "${{ matrix.connector }}"
+          --repo-path "$GITHUB_WORKSPACE"
+          --output-file "progressive-rollout-results/${{ matrix.connector }}.json"
+
+      - name: Upload progressive rollout result
+        if: always() && !cancelled() && matrix.connector
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: progressive-rollout-gate-${{ matrix.connector }}
+          path: progressive-rollout-results/${{ matrix.connector }}.json
+          retention-days: 7
+          if-no-files-found: ignore
+
+  progressive-rollout-gate-summary:
+    name: Progressive Rollout Gate Summary
+    if: always() && github.event.pull_request.draft == false
+    needs:
+      - generate-matrix
+      - progressive-rollout-gate
+    runs-on: ubuntu-24.04
+    outputs:
+      result: ${{ steps.render.outputs.result }}
+    env:
+      GITHUB_TOKEN: ${{ github.token }}
+      PR_NUMBER: ${{ inputs.pr || github.event.pull_request.number }}
+      RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+      ROLLOUT_MATRIX_RESULT: ${{ needs.progressive-rollout-gate.result }}
+    steps:
+      - name: Checkout Airbyte
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: ${{ inputs.repo || github.event.pull_request.head.repo.full_name }}
+          ref: ${{ inputs.gitref || github.head_ref || github.ref_name }}
+          submodules: true # Needed for airbyte-enterprise connectors (no-op otherwise)
+          fetch-depth: 1
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
+
+      - name: Download progressive rollout results
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        continue-on-error: true
+        with:
+          pattern: progressive-rollout-gate-*
+          path: progressive-rollout-results
+          merge-multiple: true
+
+      - name: Render progressive rollout status
+        id: render
+        run: >
+          ./.github/scripts/render-progressive-rollout-gate.uv
+          --artifacts-dir progressive-rollout-results
+          --comment-body-path "$RUNNER_TEMP/progressive-rollout-comment.md"
+
+      - name: Find progressive rollout comment
+        if: github.event_name == 'pull_request'
+        id: find-comment
+        uses: peter-evans/find-comment@c508ad706980ed44e6c7cc5518bd6811bd6a7028 # v3.1.0
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-author: "github-actions[bot]"
+          body-includes: "<!-- progressive-rollout-gate -->"
+
+      - name: Update progressive rollout comment
+        if: github.event_name == 'pull_request'
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-id: ${{ steps.find-comment.outputs.comment-id }}
+          body-path: ${{ steps.render.outputs.comment-body-path }}
+          edit-mode: replace
+
+      - name: Print ACK warning
+        if: steps.render.outputs.acked == 'true' && steps.render.outputs.has-rollouts == 'true'
+        run: |
+          echo "::warning::Active progressive rollouts were acknowledged in the PR description."
+
+      - name: Fail on unacknowledged rollout
+        if: steps.render.outputs.result != 'success'
+        run: |
+          echo "::error::Active progressive rollout found. Add the ACK checkbox to the PR description or wait for rollout completion."
+          exit 1
+
   # --- Soft launch: ops CLI artifact generation + validation (parallel job) ---
   # Runs alongside existing pre-release checks to validate the new ops CLI path.
   # continue-on-error: true ensures this does not block the CI pipeline.
@@ -580,6 +733,7 @@ jobs:
       - jvm-connectors-test
       - non-jvm-connectors-test
       - pre-release-checks
+      - progressive-rollout-gate-summary
       - connectors-lint
     runs-on: ubuntu-24.04
     outputs:
@@ -590,6 +744,7 @@ jobs:
         run: |
           if [[ "${{ needs.jvm-connectors-test.result }}" == "success" &&
                 "${{ needs.non-jvm-connectors-test.result }}" == "success" &&
+                "${{ needs.progressive-rollout-gate-summary.result }}" != "failure" &&
                 "${{ needs.connectors-lint.result }}" == "success" ]]; then
             echo "result=success" | tee -a $GITHUB_OUTPUT
           else


### PR DESCRIPTION
## What
Adds a Connector CI gate that checks modified connectors for active progressive rollouts and blocks ready PRs until the rollout completes or the PR author explicitly acknowledges the risk.

## How
- Adds a matrix job that uses each modified connector's `metadata.yaml` `definitionId` to query active rollout state through `airbyte-internal-ops` and the Cloud SQL proxy.
- Aggregates per-connector results into a single PR comment that lists active rollout IDs, states, RC versions, rollout PR links when available, ACK status, and a workflow run link for re-runs.
- Uses an exact ACK checkbox in the PR description so the workflow can be re-run after an edit without a dummy commit.
- Includes the gate result in the existing Connector CI aggregate check.

## Review guide
1. `.github/workflows/connector-ci-checks.yml`
2. `.github/scripts/query-progressive-rollout.uv`
3. `.github/scripts/render-progressive-rollout-gate.uv`

## User Impact
Connector PRs with active progressive rollouts get a blocking disclosure comment before merge. Authors can intentionally proceed by adding the ACK checkbox to the PR description and re-running the workflow.

## Can this PR be safely reverted and rolled back?
- [x] YES 💚
- [ ] NO ❌

## Testing
- `uvx ruff check .github/scripts/query-progressive-rollout.uv .github/scripts/render-progressive-rollout-gate.uv`
- `python -m py_compile .github/scripts/query-progressive-rollout.uv .github/scripts/render-progressive-rollout-gate.uv`
- `uv run --with pyyaml python - <<'PY' ... yaml.safe_load(Path('.github/workflows/connector-ci-checks.yml').read_text()) ... PY`
- Locally smoke-tested no-connector, skipped-credentials, and active-rollout fixture rendering paths.

Link to Devin session: https://app.devin.ai/sessions/13ae42611c254ef8a91c77ddc207bbb6
Requested by: @aaronsteers