### PR TITLE
ci(ai-dev): resolve playbook schemas from ai-skills

### DIFF
--- a/.github/workflows/ai-dev-command.yml
+++ b/.github/workflows/ai-dev-command.yml
@@ -64,7 +64,7 @@ jobs:
         id: get-app-token
         with:
           owner: "airbytehq"
-          repositories: "airbyte"
+          repositories: "airbyte,ai-skills"
           app-id: ${{ secrets.OCTAVIA_BOT_APP_ID }}
           private-key: ${{ secrets.OCTAVIA_BOT_PRIVATE_KEY }}
 
@@ -154,6 +154,7 @@ jobs:
           comment-id: ${{ steps.resolve.outputs.comment_id }}
           issue-number: ${{ steps.resolve.outputs.issue_number }}
           playbook-macro: ${{ steps.resolve.outputs.dev_macro }}
+          playbook-source-ref: refs/pull/${{ steps.resolve.outputs.pr_number }}/head
           devin-token: ${{ secrets.DEVIN_AI_API_KEY }}
           github-token: ${{ steps.get-app-token.outputs.token }}
           api-version: v3

--- a/.github/workflows/oss-issue-triage.yml
+++ b/.github/workflows/oss-issue-triage.yml
@@ -80,7 +80,7 @@ jobs:
         id: get-app-token
         with:
           owner: "airbytehq"
-          repositories: "airbyte,oncall"
+          repositories: "airbyte,oncall,ai-skills"
           app-id: ${{ secrets.OCTAVIA_BOT_APP_ID }}
           private-key: ${{ secrets.OCTAVIA_BOT_PRIVATE_KEY }}
 
@@ -121,7 +121,7 @@ jobs:
         id: get-app-token
         with:
           owner: "airbytehq"
-          repositories: "airbyte,oncall"
+          repositories: "airbyte,oncall,ai-skills"
           app-id: ${{ secrets.OCTAVIA_BOT_APP_ID }}
           private-key: ${{ secrets.OCTAVIA_BOT_PRIVATE_KEY }}
 


### PR DESCRIPTION
## What

Allow the Airbyte repo's AI slash-command workflows to read playbook schema metadata from `airbytehq/ai-skills`.

This supports both normal `!oss_issue_triage` sessions and `/ai-dev` sessions once `aaronsteers/devin-action` resolves schemas from playbook frontmatter.

## How

- Adds `ai-skills` to the Octavia GitHub App token scope for `oss-issue-triage.yml` and `ai-dev-command.yml`.
- Passes `playbook-source-ref: refs/pull/${{ steps.resolve.outputs.pr_number }}/head` for `/ai-dev`, so dev playbook sessions resolve schema metadata from the same ai-skills PR under test.

## Review guide

1. `.github/workflows/ai-dev-command.yml`
2. `.github/workflows/oss-issue-triage.yml`

## User Impact

Airbyte `/ai-dev` and OSS issue triage sessions can pick up structured output schemas declared in ai-skills playbook frontmatter without duplicating schema YAML in this repo.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚
- [ ] NO ❌

Link to Devin session: https://app.devin.ai/sessions/b73fc7353ed24cbfb1a8aef0ade8d24b
Requested by: @pedroslopez