### PR TITLE
docs: clarify progressive rollout gate scenarios

### DIFF
--- a/.github/progressive-rollout-gate-comment.md
+++ b/.github/progressive-rollout-gate-comment.md
@@ -48,7 +48,7 @@ The active rollout is not stopped immediately by the merge.
 
 <details><summary>If the connector version increments to a higher `-rc` version...</summary>
 
-After this PR is merged, the new RC may be published and registered, replacing the active RC marker. When the new RC is registered, the platform cancels any existing non-terminal rollout for this connector without unpinning actors.
+After this PR is merged, the new RC will be published and registered, replacing the active RC marker. When the new RC is registered, the platform cancels any existing non-terminal rollout for this connector without unpinning actors.
 
 After merging, you still need to start the new rollout. During start, pinned actors from the previous rollout can be moved to the new RC.
 

--- a/.github/progressive-rollout-gate-comment.md
+++ b/.github/progressive-rollout-gate-comment.md
@@ -42,7 +42,8 @@ The active rollout is not stopped immediately by the merge.
 
 - If this PR removes the stable-version `registryOverrides` and disables progressive rollout, the published GA version can become the default for eligible non-pinned actors.
 - If this PR leaves stable-version `registryOverrides` in place or leaves progressive rollout enabled, non-rollout registry consumers should continue to see the pre-RC stable version.
-- Actors already pinned by the active rollout remain pinned until that rollout finalizes or is canceled.
+- Actors already pinned by the active rollout remain pinned; publishing the GA version does not immediately unpin them, even when the GA version matches the RC stem.
+- If the rollout later finalizes as promoted and the platform default matches the RC stem, the rollout succeeds and unpins actors. If the platform default does not match the RC stem, the rollout is canceled as superseded.
 
 </details>
 

--- a/.github/progressive-rollout-gate-comment.md
+++ b/.github/progressive-rollout-gate-comment.md
@@ -48,7 +48,7 @@ The active rollout is not stopped immediately by the merge.
 
 <details><summary>If the connector version increments to a higher `-rc` version...</summary>
 
-The merged PR may publish a new release candidate and replace the active RC marker. When the new RC is registered, the platform cancels any existing non-terminal rollout for this connector. If the new rollout is started with pin migration enabled, actors pinned by the previous rollout are moved to the new RC.
+The merged PR may publish a new release candidate and replace the active RC marker. When the new RC is registered, the platform cancels any existing non-terminal rollout for this connector. When the new rollout is started through the normal rollout flow, actors pinned by the previous rollout are moved to the new RC.
 
 </details>
 

--- a/.github/progressive-rollout-gate-comment.md
+++ b/.github/progressive-rollout-gate-comment.md
@@ -26,7 +26,7 @@
 
 #### 🤔 What happens if this PR is merged
 
-Checking the checkbox will allow the PR to merge, but it does not stop the active rollout by itself. The rollout worker is not notified just because another PR publishes a GA version; it only notices a superseding default version later if this rollout itself finalizes as promoted.
+Checking the checkbox will allow the PR to merge, but it does not necessarily stop the active rollout by itself. The result of merging depends on the connector version and rollout metadata that are published.
 
 Expected outcomes by type of version number change:
 
@@ -42,7 +42,7 @@ The merged PR may publish a GA version, but the active rollout is not stopped im
 
 During an active RC rollout, `registryOverrides.cloud.dockerImageTag` and `registryOverrides.oss.dockerImageTag` usually pin non-rollout registry consumers to the pre-RC stable version. Older registry generation depended on those overrides to prevent the RC from becoming default. The newer `airbyte-ops registry compile` path is semver-aware, so `-rc` versions are not eligible as GA/default/latest versions. It also skips GA versions whose metadata still has progressive rollout enabled. If this PR removes those overrides and disables progressive rollout, the newly published GA version can become the registry default for eligible non-pinned actors.
 
-If the active rollout later finalizes as promoted, the rollout worker polls the platform default version and compares it to this rollout's RC stem. For example, `1.2.3-rc.1` is expected to become `1.2.3`. If the default is a different GA version, the rollout is marked `CANCELED` as superseded. If the default matches the RC stem, the rollout can complete as promoted.
+If the active rollout is later promoted, the platform verifies that the default version matches this rollout's RC stem. For example, `1.2.3-rc.1` is expected to become `1.2.3`. If the default is a different GA version, the rollout is marked `CANCELED` as superseded. If the default matches the RC stem, the rollout can complete as promoted.
 
 </details>
 

--- a/.github/progressive-rollout-gate-comment.md
+++ b/.github/progressive-rollout-gate-comment.md
@@ -38,11 +38,11 @@ No new connector version should be released, and the active rollout should conti
 
 <details><summary>If the connector version changes from RC to non-RC (GA) version...</summary>
 
-The merged PR may publish a GA version, but the active rollout is not stopped immediately by the merge.
+The active rollout is not stopped immediately by the merge.
 
-During an active RC rollout, `registryOverrides.cloud.dockerImageTag` and `registryOverrides.oss.dockerImageTag` usually pin non-rollout registry consumers to the pre-RC stable version. Older registry generation depended on those overrides to prevent the RC from becoming default. The newer `airbyte-ops registry compile` path is semver-aware, so `-rc` versions are not eligible as GA/default/latest versions. It also skips GA versions whose metadata still has progressive rollout enabled. If this PR removes those overrides and disables progressive rollout, the newly published GA version can become the registry default for eligible non-pinned actors.
-
-If the active rollout is later promoted, the platform verifies that the default version matches this rollout's RC stem. For example, `1.2.3-rc.1` is expected to become `1.2.3`. If the default is a different GA version, the rollout is marked `CANCELED` as superseded. If the default matches the RC stem, the rollout can complete as promoted.
+- If this PR removes the stable-version `registryOverrides` and disables progressive rollout, the published GA version can become the default for eligible non-pinned actors.
+- If this PR leaves stable-version `registryOverrides` in place or leaves progressive rollout enabled, non-rollout registry consumers should continue to see the pre-RC stable version.
+- Actors already pinned by the active rollout remain pinned until that rollout finalizes or is canceled.
 
 </details>
 

--- a/.github/progressive-rollout-gate-comment.md
+++ b/.github/progressive-rollout-gate-comment.md
@@ -48,7 +48,7 @@ The active rollout is not stopped immediately by the merge.
 
 <details><summary>If the connector version increments to a higher `-rc` version...</summary>
 
-The merged PR may publish a new release candidate and replace the active RC marker. When the new RC is registered, the platform cancels any existing non-terminal rollout for this connector. When the new rollout is started through the normal rollout flow, actors pinned by the previous rollout are moved to the new RC.
+After this PR is merged, it may publish a new release candidate and replace the active RC marker. When the new RC is registered, the platform cancels any existing non-terminal rollout for this connector. After that, when the new rollout is started through the normal rollout flow, actors pinned by the previous rollout are moved to the new RC.
 
 </details>
 

--- a/.github/progressive-rollout-gate-comment.md
+++ b/.github/progressive-rollout-gate-comment.md
@@ -26,7 +26,7 @@
 
 #### 🤔 What happens if this PR is merged
 
-Checking the checkbox will allow the PR to merge, but it does not necessarily stop the active rollout by itself. The result of the PR merging depends on what connector version is published.
+Checking the checkbox will allow the PR to merge, but it does not stop the active rollout by itself. The rollout worker is not notified just because another PR publishes a GA version; it only notices a superseding default version later if this rollout itself finalizes as promoted.
 
 Expected outcomes by type of version number change:
 
@@ -38,13 +38,17 @@ No new connector version should be released, and the active rollout should conti
 
 <details><summary>If the connector version changes from RC to non-RC (GA) version...</summary>
 
-The merged PR may publish the GA version and make it default for eligible non-pinned actors. The existing rollout is not stopped immediately by the merge, but the rollout worker can later cancel it as superseded when finalizing.
+The merged PR may publish a GA version, but the active rollout is not stopped immediately by the merge.
+
+During an active RC rollout, `registryOverrides.cloud.dockerImageTag` and `registryOverrides.oss.dockerImageTag` usually pin non-rollout registry consumers to the pre-RC stable version. Older registry generation depended on those overrides to prevent the RC from becoming default. The newer `airbyte-ops registry compile` path is semver-aware, so `-rc` versions are not eligible as GA/default/latest versions. It also skips GA versions whose metadata still has progressive rollout enabled. If this PR removes those overrides and disables progressive rollout, the newly published GA version can become the registry default for eligible non-pinned actors.
+
+If the active rollout later finalizes as promoted, the rollout worker polls the platform default version and compares it to this rollout's RC stem. For example, `1.2.3-rc.1` is expected to become `1.2.3`. If the default is a different GA version, the rollout is marked `CANCELED` as superseded. If the default matches the RC stem, the rollout can complete as promoted.
 
 </details>
 
 <details><summary>If the connector version increments to a higher `-rc` version...</summary>
 
-The merged PR may publish a new release candidate and replace the active RC marker. The previous incomplete rollout is canceled without unpinning, and a new rollout is created for the subsequent RC version.
+The merged PR may publish a new release candidate and replace the active RC marker. The active rollout is not stopped just because the RC marker changes; it must still be explicitly finalized, canceled, or superseded during its own promote finalization path. Actors already pinned by the active rollout remain pinned until that rollout finalizes or is canceled.
 
 </details>
 

--- a/.github/progressive-rollout-gate-comment.md
+++ b/.github/progressive-rollout-gate-comment.md
@@ -48,10 +48,7 @@ After merging, you still need to start the new rollout. During start, pinned act
 
 This PR should not be merged while the RC rollout is active. First finalize the active rollout as successful or cancel it.
 
-- If the rollout is finalized as successful, the platform triggers a promotion workflow that strips the `-rc` suffix, removes stable-version `registryOverrides`, disables progressive rollout, merges that promotion, and unpins actors.
-- If this PR is merged anyway, it should remove stable-version `registryOverrides` and disable progressive rollout so the published GA version becomes the default for eligible non-pinned actors.
-- The active rollout is not stopped immediately by the merge, and actors already pinned by the rollout remain pinned until the rollout later finalizes or is canceled.
-- If the rollout later finalizes as promoted and the platform default no longer matches the rollout's RC version stem, the rollout is canceled as superseded.
+If the rollout is finalized as successful, the platform triggers a promotion workflow that strips the `-rc` suffix, removes stable-version `registryOverrides`, disables progressive rollout, merges that promotion, and unpins actors.
 
 </details>
 

--- a/.github/progressive-rollout-gate-comment.md
+++ b/.github/progressive-rollout-gate-comment.md
@@ -36,6 +36,14 @@ No new connector version should be released, and the active rollout should conti
 
 </details>
 
+<details><summary>If the connector version increments to a higher `-rc` version...</summary>
+
+After this PR is merged, the new RC will be published and registered, replacing the active RC marker. When the new RC is registered, the platform cancels any existing non-terminal rollout for this connector without unpinning actors.
+
+After merging, you still need to start the new rollout. During start, pinned actors from the previous rollout can be moved to the new RC.
+
+</details>
+
 <details><summary>If the connector version changes from RC to non-RC (GA) version...</summary>
 
 This PR should not be merged while the RC rollout is active. First finalize the active rollout as successful or cancel it.
@@ -44,14 +52,6 @@ This PR should not be merged while the RC rollout is active. First finalize the 
 - If this PR is merged anyway, it should remove stable-version `registryOverrides` and disable progressive rollout so the published GA version becomes the default for eligible non-pinned actors.
 - The active rollout is not stopped immediately by the merge, and actors already pinned by the rollout remain pinned until the rollout later finalizes or is canceled.
 - If the rollout later finalizes as promoted and the platform default no longer matches the rollout's RC version stem, the rollout is canceled as superseded.
-
-</details>
-
-<details><summary>If the connector version increments to a higher `-rc` version...</summary>
-
-After this PR is merged, the new RC will be published and registered, replacing the active RC marker. When the new RC is registered, the platform cancels any existing non-terminal rollout for this connector without unpinning actors.
-
-After merging, you still need to start the new rollout. During start, pinned actors from the previous rollout can be moved to the new RC.
 
 </details>
 

--- a/.github/progressive-rollout-gate-comment.md
+++ b/.github/progressive-rollout-gate-comment.md
@@ -36,22 +36,14 @@ No new connector version should be released, and the active rollout should conti
 
 </details>
 
-<details><summary>If the connector version changes to the active RC's version stem...</summary>
+<details><summary>If the connector version changes from RC to non-RC (GA) version...</summary>
 
 This PR should not be merged while the RC rollout is active. First finalize the active rollout as successful or cancel it.
 
 - If the rollout is finalized as successful, the platform triggers a promotion workflow that strips the `-rc` suffix, removes stable-version `registryOverrides`, disables progressive rollout, merges that promotion, and unpins actors.
-- If this PR is merged instead, the active rollout is not stopped immediately and actors already pinned by the rollout remain pinned until the rollout later finalizes or is canceled.
-
-</details>
-
-<details><summary>If the connector version changes from RC to a new (distinct) GA version...</summary>
-
-This PR should not be merged while the RC rollout is active. First finalize or cancel the active rollout.
-
 - If this PR is merged anyway, it should remove stable-version `registryOverrides` and disable progressive rollout so the published GA version becomes the default for eligible non-pinned actors.
 - The active rollout is not stopped immediately by the merge, and actors already pinned by the rollout remain pinned until the rollout later finalizes or is canceled.
-- If the rollout later finalizes as promoted and the platform default is still this distinct GA version, the rollout is canceled as superseded.
+- If the rollout later finalizes as promoted and the platform default no longer matches the rollout's RC version stem, the rollout is canceled as superseded.
 
 </details>
 

--- a/.github/progressive-rollout-gate-comment.md
+++ b/.github/progressive-rollout-gate-comment.md
@@ -48,7 +48,7 @@ The active rollout is not stopped immediately by the merge.
 
 <details><summary>If the connector version increments to a higher `-rc` version...</summary>
 
-The merged PR may publish a new release candidate and replace the active RC marker. The active rollout is not stopped just because the RC marker changes; it must still be explicitly finalized, canceled, or superseded during its own promote finalization path. Actors already pinned by the active rollout remain pinned until that rollout finalizes or is canceled.
+The merged PR may publish a new release candidate and replace the active RC marker. When the new RC is registered, the platform cancels any existing non-terminal rollout for this connector. If the new rollout is started with pin migration enabled, actors pinned by the previous rollout are moved to the new RC.
 
 </details>
 

--- a/.github/progressive-rollout-gate-comment.md
+++ b/.github/progressive-rollout-gate-comment.md
@@ -40,8 +40,7 @@ No new connector version should be released, and the active rollout should conti
 
 The active rollout is not stopped immediately by the merge.
 
-- If this PR removes the stable-version `registryOverrides` and disables progressive rollout, the published GA version can become the default for eligible non-pinned actors.
-- If this PR leaves stable-version `registryOverrides` in place or leaves progressive rollout enabled, non-rollout registry consumers should continue to see the pre-RC stable version.
+- This PR should remove the stable-version `registryOverrides` and disable progressive rollout so the published GA version becomes the default for eligible non-pinned actors.
 - Actors already pinned by the active rollout remain pinned; publishing the GA version does not immediately unpin them.
 - If the rollout later finalizes as promoted and the platform default matches this version, the rollout succeeds and unpins actors.
 
@@ -51,8 +50,7 @@ The active rollout is not stopped immediately by the merge.
 
 The active rollout is not stopped immediately by the merge.
 
-- If this PR removes the stable-version `registryOverrides` and disables progressive rollout, the published GA version can become the default for eligible non-pinned actors.
-- If this PR leaves stable-version `registryOverrides` in place or leaves progressive rollout enabled, non-rollout registry consumers should continue to see the pre-RC stable version.
+- This PR should remove the stable-version `registryOverrides` and disable progressive rollout so the published GA version becomes the default for eligible non-pinned actors.
 - Actors already pinned by the active rollout remain pinned; publishing a distinct GA version does not immediately unpin them.
 - If the rollout later finalizes as promoted and the platform default is still this distinct GA version, the rollout is canceled as superseded.
 

--- a/.github/progressive-rollout-gate-comment.md
+++ b/.github/progressive-rollout-gate-comment.md
@@ -36,14 +36,25 @@ No new connector version should be released, and the active rollout should conti
 
 </details>
 
-<details><summary>If the connector version changes from RC to non-RC (GA) version...</summary>
+<details><summary>If the connector version changes to the active RC's version stem...</summary>
 
 The active rollout is not stopped immediately by the merge.
 
 - If this PR removes the stable-version `registryOverrides` and disables progressive rollout, the published GA version can become the default for eligible non-pinned actors.
 - If this PR leaves stable-version `registryOverrides` in place or leaves progressive rollout enabled, non-rollout registry consumers should continue to see the pre-RC stable version.
-- Actors already pinned by the active rollout remain pinned; publishing the GA version does not immediately unpin them, even when the GA version matches the RC stem.
-- If the rollout later finalizes as promoted and the platform default matches the RC stem, the rollout succeeds and unpins actors. If the platform default does not match the RC stem, the rollout is canceled as superseded.
+- Actors already pinned by the active rollout remain pinned; publishing the GA version does not immediately unpin them.
+- If the rollout later finalizes as promoted and the platform default matches this version, the rollout succeeds and unpins actors.
+
+</details>
+
+<details><summary>If the connector version changes from RC to a new (distinct) GA version...</summary>
+
+The active rollout is not stopped immediately by the merge.
+
+- If this PR removes the stable-version `registryOverrides` and disables progressive rollout, the published GA version can become the default for eligible non-pinned actors.
+- If this PR leaves stable-version `registryOverrides` in place or leaves progressive rollout enabled, non-rollout registry consumers should continue to see the pre-RC stable version.
+- Actors already pinned by the active rollout remain pinned; publishing a distinct GA version does not immediately unpin them.
+- If the rollout later finalizes as promoted and the platform default is still this distinct GA version, the rollout is canceled as superseded.
 
 </details>
 

--- a/.github/progressive-rollout-gate-comment.md
+++ b/.github/progressive-rollout-gate-comment.md
@@ -38,21 +38,20 @@ No new connector version should be released, and the active rollout should conti
 
 <details><summary>If the connector version changes to the active RC's version stem...</summary>
 
-The active rollout is not stopped immediately by the merge.
+This PR should not be merged while the RC rollout is active. First finalize the active rollout as successful or cancel it.
 
-- This PR should remove the stable-version `registryOverrides` and disable progressive rollout so the published GA version becomes the default for eligible non-pinned actors.
-- Actors already pinned by the active rollout remain pinned; publishing the GA version does not immediately unpin them.
-- The matching version stem matters when the rollout later finalizes: if the rollout is promoted and the platform default is this version, the rollout succeeds and unpins actors.
+- If the rollout is finalized as successful, the platform triggers a promotion workflow that strips the `-rc` suffix, removes stable-version `registryOverrides`, disables progressive rollout, merges that promotion, and unpins actors.
+- If this PR is merged instead, the active rollout is not stopped immediately and actors already pinned by the rollout remain pinned until the rollout later finalizes or is canceled.
 
 </details>
 
 <details><summary>If the connector version changes from RC to a new (distinct) GA version...</summary>
 
-The active rollout is not stopped immediately by the merge.
+This PR should not be merged while the RC rollout is active. First finalize or cancel the active rollout.
 
-- This PR should remove the stable-version `registryOverrides` and disable progressive rollout so the published GA version becomes the default for eligible non-pinned actors.
-- Actors already pinned by the active rollout remain pinned; publishing a distinct GA version does not immediately unpin them.
-- The distinct version matters when the rollout later finalizes: if the rollout is promoted and the platform default is still this distinct GA version, the rollout is canceled as superseded.
+- If this PR is merged anyway, it should remove stable-version `registryOverrides` and disable progressive rollout so the published GA version becomes the default for eligible non-pinned actors.
+- The active rollout is not stopped immediately by the merge, and actors already pinned by the rollout remain pinned until the rollout later finalizes or is canceled.
+- If the rollout later finalizes as promoted and the platform default is still this distinct GA version, the rollout is canceled as superseded.
 
 </details>
 

--- a/.github/progressive-rollout-gate-comment.md
+++ b/.github/progressive-rollout-gate-comment.md
@@ -42,7 +42,7 @@ The active rollout is not stopped immediately by the merge.
 
 - This PR should remove the stable-version `registryOverrides` and disable progressive rollout so the published GA version becomes the default for eligible non-pinned actors.
 - Actors already pinned by the active rollout remain pinned; publishing the GA version does not immediately unpin them.
-- If the rollout later finalizes as promoted and the platform default matches this version, the rollout succeeds and unpins actors.
+- The matching version stem matters when the rollout later finalizes: if the rollout is promoted and the platform default is this version, the rollout succeeds and unpins actors.
 
 </details>
 
@@ -52,7 +52,7 @@ The active rollout is not stopped immediately by the merge.
 
 - This PR should remove the stable-version `registryOverrides` and disable progressive rollout so the published GA version becomes the default for eligible non-pinned actors.
 - Actors already pinned by the active rollout remain pinned; publishing a distinct GA version does not immediately unpin them.
-- If the rollout later finalizes as promoted and the platform default is still this distinct GA version, the rollout is canceled as superseded.
+- The distinct version matters when the rollout later finalizes: if the rollout is promoted and the platform default is still this distinct GA version, the rollout is canceled as superseded.
 
 </details>
 

--- a/.github/progressive-rollout-gate-comment.md
+++ b/.github/progressive-rollout-gate-comment.md
@@ -48,7 +48,7 @@ After merging, you still need to start the new rollout. During start, pinned act
 
 This PR should not be merged while the RC rollout is active. First finalize the active rollout as successful or cancel it.
 
-If the rollout is finalized as successful, the platform triggers a promotion workflow that strips the `-rc` suffix, removes stable-version `registryOverrides`, disables progressive rollout, merges that promotion, and unpins actors.
+When you finalize an RC rollout as successful, the platform triggers a promotion workflow that strips the `-rc` suffix, removes stable-version `registryOverrides`, disables progressive rollout, force-merges that promotion, and unpins actors.
 
 </details>
 

--- a/.github/progressive-rollout-gate-comment.md
+++ b/.github/progressive-rollout-gate-comment.md
@@ -48,7 +48,9 @@ The active rollout is not stopped immediately by the merge.
 
 <details><summary>If the connector version increments to a higher `-rc` version...</summary>
 
-After this PR is merged, it may publish a new release candidate and replace the active RC marker. When the new RC is registered, the platform cancels any existing non-terminal rollout for this connector. After that, when the new rollout is started through the normal rollout flow, actors pinned by the previous rollout are moved to the new RC.
+After this PR is merged, the new RC may be published and registered, replacing the active RC marker. When the new RC is registered, the platform cancels any existing non-terminal rollout for this connector without unpinning actors.
+
+After merging, you still need to start the new rollout. During start, pinned actors from the previous rollout can be moved to the new RC.
 
 </details>
 

--- a/.github/progressive-rollout-gate-comment.md
+++ b/.github/progressive-rollout-gate-comment.md
@@ -46,7 +46,10 @@ After merging, you still need to start the new rollout. During start, pinned act
 
 <details><summary>If the connector version changes from RC to non-RC (GA) version...</summary>
 
-This PR should not be merged while the RC rollout is active. First finalize the active rollout as successful or cancel it.
+You should not merge the PR unless/until the RC has been finalized as canceled. See above `Rollout state` for detected status.
+
+> [!Warning]
+> This PR should not be merged if the RC rollout is still active. First finalize the active rollout as successful or cancel it.
 
 When you finalize an RC rollout as successful, the platform triggers a promotion workflow that strips the `-rc` suffix, removes stable-version `registryOverrides`, disables progressive rollout, force-merges that promotion, and unpins actors.
 

--- a/.github/progressive-rollout-gate-comment.md
+++ b/.github/progressive-rollout-gate-comment.md
@@ -26,7 +26,7 @@
 
 #### 🤔 What happens if this PR is merged
 
-Checking the checkbox will allow the PR to merge, but it does not necessarily stop the active rollout by itself. The result of merging depends on the connector version and rollout metadata that are published.
+Checking the checkbox will allow the PR to merge, but it does not necessarily stop the active rollout by itself. The result of the PR merging depends on what connector version is published.
 
 Expected outcomes by type of version number change:
 


### PR DESCRIPTION
## What

Updates `.github/progressive-rollout-gate-comment.md` to clarify what the active progressive rollout gate means when a connector PR changes versions.

## How

- Keeps the intentionally broad "it depends" intro.
- Moves the higher `-rc` scenario before the GA scenario.
- Clarifies that a higher RC is published/registered after merge, replaces the active RC marker, and cancels existing non-terminal rollout state without unpinning.
- Adds a warning that RC-to-GA PRs should not be merged while the RC rollout is still active; operators should finalize the rollout as successful or cancel it first.
- Notes that successful finalization triggers the promotion workflow to strip the `-rc` suffix, remove stable-version `registryOverrides`, disable progressive rollout, force-merge the promotion, and unpin actors.
- Removes implementation jargon from the gate comment.

## Review guide

1. `.github/progressive-rollout-gate-comment.md`

## User Impact

The gate comment should give maintainers clearer operational guidance when a PR interacts with an active progressive rollout.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚
- [ ] NO ❌

Link to Devin session: https://app.devin.ai/sessions/bd1aa7a6ad6e4775a25659e5f9760e4f
Requested by: @aaronsteers