### PR TITLE
docs(source-service-now): add 0.2.0 changelog entry

### DIFF
--- a/docs/integrations/enterprise-connectors/source-service-now.md
+++ b/docs/integrations/enterprise-connectors/source-service-now.md
@@ -57,6 +57,7 @@ Airbyte’s incubating ServiceNow enterprise source connector currently offers F
 
 The connector is still incubating; this section exists to satisfy Airbyte's QA checks.
 
+- 0.2.0
 - 0.1.0
 
 </details>


### PR DESCRIPTION
## What
- Add the missing ServiceNow source `0.2.0` changelog entry required by connector prerelease QA.
- This unblocks airbyte-enterprise PR https://github.com/airbytehq/airbyte-enterprise/pull/430, which points the enterprise docs URL at this Airbyte docs page.

## How
- Add `0.2.0` to the changelog in `docs/integrations/enterprise-connectors/source-service-now.md`.

## Review guide
1. `docs/integrations/enterprise-connectors/source-service-now.md`

## User Impact
- No product behavior changes.
- Connector prerelease QA can validate the ServiceNow source metadata version against the docs changelog.

## Can this PR be safely reverted and rolled back?
- [x] YES 💚
- [ ] NO ❌

Link to Devin session: https://app.devin.ai/sessions/45b76bb47d014a5a9e6ae509e43c2603
Requested by: @darynaishchenko