### PR TITLE
ci(docs): Pin docs build to Node 20

### DIFF
--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -58,6 +58,12 @@ jobs:
             echo skip-build=false | tee -a $GITHUB_OUTPUT
           fi
 
+      - name: Set Up Node.js
+        if: steps.check-skip.outputs.skip-build != 'true'
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: "20"
+
       - name: Set Up pnpm
         if: steps.check-skip.outputs.skip-build != 'true'
         # pnpm is used to manage the dependencies of the documentation build.


### PR DESCRIPTION
## What
Pins the Docs workflow build job to Node 20 before installing pnpm and running `poe docs-build`.

This was split out from https://github.com/airbytehq/airbyte/pull/78233 at @ian-at-airbyte's request.

## How
Adds `actions/setup-node` with `node-version: "20"` to `.github/workflows/docs-build.yml` before the existing pnpm setup step.

The workflow currently runs on `ubuntu-24.04`, whose default Node version in CI was v22.22.3. `docusaurus/package.json` requires Node `>=20 <22`, so `pnpm install --ignore-scripts` exits with `ERR_PNPM_UNSUPPORTED_ENGINE` before the docs build can run.

## Review guide
1. `.github/workflows/docs-build.yml`

## User Impact
Docs build CI uses a Node version compatible with the Docusaurus engine constraint.

## Can this PR be safely reverted and rolled back?
- [x] YES 💚
- [ ] NO ❌

Link to Devin session: https://app.devin.ai/sessions/46624bdcc2914d82b8afcca693727ff8