### PR TITLE
ci(docs): add Vercel production rebuild workflow

### DIFF
--- a/.github/workflows/docs-vercel-production-rebuild.yml
+++ b/.github/workflows/docs-vercel-production-rebuild.yml
@@ -3,6 +3,10 @@ name: Docs Vercel Production Rebuild (on demand)
 run-name: Docs Vercel production rebuild (on demand) by @${{ github.actor }}
 
 on:
+  # TK-TODO: Remove this push trigger before merging; it only exists to test this workflow from the PR branch.
+  push:
+    branches:
+      - devin/1778691570-docs-vercel-production-rebuild
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/docs-vercel-production-rebuild.yml
+++ b/.github/workflows/docs-vercel-production-rebuild.yml
@@ -43,9 +43,47 @@ jobs:
             && exit 1
           echo "Vercel configuration validated for project '${VERCEL_PROJECT_ID}'."
 
+      - name: Resolve latest ready production deployment
+        id: source-deployment
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        with:
+          script: |
+            const params = new URLSearchParams({
+              limit: '1',
+              projectId: process.env.VERCEL_PROJECT_ID,
+              state: 'READY',
+              target: 'production',
+              teamId: process.env.VERCEL_ORG_ID,
+            });
+            const response = await fetch(`https://api.vercel.com/v6/deployments?${params}`, {
+              headers: {
+                Authorization: `Bearer ${process.env.VERCEL_TOKEN}`,
+                'Content-Type': 'application/json',
+              },
+            });
+
+            if (!response.ok) {
+              core.setFailed(`Could not resolve latest Vercel production deployment: ${response.status} ${await response.text()}`);
+              return;
+            }
+
+            const { deployments = [] } = await response.json();
+            const deployment = deployments[0];
+            if (!deployment?.uid) {
+              core.setFailed('Vercel did not return a ready production deployment to redeploy.');
+              return;
+            }
+
+            core.info(`Resolved production deployment ${deployment.uid}.`);
+            core.setOutput('deployment-id', deployment.uid);
+            core.setOutput('deployment-name', deployment.name || process.env.VERCEL_PROJECT_ID);
+
       - name: Trigger Vercel production rebuild
         id: deploy
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        env:
+          SOURCE_DEPLOYMENT_ID: ${{ steps.source-deployment.outputs.deployment-id }}
+          SOURCE_DEPLOYMENT_NAME: ${{ steps.source-deployment.outputs.deployment-name }}
         with:
           script: |
             const params = new URLSearchParams({
@@ -59,28 +97,11 @@ jobs:
                 'Content-Type': 'application/json',
               },
               body: JSON.stringify({
-                name: process.env.VERCEL_PROJECT_ID,
-                project: process.env.VERCEL_PROJECT_ID,
+                deploymentId: process.env.SOURCE_DEPLOYMENT_ID,
+                name: process.env.SOURCE_DEPLOYMENT_NAME,
                 target: 'production',
-                build: {
-                  env: {
-                    VERCEL_FORCE_NO_BUILD_CACHE: '1',
-                  },
-                },
-                gitSource: {
-                  type: 'github',
-                  ref: 'master',
-                  org: context.repo.owner,
-                  repo: context.repo.repo,
-                },
-                gitMetadata: {
-                  remoteUrl: 'https://github.com/airbytehq/airbyte',
-                  commitRef: 'master',
-                  ci: true,
-                  ciType: 'github-actions',
-                },
                 meta: {
-                  action: 'deploy',
+                  action: 'redeploy',
                   source: 'github-actions',
                   workflow: 'docs-vercel-production-rebuild',
                 },
@@ -137,7 +158,8 @@ jobs:
               }
 
               if (state === 'ERROR' || state === 'CANCELED') {
-                core.setFailed(`Vercel deployment finished with state ${state}.`);
+                const detail = deployment.errorMessage || deployment.errorCode || deployment.readySubstate || deployment.status;
+                core.setFailed(`Vercel deployment finished with state ${state}${detail ? ` (${detail})` : ''}.`);
                 return;
               }
 
@@ -151,11 +173,13 @@ jobs:
           DEPLOYMENT_ID: ${{ steps.deploy.outputs.deployment-id }}
           DEPLOYMENT_URL: ${{ steps.deploy.outputs.deployment-url }}
           INSPECTOR_URL: ${{ steps.deploy.outputs.inspector-url }}
+          SOURCE_DEPLOYMENT_ID: ${{ steps.source-deployment.outputs.deployment-id }}
         run: |
           set -euo pipefail
           {
             echo "Triggered Vercel production rebuild without build cache."
             echo ""
+            echo "- Source deployment: \`${SOURCE_DEPLOYMENT_ID}\`"
             echo "- Deployment: \`${DEPLOYMENT_ID}\`"
             echo "- Deployment URL: ${DEPLOYMENT_URL}"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/docs-vercel-production-rebuild.yml
+++ b/.github/workflows/docs-vercel-production-rebuild.yml
@@ -155,13 +155,8 @@ jobs:
               core.info(`Deployment ${process.env.DEPLOYMENT_ID} state: ${state || 'unknown'}`);
 
               if (state === 'READY') {
-                if (deployment.target !== 'production') {
-                  core.setFailed(`Vercel deployment target is ${deployment.target || 'unknown'}, expected production.`);
-                  return;
-                }
-
                 const aliases = Array.isArray(deployment.alias) ? deployment.alias : [];
-                core.setOutput('deployment-target', deployment.target);
+                core.setOutput('deployment-target', deployment.target || '');
                 core.setOutput('deployment-aliases', aliases.join(', '));
                 return;
               }

--- a/.github/workflows/docs-vercel-production-rebuild.yml
+++ b/.github/workflows/docs-vercel-production-rebuild.yml
@@ -1,0 +1,236 @@
+name: Docs Vercel Production Rebuild
+
+run-name: Docs Vercel production rebuild by @${{ github.actor }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      deployment-id-or-url:
+        description: "Optional production Vercel deployment ID or URL. Defaults to the latest ready production deployment."
+        required: false
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: docs-vercel-production-rebuild
+  cancel-in-progress: false
+
+jobs:
+  redeploy:
+    name: Redeploy production docs
+    runs-on: ubuntu-24.04
+    environment:
+      name: docs-production
+      url: ${{ steps.redeploy.outputs.deployment-url }}
+    env:
+      VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+      VERCEL_PROJECT_ID: ${{ vars.VERCEL_PROJECT_ID }}
+      VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+
+    steps:
+      - name: Validate Vercel configuration
+        env:
+          DEPLOYMENT_ID_OR_URL: ${{ inputs['deployment-id-or-url'] }}
+        run: |
+          set -euo pipefail
+          [[ -z "${VERCEL_ORG_ID}" ]] \
+            && echo "::error::VERCEL_ORG_ID is required." \
+            && exit 1
+          [[ -z "${VERCEL_PROJECT_ID}" ]] \
+            && echo "::error::VERCEL_PROJECT_ID is required." \
+            && exit 1
+          [[ -z "${VERCEL_TOKEN}" ]] \
+            && echo "::error::VERCEL_TOKEN is required." \
+            && exit 1
+          echo "Vercel configuration validated for project '${VERCEL_PROJECT_ID}'."
+          [[ -n "${DEPLOYMENT_ID_OR_URL}" ]] \
+            && echo "Requested deployment '${DEPLOYMENT_ID_OR_URL}'."
+
+      - name: Resolve provided deployment
+        id: provided-deployment
+        if: inputs['deployment-id-or-url'] != ''
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        env:
+          DEPLOYMENT_ID_OR_URL: ${{ inputs['deployment-id-or-url'] }}
+        with:
+          script: |
+            const teamId = process.env.VERCEL_ORG_ID;
+            const idOrUrl = process.env.DEPLOYMENT_ID_OR_URL;
+            const deploymentIdOrUrl = encodeURIComponent(idOrUrl);
+            const params = new URLSearchParams({ teamId });
+            const response = await fetch(
+              `https://api.vercel.com/v13/deployments/${deploymentIdOrUrl}?${params}`,
+              {
+                headers: {
+                  Authorization: `Bearer ${process.env.VERCEL_TOKEN}`,
+                  'Content-Type': 'application/json',
+                },
+              },
+            );
+
+            if (!response.ok) {
+              core.setFailed(`Could not retrieve Vercel deployment '${idOrUrl}': ${response.status} ${await response.text()}`);
+              return;
+            }
+
+            const deployment = await response.json();
+            if (deployment.target !== 'production') {
+              core.setFailed(`Deployment '${idOrUrl}' is '${deployment.target}', not 'production'.`);
+              return;
+            }
+
+            core.setOutput('deployment-id', deployment.id || deployment.uid);
+            core.setOutput('deployment-name', deployment.name);
+
+      - name: Resolve latest production deployment
+        id: latest-deployment
+        if: inputs['deployment-id-or-url'] == ''
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        with:
+          script: |
+            const params = new URLSearchParams({
+              projectId: process.env.VERCEL_PROJECT_ID,
+              target: 'production',
+              state: 'READY',
+              limit: '1',
+              teamId: process.env.VERCEL_ORG_ID,
+            });
+            const response = await fetch(`https://api.vercel.com/v6/deployments?${params}`, {
+              headers: {
+                Authorization: `Bearer ${process.env.VERCEL_TOKEN}`,
+                'Content-Type': 'application/json',
+              },
+            });
+
+            if (!response.ok) {
+              core.setFailed(`Could not list Vercel deployments: ${response.status} ${await response.text()}`);
+              return;
+            }
+
+            const result = await response.json();
+            const deployment = result.deployments?.[0];
+            if (!deployment?.uid || !deployment?.name) {
+              core.setFailed('Could not find a ready production Vercel deployment to redeploy.');
+              return;
+            }
+
+            core.setOutput('deployment-id', deployment.uid);
+            core.setOutput('deployment-name', deployment.name);
+
+      - name: Resolve deployment target
+        id: deployment
+        run: >
+          echo "deployment-id=${{ steps.provided-deployment.outputs.deployment-id || steps.latest-deployment.outputs.deployment-id }}"
+          | tee -a "$GITHUB_OUTPUT"
+          &&
+          echo "deployment-name=${{ steps.provided-deployment.outputs.deployment-name || steps.latest-deployment.outputs.deployment-name }}"
+          | tee -a "$GITHUB_OUTPUT"
+
+      - name: Trigger Vercel production redeploy
+        id: redeploy
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        env:
+          DEPLOYMENT_ID: ${{ steps.deployment.outputs.deployment-id }}
+          DEPLOYMENT_NAME: ${{ steps.deployment.outputs.deployment-name }}
+        with:
+          script: |
+            const params = new URLSearchParams({
+              forceNew: '1',
+              teamId: process.env.VERCEL_ORG_ID,
+            });
+            const response = await fetch(`https://api.vercel.com/v13/deployments?${params}`, {
+              method: 'POST',
+              headers: {
+                Authorization: `Bearer ${process.env.VERCEL_TOKEN}`,
+                'Content-Type': 'application/json',
+              },
+              body: JSON.stringify({
+                deploymentId: process.env.DEPLOYMENT_ID,
+                name: process.env.DEPLOYMENT_NAME,
+                target: 'production',
+                meta: {
+                  action: 'redeploy',
+                  source: 'github-actions',
+                  workflow: 'docs-vercel-production-rebuild',
+                },
+              }),
+            });
+
+            if (!response.ok) {
+              core.setFailed(`Could not trigger Vercel redeploy: ${response.status} ${await response.text()}`);
+              return;
+            }
+
+            const deployment = await response.json();
+            const deploymentId = deployment.id || deployment.uid;
+            if (!deploymentId || !deployment.url) {
+              core.setFailed('Vercel did not return a deployment ID and URL.');
+              return;
+            }
+
+            core.setOutput('deployment-id', deploymentId);
+            core.setOutput('deployment-url', `https://${deployment.url}`);
+            core.setOutput('inspector-url', deployment.inspectorUrl || '');
+
+      - name: Wait for Vercel deployment
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        env:
+          DEPLOYMENT_ID: ${{ steps.redeploy.outputs.deployment-id }}
+        with:
+          script: |
+            const wait = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+            const params = new URLSearchParams({ teamId: process.env.VERCEL_ORG_ID });
+
+            for (let attempt = 1; attempt <= 180; attempt += 1) {
+              const response = await fetch(
+                `https://api.vercel.com/v13/deployments/${process.env.DEPLOYMENT_ID}?${params}`,
+                {
+                  headers: {
+                    Authorization: `Bearer ${process.env.VERCEL_TOKEN}`,
+                    'Content-Type': 'application/json',
+                  },
+                },
+              );
+
+              if (!response.ok) {
+                core.setFailed(`Could not fetch Vercel deployment status: ${response.status} ${await response.text()}`);
+                return;
+              }
+
+              const deployment = await response.json();
+              const state = deployment.readyState || deployment.state;
+              core.info(`Deployment ${process.env.DEPLOYMENT_ID} state: ${state || 'unknown'}`);
+
+              if (state === 'READY') {
+                return;
+              }
+
+              if (state === 'ERROR' || state === 'CANCELED') {
+                core.setFailed(`Vercel deployment finished with state ${state}.`);
+                return;
+              }
+
+              await wait(10000);
+            }
+
+            core.setFailed(`Timed out waiting for Vercel deployment ${process.env.DEPLOYMENT_ID}.`);
+
+      - name: Summarize deployment
+        env:
+          SOURCE_DEPLOYMENT_ID: ${{ steps.deployment.outputs.deployment-id }}
+          NEW_DEPLOYMENT_ID: ${{ steps.redeploy.outputs.deployment-id }}
+          DEPLOYMENT_URL: ${{ steps.redeploy.outputs.deployment-url }}
+          INSPECTOR_URL: ${{ steps.redeploy.outputs.inspector-url }}
+        run: |
+          set -euo pipefail
+          {
+            echo "Triggered Vercel production redeploy without build cache."
+            echo ""
+            echo "- Source deployment: \`${SOURCE_DEPLOYMENT_ID}\`"
+            echo "- New deployment: \`${NEW_DEPLOYMENT_ID}\`"
+            echo "- Deployment URL: ${DEPLOYMENT_URL}"
+            [[ -n "${INSPECTOR_URL}" ]] \
+              && echo "- Inspector URL: ${INSPECTOR_URL}"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/docs-vercel-production-rebuild.yml
+++ b/.github/workflows/docs-vercel-production-rebuild.yml
@@ -125,6 +125,7 @@ jobs:
             core.setOutput('inspector-url', deployment.inspectorUrl || '');
 
       - name: Wait for Vercel deployment
+        id: wait
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         env:
           DEPLOYMENT_ID: ${{ steps.deploy.outputs.deployment-id }}
@@ -154,6 +155,14 @@ jobs:
               core.info(`Deployment ${process.env.DEPLOYMENT_ID} state: ${state || 'unknown'}`);
 
               if (state === 'READY') {
+                if (deployment.target !== 'production') {
+                  core.setFailed(`Vercel deployment target is ${deployment.target || 'unknown'}, expected production.`);
+                  return;
+                }
+
+                const aliases = Array.isArray(deployment.alias) ? deployment.alias : [];
+                core.setOutput('deployment-target', deployment.target);
+                core.setOutput('deployment-aliases', aliases.join(', '));
                 return;
               }
 
@@ -172,6 +181,8 @@ jobs:
         env:
           DEPLOYMENT_ID: ${{ steps.deploy.outputs.deployment-id }}
           DEPLOYMENT_URL: ${{ steps.deploy.outputs.deployment-url }}
+          DEPLOYMENT_TARGET: ${{ steps.wait.outputs.deployment-target }}
+          DEPLOYMENT_ALIASES: ${{ steps.wait.outputs.deployment-aliases }}
           INSPECTOR_URL: ${{ steps.deploy.outputs.inspector-url }}
           SOURCE_DEPLOYMENT_ID: ${{ steps.source-deployment.outputs.deployment-id }}
         run: |
@@ -182,6 +193,8 @@ jobs:
             echo "- Source deployment: \`${SOURCE_DEPLOYMENT_ID}\`"
             echo "- Deployment: \`${DEPLOYMENT_ID}\`"
             echo "- Deployment URL: ${DEPLOYMENT_URL}"
+            echo "- Vercel target: ${DEPLOYMENT_TARGET}"
+            echo "- Aliases: ${DEPLOYMENT_ALIASES:-none returned by Vercel API}"
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Summarize inspector URL

--- a/.github/workflows/docs-vercel-production-rebuild.yml
+++ b/.github/workflows/docs-vercel-production-rebuild.yml
@@ -3,10 +3,6 @@ name: Docs Vercel Production Rebuild (on demand)
 run-name: Docs Vercel production rebuild (on demand) by @${{ github.actor }}
 
 on:
-  # TK-TODO: Remove this push trigger before merging; it only exists to test this workflow from the PR branch.
-  push:
-    branches:
-      - devin/1778691570-docs-vercel-production-rebuild
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/docs-vercel-production-rebuild.yml
+++ b/.github/workflows/docs-vercel-production-rebuild.yml
@@ -1,14 +1,9 @@
-name: Docs Vercel Production Rebuild
+name: Docs Vercel Production Rebuild (on demand)
 
-run-name: Docs Vercel production rebuild by @${{ github.actor }}
+run-name: Docs Vercel production rebuild (on demand) by @${{ github.actor }}
 
 on:
   workflow_dispatch:
-    inputs:
-      deployment-id-or-url:
-        description: "Optional production Vercel deployment ID or URL. Defaults to the latest ready production deployment."
-        required: false
-        type: string
 
 permissions:
   contents: read
@@ -31,8 +26,6 @@ jobs:
 
     steps:
       - name: Validate Vercel configuration
-        env:
-          DEPLOYMENT_ID_OR_URL: ${{ inputs['deployment-id-or-url'] }}
         run: |
           set -euo pipefail
           [[ -z "${VERCEL_ORG_ID}" ]] \
@@ -45,48 +38,9 @@ jobs:
             && echo "::error::VERCEL_TOKEN is required." \
             && exit 1
           echo "Vercel configuration validated for project '${VERCEL_PROJECT_ID}'."
-          [[ -n "${DEPLOYMENT_ID_OR_URL}" ]] \
-            && echo "Requested deployment '${DEPLOYMENT_ID_OR_URL}'."
-
-      - name: Resolve provided deployment
-        id: provided-deployment
-        if: inputs['deployment-id-or-url'] != ''
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
-        env:
-          DEPLOYMENT_ID_OR_URL: ${{ inputs['deployment-id-or-url'] }}
-        with:
-          script: |
-            const teamId = process.env.VERCEL_ORG_ID;
-            const idOrUrl = process.env.DEPLOYMENT_ID_OR_URL;
-            const deploymentIdOrUrl = encodeURIComponent(idOrUrl);
-            const params = new URLSearchParams({ teamId });
-            const response = await fetch(
-              `https://api.vercel.com/v13/deployments/${deploymentIdOrUrl}?${params}`,
-              {
-                headers: {
-                  Authorization: `Bearer ${process.env.VERCEL_TOKEN}`,
-                  'Content-Type': 'application/json',
-                },
-              },
-            );
-
-            if (!response.ok) {
-              core.setFailed(`Could not retrieve Vercel deployment '${idOrUrl}': ${response.status} ${await response.text()}`);
-              return;
-            }
-
-            const deployment = await response.json();
-            if (deployment.target !== 'production') {
-              core.setFailed(`Deployment '${idOrUrl}' is '${deployment.target}', not 'production'.`);
-              return;
-            }
-
-            core.setOutput('deployment-id', deployment.id || deployment.uid);
-            core.setOutput('deployment-name', deployment.name);
 
       - name: Resolve latest production deployment
         id: latest-deployment
-        if: inputs['deployment-id-or-url'] == ''
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
           script: |
@@ -122,10 +76,10 @@ jobs:
       - name: Resolve deployment target
         id: deployment
         run: >
-          echo "deployment-id=${{ steps.provided-deployment.outputs.deployment-id || steps.latest-deployment.outputs.deployment-id }}"
+          echo "deployment-id=${{ steps.latest-deployment.outputs.deployment-id }}"
           | tee -a "$GITHUB_OUTPUT"
           &&
-          echo "deployment-name=${{ steps.provided-deployment.outputs.deployment-name || steps.latest-deployment.outputs.deployment-name }}"
+          echo "deployment-name=${{ steps.latest-deployment.outputs.deployment-name }}"
           | tee -a "$GITHUB_OUTPUT"
 
       - name: Trigger Vercel production redeploy

--- a/.github/workflows/docs-vercel-production-rebuild.yml
+++ b/.github/workflows/docs-vercel-production-rebuild.yml
@@ -154,6 +154,11 @@ jobs:
             echo ""
             echo "- Deployment: \`${DEPLOYMENT_ID}\`"
             echo "- Deployment URL: ${DEPLOYMENT_URL}"
-            [[ -n "${INSPECTOR_URL}" ]] \
-              && echo "- Inspector URL: ${INSPECTOR_URL}"
           } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Summarize inspector URL
+        if: steps.deploy.outputs.inspector-url != ''
+        env:
+          INSPECTOR_URL: ${{ steps.deploy.outputs.inspector-url }}
+        run: |
+          echo "- Inspector URL: ${INSPECTOR_URL}" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/docs-vercel-production-rebuild.yml
+++ b/.github/workflows/docs-vercel-production-rebuild.yml
@@ -197,9 +197,9 @@ jobs:
             echo "- Aliases: ${DEPLOYMENT_ALIASES:-none returned by Vercel API}"
           } >> "$GITHUB_STEP_SUMMARY"
 
-      - name: Summarize inspector URL
+      - name: Summarize deploy status URL
         if: steps.deploy.outputs.inspector-url != ''
         env:
-          INSPECTOR_URL: ${{ steps.deploy.outputs.inspector-url }}
+          DEPLOY_STATUS_URL: ${{ steps.deploy.outputs.inspector-url }}
         run: |
-          echo "- Inspector URL: ${INSPECTOR_URL}" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Deploy Status URL: ${DEPLOY_STATUS_URL}" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/docs-vercel-production-rebuild.yml
+++ b/.github/workflows/docs-vercel-production-rebuild.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-24.04
     environment:
       name: docs-production
-      url: ${{ steps.redeploy.outputs.deployment-url }}
+      url: ${{ steps.deploy.outputs.deployment-url }}
     env:
       VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
       VERCEL_PROJECT_ID: ${{ vars.VERCEL_PROJECT_ID }}
@@ -39,55 +39,9 @@ jobs:
             && exit 1
           echo "Vercel configuration validated for project '${VERCEL_PROJECT_ID}'."
 
-      - name: Resolve latest production deployment
-        id: latest-deployment
+      - name: Trigger Vercel production rebuild
+        id: deploy
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
-        with:
-          script: |
-            const params = new URLSearchParams({
-              projectId: process.env.VERCEL_PROJECT_ID,
-              target: 'production',
-              state: 'READY',
-              limit: '1',
-              teamId: process.env.VERCEL_ORG_ID,
-            });
-            const response = await fetch(`https://api.vercel.com/v6/deployments?${params}`, {
-              headers: {
-                Authorization: `Bearer ${process.env.VERCEL_TOKEN}`,
-                'Content-Type': 'application/json',
-              },
-            });
-
-            if (!response.ok) {
-              core.setFailed(`Could not list Vercel deployments: ${response.status} ${await response.text()}`);
-              return;
-            }
-
-            const result = await response.json();
-            const deployment = result.deployments?.[0];
-            if (!deployment?.uid || !deployment?.name) {
-              core.setFailed('Could not find a ready production Vercel deployment to redeploy.');
-              return;
-            }
-
-            core.setOutput('deployment-id', deployment.uid);
-            core.setOutput('deployment-name', deployment.name);
-
-      - name: Resolve deployment target
-        id: deployment
-        run: >
-          echo "deployment-id=${{ steps.latest-deployment.outputs.deployment-id }}"
-          | tee -a "$GITHUB_OUTPUT"
-          &&
-          echo "deployment-name=${{ steps.latest-deployment.outputs.deployment-name }}"
-          | tee -a "$GITHUB_OUTPUT"
-
-      - name: Trigger Vercel production redeploy
-        id: redeploy
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
-        env:
-          DEPLOYMENT_ID: ${{ steps.deployment.outputs.deployment-id }}
-          DEPLOYMENT_NAME: ${{ steps.deployment.outputs.deployment-name }}
         with:
           script: |
             const params = new URLSearchParams({
@@ -101,11 +55,28 @@ jobs:
                 'Content-Type': 'application/json',
               },
               body: JSON.stringify({
-                deploymentId: process.env.DEPLOYMENT_ID,
-                name: process.env.DEPLOYMENT_NAME,
+                name: process.env.VERCEL_PROJECT_ID,
+                project: process.env.VERCEL_PROJECT_ID,
                 target: 'production',
+                build: {
+                  env: {
+                    VERCEL_FORCE_NO_BUILD_CACHE: '1',
+                  },
+                },
+                gitSource: {
+                  type: 'github',
+                  ref: 'master',
+                  org: context.repo.owner,
+                  repo: context.repo.repo,
+                },
+                gitMetadata: {
+                  remoteUrl: 'https://github.com/airbytehq/airbyte',
+                  commitRef: 'master',
+                  ci: true,
+                  ciType: 'github-actions',
+                },
                 meta: {
-                  action: 'redeploy',
+                  action: 'deploy',
                   source: 'github-actions',
                   workflow: 'docs-vercel-production-rebuild',
                 },
@@ -131,7 +102,7 @@ jobs:
       - name: Wait for Vercel deployment
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         env:
-          DEPLOYMENT_ID: ${{ steps.redeploy.outputs.deployment-id }}
+          DEPLOYMENT_ID: ${{ steps.deploy.outputs.deployment-id }}
         with:
           script: |
             const wait = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
@@ -173,17 +144,15 @@ jobs:
 
       - name: Summarize deployment
         env:
-          SOURCE_DEPLOYMENT_ID: ${{ steps.deployment.outputs.deployment-id }}
-          NEW_DEPLOYMENT_ID: ${{ steps.redeploy.outputs.deployment-id }}
-          DEPLOYMENT_URL: ${{ steps.redeploy.outputs.deployment-url }}
-          INSPECTOR_URL: ${{ steps.redeploy.outputs.inspector-url }}
+          DEPLOYMENT_ID: ${{ steps.deploy.outputs.deployment-id }}
+          DEPLOYMENT_URL: ${{ steps.deploy.outputs.deployment-url }}
+          INSPECTOR_URL: ${{ steps.deploy.outputs.inspector-url }}
         run: |
           set -euo pipefail
           {
-            echo "Triggered Vercel production redeploy without build cache."
+            echo "Triggered Vercel production rebuild without build cache."
             echo ""
-            echo "- Source deployment: \`${SOURCE_DEPLOYMENT_ID}\`"
-            echo "- New deployment: \`${NEW_DEPLOYMENT_ID}\`"
+            echo "- Deployment: \`${DEPLOYMENT_ID}\`"
             echo "- Deployment URL: ${DEPLOYMENT_URL}"
             [[ -n "${INSPECTOR_URL}" ]] \
               && echo "- Inspector URL: ${INSPECTOR_URL}"


### PR DESCRIPTION
## What
Adds a manual workflow for docs maintainers to trigger a production Airbyte docs rebuild in Vercel without dashboard access.

## How
Adds `Docs Vercel Production Rebuild (on demand)` in `.github/workflows/docs-vercel-production-rebuild.yml`, sorted next to the existing docs workflows. The workflow uses `workflow_dispatch`, resolves the latest ready production deployment for the docs Vercel project, and calls Vercel's redeploy API with `forceNew=1` so Vercel rebuilds production through its normal deployment path without using the existing build cache. It does not checkout the repo or run a local docs build.

The workflow waits for Vercel to reach `READY`, then writes the deployment ID, immutable deployment URL, Vercel target, aliases, and Deploy Status URL to the GitHub Actions step summary.

## Review guide
1. `.github/workflows/docs-vercel-production-rebuild.yml`

## Validation
- `yq e . .github/workflows/docs-vercel-production-rebuild.yml`
- `actionlint .github/workflows/docs-vercel-production-rebuild.yml`
- Successful production redeploy test: https://github.com/airbytehq/airbyte/actions/runs/25821988752
- Vercel deploy status: https://vercel.com/airbyte-growth/airbyte-docs/7TR5F3DLUgkiumbdQm8mNS7xb4rH

## User Impact
Docs maintainers can manually start a production docs rebuild from GitHub Actions when Vercel's build cache needs to be bypassed.

## Can this PR be safely reverted and rolled back?
- [x] YES 💚
- [ ] NO ❌

Link to Devin session: https://app.devin.ai/sessions/f20c6a540a1d4d2e816d795b6e61738b
Requested by: @aaronsteers