### PR TITLE
feat(source-linear): start concurrency tuning at c=4 (0.2.1-rc.1, Path A)

### DIFF
--- a/airbyte-integrations/connectors/source-linear/manifest.yaml
+++ b/airbyte-integrations/connectors/source-linear/manifest.yaml
@@ -1422,6 +1422,22 @@ streams:
   - $ref: "#/definitions/streams/customer_statuses"
   - $ref: "#/definitions/streams/customer_tiers"
 
+# Linear API documented rate limits (per-user, per-hour windows):
+# - API key auth: 2,500 requests / hour (approximately 0.69 req/sec).
+# - OAuth app auth: 5,000 requests / hour (approximately 1.39 req/sec).
+# - Workspace OAuth auth: dynamic uplift based on paid seat count.
+# - Source: https://linear.app/developers/rate-limiting
+#
+# Starting concurrency follows the connector concurrency tuning playbook
+# (Path A, tuned against the lowest documented tier — 2,500 req/hr API key):
+# floor((2500/3600) / 4) = 0 ≤ 2 triggers the low-rate-limit special case →
+# starting_concurrency = 4, step = 1. Empirical tuning will adjust against
+# the documented 2,500 req/hr ceiling.
+concurrency_level:
+  type: ConcurrencyLevel
+  default_concurrency: 4
+  max_concurrency: 16
+
 spec:
   type: Spec
   connection_specification:

--- a/airbyte-integrations/connectors/source-linear/metadata.yaml
+++ b/airbyte-integrations/connectors/source-linear/metadata.yaml
@@ -12,12 +12,15 @@ data:
     pypi:
       enabled: false
       packageName: airbyte-source-linear
+  releases:
+    rolloutConfiguration:
+      enableProgressiveRollout: true
   connectorBuildOptions:
     baseImage: docker.io/airbyte/source-declarative-manifest:7.17.4@sha256:f85ae668c118cc9a42dae007325b916d63c2df72d6809677582b4fa8a1c65bbb
   connectorSubtype: api
   connectorType: source
   definitionId: 1c5d8316-ed42-4473-8fbc-2626f03f070c
-  dockerImageTag: 0.2.0
+  dockerImageTag: 0.2.1-rc.1
   dockerRepository: airbyte/source-linear
   githubIssueLabel: source-linear
   icon: icon.svg

--- a/docs/integrations/sources/linear.md
+++ b/docs/integrations/sources/linear.md
@@ -122,6 +122,7 @@ For programmatic configuration, use these parameter names:
 
 | Version | Date | Pull Request | Subject |
 | ------- | ---- | ------------ | ------- |
+| 0.2.1-rc.1 | 2026-05-06 | [TBD](https://github.com/airbytehq/airbyte/pull/TBD) | Start concurrency tuning at default_concurrency=4 (Path A) and enable progressive rollout |
 | 0.2.0 | 2026-05-11 | [77578](https://github.com/airbytehq/airbyte/pull/77578) | Add OAuth 2.0 authentication support and migrate existing API key configurations to nested credentials |
 | 0.1.2 | 2026-04-28 | [77318](https://github.com/airbytehq/airbyte/pull/77318) | Update dependencies |
 | 0.1.1 | 2026-04-21 | [76654](https://github.com/airbytehq/airbyte/pull/76654) | Update dependencies |

--- a/docs/integrations/sources/linear.md
+++ b/docs/integrations/sources/linear.md
@@ -122,7 +122,7 @@ For programmatic configuration, use these parameter names:
 
 | Version | Date | Pull Request | Subject |
 | ------- | ---- | ------------ | ------- |
-| 0.2.1-rc.1 | 2026-05-06 | [TBD](https://github.com/airbytehq/airbyte/pull/TBD) | Start concurrency tuning at default_concurrency=4 (Path A) and enable progressive rollout |
+| 0.2.1-rc.1 | 2026-05-06 | [78008](https://github.com/airbytehq/airbyte/pull/78008) | Start concurrency tuning at default_concurrency=4 (Path A) and enable progressive rollout |
 | 0.2.0 | 2026-05-11 | [77578](https://github.com/airbytehq/airbyte/pull/77578) | Add OAuth 2.0 authentication support and migrate existing API key configurations to nested credentials |
 | 0.1.2 | 2026-04-28 | [77318](https://github.com/airbytehq/airbyte/pull/77318) | Update dependencies |
 | 0.1.1 | 2026-04-21 | [76654](https://github.com/airbytehq/airbyte/pull/76654) | Update dependencies |


### PR DESCRIPTION
## What

First RC of the [Connector Concurrency Tuning & Rollout](https://github.com/airbytehq/airbyte-internal-issues) playbook for `source-linear`.

- Adds `concurrency_level` with `default_concurrency: 4`, `max_concurrency: 16`.
- Bumps `dockerImageTag`: `0.2.0` → `0.2.1-rc.1`.
- Enables `releases.rolloutConfiguration.enableProgressiveRollout: true`.
- Adds the `0.2.1-rc.1` changelog entry to `docs/integrations/sources/linear.md`.

No `num_workers` config field is exposed in this RC — per playbook, the user-configurable `num_workers` is added at GA (Phase 4).

## How

**Path A (single-tier rate-limit ceiling), tuned against Linear's lowest documented tier — API key auth, 2,500 requests / hour (≈ 0.69 req/sec).**

[Linear's documented rate limits](https://linear.app/developers/rate-limiting) are per-user, per-hour windows:

- API key auth: 2,500 requests / hour
- OAuth app auth: 5,000 requests / hour
- Workspace OAuth auth: dynamic uplift based on paid seats

Playbook starting-concurrency formula: `floor(max_rate_limit_per_sec / 4)`.
- `floor((2500/3600) / 4) = floor(0.17) = 0 ≤ 2` → low-rate-limit special case applies.
- → `starting_concurrency = 4`, `step = 1`.
- `max_concurrency = 16` matches the floor/step bounds used by recent concurrency-tuning RCs (e.g. `source-greenhouse#77826`, `source-zendesk-support#76953`).

No HTTPAPIBudget is configured in this RC. The connector currently has no rate-limit budget. Adding one is a separate workstream (rate-limit playbook), to be handled in a follow-up after concurrency tuning settles.

## Review guide

1. `airbyte-integrations/connectors/source-linear/manifest.yaml` — new `concurrency_level` block + explanatory comment, placed between `streams:` and `spec:`.
2. `airbyte-integrations/connectors/source-linear/metadata.yaml` — version bump + `releases.rolloutConfiguration.enableProgressiveRollout: true`.
3. `docs/integrations/sources/linear.md` — changelog entry for `0.2.1-rc.1`.

## User Impact

- **Before**: source-linear runs single-threaded against the Linear GraphQL API.
- **After** (this RC, once published and rolled out): source-linear runs up to 4 concurrent stream reads on Tier 2 pinned actors during tuning. Should reduce wall-clock for actors with non-trivial source-read time; no expected effect on small-row actors that are orchestration-dominated.
- Rollout will be progressive, manual, starting with a 23-actor Tier 2 cohort (see Phase 0 plan in the linked session). No customer-visible config change in this RC.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Yes — this change is purely manifest-level (default_concurrency + enableProgressiveRollout). Reverting the PR reverts to the prior sequential-read behaviour with no migration needed.

---
[Devin session](https://app.devin.ai/sessions/42d4620ee6274df1b32bcc501d7d87ce)


Requested by: @sophiecuiy