### PR TITLE
fix(source-amazon-seller-partner): show retry tuning spec fields

### DIFF
--- a/airbyte-integrations/connectors/source-amazon-seller-partner/manifest.yaml
+++ b/airbyte-integrations/connectors/source-amazon-seller-partner/manifest.yaml
@@ -347,7 +347,6 @@ spec:
         minimum: 1
         maximum: 14400
         order: 18
-        airbyte_hidden: true
       creation_requester_429_max_retries:
         title: Report Creation 429 Max Retries
         description: >-
@@ -359,7 +358,6 @@ spec:
         default: 5
         minimum: 0
         order: 19
-        airbyte_hidden: true
   advanced_auth:
     auth_flow_type: oauth2.0
     predicate_key:

--- a/airbyte-integrations/connectors/source-amazon-seller-partner/metadata.yaml
+++ b/airbyte-integrations/connectors/source-amazon-seller-partner/metadata.yaml
@@ -15,7 +15,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: e55879a8-0ef8-4557-abcf-ab34c53ec460
-  dockerImageTag: 5.7.6-rc.3
+  dockerImageTag: 5.7.6-rc.4
   dockerRepository: airbyte/source-amazon-seller-partner
   documentationUrl: https://docs.airbyte.com/integrations/sources/amazon-seller-partner
   erdUrl: https://dbdocs.io/airbyteio/source-amazon-seller-partner?view=relationships

--- a/docs/integrations/sources/amazon-seller-partner.md
+++ b/docs/integrations/sources/amazon-seller-partner.md
@@ -353,6 +353,7 @@ You may also combine this with a smaller **Financial Events Step Size** (e.g., 1
 
 | Version    | Date       | Pull Request                                              | Subject                                                                                                                                                                             |
 |:-----------|:-----------|:----------------------------------------------------------|:------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 5.7.6-rc.4 | 2026-05-13 | [78037](https://github.com/airbytehq/airbyte/pull/78037) | Make failed report retry wait time and report creation 429 max retries visible in the source configuration |
 | 5.7.6-rc.3 | 2026-05-11 | [77837](https://github.com/airbytehq/airbyte/pull/77837) | Add configurable cooldown-aware deferred retry for FATAL reports and dedicated 429 error handler with backoff on report creation |
 | 5.7.6-rc.2 | 2026-05-06 | [77800](https://github.com/airbytehq/airbyte/pull/77800) | Skip FATAL reports when checking for existing reports to prevent infinite retry loops |
 | 5.7.6-rc.1 | 2026-04-28 | [76093](https://github.com/airbytehq/airbyte/pull/76093) | Check for existing reports before creating new ones to avoid hitting Amazon SP-API rate limits |


### PR DESCRIPTION
## What

Removes `airbyte_hidden: true` from the Amazon Seller Partner spec fields `failed_retry_wait_time_in_seconds` and `creation_requester_429_max_retries` so users can configure them.

Bumps `source-amazon-seller-partner` from `5.7.6-rc.3` to `5.7.6-rc.4` and adds the matching changelog entry.

## How

Deleted the hidden flags from the two existing connector spec properties in `manifest.yaml`. Defaults, validation bounds, descriptions, and runtime config lookups are unchanged.

Used the Airbyte Ops MCP version bump tool with `bump_type=rc` to update `metadata.yaml` and the connector changelog.

## Review guide

1. `airbyte-integrations/connectors/source-amazon-seller-partner/manifest.yaml`
2. `airbyte-integrations/connectors/source-amazon-seller-partner/metadata.yaml`
3. `docs/integrations/sources/amazon-seller-partner.md`

## User Impact

Users can see and tune the failed report retry wait time and report creation 429 retry count in the connector configuration.

## Can this PR be safely reverted and rolled back?

- [x] YES
- [ ] NO

---
[Devin session](https://app.devin.ai/sessions/a610531bd2724e4790bfa320979e0139)

Requested by: @darynaishchenko

> [!IMPORTANT]
> Active progressive rollout warning for source-amazon-seller-partner.

- [ ] (Click to Approve:) Bypass the active progressive rollout warning for source-amazon-seller-partner in the PR comment [here](https://github.com/airbytehq/airbyte/pull/78037#issuecomment-4433158354).