### PR TITLE
ci: bump AI docs review devin-action to v1.0.0

### DIFF
--- a/.github/workflows/ai-docs-review-command.yml
+++ b/.github/workflows/ai-docs-review-command.yml
@@ -176,7 +176,7 @@ jobs:
 
       - name: Start AI documentation recommendation session
         if: steps.validate.outputs.valid == 'true' && steps.pr-files.outputs.has_connector_changes == 'true'
-        uses: aaronsteers/devin-action@main
+        uses: aaronsteers/devin-action@v1.0.0
         with:
           comment-id: ${{ inputs.comment-id }}
           issue-number: ${{ inputs.pr }}


### PR DESCRIPTION
## What
Bumps the production `AI Docs Review Command` workflow from `aaronsteers/devin-action@main` to the released `aaronsteers/devin-action@v1.0.0` so we can validate the v1.0.0 action release against a real Airbyte workflow before broader rollout.

Requested by AJ Steers.

## How
Updates `.github/workflows/ai-docs-review-command.yml` to pin the `Start AI documentation recommendation session` step to `aaronsteers/devin-action@v1.0.0`.

## Review guide
1. `.github/workflows/ai-docs-review-command.yml`

## User Impact
No product/runtime user impact. This only changes the GitHub Actions version used by the AI docs review workflow.

## Can this PR be safely reverted and rolled back?
- [x] YES 💚
- [ ] NO ❌

## Test plan
- [ ] Dispatch `AI Docs Review Command` from this PR branch via Ops MCP with a connector-change PR and blank `comment-id`.
- [ ] Confirm the workflow reaches the `aaronsteers/devin-action@v1.0.0` step and creates a Devin session successfully.

Link to Devin session: https://app.devin.ai/sessions/c1c780d8a28c4ece9e787572e1a69c2d
Requested by: @aaronsteers