### PR TITLE
fix(source-granola): update API key instructions

### DIFF
--- a/airbyte-integrations/connectors/source-granola/manifest.yaml
+++ b/airbyte-integrations/connectors/source-granola/manifest.yaml
@@ -4,7 +4,7 @@ type: DeclarativeSource
 
 description: >-
   Granola is an AI-powered meeting notes tool. This connector reads meeting
-  notes from your Granola workspace using the Granola Enterprise API.
+  notes from your Granola workspace using the Granola API.
 
 concurrency_level:
   type: ConcurrencyLevel
@@ -143,8 +143,11 @@ spec:
         type: string
         title: API Key
         description: >-
-          Your Granola Enterprise API key. Generate one from Settings >
-          Workspaces > API in your Granola workspace.
+          Your Granola API key. For a personal key, open the Granola desktop app
+          and go to Settings > Connectors > API keys > Create new key. For an
+          Enterprise API key, go to Settings > API > Create new key. On Enterprise
+          plans, workspace admins must enable "Allow personal API keys" in
+          Settings > Workspace > General before personal keys can be created.
         airbyte_secret: true
         order: 0
       start_date:

--- a/airbyte-integrations/connectors/source-granola/metadata.yaml
+++ b/airbyte-integrations/connectors/source-granola/metadata.yaml
@@ -7,7 +7,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 9023923c-002f-4131-9554-3ebdf56540a4
-  dockerImageTag: 0.2.0
+  dockerImageTag: 0.2.1
   dockerRepository: airbyte/source-granola
   documentationUrl: https://docs.airbyte.com/integrations/sources/granola
   githubIssueLabel: source-granola

--- a/docs/integrations/sources/granola.md
+++ b/docs/integrations/sources/granola.md
@@ -103,6 +103,7 @@ The connector handles rate limiting automatically by retrying requests when a `4
 
 | Version | Date       | Pull Request | Subject         |
 | :------ | :--------- | :----------- | :-------------- |
+| 0.2.1 | 2026-05-15 | | Update API key setup instructions |
 | 0.2.0 | 2026-05-07 | [77861](https://github.com/airbytehq/airbyte/pull/77861) | Promoted release candidate to GA |
 | 0.2.0-rc.4 | 2026-05-01 | [77698](https://github.com/airbytehq/airbyte/pull/77698) | Revert default_concurrency from 6 to 5 (optimal value from tuning) and add HTTP API budget matching Granola's documented rate limit (25 req/5s burst) |
 | 0.2.0-rc.3 | 2026-04-28 | [77645](https://github.com/airbytehq/airbyte/pull/77645) | Increase default_concurrency from 5 to 6 for concurrency tuning iteration 3 (final) |


### PR DESCRIPTION
## What
Updates the Granola source connector spec for Linear issue AGENTIC-1608 so the API key help text no longer points users to the outdated `Settings > Workspaces > API` path.

---
[Devin session](https://app.devin.ai/sessions/64f5f01c95614323acebf6b9b9db25cf)

## How
- Updates the source-granola manifest description for the `api_key` config field with the current personal and Enterprise API key setup paths.
- Bumps the connector patch version from `0.2.0` to `0.2.1`.
- Adds a matching changelog entry for the connector docs.

## Review guide
1. `airbyte-integrations/connectors/source-granola/manifest.yaml`
2. `airbyte-integrations/connectors/source-granola/metadata.yaml`
3. `docs/integrations/sources/granola.md`

## User Impact
Users configuring Granola will see the current API key setup instructions in connector-auth help text. Existing connections and sync behavior are unchanged.

## Can this PR be safely reverted and rolled back?
- [x] YES 💚
- [ ] NO ❌

## Testing
- `yq eval '.' airbyte-integrations/connectors/source-granola/manifest.yaml >/dev/null`
- `yq eval '.' airbyte-integrations/connectors/source-granola/metadata.yaml >/dev/null`
- `git diff --check`
- `(cd airbyte-integrations/connectors/source-granola && poe format-check)`
- `(cd airbyte-integrations/connectors/source-granola && poe lint-check)` failed before running the task because `poe-tasks/manifest-only-connector-tasks.toml` has an unmatched quote in the shared `lint-check` task definition.
- `(cd airbyte-integrations/connectors/source-granola && uvx --from 'airbyte-cdk[dev]' airbyte-cdk connector test /home/ubuntu/repos/airbyte/airbyte-integrations/connectors/source-granola)` passed: 2 passed, 6 skipped.

Requested by: @aldogonzalez8

> [!IMPORTANT]
> Active progressive rollout warning for source-granola.

- [ ] (Click to Approve:) Bypass the active progressive rollout warning for source-granola in the PR comment [here](https://github.com/airbytehq/airbyte/pull/78117#issuecomment-4461457857).