### PR TITLE
docs: remove external secrets horizontal rules

### DIFF
--- a/docs/platform/operating-airbyte/external-secrets.md
+++ b/docs/platform/operating-airbyte/external-secrets.md
@@ -14,16 +14,12 @@ This guide provides step-by-step instructions for configuring external secrets m
 External secrets management is available for Airbyte Pro and Enterprise Flex customers.
 :::
 
----
-
 ## Prerequisites
 
 - Airbyte organization on a Pro or Enterprise Flex plan
 - Active account with your chosen cloud provider (AWS, Azure, or GCP)
 - Appropriate permissions to create and manage IAM roles/policies or service principals
 - Access to your cloud provider's secrets management service
-
----
 
 ## Step 1: Configure Cloud Provider Permissions
 
@@ -46,8 +42,6 @@ Contact your Airbyte representative for GCP setup guidance and policy documentat
 
 </TabItem>
 </Tabs>
-
----
 
 ## Step 2: Choose Authentication Method
 
@@ -79,8 +73,6 @@ GCP authentication methods will be provided by your Airbyte representative durin
 
 </TabItem>
 </Tabs>
-
----
 
 ## Step 3: Set Up Cloud Provider Authentication
 
@@ -149,8 +141,6 @@ Contact your Airbyte representative for detailed GCP setup instructions.
 </TabItem>
 </Tabs>
 
----
-
 ## Step 4: Provide Configuration to Airbyte
 
 Provide Airbyte with the configuration details using the appropriate JSON format for your cloud provider:
@@ -204,8 +194,6 @@ Configuration format will be provided by your Airbyte representative.
 </Tabs>
 
 In the Airbyte API, these secret storage configuration endpoints use the internal configuration API path, such as `POST /v1/secret_storage/create`, `POST /v1/secret_storage/list`, `POST /v1/secret_storage/get`, `POST /v1/secret_storage/delete`, and `POST /v1/secret_storage/migrate`.
-
----
 
 ## Using External Secret References in Connector Configurations {#external-secret-references}
 
@@ -305,8 +293,6 @@ The internal `POST /v1/sources/get` and `POST /v1/destinations/get` endpoints al
 - The secret coordinate you pass after the `secret_coordinate::` prefix must match the key, path, or name of a secret that exists (or will exist) in the secret manager configured for your workspace or organization.
 - If no custom secret storage is configured for your workspace/organization, the `secret_coordinate::` prefix will not resolve correctly at runtime.
 
----
-
 ## Verification Steps
 
 After providing your configuration to Airbyte:
@@ -318,8 +304,6 @@ After providing your configuration to Airbyte:
    - **GCP**: Check Google Cloud Secret Manager
 3. Confirm the secret has the appropriate tags or identifiers (e.g., `AirbyteManaged=true` for AWS)
 4. All future connection credentials will be stored as secrets in your external secrets manager
-
----
 
 ## Best Practices
 
@@ -342,8 +326,6 @@ After providing your configuration to Airbyte:
 - **Rotate client secrets regularly** before they expire
 - **Use Azure Key Vault's built-in logging** to monitor access patterns
 - **Consider using managed identities** where possible for additional security
-
----
 
 ## Troubleshooting
 
@@ -391,8 +373,6 @@ After providing your configuration to Airbyte:
 </TabItem>
 </Tabs>
 
----
-
 ## Security Considerations
 
 - **Never commit credentials to version control** - always use secure methods to share configuration details with Airbyte
@@ -401,8 +381,6 @@ After providing your configuration to Airbyte:
 - **Use encryption** - ensure data is encrypted both in transit and at rest (most cloud providers enable this by default)
 - **Implement network restrictions** where possible - limit access to your secrets manager to known IP ranges or VPCs
 - **Set appropriate secret expiration policies** - configure automatic rotation where supported
-
----
 
 ## Additional Resources
 
@@ -422,8 +400,6 @@ After providing your configuration to Airbyte:
 
 - [Google Cloud Secret Manager Documentation](https://cloud.google.com/secret-manager/docs)
 - Contact your Airbyte representative for GCP-specific guidance
-
----
 
 ## Support
 

--- a/docusaurus/platform_versioned_docs/version-2.1/operating-airbyte/external-secrets.md
+++ b/docusaurus/platform_versioned_docs/version-2.1/operating-airbyte/external-secrets.md
@@ -14,16 +14,12 @@ This guide provides step-by-step instructions for configuring external secrets m
 External secrets management is available for Airbyte Pro and Enterprise Flex customers.
 :::
 
----
-
 ## Prerequisites
 
 - Airbyte organization on a Pro or Enterprise Flex plan
 - Active account with your chosen cloud provider (AWS, Azure, or GCP)
 - Appropriate permissions to create and manage IAM roles/policies or service principals
 - Access to your cloud provider's secrets management service
-
----
 
 ## Step 1: Configure Cloud Provider Permissions
 
@@ -46,8 +42,6 @@ Contact your Airbyte representative for GCP setup guidance and policy documentat
 
 </TabItem>
 </Tabs>
-
----
 
 ## Step 2: Choose Authentication Method
 
@@ -79,8 +73,6 @@ GCP authentication methods will be provided by your Airbyte representative durin
 
 </TabItem>
 </Tabs>
-
----
 
 ## Step 3: Set Up Cloud Provider Authentication
 
@@ -149,8 +141,6 @@ Contact your Airbyte representative for detailed GCP setup instructions.
 </TabItem>
 </Tabs>
 
----
-
 ## Step 4: Provide Configuration to Airbyte
 
 Provide Airbyte with the configuration details using the appropriate JSON format for your cloud provider:
@@ -203,8 +193,6 @@ Configuration format will be provided by your Airbyte representative.
 </TabItem>
 </Tabs>
 
----
-
 ## Verification Steps
 
 After providing your configuration to Airbyte:
@@ -216,8 +204,6 @@ After providing your configuration to Airbyte:
    - **GCP**: Check Google Cloud Secret Manager
 3. Confirm the secret has the appropriate tags or identifiers (e.g., `AirbyteManaged=true` for AWS)
 4. All future connection credentials will be stored as secrets in your external secrets manager
-
----
 
 ## Best Practices
 
@@ -240,8 +226,6 @@ After providing your configuration to Airbyte:
 - **Rotate client secrets regularly** before they expire
 - **Use Azure Key Vault's built-in logging** to monitor access patterns
 - **Consider using managed identities** where possible for additional security
-
----
 
 ## Troubleshooting
 
@@ -289,8 +273,6 @@ After providing your configuration to Airbyte:
 </TabItem>
 </Tabs>
 
----
-
 ## Security Considerations
 
 - **Never commit credentials to version control** - always use secure methods to share configuration details with Airbyte
@@ -299,8 +281,6 @@ After providing your configuration to Airbyte:
 - **Use encryption** - ensure data is encrypted both in transit and at rest (most cloud providers enable this by default)
 - **Implement network restrictions** where possible - limit access to your secrets manager to known IP ranges or VPCs
 - **Set appropriate secret expiration policies** - configure automatic rotation where supported
-
----
 
 ## Additional Resources
 
@@ -320,8 +300,6 @@ After providing your configuration to Airbyte:
 
 - [Google Cloud Secret Manager Documentation](https://cloud.google.com/secret-manager/docs)
 - Contact your Airbyte representative for GCP-specific guidance
-
----
 
 ## Support
 


### PR DESCRIPTION
## What
Removes the horizontal rule separators from the External Secret Management docs page as requested by Ian Alton.

## How
Deletes standalone Markdown horizontal rules from both the source platform doc and the current versioned Docusaurus copy, while preserving frontmatter delimiters.

## Review guide
1. `docs/platform/operating-airbyte/external-secrets.md`
2. `docusaurus/platform_versioned_docs/version-2.1/operating-airbyte/external-secrets.md`

## User Impact
Readers no longer see horizontal divider lines between sections on the External Secret Management docs page.

## Can this PR be safely reverted and rolled back?
- [x] YES 💚
- [ ] NO ❌

---
[Devin session](https://app.devin.ai/sessions/d59ed49ac3fc4440844848f3c3abdd25)

Requested by: @ian-at-airbyte