### PR TITLE
feat(source-linear): resume concurrency tuning at c=4 (0.2.2-rc.1, Path A)

### DIFF
--- a/airbyte-integrations/connectors/source-linear/manifest.yaml
+++ b/airbyte-integrations/connectors/source-linear/manifest.yaml
@@ -1422,6 +1422,22 @@ streams:
   - $ref: "#/definitions/streams/customer_statuses"
   - $ref: "#/definitions/streams/customer_tiers"
 
+# Linear API documented rate limits (per-user, per-hour windows):
+# - API key auth: 2,500 requests / hour (approximately 0.69 req/sec).
+# - OAuth app auth: 5,000 requests / hour (approximately 1.39 req/sec).
+# - Workspace OAuth auth: dynamic uplift based on paid seat count.
+# - Source: https://linear.app/developers/rate-limiting
+#
+# Starting concurrency follows the connector concurrency tuning playbook
+# (Path A, tuned against the lowest documented tier — 2,500 req/hr API key):
+# floor((2500/3600) / 4) = 0 ≤ 2 triggers the low-rate-limit special case →
+# starting_concurrency = 4, step = 1. Empirical tuning will adjust against
+# the documented 2,500 req/hr ceiling.
+concurrency_level:
+  type: ConcurrencyLevel
+  default_concurrency: 4
+  max_concurrency: 16
+
 spec:
   type: Spec
   connection_specification:

--- a/airbyte-integrations/connectors/source-linear/metadata.yaml
+++ b/airbyte-integrations/connectors/source-linear/metadata.yaml
@@ -12,12 +12,15 @@ data:
     pypi:
       enabled: false
       packageName: airbyte-source-linear
+  releases:
+    rolloutConfiguration:
+      enableProgressiveRollout: true
   connectorBuildOptions:
     baseImage: docker.io/airbyte/source-declarative-manifest:7.17.4@sha256:f85ae668c118cc9a42dae007325b916d63c2df72d6809677582b4fa8a1c65bbb
   connectorSubtype: api
   connectorType: source
   definitionId: 1c5d8316-ed42-4473-8fbc-2626f03f070c
-  dockerImageTag: 0.2.1
+  dockerImageTag: 0.2.2-rc.1
   dockerRepository: airbyte/source-linear
   githubIssueLabel: source-linear
   icon: icon.svg

--- a/docs/integrations/sources/linear.md
+++ b/docs/integrations/sources/linear.md
@@ -122,6 +122,7 @@ For programmatic configuration, use these parameter names:
 
 | Version | Date | Pull Request | Subject |
 | ------- | ---- | ------------ | ------- |
+| 0.2.2-rc.1 | 2026-05-12 | [PR_NUMBER](https://github.com/airbytehq/airbyte/pull/PR_NUMBER) | Resume concurrency tuning at default_concurrency=4 (Path A, 2,500 req/hr API key ceiling); re-enable progressive rollout |
 | 0.2.1 | 2026-05-12 | [78013](https://github.com/airbytehq/airbyte/pull/78013) | Fix API key config migration for existing connections |
 | 0.2.0 | 2026-05-11 | [77578](https://github.com/airbytehq/airbyte/pull/77578) | Add OAuth 2.0 authentication support and migrate existing API key configurations to nested credentials |
 | 0.1.2 | 2026-04-28 | [77318](https://github.com/airbytehq/airbyte/pull/77318) | Update dependencies |


### PR DESCRIPTION
## What

Resumes Phase 1 of the **Connector Concurrency Tuning & Rollout** playbook for `source-linear` on top of stable `0.2.1`. The previous tuning RC (`0.2.1-rc.1`, airbytehq/airbyte#78008) and its progressive rollout were rolled back as part of airbytehq/airbyte#78013, which shipped an unrelated API key config migration fix as `0.2.1` GA and explicitly removed the unvetted concurrency tuning changes from the active release path.

This PR re-applies the same Path A starting point on top of stable `0.2.1`:

- Re-adds the `concurrency_level` block to `manifest.yaml`:
  - `default_concurrency: 4`
  - `max_concurrency: 16`
- Re-enables `releases.rolloutConfiguration.enableProgressiveRollout: true` in `metadata.yaml`.
- Bumps `dockerImageTag` to `0.2.2-rc.1` so the registry-publish workflow auto-publishes the new RC on merge.
- Adds the `0.2.2-rc.1` row to the changelog in `docs/integrations/sources/linear.md`.

The connector logic itself is **unchanged** — only `manifest.yaml` concurrency settings, `metadata.yaml` rollout flag, and the changelog row are modified. The API key config migration fix from `0.2.1` is preserved.

## Path A starting-concurrency rationale

Linear's documented per-user, per-hour rate limits (https://linear.app/developers/rate-limiting):

- API key auth: 2,500 requests / hour (~0.69 req/s) — Path A tunes against this lowest ceiling.
- OAuth app auth: 5,000 requests / hour (~1.39 req/s).
- Workspace OAuth auth: dynamic uplift based on paid seat count.

Playbook starting-concurrency formula yields `floor((2500/3600)/4) = 0 ≤ 2` → low-rate-limit special case → `starting_concurrency = 4, step = 1` (identical for OAuth auth tier).

## How

`manifest.yaml` — inserts a `concurrency_level: ConcurrencyLevel` block between the closing of `streams:` and the opening of `spec:`, with the Linear rate-limit context and Path A derivation captured in a leading comment block.

`metadata.yaml` — inserts `releases.rolloutConfiguration.enableProgressiveRollout: true`, bumps `dockerImageTag` from `0.2.1` to `0.2.2-rc.1`.

`docs/integrations/sources/linear.md` — adds the `0.2.2-rc.1` changelog entry above the `0.2.1` row.

## Review guide

1. `airbyte-integrations/connectors/source-linear/manifest.yaml` — concurrency_level block re-introduced.
2. `airbyte-integrations/connectors/source-linear/metadata.yaml` — progressive rollout re-enabled, version bumped.
3. `docs/integrations/sources/linear.md` — changelog entry for `0.2.2-rc.1`.

## User Impact

End users are **not** impacted by this PR alone. The RC will only reach 23 pinned Tier 2 actors via a fresh progressive rollout after this PR merges and `0.2.2-rc.1` is published. The remaining Tier 2 + all Tier 1 + Tier 0 actors continue on stable `0.2.1` until the rollout is finalized at Phase 4 (GA). The rollout will be opened, monitored, and finalized per the standard playbook with explicit human approval at each phase transition.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚
- [ ] NO ❌

This is a pure manifest/metadata change. Reverting restores stable `0.2.1` behavior (no concurrency tuning, no progressive rollout) with no data or state migration required, identical to how airbytehq/airbyte#78013 reverted the previous tuning RC.

## Tuning context

- Parent session (Phase 0 planning, cohort selection, original 0.2.1-rc.1 PR): https://app.devin.ai/sessions/42d4620ee6274df1b32bcc501d7d87ce
- Resume session (this session — 0.2.1-rc.1 rolled back externally, restarting on 0.2.2-rc.1): https://app.devin.ai/sessions/43bd595b009b452187d11c6a7ab84193
- Previous tuning PR (superseded): airbytehq/airbyte#78008
- Revert + GA PR (`0.2.1`): airbytehq/airbyte#78013
- Cohort size: 23 Tier 2 actors (50% of 47 eligible, minimum 20). Will be re-snapshotted on a fresh 14d window before rollout.

Requested by: @sophiecuiy