### PR TITLE
fix(source-greenhouse): promote tuned concurrency to ga

### DIFF
--- a/airbyte-integrations/connectors/source-greenhouse/manifest.yaml
+++ b/airbyte-integrations/connectors/source-greenhouse/manifest.yaml
@@ -1802,7 +1802,7 @@ streams:
 # against the documented 5 req/sec ceiling.
 concurrency_level:
   type: ConcurrencyLevel
-  default_concurrency: 2
+  default_concurrency: "{{ config.get('num_workers', 2) }}"
   max_concurrency: 16
 
 spec:
@@ -1822,6 +1822,22 @@ spec:
         title: API Key
         airbyte_secret: true
         order: 0
+      num_workers:
+        type: integer
+        title: Number of concurrent threads
+        description: >-
+          The number of worker threads to use for syncing. The default is tuned
+          against Greenhouse's documented limit of 50 requests per 10 seconds.
+          Increase this only if your Greenhouse account can support higher API
+          usage, or lower it if you see rate-limit errors.
+        minimum: 1
+        maximum: 16
+        default: 2
+        examples:
+          - 1
+          - 2
+          - 3
+        order: 1
     additionalProperties: true
 
 metadata:

--- a/airbyte-integrations/connectors/source-greenhouse/manifest.yaml
+++ b/airbyte-integrations/connectors/source-greenhouse/manifest.yaml
@@ -1803,7 +1803,7 @@ streams:
 concurrency_level:
   type: ConcurrencyLevel
   default_concurrency: "{{ config.get('num_workers', 2) }}"
-  max_concurrency: 16
+  max_concurrency: 8
 
 spec:
   type: Spec
@@ -1831,7 +1831,7 @@ spec:
           Increase this only if your Greenhouse account can support higher API
           usage, or lower it if you see rate-limit errors.
         minimum: 1
-        maximum: 16
+        maximum: 8
         default: 2
         examples:
           - 1

--- a/airbyte-integrations/connectors/source-greenhouse/manifest.yaml
+++ b/airbyte-integrations/connectors/source-greenhouse/manifest.yaml
@@ -1802,7 +1802,7 @@ streams:
 # against the documented 5 req/sec ceiling.
 concurrency_level:
   type: ConcurrencyLevel
-  default_concurrency: 3
+  default_concurrency: 2
   max_concurrency: 16
 
 spec:

--- a/airbyte-integrations/connectors/source-greenhouse/manifest.yaml
+++ b/airbyte-integrations/connectors/source-greenhouse/manifest.yaml
@@ -1805,6 +1805,15 @@ concurrency_level:
   default_concurrency: "{{ config.get('num_workers', 2) }}"
   max_concurrency: 8
 
+api_budget:
+  type: HTTPAPIBudget
+  policies:
+    - type: MovingWindowCallRatePolicy
+      rates:
+        - limit: 50
+          interval: PT10S
+      matchers: []
+
 spec:
   type: Spec
   connection_specification:

--- a/airbyte-integrations/connectors/source-greenhouse/metadata.yaml
+++ b/airbyte-integrations/connectors/source-greenhouse/metadata.yaml
@@ -22,9 +22,6 @@ data:
     pypi:
       enabled: false
       packageName: airbyte-source-greenhouse
-  releases:
-    rolloutConfiguration:
-      enableProgressiveRollout: true
   registryOverrides:
     cloud:
       enabled: true

--- a/airbyte-integrations/connectors/source-greenhouse/metadata.yaml
+++ b/airbyte-integrations/connectors/source-greenhouse/metadata.yaml
@@ -10,7 +10,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 59f1e50a-331f-4f09-b3e8-2e8d4d355f44
-  dockerImageTag: 0.7.22-rc.4
+  dockerImageTag: 0.7.22
   dockerRepository: airbyte/source-greenhouse
   documentationUrl: https://docs.airbyte.com/integrations/sources/greenhouse
   githubIssueLabel: source-greenhouse

--- a/airbyte-integrations/connectors/source-greenhouse/metadata.yaml
+++ b/airbyte-integrations/connectors/source-greenhouse/metadata.yaml
@@ -10,7 +10,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 59f1e50a-331f-4f09-b3e8-2e8d4d355f44
-  dockerImageTag: 0.7.22-rc.3
+  dockerImageTag: 0.7.22-rc.4
   dockerRepository: airbyte/source-greenhouse
   documentationUrl: https://docs.airbyte.com/integrations/sources/greenhouse
   githubIssueLabel: source-greenhouse

--- a/docs/integrations/sources/greenhouse.md
+++ b/docs/integrations/sources/greenhouse.md
@@ -74,6 +74,7 @@ The Greenhouse connector should not run into Greenhouse API limitations under no
 
 | Version    | Date       | Pull Request                                             | Subject                                                                                                                                                                |
 |:-----------|:-----------|:---------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 0.7.22-rc.4 | 2026-05-15 | [*PR_NUMBER_PLACEHOLDER*](https://github.com/airbytehq/airbyte/pull/*PR_NUMBER_PLACEHOLDER*) | Reduce default_concurrency to 2 for concurrency tuning after rate-limit failures at c=3. |
 | 0.7.22-rc.3 | 2026-05-12 | [78052](https://github.com/airbytehq/airbyte/pull/78052) | Reduce default_concurrency to 3 for concurrency tuning after rate-limit failures at higher settings. |
 | 0.7.22-rc.2 | 2026-05-08 | [78006](https://github.com/airbytehq/airbyte/pull/78006) | Concurrency tuning iteration: bump default_concurrency to 5 |
 | 0.7.22-rc.1 | 2026-05-06 | [77826](https://github.com/airbytehq/airbyte/pull/77826) | Start concurrency tuning at default_concurrency=4 (Path A) and enable progressive rollout |

--- a/docs/integrations/sources/greenhouse.md
+++ b/docs/integrations/sources/greenhouse.md
@@ -74,7 +74,7 @@ The Greenhouse connector should not run into Greenhouse API limitations under no
 
 | Version    | Date       | Pull Request                                             | Subject                                                                                                                                                                |
 |:-----------|:-----------|:---------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| 0.7.22-rc.4 | 2026-05-15 | [*PR_NUMBER_PLACEHOLDER*](https://github.com/airbytehq/airbyte/pull/*PR_NUMBER_PLACEHOLDER*) | Reduce default_concurrency to 2 for concurrency tuning after rate-limit failures at c=3. |
+| 0.7.22-rc.4 | 2026-05-15 | [78119](https://github.com/airbytehq/airbyte/pull/78119) | Reduce default_concurrency to 2 for concurrency tuning after rate-limit failures at c=3. |
 | 0.7.22-rc.3 | 2026-05-12 | [78052](https://github.com/airbytehq/airbyte/pull/78052) | Reduce default_concurrency to 3 for concurrency tuning after rate-limit failures at higher settings. |
 | 0.7.22-rc.2 | 2026-05-08 | [78006](https://github.com/airbytehq/airbyte/pull/78006) | Concurrency tuning iteration: bump default_concurrency to 5 |
 | 0.7.22-rc.1 | 2026-05-06 | [77826](https://github.com/airbytehq/airbyte/pull/77826) | Start concurrency tuning at default_concurrency=4 (Path A) and enable progressive rollout |

--- a/docs/integrations/sources/greenhouse.md
+++ b/docs/integrations/sources/greenhouse.md
@@ -74,7 +74,7 @@ The Greenhouse connector should not run into Greenhouse API limitations under no
 
 | Version    | Date       | Pull Request                                             | Subject                                                                                                                                                                |
 |:-----------|:-----------|:---------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| 0.7.22-rc.4 | 2026-05-15 | [78119](https://github.com/airbytehq/airbyte/pull/78119) | Reduce default_concurrency to 2 for concurrency tuning after rate-limit failures at c=3. |
+| 0.7.22 | 2026-05-15 | [78119](https://github.com/airbytehq/airbyte/pull/78119) | Set the default concurrency to 2 and expose the number of concurrent threads as a user-configurable option. |
 | 0.7.22-rc.3 | 2026-05-12 | [78052](https://github.com/airbytehq/airbyte/pull/78052) | Reduce default_concurrency to 3 for concurrency tuning after rate-limit failures at higher settings. |
 | 0.7.22-rc.2 | 2026-05-08 | [78006](https://github.com/airbytehq/airbyte/pull/78006) | Concurrency tuning iteration: bump default_concurrency to 5 |
 | 0.7.22-rc.1 | 2026-05-06 | [77826](https://github.com/airbytehq/airbyte/pull/77826) | Start concurrency tuning at default_concurrency=4 (Path A) and enable progressive rollout |


### PR DESCRIPTION
## What
Promote the source-greenhouse concurrency tuning result to GA at `0.7.22` instead of shipping another release candidate. The GA default is concurrency `2`, matching the last stable effective fallback while keeping the tuned value explicit and user-configurable.

## How
- Set `default_concurrency` to read from `config.get('num_workers', 2)`.
- Add a `num_workers` integer field to the connector spec with default `2`, min `1`, and max `8`.
- Cap `max_concurrency` at `8` so the runtime and user-configurable maximum match.
- Add a global HTTP API budget for Greenhouse's documented limit of 50 requests per 10 seconds.
- Promote the connector image tag from `0.7.22-rc.3` to `0.7.22` and add the GA changelog entry.

## Review guide
1. `airbyte-integrations/connectors/source-greenhouse/manifest.yaml`
2. `airbyte-integrations/connectors/source-greenhouse/metadata.yaml`
3. `docs/integrations/sources/greenhouse.md`

## User Impact
Greenhouse syncs default to two concurrent worker threads and are throttled to Greenhouse's documented limit of 50 requests per 10 seconds. Users can lower or raise the number of concurrent threads from the connector configuration, up to `8`, if their environment needs less API pressure or can support more API usage.

## Can this PR be safely reverted and rolled back?
- [x] YES 💚
- [ ] NO ❌

## Testing
- [x] `uvx --with pyyaml python - <<'PY' ...` validated the manifest and metadata YAML, including `num_workers`, `max_concurrency: 8`, `HTTPAPIBudget` at 50 requests per 10 seconds, and `dockerImageTag: 0.7.22`.
- [x] `git diff --check`

---
[Devin session](https://app.devin.ai/sessions/9f063eb099b24f8c90f4c28ebc857698)

> [!IMPORTANT]
> Active progressive rollout warning for source-greenhouse.

- [x] (Click to Approve:) Bypass the active progressive rollout warning for source-greenhouse in the PR comment [here](https://github.com/airbytehq/airbyte/pull/78119#issuecomment-4461689041).

Requested by: @sophiecuiy