### PR TITLE
chore(source-amazon-ads): finalize 8.0.3 GA at num_workers=14

### DIFF
--- a/airbyte-integrations/connectors/source-amazon-ads/metadata.yaml
+++ b/airbyte-integrations/connectors/source-amazon-ads/metadata.yaml
@@ -13,7 +13,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: c6b0a29e-1da9-4512-9002-7bfd0cba2246
-  dockerImageTag: 8.0.3-rc.2
+  dockerImageTag: 8.0.3
   dockerRepository: airbyte/source-amazon-ads
   documentationUrl: https://docs.airbyte.com/integrations/sources/amazon-ads
   githubIssueLabel: source-amazon-ads
@@ -34,8 +34,6 @@ data:
       enabled: true
   releaseStage: generally_available
   releases:
-    rolloutConfiguration:
-      enableProgressiveRollout: true
     breakingChanges:
       8.0.0:
         message:

--- a/docs/integrations/sources/amazon-ads.md
+++ b/docs/integrations/sources/amazon-ads.md
@@ -164,7 +164,7 @@ If you need better sync performance and are not experiencing rate limiting error
 
 | Version    | Date       | Pull Request                                             | Subject                                                                                                                                                                |
 |:-----------|:-----------|:---------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| 8.0.3 | 2026-05-19 | [PR_NUMBER_PLACEHOLDER](https://github.com/airbytehq/airbyte/pull/PR_NUMBER_PLACEHOLDER) | Bump default `num_workers` 10 → 14 for improved throughput on parallelizable workloads |
+| 8.0.3 | 2026-05-19 | [78158](https://github.com/airbytehq/airbyte/pull/78158) | Bump default `num_workers` 10 → 14 for improved throughput on parallelizable workloads |
 | 8.0.2 | 2026-05-05 | [77660](https://github.com/airbytehq/airbyte/pull/77660) | Skip profiles without Amazon Attribution access on attribution report performance streams instead of failing the sync |
 | 8.0.1 | 2026-04-28 | [77149](https://github.com/airbytehq/airbyte/pull/77149) | Update dependencies |
 | 8.0.0 | 2026-04-22 | [75490](https://github.com/airbytehq/airbyte/pull/75490) | Use `date` field from API response as cursor and primary key for daily report streams instead of synthetic `reportDate`. Fixes ~96% data loss from incorrect deduplication. |

--- a/docs/integrations/sources/amazon-ads.md
+++ b/docs/integrations/sources/amazon-ads.md
@@ -164,8 +164,7 @@ If you need better sync performance and are not experiencing rate limiting error
 
 | Version    | Date       | Pull Request                                             | Subject                                                                                                                                                                |
 |:-----------|:-----------|:---------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| 8.0.3-rc.2 | 2026-05-12 | [78055](https://github.com/airbytehq/airbyte/pull/78055) | Concurrency tuning iteration 2: bump default `num_workers` from 12 to 14 for progressive rollout |
-| 8.0.3-rc.1 | 2026-05-11 | [78010](https://github.com/airbytehq/airbyte/pull/78010) | Concurrency tuning iteration 1: bump default `num_workers` from 10 to 12 for progressive rollout |
+| 8.0.3 | 2026-05-19 | [PR_NUMBER_PLACEHOLDER](https://github.com/airbytehq/airbyte/pull/PR_NUMBER_PLACEHOLDER) | Bump default `num_workers` 10 → 14 for improved throughput on parallelizable workloads |
 | 8.0.2 | 2026-05-05 | [77660](https://github.com/airbytehq/airbyte/pull/77660) | Skip profiles without Amazon Attribution access on attribution report performance streams instead of failing the sync |
 | 8.0.1 | 2026-04-28 | [77149](https://github.com/airbytehq/airbyte/pull/77149) | Update dependencies |
 | 8.0.0 | 2026-04-22 | [75490](https://github.com/airbytehq/airbyte/pull/75490) | Use `date` field from API response as cursor and primary key for daily report streams instead of synthetic `reportDate`. Fixes ~96% data loss from incorrect deduplication. |


### PR DESCRIPTION
## What

Finalize `source-amazon-ads` 8.0.3 as a GA release at `num_workers=14`, completing the concurrency tuning rollout. Requested by Sophie (`sophie.cui@airbyte.io`).

- Bumps `dockerImageTag` 8.0.3-rc.2 → 8.0.3
- Drops `releases.rolloutConfiguration.enableProgressiveRollout: true`
- Collapses the per-iteration RC changelog entries (rc.1 `num_workers=12`, rc.2 `num_workers=14`) into a single 8.0.3 GA entry

Context:
- Tracking issue: airbytehq/airbyte-internal-issues#15305
- Parent epic: airbytehq/airbyte-internal-issues#15262
- RC.1 PR: #78010 (merged, `num_workers=12`, iter-1 PASS)
- RC.2 PR: #78055 (merged, `num_workers=14`, iter-2 PASS after phase-breakdown analysis)
- RC.3 PR: #78121 (closed; user pivoted to full TIER_2 rollout at `num_workers=14`)

## How

Two-file edit:
- `airbyte-integrations/connectors/source-amazon-ads/metadata.yaml`: bump `dockerImageTag` and remove `rolloutConfiguration` block.
- `docs/integrations/sources/amazon-ads.md`: collapse rc.1 + rc.2 changelog rows into a single 8.0.3 GA row.

`num_workers` spec default and `concurrency_level.default_concurrency` fallback are already at 14 from PR #78055, so no manifest changes needed.

## Review guide

1. `airbyte-integrations/connectors/source-amazon-ads/metadata.yaml`
2. `docs/integrations/sources/amazon-ads.md`

## User Impact

Sets the default `num_workers` for Amazon Ads syncs to 14 (up from 10). Phase 2 health check (rollout `0d9e56c3-d71b-484a-b5c4-e8d3f0c88296`, 129 pinned TIER_2 actors, 932 successful rc.2 attempts) showed:

- 0 of 932 `429 / Too Many Requests` errors
- Per-actor pairwise `source_read_duration_seconds`: median -1.0% (essentially flat), 21/32 paired actors improved >5%, 6/32 regressed >5% — and 4 of the 6 regressions were noise/volume/tiny-baseline; only 2 had real but small-n regressions.
- Heavy actors (long Amazon Ads report-poll loops) see substantial wins: `d1e13a66-…` -38%, `bc969f25-…` -49%, `a0abf17f-…` -42%.

Users on default `num_workers` will get faster syncs for parallelizable workloads, with no observed rate-limit impact.

## Can this PR be safely reverted and rolled back?
- [x] YES 💚

After merge, will run `finalize_connector_rollout(state='succeeded')` on the in-progress rollout `0d9e56c3-d71b-484a-b5c4-e8d3f0c88296` so all rc.2 pins automatically migrate to 8.0.3 GA.

---
[Devin session](https://app.devin.ai/sessions/6637a07c867f4b3785588328533041a8)


Requested by: @sophiecuiy

> [!IMPORTANT]
> Active progressive rollout warning for source-amazon-ads.

- [ ] (Click to Approve:) Bypass the active progressive rollout warning for source-amazon-ads in the PR comment [here](https://github.com/airbytehq/airbyte/pull/78158#issuecomment-4483062843).