### PR TITLE
docs(ai-agents): add Agent CLI interface section

### DIFF
--- a/docs/ai-agents/README.md
+++ b/docs/ai-agents/README.md
@@ -25,7 +25,7 @@ Airbyte Agents is a data and context layer for AI agents. It gives your agents r
 
 <Grid columns="2">
 
-<CardWithIcon title="Interfaces" description="Choose how to work with your data: the web app, MCP server, Python SDK, or API." ctaText="Interfaces" ctaLink="/ai-agents/interfaces/" icon="fa-plug" />
+<CardWithIcon title="Interfaces" description="Choose how to work with your data: the web app, MCP server, Python SDK, CLI, or API." ctaText="Interfaces" ctaLink="/ai-agents/interfaces/" icon="fa-plug" />
 
 <CardWithIcon title="Agent connectors" description="Browse the catalog of open-source connectors that equip agents to call third-party APIs." ctaText="Agent connectors" ctaLink="/ai-agents/connectors/" icon="fa-puzzle-piece" />
 

--- a/docs/ai-agents/admin/sessions.md
+++ b/docs/ai-agents/admin/sessions.md
@@ -16,7 +16,7 @@ A session is a single agent run, from the moment an agent starts working to the 
 - The input and output tokens the agent consumed.
 - The resulting AOs charged to your plan.
 
-Airbyte logs sessions for work initiated in the web app. Work initiated through [MCP](../interfaces/mcp/readme.md), the [API](../reference/api/readme.md), or the [SDK](../interfaces/sdk/readme.md) is billed by tool call but isn't logged as a session. See [Session types](#session-types) for details.
+Airbyte logs sessions for work initiated in the web app. Work initiated through [MCP](../interfaces/mcp/readme.md), the [API](../reference/api/readme.md), the [SDK](../interfaces/sdk/readme.md), or the [CLI](../interfaces/cli/readme.md) is billed by tool call but isn't logged as a session. See [Session types](#session-types) for details.
 
 ## How to understand the Sessions table
 
@@ -60,6 +60,7 @@ Airbyte also processes tool calls from these sources, but doesn't log them as se
 - **[MCP](../interfaces/mcp/readme.md)**: Tool calls from agents connected through the Model Context Protocol.
 - **[API](../reference/api/readme.md)**: Direct calls to the Agent API.
 - **[SDK](../interfaces/sdk/readme.md)**: Calls made from an agent built with the Agent SDK.
+- **[CLI](../interfaces/cli/readme.md)**: Calls made from `airbyte-agent`. Because the CLI is a thin wrapper over the Agent API, these tool calls appear under the **API** source in the Usage panel.
 
 These tool calls still consume AOs and appear in your [Usage panel](./billing.md#monitor-usage), but they don't have a corresponding Sessions row. To review them, open the Usage panel on the Billing page and filter by the **MCP**, **API**, or **SDK** source.
 

--- a/docs/ai-agents/concepts/agent-operations.md
+++ b/docs/ai-agents/concepts/agent-operations.md
@@ -29,6 +29,8 @@ Any interaction with an agent consumes AOs. The source of the interaction determ
 | **API**                     | Direct calls to the Agent API.                                              | No                    | Yes                 |
 | **SDK**                     | Calls from an agent built with the Agent SDK.                               | No                    | Yes                 |
 
+Calls from the [CLI](../interfaces/cli/readme.md) (`airbyte-agent`) consume AOs the same way other API clients do; the CLI is a thin wrapper over the Agent API, so its tool calls are tracked under the **API** source rather than as a separate row.
+
 Sources tracked as sessions appear on the [Sessions](../admin/sessions.md) page, where you can review the full conversation and tool calls. Sources that aren't tracked as sessions still consume AOs and appear in the [Usage panel](../admin/billing.md#monitor-usage) on the Billing page. To inspect individual tool calls from MCP, API, or SDK usage, use the [Tool calls](../admin/tool-calls.md) page.
 
 ## How AOs relate to billing

--- a/docs/ai-agents/concepts/architecture/connectors-and-credentials.md
+++ b/docs/ai-agents/concepts/architecture/connectors-and-credentials.md
@@ -54,7 +54,7 @@ Airbyte Agents uses a two-layer credential model.
 
 ### Platform credentials
 
-Platform credentials identify your organization with Airbyte. When you sign in to the web app, Airbyte authenticates you behind the scenes. For programmatic access through the API, SDK, or MCP server, your organization's `client_id`, `client_secret`, and `organization_id` (available on the [Profile page](../../admin/profile)) serve the same purpose. The platform uses these to issue short-lived tokens.
+Platform credentials identify your organization with Airbyte. When you sign in to the web app, Airbyte authenticates you behind the scenes. For programmatic access through the API, SDK, CLI, or MCP server, your organization's `client_id`, `client_secret`, and `organization_id` (available on the [Profile page](../../admin/profile)) serve the same purpose. The platform uses these to issue short-lived tokens.
 
 | Token type | Scope | Lifetime | Use case |
 | --- | --- | --- | --- |
@@ -74,7 +74,7 @@ Airbyte stores all connector credentials securely. You provide them once, and Ai
 
 ### Add once, use everywhere
 
-Credentials you add through one interface are available to all of them. A connector configured in the web app works through the API, SDK, or MCP server without re-entering credentials. This applies to every interface in the platform.
+Credentials you add through one interface are available to all of them. A connector configured in the web app works through the API, SDK, CLI, or MCP server without re-entering credentials. This applies to every interface in the platform.
 
 ## Security
 

--- a/docs/ai-agents/concepts/architecture/readme.md
+++ b/docs/ai-agents/concepts/architecture/readme.md
@@ -7,14 +7,15 @@ sidebar_position: 3
 
 Airbyte Agents is a cloud platform that gives AI agents authenticated, structured access to third-party SaaS data. It stores credentials, manages token refresh, and exposes a uniform execution interface so agents can read, search, and write data across dozens of services.
 
-You can interact with the platform through four interfaces. They all connect to the same service, so credentials you configure through one interface are available to all of them.
+You can interact with the platform through five interfaces. They all connect to the same service, so credentials you configure through one interface are available to all of them.
 
 - [**Web app**](../../interfaces/ui) at [app.airbyte.ai](https://app.airbyte.ai): Talk to an Airbyte-hosted agent in Chats, or define Automations that run manually or on a schedule.
 - [**API**](../../interfaces/api): HTTP endpoints for managing connectors, tokens, and executing operations from any language.
 - [**SDK**](../../interfaces/sdk): Python SDK for building agents that authenticate, connect, and execute operations in your own code.
+- [**CLI**](../../interfaces/cli): A single Go binary (`airbyte-agent`) that wraps the API for shell scripts, CI jobs, and AI-agent harnesses.
 - [**MCP server**](../../interfaces/mcp): A remote Model Context Protocol server that connects MCP-capable agents like Claude, Cursor, and ChatGPT to your data.
 
-![System architecture diagram showing Interfaces (Web app, API, SDK, MCP server) connecting to Airbyte Agents (Authentication and token management, Execution engine with Search and Direct modes, Context Store) which interacts with Third-party services (CRM, Support desk, Analytics, and more).](/img/ai-agents-system-architecture.svg)
+![System architecture diagram showing Interfaces (Web app, API, SDK, CLI, MCP server) connecting to Airbyte Agents (Authentication and token management, Execution engine with Search and Direct modes, Context Store) which interacts with Third-party services (CRM, Support desk, Analytics, and more).](/img/ai-agents-system-architecture.svg)
 
 ## Resource hierarchy
 
@@ -41,7 +42,7 @@ flowchart TB
 
 Airbyte Agents uses a two-layer credential model.
 
-- **Platform credentials** identify your organization with Airbyte. When you sign in to the web app, Airbyte authenticates you behind the scenes. For the API, SDK, and MCP server, your organization's `client_id` and `client_secret` (available on the Profile page at [app.airbyte.ai](https://app.airbyte.ai)) serve the same purpose.
+- **Platform credentials** identify your organization with Airbyte. When you sign in to the web app, Airbyte authenticates you behind the scenes. For the API, SDK, CLI, and MCP server, your organization's `client_id` and `client_secret` (available on the Profile page at [app.airbyte.ai](https://app.airbyte.ai)) serve the same purpose.
 - **Connector credentials** authenticate with each third-party service. When you add a connector, you provide the service's API key, OAuth tokens, or other credentials. Airbyte stores them securely and handles token refresh at execution time.
 
 Add credentials once through any interface and every other interface can use them. For details, see [Connectors and credentials](./connectors-and-credentials).

--- a/docs/ai-agents/concepts/architecture/workspaces.md
+++ b/docs/ai-agents/concepts/architecture/workspaces.md
@@ -9,7 +9,7 @@ A workspace is an isolation boundary within an [organization](./organizations). 
 
 ## The default workspace
 
-Every organization starts with a workspace named `default`. Most people use this single workspace and never need to create additional ones. The web app, SDK, API, and MCP server all target the `default` workspace unless you specify otherwise.
+Every organization starts with a workspace named `default`. Most people use this single workspace and never need to create additional ones. The web app, SDK, API, CLI, and MCP server all target the `default` workspace unless you specify otherwise.
 
 ## When to create additional workspaces
 

--- a/docs/ai-agents/concepts/connect-ask-act.md
+++ b/docs/ai-agents/concepts/connect-ask-act.md
@@ -15,7 +15,7 @@ The platform manages the hard parts of connecting to third-party systems:
 
 - **Authentication.** The platform handles OAuth flows, API keys, and token refresh for you. Store end-user credentials once and use them from any interface.
 - **Multi-tenancy.** [Workspaces](../interfaces/sdk/workspaces) isolate connectors and credentials across tenants, teams, or environments within an organization.
-- **Multiple interfaces.** Use connectors through the [web app](../interfaces/ui) in chats and automations, the [Python SDK](../interfaces/sdk), the [HTTP API](../interfaces/api), or the [MCP server](../interfaces/mcp), whichever fits your stack.
+- **Multiple interfaces.** Use connectors through the [web app](../interfaces/ui) in chats and automations, the [Python SDK](../interfaces/sdk), the [Agent API](../interfaces/api), the [CLI](../interfaces/cli), or the [MCP server](../interfaces/mcp), whichever fits your stack.
 
 Connecting a new data source takes minutes, not weeks. You don't build or maintain API wrappers, manage credential storage, or handle token lifecycle.
 
@@ -45,7 +45,7 @@ execute(entity, action, params)
 - **Read.** `list`, `get`, and `search` retrieve records from a connector. When the Context Store is on, `context_store_search` provides fast, indexed retrieval.
 - **Write.** `create`, `update`, and `delete` push changes back to the source system, such as creating a ticket, updating a contact, or sending a message.
 
-This pattern is the same across every connector and every interface. Whether an agent runs in the web app, through the SDK, over the API, or via MCP, it calls the same entities and actions with the same parameters.
+This pattern is the same across every connector and every interface. Whether an agent runs in the web app, through the SDK, over the API, via the CLI, or via MCP, it calls the same entities and actions with the same parameters.
 
 Airbyte Agents act through two modes:
 

--- a/docs/ai-agents/concepts/readme.md
+++ b/docs/ai-agents/concepts/readme.md
@@ -10,8 +10,8 @@ This section covers the building blocks of Airbyte Agents: the models, resources
 - [**Connect, Ask, Act**](./connect-ask-act.md): The three-layer model at the heart of the platform. Connect agents to any system through managed connectors, ask questions across all your data in one searchable layer, and let agents act on that data in real time.
 - [**Agent operations**](./agent-operations.md): The unit of work in Airbyte Agents. Learn how tool calls and token usage combine into agent operations, and how AOs relate to your plan's billing.
 - [**Context Store**](./context-store.md): A managed, searchable replica of your connector data. The Context Store gives agents fast, indexed access to business data without live API crawls.
-- [**System architecture**](./architecture/readme.md): How the platform is organized. Covers the four interfaces, the resource hierarchy of organizations, workspaces, and connectors, and the execution model that routes agent requests.
-- [**Time zones**](./time-zones.md): How Airbyte Agents stores, displays, and schedules dates and times across the web app, API, SDK, and MCP server.
+- [**System architecture**](./architecture/readme.md): How the platform is organized. Covers the five interfaces, the resource hierarchy of organizations, workspaces, and connectors, and the execution model that routes agent requests.
+- [**Time zones**](./time-zones.md): How Airbyte Agents stores, displays, and schedules dates and times across the web app, API, SDK, CLI, and MCP server.
 
 import DocCardList from '@theme/DocCardList';
 

--- a/docs/ai-agents/concepts/time-zones.md
+++ b/docs/ai-agents/concepts/time-zones.md
@@ -11,7 +11,7 @@ Airbyte Agents handles dates and times the same way across every interface: disp
 
 - **Display**: The [web app](../interfaces/ui) formats every date and time in the local time zone set in your browser.
 - **Storage**: The backend stores every timestamp in UTC.
-- **Data in transit**: The [API](../interfaces/api), [SDK](../interfaces/sdk), and [MCP server](../interfaces/mcp) read and return timestamps in UTC, formatted as ISO 8601 strings.
+- **Data in transit**: The [API](../interfaces/api), [SDK](../interfaces/sdk), [CLI](../interfaces/cli), and [MCP server](../interfaces/mcp) read and return timestamps in UTC, formatted as ISO 8601 strings.
 - **Automation schedules**: You pick a time zone per Automation. Airbyte stores it as an [IANA time zone identifier](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones) (for example, `America/New_York` or `Asia/Kolkata`).
 
 ## Display in the web app
@@ -26,6 +26,7 @@ All timestamps are UTC on the backend, and every interface that reads or writes 
 
 - **API**: Request and response bodies use ISO 8601 UTC strings (for example, `2026-03-18T13:32:00Z`).
 - **SDK**: The Python SDK returns the same ISO 8601 UTC strings through its response models.
+- **CLI**: `airbyte-agent` returns the API's UTC strings unchanged. The CLI doesn't apply any local-time formatting on top.
 - **MCP server**: Tools that return timestamps return them in UTC. The `current_datetime` tool, which an agent calls to resolve relative dates like "today" or "last week," returns the current UTC time.
 
 :::warning

--- a/docs/ai-agents/get-started/choose-how-to-use.md
+++ b/docs/ai-agents/get-started/choose-how-to-use.md
@@ -6,7 +6,7 @@ sidebar_label: Choose how to use Airbyte Agents
 
 # Choose how to use Airbyte Agents
 
-Airbyte Agents offers four interfaces. They all share the same platform, the same connectors, and the same [Context Store](../concepts/context-store), so you can start with one and add others as your needs grow.
+Airbyte Agents offers five interfaces. They all share the same platform, the same connectors, and the same [Context Store](../concepts/context-store), so you can start with one and add others as your needs grow.
 
 Use the flowchart below to find the best starting point, then read the section that matches your path.
 
@@ -15,11 +15,13 @@ flowchart TD
     START(["How do you want to use<br/>Airbyte Agents?"])
     START -->|"I already use Claude,<br/>Cursor, or ChatGPT"| MCP["MCP server"]
     START -->|"I'm building a<br/>Python agent"| SDK["Python SDK"]
+    START -->|"I want a shell-first<br/>or agent-harness tool"| CLI["CLI"]
     START -->|"No code needed"| WEB["Web app"]
     START -->|"Non-Python backend<br/>or custom admin"| API["HTTP API"]
 
     click MCP "#mcp-server"
     click SDK "#python-sdk"
+    click CLI "#cli"
     click WEB "#web-app"
     click API "#http-api"
 ```
@@ -61,6 +63,18 @@ Two primary surfaces:
 
 **Get started:** Sign up at [app.airbyte.ai](https://app.airbyte.ai), add a connector on the Connectors page, and open New Chat.
 
+## CLI
+
+**Best for:** Shell scripts, CI jobs, and AI-agent harnesses (Claude Code, Codex, and similar) that shell out for tool calls.
+
+The [CLI](../interfaces/cli) (`airbyte-agent`) is a single Go binary that exposes Airbyte Agents as `airbyte-agent <resource> <operation>` with JSON-in, JSON-out, schema introspection via `--describe`, and stable exit codes. Install once, authenticate with the same `AIRBYTE_CLIENT_ID` and `AIRBYTE_CLIENT_SECRET` you use with the SDK, and your agent (or your shell) can immediately run connector operations against any workspace.
+
+```bash
+brew install airbytehq/tap/airbyte-agent
+```
+
+**Get started:** See the [CLI docs](../interfaces/cli) for install, authentication, and the quickstarts for listing workspaces, adding a connector, and executing an action. The bundled [agent skills](../interfaces/cli/using-with-ai-agents#install-the-bundled-skills) can be installed straight into a Claude Code or compatible harness with `npx skills add airbytehq/airbyte-agent-cli`.
+
 ## HTTP API
 
 **Best for:** Backend engineers, non-Python stacks, custom admin flows, and embedding the authentication module in your application.
@@ -71,6 +85,6 @@ The [HTTP API](../interfaces/api) exposes REST endpoints for managing connectors
 
 ## All paths lead to the same data
 
-Whichever interface you choose, your agents work with the same connectors, the same credentials, and the same Context Store. A connector you add in the web app is immediately available through the SDK, API, and MCP server. You can mix and match interfaces as your needs evolve.
+Whichever interface you choose, your agents work with the same connectors, the same credentials, and the same Context Store. A connector you add in the web app is immediately available through the SDK, CLI, API, and MCP server. You can mix and match interfaces as your needs evolve.
 
 For a deeper look at how the platform is organized, see [System architecture](../concepts/architecture).

--- a/docs/ai-agents/get-started/choose-how-to-use.md
+++ b/docs/ai-agents/get-started/choose-how-to-use.md
@@ -17,13 +17,13 @@ flowchart TD
     START -->|"I'm building a<br/>Python agent"| SDK["Python SDK"]
     START -->|"I want a shell-first<br/>or agent-harness tool"| CLI["CLI"]
     START -->|"No code needed"| WEB["Web app"]
-    START -->|"Non-Python backend<br/>or custom admin"| API["HTTP API"]
+    START -->|"Non-Python backend<br/>or custom admin"| API["Agent API"]
 
     click MCP "#mcp-server"
     click SDK "#python-sdk"
     click CLI "#cli"
     click WEB "#web-app"
-    click API "#http-api"
+    click API "#agent-api"
 ```
 
 ## MCP server
@@ -75,11 +75,11 @@ brew install airbytehq/tap/airbyte-agent
 
 **Get started:** See the [CLI docs](../interfaces/cli) for install, authentication, and the quickstarts for listing workspaces, adding a connector, and executing an action. The bundled [agent skills](../interfaces/cli/using-with-ai-agents#install-the-bundled-skills) can be installed straight into a Claude Code or compatible harness with `npx skills add airbytehq/airbyte-agent-cli`.
 
-## HTTP API
+## Agent API
 
 **Best for:** Backend engineers, non-Python stacks, custom admin flows, and embedding the authentication module in your application.
 
-The [HTTP API](../interfaces/api) exposes REST endpoints for managing connectors, tokens, and executing operations from any language or backend service. Use it when you need programmatic control over Airbyte Agents from a stack that isn't Python, or when you're building a custom integration layer.
+The [Agent API](../interfaces/api) exposes REST endpoints for managing connectors, tokens, and executing operations from any language or backend service. Use it when you need programmatic control over Airbyte Agents from a stack that isn't Python, or when you're building a custom integration layer.
 
 **Get started:** See the [API docs](../interfaces/api) for authentication, connector management, and execution endpoints. The [Developer Quickstart](developer-quickstart) also covers common patterns.
 

--- a/docs/ai-agents/get-started/readme.md
+++ b/docs/ai-agents/get-started/readme.md
@@ -21,6 +21,8 @@ New to Airbyte Agents? Start here. Learn what the product is, choose the right i
 
 <CardWithIcon title="MCP server" description="Connect MCP-capable agents like Claude, Cursor, and ChatGPT to your data." ctaText="MCP server" ctaLink="/ai-agents/interfaces/mcp/" icon="fa-plug" />
 
+<CardWithIcon title="CLI" description="Shell out to airbyte-agent from scripts, CI, and AI-agent harnesses." ctaText="CLI" ctaLink="/ai-agents/interfaces/cli/" icon="fa-terminal" />
+
 <CardWithIcon title="API" description="Integrate Airbyte Agents into any language or framework over HTTP." ctaText="API" ctaLink="/ai-agents/interfaces/api/" icon="fa-code" />
 
 </Grid>

--- a/docs/ai-agents/get-started/what-is-airbyte-agents.md
+++ b/docs/ai-agents/get-started/what-is-airbyte-agents.md
@@ -8,7 +8,7 @@ sidebar_label: What is Airbyte Agents?
 
 Airbyte Agents gives AI agents reliable, real-time access to your business data. It connects agents to the tools your organization runs on, unifies that data into one searchable layer, and lets agents read, search, and write across every connected system.
 
-You get managed connectors, secure credential storage, and a pre-indexed Context Store that agents can query in milliseconds. Whether you use the web app, the Agent MCP, the Agent SDK, or the Agent API, your agents work with the same data, the same connectors, and the same permissions.
+You get managed connectors, secure credential storage, and a pre-indexed Context Store that agents can query in milliseconds. Whether you use the web app, the Agent MCP, the Agent SDK, the Agent CLI, or the Agent API, your agents work with the same data, the same connectors, and the same permissions.
 
 Sign up for free at [app.airbyte.ai](https://app.airbyte.ai).
 
@@ -92,15 +92,17 @@ The interface is the same across every connector and every access path. Airbyte 
 
 - **Operations teams and individual users** who want their AI tools to work with real business data, no coding required.
 
-## Four ways to use it
+## Five ways to use it
 
-Airbyte Agents supports four interfaces. They all connect to the same platform, so connectors and credentials you configure through one interface are available to all of them.
+Airbyte Agents supports five interfaces. They all connect to the same platform, so connectors and credentials you configure through one interface are available to all of them.
 
 - [**Web app**](../interfaces/ui): Chat with an Airbyte-hosted agent or build scheduled Automations. No code required.
 
 - [**MCP server**](../interfaces/mcp): Connect MCP-capable agents like ChatGPT, Claude, and Cursor to your data. Nothing to install.
 
 - [**Python SDK**](../interfaces/sdk): Build agents with typed connectors, automatic credential handling, and framework integrations.
+
+- [**CLI**](../interfaces/cli): A single Go binary (`airbyte-agent`) for shell scripts, CI jobs, and AI-agent harnesses that prefer shelling out for tool calls.
 
 - [**Agent API**](../interfaces/api): Manage connectors, tokens, and execution from any language or backend.
 

--- a/docs/ai-agents/interfaces/api/readme.md
+++ b/docs/ai-agents/interfaces/api/readme.md
@@ -1,6 +1,6 @@
 ---
 plan: all
-sidebar_position: 3
+sidebar_position: 4
 ---
 
 import SdkVsApi from '@site/static/_ai-agents-sdk-vs-api.md';

--- a/docs/ai-agents/interfaces/api/readme.md
+++ b/docs/ai-agents/interfaces/api/readme.md
@@ -15,6 +15,8 @@ This section walks through the four operations most apps need: authenticate, add
 
 <SdkVsApi />
 
+For the no-code option, see the [web app](../ui); for MCP-capable clients, see the [MCP server](../mcp).
+
 ## Base URL
 
 All API requests use the base URL `https://api.airbyte.ai`.

--- a/docs/ai-agents/interfaces/cli/_category_.json
+++ b/docs/ai-agents/interfaces/cli/_category_.json
@@ -1,0 +1,4 @@
+{
+  "label": "CLI",
+  "description": "Drive Airbyte Agents from your shell or AI-agent harness."
+}

--- a/docs/ai-agents/interfaces/cli/add-connector.md
+++ b/docs/ai-agents/interfaces/cli/add-connector.md
@@ -19,7 +19,7 @@ The CLI deliberately doesn't accept third-party credentials (API keys, OAuth tok
 airbyte-agent connectors list-available
 ```
 
-The output lists every connector the CLI can create. Each row has a name like `hubspot`, `linear`, or `stripe`; that's the value you pass as `name` when you create the connector.
+The output is a wrapped list (`{"data": [...]}`) where each row has both a display `name` (for example, `HubSpot`, `Google Drive`, `GitHub`) and a slugified `connector_name` (for example, `hubspot`, `google-drive`, `github`). The CLI matches the value you pass as `name` to `connectors create` against the display `name` field, case-insensitively, so `"HubSpot"`, `"hubspot"`, and `"HUBSPOT"` all resolve to the same connector. Display names with spaces (`"Google Drive"`) must be passed verbatim, including the space.
 
 If you already know the connector type, you can skip this step.
 
@@ -28,7 +28,7 @@ If you already know the connector type, you can skip this step.
 ```bash
 airbyte-agent connectors create --json '{
   "workspace": "default",
-  "name": "hubspot"
+  "name": "HubSpot"
 }'
 ```
 

--- a/docs/ai-agents/interfaces/cli/add-connector.md
+++ b/docs/ai-agents/interfaces/cli/add-connector.md
@@ -16,7 +16,7 @@ The CLI deliberately doesn't accept third-party credentials (API keys, OAuth tok
 ## Find an available connector
 
 ```bash
-airbyte-agent connectors list-available --format table
+airbyte-agent connectors list-available
 ```
 
 The output lists every connector the CLI can create. Each row has a name like `hubspot`, `linear`, or `stripe`; that's the value you pass as `name` when you create the connector.
@@ -52,7 +52,7 @@ airbyte-agent connectors create --json '{
 
 ## Timeouts and re-tries
 
-The default credential-flow timeout is 180 seconds. If the browser tab idles too long, the CLI returns a `validation_error` and you can re-run the command. Raise the timeout for slow flows:
+The default credential-flow timeout is 180 seconds. If the browser tab idles too long, the command returns successfully with a result like `{"error": "timeout", "message": "Credential flow timed out after 3m0s", "session_id": "..."}` and exit code `0`, and you can re-run it. Raise the timeout for slow flows:
 
 ```bash
 AIRBYTE_CREDENTIAL_TIMEOUT=300 airbyte-agent connectors create --json '{...}'
@@ -65,7 +65,7 @@ If the browser doesn't open automatically (for example, on a headless machine), 
 After creating a connector, confirm it's in the workspace:
 
 ```bash
-airbyte-agent connectors list --json '{"workspace": "default"}' --format table
+airbyte-agent connectors list --json '{"workspace": "default"}'
 ```
 
 ## Next steps

--- a/docs/ai-agents/interfaces/cli/add-connector.md
+++ b/docs/ai-agents/interfaces/cli/add-connector.md
@@ -13,13 +13,13 @@ The CLI creates connectors through `connectors create`, which opens a browser ta
 The CLI deliberately doesn't accept third-party credentials (API keys, OAuth tokens, passwords) as parameters or on stdin. If an agent or script needs a new connector, it must run `connectors create` and let the browser flow handle the credential exchange. This keeps secrets out of shell history, prompt logs, and agent transcripts.
 :::
 
-## Find an available connector template
+## Find an available connector
 
 ```bash
 airbyte-agent connectors list-available --format table
 ```
 
-The output lists every connector template the CLI can create. Each row has a name (for example, `hubspot`, `linear`, `stripe`) — that's the value you pass as `name` when you create the connector.
+The output lists every connector the CLI can create. Each row has a name (for example, `hubspot`, `linear`, `stripe`) — that's the value you pass as `name` when you create the connector.
 
 If you already know the connector type, you can skip this step.
 
@@ -34,8 +34,8 @@ airbyte-agent connectors create --json '{
 
 What happens:
 
-1. The CLI resolves the template by name and mints a short-lived widget token for the web app.
-2. It opens a browser tab against the Airbyte web app's credential bridge for that template.
+1. The CLI resolves the connector by name and mints a short-lived widget token for the web app.
+2. It opens a browser tab against the Airbyte web app's credential bridge for that connector.
 3. You sign in to the third-party service in the browser. The web app captures the credentials and reports completion back to the CLI.
 4. The CLI polls the session with exponential backoff and, when the browser flow finishes, creates the connector in your workspace with the captured credentials.
 

--- a/docs/ai-agents/interfaces/cli/add-connector.md
+++ b/docs/ai-agents/interfaces/cli/add-connector.md
@@ -1,0 +1,73 @@
+---
+plan: all
+sidebar_position: 3
+---
+
+# Add a connector
+
+A **connector** in Airbyte Agents is a stored set of credentials for a third-party service plus everything needed to execute operations against it. You create a connector once, then reference it on every subsequent call by its name (preferred) when the workspace has one connector of that type, or by its `id` when you need to disambiguate.
+
+The CLI creates connectors through `connectors create`, which opens a browser tab so you can sign in to the third-party service directly. The CLI itself never touches the credentials.
+
+:::warning Never paste connector credentials into the CLI
+The CLI deliberately doesn't accept third-party credentials (API keys, OAuth tokens, passwords) as parameters or on stdin. If an agent or script needs a new connector, it must run `connectors create` and let the browser flow handle the credential exchange. This keeps secrets out of shell history, prompt logs, and agent transcripts.
+:::
+
+## Find an available connector template
+
+```bash
+airbyte-agent connectors list-available --format table
+```
+
+The output lists every connector template the CLI can create. Each row has a name (for example, `hubspot`, `linear`, `stripe`) — that's the value you pass as `name` when you create the connector.
+
+If you already know the connector type, you can skip this step.
+
+## Create a connector
+
+```bash
+airbyte-agent connectors create --json '{
+  "workspace": "default",
+  "name": "hubspot"
+}'
+```
+
+What happens:
+
+1. The CLI resolves the template by name and mints a short-lived widget token for the web app.
+2. It opens a browser tab against the Airbyte web app's credential bridge for that template.
+3. You sign in to the third-party service in the browser. The web app captures the credentials and reports completion back to the CLI.
+4. The CLI polls the session with exponential backoff and, when the browser flow finishes, creates the connector in your workspace with the captured credentials.
+
+When it returns, the response includes the new connector's `id` and `name`. Use either to reference the connector from [`connectors describe`](./describe-connector), [`connectors execute`](./execute), or [`connectors delete`](./troubleshooting#deleting-a-connector).
+
+You can also pass the source definition ID directly with `--id` if you already have it:
+
+```bash
+airbyte-agent connectors create --json '{
+  "workspace": "default",
+  "id": "<source_definition_id>"
+}'
+```
+
+## Timeouts and re-tries
+
+The default credential-flow timeout is 180 seconds. If the browser tab idles too long, the CLI returns a `validation_error` and you can re-run the command. Raise the timeout for slow flows:
+
+```bash
+AIRBYTE_CREDENTIAL_TIMEOUT=300 airbyte-agent connectors create --json '{...}'
+```
+
+If the browser doesn't open automatically (for example, on a headless machine), the CLI prints the URL to stderr so you can open it manually on another device.
+
+## List existing connectors
+
+After creating a connector, confirm it's in the workspace:
+
+```bash
+airbyte-agent connectors list --json '{"workspace": "default"}' --format table
+```
+
+## Next steps
+
+Once the connector exists, run [`connectors describe`](./describe-connector) to see which entities and actions it exposes — that's the contract for every [`connectors execute`](./execute) call against it.

--- a/docs/ai-agents/interfaces/cli/add-connector.md
+++ b/docs/ai-agents/interfaces/cli/add-connector.md
@@ -19,7 +19,7 @@ The CLI deliberately doesn't accept third-party credentials (API keys, OAuth tok
 airbyte-agent connectors list-available --format table
 ```
 
-The output lists every connector the CLI can create. Each row has a name (for example, `hubspot`, `linear`, `stripe`) — that's the value you pass as `name` when you create the connector.
+The output lists every connector the CLI can create. Each row has a name like `hubspot`, `linear`, or `stripe`; that's the value you pass as `name` when you create the connector.
 
 If you already know the connector type, you can skip this step.
 
@@ -70,4 +70,4 @@ airbyte-agent connectors list --json '{"workspace": "default"}' --format table
 
 ## Next steps
 
-Once the connector exists, run [`connectors describe`](./describe-connector) to see which entities and actions it exposes — that's the contract for every [`connectors execute`](./execute) call against it.
+Once the connector exists, run [`connectors describe`](./describe-connector) to see which entities and actions it exposes. That's the contract for every [`connectors execute`](./execute) call against it.

--- a/docs/ai-agents/interfaces/cli/add-connector.md
+++ b/docs/ai-agents/interfaces/cli/add-connector.md
@@ -39,7 +39,7 @@ What happens:
 3. You sign in to the third-party service in the browser. The web app captures the credentials and reports completion back to the CLI.
 4. The CLI polls the session with exponential backoff and, when the browser flow finishes, creates the connector in your workspace with the captured credentials.
 
-When it returns, the response includes the new connector's `id` and `name`. Use either to reference the connector from [`connectors describe`](./describe-connector), [`connectors execute`](./execute), or [`connectors delete`](./troubleshooting#deleting-a-connector).
+When it returns, the response includes the new connector's `id` and `name`. Use either to reference the connector from [`connectors describe`](./describe-connector), [`connectors execute`](./execute), or [`connectors delete`](./command-reference#connectors-delete).
 
 You can also pass the source definition ID directly with `--id` if you already have it:
 

--- a/docs/ai-agents/interfaces/cli/add-connector.md
+++ b/docs/ai-agents/interfaces/cli/add-connector.md
@@ -50,7 +50,7 @@ airbyte-agent connectors create --json '{
 }'
 ```
 
-## Timeouts and re-tries
+## Timeouts and retries
 
 The default credential-flow timeout is 180 seconds. If the browser tab idles too long, the command returns successfully with a result like `{"error": "timeout", "message": "Credential flow timed out after 3m0s", "session_id": "..."}` and exit code `0`, and you can re-run it. Raise the timeout for slow flows:
 

--- a/docs/ai-agents/interfaces/cli/authenticate.md
+++ b/docs/ai-agents/interfaces/cli/authenticate.md
@@ -8,7 +8,7 @@ sidebar_position: 1
 The CLI authenticates with Airbyte Agents using an `AIRBYTE_CLIENT_ID`, an `AIRBYTE_CLIENT_SECRET`, and an `AIRBYTE_ORGANIZATION_ID`. After you provide those three values once, the CLI obtains a short-lived OAuth token on first use, caches it locally, and refreshes it automatically before it expires. You never manage tokens yourself.
 
 :::note Two sets of credentials
-The credentials on this page authenticate *your machine* with Airbyte Agents. They aren't the same as the per-connector credentials (an OAuth `client_id`/`client_secret`/`refresh_token`, an API key, and so on) that you provide when you [add a connector](./add-connector). The two are independent — rotating one doesn't affect the other. The CLI also never accepts per-connector credentials inline; those always go through the browser flow.
+The credentials on this page authenticate *your machine* with Airbyte Agents. They aren't the same as the per-connector credentials (an OAuth `client_id`/`client_secret`/`refresh_token`, an API key, and so on) that you provide when you [add a connector](./add-connector). The two are independent, and rotating one doesn't affect the other. The CLI also never accepts per-connector credentials inline; those always go through the browser flow.
 :::
 
 ## Get your credentials
@@ -94,7 +94,7 @@ After authenticating, list your organizations to confirm the CLI can reach the A
 airbyte-agent organizations list
 ```
 
-A successful response is a JSON array of organizations. Authentication failures exit with code `2` and return a structured error on stderr — see [Troubleshooting](./troubleshooting#authentication-fails) for the most common causes.
+A successful response is a JSON array of organizations. Authentication failures exit with code `2` and return a structured error on stderr. See [Troubleshooting](./troubleshooting#authentication-fails) for the most common causes.
 
 ## Token refresh
 

--- a/docs/ai-agents/interfaces/cli/authenticate.md
+++ b/docs/ai-agents/interfaces/cli/authenticate.md
@@ -1,0 +1,114 @@
+---
+plan: all
+sidebar_position: 1
+---
+
+# Authenticate
+
+The CLI authenticates with Airbyte Agents using an `AIRBYTE_CLIENT_ID`, an `AIRBYTE_CLIENT_SECRET`, and an `AIRBYTE_ORGANIZATION_ID`. After you provide those three values once, the CLI obtains a short-lived OAuth token on first use, caches it locally, and refreshes it automatically before it expires. You never manage tokens yourself.
+
+:::note Two sets of credentials
+The credentials on this page authenticate *your machine* with Airbyte Agents. They aren't the same as the per-connector credentials (an OAuth `client_id`/`client_secret`/`refresh_token`, an API key, and so on) that you provide when you [add a connector](./add-connector). The two are independent — rotating one doesn't affect the other. The CLI also never accepts per-connector credentials inline; those always go through the browser flow.
+:::
+
+## Get your credentials
+
+1. Sign in to [app.airbyte.ai](https://app.airbyte.ai/).
+2. Open the **Profile** page and copy your `AIRBYTE_CLIENT_ID`, `AIRBYTE_CLIENT_SECRET`, and `AIRBYTE_ORGANIZATION_ID`.
+
+For details, see [Manage your user profile](../../admin/profile).
+
+## Provide credentials
+
+The CLI accepts credentials three ways. Pick whichever fits your environment best. The CLI resolves them in this order:
+
+**Environment variables → settings file**
+
+When all three environment variables are set, they take precedence. Otherwise, the CLI falls through to `~/.airbyte-agent/settings.json`.
+
+### Recommended: `airbyte-agent configure`
+
+`configure` prompts for the three values, verifies them by listing organizations, and writes them to `~/.airbyte-agent/settings.json` with `0600` permissions:
+
+```bash
+airbyte-agent configure
+```
+
+It also prompts for a default workspace name. You can press Enter to keep `default`, or set one later with [`workspaces use`](./workspaces#set-a-default-workspace).
+
+This is the right choice on a developer laptop or any machine where the credentials should persist across sessions.
+
+### Environment variables
+
+Useful for CI, containers, and one-off overrides. All three must be set; if any is missing, the CLI falls through to the settings file.
+
+```bash title=".env"
+AIRBYTE_CLIENT_ID=<your_client_id>
+AIRBYTE_CLIENT_SECRET=<your_client_secret>
+AIRBYTE_ORGANIZATION_ID=<your_organization_id>
+```
+
+```bash
+export $(grep -v '^#' .env | xargs)
+airbyte-agent workspaces list
+```
+
+Environment variables override the settings file when all three are present, so you can flip orgs for a single invocation without editing any files:
+
+```bash
+AIRBYTE_ORGANIZATION_ID=<other_org_id> airbyte-agent organizations list
+```
+
+### Settings file
+
+You can also write `~/.airbyte-agent/settings.json` directly. `configure` writes the same shape:
+
+```json title="~/.airbyte-agent/settings.json"
+{
+  "settings": {
+    "credentials": {
+      "client_id": "your-client-id",
+      "client_secret": "your-client-secret"
+    },
+    "organization_id": "your-org-id",
+    "workspace": "default",
+    "allow_destructive": false,
+    "telemetry_enabled": true
+  }
+}
+```
+
+`workspace` is optional. When set, commands that take a `workspace` parameter without receiving one fall back to this value instead of the literal `"default"`. Set it with [`workspaces use`](./workspaces#set-a-default-workspace) so the CLI verifies the workspace exists and writes the canonical name.
+
+`allow_destructive` and `telemetry_enabled` are also optional. See [Troubleshooting](./troubleshooting) for when you'd flip them.
+
+The file must be readable only by you. The CLI writes it at `0600` by default; if you create it by hand, set the permissions explicitly:
+
+```bash
+chmod 600 ~/.airbyte-agent/settings.json
+```
+
+## Verify
+
+After authenticating, list your organizations to confirm the CLI can reach the API:
+
+```bash
+airbyte-agent organizations list
+```
+
+A successful response is a JSON array of organizations. Authentication failures exit with code `2` and return a structured error on stderr — see [Troubleshooting](./troubleshooting#authentication-fails) for the most common causes.
+
+## Token refresh
+
+The CLI obtains a short-lived OAuth token on first use and refreshes it automatically before it expires. The token is cached on disk so subsequent commands don't have to re-authenticate. There's nothing for you to manage.
+
+## Self-hosted or staging endpoints
+
+By default, the CLI talks to `https://api.airbyte.ai` and opens browser credential flows against `https://app.airbyte.ai`. Override either with an environment variable:
+
+| Variable | Description | Default |
+| --- | --- | --- |
+| `AIRBYTE_API_HOST` | API base URL. | `https://api.airbyte.ai` |
+| `AIRBYTE_WEBAPP_URL` | Web app URL used for [`connectors create`](./add-connector). | `https://app.airbyte.ai` |
+
+Set both when you point the CLI at a staging or self-hosted environment so the credential flow lands on the matching web app.

--- a/docs/ai-agents/interfaces/cli/authenticate.md
+++ b/docs/ai-agents/interfaces/cli/authenticate.md
@@ -38,7 +38,7 @@ This is the right choice on a developer laptop or any machine where the credenti
 
 ### Environment variables
 
-Useful for CI, containers, and one-off overrides. All three must be set; if any is missing, the CLI falls through to the settings file.
+Environment variables are the preferred way to authenticate whenever the CLI runs somewhere there's no browser and no persistent settings file: agent sandboxes, scheduled jobs, container deployments, and serverless platforms like Modal, AWS Lambda, or Cloud Run. They also work for CI and one-off overrides on a developer machine. All three must be set; if any is missing, the CLI falls through to the settings file.
 
 ```bash title=".env"
 AIRBYTE_CLIENT_ID=<your_client_id>
@@ -49,6 +49,40 @@ AIRBYTE_ORGANIZATION_ID=<your_organization_id>
 ```bash
 export $(grep -v '^#' .env | xargs)
 airbyte-agent workspaces list
+```
+
+In a sandbox or any other long-lived deployment, supply the three values through whatever secret mechanism your platform offers (a `modal.Secret`, GitHub Actions secrets, Kubernetes secrets, AWS Secrets Manager, and so on). Once the values land in the process environment, the CLI picks them up automatically.
+
+#### Example: scheduled job on Modal
+
+On [Modal](https://modal.com/), bake the binary into the image and attach a `modal.Secret` to the function so the three values are present at runtime. The same pattern (image + secret) applies to most container and serverless platforms.
+
+```python
+import subprocess
+
+import modal
+
+image = (
+    modal.Image.debian_slim()
+    .apt_install("curl", "ca-certificates")
+    .run_commands(
+        # Install the latest linux_amd64 build of airbyte-agent.
+        "curl -sL https://api.github.com/repos/airbytehq/airbyte-agent-cli/releases/latest "
+        "| grep 'browser_download_url.*linux_amd64.tar.gz' | cut -d '\"' -f 4 "
+        "| xargs curl -sL | tar -xz -C /usr/local/bin airbyte-agent",
+    )
+)
+
+app = modal.App("airbyte-agent-sync")
+
+@app.function(
+    image=image,
+    schedule=modal.Period(hours=1),
+    # Secret holds AIRBYTE_CLIENT_ID, AIRBYTE_CLIENT_SECRET, AIRBYTE_ORGANIZATION_ID.
+    secrets=[modal.Secret.from_name("airbyte-agent")],
+)
+def list_workspaces() -> None:
+    subprocess.run(["airbyte-agent", "workspaces", "list"], check=True)
 ```
 
 Environment-variable resolution is all-or-nothing: the CLI uses env vars only when **all three** of `AIRBYTE_CLIENT_ID`, `AIRBYTE_CLIENT_SECRET`, and `AIRBYTE_ORGANIZATION_ID` are set. If any one is missing, it falls back to `~/.airbyte-agent/settings.json` and the env values are ignored. There's no partial override: setting only `AIRBYTE_ORGANIZATION_ID` alongside a populated settings file will use the file's org ID, not the env var.

--- a/docs/ai-agents/interfaces/cli/authenticate.md
+++ b/docs/ai-agents/interfaces/cli/authenticate.md
@@ -11,13 +11,6 @@ The CLI authenticates with Airbyte Agents using an `AIRBYTE_CLIENT_ID`, an `AIRB
 The credentials on this page authenticate *your machine* with Airbyte Agents. They aren't the same as the per-connector credentials (an OAuth `client_id`/`client_secret`/`refresh_token`, an API key, and so on) that you provide when you [add a connector](./add-connector). The two are independent, and rotating one doesn't affect the other. The CLI also never accepts per-connector credentials inline; those always go through the browser flow.
 :::
 
-## Get your credentials
-
-1. Sign in to [app.airbyte.ai](https://app.airbyte.ai/).
-2. Find the **Your API Credentials** card in the app and copy your `AIRBYTE_CLIENT_ID`, `AIRBYTE_CLIENT_SECRET`, and `AIRBYTE_ORGANIZATION_ID` from there. New accounts see this card on the onboarding screen; if you've already finished onboarding, it's available alongside your other account details.
-
-If the card isn't visible, copy the organization ID from the URL of any organization page (the UUID after `/organizations/`).
-
 ## Provide credentials
 
 The CLI accepts credentials three ways. Pick whichever fits your environment best.
@@ -26,15 +19,33 @@ The CLI resolves them in this order: environment variables, then the settings fi
 
 ### Recommended: `airbyte-agent login`
 
-`login` prompts for the three values, verifies them by listing organizations, and writes them to `~/.airbyte-agent/settings.json` with `0600` permissions. The `client_secret` prompt is masked on a terminal:
+`login` opens your browser to [app.airbyte.ai](https://app.airbyte.ai/) for a Keycloak sign-in, then fetches your `client_id`, `client_secret`, and `organization_id` from the airbyte.ai bootstrap endpoints and writes them to `~/.airbyte-agent/settings.json` with `0600` permissions. You never see or paste the values yourself.
 
 ```bash
 airbyte-agent login
 ```
 
-It also prompts for a default workspace name. You can press Enter to keep `default`, or set one later with [`workspaces use`](./workspaces#set-a-default-workspace).
+If you belong to more than one organization, the CLI prints a numbered picker on stderr and asks you to choose. To skip it on subsequent runs (or in scripted setups), pass `--org-id`:
 
-This is the right choice on a developer laptop or any machine where the credentials should persist across sessions.
+```bash
+airbyte-agent login --org-id <organization-uuid>
+```
+
+Get the organization UUID from the **Your API Credentials** card in the web app, or from the URL of any organization page (the UUID after `/organizations/`).
+
+The browser flow does not prompt for a default workspace. Set one with [`workspaces use`](./workspaces#set-a-default-workspace) once you're signed in, or edit `workspace` in `~/.airbyte-agent/settings.json` directly.
+
+This is the right choice on a developer laptop or any machine where the credentials should persist across sessions and a browser is available.
+
+#### Headless machines: `--manual`
+
+On a server, a remote shell, or any machine where no browser is reachable, pass `--manual` to fall back to the legacy prompt-based flow. The CLI asks for the three values plus an optional default workspace, with `client_secret` masked on a terminal:
+
+```bash
+airbyte-agent login --manual
+```
+
+Get the three values from the **Your API Credentials** card on [app.airbyte.ai](https://app.airbyte.ai/). New accounts see this card on the onboarding screen; if you've already finished onboarding, it's available alongside your other account details. If the card isn't visible, copy the organization ID from the URL of any organization page (the UUID after `/organizations/`).
 
 ### Environment variables
 
@@ -105,7 +116,7 @@ AIRBYTE_ORGANIZATION_ID=<other_org_id> \
 
 ### Settings file
 
-You can also write `~/.airbyte-agent/settings.json` directly. `login` writes the same shape:
+You can also write `~/.airbyte-agent/settings.json` directly. `login` writes the same shape (the browser flow populates `credentials` and `organization_id`; `--manual` also writes `workspace`):
 
 ```json title="~/.airbyte-agent/settings.json"
 {

--- a/docs/ai-agents/interfaces/cli/authenticate.md
+++ b/docs/ai-agents/interfaces/cli/authenticate.md
@@ -35,6 +35,14 @@ Get the organization UUID from the **Your API Credentials** card in the web app,
 
 The browser flow does not prompt for a default workspace. Set one with [`workspaces use`](./workspaces#set-a-default-workspace) once you're signed in, or edit `workspace` in `~/.airbyte-agent/settings.json` directly.
 
+To switch the default organization later without re-running `login`, use [`organizations use`](./command-reference#organizations-use):
+
+```bash
+airbyte-agent organizations use --json '{"id": "<organization-uuid>"}'
+```
+
+The CLI verifies the org belongs to your account before writing it to settings.
+
 This is the right choice on a developer laptop or any machine where the credentials should persist across sessions and a browser is available.
 
 #### Headless machines: `--manual`

--- a/docs/ai-agents/interfaces/cli/authenticate.md
+++ b/docs/ai-agents/interfaces/cli/authenticate.md
@@ -58,6 +58,7 @@ In a sandbox or any other long-lived deployment, supply the three values through
 On [Modal](https://modal.com/), bake the binary into the image and attach a `modal.Secret` to the function so the three values are present at runtime. The same pattern (image + secret) applies to most container and serverless platforms.
 
 ```python
+import os
 import subprocess
 
 import modal
@@ -82,8 +83,14 @@ app = modal.App("airbyte-agent-sync")
     secrets=[modal.Secret.from_name("airbyte-agent")],
 )
 def list_workspaces() -> None:
-    subprocess.run(["airbyte-agent", "workspaces", "list"], check=True)
+    subprocess.run(
+        ["airbyte-agent", "workspaces", "list"],
+        check=True,
+        env={"AIRBYTE_VERSION_CHECK": "disabled", **os.environ},
+    )
 ```
+
+`AIRBYTE_VERSION_CHECK=disabled` opts the run out of the daily GitHub check for a newer release. The binary version is pinned by the image, so the network call adds latency and noise without any actionable nudge for the operator. See the [settings file table](#settings-file) for the rest of the per-deployment knobs (`AIRBYTE_ALLOW_DESTRUCTIVE`, `AIRBYTE_TELEMETRY_MODE`).
 
 Environment-variable resolution is all-or-nothing: the CLI uses env vars only when **all three** of `AIRBYTE_CLIENT_ID`, `AIRBYTE_CLIENT_SECRET`, and `AIRBYTE_ORGANIZATION_ID` are set. If any one is missing, it falls back to `~/.airbyte-agent/settings.json` and the env values are ignored. There's no partial override: setting only `AIRBYTE_ORGANIZATION_ID` alongside a populated settings file will use the file's org ID, not the env var.
 
@@ -110,14 +117,24 @@ You can also write `~/.airbyte-agent/settings.json` directly. `login` writes the
     "organization_id": "your-org-id",
     "workspace": "default",
     "allow_destructive": false,
-    "telemetry_enabled": true
+    "telemetry_enabled": true,
+    "is_internal_user": false,
+    "version_check_enabled": true
   }
 }
 ```
 
-`workspace` is optional. When set, commands that take a `workspace` parameter without receiving one fall back to this value instead of the literal `"default"`. Set it with [`workspaces use`](./workspaces#set-a-default-workspace) so the CLI verifies the workspace exists and writes the canonical name.
+Only the `credentials` block and `organization_id` are required. The rest are optional and have safe defaults:
 
-`allow_destructive` and `telemetry_enabled` are also optional. See [Troubleshooting](./troubleshooting) for when you'd flip them.
+| Field | Default | What it does | Env override |
+| --- | --- | --- | --- |
+| `workspace` | `"default"` | Default workspace for commands that take a `workspace` parameter without receiving one. Set it with [`workspaces use`](./workspaces#set-a-default-workspace) so the CLI verifies the workspace exists and writes the canonical name. | `AIRBYTE_WORKSPACE` |
+| `allow_destructive` | `false` | When `true`, destructive commands like [`connectors delete`](./command-reference#connectors-delete) skip the interactive confirmation prompt. Useful for agent harnesses that can't answer a TTY prompt. | `AIRBYTE_ALLOW_DESTRUCTIVE=true` |
+| `telemetry_enabled` | `true` | Anonymous usage telemetry. Set to `false` to opt out. | `AIRBYTE_TELEMETRY_MODE=disabled` |
+| `is_internal_user` | `false` | Marks the invocation as an Airbyte employee so internal events can be filtered out of customer analytics. Leave at `false` outside of Airbyte. | `AIRBYTE_INTERNAL_USER` |
+| `version_check_enabled` | `true` | Once per day, the CLI checks GitHub for a newer release and prints a nudge. Set to `false` to disable the network call. **Recommended for sandboxed agents, long-running automations, and any deployment where the binary version is pinned by the image.** | `AIRBYTE_VERSION_CHECK=disabled` |
+
+See [Troubleshooting](./troubleshooting) for when you'd flip `allow_destructive` or `telemetry_enabled`.
 
 The file must be readable only by you. The CLI writes it at `0600` by default; if you create it by hand, set the permissions explicitly:
 

--- a/docs/ai-agents/interfaces/cli/authenticate.md
+++ b/docs/ai-agents/interfaces/cli/authenticate.md
@@ -22,7 +22,7 @@ For details, see [Manage your user profile](../../admin/profile).
 
 The CLI accepts credentials three ways. Pick whichever fits your environment best.
 
-The CLI resolves them in this order: environment variables, then the settings file. When all three environment variables are set, they take precedence. Otherwise, the CLI falls through to `~/.airbyte-agent/settings.json`.
+The CLI resolves them in this order: environment variables, then the settings file. Environment variables take precedence only when all three (`AIRBYTE_CLIENT_ID`, `AIRBYTE_CLIENT_SECRET`, and `AIRBYTE_ORGANIZATION_ID`) are set. If any one is missing, the CLI ignores the env vars entirely and reads `~/.airbyte-agent/settings.json` instead.
 
 ### Recommended: `airbyte-agent configure`
 
@@ -51,10 +51,15 @@ export $(grep -v '^#' .env | xargs)
 airbyte-agent workspaces list
 ```
 
-Environment variables override the settings file when all three are present, so you can flip orgs for a single invocation without editing any files:
+Environment-variable resolution is all-or-nothing: the CLI uses env vars only when **all three** of `AIRBYTE_CLIENT_ID`, `AIRBYTE_CLIENT_SECRET`, and `AIRBYTE_ORGANIZATION_ID` are set. If any one is missing, it falls back to `~/.airbyte-agent/settings.json` and the env values are ignored. There's no partial override: setting only `AIRBYTE_ORGANIZATION_ID` alongside a populated settings file will use the file's org ID, not the env var.
+
+To flip orgs for a single invocation, pass all three:
 
 ```bash
-AIRBYTE_ORGANIZATION_ID=<other_org_id> airbyte-agent organizations list
+AIRBYTE_CLIENT_ID=<other_client_id> \
+AIRBYTE_CLIENT_SECRET=<other_client_secret> \
+AIRBYTE_ORGANIZATION_ID=<other_org_id> \
+  airbyte-agent organizations list
 ```
 
 ### Settings file

--- a/docs/ai-agents/interfaces/cli/authenticate.md
+++ b/docs/ai-agents/interfaces/cli/authenticate.md
@@ -20,11 +20,9 @@ For details, see [Manage your user profile](../../admin/profile).
 
 ## Provide credentials
 
-The CLI accepts credentials three ways. Pick whichever fits your environment best. The CLI resolves them in this order:
+The CLI accepts credentials three ways. Pick whichever fits your environment best.
 
-**Environment variables → settings file**
-
-When all three environment variables are set, they take precedence. Otherwise, the CLI falls through to `~/.airbyte-agent/settings.json`.
+The CLI resolves them in this order: environment variables, then the settings file. When all three environment variables are set, they take precedence. Otherwise, the CLI falls through to `~/.airbyte-agent/settings.json`.
 
 ### Recommended: `airbyte-agent configure`
 

--- a/docs/ai-agents/interfaces/cli/authenticate.md
+++ b/docs/ai-agents/interfaces/cli/authenticate.md
@@ -104,7 +104,7 @@ A successful response is a JSON object with two keys, `organizations` (an array)
 ```json
 {
   "organizations": [
-    { "organization_id": "...", "organization_name": "...", ... }
+    { "id": "...", "organization_name": "...", "first_workspace_id": "..." }
   ],
   "is_instance_admin": false
 }

--- a/docs/ai-agents/interfaces/cli/authenticate.md
+++ b/docs/ai-agents/interfaces/cli/authenticate.md
@@ -14,9 +14,9 @@ The credentials on this page authenticate *your machine* with Airbyte Agents. Th
 ## Get your credentials
 
 1. Sign in to [app.airbyte.ai](https://app.airbyte.ai/).
-2. Open the **Profile** page and copy your `AIRBYTE_CLIENT_ID`, `AIRBYTE_CLIENT_SECRET`, and `AIRBYTE_ORGANIZATION_ID`.
+2. Find the **Your API Credentials** card in the app and copy your `AIRBYTE_CLIENT_ID`, `AIRBYTE_CLIENT_SECRET`, and `AIRBYTE_ORGANIZATION_ID` from there. New accounts see this card on the onboarding screen; if you've already finished onboarding, it's available alongside your other account details.
 
-For details, see [Manage your user profile](../../admin/profile).
+If the card isn't visible, copy the organization ID from the URL of any organization page (the UUID after `/organizations/`).
 
 ## Provide credentials
 
@@ -99,7 +99,18 @@ After authenticating, list your organizations to confirm the CLI can reach the A
 airbyte-agent organizations list
 ```
 
-A successful response is a JSON array of organizations. Authentication failures exit with code `2` and return a structured error on stderr. See [Troubleshooting](./troubleshooting#authentication-fails) for the most common causes.
+A successful response is a JSON object with two keys, `organizations` (an array) and `is_instance_admin` (a boolean):
+
+```json
+{
+  "organizations": [
+    { "organization_id": "...", "organization_name": "...", ... }
+  ],
+  "is_instance_admin": false
+}
+```
+
+Authentication failures exit with code `2` and return a structured error on stderr. See [Troubleshooting](./troubleshooting#authentication-fails) for the most common causes.
 
 ## Token refresh
 

--- a/docs/ai-agents/interfaces/cli/authenticate.md
+++ b/docs/ai-agents/interfaces/cli/authenticate.md
@@ -24,12 +24,12 @@ The CLI accepts credentials three ways. Pick whichever fits your environment bes
 
 The CLI resolves them in this order: environment variables, then the settings file. Environment variables take precedence only when all three (`AIRBYTE_CLIENT_ID`, `AIRBYTE_CLIENT_SECRET`, and `AIRBYTE_ORGANIZATION_ID`) are set. If any one is missing, the CLI ignores the env vars entirely and reads `~/.airbyte-agent/settings.json` instead.
 
-### Recommended: `airbyte-agent configure`
+### Recommended: `airbyte-agent login`
 
-`configure` prompts for the three values, verifies them by listing organizations, and writes them to `~/.airbyte-agent/settings.json` with `0600` permissions:
+`login` prompts for the three values, verifies them by listing organizations, and writes them to `~/.airbyte-agent/settings.json` with `0600` permissions. The `client_secret` prompt is masked on a terminal:
 
 ```bash
-airbyte-agent configure
+airbyte-agent login
 ```
 
 It also prompts for a default workspace name. You can press Enter to keep `default`, or set one later with [`workspaces use`](./workspaces#set-a-default-workspace).
@@ -64,7 +64,7 @@ AIRBYTE_ORGANIZATION_ID=<other_org_id> \
 
 ### Settings file
 
-You can also write `~/.airbyte-agent/settings.json` directly. `configure` writes the same shape:
+You can also write `~/.airbyte-agent/settings.json` directly. `login` writes the same shape:
 
 ```json title="~/.airbyte-agent/settings.json"
 {

--- a/docs/ai-agents/interfaces/cli/command-reference.md
+++ b/docs/ai-agents/interfaces/cli/command-reference.md
@@ -186,7 +186,7 @@ The HTTP client retries transient failures automatically:
 - **Strategy:** Up to 3 retries with exponential backoff (1s, 2s, 4s).
 - **Per-request timeout:** 30 seconds.
 
-For long-running operations that exceed 30 seconds, run them via a job (for example, the [HTTP API](../api/execute) async endpoints) and poll for the result.
+For long-running operations that exceed 30 seconds, run them via a job (for example, the [Agent API](../api/execute) async endpoints) and poll for the result.
 
 ## Environment variables
 

--- a/docs/ai-agents/interfaces/cli/command-reference.md
+++ b/docs/ai-agents/interfaces/cli/command-reference.md
@@ -163,7 +163,7 @@ airbyte-agent connectors delete --json '{"workspace": "default", "name": "old-hu
 | `workspace` | string | with `name` | Workspace the connector lives in. |
 | `id` | string | one of `name`+`workspace` or `id` | Connector ID (UUID). |
 
-Without a TTY (piped input from an agent harness, for example), the prompt can't run. The command refuses with a `validation_error` whose hint tells you to grant one-time permission by setting `"allow_destructive": true` in `~/.airbyte-agent/settings.json` (or `AIRBYTE_ALLOW_DESTRUCTIVE=true` for a single invocation). See [Troubleshooting](./troubleshooting#cant-confirm-destructive-delete-on-a-non-tty-machine).
+Without a TTY (piped input from an agent harness, for example), the prompt can't run. The command refuses with a `validation_error` whose hint tells you to grant one-time permission by setting `"allow_destructive": true` in `~/.airbyte-agent/settings.json` (or `AIRBYTE_ALLOW_DESTRUCTIVE=true` for a single invocation). See [Troubleshooting](./troubleshooting#destructive-delete-on-a-non-tty-machine).
 
 ## Exit codes
 

--- a/docs/ai-agents/interfaces/cli/command-reference.md
+++ b/docs/ai-agents/interfaces/cli/command-reference.md
@@ -1,0 +1,206 @@
+---
+plan: all
+sidebar_position: 7
+---
+
+# Command reference
+
+Every command on the CLI follows the same shape:
+
+```bash
+airbyte-agent <resource> <operation> [flags]
+```
+
+Run `airbyte-agent --help` to list resources, `airbyte-agent <resource> --help` to list operations, and `airbyte-agent <resource> <operation> --describe` to print the parameter schema and the underlying OpenAPI request and response shapes without executing the call. This page summarizes that surface in one place.
+
+:::note Single source of truth
+If anything on this page disagrees with `--describe` output, `--describe` wins. Run it whenever you need the canonical parameter list for a command.
+:::
+
+## Common flags
+
+These flags are available on every operation.
+
+| Flag | Description | Default |
+| --- | --- | --- |
+| `--json` | Inline JSON parameters. Pass `@filename` to load from a file. Mutually exclusive with per-parameter flags. | — |
+| `--format` | Output format: `json` or `table`. | `json` |
+| `--describe` | Print the operation's parameter schema (plus OpenAPI shape) and exit without executing. | `false` |
+| `--output`, `-o` | Write stdout to a file instead of the terminal. | — |
+| `--verbose`, `-v` | Enable debug logging on stderr. | `false` |
+| `--fields` | Client-side response filter. Comma-separated dot paths (for example, `data.id,data.name`). Errors are not filtered. | — |
+
+Per-parameter flags are generated from each operation's schema. Snake_case parameter names become kebab-case flags — for example, `select_fields` is exposed as `--select-fields`.
+
+## `organizations`
+
+### `organizations list`
+
+List the organizations you belong to.
+
+```bash
+airbyte-agent organizations list
+airbyte-agent organizations list --format table --fields id,organization_name
+```
+
+No required parameters.
+
+## `workspaces`
+
+### `workspaces list`
+
+List or filter workspaces in the current organization. Paginates automatically.
+
+```bash
+airbyte-agent workspaces list --json '{"name_contains": "prod", "status": "active", "limit": 10}'
+```
+
+| Param | Type | Required | Description |
+| --- | --- | --- | --- |
+| `name_contains` | string | no | Filter by case-insensitive substring match against `name`. |
+| `status` | string | no | Filter by workspace status (for example, `active`). |
+| `limit` | integer | no | Cap the result count. |
+
+### `workspaces use`
+
+Persist a default workspace name to `~/.airbyte-agent/settings.json`. Subsequent commands that take a `workspace` parameter without receiving one fall back to this value.
+
+```bash
+airbyte-agent workspaces use --json '{"name": "Production"}'
+```
+
+| Param | Type | Required | Description |
+| --- | --- | --- | --- |
+| `name` | string | yes | Workspace name (case-insensitive match). The canonical-cased name is what gets persisted. |
+
+## `connectors`
+
+### `connectors list`
+
+List connectors in a workspace.
+
+```bash
+airbyte-agent connectors list --json '{"workspace": "default"}'
+```
+
+| Param | Type | Required | Description |
+| --- | --- | --- | --- |
+| `workspace` | string | yes | Workspace name. Falls back to the default set by `workspaces use`. |
+
+### `connectors list-available`
+
+List the connector templates you can create from. No required parameters.
+
+```bash
+airbyte-agent connectors list-available --format table
+```
+
+### `connectors describe`
+
+Return a connector's entities, actions, and parameter schemas. See [Describe a connector](./describe-connector).
+
+```bash
+airbyte-agent connectors describe --json '{"workspace": "default", "name": "hubspot"}'
+airbyte-agent connectors describe --id <connector_id>
+```
+
+| Param | Type | Required | Description |
+| --- | --- | --- | --- |
+| `name` | string | one of `name`+`workspace` or `id` | Connector name. Requires `workspace`. |
+| `workspace` | string | with `name` | Workspace the connector lives in. |
+| `id` | string | one of `name`+`workspace` or `id` | Connector ID (UUID). |
+
+### `connectors create`
+
+Create a new connector through the browser credential flow. See [Add a connector](./add-connector).
+
+```bash
+airbyte-agent connectors create --json '{"workspace": "default", "name": "hubspot"}'
+```
+
+| Param | Type | Required | Description |
+| --- | --- | --- | --- |
+| `workspace` | string | yes | Workspace to create the connector in. |
+| `name` | string | one of `name` or `id` | Connector template name (for example, `hubspot`). |
+| `id` | string | one of `name` or `id` | Source definition ID. Alternative to `name`. |
+
+### `connectors execute`
+
+Run an action against an entity on a connector. See [Execute operations](./execute).
+
+```bash
+airbyte-agent connectors execute --json '{
+  "workspace": "default",
+  "name": "hubspot",
+  "entity": "contacts",
+  "action": "read",
+  "select_fields": ["id", "email"]
+}'
+```
+
+| Param | Type | Required | Description |
+| --- | --- | --- | --- |
+| `name` | string | one of `name`+`workspace` or `id` | Connector name. Requires `workspace`. |
+| `workspace` | string | with `name` | Workspace the connector lives in. |
+| `id` | string | one of `name`+`workspace` or `id` | Connector ID (UUID). |
+| `entity` | string | yes | Entity to act on (for example, `contacts`). |
+| `action` | string | yes | Action to run (for example, `read`, `context_store_search`, `get`). |
+| `params` | object | no | Action-specific arguments. Shape depends on entity and action — run `connectors describe` for the schema. |
+| `select_fields` | string[] | no | Allowlist of fields the source connector should return. |
+| `exclude_fields` | string[] | no | Blocklist of fields the source connector should omit. `select_fields` wins if both are passed. |
+
+### `connectors delete`
+
+Delete a connector. Destructive — prompts for `"Type 'yes' to confirm:"` on a TTY.
+
+```bash
+airbyte-agent connectors delete --json '{"workspace": "default", "name": "old-hubspot"}'
+```
+
+| Param | Type | Required | Description |
+| --- | --- | --- | --- |
+| `name` | string | one of `name`+`workspace` or `id` | Connector name. Requires `workspace`. |
+| `workspace` | string | with `name` | Workspace the connector lives in. |
+| `id` | string | one of `name`+`workspace` or `id` | Connector ID (UUID). |
+
+Without a TTY (piped input from an agent harness, for example), the prompt can't run. The command refuses with a `validation_error` whose hint tells you to grant one-time permission by setting `"allow_destructive": true` in `~/.airbyte-agent/settings.json` (or `AIRBYTE_ALLOW_DESTRUCTIVE=true` for a single invocation). See [Troubleshooting](./troubleshooting#cant-confirm-destructive-delete-on-a-non-tty-machine).
+
+## Exit codes
+
+All errors are returned as JSON on stderr, with a stable exit code:
+
+| Code | Meaning | Typical HTTP status |
+| --- | --- | --- |
+| `0` | Success. | 2xx |
+| `1` | General error. | 500, others |
+| `2` | Authentication error. | 401, 403 |
+| `3` | Not found. | 404 |
+| `4` | Validation error. | 400, 422 |
+
+## Retry behavior
+
+The HTTP client retries transient failures automatically:
+
+- **Retryable:** 429 (rate limit), 502, 503, 504.
+- **Not retryable:** 400, 401, 403, 404, 422.
+- **Strategy:** Up to 3 retries with exponential backoff (1s, 2s, 4s).
+- **Per-request timeout:** 30 seconds.
+
+For long-running operations that exceed 30 seconds, run them via a job (for example, the [HTTP API](../api/execute) async endpoints) and poll for the result.
+
+## Environment variables
+
+| Variable | Description | Default |
+| --- | --- | --- |
+| `AIRBYTE_CLIENT_ID` | OAuth client ID. | (required) |
+| `AIRBYTE_CLIENT_SECRET` | OAuth client secret. | (required) |
+| `AIRBYTE_ORGANIZATION_ID` | Organization ID. | (required) |
+| `AIRBYTE_WORKSPACE` | Default workspace name when commands don't pass `workspace`. | `default` |
+| `AIRBYTE_API_HOST` | API base URL. | `https://api.airbyte.ai` |
+| `AIRBYTE_WEBAPP_URL` | Web app URL for the [`connectors create`](./add-connector) browser flow. | `https://app.airbyte.ai` |
+| `AIRBYTE_CREDENTIAL_TIMEOUT` | Credential-flow timeout in seconds. | `180` |
+| `AIRBYTE_ALLOW_DESTRUCTIVE` | When truthy (`1`/`true`/`yes`/`on`), skip the interactive confirmation prompt on destructive commands. | (settings file) |
+| `AIRBYTE_TELEMETRY_MODE` | Set to `disabled` to turn off telemetry emission. | (settings file) |
+| `AIRBYTE_EXECUTION_CONTEXT` | Self-reported invocation context. Common values: `mcp`, `agent`, `direct`. | `direct` |
+
+The full env var matrix, including internal-user flags, lives in the [CLI repo README](https://github.com/airbytehq/airbyte-agent-cli/blob/main/README.md).

--- a/docs/ai-agents/interfaces/cli/command-reference.md
+++ b/docs/ai-agents/interfaces/cli/command-reference.md
@@ -89,7 +89,7 @@ airbyte-agent connectors list --json '{"workspace": "default"}'
 
 ### `connectors list-available`
 
-List the connector templates you can create from. No required parameters.
+List the connectors you can create. No required parameters.
 
 ```bash
 airbyte-agent connectors list-available --format table
@@ -121,7 +121,7 @@ airbyte-agent connectors create --json '{"workspace": "default", "name": "hubspo
 | Param | Type | Required | Description |
 | --- | --- | --- | --- |
 | `workspace` | string | yes | Workspace to create the connector in. |
-| `name` | string | one of `name` or `id` | Connector template name (for example, `hubspot`). |
+| `name` | string | one of `name` or `id` | Connector name (for example, `hubspot`). |
 | `id` | string | one of `name` or `id` | Source definition ID. Alternative to `name`. |
 
 ### `connectors execute`

--- a/docs/ai-agents/interfaces/cli/command-reference.md
+++ b/docs/ai-agents/interfaces/cli/command-reference.md
@@ -32,7 +32,7 @@ These flags are exposed on every resource operation:
 
 Per-parameter flags are generated from each operation's schema. Snake_case parameter names become kebab-case flags. For example, `select_fields` is exposed as `--select-fields`.
 
-The flags above don't all apply to the top-level commands (`configure`, `configure show`, `version`, `schema`). `--json` in particular isn't a valid flag on those: `airbyte-agent version --json '{}'` exits `1` because the flag is unknown to that command.
+The flags above don't all apply to the top-level commands (`login`, `login show`, `version`, `schema`). `--json` in particular isn't a valid flag on those: `airbyte-agent version --json '{}'` exits `1` because the flag is unknown to that command.
 
 `--fields`, `--format`, and `--output` (`-o`) are silently accepted on top-level commands but don't do anything. `version --format table` still prints JSON, `version --fields version` still prints every field, and `version -o out.json` exits `0` without writing `out.json`. Treat top-level commands as JSON-to-stdout only, and use shell tools (`jq`, redirection) if you need to post-process the result.
 
@@ -42,8 +42,8 @@ A few commands live at the top level rather than under a resource:
 
 | Command | Description |
 | --- | --- |
-| `airbyte-agent configure` | Prompt for `client_id`, `client_secret`, `organization_id`, and a default workspace, then write `~/.airbyte-agent/settings.json` with `0600` permissions. See [Authenticate](./authenticate). |
-| `airbyte-agent configure show` | Print the saved settings (with `client_secret` obfuscated). Useful for `--verbose` debugging and for sharing a redacted dump in bug reports. |
+| `airbyte-agent login` | Prompt for `client_id`, `client_secret`, `organization_id`, and a default workspace, then write `~/.airbyte-agent/settings.json` with `0600` permissions. The `client_secret` prompt is masked on a terminal. See [Authenticate](./authenticate). |
+| `airbyte-agent login show` | Print the saved settings (with `client_secret` obfuscated). Useful for `--verbose` debugging and for sharing a redacted dump in bug reports. |
 | `airbyte-agent version` | Print version, commit, and build date as JSON. |
 | `airbyte-agent schema <resource> <operation>` | Equivalent to `<resource> <operation> --describe`, but discoverable as a top-level command. Returns `{"type": "not_supported", ...}` (exit `3`) for operations backed by internal-only API routes. |
 | `airbyte-agent completion <shell>` | Cobra-generated shell-completion script for `bash`, `zsh`, `fish`, or `powershell`. Pipe the output into your shell's completion directory. Run `airbyte-agent completion --help` for installation steps. |
@@ -91,7 +91,7 @@ airbyte-agent workspaces use --json '{"name": "Production"}'
 | --- | --- | --- | --- |
 | `name` | string | yes | Workspace name (case-insensitive match). The canonical-cased name is what gets persisted. |
 
-Requires an existing `~/.airbyte-agent/settings.json`. Run `airbyte-agent configure` first on a fresh machine; `workspaces use` doesn't bootstrap a settings file from environment variables alone.
+Requires an existing `~/.airbyte-agent/settings.json`. Run `airbyte-agent login` first on a fresh machine; `workspaces use` doesn't bootstrap a settings file from environment variables alone.
 
 ## `connectors`
 

--- a/docs/ai-agents/interfaces/cli/command-reference.md
+++ b/docs/ai-agents/interfaces/cli/command-reference.md
@@ -23,14 +23,14 @@ These flags are available on every operation.
 
 | Flag | Description | Default |
 | --- | --- | --- |
-| `--json` | Inline JSON parameters. Pass `@filename` to load from a file. Mutually exclusive with per-parameter flags. | — |
+| `--json` | Inline JSON parameters. Pass `@filename` to load from a file. Mutually exclusive with per-parameter flags. | (none) |
 | `--format` | Output format: `json` or `table`. | `json` |
 | `--describe` | Print the operation's parameter schema (plus OpenAPI shape) and exit without executing. | `false` |
-| `--output`, `-o` | Write stdout to a file instead of the terminal. | — |
+| `--output`, `-o` | Write stdout to a file instead of the terminal. | (none) |
 | `--verbose`, `-v` | Enable debug logging on stderr. | `false` |
-| `--fields` | Client-side response filter. Comma-separated dot paths (for example, `data.id,data.name`). Errors are not filtered. | — |
+| `--fields` | Client-side response filter. Comma-separated dot paths (for example, `data.id,data.name`). Errors are not filtered. | (none) |
 
-Per-parameter flags are generated from each operation's schema. Snake_case parameter names become kebab-case flags — for example, `select_fields` is exposed as `--select-fields`.
+Per-parameter flags are generated from each operation's schema. Snake_case parameter names become kebab-case flags. For example, `select_fields` is exposed as `--select-fields`.
 
 ## `organizations`
 
@@ -145,13 +145,13 @@ airbyte-agent connectors execute --json '{
 | `id` | string | one of `name`+`workspace` or `id` | Connector ID (UUID). |
 | `entity` | string | yes | Entity to act on (for example, `contacts`). |
 | `action` | string | yes | Action to run (for example, `read`, `context_store_search`, `get`). |
-| `params` | object | no | Action-specific arguments. Shape depends on entity and action — run `connectors describe` for the schema. |
+| `params` | object | no | Action-specific arguments. Shape depends on entity and action; run `connectors describe` for the schema. |
 | `select_fields` | string[] | no | Allowlist of fields the source connector should return. |
 | `exclude_fields` | string[] | no | Blocklist of fields the source connector should omit. `select_fields` wins if both are passed. |
 
 ### `connectors delete`
 
-Delete a connector. Destructive — prompts for `"Type 'yes' to confirm:"` on a TTY.
+Delete a connector. This is destructive, so on a TTY it prompts for `"Type 'yes' to confirm:"`.
 
 ```bash
 airbyte-agent connectors delete --json '{"workspace": "default", "name": "old-hubspot"}'

--- a/docs/ai-agents/interfaces/cli/command-reference.md
+++ b/docs/ai-agents/interfaces/cli/command-reference.md
@@ -11,10 +11,10 @@ Every command on the CLI follows the same shape:
 airbyte-agent <resource> <operation> [flags]
 ```
 
-Run `airbyte-agent --help` to list resources, `airbyte-agent <resource> --help` to list operations, and `airbyte-agent <resource> <operation> --describe` to print the parameter schema (plus the underlying OpenAPI request and response shapes when the operation maps to a public API route) without executing the call. This page summarizes that surface in one place.
+Run `airbyte-agent --help` to list resources, `airbyte-agent <resource> --help` to list operations, and `airbyte-agent schema <resource> <operation>` to print the parameter schema (plus the underlying OpenAPI request and response shapes when the operation maps to a public API route) without executing the call. This page summarizes that surface in one place.
 
 :::note Single source of truth
-If anything on this page disagrees with `--describe` output, `--describe` wins. Run it whenever you need the canonical parameter list for a command.
+If anything on this page disagrees with `airbyte-agent schema <resource> <operation>` output, `schema` wins. Run it whenever you need the canonical parameter list for a command.
 :::
 
 ## Common flags
@@ -24,17 +24,17 @@ These flags are exposed on every resource operation:
 | Flag | Description | Default |
 | --- | --- | --- |
 | `--json` | Inline JSON parameters. Pass `@filename` to load from a file. Mutually exclusive with per-parameter flags. | (none) |
-| `--format` | Output format: `json` or `table`. `table` works best on operations whose response is a flat array of records; responses wrapped in `{ "data": [...], "meta": {...} }` render with the array under a `DATA` column. When in doubt, stick with `json` and use `--fields` to trim it. | `json` |
-| `--describe` | Print the operation's parameter schema (and OpenAPI shape, when the operation maps to a public API route) and exit without executing. Operations backed by internal-only routes return `{"type": "not_supported", ...}` on stderr with exit code `3`; use `--help` instead. | `false` |
 | `--output`, `-o` | Write stdout to a file instead of the terminal. | (none) |
 | `--verbose`, `-v` | Enable debug logging on stderr. | `false` |
 | `--fields` | Client-side response filter. Comma-separated dot paths (for example, `organizations.id,organizations.organization_name`). Errors are not filtered. | (none) |
 
+The CLI always prints JSON to stdout. There is no `--format` flag; pipe the output through `jq` if you need to reshape it.
+
 Per-parameter flags are generated from each operation's schema. Snake_case parameter names become kebab-case flags. For example, `select_fields` is exposed as `--select-fields`.
 
-The flags above don't all apply to the top-level commands (`login`, `login show`, `version`, `schema`). `--json` in particular isn't a valid flag on those: `airbyte-agent version --json '{}'` exits `1` because the flag is unknown to that command.
+The flags above don't all apply to the top-level commands (`login`, `login show`, `version`, `schema`, `completion`). `--json` in particular isn't a valid flag on those: `airbyte-agent version --json '{}'` exits `1` because the flag is unknown to that command.
 
-`--fields`, `--format`, and `--output` (`-o`) are silently accepted on top-level commands but don't do anything. `version --format table` still prints JSON, `version --fields version` still prints every field, and `version -o out.json` exits `0` without writing `out.json`. Treat top-level commands as JSON-to-stdout only, and use shell tools (`jq`, redirection) if you need to post-process the result.
+`--fields` and `--output` (`-o`) are silently accepted on top-level commands but don't do anything. `version --fields version` still prints the same string, and `version -o out.json` exits `0` without writing `out.json`. Treat top-level commands as plain-stdout output, and use shell tools (`jq`, redirection) if you need to post-process the result.
 
 ## Top-level commands
 
@@ -42,10 +42,10 @@ A few commands live at the top level rather than under a resource:
 
 | Command | Description |
 | --- | --- |
-| `airbyte-agent login` | Prompt for `client_id`, `client_secret`, `organization_id`, and a default workspace, then write `~/.airbyte-agent/settings.json` with `0600` permissions. The `client_secret` prompt is masked on a terminal. See [Authenticate](./authenticate). |
+| `airbyte-agent login` | Open a browser to [app.airbyte.ai](https://app.airbyte.ai/) for Keycloak sign-in, then fetch `client_id`, `client_secret`, and `organization_id` from the bootstrap endpoints and write them to `~/.airbyte-agent/settings.json` with `0600` permissions. Flags: `--manual` falls back to the legacy prompt-based flow for headless machines; `--org-id <uuid>` skips the multi-organization picker when you belong to more than one. See [Authenticate](./authenticate). |
 | `airbyte-agent login show` | Print the saved settings (with `client_secret` obfuscated). Useful for `--verbose` debugging and for sharing a redacted dump in bug reports. |
-| `airbyte-agent version` | Print version, commit, and build date as JSON. |
-| `airbyte-agent schema <resource> <operation>` | Equivalent to `<resource> <operation> --describe`, but discoverable as a top-level command. Returns `{"type": "not_supported", ...}` (exit `3`) for operations backed by internal-only API routes. |
+| `airbyte-agent version` | Print the CLI version string to stdout. Output is plain text, not JSON. |
+| `airbyte-agent schema <resource> <operation>` | Print the operation's parameter schema and, when it maps to a public API route, the underlying OpenAPI request and response shapes. Returns `{"type": "not_supported", ...}` (exit `3`) for operations backed by internal-only API routes. |
 | `airbyte-agent completion <shell>` | Cobra-generated shell-completion script for `bash`, `zsh`, `fish`, or `powershell`. Pipe the output into your shell's completion directory. Run `airbyte-agent completion --help` for installation steps. |
 
 ## `organizations`

--- a/docs/ai-agents/interfaces/cli/command-reference.md
+++ b/docs/ai-agents/interfaces/cli/command-reference.md
@@ -77,7 +77,7 @@ airbyte-agent workspaces list --json '{"name_contains": "prod", "status": "activ
 | --- | --- | --- | --- |
 | `name_contains` | string | no | Filter by case-insensitive substring match against `name`. |
 | `status` | string | no | Filter by workspace status (for example, `active`). |
-| `limit` | integer | no | Cap the result count. |
+| `limit` | integer | no | Page size hint passed to the API. The CLI auto-paginates and returns every matching workspace regardless of `limit`; it does not cap the final result count. To narrow the response, use `name_contains` or `status`. |
 
 ### `workspaces use`
 
@@ -153,7 +153,7 @@ airbyte-agent connectors execute --json '{
   "workspace": "default",
   "name": "hubspot",
   "entity": "contacts",
-  "action": "read",
+  "action": "context_store_search",
   "select_fields": ["id", "email"]
 }'
 ```
@@ -164,7 +164,7 @@ airbyte-agent connectors execute --json '{
 | `workspace` | string | with `name` | Workspace the connector lives in. |
 | `id` | string | one of `name`+`workspace` or `id` | Connector ID (UUID). |
 | `entity` | string | yes | Entity to act on (for example, `contacts`). |
-| `action` | string | yes | Action to run (for example, `read`, `context_store_search`, `get`). |
+| `action` | string | yes | Action to run. Baseline: `context_store_search`, `list`, `get`, `api_search`, `create`, `update`. Run `connectors describe` for the connector's actual supported set. |
 | `params` | object | no | Action-specific arguments. Shape depends on entity and action; run `connectors describe` for the schema. |
 | `select_fields` | string[] | no | Allowlist of fields the source connector should return. |
 | `exclude_fields` | string[] | no | Blocklist of fields the source connector should omit. `select_fields` wins if both are passed. |

--- a/docs/ai-agents/interfaces/cli/command-reference.md
+++ b/docs/ai-agents/interfaces/cli/command-reference.md
@@ -32,7 +32,9 @@ These flags are exposed on every resource operation:
 
 Per-parameter flags are generated from each operation's schema. Snake_case parameter names become kebab-case flags. For example, `select_fields` is exposed as `--select-fields`.
 
-The flags above don't all apply to the top-level commands (`configure`, `configure show`, `version`, `schema`). `--json` in particular isn't a valid flag on those: `airbyte-agent version --json '{}'` exits `1` because the flag is unknown to that command. Top-level commands write their output directly to stdout, so `--fields`, `--format`, and `--output` are also no-ops there; use shell tools (`jq`, redirection) if you need to post-process the result.
+The flags above don't all apply to the top-level commands (`configure`, `configure show`, `version`, `schema`). `--json` in particular isn't a valid flag on those: `airbyte-agent version --json '{}'` exits `1` because the flag is unknown to that command.
+
+`--fields`, `--format`, and `--output` (`-o`) are silently accepted on top-level commands but don't do anything. `version --format table` still prints JSON, `version --fields version` still prints every field, and `version -o out.json` exits `0` without writing `out.json`. Treat top-level commands as JSON-to-stdout only, and use shell tools (`jq`, redirection) if you need to post-process the result.
 
 ## Top-level commands
 
@@ -44,6 +46,7 @@ A few commands live at the top level rather than under a resource:
 | `airbyte-agent configure show` | Print the saved settings (with `client_secret` obfuscated). Useful for `--verbose` debugging and for sharing a redacted dump in bug reports. |
 | `airbyte-agent version` | Print version, commit, and build date as JSON. |
 | `airbyte-agent schema <resource> <operation>` | Equivalent to `<resource> <operation> --describe`, but discoverable as a top-level command. Returns `{"type": "not_supported", ...}` (exit `3`) for operations backed by internal-only API routes. |
+| `airbyte-agent completion <shell>` | Cobra-generated shell-completion script for `bash`, `zsh`, `fish`, or `powershell`. Pipe the output into your shell's completion directory. Run `airbyte-agent completion --help` for installation steps. |
 
 ## `organizations`
 
@@ -87,6 +90,8 @@ airbyte-agent workspaces use --json '{"name": "Production"}'
 | Param | Type | Required | Description |
 | --- | --- | --- | --- |
 | `name` | string | yes | Workspace name (case-insensitive match). The canonical-cased name is what gets persisted. |
+
+Requires an existing `~/.airbyte-agent/settings.json`. Run `airbyte-agent configure` first on a fresh machine; `workspaces use` doesn't bootstrap a settings file from environment variables alone.
 
 ## `connectors`
 
@@ -191,6 +196,8 @@ All errors are returned as JSON on stderr, with a stable exit code:
 | `2` | Authentication error. | 401, 403 |
 | `3` | Not found. | 404 |
 | `4` | Validation error. | 400, 422 |
+
+The mapping above is the contract for **server-side** failures: anything the API returns with a recognized HTTP status maps to a typed exit code. **Client-side** validation (malformed inputs, bad UUIDs, unknown flags, unreachable hosts) may exit `1` with `{"type": "error", ...}` even when the underlying problem is auth- or validation-shaped. Don't dispatch on exit code alone: agents and scripts should parse the stderr JSON and branch on the `type` field. See [Rules for agents](./using-with-ai-agents#rules-for-agents).
 
 ## Retry behavior
 

--- a/docs/ai-agents/interfaces/cli/command-reference.md
+++ b/docs/ai-agents/interfaces/cli/command-reference.md
@@ -63,6 +63,20 @@ The response is wrapped under an `organizations` key (`{"organizations": [...], 
 
 No required parameters.
 
+### `organizations use`
+
+Persist a default organization UUID to `~/.airbyte-agent/settings.json`. Subsequent commands scope to this organization. Useful when you belong to more than one and don't want to pass `--org-id` to `login` each time.
+
+```bash
+airbyte-agent organizations use --json '{"id": "<organization-uuid>"}'
+```
+
+| Param | Type | Required | Description |
+| --- | --- | --- | --- |
+| `id` | string | yes | Organization UUID. Must belong to the authenticated account; the CLI verifies via `organizations list` before writing. Match is case-insensitive. |
+
+Requires an existing `~/.airbyte-agent/settings.json`. Run `airbyte-agent login` first on a fresh machine; `organizations use` doesn't bootstrap a settings file from environment variables alone.
+
 ## `workspaces`
 
 ### `workspaces list`

--- a/docs/ai-agents/interfaces/cli/command-reference.md
+++ b/docs/ai-agents/interfaces/cli/command-reference.md
@@ -11,7 +11,7 @@ Every command on the CLI follows the same shape:
 airbyte-agent <resource> <operation> [flags]
 ```
 
-Run `airbyte-agent --help` to list resources, `airbyte-agent <resource> --help` to list operations, and `airbyte-agent <resource> <operation> --describe` to print the parameter schema and the underlying OpenAPI request and response shapes without executing the call. This page summarizes that surface in one place.
+Run `airbyte-agent --help` to list resources, `airbyte-agent <resource> --help` to list operations, and `airbyte-agent <resource> <operation> --describe` to print the parameter schema (plus the underlying OpenAPI request and response shapes when the operation maps to a public API route) without executing the call. This page summarizes that surface in one place.
 
 :::note Single source of truth
 If anything on this page disagrees with `--describe` output, `--describe` wins. Run it whenever you need the canonical parameter list for a command.
@@ -24,13 +24,24 @@ These flags are available on every operation.
 | Flag | Description | Default |
 | --- | --- | --- |
 | `--json` | Inline JSON parameters. Pass `@filename` to load from a file. Mutually exclusive with per-parameter flags. | (none) |
-| `--format` | Output format: `json` or `table`. | `json` |
-| `--describe` | Print the operation's parameter schema (plus OpenAPI shape) and exit without executing. | `false` |
+| `--format` | Output format: `json` or `table`. `table` works best on operations whose response is a flat array of records; responses wrapped in `{ "data": [...], "meta": {...} }` render with the array under a `DATA` column. When in doubt, stick with `json` and use `--fields` to trim it. | `json` |
+| `--describe` | Print the operation's parameter schema (and OpenAPI shape, when the operation maps to a public API route) and exit without executing. Operations backed by internal-only routes return `{"type": "not_supported", ...}` on stderr with exit code `3`; use `--help` instead. | `false` |
 | `--output`, `-o` | Write stdout to a file instead of the terminal. | (none) |
 | `--verbose`, `-v` | Enable debug logging on stderr. | `false` |
 | `--fields` | Client-side response filter. Comma-separated dot paths (for example, `data.id,data.name`). Errors are not filtered. | (none) |
 
 Per-parameter flags are generated from each operation's schema. Snake_case parameter names become kebab-case flags. For example, `select_fields` is exposed as `--select-fields`.
+
+## Top-level commands
+
+A few commands live at the top level rather than under a resource:
+
+| Command | Description |
+| --- | --- |
+| `airbyte-agent configure` | Prompt for `client_id`, `client_secret`, `organization_id`, and a default workspace, then write `~/.airbyte-agent/settings.json` with `0600` permissions. See [Authenticate](./authenticate). |
+| `airbyte-agent configure show` | Print the saved settings (with `client_secret` obfuscated). Useful for `--verbose` debugging and for sharing a redacted dump in bug reports. |
+| `airbyte-agent version` | Print version, commit, and build date as JSON. |
+| `airbyte-agent schema <resource> <operation>` | Equivalent to `<resource> <operation> --describe`, but discoverable as a top-level command. Returns `{"type": "not_supported", ...}` (exit `3`) for operations backed by internal-only API routes. |
 
 ## `organizations`
 
@@ -40,7 +51,7 @@ List the organizations you belong to.
 
 ```bash
 airbyte-agent organizations list
-airbyte-agent organizations list --format table --fields id,organization_name
+airbyte-agent organizations list --fields data.id,data.organization_name
 ```
 
 No required parameters.
@@ -92,7 +103,7 @@ airbyte-agent connectors list --json '{"workspace": "default"}'
 List the connectors you can create. No required parameters.
 
 ```bash
-airbyte-agent connectors list-available --format table
+airbyte-agent connectors list-available
 ```
 
 ### `connectors describe`

--- a/docs/ai-agents/interfaces/cli/command-reference.md
+++ b/docs/ai-agents/interfaces/cli/command-reference.md
@@ -19,7 +19,7 @@ If anything on this page disagrees with `--describe` output, `--describe` wins. 
 
 ## Common flags
 
-These flags are available on every operation.
+These flags are exposed on every resource operation:
 
 | Flag | Description | Default |
 | --- | --- | --- |
@@ -28,9 +28,11 @@ These flags are available on every operation.
 | `--describe` | Print the operation's parameter schema (and OpenAPI shape, when the operation maps to a public API route) and exit without executing. Operations backed by internal-only routes return `{"type": "not_supported", ...}` on stderr with exit code `3`; use `--help` instead. | `false` |
 | `--output`, `-o` | Write stdout to a file instead of the terminal. | (none) |
 | `--verbose`, `-v` | Enable debug logging on stderr. | `false` |
-| `--fields` | Client-side response filter. Comma-separated dot paths (for example, `data.id,data.name`). Errors are not filtered. | (none) |
+| `--fields` | Client-side response filter. Comma-separated dot paths (for example, `organizations.id,organizations.organization_name`). Errors are not filtered. | (none) |
 
 Per-parameter flags are generated from each operation's schema. Snake_case parameter names become kebab-case flags. For example, `select_fields` is exposed as `--select-fields`.
+
+The flags above don't all apply to the top-level commands (`configure`, `configure show`, `version`, `schema`). `--json` in particular isn't a valid flag on those: `airbyte-agent version --json '{}'` exits `1` because the flag is unknown to that command. Top-level commands write their output directly to stdout, so `--fields`, `--format`, and `--output` are also no-ops there; use shell tools (`jq`, redirection) if you need to post-process the result.
 
 ## Top-level commands
 
@@ -51,8 +53,10 @@ List the organizations you belong to.
 
 ```bash
 airbyte-agent organizations list
-airbyte-agent organizations list --fields data.id,data.organization_name
+airbyte-agent organizations list --fields organizations.id,organizations.organization_name
 ```
+
+The response is wrapped under an `organizations` key (`{"organizations": [...], "is_instance_admin": ...}`), so `--fields` paths start with `organizations.` rather than `data.`.
 
 No required parameters.
 
@@ -174,7 +178,7 @@ airbyte-agent connectors delete --json '{"workspace": "default", "name": "old-hu
 | `workspace` | string | with `name` | Workspace the connector lives in. |
 | `id` | string | one of `name`+`workspace` or `id` | Connector ID (UUID). |
 
-Without a TTY (piped input from an agent harness, for example), the prompt can't run. The command refuses with a `validation_error` whose hint tells you to grant one-time permission by setting `"allow_destructive": true` in `~/.airbyte-agent/settings.json` (or `AIRBYTE_ALLOW_DESTRUCTIVE=true` for a single invocation). See [Troubleshooting](./troubleshooting#destructive-delete-on-a-non-tty-machine).
+If you type something other than `yes` (or just press Enter), the command exits `4` with `"destructive action cancelled by user"`. Without a TTY (piped input from an agent harness, for example), the prompt can't run at all and the command refuses with `"destructive action requires confirmation but no TTY is available"`. Grant one-time permission to skip the prompt by setting `"allow_destructive": true` in `~/.airbyte-agent/settings.json` (or `AIRBYTE_ALLOW_DESTRUCTIVE=true` for a single invocation). See [Troubleshooting](./troubleshooting#destructive-delete-refused).
 
 ## Exit codes
 

--- a/docs/ai-agents/interfaces/cli/describe-connector.md
+++ b/docs/ai-agents/interfaces/cli/describe-connector.md
@@ -1,0 +1,73 @@
+---
+plan: all
+sidebar_position: 4
+---
+
+# Describe a connector
+
+`connectors describe` returns the contract for a connector: every entity it exposes, every action valid on each entity, and the parameter schema each action accepts. It's the source of truth for what a specific connector supports, and the first thing you should call before running [`connectors execute`](./execute) against an unfamiliar connector.
+
+Entity and action names vary by connector type. Don't guess them — every guess is an avoidable round trip and, for write actions, a possible mistake.
+
+## Describe by name
+
+```bash
+airbyte-agent connectors describe --json '{
+  "workspace": "default",
+  "name": "hubspot"
+}'
+```
+
+`name` plus `workspace` resolves to a single connector. `workspace` falls back to the default set by [`workspaces use`](./workspaces#set-a-default-workspace) when omitted.
+
+## Describe by ID
+
+When a workspace has multiple connectors of the same type, pass the connector ID directly:
+
+```bash
+airbyte-agent connectors describe --id <connector_id>
+```
+
+You can get the ID from [`connectors list`](./add-connector#list-existing-connectors) or from the create response.
+
+## Reading the output
+
+The response is a JSON document with three sections:
+
+- `connector`: high-level metadata (`id`, `name`, `type`, status).
+- `entities`: an array of entities the connector exposes. Each entity has a `name`, a list of `actions`, and per-action parameter schemas.
+- `schema`: when available, the JSON Schema for entity records the connector returns. Useful for figuring out which fields to pass to `select_fields` or `--fields`.
+
+A trimmed example:
+
+```jsonc
+{
+  "connector": { "id": "f24fb2b0-...", "name": "hubspot", "type": "HubSpot" },
+  "entities": [
+    {
+      "name": "contacts",
+      "actions": [
+        { "name": "list", "params": { "limit": { "type": "integer" } } },
+        { "name": "context_store_search", "params": { "query": { "type": "object" } } },
+        { "name": "get", "params": { "id": { "type": "string", "required": true } } }
+      ]
+    }
+  ]
+}
+```
+
+Once you know the entity and action you want to run, pass them to [`connectors execute`](./execute).
+
+## Trim the response
+
+Describe responses can be large. Use `--fields` to keep only what you need:
+
+```bash
+# Just the entity and action names
+airbyte-agent connectors describe --json '{"workspace": "default", "name": "hubspot"}' \
+  --fields 'entities.name,entities.actions.name'
+```
+
+## When entities or actions look wrong
+
+If `describe` returns an unexpected schema — missing entities, unexpected required params — the underlying connector definition may have changed. Re-run `connectors list-available` to make sure the template is still present, and check the connector's [reference page](../../connectors) for the canonical entity list.

--- a/docs/ai-agents/interfaces/cli/describe-connector.md
+++ b/docs/ai-agents/interfaces/cli/describe-connector.md
@@ -70,4 +70,4 @@ airbyte-agent connectors describe --json '{"workspace": "default", "name": "hubs
 
 ## When entities or actions look wrong
 
-If `describe` returns an unexpected schema — missing entities, unexpected required params — the underlying connector definition may have changed. Re-run `connectors list-available` to make sure the template is still present, and check the connector's [reference page](../../connectors) for the canonical entity list.
+If `describe` returns an unexpected schema — missing entities, unexpected required params — the underlying connector definition may have changed. Re-run `connectors list-available` to make sure the connector is still available, and check the connector's [reference page](../../connectors) for the canonical entity list.

--- a/docs/ai-agents/interfaces/cli/describe-connector.md
+++ b/docs/ai-agents/interfaces/cli/describe-connector.md
@@ -7,7 +7,7 @@ sidebar_position: 4
 
 `connectors describe` returns the contract for a connector: every entity it exposes, every action valid on each entity, and the parameter schema each action accepts. It's the source of truth for what a specific connector supports, and the first thing you should call before running [`connectors execute`](./execute) against an unfamiliar connector.
 
-Entity and action names vary by connector type. Don't guess them — every guess is an avoidable round trip and, for write actions, a possible mistake.
+Entity and action names vary by connector type. Don't guess them. Every guess is an avoidable round trip, and for write actions, a possible mistake.
 
 ## Describe by name
 
@@ -70,4 +70,4 @@ airbyte-agent connectors describe --json '{"workspace": "default", "name": "hubs
 
 ## When entities or actions look wrong
 
-If `describe` returns an unexpected schema — missing entities, unexpected required params — the underlying connector definition may have changed. Re-run `connectors list-available` to make sure the connector is still available, and check the connector's [reference page](../../connectors) for the canonical entity list.
+If `describe` returns an unexpected schema (missing entities, or unexpected required params), the underlying connector definition may have changed. Re-run `connectors list-available` to make sure the connector is still available, and check the connector's [reference page](../../connectors) for the canonical entity list.

--- a/docs/ai-agents/interfaces/cli/execute.md
+++ b/docs/ai-agents/interfaces/cli/execute.md
@@ -1,0 +1,150 @@
+---
+plan: all
+sidebar_position: 5
+---
+
+# Execute operations
+
+`connectors execute` runs an action against an entity on a connector. It's the workhorse command — every actual read, search, or write happens through it.
+
+```bash
+airbyte-agent connectors execute --json '{
+  "workspace": "default",
+  "name": "hubspot",
+  "entity": "contacts",
+  "action": "read",
+  "select_fields": ["id", "email", "name"]
+}'
+```
+
+Required fields:
+
+- `name` (with `workspace`) or `id`: which connector to run against.
+- `entity`: the resource, such as `contacts`, `issues`, `repositories`.
+- `action`: an action the connector supports on that entity, such as `list`, `get`, `context_store_search`, or `read`.
+
+Always run [`connectors describe`](./describe-connector) before the first execute on a connector. Entity and action names vary per connector and aren't guessable.
+
+## Pick the right action
+
+Most connectors expose a baseline set of actions. The authoritative list for a given connector comes from `connectors describe`, but as a starting point:
+
+| Action | Purpose | Filtering |
+| --- | --- | --- |
+| `context_store_search` | Default for reads. Filter, sort, paginate over the indexed entity store. | Yes (rich). |
+| `list` | Live read directly from the source. Use when the search index may lag or when you need today's data. | Limited. |
+| `get` | Fetch a single entity by ID. | N/A. |
+| `api_search` | Provider-native search (for example, Slack search syntax). | Provider-specific. |
+| `create` | Write a new entity. | N/A. |
+| `update` | Modify an existing entity. | N/A. |
+
+For reads, prefer `context_store_search` unless you specifically need real-time data — the indexed store is faster and supports richer filtering. Fall back to `list` when search returns empty and you suspect indexing lag.
+
+## Pass action-specific parameters
+
+Action-specific arguments go under `params`. The shape is entity- and action-dependent — `describe` is authoritative:
+
+```bash
+airbyte-agent connectors execute --json '{
+  "workspace": "default",
+  "name": "hubspot",
+  "entity": "contacts",
+  "action": "context_store_search",
+  "select_fields": ["id", "email", "firstName"],
+  "params": {
+    "limit": 20,
+    "query": {"filter": {"fuzzy": {"firstName": "Teo"}}}
+  }
+}'
+```
+
+## Filter the response
+
+Unfiltered responses can be large. The CLI gives you two layers of filtering — use both whenever you know which fields you need.
+
+### `select_fields` and `exclude_fields` (API-side)
+
+Both belong inside the JSON payload and are forwarded to the source connector. `select_fields` is an allowlist; `exclude_fields` is a blocklist. They support dot notation for nested fields. If both are passed, `select_fields` wins.
+
+```bash
+# Keep only id, email, name
+airbyte-agent connectors execute --json '{
+  "workspace": "default", "name": "hubspot",
+  "entity": "contacts", "action": "read",
+  "select_fields": ["id", "email", "name"]
+}'
+
+# Drop heavy fields
+airbyte-agent connectors execute --json '{
+  "workspace": "default", "name": "hubspot",
+  "entity": "messages", "action": "read",
+  "exclude_fields": ["body_html", "attachments"]
+}'
+```
+
+API-side filtering reduces upstream work — the source connector doesn't emit columns you don't need.
+
+### `--fields` (client-side)
+
+`--fields` filters the response after the API returns it. Use it to shape the printed payload without changing what the source connector emits.
+
+```bash
+airbyte-agent connectors execute --json '{...}' --fields 'data.id,data.email'
+```
+
+Paths use dot notation. When a path crosses an array, the remaining segments apply to every element ("array broadcast"). For list-style responses wrapped in `{"data": [...]}`, you can omit the `data.` prefix:
+
+```bash
+airbyte-agent organizations list --fields id,organization_name
+airbyte-agent organizations list --fields data.id,data.organization_name
+```
+
+Both forms work. The CLI auto-broadcasts when no path matches a top-level key.
+
+The two layers are complementary. Pass `select_fields` to reduce upstream work and `--fields` to keep stdout clean for human consumption. Errors are never filtered — you always see the full error payload.
+
+## Long payloads
+
+`execute` payloads can get long (large `query` objects, nested filters). Load them from a file with `--json @path/to/file.json`:
+
+```bash
+cat > read-contacts.json <<'JSON'
+{
+  "workspace": "default",
+  "name": "hubspot",
+  "entity": "contacts",
+  "action": "context_store_search",
+  "select_fields": ["id", "email", "firstName"],
+  "params": {
+    "limit": 50,
+    "query": {
+      "filter": {"and": [{"equals": {"email_status": "verified"}}]}
+    }
+  }
+}
+JSON
+
+airbyte-agent connectors execute --json @read-contacts.json
+```
+
+`@filename` is resolved relative to the current working directory.
+
+## Pagination
+
+Pagination is action- and connector-specific. `list` typically accepts `cursor`, `per_page`, or both. `context_store_search` returns a `next` token alongside `data`. Run `describe` to see the exact params and the cursor shape an action returns.
+
+## Errors
+
+Validation errors (missing `entity`, missing `action`, malformed `params`) exit with code `4` and a JSON error on stderr. API errors include the full server response in `detail`:
+
+```json
+{
+  "type": "validation_error",
+  "message": "Invalid configuration",
+  "status_code": 400,
+  "retryable": false,
+  "detail": {"errors": [{"field": "limit", "message": "must be <= 100"}]}
+}
+```
+
+For the full error matrix and retry behavior, see [Troubleshooting](./troubleshooting).

--- a/docs/ai-agents/interfaces/cli/execute.md
+++ b/docs/ai-agents/interfaces/cli/execute.md
@@ -12,8 +12,8 @@ airbyte-agent connectors execute --json '{
   "workspace": "default",
   "name": "hubspot",
   "entity": "contacts",
-  "action": "read",
-  "select_fields": ["id", "email", "name"]
+  "action": "context_store_search",
+  "select_fields": ["id", "email", "firstName"]
 }'
 ```
 
@@ -21,7 +21,7 @@ Required fields:
 
 - `name` (with `workspace`) or `id`: which connector to run against.
 - `entity`: the resource, such as `contacts`, `issues`, `repositories`.
-- `action`: an action the connector supports on that entity, such as `list`, `get`, `context_store_search`, or `read`.
+- `action`: an action the connector supports on that entity. The baseline set is `context_store_search`, `list`, `get`, `api_search`, `create`, and `update`; the authoritative list for a specific connector comes from `connectors describe`.
 
 Always run [`connectors describe`](./describe-connector) before the first execute on a connector. Entity and action names vary per connector and aren't guessable.
 
@@ -67,18 +67,18 @@ Unfiltered responses can be large. The CLI gives you two layers of filtering, an
 Both belong inside the JSON payload and are forwarded to the source connector. `select_fields` is an allowlist; `exclude_fields` is a blocklist. They support dot notation for nested fields. If both are passed, `select_fields` wins.
 
 ```bash
-# Keep only id, email, name
+# Keep only id, email, firstName
 airbyte-agent connectors execute --json '{
   "workspace": "default", "name": "hubspot",
-  "entity": "contacts", "action": "read",
-  "select_fields": ["id", "email", "name"]
+  "entity": "contacts", "action": "context_store_search",
+  "select_fields": ["id", "email", "firstName"]
 }'
 
 # Drop heavy fields
 airbyte-agent connectors execute --json '{
-  "workspace": "default", "name": "hubspot",
-  "entity": "messages", "action": "read",
-  "exclude_fields": ["body_html", "attachments"]
+  "workspace": "default", "name": "slack",
+  "entity": "messages", "action": "list",
+  "exclude_fields": ["blocks", "attachments"]
 }'
 ```
 

--- a/docs/ai-agents/interfaces/cli/execute.md
+++ b/docs/ai-agents/interfaces/cli/execute.md
@@ -5,7 +5,7 @@ sidebar_position: 5
 
 # Execute operations
 
-`connectors execute` runs an action against an entity on a connector. It's the workhorse command — every actual read, search, or write happens through it.
+`connectors execute` runs an action against an entity on a connector. It's the workhorse command: every read, search, or write happens through it.
 
 ```bash
 airbyte-agent connectors execute --json '{
@@ -38,11 +38,11 @@ Most connectors expose a baseline set of actions. The authoritative list for a g
 | `create` | Write a new entity. | N/A. |
 | `update` | Modify an existing entity. | N/A. |
 
-For reads, prefer `context_store_search` unless you specifically need real-time data — the indexed store is faster and supports richer filtering. Fall back to `list` when search returns empty and you suspect indexing lag.
+For reads, prefer `context_store_search` unless you specifically need real-time data. The indexed store is faster and supports richer filtering. Fall back to `list` when search returns empty and you suspect indexing lag.
 
 ## Pass action-specific parameters
 
-Action-specific arguments go under `params`. The shape is entity- and action-dependent — `describe` is authoritative:
+Action-specific arguments go under `params`. The shape is entity- and action-dependent, and `describe` is authoritative:
 
 ```bash
 airbyte-agent connectors execute --json '{
@@ -60,7 +60,7 @@ airbyte-agent connectors execute --json '{
 
 ## Filter the response
 
-Unfiltered responses can be large. The CLI gives you two layers of filtering — use both whenever you know which fields you need.
+Unfiltered responses can be large. The CLI gives you two layers of filtering, and you should use both whenever you know which fields you need.
 
 ### `select_fields` and `exclude_fields` (API-side)
 
@@ -82,7 +82,7 @@ airbyte-agent connectors execute --json '{
 }'
 ```
 
-API-side filtering reduces upstream work — the source connector doesn't emit columns you don't need.
+API-side filtering reduces upstream work; the source connector doesn't emit columns you don't need.
 
 ### `--fields` (client-side)
 
@@ -101,7 +101,7 @@ airbyte-agent organizations list --fields data.id,data.organization_name
 
 Both forms work. The CLI auto-broadcasts when no path matches a top-level key.
 
-The two layers are complementary. Pass `select_fields` to reduce upstream work and `--fields` to keep stdout clean for human consumption. Errors are never filtered — you always see the full error payload.
+The two layers are complementary. Pass `select_fields` to reduce upstream work and `--fields` to keep stdout clean for human consumption. Errors are never filtered; you always see the full error payload.
 
 ## Long payloads
 

--- a/docs/ai-agents/interfaces/cli/readme.md
+++ b/docs/ai-agents/interfaces/cli/readme.md
@@ -7,7 +7,7 @@ import DocCardList from '@theme/DocCardList';
 
 # CLI
 
-The Airbyte Agent CLI (`airbyte-agent`) is a single Go binary that exposes Airbyte Agents through a uniform `airbyte-agent <resource> <operation>` interface. Every command takes JSON in (`--json`), returns JSON out, supports schema introspection via `--describe`, and exits with stable error codes — which makes it safe to script from a shell and easy for AI agents to discover and call at runtime.
+The Airbyte Agent CLI (`airbyte-agent`) is a single Go binary that exposes Airbyte Agents through a uniform `airbyte-agent <resource> <operation>` interface. Every command takes JSON in (`--json`), returns JSON out, supports schema introspection via `--describe`, and exits with stable error codes, so it's safe to script from a shell and easy for AI agents to discover and call at runtime.
 
 The CLI is the right interface when you want:
 
@@ -81,7 +81,7 @@ There are three resources today:
 | `workspaces` | `list`, `use` | List workspaces, and persist a default in `~/.airbyte-agent/settings.json`. |
 | `connectors` | `list`, `list-available`, `describe`, `create`, `execute`, `delete` | Manage and run connectors in a workspace. |
 
-For the full command surface — params, flags, and exit codes — see the [Command reference](./command-reference).
+For the full command surface, including params, flags, and exit codes, see the [Command reference](./command-reference).
 
 ### JSON in, JSON out
 
@@ -108,7 +108,7 @@ To load a long JSON payload from a file, use `--json @path/to/file.json`.
 
 ### Discover before you execute
 
-`--describe` returns the schema for an operation — parameters, types, and the underlying OpenAPI request and response shapes — without running it. Use it whenever you're unsure what an operation accepts:
+`--describe` returns the schema for an operation (parameters, types, and the underlying OpenAPI request and response shapes) without running it. Use it whenever you're unsure what an operation accepts:
 
 ```bash
 airbyte-agent connectors execute --describe

--- a/docs/ai-agents/interfaces/cli/readme.md
+++ b/docs/ai-agents/interfaces/cli/readme.md
@@ -7,7 +7,7 @@ import DocCardList from '@theme/DocCardList';
 
 # CLI
 
-The Airbyte Agent CLI (`airbyte-agent`) is a single Go binary that exposes Airbyte Agents through a uniform `airbyte-agent <resource> <operation>` interface. Every command takes JSON in (`--json`), returns JSON out, supports schema introspection via `--describe`, and exits with stable error codes, so it's safe to script from a shell and easy for AI agents to discover and call at runtime.
+The Airbyte Agent CLI (`airbyte-agent`) is a single Go binary that exposes Airbyte Agents through a uniform `airbyte-agent <resource> <operation>` interface. Resource operations accept JSON in (`--json`), return JSON out, and support schema introspection via `--describe`. Every command exits with a stable code, so it's safe to script from a shell and easy for AI agents to discover and call at runtime. A few top-level commands (`configure`, `version`, `schema`) sit outside the resource model and don't take `--json`.
 
 The CLI is the right interface when you want:
 

--- a/docs/ai-agents/interfaces/cli/readme.md
+++ b/docs/ai-agents/interfaces/cli/readme.md
@@ -60,10 +60,10 @@ airbyte-agent version
 After [authenticating](./authenticate), list the workspaces in your organization:
 
 ```bash
-airbyte-agent workspaces list --format table
+airbyte-agent workspaces list
 ```
 
-The CLI prints JSON to stdout by default. Pass `--format table` for a human-readable table, or `--fields` to keep only the columns you want. See [Execute operations](./execute) for the full output-filtering rules.
+The CLI prints JSON to stdout by default. Pass `--fields` to keep only the columns you want, or `--format table` for a human-readable rendering of array-of-record responses. See [Execute operations](./execute) for the full output-filtering rules.
 
 ## Command model
 
@@ -108,13 +108,15 @@ To load a long JSON payload from a file, use `--json @path/to/file.json`.
 
 ### Discover before you execute
 
-`--describe` returns the schema for an operation (parameters, types, and the underlying OpenAPI request and response shapes) without running it. Use it whenever you're unsure what an operation accepts:
+`--describe` returns the schema for an operation (parameters, types, and, when the operation maps to a public API route, the underlying OpenAPI request and response shapes) without running it. Use it whenever you're unsure what an operation accepts:
 
 ```bash
 airbyte-agent connectors execute --describe
 ```
 
 For connector-specific entities and actions, [`connectors describe`](./describe-connector) is the authoritative source. Never guess what a connector supports; ask `describe` first.
+
+A handful of operations are backed by internal-only API routes (currently `organizations list`) and return `{"type": "not_supported", ...}` on stderr with exit code `3` when introspected via `--describe`. Use `airbyte-agent <resource> <operation> --help` for those. `airbyte-agent schema <resource> <operation>` is an alias for `--describe` and behaves the same way.
 
 ### Exit codes and errors
 

--- a/docs/ai-agents/interfaces/cli/readme.md
+++ b/docs/ai-agents/interfaces/cli/readme.md
@@ -126,7 +126,7 @@ airbyte-agent schema connectors execute
 
 For connector-specific entities and actions, [`connectors describe`](./describe-connector) is the authoritative source. Never guess what a connector supports; ask `describe` first.
 
-A handful of operations are backed by internal-only API routes (currently `organizations list`) and return `{"type": "not_supported", ...}` on stderr with exit code `3` when introspected via `schema`. Use `airbyte-agent <resource> <operation> --help` for those.
+A handful of operations are backed by internal-only API routes (`organizations list` and `organizations use`) and return `{"type": "not_supported", ...}` on stderr with exit code `3` when introspected via `schema`. Use `airbyte-agent <resource> <operation> --help` for those.
 
 ### Exit codes and errors
 

--- a/docs/ai-agents/interfaces/cli/readme.md
+++ b/docs/ai-agents/interfaces/cli/readme.md
@@ -63,15 +63,17 @@ After [authenticating](./authenticate), list the workspaces in your organization
 airbyte-agent workspaces list
 ```
 
-The CLI prints JSON to stdout by default. Pass `--fields` to keep only the columns you want, or `--format table` for a human-readable rendering of array-of-record responses. See [Execute operations](./execute) for the full output-filtering rules.
+The CLI prints JSON to stdout by default. Pass `--fields` to keep only the columns you want. `--format table` works best on responses that are a flat array of records; wrapped responses (`{"data": [...]}`, `{"workspaces": [...]}`, and so on) render with the array under a single `DATA` column containing JSON, so for those `json` plus `--fields` is usually more readable. See [Execute operations](./execute) for the full output-filtering rules.
 
 ## Command model
 
-Every command follows the same shape:
+Resource commands follow the same shape:
 
 ```bash
 airbyte-agent <resource> <operation> [flags]
 ```
+
+A few top-level commands (`configure`, `configure show`, `version`, and `schema <resource> <operation>`) sit outside this pattern and don't take `--json`; see the [Command reference](./command-reference) for details.
 
 There are three resources today:
 

--- a/docs/ai-agents/interfaces/cli/readme.md
+++ b/docs/ai-agents/interfaces/cli/readme.md
@@ -1,0 +1,135 @@
+---
+plan: all
+sidebar_position: 3
+---
+
+import DocCardList from '@theme/DocCardList';
+
+# CLI
+
+The Airbyte Agent CLI (`airbyte-agent`) is a single Go binary that exposes Airbyte Agents through a uniform `airbyte-agent <resource> <operation>` interface. Every command takes JSON in (`--json`), returns JSON out, supports schema introspection via `--describe`, and exits with stable error codes — which makes it safe to script from a shell and easy for AI agents to discover and call at runtime.
+
+The CLI is the right interface when you want:
+
+- A shell-first way to talk to Airbyte Agents (scripts, CI jobs, ad-hoc terminal use).
+- A non-Python tool an AI-agent harness (Claude Code, Codex, and similar) can shell out to.
+- A portable single-binary alternative to the [Python SDK](../sdk) or the [HTTP API](../api).
+
+Source code, releases, and bundled agent skills live at [`airbytehq/airbyte-agent-cli`](https://github.com/airbytehq/airbyte-agent-cli).
+
+## Prerequisites
+
+Before you install the CLI, make sure you have:
+
+- An Airbyte Agents account. [Sign up at app.airbyte.ai](https://app.airbyte.ai) if you don't have one.
+- An `AIRBYTE_CLIENT_ID`, `AIRBYTE_CLIENT_SECRET`, and `AIRBYTE_ORGANIZATION_ID`. You can read these from **Settings > Profile** in the web app. See [Manage your user profile](../../admin/profile) for details.
+- For [`connectors create`](./add-connector), a browser on the machine running the CLI. The credential flow opens a browser tab so you can authenticate with the third-party service.
+
+## Install
+
+Choose the install method that fits your environment.
+
+### Homebrew (macOS, Linux)
+
+```bash
+brew install airbytehq/tap/airbyte-agent
+```
+
+### Manual binary download
+
+Download the archive for your platform from the [latest release](https://github.com/airbytehq/airbyte-agent-cli/releases/latest), extract it, and put `airbyte-agent` somewhere on your `PATH`. Builds are published for `linux`, `darwin`, and `windows` on both `amd64` and `arm64` (except Windows `arm64`).
+
+### Build from source
+
+```bash
+git clone https://github.com/airbytehq/airbyte-agent-cli.git
+cd airbyte-agent-cli
+make build         # builds ./airbyte-agent
+# or
+make install       # installs to $GOBIN
+```
+
+### Verify the install
+
+```bash
+airbyte-agent version
+```
+
+## Your first command
+
+After [authenticating](./authenticate), list the workspaces in your organization:
+
+```bash
+airbyte-agent workspaces list --format table
+```
+
+The CLI prints JSON to stdout by default. Pass `--format table` for a human-readable table, or `--fields` to keep only the columns you want. See [Execute operations](./execute) for the full output-filtering rules.
+
+## Command model
+
+Every command follows the same shape:
+
+```bash
+airbyte-agent <resource> <operation> [flags]
+```
+
+There are three resources today:
+
+| Resource | Operations | What it covers |
+| --- | --- | --- |
+| `organizations` | `list` | Read your organizations. |
+| `workspaces` | `list`, `use` | List workspaces, and persist a default in `~/.airbyte-agent/settings.json`. |
+| `connectors` | `list`, `list-available`, `describe`, `create`, `execute`, `delete` | Manage and run connectors in a workspace. |
+
+For the full command surface — params, flags, and exit codes — see the [Command reference](./command-reference).
+
+### JSON in, JSON out
+
+Every operation accepts parameters either as a single JSON document (`--json '{...}'`) or as individual flags (`--workspace foo --name bar`). The two modes are mutually exclusive. JSON is the recommended path for agents and for any payload with nested objects; flags are convenient at a human terminal.
+
+```bash
+# JSON
+airbyte-agent connectors execute --json '{
+  "workspace": "default",
+  "name": "hubspot",
+  "entity": "contacts",
+  "action": "read",
+  "select_fields": ["id", "email"]
+}'
+
+# Flags
+airbyte-agent connectors execute \
+  --workspace default --name hubspot \
+  --entity contacts --action read \
+  --select-fields id,email
+```
+
+To load a long JSON payload from a file, use `--json @path/to/file.json`.
+
+### Discover before you execute
+
+`--describe` returns the schema for an operation — parameters, types, and the underlying OpenAPI request and response shapes — without running it. Use it whenever you're unsure what an operation accepts:
+
+```bash
+airbyte-agent connectors execute --describe
+```
+
+For connector-specific entities and actions, [`connectors describe`](./describe-connector) is the authoritative source. Never guess what a connector supports; ask `describe` first.
+
+### Exit codes and errors
+
+The CLI returns structured JSON errors on stderr with stable exit codes you can branch on from a script or an agent:
+
+| Exit code | Meaning |
+| --- | --- |
+| `0` | Success. |
+| `1` | General error. |
+| `2` | Authentication error. |
+| `3` | Not found. |
+| `4` | Validation error. |
+
+See [Troubleshooting](./troubleshooting) for the common ones.
+
+## Next steps
+
+<DocCardList />

--- a/docs/ai-agents/interfaces/cli/readme.md
+++ b/docs/ai-agents/interfaces/cli/readme.md
@@ -35,6 +35,14 @@ Choose the install method that fits your environment.
 brew install airbytehq/tap/airbyte-agent
 ```
 
+### Install script (CLI + agent skill)
+
+```bash
+curl -fsSL https://airbyte.ai/install.sh | bash
+```
+
+Installs the latest CLI binary plus the bundled [agent skill](./using-with-ai-agents#install-the-bundled-skill) to `~/.claude/skills/airbyte-agent/`. Set `AIRBYTE_AGENT_SKIP_SKILLS=1` to install the binary only, or `AIRBYTE_AGENT_SKILLS_DIR=...` to redirect the skill.
+
 ### Manual binary download
 
 Download the archive for your platform from the [latest release](https://github.com/airbytehq/airbyte-agent-cli/releases/latest), extract it, and put `airbyte-agent` somewhere on your `PATH`. Builds are published for `linux`, `darwin`, and `windows` on both `amd64` and `arm64` (except Windows `arm64`).

--- a/docs/ai-agents/interfaces/cli/readme.md
+++ b/docs/ai-agents/interfaces/cli/readme.md
@@ -13,7 +13,7 @@ The CLI is the right interface when you want:
 
 - A shell-first way to talk to Airbyte Agents (scripts, CI jobs, ad-hoc terminal use).
 - A non-Python tool an AI-agent harness (Claude Code, Codex, and similar) can shell out to.
-- A portable single-binary alternative to the [Python SDK](../sdk) or the [HTTP API](../api).
+- A portable single-binary alternative to the [Python SDK](../sdk) or the [Agent API](../api).
 
 Source code, releases, and bundled agent skills live at [`airbytehq/airbyte-agent-cli`](https://github.com/airbytehq/airbyte-agent-cli).
 

--- a/docs/ai-agents/interfaces/cli/readme.md
+++ b/docs/ai-agents/interfaces/cli/readme.md
@@ -95,14 +95,14 @@ airbyte-agent connectors execute --json '{
   "workspace": "default",
   "name": "hubspot",
   "entity": "contacts",
-  "action": "read",
+  "action": "context_store_search",
   "select_fields": ["id", "email"]
 }'
 
 # Flags
 airbyte-agent connectors execute \
   --workspace default --name hubspot \
-  --entity contacts --action read \
+  --entity contacts --action context_store_search \
   --select-fields id,email
 ```
 

--- a/docs/ai-agents/interfaces/cli/readme.md
+++ b/docs/ai-agents/interfaces/cli/readme.md
@@ -22,7 +22,7 @@ Source code, releases, and bundled agent skills live at [`airbytehq/airbyte-agen
 Before you install the CLI, make sure you have:
 
 - An Airbyte Agents account. [Sign up at app.airbyte.ai](https://app.airbyte.ai) if you don't have one.
-- An `AIRBYTE_CLIENT_ID`, `AIRBYTE_CLIENT_SECRET`, and `AIRBYTE_ORGANIZATION_ID`. You can read these from **Settings > Profile** in the web app. See [Manage your user profile](../../admin/profile) for details.
+- An `AIRBYTE_CLIENT_ID`, `AIRBYTE_CLIENT_SECRET`, and `AIRBYTE_ORGANIZATION_ID`. Sign in to [app.airbyte.ai](https://app.airbyte.ai/) and find the **Your API Credentials** card to copy them. See [Authenticate](./authenticate#get-your-credentials) for the full walkthrough.
 - For [`connectors create`](./add-connector), a browser on the machine running the CLI. The credential flow opens a browser tab so you can authenticate with the third-party service.
 
 ## Install

--- a/docs/ai-agents/interfaces/cli/readme.md
+++ b/docs/ai-agents/interfaces/cli/readme.md
@@ -7,7 +7,7 @@ import DocCardList from '@theme/DocCardList';
 
 # CLI
 
-The Airbyte Agent CLI (`airbyte-agent`) is a single Go binary that exposes Airbyte Agents through a uniform `airbyte-agent <resource> <operation>` interface. Resource operations accept JSON in (`--json`), return JSON out, and support schema introspection via `--describe`. Every command exits with a stable code, so it's safe to script from a shell and easy for AI agents to discover and call at runtime. A few top-level commands (`configure`, `version`, `schema`) sit outside the resource model and don't take `--json`.
+The Airbyte Agent CLI (`airbyte-agent`) is a single Go binary that exposes Airbyte Agents through a uniform `airbyte-agent <resource> <operation>` interface. Resource operations accept JSON in (`--json`), return JSON out, and support schema introspection via `--describe`. Every command exits with a stable code, so it's safe to script from a shell and easy for AI agents to discover and call at runtime. A few top-level commands (`login`, `version`, `schema`) sit outside the resource model and don't take `--json`.
 
 The CLI is the right interface when you want:
 
@@ -73,7 +73,7 @@ Resource commands follow the same shape:
 airbyte-agent <resource> <operation> [flags]
 ```
 
-A few top-level commands (`configure`, `configure show`, `version`, and `schema <resource> <operation>`) sit outside this pattern and don't take `--json`; see the [Command reference](./command-reference) for details.
+A few top-level commands (`login`, `login show`, `version`, and `schema <resource> <operation>`) sit outside this pattern and don't take `--json`; see the [Command reference](./command-reference) for details.
 
 There are three resources today:
 

--- a/docs/ai-agents/interfaces/cli/readme.md
+++ b/docs/ai-agents/interfaces/cli/readme.md
@@ -7,7 +7,7 @@ import DocCardList from '@theme/DocCardList';
 
 # CLI
 
-The Airbyte Agent CLI (`airbyte-agent`) is a single Go binary that exposes Airbyte Agents through a uniform `airbyte-agent <resource> <operation>` interface. Resource operations accept JSON in (`--json`), return JSON out, and support schema introspection via `--describe`. Every command exits with a stable code, so it's safe to script from a shell and easy for AI agents to discover and call at runtime. A few top-level commands (`login`, `version`, `schema`) sit outside the resource model and don't take `--json`.
+The Airbyte Agent CLI (`airbyte-agent`) is a single Go binary that exposes Airbyte Agents through a uniform `airbyte-agent <resource> <operation>` interface. Resource operations accept JSON in (`--json`), return JSON out, and support schema introspection via `airbyte-agent schema <resource> <operation>`. Every command exits with a stable code, so it's safe to script from a shell and easy for AI agents to discover and call at runtime. A few top-level commands (`login`, `version`, `schema`, `completion`) sit outside the resource model and don't take `--json`.
 
 The CLI is the right interface when you want:
 
@@ -22,7 +22,7 @@ Source code, releases, and bundled agent skills live at [`airbytehq/airbyte-agen
 Before you install the CLI, make sure you have:
 
 - An Airbyte Agents account. [Sign up at app.airbyte.ai](https://app.airbyte.ai) if you don't have one.
-- An `AIRBYTE_CLIENT_ID`, `AIRBYTE_CLIENT_SECRET`, and `AIRBYTE_ORGANIZATION_ID`. Sign in to [app.airbyte.ai](https://app.airbyte.ai/) and find the **Your API Credentials** card to copy them. See [Authenticate](./authenticate#get-your-credentials) for the full walkthrough.
+- A signed-in [app.airbyte.ai](https://app.airbyte.ai/) account. `airbyte-agent login` opens your browser to complete the sign-in and writes credentials for you; for headless machines, [`--manual`](./authenticate#headless-machines-manual) reads them from the **Your API Credentials** card in the web app. See [Authenticate](./authenticate) for the full walkthrough.
 - For [`connectors create`](./add-connector), a browser on the machine running the CLI. The credential flow opens a browser tab so you can authenticate with the third-party service.
 
 ## Install
@@ -63,7 +63,7 @@ After [authenticating](./authenticate), list the workspaces in your organization
 airbyte-agent workspaces list
 ```
 
-The CLI prints JSON to stdout by default. Pass `--fields` to keep only the columns you want. `--format table` works best on responses that are a flat array of records; wrapped responses (`{"data": [...]}`, `{"workspaces": [...]}`, and so on) render with the array under a single `DATA` column containing JSON, so for those `json` plus `--fields` is usually more readable. See [Execute operations](./execute) for the full output-filtering rules.
+The CLI prints JSON to stdout. Pass `--fields` to keep only the dotted paths you want (for example, `--fields workspaces.id,workspaces.name`); pipe through `jq` for anything more involved. See [Execute operations](./execute) for the full output-filtering rules.
 
 ## Command model
 
@@ -110,15 +110,15 @@ To load a long JSON payload from a file, use `--json @path/to/file.json`.
 
 ### Discover before you execute
 
-`--describe` returns the schema for an operation (parameters, types, and, when the operation maps to a public API route, the underlying OpenAPI request and response shapes) without running it. Use it whenever you're unsure what an operation accepts:
+`airbyte-agent schema <resource> <operation>` returns the schema for an operation (parameters, types, and, when the operation maps to a public API route, the underlying OpenAPI request and response shapes) without running it. Use it whenever you're unsure what an operation accepts:
 
 ```bash
-airbyte-agent connectors execute --describe
+airbyte-agent schema connectors execute
 ```
 
 For connector-specific entities and actions, [`connectors describe`](./describe-connector) is the authoritative source. Never guess what a connector supports; ask `describe` first.
 
-A handful of operations are backed by internal-only API routes (currently `organizations list`) and return `{"type": "not_supported", ...}` on stderr with exit code `3` when introspected via `--describe`. Use `airbyte-agent <resource> <operation> --help` for those. `airbyte-agent schema <resource> <operation>` is an alias for `--describe` and behaves the same way.
+A handful of operations are backed by internal-only API routes (currently `organizations list`) and return `{"type": "not_supported", ...}` on stderr with exit code `3` when introspected via `schema`. Use `airbyte-agent <resource> <operation> --help` for those.
 
 ### Exit codes and errors
 

--- a/docs/ai-agents/interfaces/cli/troubleshooting.md
+++ b/docs/ai-agents/interfaces/cli/troubleshooting.md
@@ -109,9 +109,24 @@ airbyte-agent connectors list --json '{"workspace": "default"}'
 
 If the connector genuinely doesn't exist yet, create it with [`connectors create`](./add-connector).
 
-## Destructive delete on a non-TTY machine
+## Destructive delete refused
 
 ### Symptom
+
+`connectors delete` exits with code `4` and one of two `validation_error` payloads on stderr.
+
+**Cancelled at the TTY prompt** (you ran the command in a terminal and typed something other than `yes`, or pressed Enter):
+
+```json
+{
+  "type": "validation_error",
+  "message": "destructive action cancelled by user",
+  "status_code": 400,
+  "hint": "re-run the command and type 'yes' to confirm, or set \"allow_destructive\": true in settings.json"
+}
+```
+
+**No TTY available** (an agent harness, CI job, or script piped stdin, so there's no terminal to read from):
 
 ```json
 {
@@ -122,15 +137,13 @@ If the connector genuinely doesn't exist yet, create it with [`connectors create
 }
 ```
 
-Exit code `4`.
-
 ### Cause
 
-`connectors delete` is destructive. On a terminal, it prompts for `"Type 'yes' to confirm:"`. When stdin is piped (an agent harness driving the CLI, a CI job, a script), there's nothing to type, so the command refuses rather than hanging on a prompt that can never resolve.
+`connectors delete` is destructive. On a terminal, it prompts for `"Type 'yes' to confirm:"` and only proceeds when you type `yes`. Anything else is treated as a cancellation. Without a TTY, the prompt can't run at all, so the command refuses rather than hanging on input that never arrives.
 
 ### Fix
 
-Grant one-time permission. Either:
+Re-run and type `yes` at the prompt, or grant one-time permission to skip it:
 
 ```bash
 AIRBYTE_ALLOW_DESTRUCTIVE=true airbyte-agent connectors delete --json '{"workspace": "default", "name": "old-hubspot"}'

--- a/docs/ai-agents/interfaces/cli/troubleshooting.md
+++ b/docs/ai-agents/interfaces/cli/troubleshooting.md
@@ -32,7 +32,7 @@ The error text refers to a legacy `~/.airbyte-agent/credentials` path and only t
 
 ### Fix
 
-Run `airbyte-agent login` to prompt for the three values and write the settings file. See [Authenticate](./authenticate) for the alternatives.
+Run `airbyte-agent login` to open a browser, sign in to [app.airbyte.ai](https://app.airbyte.ai/), and write the settings file. On a headless machine without a browser, run `airbyte-agent login --manual` and paste the three values from the **Your API Credentials** card instead. See [Authenticate](./authenticate) for the env-var path.
 
 ## Authentication fails
 
@@ -55,9 +55,8 @@ Stale or rotated credentials, a `client_id`/`client_secret` from a different org
 
 ### Fix
 
-1. Re-read your credentials from the **Your API Credentials** card in the web app. See [Authenticate](./authenticate#get-your-credentials) if you can't find it.
-2. Re-run `airbyte-agent login`, or update the env vars.
-3. If you switched orgs, also update `AIRBYTE_ORGANIZATION_ID`.
+1. Re-run `airbyte-agent login` to refresh the credentials, or read them from the **Your API Credentials** card in the web app and update your env vars. See [Authenticate](./authenticate) if you can't find it.
+2. If you switched orgs, also update `AIRBYTE_ORGANIZATION_ID` (or sign in to the right org via `airbyte-agent login --org-id <uuid>`).
 
 ## Workspace not found
 
@@ -203,7 +202,7 @@ airbyte-agent connectors execute --json '{
   "workspace": "default",
   "name": "hubspot",
   "entity": "contacts",
-  "action": "read",
+  "action": "list",
   "select_fields": ["id", "email", "name"]
 }' --fields data.id,data.email,data.name
 ```
@@ -216,11 +215,11 @@ For very large responses, also write the output to a file:
 airbyte-agent connectors execute --json '{...}' -o response.json
 ```
 
-## `--describe` returns no `api` block or `not_supported`
+## `schema` returns no `api` block or `not_supported`
 
 ### Symptom
 
-One of two things happens when you run `--describe` (or the equivalent `airbyte-agent schema <resource> <operation>`):
+One of two things happens when you run `airbyte-agent schema <resource> <operation>`:
 
 1. The response includes `params` but the `api` block is empty or missing.
 2. The response is an error on stderr with exit code `3`:
@@ -234,7 +233,7 @@ One of two things happens when you run `--describe` (or the equivalent `airbyte-
 
 ### Cause
 
-The OpenAPI schemas in `--describe` are extracted at build time from the CLI's checked-in specs and only cover routes the CLI maps to a public API endpoint.
+The OpenAPI schemas in `schema` output are extracted at build time from the CLI's checked-in specs and only cover routes the CLI maps to a public API endpoint.
 
 - Case 1 happens when the operation maps to a route that exists in the public spec but isn't bundled, leaving `params` populated but `api` empty.
 - Case 2 happens when the operation maps to an internal-only route (any path starting with `/api/v1/internal/`). The schema lookup deliberately refuses these. Today this affects `organizations list`; the same shape applies to any future operation backed by an internal route.

--- a/docs/ai-agents/interfaces/cli/troubleshooting.md
+++ b/docs/ai-agents/interfaces/cli/troubleshooting.md
@@ -236,7 +236,7 @@ One of two things happens when you run `airbyte-agent schema <resource> <operati
 The OpenAPI schemas in `schema` output are extracted at build time from the CLI's checked-in specs and only cover routes the CLI maps to a public API endpoint.
 
 - Case 1 happens when the operation maps to a route that exists in the public spec but isn't bundled, leaving `params` populated but `api` empty.
-- Case 2 happens when the operation maps to an internal-only route (any path starting with `/api/v1/internal/`). The schema lookup deliberately refuses these. Today this affects `organizations list`; the same shape applies to any future operation backed by an internal route.
+- Case 2 happens when the operation maps to an internal-only route (any path starting with `/api/v1/internal/`) or doesn't map to an API route at all. The schema lookup deliberately refuses these. Today this affects `organizations list` and `organizations use`; the same shape applies to any future operation backed by an internal or non-API code path.
 
 ### Fix
 

--- a/docs/ai-agents/interfaces/cli/troubleshooting.md
+++ b/docs/ai-agents/interfaces/cli/troubleshooting.md
@@ -1,0 +1,236 @@
+---
+plan: all
+sidebar_position: 8
+---
+
+# Troubleshooting
+
+Errors from the CLI are returned as JSON on stderr with a stable exit code. The full taxonomy is in the [command reference](./command-reference#exit-codes). This page covers the common ones, plus a few non-error symptoms that come up in day-to-day use.
+
+For every entry: **Symptom → Cause → Fix.**
+
+## Missing settings on a fresh machine
+
+**Symptom**
+
+```json
+{
+  "type": "authentication_error",
+  "message": "no credentials found",
+  "status_code": 401,
+  "retryable": false
+}
+```
+
+Exit code `2`.
+
+**Cause**
+
+Either `~/.airbyte-agent/settings.json` doesn't exist, or it exists but `client_id`, `client_secret`, or `organization_id` is missing. Environment variables are also unset (or only some of the three are set — env-var resolution requires all three).
+
+**Fix**
+
+Run `airbyte-agent configure` to prompt for the three values and write the settings file. See [Authenticate](./authenticate) for the alternatives.
+
+## Authentication fails
+
+**Symptom**
+
+```json
+{
+  "type": "authentication_error",
+  "message": "invalid client credentials",
+  "status_code": 401,
+  "retryable": false
+}
+```
+
+Exit code `2`.
+
+**Cause**
+
+Stale or rotated credentials, a `client_id`/`client_secret` from a different organization, or a typo when you ran `configure`.
+
+**Fix**
+
+1. Re-read your credentials from **Settings > Profile** in the web app.
+2. Re-run `airbyte-agent configure`, or update the env vars.
+3. If you switched orgs, also update `AIRBYTE_ORGANIZATION_ID`.
+
+## Workspace not found
+
+**Symptom**
+
+```json
+{
+  "type": "not_found",
+  "message": "workspace \"prod\" not found",
+  "status_code": 404,
+  "hint": "run 'airbyte-agent workspaces list' to see available workspaces"
+}
+```
+
+Exit code `3`.
+
+**Cause**
+
+Typo in the workspace name, or the workspace was deleted.
+
+**Fix**
+
+Run `airbyte-agent workspaces list --format table` to see the canonical names, then retry the command with the right one. To stop typing it on every call, persist a default with `airbyte-agent workspaces use --json '{"name": "..."}'` — see [List and set workspaces](./workspaces#set-a-default-workspace).
+
+## Connector not found
+
+**Symptom**
+
+```json
+{
+  "type": "not_found",
+  "message": "connector \"gong\" not found in workspace \"default\"",
+  "status_code": 404,
+  "hint": "run 'airbyte-agent connectors list --json {\"workspace\": \"default\"}' to see available connectors"
+}
+```
+
+Exit code `3`.
+
+**Cause**
+
+The named connector doesn't exist in that workspace. Often this means it lives in a different workspace, or it was created under a different name.
+
+**Fix**
+
+```bash
+airbyte-agent connectors list --json '{"workspace": "default"}' --format table
+```
+
+If the connector genuinely doesn't exist yet, create it with [`connectors create`](./add-connector).
+
+## Can't confirm destructive delete on a non-TTY machine
+
+**Symptom**
+
+```json
+{
+  "type": "validation_error",
+  "message": "destructive operation requires explicit permission on non-TTY",
+  "status_code": 400,
+  "hint": "set \"allow_destructive\": true in ~/.airbyte-agent/settings.json (or AIRBYTE_ALLOW_DESTRUCTIVE=true)"
+}
+```
+
+Exit code `4`.
+
+**Cause**
+
+`connectors delete` is destructive. On a terminal, it prompts for `"Type 'yes' to confirm:"`. When stdin is piped (an agent harness driving the CLI, a CI job, a script), there's nothing to type, so the command refuses rather than hanging on a prompt that can never resolve.
+
+**Fix**
+
+Grant one-time permission. Either:
+
+```bash
+AIRBYTE_ALLOW_DESTRUCTIVE=true airbyte-agent connectors delete --json '{"workspace": "default", "name": "old-hubspot"}'
+```
+
+…or set `"allow_destructive": true` in `~/.airbyte-agent/settings.json` for a persistent grant. This is intended as a deliberate permission for agent harnesses that have no way to answer a TTY prompt.
+
+## Credential-flow timeout
+
+**Symptom**
+
+```json
+{
+  "type": "validation_error",
+  "message": "credential flow timed out after 180 seconds",
+  "status_code": 408,
+  "retryable": false
+}
+```
+
+Exit code `4`.
+
+**Cause**
+
+[`connectors create`](./add-connector) opens a browser and polls for completion. If you don't finish signing in within 180 seconds (the default), the CLI gives up.
+
+**Fix**
+
+Re-run the command and complete the browser flow faster. For slow flows (corporate SSO, MFA prompts, multi-step OAuth), raise the timeout:
+
+```bash
+AIRBYTE_CREDENTIAL_TIMEOUT=600 airbyte-agent connectors create --json '{
+  "workspace": "default",
+  "name": "salesforce"
+}'
+```
+
+If the browser doesn't open automatically (headless machine, SSH session, restricted environment), the CLI prints the credential-flow URL to stderr. Open it manually on a device that has a browser.
+
+## Large responses
+
+**Symptom**
+
+`connectors execute` returns a payload that overflows your terminal, your agent's context window, or your shell pipeline.
+
+**Cause**
+
+The default response shape for many connectors includes nested objects and metadata you don't need.
+
+**Fix**
+
+Filter the response with both layers of `select_fields` and `--fields`:
+
+```bash
+airbyte-agent connectors execute --json '{
+  "workspace": "default",
+  "name": "hubspot",
+  "entity": "contacts",
+  "action": "read",
+  "select_fields": ["id", "email", "name"]
+}' --fields data.id,data.email,data.name
+```
+
+`select_fields` (and `exclude_fields`) is API-side — the source connector doesn't emit columns you don't need. `--fields` is client-side — it trims what the CLI prints to stdout. They're complementary. See [Filter the response](./execute#filter-the-response).
+
+For very large responses, also write the output to a file:
+
+```bash
+airbyte-agent connectors execute --json '{...}' -o response.json
+```
+
+## `--describe` returns no `api` block
+
+**Symptom**
+
+Running `--describe` returns the `params` section but the `api` block is empty or missing.
+
+**Cause**
+
+The OpenAPI schemas in `--describe` are extracted at build time from the CLI's checked-in specs and only cover routes the CLI maps to a public API endpoint. Some operations (for example, internal helpers) don't have a public OpenAPI counterpart, so there's no API shape to print.
+
+**Fix**
+
+No action needed — the `params` section is still authoritative for what the CLI accepts. The missing `api` block only means there's no public REST endpoint to show alongside it.
+
+## Rate limited
+
+**Symptom**
+
+```json
+{
+  "type": "rate_limited",
+  "message": "rate limit exceeded",
+  "status_code": 429,
+  "retryable": true
+}
+```
+
+**Cause**
+
+You (or your agent) made too many requests in a short window.
+
+**Fix**
+
+The CLI already retries 429s with exponential backoff (3 attempts, 1s/2s/4s). If you're still hitting the limit, slow down your loop or batch operations. See [Retry behavior](./command-reference#retry-behavior).

--- a/docs/ai-agents/interfaces/cli/troubleshooting.md
+++ b/docs/ai-agents/interfaces/cli/troubleshooting.md
@@ -32,7 +32,7 @@ The error text refers to a legacy `~/.airbyte-agent/credentials` path and only t
 
 ### Fix
 
-Run `airbyte-agent configure` to prompt for the three values and write the settings file. See [Authenticate](./authenticate) for the alternatives.
+Run `airbyte-agent login` to prompt for the three values and write the settings file. See [Authenticate](./authenticate) for the alternatives.
 
 ## Authentication fails
 
@@ -51,12 +51,12 @@ Exit code `2`.
 
 ### Cause
 
-Stale or rotated credentials, a `client_id`/`client_secret` from a different organization, or a typo when you ran `configure`.
+Stale or rotated credentials, a `client_id`/`client_secret` from a different organization, or a typo when you ran `login`.
 
 ### Fix
 
 1. Re-read your credentials from the **Your API Credentials** card in the web app. See [Authenticate](./authenticate#get-your-credentials) if you can't find it.
-2. Re-run `airbyte-agent configure`, or update the env vars.
+2. Re-run `airbyte-agent login`, or update the env vars.
 3. If you switched orgs, also update `AIRBYTE_ORGANIZATION_ID`.
 
 ## Workspace not found

--- a/docs/ai-agents/interfaces/cli/troubleshooting.md
+++ b/docs/ai-agents/interfaces/cli/troubleshooting.md
@@ -15,8 +15,8 @@ For every entry: **Symptom → Cause → Fix.**
 
 ```json
 {
-  "type": "authentication_error",
-  "message": "no credentials found",
+  "type": "auth_error",
+  "message": "no credentials configured: set AIRBYTE_CLIENT_ID and AIRBYTE_CLIENT_SECRET environment variables, or create ~/.airbyte-agent/credentials",
   "status_code": 401,
   "retryable": false
 }
@@ -26,7 +26,9 @@ Exit code `2`.
 
 ### Cause
 
-Either `~/.airbyte-agent/settings.json` doesn't exist, or it exists but `client_id`, `client_secret`, or `organization_id` is missing. Environment variables are also unset, or only some of the three are set (env-var resolution requires all three).
+Either `~/.airbyte-agent/settings.json` doesn't exist, or it exists but `client_id`, `client_secret`, or `organization_id` is missing. Environment variables are also unset, or only some of `AIRBYTE_CLIENT_ID`, `AIRBYTE_CLIENT_SECRET`, and `AIRBYTE_ORGANIZATION_ID` are set (env-var resolution requires all three).
+
+The error text refers to a legacy `~/.airbyte-agent/credentials` path and only the two OAuth env vars. The current settings file is `~/.airbyte-agent/settings.json` and resolution requires the organization ID as well. The fix below is what to actually do.
 
 ### Fix
 
@@ -38,7 +40,7 @@ Run `airbyte-agent configure` to prompt for the three values and write the setti
 
 ```json
 {
-  "type": "authentication_error",
+  "type": "unauthorized",
   "message": "invalid client credentials",
   "status_code": 401,
   "retryable": false
@@ -78,7 +80,7 @@ Typo in the workspace name, or the workspace was deleted.
 
 ### Fix
 
-Run `airbyte-agent workspaces list --format table` to see the canonical names, then retry the command with the right one. To stop typing it on every call, persist a default with `airbyte-agent workspaces use --json '{"name": "..."}'`. See [List and set workspaces](./workspaces#set-a-default-workspace).
+Run `airbyte-agent workspaces list` to see the canonical names, then retry the command with the right one. To stop typing it on every call, persist a default with `airbyte-agent workspaces use --json '{"name": "..."}'`. See [List and set workspaces](./workspaces#set-a-default-workspace).
 
 ## Connector not found
 
@@ -102,7 +104,7 @@ The named connector doesn't exist in that workspace. Often this means it lives i
 ### Fix
 
 ```bash
-airbyte-agent connectors list --json '{"workspace": "default"}' --format table
+airbyte-agent connectors list --json '{"workspace": "default"}'
 ```
 
 If the connector genuinely doesn't exist yet, create it with [`connectors create`](./add-connector).
@@ -114,9 +116,9 @@ If the connector genuinely doesn't exist yet, create it with [`connectors create
 ```json
 {
   "type": "validation_error",
-  "message": "destructive operation requires explicit permission on non-TTY",
+  "message": "destructive action requires confirmation but no TTY is available",
   "status_code": 400,
-  "hint": "set \"allow_destructive\": true in ~/.airbyte-agent/settings.json (or AIRBYTE_ALLOW_DESTRUCTIVE=true)"
+  "hint": "set \"allow_destructive\": true in ~/.airbyte-agent/settings.json (or AIRBYTE_ALLOW_DESTRUCTIVE=true) to allow non-interactive destructive operations"
 }
 ```
 
@@ -140,20 +142,21 @@ AIRBYTE_ALLOW_DESTRUCTIVE=true airbyte-agent connectors delete --json '{"workspa
 
 ### Symptom
 
+[`connectors create`](./add-connector) returns successfully (exit code `0`) and prints a result object to stdout with an `error` field:
+
 ```json
 {
-  "type": "validation_error",
-  "message": "credential flow timed out after 180 seconds",
-  "status_code": 408,
-  "retryable": false
+  "error": "timeout",
+  "message": "Credential flow timed out after 3m0s",
+  "session_id": "<session-uuid>"
 }
 ```
 
-Exit code `4`.
+This is not a structured CLI error (`type` / `status_code` / exit code 4). It's the success-path payload of the create command, indicating the polling loop expired before the browser flow completed.
 
 ### Cause
 
-[`connectors create`](./add-connector) opens a browser and polls for completion. If you don't finish signing in within 180 seconds (the default), the CLI gives up.
+`connectors create` opens a browser and polls for completion. If you don't finish signing in within 180 seconds (the default), the polling loop exits and returns the timeout result.
 
 ### Fix
 
@@ -200,19 +203,34 @@ For very large responses, also write the output to a file:
 airbyte-agent connectors execute --json '{...}' -o response.json
 ```
 
-## `--describe` returns no `api` block
+## `--describe` returns no `api` block or `not_supported`
 
 ### Symptom
 
-Running `--describe` returns the `params` section but the `api` block is empty or missing.
+One of two things happens when you run `--describe` (or the equivalent `airbyte-agent schema <resource> <operation>`):
+
+1. The response includes `params` but the `api` block is empty or missing.
+2. The response is an error on stderr with exit code `3`:
+
+   ```json
+   {
+     "type": "not_supported",
+     "message": "no published schema for \"list\"; run `airbyte-agent organizations list --help` for argument details"
+   }
+   ```
 
 ### Cause
 
-The OpenAPI schemas in `--describe` are extracted at build time from the CLI's checked-in specs and only cover routes the CLI maps to a public API endpoint. Some operations (for example, internal helpers) don't have a public OpenAPI counterpart, so there's no API shape to print.
+The OpenAPI schemas in `--describe` are extracted at build time from the CLI's checked-in specs and only cover routes the CLI maps to a public API endpoint.
+
+- Case 1 happens when the operation maps to a route that exists in the public spec but isn't bundled, leaving `params` populated but `api` empty.
+- Case 2 happens when the operation maps to an internal-only route (any path starting with `/api/v1/internal/`). The schema lookup deliberately refuses these. Today this affects `organizations list`; the same shape applies to any future operation backed by an internal route.
 
 ### Fix
 
-No action needed. The `params` section is still authoritative for what the CLI accepts. The missing `api` block only means there's no public REST endpoint to show alongside it.
+For case 1, no action needed. `params` is authoritative for what the CLI accepts. The missing `api` block only means there's no public REST endpoint to show alongside it.
+
+For case 2, run `airbyte-agent <resource> <operation> --help` instead. The Cobra-generated help text lists the flags the CLI exposes.
 
 ## Rate limited
 

--- a/docs/ai-agents/interfaces/cli/troubleshooting.md
+++ b/docs/ai-agents/interfaces/cli/troubleshooting.md
@@ -55,7 +55,7 @@ Stale or rotated credentials, a `client_id`/`client_secret` from a different org
 
 ### Fix
 
-1. Re-read your credentials from **Settings > Profile** in the web app.
+1. Re-read your credentials from the **Your API Credentials** card in the web app. See [Authenticate](./authenticate#get-your-credentials) if you can't find it.
 2. Re-run `airbyte-agent configure`, or update the env vars.
 3. If you switched orgs, also update `AIRBYTE_ORGANIZATION_ID`.
 

--- a/docs/ai-agents/interfaces/cli/troubleshooting.md
+++ b/docs/ai-agents/interfaces/cli/troubleshooting.md
@@ -26,7 +26,7 @@ Exit code `2`.
 
 ### Cause
 
-Either `~/.airbyte-agent/settings.json` doesn't exist, or it exists but `client_id`, `client_secret`, or `organization_id` is missing. Environment variables are also unset (or only some of the three are set — env-var resolution requires all three).
+Either `~/.airbyte-agent/settings.json` doesn't exist, or it exists but `client_id`, `client_secret`, or `organization_id` is missing. Environment variables are also unset, or only some of the three are set (env-var resolution requires all three).
 
 ### Fix
 
@@ -78,7 +78,7 @@ Typo in the workspace name, or the workspace was deleted.
 
 ### Fix
 
-Run `airbyte-agent workspaces list --format table` to see the canonical names, then retry the command with the right one. To stop typing it on every call, persist a default with `airbyte-agent workspaces use --json '{"name": "..."}'` — see [List and set workspaces](./workspaces#set-a-default-workspace).
+Run `airbyte-agent workspaces list --format table` to see the canonical names, then retry the command with the right one. To stop typing it on every call, persist a default with `airbyte-agent workspaces use --json '{"name": "..."}'`. See [List and set workspaces](./workspaces#set-a-default-workspace).
 
 ## Connector not found
 
@@ -192,7 +192,7 @@ airbyte-agent connectors execute --json '{
 }' --fields data.id,data.email,data.name
 ```
 
-`select_fields` (and `exclude_fields`) is API-side — the source connector doesn't emit columns you don't need. `--fields` is client-side — it trims what the CLI prints to stdout. They're complementary. See [Filter the response](./execute#filter-the-response).
+`select_fields` (and `exclude_fields`) is API-side; the source connector doesn't emit columns you don't need. `--fields` is client-side; it trims what the CLI prints to stdout. They're complementary. See [Filter the response](./execute#filter-the-response).
 
 For very large responses, also write the output to a file:
 
@@ -212,7 +212,7 @@ The OpenAPI schemas in `--describe` are extracted at build time from the CLI's c
 
 ### Fix
 
-No action needed — the `params` section is still authoritative for what the CLI accepts. The missing `api` block only means there's no public REST endpoint to show alongside it.
+No action needed. The `params` section is still authoritative for what the CLI accepts. The missing `api` block only means there's no public REST endpoint to show alongside it.
 
 ## Rate limited
 

--- a/docs/ai-agents/interfaces/cli/troubleshooting.md
+++ b/docs/ai-agents/interfaces/cli/troubleshooting.md
@@ -11,7 +11,7 @@ For every entry: **Symptom → Cause → Fix.**
 
 ## Missing settings on a fresh machine
 
-**Symptom**
+### Symptom
 
 ```json
 {
@@ -24,17 +24,17 @@ For every entry: **Symptom → Cause → Fix.**
 
 Exit code `2`.
 
-**Cause**
+### Cause
 
 Either `~/.airbyte-agent/settings.json` doesn't exist, or it exists but `client_id`, `client_secret`, or `organization_id` is missing. Environment variables are also unset (or only some of the three are set — env-var resolution requires all three).
 
-**Fix**
+### Fix
 
 Run `airbyte-agent configure` to prompt for the three values and write the settings file. See [Authenticate](./authenticate) for the alternatives.
 
 ## Authentication fails
 
-**Symptom**
+### Symptom
 
 ```json
 {
@@ -47,11 +47,11 @@ Run `airbyte-agent configure` to prompt for the three values and write the setti
 
 Exit code `2`.
 
-**Cause**
+### Cause
 
 Stale or rotated credentials, a `client_id`/`client_secret` from a different organization, or a typo when you ran `configure`.
 
-**Fix**
+### Fix
 
 1. Re-read your credentials from **Settings > Profile** in the web app.
 2. Re-run `airbyte-agent configure`, or update the env vars.
@@ -59,7 +59,7 @@ Stale or rotated credentials, a `client_id`/`client_secret` from a different org
 
 ## Workspace not found
 
-**Symptom**
+### Symptom
 
 ```json
 {
@@ -72,17 +72,17 @@ Stale or rotated credentials, a `client_id`/`client_secret` from a different org
 
 Exit code `3`.
 
-**Cause**
+### Cause
 
 Typo in the workspace name, or the workspace was deleted.
 
-**Fix**
+### Fix
 
 Run `airbyte-agent workspaces list --format table` to see the canonical names, then retry the command with the right one. To stop typing it on every call, persist a default with `airbyte-agent workspaces use --json '{"name": "..."}'` — see [List and set workspaces](./workspaces#set-a-default-workspace).
 
 ## Connector not found
 
-**Symptom**
+### Symptom
 
 ```json
 {
@@ -95,11 +95,11 @@ Run `airbyte-agent workspaces list --format table` to see the canonical names, t
 
 Exit code `3`.
 
-**Cause**
+### Cause
 
 The named connector doesn't exist in that workspace. Often this means it lives in a different workspace, or it was created under a different name.
 
-**Fix**
+### Fix
 
 ```bash
 airbyte-agent connectors list --json '{"workspace": "default"}' --format table
@@ -107,9 +107,9 @@ airbyte-agent connectors list --json '{"workspace": "default"}' --format table
 
 If the connector genuinely doesn't exist yet, create it with [`connectors create`](./add-connector).
 
-## Can't confirm destructive delete on a non-TTY machine
+## Destructive delete on a non-TTY machine
 
-**Symptom**
+### Symptom
 
 ```json
 {
@@ -122,11 +122,11 @@ If the connector genuinely doesn't exist yet, create it with [`connectors create
 
 Exit code `4`.
 
-**Cause**
+### Cause
 
 `connectors delete` is destructive. On a terminal, it prompts for `"Type 'yes' to confirm:"`. When stdin is piped (an agent harness driving the CLI, a CI job, a script), there's nothing to type, so the command refuses rather than hanging on a prompt that can never resolve.
 
-**Fix**
+### Fix
 
 Grant one-time permission. Either:
 
@@ -138,7 +138,7 @@ AIRBYTE_ALLOW_DESTRUCTIVE=true airbyte-agent connectors delete --json '{"workspa
 
 ## Credential-flow timeout
 
-**Symptom**
+### Symptom
 
 ```json
 {
@@ -151,11 +151,11 @@ AIRBYTE_ALLOW_DESTRUCTIVE=true airbyte-agent connectors delete --json '{"workspa
 
 Exit code `4`.
 
-**Cause**
+### Cause
 
 [`connectors create`](./add-connector) opens a browser and polls for completion. If you don't finish signing in within 180 seconds (the default), the CLI gives up.
 
-**Fix**
+### Fix
 
 Re-run the command and complete the browser flow faster. For slow flows (corporate SSO, MFA prompts, multi-step OAuth), raise the timeout:
 
@@ -170,15 +170,15 @@ If the browser doesn't open automatically (headless machine, SSH session, restri
 
 ## Large responses
 
-**Symptom**
+### Symptom
 
 `connectors execute` returns a payload that overflows your terminal, your agent's context window, or your shell pipeline.
 
-**Cause**
+### Cause
 
 The default response shape for many connectors includes nested objects and metadata you don't need.
 
-**Fix**
+### Fix
 
 Filter the response with both layers of `select_fields` and `--fields`:
 
@@ -202,21 +202,21 @@ airbyte-agent connectors execute --json '{...}' -o response.json
 
 ## `--describe` returns no `api` block
 
-**Symptom**
+### Symptom
 
 Running `--describe` returns the `params` section but the `api` block is empty or missing.
 
-**Cause**
+### Cause
 
 The OpenAPI schemas in `--describe` are extracted at build time from the CLI's checked-in specs and only cover routes the CLI maps to a public API endpoint. Some operations (for example, internal helpers) don't have a public OpenAPI counterpart, so there's no API shape to print.
 
-**Fix**
+### Fix
 
 No action needed — the `params` section is still authoritative for what the CLI accepts. The missing `api` block only means there's no public REST endpoint to show alongside it.
 
 ## Rate limited
 
-**Symptom**
+### Symptom
 
 ```json
 {
@@ -227,10 +227,10 @@ No action needed — the `params` section is still authoritative for what the CL
 }
 ```
 
-**Cause**
+### Cause
 
 You (or your agent) made too many requests in a short window.
 
-**Fix**
+### Fix
 
 The CLI already retries 429s with exponential backoff (3 attempts, 1s/2s/4s). If you're still hitting the limit, slow down your loop or batch operations. See [Retry behavior](./command-reference#retry-behavior).

--- a/docs/ai-agents/interfaces/cli/using-with-ai-agents.md
+++ b/docs/ai-agents/interfaces/cli/using-with-ai-agents.md
@@ -13,31 +13,33 @@ The CLI was designed to be driven by AI agent harnesses (Claude Code, Codex, Cur
 - Stable exit codes (`0`, `1`, `2`, `3`, `4`) for **server-side** failures (auth, not found, validation, rate limits). Client-side validation failures (bad UUIDs, unreachable hosts, malformed payloads) can surface as a generic `{"type": "error", ...}` with exit `1`, so agents should always parse the stderr JSON and branch on `type` rather than dispatching on exit code alone. The full taxonomy and one important exception (`connectors create` reports timeouts as a `0` success payload) are covered below.
 - A credential model that keeps third-party secrets out of agent transcripts entirely.
 
-## Install the bundled skills
+## Install the bundled skill
 
-The CLI ships with per-command [skill](https://github.com/vercel-labs/skills) documents: small markdown files with YAML frontmatter that tell an agent how and when to call each command. They live in the `skills/` directory of [`airbytehq/airbyte-agent-cli`](https://github.com/airbytehq/airbyte-agent-cli) and are designed to be consumed by skill-aware agent harnesses.
+The CLI ships with an [agent skill](https://github.com/vercel-labs/skills) document at `skills/airbyte-agent/SKILL.md` in [`airbytehq/airbyte-agent-cli`](https://github.com/airbytehq/airbyte-agent-cli). It's a single top-level skill plus per-command references under `references/`, designed to be consumed by skill-aware agent harnesses.
 
-Install them with `npx skills add`:
+There are two install paths.
+
+### `npx skills add`
+
+For harnesses that understand the [`skills` CLI](https://github.com/vercel-labs/skills):
 
 ```bash
-# Install every skill into the current project
 npx skills add airbytehq/airbyte-agent-cli
-
-# Install a single skill
-npx skills add airbytehq/airbyte-agent-cli --skill connectors-execute
-
-# Preview without installing
-npx skills add airbytehq/airbyte-agent-cli --list
-
-# Install globally instead of per-project
-npx skills add airbytehq/airbyte-agent-cli -g
 ```
 
-Target a specific agent with `--agent claude-code` (or another supported agent). See the [`skills` CLI docs](https://github.com/vercel-labs/skills) for the full flag set.
+Target a specific agent with `--agent claude-code` (or another supported agent). `npx skills add` writes to the harness's default skill directory, typically `~/.agents/skills/airbyte-agent/`. It doesn't honor a custom destination flag; if you need the skill somewhere else, copy or symlink the installed directory afterwards.
 
-`npx skills add` writes to the harness's default skill directory (typically `~/.agents/skills/<skill>/` for a global install, or `.agents/skills/<skill>/` inside the current project). It does not honor a custom destination flag, so don't pass `--target` expecting it to redirect the install; if you need a non-default location, copy or symlink the installed directory afterwards.
+### Install script (CLI + skill in one step)
 
-If your harness doesn't support `npx skills`, copy or symlink the `skills/<command>/` directories into the agent's skill directory directly (for example, `~/.claude/skills/` for Claude Code).
+For Claude Code or any harness that reads from `~/.claude/skills/`, the [official install script](https://github.com/airbytehq/airbyte-agent-cli/blob/main/scripts/install.sh) installs the CLI binary and the skill together:
+
+```bash
+curl -fsSL https://airbyte.ai/install.sh | bash
+```
+
+It writes the skill to `~/.claude/skills/airbyte-agent/` by default. Set `AIRBYTE_AGENT_SKILLS_DIR=...` to redirect the skill directory, or `AIRBYTE_AGENT_SKIP_SKILLS=1` to install the CLI binary only.
+
+If your harness doesn't support either of those paths, copy or symlink the `skills/airbyte-agent/` directory from the repo into the agent's skill directory directly.
 
 ## Rules for agents
 

--- a/docs/ai-agents/interfaces/cli/using-with-ai-agents.md
+++ b/docs/ai-agents/interfaces/cli/using-with-ai-agents.md
@@ -10,7 +10,7 @@ The CLI was designed to be driven by AI agent harnesses (Claude Code, Codex, Cur
 - A uniform `<resource> <operation>` surface that doesn't change between connectors.
 - Schema introspection via `--describe` on resource operations, so the agent can plan without round-tripping documentation. A few operations are backed by internal-only routes and return `{"type": "not_supported", ...}`; use `--help` on those instead.
 - Stable JSON-in, JSON-out payloads suitable for tool calls.
-- Stable exit codes (`0`, `1`, `2`, `3`, `4`) that map cleanly onto retry policies for most commands. One exception: [`connectors create`](./add-connector) reports a credential-flow timeout as a success-path payload (`{"error": "timeout", ...}` with exit code `0`), so an agent driving that command must inspect the result body, not just the exit code. See [Inspect `connectors create` for timeouts](#inspect-connectors-create-for-timeouts).
+- Stable exit codes (`0`, `1`, `2`, `3`, `4`) for **server-side** failures (auth, not found, validation, rate limits). Client-side validation failures (bad UUIDs, unreachable hosts, malformed payloads) can surface as a generic `{"type": "error", ...}` with exit `1`, so agents should always parse the stderr JSON and branch on `type` rather than dispatching on exit code alone. The full taxonomy and one important exception (`connectors create` reports timeouts as a `0` success payload) are covered below.
 - A credential model that keeps third-party secrets out of agent transcripts entirely.
 
 ## Install the bundled skills
@@ -35,11 +35,17 @@ npx skills add airbytehq/airbyte-agent-cli -g
 
 Target a specific agent with `--agent claude-code` (or another supported agent). See the [`skills` CLI docs](https://github.com/vercel-labs/skills) for the full flag set.
 
+`npx skills add` writes to the harness's default skill directory (typically `~/.agents/skills/<skill>/` for a global install, or `.agents/skills/<skill>/` inside the current project). It does not honor a custom destination flag, so don't pass `--target` expecting it to redirect the install; if you need a non-default location, copy or symlink the installed directory afterwards.
+
 If your harness doesn't support `npx skills`, copy or symlink the `skills/<command>/` directories into the agent's skill directory directly (for example, `~/.claude/skills/` for Claude Code).
 
-## Three rules for agents
+## Rules for agents
 
-Every skill document repeats some version of these three rules. They're worth restating because they materially affect whether an agent's calls succeed.
+Every skill document repeats some version of these rules. They're worth restating because they materially affect whether an agent's calls succeed. Rule 0 takes precedence over the others; it's how an agent figures out whether any of them just got violated.
+
+### 0. Parse stderr JSON; don't dispatch on exit code alone
+
+The exit codes documented in the [command reference](./command-reference#exit-codes) are stable for server-side failures, but client-side validation can return a generic `{"type": "error", ...}` with exit `1` even when the underlying problem is auth- or validation-shaped. Read the stderr JSON, branch on the `type` field (`auth_error`, `unauthorized`, `not_found`, `validation_error`, `rate_limited`, `error`, `not_supported`), and treat the exit code as a coarse fallback.
 
 ### 1. Always run `connectors describe` before the first execute
 

--- a/docs/ai-agents/interfaces/cli/using-with-ai-agents.md
+++ b/docs/ai-agents/interfaces/cli/using-with-ai-agents.md
@@ -15,7 +15,7 @@ The CLI was designed to be driven by AI agent harnesses (Claude Code, Codex, Cur
 
 ## Install the bundled skills
 
-The CLI ships with per-command [skill](https://github.com/vercel-labs/skills) documents — small markdown files with YAML frontmatter that tell an agent how and when to call each command. They live in the `skills/` directory of [`airbytehq/airbyte-agent-cli`](https://github.com/airbytehq/airbyte-agent-cli) and are designed to be consumed by skill-aware agent harnesses.
+The CLI ships with per-command [skill](https://github.com/vercel-labs/skills) documents: small markdown files with YAML frontmatter that tell an agent how and when to call each command. They live in the `skills/` directory of [`airbytehq/airbyte-agent-cli`](https://github.com/airbytehq/airbyte-agent-cli) and are designed to be consumed by skill-aware agent harnesses.
 
 Install them with `npx skills add`:
 
@@ -57,11 +57,11 @@ Per-parameter flags (`--workspace`, `--name`, and so on) exist for human conveni
 - **Replayable.** The same payload can be saved to a file and re-run with `--json @file.json`.
 - **Less prone to shell quoting bugs.** Nested objects (like `params` on [`connectors execute`](./execute)) can only be passed via JSON anyway.
 
-The two modes are mutually exclusive — mixing them is an error.
+The two modes are mutually exclusive; mixing them is an error.
 
 ### 3. Never ask the user for connector credentials
 
-If your agent decides a new connector is needed, it must run [`connectors create`](./add-connector), which opens a browser tab for the user to sign in directly. The CLI does not accept third-party credentials inline, on stdin, or in any other channel. An agent that asks a user to paste an API key into chat is doing the wrong thing — that key would end up in transcripts, logs, and possibly training data.
+If your agent decides a new connector is needed, it must run [`connectors create`](./add-connector), which opens a browser tab for the user to sign in directly. The CLI does not accept third-party credentials inline, on stdin, or in any other channel. An agent that asks a user to paste an API key into chat is doing the wrong thing. That key would end up in transcripts, logs, and possibly training data.
 
 If a user volunteers credentials anyway, decline politely and run `connectors create` instead.
 

--- a/docs/ai-agents/interfaces/cli/using-with-ai-agents.md
+++ b/docs/ai-agents/interfaces/cli/using-with-ai-agents.md
@@ -8,9 +8,9 @@ sidebar_position: 6
 The CLI was designed to be driven by AI agent harnesses (Claude Code, Codex, Cursor, and similar) as much as by humans. Compared to writing a custom MCP server or wiring a Python SDK call, shelling out to `airbyte-agent` gives an agent:
 
 - A uniform `<resource> <operation>` surface that doesn't change between connectors.
-- Self-describing schemas via `--describe` so the agent can plan without round-tripping documentation.
+- Schema introspection via `--describe` on resource operations, so the agent can plan without round-tripping documentation. A few operations are backed by internal-only routes and return `{"type": "not_supported", ...}`; use `--help` on those instead.
 - Stable JSON-in, JSON-out payloads suitable for tool calls.
-- Stable exit codes (`0`, `1`, `2`, `3`, `4`) that map cleanly onto retry policies.
+- Stable exit codes (`0`, `1`, `2`, `3`, `4`) that map cleanly onto retry policies for most commands. One exception: [`connectors create`](./add-connector) reports a credential-flow timeout as a success-path payload (`{"error": "timeout", ...}` with exit code `0`), so an agent driving that command must inspect the result body, not just the exit code. See [Inspect `connectors create` for timeouts](#inspect-connectors-create-for-timeouts).
 - A credential model that keeps third-party secrets out of agent transcripts entirely.
 
 ## Install the bundled skills
@@ -64,6 +64,20 @@ The two modes are mutually exclusive; mixing them is an error.
 If your agent decides a new connector is needed, it must run [`connectors create`](./add-connector), which opens a browser tab for the user to sign in directly. The CLI does not accept third-party credentials inline, on stdin, or in any other channel. An agent that asks a user to paste an API key into chat is doing the wrong thing. That key would end up in transcripts, logs, and possibly training data.
 
 If a user volunteers credentials anyway, decline politely and run `connectors create` instead.
+
+## Inspect `connectors create` for timeouts
+
+Most CLI failures show up as a non-zero exit code with a structured error on stderr, which makes retry logic straightforward. [`connectors create`](./add-connector) is the exception. If the browser credential flow doesn't complete within `AIRBYTE_CREDENTIAL_TIMEOUT` seconds (default `180`), the command exits `0` and prints the timeout as a normal stdout payload:
+
+```json
+{
+  "error": "timeout",
+  "message": "Credential flow timed out after 3m0s",
+  "session_id": "<session-uuid>"
+}
+```
+
+An agent that retries only on non-zero exit will silently treat this as a successful create. When driving `connectors create`, parse the stdout JSON and check for `error == "timeout"` before claiming success.
 
 ## Output discipline
 

--- a/docs/ai-agents/interfaces/cli/using-with-ai-agents.md
+++ b/docs/ai-agents/interfaces/cli/using-with-ai-agents.md
@@ -1,0 +1,83 @@
+---
+plan: all
+sidebar_position: 6
+---
+
+# Using the CLI with AI agents
+
+The CLI was designed to be driven by AI agent harnesses (Claude Code, Codex, Cursor, and similar) as much as by humans. Compared to writing a custom MCP server or wiring a Python SDK call, shelling out to `airbyte-agent` gives an agent:
+
+- A uniform `<resource> <operation>` surface that doesn't change between connectors.
+- Self-describing schemas via `--describe` so the agent can plan without round-tripping documentation.
+- Stable JSON-in, JSON-out payloads suitable for tool calls.
+- Stable exit codes (`0`, `1`, `2`, `3`, `4`) that map cleanly onto retry policies.
+- A credential model that keeps third-party secrets out of agent transcripts entirely.
+
+## Install the bundled skills
+
+The CLI ships with per-command [skill](https://github.com/vercel-labs/skills) documents — small markdown files with YAML frontmatter that tell an agent how and when to call each command. They live in the `skills/` directory of [`airbytehq/airbyte-agent-cli`](https://github.com/airbytehq/airbyte-agent-cli) and are designed to be consumed by skill-aware agent harnesses.
+
+Install them with `npx skills add`:
+
+```bash
+# Install every skill into the current project
+npx skills add airbytehq/airbyte-agent-cli
+
+# Install a single skill
+npx skills add airbytehq/airbyte-agent-cli --skill connectors-execute
+
+# Preview without installing
+npx skills add airbytehq/airbyte-agent-cli --list
+
+# Install globally instead of per-project
+npx skills add airbytehq/airbyte-agent-cli -g
+```
+
+Target a specific agent with `--agent claude-code` (or another supported agent). See the [`skills` CLI docs](https://github.com/vercel-labs/skills) for the full flag set.
+
+If your harness doesn't support `npx skills`, copy or symlink the `skills/<command>/` directories into the agent's skill directory directly (for example, `~/.claude/skills/` for Claude Code).
+
+## Three rules for agents
+
+Every skill document repeats some version of these three rules. They're worth restating because they materially affect whether an agent's calls succeed.
+
+### 1. Always run `connectors describe` before the first execute
+
+Entity names, action names, and parameter shapes vary per connector. Guessing them costs round trips and produces validation errors. Run [`connectors describe`](./describe-connector) once per connector you intend to use, cache the result for the duration of the session, and read entities and actions from it.
+
+```bash
+airbyte-agent connectors describe --json '{"workspace": "default", "name": "hubspot"}'
+```
+
+### 2. Always pass parameters as `--json '{...}'`
+
+Per-parameter flags (`--workspace`, `--name`, and so on) exist for human convenience, but agents should send a single JSON payload. JSON is:
+
+- **Self-describing.** A reviewer reading a transcript sees the full input without inferring flag semantics.
+- **Replayable.** The same payload can be saved to a file and re-run with `--json @file.json`.
+- **Less prone to shell quoting bugs.** Nested objects (like `params` on [`connectors execute`](./execute)) can only be passed via JSON anyway.
+
+The two modes are mutually exclusive — mixing them is an error.
+
+### 3. Never ask the user for connector credentials
+
+If your agent decides a new connector is needed, it must run [`connectors create`](./add-connector), which opens a browser tab for the user to sign in directly. The CLI does not accept third-party credentials inline, on stdin, or in any other channel. An agent that asks a user to paste an API key into chat is doing the wrong thing — that key would end up in transcripts, logs, and possibly training data.
+
+If a user volunteers credentials anyway, decline politely and run `connectors create` instead.
+
+## Output discipline
+
+Two practical tips that meaningfully reduce context-window pressure:
+
+- **Always filter responses.** Pass `select_fields` (API-side) and `--fields` (client-side) on every [`execute`](./execute#filter-the-response) call. The default response shape often includes nested objects and metadata you don't need; trimming it saves both bandwidth and prompt budget.
+- **Prefer `context_store_search` over `list`.** For reads, the indexed store supports filtering, sorting, and pagination natively. Fall back to `list` only when you need real-time data or when search returns empty.
+
+## Telemetry and execution context
+
+The CLI emits anonymous usage telemetry by default. Agents can self-identify so internal usage can be filtered out of customer analytics:
+
+```bash
+AIRBYTE_EXECUTION_CONTEXT=agent airbyte-agent connectors execute --json '{...}'
+```
+
+Common values: `mcp`, `agent`, `direct`. Set `AIRBYTE_TELEMETRY_MODE=disabled` to turn telemetry off entirely.

--- a/docs/ai-agents/interfaces/cli/using-with-ai-agents.md
+++ b/docs/ai-agents/interfaces/cli/using-with-ai-agents.md
@@ -8,7 +8,7 @@ sidebar_position: 6
 The CLI was designed to be driven by AI agent harnesses (Claude Code, Codex, Cursor, and similar) as much as by humans. Compared to writing a custom MCP server or wiring a Python SDK call, shelling out to `airbyte-agent` gives an agent:
 
 - A uniform `<resource> <operation>` surface that doesn't change between connectors.
-- Schema introspection via `--describe` on resource operations, so the agent can plan without round-tripping documentation. A few operations are backed by internal-only routes and return `{"type": "not_supported", ...}`; use `--help` on those instead.
+- Schema introspection via `airbyte-agent schema <resource> <operation>`, so the agent can plan without round-tripping documentation. A few operations are backed by internal-only routes and return `{"type": "not_supported", ...}`; use `--help` on those instead.
 - Stable JSON-in, JSON-out payloads suitable for tool calls.
 - Stable exit codes (`0`, `1`, `2`, `3`, `4`) for **server-side** failures (auth, not found, validation, rate limits). Client-side validation failures (bad UUIDs, unreachable hosts, malformed payloads) can surface as a generic `{"type": "error", ...}` with exit `1`, so agents should always parse the stderr JSON and branch on `type` rather than dispatching on exit code alone. The full taxonomy and one important exception (`connectors create` reports timeouts as a `0` success payload) are covered below.
 - A credential model that keeps third-party secrets out of agent transcripts entirely.

--- a/docs/ai-agents/interfaces/cli/workspaces.md
+++ b/docs/ai-agents/interfaces/cli/workspaces.md
@@ -1,0 +1,59 @@
+---
+plan: all
+sidebar_position: 2
+---
+
+# List and set workspaces
+
+A **workspace** in Airbyte Agents is a container inside your organization that holds connectors and credentials. Every organization starts with a `default` workspace, and most users stay there. Use additional workspaces when you need to isolate credentials across tenants, teams, or environments.
+
+The CLI lets you list workspaces and persist a default in your settings file so you don't have to pass `workspace` on every command.
+
+## List workspaces
+
+```bash
+airbyte-agent workspaces list
+```
+
+`workspaces list` paginates automatically — the response includes every workspace in your organization. Common filters:
+
+```bash
+# Filter by substring (case-insensitive)
+airbyte-agent workspaces list --json '{"name_contains": "prod"}'
+
+# Filter by status
+airbyte-agent workspaces list --json '{"status": "active"}'
+
+# Cap the result count
+airbyte-agent workspaces list --json '{"limit": 5}'
+```
+
+For a human-readable view, pass `--format table`:
+
+```bash
+airbyte-agent workspaces list --format table
+```
+
+To trim the response to just the fields you need, pass `--fields`:
+
+```bash
+airbyte-agent workspaces list --fields id,name,status
+```
+
+## Set a default workspace
+
+`workspaces use` persists a default workspace name to `~/.airbyte-agent/settings.json`. After running it, any command that takes a `workspace` parameter and doesn't receive one falls back to this value instead of the literal `"default"`.
+
+```bash
+airbyte-agent workspaces use --json '{"name": "Production"}'
+```
+
+`name` is required and is matched case-insensitively against the workspace's actual `name` field. The CLI verifies that the workspace exists before writing, and persists the canonical-cased name from the API — so typing `production` saves `Production` if that's how it's stored.
+
+This is typically the second step in onboarding, right after [`configure`](./authenticate#recommended-airbyte-agent-configure). Run it again whenever you switch projects.
+
+To clear the default and fall back to `"default"`, edit `~/.airbyte-agent/settings.json` and remove the `workspace` key.
+
+## Workspace creation and admin operations
+
+The CLI doesn't expose workspace creation, renaming, or deletion. For those administrative operations, use the [HTTP API](../api/workspaces). Once a workspace exists, the CLI can use it.

--- a/docs/ai-agents/interfaces/cli/workspaces.md
+++ b/docs/ai-agents/interfaces/cli/workspaces.md
@@ -30,16 +30,10 @@ airbyte-agent workspaces list --json '{"status": "active"}'
 airbyte-agent workspaces list --json '{"limit": 5}'
 ```
 
-For a human-readable view, pass `--format table`:
-
-```bash
-airbyte-agent workspaces list --format table
-```
-
 To trim the response to just the fields you need, pass `--fields`:
 
 ```bash
-airbyte-agent workspaces list --fields id,name,status
+airbyte-agent workspaces list --fields data.id,data.name,data.status
 ```
 
 ## Set a default workspace

--- a/docs/ai-agents/interfaces/cli/workspaces.md
+++ b/docs/ai-agents/interfaces/cli/workspaces.md
@@ -1,5 +1,5 @@
 ---
-plan: all
+plan: team, custom
 sidebar_position: 2
 ---
 

--- a/docs/ai-agents/interfaces/cli/workspaces.md
+++ b/docs/ai-agents/interfaces/cli/workspaces.md
@@ -25,10 +25,9 @@ airbyte-agent workspaces list --json '{"name_contains": "prod"}'
 
 # Filter by status
 airbyte-agent workspaces list --json '{"status": "active"}'
-
-# Cap the result count
-airbyte-agent workspaces list --json '{"limit": 5}'
 ```
+
+`limit` is a page size hint that gets forwarded to the API. The CLI auto-paginates and returns every matching workspace, so setting `limit` doesn't cap the final result count. To narrow the response, use `name_contains` or `status`.
 
 To trim the response to just the fields you need, pass `--fields`:
 

--- a/docs/ai-agents/interfaces/cli/workspaces.md
+++ b/docs/ai-agents/interfaces/cli/workspaces.md
@@ -5,7 +5,9 @@ sidebar_position: 2
 
 # List and set workspaces
 
-A **workspace** in Airbyte Agents is a container inside your organization that holds connectors and credentials. Every organization starts with a `default` workspace, and most users stay there. Use additional workspaces when you need to isolate credentials across tenants, teams, or environments.
+A **workspace** in Airbyte Agents is a container inside your organization that holds connectors and credentials. Every organization starts with a single `default` workspace. **Additional workspaces require a Team plan or higher** — orgs on the free or individual plan have only the one, so most CLI users can skip the rest of this page and rely on the default.
+
+Use additional workspaces when you need to isolate credentials across tenants, teams, or environments.
 
 The CLI lets you list workspaces and persist a default in your settings file so you don't have to pass `workspace` on every command.
 
@@ -56,4 +58,4 @@ To clear the default and fall back to `"default"`, edit `~/.airbyte-agent/settin
 
 ## Workspace creation and admin operations
 
-The CLI doesn't expose workspace creation, renaming, or deletion. For those administrative operations, use the [HTTP API](../api/workspaces). Once a workspace exists, the CLI can use it.
+The CLI doesn't expose workspace creation, renaming, or deletion. For those administrative operations, use the [Agent API](../api/workspaces). Once a workspace exists, the CLI can use it.

--- a/docs/ai-agents/interfaces/cli/workspaces.md
+++ b/docs/ai-agents/interfaces/cli/workspaces.md
@@ -45,10 +45,10 @@ airbyte-agent workspaces use --json '{"name": "Production"}'
 
 `name` is required and is matched case-insensitively against the workspace's actual `name` field. The CLI verifies that the workspace exists before writing, and persists the canonical-cased name from the API. For example, typing `production` saves `Production` if that's how it's stored.
 
-This is typically the second step in onboarding, right after [`configure`](./authenticate#recommended-airbyte-agent-configure). Run it again whenever you switch projects.
+This is typically the second step in onboarding, right after [`login`](./authenticate#recommended-airbyte-agent-login). Run it again whenever you switch projects.
 
 :::note Prerequisite
-`workspaces use` writes to `~/.airbyte-agent/settings.json` and needs that file to already exist. On a fresh machine, run `airbyte-agent configure` first so the file gets created; `workspaces use` won't bootstrap a settings file from environment variables alone. If you're using env vars exclusively and don't want a settings file, pass `--workspace <name>` (or set `AIRBYTE_WORKSPACE`) on each command instead.
+`workspaces use` writes to `~/.airbyte-agent/settings.json` and needs that file to already exist. On a fresh machine, run `airbyte-agent login` first so the file gets created; `workspaces use` won't bootstrap a settings file from environment variables alone. If you're using env vars exclusively and don't want a settings file, pass `--workspace <name>` (or set `AIRBYTE_WORKSPACE`) on each command instead.
 :::
 
 To clear the default and fall back to `"default"`, edit `~/.airbyte-agent/settings.json` and remove the `workspace` key.

--- a/docs/ai-agents/interfaces/cli/workspaces.md
+++ b/docs/ai-agents/interfaces/cli/workspaces.md
@@ -48,6 +48,10 @@ airbyte-agent workspaces use --json '{"name": "Production"}'
 
 This is typically the second step in onboarding, right after [`configure`](./authenticate#recommended-airbyte-agent-configure). Run it again whenever you switch projects.
 
+:::note Prerequisite
+`workspaces use` writes to `~/.airbyte-agent/settings.json` and needs that file to already exist. On a fresh machine, run `airbyte-agent configure` first so the file gets created; `workspaces use` won't bootstrap a settings file from environment variables alone. If you're using env vars exclusively and don't want a settings file, pass `--workspace <name>` (or set `AIRBYTE_WORKSPACE`) on each command instead.
+:::
+
 To clear the default and fall back to `"default"`, edit `~/.airbyte-agent/settings.json` and remove the `workspace` key.
 
 ## Workspace creation and admin operations

--- a/docs/ai-agents/interfaces/cli/workspaces.md
+++ b/docs/ai-agents/interfaces/cli/workspaces.md
@@ -5,7 +5,7 @@ sidebar_position: 2
 
 # List and set workspaces
 
-A **workspace** in Airbyte Agents is a container inside your organization that holds connectors and credentials. Every organization starts with a single `default` workspace. **Additional workspaces require a Team plan or higher** — orgs on the free or individual plan have only the one, so most CLI users can skip the rest of this page and rely on the default.
+A **workspace** in Airbyte Agents is a container inside your organization that holds connectors and credentials. Every organization starts with a single `default` workspace. **Additional workspaces require a Team plan or higher.** If you're on the free or individual plan, you have only the one, so you can skip the rest of this page and rely on the default.
 
 Use additional workspaces when you need to isolate credentials across tenants, teams, or environments.
 
@@ -17,7 +17,7 @@ The CLI lets you list workspaces and persist a default in your settings file so 
 airbyte-agent workspaces list
 ```
 
-`workspaces list` paginates automatically — the response includes every workspace in your organization. Common filters:
+`workspaces list` paginates automatically; the response includes every workspace in your organization. Common filters:
 
 ```bash
 # Filter by substring (case-insensitive)
@@ -50,7 +50,7 @@ airbyte-agent workspaces list --fields id,name,status
 airbyte-agent workspaces use --json '{"name": "Production"}'
 ```
 
-`name` is required and is matched case-insensitively against the workspace's actual `name` field. The CLI verifies that the workspace exists before writing, and persists the canonical-cased name from the API — so typing `production` saves `Production` if that's how it's stored.
+`name` is required and is matched case-insensitively against the workspace's actual `name` field. The CLI verifies that the workspace exists before writing, and persists the canonical-cased name from the API. For example, typing `production` saves `Production` if that's how it's stored.
 
 This is typically the second step in onboarding, right after [`configure`](./authenticate#recommended-airbyte-agent-configure). Run it again whenever you switch projects.
 

--- a/docs/ai-agents/interfaces/readme.md
+++ b/docs/ai-agents/interfaces/readme.md
@@ -11,7 +11,7 @@ Airbyte Agents supports five interfaces for working with your data and your agen
 - [**MCP server**](mcp): A remote, Airbyte-hosted Model Context Protocol server that connects MCP-capable agents (like Claude, Cursor, and ChatGPT) to your data. Best for conversational agents that use off-the-shelf clients.
 - [**SDK**](sdk): Python SDK for building, authenticating, and executing agent connectors directly in your Python applications. Best for Python-based agents you build and host yourself.
 - [**CLI**](cli): A single Go binary that exposes Airbyte Agents as `airbyte-agent <resource> <operation>`. Best for shell scripts, CI jobs, and AI-agent harnesses that shell out for tool calls.
-- [**API**](api): HTTP API for managing connectors, tokens, and executing operations from any language or backend service. Best for non-Python backends, custom admin flows, and embedding the authentication module in your app.
+- [**API**](api): REST endpoints for managing connectors, tokens, and executing operations from any language or backend service. Best for non-Python backends, custom admin flows, and embedding the authentication module in your app.
 
 import DocCardList from '@theme/DocCardList';
 

--- a/docs/ai-agents/interfaces/readme.md
+++ b/docs/ai-agents/interfaces/readme.md
@@ -5,11 +5,12 @@ sidebar_position: 4
 
 # Interfaces
 
-Airbyte Agents supports four interfaces for working with your data and your agents. Choose the interface that best fits how you want to build and run agents.
+Airbyte Agents supports five interfaces for working with your data and your agents. Choose the interface that best fits how you want to build and run agents.
 
 - [**Web app**](ui): The Airbyte Agents web app at [app.airbyte.ai](https://app.airbyte.ai). Talk to an Airbyte-hosted agent in [Chats](ui/chats), or define [Automations](ui/automations) that run on a schedule or webhook. Best when you want Airbyte itself to be your agent, with no code required.
 - [**MCP server**](mcp): A remote, Airbyte-hosted Model Context Protocol server that connects MCP-capable agents (like Claude, Cursor, and ChatGPT) to your data. Best for conversational agents that use off-the-shelf clients.
 - [**SDK**](sdk): Python SDK for building, authenticating, and executing agent connectors directly in your Python applications. Best for Python-based agents you build and host yourself.
+- [**CLI**](cli): A single Go binary that exposes Airbyte Agents as `airbyte-agent <resource> <operation>`. Best for shell scripts, CI jobs, and AI-agent harnesses that shell out for tool calls.
 - [**API**](api): HTTP API for managing connectors, tokens, and executing operations from any language or backend service. Best for non-Python backends, custom admin flows, and embedding the authentication module in your app.
 
 import DocCardList from '@theme/DocCardList';

--- a/docs/ai-agents/interfaces/sdk/readme.md
+++ b/docs/ai-agents/interfaces/sdk/readme.md
@@ -16,6 +16,8 @@ This section walks through authenticate, add a connector, and execute operations
 
 <SdkVsApi />
 
+For the no-code option, see the [web app](../ui); for MCP-capable clients, see the [MCP server](../mcp).
+
 ## Log in and sign up
 
 Log in or sign up at [app.airbyte.ai](https://app.airbyte.ai/).

--- a/docs/ai-agents/interfaces/ui/add-connector.md
+++ b/docs/ai-agents/interfaces/ui/add-connector.md
@@ -5,7 +5,7 @@ sidebar_position: 3
 
 # Add a connector
 
-Before an Airbyte agent can read from or write to a data source, someone has to authenticate that source for the workspace. In the web app, that happens on the **Connectors** page. Adding a connector means picking a workspace, picking a data source, and completing an authentication flow once; after that, every interface you use (Chats, Automations, the SDK, the API, and the MCP server) can use the resulting connector.
+Before an Airbyte agent can read from or write to a data source, someone has to authenticate that source for the workspace. In the web app, that happens on the **Connectors** page. Adding a connector means picking a workspace, picking a data source, and completing an authentication flow once; after that, every interface you use (Chats, Automations, the SDK, the CLI, the API, and the MCP server) can use the resulting connector.
 
 This page walks through adding connectors end-to-end: where to add them, how to add them from inside a chat or the Automation Builder, how workspaces and multiple connectors fit together, and how to update or remove connectors you've already added.
 
@@ -18,7 +18,7 @@ It helps to separate two ideas that both get called "a connector":
 
 When this doc says "add a connector," it means the second thing: creating an authenticated instance of a connector type inside one of your workspaces. Once it exists, any Chat, Automation, or external client that runs in the same workspace can use it without re-authenticating.
 
-Adding a connector is a one-time setup step per workspace. You don't need to pick a "mode" or opt into specific use cases. The same connector is available to agents in Chats, scheduled Automations, the [SDK](../sdk), the [API](../api), and the [MCP server](../mcp).
+Adding a connector is a one-time setup step per workspace. You don't need to pick a "mode" or opt into specific use cases. The same connector is available to agents in Chats, scheduled Automations, the [SDK](../sdk), the [CLI](../cli), the [API](../api), and the [MCP server](../mcp).
 
 ## Workspaces and connectors
 
@@ -120,6 +120,7 @@ Everything on this page has programmatic equivalents:
 
 - Use the [API](../api/add-connector) to create, update, and delete connectors from a script or backend service.
 - Use the [SDK](../sdk) to manage connectors from Python code, including inside your own agent implementations.
+- Use the [CLI](../cli/add-connector) to drive the browser-based credential flow from a terminal, a CI job, or an agent harness that shells out.
 - Use the [MCP server](../mcp) to expose an authenticated connector to any MCP-compatible client.
 
-All three act on the same underlying connectors, so a connector added in the web app is immediately usable from the API, SDK, and MCP server, and vice versa.
+All four act on the same underlying connectors, so a connector added in the web app is immediately usable from the API, SDK, CLI, and MCP server, and vice versa.

--- a/docs/ai-agents/interfaces/ui/readme.md
+++ b/docs/ai-agents/interfaces/ui/readme.md
@@ -7,7 +7,7 @@ sidebar_position: 1
 
 The Airbyte Agents web app at [app.airbyte.ai](https://app.airbyte.ai) is the fastest way to use Airbyte Agents without writing code. Describe what you want in natural language, and Airbyte picks the right connectors, makes the necessary tool calls, and replies with an answer grounded in your data.
 
-Use the web app when you want Airbyte itself to be your agent. For Python agents you build yourself, use the [SDK](../sdk). For agents in any other language, use the [API](../api). For agents that already speak Model Context Protocol, use the [MCP server](../mcp).
+Use the web app when you want Airbyte itself to be your agent. For Python agents you build yourself, use the [SDK](../sdk). For agents in any other language, use the [API](../api). For agents that already speak Model Context Protocol, use the [MCP server](../mcp). For agents that shell out for tool calls (or for shell scripts and CI jobs), use the [CLI](../cli).
 
 ## Chats and Automations
 

--- a/docusaurus/src/components/AiAgentsHome/QuickInstall.jsx
+++ b/docusaurus/src/components/AiAgentsHome/QuickInstall.jsx
@@ -87,6 +87,19 @@ const TABS = [
     ],
   },
   {
+    id: "cli",
+    label: "CLI",
+    command: "brew install airbytehq/tap/airbyte-agent",
+    description: "Install the airbyte-agent CLI for shell scripts, CI jobs, and AI-agent harnesses.",
+    tools: [
+      {
+        name: "CLI docs",
+        href: "/ai-agents/interfaces/cli/",
+        icon: "/img/favicon.png",
+      },
+    ],
+  },
+  {
     id: "api",
     label: "API",
     command: null,

--- a/docusaurus/static/_ai-agents-sdk-vs-api.md
+++ b/docusaurus/static/_ai-agents-sdk-vs-api.md
@@ -1,6 +1,7 @@
-You can use Airbyte Agents programmatically two ways:
+You can use Airbyte Agents programmatically three ways:
 
 - [**SDK**](/ai-agents/interfaces/sdk): a typed Python library. Best for Python apps, notebooks, scripts, and AI agents.
 - [**API**](/ai-agents/interfaces/api): an HTTP API. Best for non-Python backends and languages the SDK doesn't cover.
+- [**CLI**](/ai-agents/interfaces/cli): a Go binary (`airbyte-agent`) that wraps the API. Best for shell scripts, CI jobs, and AI-agent harnesses that prefer shelling out to making HTTP calls.
 
-Most Airbyte Agents operations are available through both interfaces. Where the SDK can't do something directly, use the API as noted explicitly in docs.
+Most Airbyte Agents operations are available through all three interfaces. Where the SDK can't do something directly, use the API (or the CLI, which wraps it) as noted explicitly in docs.


### PR DESCRIPTION
## What

Adds public docs for the Airbyte Agent CLI (`airbyte-agent`), the new Go binary at [`airbytehq/airbyte-agent-cli`](https://github.com/airbytehq/airbyte-agent-cli), and integrates it into the Airbyte Agents IA as a fifth interface alongside Web app, MCP, SDK, and Agent API.

Closes [AGENTIC-1556](https://linear.app/airbyteio/issue/AGENTIC-1556/agent-cli-docs).

## How

New directory `docs/ai-agents/interfaces/cli/`, modeled after the existing `interfaces/sdk/` and `interfaces/api/` sections:

- `readme.md` — landing page (what it is, when to choose it, prerequisites, install via Homebrew / manual download / source, first command, command model, exit codes).
- `authenticate.md` — get `AIRBYTE_CLIENT_ID` / `AIRBYTE_CLIENT_SECRET` / `AIRBYTE_ORGANIZATION_ID` from the **Your API Credentials** card in [app.airbyte.ai](https://app.airbyte.ai/), `airbyte-agent configure`, env vars, settings file, token refresh, self-hosted/staging overrides.
- `workspaces.md` — `workspaces list` (with filters) and `workspaces use` to persist a default in `~/.airbyte-agent/settings.json`.
- `add-connector.md` — browser-based credential flow with `connectors create`, including the hard rule that the CLI never accepts third-party credentials inline.
- `describe-connector.md` — `connectors describe` as the authoritative source for entities, actions, and per-action param schemas.
- `execute.md` — `connectors execute`, JSON-vs-flags, the baseline action table, action params, `select_fields`/`exclude_fields` (API-side) vs `--fields` (client-side), `--json @file`, pagination, errors.
- `using-with-ai-agents.md` — install bundled skills via `npx skills add airbytehq/airbyte-agent-cli`, agent rules (parse stderr JSON, `describe` before `execute`, always JSON payloads, never ask users for credentials), output discipline, telemetry execution-context tagging.
- `command-reference.md` — every operation summarized with param tables, common flags, exit codes, retry behavior, env-var matrix.
- `troubleshooting.md` — missing settings, auth failures, workspace/connector not found, destructive-delete on non-TTY, credential-flow timeout, large responses, missing `api` block in `--describe`, rate limits.

Integration with the rest of the docs:

- `docs/ai-agents/interfaces/readme.md` — adds CLI as a fifth bullet between SDK and API.
- `docs/ai-agents/get-started/choose-how-to-use.md` — adds a CLI branch to the mermaid flowchart and a "## CLI" section between "Web app" and "Agent API"; updates the "All paths lead to the same data" paragraph to mention five interfaces.
- `docs/ai-agents/interfaces/api/readme.md` — bumps `sidebar_position` from `3` to `4` so the CLI sits at `3` (between SDK at `2` and API at `4`). MCP stays at `6`.

Audit pass: the new CLI section is referenced from every page in `docs/ai-agents/` that enumerates the available interfaces. Pages that filter by Usage panel categories (sessions, agent operations) stay narrow with explicit scoping; the shared `_ai-agents-sdk-vs-api.md` partial now also lists CLI as a third programmatic option.

All material is sourced from the CLI repo's checked-in docs (`README.md`, `AGENTS.md`, `CONTEXT.md`, and the per-command `skills/<command>/SKILL.md` files). No content was invented.

### Eval feedback addressed in this PR

Two rounds of agent-driven evaluation flagged accuracy issues. Doc fixes landed in `566aef6` and `824dfcc`:

- Removed the dead `/profile` route reference and pointed to the **Your API Credentials** card on the onboarding screen / account details.
- Corrected the `organizations list` response shape (wrapped object, with sample row using `id` / `organization_name` / `first_workspace_id` to match Sonar's `OrganizationsListResponse` schema).
- Added a prerequisite note that `workspaces use` requires the settings file from `airbyte-agent configure` and won't bootstrap from env vars alone.
- Softened exit-code claims for malformed input — added Rule 0 in `using-with-ai-agents.md` telling agents to parse stderr JSON `type` rather than dispatch on exit code alone, and repeated the caveat under the `command-reference.md` exit-codes table.
- Pinned down top-level global flag behavior (`-o`, `--fields`, `--format` silently accepted but no-ops) with explicit examples in the command reference.
- Added the `completion` command to the top-level commands table.
- Replaced `action: "read"` examples with baseline actions (`context_store_search`, `list`) — `read` isn't in the upstream baseline.
- Softened `workspaces list --json '{"limit":1}'` wording: `limit` is a page size hint the CLI overrides with auto-pagination, so it doesn't cap the final result count.
- Noted that `npx skills add` writes to the harness default directory (`~/.agents/skills/...`) and doesn't honor a custom destination flag.

Three upstream CLI behaviors remain open and are tracked in Linear (do not block this PR):

- [AGENTIC-1558](https://linear.app/airbyteio/issue/AGENTIC-1558) — `workspaces list` ignores the `limit` parameter.
- [AGENTIC-1559](https://linear.app/airbyteio/issue/AGENTIC-1559) — `workspaces list --describe` OpenAPI text says "external users" instead of workspaces.
- [AGENTIC-1560](https://linear.app/airbyteio/issue/AGENTIC-1560) — top-level `-o` silently fails to write the output file.

## Review guide

1. `docs/ai-agents/interfaces/cli/readme.md` — start here for the overall framing.
2. `docs/ai-agents/get-started/choose-how-to-use.md` — verify the CLI's position in the flowchart and the body order reads naturally.
3. `docs/ai-agents/interfaces/cli/using-with-ai-agents.md` — the page most likely to need product/positioning review (skills install path is presented as the recommended approach, easy to soften if you want it called experimental).
4. `docs/ai-agents/interfaces/cli/command-reference.md` — spot-check param tables against `--describe` output if you have the CLI installed.
5. Other pages (`authenticate`, `workspaces`, `add-connector`, `describe-connector`, `execute`, `troubleshooting`) — content review.

## User Impact

Users get a discoverable docs path for the new CLI, with the same shape as the existing SDK/API sections so the IA stays predictable. No runtime or product behavior changes. The CLI repo is currently private but will be public; all links assume the public URL.

## Can this PR be safely reverted and rolled back?
- [x] YES 💚
- [ ] NO ❌

Docs-only.

Link to Devin session: https://app.devin.ai/sessions/85c590e5d3fd49478b3f344137d79662
Requested by: @ian-at-airbyte