### PR TITLE
feat(source-greenhouse): bump concurrency tuning RC to default_concurrency=5 (0.7.22-rc.2)

### DIFF
--- a/airbyte-integrations/connectors/source-greenhouse/manifest.yaml
+++ b/airbyte-integrations/connectors/source-greenhouse/manifest.yaml
@@ -1796,13 +1796,13 @@ streams:
 # - 50 requests per 10 seconds (5 req/sec) for all accounts.
 # - Source: https://developers.greenhouse.io/harvest.html#throttling
 #
-# Starting concurrency follows the connector concurrency tuning playbook:
-# floor(5 / 4) = 1 ≤ 2 triggers the low-rate-limit special case →
-# starting_concurrency = 4, step = 1. Empirical tuning will adjust upward
+# Starting concurrency followed the connector concurrency tuning playbook:
+# floor(5 / 4) = 1 ≤ 2 triggered the low-rate-limit special case →
+# starting_concurrency = 4, step = 1. Empirical tuning iterates upward
 # in steps of 1 against the documented 5 req/sec ceiling.
 concurrency_level:
   type: ConcurrencyLevel
-  default_concurrency: 4
+  default_concurrency: 5
   max_concurrency: 16
 
 spec:

--- a/airbyte-integrations/connectors/source-greenhouse/metadata.yaml
+++ b/airbyte-integrations/connectors/source-greenhouse/metadata.yaml
@@ -10,7 +10,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 59f1e50a-331f-4f09-b3e8-2e8d4d355f44
-  dockerImageTag: 0.7.22-rc.1
+  dockerImageTag: 0.7.22-rc.2
   dockerRepository: airbyte/source-greenhouse
   documentationUrl: https://docs.airbyte.com/integrations/sources/greenhouse
   githubIssueLabel: source-greenhouse

--- a/docs/integrations/sources/greenhouse.md
+++ b/docs/integrations/sources/greenhouse.md
@@ -74,7 +74,7 @@ The Greenhouse connector should not run into Greenhouse API limitations under no
 
 | Version    | Date       | Pull Request                                             | Subject                                                                                                                                                                |
 |:-----------|:-----------|:---------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| 0.7.22-rc.2 | 2026-05-08 | [TBD](https://github.com/airbytehq/airbyte/pull/TBD) | Concurrency tuning iteration: bump default_concurrency to 5 |
+| 0.7.22-rc.2 | 2026-05-08 | [78006](https://github.com/airbytehq/airbyte/pull/78006) | Concurrency tuning iteration: bump default_concurrency to 5 |
 | 0.7.22-rc.1 | 2026-05-06 | [77826](https://github.com/airbytehq/airbyte/pull/77826) | Start concurrency tuning at default_concurrency=4 (Path A) and enable progressive rollout |
 | 0.7.21 | 2026-04-28 | [77287](https://github.com/airbytehq/airbyte/pull/77287) | Update dependencies |
 | 0.7.20 | 2026-04-21 | [76637](https://github.com/airbytehq/airbyte/pull/76637) | Update dependencies |

--- a/docs/integrations/sources/greenhouse.md
+++ b/docs/integrations/sources/greenhouse.md
@@ -74,6 +74,7 @@ The Greenhouse connector should not run into Greenhouse API limitations under no
 
 | Version    | Date       | Pull Request                                             | Subject                                                                                                                                                                |
 |:-----------|:-----------|:---------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 0.7.22-rc.2 | 2026-05-08 | [TBD](https://github.com/airbytehq/airbyte/pull/TBD) | Concurrency tuning iteration: bump default_concurrency to 5 |
 | 0.7.22-rc.1 | 2026-05-06 | [77826](https://github.com/airbytehq/airbyte/pull/77826) | Start concurrency tuning at default_concurrency=4 (Path A) and enable progressive rollout |
 | 0.7.21 | 2026-04-28 | [77287](https://github.com/airbytehq/airbyte/pull/77287) | Update dependencies |
 | 0.7.20 | 2026-04-21 | [76637](https://github.com/airbytehq/airbyte/pull/76637) | Update dependencies |


### PR DESCRIPTION
## What

Phase 1 tuning iteration #2 for source-greenhouse — bumping `default_concurrency` from 4 to 5 on a new RC `0.7.22-rc.2`.

Part of the concurrency tuning epic ([airbyte-internal-issues#15262](https://github.com/airbytehq/airbyte-internal-issues/issues/15262)). Prior RC: #77826.

## How

- `airbyte-integrations/connectors/source-greenhouse/manifest.yaml`: `concurrency_level.default_concurrency` `4 -> 5`. `max_concurrency` and `ConcurrencyLevel` type unchanged.
- `airbyte-integrations/connectors/source-greenhouse/metadata.yaml`: `dockerImageTag: 0.7.22-rc.1 -> 0.7.22-rc.2`. `enableProgressiveRollout: true` retained.
- `docs/integrations/sources/greenhouse.md`: changelog entry for `0.7.22-rc.2`.

## Review guide

The only behavioral change is the manifest's `default_concurrency`. Everything else is metadata/changelog.

## User Impact

Tier-2 Cloud actors pinned to `0.7.22-rc.2` via the progressive rollout will use 5 concurrent source-read workers instead of 4. Greenhouse Harvest API caps at 50 requests / 10 s (`5 req/s`); this step probes whether the platform begins to hit 429 backoff under c=5. If clean after 24h, the tuning loop will iterate to c=6. If failures or speed regressions emerge, we back off to c=4 as the final tuned value.

## Phase 1 health check #1 results (c=4 on 0.7.22-rc.1, 24h window)

- 0 / 69 failures across all 7 pinned actors (5 perf-comparison + 2 failure-monitoring).
- `source_read_duration_seconds` median, RC vs baseline:
  - `178bc05d`: `15s -> 14s` (-6.7%)
  - `4ee88fce`: `17s -> 17s` (0.0%)
  - `759a98bd`: `1s -> 1s` (0.0%)
  - `d2cfa5f4`: `464s -> 428s` (-7.8%) — only meaningful source-read in the cohort
  - `35ac73ce`: `12s -> 12s` (0.0%)

## Can this PR be safely reverted and rolled back?

- [x] YES 💚 (revert + cancel rollout)

Link to Devin session: https://app.devin.ai/sessions/d29bbca914074401b056b51c68b85d86
Requested by: @sophiecuiy