### PR TITLE
docs(source-sharepoint-lists-enterprise): replace customer name in config example

### DIFF
--- a/docs/integrations/enterprise-connectors/source-sharepoint-lists-enterprise.md
+++ b/docs/integrations/enterprise-connectors/source-sharepoint-lists-enterprise.md
@@ -83,7 +83,7 @@ The Site ID is required to identify which SharePoint site to sync from. You can 
 | `client_secret` | Yes | Azure AD Application client secret |
 | `tenant_id` | Yes | Azure AD Tenant ID |
 | `site_id` | Yes | SharePoint Site ID in format: `hostname,site-guid,web-guid` |
-| `list_name_filter` | No | Regular expression pattern to filter which lists to sync (for example, `Perdue.*` to match lists starting with "Perdue") |
+| `list_name_filter` | No | Regular expression pattern to filter which lists to sync (for example, `Project.*` to match lists starting with "Project") |
 | `skip_document_libraries` | No | Skip document library lists (default: `true`) |
 | `num_workers` | No | Number of concurrent threads for parallel processing (default: `10`, range: 1-20) |
 


### PR DESCRIPTION
## What

Removes a specific customer/company name ("Perdue") from the `list_name_filter` configuration example in the SharePoint Lists Enterprise connector docs and replaces it with a generic example (`Project.*`).

Requested by @rwask.

## How

Single-line edit in the Configuration table: changed the regex example from `Perdue.*` → `Project.*` and the surrounding description text accordingly.

## Review guide

1. `docs/integrations/enterprise-connectors/source-sharepoint-lists-enterprise.md` (line 86)

## User Impact

No functional change. The docs example is now generic and does not reference any specific company.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Link to Devin session: https://app.devin.ai/sessions/62ea9d921d42488fa28761a3631fe393