### PR TITLE
build(connectors): Use generated PyPI READMEs

### DIFF
--- a/poe-tasks/publish-python-registry.sh
+++ b/poe-tasks/publish-python-registry.sh
@@ -46,10 +46,12 @@ function get_pypi_package_name() {
     yq eval '.data.remoteRegistries.pypi.packageName' "$1"
 }
 
+# Read a metadata.yaml value and return an empty string when the key is absent.
 function get_metadata_value() {
     yq eval "$1 // \"\"" "$2"
 }
 
+# Map a published Airbyte docs URL back to the corresponding local docs markdown file.
 function get_local_docs_path() {
     local documentation_url="$1"
     local repo_root="$2"
@@ -74,6 +76,7 @@ function get_local_docs_path() {
     fi
 }
 
+# Create the temporary PyPI long description from connector docs content.
 function write_docs_pypi_readme() {
     local docs_file="$1"
     local readme_file="$2"

--- a/poe-tasks/publish-python-registry.sh
+++ b/poe-tasks/publish-python-registry.sh
@@ -46,65 +46,19 @@ function get_pypi_package_name() {
     yq eval '.data.remoteRegistries.pypi.packageName' "$1"
 }
 
-# Read a metadata.yaml value and return an empty string when the key is absent.
-function get_metadata_value() {
-    yq eval "$1 // \"\"" "$2"
-}
-
-# Map a published Airbyte docs URL back to the corresponding local docs markdown file.
-function get_local_docs_path() {
-    local documentation_url="$1"
-    local repo_root="$2"
-    local docs_path=""
-
-    if [[ "$documentation_url" == "https://docs.airbyte.com/integrations/"* ]]; then
-        docs_path="${documentation_url#https://docs.airbyte.com/}"
-        docs_path="${docs_path%%#*}"
-        docs_path="${docs_path%%\?*}"
-        docs_path="${docs_path%/}"
-        docs_path="$repo_root/docs/$docs_path.md"
-    fi
-
-    if [[ -n "$docs_path" && -f "$docs_path" ]]; then
-        echo "$docs_path"
-    elif [[ -n "$docs_path" ]]; then
-        echo "Error: Connector documentation file not found: $docs_path" >&2
-        return 1
-    else
-        echo "Error: Connector documentation URL must point to docs.airbyte.com/integrations: $documentation_url" >&2
-        return 1
-    fi
-}
-
-# Create the temporary PyPI long description from connector docs content.
-function write_docs_pypi_readme() {
-    local docs_file="$1"
+# Create the temporary PyPI long description used during package builds.
+function write_pypi_readme() {
+    local connector_title="$1"
     local readme_file="$2"
-    local documentation_url="$3"
 
-    awk '
-        /^## Changelog[[:space:]]*$/ { exit }
-        /^<HideInUI>[[:space:]]*$/ { in_hidden_block = 1; next }
-        /^<\/HideInUI>[[:space:]]*$/ { in_hidden_block = 0; next }
-        in_hidden_block { next }
-        /^import .* from / { next }
-        /^export const / { next }
-        /^<!--/ { next }
-        /^<FieldAnchor[ >]/ { next }
-        /^<\/FieldAnchor>/ { next }
-        { print }
-    ' "$docs_file" > "$readme_file"
+    cat > "$readme_file" << EOF
+# $connector_title
 
-    if [[ ! -s "$readme_file" ]]; then
-        return 1
-    fi
+This package contains the Airbyte $connector_title connector.
 
-    cat >> "$readme_file" << EOF
+Airbyte is open-source data movement for ELT pipelines and AI agents. It moves data from APIs, databases, and files to warehouses, lakes, and AI applications.
 
----
-
-For the latest connector documentation, see the [Airbyte docs]($documentation_url).
-For PyAirbyte usage, see the [PyAirbyte documentation](https://docs.airbyte.com/developers/pyairbyte).
+Airbyte provides a catalog of 600+ connectors for APIs, databases, data warehouses, data lakes, and AI applications. Use this package with [PyAirbyte](https://docs.airbyte.com/developers/pyairbyte) to run the connector from Python.
 EOF
 }
 
@@ -190,7 +144,6 @@ fi
 
 
 # Navigate to connector directory
-REPO_ROOT=$(pwd)
 CONNECTOR_DIR="airbyte-integrations/connectors/$CONNECTOR_NAME"
 if [[ ! -d "$CONNECTOR_DIR" ]]; then
     echo "Error: Connector directory not found: $CONNECTOR_DIR" >&2
@@ -220,8 +173,7 @@ if [[ -z "$PACKAGE_NAME" ]]; then
     echo "⚠️ Error: Package name not found in metadata.yaml, skipping PyPI publishing." >&2
     exit 0
 fi
-DOCUMENTATION_URL=$(get_metadata_value '.data.documentationUrl' "$METADATA_FILE")
-LOCAL_DOCS_PATH=$(get_local_docs_path "$DOCUMENTATION_URL" "$REPO_ROOT")
+CONNECTOR_TITLE=$(yq eval '.data.name' "$METADATA_FILE")
 BASE_VERSION=$(poe -qq get-version)
 
 # Determine version to use
@@ -280,8 +232,8 @@ if [[ -f "pyproject.toml" ]]; then
     }
     trap cleanup EXIT   
 
-    write_docs_pypi_readme "$LOCAL_DOCS_PATH" "$PYPI_README_FILE" "$DOCUMENTATION_URL"
-    echo "Using connector docs for PyPI README: $LOCAL_DOCS_PATH"
+    write_pypi_readme "$CONNECTOR_TITLE" "$PYPI_README_FILE"
+    echo "Using generated PyPI README for $CONNECTOR_TITLE"
 
     # to support overriding the package name and the version when publishing to PyPI, the script modifies the pyproject.toml file 
     # we keep a backup at pyproject.toml.bak that is used to restore the initial state at the end

--- a/poe-tasks/publish-python-registry.sh
+++ b/poe-tasks/publish-python-registry.sh
@@ -20,6 +20,7 @@ Options:
     -v, --version VERSION         Override version (optional)
     --with-semver-suffix TYPE     Semver suffix (optional): 'none', 'preview', or 'rc' (default is 'preview')
     --test-registry               Use the test PyPI registry (default is production registry)
+    --dry-run                     Build the package and skip upload
     -h, --help                    Show this help message
 
 Environment Variables:
@@ -45,6 +46,65 @@ function get_pypi_package_name() {
     yq eval '.data.remoteRegistries.pypi.packageName' "$1"
 }
 
+function get_metadata_value() {
+    yq eval "$1 // \"\"" "$2"
+}
+
+function get_local_docs_path() {
+    local documentation_url="$1"
+    local repo_root="$2"
+    local docs_path=""
+
+    if [[ "$documentation_url" == "https://docs.airbyte.com/integrations/"* ]]; then
+        docs_path="${documentation_url#https://docs.airbyte.com/}"
+        docs_path="${docs_path%%#*}"
+        docs_path="${docs_path%%\?*}"
+        docs_path="${docs_path%/}"
+        docs_path="$repo_root/docs/$docs_path.md"
+    fi
+
+    if [[ -n "$docs_path" && -f "$docs_path" ]]; then
+        echo "$docs_path"
+    elif [[ -n "$docs_path" ]]; then
+        echo "Error: Connector documentation file not found: $docs_path" >&2
+        return 1
+    else
+        echo "Error: Connector documentation URL must point to docs.airbyte.com/integrations: $documentation_url" >&2
+        return 1
+    fi
+}
+
+function write_docs_pypi_readme() {
+    local docs_file="$1"
+    local readme_file="$2"
+    local documentation_url="$3"
+
+    awk '
+        /^## Changelog[[:space:]]*$/ { exit }
+        /^<HideInUI>[[:space:]]*$/ { in_hidden_block = 1; next }
+        /^<\/HideInUI>[[:space:]]*$/ { in_hidden_block = 0; next }
+        in_hidden_block { next }
+        /^import .* from / { next }
+        /^export const / { next }
+        /^<!--/ { next }
+        /^<FieldAnchor[ >]/ { next }
+        /^<\/FieldAnchor>/ { next }
+        { print }
+    ' "$docs_file" > "$readme_file"
+
+    if [[ ! -s "$readme_file" ]]; then
+        return 1
+    fi
+
+    cat >> "$readme_file" << EOF
+
+---
+
+For the latest connector documentation, see the [Airbyte docs]($documentation_url).
+For PyAirbyte usage, see the [PyAirbyte documentation](https://docs.airbyte.com/developers/pyairbyte).
+EOF
+}
+
 # Default values
 REGISTRY_UPLOAD_URL="https://upload.pypi.org/legacy/"
 REGISTRY_CHECK_URL="https://pypi.org/pypi"
@@ -58,6 +118,7 @@ SEMVER_SUFFIX="preview"
 CONNECTOR_NAME=""
 PYPI_TOKEN=""
 VERSION_OVERRIDE=""
+DRY_RUN="false"
 
 # Parse command line arguments
 while [[ $# -gt 0 ]]; do
@@ -83,6 +144,10 @@ while [[ $# -gt 0 ]]; do
             REGISTRY_CHECK_URL="$TEST_REGISTRY_CHECK_URL"
             REGISTRY_PACKAGE_URL="$TEST_REGISTRY_PACKAGE_URL"
             echo "🧪 Using Test PyPI registry: $REGISTRY_UPLOAD_URL"
+            shift
+            ;;
+        --dry-run)
+            DRY_RUN="true"
             shift
             ;;
         -h|--help)
@@ -115,13 +180,14 @@ if [[ -z "$PYPI_TOKEN" && -n "${PYTHON_REGISTRY_TOKEN:-}" ]]; then
     PYPI_TOKEN="$PYTHON_REGISTRY_TOKEN"
 fi
 
-if [[ -z "$PYPI_TOKEN" ]]; then
+if [[ -z "$PYPI_TOKEN" && "$DRY_RUN" != "true" ]]; then
     echo "Error: PyPI token is required (use --token or set PYTHON_REGISTRY_TOKEN in your environment), skipping PyPI publishing" >&2
     exit 0
 fi
 
 
 # Navigate to connector directory
+REPO_ROOT=$(pwd)
 CONNECTOR_DIR="airbyte-integrations/connectors/$CONNECTOR_NAME"
 if [[ ! -d "$CONNECTOR_DIR" ]]; then
     echo "Error: Connector directory not found: $CONNECTOR_DIR" >&2
@@ -151,6 +217,8 @@ if [[ -z "$PACKAGE_NAME" ]]; then
     echo "⚠️ Error: Package name not found in metadata.yaml, skipping PyPI publishing." >&2
     exit 0
 fi
+DOCUMENTATION_URL=$(get_metadata_value '.data.documentationUrl' "$METADATA_FILE")
+LOCAL_DOCS_PATH=$(get_local_docs_path "$DOCUMENTATION_URL" "$REPO_ROOT")
 BASE_VERSION=$(poe -qq get-version)
 
 # Determine version to use
@@ -177,12 +245,16 @@ echo "Version: $VERSION"
 echo "Semver suffix: $SEMVER_SUFFIX"
 echo
 
-# Check if package already exists
-if [[ $(curl -s -o /dev/null -w "%{http_code}" "$REGISTRY_CHECK_URL/$PACKAGE_NAME/$VERSION/json") == "200" ]]; then
-    echo "⚠️ Package $PACKAGE_NAME version $VERSION already exists on PyPI  at $REGISTRY_CHECK_URL/$PACKAGE_NAME/$VERSION/json. Skipping publishing."
-    exit 0
+if [[ "$DRY_RUN" == "true" ]]; then
+    echo "Dry run: skipping package existence check and upload."
 else
-    echo "✅ Package $PACKAGE_NAME version $VERSION does not exist already on PyPI. Proceeding with publishing."
+    # Check if package already exists
+    if [[ $(curl -s -o /dev/null -w "%{http_code}" "$REGISTRY_CHECK_URL/$PACKAGE_NAME/$VERSION/json") == "200" ]]; then
+        echo "⚠️ Package $PACKAGE_NAME version $VERSION already exists on PyPI  at $REGISTRY_CHECK_URL/$PACKAGE_NAME/$VERSION/json. Skipping publishing."
+        exit 0
+    else
+        echo "✅ Package $PACKAGE_NAME version $VERSION does not exist already on PyPI. Proceeding with publishing."
+    fi
 fi
 
 
@@ -190,39 +262,59 @@ fi
 if [[ -f "pyproject.toml" ]]; then
     echo "Detected Poetry project"
 
+    PYPI_README_FILE=".airbyte-pypi-readme.md"
+
     # runs automatically on script error or exit
     cleanup() {
         if [[ -f pyproject.toml.bak ]]; then
             mv pyproject.toml.bak pyproject.toml
             echo "Restored original pyproject.toml"
         fi
+        if [[ -f "$PYPI_README_FILE" ]]; then
+            rm "$PYPI_README_FILE"
+            echo "Removed temporary PyPI README"
+        fi
     }
     trap cleanup EXIT   
+
+    write_docs_pypi_readme "$LOCAL_DOCS_PATH" "$PYPI_README_FILE" "$DOCUMENTATION_URL"
+    echo "Using connector docs for PyPI README: $LOCAL_DOCS_PATH"
 
     # to support overriding the package name and the version when publishing to PyPI, the script modifies the pyproject.toml file 
     # we keep a backup at pyproject.toml.bak that is used to restore the initial state at the end
     # TODO: figure out if we can do this in a less hacky way and reevaluate whether to continue defining PyPI package information in metadata.yaml
     sed -i.bak -E \
         "s/^([[:space:]]*name[[:space:]]*=[[:space:]]*\").*(\".*)$/\\1${PACKAGE_NAME}\\2/;
-        s/^([[:space:]]*version[[:space:]]*=[[:space:]]*\").*(\".*)$/\\1${VERSION}\\2/" \
+        s/^([[:space:]]*version[[:space:]]*=[[:space:]]*\").*(\".*)$/\\1${VERSION}\\2/;
+        s/^([[:space:]]*readme[[:space:]]*=[[:space:]]*\").*(\".*)$/\\1${PYPI_README_FILE}\\2/" \
         pyproject.toml
 
-    echo "✅ Temporary override package name to '$PACKAGE_NAME' and version to '$VERSION' in pyproject.toml"
+    echo "✅ Temporary override package name to '$PACKAGE_NAME', version to '$VERSION', and readme to '$PYPI_README_FILE' in pyproject.toml"
 
     # Configure Poetry for PyPI publishing
     poetry config repositories.mypypi "$REGISTRY_UPLOAD_URL"
-    poetry config pypi-token.mypypi "$PYPI_TOKEN"
+    if [[ -n "$PYPI_TOKEN" ]]; then
+        poetry config pypi-token.mypypi "$PYPI_TOKEN"
+    fi
 
     # Default timeout is set to 15 seconds
     # We sometime face 443 HTTP read timeout responses from PyPi
     # Setting it to 60 seconds to avoid transient publish failures
     export POETRY_REQUESTS_TIMEOUT=60
 
-    poetry publish --build --repository mypypi --no-interaction -vvv
+    PUBLISH_ARGS=(publish --build --repository mypypi --no-interaction -vvv)
+    if [[ "$DRY_RUN" == "true" ]]; then
+        PUBLISH_ARGS+=(--dry-run)
+    fi
+    poetry "${PUBLISH_ARGS[@]}"
 
 else
     echo "⚠️ Error: No pyproject.toml, skipping publishing to PyPI" >&2
     exit 0
 fi
 
-echo "✅ Successfully published $PACKAGE_NAME ($VERSION) to PyPI ($REGISTRY_PACKAGE_URL/$PACKAGE_NAME/$VERSION)"
+if [[ "$DRY_RUN" == "true" ]]; then
+    echo "✅ Dry run completed for $PACKAGE_NAME ($VERSION)"
+else
+    echo "✅ Successfully published $PACKAGE_NAME ($VERSION) to PyPI ($REGISTRY_PACKAGE_URL/$PACKAGE_NAME/$VERSION)"
+fi


### PR DESCRIPTION
## What

Prevent Python connector PyPI publishing from failing when a connector `README.md` is a symlink outside the connector package directory. The publish step now uses a minimal generated PyPI README instead of packaging the connector source README.

## How

- Generate a temporary `.airbyte-pypi-readme.md` during publish with standard Airbyte boilerplate and the connector title from `metadata.yaml`.
- Temporarily point Poetry's `readme` field at the generated file, then restore `pyproject.toml` and delete the temporary README during cleanup.
- Add `--dry-run` to exercise the build path without requiring a PyPI token or uploading artifacts.

## Review guide

1. `poe-tasks/publish-python-registry.sh`

## User Impact

Python connector PyPI publish jobs no longer depend on packaging source-tree `README.md` files, including external symlinks. PyPI package pages get consistent minimal Airbyte connector content with the connector title.

## Test plan

- `git diff --check`
- `bash -n poe-tasks/publish-python-registry.sh`
- `./poe-tasks/publish-python-registry.sh --name source-faker --with-semver-suffix preview --dry-run`
- Inspected the generated source-faker sdist and verified `.airbyte-pypi-readme.md` contains the generated boilerplate with the `Sample Data` connector title.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚
- [ ] NO ❌

Link to Devin session: https://app.devin.ai/sessions/b25438b385594d60be097f5b2c68402e
Requested by: @aaronsteers