### PR TITLE
ci(workflows): Detect rollout connectors without checkout

### DIFF
--- a/.github/progressive-rollout-gate-comment.md
+++ b/.github/progressive-rollout-gate-comment.md
@@ -1,36 +1,53 @@
 <!-- progressive-rollout-gate:{{ .connector }} -->
 
 > [!IMPORTANT]
-> Active progressive rollout warning for `{{ .connector }}`.
+> Active progressive rollout warning for .
 >
-> This PR can bypass the warning only after the PR-description ACK checkbox is checked.
+> To bypass this warning, click on the checkbox in the PR description - or read below for more information.
 
-Detected signals:
+**Detected `{{ .connector }}` Active Rollout: `{{ .active_rollout }}`**
 
-- Active rollout: `{{ .active_rollout }}`
 - Rollout version: `{{ .rollout_docker_image_tag }}`
 - Rollout state: `{{ .rollout_state }}`
-- Master version: `{{ .master_version }}`
+
+**Version on `master` Branch: `{{ .master_version }}`**
+
 - Master RC marker: `{{ .master_rc_marker }}`
-- Bypass ACK checked: `{{ .bypass_ack_checked }}`
 
-To bypass this warning, check this box in the PR description:
+**Bypass Checkbox Checked: `{{ .bypass_ack_checked }}`**
 
-`- [ ] {{ .ack_checkbox_text }} [here]({{ .rollout_comment_url }}).`
+To bypass this warning, click on the checkbox in the PR description with the text:
+
+> {{ .ack_checkbox_text }} here.
 
 <details>
-<summary>What happens if this PR is merged?</summary>
+<summary>**ℹ️ More Info**</summary>
+
+<details>
+<summary>🤔 What happens if this PR is merged?</summary>
 
 Checking the ACK box does not stop the active rollout by itself. It only allows this workflow's required check to pass. If the PR then merges, the result depends on what connector version is published after merge.
 
-<details>
-<summary>Expected outcomes by version-change type</summary>
+Expected outcomes by version-change type:
 
-- No connector version change: no new connector version should be released, and the active rollout should continue unchanged.
-- RC to GA: the merged PR may publish the GA version and make it default for eligible non-pinned actors. The existing rollout is not stopped immediately by the merge, but the rollout worker can later cancel it as superseded when finalizing.
-- RCn to RCn+1: the merged PR may publish a new release candidate and replace the active RC marker. The previous incomplete rollout is canceled without unpinning, and a new rollout is created for RCn+1.
+<details><summary>**If connector version is not modified in this PR...**</summary>
 
-</details>
+No new connector version should be released, and the active rollout should continue unchanged.
+
+<details><summary>**If the connector version changes from RC to non-RC (GA) version...**</summary>
+
+The merged PR may publish the GA version and make it default for eligible non-pinned actors. The existing rollout is not stopped immediately by the merge, but the rollout worker can later cancel it as superseded when finalizing.
+
+<details><summary>**If the connector version increments to a higher `-rc` version...**</summary>
+
+The merged PR may publish a new release candidate and replace the active RC marker. The previous incomplete rollout is canceled without unpinning, and a new rollout is created for RCn+1.
+
+<details><summary>**🔁 How can I rerun this check?**</summary>
+
+To rerun the check, simple check and uncheck the box, or else modify the PR description and/or title in any way.
+
+Alternatively, you can find the Active Progressive Rollout CI workflow and manually rerun it (although this is generally slower than the above methods).
+
 </details>
 
 [Workflow run]({{ .workflow_run_url }})

--- a/.github/progressive-rollout-gate-comment.md
+++ b/.github/progressive-rollout-gate-comment.md
@@ -1,11 +1,12 @@
 <!-- progressive-rollout-gate:{{ .connector }} -->
 
-## Detected `{{ .connector }}` Active Rollout: `{{ .active_rollout }}`**
+## Detected `{{ .connector }}` Active Rollout: `{{ .active_rollout }}`
 
 > [!IMPORTANT]
 > Active progressive rollout warning for `{{ .connector }}`.
 >
 > To bypass this warning, click on the matching checkbox in the PR description. Look for the checkbox text:
+>
 > > {{ .ack_checkbox_text }}
 
 - Rollout version: `{{ .rollout_docker_image_tag }}`
@@ -51,7 +52,7 @@ To rerun the check, simply check and uncheck the box, or else modify the PR desc
 
 Alternatively, you can find the Active Progressive Rollout CI workflow and manually rerun it (although this is generally slower than the above methods).
 
------
+---
 
 This comment will be updated as PR and/or rollout status changes.
 

--- a/.github/progressive-rollout-gate-comment.md
+++ b/.github/progressive-rollout-gate-comment.md
@@ -19,11 +19,13 @@
 
 - Bypass checkbox checked: `{{ .bypass_ack_checked }}`
 
+## ℹ️ More Information
+
+<details><summary>Show/hide details...</summary>
+
 ### 🤔 What happens if this PR is merged
 
-Checking the checkbox will allow the PR to merge, but it does not necessarily stop the active rollout by itself.
-
-The result of the PR merging depends on what connector version is published.
+Checking the checkbox will allow the PR to merge, but it does not necessarily stop the active rollout by itself. The result of the PR merging depends on what connector version is published.
 
 Expected outcomes by type of version number change:
 
@@ -50,6 +52,8 @@ The merged PR may publish a new release candidate and replace the active RC mark
 To rerun the check, simply check and uncheck the box, or else modify the PR description and/or title in any way.
 
 Alternatively, you can find the Active Progressive Rollout CI workflow and manually rerun it (although this is generally slower than the above methods).
+
+</details>
 
 -----
 

--- a/.github/progressive-rollout-gate-comment.md
+++ b/.github/progressive-rollout-gate-comment.md
@@ -56,7 +56,7 @@ Alternatively, you can find the Active Progressive Rollout CI workflow and manua
 
 </details>
 
------
+---
 
 This comment will be updated as PR and/or rollout status changes.
 

--- a/.github/progressive-rollout-gate-comment.md
+++ b/.github/progressive-rollout-gate-comment.md
@@ -5,9 +5,7 @@
 > [!IMPORTANT]
 > Active progressive rollout warning for `{{ .connector }}`.
 >
-> To bypass this warning, click on the matching checkbox in the PR description.
->
-> Checkbox text:
+> To bypass this warning, click on the matching checkbox in the PR description. Look for the checkbox text:
 > > {{ .ack_checkbox_text }}
 
 - Rollout version: `{{ .rollout_docker_image_tag }}`

--- a/.github/progressive-rollout-gate-comment.md
+++ b/.github/progressive-rollout-gate-comment.md
@@ -20,11 +20,11 @@
 
 - Bypass checkbox checked: `{{ .bypass_ack_checked }}`
 
-## ℹ️ More Information
+### ℹ️ More Information
 
 <details><summary>Show/hide details...</summary>
 
-### 🤔 What happens if this PR is merged
+#### 🤔 What happens if this PR is merged
 
 Checking the checkbox will allow the PR to merge, but it does not necessarily stop the active rollout by itself. The result of the PR merging depends on what connector version is published.
 
@@ -48,7 +48,7 @@ The merged PR may publish a new release candidate and replace the active RC mark
 
 </details>
 
-### 🔁 How to rerun this check
+#### 🔁 How to rerun this check
 
 To rerun the check, simply check and uncheck the box, or else modify the PR description and/or title in any way.
 

--- a/.github/progressive-rollout-gate-comment.md
+++ b/.github/progressive-rollout-gate-comment.md
@@ -1,52 +1,42 @@
 <!-- progressive-rollout-gate:{{ .connector }} -->
 
 > [!IMPORTANT]
-> Active progressive rollout warning for .
+> Active progressive rollout warning for `{{ .connector }}`.
 >
-> To bypass this warning, click on the checkbox in the PR description - or read below for more information.
+> To bypass this warning, check the matching box in the PR description.
 
-**Detected `{{ .connector }}` Active Rollout: `{{ .active_rollout }}`**
+**Rollout status**
 
+- Active rollout: `{{ .active_rollout }}`
 - Rollout version: `{{ .rollout_docker_image_tag }}`
 - Rollout state: `{{ .rollout_state }}`
-
-**Version on `master` Branch: `{{ .master_version }}`**
-
+- Version on `master`: `{{ .master_version }}`
 - Master RC marker: `{{ .master_rc_marker }}`
+- Bypass checkbox checked: `{{ .bypass_ack_checked }}`
 
-**Bypass Checkbox Checked: `{{ .bypass_ack_checked }}`**
+Checkbox text:
 
-To bypass this warning, click on the checkbox in the PR description with the text:
-
-> {{ .ack_checkbox_text }} here.
-
-<details>
-<summary>**ℹ️ More Info**</summary>
+> {{ .ack_checkbox_text }}
 
 <details>
-<summary>🤔 What happens if this PR is merged?</summary>
+<summary>What happens if this PR merges?</summary>
 
-Checking the ACK box does not stop the active rollout by itself. It only allows this workflow's required check to pass. If the PR then merges, the result depends on what connector version is published after merge.
+Checking the ACK box does not stop the active rollout by itself. It only allows this workflow's required check to pass. If the PR merges, the result depends on what connector version is published after merge.
 
 Expected outcomes by version-change type:
 
-<details><summary>**If connector version is not modified in this PR...**</summary>
+- If this PR does not change the connector version, no new connector version should be released and the active rollout should continue unchanged.
+- If this PR promotes an RC to a GA version, the merged PR may publish the GA version and make it default for eligible non-pinned actors. The existing rollout is not stopped immediately by the merge, but the rollout worker can later cancel it as superseded when finalizing.
+- If this PR increments to a higher `-rc` version, the merged PR may publish a new release candidate and replace the active RC marker. The previous incomplete rollout is canceled without unpinning, and a new rollout is created for the next RC.
 
-No new connector version should be released, and the active rollout should continue unchanged.
+</details>
 
-<details><summary>**If the connector version changes from RC to non-RC (GA) version...**</summary>
+<details>
+<summary>How can I rerun this check?</summary>
 
-The merged PR may publish the GA version and make it default for eligible non-pinned actors. The existing rollout is not stopped immediately by the merge, but the rollout worker can later cancel it as superseded when finalizing.
+To rerun the check, check and uncheck the box, or edit the PR description or title.
 
-<details><summary>**If the connector version increments to a higher `-rc` version...**</summary>
-
-The merged PR may publish a new release candidate and replace the active RC marker. The previous incomplete rollout is canceled without unpinning, and a new rollout is created for RCn+1.
-
-<details><summary>**🔁 How can I rerun this check?**</summary>
-
-To rerun the check, simple check and uncheck the box, or else modify the PR description and/or title in any way.
-
-Alternatively, you can find the Active Progressive Rollout CI workflow and manually rerun it (although this is generally slower than the above methods).
+You can also rerun the Active Progressive Rollout CI workflow manually, although that is usually slower.
 
 </details>
 

--- a/.github/progressive-rollout-gate-comment.md
+++ b/.github/progressive-rollout-gate-comment.md
@@ -1,53 +1,97 @@
 <!-- progressive-rollout-gate:{{ .connector }} -->
 
+## Detected `{{ .connector }}` Active Rollout: `{{ .active_rollout }}`**
+
 > [!IMPORTANT]
-> Active progressive rollout warning for .
+> Active progressive rollout warning for `{{ .connector }}`.
 >
-> To bypass this warning, click on the checkbox in the PR description - or read below for more information.
+> To bypass this warning, check the matching box in the PR description.
 
-**Detected `{{ .connector }}` Active Rollout: `{{ .active_rollout }}`**
-
+<<<<<<< HEAD
 - Rollout version: `{{ .rollout_docker_image_tag }}`
 - Rollout state: `{{ .rollout_state }}`
 
-**Version on `master` Branch: `{{ .master_version }}`**
+### Version on `master` Branch: `{{ .master_version }}`
 
+=======
+**Rollout status**
+
+- Active rollout: `{{ .active_rollout }}`
+- Rollout version: `{{ .rollout_docker_image_tag }}`
+- Rollout state: `{{ .rollout_state }}`
+- Version on `master`: `{{ .master_version }}`
+>>>>>>> b0dee443a3c089009d375799aeee7eeb09c49758
 - Master RC marker: `{{ .master_rc_marker }}`
+- Bypass checkbox checked: `{{ .bypass_ack_checked }}`
 
-**Bypass Checkbox Checked: `{{ .bypass_ack_checked }}`**
+<<<<<<< HEAD
+### Bypass Checkbox Checked: `{{ .bypass_ack_checked }}`
+=======
+Checkbox text:
+>>>>>>> b0dee443a3c089009d375799aeee7eeb09c49758
 
-To bypass this warning, click on the checkbox in the PR description with the text:
+> {{ .ack_checkbox_text }}
 
-> {{ .ack_checkbox_text }} here.
+<<<<<<< HEAD
+### ℹ️ More Info
 
 <details>
-<summary>**ℹ️ More Info**</summary>
+<summary>Show/hide additional information...</summary>
 
+#### 🤔 What happens if this PR is merged
+=======
 <details>
-<summary>🤔 What happens if this PR is merged?</summary>
+<summary>What happens if this PR merges?</summary>
 
-Checking the ACK box does not stop the active rollout by itself. It only allows this workflow's required check to pass. If the PR then merges, the result depends on what connector version is published after merge.
+Checking the ACK box does not stop the active rollout by itself. It only allows this workflow's required check to pass. If the PR merges, the result depends on what connector version is published after merge.
+>>>>>>> b0dee443a3c089009d375799aeee7eeb09c49758
 
-Expected outcomes by version-change type:
+Checking the checkbox will allow the PR to merge, but it does not necessarily stop the active rollout by itself.
 
-<details><summary>**If connector version is not modified in this PR...**</summary>
+<<<<<<< HEAD
+The result of the PR merging depends on what connector version is published.
+
+Expected outcomes by type of version number change:
+
+<details><summary>If connector version is not modified in this PR...</summary>
 
 No new connector version should be released, and the active rollout should continue unchanged.
+</details>
 
-<details><summary>**If the connector version changes from RC to non-RC (GA) version...**</summary>
+<details><summary>If the connector version changes from RC to non-RC (GA) version...</summary>
 
 The merged PR may publish the GA version and make it default for eligible non-pinned actors. The existing rollout is not stopped immediately by the merge, but the rollout worker can later cancel it as superseded when finalizing.
+</details>
 
-<details><summary>**If the connector version increments to a higher `-rc` version...**</summary>
+<details><summary>If the connector version increments to a higher `-rc` version...</summary>
 
 The merged PR may publish a new release candidate and replace the active RC marker. The previous incomplete rollout is canceled without unpinning, and a new rollout is created for RCn+1.
+</details>
 
-<details><summary>**🔁 How can I rerun this check?**</summary>
+### 🔁 How to rerun this check
 
-To rerun the check, simple check and uncheck the box, or else modify the PR description and/or title in any way.
+To rerun the check, simply check and uncheck the box, or else modify the PR description and/or title in any way.
 
 Alternatively, you can find the Active Progressive Rollout CI workflow and manually rerun it (although this is generally slower than the above methods).
+=======
+- If this PR does not change the connector version, no new connector version should be released and the active rollout should continue unchanged.
+- If this PR promotes an RC to a GA version, the merged PR may publish the GA version and make it default for eligible non-pinned actors. The existing rollout is not stopped immediately by the merge, but the rollout worker can later cancel it as superseded when finalizing.
+- If this PR increments to a higher `-rc` version, the merged PR may publish a new release candidate and replace the active RC marker. The previous incomplete rollout is canceled without unpinning, and a new rollout is created for the next RC.
 
 </details>
+
+<details>
+<summary>How can I rerun this check?</summary>
+
+To rerun the check, check and uncheck the box, or edit the PR description or title.
+
+You can also rerun the Active Progressive Rollout CI workflow manually, although that is usually slower.
+>>>>>>> b0dee443a3c089009d375799aeee7eeb09c49758
+
+</details>
+
+-----
+
+This comment will be updated as PR and/or rollout status changes.
 
 [Workflow run]({{ .workflow_run_url }})

--- a/.github/workflows/connector-active-progressive-rollout-checks.yml
+++ b/.github/workflows/connector-active-progressive-rollout-checks.yml
@@ -19,10 +19,6 @@ on:
         description: "The pull request number to inspect and comment on."
         required: true
         type: number
-      connector:
-        description: "Single connector name to check. If omitted, auto-detects from PR changed files."
-        required: false
-        type: string
 
 permissions:
   contents: read
@@ -69,30 +65,23 @@ jobs:
           echo "is-fork=${is_fork}" | tee -a "${GITHUB_OUTPUT}"
 
       - name: Install uv
-        if: >
-          inputs.connector == '' &&
-          steps.vars.outputs.pr-number != ''
+        if: steps.vars.outputs.pr-number != ''
         uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
         with:
           ignore-empty-workdir: true
 
       - name: Install Ops CLI
-        if: >
-          inputs.connector == '' &&
-          steps.vars.outputs.pr-number != ''
+        if: steps.vars.outputs.pr-number != ''
         run: uv tool install 'airbyte-internal-ops>=0.55.0'
 
       - name: Resolve connector matrix
         id: connector-matrix
         env:
-          INPUT_CONNECTOR: ${{ inputs.connector }}
           PR_NUMBER: ${{ steps.vars.outputs.pr-number }}
           PR_REPOSITORY: ${{ steps.vars.outputs.pr-repository }}
           GITHUB_TOKEN: ${{ github.token }}
         run: |
-          if [[ -n "${INPUT_CONNECTOR}" ]]; then
-            connectors_matrix="{\"connector\":[\"${INPUT_CONNECTOR}\"]}"
-          elif [[ -n "${PR_NUMBER}" ]]; then
+          if [[ -n "${PR_NUMBER}" ]]; then
             repo_owner="${PR_REPOSITORY%%/*}"
             repo_name="${PR_REPOSITORY#*/}"
             connectors_matrix="$(
@@ -105,7 +94,7 @@ jobs:
                 --output-format json-gh-matrix
             )"
           else
-            echo "::error::Auto-detecting modified connectors requires a pull request number or explicit connector input."
+            echo "::error::Auto-detecting modified connectors requires a pull request number."
             exit 1
           fi
           echo "connectors_matrix=${connectors_matrix}" | tee -a "${GITHUB_OUTPUT}"

--- a/.github/workflows/connector-active-progressive-rollout-checks.yml
+++ b/.github/workflows/connector-active-progressive-rollout-checks.yml
@@ -48,10 +48,12 @@ jobs:
           INPUT_REPO: ${{ inputs.repo }}
           INPUT_PR: ${{ inputs.pr }}
           INPUT_GITREF: ${{ inputs.gitref }}
+          EVENT_PR_NUMBER: ${{ github.event.pull_request.number }}
           PR_HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
           GITHUB_HEAD_REF: ${{ github.head_ref }}
           GITHUB_REF_NAME: ${{ github.ref_name }}
         run: |
+          pr_number="${INPUT_PR:-${EVENT_PR_NUMBER}}"
           repository="${INPUT_REPO:-${PR_HEAD_REPO:-${GITHUB_REPOSITORY}}}"
           if [[ -n "${INPUT_PR}" ]]; then
             ref="refs/pull/${INPUT_PR}/head"
@@ -65,12 +67,15 @@ jobs:
             is_fork="false"
           fi
 
+          echo "pr-number=${pr_number}" | tee -a "${GITHUB_OUTPUT}"
           echo "repository=${repository}" | tee -a "${GITHUB_OUTPUT}"
           echo "ref=${ref}" | tee -a "${GITHUB_OUTPUT}"
           echo "is-fork=${is_fork}" | tee -a "${GITHUB_OUTPUT}"
 
       - name: Checkout Airbyte
-        if: inputs.connector == ''
+        if: >
+          inputs.connector == '' &&
+          steps.vars.outputs.pr-number == ''
         id: checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -82,6 +87,7 @@ jobs:
       - name: Add upstream remote (forks only)
         if: >
           inputs.connector == '' &&
+          steps.vars.outputs.pr-number == '' &&
           steps.vars.outputs.is-fork == 'true'
         run: |
           if ! git remote | grep -q upstream; then
@@ -89,13 +95,32 @@ jobs:
           fi
           git fetch --quiet upstream master
 
+      - name: Install uv
+        if: >
+          inputs.connector == '' &&
+          steps.vars.outputs.pr-number != ''
+        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
+
+      - name: Install Ops CLI
+        if: >
+          inputs.connector == '' &&
+          steps.vars.outputs.pr-number != ''
+        run: uv tool install airbyte-internal-ops
+
       - name: Resolve connector matrix
         id: connector-matrix
         env:
           INPUT_CONNECTOR: ${{ inputs.connector }}
+          PR_NUMBER: ${{ steps.vars.outputs.pr-number }}
+          REPOSITORY: ${{ steps.vars.outputs.repository }}
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           if [[ -n "${INPUT_CONNECTOR}" ]]; then
             connectors_matrix="{\"connector\":[\"${INPUT_CONNECTOR}\"]}"
+          elif [[ -n "${PR_NUMBER}" ]]; then
+            repo_owner="${REPOSITORY%%/*}"
+            repo_name="${REPOSITORY#*/}"
+            connectors_matrix="$(airbyte-ops gh connector list --modified-only --pr "${PR_NUMBER}" --owner "${repo_owner}" --repo "${repo_name}" --gh-token "${GITHUB_TOKEN}" --output-format json-gh-matrix)"
           else
             connectors_matrix="$(./poe-tasks/get-modified-connectors.sh --json)"
           fi

--- a/.github/workflows/connector-active-progressive-rollout-checks.yml
+++ b/.github/workflows/connector-active-progressive-rollout-checks.yml
@@ -15,16 +15,12 @@ on:
         required: false
         default: "airbytehq/airbyte"
         type: string
-      gitref:
-        description: "The git reference (branch or tag). Ignored when pr is provided."
-        required: false
-        type: string
       pr:
-        description: "The pull request number to check out and comment on, if applicable."
-        required: false
+        description: "The pull request number to inspect and comment on."
+        required: true
         type: number
       connector:
-        description: "Single connector name to check. If omitted, auto-detects from changed files."
+        description: "Single connector name to check. If omitted, auto-detects from PR changed files."
         required: false
         type: string
 
@@ -47,89 +43,76 @@ jobs:
         env:
           INPUT_REPO: ${{ inputs.repo }}
           INPUT_PR: ${{ inputs.pr }}
-          INPUT_GITREF: ${{ inputs.gitref }}
           EVENT_PR_NUMBER: ${{ github.event.pull_request.number }}
           PR_HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
           GITHUB_HEAD_REF: ${{ github.head_ref }}
           GITHUB_REF_NAME: ${{ github.ref_name }}
         run: |
           pr_number="${INPUT_PR:-${EVENT_PR_NUMBER}}"
-          repository="${INPUT_REPO:-${PR_HEAD_REPO:-${GITHUB_REPOSITORY}}}"
+          checkout_repository="${INPUT_REPO:-${PR_HEAD_REPO:-${GITHUB_REPOSITORY}}}"
+          pr_repository="${INPUT_REPO:-${GITHUB_REPOSITORY}}"
           if [[ -n "${INPUT_PR}" ]]; then
             ref="refs/pull/${INPUT_PR}/head"
-          elif [[ -n "${INPUT_GITREF}" ]]; then
-            ref="${INPUT_GITREF}"
           else
             ref="${GITHUB_HEAD_REF:-${GITHUB_REF_NAME}}"
           fi
           is_fork="true"
-          if [[ "${repository}" == airbytehq/* ]]; then
+          if [[ "${checkout_repository}" == airbytehq/* ]]; then
             is_fork="false"
           fi
 
           echo "pr-number=${pr_number}" | tee -a "${GITHUB_OUTPUT}"
-          echo "repository=${repository}" | tee -a "${GITHUB_OUTPUT}"
+          echo "pr-repository=${pr_repository}" | tee -a "${GITHUB_OUTPUT}"
+          echo "checkout-repository=${checkout_repository}" | tee -a "${GITHUB_OUTPUT}"
           echo "ref=${ref}" | tee -a "${GITHUB_OUTPUT}"
           echo "is-fork=${is_fork}" | tee -a "${GITHUB_OUTPUT}"
-
-      - name: Checkout Airbyte
-        if: >
-          inputs.connector == '' &&
-          steps.vars.outputs.pr-number == ''
-        id: checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          repository: ${{ steps.vars.outputs.repository }}
-          ref: ${{ steps.vars.outputs.ref }}
-          submodules: true # Needed for airbyte-enterprise connectors (no-op otherwise)
-          fetch-depth: 0
-
-      - name: Add upstream remote (forks only)
-        if: >
-          inputs.connector == '' &&
-          steps.vars.outputs.pr-number == '' &&
-          steps.vars.outputs.is-fork == 'true'
-        run: |
-          if ! git remote | grep -q upstream; then
-            git remote add upstream https://github.com/airbytehq/airbyte.git
-          fi
-          git fetch --quiet upstream master
 
       - name: Install uv
         if: >
           inputs.connector == '' &&
           steps.vars.outputs.pr-number != ''
         uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
+        with:
+          ignore-empty-workdir: true
 
       - name: Install Ops CLI
         if: >
           inputs.connector == '' &&
           steps.vars.outputs.pr-number != ''
-        run: uv tool install airbyte-internal-ops
+        run: uv tool install 'airbyte-internal-ops>=0.55.0'
 
       - name: Resolve connector matrix
         id: connector-matrix
         env:
           INPUT_CONNECTOR: ${{ inputs.connector }}
           PR_NUMBER: ${{ steps.vars.outputs.pr-number }}
-          REPOSITORY: ${{ steps.vars.outputs.repository }}
+          PR_REPOSITORY: ${{ steps.vars.outputs.pr-repository }}
           GITHUB_TOKEN: ${{ github.token }}
         run: |
           if [[ -n "${INPUT_CONNECTOR}" ]]; then
             connectors_matrix="{\"connector\":[\"${INPUT_CONNECTOR}\"]}"
           elif [[ -n "${PR_NUMBER}" ]]; then
-            repo_owner="${REPOSITORY%%/*}"
-            repo_name="${REPOSITORY#*/}"
-            connectors_matrix="$(airbyte-ops gh connector list --modified-only --pr "${PR_NUMBER}" --owner "${repo_owner}" --repo "${repo_name}" --gh-token "${GITHUB_TOKEN}" --output-format json-gh-matrix)"
+            repo_owner="${PR_REPOSITORY%%/*}"
+            repo_name="${PR_REPOSITORY#*/}"
+            connectors_matrix="$(
+              airbyte-ops gh connector list \
+                --modified-only \
+                --pr "${PR_NUMBER}" \
+                --owner "${repo_owner}" \
+                --repo "${repo_name}" \
+                --gh-token "${GITHUB_TOKEN}" \
+                --output-format json-gh-matrix
+            )"
           else
-            connectors_matrix="$(./poe-tasks/get-modified-connectors.sh --json)"
+            echo "::error::Auto-detecting modified connectors requires a pull request number or explicit connector input."
+            exit 1
           fi
           echo "connectors_matrix=${connectors_matrix}" | tee -a "${GITHUB_OUTPUT}"
 
     outputs:
       connectors-matrix: ${{ steps.connector-matrix.outputs.connectors_matrix }}
-      commit-sha: ${{ steps.checkout.outputs.commit }}
-      checkout-repository: ${{ steps.vars.outputs.repository }}
+      checkout-repository: ${{ steps.vars.outputs.checkout-repository }}
       checkout-ref: ${{ steps.vars.outputs.ref }}
 
   progressive-rollout-gate:


### PR DESCRIPTION
## What
Use the merged ops CLI checkout-free connector list command in the progressive rollout gate matrix job, and refine the active-rollout PR comment copy.

## How
- Makes manual `workflow_dispatch` PR-centric by requiring `pr` and removing `gitref` and `connector` inputs.
- Removes checkout entirely from the `generate-matrix` job.
- Installs `airbyte-internal-ops>=0.55.0` and runs `airbyte-ops gh connector list --modified-only --output-format json-gh-matrix` to build the connector matrix from GitHub PR files.
- Updates `.github/progressive-rollout-gate-comment.md` with clearer active-rollout warning text and valid collapsible sections.

## Review guide
1. `.github/workflows/connector-active-progressive-rollout-checks.yml`
2. `.github/progressive-rollout-gate-comment.md`

## User Impact
Progressive rollout gate matrix detection no longer checks out the repository just to identify modified connectors. Active-rollout warnings also explain the ACK and rerun paths more clearly.

## Can this PR be safely reverted and rolled back?
- [x] YES 💚
- [ ] NO ❌

## Testing
- `yq . .github/workflows/connector-active-progressive-rollout-checks.yml`
- `npx prettier --check .github/workflows/connector-active-progressive-rollout-checks.yml .github/progressive-rollout-gate-comment.md`
- `git diff --check`
- pre-commit hook on commit
- Published package smoke test: `uvx --from 'airbyte-internal-ops>=0.55.0' airbyte-ops gh connector list --modified-only --pr 78019 --repo airbyte --owner airbytehq --output-format json-gh-matrix` returned `{"connector":["source-faker"]}`
- CI: #78039 own no-op matrix path passed without checkout and output `{"connector":[""]}`.
- E2E no-active-rollout path: `workflow_dispatch` with `pr=78019` passed and derived `source-faker`: https://github.com/airbytehq/airbyte/actions/runs/25755440949?pr=78039
- E2E active-rollout ACK path: `workflow_dispatch` with `pr=78020` passed and derived `source-greenhouse`: https://github.com/airbytehq/airbyte/actions/runs/25755452589?pr=78039
- CI: all checks green, 40 passed / 0 failed.

Link to Devin session: https://app.devin.ai/sessions/13ae42611c254ef8a91c77ddc207bbb6
Requested by: @aaronsteers