### PR TITLE
docs(knowledge-transfer): add multi-file KT docs for Bulk CDK & destinations

### DIFF
--- a/KNOWLEDGE-TRANSFER.md
+++ b/KNOWLEDGE-TRANSFER.md
@@ -1,0 +1,22 @@
+# Knowledge Transfer: Bulk CDK & Destination Connectors
+
+This document is a knowledge transfer reference for the systems I (Benoit, `@benmoriceau`) have built and maintained in the `airbyte` (OSS) repository between late 2024 and early 2026. The scope is intentionally narrow: the **Bulk CDK** (the next-generation Kotlin Connector Development Kit for destinations) and the connectors that were either built on it or migrated to it. Earlier work on the Airbyte platform (Temporal, per-stream state, Micronaut server migration) lives in the sister repo `airbyte-platform-internal` and is covered there.
+
+Each section explains the architecture, the design decisions that shaped it, the edge cases that bit us, and where to find the code. Every file path and class name has been verified against the working tree on the branch this doc lives on.
+
+The repository is a polyglot monorepo. The Bulk CDK is Kotlin (`airbyte-cdk/bulk/`). Connectors live in `airbyte-integrations/connectors/<name>/` and are mostly Kotlin for the destinations covered here. CI/CD workflows live in `.github/workflows/`.
+
+---
+
+## Table of Contents
+
+| # | Section | Description |
+|---|---------|-------------|
+| 1 | [Overview](docs/knowledge-transfer/01-overview.md) | Summary of areas covered and codebase map |
+| 2 | [Bulk CDK](docs/knowledge-transfer/02-bulk-cdk.md) | The dataflow pipeline, finalization, teardown, `AirbyteValueCoercer`, independent SemVer modules |
+| 3 | [Destination ClickHouse](docs/knowledge-transfer/03-clickhouse.md) | Ground-up rewrite on the Bulk CDK -- schema mapping, dedup/truncate via shared loaders, JSON-as-String, batch sizing |
+| 4 | [Destination Postgres](docs/knowledge-transfer/04-destination-postgres.md) | Direct Load Postgres -- raw-tables-only mode, OSS/Cloud checker split, schema-utility refactor following the Snowflake pattern |
+| 5 | [Snowflake, Iceberg/S3 Data Lake, MSSQL, Redshift](docs/knowledge-transfer/05-other-destinations.md) | Snowflake checker refactor, Iceberg PK type mapping and identifier-field deferral, MSSQL SSH tunnel, Redshift Bulk CDK migration plan |
+| 6 | [File Transfer](docs/knowledge-transfer/06-file-transfer.md) | The `DestinationFile` message, legacy file-transfer toolkit, opt-in via Micronaut property |
+| 7 | [CI/CD Tooling](docs/knowledge-transfer/07-ci-cd-tooling.md) | CDK / Bulk CDK auto-bump workflows, per-module version-bump enforcement, test-only-changes skip |
+| 8 | [Appendix: Key File Paths](docs/knowledge-transfer/08-appendix-key-file-paths.md) | Master table of all key files grouped by area |

--- a/docs/knowledge-transfer/01-overview.md
+++ b/docs/knowledge-transfer/01-overview.md
@@ -1,0 +1,35 @@
+# Overview
+
+> *Quick file reference: [Appendix](08-appendix-key-file-paths.md) for the master file-path tables across every section below.*
+
+The work covered in this document spans seven areas of the Airbyte destination stack, all completed between November 2024 and April 2026:
+
+| Area | What It Is | Where It Lives |
+|------|-----------|----------------|
+| Bulk CDK | The Kotlin destination CDK framework -- pipeline, lifecycle, value coercion, schema mapping toolkit | [`airbyte-cdk/bulk/`](../../airbyte-cdk/bulk) |
+| Destination ClickHouse | Ground-up rewrite on the Bulk CDK (was previously a separate Java connector) | [`airbyte-integrations/connectors/destination-clickhouse/`](../../airbyte-integrations/connectors/destination-clickhouse) |
+| Destination Postgres | Migration of the Postgres destination to the Bulk CDK with Direct Load | [`airbyte-integrations/connectors/destination-postgres/`](../../airbyte-integrations/connectors/destination-postgres) |
+| Destination Snowflake | Migration of the Snowflake destination to the Bulk CDK, plus raw-tables-mode check fix | [`airbyte-integrations/connectors/destination-snowflake/`](../../airbyte-integrations/connectors/destination-snowflake) |
+| Iceberg / S3 Data Lake | PK type mapping and Iceberg identifier-field-evolution fix | [`airbyte-integrations/connectors/destination-s3-data-lake/`](../../airbyte-integrations/connectors/destination-s3-data-lake) + [`airbyte-cdk/bulk/toolkits/load-iceberg-parquet/`](../../airbyte-cdk/bulk/toolkits/load-iceberg-parquet) |
+| File Transfer | The `DestinationFile` message and legacy file-transfer toolkit on the Bulk CDK | [`airbyte-cdk/bulk/toolkits/legacy-task-loader/`](../../airbyte-cdk/bulk/toolkits/legacy-task-loader), [`airbyte-cdk/bulk/toolkits/legacy-task-load-object-storage/`](../../airbyte-cdk/bulk/toolkits/legacy-task-load-object-storage) |
+| CI/CD Tooling | GitHub Actions workflows for auto-bumping CDK / Bulk CDK versions across connectors | [`.github/workflows/`](../../.github/workflows) |
+
+## How these areas fit together
+
+The Bulk CDK ([§2](02-bulk-cdk.md)) provides a common Kotlin framework that every modern destination uses. Each destination implements a small set of pluggable interfaces (`DestinationWriter`, `StreamLoader`, value coercer, SQL generator, schema mapper) and inherits everything else -- pipeline orchestration, lifecycle (setup / per-stream loaders / teardown), value coercion, dedup/truncate semantics, table-direct-load loaders, the AirbyteValue type system -- from the CDK.
+
+ClickHouse ([§3](03-clickhouse.md)) was the first ground-up Bulk-CDK destination I shipped; Snowflake ([§5.1](05-other-destinations.md#51-destination-snowflake)) and Postgres ([§4](04-destination-postgres.md)) were migrations from older Java/Java-CDK connectors. Iceberg / S3 Data Lake ([§5.2](05-other-destinations.md#52-iceberg--s3-data-lake)) was a smaller set of correctness fixes on a connector built by another team.
+
+File Transfer ([§6](06-file-transfer.md)) is the one piece that hasn't yet been ported to the modern `core/load/dataflow/` pipeline. It lives entirely in the `legacy-task-loader` toolkit -- a deliberate scoping decision (see [§6.4](06-file-transfer.md#64-potential-improvements)).
+
+CI/CD Tooling ([§7](07-ci-cd-tooling.md)) wraps all of the above with automation: when the Bulk CDK ships a new version, the auto-upgrade workflow opens PRs against every certified connector to pull in the new version, and the per-module version-bump check rejects PRs that change CDK source without bumping the corresponding `version.properties` file.
+
+## How the docs are organized
+
+Each section is self-contained. The numbering matches the order of dependency: read [§2 Bulk CDK](02-bulk-cdk.md) first if you want to understand the framework, then any individual destination chapter ([§3](03-clickhouse.md)-[§5](05-other-destinations.md)) for connector-specific behavior. Sections [§6 File Transfer](06-file-transfer.md) and [§7 CI/CD Tooling](07-ci-cd-tooling.md) sit on the side. [§8 Appendix](08-appendix-key-file-paths.md) collects every key path into one master table.
+
+Most sections close with a **Past Issues** subsection (real PR-level incidents and what we learned) and a **Potential Improvements** subsection (forward-looking ideas, not a TODO list).
+
+---
+
+[Back to Index](../../KNOWLEDGE-TRANSFER.md)

--- a/docs/knowledge-transfer/02-bulk-cdk.md
+++ b/docs/knowledge-transfer/02-bulk-cdk.md
@@ -1,0 +1,212 @@
+# Bulk CDK
+
+The Bulk CDK is the Kotlin framework that every modern Airbyte destination connector is built on. It lives at [`airbyte-cdk/bulk/`](../../airbyte-cdk/bulk) and is split into three independently versioned modules: `core/base`, `core/extract`, `core/load`. Most of the work covered in this doc is in `core/load` -- the destination-side framework. The pipeline-rewrite + lifecycle work was done in summer 2025 ([#64163](https://github.com/airbytehq/airbyte/pull/64163), [#64555](https://github.com/airbytehq/airbyte/pull/64555), [#64881](https://github.com/airbytehq/airbyte/pull/64881), [#64887](https://github.com/airbytehq/airbyte/pull/64887)). The independent-SemVer-per-module migration was [#63740](https://github.com/airbytehq/airbyte/pull/63740). The 1.x major bump that surfaced an `AirbyteValueCoercer` API break landed in early 2026.
+
+> *Quick file reference: [Appendix §8.1 -- Bulk CDK](08-appendix-key-file-paths.md#81-bulk-cdk).*
+
+## Introduction
+
+Before the Bulk CDK, destination connectors lived in `airbyte-cdk/java` and inherited from a deep class hierarchy that mixed framework code with connector-specific code. The Bulk CDK is a clean-slate rewrite around three principles:
+
+1. **Composition over inheritance.** Each connector implements a few small interfaces -- `DestinationWriter`, `StreamLoader`, `AirbyteValueCoercer`, a SQL generator, a schema mapper. The framework handles the rest.
+2. **One pipeline, many destinations.** The dataflow pipeline (parse → aggregate → flush → state) runs identically for every connector; what differs is the per-batch flush implementation each connector plugs in.
+3. **Independent SemVer per module.** `core/base`, `core/extract`, and `core/load` each have their own `version.properties` and can be released independently, so a load-side change doesn't force every source connector to rebuild.
+
+The framework code lives under `airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/`, organized by concern: `check`, `command`, `config`, `data`, `dataflow`, `file`, `message`, `schema`, `spec`, `state`, `table`, `test`, `util`, `write`.
+
+## 2.1 Module Layout and Independent SemVer
+
+The Bulk CDK is published as three Maven artifacts under group `io.airbyte.bulk-cdk` ([`airbyte-cdk/bulk/build.gradle:42`](../../airbyte-cdk/bulk/build.gradle)):
+
+| Module | Path | Current version |
+|--------|------|------|
+| `core/base` | [`airbyte-cdk/bulk/core/base/`](../../airbyte-cdk/bulk/core/base) | `1.0.3` (`version.properties:1`) |
+| `core/extract` | [`airbyte-cdk/bulk/core/extract/`](../../airbyte-cdk/bulk/core/extract) | `1.1.6` (`version.properties:1`) |
+| `core/load` | [`airbyte-cdk/bulk/core/load/`](../../airbyte-cdk/bulk/core/load) | `1.0.11` (`version.properties:1`) |
+
+Three independent `version.properties` files are loaded by [`airbyte-cdk/bulk/build.gradle:13-33`](../../airbyte-cdk/bulk/build.gradle). The previous scheme used a single monotonically-incrementing integer shared across base+load. Switching to SemVer-per-module ([#63740](https://github.com/airbytehq/airbyte/pull/63740)) decoupled the release cadences and made breaking changes legible: a major-version bump on `core/load` (e.g. `0.x` → `1.0`) signals that connector consumers must update.
+
+Beyond `core/*`, the `airbyte-cdk/bulk/toolkits/` directory holds optional toolkits that connectors opt into (e.g. `load-db`, `load-object-storage`, `load-iceberg-parquet`, `legacy-task-loader`, `legacy-task-load-db`, `legacy-task-load-object-storage`). The `legacy-task-*` toolkits exist because the pre-rewrite "task-based" pipeline was kept available for connectors that hadn't migrated to the dataflow pipeline yet -- see [§6 File Transfer](06-file-transfer.md) for the canonical example.
+
+### 2.1.1 The `AirbyteValueCoercer` 1.x bump
+
+Shortly after the move to SemVer-per-module, a breaking change in the `AirbyteValueCoercer.coerce` signature forced `core/load` to bump from `0.x` to `1.0`. The class is at [`airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/data/AirbyteValueCoercer.kt:37`](../../airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/data/AirbyteValueCoercer.kt). The breaking change was surfaced and the load CDK bumped to `1.1.0` in a single chore commit -- it's the canonical example of "use the major-version channel to signal a contract change every consumer must absorb."
+
+## 2.2 The Dataflow Pipeline
+
+The destination-side data path lives in [`airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/dataflow/`](../../airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/dataflow). It replaces the older task-graph pipeline (still preserved under `toolkits/legacy-task-loader/`) with a simpler linear stage pipeline ([#64163](https://github.com/airbytehq/airbyte/pull/64163) was the original spike, [#64887](https://github.com/airbytehq/airbyte/pull/64887) added the test coverage that made it shippable).
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant Input as PipelineRunner<br/>(STDIN reader)
+    participant Parse as ParseStage
+    participant Agg as AggregateStage
+    participant Flush as FlushStage
+    participant State as StateStage
+    participant Tracker as StreamCompletionTracker
+    participant Lifecycle as DestinationLifecycle
+
+    Note over Input,Lifecycle: setup phase
+    Lifecycle->>Lifecycle: destinationInitializer.setup()
+    Lifecycle->>Lifecycle: streamLoaders[*].start()
+
+    Note over Input,State: data phase (per record/batch)
+    Input->>Parse: raw JSON line
+    Parse->>Agg: typed AirbyteMessage
+    Agg->>Flush: batched aggregate (per stream)
+    Flush->>State: write result + checkpoint
+    State-->>Input: ACK upstream
+    Parse->>Tracker: DestinationRecordStreamComplete
+
+    Note over Input,Lifecycle: finalize phase (all streams done)
+    Tracker->>Lifecycle: allStreamsComplete()
+    loop per stream
+        Lifecycle->>Lifecycle: streamLoader.teardown(completed)
+    end
+    Lifecycle->>Lifecycle: destinationInitializer.teardown()
+```
+
+The five pipeline stages live in [`airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/dataflow/stages/`](../../airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/dataflow/stages):
+
+| Stage | File | Responsibility |
+|-------|------|----------------|
+| Parse | `ParseStage.kt` | Deserialize STDIN messages into typed `AirbyteMessage`s; route stream-complete signals to `StreamCompletionTracker` |
+| Aggregate | `AggregateStage.kt` | Build per-stream aggregates (batches of records) until a size/time threshold trips |
+| Flush | `FlushStage.kt` | Hand the aggregate to the per-stream `StreamLoader` to write to the destination |
+| State | `StateStage.kt` | Track which checkpoints have been durably committed; emit state acks upstream |
+
+The runner glue lives in [`airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/dataflow/pipeline/`](../../airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/dataflow/pipeline): `DataFlowPipeline.kt`, `DataFlowStage.kt`, `DataFlowStageIO.kt`, `PipelineCompletionHandler.kt`, `PipelineRunner.kt`.
+
+Per-concern configuration lives in [`airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/dataflow/config/model/`](../../airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/dataflow/config/model): `AggregatePublishingConfig.kt`, `DataFlowSocketConfig.kt`, `LifecycleParallelismConfig.kt`, `MediumConverterConfig.kt`, `ConnectorInputStreams.kt`. There is no single `ResourceConfig` class -- resource sizing is split per concern so each can evolve independently ([#64885](https://github.com/airbytehq/airbyte/pull/64885) introduced this split).
+
+## 2.3 The Lifecycle: setup, finalize, teardown
+
+The framework's outermost layer is `DestinationLifecycle`, which sequences the pipeline within a setup/teardown bracket.
+
+`DestinationLifecycle` -- [`airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/dataflow/DestinationLifecycle.kt:22`](../../airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/dataflow/DestinationLifecycle.kt). The `run()` method at line 32 executes five phases in order:
+
+1. **Setup** -- `destinationInitializer.setup()` (create the warehouse, validate credentials, etc.).
+2. **Init streams** -- for each stream in the configured catalog, instantiate a `StreamLoader` via `DestinationWriter.createStreamLoader(stream)` and call `start()`.
+3. **Pipeline** -- run the dataflow pipeline until STDIN closes.
+4. **Finalize individual streams** -- `finalizeIndividualStreams()` at line 82 calls `streamLoader.teardown(completionTracker.allStreamsComplete())` at line 96, **one call per stream**.
+5. **Teardown destination** -- `teardownDestination()` at line 106 calls `destinationInitializer.teardown()`.
+
+### 2.3.1 Finalization (PR [#64555](https://github.com/airbytehq/airbyte/pull/64555))
+
+"Finalization" is the per-stream end-of-sync hook a connector uses to materialize whatever it was buffering. Each connector implements it inside `StreamLoader.teardown`. The interface is at [`airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/write/StreamLoader.kt:17`](../../airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/write/StreamLoader.kt):
+
+```kotlin
+interface StreamLoader {
+    val stream: DestinationStream
+    suspend fun start()
+    suspend fun teardown(completedSuccessfully: Boolean)
+}
+```
+
+Whether the sync completed successfully is tracked by `StreamCompletionTracker` -- [`airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/dataflow/finalization/StreamCompletionTracker.kt:15`](../../airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/dataflow/finalization/StreamCompletionTracker.kt). It exposes:
+
+- `accept(msg: DestinationRecordStreamComplete)` -- record that a stream emitted its stream-complete signal.
+- `allStreamsComplete()` -- did every expected stream finish cleanly?
+
+`DestinationLifecycle.finalizeIndividualStreams` calls this and passes the boolean down to each `StreamLoader.teardown`, so the per-stream finalization knows whether to commit-and-drop-staging or to leave-staging-for-debugging.
+
+### 2.3.2 Teardown semantic mismatch (a quirk to know about)
+
+The two `teardown` entry points use **inverse boolean semantics**:
+
+| Method | Arg name | `true` means |
+|--------|----------|-------------|
+| `StreamLoader.teardown(completedSuccessfully)` | `completedSuccessfully` | the stream finished cleanly |
+| `DestinationWriter.teardown(hadFailure)` | `hadFailure` | the sync failed |
+
+The destination-level signature is at [`airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/write/DestinationWriter.kt:21`](../../airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/write/DestinationWriter.kt): `suspend fun teardown(hadFailure: Boolean = false) {}`. As of today, `DestinationLifecycle.teardownDestination()` calls it with **no argument**, so the default `hadFailure = false` is always passed -- the destination-level teardown effectively can't observe failures even if a stream-level teardown saw them. This is a bug worth tracking, but the existing connectors don't rely on the destination-level boolean.
+
+## 2.4 Direct Load Table Stream Loaders (PR [#74715](https://github.com/airbytehq/airbyte/pull/74715))
+
+Every database destination using direct load (Postgres, Snowflake, ClickHouse, MSSQL) picks one of three pluggable `StreamLoader` strategies. All three live in [`airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/table/directload/DirectLoadTableStreamLoader.kt`](../../airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/table/directload/DirectLoadTableStreamLoader.kt):
+
+| Class | Line | Use case |
+|-------|------|----------|
+| `DirectLoadTableAppendStreamLoader` | 26 | Append-only / incremental |
+| `DirectLoadTableAppendTruncateStreamLoader` | 141 | Full-refresh / overwrite |
+| `DirectLoadTableDedupTruncateStreamLoader` | 266 | Dedup + full-refresh (write into temp, swap into real table) |
+
+Snowflake (see [§5.1](05-other-destinations.md#51-destination-snowflake)) wires up Append-Truncate and Dedup-Truncate ([`SnowflakeWriter.kt:16-18, 101, 113, 125`](../../airbyte-integrations/connectors/destination-snowflake/src/main/kotlin/io/airbyte/integrations/destination/snowflake/write/SnowflakeWriter.kt)). ClickHouse wires Append and Append-Truncate only ([`ClickHouseWriter.kt:13-14, 45-72`](../../airbyte-integrations/connectors/destination-clickhouse/src/main/kotlin/io/airbyte/integrations/destination/clickhouse/write/ClickHouseWriter.kt)) -- dedup is handled by ClickHouse's `ReplacingMergeTree` engine rather than by a temp-table swap, so the Dedup-Truncate loader isn't needed (see [§3.4](03-clickhouse.md#34-dedup-via-replacingmergetree-not-temp-table-swap)).
+
+### 2.4.1 The temp-table drop fix
+
+`DirectLoadTableDedupTruncateStreamLoader` writes the incoming batch into a temp table, runs the `MERGE` / `DELETE+INSERT` upsert against the real table, then drops the temp table. The drop was originally placed in a path that ran on every teardown, including failed runs. In failure cases, the next attempt would find the old temp table and -- depending on the connector -- either re-merge stale data (duplicates) or fail with "table already exists". [#74715](https://github.com/airbytehq/airbyte/pull/74715) moved the drop into the success branch only. Tests live at [`airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/table/directload/DirectLoadTableStreamLoaderTest.kt`](../../airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/table/directload/DirectLoadTableStreamLoaderTest.kt) (lines 42, 77, 104, 160, 199 cover drop-on-success and no-drop-on-failure).
+
+## 2.5 `AirbyteValueCoercer`
+
+The single class responsible for taking a typed `AirbyteValue` (after JSON deserialization + schema typing) and coercing it into whatever the destination accepts (a JDBC value, a Parquet primitive, etc.). Lives at [`airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/data/AirbyteValueCoercer.kt:37`](../../airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/data/AirbyteValueCoercer.kt) (`@Singleton`).
+
+```kotlin
+@Singleton
+class AirbyteValueCoercer {
+    fun coerce(value: AirbyteValue, type: AirbyteType, respectLegacyUnions: Boolean): AirbyteValue { /* ... */ }
+}
+```
+
+The `respectLegacyUnions` flag is the lever for the 1.x breaking change ([§2.1.1](#211-the-airbytevaluecoercer-1x-bump)). Older connectors that expected unions to fall through to one of their member types pass `true`; new connectors that prefer strict typing pass `false`.
+
+Per-connector coercers compose with this one rather than reimplementing it -- e.g. [`SnowflakeValueCoercer`](../../airbyte-integrations/connectors/destination-snowflake/src/main/kotlin/io/airbyte/integrations/destination/snowflake/write/transform/SnowflakeValueCoercer.kt), [`ClickhouseCoercer`](../../airbyte-integrations/connectors/destination-clickhouse/src/main/kotlin/io/airbyte/integrations/destination/clickhouse/write/transform/ClickhouseCoercer.kt), [`S3DataLakeValueCoercer`](../../airbyte-integrations/connectors/destination-s3-data-lake/src/main/kotlin/io/airbyte/integrations/destination/s3_data_lake/write/transform/S3DataLakeValueCoercer.kt).
+
+## 2.6 Past Issues
+
+### 2.6.1 Temp tables leaking across failed retries ([PR #74715](https://github.com/airbytehq/airbyte/pull/74715))
+
+The most visible Bulk CDK incident in the era covered by this doc.
+
+#### How we got there
+
+`DirectLoadTableDedupTruncateStreamLoader` originally dropped its temp table in `teardown` unconditionally. If a sync failed after writing some rows to the temp table but before the upsert, the next attempt would either:
+- Re-run the upsert against a temp table that still had stale rows from the previous attempt (silent duplicates in dedup mode).
+- Fail with "temp table already exists" depending on the connector's create-temp-table SQL.
+
+We saw both behaviors in the wild on Postgres and Snowflake. The bug was a "looks right at line-of-code level, wrong at lifecycle level" issue: the drop was where you'd expect it, but the success/failure signal wasn't being consulted.
+
+#### What we did to fix it
+
+1. Moved the temp-table drop into the `completedSuccessfully == true` branch of `teardown`.
+2. Added two test cases in [`DirectLoadTableStreamLoaderTest.kt`](../../airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/table/directload/DirectLoadTableStreamLoaderTest.kt) -- one verifying drop-on-success, one verifying no-drop-on-failure (lines 160 and 199).
+3. Bumped the load CDK and forced consumers to pick up the fix via the auto-upgrade workflow ([§7.2](07-ci-cd-tooling.md#72-auto-upgrade-certified-connectors-cdk)).
+
+#### Lessons
+
+- **The `completedSuccessfully` boolean is the most important signal in `StreamLoader.teardown`.** Every code path that mutates persistent destination state has to consult it.
+- **Test the lifecycle, not just the SQL.** The original PR had SQL-level tests for the upsert; what was missing was a test that simulated a failure mid-teardown and asserted the temp table survived.
+- **The destination-level teardown is currently always called with `hadFailure = false`** (see [§2.3.2](#232-teardown-semantic-mismatch-a-quirk-to-know-about)). Connectors should not rely on it for failure-aware cleanup -- do it stream-by-stream.
+
+### 2.6.2 Acceptance-test re-enabling churn (ClickHouse / Postgres rewrites)
+
+Across the ClickHouse and Postgres migrations, the standard pattern was to disable nearly every acceptance test at the start of the rewrite, then re-enable them one-by-one as features came online. This produced ~30 small "re-enable test X" PRs per connector ([#61509](https://github.com/airbytehq/airbyte/pull/61509), [#61515](https://github.com/airbytehq/airbyte/pull/61515), [#61519](https://github.com/airbytehq/airbyte/pull/61519), [#61728](https://github.com/airbytehq/airbyte/pull/61728), [#61734](https://github.com/airbytehq/airbyte/pull/61734), [#61735](https://github.com/airbytehq/airbyte/pull/61735) on ClickHouse; [#68142](https://github.com/airbytehq/airbyte/pull/68142), [#68151](https://github.com/airbytehq/airbyte/pull/68151), [#69086](https://github.com/airbytehq/airbyte/pull/69086) on Postgres). The volume of PRs made it hard to tell from `git log` whether the connector was making progress or thrashing. The lesson, captured in the Redshift migration plan ([§5.4](05-other-destinations.md#54-destination-redshift-migration-plan)), is to **track progress via a checklist that lists every test by name and its enable/disable status**, not by counting merged PRs.
+
+## 2.7 Potential Improvements
+
+### 2.7.1 Surface the destination-level failure signal
+
+**Current:** `DestinationLifecycle.teardownDestination()` calls `destinationInitializer.teardown()` with no argument, defaulting `hadFailure` to `false`. No connector can act on a destination-wide failure during teardown (e.g. mark a warehouse-level token as suspect, drop a transient schema).
+
+**With a propagated signal:** Pass a destination-wide success/failure boolean -- derived from `streamLoaders.all { it.lastTeardownSucceeded }` or the pipeline's overall outcome -- into `destinationInitializer.teardown`. Connectors could then implement destination-level cleanup (e.g. drop a per-sync schema only if every stream finished cleanly).
+
+Concretely: change `DestinationWriter.teardown(hadFailure: Boolean = false)` to `teardown(hadFailure: Boolean)` (drop the default), thread the value through `DestinationLifecycle`, and add a test that asserts a synthetic failure propagates.
+
+### 2.7.2 Promote the file-transfer toolkit to the dataflow pipeline
+
+**Current:** File transfer lives only in [`airbyte-cdk/bulk/toolkits/legacy-task-loader/`](../../airbyte-cdk/bulk/toolkits/legacy-task-loader) ([§6](06-file-transfer.md)). Connectors that want to use file transfer have to consume the legacy task-based pipeline rather than the modern dataflow pipeline.
+
+**With a port to `core/load/dataflow/`:** Add `DestinationFile` handling to `ParseStage` and a corresponding `FileFlushStage`, so file-mode is a first-class citizen of the new pipeline. The migration is non-trivial because the legacy file-transfer queue is bookkeeping-heavy ([`PipelineEventBookkeepingRouter.kt`](../../airbyte-cdk/bulk/toolkits/legacy-task-loader/src/main/kotlin/io/airbyte/cdk/load/state/PipelineEventBookkeepingRouter.kt)), but unifying the two pipelines would let us delete `legacy-task-loader` and `legacy-task-load-object-storage` entirely.
+
+### 2.7.3 Reduce `version.properties` toil
+
+**Current:** Three modules, three `version.properties` files, and every PR touching CDK source has to bump the right one or CI fails. PRs that touch multiple modules sometimes need three bumps, and the test-only escape hatch (`#64913`) is a useful relief valve, but the manual-edit step is friction.
+
+**With a generated/auto-bumped version:** Have the CI infer the bump kind from the diff -- patch for additive non-API changes, minor for new API, major for signature breaks -- and emit the bump as part of the PR rather than asking the author to choose. This is a long-term direction; the short-term improvement is clearer documentation of "which module owns which classes" so PR authors don't bump the wrong file.
+
+Pragmatic note: none of these are "drop everything and rewrite" recommendations. They are the patterns I'd reach for first the next time we revisit this area.
+
+---
+
+[Back to Index](../../KNOWLEDGE-TRANSFER.md)

--- a/docs/knowledge-transfer/03-clickhouse.md
+++ b/docs/knowledge-transfer/03-clickhouse.md
@@ -1,0 +1,160 @@
+# Destination ClickHouse
+
+The ClickHouse destination was rewritten from scratch on the Bulk CDK between June and September 2025. The connector directory is [`airbyte-integrations/connectors/destination-clickhouse/`](../../airbyte-integrations/connectors/destination-clickhouse) (the rewrite reused the original directory name -- there is **no `destination-clickhouse-v2`** directory). Current docker image: `2.1.23`.
+
+> *Quick file reference: [Appendix §8.2 -- Destination ClickHouse](08-appendix-key-file-paths.md#82-destination-clickhouse).*
+
+## Introduction
+
+The legacy ClickHouse destination was a Java connector built on the old Java CDK. It worked but had three operational problems that compounded:
+
+1. **Tightly coupled to staging.** It wrote to an S3 staging bucket first and then `COPY`-ed into ClickHouse, which made the data path slow and required extra credentials.
+2. **No real schema evolution.** When the source catalog added a column, the destination didn't pick it up; users had to manually drop and recreate the table.
+3. **Hard to extend.** Adding ClickHouse-specific features (custom engine choices, JSON-as-String, cluster-aware connections) meant overriding deep class hierarchies in the old CDK.
+
+The rewrite kept the same connector definition ID (`ce0d828e-1dc4-496c-b122-2da42e637e48` in [`metadata.yaml`](../../airbyte-integrations/connectors/destination-clickhouse/metadata.yaml)) so existing users transitioned in place. The work shipped in roughly four phases:
+
+1. **Abstraction + spec.** [#61354](https://github.com/airbytehq/airbyte/pull/61354) introduced the connector skeleton; [#61510](https://github.com/airbytehq/airbyte/pull/61510), [#62047](https://github.com/airbytehq/airbyte/pull/62047) finalized the spec.
+2. **Schema, dedup, truncate.** [#61558](https://github.com/airbytehq/airbyte/pull/61558) and [#66143](https://github.com/airbytehq/airbyte/pull/66143) added schema-change support; [#61696](https://github.com/airbytehq/airbyte/pull/61696) added dedup; [#61679](https://github.com/airbytehq/airbyte/pull/61679) added truncate.
+3. **Types.** [#62100](https://github.com/airbytehq/airbyte/pull/62100) added JSON support (as `String`); [#66134](https://github.com/airbytehq/airbyte/pull/66134) changed decimal handling.
+4. **Hardening.** [#62447](https://github.com/airbytehq/airbyte/pull/62447) fixed temp-table behavior, [#63721](https://github.com/airbytehq/airbyte/pull/63721) fixed PK table alter, [#63760](https://github.com/airbytehq/airbyte/pull/63760) improved error messages, [#64104](https://github.com/airbytehq/airbyte/pull/64104) made batch size configurable, [#64881](https://github.com/airbytehq/airbyte/pull/64881) wired teardown, [#65117](https://github.com/airbytehq/airbyte/pull/65117) fixed column mapping.
+
+## 3.1 Connector layout
+
+Package root: [`airbyte-integrations/connectors/destination-clickhouse/src/main/kotlin/io/airbyte/integrations/destination/clickhouse/`](../../airbyte-integrations/connectors/destination-clickhouse/src/main/kotlin/io/airbyte/integrations/destination/clickhouse). The directory matches the Bulk-CDK connector skeleton one-to-one:
+
+| Subpackage | Purpose | Key files |
+|------------|---------|-----------|
+| `spec/` | Connector spec + parsed config | `ClickhouseSpecification.kt`, `ClickhouseConfiguration.kt` |
+| `config/` | Micronaut bean factories | `ClickhouseBeanFactory.kt`, `ClickhouseDirectLoadDatabaseInitialStatusGatherer.kt` |
+| `client/` | JDBC + SQL generation | `ClickhouseAirbyteClient.kt`, `ClickhouseSqlGenerator.kt`, `ClickhouseSqlTypes.kt` |
+| `schema/` | Schema/column mapping | `ClickhouseTableSchemaMapper.kt`, `ClickhouseNamingUtils.kt` |
+| `write/` | Write path | `ClickHouseWriter.kt`, `load/BinaryRowInsertBuffer.kt`, `transform/ClickhouseCoercer.kt` |
+| `check/` | Connection check | `ClickhouseChecker.kt` |
+| `dataflow/` | Aggregation hook | `ClickhouseAggregate.kt` |
+| `model/` | Domain types | `AlterationSummary.kt` |
+
+Top-level: `ClickhouseDestination.kt` (Micronaut entry point).
+
+## 3.2 The Writer
+
+`ClickHouseWriter` -- [`airbyte-integrations/connectors/destination-clickhouse/src/main/kotlin/io/airbyte/integrations/destination/clickhouse/write/ClickHouseWriter.kt:23`](../../airbyte-integrations/connectors/destination-clickhouse/src/main/kotlin/io/airbyte/integrations/destination/clickhouse/write/ClickHouseWriter.kt) implements `DestinationWriter`. It does two things:
+
+1. **`setup()`** (line 31) -- creates the destination namespace (database) for every stream in the catalog and gathers initial status (does the table exist already? what's its current schema?) via `ClickhouseDirectLoadDatabaseInitialStatusGatherer`.
+2. **`createStreamLoader(stream)`** (line 39) -- picks one of two Bulk-CDK loaders:
+   - `DirectLoadTableAppendStreamLoader` when `stream.minimumGenerationId == 0L` (incremental / append).
+   - `DirectLoadTableAppendTruncateStreamLoader` when `stream.minimumGenerationId == stream.generationId` (full-refresh).
+   - Anything else throws `SystemErrorException("Cannot execute a hybrid refresh ...")`.
+
+Note that **`DirectLoadTableDedupTruncateStreamLoader` is not used** -- dedup is solved differently (see [§3.4](#34-dedup-via-replacingmergetree-not-temp-table-swap)).
+
+## 3.3 SQL generation, table engine, naming
+
+`ClickhouseSqlGenerator` -- [`airbyte-integrations/connectors/destination-clickhouse/src/main/kotlin/io/airbyte/integrations/destination/clickhouse/client/ClickhouseSqlGenerator.kt`](../../airbyte-integrations/connectors/destination-clickhouse/src/main/kotlin/io/airbyte/integrations/destination/clickhouse/client/ClickhouseSqlGenerator.kt) produces every DDL/DML statement. Notable shapes:
+
+| Statement | Method | Notes |
+|-----------|--------|-------|
+| `CREATE TABLE` | `createTable` | Always includes the four Airbyte metadata columns (`_airbyte_raw_id`, `_airbyte_extracted_at`, `_airbyte_meta`, `_airbyte_generation_id`) plus the user's columns. Engine depends on import type ([§3.4](#34-dedup-via-replacingmergetree-not-temp-table-swap)). |
+| `DROP TABLE IF EXISTS` | `dropTable` (line 88) | Quotes namespace + name with backticks. |
+| `EXCHANGE TABLES` | `exchangeTable` (line 91) | Atomic table swap, used to install a freshly-built table over the previous one on truncate. |
+| `INSERT INTO ... FROM` | `copyTable` (line 99) | Intersection-only copy ([#63751](https://github.com/airbytehq/airbyte/pull/63751)): the column list is the intersection of source and destination columns so adding a column doesn't break the copy. |
+
+Names go through `ClickhouseNamingUtils` to apply ClickHouse-compatible quoting (backtick on every identifier) and length limits ([#63724](https://github.com/airbytehq/airbyte/pull/63724)).
+
+## 3.4 Dedup via `ReplacingMergeTree`, not temp-table swap
+
+ClickHouse has a native engine for "keep only the latest version of each row" semantics -- `ReplacingMergeTree(<version_column>)` -- and the rewrite leans on it instead of the Bulk-CDK temp-table-swap pattern used by Snowflake / Postgres.
+
+The choice happens at table-create time in `ClickhouseSqlGenerator.createTable` ([`ClickhouseSqlGenerator.kt:51-71`](../../airbyte-integrations/connectors/destination-clickhouse/src/main/kotlin/io/airbyte/integrations/destination/clickhouse/client/ClickhouseSqlGenerator.kt)):
+
+```kotlin
+val engine = when (tableSchema.importType) {
+    is Dedupe -> {
+        // pick the cursor column as the version column if it's a valid type;
+        // otherwise fall back to _airbyte_extracted_at
+        val cursor = tableSchema.getCursor().firstOrNull()
+        val useCursorAsVersion = cursor != null && isValidVersionColumn(cursor, cursorType)
+        val versionColumn = if (useCursorAsVersion) "`$cursor`" else COLUMN_NAME_AB_EXTRACTED_AT
+        "ReplacingMergeTree($versionColumn)"
+    }
+    else -> "MergeTree()"
+}
+```
+
+For `Dedupe` streams the `ORDER BY` clause is the primary key list; for everything else it is `_airbyte_raw_id`.
+
+**Implication:** ClickHouse-side dedup is **eventual**. `ReplacingMergeTree` collapses duplicates during background merges and during `OPTIMIZE FINAL` -- a fresh `SELECT *` may still return duplicates until a merge runs. This is by design; the alternative was to run a full upsert with a temp table, which doesn't scale well in ClickHouse (no per-row updates without `ALTER ... UPDATE`).
+
+## 3.5 JSON, decimals, and the type system
+
+| Source type | Destination type | PR | Rationale |
+|-------------|------------------|----|-----------|
+| `object` / `array` | `String` | [#62100](https://github.com/airbytehq/airbyte/pull/62100) | ClickHouse has a native `JSON` type but it was unstable at the time of the rewrite; serializing to a JSON string keeps the data round-trippable. |
+| `number` | `Decimal` (with precision/scale) | [#66134](https://github.com/airbytehq/airbyte/pull/66134) | Switched away from `Float64` because precision loss caused acceptance-test failures for monetary data. |
+| `integer` | `Int64` | -- | Standard. |
+| `string` | `String` | -- | Standard. |
+| `boolean` | `Bool` | -- | Standard. |
+
+The mapping lives in [`ClickhouseSqlTypes.kt`](../../airbyte-integrations/connectors/destination-clickhouse/src/main/kotlin/io/airbyte/integrations/destination/clickhouse/client/ClickhouseSqlTypes.kt) and the value-side conversion lives in [`ClickhouseCoercer`](../../airbyte-integrations/connectors/destination-clickhouse/src/main/kotlin/io/airbyte/integrations/destination/clickhouse/write/transform/ClickhouseCoercer.kt).
+
+## 3.6 Past Issues
+
+### 3.6.1 Temp table left behind on failure ([PR #62447](https://github.com/airbytehq/airbyte/pull/62447))
+
+#### How we got there
+
+Before [§2.6.1](02-bulk-cdk.md#261-temp-tables-leaking-across-failed-retries-pr-74715)'s framework-level fix, ClickHouse had its own connector-level version of the same bug. The truncate path created a temp table and used `EXCHANGE TABLES` to swap it into the real name; if the sync failed before the exchange, the temp table stayed around and the next attempt would either fail at `CREATE` (table exists) or overwrite stale data.
+
+#### What we did to fix it
+
+1. Added explicit `DROP TABLE IF EXISTS` for the temp table at the start of every sync.
+2. Made the exchange-or-drop logic explicit in `ClickHouseWriter` and `ClickhouseAirbyteClient`.
+3. Eventually folded into the broader CDK-level fix in [#74715](https://github.com/airbytehq/airbyte/pull/74715), which now applies the success/failure gate uniformly across every Bulk-CDK destination.
+
+#### Lessons
+
+- **Connector-level fixes are valuable but eventually want to live in the CDK.** The original ClickHouse fix worked but only protected ClickHouse; Postgres and Snowflake had the same shape of bug and needed their own fixes until the CDK-level one shipped.
+- **The defensive `DROP IF EXISTS` at sync start is cheap and worth keeping** even after the CDK-level fix, because it also protects against orphan temp tables from older connector versions still in production.
+
+### 3.6.2 Column mapping mismatches on schema change ([PR #65117](https://github.com/airbytehq/airbyte/pull/65117))
+
+#### How we got there
+
+ClickHouse identifier rules are stricter than Airbyte's (no dots, length limits) and the connector applies its own naming policy via `ClickhouseNamingUtils`. When the source catalog renamed a column, the destination was using the **source name** in some places (intersection check) and the **mapped name** in others (insert), so on schema change the intersection-copy would drop the renamed column silently.
+
+#### What we did to fix it
+
+1. Centralized the source-to-final-column-name mapping in `ColumnNameMapping` (from the Bulk CDK).
+2. Made every SQL generator method take the `ColumnNameMapping` explicitly so source-vs-final names couldn't be confused at a call site.
+3. Added schema-change tests covering rename + add-column + drop-column combinations ([#66143](https://github.com/airbytehq/airbyte/pull/66143)).
+
+#### Lessons
+
+- **Pass the mapping, don't reconstruct it.** Every place that produced a name was a place a future rename could go wrong.
+- **Acceptance tests need to cover schema *change* explicitly, not just the initial schema** -- the original test suite mostly created a fresh table per test, which never exercised the rename path.
+
+## 3.7 Potential Improvements
+
+### 3.7.1 Native ClickHouse `JSON` type
+
+**Current:** JSON/object/array columns are serialized to `String` ([§3.5](#35-json-decimals-and-the-type-system)). Users who want to query nested fields in ClickHouse have to parse the string client-side or use ClickHouse's `JSONExtract*` functions.
+
+**With native JSON:** ClickHouse 24.x stabilized its native `JSON` type. Switching the destination column type to `JSON` would let users write `SELECT data.user.email FROM ...` directly. The migration is non-trivial because existing tables would need to be re-created (column type can't be altered from `String` to `JSON` in-place), so the rollout path is opt-in via the spec.
+
+### 3.7.2 Cluster-aware DDL (`ON CLUSTER ...`)
+
+**Current:** Every DDL statement targets the local node. In a replicated cluster, the user has to either set up `Distributed` tables manually or run the connector against the master node and rely on replication.
+
+**With cluster-aware DDL:** Add an `On Cluster` field to the spec. When set, the generator appends `ON CLUSTER <name>` to `CREATE`, `DROP`, and `EXCHANGE` statements, so the destination works natively on replicated clusters.
+
+### 3.7.3 Migrate to `DirectLoadTableDedupTruncateStreamLoader`
+
+**Current:** Dedup is delegated to `ReplacingMergeTree` ([§3.4](#34-dedup-via-replacingmergetree-not-temp-table-swap)), which gives eventual semantics. Users who want strict dedup-on-write have to run `OPTIMIZE FINAL` manually.
+
+**With temp-table dedup:** Wire `DirectLoadTableDedupTruncateStreamLoader` for dedup streams, like Snowflake does. The cost is more SQL traffic per batch; the benefit is post-sync queries see deduplicated data immediately.
+
+Pragmatic note: I would not pursue any of these without a customer signal. `ReplacingMergeTree` + `String` JSON is the cheapest correct choice; the improvements above are pure capability extensions, not bug fixes.
+
+---
+
+[Back to Index](../../KNOWLEDGE-TRANSFER.md)

--- a/docs/knowledge-transfer/04-destination-postgres.md
+++ b/docs/knowledge-transfer/04-destination-postgres.md
@@ -1,0 +1,156 @@
+# Destination Postgres
+
+A migration of the Postgres destination to the Bulk CDK using the **Direct Load** pattern: no S3/GCS staging, the connector writes directly via JDBC. The work ran from October 2025 through January 2026; the connector lives at [`airbyte-integrations/connectors/destination-postgres/`](../../airbyte-integrations/connectors/destination-postgres). Current docker image: `3.0.13`.
+
+> *Quick file reference: [Appendix §8.3 -- Destination Postgres](08-appendix-key-file-paths.md#83-destination-postgres).*
+
+## Introduction
+
+The legacy Postgres destination was a Java connector built on the old Java CDK with the same architectural problems as the legacy ClickHouse one ([§3](03-clickhouse.md)), plus an additional Postgres-specific cost: it ran every write through a staging step even though Postgres is a transactional database and can absorb writes directly. The Bulk-CDK migration shipped Direct Load -- batched JDBC inserts with optional dedup via temp-table upsert -- and reused the same connector ID (`25c5221d-dce2-4163-ade9-739ef790f503` in [`metadata.yaml`](../../airbyte-integrations/connectors/destination-postgres/metadata.yaml)) so existing users transitioned in place.
+
+The migration shipped in roughly four phases:
+
+1. **Acceptance harness.** [#67592](https://github.com/airbytehq/airbyte/pull/67592), [#67596](https://github.com/airbytehq/airbyte/pull/67596) set up the acceptance test framework before any real connector code shipped.
+2. **Spec + value coercion.** [#68117](https://github.com/airbytehq/airbyte/pull/68117) defined the spec; [#68126](https://github.com/airbytehq/airbyte/pull/68126) implemented the Postgres value coercer; [#68123](https://github.com/airbytehq/airbyte/pull/68123) added the Postgres test-fixture init script.
+3. **Raw-tables mode + RC.** [#68580](https://github.com/airbytehq/airbyte/pull/68580) implemented raw-tables-only mode (see [§4.3](#43-raw-tables-only-mode)); [#69846](https://github.com/airbytehq/airbyte/pull/69846) shipped the first RC.
+4. **Hardening + refactor.** [#70326](https://github.com/airbytehq/airbyte/pull/70326), [#70337](https://github.com/airbytehq/airbyte/pull/70337), [#70347](https://github.com/airbytehq/airbyte/pull/70347), [#70348](https://github.com/airbytehq/airbyte/pull/70348), [#70364](https://github.com/airbytehq/airbyte/pull/70364), [#71146](https://github.com/airbytehq/airbyte/pull/71146), [#71163](https://github.com/airbytehq/airbyte/pull/71163), [#71183](https://github.com/airbytehq/airbyte/pull/71183) hardened the connector and refactored the schema utilities to match Snowflake's pattern.
+
+## 4.1 Connector layout
+
+Package root: [`airbyte-integrations/connectors/destination-postgres/src/main/kotlin/io/airbyte/integrations/destination/postgres/`](../../airbyte-integrations/connectors/destination-postgres/src/main/kotlin/io/airbyte/integrations/destination/postgres).
+
+| Subpackage | Purpose | Key files |
+|------------|---------|-----------|
+| `spec/` | Spec + parsed config | `PostgresSpecification.kt`, `PostgresConfiguration.kt` |
+| `config/` | Micronaut bean factories | -- |
+| `client/` | JDBC client | `PostgresAirbyteClient.kt` |
+| `sql/` | SQL generation | `PostgresDirectLoadSqlGenerator.kt` |
+| `schema/` | Schema mapping + column management | `PostgresTableSchemaMapper.kt`, `PostgresColumnManager.kt`, `PostgresNamingUtils.kt` |
+| `write/` | Write path | `PostgresWriter.kt`, `load/PostgresInsertBuffer.kt` |
+| `check/` | Connection check (OSS / Cloud split) | `PostgresOssChecker.kt`, `PostgresCloudChecker.kt` |
+| `dataflow/` | Aggregation hook | -- |
+
+Top-level: `PostgresDestinationV2.kt` (Micronaut entry point; the "V2" is in the class name, not the directory).
+
+## 4.2 The `PostgresColumnUtils` deletion and schema refactor ([PR #71183](https://github.com/airbytehq/airbyte/pull/71183))
+
+The early Postgres connector concentrated all column-name and type-mapping logic in a single `PostgresColumnUtils.kt` static-helper file. As the connector matured, this single class accreted nearly every cross-cutting concern -- mapping, quoting, type inference, alteration planning -- and became hard to test in isolation.
+
+[#71183](https://github.com/airbytehq/airbyte/pull/71183) **deleted `PostgresColumnUtils.kt`** entirely and replaced it with three injectable classes that mirror the Snowflake pattern:
+
+| New class | Path | Responsibility |
+|-----------|------|----------------|
+| `PostgresTableSchemaMapper` | [`schema/PostgresTableSchemaMapper.kt`](../../airbyte-integrations/connectors/destination-postgres/src/main/kotlin/io/airbyte/integrations/destination/postgres/schema/PostgresTableSchemaMapper.kt) | Maps Airbyte stream schema → Postgres table schema. Mode-aware (raw vs full). |
+| `PostgresColumnManager` | [`schema/PostgresColumnManager.kt`](../../airbyte-integrations/connectors/destination-postgres/src/main/kotlin/io/airbyte/integrations/destination/postgres/schema/PostgresColumnManager.kt) | Plans column add/drop/alter operations. |
+| `PostgresNamingUtils` | [`schema/PostgresNamingUtils.kt`](../../airbyte-integrations/connectors/destination-postgres/src/main/kotlin/io/airbyte/integrations/destination/postgres/schema/PostgresNamingUtils.kt) | Identifier quoting and length-limit handling. |
+
+This is the canonical example of "follow the existing pattern, even if the connector was first" -- when Snowflake migrated first and converged on this trio, Postgres followed even at the cost of a non-trivial refactor.
+
+## 4.3 Raw-tables-only mode
+
+Postgres supports two write modes:
+
+| Mode | Spec field | What lands in the destination |
+|------|------------|-------------------------------|
+| **Full mode** | `legacyRawTablesOnly = false` (default) | Final typed table with one column per source field, plus Airbyte metadata columns |
+| **Raw-tables-only mode** | `legacyRawTablesOnly = true` | A single `_airbyte_data jsonb` column per stream, plus Airbyte metadata columns -- no typing |
+
+The flag is on [`PostgresSpecification.kt:41`](../../airbyte-integrations/connectors/destination-postgres/src/main/kotlin/io/airbyte/integrations/destination/postgres/spec/PostgresSpecification.kt) (abstract; defaults at lines 155 and 305) and surfaced on [`PostgresConfiguration.kt:24, 53`](../../airbyte-integrations/connectors/destination-postgres/src/main/kotlin/io/airbyte/integrations/destination/postgres/spec/PostgresConfiguration.kt). It is consulted everywhere a typed-vs-raw decision is made:
+
+- [`write/PostgresWriter.kt:65-69`](../../airbyte-integrations/connectors/destination-postgres/src/main/kotlin/io/airbyte/integrations/destination/postgres/write/PostgresWriter.kt) -- which loader to construct
+- [`write/load/PostgresInsertBuffer.kt:39`](../../airbyte-integrations/connectors/destination-postgres/src/main/kotlin/io/airbyte/integrations/destination/postgres/write/load/PostgresInsertBuffer.kt) -- raw-payload buffering
+- [`schema/PostgresTableSchemaMapper.kt:43, 67, 105`](../../airbyte-integrations/connectors/destination-postgres/src/main/kotlin/io/airbyte/integrations/destination/postgres/schema/PostgresTableSchemaMapper.kt) -- skip typed columns
+- [`schema/PostgresColumnManager.kt:43, 56`](../../airbyte-integrations/connectors/destination-postgres/src/main/kotlin/io/airbyte/integrations/destination/postgres/schema/PostgresColumnManager.kt) -- never alter user columns
+- [`sql/PostgresDirectLoadSqlGenerator.kt:107-120`](../../airbyte-integrations/connectors/destination-postgres/src/main/kotlin/io/airbyte/integrations/destination/postgres/sql/PostgresDirectLoadSqlGenerator.kt) -- generate raw-mode `CREATE TABLE`
+- [`client/PostgresAirbyteClient.kt:145, 188`](../../airbyte-integrations/connectors/destination-postgres/src/main/kotlin/io/airbyte/integrations/destination/postgres/client/PostgresAirbyteClient.kt) -- client-side dispatch
+
+### 4.3.1 Dedup is forced to Append in raw mode ([PR #70364](https://github.com/airbytehq/airbyte/pull/70364))
+
+In raw-tables-only mode, there is no typed column to dedup against. If a user configures a stream with `DestinationSyncMode.APPEND_DEDUP` and `legacyRawTablesOnly = true`, the writer **forces the import type to `Append`**. The dedup semantics are simply not achievable in raw mode; emitting an error would surprise users who toggled the flag without understanding the implication. The behavior is intentional but is the kind of "fine print" worth flagging in support tickets.
+
+## 4.4 The check operation: OSS / Cloud split
+
+Unlike Snowflake ([§5.1.2](05-other-destinations.md#512-the-snowflakechecker-recordformatter-fix)), Postgres splits its check into two implementations rather than using a single check class with an injected formatter:
+
+| Class | Active in | Path |
+|-------|-----------|------|
+| `PostgresOssChecker` | OSS only (`@Requires(notEnv = [AIRBYTE_CLOUD_ENV])`) | [`check/PostgresOssChecker.kt:35`](../../airbyte-integrations/connectors/destination-postgres/src/main/kotlin/io/airbyte/integrations/destination/postgres/check/PostgresOssChecker.kt) |
+| `PostgresCloudChecker` | Cloud (no env restriction) | [`check/PostgresCloudChecker.kt`](../../airbyte-integrations/connectors/destination-postgres/src/main/kotlin/io/airbyte/integrations/destination/postgres/check/PostgresCloudChecker.kt) |
+
+Each checker builds a small synthetic `ObjectType` test record by hand (see lines 41-51 of `PostgresOssChecker.kt`) rather than reusing a connector-side `RecordFormatter` -- the Postgres check is intentionally minimal (`test_key` + Airbyte metadata only) and doesn't need full schema processing. This is **a deliberate departure from the Snowflake pattern**: Snowflake needs the formatter because its check has to round-trip through the same value-coercion path as a real write; Postgres's check can stay simpler.
+
+## 4.5 Schema evolution: CASCADE and `ALTER COLUMN TYPE` ([PR #71146](https://github.com/airbytehq/airbyte/pull/71146))
+
+Postgres has two operations that look similar but need different CASCADE handling:
+
+| Operation | CASCADE? | Why |
+|-----------|----------|-----|
+| `ALTER TABLE ... DROP COLUMN ...` | Yes -- `DROP COLUMN ... CASCADE` if `cascadeDropForColumnRemoval = true` ([`PostgresDirectLoadSqlGenerator.kt:34, 595`](../../airbyte-integrations/connectors/destination-postgres/src/main/kotlin/io/airbyte/integrations/destination/postgres/sql/PostgresDirectLoadSqlGenerator.kt)) | A dropped column may have dependent views / indexes; CASCADE silently drops them. User opts in via spec. |
+| `ALTER TABLE ... ALTER COLUMN ... TYPE ...` | **No CASCADE** ([`PostgresDirectLoadSqlGenerator.kt:599-619`](../../airbyte-integrations/connectors/destination-postgres/src/main/kotlin/io/airbyte/integrations/destination/postgres/sql/PostgresDirectLoadSqlGenerator.kt)) | A type change should not silently drop dependent objects -- the user should know if a view they own references a column whose type just changed. |
+
+Earlier code applied CASCADE to both. The fix narrowed CASCADE to `DROP COLUMN` only. The `ALTER COLUMN TYPE` path now also constructs a smart `USING` clause:
+
+```kotlin
+val usingClause = when {
+    newType == "jsonb" -> "USING to_jsonb($quotedName)"
+    oldType == "jsonb" && newType in setOf("varchar", "text", "character varying") -> "USING $quotedName #>> '{}'"
+    else -> "USING $quotedName::$newType"
+}
+```
+
+This handles two real cases that bit users:
+- **Converting to `jsonb`** from a text column with valid JSON content -- the cast `text → jsonb` requires `to_jsonb` to wrap the value, not just `::jsonb`, which fails on numeric strings.
+- **Converting from `jsonb` to `text`** -- a plain `::text` would render `"foo"` as `"\"foo\""` (with quotes); `#>> '{}'` extracts the raw text.
+
+User-facing CASCADE option: [`PostgresSpecification.kt:157, 307`](../../airbyte-integrations/connectors/destination-postgres/src/main/kotlin/io/airbyte/integrations/destination/postgres/spec/PostgresSpecification.kt). Error guidance for CASCADE failures: [`PostgresAirbyteClient.kt:455-465`](../../airbyte-integrations/connectors/destination-postgres/src/main/kotlin/io/airbyte/integrations/destination/postgres/client/PostgresAirbyteClient.kt).
+
+## 4.6 Past Issues
+
+### 4.6.1 Index recreation on non-existent columns ([PRs #70326](https://github.com/airbytehq/airbyte/pull/70326), [#70337](https://github.com/airbytehq/airbyte/pull/70337), [#70347](https://github.com/airbytehq/airbyte/pull/70347))
+
+#### How we got there
+
+In raw-tables-only mode ([§4.3](#43-raw-tables-only-mode)), there are no typed columns. The early index-creation code was running unconditionally and tried to create a primary-key index on `_airbyte_raw_id` and the dedup columns -- but the dedup columns don't exist in raw mode, so the `CREATE INDEX` statement failed with `column "..." does not exist` on first run, and again on every re-run because the index-recreation path was triggered by schema-change detection.
+
+#### What we did to fix it
+
+1. **[#70326](https://github.com/airbytehq/airbyte/pull/70326)** -- gated index creation on `legacyRawTablesOnly == false` at the immediate call site.
+2. **[#70337](https://github.com/airbytehq/airbyte/pull/70337)** -- moved the raw-tables check **out** of the call sites and **into** the index-creation method itself, so adding a future caller wouldn't accidentally re-introduce the bug.
+3. **[#70347](https://github.com/airbytehq/airbyte/pull/70347)** -- fixed the index-recreation path (the schema-change branch had been overlooked; same fix as #70337 but on the recreate-after-alter path).
+
+#### Lessons
+
+- **Defensive checks belong inside the method, not at every call site.** The same bug showed up in two places because the gate was at the caller; moving it inside the callee made the second occurrence impossible.
+- **Raw-tables-only mode needs to be tested as a first-class mode, not a flag-flipped variant.** Most acceptance tests ran in full mode; the bug shipped because no test exercised raw mode + schema change.
+
+### 4.6.2 The schema-utility monolith ([PR #71183](https://github.com/airbytehq/airbyte/pull/71183) -- design tax, not an incident)
+
+Not a customer-visible incident but worth recording as a pattern lesson. The original `PostgresColumnUtils.kt` worked correctly but accumulated every Postgres-specific bit of schema knowledge in one file. Each new feature (CASCADE drop, smart `USING` clause, raw-mode gating) added another method to the monolith. By PR #70347 it was clear that the file was the bottleneck on every schema change.
+
+The fix was to delete it and split the concerns into the three classes documented in [§4.2](#42-the-postgrescolumnutils-deletion-and-schema-refactor-pr-71183). The lesson is to **converge on the same shape as a sibling connector when one exists** -- Snowflake had the trio first, Postgres should have mirrored it from the start rather than building a parallel-but-different abstraction.
+
+## 4.7 Potential Improvements
+
+### 4.7.1 Cloud-pre-check the OSS/Cloud split
+
+**Current:** [§4.4](#44-the-check-operation-oss--cloud-split) splits checks via `@Requires(notEnv = [AIRBYTE_CLOUD_ENV])`. At runtime, exactly one of `PostgresOssChecker` and `PostgresCloudChecker` exists in the Micronaut context, and the other is filtered out by environment. This works but is invisible at PR-review time -- it's easy to add a method to one and forget the other.
+
+**With a shared base class:** Extract a `PostgresChecker` interface (or `AbstractPostgresChecker` base) that both implementations conform to. The Cloud-only behavior lives in `PostgresCloudChecker.checkCloudSpecifics()`; OSS overrides it as a no-op. This makes the divergence reviewable in one place and gives a single API surface for users of either flavor.
+
+### 4.7.2 Move the index-creation gate further down
+
+**Current:** [§4.6.1](#461-index-recreation-on-non-existent-columns-prs-70326-70337-70347)'s fix moved the raw-mode gate into the index-creation method. That's good, but the same gate is repeated in `PostgresAirbyteClient`, `PostgresTableSchemaMapper`, and `PostgresColumnManager`.
+
+**With a typed write-mode object:** Encode the mode as a `WriteMode` sealed class (`Full(...)`, `RawOnly(...)`) and dispatch on it at the writer-construction boundary, not at the every-method boundary. The downstream classes don't take a flag, they take the mode-specific arguments. This is the same direction as the Snowflake refactor that pushed the formatter out of the checker.
+
+### 4.7.3 Push the `USING`-clause matrix to the CDK
+
+**Current:** [§4.5](#45-schema-evolution-cascade-and-alter-column-type-pr-71146)'s smart `USING` clause lives in `PostgresDirectLoadSqlGenerator`. The same problem -- "produce a safe CAST when changing a column type" -- exists in MSSQL and would exist in Redshift.
+
+**With a CDK abstraction:** Add `TypeConversionSql` to the Bulk CDK's `load-db` toolkit, parameterized by source and target dialect. Each connector contributes its own conversion table; the generator picks the matching entry. The cost is the abstraction itself; the benefit is that the next connector inherits the same hard-won corner cases.
+
+Pragmatic note: §4.7.1 and §4.7.2 are clean-up rather than capability work. §4.7.3 only pays off once we have a third or fourth connector hitting the same problem -- premature today, worth revisiting at Redshift.
+
+---
+
+[Back to Index](../../KNOWLEDGE-TRANSFER.md)

--- a/docs/knowledge-transfer/05-other-destinations.md
+++ b/docs/knowledge-transfer/05-other-destinations.md
@@ -1,0 +1,168 @@
+# Snowflake, Iceberg / S3 Data Lake, MSSQL, Redshift
+
+This section gathers smaller-scoped contributions across four destinations: a Snowflake migration with a notable `check` refactor; Iceberg / S3 Data Lake correctness fixes; an MSSQL SSH-tunnel addition; and the Redshift migration plan.
+
+> *Quick file reference: [Appendix §8.4 -- Other Destinations](08-appendix-key-file-paths.md#84-other-destinations).*
+
+## 5.1 Destination Snowflake
+
+Snowflake was migrated to the Bulk CDK in parallel with the ClickHouse rewrite. The work landed across roughly ten PRs between September 2025 and March 2026 ([#66189](https://github.com/airbytehq/airbyte/pull/66189), [#66293](https://github.com/airbytehq/airbyte/pull/66293), [#66302](https://github.com/airbytehq/airbyte/pull/66302), [#66354](https://github.com/airbytehq/airbyte/pull/66354), [#66507](https://github.com/airbytehq/airbyte/pull/66507), [#66513](https://github.com/airbytehq/airbyte/pull/66513), [#66518](https://github.com/airbytehq/airbyte/pull/66518), [#66528](https://github.com/airbytehq/airbyte/pull/66528), [#71273](https://github.com/airbytehq/airbyte/pull/71273), [#74824](https://github.com/airbytehq/airbyte/pull/74824)). The connector lives at [`airbyte-integrations/connectors/destination-snowflake/`](../../airbyte-integrations/connectors/destination-snowflake); current docker image: `4.0.41`.
+
+### 5.1.1 Loader strategy
+
+The Snowflake writer wires up two of the three Direct-Load loaders ([§2.4](02-bulk-cdk.md#24-direct-load-table-stream-loaders-pr-74715)) -- [`SnowflakeWriter.kt:16-18, 101, 113, 125`](../../airbyte-integrations/connectors/destination-snowflake/src/main/kotlin/io/airbyte/integrations/destination/snowflake/write/SnowflakeWriter.kt):
+
+| `importType` × `minimumGenerationId` | Loader |
+|--------------------------------------|--------|
+| `Append` / `Dedupe` with `minimumGenerationId == 0` | `DirectLoadTableAppendStreamLoader` |
+| `Append` with `minimumGenerationId == generationId` | `DirectLoadTableAppendTruncateStreamLoader` |
+| `Dedupe` with `minimumGenerationId == generationId` | `DirectLoadTableDedupTruncateStreamLoader` |
+
+This is the canonical pattern for Direct-Load destinations and the same shape Postgres ([§4](04-destination-postgres.md)) follows. ClickHouse ([§3.2](03-clickhouse.md#32-the-writer)) deviates because it dedup-via-engine instead of dedup-via-temp-table.
+
+### 5.1.2 The `SnowflakeChecker` recordformatter fix ([PR #71273](https://github.com/airbytehq/airbyte/pull/71273))
+
+Before this fix, `SnowflakeChecker` instantiated `SnowflakeRecordFormatter` directly inside `check()`, hard-coding the standard (non-raw-mode) formatter. In raw-tables-only mode (`legacyRawTablesOnly = true`), the standard formatter does not emit the `_airbyte_loaded_at` column -- a required column in raw mode -- so the check would fail with `column "_airbyte_loaded_at" does not exist` even though a real sync in raw mode would succeed.
+
+The fix refactored `SnowflakeChecker` to **inject** the formatter via the constructor ([`SnowflakeChecker.kt:34-39`](../../airbyte-integrations/connectors/destination-snowflake/src/main/kotlin/io/airbyte/integrations/destination/snowflake/check/SnowflakeChecker.kt)):
+
+```kotlin
+@Singleton
+class SnowflakeChecker(
+    private val snowflakeAirbyteClient: SnowflakeAirbyteClient,
+    private val snowflakeConfiguration: SnowflakeConfiguration,
+    private val columnManager: SnowflakeColumnManager,
+    private val snowflakeRecordFormatter: SnowflakeRecordFormatter,
+) : DestinationChecker { ... }
+```
+
+The mode-aware `SnowflakeRecordFormatter` bean is selected at Micronaut wire time based on `legacyRawTablesOnly`, so the check now uses the same formatter a real sync would use. This is the pattern Postgres ([§4.4](04-destination-postgres.md#44-the-check-operation-oss--cloud-split)) intentionally **does not** adopt -- Postgres splits OSS/Cloud as separate classes and keeps the check minimal rather than going through the full record-formatting pipeline.
+
+The class name is `SnowflakeRecordFormatter` ([`write/load/SnowflakeRecordFormatter.kt`](../../airbyte-integrations/connectors/destination-snowflake/src/main/kotlin/io/airbyte/integrations/destination/snowflake/write/load/SnowflakeRecordFormatter.kt)); the fix also affected the Postgres equivalent in the same PR.
+
+## 5.2 Iceberg / S3 Data Lake
+
+The active Iceberg destination is [`destination-s3-data-lake`](../../airbyte-integrations/connectors/destination-s3-data-lake) (the [`destination-iceberg`](../../airbyte-integrations/connectors/destination-iceberg) directory is essentially empty -- it contains only `metadata.yaml` and `icon.svg`; the real implementation moved). The connector is built on top of the [`airbyte-cdk/bulk/toolkits/load-iceberg-parquet/`](../../airbyte-cdk/bulk/toolkits/load-iceberg-parquet) toolkit, where most of the work covered here lives.
+
+Three correctness fixes shipped in March 2026.
+
+### 5.2.1 PK `NumberType` → `StringType` ([PR #74328](https://github.com/airbytehq/airbyte/pull/74328))
+
+Iceberg has a concept of **identifier fields**: a set of columns that uniquely identify a row, used for equality deletes and merge-on-read. Iceberg disallows `float`, `double`, and `decimal` types as identifier fields. Airbyte's `NumberType` maps to Iceberg's `Types.DoubleType.get()` by default ([`AirbyteTypeToIcebergSchema.kt:70`](../../airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/kotlin/io/airbyte/cdk/load/data/iceberg/parquet/AirbyteTypeToIcebergSchema.kt)), which fails when a `NumberType` column is declared as a primary key.
+
+The fix added a PK-specific override at [`AirbyteTypeToIcebergSchema.kt:111-114`](../../airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/kotlin/io/airbyte/cdk/load/data/iceberg/parquet/AirbyteTypeToIcebergSchema.kt):
+
+```kotlin
+val icebergType =
+    if (isPrimaryKey && field.type is NumberType) {
+        // Override PK NumberType fields to StringType so they can be used as
+        // Iceberg identifier fields (float/double are disallowed as identifiers).
+        Types.StringType.get()
+    } else {
+        icebergTypeConverter.convert(field.type, stringifyObjects = stringifyObjects)
+    }
+```
+
+The runtime value-side counterpart is at [`AirbyteValueToIcebergRecord.kt:68`](../../airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/kotlin/io/airbyte/cdk/load/data/iceberg/parquet/AirbyteValueToIcebergRecord.kt), which stringifies the value before writing it to the Parquet file.
+
+This is a deliberate type narrowing for the PK case only -- non-PK number columns continue to map to `DoubleType`. (The previously circulating claim that the fix mapped `NumberType` → `DecimalType` is inaccurate.)
+
+### 5.2.2 Deferred identifier-field update on column replacement ([PR #74723](https://github.com/airbytehq/airbyte/pull/74723))
+
+Schema evolution that replaces a column whose **name** is also in the table's identifier-fields list previously failed with `IllegalArgumentException: ... is not a valid identifier field`. The chain of events:
+
+1. `IcebergTableSynchronizer.synchronize` ([`load-iceberg-parquet/IcebergTableSynchronizer.kt:110-274`](../../airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/kotlin/io/airbyte/cdk/load/toolkits/iceberg/parquet/IcebergTableSynchronizer.kt)) detected an identifier-field change AND a column replacement.
+2. It called `updateSchema().setIdentifierFields(newPks)` **before** the column was replaced.
+3. Iceberg checked the identifier-field set against the *current* schema (which still had the old column), found it didn't include `newPk`, and threw.
+
+The fix deferred the `setIdentifierFields` call until **after** the column-replacement transaction committed (the call sites at lines 230, 253, 274 now run in the post-replace branch). Tests at [`IcebergTypesComparator.kt:71, 97-99`](../../airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/kotlin/io/airbyte/cdk/load/toolkits/iceberg/parquet/IcebergTypesComparator.kt) cover `identifierFieldsChanged` detection.
+
+### 5.2.3 CDK bump ([PR #74326](https://github.com/airbytehq/airbyte/pull/74326))
+
+Routine bump to pick up the fixes in §5.2.1 and §5.2.2 in the S3-Data-Lake connector. The connector's `dockerImageTag` is currently `0.3.48`.
+
+## 5.3 Destination MSSQL: SSH tunnel ([PR #62078](https://github.com/airbytehq/airbyte/pull/62078))
+
+The MSSQL destination lives at [`airbyte-integrations/connectors/destination-mssql/`](../../airbyte-integrations/connectors/destination-mssql); current image `2.2.16`. Note the package path is under `…/mssql/v2/…` -- the "v2" indicates the Bulk-CDK rewrite but is in the package, not the directory name.
+
+The connector previously had no way to reach a database behind a bastion host. [#62078](https://github.com/airbytehq/airbyte/pull/62078) added SSH-tunnel support by reusing the CDK's existing SSH primitives. The tunnel is created in `DataSourceFactory` (note the camelcase S) at [`src/main/kotlin/io/airbyte/integrations/destination/mssql/v2/config/DataSourceFactory.kt:20`](../../airbyte-integrations/connectors/destination-mssql/src/main/kotlin/io/airbyte/integrations/destination/mssql/v2/config/DataSourceFactory.kt):
+
+| Function | Line | Role |
+|----------|------|------|
+| `@Factory class DataSourceFactory` | 20 | Micronaut factory |
+| `MSSQLConfiguration.toSQLServerDataSource()` (extension) | 37 | Build the JDBC datasource |
+| SSH-tunnel branch | 44-57 | If `ssh is SshKeyAuthTunnelMethod \| SshPasswordAuthTunnelMethod`, create a local-forwarded session via `createTunnelSession` (line 51) and rewrite the JDBC URL to point at `localhost:<localPort>` |
+| `MSSQLDataSourceFactory` | 99 | The Micronaut-registered factory bean |
+
+Spec wiring: [`MSSQLSpecification.kt:20-21, 89-107`](../../airbyte-integrations/connectors/destination-mssql/src/main/kotlin/io/airbyte/integrations/destination/mssql/v2/config/MSSQLSpecification.kt). Config wiring: [`MSSQLConfiguration.kt:13, 26, 74`](../../airbyte-integrations/connectors/destination-mssql/src/main/kotlin/io/airbyte/integrations/destination/mssql/v2/config/MSSQLConfiguration.kt).
+
+The implementation deliberately reused the CDK's existing SSH tunnel primitives rather than building a new one -- the only MSSQL-specific code is the URL rewrite, everything else is CDK.
+
+## 5.4 Destination Redshift: migration plan
+
+The Redshift connector has not yet been migrated to the Bulk CDK; the migration plan was written in early 2026 by analyzing the Snowflake, Postgres, and ClickHouse migrations already completed. The plan is documented as part of [`destination-redshift`](../../airbyte-integrations/connectors/destination-redshift)'s docs (not as a markdown file in the connector root) and breaks the work into eleven phases:
+
+1. **Build system** -- Gradle migration, dependency cleanup.
+2. **Config / spec** -- Convert `RedshiftDestinationConfig` to a `RedshiftSpecification` + `RedshiftConfiguration` pair, preserving JSON-shape compatibility with the legacy connector.
+3. **Schema mapping** -- Create `RedshiftTableSchemaMapper` mirroring the Postgres / Snowflake trio.
+4. **SQL generation** -- Implement a `RedshiftDirectLoadSqlGenerator`, modeling Redshift's `COPY` from S3 and avoiding Postgres-only DDL.
+5. **Client layer** -- `RedshiftAirbyteClient` for JDBC + IAM-role assumption for S3 staging.
+6. **S3 staging data loading** -- Reuse the `load-object-storage` toolkit for the staging step (the one place where Redshift cannot do Direct Load without staging).
+7. **Value coercion** -- `RedshiftValueCoercer` composing with `AirbyteValueCoercer`.
+8. **Writer orchestration** -- Wire up `DirectLoadTableAppendStreamLoader`, `DirectLoadTableAppendTruncateStreamLoader`, `DirectLoadTableDedupTruncateStreamLoader`.
+9. **Connection check** -- Decide OSS/Cloud-split vs formatter-injection (lean toward OSS/Cloud split per [§4.4](04-destination-postgres.md#44-the-check-operation-oss--cloud-split)).
+10. **Testing** -- Port the acceptance suite incrementally, tracked by a per-test checklist (see lesson from [§2.6.2](02-bulk-cdk.md#262-acceptance-test-re-enabling-churn-clickhouse--postgres-rewrites)).
+11. **Deployment** -- RC release, parallel run against legacy connector, cutover.
+
+The plan is structured as an explicit application of the patterns learned from the prior migrations rather than a clean-room design.
+
+## 5.5 Past Issues
+
+### 5.5.1 Raw-tables-mode check failure ([PR #71273](https://github.com/airbytehq/airbyte/pull/71273))
+
+#### How we got there
+
+When Snowflake first migrated, the check operation was written before `legacyRawTablesOnly` mode existed. When the raw-tables mode was added, the check was not updated -- it continued to use the standard `SnowflakeRecordFormatter`, which doesn't emit `_airbyte_loaded_at`. Users who configured raw-tables-only mode saw their initial `Test connection` fail even though a real sync would succeed.
+
+The bug also existed in Postgres -- the same PR fixed both.
+
+#### What we did to fix it
+
+1. Refactored `SnowflakeChecker` to inject the formatter via the constructor ([§5.1.2](#512-the-snowflakechecker-recordformatter-fix-pr-71273)).
+2. Added Micronaut wiring that selects the mode-appropriate formatter at startup.
+3. For Postgres, used the OSS/Cloud split rather than formatter injection ([§4.4](04-destination-postgres.md#44-the-check-operation-oss--cloud-split)) because the Postgres check is much simpler and doesn't need full formatter behavior.
+
+#### Lessons
+
+- **The check operation has to exercise the same code paths a real sync does**, including mode-specific formatters. Anything less and the check becomes a misleading green light.
+- **Multiple connectors with the same shape of bug.** When you find a bug in one connector, immediately check whether the same pattern exists in sibling connectors -- the cost of a parallel-fix PR is low and the cost of a parallel-bug-discovered-by-a-customer is high.
+
+### 5.5.2 Iceberg identifier-field ordering ([PR #74723](https://github.com/airbytehq/airbyte/pull/74723))
+
+Documented inline in [§5.2.2](#522-deferred-identifier-field-update-on-column-replacement-pr-74723). The general lesson: when a destination has an **invariant** (Iceberg: "every identifier field must exist in the current schema"), schema-evolution code has to commit changes in an order that respects the invariant at every intermediate state, not just the final state.
+
+## 5.6 Potential Improvements
+
+### 5.6.1 Converge Snowflake and Postgres `Checker` shapes
+
+**Current:** Snowflake's check uses constructor-injected formatter ([§5.1.2](#512-the-snowflakechecker-recordformatter-fix-pr-71273)); Postgres splits OSS/Cloud as separate classes ([§4.4](04-destination-postgres.md#44-the-check-operation-oss--cloud-split)). Both work, but they're divergent for no strong reason -- it's an accident of who wrote them when.
+
+**With convergence:** Pick one shape and apply it everywhere. The Snowflake shape is more general (supports any per-mode dispatch); the Postgres shape is simpler. Either is defensible -- the value is in picking one so reviewers know which pattern to expect.
+
+### 5.6.2 Bring `destination-iceberg` and `destination-s3-data-lake` together
+
+**Current:** `destination-iceberg` is an empty husk (metadata + icon) and `destination-s3-data-lake` is the real connector. The duplication confuses users who search the registry for "iceberg".
+
+**With a rename or alias:** Either delete the `destination-iceberg` entry entirely, or repurpose it as a thin alias that delegates to `destination-s3-data-lake`. The alias path is more disruptive (existing users with `iceberg` configs); the delete is cleaner if we're confident no one references it.
+
+### 5.6.3 Push the SSH-tunnel logic into a CDK toolkit
+
+**Current:** MSSQL's SSH-tunnel code ([§5.3](#53-destination-mssql-ssh-tunnel-pr-62078)) reuses the CDK's SSH primitives but lives in MSSQL's `DataSourceFactory`. Postgres and Redshift will want the same.
+
+**With a toolkit module:** Add an `ssh-tunnel` helper to the `load-db` toolkit that takes a JDBC URL + an `SshTunnelMethod` and returns a rewritten URL + a session to close in teardown. The next connector that needs SSH adds one line of wiring instead of reproducing the MSSQL code.
+
+Pragmatic note: §5.6.1 and §5.6.2 are tidying; do them when you're already in the area. §5.6.3 pays off at the third user of SSH tunnels; given Redshift is in planning ([§5.4](#54-destination-redshift-migration-plan)) and will need SSH, that's probably the right moment.
+
+---
+
+[Back to Index](../../KNOWLEDGE-TRANSFER.md)

--- a/docs/knowledge-transfer/06-file-transfer.md
+++ b/docs/knowledge-transfer/06-file-transfer.md
@@ -1,0 +1,138 @@
+# File Transfer
+
+File transfer is the destination-side path for moving raw files (not records) through the replication pipeline. A source emits `RECORD` messages with a `file` payload pointing at a staging URL; the destination downloads the file and writes it to the user's storage. The work landed across roughly nine PRs in late 2024 / early 2025 ([#48308](https://github.com/airbytehq/airbyte/pull/48308), [#48385](https://github.com/airbytehq/airbyte/pull/48385), [#48468](https://github.com/airbytehq/airbyte/pull/48468), [#48598](https://github.com/airbytehq/airbyte/pull/48598), [#48622](https://github.com/airbytehq/airbyte/pull/48622), [#48692](https://github.com/airbytehq/airbyte/pull/48692), [#48727](https://github.com/airbytehq/airbyte/pull/48727), [#49931](https://github.com/airbytehq/airbyte/pull/49931), [#50961](https://github.com/airbytehq/airbyte/pull/50961)).
+
+> *Quick file reference: [Appendix §8.5 -- File Transfer](08-appendix-key-file-paths.md#85-file-transfer).*
+
+## Introduction
+
+The destination-side of file transfer was added to the Bulk CDK before the dataflow-pipeline rewrite ([§2.2](02-bulk-cdk.md#22-the-dataflow-pipeline)). As of today, **file transfer lives only in the `legacy-task-loader` toolkit** -- it has not yet been ported to `core/load/dataflow/`. Two consequences flow from this:
+
+1. Destinations that want to use file transfer have to consume the legacy task-based pipeline (the `legacy-task-load-*` toolkits).
+2. The path from `RECORD(file=...)` on STDIN to the destination's file-write hook is bookkeeping-heavy. It's correct but it isn't the same shape as the record-mode dataflow.
+
+The unification is a tracked improvement ([§6.4.1](#641-port-to-the-dataflow-pipeline)) but is not in scope for the doc as of writing.
+
+## 6.1 The `DestinationFile` message
+
+The message is `DestinationFile`, defined at [`airbyte-cdk/bulk/toolkits/legacy-task-loader/src/main/kotlin/io/airbyte/cdk/load/message/DestinationMessage.kt:357`](../../airbyte-cdk/bulk/toolkits/legacy-task-loader/src/main/kotlin/io/airbyte/cdk/load/message/DestinationMessage.kt). (The class name in the existing summary as "`DestinationFileMessage`" is wrong; the actual class is `DestinationFile` and the inner protocol message it wraps is `AirbyteRecordMessageFile`.)
+
+```kotlin
+data class DestinationFile(
+    override val stream: DestinationStream,
+    val emittedAtMs: Long,
+    val fileMessage: AirbyteRecordMessageFile
+) : DestinationFileDomainMessage {
+    // ...
+}
+```
+
+The inner `AirbyteRecordMessageFile` has five JSON-mapped fields:
+
+| Field | JSON key | Meaning |
+|-------|----------|---------|
+| `fileUrl` | `file_url` | The staging URL where the source put the file (typically S3 or local volume) |
+| `bytes` | `bytes` | File size in bytes |
+| `fileRelativePath` | `file_relative_path` | Path relative to a per-stream root, used by the destination to construct the final filename |
+| `modified` | `modified` | Source-side modification timestamp |
+| `sourceFileUrl` | `source_file_url` | The original URL on the source side (for provenance) |
+
+A separate `DestinationFileStreamComplete` at [line 464](../../airbyte-cdk/bulk/toolkits/legacy-task-loader/src/main/kotlin/io/airbyte/cdk/load/message/DestinationMessage.kt) parallels `DestinationRecordStreamComplete` -- it signals "no more files for this stream", which the destination uses to commit any per-stream finalization (e.g. write a manifest).
+
+The sealed interface that file messages implement is `DestinationFileDomainMessage` at [line 71](../../airbyte-cdk/bulk/toolkits/legacy-task-loader/src/main/kotlin/io/airbyte/cdk/load/message/DestinationMessage.kt).
+
+There is also a separate `FileReference` data class at [line 342](../../airbyte-cdk/bulk/toolkits/legacy-task-loader/src/main/kotlin/io/airbyte/cdk/load/message/DestinationMessage.kt) used in `RECORD` messages that *reference* a file rather than being the file payload themselves -- this is for record-mode connectors that want to pin one column to a file URL without switching the whole stream to file mode.
+
+## 6.2 How a file flows through the legacy pipeline
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant Source as Source connector<br/>(STDIN)
+    participant Factory as DestinationMessageFactory
+    participant Router as PipelineEventBookkeepingRouter
+    participant Queue as FileTransferQueue
+    participant Loader as StreamLoader (per stream)
+    participant Storage as Object storage<br/>(per destination)
+
+    Source->>Factory: AirbyteMessage (RECORD with file payload)
+    Factory->>Factory: parse into DestinationFile
+    Factory->>Router: DestinationFile
+    Router->>Queue: FileTransferQueueRecord(file=DestinationFile)
+    Loader->>Queue: poll FileTransferQueueRecord
+    Loader->>Storage: download from file.stagingFileUrl
+    Loader->>Storage: upload to destination path
+    Source->>Factory: AirbyteMessage (STREAM_STATUS=COMPLETE)
+    Factory->>Router: DestinationFileStreamComplete
+    Router->>Loader: signal end-of-stream
+    Loader->>Loader: per-stream finalize
+```
+
+The router that coordinates this is `PipelineEventBookkeepingRouter` at [`airbyte-cdk/bulk/toolkits/legacy-task-loader/src/main/kotlin/io/airbyte/cdk/load/state/PipelineEventBookkeepingRouter.kt`](../../airbyte-cdk/bulk/toolkits/legacy-task-loader/src/main/kotlin/io/airbyte/cdk/load/state/PipelineEventBookkeepingRouter.kt) (key lines: 14-21 for the routing types, 66 for the file-mode dispatch, 135-145 for queue insertion, 297 for the stream-complete handling). The queue type itself is `FileTransferQueueMessage`, defined at [`FileTransferQueueMessageLegacy.kt:11`](../../airbyte-cdk/bulk/toolkits/legacy-task-loader/src/main/kotlin/io/airbyte/cdk/load/message/FileTransferQueueMessageLegacy.kt) -- the carrier is `FileTransferQueueRecord(file: DestinationFile)` at line 17.
+
+For object-storage destinations specifically, the file-write logic lives in `FilePartAccumulatorLegacy` at [`airbyte-cdk/bulk/toolkits/legacy-task-load-object-storage/src/main/kotlin/io/airbyte/cdk/load/write/object_storage/FilePartAccumulatorLegacy.kt:41`](../../airbyte-cdk/bulk/toolkits/legacy-task-load-object-storage/src/main/kotlin/io/airbyte/cdk/load/write/object_storage/FilePartAccumulatorLegacy.kt), which handles multipart upload assembly for the destination-side upload.
+
+## 6.3 Enabling file transfer in a connector
+
+File transfer is **opt-in per destination** via a Micronaut property. The flag is:
+
+```yaml
+airbyte:
+  destination:
+    core:
+      file-transfer:
+        enabled: true
+```
+
+Set in a connector's `application.yaml` (per [#48385](https://github.com/airbytehq/airbyte/pull/48385)). For test fixtures, the same flag is reachable as a boolean kwarg `useFileTransfer: Boolean` on `IntegrationTest`, `DestinationProcess`, `DockerizedDestination`, `NonDockerizedDestination` (both in the `core/load` test fixtures and the `legacy-task-loader` test fixtures). Default is `false` -- connectors that haven't opted in will silently ignore file payloads.
+
+## 6.4 Past Issues
+
+### 6.4.1 File delete on overwrite ([PR #48622](https://github.com/airbytehq/airbyte/pull/48622))
+
+#### How we got there
+
+The initial file-transfer implementation didn't delete files from the destination on overwrite-mode syncs. Users running a full refresh against an object-storage destination ended up with the *union* of the previous and current sync's files, with no obvious way to tell them apart. The bug came from treating files like records -- records-in-overwrite are wiped by table-level truncate at the destination; files have no analogous primitive.
+
+#### What we did to fix it
+
+1. Added an explicit "list and delete previous files" step at the start of an overwrite sync.
+2. Scoped the delete by generation_id stamped on the destination-side path, so concurrent syncs (different generations) don't delete each other's files.
+3. Re-enabled the file-related DAT (Destination Acceptance Test) suite ([#48727](https://github.com/airbytehq/airbyte/pull/48727)) which surfaced the original bug.
+
+#### Lessons
+
+- **File-mode is not record-mode-with-bigger-payloads.** Overwrite semantics need explicit per-mode design rather than reusing the table-truncate primitive.
+- **DAT acceptance tests catch real issues only when they're enabled.** The fix here was as much "re-enable the test that already existed" as "write new test logic."
+
+### 6.4.2 Initial integration testing gaps ([PR #48692](https://github.com/airbytehq/airbyte/pull/48692))
+
+The first cut of file-transfer integration tests existed but ran only in single-record / single-file scenarios. They missed: large files (which exercise the multipart upload path in `FilePartAccumulatorLegacy`); files larger than memory; and concurrent multi-stream file flows. [#48692](https://github.com/airbytehq/airbyte/pull/48692) added these scenarios to the integration suite. No customer-visible incident, but a category of bugs we would have shipped without it.
+
+The lesson: when adding a new pipeline mode, the integration test suite has to cover **size**, **count**, and **concurrency** independently; testing only one dimension at a time leaves gaps that aren't visible in PR review.
+
+## 6.5 Potential Improvements
+
+### 6.5.1 Port to the dataflow pipeline
+
+**Current:** File transfer lives entirely under `legacy-task-loader` and `legacy-task-load-object-storage`. Destinations that use file transfer have to consume the legacy task-based pipeline; they can't use the modern dataflow pipeline at [`airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/dataflow/`](../../airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/dataflow/).
+
+**With a port:** Add `DestinationFile` handling to `ParseStage` and a `FileFlushStage` to the dataflow pipeline; route via `FlushStage` for record streams and `FileFlushStage` for file streams. The migration is non-trivial because `PipelineEventBookkeepingRouter` is the bookkeeping heart of file transfer and has no dataflow-pipeline analog yet. Once ported, the `legacy-task-loader` and `legacy-task-load-object-storage` toolkits can be deleted in their entirety.
+
+### 6.5.2 First-class file-reference column type
+
+**Current:** `FileReference` ([§6.1](#61-the-destinationfile-message)) exists as a domain class but isn't a first-class `AirbyteType` -- columns that hold file URLs are typed as `string` in the catalog. Destinations have no way to tell a "this is a real string" from a "this is a file URL we should download."
+
+**With a type:** Add `FileReferenceType` to the AirbyteType hierarchy, surface it in the source-side catalog, and let destinations choose to materialize it as a downloaded file rather than a literal URL. This is a protocol-level change and would need source-side coordination.
+
+### 6.5.3 Drop the dual `useFileTransfer` test plumbing
+
+**Current:** The test-fixture `useFileTransfer: Boolean` flag exists in both `core/load`'s test fixtures **and** `legacy-task-loader`'s test fixtures. New tests sometimes set the flag on one but not the other and end up running in record-mode by accident.
+
+**With unification:** After the dataflow-pipeline port ([§6.5.1](#651-port-to-the-dataflow-pipeline)), there is one set of test fixtures, one flag, and no ambiguity. Until then, the simplest improvement is to make the legacy test-fixture flag a forwarder to the modern one (and rip out the duplicate code paths).
+
+Pragmatic note: §6.5.1 is the biggest improvement but the biggest investment -- multiple weeks of work. §6.5.2 only pays off with source-side cooperation and is the kind of change that needs a design RFC first. §6.5.3 is small and self-contained; do it next time someone touches the area.
+
+---
+
+[Back to Index](../../KNOWLEDGE-TRANSFER.md)

--- a/docs/knowledge-transfer/07-ci-cd-tooling.md
+++ b/docs/knowledge-transfer/07-ci-cd-tooling.md
@@ -1,0 +1,163 @@
+# CI/CD Tooling
+
+The Bulk CDK ships independent SemVer modules ([§2.1](02-bulk-cdk.md#21-module-layout-and-independent-semver)); the connectors that consume it ship their own docker tags. The CI/CD tooling described here automates the cross-cutting parts of that release model: enforcing that CDK source changes are paired with a version bump, scheduling automated CDK upgrades into every certified connector, and bumping connector dependencies for security advisories. The work shipped between April and August 2025 ([#58118](https://github.com/airbytehq/airbyte/pull/58118), [#58125](https://github.com/airbytehq/airbyte/pull/58125), [#58126](https://github.com/airbytehq/airbyte/pull/58126), [#58604](https://github.com/airbytehq/airbyte/pull/58604), [#58648](https://github.com/airbytehq/airbyte/pull/58648), [#59206](https://github.com/airbytehq/airbyte/pull/59206), [#62482](https://github.com/airbytehq/airbyte/pull/62482), [#64913](https://github.com/airbytehq/airbyte/pull/64913)) with continued maintenance into 2026.
+
+> *Quick file reference: [Appendix §8.6 -- CI/CD Tooling](08-appendix-key-file-paths.md#86-cicd-tooling).*
+
+## Introduction
+
+Before this set of workflows, the loop "the CDK shipped a new version → every connector picks it up" was manual. A maintainer ran a script locally, opened a few dozen PRs by hand, and merged them as time allowed. The connectors that needed the new CDK most urgently were typically the slowest to pick it up because everyone else was waiting for someone to do the toil. The workflows here collapse that loop into a single scheduled run.
+
+Two distinct sets of workflows handle the CDK lifecycle:
+
+1. **Per-module CDK version-bump enforcement** -- if you touch CDK source code in a PR, you must also bump the matching `version.properties`, or CI fails. ([§7.1](#71-per-module-cdk-version-bump-enforcement))
+2. **Scheduled auto-upgrade of certified connectors** -- once a month, scan certified connectors, open a PR to bump each one to the latest published Bulk CDK. ([§7.2](#72-auto-upgrade-certified-connectors-cdk))
+
+Beyond these, several support workflows exist for ad-hoc bumps via slash command ([§7.3](#73-slash-command-driven-bumps)) and a "test-only changes" escape hatch ([§7.4](#74-test-only-changes-escape-hatch)).
+
+## 7.1 Per-module CDK version-bump enforcement
+
+The Bulk CDK has three modules with independent SemVer ([§2.1](02-bulk-cdk.md#21-module-layout-and-independent-semver)); each has its own `version.properties`. The enforcement workflow is in [`.github/workflows/java-cdk-tests.yml`](../../.github/workflows/java-cdk-tests.yml). It runs on every PR and has two jobs that matter here:
+
+| Job | Lines | Role |
+|-----|-------|------|
+| `changes-in-bulk-cdk-packages` | 44-69 | Use `dorny/paths-filter` to detect which of `base`, `extract`, `load` had source-file changes |
+| `run-check-bulk-cdk-version` | 71-118 | For each module that changed, run the corresponding Gradle task (`:airbyte-cdk:bulk:checkBaseVersion`, `:checkExtractVersion`, `:checkLoadVersion`) |
+| `bulk-cdk-version-check-result` | 151 | Aggregate the three sub-checks into a single required check that branch-protection can gate on |
+
+The paths-filter (line 59) is the key piece -- it scopes detection to the right module:
+
+```yaml
+base:    - 'airbyte-cdk/bulk/core/base/**'
+extract: - 'airbyte-cdk/bulk/core/extract/**'
+         - 'airbyte-cdk/bulk/toolkits/extract-*/**'
+         - 'airbyte-cdk/bulk/toolkits/*source*/**'
+load:    - 'airbyte-cdk/bulk/core/load/**'
+         - 'airbyte-cdk/bulk/toolkits/load-*/**'
+         - 'airbyte-cdk/bulk/toolkits/legacy-task-load*/**'
+```
+
+A PR that touches `airbyte-cdk/bulk/core/load/` but doesn't bump `airbyte-cdk/bulk/core/load/version.properties` fails the `checkLoadVersion` job. The Gradle task compares the local `version.properties` to the latest version published to Maven; if they match, it fails.
+
+The "what should I bump?" question is up to the author -- `version.properties` is a single string and the workflow doesn't enforce SemVer rules (e.g. it doesn't reject a patch bump for a breaking API change). That's a tradeoff: a stricter check would require static analysis of every PR's Kotlin diff, which is expensive. In practice, code review catches semver violations and the `AirbyteValueCoercer` 1.x bump ([§2.1.1](02-bulk-cdk.md#211-the-airbytevaluecoercer-1x-bump)) is the kind of major signal that gets attention regardless of automation.
+
+## 7.2 Auto-upgrade certified connectors CDK
+
+Workflow: [`.github/workflows/auto-upgrade-certified-connectors-cdk.yml`](../../.github/workflows/auto-upgrade-certified-connectors-cdk.yml). Scheduled at `cron: "37 16 1 * *"` (16:37 UTC on the first of every month, line 5). Also callable on-demand via `workflow_dispatch` and `workflow_call` (so the enterprise repo can invoke it on its own connectors).
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant Schedule as cron / workflow_dispatch
+    participant List as list-certified-connectors
+    participant Matrix as upgrade-connector-cdk<br/>(matrix per connector)
+    participant Scripts as tools/bin/bulk-cdk/auto-upgrade/*
+    participant GH as GitHub API
+
+    Schedule->>List: trigger
+    List->>List: tools/bin/bulk-cdk/get-certified-connectors.sh
+    List-->>Matrix: connectors JSON array
+    loop per connector (parallelism = 5)
+        Matrix->>Scripts: bump-connector-cdk.sh
+        Matrix->>Matrix: git diff -- detect changes
+        alt has changes
+            Matrix->>Scripts: bump-connector-metadata.sh<br/>(bumps dockerImageTag patch)
+            Matrix->>GH: peter-evans/create-pull-request<br/>(branch: auto-upgrade-jvm-bulk-cdk/<ver>/<connector>)
+            Matrix->>Scripts: populate-connector-changelog.sh<br/>(commits to PR branch)
+            Matrix->>GH: gh pr ready (un-draft)
+        end
+    end
+```
+
+The matrix fans out across every certified connector ([`auto-upgrade-certified-connectors-cdk.yml:44`](../../.github/workflows/auto-upgrade-certified-connectors-cdk.yml)), capped at 5 in parallel (`max-parallel: 5`, line 46) to avoid blowing through GitHub API rate limits. `fail-fast: false` means one connector's failure does not abort the others.
+
+For each connector:
+
+1. **Compute the upgrade** -- the per-connector upgrade script reads the connector's current Bulk CDK version, compares it to the latest published, and writes the new version into the connector's Gradle file.
+2. **Detect changes** (lines 95-103) -- `git diff --quiet`; skip if nothing changed.
+3. **Bump connector version** (lines 105-112) -- run [`tools/bin/bulk-cdk/auto-upgrade/bump-connector-metadata.sh`](../../tools/bin/bulk-cdk/auto-upgrade/bump-connector-metadata.sh) (line 110) to patch-bump the connector's `dockerImageTag` in `metadata.yaml`.
+4. **Create a draft PR** (lines 114-136) -- branch name `auto-upgrade-jvm-bulk-cdk/<new_cdk_version>/<connector>` (line 121). The PR is created as a draft because the changelog hasn't been written yet.
+5. **Write the changelog** (lines 138-156) -- run [`populate-connector-changelog.sh`](../../tools/bin/bulk-cdk/auto-upgrade/populate-connector-changelog.sh) with the connector name, new version, PR number, and message "Upgrade to Bulk CDK <ver>." Commit and push to the PR branch.
+6. **Un-draft** (lines 159-163) -- `gh pr ready <pr-number>`.
+
+The deliberate "draft → push changelog commit → un-draft" sequence prevents code review from happening on a PR that's still missing the changelog -- a class of "looks fine, ship it" mistakes that bit us early on.
+
+The `airbyte-enterprise` branch (line 141 check) is the same workflow run by the internal-cloud repo against its own connectors; the changelog step is skipped there because the enterprise repo doesn't maintain user-facing changelogs.
+
+## 7.3 Slash-command-driven bumps
+
+Two on-demand workflows complement the scheduled flow:
+
+| Workflow | Trigger | Purpose |
+|----------|---------|---------|
+| [`bump-version-command.yml`](../../.github/workflows/bump-version-command.yml) | `workflow_dispatch` + `/bump-version <connector> <bump-type>` comment | Patch/minor/major bump for a single connector |
+| [`update-connector-cdk-version-command.yml`](../../.github/workflows/update-connector-cdk-version-command.yml) | `/update-connector-cdk-version <connector>` comment | Bump the Bulk CDK reference for a single connector |
+
+These are useful for two scenarios the scheduled flow doesn't cover:
+- **Security advisories** -- bumping a single connector ahead of the monthly schedule (e.g. [#72973](https://github.com/airbytehq/airbyte/pull/72973), [#72975](https://github.com/airbytehq/airbyte/pull/72975) for CVE fixes to `destination-customer-io` and `destination-hubspot`).
+- **One-off contributor bumps** -- a contributor can run the slash command without needing local repo access.
+
+The dispatcher that converts slash-command comments into workflow calls is [`slash-commands.yml`](../../.github/workflows/slash-commands.yml).
+
+## 7.4 Test-only-changes escape hatch ([PR #64913](https://github.com/airbytehq/airbyte/pull/64913))
+
+The version-bump enforcement in [§7.1](#71-per-module-cdk-version-bump-enforcement) is intentionally strict: any change to the matched paths forces a `version.properties` bump. But not every change ships. A PR that only adds tests (no production code change) shouldn't force a bump, because shipping `version.properties` from a test-only PR triggers a Maven publish that doesn't ship any new behavior.
+
+[#64913](https://github.com/airbytehq/airbyte/pull/64913) added the escape hatch: if every changed file in the relevant module is under `src/test/` or `src/testFixtures/`, the version check is skipped. Implementation lives in the `:airbyte-cdk:bulk:checkBaseVersion` (and Extract/Load) Gradle tasks rather than in the workflow YAML, so the same rule applies whether the check runs in CI or locally.
+
+The tradeoff is that a test-only PR can ship without a published Maven artifact -- which is exactly the desired behavior, but it also means consumers can't pick up the new test fixtures via a Maven coordinate until a real bump happens. In practice this is fine because consumers reach for the test fixtures by source-set dependency, not by version.
+
+## 7.5 Skip missing connectors ([PR #62482](https://github.com/airbytehq/airbyte/pull/62482))
+
+The CDK compatibility test ([`cdk-destination-connector-compatibility-test.yml`](../../.github/workflows/cdk-destination-connector-compatibility-test.yml)) and the auto-upgrade workflow ([§7.2](#72-auto-upgrade-certified-connectors-cdk)) both enumerate connectors from a static list (`tools/bin/bulk-cdk/get-certified-connectors.sh`). Before [#62482](https://github.com/airbytehq/airbyte/pull/62482), if the list contained a connector that had been deleted or renamed, the workflow failed at "directory does not exist" and aborted the entire matrix.
+
+The fix: when a connector listed but-not-found is detected, skip it with a warning and continue. This is the kind of defensive engineering that you don't notice working but you do notice missing: a single stale entry in `get-certified-connectors.sh` used to take out a monthly run.
+
+## 7.6 Past Issues
+
+### 7.6.1 The empty action / workflow dispatcher missteps ([PRs #58118](https://github.com/airbytehq/airbyte/pull/58118), [#58604](https://github.com/airbytehq/airbyte/pull/58604))
+
+#### How we got there
+
+Early iterations of the auto-upgrade workflow used a custom "empty action" pattern -- a no-op composite action whose only job was to be addressable from `workflow_dispatch`. The pattern was clever but obscure: someone reading the workflow couldn't tell where the actual work happened. We tried two iterations of the dispatcher before settling on the current shape ([§7.3](#73-slash-command-driven-bumps)).
+
+#### What we did to fix it
+
+1. Replaced the empty-action pattern with a straightforward `workflow_dispatch` + `workflow_call` combination on the actual workflow.
+2. Centralized all slash-command routing in `slash-commands.yml`, which is the single place a reader has to look to understand "what does `/<command>` do".
+3. Renamed the workflow in [#59206](https://github.com/airbytehq/airbyte/pull/59206) to match its current behavior (the original name predated the rework).
+
+#### Lessons
+
+- **Workflow indirection is expensive to read.** Even when it's technically correct, a chain of three "dispatcher → empty action → real workflow" hops is hostile to the next person.
+- **Name the workflow after what it does, not when it was added.** "v2" / "new" / "improved" in workflow filenames ages badly.
+
+### 7.6.2 Static connector list staleness ([PR #62482](https://github.com/airbytehq/airbyte/pull/62482) -- covered in [§7.5](#75-skip-missing-connectors-pr-62482))
+
+Same story as [§7.5](#75-skip-missing-connectors-pr-62482); not repeated here. The general lesson: any workflow whose input is a static list needs a "gracefully skip missing entries" code path, because the list will drift from reality on its own.
+
+## 7.7 Potential Improvements
+
+### 7.7.1 Compute the list of certified connectors dynamically
+
+**Current:** [`tools/bin/bulk-cdk/get-certified-connectors.sh`](../../tools/bin/bulk-cdk/get-certified-connectors.sh) is a script that walks `airbyte-integrations/connectors/*/metadata.yaml` and filters by `ab_internal.sl >= 200`. It works, but the script lives in `tools/bin/` and the metadata convention lives in the connector dir, so the link is invisible.
+
+**With a Gradle task:** Expose the same query as `./gradlew listCertifiedConnectors` (returning JSON). The workflow shells out to Gradle. The advantage is that the rule lives next to the connector code; the cost is that Gradle startup is slower than a shell script.
+
+### 7.7.2 Auto-categorize the version bump (patch / minor / major)
+
+**Current:** [§7.1](#71-per-module-cdk-version-bump-enforcement) accepts any bump as long as the file changed. A PR that adds a breaking API change and only patch-bumps will pass CI.
+
+**With a heuristic:** Use a Kotlin source analyzer (e.g. `revapi`, `metalava`) to detect public-API signature changes between HEAD and the latest published Maven artifact. Map the detected change to a minimum bump requirement and enforce it. The cost is the analyzer dependency and a non-trivial config surface; the benefit is automatic enforcement of the SemVer contract the project already aspires to.
+
+### 7.7.3 Replace the `peter-evans/create-pull-request` step with a thinner action
+
+**Current:** [§7.2](#72-auto-upgrade-certified-connectors-cdk) uses a popular third-party action for PR creation. It works but does a lot of magic (auto-stashes uncommitted changes, auto-creates a branch, auto-detects "no changes"). Some of that magic surprised us during the early rollout.
+
+**With `gh pr create`:** Wrap `git checkout -b ... && git commit && git push && gh pr create` directly. Slightly more verbose, much more transparent. Worth doing if we ever debug another auto-upgrade outage that traces back to action behavior.
+
+Pragmatic note: §7.7.1 is mostly a refactor; §7.7.2 is a real capability improvement but a real investment; §7.7.3 is the kind of fix you make after one bad outage, not before.
+
+---
+
+[Back to Index](../../KNOWLEDGE-TRANSFER.md)

--- a/docs/knowledge-transfer/08-appendix-key-file-paths.md
+++ b/docs/knowledge-transfer/08-appendix-key-file-paths.md
@@ -1,0 +1,193 @@
+# Appendix: Key File Paths
+
+Master table of all key files referenced in this knowledge transfer, grouped by section. Each path is clickable.
+
+## 8.1 Bulk CDK
+
+[§2 Bulk CDK](02-bulk-cdk.md)
+
+### Module roots and versions
+
+| File | Purpose |
+|------|---------|
+| [`airbyte-cdk/bulk/`](../../airbyte-cdk/bulk) | Bulk CDK root |
+| [`airbyte-cdk/bulk/build.gradle`](../../airbyte-cdk/bulk/build.gradle) | Loads three independent `version.properties`; sets group `io.airbyte.bulk-cdk` |
+| [`airbyte-cdk/bulk/core/base/version.properties`](../../airbyte-cdk/bulk/core/base/version.properties) | `base` module version (`1.0.3`) |
+| [`airbyte-cdk/bulk/core/extract/version.properties`](../../airbyte-cdk/bulk/core/extract/version.properties) | `extract` module version (`1.1.6`) |
+| [`airbyte-cdk/bulk/core/load/version.properties`](../../airbyte-cdk/bulk/core/load/version.properties) | `load` module version (`1.0.11`) |
+
+### Dataflow pipeline
+
+| File | Class / role |
+|------|--------------|
+| [`airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/dataflow/DestinationLifecycle.kt`](../../airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/dataflow/DestinationLifecycle.kt) | `DestinationLifecycle` (line 22): setup → init streams → pipeline → finalize streams → teardown |
+| [`airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/dataflow/finalization/StreamCompletionTracker.kt`](../../airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/dataflow/finalization/StreamCompletionTracker.kt) | `StreamCompletionTracker` (line 15) |
+| [`airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/dataflow/stages/ParseStage.kt`](../../airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/dataflow/stages/ParseStage.kt) | Parse stage |
+| [`airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/dataflow/stages/AggregateStage.kt`](../../airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/dataflow/stages/AggregateStage.kt) | Aggregate stage |
+| [`airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/dataflow/stages/FlushStage.kt`](../../airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/dataflow/stages/FlushStage.kt) | Flush stage |
+| [`airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/dataflow/stages/StateStage.kt`](../../airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/dataflow/stages/StateStage.kt) | State stage |
+| [`airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/dataflow/pipeline/DataFlowPipeline.kt`](../../airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/dataflow/pipeline/DataFlowPipeline.kt) | Pipeline runner |
+| [`airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/dataflow/pipeline/PipelineRunner.kt`](../../airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/dataflow/pipeline/PipelineRunner.kt) | STDIN reader / outer driver |
+| [`airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/dataflow/config/model/`](../../airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/dataflow/config/model) | Per-concern resource config (no `ResourceConfig` umbrella class) |
+
+### Write API and stream loaders
+
+| File | Class / role |
+|------|--------------|
+| [`airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/write/StreamLoader.kt`](../../airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/write/StreamLoader.kt) | `StreamLoader` (line 17): `start()`, `teardown(completedSuccessfully)` |
+| [`airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/write/DestinationWriter.kt`](../../airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/write/DestinationWriter.kt) | `DestinationWriter` (line 13): `setup()`, `createStreamLoader(stream)`, `teardown(hadFailure = false)` |
+| [`airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/table/directload/DirectLoadTableStreamLoader.kt`](../../airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/table/directload/DirectLoadTableStreamLoader.kt) | `DirectLoadTableAppendStreamLoader` (line 26), `…AppendTruncate…` (line 141), `…DedupTruncate…` (line 266) |
+| [`airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/table/directload/DirectLoadTableStreamLoaderTest.kt`](../../airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/table/directload/DirectLoadTableStreamLoaderTest.kt) | Drop-temp-on-success / no-drop-on-failure tests (lines 160, 199) |
+
+### Value coercion
+
+| File | Class / role |
+|------|--------------|
+| [`airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/data/AirbyteValueCoercer.kt`](../../airbyte-cdk/bulk/core/load/src/main/kotlin/io/airbyte/cdk/load/data/AirbyteValueCoercer.kt) | `AirbyteValueCoercer` (line 37), `coerce(value, type, respectLegacyUnions)` (line 38) |
+| [`airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/data/AirbyteValueCoercerTest.kt`](../../airbyte-cdk/bulk/core/load/src/test/kotlin/io/airbyte/cdk/load/data/AirbyteValueCoercerTest.kt) | Tests |
+
+## 8.2 Destination ClickHouse
+
+[§3 Destination ClickHouse](03-clickhouse.md)
+
+| File | Class / role |
+|------|--------------|
+| [`airbyte-integrations/connectors/destination-clickhouse/`](../../airbyte-integrations/connectors/destination-clickhouse) | Connector root (image `2.1.23`) |
+| [`airbyte-integrations/connectors/destination-clickhouse/metadata.yaml`](../../airbyte-integrations/connectors/destination-clickhouse/metadata.yaml) | Connector metadata (definitionId `ce0d828e-…`) |
+| [`airbyte-integrations/connectors/destination-clickhouse/src/main/kotlin/io/airbyte/integrations/destination/clickhouse/ClickhouseDestination.kt`](../../airbyte-integrations/connectors/destination-clickhouse/src/main/kotlin/io/airbyte/integrations/destination/clickhouse/ClickhouseDestination.kt) | Micronaut entry point |
+| [`airbyte-integrations/connectors/destination-clickhouse/src/main/kotlin/io/airbyte/integrations/destination/clickhouse/write/ClickHouseWriter.kt`](../../airbyte-integrations/connectors/destination-clickhouse/src/main/kotlin/io/airbyte/integrations/destination/clickhouse/write/ClickHouseWriter.kt) | `ClickHouseWriter` (line 23): Append + AppendTruncate dispatch |
+| [`airbyte-integrations/connectors/destination-clickhouse/src/main/kotlin/io/airbyte/integrations/destination/clickhouse/client/ClickhouseSqlGenerator.kt`](../../airbyte-integrations/connectors/destination-clickhouse/src/main/kotlin/io/airbyte/integrations/destination/clickhouse/client/ClickhouseSqlGenerator.kt) | DDL/DML, engine selection (`ReplacingMergeTree` for dedup, lines 51-71) |
+| [`airbyte-integrations/connectors/destination-clickhouse/src/main/kotlin/io/airbyte/integrations/destination/clickhouse/client/ClickhouseAirbyteClient.kt`](../../airbyte-integrations/connectors/destination-clickhouse/src/main/kotlin/io/airbyte/integrations/destination/clickhouse/client/ClickhouseAirbyteClient.kt) | JDBC client |
+| [`airbyte-integrations/connectors/destination-clickhouse/src/main/kotlin/io/airbyte/integrations/destination/clickhouse/client/ClickhouseSqlTypes.kt`](../../airbyte-integrations/connectors/destination-clickhouse/src/main/kotlin/io/airbyte/integrations/destination/clickhouse/client/ClickhouseSqlTypes.kt) | Type mapping (`String` for JSON, `Decimal` for number) |
+| [`airbyte-integrations/connectors/destination-clickhouse/src/main/kotlin/io/airbyte/integrations/destination/clickhouse/schema/ClickhouseTableSchemaMapper.kt`](../../airbyte-integrations/connectors/destination-clickhouse/src/main/kotlin/io/airbyte/integrations/destination/clickhouse/schema/ClickhouseTableSchemaMapper.kt) | Schema mapper |
+| [`airbyte-integrations/connectors/destination-clickhouse/src/main/kotlin/io/airbyte/integrations/destination/clickhouse/schema/ClickhouseNamingUtils.kt`](../../airbyte-integrations/connectors/destination-clickhouse/src/main/kotlin/io/airbyte/integrations/destination/clickhouse/schema/ClickhouseNamingUtils.kt) | Identifier quoting and length limits |
+| [`airbyte-integrations/connectors/destination-clickhouse/src/main/kotlin/io/airbyte/integrations/destination/clickhouse/write/transform/ClickhouseCoercer.kt`](../../airbyte-integrations/connectors/destination-clickhouse/src/main/kotlin/io/airbyte/integrations/destination/clickhouse/write/transform/ClickhouseCoercer.kt) | Value coercion |
+| [`airbyte-integrations/connectors/destination-clickhouse/src/main/kotlin/io/airbyte/integrations/destination/clickhouse/check/ClickhouseChecker.kt`](../../airbyte-integrations/connectors/destination-clickhouse/src/main/kotlin/io/airbyte/integrations/destination/clickhouse/check/ClickhouseChecker.kt) | Check operation |
+| [`airbyte-integrations/connectors/destination-clickhouse/src/main/kotlin/io/airbyte/integrations/destination/clickhouse/spec/ClickhouseSpecification.kt`](../../airbyte-integrations/connectors/destination-clickhouse/src/main/kotlin/io/airbyte/integrations/destination/clickhouse/spec/ClickhouseSpecification.kt) | Connector spec |
+| [`airbyte-integrations/connectors/destination-clickhouse/src/main/kotlin/io/airbyte/integrations/destination/clickhouse/spec/ClickhouseConfiguration.kt`](../../airbyte-integrations/connectors/destination-clickhouse/src/main/kotlin/io/airbyte/integrations/destination/clickhouse/spec/ClickhouseConfiguration.kt) | Parsed config |
+
+## 8.3 Destination Postgres
+
+[§4 Destination Postgres](04-destination-postgres.md)
+
+| File | Class / role |
+|------|--------------|
+| [`airbyte-integrations/connectors/destination-postgres/`](../../airbyte-integrations/connectors/destination-postgres) | Connector root (image `3.0.13`) |
+| [`airbyte-integrations/connectors/destination-postgres/metadata.yaml`](../../airbyte-integrations/connectors/destination-postgres/metadata.yaml) | Connector metadata (definitionId `25c5221d-…`) |
+| [`airbyte-integrations/connectors/destination-postgres/src/main/kotlin/io/airbyte/integrations/destination/postgres/PostgresDestinationV2.kt`](../../airbyte-integrations/connectors/destination-postgres/src/main/kotlin/io/airbyte/integrations/destination/postgres/PostgresDestinationV2.kt) | Micronaut entry point |
+| [`airbyte-integrations/connectors/destination-postgres/src/main/kotlin/io/airbyte/integrations/destination/postgres/schema/PostgresTableSchemaMapper.kt`](../../airbyte-integrations/connectors/destination-postgres/src/main/kotlin/io/airbyte/integrations/destination/postgres/schema/PostgresTableSchemaMapper.kt) | Schema mapper (replaces deleted `PostgresColumnUtils.kt`) |
+| [`airbyte-integrations/connectors/destination-postgres/src/main/kotlin/io/airbyte/integrations/destination/postgres/schema/PostgresColumnManager.kt`](../../airbyte-integrations/connectors/destination-postgres/src/main/kotlin/io/airbyte/integrations/destination/postgres/schema/PostgresColumnManager.kt) | Column add/drop/alter planning |
+| [`airbyte-integrations/connectors/destination-postgres/src/main/kotlin/io/airbyte/integrations/destination/postgres/schema/PostgresNamingUtils.kt`](../../airbyte-integrations/connectors/destination-postgres/src/main/kotlin/io/airbyte/integrations/destination/postgres/schema/PostgresNamingUtils.kt) | Identifier quoting and length limits |
+| [`airbyte-integrations/connectors/destination-postgres/src/main/kotlin/io/airbyte/integrations/destination/postgres/sql/PostgresDirectLoadSqlGenerator.kt`](../../airbyte-integrations/connectors/destination-postgres/src/main/kotlin/io/airbyte/integrations/destination/postgres/sql/PostgresDirectLoadSqlGenerator.kt) | DDL/DML generation; `ALTER COLUMN TYPE` `USING` matrix at lines 599-619 |
+| [`airbyte-integrations/connectors/destination-postgres/src/main/kotlin/io/airbyte/integrations/destination/postgres/client/PostgresAirbyteClient.kt`](../../airbyte-integrations/connectors/destination-postgres/src/main/kotlin/io/airbyte/integrations/destination/postgres/client/PostgresAirbyteClient.kt) | JDBC client; CASCADE error guidance at 455-465 |
+| [`airbyte-integrations/connectors/destination-postgres/src/main/kotlin/io/airbyte/integrations/destination/postgres/write/PostgresWriter.kt`](../../airbyte-integrations/connectors/destination-postgres/src/main/kotlin/io/airbyte/integrations/destination/postgres/write/PostgresWriter.kt) | Loader dispatch (`legacyRawTablesOnly` at 65-69) |
+| [`airbyte-integrations/connectors/destination-postgres/src/main/kotlin/io/airbyte/integrations/destination/postgres/write/load/PostgresInsertBuffer.kt`](../../airbyte-integrations/connectors/destination-postgres/src/main/kotlin/io/airbyte/integrations/destination/postgres/write/load/PostgresInsertBuffer.kt) | Insert buffering; raw-payload branch at 39 |
+| [`airbyte-integrations/connectors/destination-postgres/src/main/kotlin/io/airbyte/integrations/destination/postgres/check/PostgresOssChecker.kt`](../../airbyte-integrations/connectors/destination-postgres/src/main/kotlin/io/airbyte/integrations/destination/postgres/check/PostgresOssChecker.kt) | OSS check (`@Requires(notEnv = [AIRBYTE_CLOUD_ENV])`, line 35) |
+| [`airbyte-integrations/connectors/destination-postgres/src/main/kotlin/io/airbyte/integrations/destination/postgres/check/PostgresCloudChecker.kt`](../../airbyte-integrations/connectors/destination-postgres/src/main/kotlin/io/airbyte/integrations/destination/postgres/check/PostgresCloudChecker.kt) | Cloud check |
+| [`airbyte-integrations/connectors/destination-postgres/src/main/kotlin/io/airbyte/integrations/destination/postgres/spec/PostgresSpecification.kt`](../../airbyte-integrations/connectors/destination-postgres/src/main/kotlin/io/airbyte/integrations/destination/postgres/spec/PostgresSpecification.kt) | Spec (raw mode at 41, CASCADE at 157) |
+| [`airbyte-integrations/connectors/destination-postgres/src/main/kotlin/io/airbyte/integrations/destination/postgres/spec/PostgresConfiguration.kt`](../../airbyte-integrations/connectors/destination-postgres/src/main/kotlin/io/airbyte/integrations/destination/postgres/spec/PostgresConfiguration.kt) | Parsed config (`legacyRawTablesOnly` at 24, 53) |
+
+## 8.4 Other Destinations
+
+[§5 Other Destinations](05-other-destinations.md)
+
+### Snowflake
+
+| File | Class / role |
+|------|--------------|
+| [`airbyte-integrations/connectors/destination-snowflake/`](../../airbyte-integrations/connectors/destination-snowflake) | Connector root (image `4.0.41`) |
+| [`airbyte-integrations/connectors/destination-snowflake/src/main/kotlin/io/airbyte/integrations/destination/snowflake/SnowflakeDestination.kt`](../../airbyte-integrations/connectors/destination-snowflake/src/main/kotlin/io/airbyte/integrations/destination/snowflake/SnowflakeDestination.kt) | Micronaut entry point |
+| [`airbyte-integrations/connectors/destination-snowflake/src/main/kotlin/io/airbyte/integrations/destination/snowflake/write/SnowflakeWriter.kt`](../../airbyte-integrations/connectors/destination-snowflake/src/main/kotlin/io/airbyte/integrations/destination/snowflake/write/SnowflakeWriter.kt) | Writer; loader dispatch (Append + AppendTruncate + DedupTruncate) |
+| [`airbyte-integrations/connectors/destination-snowflake/src/main/kotlin/io/airbyte/integrations/destination/snowflake/write/load/SnowflakeRecordFormatter.kt`](../../airbyte-integrations/connectors/destination-snowflake/src/main/kotlin/io/airbyte/integrations/destination/snowflake/write/load/SnowflakeRecordFormatter.kt) | Mode-aware record formatter (injected into checker) |
+| [`airbyte-integrations/connectors/destination-snowflake/src/main/kotlin/io/airbyte/integrations/destination/snowflake/check/SnowflakeChecker.kt`](../../airbyte-integrations/connectors/destination-snowflake/src/main/kotlin/io/airbyte/integrations/destination/snowflake/check/SnowflakeChecker.kt) | `SnowflakeChecker` (line 34); injects formatter at line 38 |
+| [`airbyte-integrations/connectors/destination-snowflake/src/main/kotlin/io/airbyte/integrations/destination/snowflake/sql/SnowflakeDirectLoadSqlGenerator.kt`](../../airbyte-integrations/connectors/destination-snowflake/src/main/kotlin/io/airbyte/integrations/destination/snowflake/sql/SnowflakeDirectLoadSqlGenerator.kt) | SQL generation |
+| [`airbyte-integrations/connectors/destination-snowflake/src/main/kotlin/io/airbyte/integrations/destination/snowflake/schema/SnowflakeTableSchemaMapper.kt`](../../airbyte-integrations/connectors/destination-snowflake/src/main/kotlin/io/airbyte/integrations/destination/snowflake/schema/SnowflakeTableSchemaMapper.kt) | Schema mapper (pattern Postgres mirrored) |
+| [`airbyte-integrations/connectors/destination-snowflake/src/main/kotlin/io/airbyte/integrations/destination/snowflake/write/transform/SnowflakeValueCoercer.kt`](../../airbyte-integrations/connectors/destination-snowflake/src/main/kotlin/io/airbyte/integrations/destination/snowflake/write/transform/SnowflakeValueCoercer.kt) | Value coercion |
+
+### Iceberg / S3 Data Lake
+
+| File | Class / role |
+|------|--------------|
+| [`airbyte-integrations/connectors/destination-s3-data-lake/`](../../airbyte-integrations/connectors/destination-s3-data-lake) | Active connector root (image `0.3.48`) |
+| [`airbyte-integrations/connectors/destination-iceberg/`](../../airbyte-integrations/connectors/destination-iceberg) | Empty husk (metadata + icon only); see [§5.6.2](05-other-destinations.md#562-bring-destination-iceberg-and-destination-s3-data-lake-together) |
+| [`airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/kotlin/io/airbyte/cdk/load/data/iceberg/parquet/AirbyteTypeToIcebergSchema.kt`](../../airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/kotlin/io/airbyte/cdk/load/data/iceberg/parquet/AirbyteTypeToIcebergSchema.kt) | Type conversion; `NumberType → DoubleType` (line 70), PK override → `StringType` (lines 111-114) |
+| [`airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/kotlin/io/airbyte/cdk/load/data/iceberg/parquet/AirbyteValueToIcebergRecord.kt`](../../airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/kotlin/io/airbyte/cdk/load/data/iceberg/parquet/AirbyteValueToIcebergRecord.kt) | Value side; PK stringification at line 68 |
+| [`airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/kotlin/io/airbyte/cdk/load/toolkits/iceberg/parquet/IcebergTableSynchronizer.kt`](../../airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/kotlin/io/airbyte/cdk/load/toolkits/iceberg/parquet/IcebergTableSynchronizer.kt) | Schema sync; deferred `setIdentifierFields` at lines 230, 253, 274 |
+| [`airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/kotlin/io/airbyte/cdk/load/toolkits/iceberg/parquet/IcebergTypesComparator.kt`](../../airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/kotlin/io/airbyte/cdk/load/toolkits/iceberg/parquet/IcebergTypesComparator.kt) | `identifierFieldsChanged` detection (lines 71, 97-99) |
+| [`airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/kotlin/io/airbyte/cdk/load/toolkits/iceberg/parquet/io/IcebergUtil.kt`](../../airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/kotlin/io/airbyte/cdk/load/toolkits/iceberg/parquet/io/IcebergUtil.kt) | `toIcebergSchema(stream)` at line 174; identifier sort fields at 187 |
+
+### MSSQL
+
+| File | Class / role |
+|------|--------------|
+| [`airbyte-integrations/connectors/destination-mssql/`](../../airbyte-integrations/connectors/destination-mssql) | Connector root (image `2.2.16`) |
+| [`airbyte-integrations/connectors/destination-mssql/src/main/kotlin/io/airbyte/integrations/destination/mssql/v2/config/DataSourceFactory.kt`](../../airbyte-integrations/connectors/destination-mssql/src/main/kotlin/io/airbyte/integrations/destination/mssql/v2/config/DataSourceFactory.kt) | `DataSourceFactory` (line 20); SSH tunnel branch 44-57; `createTunnelSession` at 51 |
+| [`airbyte-integrations/connectors/destination-mssql/src/main/kotlin/io/airbyte/integrations/destination/mssql/v2/config/MSSQLSpecification.kt`](../../airbyte-integrations/connectors/destination-mssql/src/main/kotlin/io/airbyte/integrations/destination/mssql/v2/config/MSSQLSpecification.kt) | Spec; SSH at 20-21, 89-107 |
+| [`airbyte-integrations/connectors/destination-mssql/src/main/kotlin/io/airbyte/integrations/destination/mssql/v2/config/MSSQLConfiguration.kt`](../../airbyte-integrations/connectors/destination-mssql/src/main/kotlin/io/airbyte/integrations/destination/mssql/v2/config/MSSQLConfiguration.kt) | Parsed config; SSH at 13, 26, 74 |
+
+### Redshift
+
+| File | Class / role |
+|------|--------------|
+| [`airbyte-integrations/connectors/destination-redshift/`](../../airbyte-integrations/connectors/destination-redshift) | Connector root (Bulk-CDK migration planned, not yet shipped) |
+
+## 8.5 File Transfer
+
+[§6 File Transfer](06-file-transfer.md)
+
+| File | Class / role |
+|------|--------------|
+| [`airbyte-cdk/bulk/toolkits/legacy-task-loader/src/main/kotlin/io/airbyte/cdk/load/message/DestinationMessage.kt`](../../airbyte-cdk/bulk/toolkits/legacy-task-loader/src/main/kotlin/io/airbyte/cdk/load/message/DestinationMessage.kt) | `DestinationFile` (line 357), `DestinationFileStreamComplete` (464), `DestinationFileDomainMessage` sealed interface (71), `FileReference` (342) |
+| [`airbyte-cdk/bulk/toolkits/legacy-task-loader/src/main/kotlin/io/airbyte/cdk/load/message/FileTransferQueueMessageLegacy.kt`](../../airbyte-cdk/bulk/toolkits/legacy-task-loader/src/main/kotlin/io/airbyte/cdk/load/message/FileTransferQueueMessageLegacy.kt) | `FileTransferQueueMessage` sealed interface (line 11); `FileTransferQueueRecord(file: DestinationFile)` (17) |
+| [`airbyte-cdk/bulk/toolkits/legacy-task-loader/src/main/kotlin/io/airbyte/cdk/load/message/DestinationMessageFactory.kt`](../../airbyte-cdk/bulk/toolkits/legacy-task-loader/src/main/kotlin/io/airbyte/cdk/load/message/DestinationMessageFactory.kt) | Factory; file-mode dispatch at 66, 70, 123 |
+| [`airbyte-cdk/bulk/toolkits/legacy-task-loader/src/main/kotlin/io/airbyte/cdk/load/state/PipelineEventBookkeepingRouter.kt`](../../airbyte-cdk/bulk/toolkits/legacy-task-loader/src/main/kotlin/io/airbyte/cdk/load/state/PipelineEventBookkeepingRouter.kt) | Router; routing types (14-21), file-mode dispatch (66), queue insertion (135-145), stream-complete (297) |
+| [`airbyte-cdk/bulk/toolkits/legacy-task-loader/src/main/kotlin/io/airbyte/cdk/load/message/InputMessage.kt`](../../airbyte-cdk/bulk/toolkits/legacy-task-loader/src/main/kotlin/io/airbyte/cdk/load/message/InputMessage.kt) | Input parsing; file branch at 173-180 |
+| [`airbyte-cdk/bulk/toolkits/legacy-task-load-object-storage/src/main/kotlin/io/airbyte/cdk/load/write/object_storage/FilePartAccumulatorLegacy.kt`](../../airbyte-cdk/bulk/toolkits/legacy-task-load-object-storage/src/main/kotlin/io/airbyte/cdk/load/write/object_storage/FilePartAccumulatorLegacy.kt) | Object-storage multipart upload assembly (line 41) |
+
+### Configuration flag
+
+| Knob | Where |
+|------|-------|
+| Micronaut property `airbyte.destination.core.file-transfer.enabled` | Connector `application.yaml` |
+| Test fixture `useFileTransfer: Boolean` | `IntegrationTest`, `DestinationProcess`, `Dockerized/NonDockerizedDestination` (both `core/load` and `legacy-task-loader` testFixtures) |
+
+## 8.6 CI/CD Tooling
+
+[§7 CI/CD Tooling](07-ci-cd-tooling.md)
+
+### Per-module version-bump enforcement
+
+| File | Role |
+|------|------|
+| [`.github/workflows/java-cdk-tests.yml`](../../.github/workflows/java-cdk-tests.yml) | `changes-in-bulk-cdk-packages` (44), `run-check-bulk-cdk-version` (71), `bulk-cdk-version-check-result` aggregator (151) |
+| [`.github/workflows/java-bulk-cdk-base-publish.yml`](../../.github/workflows/java-bulk-cdk-base-publish.yml) | Publish workflow for `core/base` |
+| [`.github/workflows/java-bulk-cdk-extract-publish.yml`](../../.github/workflows/java-bulk-cdk-extract-publish.yml) | Publish workflow for `core/extract` |
+| [`.github/workflows/java-bulk-cdk-load-publish.yml`](../../.github/workflows/java-bulk-cdk-load-publish.yml) | Publish workflow for `core/load` |
+| [`.github/workflows/kotlin-bulk-cdk-dokka-publish.yml`](../../.github/workflows/kotlin-bulk-cdk-dokka-publish.yml) | Dokka API-docs publish |
+
+### Auto-upgrade and connector compatibility
+
+| File | Role |
+|------|------|
+| [`.github/workflows/auto-upgrade-certified-connectors-cdk.yml`](../../.github/workflows/auto-upgrade-certified-connectors-cdk.yml) | Monthly scheduled auto-upgrade (cron line 5) |
+| [`.github/workflows/cdk-destination-connector-compatibility-test.yml`](../../.github/workflows/cdk-destination-connector-compatibility-test.yml) | Connector matrix from `get-certified-connectors.sh destinations` (29); auto-file gh-issue (135) |
+| [`.github/workflows/cdk-source-connector-compatibility-test.yml`](../../.github/workflows/cdk-source-connector-compatibility-test.yml) | Source-side compatibility test |
+| [`.github/workflows/connectors-cdk-version-check.yml`](../../.github/workflows/connectors-cdk-version-check.yml) | Test-only-changes escape hatch |
+| [`tools/bin/bulk-cdk/get-certified-connectors.sh`](../../tools/bin/bulk-cdk/get-certified-connectors.sh) | Source of truth for the auto-upgrade matrix |
+| [`tools/bin/bulk-cdk/auto-upgrade/bump-connector-metadata.sh`](../../tools/bin/bulk-cdk/auto-upgrade/bump-connector-metadata.sh) | Patch-bumps a connector's `dockerImageTag` |
+| [`tools/bin/bulk-cdk/auto-upgrade/populate-connector-changelog.sh`](../../tools/bin/bulk-cdk/auto-upgrade/populate-connector-changelog.sh) | Writes the per-connector changelog entry |
+
+### Slash-command dispatcher and ad-hoc bumps
+
+| File | Role |
+|------|------|
+| [`.github/workflows/slash-commands.yml`](../../.github/workflows/slash-commands.yml) | Slash-command router (`/bump-version` and `/bump-progressive-rollout-version` at lines 69-70) |
+| [`.github/workflows/bump-version-command.yml`](../../.github/workflows/bump-version-command.yml) | Ad-hoc per-connector version bump (`workflow_dispatch` line 28, `bump-version` job 71) |
+| [`.github/workflows/bump-progressive-rollout-version-command.yml`](../../.github/workflows/bump-progressive-rollout-version-command.yml) | Delegates to `bump-version-command.yml` |
+| [`.github/workflows/update-connector-cdk-version-command.yml`](../../.github/workflows/update-connector-cdk-version-command.yml) | Ad-hoc per-connector CDK reference bump |
+| [`.github/workflows/connectors-up-to-date.yml`](../../.github/workflows/connectors-up-to-date.yml) | Periodic check; programmatic version bump at 351 |
+| [`.github/workflows/publish-java-cdk-command.yml`](../../.github/workflows/publish-java-cdk-command.yml) | Manual Java CDK publish |
+
+---
+
+[Back to Index](../../KNOWLEDGE-TRANSFER.md)


### PR DESCRIPTION
## Summary

- Adds a multi-file knowledge transfer doc set rooted at [`KNOWLEDGE-TRANSFER.md`](../blob/benoit/knowledge-transfer-multifile/KNOWLEDGE-TRANSFER.md) with eight topic files under [`docs/knowledge-transfer/`](../tree/benoit/knowledge-transfer-multifile/docs/knowledge-transfer).
- Mirrors the structure of [airbytehq/airbyte-platform-internal#18924](https://github.com/airbytehq/airbyte-platform-internal/pull/18924): numbered sections, mermaid sequence diagrams, "Past Issues" and "Potential Improvements" subsections, and a master file-paths appendix.
- Scope is intentionally narrow: my work on the **Bulk CDK** and destination connectors from November 2024 through April 2026. Earlier (2022) platform work lives in `airbyte-platform-internal` and is covered there.

## What's in here

| # | Section | Topic |
|---|---------|-------|
| 1 | [Overview](../blob/benoit/knowledge-transfer-multifile/docs/knowledge-transfer/01-overview.md) | Area map and how the sections connect |
| 2 | [Bulk CDK](../blob/benoit/knowledge-transfer-multifile/docs/knowledge-transfer/02-bulk-cdk.md) | Dataflow pipeline, lifecycle, `AirbyteValueCoercer`, independent SemVer modules |
| 3 | [Destination ClickHouse](../blob/benoit/knowledge-transfer-multifile/docs/knowledge-transfer/03-clickhouse.md) | Ground-up rewrite, `ReplacingMergeTree`-based dedup, JSON-as-String |
| 4 | [Destination Postgres](../blob/benoit/knowledge-transfer-multifile/docs/knowledge-transfer/04-destination-postgres.md) | Direct Load migration, raw-tables-only mode, OSS/Cloud checker split, schema-utility refactor |
| 5 | [Snowflake / Iceberg-S3-Data-Lake / MSSQL / Redshift](../blob/benoit/knowledge-transfer-multifile/docs/knowledge-transfer/05-other-destinations.md) | Snowflake checker refactor, Iceberg PK type mapping & identifier-field deferral, MSSQL SSH tunnel, Redshift plan |
| 6 | [File Transfer](../blob/benoit/knowledge-transfer-multifile/docs/knowledge-transfer/06-file-transfer.md) | `DestinationFile` message, legacy task-loader toolkit, opt-in via Micronaut property |
| 7 | [CI/CD Tooling](../blob/benoit/knowledge-transfer-multifile/docs/knowledge-transfer/07-ci-cd-tooling.md) | Per-module version-bump enforcement, monthly auto-upgrade workflow, test-only-changes escape hatch |
| 8 | [Appendix: Key File Paths](../blob/benoit/knowledge-transfer-multifile/docs/knowledge-transfer/08-appendix-key-file-paths.md) | Master clickable table of every file referenced |

## How it was produced

- **Source of contributions:** `gh search prs --author benmoriceau --repo airbytehq/airbyte` + `git log --author='Benoit Moriceau'` (~336 commits / 250+ merged PRs).
- **Code verification:** an `explore` subagent re-read every cited class, file, and line before drafting; it surfaced 12 inaccuracies in the initial draft (wrong class names, wrong connector versions, wrong type-mapping claims, etc.) that have been corrected.
- **Final sanity check:** every path cited in the docs was re-tested with `[ -f <path> ]` after writing; all resolve.

Audience is the team members who will pick up these systems. Each section ends with a "Past Issues" subsection capturing real PR-level incidents and a forward-looking "Potential Improvements" subsection with a pragmatic-note caveat.

## Reviewer notes

- The docs are non-shipping (Markdown only under `docs/`); no code or workflow files are touched.
- The OpenCode skill used to produce these is `knowledge-transfer-docs` (already present at `~/.config/opencode/skills/knowledge-transfer-docs/`). The PR follows that skill's conventions exactly.
- Suggestions on trims, reorderings, or "this section should also mention X" are welcome -- the structure is intentionally append-friendly.