### PR TITLE
docs(platform): document capacity warning before manual sync

### DIFF
--- a/docs/platform/cloud/managing-airbyte-cloud/manage-data-workers.md
+++ b/docs/platform/cloud/managing-airbyte-cloud/manage-data-workers.md
@@ -61,6 +61,10 @@ An infrequent instance of maximum usage probably isn't a problem. If you're regu
 
 On connections with a manual schedule type, syncs that remain queued for 8 hours are automatically cancelled. On scheduled or cron connections, a queued sync waits until the next scheduled run arrives, at which point the older queued sync is replaced.
 
+### Manually queue a sync when capacity is exhausted
+
+If all committed data workers are in use and you click **Sync now** on a connection, Airbyte shows an **Insufficient capacity** confirmation before it queues the sync. To queue the sync until enough committed capacity is available, click **Queue sync**. To leave the connection unchanged, click **Cancel**.
+
 ### Optimize data worker usage
 
 If you can, it's preferable to optimize Airbyte by rescheduling connections outside of busy periods.


### PR DESCRIPTION
## Documentation Confidence Assessment

**Overall Confidence: 4/5**

| Dimension | Score | Rationale |
|-----------|-------|-----------|
| Code Comprehension | 4/5 | The source PR is a small webapp change with a clear path from **Sync now** to the capacity check and confirmation modal. |
| Context Availability | 5/5 | The source PR, linked issue, related endpoint PR, tests, and UI copy all describe the same behavior. |
| Existing Doc Quantity | 3/5 | The data worker page already covered usage, queuing, on-demand capacity, and queued connection status. |
| Existing Doc Quality | 4/5 | The existing page was accurate and organized, with one gap around the new manual sync confirmation. |
| Feature Area Maturity | 3/5 | Syncs and connections are mature, but data worker capacity enforcement and on-demand capacity are newer Cloud plan features. |
| Change Scope & Risk | 5/5 | The docs diff adds one short subsection to an existing page. |
| Inference Ratio | 5/5 | The new documentation text is directly supported by source PR code, UI strings, and the linked issue. |

### What I Verified vs. What I Inferred

- **Verified from code**: `useSyncWithCapacityCheck` checks `FeatureItem.OnDemandCapacity`, calls `getWorkspaceDataWorkerAvailability`, opens an **Insufficient capacity** modal when `outOfDataWorkers` is true, and proceeds only after the user clicks **Queue sync**. The hook is used by the main connection header **Sync now** button and the no-data **Sync now** button.
- **Verified from PR/issue context**: airbytehq/airbyte-platform-internal#18872 and airbytehq/hydra-issues-internal#126 describe the same warning behavior, modal title/body/button labels, fallback behavior when the flag is disabled, and graceful fallback if the capacity check API fails. airbytehq/airbyte-platform-internal#18856 confirms the availability endpoint is Cloud-only.
- **Verified from existing docs**: `docs/platform/cloud/managing-airbyte-cloud/manage-data-workers.md` already documents capacity-based Cloud plans, data worker queuing, cancellation timing, on-demand capacity, and queued connection status.
- **Inferred**: The page's existing Cloud Pro and Enterprise Flex plan framing remains the correct public plan language for this behavior. This is inferred from the existing docs because the source PR gates by entitlement flag rather than plan-name constants.

### Reviewer Focus Areas

1. Verify the new **Manually queue a sync when capacity is exhausted** subsection uses the intended public wording for the modal flow.
2. Confirm that this behavior should be documented on the existing **Monitor data worker usage** page rather than a connection settings page.
3. Confirm that no separate Self-Managed documentation is needed. The related endpoint is Cloud-only, and the existing page is scoped to capacity-based Cloud plans.

### Areas of Concern

- Feature flag and rollout status: the source PR requires the `OnDemandCapacity` webapp entitlement feature flag. If the flag is disabled, sync behavior is unchanged. The backend capacity enforcement flag `platform.enforce-data-worker-capacity` defaults to false in `FlagDefinitions.kt`; the source PR only shows the modal when the webapp entitlement is enabled and the availability response reports exhausted capacity.

---

## What
Documents the manual sync capacity warning added by airbytehq/airbyte-platform-internal#18872, requested by @ian-at-airbyte. The source PR adds an **Insufficient capacity** confirmation when a user clicks **Sync now** while committed data worker capacity is exhausted.

## How
Adds a focused note to the existing **Monitor data worker usage** page explaining that users can either queue the sync with **Queue sync** or dismiss the confirmation with **Cancel**.

## Review guide
1. `docs/platform/cloud/managing-airbyte-cloud/manage-data-workers.md`

## User Impact
Cloud Pro and Enterprise Flex users on capacity-based plans can understand what happens when they manually start a sync while committed data worker capacity is exhausted.

## Source
Documentation for airbytehq/airbyte-platform-internal#18872. Related endpoint PR: airbytehq/airbyte-platform-internal#18856. Linked issue: airbytehq/hydra-issues-internal#126.

## Validation
- `git diff --check`
- `npx --yes markdownlint-cli2 "docs/platform/cloud/managing-airbyte-cloud/manage-data-workers.md"`
- `cd docusaurus && corepack pnpm install && corepack pnpm clear && corepack pnpm build` (passed; Docusaurus reported pre-existing broken anchors in generated AI agent docs, unrelated to this change)
- CI passed, including Docs / MarkDownLint, Docs / Vale, Format Check, and Build Airbyte Docs

## Can this PR be safely reverted and rolled back?
- [x] YES 💚
- [ ] NO ❌

> **Note**: I am an AI assistant (Devin) and have proposed these documentation updates based on a review of platform source code changes. All platform documentation PRs require human review. Reviewers may merge, modify, or close this PR as they see fit.

Link to Devin session: https://app.devin.ai/sessions/cd15ee11e5244ac0bf005ce95915551f