### PR TITLE
chore: bump to latest cdk.

### DIFF
--- a/airbyte-integrations/connectors/destination-gcs-data-lake/gradle.properties
+++ b/airbyte-integrations/connectors/destination-gcs-data-lake/gradle.properties
@@ -1,3 +1,3 @@
 testExecutionConcurrency=1
-cdkVersion=1.0.9
+cdkVersion=1.0.13
 JunitMethodExecutionTimeout=10m

--- a/airbyte-integrations/connectors/destination-gcs-data-lake/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-gcs-data-lake/metadata.yaml
@@ -21,7 +21,7 @@ data:
             alias: airbyte-connector-testing-secret-store
   connectorType: destination
   definitionId: 8c8a2d3e-1b4f-4a9c-9e7d-6f5a4b3c2d1e
-  dockerImageTag: 1.0.9
+  dockerImageTag: 1.0.10
   dockerRepository: airbyte/destination-gcs-data-lake
   documentationUrl: https://docs.airbyte.com/integrations/destinations/gcs-data-lake
   githubIssueLabel: destination-gcs-data-lake

--- a/airbyte-integrations/connectors/destination-gcs-data-lake/src/test-integration/kotlin/io/airbyte/integrations/destination/gcs_data_lake/GcsDataLakeTestUtil.kt
+++ b/airbyte-integrations/connectors/destination-gcs-data-lake/src/test-integration/kotlin/io/airbyte/integrations/destination/gcs_data_lake/GcsDataLakeTestUtil.kt
@@ -39,7 +39,7 @@ object GcsDataLakeTestUtil {
     ): Catalog {
         // Create utility instances for test
         val icebergUtil =
-            IcebergUtil(tableIdGenerator, AirbyteValueCoercer(useFastTimestampParsing = true))
+            IcebergUtil(tableIdGenerator, AirbyteValueCoercer())
         val gcsDataLakeCatalogUtil = GcsDataLakeCatalogUtil(icebergUtil)
 
         val properties = gcsDataLakeCatalogUtil.toCatalogProperties(config)

--- a/airbyte-integrations/connectors/destination-gcs-data-lake/src/test-integration/kotlin/io/airbyte/integrations/destination/gcs_data_lake/GcsDataLakeTestUtil.kt
+++ b/airbyte-integrations/connectors/destination-gcs-data-lake/src/test-integration/kotlin/io/airbyte/integrations/destination/gcs_data_lake/GcsDataLakeTestUtil.kt
@@ -38,8 +38,7 @@ object GcsDataLakeTestUtil {
         tableIdGenerator: TableIdGenerator = SimpleTableIdGenerator(config.namespace),
     ): Catalog {
         // Create utility instances for test
-        val icebergUtil =
-            IcebergUtil(tableIdGenerator, AirbyteValueCoercer())
+        val icebergUtil = IcebergUtil(tableIdGenerator, AirbyteValueCoercer())
         val gcsDataLakeCatalogUtil = GcsDataLakeCatalogUtil(icebergUtil)
 
         val properties = gcsDataLakeCatalogUtil.toCatalogProperties(config)

--- a/docs/integrations/destinations/gcs-data-lake.md
+++ b/docs/integrations/destinations/gcs-data-lake.md
@@ -221,6 +221,7 @@ This destination supports [namespaces](https://docs.airbyte.com/platform/using-a
 
 | Version | Date       | Pull Request                                                 | Subject                                                                               |
 |:--------|:-----------|:-------------------------------------------------------------|:--------------------------------------------------------------------------------------|
+| 1.0.10  | 2026-05-19 |     | Upgrade CDK to 1.0.13 |
 | 1.0.9   | 2026-04-16 | [76406](https://github.com/airbytehq/airbyte/pull/76406)     | Upgrade CDK to 1.0.9.                                                                 |
 | 1.0.8   | 2026-03-30 | [75630](https://github.com/airbytehq/airbyte/pull/75630)     | Upgrade CDK to 1.0.7: fix sort order handling during schema evolution.                |
 | 1.0.7   | 2026-02-04 | [72855](https://github.com/airbytehq/airbyte/pull/72855)     | Upgrade CDK to 0.2.8                                                                  |

--- a/docs/integrations/destinations/gcs-data-lake.md
+++ b/docs/integrations/destinations/gcs-data-lake.md
@@ -221,7 +221,7 @@ This destination supports [namespaces](https://docs.airbyte.com/platform/using-a
 
 | Version | Date       | Pull Request                                                 | Subject                                                                               |
 |:--------|:-----------|:-------------------------------------------------------------|:--------------------------------------------------------------------------------------|
-| 1.0.10  | 2026-05-19 |     | Upgrade CDK to 1.0.13 |
+| 1.0.10  | 2026-05-19 | [78235](https://github.com/airbytehq/airbyte/pull/78235)     | Upgrade CDK to 1.0.13 |
 | 1.0.9   | 2026-04-16 | [76406](https://github.com/airbytehq/airbyte/pull/76406)     | Upgrade CDK to 1.0.9.                                                                 |
 | 1.0.8   | 2026-03-30 | [75630](https://github.com/airbytehq/airbyte/pull/75630)     | Upgrade CDK to 1.0.7: fix sort order handling during schema evolution.                |
 | 1.0.7   | 2026-02-04 | [72855](https://github.com/airbytehq/airbyte/pull/72855)     | Upgrade CDK to 0.2.8                                                                  |


### PR DESCRIPTION
## What
Bump destination-gcs-data-lake CDK to 1.0.13 to support INCOMPLETE stream status handling in SPEED mode.
## How
- Updated `cdkVersion` in `gradle.properties` from 1.0.9 to 1.0.13
- Bumped `dockerImageTag` from 1.0.9 to 1.0.10
- Removed `useFastTimestampParsing` param from test util (flag was removed in CDK 1.0.11 when fast timestamp coercion was mainlined)
## User Impact
No user-facing change.
## Can this PR be safely reverted and rolled back?
- [x] YES
- [ ] NO

> [!IMPORTANT]
> ⚡ **Auto-merge enabled.**
> 
> _This PR is set to merge automatically when all requirements are met._