### PR TITLE
ci: support registry refresh-only connector publish

### DIFF
--- a/.github/workflows/generate-connector-registries.yml
+++ b/.github/workflows/generate-connector-registries.yml
@@ -26,6 +26,15 @@ on:
         description: "Associated pull request number, for linking in notifications."
         required: false
         type: string
+      force:
+        description: "Force resync of latest/ directories even if version markers are current. Useful when metadata changes without a version bump."
+        required: false
+        type: boolean
+        default: false
+      connector-name:
+        description: "A connector name to limit the latest/ resync scope (e.g. 'source-faker'). Leave empty to compile all connectors."
+        required: false
+        type: string
 
 permissions:
   contents: read

--- a/.github/workflows/publish_connectors.yml
+++ b/.github/workflows/publish_connectors.yml
@@ -35,11 +35,6 @@ on:
         required: false
         default: false
         type: boolean
-      metadata-only:
-        description: "Only generate and publish registry metadata artifacts. Skips connector image/package publishing."
-        required: false
-        default: false
-        type: boolean
       pr:
         description: "Pull request number that triggered this workflow (used for Slack notifications and run URL linking)."
         required: false
@@ -75,6 +70,11 @@ on:
         type: boolean
       dry-run:
         description: "Dry run mode: run all logic but skip actual uploads (Docker, GCS, registry). Useful for testing workflow changes."
+        required: false
+        default: false
+        type: boolean
+      metadata-only:
+        description: "Only generate and publish registry metadata artifacts. Skips connector image/package publishing."
         required: false
         default: false
         type: boolean

--- a/.github/workflows/publish_connectors.yml
+++ b/.github/workflows/publish_connectors.yml
@@ -141,6 +141,10 @@ jobs:
             echo "registry-refresh-only publishes require at least one connector."
             exit 1
           fi
+          if [[ "$CONNECTOR_COUNT" -gt 1 ]]; then
+            echo "registry-refresh-only publishes currently support exactly one connector."
+            exit 1
+          fi
           if [[ "${{ steps.resolve-semver-suffix.outputs.with-semver-suffix }}" != "none" ]]; then
             echo "registry-refresh-only publishes must use with-semver-suffix=none or default."
             exit 1
@@ -167,6 +171,8 @@ jobs:
       dry-run: ${{ inputs.dry-run || 'false' }}
       # registry-refresh-only skips connector image/package publishing but still publishes registry artifacts
       registry-refresh-only: ${{ inputs.registry-refresh-only || 'false' }}
+      # registry-refresh-only is validated to exactly one connector, so this is safe to pass to scoped registry compile.
+      registry-refresh-connector-name: ${{ fromJson(steps.list-connectors-manual.outputs.connectors-to-publish || '{"connector":[""]}').connector[0] }}
   publish_connectors:
     name: Publish connectors
     needs: [publish_options]
@@ -567,6 +573,8 @@ jobs:
     uses: ./.github/workflows/generate-connector-registries.yml
     with:
       pr: ${{ inputs.pr }}
+      force: ${{ needs.publish_options.outputs.registry-refresh-only == 'true' }}
+      connector-name: ${{ needs.publish_options.outputs.registry-refresh-only == 'true' && needs.publish_options.outputs.registry-refresh-connector-name || '' }}
     secrets: inherit
 
   notify-failure-slack-channel:

--- a/.github/workflows/publish_connectors.yml
+++ b/.github/workflows/publish_connectors.yml
@@ -35,6 +35,11 @@ on:
         required: false
         default: false
         type: boolean
+      metadata-only:
+        description: "Only generate and publish registry metadata artifacts. Skips connector image/package publishing."
+        required: false
+        default: false
+        type: boolean
       pr:
         description: "Pull request number that triggered this workflow (used for Slack notifications and run URL linking)."
         required: false
@@ -111,6 +116,9 @@ jobs:
             if [[ "${{ github.event_name }}" == "push" ]]; then
               # On merge to master, use exact version (no suffix)
               SEMVER_SUFFIX="none"
+            elif [[ "${{ inputs.metadata-only || 'false' }}" == "true" ]]; then
+              # Metadata-only publishes use the exact version already declared in metadata.yaml.
+              SEMVER_SUFFIX="none"
             else
               # On manual trigger, use preview suffix
               SEMVER_SUFFIX="preview"
@@ -118,6 +126,24 @@ jobs:
           fi
 
           echo "with-semver-suffix=$SEMVER_SUFFIX" | tee -a $GITHUB_OUTPUT
+      - name: Validate metadata-only options
+        if: inputs.metadata-only == true
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ "${{ github.event_name }}" != "workflow_dispatch" ]]; then
+            echo "metadata-only publishes are only supported from workflow_dispatch."
+            exit 1
+          fi
+          CONNECTOR_COUNT=$(echo '${{ steps.list-connectors-manual.outputs.connectors-to-publish }}' | jq '.connector | length')
+          if [[ "$CONNECTOR_COUNT" -eq 0 ]]; then
+            echo "metadata-only publishes require at least one connector."
+            exit 1
+          fi
+          if [[ "${{ steps.resolve-semver-suffix.outputs.with-semver-suffix }}" != "none" ]]; then
+            echo "metadata-only publishes must use with-semver-suffix=none or default."
+            exit 1
+          fi
       - name: Resolve publish-java-tars
         id: resolve-publish-java-tars
         shell: bash
@@ -138,6 +164,8 @@ jobs:
       publish-java-tars: ${{ steps.resolve-publish-java-tars.outputs.publish-java-tars }}
       # dry-run mode skips all uploads but runs all logic
       dry-run: ${{ inputs.dry-run || 'false' }}
+      # metadata-only skips connector image/package publishing but still publishes registry artifacts
+      metadata-only: ${{ inputs.metadata-only || 'false' }}
   publish_connectors:
     name: Publish connectors
     needs: [publish_options]
@@ -287,7 +315,7 @@ jobs:
 
       - name: Publish to Python Registry
         id: publish-python-registry
-        if: steps.connector-metadata.outputs.connector-language == 'python' && needs.publish_options.outputs.dry-run != 'true' && needs.publish_options.outputs.with-semver-suffix == 'none'
+        if: steps.connector-metadata.outputs.connector-language == 'python' && needs.publish_options.outputs.dry-run != 'true' && needs.publish_options.outputs.with-semver-suffix == 'none' && needs.publish_options.outputs.metadata-only != 'true'
         shell: bash
         run: |
           ./poe-tasks/publish-python-registry.sh --name ${{ matrix.connector }} --with-semver-suffix ${{ needs.publish_options.outputs.with-semver-suffix }}
@@ -296,13 +324,13 @@ jobs:
           CONNECTOR_VERSION_TAG: ${{ steps.resolve-version.outputs.connector-version-tag }}
 
       - name: "[DRY-RUN] Skip Publish to Python Registry"
-        if: steps.connector-metadata.outputs.connector-language == 'python' && needs.publish_options.outputs.dry-run == 'true' && needs.publish_options.outputs.with-semver-suffix == 'none'
+        if: steps.connector-metadata.outputs.connector-language == 'python' && needs.publish_options.outputs.dry-run == 'true' && needs.publish_options.outputs.with-semver-suffix == 'none' && needs.publish_options.outputs.metadata-only != 'true'
         run: |
           echo "DRY-RUN: Skipping Python Registry publish for ${{ matrix.connector }}"
 
       - name: Build and publish JVM connectors images
         id: build-and-publish-JVM-connectors-images
-        if: steps.connector-metadata.outputs.connector-language == 'java' && needs.publish_options.outputs.dry-run != 'true'
+        if: steps.connector-metadata.outputs.connector-language == 'java' && needs.publish_options.outputs.dry-run != 'true' && needs.publish_options.outputs.metadata-only != 'true'
         shell: bash
         env:
           CONNECTOR_VERSION_TAG: ${{ steps.resolve-version.outputs.connector-version-tag }}
@@ -311,7 +339,7 @@ jobs:
 
       - name: "[DRY-RUN] Build JVM connectors images (no publish)"
         id: build-JVM-connectors-images-dry-run
-        if: steps.connector-metadata.outputs.connector-language == 'java' && needs.publish_options.outputs.dry-run == 'true'
+        if: steps.connector-metadata.outputs.connector-language == 'java' && needs.publish_options.outputs.dry-run == 'true' && needs.publish_options.outputs.metadata-only != 'true'
         shell: bash
         env:
           CONNECTOR_VERSION_TAG: ${{ steps.resolve-version.outputs.connector-version-tag }}
@@ -321,7 +349,7 @@ jobs:
 
       - name: Publish JVM connectors tar file
         id: publish-JVM-connectors-tar-file
-        if: steps.connector-metadata.outputs.connector-language == 'java' && needs.publish_options.outputs.publish-java-tars == 'true' && needs.publish_options.outputs.dry-run != 'true'
+        if: steps.connector-metadata.outputs.connector-language == 'java' && needs.publish_options.outputs.publish-java-tars == 'true' && needs.publish_options.outputs.dry-run != 'true' && needs.publish_options.outputs.metadata-only != 'true'
         shell: bash
         run: ./poe-tasks/upload-java-connector-tar-file.sh --name ${{ matrix.connector }} --with-semver-suffix ${{ needs.publish_options.outputs.with-semver-suffix }}
         env:
@@ -331,13 +359,13 @@ jobs:
         continue-on-error: true
 
       - name: "[DRY-RUN] Skip Publish JVM connectors tar file"
-        if: steps.connector-metadata.outputs.connector-language == 'java' && needs.publish_options.outputs.publish-java-tars == 'true' && needs.publish_options.outputs.dry-run == 'true'
+        if: steps.connector-metadata.outputs.connector-language == 'java' && needs.publish_options.outputs.publish-java-tars == 'true' && needs.publish_options.outputs.dry-run == 'true' && needs.publish_options.outputs.metadata-only != 'true'
         run: |
           echo "DRY-RUN: Skipping JVM connector tar file upload for ${{ matrix.connector }}"
 
       - name: Build and publish Python and Manifest-Only connectors images
         id: build-and-publish-python-manifest-only-connectors-images
-        if: steps.connector-metadata.outputs.connector-language != 'java'
+        if: steps.connector-metadata.outputs.connector-language != 'java' && needs.publish_options.outputs.metadata-only != 'true'
         uses: ./.github/actions/connector-image-build-push
         with:
           connector-name: ${{ matrix.connector }}
@@ -469,6 +497,10 @@ jobs:
           else
             RELEASE_TYPE="Pre-release"
             EMOJI="🔵"
+          fi
+          if [[ "${{ needs.publish_options.outputs.metadata-only }}" == "true" ]]; then
+            RELEASE_TYPE="Metadata-only registry artifact"
+            EMOJI="🟡"
           fi
 
           # Build URLs for hyperlinks

--- a/.github/workflows/publish_connectors.yml
+++ b/.github/workflows/publish_connectors.yml
@@ -323,11 +323,6 @@ jobs:
           PYTHON_REGISTRY_TOKEN: ${{ secrets.PYPI_TOKEN }}
           CONNECTOR_VERSION_TAG: ${{ steps.resolve-version.outputs.connector-version-tag }}
 
-      - name: "[DRY-RUN] Skip Publish to Python Registry"
-        if: steps.connector-metadata.outputs.connector-language == 'python' && needs.publish_options.outputs.dry-run == 'true' && needs.publish_options.outputs.with-semver-suffix == 'none' && needs.publish_options.outputs.metadata-only != 'true'
-        run: |
-          echo "DRY-RUN: Skipping Python Registry publish for ${{ matrix.connector }}"
-
       - name: Build and publish JVM connectors images
         id: build-and-publish-JVM-connectors-images
         if: steps.connector-metadata.outputs.connector-language == 'java' && needs.publish_options.outputs.dry-run != 'true' && needs.publish_options.outputs.metadata-only != 'true'

--- a/.github/workflows/publish_connectors.yml
+++ b/.github/workflows/publish_connectors.yml
@@ -127,7 +127,8 @@ jobs:
 
           echo "with-semver-suffix=$SEMVER_SUFFIX" | tee -a $GITHUB_OUTPUT
       - name: Validate registry-refresh-only options
-        if: inputs.registry-refresh-only == true
+        if: >
+          inputs.registry-refresh-only == true
         shell: bash
         run: |
           set -euo pipefail
@@ -315,7 +316,11 @@ jobs:
 
       - name: Publish to Python Registry
         id: publish-python-registry
-        if: steps.connector-metadata.outputs.connector-language == 'python' && needs.publish_options.outputs.dry-run != 'true' && needs.publish_options.outputs.with-semver-suffix == 'none' && needs.publish_options.outputs.registry-refresh-only != 'true'
+        if: >
+          steps.connector-metadata.outputs.connector-language == 'python' &&
+          needs.publish_options.outputs.dry-run != 'true' &&
+          needs.publish_options.outputs.with-semver-suffix == 'none' &&
+          needs.publish_options.outputs.registry-refresh-only != 'true'
         shell: bash
         run: |
           ./poe-tasks/publish-python-registry.sh --name ${{ matrix.connector }} --with-semver-suffix ${{ needs.publish_options.outputs.with-semver-suffix }}
@@ -325,7 +330,10 @@ jobs:
 
       - name: Build and publish JVM connectors images
         id: build-and-publish-JVM-connectors-images
-        if: steps.connector-metadata.outputs.connector-language == 'java' && needs.publish_options.outputs.dry-run != 'true' && needs.publish_options.outputs.registry-refresh-only != 'true'
+        if: >
+          steps.connector-metadata.outputs.connector-language == 'java' &&
+          needs.publish_options.outputs.dry-run != 'true' &&
+          needs.publish_options.outputs.registry-refresh-only != 'true'
         shell: bash
         env:
           CONNECTOR_VERSION_TAG: ${{ steps.resolve-version.outputs.connector-version-tag }}
@@ -334,7 +342,10 @@ jobs:
 
       - name: "[DRY-RUN] Build JVM connectors images (no publish)"
         id: build-JVM-connectors-images-dry-run
-        if: steps.connector-metadata.outputs.connector-language == 'java' && needs.publish_options.outputs.dry-run == 'true' && needs.publish_options.outputs.registry-refresh-only != 'true'
+        if: >
+          steps.connector-metadata.outputs.connector-language == 'java' &&
+          needs.publish_options.outputs.dry-run == 'true' &&
+          needs.publish_options.outputs.registry-refresh-only != 'true'
         shell: bash
         env:
           CONNECTOR_VERSION_TAG: ${{ steps.resolve-version.outputs.connector-version-tag }}
@@ -344,7 +355,11 @@ jobs:
 
       - name: Publish JVM connectors tar file
         id: publish-JVM-connectors-tar-file
-        if: steps.connector-metadata.outputs.connector-language == 'java' && needs.publish_options.outputs.publish-java-tars == 'true' && needs.publish_options.outputs.dry-run != 'true' && needs.publish_options.outputs.registry-refresh-only != 'true'
+        if: >
+          steps.connector-metadata.outputs.connector-language == 'java' &&
+          needs.publish_options.outputs.publish-java-tars == 'true' &&
+          needs.publish_options.outputs.dry-run != 'true' &&
+          needs.publish_options.outputs.registry-refresh-only != 'true'
         shell: bash
         run: ./poe-tasks/upload-java-connector-tar-file.sh --name ${{ matrix.connector }} --with-semver-suffix ${{ needs.publish_options.outputs.with-semver-suffix }}
         env:
@@ -354,13 +369,19 @@ jobs:
         continue-on-error: true
 
       - name: "[DRY-RUN] Skip Publish JVM connectors tar file"
-        if: steps.connector-metadata.outputs.connector-language == 'java' && needs.publish_options.outputs.publish-java-tars == 'true' && needs.publish_options.outputs.dry-run == 'true' && needs.publish_options.outputs.registry-refresh-only != 'true'
+        if: >
+          steps.connector-metadata.outputs.connector-language == 'java' &&
+          needs.publish_options.outputs.publish-java-tars == 'true' &&
+          needs.publish_options.outputs.dry-run == 'true' &&
+          needs.publish_options.outputs.registry-refresh-only != 'true'
         run: |
           echo "DRY-RUN: Skipping JVM connector tar file upload for ${{ matrix.connector }}"
 
       - name: Build and publish Python and Manifest-Only connectors images
         id: build-and-publish-python-manifest-only-connectors-images
-        if: steps.connector-metadata.outputs.connector-language != 'java' && needs.publish_options.outputs.registry-refresh-only != 'true'
+        if: >
+          steps.connector-metadata.outputs.connector-language != 'java' &&
+          needs.publish_options.outputs.registry-refresh-only != 'true'
         uses: ./.github/actions/connector-image-build-push
         with:
           connector-name: ${{ matrix.connector }}

--- a/.github/workflows/publish_connectors.yml
+++ b/.github/workflows/publish_connectors.yml
@@ -73,8 +73,8 @@ on:
         required: false
         default: false
         type: boolean
-      metadata-only:
-        description: "Only generate and publish registry metadata artifacts. Skips connector image/package publishing."
+      registry-refresh-only:
+        description: "Registry Refresh Only. Generate and publish registry metadata artifacts. Skips connector image/package publishing."
         required: false
         default: false
         type: boolean
@@ -116,8 +116,8 @@ jobs:
             if [[ "${{ github.event_name }}" == "push" ]]; then
               # On merge to master, use exact version (no suffix)
               SEMVER_SUFFIX="none"
-            elif [[ "${{ inputs.metadata-only || 'false' }}" == "true" ]]; then
-              # Metadata-only publishes use the exact version already declared in metadata.yaml.
+            elif [[ "${{ inputs.registry-refresh-only || 'false' }}" == "true" ]]; then
+              # Registry refresh-only publishes use the exact version already declared in metadata.yaml.
               SEMVER_SUFFIX="none"
             else
               # On manual trigger, use preview suffix
@@ -126,22 +126,22 @@ jobs:
           fi
 
           echo "with-semver-suffix=$SEMVER_SUFFIX" | tee -a $GITHUB_OUTPUT
-      - name: Validate metadata-only options
-        if: inputs.metadata-only == true
+      - name: Validate registry-refresh-only options
+        if: inputs.registry-refresh-only == true
         shell: bash
         run: |
           set -euo pipefail
           if [[ "${{ github.event_name }}" != "workflow_dispatch" ]]; then
-            echo "metadata-only publishes are only supported from workflow_dispatch."
+            echo "registry-refresh-only publishes are only supported from workflow_dispatch."
             exit 1
           fi
           CONNECTOR_COUNT=$(echo '${{ steps.list-connectors-manual.outputs.connectors-to-publish }}' | jq '.connector | length')
           if [[ "$CONNECTOR_COUNT" -eq 0 ]]; then
-            echo "metadata-only publishes require at least one connector."
+            echo "registry-refresh-only publishes require at least one connector."
             exit 1
           fi
           if [[ "${{ steps.resolve-semver-suffix.outputs.with-semver-suffix }}" != "none" ]]; then
-            echo "metadata-only publishes must use with-semver-suffix=none or default."
+            echo "registry-refresh-only publishes must use with-semver-suffix=none or default."
             exit 1
           fi
       - name: Resolve publish-java-tars
@@ -164,8 +164,8 @@ jobs:
       publish-java-tars: ${{ steps.resolve-publish-java-tars.outputs.publish-java-tars }}
       # dry-run mode skips all uploads but runs all logic
       dry-run: ${{ inputs.dry-run || 'false' }}
-      # metadata-only skips connector image/package publishing but still publishes registry artifacts
-      metadata-only: ${{ inputs.metadata-only || 'false' }}
+      # registry-refresh-only skips connector image/package publishing but still publishes registry artifacts
+      registry-refresh-only: ${{ inputs.registry-refresh-only || 'false' }}
   publish_connectors:
     name: Publish connectors
     needs: [publish_options]
@@ -315,7 +315,7 @@ jobs:
 
       - name: Publish to Python Registry
         id: publish-python-registry
-        if: steps.connector-metadata.outputs.connector-language == 'python' && needs.publish_options.outputs.dry-run != 'true' && needs.publish_options.outputs.with-semver-suffix == 'none' && needs.publish_options.outputs.metadata-only != 'true'
+        if: steps.connector-metadata.outputs.connector-language == 'python' && needs.publish_options.outputs.dry-run != 'true' && needs.publish_options.outputs.with-semver-suffix == 'none' && needs.publish_options.outputs.registry-refresh-only != 'true'
         shell: bash
         run: |
           ./poe-tasks/publish-python-registry.sh --name ${{ matrix.connector }} --with-semver-suffix ${{ needs.publish_options.outputs.with-semver-suffix }}
@@ -325,7 +325,7 @@ jobs:
 
       - name: Build and publish JVM connectors images
         id: build-and-publish-JVM-connectors-images
-        if: steps.connector-metadata.outputs.connector-language == 'java' && needs.publish_options.outputs.dry-run != 'true' && needs.publish_options.outputs.metadata-only != 'true'
+        if: steps.connector-metadata.outputs.connector-language == 'java' && needs.publish_options.outputs.dry-run != 'true' && needs.publish_options.outputs.registry-refresh-only != 'true'
         shell: bash
         env:
           CONNECTOR_VERSION_TAG: ${{ steps.resolve-version.outputs.connector-version-tag }}
@@ -334,7 +334,7 @@ jobs:
 
       - name: "[DRY-RUN] Build JVM connectors images (no publish)"
         id: build-JVM-connectors-images-dry-run
-        if: steps.connector-metadata.outputs.connector-language == 'java' && needs.publish_options.outputs.dry-run == 'true' && needs.publish_options.outputs.metadata-only != 'true'
+        if: steps.connector-metadata.outputs.connector-language == 'java' && needs.publish_options.outputs.dry-run == 'true' && needs.publish_options.outputs.registry-refresh-only != 'true'
         shell: bash
         env:
           CONNECTOR_VERSION_TAG: ${{ steps.resolve-version.outputs.connector-version-tag }}
@@ -344,7 +344,7 @@ jobs:
 
       - name: Publish JVM connectors tar file
         id: publish-JVM-connectors-tar-file
-        if: steps.connector-metadata.outputs.connector-language == 'java' && needs.publish_options.outputs.publish-java-tars == 'true' && needs.publish_options.outputs.dry-run != 'true' && needs.publish_options.outputs.metadata-only != 'true'
+        if: steps.connector-metadata.outputs.connector-language == 'java' && needs.publish_options.outputs.publish-java-tars == 'true' && needs.publish_options.outputs.dry-run != 'true' && needs.publish_options.outputs.registry-refresh-only != 'true'
         shell: bash
         run: ./poe-tasks/upload-java-connector-tar-file.sh --name ${{ matrix.connector }} --with-semver-suffix ${{ needs.publish_options.outputs.with-semver-suffix }}
         env:
@@ -354,13 +354,13 @@ jobs:
         continue-on-error: true
 
       - name: "[DRY-RUN] Skip Publish JVM connectors tar file"
-        if: steps.connector-metadata.outputs.connector-language == 'java' && needs.publish_options.outputs.publish-java-tars == 'true' && needs.publish_options.outputs.dry-run == 'true' && needs.publish_options.outputs.metadata-only != 'true'
+        if: steps.connector-metadata.outputs.connector-language == 'java' && needs.publish_options.outputs.publish-java-tars == 'true' && needs.publish_options.outputs.dry-run == 'true' && needs.publish_options.outputs.registry-refresh-only != 'true'
         run: |
           echo "DRY-RUN: Skipping JVM connector tar file upload for ${{ matrix.connector }}"
 
       - name: Build and publish Python and Manifest-Only connectors images
         id: build-and-publish-python-manifest-only-connectors-images
-        if: steps.connector-metadata.outputs.connector-language != 'java' && needs.publish_options.outputs.metadata-only != 'true'
+        if: steps.connector-metadata.outputs.connector-language != 'java' && needs.publish_options.outputs.registry-refresh-only != 'true'
         uses: ./.github/actions/connector-image-build-push
         with:
           connector-name: ${{ matrix.connector }}
@@ -493,8 +493,8 @@ jobs:
             RELEASE_TYPE="Pre-release"
             EMOJI="🔵"
           fi
-          if [[ "${{ needs.publish_options.outputs.metadata-only }}" == "true" ]]; then
-            RELEASE_TYPE="Metadata-only registry artifact"
+          if [[ "${{ needs.publish_options.outputs.registry-refresh-only }}" == "true" ]]; then
+            RELEASE_TYPE="Registry refresh-only artifact"
             EMOJI="🟡"
           fi
 

--- a/.github/workflows/publish_connectors.yml
+++ b/.github/workflows/publish_connectors.yml
@@ -433,6 +433,7 @@ jobs:
           echo "Generating registry artifacts for ${{ matrix.connector }}"
           DOCKER_REPOSITORY=$(yq -r '.data.dockerRepository' "airbyte-integrations/connectors/${{ matrix.connector }}/metadata.yaml")
           DOCKER_IMAGE="${DOCKER_REPOSITORY}:${{ steps.resolve-docker-image-tag.outputs.docker-image-tag }}"
+          docker pull "${DOCKER_IMAGE}"
           airbyte-ops \
             registry connector-version artifacts generate \
             --metadata-file "airbyte-integrations/connectors/${{ matrix.connector }}/metadata.yaml" \

--- a/.github/workflows/publish_connectors.yml
+++ b/.github/workflows/publish_connectors.yml
@@ -393,6 +393,15 @@ jobs:
 
       # --- Registry artifact generation and publishing ---
 
+      - name: Pull existing connector image for registry refresh
+        if: >
+          needs.publish_options.outputs.registry-refresh-only == 'true'
+        shell: bash
+        run: |
+          DOCKER_REPOSITORY=$(yq -r '.data.dockerRepository' "airbyte-integrations/connectors/${{ matrix.connector }}/metadata.yaml")
+          DOCKER_IMAGE="${DOCKER_REPOSITORY}:${{ steps.resolve-docker-image-tag.outputs.docker-image-tag }}"
+          docker pull "${DOCKER_IMAGE}"
+
       - name: Enable progressive rollout for RC builds
         if: needs.publish_options.outputs.with-semver-suffix == 'rc'
         working-directory: airbyte-integrations/connectors/${{ matrix.connector }}
@@ -433,7 +442,6 @@ jobs:
           echo "Generating registry artifacts for ${{ matrix.connector }}"
           DOCKER_REPOSITORY=$(yq -r '.data.dockerRepository' "airbyte-integrations/connectors/${{ matrix.connector }}/metadata.yaml")
           DOCKER_IMAGE="${DOCKER_REPOSITORY}:${{ steps.resolve-docker-image-tag.outputs.docker-image-tag }}"
-          docker pull "${DOCKER_IMAGE}"
           airbyte-ops \
             registry connector-version artifacts generate \
             --metadata-file "airbyte-integrations/connectors/${{ matrix.connector }}/metadata.yaml" \


### PR DESCRIPTION
## What
Adds a manual `registry-refresh-only` input to the Publish Connectors workflow so operators can regenerate and publish registry artifacts for an existing connector image without rebuilding or republishing the connector package/image.

This is intended as a phase 1 registry artifact repair/backfill path where `metadata.yaml` exists but versioned `cloud.json` or `oss.json` artifacts are missing. It prioritizes reusing the existing publish pipeline over adding new ops CLI flags first.

## How
- Adds `registry-refresh-only` to `workflow_dispatch` inputs with a human-visible description prefix.
- Resolves `registry-refresh-only` default semver mode to `none`, using the exact version in connector `metadata.yaml`.
- Validates that `registry-refresh-only` is only used from `workflow_dispatch`, has exactly one connector for phase 1, and uses `with-semver-suffix=none` or `default`.
- Skips Python package publishing, JVM image/tar publishing, and Python/manifest image build/push when `registry-refresh-only` is enabled.
- Adds a dedicated `registry-refresh-only` step that explicitly pulls the resolved existing Docker image before registry artifact generation.
- Removes the Python registry dry-run no-op step.
- Formats the modified workflow conditions as multiline folded strings for readability.
- Leaves existing registry artifact generation, artifact publish, and notifications intact.
- Adds `force` and `connector-name` inputs to the reusable registry compile workflow, and passes `force=true` plus the single connector name only for `registry-refresh-only` compiles.

Phase 1 note: this still runs the existing full registry artifact generate/publish pair. That means it regenerates `cloud.json` and `oss.json` from the existing Docker image spec and uses the current ops publish semantics. A follow-up ops PR can add more precise flags such as merge-only publish behavior or optional artifact selection.

Dry-run validation before scoped compile fix:
- Triggered `publish_connectors.yml` from branch `devin/1778692932-publish-metadata-only` for `source-qonto` with `registry-refresh-only=true`, `dry-run=true`, and `with-semver-suffix=none`.
- Run succeeded: https://github.com/airbytehq/airbyte/actions/runs/25818401315
- The build/publish steps were skipped, including Python registry publish, JVM image/tar publish, and Python/manifest image build/push.
- The dedicated image pull step succeeded for `airbyte/source-qonto:0.3.22`.
- Registry artifact generation succeeded and wrote `cloud.json`, `oss.json`, `metadata.yaml`, `spdx.json`, `icon.svg`, `doc.md`, `manifest.yaml`, and `version=0.3.22`.
- Artifact uploaded as `registry-artifacts-source-qonto-0.3.22`; Artifact ID `6978375866`.

Non-dry-run validation before scoped compile fix:
- Triggered `registry-refresh-only=true`, `dry-run=false` for `source-qonto`.
- Run succeeded: https://github.com/airbytehq/airbyte/actions/runs/25819482909
- The versioned `0.3.22/cloud.json` and `0.3.22/oss.json` artifacts were created.
- Registry availability was not restored because the downstream compile saw `latest/version=0.3.22` already current and skipped recopying `latest/`.
- This led to the scoped compile fix in this PR.

## Review guide
1. `.github/workflows/publish_connectors.yml`
2. `.github/workflows/generate-connector-registries.yml`

## User Impact
Operators get a manual repair path for registry metadata artifacts without triggering a full connector image/package publish.

## Can this PR be safely reverted and rolled back?
- [x] YES 💚
- [ ] NO ❌

---
[Devin session](https://app.devin.ai/sessions/64751052e0304f2a8bf6490ec3aa8ea7)

Requested by: @aaronsteers