### PR TITLE
docs(platform): clarify on-demand capacity admin roles

### DIFF
--- a/docs/platform/cloud/managing-airbyte-cloud/configuring-connections.md
+++ b/docs/platform/cloud/managing-airbyte-cloud/configuring-connections.md
@@ -63,7 +63,7 @@ You can configure the following settings:
 | [Destination Namespace](../../using-airbyte/core-concepts/namespaces)               | Determines where the replicated data is written to in the destination          |
 | [Destination Stream Prefix](../../using-airbyte/configuring-schema)                   | (Optional) Adds a prefix to each table name in the destination                  |
 | [Detect and propagate schema changes](../../using-airbyte/schema-change-management) | Set how Airbyte handles schema changes in the source                           |
-| Use on-demand capacity (Cloud Pro and Enterprise Flex only)                               | When enabled, syncs always run even if committed capacity is exhausted. Syncs that run when committed data worker capacity is exhausted will be charged a premium rate. Only instance admins, organization admins, and workspace admins can change this toggle. Airbyte disables it for other roles and explains that only admins can enable or disable on-demand capacity. It also appears during connection creation. See [Monitor data worker usage](./manage-data-workers.md). |
+| Use on-demand capacity (Cloud Pro and Enterprise Flex only)                               | When enabled, syncs always run even if committed capacity is exhausted. Syncs that run when committed data worker capacity is exhausted will be charged a premium rate. Only organization admins and workspace admins can change this toggle. Airbyte disables it for other roles and explains that only admins can enable or disable on-demand capacity. It also appears during connection creation. See [Monitor data worker usage](./manage-data-workers.md). |
 
 ## Stream Settings
 

--- a/docs/platform/cloud/managing-airbyte-cloud/configuring-connections.md
+++ b/docs/platform/cloud/managing-airbyte-cloud/configuring-connections.md
@@ -63,7 +63,7 @@ You can configure the following settings:
 | [Destination Namespace](../../using-airbyte/core-concepts/namespaces)               | Determines where the replicated data is written to in the destination          |
 | [Destination Stream Prefix](../../using-airbyte/configuring-schema)                   | (Optional) Adds a prefix to each table name in the destination                  |
 | [Detect and propagate schema changes](../../using-airbyte/schema-change-management) | Set how Airbyte handles schema changes in the source                           |
-| Use on-demand capacity (Cloud Pro and Enterprise Flex only)                               | When enabled, syncs always run even if committed capacity is exhausted. Syncs that run when committed data worker capacity is exhausted will be charged a premium rate. Only organization admins and workspace admins can change this toggle. It also appears during connection creation. See [Monitor data worker usage](./manage-data-workers.md). |
+| Use on-demand capacity (Cloud Pro and Enterprise Flex only)                               | When enabled, syncs always run even if committed capacity is exhausted. Syncs that run when committed data worker capacity is exhausted will be charged a premium rate. Only instance admins, organization admins, and workspace admins can change this toggle. Airbyte disables it for other roles and explains that only admins can enable or disable on-demand capacity. It also appears during connection creation. See [Monitor data worker usage](./manage-data-workers.md). |
 
 ## Stream Settings
 

--- a/docs/platform/cloud/managing-airbyte-cloud/manage-data-workers.md
+++ b/docs/platform/cloud/managing-airbyte-cloud/manage-data-workers.md
@@ -85,7 +85,7 @@ If you've tried to optimize scheduling and still need more data workers, contact
 
 For critical data pipelines that must always run on time, you can enable on-demand capacity on individual connections. When committed capacity is available, the sync uses it at no extra cost. When committed capacity is exhausted, the sync runs immediately instead of being queued.
 
-Once your organization administrator enables on-demand capacity at the organization level, instance admins, organization admins, and workspace admins can enable it per connection. Other roles can view the toggle, but Airbyte disables it and shows a tooltip: "Only admins can enable or disable on-demand capacity."
+Once your organization administrator enables on-demand capacity at the organization level, organization admins and workspace admins can enable it per connection. Other roles can view the toggle, but Airbyte disables it and shows a tooltip: "Only admins can enable or disable on-demand capacity."
 
 ### Enable on-demand capacity on a connection
 
@@ -93,7 +93,7 @@ Once your organization administrator enables on-demand capacity at the organizat
 
 2. Click **Settings**.
 
-3. Toggle **Use on-demand capacity**. The toggle description reads: "Enable on demand capacity for this connection. Syncs for this connection will never be queued. Syncs that run when committed data worker is exhausted will be charged a premium rate." You must have the instance admin, organization admin, or workspace admin role to change this toggle.
+3. Toggle **Use on-demand capacity**. The toggle description reads: "Enable on demand capacity for this connection. Syncs for this connection will never be queued. Syncs that run when committed data worker is exhausted will be charged a premium rate." You must have the organization admin or workspace admin role to change this toggle.
 
 You can also enable on-demand capacity when first creating a connection. The toggle appears in the connection configuration during setup.
 

--- a/docs/platform/cloud/managing-airbyte-cloud/manage-data-workers.md
+++ b/docs/platform/cloud/managing-airbyte-cloud/manage-data-workers.md
@@ -85,7 +85,7 @@ If you've tried to optimize scheduling and still need more data workers, contact
 
 For critical data pipelines that must always run on time, you can enable on-demand capacity on individual connections. When committed capacity is available, the sync uses it at no extra cost. When committed capacity is exhausted, the sync runs immediately instead of being queued.
 
-Once your organization administrator enables on-demand capacity at the organization level, organization admins and workspace admins can enable it per connection. Other roles can view the toggle but cannot change it.
+Once your organization administrator enables on-demand capacity at the organization level, instance admins, organization admins, and workspace admins can enable it per connection. Other roles can view the toggle, but Airbyte disables it and shows a tooltip: "Only admins can enable or disable on-demand capacity."
 
 ### Enable on-demand capacity on a connection
 
@@ -93,7 +93,7 @@ Once your organization administrator enables on-demand capacity at the organizat
 
 2. Click **Settings**.
 
-3. Toggle **Use on-demand capacity**. The toggle description reads: "Enable on demand capacity for this connection. Syncs for this connection will never be queued. Syncs that run when committed data worker is exhausted will be charged a premium rate." You must have the organization admin or workspace admin role to change this toggle.
+3. Toggle **Use on-demand capacity**. The toggle description reads: "Enable on demand capacity for this connection. Syncs for this connection will never be queued. Syncs that run when committed data worker is exhausted will be charged a premium rate." You must have the instance admin, organization admin, or workspace admin role to change this toggle.
 
 You can also enable on-demand capacity when first creating a connection. The toggle appears in the connection configuration during setup.
 


### PR DESCRIPTION
## Documentation Confidence Assessment

**Overall Confidence: 4/5**

| Dimension | Score | Rationale |
|-----------|-------|-----------|
| Code Comprehension | 5/5 | The source PR is a small UI/RBAC change with a direct mapping from the new intent and tooltip copy to user-visible behavior. |
| Context Availability | 5/5 | The PR description, linked issue, diff, existing docs, and reviewer feedback clearly explain the billing-related restriction. |
| Existing Doc Quantity | 4/5 | The data worker capacity feature already has a hub page and related connection, tagging, schedule, and status docs. |
| Existing Doc Quality | 4/5 | Existing docs were mostly accurate, but the disabled-toggle behavior needed updating. |
| Feature Area Maturity | 4/5 | Connections and RBAC are established platform areas, while data worker capacity is a newer Cloud plan-specific feature. |
| Change Scope & Risk | 5/5 | The docs diff is a targeted wording update in two existing files with fewer than 10 changed lines. |
| Inference Ratio | 5/5 | The documented Cloud role list, disabled-toggle behavior, and tooltip copy are verified from the source PR diff, existing docs, and reviewer feedback. |

### What I Verified vs. What I Inferred

- **Verified from code**: airbytehq/airbyte-platform-internal#18851 adds `ManageConnectionOnDemandCapacity` for `ADMIN`, `ORGANIZATION_ADMIN`, and `WORKSPACE_ADMIN`; non-authorized users see a disabled switch with the tooltip `Only admins can enable or disable on-demand capacity`.
- **Verified from PR/issue context**: The change was requested because **Use on-demand capacity** has billing implications and should only be editable by admin roles.
- **Verified from existing docs and reviewer feedback**: This Cloud documentation should name organization admins and workspace admins as end-user roles. Ian clarified that `instance admin` is not a role an end user can occupy in this context.
- **Inferred**: No new rollout flag was introduced by this PR. I searched `FlagDefinitions.kt` and found existing data worker flags, but no changed or new flag in the source PR.

### Reviewer Focus Areas

1. Verify that organization admins and workspace admins are the only Cloud user-facing roles that should be named here.
2. Verify that the disabled-toggle tooltip text should be quoted exactly as implemented, rather than using the longer tooltip requested in the linked issue.
3. Verify the existing Cloud Pro and Enterprise Flex plan scope still applies to this setting.

### Areas of Concern

- Local Docusaurus build failed on unrelated infrastructure/dependency issues: repeated network failures fetching `https://connectors.airbyte.com/files/registries/v0/composite_registry.json`, followed by Rspack errors resolving Node built-ins such as `path` from `postman-code-generators`. CI docs checks passed before the reviewer-requested follow-up commit; re-checking CI after the follow-up.

---

## What

Updates the Airbyte Cloud data worker capacity docs for airbytehq/airbyte-platform-internal#18851, which restricts the **Use on-demand capacity** toggle to admin roles because the setting has billing implications.

Requested by @ian-at-airbyte.

## How

- Clarifies that organization admins and workspace admins can enable or disable on-demand capacity per connection.
- Documents the disabled-toggle behavior for other roles, including the tooltip text added in the source PR.
- Keeps the existing Cloud Pro and Enterprise Flex plan scope and org-level enablement wording unchanged.

Feature flag / rollout status: airbytehq/airbyte-platform-internal#18851 adds a new RBAC intent and tooltip, but no new feature flag. Existing data worker capacity behavior remains scoped to capacity-based Cloud plans as already documented.

## Source

Documentation for airbytehq/airbyte-platform-internal#18851.

## Review guide

1. `docs/platform/cloud/managing-airbyte-cloud/manage-data-workers.md` — confirm the role list and disabled-toggle tooltip match the platform PR and Cloud-facing terminology.
2. `docs/platform/cloud/managing-airbyte-cloud/configuring-connections.md` — confirm the connection settings table accurately summarizes the admin-only toggle behavior.

## User Impact

Readers can see which roles can change the on-demand capacity setting and what non-admin roles see in the UI.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚
- [ ] NO ❌

---

> **Note**: I am an AI assistant (Devin) and have proposed these documentation updates based on a review of platform source code changes. All platform documentation PRs require human review. Reviewers may merge, modify, or close this PR as they see fit.

---
[Devin session](https://app.devin.ai/sessions/ba24ebf68c764fe6a75172710f866400)