### PR TITLE
feat: Hydra AI-gated auto-merge workflow

### DIFF
--- a/.github/workflows/ai-ready-command.yml
+++ b/.github/workflows/ai-ready-command.yml
@@ -20,6 +20,11 @@ on:
         description: "PR number, if triggered from a PR"
         required: false
         type: string
+      dry-run:
+        description: "If 'true', evaluate only -- do not approve or merge"
+        required: false
+        default: ""
+        type: string
 
 run-name: "AI Ready for #${{ inputs.pr || inputs.comment-id }}"
 
@@ -67,4 +72,5 @@ jobs:
     with:
       pr: ${{ inputs.pr }}
       comment-id: ${{ inputs.comment-id }}
+      dry-run: ${{ inputs.dry-run }}
     secrets: inherit

--- a/.github/workflows/ai-ready-command.yml
+++ b/.github/workflows/ai-ready-command.yml
@@ -29,7 +29,7 @@ permissions:
   pull-requests: read
 
 jobs:
-  ai-ready:
+  validate:
     runs-on: ubuntu-24.04
     steps:
       - name: Authenticate as GitHub App
@@ -60,3 +60,11 @@ jobs:
           GH_TOKEN: ${{ steps.get-app-token.outputs.token }}
           PR_NUMBER: ${{ inputs.pr }}
         run: gh issue edit "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --add-label hyd-ready
+
+  hydra-automerge:
+    needs: validate
+    uses: ./.github/workflows/hydra-automerge.yml
+    with:
+      pr: ${{ inputs.pr }}
+      comment-id: ${{ inputs.comment-id }}
+    secrets: inherit

--- a/.github/workflows/hydra-automerge.yml
+++ b/.github/workflows/hydra-automerge.yml
@@ -1,0 +1,537 @@
+name: "Hydra: Auto-merge (AI-gated)"
+# Triggered when the 'hyd-ready' label is added to a PR.
+# Kicks off a Devin AI session with structured output to evaluate whether
+# the PR is safe to auto-merge, then evaluates the result deterministically:
+#   pass = ALL(preconditions) AND ANY(allowed_scopes)
+#
+# Dry-run mode is controlled by the org-level variable ENABLE_CONNECTOR_AUTO_MERGE.
+# Set to "true" to enable real merges; any other value (or unset) runs in dry-run mode.
+
+on:
+  pull_request_target:
+    types: [labeled]
+
+run-name: "Auto-merge eval for PR #${{ github.event.pull_request.number }}"
+
+# All repo operations use GitHub App tokens, not GITHUB_TOKEN.
+permissions: {}
+
+jobs:
+  evaluate-and-merge:
+    name: "Evaluate PR #${{ github.event.pull_request.number }}"
+    if: github.event.label.name == 'hyd-ready' && github.event.pull_request.state == 'open'
+    runs-on: ubuntu-24.04
+    env:
+      PR_NUMBER: ${{ github.event.pull_request.number }}
+      PR_TITLE: ${{ github.event.pull_request.title }}
+    steps:
+      # ── Authentication ──────────────────────────────────────────────
+      - name: Authenticate as 'octavia-bot-hoard' GitHub App
+        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
+        id: get-hoard-token
+        with:
+          owner: "airbytehq"
+          repositories: "airbyte"
+          app-id: ${{ secrets.OCTAVIA_BOT_HOARD_APP_ID }}
+          private-key: ${{ secrets.OCTAVIA_BOT_HOARD_PRIVATE_KEY }}
+
+      # ── Pre-checks ─────────────────────────────────────────────────
+      - name: Check PR is still open and not a draft
+        id: pre-check
+        env:
+          GH_TOKEN: ${{ steps.get-hoard-token.outputs.token }}
+        run: |
+          pr_json=$(gh pr view "$PR_NUMBER" --repo airbytehq/airbyte --json state,isDraft)
+          state=$(echo "$pr_json" | jq -r '.state')
+          is_draft=$(echo "$pr_json" | jq -r '.isDraft')
+          echo "state=$state" | tee -a "$GITHUB_OUTPUT"
+          echo "is_draft=$is_draft" | tee -a "$GITHUB_OUTPUT"
+          if [[ "$state" != "OPEN" ]]; then
+            echo "::warning::PR #$PR_NUMBER is no longer open (state=$state). Skipping."
+          fi
+
+      - name: Validate connector-only file paths
+        if: steps.pre-check.outputs.state == 'OPEN'
+        id: validate-paths
+        env:
+          GH_TOKEN: ${{ steps.get-hoard-token.outputs.token }}
+        run: |
+          set -e
+          gh pr diff "$PR_NUMBER" --repo airbytehq/airbyte --name-only > /tmp/changed-files.txt
+          valid=true
+          while IFS= read -r file; do
+            case "$file" in
+              airbyte-integrations/connectors/*) ;;
+              docs/integrations/sources/*) ;;
+              docs/integrations/destinations/*) ;;
+              docs/ai-agents/connectors/*) ;;
+              docs/developers/pyairbyte/*) ;;
+              docusaurus/src/data/*) ;;
+              *) valid=false; echo "::warning::Non-connector file: $file"; break ;;
+            esac
+          done < /tmp/changed-files.txt
+          echo "valid=$valid" | tee -a "$GITHUB_OUTPUT"
+
+      - name: Post comment if path validation fails
+        if: steps.pre-check.outputs.state == 'OPEN' && steps.validate-paths.outputs.valid == 'false'
+        env:
+          GH_TOKEN: ${{ steps.get-hoard-token.outputs.token }}
+        run: |
+          gh pr comment "$PR_NUMBER" --repo airbytehq/airbyte --body "$(cat <<'EOF'
+          ## Auto-merge evaluation: **SKIPPED**
+
+          This PR modifies files outside the allowed connector paths. Auto-merge is only available for PRs that exclusively touch connector-related files.
+
+          > [Workflow run](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})
+          EOF
+          )"
+
+      - name: Fetch required checks for master branch
+        if: steps.pre-check.outputs.state == 'OPEN' && steps.validate-paths.outputs.valid == 'true'
+        id: required-checks
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ steps.get-hoard-token.outputs.token }}
+          script: |
+            const { data: rules } = await github.request(
+              'GET /repos/{owner}/{repo}/rules/branches/{branch}',
+              { owner: 'airbytehq', repo: 'airbyte', branch: 'master' }
+            );
+            const checks = [];
+            for (const rule of rules) {
+              if (rule.type === 'required_status_checks') {
+                for (const check of (rule.parameters?.required_status_checks || [])) {
+                  checks.push(check.context);
+                }
+              }
+            }
+            core.info(`Required checks (${checks.length}): ${JSON.stringify(checks)}`);
+            core.setOutput('checks', JSON.stringify(checks));
+
+      - name: Verify required status checks pass
+        if: steps.pre-check.outputs.state == 'OPEN' && steps.validate-paths.outputs.valid == 'true'
+        id: verify-checks
+        uses: actions/github-script@v7
+        env:
+          REQUIRED_CHECKS_JSON: ${{ steps.required-checks.outputs.checks }}
+        with:
+          github-token: ${{ steps.get-hoard-token.outputs.token }}
+          script: |
+            const prNum = Number(process.env.PR_NUMBER);
+            const requiredChecks = new Set(JSON.parse(process.env.REQUIRED_CHECKS_JSON || '[]'));
+
+            const { data: pr } = await github.rest.pulls.get({
+              owner: 'airbytehq', repo: 'airbyte', pull_number: prNum,
+            });
+            const sha = pr.head.sha;
+
+            const statuses = await github.paginate(
+              github.rest.repos.listCommitStatusesForRef,
+              { owner: 'airbytehq', repo: 'airbyte', ref: sha, per_page: 100 }
+            );
+            const successStatuses = new Set(
+              statuses.filter(s => s.state === 'success').map(s => s.context)
+            );
+
+            const checkRuns = await github.paginate(
+              github.rest.checks.listForRef,
+              { owner: 'airbytehq', repo: 'airbyte', ref: sha, per_page: 100 },
+              (response) => response.data
+            );
+            const successChecks = new Set(
+              checkRuns
+                .filter(cr => cr.conclusion === 'success' || cr.conclusion === 'skipped')
+                .map(cr => cr.name)
+            );
+
+            const allPassing = new Set([...successStatuses, ...successChecks]);
+            const missing = [...requiredChecks].filter(c => !allPassing.has(c));
+
+            if (missing.length > 0) {
+              core.info(`Missing checks: ${missing.join(', ')}`);
+              core.setOutput('ready', 'false');
+              core.setOutput('missing', missing.join(', '));
+            } else {
+              core.info('All required checks passing');
+              core.setOutput('ready', 'true');
+              core.setOutput('missing', '');
+            }
+
+      - name: Post comment if required checks are not passing
+        if: steps.pre-check.outputs.state == 'OPEN' && steps.validate-paths.outputs.valid == 'true' && steps.verify-checks.outputs.ready == 'false'
+        env:
+          GH_TOKEN: ${{ steps.get-hoard-token.outputs.token }}
+          MISSING_CHECKS: ${{ steps.verify-checks.outputs.missing }}
+        run: |
+          gh pr comment "$PR_NUMBER" --repo airbytehq/airbyte --body "$(cat <<EOF
+          ## Auto-merge evaluation: **BLOCKED**
+
+          Required status checks are not passing. Missing: \`${MISSING_CHECKS}\`
+
+          The \`hyd-ready\` label has been kept. The evaluation will re-run when the label is re-applied or can be retried manually.
+
+          > [Workflow run](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})
+          EOF
+          )"
+
+      # ── Devin AI evaluation ────────────────────────────────────────
+      - name: Create Devin session with structured output
+        if: >
+          steps.pre-check.outputs.state == 'OPEN'
+          && steps.validate-paths.outputs.valid == 'true'
+          && steps.verify-checks.outputs.ready == 'true'
+        id: create-session
+        env:
+          DEVIN_API_KEY: ${{ secrets.DEVIN_AI_API_KEY }}
+          DEVIN_ORG_ID: ${{ vars.DEVIN_AI_ORG_ID }}
+        run: |
+          set -euo pipefail
+
+          PROMPT="Analyze this pull request and classify it by filling out the structured output schema:
+          https://github.com/airbytehq/airbyte/pull/${PR_NUMBER}
+
+          Review the PR diff, changed files, and PR comments. Each field in the schema has a description explaining exactly what to check and when to set pass to true or false.
+
+          Important:
+          - For allowed_scopes, each scope is mutually exclusive. A scope should only be true if the ENTIRE PR consists of that type of change and nothing else.
+          - Be precise and conservative: when in doubt, set pass to false.
+          - Do NOT create any files, branches, or PRs. Do NOT write any code. Only analyze."
+
+          SCHEMA='{
+            "type": "object",
+            "properties": {
+              "preconditions": {
+                "type": "object",
+                "description": "Safety and readiness checks for the PR.",
+                "properties": {
+                  "no_breaking_changes": {
+                    "type": "object",
+                    "description": "Set pass to true ONLY if the PR does not introduce any breaking changes. A breaking change includes: major version bumps, removed or renamed public APIs, changed function signatures, removed configuration options, backward-incompatible schema changes, or anything that would require downstream consumers to modify their code or configuration.",
+                    "properties": {
+                      "pass": { "type": "boolean" },
+                      "reasoning": { "type": "string" }
+                    },
+                    "required": ["pass", "reasoning"]
+                  },
+                  "ai_review_passed": {
+                    "type": "object",
+                    "description": "Set pass to true ONLY if the PR has a comment from devin-ai-integration[bot] containing the HTML marker '"'"'<!-- pr_ai_review_result: APPROVE'"'"' (exactly that string). Look through all PR comments to find this marker. If no such comment exists, or if the marker says FAIL, UNKNOWN, or SKIP, set pass to false.",
+                    "properties": {
+                      "pass": { "type": "boolean" },
+                      "reasoning": { "type": "string" }
+                    },
+                    "required": ["pass", "reasoning"]
+                  }
+                },
+                "required": ["no_breaking_changes", "ai_review_passed"]
+              },
+              "allowed_scopes": {
+                "type": "object",
+                "description": "Classification of the type of change in this PR. Each scope is mutually exclusive -- set pass to true ONLY if the PR consists ENTIRELY of that type of change and nothing else.",
+                "properties": {
+                  "docs_only_change": {
+                    "type": "object",
+                    "description": "Set pass to true ONLY if every file changed in the PR is a documentation file (markdown, rst, mdx, or files under docs/ directories). If even one non-documentation file is changed, set pass to false.",
+                    "properties": {
+                      "pass": { "type": "boolean" },
+                      "reasoning": { "type": "string" }
+                    },
+                    "required": ["pass", "reasoning"]
+                  },
+                  "comment_only_change": {
+                    "type": "object",
+                    "description": "Set pass to true ONLY if the entire diff consists exclusively of code comment additions, removals, or modifications (e.g. Python # comments, Java/Kotlin // or /* */ comments, YAML # comments). No functional code, imports, or logic may be added, removed, or changed. If any non-comment line is modified, set pass to false.",
+                    "properties": {
+                      "pass": { "type": "boolean" },
+                      "reasoning": { "type": "string" }
+                    },
+                    "required": ["pass", "reasoning"]
+                  },
+                  "dependency_version_bump": {
+                    "type": "object",
+                    "description": "Set pass to true ONLY if the PR exclusively bumps dependency versions (e.g. changes to pyproject.toml, setup.py, build.gradle, package.json version pins, or lockfiles) without any other functional code changes. The version bump must be a patch or minor version increment, NOT a major version bump. If the PR includes any other changes beyond the version bump and its lockfile updates, set pass to false.",
+                    "properties": {
+                      "pass": { "type": "boolean" },
+                      "reasoning": { "type": "string" }
+                    },
+                    "required": ["pass", "reasoning"]
+                  },
+                  "metadata_only_change": {
+                    "type": "object",
+                    "description": "Set pass to true ONLY if every file changed in the PR is a connector metadata file such as metadata.yaml, icon.svg, or similar non-code connector configuration files. If any source code, test, or documentation file is changed, set pass to false.",
+                    "properties": {
+                      "pass": { "type": "boolean" },
+                      "reasoning": { "type": "string" }
+                    },
+                    "required": ["pass", "reasoning"]
+                  }
+                },
+                "required": ["docs_only_change", "comment_only_change", "dependency_version_bump", "metadata_only_change"]
+              }
+            },
+            "required": ["preconditions", "allowed_scopes"]
+          }'
+
+          RESPONSE=$(curl -sf -X POST \
+            "https://api.devin.ai/v3/organizations/$DEVIN_ORG_ID/sessions" \
+            -H "Authorization: Bearer $DEVIN_API_KEY" \
+            -H "Content-Type: application/json" \
+            --data "$(jq -n \
+              --arg prompt "$PROMPT" \
+              --arg title "Auto-merge eval: PR #${PR_NUMBER}" \
+              --argjson schema "$SCHEMA" \
+              '{
+                "prompt": $prompt,
+                "title": $title,
+                "max_acu_limit": 2,
+                "tags": ["auto-merge-eval", "hyd-ready"],
+                "structured_output_required": true,
+                "structured_output_schema": $schema
+              }')")
+
+          SESSION_ID=$(echo "$RESPONSE" | jq -r '.session_id')
+          SESSION_URL=$(echo "$RESPONSE" | jq -r '.url')
+
+          echo "session_id=$SESSION_ID" | tee -a "$GITHUB_OUTPUT"
+          echo "session_url=$SESSION_URL" | tee -a "$GITHUB_OUTPUT"
+          echo "::notice::Devin session created: $SESSION_URL"
+
+      - name: Poll for structured output
+        if: steps.create-session.outputs.session_id
+        id: poll
+        env:
+          DEVIN_API_KEY: ${{ secrets.DEVIN_AI_API_KEY }}
+          DEVIN_ORG_ID: ${{ vars.DEVIN_AI_ORG_ID }}
+          SESSION_ID: ${{ steps.create-session.outputs.session_id }}
+        run: |
+          set -euo pipefail
+
+          POLL_INTERVAL=15
+          MAX_WAIT=600
+          elapsed=0
+
+          while true; do
+            RESPONSE=$(curl -sf \
+              "https://api.devin.ai/v3/organizations/$DEVIN_ORG_ID/sessions/$SESSION_ID" \
+              -H "Authorization: Bearer $DEVIN_API_KEY")
+
+            STATUS=$(echo "$RESPONSE" | jq -r '.status')
+            HAS_OUTPUT=$(echo "$RESPONSE" | jq -e '.structured_output != null' 2>/dev/null && echo "yes" || echo "no")
+
+            echo "[${elapsed}s] status=$STATUS structured_output=$HAS_OUTPUT"
+
+            if [[ "$HAS_OUTPUT" == "yes" ]]; then
+              echo "Structured output received."
+              STRUCTURED_OUTPUT=$(echo "$RESPONSE" | jq -c '.structured_output')
+              echo "structured_output=$STRUCTURED_OUTPUT" >> "$GITHUB_OUTPUT"
+              echo "success=true" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+
+            if [[ "$STATUS" == "exit" || "$STATUS" == "error" ]]; then
+              echo "::error::Devin session ended ($STATUS) without producing structured output."
+              echo "success=false" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+
+            if [[ "$elapsed" -ge "$MAX_WAIT" ]]; then
+              echo "::error::Timed out after ${MAX_WAIT}s waiting for Devin structured output."
+              echo "success=false" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+
+            sleep "$POLL_INTERVAL"
+            elapsed=$((elapsed + POLL_INTERVAL))
+          done
+
+      - name: Terminate Devin session
+        if: always() && steps.create-session.outputs.session_id
+        env:
+          DEVIN_API_KEY: ${{ secrets.DEVIN_AI_API_KEY }}
+          DEVIN_ORG_ID: ${{ vars.DEVIN_AI_ORG_ID }}
+          SESSION_ID: ${{ steps.create-session.outputs.session_id }}
+        run: |
+          curl -sf -X DELETE \
+            "https://api.devin.ai/v3/organizations/$DEVIN_ORG_ID/sessions/$SESSION_ID" \
+            -H "Authorization: Bearer $DEVIN_API_KEY" > /dev/null 2>&1 || true
+
+      # ── Evaluate structured output ─────────────────────────────────
+      - name: Evaluate auto-merge gates
+        if: steps.poll.outputs.success == 'true'
+        id: evaluate
+        env:
+          STRUCTURED_OUTPUT: ${{ steps.poll.outputs.structured_output }}
+        run: |
+          set -euo pipefail
+
+          echo "::group::Structured output"
+          echo "$STRUCTURED_OUTPUT" | jq .
+          echo "::endgroup::"
+
+          # Preconditions: ALL must be true
+          no_breaking=$(echo "$STRUCTURED_OUTPUT" | jq -r '.preconditions.no_breaking_changes.pass')
+          ai_review=$(echo "$STRUCTURED_OUTPUT" | jq -r '.preconditions.ai_review_passed.pass')
+
+          if [[ "$no_breaking" == "true" && "$ai_review" == "true" ]]; then
+            preconditions_pass="true"
+          else
+            preconditions_pass="false"
+          fi
+
+          # Allowed scopes: ANY must be true
+          docs_only=$(echo "$STRUCTURED_OUTPUT" | jq -r '.allowed_scopes.docs_only_change.pass')
+          comment_only=$(echo "$STRUCTURED_OUTPUT" | jq -r '.allowed_scopes.comment_only_change.pass')
+          dep_bump=$(echo "$STRUCTURED_OUTPUT" | jq -r '.allowed_scopes.dependency_version_bump.pass')
+          metadata_only=$(echo "$STRUCTURED_OUTPUT" | jq -r '.allowed_scopes.metadata_only_change.pass')
+
+          if [[ "$docs_only" == "true" || "$comment_only" == "true" || "$dep_bump" == "true" || "$metadata_only" == "true" ]]; then
+            scope_pass="true"
+          else
+            scope_pass="false"
+          fi
+
+          # Final decision
+          if [[ "$preconditions_pass" == "true" && "$scope_pass" == "true" ]]; then
+            result="PASS"
+          else
+            result="FAIL"
+          fi
+
+          echo "preconditions_pass=$preconditions_pass" | tee -a "$GITHUB_OUTPUT"
+          echo "scope_pass=$scope_pass" | tee -a "$GITHUB_OUTPUT"
+          echo "result=$result" | tee -a "$GITHUB_OUTPUT"
+
+          echo "::notice::Auto-merge evaluation result: $result (preconditions=$preconditions_pass, scope=$scope_pass)"
+
+      # ── Post PR comment with results ───────────────────────────────
+      - name: Build evaluation report
+        if: steps.poll.outputs.success == 'true'
+        id: report
+        env:
+          STRUCTURED_OUTPUT: ${{ steps.poll.outputs.structured_output }}
+          EVAL_RESULT: ${{ steps.evaluate.outputs.result }}
+          SESSION_URL: ${{ steps.create-session.outputs.session_url }}
+        run: |
+          set -euo pipefail
+
+          # Helper: emit a checkbox line with reasoning
+          checkbox() {
+            local pass="$1" label="$2" reasoning="$3"
+            if [[ "$pass" == "true" ]]; then
+              echo "- :white_check_mark: **${label}** -- ${reasoning}"
+            else
+              echo "- :x: **${label}** -- ${reasoning}"
+            fi
+          }
+
+          {
+            echo "## Auto-merge evaluation: **${EVAL_RESULT}**"
+            echo ""
+            echo "### Preconditions (all must pass)"
+            checkbox \
+              "$(echo "$STRUCTURED_OUTPUT" | jq -r '.preconditions.no_breaking_changes.pass')" \
+              "No breaking changes" \
+              "$(echo "$STRUCTURED_OUTPUT" | jq -r '.preconditions.no_breaking_changes.reasoning')"
+            checkbox \
+              "$(echo "$STRUCTURED_OUTPUT" | jq -r '.preconditions.ai_review_passed.pass')" \
+              "AI review passed" \
+              "$(echo "$STRUCTURED_OUTPUT" | jq -r '.preconditions.ai_review_passed.reasoning')"
+            echo ""
+            echo "### Allowed scopes (at least one must pass)"
+            checkbox \
+              "$(echo "$STRUCTURED_OUTPUT" | jq -r '.allowed_scopes.docs_only_change.pass')" \
+              "Docs-only change" \
+              "$(echo "$STRUCTURED_OUTPUT" | jq -r '.allowed_scopes.docs_only_change.reasoning')"
+            checkbox \
+              "$(echo "$STRUCTURED_OUTPUT" | jq -r '.allowed_scopes.comment_only_change.pass')" \
+              "Comment-only change" \
+              "$(echo "$STRUCTURED_OUTPUT" | jq -r '.allowed_scopes.comment_only_change.reasoning')"
+            checkbox \
+              "$(echo "$STRUCTURED_OUTPUT" | jq -r '.allowed_scopes.dependency_version_bump.pass')" \
+              "Dependency version bump" \
+              "$(echo "$STRUCTURED_OUTPUT" | jq -r '.allowed_scopes.dependency_version_bump.reasoning')"
+            checkbox \
+              "$(echo "$STRUCTURED_OUTPUT" | jq -r '.allowed_scopes.metadata_only_change.pass')" \
+              "Metadata-only change" \
+              "$(echo "$STRUCTURED_OUTPUT" | jq -r '.allowed_scopes.metadata_only_change.reasoning')"
+            echo ""
+            echo "> [Devin session](${SESSION_URL}) | [Workflow run](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})"
+          } > /tmp/eval-comment.md
+
+          # Store for next step
+          {
+            echo "comment<<EVAL_EOF"
+            cat /tmp/eval-comment.md
+            echo "EVAL_EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Post evaluation comment on PR
+        if: steps.report.outputs.comment
+        env:
+          GH_TOKEN: ${{ steps.get-hoard-token.outputs.token }}
+          EVAL_COMMENT: ${{ steps.report.outputs.comment }}
+        run: |
+          gh pr comment "$PR_NUMBER" --repo airbytehq/airbyte --body "$EVAL_COMMENT"
+
+      - name: Post comment on Devin error/timeout
+        if: steps.poll.outputs.success == 'false'
+        env:
+          GH_TOKEN: ${{ steps.get-hoard-token.outputs.token }}
+          SESSION_URL: ${{ steps.create-session.outputs.session_url }}
+        run: |
+          gh pr comment "$PR_NUMBER" --repo airbytehq/airbyte --body "$(cat <<EOF
+          ## Auto-merge evaluation: **ERROR**
+
+          The Devin AI evaluation session did not produce structured output (timeout or session error).
+          The \`hyd-ready\` label has been kept -- re-apply or retry manually.
+
+          > [Devin session](${SESSION_URL}) | [Workflow run](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})
+          EOF
+          )"
+
+      # ── Merge (if evaluation passed) ───────────────────────────────
+      - name: Authenticate as 'octavia-bot-admin' GitHub App
+        if: steps.evaluate.outputs.result == 'PASS'
+        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
+        id: get-admin-token
+        with:
+          owner: "airbytehq"
+          repositories: "airbyte"
+          app-id: ${{ secrets.OCTAVIA_BOT_ADMIN_APP_ID }}
+          private-key: ${{ secrets.OCTAVIA_BOT_ADMIN_PRIVATE_KEY }}
+
+      - name: Mark draft PR as ready for review
+        if: steps.evaluate.outputs.result == 'PASS' && steps.pre-check.outputs.is_draft == 'true'
+        env:
+          GH_TOKEN: ${{ steps.get-hoard-token.outputs.token }}
+        run: gh pr ready "$PR_NUMBER" --repo airbytehq/airbyte
+
+      - name: Approve PR with admin bot
+        if: steps.evaluate.outputs.result == 'PASS'
+        env:
+          GH_TOKEN: ${{ steps.get-admin-token.outputs.token }}
+        run: >
+          gh pr review "$PR_NUMBER"
+          --repo airbytehq/airbyte
+          --approve
+          --body "Auto-approved by AI-gated auto-merge evaluation."
+
+      - name: Squash merge PR
+        if: steps.evaluate.outputs.result == 'PASS' && vars.ENABLE_CONNECTOR_AUTO_MERGE == 'true'
+        env:
+          GH_TOKEN: ${{ steps.get-hoard-token.outputs.token }}
+        run: |
+          for attempt in 1 2 3; do
+            if gh pr merge "$PR_NUMBER" --repo airbytehq/airbyte --squash; then
+              echo "::notice::Merged PR #${PR_NUMBER}: ${PR_TITLE}"
+              exit 0
+            fi
+            echo "::warning::Merge attempt $attempt/3 failed, retrying in 60s..."
+            sleep 60
+          done
+          echo "::error::Failed to merge PR #$PR_NUMBER after 3 attempts"
+          exit 1
+
+      - name: Dry-run notice
+        if: steps.evaluate.outputs.result == 'PASS' && vars.ENABLE_CONNECTOR_AUTO_MERGE != 'true'
+        run: echo "::notice::DRY RUN -- would merge PR #${PR_NUMBER}"

--- a/.github/workflows/hydra-automerge.yml
+++ b/.github/workflows/hydra-automerge.yml
@@ -236,192 +236,129 @@ jobs:
           > [Workflow run](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})"
 
       # ── Devin AI evaluation ────────────────────────────────────────
-      - name: Create Devin session with structured output
+      - name: Checkout code
         if: >
           steps.pre-check.outputs.state == 'OPEN'
           && steps.validate-paths.outputs.valid == 'true'
           && steps.verify-checks.outputs.ready == 'true'
-        id: create-session
-        env:
-          DEVIN_API_KEY: ${{ secrets.DEVIN_AI_API_KEY }}
-          DEVIN_ORG_ID: ${{ vars.DEVIN_AI_ORG_ID }}
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Run Devin auto-merge evaluation
+        if: >
+          steps.pre-check.outputs.state == 'OPEN'
+          && steps.validate-paths.outputs.valid == 'true'
+          && steps.verify-checks.outputs.ready == 'true'
+        id: devin
+        uses: aaronsteers/devin-action@main
+        with:
+          devin-token: ${{ secrets.DEVIN_AI_API_KEY }}
+          github-token: ${{ steps.get-hoard-token.outputs.token }}
+          org-id: ${{ vars.DEVIN_AI_ORG_ID }}
+          issue-number: ${{ inputs.pr }}
+          max-acu-limit: "2"
+          wait-for-stopped-status: "true"
+          wait-minutes-max: "10"
+          structured-output-required: "true"
+          start-message: "**Auto-merge evaluation** starting..."
+          tags: |
+            auto-merge-eval
+            hyd-ready
+          prompt-text: |
+            Analyze this pull request and classify it by filling out the structured output schema:
+            https://github.com/airbytehq/airbyte/pull/${{ inputs.pr }}
+
+            Review the PR diff, changed files, and PR comments. Each field in the schema has a description explaining exactly what to check and when to set pass to true or false.
+
+            Important:
+            - For allowed_scopes, each scope is mutually exclusive. A scope should only be true if the ENTIRE PR consists of that type of change and nothing else.
+            - Be precise and conservative: when in doubt, set pass to false.
+            - Do NOT create any files, branches, or PRs. Do NOT write any code. Only analyze.
+          structured-output-schema: |
+            type: object
+            properties:
+              preconditions:
+                type: object
+                description: "Safety and readiness checks for the PR."
+                properties:
+                  no_breaking_changes:
+                    type: object
+                    description: "Set pass to true ONLY if the PR does not introduce any breaking changes. A breaking change includes: major version bumps, removed or renamed public APIs, changed function signatures, removed configuration options, backward-incompatible schema changes, or anything that would require downstream consumers to modify their code or configuration."
+                    properties:
+                      pass:
+                        type: boolean
+                      reasoning:
+                        type: string
+                    required: [pass, reasoning]
+                  ai_review_passed:
+                    type: object
+                    description: "Set pass to true ONLY if the PR has a comment from devin-ai-integration[bot] containing the HTML marker '<!-- pr_ai_review_result: APPROVE' (exactly that string). Look through all PR comments to find this marker. If no such comment exists, or if the marker says FAIL, UNKNOWN, or SKIP, set pass to false."
+                    properties:
+                      pass:
+                        type: boolean
+                      reasoning:
+                        type: string
+                    required: [pass, reasoning]
+                required: [no_breaking_changes, ai_review_passed]
+              allowed_scopes:
+                type: object
+                description: "Classification of the type of change in this PR. Each scope is mutually exclusive -- set pass to true ONLY if the PR consists ENTIRELY of that type of change and nothing else."
+                properties:
+                  docs_only_change:
+                    type: object
+                    description: "Set pass to true ONLY if every file changed in the PR is a documentation file (markdown, rst, mdx, or files under docs/ directories). If even one non-documentation file is changed, set pass to false."
+                    properties:
+                      pass:
+                        type: boolean
+                      reasoning:
+                        type: string
+                    required: [pass, reasoning]
+                  comment_only_change:
+                    type: object
+                    description: "Set pass to true ONLY if the entire diff consists exclusively of code comment additions, removals, or modifications (e.g. Python # comments, Java/Kotlin // or /* */ comments, YAML # comments). No functional code, imports, or logic may be added, removed, or changed. If any non-comment line is modified, set pass to false."
+                    properties:
+                      pass:
+                        type: boolean
+                      reasoning:
+                        type: string
+                    required: [pass, reasoning]
+                  dependency_version_bump:
+                    type: object
+                    description: "Set pass to true ONLY if the PR exclusively bumps dependency versions (e.g. changes to pyproject.toml, setup.py, build.gradle, package.json version pins, or lockfiles) without any other functional code changes. The version bump must be a patch or minor version increment, NOT a major version bump. If the PR includes any other changes beyond the version bump and its lockfile updates, set pass to false."
+                    properties:
+                      pass:
+                        type: boolean
+                      reasoning:
+                        type: string
+                    required: [pass, reasoning]
+                  metadata_only_change:
+                    type: object
+                    description: "Set pass to true ONLY if every file changed in the PR is a connector metadata file such as metadata.yaml, icon.svg, or similar non-code connector configuration files. If any source code, test, or documentation file is changed, set pass to false."
+                    properties:
+                      pass:
+                        type: boolean
+                      reasoning:
+                        type: string
+                    required: [pass, reasoning]
+                required: [docs_only_change, comment_only_change, dependency_version_bump, metadata_only_change]
+            required: [preconditions, allowed_scopes]
+
+      - name: Check for structured output
+        if: steps.devin.outputs.session-id
+        id: check-output
         run: |
-          set -euo pipefail
-
-          PROMPT="Analyze this pull request and classify it by filling out the structured output schema:
-          https://github.com/airbytehq/airbyte/pull/${PR_NUMBER}
-
-          Review the PR diff, changed files, and PR comments. Each field in the schema has a description explaining exactly what to check and when to set pass to true or false.
-
-          Important:
-          - For allowed_scopes, each scope is mutually exclusive. A scope should only be true if the ENTIRE PR consists of that type of change and nothing else.
-          - Be precise and conservative: when in doubt, set pass to false.
-          - Do NOT create any files, branches, or PRs. Do NOT write any code. Only analyze."
-
-          SCHEMA='{
-            "type": "object",
-            "properties": {
-              "preconditions": {
-                "type": "object",
-                "description": "Safety and readiness checks for the PR.",
-                "properties": {
-                  "no_breaking_changes": {
-                    "type": "object",
-                    "description": "Set pass to true ONLY if the PR does not introduce any breaking changes. A breaking change includes: major version bumps, removed or renamed public APIs, changed function signatures, removed configuration options, backward-incompatible schema changes, or anything that would require downstream consumers to modify their code or configuration.",
-                    "properties": {
-                      "pass": { "type": "boolean" },
-                      "reasoning": { "type": "string" }
-                    },
-                    "required": ["pass", "reasoning"]
-                  },
-                  "ai_review_passed": {
-                    "type": "object",
-                    "description": "Set pass to true ONLY if the PR has a comment from devin-ai-integration[bot] containing the HTML marker '"'"'<!-- pr_ai_review_result: APPROVE'"'"' (exactly that string). Look through all PR comments to find this marker. If no such comment exists, or if the marker says FAIL, UNKNOWN, or SKIP, set pass to false.",
-                    "properties": {
-                      "pass": { "type": "boolean" },
-                      "reasoning": { "type": "string" }
-                    },
-                    "required": ["pass", "reasoning"]
-                  }
-                },
-                "required": ["no_breaking_changes", "ai_review_passed"]
-              },
-              "allowed_scopes": {
-                "type": "object",
-                "description": "Classification of the type of change in this PR. Each scope is mutually exclusive -- set pass to true ONLY if the PR consists ENTIRELY of that type of change and nothing else.",
-                "properties": {
-                  "docs_only_change": {
-                    "type": "object",
-                    "description": "Set pass to true ONLY if every file changed in the PR is a documentation file (markdown, rst, mdx, or files under docs/ directories). If even one non-documentation file is changed, set pass to false.",
-                    "properties": {
-                      "pass": { "type": "boolean" },
-                      "reasoning": { "type": "string" }
-                    },
-                    "required": ["pass", "reasoning"]
-                  },
-                  "comment_only_change": {
-                    "type": "object",
-                    "description": "Set pass to true ONLY if the entire diff consists exclusively of code comment additions, removals, or modifications (e.g. Python # comments, Java/Kotlin // or /* */ comments, YAML # comments). No functional code, imports, or logic may be added, removed, or changed. If any non-comment line is modified, set pass to false.",
-                    "properties": {
-                      "pass": { "type": "boolean" },
-                      "reasoning": { "type": "string" }
-                    },
-                    "required": ["pass", "reasoning"]
-                  },
-                  "dependency_version_bump": {
-                    "type": "object",
-                    "description": "Set pass to true ONLY if the PR exclusively bumps dependency versions (e.g. changes to pyproject.toml, setup.py, build.gradle, package.json version pins, or lockfiles) without any other functional code changes. The version bump must be a patch or minor version increment, NOT a major version bump. If the PR includes any other changes beyond the version bump and its lockfile updates, set pass to false.",
-                    "properties": {
-                      "pass": { "type": "boolean" },
-                      "reasoning": { "type": "string" }
-                    },
-                    "required": ["pass", "reasoning"]
-                  },
-                  "metadata_only_change": {
-                    "type": "object",
-                    "description": "Set pass to true ONLY if every file changed in the PR is a connector metadata file such as metadata.yaml, icon.svg, or similar non-code connector configuration files. If any source code, test, or documentation file is changed, set pass to false.",
-                    "properties": {
-                      "pass": { "type": "boolean" },
-                      "reasoning": { "type": "string" }
-                    },
-                    "required": ["pass", "reasoning"]
-                  }
-                },
-                "required": ["docs_only_change", "comment_only_change", "dependency_version_bump", "metadata_only_change"]
-              }
-            },
-            "required": ["preconditions", "allowed_scopes"]
-          }'
-
-          RESPONSE=$(curl -sf -X POST \
-            "https://api.devin.ai/v3/organizations/$DEVIN_ORG_ID/sessions" \
-            -H "Authorization: Bearer $DEVIN_API_KEY" \
-            -H "Content-Type: application/json" \
-            --data "$(jq -n \
-              --arg prompt "$PROMPT" \
-              --arg title "Auto-merge eval: PR #${PR_NUMBER}" \
-              --argjson schema "$SCHEMA" \
-              '{
-                "prompt": $prompt,
-                "title": $title,
-                "max_acu_limit": 2,
-                "tags": ["auto-merge-eval", "hyd-ready"],
-                "structured_output_required": true,
-                "structured_output_schema": $schema
-              }')")
-
-          SESSION_ID=$(echo "$RESPONSE" | jq -r '.session_id')
-          SESSION_URL=$(echo "$RESPONSE" | jq -r '.url')
-
-          echo "session_id=$SESSION_ID" | tee -a "$GITHUB_OUTPUT"
-          echo "session_url=$SESSION_URL" | tee -a "$GITHUB_OUTPUT"
-          echo "::notice::Devin session created: $SESSION_URL"
-
-      - name: Poll for structured output
-        if: steps.create-session.outputs.session_id
-        id: poll
-        env:
-          DEVIN_API_KEY: ${{ secrets.DEVIN_AI_API_KEY }}
-          DEVIN_ORG_ID: ${{ vars.DEVIN_AI_ORG_ID }}
-          SESSION_ID: ${{ steps.create-session.outputs.session_id }}
-        run: |
-          set -euo pipefail
-
-          POLL_INTERVAL=15
-          MAX_WAIT=600
-          elapsed=0
-
-          while true; do
-            RESPONSE=$(curl -sf \
-              "https://api.devin.ai/v3/organizations/$DEVIN_ORG_ID/sessions/$SESSION_ID" \
-              -H "Authorization: Bearer $DEVIN_API_KEY")
-
-            STATUS=$(echo "$RESPONSE" | jq -r '.status')
-            HAS_OUTPUT=$(echo "$RESPONSE" | jq -e '.structured_output != null' 2>/dev/null && echo "yes" || echo "no")
-
-            echo "[${elapsed}s] status=$STATUS structured_output=$HAS_OUTPUT"
-
-            if [[ "$HAS_OUTPUT" == "yes" ]]; then
-              echo "Structured output received."
-              STRUCTURED_OUTPUT=$(echo "$RESPONSE" | jq -c '.structured_output')
-              echo "structured_output=$STRUCTURED_OUTPUT" >> "$GITHUB_OUTPUT"
-              echo "success=true" >> "$GITHUB_OUTPUT"
-              exit 0
-            fi
-
-            if [[ "$STATUS" == "exit" || "$STATUS" == "error" ]]; then
-              echo "::error::Devin session ended ($STATUS) without producing structured output."
-              echo "success=false" >> "$GITHUB_OUTPUT"
-              exit 0
-            fi
-
-            if [[ "$elapsed" -ge "$MAX_WAIT" ]]; then
-              echo "::error::Timed out after ${MAX_WAIT}s waiting for Devin structured output."
-              echo "success=false" >> "$GITHUB_OUTPUT"
-              exit 0
-            fi
-
-            sleep "$POLL_INTERVAL"
-            elapsed=$((elapsed + POLL_INTERVAL))
-          done
-
-      - name: Terminate Devin session
-        if: always() && steps.create-session.outputs.session_id
-        env:
-          DEVIN_API_KEY: ${{ secrets.DEVIN_AI_API_KEY }}
-          DEVIN_ORG_ID: ${{ vars.DEVIN_AI_ORG_ID }}
-          SESSION_ID: ${{ steps.create-session.outputs.session_id }}
-        run: |
-          curl -sf -X DELETE \
-            "https://api.devin.ai/v3/organizations/$DEVIN_ORG_ID/sessions/$SESSION_ID" \
-            -H "Authorization: Bearer $DEVIN_API_KEY" > /dev/null 2>&1 || true
+          if [[ -n '${{ steps.devin.outputs.structured-output }}' ]]; then
+            echo "success=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "::error::Devin session completed but did not produce structured output."
+            echo "success=false" >> "$GITHUB_OUTPUT"
+          fi
 
       # ── Evaluate structured output ─────────────────────────────────
       - name: Evaluate auto-merge gates
-        if: steps.poll.outputs.success == 'true'
+        if: steps.check-output.outputs.success == 'true'
         id: evaluate
         env:
-          STRUCTURED_OUTPUT: ${{ steps.poll.outputs.structured_output }}
+          STRUCTURED_OUTPUT: ${{ steps.devin.outputs.structured-output }}
         run: |
           set -euo pipefail
 
@@ -466,12 +403,12 @@ jobs:
 
       # ── Post results ───────────────────────────────────────────────
       - name: Build evaluation report
-        if: steps.poll.outputs.success == 'true'
+        if: steps.check-output.outputs.success == 'true'
         id: report
         env:
-          STRUCTURED_OUTPUT: ${{ steps.poll.outputs.structured_output }}
+          STRUCTURED_OUTPUT: ${{ steps.devin.outputs.structured-output }}
           EVAL_RESULT: ${{ steps.evaluate.outputs.result }}
-          SESSION_URL: ${{ steps.create-session.outputs.session_url }}
+          SESSION_URL: ${{ steps.devin.outputs.session-url }}
           DRY_RUN: ${{ inputs.dry-run }}
         run: |
           set -euo pipefail
@@ -554,8 +491,8 @@ jobs:
         run: |
           gh pr comment "$PR_NUMBER" --repo airbytehq/airbyte --body "$EVAL_COMMENT"
 
-      - name: Update command comment on Devin error/timeout
-        if: steps.poll.outputs.success == 'false' && inputs.comment-id
+      - name: Update command comment on Devin error
+        if: steps.check-output.outputs.success == 'false' && inputs.comment-id
         uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
         with:
           token: ${{ steps.get-hoard-token.outputs.token }}
@@ -563,19 +500,19 @@ jobs:
           body: |
             > **Auto-merge evaluation: ERROR**
             >
-            > The Devin AI evaluation session did not produce structured output (timeout or session error).
+            > The Devin AI evaluation session did not produce structured output.
             >
-            > [Devin session](${{ steps.create-session.outputs.session_url }}) | [Workflow run](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})
+            > [Devin session](${{ steps.devin.outputs.session-url }}) | [Workflow run](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})
 
-      - name: Post new comment on Devin error/timeout (no command comment)
-        if: steps.poll.outputs.success == 'false' && !inputs.comment-id
+      - name: Post new comment on Devin error (no command comment)
+        if: steps.check-output.outputs.success == 'false' && !inputs.comment-id
         env:
           GH_TOKEN: ${{ steps.get-hoard-token.outputs.token }}
-          SESSION_URL: ${{ steps.create-session.outputs.session_url }}
+          SESSION_URL: ${{ steps.devin.outputs.session-url }}
         run: |
           gh pr comment "$PR_NUMBER" --repo airbytehq/airbyte --body "## Auto-merge evaluation: **ERROR**
 
-          The Devin AI evaluation session did not produce structured output (timeout or session error).
+          The Devin AI evaluation session did not produce structured output.
 
           > [Devin session](${SESSION_URL}) | [Workflow run](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})"
 

--- a/.github/workflows/hydra-automerge.yml
+++ b/.github/workflows/hydra-automerge.yml
@@ -1,11 +1,12 @@
 name: "Hydra: Auto-merge (AI-gated)"
-# Triggered via the /ai-ready slash command or when the 'hyd-ready' label is added.
+# Triggered via the /ai-ready slash command or called from other workflows.
 # Kicks off a Devin AI session with structured output to evaluate whether
 # the PR is safe to auto-merge, then evaluates the result deterministically:
 #   pass = ALL(preconditions) AND ANY(allowed_scopes)
 #
 # Dry-run mode is controlled by the org-level variable ENABLE_CONNECTOR_AUTO_MERGE.
 # Set to "true" to enable real merges; any other value (or unset) runs in dry-run mode.
+# The dry-run input skips approve/merge regardless of the variable.
 
 on:
   workflow_dispatch:
@@ -22,6 +23,10 @@ on:
       comment-id:
         description: "Comment ID (from slash command dispatcher)"
         required: false
+      dry-run:
+        description: "If 'true', evaluate only -- do not approve or merge"
+        required: false
+        default: ""
   workflow_call:
     inputs:
       pr:
@@ -32,23 +37,23 @@ on:
         description: "Comment ID"
         required: false
         type: string
-  pull_request_target:
-    types: [labeled]
+      dry-run:
+        description: "If 'true', evaluate only -- do not approve or merge"
+        required: false
+        type: string
+        default: ""
 
-run-name: "Auto-merge eval for PR #${{ inputs.pr || github.event.pull_request.number }}"
+run-name: "Auto-merge eval for PR #${{ inputs.pr }}"
 
 # All repo operations use GitHub App tokens, not GITHUB_TOKEN.
 permissions: {}
 
 jobs:
   evaluate-and-merge:
-    name: "Evaluate PR #${{ inputs.pr || github.event.pull_request.number }}"
-    if: >
-      inputs.pr != ''
-      || (github.event.label.name == 'hyd-ready' && github.event.pull_request.state == 'open')
+    name: "Evaluate PR #${{ inputs.pr }}"
     runs-on: ubuntu-24.04
     env:
-      PR_NUMBER: ${{ inputs.pr || github.event.pull_request.number }}
+      PR_NUMBER: ${{ inputs.pr }}
     steps:
       # ── Authentication ──────────────────────────────────────────────
       - name: Authenticate as 'octavia-bot-hoard' GitHub App
@@ -61,7 +66,7 @@ jobs:
           private-key: ${{ secrets.OCTAVIA_BOT_HOARD_PRIVATE_KEY }}
 
       # ── Pre-checks ─────────────────────────────────────────────────
-      - name: Check PR is still open and not a draft
+      - name: Check PR is still open
         id: pre-check
         env:
           GH_TOKEN: ${{ steps.get-hoard-token.outputs.token }}
@@ -76,6 +81,16 @@ jobs:
           if [[ "$state" != "OPEN" ]]; then
             echo "::warning::PR #$PR_NUMBER is no longer open (state=$state). Skipping."
           fi
+
+      - name: Update command comment with progress
+        if: inputs.comment-id && steps.pre-check.outputs.state == 'OPEN'
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
+        with:
+          token: ${{ steps.get-hoard-token.outputs.token }}
+          comment-id: ${{ inputs.comment-id }}
+          body: |
+            > **Auto-merge evaluation in progress...**
+            > [Workflow run](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})
 
       - name: Validate connector-only file paths
         if: steps.pre-check.outputs.state == 'OPEN'
@@ -99,19 +114,30 @@ jobs:
           done < /tmp/changed-files.txt
           echo "valid=$valid" | tee -a "$GITHUB_OUTPUT"
 
-      - name: Post comment if path validation fails
+      - name: Early exit -- path validation failed
         if: steps.pre-check.outputs.state == 'OPEN' && steps.validate-paths.outputs.valid == 'false'
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
+        with:
+          token: ${{ steps.get-hoard-token.outputs.token }}
+          comment-id: ${{ inputs.comment-id }}
+          body: |
+            > **Auto-merge evaluation: SKIPPED**
+            >
+            > This PR modifies files outside the allowed connector paths.
+            > Auto-merge is only available for PRs that exclusively touch connector-related files.
+            >
+            > [Workflow run](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})
+
+      - name: Post new comment if no command comment (path fail)
+        if: steps.pre-check.outputs.state == 'OPEN' && steps.validate-paths.outputs.valid == 'false' && !inputs.comment-id
         env:
           GH_TOKEN: ${{ steps.get-hoard-token.outputs.token }}
         run: |
-          gh pr comment "$PR_NUMBER" --repo airbytehq/airbyte --body "$(cat <<'EOF'
-          ## Auto-merge evaluation: **SKIPPED**
+          gh pr comment "$PR_NUMBER" --repo airbytehq/airbyte --body "## Auto-merge evaluation: **SKIPPED**
 
           This PR modifies files outside the allowed connector paths. Auto-merge is only available for PRs that exclusively touch connector-related files.
 
-          > [Workflow run](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})
-          EOF
-          )"
+          > [Workflow run](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})"
 
       - name: Fetch required checks for master branch
         if: steps.pre-check.outputs.state == 'OPEN' && steps.validate-paths.outputs.valid == 'true'
@@ -184,22 +210,30 @@ jobs:
               core.setOutput('missing', '');
             }
 
-      - name: Post comment if required checks are not passing
+      - name: Early exit -- required checks not passing
         if: steps.pre-check.outputs.state == 'OPEN' && steps.validate-paths.outputs.valid == 'true' && steps.verify-checks.outputs.ready == 'false'
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
+        with:
+          token: ${{ steps.get-hoard-token.outputs.token }}
+          comment-id: ${{ inputs.comment-id }}
+          body: |
+            > **Auto-merge evaluation: BLOCKED**
+            >
+            > Required status checks are not passing. Missing: `${{ steps.verify-checks.outputs.missing }}`
+            >
+            > [Workflow run](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})
+
+      - name: Post new comment if no command comment (checks fail)
+        if: steps.pre-check.outputs.state == 'OPEN' && steps.validate-paths.outputs.valid == 'true' && steps.verify-checks.outputs.ready == 'false' && !inputs.comment-id
         env:
           GH_TOKEN: ${{ steps.get-hoard-token.outputs.token }}
           MISSING_CHECKS: ${{ steps.verify-checks.outputs.missing }}
         run: |
-          gh pr comment "$PR_NUMBER" --repo airbytehq/airbyte --body "$(cat <<EOF
-          ## Auto-merge evaluation: **BLOCKED**
+          gh pr comment "$PR_NUMBER" --repo airbytehq/airbyte --body "## Auto-merge evaluation: **BLOCKED**
 
           Required status checks are not passing. Missing: \`${MISSING_CHECKS}\`
 
-          The \`hyd-ready\` label has been kept. The evaluation will re-run when the label is re-applied or can be retried manually.
-
-          > [Workflow run](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})
-          EOF
-          )"
+          > [Workflow run](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})"
 
       # ── Devin AI evaluation ────────────────────────────────────────
       - name: Create Devin session with structured output
@@ -430,7 +464,7 @@ jobs:
 
           echo "::notice::Auto-merge evaluation result: $result (preconditions=$preconditions_pass, scope=$scope_pass)"
 
-      # ── Post PR comment with results ───────────────────────────────
+      # ── Post results ───────────────────────────────────────────────
       - name: Build evaluation report
         if: steps.poll.outputs.success == 'true'
         id: report
@@ -438,6 +472,7 @@ jobs:
           STRUCTURED_OUTPUT: ${{ steps.poll.outputs.structured_output }}
           EVAL_RESULT: ${{ steps.evaluate.outputs.result }}
           SESSION_URL: ${{ steps.create-session.outputs.session_url }}
+          DRY_RUN: ${{ inputs.dry-run }}
         run: |
           set -euo pipefail
 
@@ -451,8 +486,16 @@ jobs:
             fi
           }
 
+          if [[ "$DRY_RUN" == "true" ]]; then
+            header="## Auto-merge evaluation: **${EVAL_RESULT}** (dry run)"
+            footer_note="Dry run -- no merge action taken."
+          else
+            header="## Auto-merge evaluation: **${EVAL_RESULT}**"
+            footer_note=""
+          fi
+
           {
-            echo "## Auto-merge evaluation: **${EVAL_RESULT}**"
+            echo "$header"
             echo ""
             echo "### Preconditions (all must pass)"
             checkbox \
@@ -481,44 +524,64 @@ jobs:
               "$(echo "$STRUCTURED_OUTPUT" | jq -r '.allowed_scopes.metadata_only_change.pass')" \
               "Metadata-only change" \
               "$(echo "$STRUCTURED_OUTPUT" | jq -r '.allowed_scopes.metadata_only_change.reasoning')"
+            if [[ -n "$footer_note" ]]; then
+              echo ""
+              echo "> $footer_note"
+            fi
             echo ""
             echo "> [Devin session](${SESSION_URL}) | [Workflow run](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})"
           } > /tmp/eval-comment.md
 
-          # Store for next step
           {
             echo "comment<<EVAL_EOF"
             cat /tmp/eval-comment.md
             echo "EVAL_EOF"
           } >> "$GITHUB_OUTPUT"
 
-      - name: Post evaluation comment on PR
-        if: steps.report.outputs.comment
+      - name: Update command comment with results
+        if: steps.report.outputs.comment && inputs.comment-id
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
+        with:
+          token: ${{ steps.get-hoard-token.outputs.token }}
+          comment-id: ${{ inputs.comment-id }}
+          body: ${{ steps.report.outputs.comment }}
+
+      - name: Post new comment with results (no command comment)
+        if: steps.report.outputs.comment && !inputs.comment-id
         env:
           GH_TOKEN: ${{ steps.get-hoard-token.outputs.token }}
           EVAL_COMMENT: ${{ steps.report.outputs.comment }}
         run: |
           gh pr comment "$PR_NUMBER" --repo airbytehq/airbyte --body "$EVAL_COMMENT"
 
-      - name: Post comment on Devin error/timeout
-        if: steps.poll.outputs.success == 'false'
+      - name: Update command comment on Devin error/timeout
+        if: steps.poll.outputs.success == 'false' && inputs.comment-id
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
+        with:
+          token: ${{ steps.get-hoard-token.outputs.token }}
+          comment-id: ${{ inputs.comment-id }}
+          body: |
+            > **Auto-merge evaluation: ERROR**
+            >
+            > The Devin AI evaluation session did not produce structured output (timeout or session error).
+            >
+            > [Devin session](${{ steps.create-session.outputs.session_url }}) | [Workflow run](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})
+
+      - name: Post new comment on Devin error/timeout (no command comment)
+        if: steps.poll.outputs.success == 'false' && !inputs.comment-id
         env:
           GH_TOKEN: ${{ steps.get-hoard-token.outputs.token }}
           SESSION_URL: ${{ steps.create-session.outputs.session_url }}
         run: |
-          gh pr comment "$PR_NUMBER" --repo airbytehq/airbyte --body "$(cat <<EOF
-          ## Auto-merge evaluation: **ERROR**
+          gh pr comment "$PR_NUMBER" --repo airbytehq/airbyte --body "## Auto-merge evaluation: **ERROR**
 
           The Devin AI evaluation session did not produce structured output (timeout or session error).
-          The \`hyd-ready\` label has been kept -- re-apply or retry manually.
 
-          > [Devin session](${SESSION_URL}) | [Workflow run](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})
-          EOF
-          )"
+          > [Devin session](${SESSION_URL}) | [Workflow run](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})"
 
-      # ── Merge (if evaluation passed) ───────────────────────────────
+      # ── Merge (if evaluation passed and not dry-run) ────────────────
       - name: Authenticate as 'octavia-bot-admin' GitHub App
-        if: steps.evaluate.outputs.result == 'PASS'
+        if: steps.evaluate.outputs.result == 'PASS' && inputs.dry-run != 'true'
         uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
         id: get-admin-token
         with:
@@ -528,13 +591,13 @@ jobs:
           private-key: ${{ secrets.OCTAVIA_BOT_ADMIN_PRIVATE_KEY }}
 
       - name: Mark draft PR as ready for review
-        if: steps.evaluate.outputs.result == 'PASS' && steps.pre-check.outputs.is_draft == 'true'
+        if: steps.evaluate.outputs.result == 'PASS' && inputs.dry-run != 'true' && steps.pre-check.outputs.is_draft == 'true'
         env:
           GH_TOKEN: ${{ steps.get-hoard-token.outputs.token }}
         run: gh pr ready "$PR_NUMBER" --repo airbytehq/airbyte
 
       - name: Approve PR with admin bot
-        if: steps.evaluate.outputs.result == 'PASS'
+        if: steps.evaluate.outputs.result == 'PASS' && inputs.dry-run != 'true'
         env:
           GH_TOKEN: ${{ steps.get-admin-token.outputs.token }}
         run: >
@@ -544,7 +607,7 @@ jobs:
           --body "Auto-approved by AI-gated auto-merge evaluation."
 
       - name: Squash merge PR
-        if: steps.evaluate.outputs.result == 'PASS' && vars.ENABLE_CONNECTOR_AUTO_MERGE == 'true'
+        if: steps.evaluate.outputs.result == 'PASS' && inputs.dry-run != 'true' && vars.ENABLE_CONNECTOR_AUTO_MERGE == 'true'
         env:
           GH_TOKEN: ${{ steps.get-hoard-token.outputs.token }}
         run: |
@@ -559,6 +622,10 @@ jobs:
           echo "::error::Failed to merge PR #$PR_NUMBER after 3 attempts"
           exit 1
 
-      - name: Dry-run notice
-        if: steps.evaluate.outputs.result == 'PASS' && vars.ENABLE_CONNECTOR_AUTO_MERGE != 'true'
-        run: echo "::notice::DRY RUN -- would merge PR #${PR_NUMBER}"
+      - name: Dry-run notice (variable)
+        if: steps.evaluate.outputs.result == 'PASS' && inputs.dry-run != 'true' && vars.ENABLE_CONNECTOR_AUTO_MERGE != 'true'
+        run: echo "::notice::DRY RUN (ENABLE_CONNECTOR_AUTO_MERGE not set) -- would merge PR #${PR_NUMBER}"
+
+      - name: Dry-run notice (flag)
+        if: steps.evaluate.outputs.result == 'PASS' && inputs.dry-run == 'true'
+        run: echo "::notice::DRY RUN (dry-run flag) -- would merge PR #${PR_NUMBER}"

--- a/.github/workflows/hydra-automerge.yml
+++ b/.github/workflows/hydra-automerge.yml
@@ -270,7 +270,7 @@ jobs:
             Review the PR diff, changed files, and PR comments. Each field in the schema has a description explaining exactly what to check and when to set pass to true or false.
 
             Important:
-            - For allowed_scopes, each scope is mutually exclusive. A scope should only be true if the ENTIRE PR consists of that type of change and nothing else.
+            - For change_scope, each scope is mutually exclusive. A scope should only be true if the ENTIRE PR consists of that type of change and nothing else.
             - Be precise and conservative: when in doubt, set pass to false.
             - Do NOT create any files, branches, or PRs. Do NOT write any code. Only analyze.
           structured-output-schema: |
@@ -299,7 +299,7 @@ jobs:
                         type: string
                     required: [pass, reasoning]
                 required: [no_breaking_changes, ai_review_passed]
-              allowed_scopes:
+              change_scope:
                 type: object
                 description: "Classification of the type of change in this PR. Each scope is mutually exclusive -- set pass to true ONLY if the PR consists ENTIRELY of that type of change and nothing else."
                 properties:
@@ -340,7 +340,7 @@ jobs:
                         type: string
                     required: [pass, reasoning]
                 required: [docs_only_change, comment_only_change, dependency_version_bump, metadata_only_change]
-            required: [preconditions, allowed_scopes]
+            required: [preconditions, change_scope]
 
       - name: Check for structured output
         if: steps.devin.outputs.session-id
@@ -376,11 +376,11 @@ jobs:
             preconditions_pass="false"
           fi
 
-          # Allowed scopes: ANY must be true
-          docs_only=$(echo "$STRUCTURED_OUTPUT" | jq -r '.allowed_scopes.docs_only_change.pass')
-          comment_only=$(echo "$STRUCTURED_OUTPUT" | jq -r '.allowed_scopes.comment_only_change.pass')
-          dep_bump=$(echo "$STRUCTURED_OUTPUT" | jq -r '.allowed_scopes.dependency_version_bump.pass')
-          metadata_only=$(echo "$STRUCTURED_OUTPUT" | jq -r '.allowed_scopes.metadata_only_change.pass')
+          # Change scope: ANY must be true
+          docs_only=$(echo "$STRUCTURED_OUTPUT" | jq -r '.change_scope.docs_only_change.pass')
+          comment_only=$(echo "$STRUCTURED_OUTPUT" | jq -r '.change_scope.comment_only_change.pass')
+          dep_bump=$(echo "$STRUCTURED_OUTPUT" | jq -r '.change_scope.dependency_version_bump.pass')
+          metadata_only=$(echo "$STRUCTURED_OUTPUT" | jq -r '.change_scope.metadata_only_change.pass')
 
           if [[ "$docs_only" == "true" || "$comment_only" == "true" || "$dep_bump" == "true" || "$metadata_only" == "true" ]]; then
             scope_pass="true"
@@ -399,7 +399,7 @@ jobs:
           echo "scope_pass=$scope_pass" | tee -a "$GITHUB_OUTPUT"
           echo "result=$result" | tee -a "$GITHUB_OUTPUT"
 
-          echo "::notice::Auto-merge evaluation result: $result (preconditions=$preconditions_pass, scope=$scope_pass)"
+          echo "::notice::Auto-merge evaluation result: $result (preconditions=$preconditions_pass, change_scope=$scope_pass)"
 
       # ── Post results ───────────────────────────────────────────────
       - name: Build evaluation report
@@ -444,23 +444,23 @@ jobs:
               "AI review passed" \
               "$(echo "$STRUCTURED_OUTPUT" | jq -r '.preconditions.ai_review_passed.reasoning')"
             echo ""
-            echo "### Allowed scopes (at least one must pass)"
+            echo "### Change scope (at least one must pass)"
             checkbox \
-              "$(echo "$STRUCTURED_OUTPUT" | jq -r '.allowed_scopes.docs_only_change.pass')" \
+              "$(echo "$STRUCTURED_OUTPUT" | jq -r '.change_scope.docs_only_change.pass')" \
               "Docs-only change" \
-              "$(echo "$STRUCTURED_OUTPUT" | jq -r '.allowed_scopes.docs_only_change.reasoning')"
+              "$(echo "$STRUCTURED_OUTPUT" | jq -r '.change_scope.docs_only_change.reasoning')"
             checkbox \
-              "$(echo "$STRUCTURED_OUTPUT" | jq -r '.allowed_scopes.comment_only_change.pass')" \
+              "$(echo "$STRUCTURED_OUTPUT" | jq -r '.change_scope.comment_only_change.pass')" \
               "Comment-only change" \
-              "$(echo "$STRUCTURED_OUTPUT" | jq -r '.allowed_scopes.comment_only_change.reasoning')"
+              "$(echo "$STRUCTURED_OUTPUT" | jq -r '.change_scope.comment_only_change.reasoning')"
             checkbox \
-              "$(echo "$STRUCTURED_OUTPUT" | jq -r '.allowed_scopes.dependency_version_bump.pass')" \
+              "$(echo "$STRUCTURED_OUTPUT" | jq -r '.change_scope.dependency_version_bump.pass')" \
               "Dependency version bump" \
-              "$(echo "$STRUCTURED_OUTPUT" | jq -r '.allowed_scopes.dependency_version_bump.reasoning')"
+              "$(echo "$STRUCTURED_OUTPUT" | jq -r '.change_scope.dependency_version_bump.reasoning')"
             checkbox \
-              "$(echo "$STRUCTURED_OUTPUT" | jq -r '.allowed_scopes.metadata_only_change.pass')" \
+              "$(echo "$STRUCTURED_OUTPUT" | jq -r '.change_scope.metadata_only_change.pass')" \
               "Metadata-only change" \
-              "$(echo "$STRUCTURED_OUTPUT" | jq -r '.allowed_scopes.metadata_only_change.reasoning')"
+              "$(echo "$STRUCTURED_OUTPUT" | jq -r '.change_scope.metadata_only_change.reasoning')"
             if [[ -n "$footer_note" ]]; then
               echo ""
               echo "> $footer_note"

--- a/.github/workflows/hydra-automerge.yml
+++ b/.github/workflows/hydra-automerge.yml
@@ -1,5 +1,5 @@
 name: "Hydra: Auto-merge (AI-gated)"
-# Triggered when the 'hyd-ready' label is added to a PR.
+# Triggered via the /ai-ready slash command or when the 'hyd-ready' label is added.
 # Kicks off a Devin AI session with structured output to evaluate whether
 # the PR is safe to auto-merge, then evaluates the result deterministically:
 #   pass = ALL(preconditions) AND ANY(allowed_scopes)
@@ -8,22 +8,47 @@ name: "Hydra: Auto-merge (AI-gated)"
 # Set to "true" to enable real merges; any other value (or unset) runs in dry-run mode.
 
 on:
+  workflow_dispatch:
+    inputs:
+      repo:
+        description: "Repo (owner/repo)"
+        required: false
+      gitref:
+        description: "Git ref"
+        required: false
+      pr:
+        description: "PR number"
+        required: true
+      comment-id:
+        description: "Comment ID (from slash command dispatcher)"
+        required: false
+  workflow_call:
+    inputs:
+      pr:
+        description: "PR number"
+        required: true
+        type: string
+      comment-id:
+        description: "Comment ID"
+        required: false
+        type: string
   pull_request_target:
     types: [labeled]
 
-run-name: "Auto-merge eval for PR #${{ github.event.pull_request.number }}"
+run-name: "Auto-merge eval for PR #${{ inputs.pr || github.event.pull_request.number }}"
 
 # All repo operations use GitHub App tokens, not GITHUB_TOKEN.
 permissions: {}
 
 jobs:
   evaluate-and-merge:
-    name: "Evaluate PR #${{ github.event.pull_request.number }}"
-    if: github.event.label.name == 'hyd-ready' && github.event.pull_request.state == 'open'
+    name: "Evaluate PR #${{ inputs.pr || github.event.pull_request.number }}"
+    if: >
+      inputs.pr != ''
+      || (github.event.label.name == 'hyd-ready' && github.event.pull_request.state == 'open')
     runs-on: ubuntu-24.04
     env:
-      PR_NUMBER: ${{ github.event.pull_request.number }}
-      PR_TITLE: ${{ github.event.pull_request.title }}
+      PR_NUMBER: ${{ inputs.pr || github.event.pull_request.number }}
     steps:
       # ── Authentication ──────────────────────────────────────────────
       - name: Authenticate as 'octavia-bot-hoard' GitHub App
@@ -41,11 +66,13 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.get-hoard-token.outputs.token }}
         run: |
-          pr_json=$(gh pr view "$PR_NUMBER" --repo airbytehq/airbyte --json state,isDraft)
+          pr_json=$(gh pr view "$PR_NUMBER" --repo airbytehq/airbyte --json state,isDraft,title)
           state=$(echo "$pr_json" | jq -r '.state')
           is_draft=$(echo "$pr_json" | jq -r '.isDraft')
+          title=$(echo "$pr_json" | jq -r '.title')
           echo "state=$state" | tee -a "$GITHUB_OUTPUT"
           echo "is_draft=$is_draft" | tee -a "$GITHUB_OUTPUT"
+          echo "title=$title" | tee -a "$GITHUB_OUTPUT"
           if [[ "$state" != "OPEN" ]]; then
             echo "::warning::PR #$PR_NUMBER is no longer open (state=$state). Skipping."
           fi
@@ -523,7 +550,7 @@ jobs:
         run: |
           for attempt in 1 2 3; do
             if gh pr merge "$PR_NUMBER" --repo airbytehq/airbyte --squash; then
-              echo "::notice::Merged PR #${PR_NUMBER}: ${PR_TITLE}"
+              echo "::notice::Merged PR #${PR_NUMBER}: ${{ steps.pre-check.outputs.title }}"
               exit 0
             fi
             echo "::warning::Merge attempt $attempt/3 failed, retrying in 60s..."

--- a/.github/workflows/hydra-automerge.yml
+++ b/.github/workflows/hydra-automerge.yml
@@ -413,15 +413,9 @@ jobs:
         run: |
           set -euo pipefail
 
-          # Helper: emit a checkbox line with reasoning
-          checkbox() {
-            local pass="$1" label="$2" reasoning="$3"
-            if [[ "$pass" == "true" ]]; then
-              echo "- :white_check_mark: **${label}** -- ${reasoning}"
-            else
-              echo "- :x: **${label}** -- ${reasoning}"
-            fi
-          }
+          # Helpers
+          icon() { if [[ "$1" == "true" ]]; then echo ":white_check_mark:"; else echo ":x:"; fi; }
+          pretty_label() { echo "$1" | sed 's/_/ /g; s/\b\(.\)/\u\1/g'; }
 
           if [[ "$DRY_RUN" == "true" ]]; then
             header="## Auto-merge evaluation: **${EVAL_RESULT}** (dry run)"
@@ -435,32 +429,35 @@ jobs:
             echo "$header"
             echo ""
             echo "### Preconditions (all must pass)"
-            checkbox \
-              "$(echo "$STRUCTURED_OUTPUT" | jq -r '.preconditions.no_breaking_changes.pass')" \
-              "No breaking changes" \
-              "$(echo "$STRUCTURED_OUTPUT" | jq -r '.preconditions.no_breaking_changes.reasoning')"
-            checkbox \
-              "$(echo "$STRUCTURED_OUTPUT" | jq -r '.preconditions.ai_review_passed.pass')" \
-              "AI review passed" \
-              "$(echo "$STRUCTURED_OUTPUT" | jq -r '.preconditions.ai_review_passed.reasoning')"
+            echo ""
+            echo "| Status | Check | Reasoning |"
+            echo "|--------|-------|-----------|"
+            for key in no_breaking_changes ai_review_passed; do
+              pass=$(echo "$STRUCTURED_OUTPUT" | jq -r ".preconditions.${key}.pass")
+              reasoning=$(echo "$STRUCTURED_OUTPUT" | jq -r ".preconditions.${key}.reasoning")
+              echo "| $(icon "$pass") | $(pretty_label "$key") | ${reasoning} |"
+            done
             echo ""
             echo "### Change scope (at least one must pass)"
-            checkbox \
-              "$(echo "$STRUCTURED_OUTPUT" | jq -r '.change_scope.docs_only_change.pass')" \
-              "Docs-only change" \
-              "$(echo "$STRUCTURED_OUTPUT" | jq -r '.change_scope.docs_only_change.reasoning')"
-            checkbox \
-              "$(echo "$STRUCTURED_OUTPUT" | jq -r '.change_scope.comment_only_change.pass')" \
-              "Comment-only change" \
-              "$(echo "$STRUCTURED_OUTPUT" | jq -r '.change_scope.comment_only_change.reasoning')"
-            checkbox \
-              "$(echo "$STRUCTURED_OUTPUT" | jq -r '.change_scope.dependency_version_bump.pass')" \
-              "Dependency version bump" \
-              "$(echo "$STRUCTURED_OUTPUT" | jq -r '.change_scope.dependency_version_bump.reasoning')"
-            checkbox \
-              "$(echo "$STRUCTURED_OUTPUT" | jq -r '.change_scope.metadata_only_change.pass')" \
-              "Metadata-only change" \
-              "$(echo "$STRUCTURED_OUTPUT" | jq -r '.change_scope.metadata_only_change.reasoning')"
+            echo ""
+            scope_matched=false
+            has_scope_row=false
+            for key in docs_only_change comment_only_change dependency_version_bump metadata_only_change; do
+              pass=$(echo "$STRUCTURED_OUTPUT" | jq -r ".change_scope.${key}.pass")
+              if [[ "$pass" == "true" ]]; then
+                if [[ "$has_scope_row" == "false" ]]; then
+                  echo "| Status | Scope | Reasoning |"
+                  echo "|--------|-------|-----------|"
+                  has_scope_row=true
+                fi
+                reasoning=$(echo "$STRUCTURED_OUTPUT" | jq -r ".change_scope.${key}.reasoning")
+                echo "| :white_check_mark: | $(pretty_label "$key") | ${reasoning} |"
+                scope_matched=true
+              fi
+            done
+            if [[ "$scope_matched" == "false" ]]; then
+              echo ":x: No matching change scope detected."
+            fi
             if [[ -n "$footer_note" ]]; then
               echo ""
               echo "> $footer_note"


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/hydra-automerge.yml` -- AI-gated auto-merge workflow triggered via `/ai-ready` slash command
- Uses Devin AI structured output to classify PRs, then evaluates gates deterministically in code
- Updates `ai-ready-command.yml` to apply the `hyd-ready` label AND call hydra-automerge directly
- Posts evaluation report inline on the original command comment (no comment spam)
- Supports `dry-run=true` flag: `/ai-ready dry-run=true` evaluates without merging

## Architecture

```mermaid
graph TD
    subgraph HydraHF["<b>Hydra Handsfree</b><br/><i>Automated PR management</i>"]
        direction TB
        AIReviewSlash["Comments <code>/ai-review</code>"]
        AiReadySlash["Comments <code>/ai-ready</code>"]
        AIReviewSlash --> AiReadySlash
    end

    AiReadySlash --> SlashDispatch["<b>slash-commands.yml</b>"]
    SlashDispatch --> AiReady["<b>ai-ready-command.yml</b>"]
    
    AiReady --> AddLabel["Apply <code>hyd-ready</code> label<br/><i>(for tracking/visibility)</i>"]
    AiReady -->|workflow_call| HydraWf

    subgraph HydraWf["<b>hydra-automerge.yml</b>"]
        direction TB
        
        PreCheck["Pre-checks<br/><i>PR open? Connector paths only?<br/>Required status checks pass?</i>"]
        
        PreCheck -->|any fail| CommentFail["Post failure reason<br/>to command comment"]
        
        PreCheck -->|all pass| DevinAction["<b>aaronsteers/devin-action@main</b><br/>Create Devin session<br/>+ poll for structured output"]
    end

    DevinAction -->|structured-output| Evaluate

    subgraph Evaluate["Gate Evaluation (deterministic)"]
        direction TB
        Preconditions["<b>Preconditions</b> — ALL must pass<br/>- no_breaking_changes<br/>- ai_review_passed"]
        Scopes["<b>Change Scope</b> — ANY must pass<br/>- docs_only_change<br/>- comment_only_change<br/>- dependency_version_bump<br/>- metadata_only_change"]
        Decision{"pass = ALL(preconditions)<br/>AND ANY(change_scope)"}
        Preconditions --> Decision
        Scopes --> Decision
    end

    Decision -->|PASS + not dry-run| Merge["Approve + Squash Merge<br/><i>(gated by ENABLE_CONNECTOR_AUTO_MERGE)</i>"]
    Decision -->|FAIL or dry-run| Report["Post evaluation report<br/>to command comment"]
    Decision -->|PASS + dry-run| Report

    Merge --> Report

    subgraph DevinSession["Devin AI Session"]
        direction TB
        Prompt["Prompt: analyze PR #N"] --> PRAnalysis["Devin reviews:<br/>- PR diff & changed files<br/>- PR comments for AI review marker<br/>- Change scope <i>(each mutually exclusive —<br/>true only if ENTIRE PR is that type)</i>"]
        PRAnalysis --> Output["Returns structured JSON<br/>with pass/fail + reasoning per gate"]
    end

    DevinAction -.->|creates & polls| DevinSession
    DevinSession -.->|structured_output| DevinAction

    style HydraHF fill:#2d1b69,stroke:#8b5cf6,color:#fff
    style HydraWf fill:#1a1a2e,stroke:#e94560,color:#fff
    style DevinSession fill:#0f3460,stroke:#16213e,color:#fff
    style Evaluate fill:#1a1a2e,stroke:#e94560,color:#fff
    style Merge fill:#0a4d2e,stroke:#16a34a,color:#fff
    style CommentFail fill:#4a1a1a,stroke:#dc2626,color:#fff
    style Report fill:#1e3a5f,stroke:#3b82f6,color:#fff
```

## Gates

**Preconditions (all must pass):**
- No breaking changes
- AI review passed (looks for `<!-- pr_ai_review_result: APPROVE` marker)

**Change scope (at least one must pass, mutually exclusive):**
- Docs-only change
- Comment-only change
- Dependency version bump (patch/minor only)
- Metadata-only change

## Usage

```
/ai-ready                    # full eval + merge if passes
/ai-ready dry-run=true       # eval only, report results, no merge
```

## Dependencies

- `aaronsteers/devin-action@main` with `structured-output` action output ([PR #52](https://github.com/aaronsteers/devin-action/pull/52) -- merged)
- Existing secrets/variables: `DEVIN_AI_API_KEY`, `DEVIN_AI_ORG_ID`, octavia bot apps
- Dry-run merge gate: `ENABLE_CONNECTOR_AUTO_MERGE` org variable