### PR TITLE
ci(workflows): Fix rollout gate empty matrix

### DIFF
--- a/.github/workflows/connector-active-progressive-rollout-checks.yml
+++ b/.github/workflows/connector-active-progressive-rollout-checks.yml
@@ -38,23 +38,38 @@ jobs:
     name: Generate Connector Matrix
     runs-on: ubuntu-24.04
     steps:
+      - name: Resolve workflow inputs
+        id: vars
+        env:
+          INPUT_GITREF: ${{ inputs.gitref }}
+          INPUT_PR: ${{ inputs.pr }}
+          INPUT_REPO: ${{ inputs.repo }}
+          PULL_REQUEST_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          DEFAULT_REPOSITORY: ${{ github.repository }}
+          HEAD_REF: ${{ github.head_ref }}
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          REPOSITORY="${INPUT_REPO:-${PULL_REQUEST_REPO:-${DEFAULT_REPOSITORY}}}"
+          REF="${REF_NAME}"
+          [[ -n "${HEAD_REF}" ]] && REF="${HEAD_REF}"
+          [[ -n "${INPUT_GITREF}" ]] && REF="${INPUT_GITREF}"
+          [[ -n "${INPUT_PR}" ]] && REF="refs/pull/${INPUT_PR}/head"
+
+          echo "repository=${REPOSITORY}" | tee -a "${GITHUB_OUTPUT}"
+          echo "ref=${REF}" | tee -a "${GITHUB_OUTPUT}"
+          echo "is-fork=$([[ "${REPOSITORY}" != airbytehq/* ]] && echo true || echo false)" | tee -a "${GITHUB_OUTPUT}"
+
       - name: Checkout Airbyte
         id: checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          repository: ${{ inputs.repo || github.event.pull_request.head.repo.full_name || github.repository }}
-          ref: ${{ (inputs.pr != '' && format('refs/pull/{0}/head', inputs.pr)) || inputs.gitref || github.head_ref || github.ref_name }}
+          repository: ${{ steps.vars.outputs.repository }}
+          ref: ${{ steps.vars.outputs.ref }}
           submodules: true # Needed for airbyte-enterprise connectors (no-op otherwise)
           fetch-depth: 0
 
       - name: Add upstream remote (forks only)
-        if: >
-          (inputs.repo != '' &&
-           ! startswith(inputs.repo, 'airbytehq/')
-          ) ||
-          (github.event.pull_request.head.repo.full_name != '' &&
-           ! startswith(github.event.pull_request.head.repo.full_name, 'airbytehq/')
-          )
+        if: steps.vars.outputs.is-fork == 'true'
         run: |
           if ! git remote | grep -q upstream; then
             git remote add upstream https://github.com/airbytehq/airbyte.git
@@ -74,6 +89,8 @@ jobs:
     outputs:
       connectors-matrix: ${{ steps.dispatch-matrix.outputs.connectors_matrix || steps.generate-matrix.outputs.connectors_matrix }}
       commit-sha: ${{ steps.checkout.outputs.commit }}
+      checkout-repository: ${{ steps.vars.outputs.repository }}
+      checkout-ref: ${{ steps.vars.outputs.ref }}
 
   progressive-rollout-gate:
     needs: [generate-matrix]
@@ -93,8 +110,8 @@ jobs:
         if: matrix.connector
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          repository: ${{ inputs.repo || github.event.pull_request.head.repo.full_name || github.repository }}
-          ref: ${{ (inputs.pr != '' && format('refs/pull/{0}/head', inputs.pr)) || inputs.gitref || github.head_ref || github.ref_name }}
+          repository: ${{ needs.generate-matrix.outputs.checkout-repository }}
+          ref: ${{ needs.generate-matrix.outputs.checkout-ref }}
           submodules: true # Needed for airbyte-enterprise connectors (no-op otherwise)
           fetch-depth: 1
 

--- a/.github/workflows/connector-active-progressive-rollout-checks.yml
+++ b/.github/workflows/connector-active-progressive-rollout-checks.yml
@@ -8,6 +8,25 @@ on:
       - reopened
       - edited
       - ready_for_review
+  workflow_dispatch:
+    inputs:
+      repo:
+        description: "The repository name"
+        required: false
+        default: "airbytehq/airbyte"
+        type: string
+      gitref:
+        description: "The git reference (branch or tag). Ignored when pr is provided."
+        required: false
+        type: string
+      pr:
+        description: "The pull request number to check out and comment on, if applicable."
+        required: false
+        type: number
+      connector:
+        description: "Single connector name to check. If omitted, auto-detects from changed files."
+        required: false
+        type: string
 
 permissions:
   contents: read
@@ -23,27 +42,37 @@ jobs:
         id: checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
-          ref: ${{ github.head_ref || github.ref_name }}
+          repository: ${{ inputs.repo || github.event.pull_request.head.repo.full_name || github.repository }}
+          ref: ${{ (inputs.pr != '' && format('refs/pull/{0}/head', inputs.pr)) || inputs.gitref || github.head_ref || github.ref_name }}
           submodules: true # Needed for airbyte-enterprise connectors (no-op otherwise)
           fetch-depth: 0
 
       - name: Add upstream remote (forks only)
         if: >
-          github.event.pull_request.head.repo.full_name != '' &&
-          ! startswith(github.event.pull_request.head.repo.full_name, 'airbytehq/')
+          (inputs.repo != '' &&
+           ! startswith(inputs.repo, 'airbytehq/')
+          ) ||
+          (github.event.pull_request.head.repo.full_name != '' &&
+           ! startswith(github.event.pull_request.head.repo.full_name, 'airbytehq/')
+          )
         run: |
           if ! git remote | grep -q upstream; then
             git remote add upstream https://github.com/airbytehq/airbyte.git
           fi
           git fetch --quiet upstream master
 
+      - name: Generate Connector Matrix from Dispatch Input
+        if: inputs.connector != ''
+        id: dispatch-matrix
+        run: echo "connectors_matrix={\"connector\":[\"${{ inputs.connector }}\"]}" | tee -a $GITHUB_OUTPUT
+
       - name: Generate Connector Matrix from Changes
+        if: inputs.connector == ''
         id: generate-matrix
         run: echo "connectors_matrix=$(./poe-tasks/get-modified-connectors.sh --json)" | tee -a $GITHUB_OUTPUT
 
     outputs:
-      connectors-matrix: ${{ steps.generate-matrix.outputs.connectors_matrix }}
+      connectors-matrix: ${{ steps.dispatch-matrix.outputs.connectors_matrix || steps.generate-matrix.outputs.connectors_matrix }}
       commit-sha: ${{ steps.checkout.outputs.commit }}
 
   progressive-rollout-gate:
@@ -58,13 +87,14 @@ jobs:
       ROLLOUT_ACK_CHECKBOX_TEXT: "(Click to Approve:) Bypass the active progressive rollout warning for ${{ matrix.connector }} in the PR comment"
       GCP_PROD_DB_ACCESS_CREDENTIALS: ${{ secrets.GCP_GSM_CREDENTIALS_FOR_TESTING_TOOL }}
       GITHUB_TOKEN: ${{ github.token }}
+      PR_NUMBER: ${{ github.event.pull_request.number || inputs.pr }}
     steps:
       - name: Checkout Airbyte
         if: matrix.connector
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
-          ref: ${{ github.head_ref || github.ref_name }}
+          repository: ${{ inputs.repo || github.event.pull_request.head.repo.full_name || github.repository }}
+          ref: ${{ (inputs.pr != '' && format('refs/pull/{0}/head', inputs.pr)) || inputs.gitref || github.head_ref || github.ref_name }}
           submodules: true # Needed for airbyte-enterprise connectors (no-op otherwise)
           fetch-depth: 1
 
@@ -123,7 +153,7 @@ jobs:
           echo "version=${VERSION}" | tee -a "${GITHUB_OUTPUT}"
 
       - name: Detect rollout bypass checkbox
-        if: matrix.connector
+        if: matrix.connector && github.event_name == 'pull_request'
         id: rollout-bypass
         uses: AhmedBaset/checklist@ecbf0bacb0d5d1fe41131db29a44984fec266017 # v3
         with:
@@ -133,31 +163,32 @@ jobs:
         if: matrix.connector
         id: bypass-state
         env:
-          APPROVED: ${{ contains(steps.rollout-bypass.outputs.checked, env.ROLLOUT_ACK_CHECKBOX_TEXT) }}
-          EXISTS: ${{ contains(steps.rollout-bypass.outputs.checked, env.ROLLOUT_ACK_CHECKBOX_TEXT) || contains(steps.rollout-bypass.outputs.unchecked, env.ROLLOUT_ACK_CHECKBOX_TEXT) }}
+          APPROVED: ${{ github.event_name == 'pull_request' && contains(steps.rollout-bypass.outputs.checked, env.ROLLOUT_ACK_CHECKBOX_TEXT) }}
+          EXISTS: ${{ github.event_name == 'pull_request' && (contains(steps.rollout-bypass.outputs.checked, env.ROLLOUT_ACK_CHECKBOX_TEXT) || contains(steps.rollout-bypass.outputs.unchecked, env.ROLLOUT_ACK_CHECKBOX_TEXT)) }}
         run: |
           echo "approved=${APPROVED}" | tee -a $GITHUB_OUTPUT
           echo "exists=${EXISTS}" | tee -a $GITHUB_OUTPUT
 
       - name: Find progressive rollout gate comment
-        if: matrix.connector
+        if: matrix.connector && env.PR_NUMBER != ''
         id: find-rollout-comment
         uses: peter-evans/find-comment@b30e6a3c0ed37e7c023ccd3f1db5c6c0b0c23aad # v4.0.0
         with:
-          issue-number: ${{ github.event.pull_request.number }}
+          issue-number: ${{ env.PR_NUMBER }}
           comment-author: github-actions[bot]
           body-includes: "<!-- progressive-rollout-gate:${{ matrix.connector }} -->"
 
       - name: Create progressive rollout gate placeholder comment
         if: >
           matrix.connector &&
+          env.PR_NUMBER != '' &&
           steps.find-rollout-comment.outputs.comment-id == '' &&
           (fromJSON(steps.rollout-status.outputs.json).has_active_rollout ||
            contains(steps.master-version.outputs.version, '-rc.'))
         id: create-rollout-comment
         uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
         with:
-          issue-number: ${{ github.event.pull_request.number }}
+          issue-number: ${{ env.PR_NUMBER }}
           edit-mode: replace
           body: |
             <!-- progressive-rollout-gate:${{ matrix.connector }} -->
@@ -174,7 +205,6 @@ jobs:
           EXISTING_COMMENT_ID: ${{ steps.find-rollout-comment.outputs.comment-id }}
           CREATED_COMMENT_ID: ${{ steps.create-rollout-comment.outputs.comment-id }}
           REPOSITORY: ${{ github.repository }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           COMMENT_ID="${EXISTING_COMMENT_ID:-${CREATED_COMMENT_ID}}"
           echo "id=${COMMENT_ID}" | tee -a $GITHUB_OUTPUT
@@ -183,6 +213,7 @@ jobs:
       - name: Add rollout bypass checkbox to PR description
         if: >
           matrix.connector &&
+          github.event_name == 'pull_request' &&
           steps.bypass-state.outputs.exists != 'true' &&
           (fromJSON(steps.rollout-status.outputs.json).has_active_rollout ||
            contains(steps.master-version.outputs.version, '-rc.'))
@@ -198,6 +229,7 @@ jobs:
       - name: Render progressive rollout gate comment
         if: >
           matrix.connector &&
+          env.PR_NUMBER != '' &&
           steps.rollout-comment.outputs.id != '' &&
           (steps.find-rollout-comment.outputs.comment-id != '' ||
            fromJSON(steps.rollout-status.outputs.json).has_active_rollout ||
@@ -228,7 +260,7 @@ jobs:
         uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
         with:
           comment-id: ${{ steps.rollout-comment.outputs.id }}
-          issue-number: ${{ github.event.pull_request.number }}
+          issue-number: ${{ env.PR_NUMBER }}
           edit-mode: replace
           body: ${{ steps.rollout-comment-template.outputs.result }}
 

--- a/.github/workflows/connector-active-progressive-rollout-checks.yml
+++ b/.github/workflows/connector-active-progressive-rollout-checks.yml
@@ -185,11 +185,11 @@ jobs:
           token: ${{ github.token }}
 
       - name: Resolve rollout bypass checkbox state
-        if: matrix.connector
+        if: matrix.connector && github.event_name == 'pull_request'
         id: bypass-state
         env:
-          APPROVED: ${{ github.event_name == 'pull_request' && contains(steps.rollout-bypass.outputs.checked, env.ROLLOUT_ACK_CHECKBOX_TEXT) }}
-          EXISTS: ${{ github.event_name == 'pull_request' && (contains(steps.rollout-bypass.outputs.checked, env.ROLLOUT_ACK_CHECKBOX_TEXT) || contains(steps.rollout-bypass.outputs.unchecked, env.ROLLOUT_ACK_CHECKBOX_TEXT)) }}
+          APPROVED: ${{ contains(steps.rollout-bypass.outputs.checked, env.ROLLOUT_ACK_CHECKBOX_TEXT) }}
+          EXISTS: ${{ contains(steps.rollout-bypass.outputs.checked, env.ROLLOUT_ACK_CHECKBOX_TEXT) || contains(steps.rollout-bypass.outputs.unchecked, env.ROLLOUT_ACK_CHECKBOX_TEXT) }}
         run: |
           echo "approved=${APPROVED}" | tee -a $GITHUB_OUTPUT
           echo "exists=${EXISTS}" | tee -a $GITHUB_OUTPUT

--- a/.github/workflows/connector-active-progressive-rollout-checks.yml
+++ b/.github/workflows/connector-active-progressive-rollout-checks.yml
@@ -182,8 +182,21 @@ jobs:
         if: matrix.connector
         id: rollout-gate-state
         env:
-          REQUIRES_ACK: ${{ fromJSON(steps.rollout-status.outputs.json).has_active_rollout || contains(steps.master-version.outputs.version, '-rc.') }}
-        run: echo "requires-ack=${REQUIRES_ACK}" | tee -a "${GITHUB_OUTPUT}"
+          ROLLOUT_STATUS_JSON: ${{ steps.rollout-status.outputs.json }}
+          MASTER_VERSION: ${{ steps.master-version.outputs.version }}
+        run: |
+          has_active_rollout="$(jq -r '.has_active_rollout' <<< "${ROLLOUT_STATUS_JSON}")"
+          has_master_rc_marker="false"
+          if [[ "${MASTER_VERSION}" == *"-rc."* ]]; then
+            has_master_rc_marker="true"
+          fi
+          requires_ack="false"
+          if [[ "${has_active_rollout}" == "true" || "${has_master_rc_marker}" == "true" ]]; then
+            requires_ack="true"
+          fi
+          echo "has-active-rollout=${has_active_rollout}" | tee -a "${GITHUB_OUTPUT}"
+          echo "has-master-rc-marker=${has_master_rc_marker}" | tee -a "${GITHUB_OUTPUT}"
+          echo "requires-ack=${requires_ack}" | tee -a "${GITHUB_OUTPUT}"
 
       - name: Detect rollout bypass checkbox
         if: matrix.connector && steps.rollout-gate-state.outputs.requires-ack == 'true' && github.event_name == 'pull_request'
@@ -360,13 +373,13 @@ jobs:
           body: ${{ steps.rollout-comment-template.outputs.result }}
 
       - name: Fail if active rollout is not acknowledged
-        if: matrix.connector && fromJSON(steps.rollout-status.outputs.json).has_active_rollout && steps.bypass-state.outputs.approved != 'true'
+        if: matrix.connector && steps.rollout-gate-state.outputs.has-active-rollout == 'true' && steps.bypass-state.outputs.approved != 'true'
         run: |
           echo "::error::${{ matrix.connector }} has an active progressive rollout. Check the bypass box in the PR description to acknowledge and rerun this workflow."
           exit 1
 
       - name: Fail if master has RC marker and is not acknowledged
-        if: matrix.connector && contains(steps.master-version.outputs.version, '-rc.') && steps.bypass-state.outputs.approved != 'true'
+        if: matrix.connector && steps.rollout-gate-state.outputs.has-master-rc-marker == 'true' && steps.bypass-state.outputs.approved != 'true'
         run: |
           echo "::error::${{ matrix.connector }} has an RC marker on master (${{ steps.master-version.outputs.version }}). Check the bypass box in the PR description to acknowledge and rerun this workflow."
           exit 1

--- a/.github/workflows/connector-active-progressive-rollout-checks.yml
+++ b/.github/workflows/connector-active-progressive-rollout-checks.yml
@@ -76,7 +76,9 @@ jobs:
           fetch-depth: 0
 
       - name: Add upstream remote (forks only)
-        if: inputs.connector == '' && steps.vars.outputs.is-fork == 'true'
+        if: >
+          inputs.connector == '' &&
+          steps.vars.outputs.is-fork == 'true'
         run: |
           if ! git remote | grep -q upstream; then
             git remote add upstream https://github.com/airbytehq/airbyte.git
@@ -199,14 +201,21 @@ jobs:
           echo "requires-ack=${requires_ack}" | tee -a "${GITHUB_OUTPUT}"
 
       - name: Detect rollout bypass checkbox
-        if: matrix.connector && steps.rollout-gate-state.outputs.requires-ack == 'true' && github.event_name == 'pull_request'
+        if: >
+          matrix.connector &&
+          steps.rollout-gate-state.outputs.requires-ack == 'true' &&
+          github.event_name == 'pull_request'
         id: rollout-bypass
         uses: AhmedBaset/checklist@ecbf0bacb0d5d1fe41131db29a44984fec266017 # v3
         with:
           token: ${{ github.token }}
 
       - name: Detect rollout bypass checkbox for dispatched PR
-        if: matrix.connector && steps.rollout-gate-state.outputs.requires-ack == 'true' && github.event_name == 'workflow_dispatch' && env.PR_NUMBER != ''
+        if: >
+          matrix.connector &&
+          steps.rollout-gate-state.outputs.requires-ack == 'true' &&
+          github.event_name == 'workflow_dispatch' &&
+          env.PR_NUMBER != ''
         id: rollout-bypass-dispatch
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         env:
@@ -230,7 +239,9 @@ jobs:
             core.setOutput("exists", (checked || unchecked).toString());
 
       - name: Resolve rollout bypass checkbox state
-        if: matrix.connector && steps.rollout-gate-state.outputs.requires-ack == 'true'
+        if: >
+          matrix.connector &&
+          steps.rollout-gate-state.outputs.requires-ack == 'true'
         id: bypass-state
         env:
           APPROVED: ${{ contains(steps.rollout-bypass.outputs.checked, env.ROLLOUT_ACK_CHECKBOX_TEXT) || steps.rollout-bypass-dispatch.outputs.approved == 'true' }}
@@ -240,7 +251,10 @@ jobs:
           echo "exists=${EXISTS}" | tee -a $GITHUB_OUTPUT
 
       - name: Find progressive rollout gate comment
-        if: matrix.connector && steps.rollout-gate-state.outputs.requires-ack == 'true' && env.PR_NUMBER != ''
+        if: >
+          matrix.connector &&
+          steps.rollout-gate-state.outputs.requires-ack == 'true' &&
+          env.PR_NUMBER != ''
         id: find-rollout-comment
         uses: peter-evans/find-comment@b30e6a3c0ed37e7c023ccd3f1db5c6c0b0c23aad # v4.0.0
         with:
@@ -268,7 +282,9 @@ jobs:
             > [Workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
 
       - name: Resolve rollout comment link
-        if: matrix.connector && steps.rollout-gate-state.outputs.requires-ack == 'true'
+        if: >
+          matrix.connector &&
+          steps.rollout-gate-state.outputs.requires-ack == 'true'
         id: rollout-comment
         env:
           EXISTING_COMMENT_ID: ${{ steps.find-rollout-comment.outputs.comment-id }}
@@ -373,13 +389,19 @@ jobs:
           body: ${{ steps.rollout-comment-template.outputs.result }}
 
       - name: Fail if active rollout is not acknowledged
-        if: matrix.connector && steps.rollout-gate-state.outputs.has-active-rollout == 'true' && steps.bypass-state.outputs.approved != 'true'
+        if: >
+          matrix.connector &&
+          steps.rollout-gate-state.outputs.has-active-rollout == 'true' &&
+          steps.bypass-state.outputs.approved != 'true'
         run: |
           echo "::error::${{ matrix.connector }} has an active progressive rollout. Check the bypass box in the PR description to acknowledge and rerun this workflow."
           exit 1
 
       - name: Fail if master has RC marker and is not acknowledged
-        if: matrix.connector && steps.rollout-gate-state.outputs.has-master-rc-marker == 'true' && steps.bypass-state.outputs.approved != 'true'
+        if: >
+          matrix.connector &&
+          steps.rollout-gate-state.outputs.has-master-rc-marker == 'true' &&
+          steps.bypass-state.outputs.approved != 'true'
         run: |
           echo "::error::${{ matrix.connector }} has an RC marker on master (${{ steps.master-version.outputs.version }}). Check the bypass box in the PR description to acknowledge and rerun this workflow."
           exit 1

--- a/.github/workflows/connector-active-progressive-rollout-checks.yml
+++ b/.github/workflows/connector-active-progressive-rollout-checks.yml
@@ -184,12 +184,36 @@ jobs:
         with:
           token: ${{ github.token }}
 
+      - name: Detect rollout bypass checkbox for dispatched PR
+        if: matrix.connector && github.event_name == 'workflow_dispatch' && env.PR_NUMBER != ''
+        id: rollout-bypass-dispatch
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        env:
+          ROLLOUT_ACK_CHECKBOX_TEXT: ${{ env.ROLLOUT_ACK_CHECKBOX_TEXT }}
+          PR_NUMBER: ${{ env.PR_NUMBER }}
+        with:
+          script: |
+            const pullNumber = Number(process.env.PR_NUMBER);
+            const checkboxText = process.env.ROLLOUT_ACK_CHECKBOX_TEXT;
+            const { owner, repo } = context.repo;
+            const { data: pull } = await github.rest.pulls.get({
+              owner,
+              repo,
+              pull_number: pullNumber,
+            });
+            const lines = (pull.body || "").split(/\r?\n/).map((line) => line.trim());
+            const checked = lines.some((line) => /^- \[[xX]\]/.test(line) && line.includes(checkboxText));
+            const unchecked = lines.some((line) => line.startsWith("- [ ]") && line.includes(checkboxText));
+
+            core.setOutput("approved", checked.toString());
+            core.setOutput("exists", (checked || unchecked).toString());
+
       - name: Resolve rollout bypass checkbox state
-        if: matrix.connector && github.event_name == 'pull_request'
+        if: matrix.connector
         id: bypass-state
         env:
-          APPROVED: ${{ contains(steps.rollout-bypass.outputs.checked, env.ROLLOUT_ACK_CHECKBOX_TEXT) }}
-          EXISTS: ${{ contains(steps.rollout-bypass.outputs.checked, env.ROLLOUT_ACK_CHECKBOX_TEXT) || contains(steps.rollout-bypass.outputs.unchecked, env.ROLLOUT_ACK_CHECKBOX_TEXT) }}
+          APPROVED: ${{ contains(steps.rollout-bypass.outputs.checked, env.ROLLOUT_ACK_CHECKBOX_TEXT) || steps.rollout-bypass-dispatch.outputs.approved == 'true' }}
+          EXISTS: ${{ contains(steps.rollout-bypass.outputs.checked, env.ROLLOUT_ACK_CHECKBOX_TEXT) || contains(steps.rollout-bypass.outputs.unchecked, env.ROLLOUT_ACK_CHECKBOX_TEXT) || steps.rollout-bypass-dispatch.outputs.exists == 'true' }}
         run: |
           echo "approved=${APPROVED}" | tee -a $GITHUB_OUTPUT
           echo "exists=${EXISTS}" | tee -a $GITHUB_OUTPUT
@@ -250,6 +274,51 @@ jobs:
             > Active progressive rollout warning for ${{ matrix.connector }}.
 
             - [ ] (Click to Approve:) Bypass the active progressive rollout warning for ${{ matrix.connector }} in the PR comment [here](${{ steps.rollout-comment.outputs.url }}).
+
+      - name: Add rollout bypass checkbox to dispatched PR description
+        if: >
+          matrix.connector &&
+          github.event_name == 'workflow_dispatch' &&
+          env.PR_NUMBER != '' &&
+          steps.bypass-state.outputs.exists != 'true' &&
+          (fromJSON(steps.rollout-status.outputs.json).has_active_rollout ||
+           contains(steps.master-version.outputs.version, '-rc.'))
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        env:
+          PR_NUMBER: ${{ env.PR_NUMBER }}
+          ROLLOUT_ACK_CHECKBOX_TEXT: ${{ env.ROLLOUT_ACK_CHECKBOX_TEXT }}
+          ROLLOUT_COMMENT_URL: ${{ steps.rollout-comment.outputs.url }}
+        with:
+          script: |
+            const pullNumber = Number(process.env.PR_NUMBER);
+            const checkboxText = process.env.ROLLOUT_ACK_CHECKBOX_TEXT;
+            const markdown = [
+              "> [!IMPORTANT]",
+              "> Active progressive rollout warning for ${{ matrix.connector }}.",
+              "",
+              `- [ ] ${checkboxText} [here](${process.env.ROLLOUT_COMMENT_URL}).`,
+            ].join("\n");
+
+            const { owner, repo } = context.repo;
+            const { data: pull } = await github.rest.pulls.get({
+              owner,
+              repo,
+              pull_number: pullNumber,
+            });
+            const body = pull.body || "";
+
+            if (body.includes(checkboxText)) {
+              core.info("Rollout bypass checkbox already exists in PR description.");
+              return;
+            }
+
+            const nextBody = body.trimEnd() ? `${body.trimEnd()}\n\n${markdown}` : markdown;
+            await github.rest.pulls.update({
+              owner,
+              repo,
+              pull_number: pullNumber,
+              body: nextBody,
+            });
 
       - name: Render progressive rollout gate comment
         if: >

--- a/.github/workflows/connector-active-progressive-rollout-checks.yml
+++ b/.github/workflows/connector-active-progressive-rollout-checks.yml
@@ -38,31 +38,32 @@ jobs:
     name: Generate Connector Matrix
     runs-on: ubuntu-24.04
     steps:
-      - name: Resolve checkout repository
-        id: checkout-repository
-        run: echo "value=${{ inputs.repo || github.event.pull_request.head.repo.full_name || github.repository }}" | tee -a "${GITHUB_OUTPUT}"
-
-      - name: Resolve checkout ref from PR input
-        if: inputs.pr != ''
-        id: checkout-ref-pr
-        run: echo "value=refs/pull/${{ inputs.pr }}/head" | tee -a "${GITHUB_OUTPUT}"
-
-      - name: Resolve checkout ref from gitref input
-        if: inputs.pr == '' && inputs.gitref != ''
-        id: checkout-ref-gitref
-        run: echo "value=${{ inputs.gitref }}" | tee -a "${GITHUB_OUTPUT}"
-
-      - name: Resolve checkout ref from event
-        if: inputs.pr == '' && inputs.gitref == ''
-        id: checkout-ref-event
-        run: echo "value=${{ github.head_ref || github.ref_name }}" | tee -a "${GITHUB_OUTPUT}"
-
       - name: Resolve workflow inputs
         id: vars
+        env:
+          INPUT_REPO: ${{ inputs.repo }}
+          INPUT_PR: ${{ inputs.pr }}
+          INPUT_GITREF: ${{ inputs.gitref }}
+          PR_HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          GITHUB_HEAD_REF: ${{ github.head_ref }}
+          GITHUB_REF_NAME: ${{ github.ref_name }}
         run: |
-          echo "repository=${{ steps.checkout-repository.outputs.value }}" | tee -a "${GITHUB_OUTPUT}"
-          echo "ref=${{ steps.checkout-ref-pr.outputs.value || steps.checkout-ref-gitref.outputs.value || steps.checkout-ref-event.outputs.value }}" | tee -a "${GITHUB_OUTPUT}"
-          echo "is-fork=${{ ! startsWith(steps.checkout-repository.outputs.value, 'airbytehq/') }}" | tee -a "${GITHUB_OUTPUT}"
+          repository="${INPUT_REPO:-${PR_HEAD_REPO:-${GITHUB_REPOSITORY}}}"
+          if [[ -n "${INPUT_PR}" ]]; then
+            ref="refs/pull/${INPUT_PR}/head"
+          elif [[ -n "${INPUT_GITREF}" ]]; then
+            ref="${INPUT_GITREF}"
+          else
+            ref="${GITHUB_HEAD_REF:-${GITHUB_REF_NAME}}"
+          fi
+          is_fork="true"
+          if [[ "${repository}" == airbytehq/* ]]; then
+            is_fork="false"
+          fi
+
+          echo "repository=${repository}" | tee -a "${GITHUB_OUTPUT}"
+          echo "ref=${ref}" | tee -a "${GITHUB_OUTPUT}"
+          echo "is-fork=${is_fork}" | tee -a "${GITHUB_OUTPUT}"
 
       - name: Checkout Airbyte
         id: checkout

--- a/.github/workflows/connector-active-progressive-rollout-checks.yml
+++ b/.github/workflows/connector-active-progressive-rollout-checks.yml
@@ -178,15 +178,22 @@ jobs:
           VERSION=$(airbyte-ops gh connector get-version --name "${CONNECTOR_NAME}" --ref master)
           echo "version=${VERSION}" | tee -a "${GITHUB_OUTPUT}"
 
+      - name: Resolve rollout gate state
+        if: matrix.connector
+        id: rollout-gate-state
+        env:
+          REQUIRES_ACK: ${{ fromJSON(steps.rollout-status.outputs.json).has_active_rollout || contains(steps.master-version.outputs.version, '-rc.') }}
+        run: echo "requires-ack=${REQUIRES_ACK}" | tee -a "${GITHUB_OUTPUT}"
+
       - name: Detect rollout bypass checkbox
-        if: matrix.connector && github.event_name == 'pull_request'
+        if: matrix.connector && steps.rollout-gate-state.outputs.requires-ack == 'true' && github.event_name == 'pull_request'
         id: rollout-bypass
         uses: AhmedBaset/checklist@ecbf0bacb0d5d1fe41131db29a44984fec266017 # v3
         with:
           token: ${{ github.token }}
 
       - name: Detect rollout bypass checkbox for dispatched PR
-        if: matrix.connector && github.event_name == 'workflow_dispatch' && env.PR_NUMBER != ''
+        if: matrix.connector && steps.rollout-gate-state.outputs.requires-ack == 'true' && github.event_name == 'workflow_dispatch' && env.PR_NUMBER != ''
         id: rollout-bypass-dispatch
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         env:
@@ -210,7 +217,7 @@ jobs:
             core.setOutput("exists", (checked || unchecked).toString());
 
       - name: Resolve rollout bypass checkbox state
-        if: matrix.connector
+        if: matrix.connector && steps.rollout-gate-state.outputs.requires-ack == 'true'
         id: bypass-state
         env:
           APPROVED: ${{ contains(steps.rollout-bypass.outputs.checked, env.ROLLOUT_ACK_CHECKBOX_TEXT) || steps.rollout-bypass-dispatch.outputs.approved == 'true' }}
@@ -220,7 +227,7 @@ jobs:
           echo "exists=${EXISTS}" | tee -a $GITHUB_OUTPUT
 
       - name: Find progressive rollout gate comment
-        if: matrix.connector && env.PR_NUMBER != ''
+        if: matrix.connector && steps.rollout-gate-state.outputs.requires-ack == 'true' && env.PR_NUMBER != ''
         id: find-rollout-comment
         uses: peter-evans/find-comment@b30e6a3c0ed37e7c023ccd3f1db5c6c0b0c23aad # v4.0.0
         with:
@@ -231,10 +238,9 @@ jobs:
       - name: Create progressive rollout gate placeholder comment
         if: >
           matrix.connector &&
+          steps.rollout-gate-state.outputs.requires-ack == 'true' &&
           env.PR_NUMBER != '' &&
-          steps.find-rollout-comment.outputs.comment-id == '' &&
-          (fromJSON(steps.rollout-status.outputs.json).has_active_rollout ||
-           contains(steps.master-version.outputs.version, '-rc.'))
+          steps.find-rollout-comment.outputs.comment-id == ''
         id: create-rollout-comment
         uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
         with:
@@ -249,7 +255,7 @@ jobs:
             > [Workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
 
       - name: Resolve rollout comment link
-        if: matrix.connector
+        if: matrix.connector && steps.rollout-gate-state.outputs.requires-ack == 'true'
         id: rollout-comment
         env:
           EXISTING_COMMENT_ID: ${{ steps.find-rollout-comment.outputs.comment-id }}
@@ -263,10 +269,9 @@ jobs:
       - name: Add rollout bypass checkbox to PR description
         if: >
           matrix.connector &&
+          steps.rollout-gate-state.outputs.requires-ack == 'true' &&
           github.event_name == 'pull_request' &&
-          steps.bypass-state.outputs.exists != 'true' &&
-          (fromJSON(steps.rollout-status.outputs.json).has_active_rollout ||
-           contains(steps.master-version.outputs.version, '-rc.'))
+          steps.bypass-state.outputs.exists != 'true'
         uses: bcgov/action-pr-description-add@14338bfe0278ead273b3c1189e5aa286ff6709c4 # v2.0.0
         with:
           github_token: ${{ github.token }}
@@ -279,11 +284,10 @@ jobs:
       - name: Add rollout bypass checkbox to dispatched PR description
         if: >
           matrix.connector &&
+          steps.rollout-gate-state.outputs.requires-ack == 'true' &&
           github.event_name == 'workflow_dispatch' &&
           env.PR_NUMBER != '' &&
-          steps.bypass-state.outputs.exists != 'true' &&
-          (fromJSON(steps.rollout-status.outputs.json).has_active_rollout ||
-           contains(steps.master-version.outputs.version, '-rc.'))
+          steps.bypass-state.outputs.exists != 'true'
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         env:
           PR_NUMBER: ${{ env.PR_NUMBER }}
@@ -324,11 +328,9 @@ jobs:
       - name: Render progressive rollout gate comment
         if: >
           matrix.connector &&
+          steps.rollout-gate-state.outputs.requires-ack == 'true' &&
           env.PR_NUMBER != '' &&
-          steps.rollout-comment.outputs.id != '' &&
-          (steps.find-rollout-comment.outputs.comment-id != '' ||
-           fromJSON(steps.rollout-status.outputs.json).has_active_rollout ||
-           contains(steps.master-version.outputs.version, '-rc.'))
+          steps.rollout-comment.outputs.id != ''
         id: rollout-comment-template
         uses: chuhlomin/render-template@f828bb5c72a3e3af89cb79808cea490166c6f1ce # v1.4
         with:
@@ -348,10 +350,8 @@ jobs:
       - name: Update progressive rollout gate comment
         if: >
           matrix.connector &&
-          steps.rollout-comment.outputs.id != '' &&
-          (steps.find-rollout-comment.outputs.comment-id != '' ||
-           fromJSON(steps.rollout-status.outputs.json).has_active_rollout ||
-           contains(steps.master-version.outputs.version, '-rc.'))
+          steps.rollout-gate-state.outputs.requires-ack == 'true' &&
+          steps.rollout-comment.outputs.id != ''
         uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
         with:
           comment-id: ${{ steps.rollout-comment.outputs.id }}

--- a/.github/workflows/connector-active-progressive-rollout-checks.yml
+++ b/.github/workflows/connector-active-progressive-rollout-checks.yml
@@ -82,18 +82,20 @@ jobs:
           fi
           git fetch --quiet upstream master
 
-      - name: Generate Connector Matrix from Dispatch Input
-        if: inputs.connector != ''
-        id: dispatch-matrix
-        run: echo "connectors_matrix={\"connector\":[\"${{ inputs.connector }}\"]}" | tee -a $GITHUB_OUTPUT
-
-      - name: Generate Connector Matrix from Changes
-        if: inputs.connector == ''
-        id: generate-matrix
-        run: echo "connectors_matrix=$(./poe-tasks/get-modified-connectors.sh --json)" | tee -a $GITHUB_OUTPUT
+      - name: Resolve connector matrix
+        id: connector-matrix
+        env:
+          INPUT_CONNECTOR: ${{ inputs.connector }}
+        run: |
+          if [[ -n "${INPUT_CONNECTOR}" ]]; then
+            connectors_matrix="{\"connector\":[\"${INPUT_CONNECTOR}\"]}"
+          else
+            connectors_matrix="$(./poe-tasks/get-modified-connectors.sh --json)"
+          fi
+          echo "connectors_matrix=${connectors_matrix}" | tee -a "${GITHUB_OUTPUT}"
 
     outputs:
-      connectors-matrix: ${{ steps.dispatch-matrix.outputs.connectors_matrix || steps.generate-matrix.outputs.connectors_matrix }}
+      connectors-matrix: ${{ steps.connector-matrix.outputs.connectors_matrix }}
       commit-sha: ${{ steps.checkout.outputs.commit }}
       checkout-repository: ${{ steps.vars.outputs.repository }}
       checkout-ref: ${{ steps.vars.outputs.ref }}

--- a/.github/workflows/connector-active-progressive-rollout-checks.yml
+++ b/.github/workflows/connector-active-progressive-rollout-checks.yml
@@ -33,6 +33,10 @@ permissions:
   issues: write
   pull-requests: write
 
+concurrency:
+  group: rollout-gate-${{ github.event.pull_request.number || inputs.pr || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   generate-matrix:
     name: Generate Connector Matrix

--- a/.github/workflows/connector-active-progressive-rollout-checks.yml
+++ b/.github/workflows/connector-active-progressive-rollout-checks.yml
@@ -66,6 +66,7 @@ jobs:
           echo "is-fork=${is_fork}" | tee -a "${GITHUB_OUTPUT}"
 
       - name: Checkout Airbyte
+        if: inputs.connector == ''
         id: checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -75,7 +76,7 @@ jobs:
           fetch-depth: 0
 
       - name: Add upstream remote (forks only)
-        if: steps.vars.outputs.is-fork == 'true'
+        if: inputs.connector == '' && steps.vars.outputs.is-fork == 'true'
         run: |
           if ! git remote | grep -q upstream; then
             git remote add upstream https://github.com/airbytehq/airbyte.git

--- a/.github/workflows/connector-active-progressive-rollout-checks.yml
+++ b/.github/workflows/connector-active-progressive-rollout-checks.yml
@@ -38,26 +38,31 @@ jobs:
     name: Generate Connector Matrix
     runs-on: ubuntu-24.04
     steps:
+      - name: Resolve checkout repository
+        id: checkout-repository
+        run: echo "value=${{ inputs.repo || github.event.pull_request.head.repo.full_name || github.repository }}" | tee -a "${GITHUB_OUTPUT}"
+
+      - name: Resolve checkout ref from PR input
+        if: inputs.pr != ''
+        id: checkout-ref-pr
+        run: echo "value=refs/pull/${{ inputs.pr }}/head" | tee -a "${GITHUB_OUTPUT}"
+
+      - name: Resolve checkout ref from gitref input
+        if: inputs.pr == '' && inputs.gitref != ''
+        id: checkout-ref-gitref
+        run: echo "value=${{ inputs.gitref }}" | tee -a "${GITHUB_OUTPUT}"
+
+      - name: Resolve checkout ref from event
+        if: inputs.pr == '' && inputs.gitref == ''
+        id: checkout-ref-event
+        run: echo "value=${{ github.head_ref || github.ref_name }}" | tee -a "${GITHUB_OUTPUT}"
+
       - name: Resolve workflow inputs
         id: vars
-        env:
-          INPUT_GITREF: ${{ inputs.gitref }}
-          INPUT_PR: ${{ inputs.pr }}
-          INPUT_REPO: ${{ inputs.repo }}
-          PULL_REQUEST_REPO: ${{ github.event.pull_request.head.repo.full_name }}
-          DEFAULT_REPOSITORY: ${{ github.repository }}
-          HEAD_REF: ${{ github.head_ref }}
-          REF_NAME: ${{ github.ref_name }}
         run: |
-          REPOSITORY="${INPUT_REPO:-${PULL_REQUEST_REPO:-${DEFAULT_REPOSITORY}}}"
-          REF="${REF_NAME}"
-          [[ -n "${HEAD_REF}" ]] && REF="${HEAD_REF}"
-          [[ -n "${INPUT_GITREF}" ]] && REF="${INPUT_GITREF}"
-          [[ -n "${INPUT_PR}" ]] && REF="refs/pull/${INPUT_PR}/head"
-
-          echo "repository=${REPOSITORY}" | tee -a "${GITHUB_OUTPUT}"
-          echo "ref=${REF}" | tee -a "${GITHUB_OUTPUT}"
-          echo "is-fork=$([[ "${REPOSITORY}" != airbytehq/* ]] && echo true || echo false)" | tee -a "${GITHUB_OUTPUT}"
+          echo "repository=${{ steps.checkout-repository.outputs.value }}" | tee -a "${GITHUB_OUTPUT}"
+          echo "ref=${{ steps.checkout-ref-pr.outputs.value || steps.checkout-ref-gitref.outputs.value || steps.checkout-ref-event.outputs.value }}" | tee -a "${GITHUB_OUTPUT}"
+          echo "is-fork=${{ ! startsWith(steps.checkout-repository.outputs.value, 'airbytehq/') }}" | tee -a "${GITHUB_OUTPUT}"
 
       - name: Checkout Airbyte
         id: checkout

--- a/.github/workflows/connector-active-progressive-rollout-checks.yml
+++ b/.github/workflows/connector-active-progressive-rollout-checks.yml
@@ -412,7 +412,7 @@ jobs:
 
   progressive-rollout-gate-summary:
     name: Connector Active Progressive Rollout Checks Summary
-    if: always()
+    if: ${{ !cancelled() }}
     needs:
       - generate-matrix
       - progressive-rollout-gate

--- a/poe-tasks/get-modified-connectors.sh
+++ b/poe-tasks/get-modified-connectors.sh
@@ -89,7 +89,7 @@ return_empty_json() {
 }
 
 # 5) drop ignored files
-filtered=$(printf '%s\n' "$all_changes" | grep -v -E "(/${ignore_globs}|^${ignore_globs})")
+filtered=$(printf '%s\n' "$all_changes" | grep -v -E "(/${ignore_globs}|^${ignore_globs})" || true)
 if [ -z "$filtered" ]; then
   echo "⚠️ Warning: No files remaining after filtering. Returning empty connector list." >&2
   return_empty_json


### PR DESCRIPTION
## What
Fixes progressive rollout gate follow-up issues found during post-merge E2E testing.

## How
- Adds `workflow_dispatch` inputs so maintainers can rerun the rollout gate against a specific PR and connector.
- Treats ignored or README-only connector changes as a no-op matrix instead of an empty-matrix failure.
- Supports PR-description ACK detection and insertion for dispatched PR checks.
- Skips matrix checkout when a dispatch input provides the connector explicitly.
- Skips ACK, comment, and template side-effect steps when both rollout indicators are clear.
- Avoids evaluating rollout JSON expressions for no-op matrix rows.
- Cancels stale rollout-gate runs for the same target PR to avoid checkbox edit race conditions.
- Skips the summary job when a stale rollout-gate run is canceled.

## Review guide
1. `.github/workflows/connector-active-progressive-rollout-checks.yml`

## User Impact
Maintainers can reliably rerun and validate the progressive rollout gate. PRs for connectors without active rollout indicators avoid unnecessary checkbox/comment work, and rapid checkbox edits cancel stale rollout-gate runs for the same PR.

## Can this PR be safely reverted and rolled back?
- [x] YES 💚
- [ ] NO ❌

## Testing
Rollout workflow E2E evidence:

- Unchecked ACK negative path: https://github.com/airbytehq/airbyte/actions/runs/25715364062?pr=78021
- Checked ACK passing path: https://github.com/airbytehq/airbyte/actions/runs/25715525764?pr=78021
- Explicit dispatch checkout-skip path: https://github.com/airbytehq/airbyte/actions/runs/25715754392?pr=78021
- No-active-rollout no-op path after skip optimization: https://github.com/airbytehq/airbyte/actions/runs/25750351610?pr=78021
- Active-rollout ACK/comment path after skip optimization: https://github.com/airbytehq/airbyte/actions/runs/25750363116?pr=78021
- Concurrency stale-run cancellation: https://github.com/airbytehq/airbyte/actions/runs/25751488865?pr=78021
- Concurrency latest-run success: https://github.com/airbytehq/airbyte/actions/runs/25751513806?pr=78021

Local validation:

- `yq . .github/workflows/connector-active-progressive-rollout-checks.yml`
- `npx prettier --check .github/workflows/connector-active-progressive-rollout-checks.yml`
- `git diff --check`
- pre-commit hook on commit

Link to Devin session: https://app.devin.ai/sessions/13ae42611c254ef8a91c77ddc207bbb6
Requested by: @aaronsteers