### PR TITLE
chore(source-amazon-ads): bump to 8.0.3-rc.2 with num_workers default=14 (tuning iter 2)

### DIFF
--- a/airbyte-integrations/connectors/source-amazon-ads/manifest.yaml
+++ b/airbyte-integrations/connectors/source-amazon-ads/manifest.yaml
@@ -3509,7 +3509,7 @@ spec:
         title: Number of concurrent threads
         minimum: 2
         maximum: 20
-        default: 12
+        default: 14
         examples:
           - 2
           - 3
@@ -3567,7 +3567,7 @@ spec:
 # continue to observe.
 concurrency_level:
   type: ConcurrencyLevel
-  default_concurrency: "{{ config.get('num_workers', 12) }}"
+  default_concurrency: "{{ config.get('num_workers', 14) }}"
   max_concurrency: 20
 
 schemas:

--- a/airbyte-integrations/connectors/source-amazon-ads/metadata.yaml
+++ b/airbyte-integrations/connectors/source-amazon-ads/metadata.yaml
@@ -13,7 +13,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: c6b0a29e-1da9-4512-9002-7bfd0cba2246
-  dockerImageTag: 8.0.3-rc.1
+  dockerImageTag: 8.0.3-rc.2
   dockerRepository: airbyte/source-amazon-ads
   documentationUrl: https://docs.airbyte.com/integrations/sources/amazon-ads
   githubIssueLabel: source-amazon-ads

--- a/docs/integrations/sources/amazon-ads.md
+++ b/docs/integrations/sources/amazon-ads.md
@@ -164,6 +164,7 @@ If you need better sync performance and are not experiencing rate limiting error
 
 | Version    | Date       | Pull Request                                             | Subject                                                                                                                                                                |
 |:-----------|:-----------|:---------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 8.0.3-rc.2 | 2026-05-12 | [*PR_NUMBER_PLACEHOLDER*](https://github.com/airbytehq/airbyte/pull/*PR_NUMBER_PLACEHOLDER*) | Concurrency tuning iteration 2: bump num_workers default 12 -> 14 (PASS at 12 over 24h, 4 daily+ TIER_2 actors, no 429s observed). |
 | 8.0.3-rc.1 | 2026-05-11 | [TBD](https://github.com/airbytehq/airbyte/pull/TBD) | Tune default concurrency from 10 to 12 (`num_workers`) for progressive rollout |
 | 8.0.2 | 2026-05-05 | [77660](https://github.com/airbytehq/airbyte/pull/77660) | Skip profiles without Amazon Attribution access on attribution report performance streams instead of failing the sync |
 | 8.0.1 | 2026-04-28 | [77149](https://github.com/airbytehq/airbyte/pull/77149) | Update dependencies |

--- a/docs/integrations/sources/amazon-ads.md
+++ b/docs/integrations/sources/amazon-ads.md
@@ -164,8 +164,8 @@ If you need better sync performance and are not experiencing rate limiting error
 
 | Version    | Date       | Pull Request                                             | Subject                                                                                                                                                                |
 |:-----------|:-----------|:---------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| 8.0.3-rc.2 | 2026-05-12 | [*PR_NUMBER_PLACEHOLDER*](https://github.com/airbytehq/airbyte/pull/*PR_NUMBER_PLACEHOLDER*) | Concurrency tuning iteration 2: bump num_workers default 12 -> 14 (PASS at 12 over 24h, 4 daily+ TIER_2 actors, no 429s observed). |
-| 8.0.3-rc.1 | 2026-05-11 | [TBD](https://github.com/airbytehq/airbyte/pull/TBD) | Tune default concurrency from 10 to 12 (`num_workers`) for progressive rollout |
+| 8.0.3-rc.2 | 2026-05-12 | [78055](https://github.com/airbytehq/airbyte/pull/78055) | Concurrency tuning iteration 2: bump default `num_workers` from 12 to 14 for progressive rollout |
+| 8.0.3-rc.1 | 2026-05-11 | [78010](https://github.com/airbytehq/airbyte/pull/78010) | Concurrency tuning iteration 1: bump default `num_workers` from 10 to 12 for progressive rollout |
 | 8.0.2 | 2026-05-05 | [77660](https://github.com/airbytehq/airbyte/pull/77660) | Skip profiles without Amazon Attribution access on attribution report performance streams instead of failing the sync |
 | 8.0.1 | 2026-04-28 | [77149](https://github.com/airbytehq/airbyte/pull/77149) | Update dependencies |
 | 8.0.0 | 2026-04-22 | [75490](https://github.com/airbytehq/airbyte/pull/75490) | Use `date` field from API response as cursor and primary key for daily report streams instead of synthetic `reportDate`. Fixes ~96% data loss from incorrect deduplication. |


### PR DESCRIPTION
## What

Concurrency tuning iteration 2 for `source-amazon-ads`, continuing the rollout tracked in [airbytehq/airbyte-internal-issues#15305](https://github.com/airbytehq/airbyte-internal-issues/issues/15305) (parent epic: [airbytehq/airbyte-internal-issues#15262](https://github.com/airbytehq/airbyte-internal-issues/issues/15262)).

The previous RC `8.0.3-rc.1` (`num_workers` default 10 → 12) was pinned for ~24h to a cohort of 4 daily+ TIER_2 actors via rollout `2af209e2-9bf3-4847-bcc9-a7ac9bd39c41`. Result over the 24h window: **PASS** — 0/38 failures, 0 `429 / Too Many Requests` observations, avg sync duration within ±5% of paired 8.0.2 baseline for 3 light actors and ~26% faster on the only heavy actor. See [comment](https://github.com/airbytehq/airbyte-internal-issues/issues/15305#issuecomment-4435772231) for details.

Per playbook (tune higher on PASS, step=2, 3-iteration cap on the higher direction), this PR bumps `num_workers` default 12 → 14 for the next 24h tuning iteration. This PR stays in draft until tuning settles.

## How

- `manifest.yaml`:
  - `num_workers.default`: 12 → 14
  - `concurrency_level.default_concurrency` fallback: 12 → 14
- `metadata.yaml`:
  - `dockerImageTag`: 8.0.3-rc.1 → 8.0.3-rc.2
  - `enableProgressiveRollout: true` retained
- Changelog entry for 8.0.3-rc.2.

No code (Python) changes; manifest-only connector.

## Review guide

1. `airbyte-integrations/connectors/source-amazon-ads/manifest.yaml` — two integer changes (12 → 14).
2. `airbyte-integrations/connectors/source-amazon-ads/metadata.yaml` — version tag.
3. `docs/integrations/sources/amazon-ads.md` — changelog row.

## User Impact

Users on the pinned cohort (4 actors) will start the next sync at `num_workers=14`. No spec-shape changes; min=2/max=20 unchanged. Existing `num_workers` overrides on user configs continue to take precedence over the default.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚
- [ ] NO ❌

The progressive rollout state machine (`enableProgressiveRollout: true`) allows immediate revert via `cancel_connector_rollout` or `finalize_connector_rollout(state='canceled')`, releasing pinned actors back to stable 8.0.2.


Link to Devin session: https://app.devin.ai/sessions/6637a07c867f4b3785588328533041a8
Requested by: @sophiecuiy

> [!IMPORTANT]
> Active progressive rollout warning for source-amazon-ads.

- [ ] (Click to Approve:) Bypass the active progressive rollout warning for source-amazon-ads in the PR comment [here](https://github.com/airbytehq/airbyte/pull/78055#issuecomment-4435783246).