### PR TITLE
chore(source-amazon-ads): bump to 8.0.3-rc.1 with default_concurrency=12 for tuning rollout

### DIFF
--- a/airbyte-integrations/connectors/source-amazon-ads/manifest.yaml
+++ b/airbyte-integrations/connectors/source-amazon-ads/manifest.yaml
@@ -3509,7 +3509,7 @@ spec:
         title: Number of concurrent threads
         minimum: 2
         maximum: 20
-        default: 10
+        default: 12
         examples:
           - 2
           - 3
@@ -3563,11 +3563,11 @@ spec:
 # depending on the time.
 # https://advertising.amazon.com/API/docs/en-us/reference/concepts/rate-limiting
 #
-# We've set the default to 10 so we can leverage some concurrency, but this can be tuned as we
+# We've set the default to 12 so we can leverage some concurrency, but this can be tuned as we
 # continue to observe.
 concurrency_level:
   type: ConcurrencyLevel
-  default_concurrency: "{{ config.get('num_workers', 10) }}"
+  default_concurrency: "{{ config.get('num_workers', 12) }}"
   max_concurrency: 20
 
 schemas:

--- a/airbyte-integrations/connectors/source-amazon-ads/metadata.yaml
+++ b/airbyte-integrations/connectors/source-amazon-ads/metadata.yaml
@@ -13,7 +13,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: c6b0a29e-1da9-4512-9002-7bfd0cba2246
-  dockerImageTag: 8.0.2
+  dockerImageTag: 8.0.3-rc.1
   dockerRepository: airbyte/source-amazon-ads
   documentationUrl: https://docs.airbyte.com/integrations/sources/amazon-ads
   githubIssueLabel: source-amazon-ads
@@ -35,7 +35,7 @@ data:
   releaseStage: generally_available
   releases:
     rolloutConfiguration:
-      enableProgressiveRollout: false
+      enableProgressiveRollout: true
     breakingChanges:
       8.0.0:
         message:

--- a/docs/integrations/sources/amazon-ads.md
+++ b/docs/integrations/sources/amazon-ads.md
@@ -164,6 +164,7 @@ If you need better sync performance and are not experiencing rate limiting error
 
 | Version    | Date       | Pull Request                                             | Subject                                                                                                                                                                |
 |:-----------|:-----------|:---------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 8.0.3-rc.1 | 2026-05-11 | [TBD](https://github.com/airbytehq/airbyte/pull/TBD) | Tune default concurrency from 10 to 12 (`num_workers`) for progressive rollout |
 | 8.0.2 | 2026-05-05 | [77660](https://github.com/airbytehq/airbyte/pull/77660) | Skip profiles without Amazon Attribution access on attribution report performance streams instead of failing the sync |
 | 8.0.1 | 2026-04-28 | [77149](https://github.com/airbytehq/airbyte/pull/77149) | Update dependencies |
 | 8.0.0 | 2026-04-22 | [75490](https://github.com/airbytehq/airbyte/pull/75490) | Use `date` field from API response as cursor and primary key for daily report streams instead of synthetic `reportDate`. Fixes ~96% data loss from incorrect deduplication. |


### PR DESCRIPTION
## What

Release candidate for source-amazon-ads concurrency tuning, as part of the Connector Concurrency Tuning & Rollout epic ([airbytehq/airbyte-internal-issues#15262](https://github.com/airbytehq/airbyte-internal-issues/issues/15262)). Tracking issue: [airbytehq/airbyte-internal-issues#15305](https://github.com/airbytehq/airbyte-internal-issues/issues/15305) (reopened).

This bumps `source-amazon-ads` to `8.0.3-rc.1` so the rollout system can pin a Tier 2 tuning cohort while the rest of production stays on stable `8.0.2`.

## How

- `metadata.yaml`
  - `dockerImageTag`: `8.0.2` → `8.0.3-rc.1`
  - `releases.rolloutConfiguration.enableProgressiveRollout`: `false` → `true`
- `manifest.yaml`
  - `spec.connection_specification.properties.num_workers.default`: `10` → `12` (effective default when user has not set `num_workers`)
  - `concurrency_level.default_concurrency`: `{{ config.get('num_workers', 10) }}` → `{{ config.get('num_workers', 12) }}`
  - Updated the surrounding comment to reflect the new default
- `docs/integrations/sources/amazon-ads.md`: changelog entry for `8.0.3-rc.1`

`max_concurrency` stays at `20`. `num_workers` spec field already exposed in master (min=2, max=20) from prior work; only the default value is changing here.

### Tuning rationale

Amazon Ads does not publish a static rate limit (limits vary by region and report-size utilization, per [their API docs](https://advertising.amazon.com/API/docs/en-us/reference/concepts/rate-limiting)). The connector-specific tracking issue was originally closed with a decision to skip `HTTPAPIBudget` for this reason. The playbook's `starting_concurrency = floor(max_rate_limit / 4)` formula therefore has no documented anchor.

Diagnostic data (last 14 days, 200 most recent failed sync attempts across 41 distinct actors):
- 64 attempts with explicit 429 / "Too Many Requests" classified as `transient_error`, across 16 distinct TIER_2 actors — these are being rate-limited at the existing `default_concurrency=10`
- 79 attempts in 6 actors classified as heartbeat timeouts with no 429 signal — likely stuck report-poll loops, not concurrency-driven
- 42 config errors (auth, destination issues) — unrelated to concurrency

Starting at the existing cap (`20`) is risky given 429s already occur at `10`. Starting at the current default (`10`) just reproduces the status quo with a new tag. Starting at `12` gives small headroom for empirical testing with `step=2`, with a clear escape path: tune downward (toward `10`, `8`, ...) if `12` increases 429 rate, or upward (`14`, `16`, ...) if `12` is clean. Approved by @sophie-cui.

## Review guide

1. `airbyte-integrations/connectors/source-amazon-ads/metadata.yaml` — version + rollout toggle
2. `airbyte-integrations/connectors/source-amazon-ads/manifest.yaml` — `num_workers` default + `concurrency_level.default_concurrency`
3. `docs/integrations/sources/amazon-ads.md` — changelog entry

## User Impact

- Actors that have not explicitly set `num_workers` will get `12` concurrent workers (up from `10`) once they are pinned to the RC, then once `8.0.3` is rolled to stable.
- Actors that have explicitly set `num_workers` are unaffected — their configured value continues to win via `config.get('num_workers', 12)`.
- The PR itself does not change anything in production until the RC is published and the rollout is started. The rollout will pin a TIER_2 tuning cohort first; full rollout is gated on 24-hour health checks per the playbook.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

The RC version can be unpinned at any time and stable `8.0.2` re-pinned. The manifest/metadata changes are independent and can be reverted with a single revert commit.

Link to Devin session: https://app.devin.ai/sessions/3aeba206ecae486f9102418a52e52794
Requested by: @sophiecuiy