### PR TITLE
fix(source-slack): remove unused OAuth history scopes

### DIFF
--- a/airbyte-integrations/connectors/source-slack/manifest.yaml
+++ b/airbyte-integrations/connectors/source-slack/manifest.yaml
@@ -628,11 +628,9 @@ spec:
           client_secret: "{{ client_secret_value }}"
           redirect_uri: "{{ redirect_uri_value }}"
         scopes:
-          - scope: "channels:history"
           - scope: "channels:join"
           - scope: "channels:read"
           - scope: "groups:read"
-          - scope: "groups:history"
           - scope: "users:read"
         scopes_join_strategy: comma
         extract_output:

--- a/airbyte-integrations/connectors/source-slack/metadata.yaml
+++ b/airbyte-integrations/connectors/source-slack/metadata.yaml
@@ -10,7 +10,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: c2281cee-86f9-4a86-bb48-d23286b4c7bd
-  dockerImageTag: 3.2.7
+  dockerImageTag: 3.2.8
   dockerRepository: airbyte/source-slack
   documentationUrl: https://docs.airbyte.com/integrations/sources/slack
   externalDocumentationUrls:

--- a/airbyte-integrations/connectors/source-slack/unit_tests/test_source.py
+++ b/airbyte-integrations/connectors/source-slack/unit_tests/test_source.py
@@ -74,11 +74,9 @@ def test_oauth_scopes_contain_only_used_scopes():
     scopes = [entry["scope"] for entry in oauth_spec["scopes"]]
 
     expected_scopes = [
-        "channels:history",
         "channels:join",
         "channels:read",
         "groups:read",
-        "groups:history",
         "users:read",
     ]
     assert scopes == expected_scopes

--- a/docs/integrations/sources/slack.md
+++ b/docs/integrations/sources/slack.md
@@ -38,7 +38,6 @@ To create a Slack App, read this [tutorial](https://api.slack.com/tutorials/trac
 5. Navigate to **Scopes**. In **Bot Token Scopes**, select the following scopes: 
 
 ```
- channels:history
  channels:join
  channels:read
  files:read

--- a/docs/integrations/sources/slack.md
+++ b/docs/integrations/sources/slack.md
@@ -35,7 +35,7 @@ To create a Slack App, read this [tutorial](https://api.slack.com/tutorials/trac
 2. Click **Create New App**. Select **From Scratch**.
 3. Choose a name for your app and select the name of your Slack workspace. Click **Create App**. 
 4. In the navigation menu, select **OAuth & Permissions**.
-5. Navigate to **Scopes**. In **Bot Token Scopes**, select the following scopes: 
+5. Navigate to **Scopes**. In **Bot Token Scopes**, select the following scopes:
 
 ```
  channels:join

--- a/docs/integrations/sources/slack.md
+++ b/docs/integrations/sources/slack.md
@@ -198,6 +198,7 @@ If your Threads stream syncs are slow, consider enabling the **Ignore messages w
 
 | Version    | Date       | Pull Request                                             | Subject                                                                                                                                                                |
 |:-----------|:-----------|:---------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 3.2.8 | 2026-05-12 | [78025](https://github.com/airbytehq/airbyte/pull/78025) | fix(source-slack): remove unused OAuth history scopes |
 | 3.2.7 | 2026-04-30 | [77628](https://github.com/airbytehq/airbyte/pull/77628) | Improve threads_ignore_no_replies filter to also check thread_ts, reducing unnecessary conversations.replies API calls |
 | 3.2.6 | 2026-04-30 | [77607](https://github.com/airbytehq/airbyte/pull/77607) | Improve error handling for Slack API ok=false responses: add catch-all for unrecognized errors and expand error code coverage |
 | 3.2.5 | 2026-04-29 | [77601](https://github.com/airbytehq/airbyte/pull/77601) | Surface missing OAuth scope as config error instead of silently failing channel joins |


### PR DESCRIPTION
## What
Remove `channels:history` and `groups:history` from the Slack connector OAuth scope request list and related user-facing docs.

## How
- Removed the two scopes from `oauth_connector_input_specification.scopes` in the Slack manifest.
- Updated the Slack unit test expected OAuth scopes list.
- Removed `channels:history` from the Slack setup guide bot token scope list and confirmed `groups:history` remains absent.
- Bumped `source-slack` to `3.2.8` and added the changelog entry from the Octavia bump commit.

## Review guide
1. `airbyte-integrations/connectors/source-slack/manifest.yaml`
2. `airbyte-integrations/connectors/source-slack/unit_tests/test_source.py`
3. `airbyte-integrations/connectors/source-slack/metadata.yaml`
4. `docs/integrations/sources/slack.md`

## User Impact
Users authorizing the Slack connector through OAuth will no longer grant `channels:history` or `groups:history`. The `channel_messages` and `threads` streams can return Slack `missing_scope` errors when syncing message data because they depend on `conversations.history`.

## Can this PR be safely reverted and rolled back?
- [x] YES
- [ ] NO

---
[Devin session](https://app.devin.ai/sessions/91210f5e2aec481a9e85a60b7e6f129e)

Requested by: @lazebnyi