### PR TITLE
fix(source-greenhouse): reduce default concurrency to 3

### DIFF
--- a/airbyte-integrations/connectors/source-greenhouse/manifest.yaml
+++ b/airbyte-integrations/connectors/source-greenhouse/manifest.yaml
@@ -1798,11 +1798,11 @@ streams:
 #
 # Starting concurrency followed the connector concurrency tuning playbook:
 # floor(5 / 4) = 1 ≤ 2 triggered the low-rate-limit special case →
-# starting_concurrency = 4, step = 1. Empirical tuning iterates upward
-# in steps of 1 against the documented 5 req/sec ceiling.
+# starting_concurrency = 4, step = 1. Empirical tuning adjusts by 1
+# against the documented 5 req/sec ceiling.
 concurrency_level:
   type: ConcurrencyLevel
-  default_concurrency: 5
+  default_concurrency: 3
   max_concurrency: 16
 
 spec:

--- a/airbyte-integrations/connectors/source-greenhouse/metadata.yaml
+++ b/airbyte-integrations/connectors/source-greenhouse/metadata.yaml
@@ -10,7 +10,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 59f1e50a-331f-4f09-b3e8-2e8d4d355f44
-  dockerImageTag: 0.7.22-rc.2
+  dockerImageTag: 0.7.22-rc.3
   dockerRepository: airbyte/source-greenhouse
   documentationUrl: https://docs.airbyte.com/integrations/sources/greenhouse
   githubIssueLabel: source-greenhouse

--- a/docs/integrations/sources/greenhouse.md
+++ b/docs/integrations/sources/greenhouse.md
@@ -74,7 +74,7 @@ The Greenhouse connector should not run into Greenhouse API limitations under no
 
 | Version    | Date       | Pull Request                                             | Subject                                                                                                                                                                |
 |:-----------|:-----------|:---------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| 0.7.22-rc.3 | 2026-05-12 | [*PR_NUMBER_PLACEHOLDER*](https://github.com/airbytehq/airbyte/pull/*PR_NUMBER_PLACEHOLDER*) | Reduce default_concurrency to 3 for concurrency tuning after rate-limit failures at higher settings. |
+| 0.7.22-rc.3 | 2026-05-12 | [78052](https://github.com/airbytehq/airbyte/pull/78052) | Reduce default_concurrency to 3 for concurrency tuning after rate-limit failures at higher settings. |
 | 0.7.22-rc.2 | 2026-05-08 | [78006](https://github.com/airbytehq/airbyte/pull/78006) | Concurrency tuning iteration: bump default_concurrency to 5 |
 | 0.7.22-rc.1 | 2026-05-06 | [77826](https://github.com/airbytehq/airbyte/pull/77826) | Start concurrency tuning at default_concurrency=4 (Path A) and enable progressive rollout |
 | 0.7.21 | 2026-04-28 | [77287](https://github.com/airbytehq/airbyte/pull/77287) | Update dependencies |

--- a/docs/integrations/sources/greenhouse.md
+++ b/docs/integrations/sources/greenhouse.md
@@ -74,6 +74,7 @@ The Greenhouse connector should not run into Greenhouse API limitations under no
 
 | Version    | Date       | Pull Request                                             | Subject                                                                                                                                                                |
 |:-----------|:-----------|:---------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 0.7.22-rc.3 | 2026-05-12 | [*PR_NUMBER_PLACEHOLDER*](https://github.com/airbytehq/airbyte/pull/*PR_NUMBER_PLACEHOLDER*) | Reduce default_concurrency to 3 for concurrency tuning after rate-limit failures at higher settings. |
 | 0.7.22-rc.2 | 2026-05-08 | [78006](https://github.com/airbytehq/airbyte/pull/78006) | Concurrency tuning iteration: bump default_concurrency to 5 |
 | 0.7.22-rc.1 | 2026-05-06 | [77826](https://github.com/airbytehq/airbyte/pull/77826) | Start concurrency tuning at default_concurrency=4 (Path A) and enable progressive rollout |
 | 0.7.21 | 2026-04-28 | [77287](https://github.com/airbytehq/airbyte/pull/77287) | Update dependencies |


### PR DESCRIPTION
## What
Reduces `source-greenhouse` default concurrency from `5` to `3` for the next Path A tuning candidate after rate-limit retries were observed at higher concurrency settings.

## How
Updates the declarative manifest `concurrency_level.default_concurrency` to `3`, bumps the progressive-rollout RC tag to `0.7.22-rc.3`, and adds the connector changelog entry for this PR.

## Review guide
1. `airbyte-integrations/connectors/source-greenhouse/manifest.yaml`
2. `airbyte-integrations/connectors/source-greenhouse/metadata.yaml`
3. `docs/integrations/sources/greenhouse.md`

## User Impact
Greenhouse syncs using this RC will run with a lower default concurrency setting to reduce rate-limit pressure while preserving progressive rollout behavior.

## Can this PR be safely reverted and rolled back?
- [x] YES 💚
- [ ] NO ❌

## Testing
- `uv run --with pyyaml python - <<'PY' ...` to parse `manifest.yaml` and `metadata.yaml`
- `uvx pre-commit run prettier --files airbyte-integrations/connectors/source-greenhouse/manifest.yaml airbyte-integrations/connectors/source-greenhouse/metadata.yaml`
- `uvx --from poethepoet poe format-check`
- `uvx --from poethepoet poe test-unit-tests` (`1 passed`)
- `git diff --check`

---
[Devin session](https://app.devin.ai/sessions/9f063eb099b24f8c90f4c28ebc857698)

Requested by: @sophiecuiy