### PR TITLE
fix(source-asana): Request Asana OAuth read scopes

### DIFF
--- a/airbyte-integrations/connectors/source-asana/source_asana/manifest.yaml
+++ b/airbyte-integrations/connectors/source-asana/source_asana/manifest.yaml
@@ -2683,7 +2683,19 @@ spec:
     predicate_value: OAuth Credentials
     oauth_config_specification:
       oauth_connector_input_specification:
-        consent_url: "https://app.asana.com/-/oauth_authorize?{{client_id_param}}&{{redirect_uri_param}}&response_type=code&{{state_param}}"
+        scopes:
+          - scope: "attachments:read"
+          - scope: "custom_fields:read"
+          - scope: "portfolios:read"
+          - scope: "projects:read"
+          - scope: "stories:read"
+          - scope: "tags:read"
+          - scope: "tasks:read"
+          - scope: "team_memberships:read"
+          - scope: "teams:read"
+          - scope: "users:read"
+          - scope: "workspaces:read"
+        consent_url: "https://app.asana.com/-/oauth_authorize?{{client_id_param}}&{{redirect_uri_param}}&response_type=code&{{scopes_param}}&{{state_param}}"
         access_token_url: "https://app.asana.com/-/oauth_token"
         access_token_headers:
           Content-Type: "application/x-www-form-urlencoded"


### PR DESCRIPTION
## What
Adds explicit Asana OAuth read scopes to the source Asana OAuth consent URL. Without a `scope` parameter, Asana only falls back to the `default` scope when the OAuth app is registered with Full permissions; scoped apps can complete OAuth but later receive 401 responses when the connector calls scoped API endpoints.

## How
Defines the read scopes needed by the connector streams in `oauth_connector_input_specification.scopes` and includes `{{scopes_param}}` in the Asana authorization URL.

## Review guide
1. `airbyte-integrations/connectors/source-asana/source_asana/manifest.yaml`

## User Impact
OAuth connections for scoped Asana apps request the API permissions needed to read Asana connector streams, avoiding downstream 401s caused by tokens without read scopes.

## Can this PR be safely reverted and rolled back?
- [x] YES 💚
- [ ] NO ❌

---
[Devin session](https://app.devin.ai/sessions/f50d36b45b9943a6a650942c176a9d61)

Requested by: @lazebnyi

> [!IMPORTANT]
> Active progressive rollout warning for source-asana.

- [ ] (Click to Approve:) Bypass the active progressive rollout warning for source-asana in the PR comment [here](https://github.com/airbytehq/airbyte/pull/78106#issuecomment-4455543371).