### PR TITLE
feat(source-linear): expose num_workers in spec (default=4) for 0.2.2-rc.2

### DIFF
--- a/airbyte-integrations/connectors/source-linear/manifest.yaml
+++ b/airbyte-integrations/connectors/source-linear/manifest.yaml
@@ -1433,9 +1433,16 @@ streams:
 # floor((2500/3600) / 4) = 0 ≤ 2 triggers the low-rate-limit special case →
 # starting_concurrency = 4, step = 1. Empirical tuning will adjust against
 # the documented 2,500 req/hr ceiling.
+#
+# The user-facing `num_workers` config field (see spec below) overrides the
+# default at the connection level; users on the higher-ceiling OAuth tiers
+# (5,000 req/hr or workspace OAuth dynamic uplift) can raise it up to the
+# max_concurrency ceiling, while users on the 2,500 req/hr API-key tier
+# should generally stay at or below the default of 4 to avoid sustained
+# rate-limit pressure.
 concurrency_level:
   type: ConcurrencyLevel
-  default_concurrency: 4
+  default_concurrency: "{{ config.get('num_workers', 4) }}"
   max_concurrency: 16
 
 spec:
@@ -1511,6 +1518,23 @@ spec:
         pattern: ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}\.[0-9]{3}Z$
         examples:
           - "2020-01-01T00:00:00.000Z"
+      num_workers:
+        type: integer
+        order: 2
+        title: Number of concurrent workers
+        description: >-
+          Number of worker threads used to read streams in parallel. Higher
+          values can speed up syncs but increase the risk of hitting Linear's
+          rate limits. The Linear API limits per-user requests by
+          authentication type: API key auth allows 2,500 requests/hour, OAuth
+          allows 5,000 requests/hour, and workspace OAuth scales dynamically
+          with paid seats. Stay at the default unless you are on OAuth and
+          have observed headroom in your rate-limit usage. See <a
+          href="https://linear.app/developers/rate-limiting">Linear API rate
+          limits</a> for details.
+        default: 4
+        minimum: 1
+        maximum: 10
     additionalProperties: true
   advanced_auth:
     auth_flow_type: oauth2.0

--- a/airbyte-integrations/connectors/source-linear/metadata.yaml
+++ b/airbyte-integrations/connectors/source-linear/metadata.yaml
@@ -20,7 +20,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 1c5d8316-ed42-4473-8fbc-2626f03f070c
-  dockerImageTag: 0.2.2-rc.1
+  dockerImageTag: 0.2.2-rc.2
   dockerRepository: airbyte/source-linear
   githubIssueLabel: source-linear
   icon: icon.svg

--- a/docs/integrations/sources/linear.md
+++ b/docs/integrations/sources/linear.md
@@ -122,7 +122,8 @@ For programmatic configuration, use these parameter names:
 
 | Version | Date | Pull Request | Subject |
 | ------- | ---- | ------------ | ------- |
-| 0.2.2-rc.1 | 2026-05-12 | [PR_NUMBER](https://github.com/airbytehq/airbyte/pull/PR_NUMBER) | Resume concurrency tuning at default_concurrency=4 (Path A, 2,500 req/hr API key ceiling); re-enable progressive rollout |
+| 0.2.2-rc.2 | 2026-05-15 | [PR_NUMBER](https://github.com/airbytehq/airbyte/pull/PR_NUMBER) | Expose `num_workers` in connector spec (default 4, min 1, max 10) so users can override the per-connection concurrency from the UI |
+| 0.2.2-rc.1 | 2026-05-12 | [78034](https://github.com/airbytehq/airbyte/pull/78034) | Resume concurrency tuning at default_concurrency=4 (Path A, 2,500 req/hr API key ceiling); re-enable progressive rollout |
 | 0.2.1 | 2026-05-12 | [78013](https://github.com/airbytehq/airbyte/pull/78013) | Fix API key config migration for existing connections |
 | 0.2.0 | 2026-05-11 | [77578](https://github.com/airbytehq/airbyte/pull/77578) | Add OAuth 2.0 authentication support and migrate existing API key configurations to nested credentials |
 | 0.1.2 | 2026-04-28 | [77318](https://github.com/airbytehq/airbyte/pull/77318) | Update dependencies |


### PR DESCRIPTION
## What

Adds a user-facing `num_workers` config field to the `source-linear` connector spec so users can override per-connection stream concurrency from the Airbyte UI. Default is `4`; minimum `1`; maximum `10`.

Queues the second RC (`0.2.2-rc.2`) for the ongoing concurrency-tuning rollout. The connector-level default `concurrency_level` introduced in #78034 (currently in *Phase 2* — full TIER_2 rollout at `default_concurrency=4`) stays unchanged; this PR only adds the *user-facing knob* that pairs with it, so Tier 1 and GA users can dial concurrency up (e.g., OAuth users on the 5,000 req/hr ceiling) or down (e.g., users who experience rate-limit pressure on API key auth) without a new release.

This PR is **draft** and intentionally queued for review while Phase 2 monitors. It is held in draft until the Phase 2 24h health check passes (scheduled 2026-05-16 10:30 PT). On Phase 2 pass + explicit user approval, it will be marked ready and merged so `0.2.2-rc.2` can publish in time for *Phase 3* (TIER_1 rollout).

## How

Three minimal file changes:

1. `airbyte-integrations/connectors/source-linear/manifest.yaml`
   - Update `concurrency_level.default_concurrency` from `4` to `"{{ config.get('num_workers', 4) }}"`. The numeric fallback preserves backward compatibility for connections without the field.
   - Add a new top-level `num_workers` integer property to `spec.connection_specification.properties` with `default: 4`, `minimum: 1`, `maximum: 10`, and a description that calls out the per-auth-type Linear rate-limit ceilings (2,500 / 5,000 req/hr / dynamic).
   - Update the inline rate-limit comment block above `concurrency_level` to document the new config field.

2. `airbyte-integrations/connectors/source-linear/metadata.yaml`
   - Bump `dockerImageTag` `0.2.2-rc.1` → `0.2.2-rc.2`.
   - `releases.rolloutConfiguration.enableProgressiveRollout: true` already present (carried over from #78034) — no change needed.

3. `docs/integrations/sources/linear.md`
   - Add a `0.2.2-rc.2` row to the changelog describing the new spec field.
   - Fix the placeholder PR number on the `0.2.2-rc.1` row left over from #78034 (now links to `#78034`).

Field-naming convention and template pattern match what other Airbyte manifest-only connectors already use for the same purpose:

- `source-klaviyo` — `num_workers` integer with `minimum: 1`, `maximum: 50`, surfaced via `default_concurrency: "{{ config.get('num_workers', 25) }}"`.
- `source-stripe` — `num_workers` integer with `minimum: 2`, `maximum: 100`, surfaced via `default_concurrency: "{{ config.get('num_workers', 4 if 'sk_test_' in config['client_secret'] else 10) }}"`.
- `source-slack` — `num_workers` integer with `minimum: 1`, `maximum: 10`, surfaced via `default_concurrency: "{{ config.get('num_workers', 2) }}"`.

`source-linear`'s `maximum: 10` choice errs conservative: the lowest-tier auth (API key) only has 2,500 req/hr headroom, so the spec maximum is intentionally well below the connector `max_concurrency: 16` ceiling.

## Review guide

1. `airbyte-integrations/connectors/source-linear/manifest.yaml` — concurrency template + new spec property.
2. `airbyte-integrations/connectors/source-linear/metadata.yaml` — `dockerImageTag` bump only.
3. `docs/integrations/sources/linear.md` — changelog row.

## User Impact

- New users get a *Number of concurrent workers* field in the connector configuration UI under the existing Start Date field (order=2). Default `4` matches the connector-level `concurrency_level` rolled out in `0.2.2-rc.1` (#78034) — no behavior change from rc.1 to rc.2 for users who leave the new field unset.
- Existing connections without the field continue to run at the connector default `4` (the Jinja fallback is `4`). No re-auth or reconfiguration is required.
- OAuth users with the 5,000 req/hr ceiling (or workspace OAuth with dynamic uplift) can raise the value up to `10` for faster syncs on multi-stream connections.
- Users who experience rate-limit pressure can dial it back to `1`–`3`.
- No spec migration / `config_migrations` block needed: adding a new optional property with a default is non-breaking by the platform's breaking-change criteria.

This is a *feature change*, not a fix, and only ships in the RC channel until Phase 3 (TIER_1) and Phase 4 (GA) of the progressive rollout pass.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Reverting restores the constant `default_concurrency: 4` and removes the spec field. Existing connections continue to function (the field is optional with a default).

---

**Rollout context:**
- Parent PR: #78034 (`0.2.2-rc.1`, currently in Phase 2 — full TIER_2 at `default_concurrency=4`, 184 actors pinned, 24h health-check scheduled 2026-05-16 10:30 PT).
- Rollout ID: `b49a1790-1a90-4f7e-bf78-0562fdfabadb`.
- This PR queues `0.2.2-rc.2` for *Phase 3* (TIER_1, 7 actors). Merge only after Phase 2 PASS + explicit approval.

---
[Devin session](https://app.devin.ai/sessions/43bd595b009b452187d11c6a7ab84193)

Requested by: @sophiecuiy

> [!IMPORTANT]
> Active progressive rollout warning for source-linear.

- [ ] (Click to Approve:) Bypass the active progressive rollout warning for source-linear in the PR comment [here](https://github.com/airbytehq/airbyte/pull/78124#issuecomment-4462238393).