### PR TITLE
fix(source-google-analytics-data-api): Restore stable default concurrency

### DIFF
--- a/airbyte-integrations/connectors/source-google-analytics-data-api/manifest.yaml
+++ b/airbyte-integrations/connectors/source-google-analytics-data-api/manifest.yaml
@@ -3062,7 +3062,7 @@ spec:
 # https://developers.google.com/analytics/devguides/reporting/data/v1/quotas
 concurrency_level:
   type: ConcurrencyLevel
-  default_concurrency: 6
+  default_concurrency: 4
   max_concurrency: 16
 
 # Original single-policy api_budget (pre-tuning). Superseded by the tier-aware

--- a/airbyte-integrations/connectors/source-google-analytics-data-api/metadata.yaml
+++ b/airbyte-integrations/connectors/source-google-analytics-data-api/metadata.yaml
@@ -12,7 +12,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 3cc2eafd-84aa-4dca-93af-322d9dfeec1a
-  dockerImageTag: 2.9.34
+  dockerImageTag: 2.9.35
   dockerRepository: airbyte/source-google-analytics-data-api
   documentationUrl: https://docs.airbyte.com/integrations/sources/google-analytics-data-api
   externalDocumentationUrls:

--- a/docs/integrations/sources/google-analytics-data-api.md
+++ b/docs/integrations/sources/google-analytics-data-api.md
@@ -280,6 +280,7 @@ The Google Analytics connector is subject to Google Analytics Data API quotas. P
 
 | Version        | Date       | Pull Request                                             | Subject                                                                                                                                                                |
 |:---------------|:-----------|:---------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 2.9.35 | 2026-05-19 | [PR-pending](https://github.com/airbytehq/airbyte/pull/PR-pending) | Restore `default_concurrency` to 4 after c=6 rollout showed heartbeat timeout outliers |
 | 2.9.34 | 2026-05-18 | [78161](https://github.com/airbytehq/airbyte/pull/78161) | Promoted release candidate to GA |
 | 2.9.34-rc.2 | 2026-05-01 | [PR-pending](https://github.com/airbytehq/airbyte/pull/PR-pending) | Phase 1 step 3: bump `default_concurrency` 5 to 6 (tier-aware `api_budget` stays live) |
 | 2.9.34-rc.1 | 2026-04-29 | [77550](https://github.com/airbytehq/airbyte/pull/77550) | Phase 1 step 2: bump `default_concurrency` 4 to 5 and activate the tier-aware `api_budget` (Standard 10 req/s, Analytics 360 50 req/s on opt-in via `subscription_tier`) |


### PR DESCRIPTION
## What
Restores the Google Analytics 4 connector stable release path to the c=4 default concurrency that was validated during the rollout. This corrective PR follows the GA promotion that produced stable `2.9.34` from the newer c=6 lineage.

Requested by Sophie Cui during the GA rollout session.

## How
- Bumps `source-google-analytics-data-api` from `2.9.34` to `2.9.35`.
- Changes `default_concurrency` from `6` back to `4` in the declarative manifest.
- Adds the corresponding changelog entry.

## Review guide
1. `airbyte-integrations/connectors/source-google-analytics-data-api/manifest.yaml`
2. `airbyte-integrations/connectors/source-google-analytics-data-api/metadata.yaml`
3. `docs/integrations/sources/google-analytics-data-api.md`

## User Impact
GA4 syncs using the next stable connector release will use the c=4 default concurrency that eliminated heartbeat timeout outliers during rollout monitoring.

## Can this PR be safely reverted and rolled back?
- [x] YES 💚
- [ ] NO ❌

Link to Devin session: https://app.devin.ai/sessions/41c208c573434671a9f4e2351294ded6
Requested by: @sophiecuiy

> [!IMPORTANT]
> Active progressive rollout warning for source-google-analytics-data-api.

- [ ] (Click to Approve:) Bypass the active progressive rollout warning for source-google-analytics-data-api in the PR comment [here](https://github.com/airbytehq/airbyte/pull/78275#issuecomment-4493181272).