### PR TITLE
chore: bump to latest cdk.

### DIFF
--- a/airbyte-integrations/connectors/destination-s3/gradle.properties
+++ b/airbyte-integrations/connectors/destination-s3/gradle.properties
@@ -1,3 +1,3 @@
 testExecutionConcurrency=-1
 JunitMethodExecutionTimeout=60m
-cdkVersion=0.2.1
+cdkVersion=1.0.13

--- a/airbyte-integrations/connectors/destination-s3/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-s3/metadata.yaml
@@ -2,7 +2,7 @@ data:
   connectorSubtype: file
   connectorType: destination
   definitionId: 4816b78f-1489-44c1-9060-4b19d5fa9362
-  dockerImageTag: 1.9.7
+  dockerImageTag: 1.9.8-rc.1
   dockerRepository: airbyte/destination-s3
   githubIssueLabel: destination-s3
   icon: s3.svg
@@ -32,7 +32,7 @@ data:
           **This release includes breaking changes, including major revisions to the schema of stored data. Do not upgrade without reviewing the migration guide.**
         upgradeDeadline: "2024-10-08"
     rolloutConfiguration:
-      enableProgressiveRollout: false
+      enableProgressiveRollout: true
   resourceRequirements:
     jobSpecific:
       - jobType: sync

--- a/docs/integrations/destinations/s3.md
+++ b/docs/integrations/destinations/s3.md
@@ -546,7 +546,7 @@ This destination supports [namespaces](https://docs.airbyte.com/platform/using-a
 
 | Version     | Date       | Pull Request                                               | Subject                                                                                                                                              |
 |:------------|:-----------|:-----------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------|
-| 1.9.8-rc.1  | 2026-05-19 | | Upgrade CDK to 1.0.13. Progressive rollout. |
+| 1.9.8-rc.1  | 2026-05-19 | [78240](https://github.com/airbytehq/airbyte/pull/78240) | Upgrade CDK to 1.0.13. Progressive rollout. |
 | 1.9.7       | 2026-01-26 | [72354](https://github.com/airbytehq/airbyte/pull/72354) | Fix sync failures for sources with empty schemas by upgrading CDK to 0.2.1                                                                           |
 | 1.9.6       | 2026-01-26 | [72298](https://github.com/airbytehq/airbyte/pull/72298) | Upgrade CDK to 0.2.0                                                                                                                                 |
 | 1.9.5       | 2025-11-04 | [69134](https://github.com/airbytehq/airbyte/pull/69134) | Upgrade to Bulk CDK 0.1.61.                                                                                                                          |

--- a/docs/integrations/destinations/s3.md
+++ b/docs/integrations/destinations/s3.md
@@ -546,6 +546,7 @@ This destination supports [namespaces](https://docs.airbyte.com/platform/using-a
 
 | Version     | Date       | Pull Request                                               | Subject                                                                                                                                              |
 |:------------|:-----------|:-----------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------|
+| 1.9.8-rc.1  | 2026-05-19 | | Upgrade CDK to 1.0.13. Progressive rollout. |
 | 1.9.7       | 2026-01-26 | [72354](https://github.com/airbytehq/airbyte/pull/72354) | Fix sync failures for sources with empty schemas by upgrading CDK to 0.2.1                                                                           |
 | 1.9.6       | 2026-01-26 | [72298](https://github.com/airbytehq/airbyte/pull/72298) | Upgrade CDK to 0.2.0                                                                                                                                 |
 | 1.9.5       | 2025-11-04 | [69134](https://github.com/airbytehq/airbyte/pull/69134) | Upgrade to Bulk CDK 0.1.61.                                                                                                                          |


### PR DESCRIPTION
## What
Bump destination-s3 CDK to 1.0.13 to support INCOMPLETE stream status handling in SPEED mode. Progressive rollout because the CDK jump crosses a major version boundary on a high-traffic destination.
## How
- Updated `cdkVersion` in `gradle.properties` from 0.2.1 to 1.0.13
- Bumped `dockerImageTag` from 1.9.7 to 1.9.8-rc.1
- Enabled progressive rollout
## User Impact
Prevents deleting old files on partial data when a source stream fails mid-sync in SPEED mode.
## Can this PR be safely reverted and rolled back?
- [x] YES