### PR TITLE
ci(connectors): allow prerelease publish with release blocks

### DIFF
--- a/.github/workflows/publish_connectors.yml
+++ b/.github/workflows/publish_connectors.yml
@@ -327,16 +327,11 @@ jobs:
       # See: https://github.com/airbytehq/airbyte-ops-mcp/issues/686
       - name: Check for release block
         id: check-release-block
+        if: needs.publish_options.outputs.with-semver-suffix == 'none'
         shell: bash
         run: |
           BLOCK_FILE="airbyte-integrations/connectors/${{ matrix.connector }}/block-release.yaml"
-          SEMVER_SUFFIX="${{ needs.publish_options.outputs.with-semver-suffix }}"
-          if [[ -f "$BLOCK_FILE" && "$SEMVER_SUFFIX" == "preview" ]]; then
-            REASON=$(cat "$BLOCK_FILE" | head -1 | sed 's/^reason: *//' | tr -d '"')
-            echo "::notice::Release block found for ${{ matrix.connector }}, but pre-release publishing is allowed: ${REASON}"
-            echo "blocked=false" >> $GITHUB_OUTPUT
-            cat "$BLOCK_FILE"
-          elif [[ -f "$BLOCK_FILE" ]]; then
+          if [[ -f "$BLOCK_FILE" ]]; then
             REASON=$(cat "$BLOCK_FILE" | head -1 | sed 's/^reason: *//' | tr -d '"')
             echo "::warning::⚠️ Release BLOCKED for ${{ matrix.connector }}: ${REASON}"
             echo "::warning::Skipping all publish steps. Remove block-release.yaml to unblock."

--- a/.github/workflows/publish_connectors.yml
+++ b/.github/workflows/publish_connectors.yml
@@ -330,7 +330,13 @@ jobs:
         shell: bash
         run: |
           BLOCK_FILE="airbyte-integrations/connectors/${{ matrix.connector }}/block-release.yaml"
-          if [[ -f "$BLOCK_FILE" ]]; then
+          SEMVER_SUFFIX="${{ needs.publish_options.outputs.with-semver-suffix }}"
+          if [[ -f "$BLOCK_FILE" && "$SEMVER_SUFFIX" == "preview" ]]; then
+            REASON=$(cat "$BLOCK_FILE" | head -1 | sed 's/^reason: *//' | tr -d '"')
+            echo "::notice::Release block found for ${{ matrix.connector }}, but pre-release publishing is allowed: ${REASON}"
+            echo "blocked=false" >> $GITHUB_OUTPUT
+            cat "$BLOCK_FILE"
+          elif [[ -f "$BLOCK_FILE" ]]; then
             REASON=$(cat "$BLOCK_FILE" | head -1 | sed 's/^reason: *//' | tr -d '"')
             echo "::warning::⚠️ Release BLOCKED for ${{ matrix.connector }}: ${REASON}"
             echo "::warning::Skipping all publish steps. Remove block-release.yaml to unblock."


### PR DESCRIPTION
## What

Allow blocked connectors to publish prerelease builds while preserving release blocks for production publishes.

Context: https://github.com/airbytehq/airbyte-ops-mcp/issues/803 and release-block validation from https://github.com/airbytehq/airbyte/pull/78099.

## How

`publish_connectors.yml` now runs the `Check for release block` step only when `with-semver-suffix` is `none`. Prerelease suffixes such as `preview` and `rc` skip the release-block check step entirely, leaving `steps.check-release-block.outputs.blocked` unset so the existing downstream `blocked != 'true'` gates continue to allow prerelease publishing.

For production publishes, `with-semver-suffix` remains `none`, so the existing block marker warning and `blocked=true` behavior is unchanged.

## Review guide

1. `.github/workflows/publish_connectors.yml`

## User Impact

Blocked connectors can still publish prerelease artifacts from PRs so teams can validate a fix before unblocking the production release. GA publish paths remain blocked while `block-release.yaml` exists.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚
- [ ] NO ❌

Link to Devin session: https://app.devin.ai/sessions/a96ed3e198ec4d80965f1412f58030b4
Requested by: @aaronsteers