### PR TITLE
chore: bump to latest cdk.

### DIFF
--- a/airbyte-integrations/connectors/destination-clickhouse/gradle.properties
+++ b/airbyte-integrations/connectors/destination-clickhouse/gradle.properties
@@ -1,2 +1,2 @@
-cdkVersion=0.2.8
+cdkVersion=1.0.13
 JunitMethodExecutionTimeout=10m

--- a/airbyte-integrations/connectors/destination-clickhouse/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-clickhouse/metadata.yaml
@@ -43,12 +43,6 @@ data:
   connectorTestSuitesOptions:
     - suite: unitTests
     - suite: integrationTests
-      testSecrets:
-        - name: destination_clickhouse_component_test_instance
-          fileName: test-instance.json
-          secretStore:
-            type: GSM
-            alias: airbyte-connector-testing-secret-store
   supportsRefreshes: true
   externalDocumentationUrls:
     - title: ClickHouse documentation

--- a/airbyte-integrations/connectors/destination-clickhouse/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-clickhouse/metadata.yaml
@@ -2,7 +2,7 @@ data:
   connectorSubtype: database
   connectorType: destination
   definitionId: ce0d828e-1dc4-496c-b122-2da42e637e48
-  dockerImageTag: 2.1.23
+  dockerImageTag: 2.1.24
   dockerRepository: airbyte/destination-clickhouse
   githubIssueLabel: destination-clickhouse
   icon: clickhouse.svg

--- a/airbyte-integrations/connectors/destination-clickhouse/src/test-integration/kotlin/io/airbyte/integrations/destination/clickhouse/ClickhouseContainerHelper.kt
+++ b/airbyte-integrations/connectors/destination-clickhouse/src/test-integration/kotlin/io/airbyte/integrations/destination/clickhouse/ClickhouseContainerHelper.kt
@@ -7,7 +7,7 @@ package io.airbyte.integrations.destination.clickhouse
 import org.testcontainers.clickhouse.ClickHouseContainer
 
 object ClickhouseContainerHelper {
-    private val container = ClickHouseContainer("clickhouse/clickhouse-server:latest")
+    private val container = ClickHouseContainer("clickhouse/clickhouse-server:26.4")
 
     fun start() {
         synchronized(lock = container) {

--- a/airbyte-integrations/connectors/destination-clickhouse/src/test-integration/kotlin/io/airbyte/integrations/destination/clickhouse/component/ClickhouseTestTableOperationsClient.kt
+++ b/airbyte-integrations/connectors/destination-clickhouse/src/test-integration/kotlin/io/airbyte/integrations/destination/clickhouse/component/ClickhouseTestTableOperationsClient.kt
@@ -9,11 +9,15 @@ import com.clickhouse.client.api.data_formats.ClickHouseBinaryFormatReader
 import com.clickhouse.data.ClickHouseFormat
 import io.airbyte.cdk.load.component.TestTableOperationsClient
 import io.airbyte.cdk.load.data.AirbyteValue
+import io.airbyte.cdk.load.data.StringValue
+import io.airbyte.cdk.load.data.TimestampWithTimezoneValue
+import io.airbyte.cdk.load.data.TimestampWithoutTimezoneValue
 import io.airbyte.cdk.load.schema.model.TableName
 import io.airbyte.cdk.load.util.serializeToString
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.micronaut.context.annotation.Requires
 import jakarta.inject.Singleton
+import java.time.format.DateTimeFormatter
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.future.await
@@ -34,11 +38,33 @@ class ClickhouseTestTableOperationsClient(
         client.execute("DROP DATABASE IF EXISTS `$namespace`").await()
     }
 
+    companion object {
+        // ClickHouse requires full yyyy-MM-dd HH:mm:ss.SSS format for DateTime64(3).
+        // Java's OffsetDateTime/LocalDateTime.toString() may omit seconds or millis.
+        private val CLICKHOUSE_DATETIME_FORMAT =
+            DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSS")
+    }
+
     override suspend fun insertRecords(table: TableName, records: List<Map<String, AirbyteValue>>) {
+        // Format timestamps as yyyy-MM-dd HH:mm:ss.SSS for DateTime64(3) columns;
+        // Java's OffsetDateTime/LocalDateTime.toString() may omit seconds or millis,
+        // which ClickHouse cannot parse.
+        val fixed =
+            records.map { record ->
+                record.mapValues { (_, value) ->
+                    when (value) {
+                        is TimestampWithTimezoneValue ->
+                            StringValue(value.value.format(CLICKHOUSE_DATETIME_FORMAT))
+                        is TimestampWithoutTimezoneValue ->
+                            StringValue(value.value.format(CLICKHOUSE_DATETIME_FORMAT))
+                        else -> value
+                    }
+                }
+            }
         client
             .insert(
                 "`${table.namespace}`.`${table.name}`",
-                records.serializeToString().byteInputStream(),
+                fixed.serializeToString().byteInputStream(),
                 ClickHouseFormat.JSONEachRow,
             )
             .await()

--- a/airbyte-integrations/connectors/destination-clickhouse/src/test-integration/kotlin/io/airbyte/integrations/destination/clickhouse/component/config/ComponentTestConfigFactory.kt
+++ b/airbyte-integrations/connectors/destination-clickhouse/src/test-integration/kotlin/io/airbyte/integrations/destination/clickhouse/component/config/ComponentTestConfigFactory.kt
@@ -4,7 +4,9 @@
 
 package io.airbyte.integrations.destination.clickhouse.component.config
 
-import io.airbyte.cdk.load.component.config.TestConfigLoader.loadTestConfig
+import io.airbyte.cdk.load.util.Jsons
+import io.airbyte.integrations.destination.clickhouse.ClickhouseConfigUpdater
+import io.airbyte.integrations.destination.clickhouse.ClickhouseContainerHelper
 import io.airbyte.integrations.destination.clickhouse.spec.ClickhouseConfiguration
 import io.airbyte.integrations.destination.clickhouse.spec.ClickhouseConfigurationFactory
 import io.airbyte.integrations.destination.clickhouse.spec.ClickhouseSpecificationOss
@@ -19,10 +21,23 @@ class ComponentTestConfigFactory {
     @Singleton
     @Primary
     fun config(): ClickhouseConfiguration {
-        return loadTestConfig(
-            ClickhouseSpecificationOss::class.java,
-            ClickhouseConfigurationFactory::class.java,
-            "test-instance.json",
-        )
+        ClickhouseContainerHelper.start()
+
+        val configJson =
+            """
+            {
+                "host": "localhost",
+                "port": "8123",
+                "protocol": "http",
+                "username": "replace_me_username",
+                "password": "replace_me_password",
+                "database": "default",
+                "enable_json": true
+            }
+        """
+
+        val updatedConfig = ClickhouseConfigUpdater().update(configJson)
+        val spec = Jsons.readValue(updatedConfig, ClickhouseSpecificationOss::class.java)
+        return ClickhouseConfigurationFactory().makeWithoutExceptionHandling(spec)
     }
 }

--- a/docs/integrations/destinations/clickhouse.md
+++ b/docs/integrations/destinations/clickhouse.md
@@ -179,6 +179,7 @@ This destination supports [namespaces](https://docs.airbyte.com/platform/using-a
 
 | Version    | Date       | Pull Request                                               | Subject                                                                        |
 |:-----------|:-----------|:-----------------------------------------------------------|:-------------------------------------------------------------------------------|
+| 2.1.24     | 2026-05-19 |   | Upgrade CDK to 1.0.13 |
 | 2.1.23     | 2026-02-04 | [72857](https://github.com/airbytehq/airbyte/pull/72857)   | No user-facing changes (Upgrade CDK to 0.2.8)                    |
 | 2.1.22     | 2026-01-26 | [71784](https://github.com/airbytehq/airbyte/pull/71784)   | No user-facing changes (internal refactor SSH tunnel logic)                    |
 | 2.1.21     | 2026-01-20 | [72294](https://github.com/airbytehq/airbyte/pull/72294)   | Upgrade CDK to 0.2.0                                                           |

--- a/docs/integrations/destinations/clickhouse.md
+++ b/docs/integrations/destinations/clickhouse.md
@@ -179,7 +179,7 @@ This destination supports [namespaces](https://docs.airbyte.com/platform/using-a
 
 | Version    | Date       | Pull Request                                               | Subject                                                                        |
 |:-----------|:-----------|:-----------------------------------------------------------|:-------------------------------------------------------------------------------|
-| 2.1.24     | 2026-05-19 | [78229](https://github.com/airbytehq/airbyte/pull/78229)   | Upgrade CDK to 1.0.13 |
+| 2.1.24     | 2026-05-20 | [77673](https://github.com/airbytehq/airbyte/pull/77673)   | Upgrade CDK to 1.0.13. Migrate component tests to Testcontainers. |
 | 2.1.23     | 2026-02-04 | [72857](https://github.com/airbytehq/airbyte/pull/72857)   | No user-facing changes (Upgrade CDK to 0.2.8)                    |
 | 2.1.22     | 2026-01-26 | [71784](https://github.com/airbytehq/airbyte/pull/71784)   | No user-facing changes (internal refactor SSH tunnel logic)                    |
 | 2.1.21     | 2026-01-20 | [72294](https://github.com/airbytehq/airbyte/pull/72294)   | Upgrade CDK to 0.2.0                                                           |

--- a/docs/integrations/destinations/clickhouse.md
+++ b/docs/integrations/destinations/clickhouse.md
@@ -179,7 +179,7 @@ This destination supports [namespaces](https://docs.airbyte.com/platform/using-a
 
 | Version    | Date       | Pull Request                                               | Subject                                                                        |
 |:-----------|:-----------|:-----------------------------------------------------------|:-------------------------------------------------------------------------------|
-| 2.1.24     | 2026-05-19 |   | Upgrade CDK to 1.0.13 |
+| 2.1.24     | 2026-05-19 | [78229](https://github.com/airbytehq/airbyte/pull/78229)   | Upgrade CDK to 1.0.13 |
 | 2.1.23     | 2026-02-04 | [72857](https://github.com/airbytehq/airbyte/pull/72857)   | No user-facing changes (Upgrade CDK to 0.2.8)                    |
 | 2.1.22     | 2026-01-26 | [71784](https://github.com/airbytehq/airbyte/pull/71784)   | No user-facing changes (internal refactor SSH tunnel logic)                    |
 | 2.1.21     | 2026-01-20 | [72294](https://github.com/airbytehq/airbyte/pull/72294)   | Upgrade CDK to 0.2.0                                                           |


### PR DESCRIPTION
## What
Bump destination-clickhouse CDK to 1.0.13 to support INCOMPLETE stream status handling in SPEED mode.

### AND
Migrate ClickHouse component tests from remote Cloud instance to Testcontainers to eliminate cloud clickhouse flakiness.

## How
- Updated `cdkVersion` in `gradle.properties` from 0.2.8 to 1.0.13
- Added test containers wiring
- Fixed the test client to properly serialize timestamps that cloud accepts for some reason

## User Impact
No user-facing change.
## Can this PR be safely reverted and rolled back?
- [x] YES
- [ ] NO