### PR TITLE
chore(source-amazon-ads): bump to 8.0.3-rc.3 with num_workers default=16 (tuning iter 3)

### DIFF
--- a/airbyte-integrations/connectors/source-amazon-ads/manifest.yaml
+++ b/airbyte-integrations/connectors/source-amazon-ads/manifest.yaml
@@ -3509,7 +3509,7 @@ spec:
         title: Number of concurrent threads
         minimum: 2
         maximum: 20
-        default: 14
+        default: 16
         examples:
           - 2
           - 3
@@ -3567,7 +3567,7 @@ spec:
 # continue to observe.
 concurrency_level:
   type: ConcurrencyLevel
-  default_concurrency: "{{ config.get('num_workers', 14) }}"
+  default_concurrency: "{{ config.get('num_workers', 16) }}"
   max_concurrency: 20
 
 schemas:

--- a/airbyte-integrations/connectors/source-amazon-ads/metadata.yaml
+++ b/airbyte-integrations/connectors/source-amazon-ads/metadata.yaml
@@ -13,7 +13,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: c6b0a29e-1da9-4512-9002-7bfd0cba2246
-  dockerImageTag: 8.0.3-rc.2
+  dockerImageTag: 8.0.3-rc.3
   dockerRepository: airbyte/source-amazon-ads
   documentationUrl: https://docs.airbyte.com/integrations/sources/amazon-ads
   githubIssueLabel: source-amazon-ads

--- a/docs/integrations/sources/amazon-ads.md
+++ b/docs/integrations/sources/amazon-ads.md
@@ -164,6 +164,7 @@ If you need better sync performance and are not experiencing rate limiting error
 
 | Version    | Date       | Pull Request                                             | Subject                                                                                                                                                                |
 |:-----------|:-----------|:---------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 8.0.3-rc.3 | 2026-05-14 | [PR_NUMBER_PLACEHOLDER](https://github.com/airbytehq/airbyte/pull/PR_NUMBER_PLACEHOLDER) | Concurrency tuning iteration 3: bump default `num_workers` from 14 to 16 for progressive rollout |
 | 8.0.3-rc.2 | 2026-05-12 | [78055](https://github.com/airbytehq/airbyte/pull/78055) | Concurrency tuning iteration 2: bump default `num_workers` from 12 to 14 for progressive rollout |
 | 8.0.3-rc.1 | 2026-05-11 | [78010](https://github.com/airbytehq/airbyte/pull/78010) | Concurrency tuning iteration 1: bump default `num_workers` from 10 to 12 for progressive rollout |
 | 8.0.2 | 2026-05-05 | [77660](https://github.com/airbytehq/airbyte/pull/77660) | Skip profiles without Amazon Attribution access on attribution report performance streams instead of failing the sync |


### PR DESCRIPTION
## What

Phase 1.10 iteration 3 of the [`source-amazon-ads` concurrency tuning rollout](https://github.com/airbytehq/airbyte-internal-issues/issues/15305).

Bumps the default `num_workers` from `14` → `16` after iter 2 (`num_workers=14`) passed daily-tuning criteria on the 4 daily+ TIER_2 pinned cohort:
- 0 `429 / Too Many Requests` across the cohort
- Source-read phase durations effectively unchanged for light actors (+0.2 to +1.3s ≈ noise) and improved -52% for the heavy actor
- Total-duration deltas on lights were driven by destination_write/replication/orchestration overhead (platform-side), not the connector

See iter 2 day-1 analysis: https://github.com/airbytehq/airbyte-internal-issues/issues/15305#issuecomment-4461732672.

This is iteration 3 of 3 on the higher-direction cap per the playbook. If iter 3 also PASSes, tuning finalizes at `num_workers=16`; if it FAILs, step halves to 1 and tuning reverses lower from 16 (no iteration cap on the lower direction; must end on a PASS).

## How

- `airbyte-integrations/connectors/source-amazon-ads/manifest.yaml`: bump `num_workers` spec `default` 14 → 16 and `concurrency_level.default_concurrency` fallback `{{ config.get('num_workers', 14) }}` → `{{ config.get('num_workers', 16) }}`.
- `airbyte-integrations/connectors/source-amazon-ads/metadata.yaml`: bump `dockerImageTag` 8.0.3-rc.2 → 8.0.3-rc.3.
- `docs/integrations/sources/amazon-ads.md`: prepend 8.0.3-rc.3 changelog row.

`releases.rolloutConfiguration.enableProgressiveRollout: true` and `max_concurrency: 20` remain unchanged.

## Review guide

1. `airbyte-integrations/connectors/source-amazon-ads/manifest.yaml` (2 lines)
2. `airbyte-integrations/connectors/source-amazon-ads/metadata.yaml` (1 line)
3. `docs/integrations/sources/amazon-ads.md` (1 line)

## User Impact

No user-visible change yet — `8.0.3-rc.3` is published as a release candidate and pinned to the same 4 daily+ TIER_2 actors as iter 2 for the next 24h measurement window. Users not in the cohort remain on stable `8.0.2`. Once tuning settles on a PASS, a follow-up PR will promote the final RC to `8.0.3` GA, drop `enableProgressiveRollout`, and roll back the per-iteration changelog rows into a single GA entry.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚 — manifest-only change. Revert restores `num_workers` default to 14 / `dockerImageTag` to 8.0.3-rc.2; revert + republish would unwind the iter 3 RC. The progressive rollout state machine (rollout records, pinned actors) is managed separately via the airbyte-ops-mcp and is unaffected by repo state.
- [ ] NO ❌


Link to Devin session: https://app.devin.ai/sessions/6637a07c867f4b3785588328533041a8
Requested by: @sophiecuiy

> [!IMPORTANT]
> Active progressive rollout warning for source-amazon-ads.

- [ ] (Click to Approve:) Bypass the active progressive rollout warning for source-amazon-ads in the PR comment [here](https://github.com/airbytehq/airbyte/pull/78121#issuecomment-4461756147).