### PR TITLE
docs(source-service-now): add 0.2.0 changelog entry

### DIFF
--- a/docs/integrations/enterprise-connectors/source-service-now.md
+++ b/docs/integrations/enterprise-connectors/source-service-now.md
@@ -57,6 +57,7 @@ Airbyte’s incubating ServiceNow enterprise source connector currently offers F
 
 The connector is still incubating; this section exists to satisfy Airbyte's QA checks.
 
+- 0.2.0
 - 0.1.0
 
 </details>


### PR DESCRIPTION
## What
- Adds the missing `0.2.0` changelog entry for the ServiceNow enterprise connector docs.
- This supports the companion enterprise connector PR: https://github.com/airbytehq/airbyte-enterprise/pull/430

## How
- Adds `0.2.0` under the existing ServiceNow enterprise connector changelog section.

## Review guide
1. `docs/integrations/enterprise-connectors/source-service-now.md`

## User Impact
- No runtime user impact.
- Connector prerelease QA can validate that the documented changelog includes the version used by the enterprise connector update.

## Can this PR be safely reverted and rolled back?
- [x] YES 💚
- [ ] NO ❌

---
[Devin session](https://app.devin.ai/sessions/8bf325e1563d4f9592c37119fa465f87)

Requested by: @lleadbet