### PR TITLE
test(source-faker): create progressive rollout rc

### DIFF
--- a/airbyte-integrations/connectors/source-faker/metadata.yaml
+++ b/airbyte-integrations/connectors/source-faker/metadata.yaml
@@ -23,13 +23,6 @@ data:
   icon: icon.svg
   license: ELv2
   name: Sample Data
-  registryOverrides:
-    cloud:
-      enabled: true
-      dockerImageTag: 7.1.1
-    oss:
-      enabled: true
-      dockerImageTag: 7.1.1
   releaseStage: beta
   releases:
     rolloutConfiguration:

--- a/airbyte-integrations/connectors/source-faker/metadata.yaml
+++ b/airbyte-integrations/connectors/source-faker/metadata.yaml
@@ -9,7 +9,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: dfd88b22-b603-4c3d-aad7-3701784586b1
-  dockerImageTag: 7.1.1
+  dockerImageTag: 7.2.0-rc.1
   dockerRepository: airbyte/source-faker
   documentationUrl: https://docs.airbyte.com/integrations/sources/faker
   externalDocumentationUrls:
@@ -26,12 +26,14 @@ data:
   registryOverrides:
     cloud:
       enabled: true
+      dockerImageTag: 7.1.1
     oss:
       enabled: true
+      dockerImageTag: 7.1.1
   releaseStage: beta
   releases:
     rolloutConfiguration:
-      enableProgressiveRollout: false
+      enableProgressiveRollout: true
     breakingChanges:
       4.0.0:
         message: This is a breaking change message

--- a/airbyte-integrations/connectors/source-faker/progressive-rollout-e2e/README.md
+++ b/airbyte-integrations/connectors/source-faker/progressive-rollout-e2e/README.md
@@ -1,2 +1,0 @@
-source-faker progressive rollout E2E test
-Session: https://app.devin.ai/sessions/f405dc912cdf44fead4aac65eec0d4e1

--- a/airbyte-integrations/connectors/source-faker/progressive-rollout-e2e/README.md
+++ b/airbyte-integrations/connectors/source-faker/progressive-rollout-e2e/README.md
@@ -1,0 +1,2 @@
+source-faker progressive rollout E2E test
+Session: https://app.devin.ai/sessions/f405dc912cdf44fead4aac65eec0d4e1

--- a/airbyte-integrations/connectors/source-faker/pyproject.toml
+++ b/airbyte-integrations/connectors/source-faker/pyproject.toml
@@ -3,7 +3,7 @@ requires = [ "poetry-core>=1.0.0",]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
-version = "7.1.1"
+version = "7.2.0-rc.1"
 name = "source-faker"
 description = "Source implementation for fake but realistic looking data."
 authors = [ "Airbyte <evan@airbyte.io>",]

--- a/docs/integrations/sources/faker.md
+++ b/docs/integrations/sources/faker.md
@@ -47,7 +47,7 @@ Each purchase record includes: `id`, `user_id`, `product_id`, `created_at`, `upd
 
 | Version     | Date       | Pull Request                                                                                                          | Subject                                                                                                         |
 |:------------|:-----------| :-------------------------------------------------------------------------------------------------------------------- |:----------------------------------------------------------------------------------------------------------------|
-| 7.2.0-rc.1 | 2026-05-14 | [*PR_NUMBER_PLACEHOLDER*](https://github.com/airbytehq/airbyte/pull/*PR_NUMBER_PLACEHOLDER*) | Progressive rollout e2e test |
+| 7.2.0-rc.1 | 2026-05-14 | [78100](https://github.com/airbytehq/airbyte/pull/78100) | Progressive rollout e2e test |
 | 7.1.1 | 2026-05-13 | [78075](https://github.com/airbytehq/airbyte/pull/78075) | Re-release to verify PyPI README publishing |
 | 7.1.0 | 2026-03-31 | [75941](https://github.com/airbytehq/airbyte/pull/75941) | Promoted release candidate to GA |
 | 7.1.0-rc.2 | 2026-03-31 | [75926](https://github.com/airbytehq/airbyte/pull/75926) | Bump source-faker to RC2 for progressive rollout e2e test |

--- a/docs/integrations/sources/faker.md
+++ b/docs/integrations/sources/faker.md
@@ -47,6 +47,7 @@ Each purchase record includes: `id`, `user_id`, `product_id`, `created_at`, `upd
 
 | Version     | Date       | Pull Request                                                                                                          | Subject                                                                                                         |
 |:------------|:-----------| :-------------------------------------------------------------------------------------------------------------------- |:----------------------------------------------------------------------------------------------------------------|
+| 7.2.0-rc.1 | 2026-05-14 | [*PR_NUMBER_PLACEHOLDER*](https://github.com/airbytehq/airbyte/pull/*PR_NUMBER_PLACEHOLDER*) | Progressive rollout e2e test |
 | 7.1.1 | 2026-05-13 | [78075](https://github.com/airbytehq/airbyte/pull/78075) | Re-release to verify PyPI README publishing |
 | 7.1.0 | 2026-03-31 | [75941](https://github.com/airbytehq/airbyte/pull/75941) | Promoted release candidate to GA |
 | 7.1.0-rc.2 | 2026-03-31 | [75926](https://github.com/airbytehq/airbyte/pull/75926) | Bump source-faker to RC2 for progressive rollout e2e test |


### PR DESCRIPTION
## What

Draft test PR for the traditional release-candidate progressive rollout E2E test on `source-faker`.

Context:
- Parent Devin session: https://app.devin.ai/sessions/4c93a19014b54a33a8eedbded53a2b61
- Related Airbyte PR: https://github.com/airbytehq/airbyte/pull/76159
- Related platform PR: https://github.com/airbytehq/airbyte-platform-internal/pull/18862
- Related ops MCP PR: https://github.com/airbytehq/airbyte-ops-mcp/pull/802

Do not merge this PR unless AJ explicitly approves. This is intended to remain draft.

## How

- Bumps `source-faker` from `7.1.1` to release candidate `7.2.0-rc.1` using the `airbyte-ops-mcp` `bump_version_in_repo` flow.
- Enables progressive rollout metadata for the RC.
- Does not add prior-version `registryOverrides.*.dockerImageTag` pins; this PR validates the no-RC-override behavior from the updated ops MCP flow.
- Updates the generated docs changelog with this PR URL; no extra connector-local marker file remains.

## Review guide

1. `airbyte-integrations/connectors/source-faker/metadata.yaml`
2. `airbyte-integrations/connectors/source-faker/pyproject.toml`
3. `docs/integrations/sources/faker.md`

## User Impact

No intended production user impact unless this draft test PR is explicitly merged and published as part of the rollout E2E. If merged, it validates that RC rollout metadata can keep the stable GA version as default without registry override pins.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚
- [ ] NO ❌

Link to Devin session: https://app.devin.ai/sessions/f405dc912cdf44fead4aac65eec0d4e1
Requested by: @aaronsteers