### PR TITLE
chore: bump to latest cdk.

### DIFF
--- a/airbyte-integrations/connectors/destination-bigquery/gradle.properties
+++ b/airbyte-integrations/connectors/destination-bigquery/gradle.properties
@@ -1,3 +1,3 @@
 testExecutionConcurrency=-1
 JunitMethodExecutionTimeout=10m
-cdkVersion=1.0.6
+cdkVersion=1.0.13

--- a/airbyte-integrations/connectors/destination-bigquery/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-bigquery/metadata.yaml
@@ -6,7 +6,7 @@ data:
   connectorSubtype: database
   connectorType: destination
   definitionId: 22f6c74f-5699-40ff-833c-4a879ea40133
-  dockerImageTag: 3.0.18
+  dockerImageTag: 3.0.19-rc.1
   dockerRepository: airbyte/destination-bigquery
   documentationUrl: https://docs.airbyte.com/integrations/destinations/bigquery
   githubIssueLabel: destination-bigquery
@@ -39,7 +39,7 @@ data:
         message: "If you never interact with the raw tables, you can upgrade without taking any action. Otherwise, make sure to read the migration guide for more details."
         upgradeDeadline: "2026-07-31"
     rolloutConfiguration:
-      enableProgressiveRollout: false
+      enableProgressiveRollout: true
   resourceRequirements:
     jobSpecific:
       - jobType: sync

--- a/docs/integrations/destinations/bigquery.md
+++ b/docs/integrations/destinations/bigquery.md
@@ -252,6 +252,7 @@ This destination supports [namespaces](https://docs.airbyte.com/platform/using-a
 
 | Version     | Date       | Pull Request                                               | Subject                                                                                                                                                                           |
 |:------------|:-----------|:-----------------------------------------------------------|:----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 3.0.19-rc.1 | 2026-05-19 | | Upgrade CDK to 1.0.13. Progressive rollout. |
 | 3.0.18 | 2026-03-31 | [75913](https://github.com/airbytehq/airbyte/pull/75913) | Finalize upgrade BigQuery Cloud dependencies and CDK version |
 | 3.0.18-rc.1 | 2026-03-27 | [75541](https://github.com/airbytehq/airbyte/pull/75541) | Upgrade BigQuery Cloud dependencies and CDK version |
 | 3.0.17 | 2026-01-28 | [72427](https://github.com/airbytehq/airbyte/pull/72427) | Finalize upgrade CDK to 0.2.0 |

--- a/docs/integrations/destinations/bigquery.md
+++ b/docs/integrations/destinations/bigquery.md
@@ -252,7 +252,7 @@ This destination supports [namespaces](https://docs.airbyte.com/platform/using-a
 
 | Version     | Date       | Pull Request                                               | Subject                                                                                                                                                                           |
 |:------------|:-----------|:-----------------------------------------------------------|:----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| 3.0.19-rc.1 | 2026-05-19 | | Upgrade CDK to 1.0.13. Progressive rollout. |
+| 3.0.19-rc.1 | 2026-05-19 | [78239](https://github.com/airbytehq/airbyte/pull/78239) | Upgrade CDK to 1.0.13. Progressive rollout. |
 | 3.0.18 | 2026-03-31 | [75913](https://github.com/airbytehq/airbyte/pull/75913) | Finalize upgrade BigQuery Cloud dependencies and CDK version |
 | 3.0.18-rc.1 | 2026-03-27 | [75541](https://github.com/airbytehq/airbyte/pull/75541) | Upgrade BigQuery Cloud dependencies and CDK version |
 | 3.0.17 | 2026-01-28 | [72427](https://github.com/airbytehq/airbyte/pull/72427) | Finalize upgrade CDK to 0.2.0 |


### PR DESCRIPTION
## What
Bump destination-bigquery CDK to 1.0.13 to support INCOMPLETE stream status handling in SPEED mode. Progressive rollout because the CDK jump spans 7 patch versions on a high-traffic destination.
## How
- Updated `cdkVersion` in `gradle.properties` from 1.0.6 to 1.0.13
- Bumped `dockerImageTag` from 3.0.18 to 3.0.19-rc.1
- Enabled progressive rollout
## User Impact
Prevents overwriting complete tables with partial data when a source stream fails mid-sync in SPEED mode.
## Can this PR be safely reverted and rolled back?
- [x] YES
- [ ] NO

> [!IMPORTANT]
> Active progressive rollout warning for destination-bigquery.

- [ ] (Click to Approve:) Bypass the active progressive rollout warning for destination-bigquery in the PR comment [here](https://github.com/airbytehq/airbyte/pull/78239#issuecomment-4491939180).