### PR TITLE
build(source-faker): Re-release for PyPI README validation

### DIFF
--- a/airbyte-integrations/connectors/source-faker/metadata.yaml
+++ b/airbyte-integrations/connectors/source-faker/metadata.yaml
@@ -9,7 +9,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: dfd88b22-b603-4c3d-aad7-3701784586b1
-  dockerImageTag: 7.1.0
+  dockerImageTag: 7.1.1
   dockerRepository: airbyte/source-faker
   documentationUrl: https://docs.airbyte.com/integrations/sources/faker
   externalDocumentationUrls:

--- a/airbyte-integrations/connectors/source-faker/pyproject.toml
+++ b/airbyte-integrations/connectors/source-faker/pyproject.toml
@@ -3,7 +3,7 @@ requires = [ "poetry-core>=1.0.0",]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
-version = "7.1.0"
+version = "7.1.1"
 name = "source-faker"
 description = "Source implementation for fake but realistic looking data."
 authors = [ "Airbyte <evan@airbyte.io>",]

--- a/docker-images/Dockerfile.python-connector
+++ b/docker-images/Dockerfile.python-connector
@@ -19,7 +19,7 @@ WORKDIR /airbyte/integration_code
 
 COPY . ./
 
-# Replace a potentially broken symlinked README before Poetry installs the connector package.
+# Replace potentially symlinked `README.md` before `poetry install`
 RUN if [ -L README.md ] && [ ! -e README.md ]; then \
         rm README.md; \
     fi; \

--- a/docker-images/Dockerfile.python-connector
+++ b/docker-images/Dockerfile.python-connector
@@ -19,6 +19,7 @@ WORKDIR /airbyte/integration_code
 
 COPY . ./
 
+# Replace a potentially broken symlinked README before Poetry installs the connector package.
 RUN if [ -L README.md ] && [ ! -e README.md ]; then \
         rm README.md; \
     fi; \

--- a/docker-images/Dockerfile.python-connector
+++ b/docker-images/Dockerfile.python-connector
@@ -19,6 +19,13 @@ WORKDIR /airbyte/integration_code
 
 COPY . ./
 
+RUN if [ -L README.md ] && [ ! -e README.md ]; then \
+        rm README.md; \
+    fi; \
+    if [ ! -e README.md ]; then \
+        printf '# %s\n\nThis package contains the Airbyte %s connector.\n' "${CONNECTOR_NAME}" "${CONNECTOR_NAME}" > README.md; \
+    fi
+
 # Conditionally copy and execute the extra build script if provided
 RUN if [ -n "${EXTRA_PREREQS_SCRIPT}" ]; then \
         cp ${EXTRA_PREREQS_SCRIPT} ./extra_prereqs_script && \

--- a/docs/integrations/sources/faker.md
+++ b/docs/integrations/sources/faker.md
@@ -47,6 +47,7 @@ Each purchase record includes: `id`, `user_id`, `product_id`, `created_at`, `upd
 
 | Version     | Date       | Pull Request                                                                                                          | Subject                                                                                                         |
 |:------------|:-----------| :-------------------------------------------------------------------------------------------------------------------- |:----------------------------------------------------------------------------------------------------------------|
+| 7.1.1 | 2026-05-13 | [*PR_NUMBER_PLACEHOLDER*](https://github.com/airbytehq/airbyte/pull/*PR_NUMBER_PLACEHOLDER*) | Re-release to verify PyPI README publishing |
 | 7.1.0 | 2026-03-31 | [75941](https://github.com/airbytehq/airbyte/pull/75941) | Promoted release candidate to GA |
 | 7.1.0-rc.2 | 2026-03-31 | [75926](https://github.com/airbytehq/airbyte/pull/75926) | Bump source-faker to RC2 for progressive rollout e2e test |
 | 7.1.0-rc.1 | 2026-03-31 | [75908](https://github.com/airbytehq/airbyte/pull/75908) | test: progressive rollout e2e test on source-faker |

--- a/docs/integrations/sources/faker.md
+++ b/docs/integrations/sources/faker.md
@@ -47,7 +47,7 @@ Each purchase record includes: `id`, `user_id`, `product_id`, `created_at`, `upd
 
 | Version     | Date       | Pull Request                                                                                                          | Subject                                                                                                         |
 |:------------|:-----------| :-------------------------------------------------------------------------------------------------------------------- |:----------------------------------------------------------------------------------------------------------------|
-| 7.1.1 | 2026-05-13 | [*PR_NUMBER_PLACEHOLDER*](https://github.com/airbytehq/airbyte/pull/*PR_NUMBER_PLACEHOLDER*) | Re-release to verify PyPI README publishing |
+| 7.1.1 | 2026-05-13 | [78075](https://github.com/airbytehq/airbyte/pull/78075) | Re-release to verify PyPI README publishing |
 | 7.1.0 | 2026-03-31 | [75941](https://github.com/airbytehq/airbyte/pull/75941) | Promoted release candidate to GA |
 | 7.1.0-rc.2 | 2026-03-31 | [75926](https://github.com/airbytehq/airbyte/pull/75926) | Bump source-faker to RC2 for progressive rollout e2e test |
 | 7.1.0-rc.1 | 2026-03-31 | [75908](https://github.com/airbytehq/airbyte/pull/75908) | test: progressive rollout e2e test on source-faker |


### PR DESCRIPTION
## What

Re-release `source-faker` to validate the connector PyPI publish path after the generated README fix in https://github.com/airbytehq/airbyte/pull/78070.

CI also exposed the same symlinked README fallout in Python connector Docker image builds: the symlink target is outside the Docker build context, so Poetry skips installing the connector package and the generated image cannot find the connector entrypoint.

## How

- Bump `source-faker` from `7.1.0` to `7.1.1`.
- Update the connector changelog with this PR as the release validation entry.
- Materialize a minimal local README during Python connector Docker builds only when `README.md` is missing or a broken symlink in the build context.

## Review guide

1. `airbyte-integrations/connectors/source-faker/metadata.yaml`
2. `airbyte-integrations/connectors/source-faker/pyproject.toml`
3. `docs/integrations/sources/faker.md`
4. `docker-images/Dockerfile.python-connector`

## User Impact

No connector behavior changes are included. This release validates that the PyPI publish pipeline can build and publish a connector package using the generated PyPI README path. The Docker build change restores Python connector package installation for connectors whose README symlink target is outside the Docker build context.

## Test plan

- `git diff --check origin/master...HEAD`
- `./poe-tasks/publish-python-registry.sh --name source-faker --with-semver-suffix preview --dry-run`
- `airbyte-cdk image build` from `airbyte-integrations/connectors/source-faker`
- `docker run --rm airbyte/source-faker:dev spec`

## Can this PR be safely reverted and rolled back?

- [x] YES 💚
- [ ] NO ❌

Link to Devin session: https://app.devin.ai/sessions/b25438b385594d60be097f5b2c68402e
Requested by: @aaronsteers