### PR TITLE
docs: update references from airbyte-ops-mcp to airbyte-ops

### DIFF
--- a/.github/workflows/block-release-check.yml
+++ b/.github/workflows/block-release-check.yml
@@ -5,7 +5,7 @@ name: Release Block Check
 # the author with the list of blocked connectors and their reasons.
 # If all blocks are later removed, updates the comment to say all-clear.
 #
-# See: https://github.com/airbytehq/airbyte-ops-mcp/issues/686
+# See: https://github.com/airbytehq/airbyte-ops/issues/686
 
 on:
   pull_request:

--- a/.github/workflows/block-release.yml
+++ b/.github/workflows/block-release.yml
@@ -7,7 +7,7 @@ name: Block/Unblock Connector Release
 # Intended to be triggered by the airbyte-ops MCP/CLI after a connector version
 # is yanked, to prevent accidental re-publish of broken code still on master.
 #
-# See: https://github.com/airbytehq/airbyte-ops-mcp/issues/686
+# See: https://github.com/airbytehq/airbyte-ops/issues/686
 
 on:
   workflow_dispatch:

--- a/.github/workflows/connector-ci-checks.yml
+++ b/.github/workflows/connector-ci-checks.yml
@@ -467,7 +467,7 @@ jobs:
   # --- Soft launch: ops CLI artifact generation + validation (parallel job) ---
   # Runs alongside existing pre-release checks to validate the new ops CLI path.
   # continue-on-error: true ensures this does not block the CI pipeline.
-  # Tracking: https://github.com/airbytehq/airbyte-ops-mcp/issues/504
+  # Tracking: https://github.com/airbytehq/airbyte-ops/issues/504
   build-and-verify-artifacts:
     if: github.event.pull_request.draft == false
     needs: [generate-matrix]

--- a/.github/workflows/publish_connectors.yml
+++ b/.github/workflows/publish_connectors.yml
@@ -324,7 +324,7 @@ jobs:
       # If a block-release.yaml marker exists for this connector, skip all
       # build and publish steps with a WARNING. Other connectors in the
       # same matrix run are unaffected.
-      # See: https://github.com/airbytehq/airbyte-ops-mcp/issues/686
+      # See: https://github.com/airbytehq/airbyte-ops/issues/686
       - name: Check for release block
         id: check-release-block
         if: needs.publish_options.outputs.with-semver-suffix == 'none'
@@ -455,7 +455,7 @@ jobs:
       # but the actual published tag is the preview version (e.g. 3.2.3-preview.820ce48).
       # The artifact generator reads dockerImageTag from metadata.yaml, so we need to
       # bump it in-place before generating artifacts. This is ephemeral — not committed.
-      # See: https://github.com/airbytehq/airbyte-ops-mcp/issues/604
+      # See: https://github.com/airbytehq/airbyte-ops/issues/604
       - name: Ephemeral version bump for pre-release
         if: >
           steps.check-release-block.outputs.blocked != 'true' &&

--- a/airbyte-integrations/connectors/source-mssql/.agents/skills/source-mssql-e2e-tests/SKILL.md
+++ b/airbyte-integrations/connectors/source-mssql/.agents/skills/source-mssql-e2e-tests/SKILL.md
@@ -67,7 +67,7 @@ The skill expects all script paths relative to the skill root.
   `airbyte-ops`) share Docker's default `bridge` network. The connector
   resolves the backend by its bridge IP, which `render-config.sh`
   substitutes into the working config at runtime. Tracked upstream in
-  [`airbytehq/airbyte-ops-mcp#765`](https://github.com/airbytehq/airbyte-ops-mcp/issues/765);
+  [`airbytehq/airbyte-ops#765`](https://github.com/airbytehq/airbyte-ops/issues/765);
   once `--network` is supported the bridge-IP dance can collapse.
 - SQL Server image is pinned to `mcr.microsoft.com/mssql/server:2022-latest`,
   not `latest`, for stable major-version behavior across CU patches.

--- a/airbyte-integrations/connectors/source-mssql/.agents/skills/source-mssql-e2e-tests/scripts/render-config.sh
+++ b/airbyte-integrations/connectors/source-mssql/.agents/skills/source-mssql-e2e-tests/scripts/render-config.sh
@@ -5,7 +5,7 @@
 #
 # The connector container launched by `airbyte-ops` is on the default
 # `bridge` network and cannot resolve a user-defined network's container
-# names. Until airbytehq/airbyte-ops-mcp#765 lands `--network` support,
+# names. Until airbytehq/airbyte-ops#765 lands `--network` support,
 # we render a working config that pins .host to the bridge IP that
 # Docker assigned to the backend container at runtime.
 #

--- a/airbyte-integrations/connectors/source-mssql/CONTRIBUTING.md
+++ b/airbyte-integrations/connectors/source-mssql/CONTRIBUTING.md
@@ -28,7 +28,7 @@ skills under [`.agents/skills/`](.agents/skills/) own the actual harness:
   (`source-mssql-db-backend`), applies SQL fixtures via `sqlcmd`, and runs
   one Airbyte protocol command (`spec` / `check` / `discover` / `read`)
   against `airbyte/source-mssql:<tag>` using the
-  [`airbyte-internal-ops`](https://github.com/airbytehq/airbyte-ops-mcp)
+  [`airbyte-internal-ops`](https://github.com/airbytehq/airbyte-ops)
   CLI's `airbyte-ops cloud connector regression-test --skip-compare=True`.
   Use this skill for any non-CDC bug or as a building block.
 - [`source-mssql-e2e-cdc-tests`](.agents/skills/source-mssql-e2e-cdc-tests/SKILL.md) —
@@ -96,7 +96,7 @@ directly.
 - **Connector cannot reach `source-mssql-db-backend`.**
   `airbyte-ops cloud connector regression-test` does not currently expose
   `--network` (tracked in
-  [`airbytehq/airbyte-ops-mcp#765`](https://github.com/airbytehq/airbyte-ops-mcp/issues/765)).
+  [`airbytehq/airbyte-ops#765`](https://github.com/airbytehq/airbyte-ops/issues/765)).
   Until it does, both containers share Docker's default `bridge` network
   and the connector resolves the source by IP. The `render-config.sh`
   script in the generic skill handles this: it inspects the backend's

--- a/docs/platform/connector-development/local-connector-development.md
+++ b/docs/platform/connector-development/local-connector-development.md
@@ -169,7 +169,7 @@ To understand which secrets are required for a connector, consult the `metadata.
 
 ### Fetching and Listing Connector Secrets Locally
 
-To view a list of secrets, or to fetch them locally, you can use the `airbyte-internal-ops` CLI via `uvx`. The canonical CLI reference lives at [airbyte_ops_mcp/cli/secrets](https://airbytehq.github.io/airbyte-ops-mcp/airbyte_ops_mcp/cli/secrets.html).
+To view a list of secrets, or to fetch them locally, you can use the `airbyte-internal-ops` CLI via `uvx`. The canonical CLI reference lives at [airbyte_ops_mcp/cli/secrets](https://airbytehq.github.io/airbyte-ops/airbyte_ops_mcp/cli/secrets.html).
 
 - `uvx airbyte-internal-ops secrets --help` - Gives general usage instructions for the `secrets` CLI functions.
 - `uvx airbyte-internal-ops secrets list` - Lists the secrets available for the given connector, along with a GSM deep link to each available secret.


### PR DESCRIPTION
## What

Updates all references from `airbyte-ops-mcp` to `airbyte-ops` in preparation for the GitHub repo rename `airbytehq/airbyte-ops-mcp` → `airbytehq/airbyte-ops`.

Companion to airbytehq/airbyte-ops-mcp#809.

## How

String-level replacements of the repo slug across 8 files:
- 4 GitHub Actions workflows (issue link comments only)
- `source-mssql` CONTRIBUTING.md and agent skill files
- Platform docs for local connector development

No behavioral changes — all modifications are in comments, documentation, and issue URLs.

## Review guide

1. `.github/workflows/` — only comment URLs changed
2. `airbyte-integrations/connectors/source-mssql/` — CONTRIBUTING.md and skill references
3. `docs/platform/connector-development/local-connector-development.md` — GitHub Pages link

## User Impact

No user-facing impact. Only internal documentation and code comment URLs updated.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Link to Devin session: https://app.devin.ai/sessions/c12086757ab54228b5833337cbadb09b
Requested by: @aaronsteers

> [!IMPORTANT]
> Active progressive rollout warning for source-mssql.

- [ ] (Click to Approve:) Bypass the active progressive rollout warning for source-mssql in the PR comment [here](https://github.com/airbytehq/airbyte/pull/78253#issuecomment-4492146862).