### PR TITLE
docs: document on-demand capacity authorization

### DIFF
--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -58,6 +58,12 @@ jobs:
             echo skip-build=false | tee -a $GITHUB_OUTPUT
           fi
 
+      - name: Set Up Node.js
+        if: steps.check-skip.outputs.skip-build != 'true'
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: "20"
+
       - name: Set Up pnpm
         if: steps.check-skip.outputs.skip-build != 'true'
         # pnpm is used to manage the dependencies of the documentation build.

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -58,12 +58,6 @@ jobs:
             echo skip-build=false | tee -a $GITHUB_OUTPUT
           fi
 
-      - name: Set Up Node.js
-        if: steps.check-skip.outputs.skip-build != 'true'
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
-        with:
-          node-version: "20"
-
       - name: Set Up pnpm
         if: steps.check-skip.outputs.skip-build != 'true'
         # pnpm is used to manage the dependencies of the documentation build.

--- a/docs/platform/cloud/managing-airbyte-cloud/manage-data-workers.md
+++ b/docs/platform/cloud/managing-airbyte-cloud/manage-data-workers.md
@@ -95,7 +95,9 @@ Once your organization administrator enables on-demand capacity at the organizat
 
 3. Toggle **Use on-demand capacity**. The toggle description reads: "Enable on demand capacity for this connection. Syncs for this connection will never be queued. Syncs that run when committed data worker is exhausted will be charged a premium rate." You must have the organization admin or workspace admin role to change this toggle.
 
-You can also enable on-demand capacity when first creating a connection. The toggle appears in the connection configuration during setup.
+When you turn on **Use on-demand capacity**, Airbyte asks you to authorize the additional paid service before enabling it. Click **Authorize & Enable** to confirm you're authorized to approve the expense on behalf of your organization. Click **Cancel** to leave on-demand capacity disabled. Turning off on-demand capacity doesn't require confirmation.
+
+You can also enable on-demand capacity when first creating a connection. The toggle appears in the connection configuration during setup and uses the same authorization confirmation.
 
 When you enable on-demand capacity on a connection, Airbyte automatically applies a "Burst" tag with an orange gradient background and a star icon. You can filter connections by the Burst tag to see all on-demand connections at a glance. If you disable on-demand capacity, Airbyte removes the Burst tag automatically. For more information about tags, see [Tagging connections](/platform/using-airbyte/tagging).
 

--- a/docs/platform/cloud/managing-airbyte-cloud/manage-data-workers.md
+++ b/docs/platform/cloud/managing-airbyte-cloud/manage-data-workers.md
@@ -95,7 +95,7 @@ Once your organization administrator enables on-demand capacity at the organizat
 
 3. Toggle **Use on-demand capacity**. The toggle description reads: "Enable on demand capacity for this connection. Syncs for this connection will never be queued. Syncs that run when committed data worker is exhausted will be charged a premium rate." You must have the organization admin or workspace admin role to change this toggle.
 
-When you turn on **Use on-demand capacity**, Airbyte asks you to authorize the additional paid service before enabling it. Click **Authorize & Enable** to confirm you're authorized to approve the expense on behalf of your organization. Click **Cancel** to leave on-demand capacity disabled. Turning off on-demand capacity doesn't require confirmation.
+When you turn on **Use on-demand capacity**, Airbyte asks you to authorize the additional paid service before enabling it. Click **Authorize & Enable** to confirm you're authorized to approve the expense on behalf of your organization. Click **Cancel** to leave on-demand capacity off. Turning off on-demand capacity doesn't require confirmation.
 
 You can also enable on-demand capacity when first creating a connection. The toggle appears in the connection configuration during setup and uses the same authorization confirmation.
 

--- a/docs/platform/cloud/managing-airbyte-cloud/manage-data-workers.md
+++ b/docs/platform/cloud/managing-airbyte-cloud/manage-data-workers.md
@@ -95,7 +95,7 @@ Once your organization administrator enables on-demand capacity at the organizat
 
 3. Toggle **Use on-demand capacity**. The toggle description reads: "Enable on demand capacity for this connection. Syncs for this connection will never be queued. Syncs that run when committed data worker is exhausted will be charged a premium rate." You must have the organization admin or workspace admin role to change this toggle.
 
-When you turn on **Use on-demand capacity**, Airbyte asks you to authorize the additional paid service before enabling it. Click **Authorize & Enable** to confirm you're authorized to approve the expense on behalf of your organization. Click **Cancel** to leave on-demand capacity off. Turning off on-demand capacity doesn't require confirmation.
+When you turn on **Use on-demand capacity**, Airbyte asks you to authorize the additional paid service before enabling it. Click **Authorize & Enable** to confirm that on-demand capacity is an additional paid service that can incur charges, you're authorized to approve the expense on behalf of your organization, and your organization agrees to pay the associated fees under Airbyte's billing terms. Click **Cancel** to leave on-demand capacity off. Turning off on-demand capacity doesn't require confirmation.
 
 You can also enable on-demand capacity when first creating a connection. The toggle appears in the connection configuration during setup and uses the same authorization confirmation.
 


### PR DESCRIPTION
## Documentation Confidence Assessment

**Overall Confidence: 4/5**

| Dimension | Score | Rationale |
|-----------|-------|-----------|
| Code Comprehension | 5/5 | Source change is a self-contained webapp UI change in `RunOnDemandFormField.tsx` with a direct mapping to user-visible modal behavior. |
| Context Availability | 5/5 | The source PR has a clear description, linked implementation issue, commit message, diff, CI result, and UI copy. |
| Existing Doc Quantity | 3/5 | The feature area had moderate existing coverage in the data worker, connection settings, schedule, and tagging docs. |
| Existing Doc Quality | 4/5 | Existing docs were accurate and structured; they only lacked the new authorization confirmation behavior. |
| Feature Area Maturity | 4/5 | On-demand capacity is an established documented Cloud feature, and this PR adds a small interaction change. |
| Change Scope & Risk | 4/5 | Documentation diff is a small targeted addition to one existing page. |
| Inference Ratio | 5/5 | The documented modal title, actions, cancellation behavior, and disable behavior are directly verified from source code and UI copy. |

### What I Verified vs. What I Inferred

- **Verified from code**: Enabling `onDemandEnabled` opens a modal titled `Authorize On-Demand Capacity Usage`; **Cancel** does not enable the toggle; **Authorize & Enable** enables the toggle; disabling the toggle calls `fieldOnChange(false)` without opening a modal.
- **Verified from PR/issue context**: airbytehq/airbyte-platform-internal#18857 and airbytehq/hydra-issues-internal#125 describe the modal as an authorization confirmation for an additional paid service.
- **Verified from existing docs**: On-demand capacity is documented for Cloud Pro and Enterprise Flex; organization admins and workspace admins can enable it after organization-level enablement; the toggle appears during setup and in connection settings.
- **Inferred**: No new Cloud plan restriction was introduced by airbytehq/airbyte-platform-internal#18857. I inferred this because the source PR only changed modal handling and localization text, and the existing entitlement gate remains `FeatureItem.OnDemandCapacity` / `feature-on-demand-capacity-enabled`.

### Reviewer Focus Areas

1. Verify the new paragraph in `docs/platform/cloud/managing-airbyte-cloud/manage-data-workers.md` accurately reflects the intended billing authorization wording.
2. Verify it is acceptable to document the confirmation for both connection creation and connection settings. The same `RunOnDemandFormField` is rendered from `ConnectionSettingsCard` in both contexts.
3. Confirm no additional legal or billing terminology is required beyond the UI copy from airbytehq/airbyte-platform-internal#18857.

### Areas of Concern

- No open build concerns. The docs-build Node 20 workflow fix was split out and merged separately in https://github.com/airbytehq/airbyte/pull/78272.

---

## What
Documents the on-demand capacity authorization confirmation added in airbytehq/airbyte-platform-internal#18857.

Asked for by @ian-at-airbyte via `/ai-write-docs` on airbytehq/airbyte-platform-internal#18857.

## How
Adds a short note to the Cloud data worker documentation explaining that turning on **Use on-demand capacity** opens an authorization confirmation for the additional paid service. It also documents the outcomes of **Authorize & Enable**, **Cancel**, and turning the setting off.

## Source

Documentation for airbytehq/airbyte-platform-internal#18857.

## Review guide
1. `docs/platform/cloud/managing-airbyte-cloud/manage-data-workers.md`

## User Impact
Users reading the on-demand capacity docs now see the confirmation step they encounter when enabling the setting during connection creation or from connection settings.

## Can this PR be safely reverted and rolled back?
- [x] YES 💚
- [ ] NO ❌

> **Note**: I am an AI assistant (Devin) and have proposed these documentation updates based on a review of platform source code changes. All platform documentation PRs require human review. Reviewers may merge, modify, or close this PR as they see fit.

Link to Devin session: https://app.devin.ai/sessions/46624bdcc2914d82b8afcca693727ff8

## CI Status

43 passed, 0 failed, 0 pending (use `git` with action=`pr_checks` for full details)