### PR TITLE
docs(ai-agents): Remove webhook automation trigger docs

### DIFF
--- a/docs/ai-agents/admin/sessions.md
+++ b/docs/ai-agents/admin/sessions.md
@@ -32,8 +32,8 @@ The Sessions table lists the most recent sessions first. Each row represents one
 - **Output Tokens**: The total tokens the agent produced, across every turn in the session.
 - **Date**: When the session last updated. Sessions that are still running show the most recent activity time. Dates display in your browser's local [time zone](../concepts/time-zones).
 - **Actions**: Per-row buttons to review or resume the session.
-    - Click the **View** icon to open the session and see its messages and tool calls.
-    - Click the **Chat** icon to jump to the chat or automation the session belongs to.
+  - Click the **View** icon to open the session and see its messages and tool calls.
+  - Click the **Chat** icon to jump to the chat or automation the session belongs to.
 
 Use the **Type**, **Status**, and **Connectors** filters above the table to narrow the list. The Type filter scopes to chats or automations. The Status filter scopes to Active, which you can resume, or Deleted. The Connectors filter scopes to sessions that used one or more specific connectors.
 
@@ -49,7 +49,7 @@ Chats you hold inside the Automation Builder, while designing or editing an auto
 
 ### Automation {#automation}
 
-An Automation session is one run of an automation. The session starts when the automation's trigger fires (a schedule, a webhook, or a manual run) and ends when the automation finishes. Automations don't have a user in the loop, so their sessions are typically a sequence of tool calls and internal reasoning rather than a back-and-forth conversation.
+An Automation session is one run of an automation. The session starts when you start a manual run or when its schedule fires, and ends when the automation finishes. Automations don't have a user in the loop, so their sessions are typically a sequence of tool calls and internal reasoning rather than a back-and-forth conversation.
 
 Each run of an automation is its own session. If the same automation runs on a schedule, each scheduled run appears as a separate row in the Sessions table.
 

--- a/docs/ai-agents/admin/sessions.md
+++ b/docs/ai-agents/admin/sessions.md
@@ -49,7 +49,7 @@ Chats you hold inside the Automation Builder, while designing or editing an auto
 
 ### Automation {#automation}
 
-An Automation session is one run of an automation. The session starts when you start a manual run or when its schedule fires, and ends when the automation finishes. Automations don't have a user in the loop, so their sessions are typically a sequence of tool calls and internal reasoning rather than a back-and-forth conversation.
+An Automation session is one run of an automation. The session starts when you start a manual run or when scheduled, and ends when the automation finishes. Automations don't have a user in the loop, so their sessions are typically a sequence of tool calls and internal reasoning rather than a back-and-forth conversation.
 
 Each run of an automation is its own session. If the same automation runs on a schedule, each scheduled run appears as a separate row in the Sessions table.
 

--- a/docs/ai-agents/concepts/agent-operations.md
+++ b/docs/ai-agents/concepts/agent-operations.md
@@ -20,14 +20,14 @@ Airbyte does not expose the exact formula that converts tool calls and reasoning
 
 Any interaction with an agent consumes AOs. The source of the interaction determines how Airbyte tracks it.
 
-| Source | Description | Tracked as a session? | Tool calls visible? |
-| --- | --- | --- | --- |
-| **Chat** | A conversation with an agent in the web app. | Yes | Yes |
-| **Automation** | A single run of a scheduled, webhook-triggered, or manually triggered automation. | Yes | Yes |
-| **Automation Builder Chat** | A conversation inside the Automation Builder while designing an automation. | Yes | Yes |
-| **MCP** | Tool calls from agents connected through the Model Context Protocol. | No | Yes |
-| **API** | Direct calls to the Agent API. | No | Yes |
-| **SDK** | Calls from an agent built with the Agent SDK. | No | Yes |
+| Source                      | Description                                                                 | Tracked as a session? | Tool calls visible? |
+| --------------------------- | --------------------------------------------------------------------------- | --------------------- | ------------------- |
+| **Chat**                    | A conversation with an agent in the web app.                                | Yes                   | Yes                 |
+| **Automation**              | A single run of a scheduled or manually triggered automation.               | Yes                   | Yes                 |
+| **Automation Builder Chat** | A conversation inside the Automation Builder while designing an automation. | Yes                   | Yes                 |
+| **MCP**                     | Tool calls from agents connected through the Model Context Protocol.        | No                    | Yes                 |
+| **API**                     | Direct calls to the Agent API.                                              | No                    | Yes                 |
+| **SDK**                     | Calls from an agent built with the Agent SDK.                               | No                    | Yes                 |
 
 Sources tracked as sessions appear on the [Sessions](../admin/sessions.md) page, where you can review the full conversation and tool calls. Sources that aren't tracked as sessions still consume AOs and appear in the [Usage panel](../admin/billing.md#monitor-usage) on the Billing page. To inspect individual tool calls from MCP, API, or SDK usage, use the [Tool calls](../admin/tool-calls.md) page.
 

--- a/docs/ai-agents/concepts/architecture/readme.md
+++ b/docs/ai-agents/concepts/architecture/readme.md
@@ -9,7 +9,7 @@ Airbyte Agents is a cloud platform that gives AI agents authenticated, structure
 
 You can interact with the platform through four interfaces. They all connect to the same service, so credentials you configure through one interface are available to all of them.
 
-- [**Web app**](../../interfaces/ui) at [app.airbyte.ai](https://app.airbyte.ai): Talk to an Airbyte-hosted agent in Chats, or define Automations that run on a schedule or webhook.
+- [**Web app**](../../interfaces/ui) at [app.airbyte.ai](https://app.airbyte.ai): Talk to an Airbyte-hosted agent in Chats, or define Automations that run manually or on a schedule.
 - [**API**](../../interfaces/api): HTTP endpoints for managing connectors, tokens, and executing operations from any language.
 - [**SDK**](../../interfaces/sdk): Python SDK for building agents that authenticate, connect, and execute operations in your own code.
 - [**MCP server**](../../interfaces/mcp): A remote Model Context Protocol server that connects MCP-capable agents like Claude, Cursor, and ChatGPT to your data.

--- a/docs/ai-agents/concepts/connect-ask-act.md
+++ b/docs/ai-agents/concepts/connect-ask-act.md
@@ -50,7 +50,7 @@ This pattern is the same across every connector and every interface. Whether an 
 Airbyte Agents act through two modes:
 
 - **[Chats](../interfaces/ui/chats).** Interactive, conversational sessions where an agent responds to prompts in real time.
-- **[Automations](../interfaces/ui/automations).** Scheduled or webhook-triggered flows that run without human intervention.
+- **[Automations](../interfaces/ui/automations).** Manual or scheduled flows that run without human intervention.
 
 Airbyte logs every action an agent takes. You can review what happened, when, and why in the [Sessions](../admin/sessions) and [Tool calls](../admin/tool-calls) views.
 

--- a/docs/ai-agents/interfaces/readme.md
+++ b/docs/ai-agents/interfaces/readme.md
@@ -7,7 +7,7 @@ sidebar_position: 4
 
 Airbyte Agents supports four interfaces for working with your data and your agents. Choose the interface that best fits how you want to build and run agents.
 
-- [**Web app**](ui): The Airbyte Agents web app at [app.airbyte.ai](https://app.airbyte.ai). Talk to an Airbyte-hosted agent in [Chats](ui/chats), or define [Automations](ui/automations) that run on a schedule or webhook. Best when you want Airbyte itself to be your agent, with no code required.
+- [**Web app**](ui): The Airbyte Agents web app at [app.airbyte.ai](https://app.airbyte.ai). Talk to an Airbyte-hosted agent in [Chats](ui/chats), or define [Automations](ui/automations) that run manually or on a schedule. Best when you want Airbyte itself to be your agent, with no code required.
 - [**MCP server**](mcp): A remote, Airbyte-hosted Model Context Protocol server that connects MCP-capable agents (like Claude, Cursor, and ChatGPT) to your data. Best for conversational agents that use off-the-shelf clients.
 - [**SDK**](sdk): Python SDK for building, authenticating, and executing agent connectors directly in your Python applications. Best for Python-based agents you build and host yourself.
 - [**API**](api): HTTP API for managing connectors, tokens, and executing operations from any language or backend service. Best for non-Python backends, custom admin flows, and embedding the authentication module in your app.

--- a/docs/ai-agents/interfaces/ui/automations.md
+++ b/docs/ai-agents/interfaces/ui/automations.md
@@ -9,7 +9,7 @@ sidebar_position: 2
 Automations are currently in Research Preview. Features, interfaces, and behavior may change as the product evolves.
 :::
 
-An Automation is an agent task that runs on its own, without a human in the loop. You describe what you want done once, pick how you want to trigger it (manually, on a schedule, or from a webhook), and Airbyte runs the task every time the trigger fires. Automations are the right choice when you need the same work to happen repeatedly, reliably, and without someone sitting at a keyboard.
+An Automation is an agent task that runs on its own, without a human in the loop. You describe what you want done once, pick how you want to trigger it manually or on a schedule, and Airbyte runs the task every time the trigger fires. Automations are the right choice when you need the same work to happen repeatedly, reliably, and without someone sitting at a keyboard.
 
 To open Automations, click **Automations** in the left sidebar.
 
@@ -51,7 +51,7 @@ Use search and filters to find what you want:
 
 - **Search**: Type in the search box at the top of the table to filter by Automation name.
 - **Status**: Filter by Running, Active, Paused, Failed, or Draft.
-- **Trigger**: Filter by Manual, Schedule, or Webhook.
+- **Trigger**: Filter by Manual or Schedule.
 - **Enabled**: Show only enabled Automations, only turned-off Automations, or both.
 
 Click the **Edit** (pencil) icon on a row to open the Automation in the Automation Builder. Automations created before session linking was introduced can't be edited from this button; Airbyte disables the icon and explains why on hover.
@@ -68,7 +68,7 @@ Open the Automation in the Automation Builder and click **Properties** to open t
 
 Scheduled Automations run automatically when their trigger fires. To pause a scheduled Automation without deleting it, turn its **Enabled** toggle off. The next scheduled time is skipped, and the Automation's status changes to Paused. Turn the toggle back on to resume.
 
-You can toggle Enabled from the table on the Automations page or from the Properties panel in the Automation Builder. The toggle is only available for Automations with a Schedule trigger; Manual and Webhook Automations are always "on" in the sense that they run whenever you invoke them, so there's nothing to pause.
+You can toggle Enabled from the table on the Automations page or from the Properties panel in the Automation Builder. The toggle is only available for Automations with a Schedule trigger; Manual Automations are always "on" in the sense that they run whenever you invoke them, so there's nothing to pause.
 
 ## The Automation Builder {#the-automation-builder}
 
@@ -97,7 +97,7 @@ Click **Properties** in the header to open the Properties panel. The panel conta
 - **Name**: The Automation's display name. Shown in the table, sidebar, and run history. Editable inline.
 - **Prompt**: The original prompt the Automation was created from, shown read-only for reference. To change what the Automation does, chat with the Automation Builder Agent.
 - **Context**: The connectors this Automation uses. Managed through the Automation Builder chat; edit connector membership by asking the agent to add or remove a source. Airbyte blocks direct editing here to keep the prompt and context consistent.
-- **Trigger**: How the Automation is invoked. Choose Manual, Schedule, or Webhook. See [Run automations](#run-automations).
+- **Trigger**: How the Automation is invoked. Choose Manual or Schedule. See [Run automations](#run-automations).
 - **Schedule**: Visible when the trigger is Schedule. A builder that lets you pick a frequency (hourly, daily, weekly, monthly, or a raw cron expression) and a timezone.
 - **Result webhook (optional)**: A destination URL where Airbyte posts results after a run finishes. See [Result webhooks](#result-webhooks).
 
@@ -125,16 +125,10 @@ Airbyte dispatches scheduled Automations at the exact moment the cron expression
 Keep this in mind when you design schedules:
 
 - **Avoid stacking many heavy Automations on the same round cadence.** If you have several Automations that each do substantial work, stagger them across different minutes (for example, `5 * * * *`, `15 * * * *`, `25 * * * *`) rather than running them all at `0 * * * *`. This spreads load on your connectors, reduces the chance of hitting upstream rate limits at the same moment, and makes failures easier to diagnose one Automation at a time.
-- **Expect near-simultaneous webhook or connector calls** when multiple Automations share a trigger time and hit the same third-party API. If that API enforces per-minute rate limits, consider splitting the schedules.
+- **Expect near-simultaneous connector calls** when multiple Automations share a trigger time and hit the same third-party API. If that API enforces per-minute rate limits, consider splitting the schedules.
 - **Dispatch time isn't execution time.** Airbyte dispatches the run on the dot, but the agent work itself takes as long as it takes. A 9:00 schedule doesn't guarantee results by 9:00, only that the run starts then.
 
 If you need a schedule that's more fine-grained than the Automation Builder's presets allow, use **Custom cron** and pick a specific minute offset that isn't shared with your other Automations.
-
-### From a webhook
-
-Webhook Automations run when an external system posts to a URL Airbyte provides. Open the Properties panel, set **Trigger** to Webhook, and copy the generated webhook URL. Configure the external system to post to that URL when the event you care about happens. Each POST starts one run.
-
-Webhook Automations are useful for event-driven workflows like "when a Salesforce deal closes, create an onboarding ticket and notify the team in Slack."
 
 ### See the status of a running automation
 
@@ -158,7 +152,7 @@ Result webhooks are currently persisted for scheduled Automations. If you leave 
 
 The Run History tab in the Automation Builder lists every run of the current Automation, most recent first. Each entry shows:
 
-- A **Test run** or **Live run** badge. Test runs come from the **Run** button in the Automation Builder; live runs come from a schedule or webhook trigger.
+- A **Test run** or **Live run** badge. Test runs come from the **Run** button in the Automation Builder; live runs come from a schedule.
 - The run's overall state: **Running**, **Succeeded**, or **Failed**.
 - When the run was created and how many jobs it produced.
 - A per-job breakdown with state (Pending, Created, Ready, Running, Retrying, Cancelled, Failed, or Completed) and the job's result.
@@ -172,7 +166,7 @@ Run History is scoped to one Automation. To audit runs across every Automation i
 Airbyte treats the current state of the Automation Builder as the draft version of the Automation. As you chat with the Automation Builder Agent or edit properties, Airbyte saves your changes automatically, and the header's **Saving…** / **Saved** indicator confirms each save.
 
 - **Test runs** always execute against the current draft. Use them to verify a change before letting a schedule pick it up.
-- **Live runs** (scheduled or webhook) also run against the current saved state. After you edit an Automation, the next live run uses the new version.
+- **Live runs** from schedules also run against the current saved state. After you edit an Automation, the next live run uses the new version.
 - **Run History** records which version of the Automation produced each run, so you can correlate behavior changes with edits.
 
 Because each edit is saved in place, there isn't a separate "publish" step. If you want to experiment without affecting a live schedule, turn **Enabled** off, iterate with test runs until you're satisfied, and turn Enabled back on.

--- a/docs/ai-agents/interfaces/ui/chats.md
+++ b/docs/ai-agents/interfaces/ui/chats.md
@@ -54,9 +54,9 @@ Chats are best for interactive, one-off work where you want to iterate with the 
 - **Summarizing and reporting**: Generate on-demand summaries, such as "What deals closed this quarter?" or "Which accounts have the most open support tickets?"
 - **Cross-system questions**: Ask questions that span multiple connectors. For example, match Salesforce accounts to HubSpot contacts or Zendesk tickets.
 - **Drafting content**: Use replies as a starting point for emails, follow-ups, status updates, or internal notes.
-- **Prototyping an Automation**: Iterate on a prompt in Chat until the agent reliably returns what you want, then convert the chat into an [Automation](./automations) so it can run on a schedule or webhook.
+- **Prototyping an Automation**: Iterate on a prompt in Chat until the agent reliably returns what you want, then convert the chat into an [Automation](./automations) so it can run on a schedule.
 
-If you want the same work to happen repeatedly, on a schedule, or in response to an event, use an Automation instead.
+If you want the same work to happen repeatedly on a schedule, use an Automation instead.
 
 ## Tips for effective conversations
 

--- a/docs/ai-agents/interfaces/ui/readme.md
+++ b/docs/ai-agents/interfaces/ui/readme.md
@@ -14,7 +14,7 @@ Use the web app when you want Airbyte itself to be your agent. For Python agents
 The web app has two primary surfaces for working with an Airbyte agent.
 
 - [**Chats**](./chats): Interactive conversations with an Airbyte agent. Ask a question, iterate on the answer, and explore your data in natural language. Chats are the fastest way to get a one-off answer or prototype an idea.
-- [**Automations**](./automations): Agent tasks that run without a person in the loop. Trigger an Automation manually, on a schedule, or from a webhook. Use Automations when you need the same work to happen repeatedly and reliably.
+- [**Automations**](./automations): Agent tasks that run without a person in the loop. Trigger an Automation manually or on a schedule. Use Automations when you need the same work to happen repeatedly and reliably.
 
 Every Chat and Automation runs against the connectors you've authenticated in your workspace. Manage connectors from the **Connectors** page in the sidebar. For the catalog of available connectors, see [Agent connectors](../../connectors).
 


### PR DESCRIPTION
## What
Remove public end-user documentation references that describe webhook-triggered Automations in the Airbyte Agents web app.

Linear: https://linear.app/airbyteio/issue/AGENTIC-1518/clarify-webhook-support-for-automations-in-docs

## How
- Update web app and conceptual AI Agents docs to describe Automations as manual or scheduled.
- Remove the Automation Builder instructions for configuring a webhook trigger.
- Leave result webhook documentation intact because it describes run output delivery, not an Automation trigger.
- Leave SDK, API, backend, and generated reference docs unchanged.

## Review guide
1. `docs/ai-agents/interfaces/ui/automations.md`
2. `docs/ai-agents/interfaces/ui/readme.md`
3. `docs/ai-agents/interfaces/ui/chats.md`
4. `docs/ai-agents/interfaces/readme.md`
5. `docs/ai-agents/concepts/connect-ask-act.md`
6. `docs/ai-agents/concepts/architecture/readme.md`
7. `docs/ai-agents/concepts/agent-operations.md`
8. `docs/ai-agents/admin/sessions.md`

## User Impact
Users no longer see public web-app docs promising webhook-triggered Automations where the UI only exposes Manual and Schedule triggers.

## Can this PR be safely reverted and rolled back?
- [x] YES 💚
- [ ] NO ❌

## Test plan
- `git diff --check`
- `npx --yes markdownlint-cli2@0.18.1 --config .markdownlint.jsonc docs/ai-agents/admin/sessions.md docs/ai-agents/concepts/agent-operations.md docs/ai-agents/concepts/architecture/readme.md docs/ai-agents/concepts/connect-ask-act.md docs/ai-agents/interfaces/readme.md docs/ai-agents/interfaces/ui/automations.md docs/ai-agents/interfaces/ui/chats.md docs/ai-agents/interfaces/ui/readme.md`
- `npx --yes prettier@3.5.3 --check docs/ai-agents/admin/sessions.md docs/ai-agents/concepts/agent-operations.md docs/ai-agents/concepts/architecture/readme.md docs/ai-agents/concepts/connect-ask-act.md docs/ai-agents/interfaces/readme.md docs/ai-agents/interfaces/ui/automations.md docs/ai-agents/interfaces/ui/chats.md docs/ai-agents/interfaces/ui/readme.md`
- `vale --config=docusaurus/vale.ini --minAlertLevel=warning ...changed docs...` reports pre-existing vocabulary/style warnings, including `Automations` spelling alerts also present before this branch.
- CI: 36 passed, 0 failed, including Docs / Vale, Docs / MarkDownLint, Format Check, and Build Airbyte Docs.
- Attempted local Docusaurus dependency install with `npx --yes pnpm@9.4.0 install --frozen-lockfile`; blocked by a `postman-code-generators` postinstall failure under Corepack/package-manager detection before a local full docs build could run.

Link to Devin session: https://app.devin.ai/sessions/9b07ba3f66694b2a886e5a036c934572
Requested by: @ian-at-airbyte