### PR TITLE
docs(mcp): rename replication MCP references

### DIFF
--- a/docs/community/mcp-servers/pyairbyte-mcp.md
+++ b/docs/community/mcp-servers/pyairbyte-mcp.md
@@ -1,18 +1,18 @@
-# PyAirbyte MCP Server
+# Airbyte Replication MCP Server
 
 :::note
 This MCP server implementation is experimental and may change without notice between minor versions of PyAirbyte. The API may be modified or entirely refactored in future versions.
 :::
 
-The PyAirbyte MCP (Model Context Protocol) server provides a standardized interface for managing Airbyte data replication connections through MCP-compatible clients. This experimental feature allows you to list connectors, validate configurations, and run sync operations using the MCP protocol.
+The Airbyte Replication MCP (Model Context Protocol) server provides a standardized interface for managing Airbyte data replication connections through MCP-compatible clients. This PyAirbyte-powered experimental feature allows you to list connectors, validate configurations, and run sync operations using the MCP protocol.
 
 Use it to manage Airbyte replication workflows. It is not the primary interface agents should use to work with data. The [Agent MCP](/ai-agents/interfaces/mcp/) is the primary way agents use Airbyte to work with data.
 
 ## Documentation
 
-For complete setup instructions, troubleshooting guidance, and detailed documentation, please refer to the authoritative PyAirbyte MCP documentation:
+For complete setup instructions, troubleshooting guidance, and detailed documentation, please refer to the authoritative Airbyte Replication MCP documentation:
 
-**[PyAirbyte MCP Server Documentation](https://airbytehq.github.io/PyAirbyte/airbyte/mcp.html)**
+**[Airbyte Replication MCP Server Documentation](https://airbytehq.github.io/PyAirbyte/airbyte/mcp.html)**
 
 The PyAirbyte documentation includes:
 
@@ -25,18 +25,18 @@ The PyAirbyte documentation includes:
 
 ## Quick Start
 
-To get started with the PyAirbyte MCP server:
+To get started with the Airbyte Replication MCP server:
 
 1. Install `uv`: `brew install uv`
 2. Create a dotenv secrets file with your Airbyte Cloud credentials and connector configurations
 3. Register the MCP server with your MCP client using `uvx --python=3.11 --from=airbyte@latest airbyte-mcp`
 4. Test the connection using your MCP client
 
-For detailed instructions on each step, see the [PyAirbyte MCP documentation](https://airbytehq.github.io/PyAirbyte/airbyte/mcp.html).
+For detailed instructions on each step, see the [Airbyte Replication MCP documentation](https://airbytehq.github.io/PyAirbyte/airbyte/mcp.html).
 
 ## Helpful Prompts
 
-Here are some things you can do with the PyAirbyte MCP server, across local and Airbyte Cloud use cases:
+Here are some things you can do with the Airbyte Replication MCP server, across local and Airbyte Cloud use cases:
 
 1. "Use your MCP tools to list all available Airbyte connectors."
 2. "Use your MCP tools to get information about the Airbyte Stripe connector."

--- a/docs/community/mcp-servers/readme.md
+++ b/docs/community/mcp-servers/readme.md
@@ -16,6 +16,6 @@ Airbyte provides MCP (Model Context Protocol) servers for connecting AI assistan
 
 <CardWithIcon title="Knowledge MCP server" description="Provide Airbyte product and developer knowledge to AI agents through semantic search over Airbyte docs, specs, videos, and GitHub content." ctaText="Set up Knowledge MCP server" ctaLink="/community/mcp-servers/airbyte-knowledge-mcp" icon="fa-magnifying-glass" />
 
-<CardWithIcon title="PyAirbyte MCP server" description="Manage Airbyte data replication workflows through MCP-compatible clients, including connector listing, configuration validation, and sync operations." ctaText="Set up PyAirbyte MCP server" ctaLink="/community/mcp-servers/pyairbyte-mcp" icon="fa-python" />
+<CardWithIcon title="Airbyte Replication MCP server" description="Manage Airbyte data replication workflows through MCP-compatible clients, including connector listing, configuration validation, and sync operations." ctaText="Set up Airbyte Replication MCP server" ctaLink="/community/mcp-servers/pyairbyte-mcp" icon="fa-python" />
 
 </Grid>

--- a/docs/community/mcp-servers/readme.md
+++ b/docs/community/mcp-servers/readme.md
@@ -16,6 +16,6 @@ Airbyte provides MCP (Model Context Protocol) servers for connecting AI assistan
 
 <CardWithIcon title="Knowledge MCP server" description="Provide Airbyte product and developer knowledge to AI agents through semantic search over Airbyte docs, specs, videos, and GitHub content." ctaText="Set up Knowledge MCP server" ctaLink="/community/mcp-servers/airbyte-knowledge-mcp" icon="fa-magnifying-glass" />
 
-<CardWithIcon title="Airbyte Replication MCP server" description="Manage Airbyte data replication workflows through MCP-compatible clients, including connector listing, configuration validation, and sync operations." ctaText="Set up Airbyte Replication MCP server" ctaLink="/community/mcp-servers/pyairbyte-mcp" icon="fa-python" />
+<CardWithIcon title="Airbyte Replication MCP server" description="Manage Airbyte data replication workflows through MCP-compatible clients, including connector listing, configuration validation, and sync operations." ctaText="Set up Airbyte Replication MCP server" ctaLink="/community/mcp-servers/replication-mcp" icon="fa-python" />
 
 </Grid>

--- a/docs/community/mcp-servers/replication-mcp.md
+++ b/docs/community/mcp-servers/replication-mcp.md
@@ -1,3 +1,7 @@
+---
+sidebar_label: Replication MCP Server
+---
+
 # Airbyte Replication MCP Server
 
 :::note

--- a/docs/developers/pyairbyte/reference/airbyte/mcp/index.md
+++ b/docs/developers/pyairbyte/reference/airbyte/mcp/index.md
@@ -3,22 +3,22 @@ id: airbyte-mcp-index
 title: airbyte.mcp.index
 ---
 
-Module airbyte.mcp
-==================
-***PyAirbyte MCP Server - Model Context Protocol Integration***
+# Module airbyte.mcp
+
+**_Airbyte Replication MCP Server - Model Context Protocol Integration_**
 
 > **NOTE:**
 > This MCP server implementation is experimental and may change without notice between minor
 > versions of PyAirbyte. The API may be modified or entirely refactored in future versions.
 
-The PyAirbyte MCP (Model Context Protocol) server provides a standardized interface for
-managing Airbyte connectors through MCP-compatible clients. This experimental feature
-allows you to list connectors, validate configurations, and run sync operations using
-the MCP protocol.
+The Airbyte Replication MCP (Model Context Protocol) server provides a standardized interface
+for managing Airbyte connectors through MCP-compatible clients. This PyAirbyte-powered
+experimental feature allows you to list connectors, validate configurations, and run sync
+operations using the MCP protocol.
 
-## Getting Started with PyAirbyte MCP
+## Getting Started with Airbyte Replication MCP
 
-To get started with the PyAirbyte MCP server, follow these steps:
+To get started with the Airbyte Replication MCP server, follow these steps:
 
 1. Create a Dotenv secrets file.
 2. Register the MCP server with your MCP client.
@@ -26,7 +26,7 @@ To get started with the PyAirbyte MCP server, follow these steps:
 
 ### Step 1: Generate a Dotenv Secrets File
 
-To get started with the PyAirbyte MCP server, you will need to create a dotenv
+To get started with the Airbyte Replication MCP server, you will need to create a dotenv
 file containing your Airbyte Cloud credentials, as well as credentials for any
 third-party services you wish to connect to via Airbyte.
 
@@ -57,11 +57,12 @@ AIRBYTE_CLOUD_WORKSPACE_ID=your_workspace_id
 ```
 
 Note:
+
 1. You can add more environment variables to this file as needed for different connectors. To start,
    you only need to create the file and pass it to the MCP server.
 2. Ensure that this file is kept secure, as it contains sensitive information. Your LLM
-   *should never* be given direct access to this file or its contents.
-3. The MCP tools will give your LLM the ability to view *which* variables are available, but it
+   _should never_ be given direct access to this file or its contents.
+3. The MCP tools will give your LLM the ability to view _which_ variables are available, but it
    does not give access to their values.
 4. The `AIRBYTE_PROJECT_DIR` variable specifies a directory where the MCP server can
    store temporary project files. Ensure this directory is writable by the user running
@@ -84,11 +85,7 @@ requirements.
   "mcpServers": {
     "airbyte": {
       "command": "uvx",
-      "args": [
-        "--python=3.11",
-        "--from=airbyte@latest",
-        "airbyte-mcp"
-      ],
+      "args": ["--python=3.11", "--from=airbyte@latest", "airbyte-mcp"],
       "env": {
         "AIRBYTE_MCP_ENV_FILE": "/path/to/my/.mcp/airbyte_mcp.env",
         "AIRBYTE_CLOUD_MCP_SAFE_MODE": "1",
@@ -100,6 +97,7 @@ requirements.
 ```
 
 Note:
+
 - Replace `/path/to/my/.mcp/airbyte_mcp.env` with the absolute path to your dotenv file created in
   Step 1.
 
@@ -118,8 +116,8 @@ Helpful prompts to try:
 
 ## Airbyte Cloud MCP Server Safety
 
-The PyAirbyte MCP server supports environment variables to control safety and access levels for
-Airbyte Cloud operations.
+The Airbyte Replication MCP server supports environment variables to control safety and access
+levels for Airbyte Cloud operations.
 
 **Important:** The below settings only affect Cloud operations; local operations are not affected.
 
@@ -178,6 +176,7 @@ stores connector artifacts, cache files, and temporary data. Ensure this directo
 - Is writable by the user account running the MCP server.
 
 Note:
+
 - In rare cases, your agent may not be able to find `uv` or `uvx` if they are not in the system
   `PATH` or if the agent has a stale `PATH` value. In these cases, you can use `which uvx` from
   your own terminal to discover the full path to the `uvx` binary, and then provide the full path
@@ -197,7 +196,7 @@ This design allows AI assistants to help configure connectors without compromisi
 
 Note: While the MCP server takes steps to secure your credentials, you are responsible for
 ensuring the agent is not given access to your secrets by other means. For example, Claude Code
-may have *full* local disk access when run in certain modes. Consult your agent's documentation
+may have _full_ local disk access when run in certain modes. Consult your agent's documentation
 for details on securing local files.
 
 ## Contributing to the Airbyte MCP Server
@@ -210,13 +209,14 @@ for details on securing local files.
 - [MCP Documentation Home](https://modelcontextprotocol.io/)
 
 For issues and questions:
+
 - [PyAirbyte GitHub Issues](https://github.com/airbytehq/pyairbyte/issues)
 - [PyAirbyte Discussions](https://github.com/airbytehq/pyairbyte/discussions)
 
-Sub-modules
------------
-* airbyte.mcp.cloud
-* airbyte.mcp.local
-* airbyte.mcp.prompts
-* airbyte.mcp.registry
-* airbyte.mcp.server
+## Sub-modules
+
+- airbyte.mcp.cloud
+- airbyte.mcp.local
+- airbyte.mcp.prompts
+- airbyte.mcp.registry
+- airbyte.mcp.server

--- a/docs/developers/pyairbyte/reference/airbyte/mcp/prompts.md
+++ b/docs/developers/pyairbyte/reference/airbyte/mcp/prompts.md
@@ -3,21 +3,20 @@ id: airbyte-mcp-prompts
 title: airbyte.mcp.prompts
 ---
 
-Module airbyte.mcp.prompts
-==========================
-MCP prompt definitions for the PyAirbyte MCP server.
+# Module airbyte.mcp.prompts
+
+MCP prompt definitions for the Airbyte Replication MCP server.
 
 This module defines prompts that can be invoked by MCP clients to perform
 common workflows.
 
-Functions
----------
+## Functions
 
 `register_prompts(app: FastMCP) ‑> None`
-:   Register prompts with the FastMCP app.
-    
+: Register prompts with the FastMCP app.
+
     Args:
         app: FastMCP application instance
 
 `test_my_tools_prompt(scope: "Annotated[str | None, Field(description='Optional free-form text to focus or constrain testing. This can be a single word, a sentence, or a paragraph describing the desired scope or constraints.')]" = None) ‑> list[dict[str, str]]`
-:   Generate a prompt that instructs the agent to test available tools.
+: Generate a prompt that instructs the agent to test available tools.

--- a/docusaurus/sidebar-community.js
+++ b/docusaurus/sidebar-community.js
@@ -49,7 +49,7 @@ const mcpServers = {
       href: "/ai-agents/interfaces/mcp/",
     },
     "mcp-servers/airbyte-knowledge-mcp",
-    "mcp-servers/pyairbyte-mcp",
+    "mcp-servers/replication-mcp",
   ],
 };
 

--- a/docusaurus/vercel.json
+++ b/docusaurus/vercel.json
@@ -228,7 +228,12 @@
     },
     {
       "source": "/developers/mcp-servers/pyairbyte-mcp",
-      "destination": "/community/mcp-servers/pyairbyte-mcp",
+      "destination": "/community/mcp-servers/replication-mcp",
+      "statusCode": 301
+    },
+    {
+      "source": "/community/mcp-servers/pyairbyte-mcp",
+      "destination": "/community/mcp-servers/replication-mcp",
       "statusCode": 301
     },
     {


### PR DESCRIPTION
## What
Renames public-facing `PyAirbyte MCP` references to `Airbyte Replication MCP` in the Airbyte docs follow-on to https://github.com/airbytehq/airbyte/pull/78241.

Requested by @aaronsteers. Updated in response to review from @ian-at-airbyte.

## How
- Updates the Community MCP landing page card title, CTA label, and link.
- Renames the Community MCP server docs page from `pyairbyte-mcp.md` to `replication-mcp.md`.
- Adds `sidebar_label: Replication MCP Server` front matter to the docs page.
- Adds Vercel redirects from the old PyAirbyte MCP docs routes to `/community/mcp-servers/replication-mcp`.
- Updates the PyAirbyte API reference mirror under `docs/developers/pyairbyte/reference/airbyte/mcp` for consistency.

## Review guide
1. `docs/community/mcp-servers/replication-mcp.md`
2. `docs/community/mcp-servers/readme.md`
3. `docusaurus/sidebar-community.js`
4. `docusaurus/vercel.json`
5. `docs/developers/pyairbyte/reference/airbyte/mcp/index.md`
6. `docs/developers/pyairbyte/reference/airbyte/mcp/prompts.md`

## User Impact
Users see the tentative `Airbyte Replication MCP` name instead of `PyAirbyte MCP` in public docs. The new page route is `/community/mcp-servers/replication-mcp`; the old community and developer PyAirbyte MCP routes redirect to it.

## Can this PR be safely reverted and rolled back?
- [x] YES 💚
- [ ] NO ❌

Validation:
- `git diff --check`
- `corepack pnpm install --frozen-lockfile`
- `corepack pnpm prettier --check ../docs/community/mcp-servers/pyairbyte-mcp.md ../docs/community/mcp-servers/readme.md ../docs/developers/pyairbyte/reference/airbyte/mcp/index.md ../docs/developers/pyairbyte/reference/airbyte/mcp/prompts.md`
- `pnpm prettier --check ../docs/community/mcp-servers/replication-mcp.md ../docs/community/mcp-servers/readme.md sidebar-community.js vercel.json`
- Deep search confirmed no remaining `PyAirbyte MCP` references in this repo.

Related PRs:
- https://github.com/airbytehq/PyAirbyte/pull/1031
- https://github.com/airbytehq/connector-builder-mcp/pull/218


Link to Devin session: https://app.devin.ai/sessions/ceda5eaaaa204e44a0cb879a03b0ba84