### PR TITLE
chore: bump to latest cdk.

### DIFF
--- a/airbyte-integrations/connectors/destination-s3-data-lake/gradle.properties
+++ b/airbyte-integrations/connectors/destination-s3-data-lake/gradle.properties
@@ -1,3 +1,3 @@
 testExecutionConcurrency=-1
-cdkVersion=1.0.9
+cdkVersion=1.0.13
 JunitMethodExecutionTimeout=10m

--- a/airbyte-integrations/connectors/destination-s3-data-lake/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-s3-data-lake/metadata.yaml
@@ -37,7 +37,7 @@ data:
             alias: airbyte-connector-testing-secret-store
   connectorType: destination
   definitionId: 716ca874-520b-4902-9f80-9fad66754b89
-  dockerImageTag: 0.3.48
+  dockerImageTag: 0.3.49
   dockerRepository: airbyte/destination-s3-data-lake
   documentationUrl: https://docs.airbyte.com/integrations/destinations/s3-data-lake
   githubIssueLabel: destination-s3-data-lake

--- a/airbyte-integrations/connectors/destination-s3-data-lake/src/test-integration/kotlin/io/airbyte/integrations/destination/s3_data_lake/S3DataLakeTestUtil.kt
+++ b/airbyte-integrations/connectors/destination-s3-data-lake/src/test-integration/kotlin/io/airbyte/integrations/destination/s3_data_lake/S3DataLakeTestUtil.kt
@@ -59,7 +59,7 @@ object S3DataLakeTestUtil {
         val icebergUtil =
             IcebergUtil(
                 SimpleTableIdGenerator(),
-                AirbyteValueCoercer(useFastTimestampParsing = true)
+                AirbyteValueCoercer()
             )
         val s3DataLakeUtil = S3DataLakeUtil(icebergUtil, awsAssumeRoleCredentials)
         val props = s3DataLakeUtil.toCatalogProperties(config)

--- a/airbyte-integrations/connectors/destination-s3-data-lake/src/test-integration/kotlin/io/airbyte/integrations/destination/s3_data_lake/S3DataLakeTestUtil.kt
+++ b/airbyte-integrations/connectors/destination-s3-data-lake/src/test-integration/kotlin/io/airbyte/integrations/destination/s3_data_lake/S3DataLakeTestUtil.kt
@@ -56,11 +56,7 @@ object S3DataLakeTestUtil {
         config: S3DataLakeConfiguration,
         awsAssumeRoleCredentials: AwsAssumeRoleCredentials?
     ): Catalog {
-        val icebergUtil =
-            IcebergUtil(
-                SimpleTableIdGenerator(),
-                AirbyteValueCoercer()
-            )
+        val icebergUtil = IcebergUtil(SimpleTableIdGenerator(), AirbyteValueCoercer())
         val s3DataLakeUtil = S3DataLakeUtil(icebergUtil, awsAssumeRoleCredentials)
         val props = s3DataLakeUtil.toCatalogProperties(config)
         return icebergUtil.createCatalog(DEFAULT_CATALOG_NAME, props)

--- a/airbyte-integrations/connectors/destination-s3-data-lake/src/test/kotlin/io/airbyte/integrations/destination/s3_data_lake/catalog/S3DataLakeUtilTest.kt
+++ b/airbyte-integrations/connectors/destination-s3-data-lake/src/test/kotlin/io/airbyte/integrations/destination/s3_data_lake/catalog/S3DataLakeUtilTest.kt
@@ -81,7 +81,7 @@ internal class S3DataLakeUtilTest {
     @BeforeEach
     fun setup() {
         icebergUtil =
-            IcebergUtil(tableIdGenerator, AirbyteValueCoercer(useFastTimestampParsing = true))
+            IcebergUtil(tableIdGenerator, AirbyteValueCoercer())
         s3DataLakeUtil = S3DataLakeUtil(icebergUtil, assumeRoleCredentials = null)
     }
 

--- a/airbyte-integrations/connectors/destination-s3-data-lake/src/test/kotlin/io/airbyte/integrations/destination/s3_data_lake/catalog/S3DataLakeUtilTest.kt
+++ b/airbyte-integrations/connectors/destination-s3-data-lake/src/test/kotlin/io/airbyte/integrations/destination/s3_data_lake/catalog/S3DataLakeUtilTest.kt
@@ -80,8 +80,7 @@ internal class S3DataLakeUtilTest {
 
     @BeforeEach
     fun setup() {
-        icebergUtil =
-            IcebergUtil(tableIdGenerator, AirbyteValueCoercer())
+        icebergUtil = IcebergUtil(tableIdGenerator, AirbyteValueCoercer())
         s3DataLakeUtil = S3DataLakeUtil(icebergUtil, assumeRoleCredentials = null)
     }
 

--- a/docs/integrations/destinations/s3-data-lake.md
+++ b/docs/integrations/destinations/s3-data-lake.md
@@ -395,6 +395,7 @@ This destination supports [namespaces](https://docs.airbyte.com/platform/using-a
 
 | Version     | Date       | Pull Request                                               | Subject                                                                                                                         |
 |:------------|:-----------|:-----------------------------------------------------------|:--------------------------------------------------------------------------------------------------------------------------------|
+| 0.3.49      | 2026-05-19 |  | Upgrade CDK to 1.0.13 |
 | 0.3.48      | 2026-05-01 | [77677](https://github.com/airbytehq/airbyte/pull/77677)  | Add configurable flush batch size for aggregate publishing.                                                                     |
 | 0.3.47      | 2026-04-16 | [76410](https://github.com/airbytehq/airbyte/pull/76410) | Upgrade CDK to 1.0.9.                                                  |
 | 0.3.46      | 2026-03-30 |                                                           | Upgrade CDK to 1.0.7: fix sort order handling during schema evolution. |

--- a/docs/integrations/destinations/s3-data-lake.md
+++ b/docs/integrations/destinations/s3-data-lake.md
@@ -395,7 +395,7 @@ This destination supports [namespaces](https://docs.airbyte.com/platform/using-a
 
 | Version     | Date       | Pull Request                                               | Subject                                                                                                                         |
 |:------------|:-----------|:-----------------------------------------------------------|:--------------------------------------------------------------------------------------------------------------------------------|
-| 0.3.49      | 2026-05-19 |  | Upgrade CDK to 1.0.13 |
+| 0.3.49      | 2026-05-19 | [78232](https://github.com/airbytehq/airbyte/pull/78232)  | Upgrade CDK to 1.0.13 |
 | 0.3.48      | 2026-05-01 | [77677](https://github.com/airbytehq/airbyte/pull/77677)  | Add configurable flush batch size for aggregate publishing.                                                                     |
 | 0.3.47      | 2026-04-16 | [76410](https://github.com/airbytehq/airbyte/pull/76410) | Upgrade CDK to 1.0.9.                                                  |
 | 0.3.46      | 2026-03-30 |                                                           | Upgrade CDK to 1.0.7: fix sort order handling during schema evolution. |


### PR DESCRIPTION
## What
Bump destination-s3-data-lake CDK to 1.0.13 to support INCOMPLETE stream status handling in SPEED mode.
## How
- Updated `cdkVersion` in `gradle.properties` from 1.0.9 to 1.0.13
- Bumped `dockerImageTag` from 0.3.48 to 0.3.49
- Removed `useFastTimestampParsing` param from test util (flag was removed in CDK 1.0.11 when fast timestamp coercion was mainlined)
## User Impact
No user-facing change.
## Can this PR be safely reverted and rolled back?
- [x] YES
- [ ] NO

> [!IMPORTANT]
> Active progressive rollout warning for destination-s3-data-lake.

- [ ] (Click to Approve:) Bypass the active progressive rollout warning for destination-s3-data-lake in the PR comment [here](https://github.com/airbytehq/airbyte/pull/78232#issuecomment-4491860916).

> [!IMPORTANT]
> ⚡ **Auto-merge enabled.**
> 
> _This PR is set to merge automatically when all requirements are met._