### PR TITLE
fix(source-apple-search-ads): increase max_retries to prevent HTTP 429 crashes

### DIFF
--- a/airbyte-integrations/connectors/source-apple-search-ads/manifest.yaml
+++ b/airbyte-integrations/connectors/source-apple-search-ads/manifest.yaml
@@ -47,6 +47,7 @@ definitions:
             type: CompositeErrorHandler
             error_handlers:
               - type: DefaultErrorHandler
+                max_retries: 20
                 backoff_strategies:
                   - type: ExponentialBackoffStrategy
                 response_filters:
@@ -107,6 +108,7 @@ definitions:
             type: CompositeErrorHandler
             error_handlers:
               - type: DefaultErrorHandler
+                max_retries: 20
                 backoff_strategies:
                   - type: ExponentialBackoffStrategy
                 response_filters:
@@ -177,6 +179,7 @@ definitions:
             type: CompositeErrorHandler
             error_handlers:
               - type: DefaultErrorHandler
+                max_retries: 20
                 backoff_strategies:
                   - type: ExponentialBackoffStrategy
                 response_filters:
@@ -254,7 +257,7 @@ definitions:
             type: CompositeErrorHandler
             error_handlers:
               - type: DefaultErrorHandler
-                max_retries: 10
+                max_retries: 20
                 response_filters:
                   - type: HttpResponseFilter
                     action: REFRESH_TOKEN_THEN_RETRY
@@ -369,7 +372,7 @@ definitions:
             type: CompositeErrorHandler
             error_handlers:
               - type: DefaultErrorHandler
-                max_retries: 10
+                max_retries: 20
                 response_filters:
                   - type: HttpResponseFilter
                     action: REFRESH_TOKEN_THEN_RETRY
@@ -491,7 +494,7 @@ definitions:
             granularity: DAILY
           error_handler:
             type: DefaultErrorHandler
-            max_retries: 10
+            max_retries: 20
             response_filters:
               - type: HttpResponseFilter
                 action: IGNORE
@@ -609,6 +612,7 @@ definitions:
             type: CompositeErrorHandler
             error_handlers:
               - type: DefaultErrorHandler
+                max_retries: 20
                 backoff_strategies:
                   - type: ExponentialBackoffStrategy
                 response_filters:
@@ -678,7 +682,7 @@ definitions:
             granularity: DAILY
           error_handler:
             type: DefaultErrorHandler
-            max_retries: 10
+            max_retries: 20
             response_filters:
               - type: HttpResponseFilter
                 action: REFRESH_TOKEN_THEN_RETRY


### PR DESCRIPTION
## What
The `source-apple-search-ads` connector frequently crashes with `Exhausted available request attempts` due to aggressive HTTP 429 (Too many requests) rate limiting by the Apple Search Ads API. The default retry limits (10 for daily report streams, 5 for base streams) are too low for syncs spanning large date ranges. 

Closes #77969

## How
Updated the declarative configuration in `manifest.yaml` to standardize `max_retries: 20` across all 8 streams (both base streams and daily report streams). By increasing the retry limit, the `ExponentialBackoffStrategy` now has sufficient runway to wait out Apple's rate-limit reset windows without prematurely failing the entire sync.

## Review guide
1. `airbyte-integrations/connectors/source-apple-search-ads/manifest.yaml` - Updated `error_handler` blocks to include `max_retries: 20`.

## User Impact
* **Positive:** Users syncing large date ranges or multiple campaigns will no longer experience failed syncs due to 429 rate limits.
* **Negative/Side Effects:** Syncs that hit heavy rate limiting may take slightly longer to complete due to the extended backoff waiting periods, but they will successfully finish rather than crashing.

## Can this PR be safely reverted and rolled back?
- [x] YES 💚
- [ ] NO ❌