### PR TITLE
docs(source-service-now): Add 0.2.0 changelog entry

### DIFF
--- a/docs/integrations/enterprise-connectors/source-service-now.md
+++ b/docs/integrations/enterprise-connectors/source-service-now.md
@@ -57,6 +57,7 @@ Airbyte’s incubating ServiceNow enterprise source connector currently offers F
 
 The connector is still incubating; this section exists to satisfy Airbyte's QA checks.
 
+- 0.2.0
 - 0.1.0
 
 </details>


### PR DESCRIPTION
## What
Adds the missing `0.2.0` changelog entry for the enterprise ServiceNow source documentation.

## How
Updates `docs/integrations/enterprise-connectors/source-service-now.md` so the connector QA changelog check can find the new connector version.

## Review guide
1. `docs/integrations/enterprise-connectors/source-service-now.md`

## User Impact
No runtime behavior change. This unblocks the ServiceNow enterprise connector prerelease QA check that validates changelog entries.

## Can this PR be safely reverted and rolled back?
- [x] YES 💚
- [ ] NO ❌

Link to Devin session: https://app.devin.ai/sessions/68993f58037f4dbaa6339850a94d53c7
Requested by: @darynaishchenko