### PR TITLE
fix(destination-databricks): IGNORE THIS PR

### DIFF
--- a/airbyte-integrations/connectors/destination-databricks/src/main/kotlin/io/airbyte/integrations/destination/databricks/jdbc/DatabricksSqlGenerator.kt
+++ b/airbyte-integrations/connectors/destination-databricks/src/main/kotlin/io/airbyte/integrations/destination/databricks/jdbc/DatabricksSqlGenerator.kt
@@ -313,6 +313,7 @@ class DatabricksSqlGenerator(
                     metaColumnTypeMap
                         .asSequence()
                         .filter { it.key.name != AB_META }
+                        .filter { it.key.name != AB_META }
                         .map { it.key.name },
                 )
                 .flatten()


### PR DESCRIPTION
Fixes https://linear.app/airbyteio/issue/MOVE-741/linear-github-integration

## Summary
- Adds an additional `.filter { it.key.name != AB_META }` to the SQL generation logic in `DatabricksSqlGenerator.kt` to ensure `AB_META` columns are properly excluded during query construction.