### PR TITLE
ci(progressive-rollout-gate): Add rollout owner and cleanup link

### DIFF
--- a/.github/progressive-rollout-gate-comment.md
+++ b/.github/progressive-rollout-gate-comment.md
@@ -11,7 +11,7 @@
 
 - Rollout version: `{{ .rollout_docker_image_tag }}`
 - Rollout state: `{{ .rollout_state }}`
-- Rollout started or last updated by: `{{ .rollout_updated_by }}`
+- Rollout created or last updated by: `{{ .rollout_created_or_updated_by }}`
 - [Open Connector Rollout Manager in Retool]({{ .retool_url }}) to clean up or close out this rollout if appropriate.
 
 ### Version on `master` Branch: `{{ .master_version }}`

--- a/.github/progressive-rollout-gate-comment.md
+++ b/.github/progressive-rollout-gate-comment.md
@@ -11,7 +11,7 @@
 
 - Rollout version: `{{ .rollout_docker_image_tag }}`
 - Rollout state: `{{ .rollout_state }}`
-- Rollout created or last updated by: `{{ .rollout_created_or_updated_by }}`
+- Rollout last updated by: `{{ .rollout_updated_by }}`
 - [Open Connector Rollout Manager in Retool]({{ .retool_url }}) to clean up or close out this rollout if appropriate.
 
 ### Version on `master` Branch: `{{ .master_version }}`

--- a/.github/progressive-rollout-gate-comment.md
+++ b/.github/progressive-rollout-gate-comment.md
@@ -11,6 +11,8 @@
 
 - Rollout version: `{{ .rollout_docker_image_tag }}`
 - Rollout state: `{{ .rollout_state }}`
+- Rollout started or last updated by: `{{ .rollout_updated_by }}`
+- [Open Connector Rollout Manager in Retool]({{ .retool_url }}) to clean up or close out this rollout if appropriate.
 
 ### Version on `master` Branch: `{{ .master_version }}`
 
@@ -49,7 +51,7 @@ After merging, you still need to start the new rollout. During start, pinned act
 You should not merge the PR unless/until the RC has been finalized as canceled. See above `Rollout state` for detected status.
 
 > [!Warning]
-> This PR should not be merged if the RC rollout is still active. First finalize the active rollout as successful or cancel it.
+> This PR should not be merged if the RC rollout is still active. First finalize the active rollout as successful or cancel it in [Connector Rollout Manager]({{ .retool_url }}).
 
 When you finalize an RC rollout as successful, the platform triggers a promotion workflow that strips the `-rc` suffix, removes stable-version `registryOverrides`, disables progressive rollout, force-merges that promotion, and unpins actors.
 

--- a/.github/workflows/connector-active-progressive-rollout-checks.yml
+++ b/.github/workflows/connector-active-progressive-rollout-checks.yml
@@ -188,6 +188,23 @@ jobs:
           ROLLOUT_STATUS_JSON: ${{ steps.rollout-status.outputs.json }}
           MASTER_VERSION: ${{ steps.master-version.outputs.version }}
         run: |
+          retool_base_url="https://airbyte.retool.com/apps/7aa774a0-8750-11ef-896b-236cbc10fa7e/Connector%20Rollout%20Manager"
+          actor_definition_id="$(jq -r '.actor_definition_id // empty' <<< "${ROLLOUT_STATUS_JSON}")"
+          retool_url="${retool_base_url}"
+          if [[ -n "${actor_definition_id}" ]]; then
+            retool_url="${retool_base_url}?actorDefinitionId=${actor_definition_id}"
+          fi
+          active_rollout='[.rollouts[]? | select(.state | IN("initialized", "workflow_started", "in_progress", "paused", "finalizing", "errored"))][0] // {}'
+          updated_by_name="$(jq -r "(${active_rollout}).updated_by_user_name // empty" <<< "${ROLLOUT_STATUS_JSON}")"
+          updated_by_email="$(jq -r "(${active_rollout}).updated_by_user_email // empty" <<< "${ROLLOUT_STATUS_JSON}")"
+          updated_by_display="unknown"
+          if [[ -n "${updated_by_name}" && -n "${updated_by_email}" ]]; then
+            updated_by_display="${updated_by_name} <${updated_by_email}>"
+          elif [[ -n "${updated_by_email}" ]]; then
+            updated_by_display="${updated_by_email}"
+          elif [[ -n "${updated_by_name}" ]]; then
+            updated_by_display="${updated_by_name}"
+          fi
           has_active_rollout="$(jq -r '.has_active_rollout' <<< "${ROLLOUT_STATUS_JSON}")"
           has_master_rc_marker="false"
           if [[ "${MASTER_VERSION}" == *"-rc."* ]]; then
@@ -200,6 +217,8 @@ jobs:
           echo "has-active-rollout=${has_active_rollout}" | tee -a "${GITHUB_OUTPUT}"
           echo "has-master-rc-marker=${has_master_rc_marker}" | tee -a "${GITHUB_OUTPUT}"
           echo "requires-ack=${requires_ack}" | tee -a "${GITHUB_OUTPUT}"
+          echo "rollout-updated-by=${updated_by_display}" | tee -a "${GITHUB_OUTPUT}"
+          echo "retool-url=${retool_url}" | tee -a "${GITHUB_OUTPUT}"
 
       - name: Detect rollout bypass checkbox
         if: >
@@ -372,6 +391,8 @@ jobs:
             rollout_state: ${{ fromJSON(steps.rollout-status.outputs.json).rollouts[0].state || 'none' }}
             master_version: ${{ steps.master-version.outputs.version }}
             master_rc_marker: ${{ contains(steps.master-version.outputs.version, '-rc.') }}
+            rollout_updated_by: ${{ steps.rollout-gate-state.outputs.rollout-updated-by }}
+            retool_url: ${{ steps.rollout-gate-state.outputs.retool-url }}
             bypass_ack_checked: ${{ steps.bypass-state.outputs.approved }}
             ack_checkbox_text: ${{ env.ROLLOUT_ACK_CHECKBOX_TEXT }}
             rollout_comment_url: ${{ steps.rollout-comment.outputs.url }}

--- a/.github/workflows/connector-active-progressive-rollout-checks.yml
+++ b/.github/workflows/connector-active-progressive-rollout-checks.yml
@@ -195,15 +195,15 @@ jobs:
             retool_url="${retool_base_url}?actorDefinitionId=${actor_definition_id}"
           fi
           active_rollout='[.rollouts[]? | select(.state | IN("initialized", "workflow_started", "in_progress", "paused", "finalizing", "errored"))][0] // {}'
-          updated_by_name="$(jq -r "(${active_rollout}).updated_by_user_name // empty" <<< "${ROLLOUT_STATUS_JSON}")"
-          updated_by_email="$(jq -r "(${active_rollout}).updated_by_user_email // empty" <<< "${ROLLOUT_STATUS_JSON}")"
-          updated_by_display="unknown"
-          if [[ -n "${updated_by_name}" && -n "${updated_by_email}" ]]; then
-            updated_by_display="${updated_by_name} <${updated_by_email}>"
-          elif [[ -n "${updated_by_email}" ]]; then
-            updated_by_display="${updated_by_email}"
-          elif [[ -n "${updated_by_name}" ]]; then
-            updated_by_display="${updated_by_name}"
+          created_or_updated_by_name="$(jq -r "(${active_rollout}).created_or_updated_by_user_name // empty" <<< "${ROLLOUT_STATUS_JSON}")"
+          created_or_updated_by_email="$(jq -r "(${active_rollout}).created_or_updated_by_user_email // empty" <<< "${ROLLOUT_STATUS_JSON}")"
+          created_or_updated_by_display="unknown"
+          if [[ -n "${created_or_updated_by_name}" && -n "${created_or_updated_by_email}" ]]; then
+            created_or_updated_by_display="${created_or_updated_by_name} <${created_or_updated_by_email}>"
+          elif [[ -n "${created_or_updated_by_email}" ]]; then
+            created_or_updated_by_display="${created_or_updated_by_email}"
+          elif [[ -n "${created_or_updated_by_name}" ]]; then
+            created_or_updated_by_display="${created_or_updated_by_name}"
           fi
           has_active_rollout="$(jq -r '.has_active_rollout' <<< "${ROLLOUT_STATUS_JSON}")"
           has_master_rc_marker="false"
@@ -217,7 +217,7 @@ jobs:
           echo "has-active-rollout=${has_active_rollout}" | tee -a "${GITHUB_OUTPUT}"
           echo "has-master-rc-marker=${has_master_rc_marker}" | tee -a "${GITHUB_OUTPUT}"
           echo "requires-ack=${requires_ack}" | tee -a "${GITHUB_OUTPUT}"
-          echo "rollout-updated-by=${updated_by_display}" | tee -a "${GITHUB_OUTPUT}"
+          echo "rollout-created-or-updated-by=${created_or_updated_by_display}" | tee -a "${GITHUB_OUTPUT}"
           echo "retool-url=${retool_url}" | tee -a "${GITHUB_OUTPUT}"
 
       - name: Detect rollout bypass checkbox
@@ -391,7 +391,7 @@ jobs:
             rollout_state: ${{ fromJSON(steps.rollout-status.outputs.json).rollouts[0].state || 'none' }}
             master_version: ${{ steps.master-version.outputs.version }}
             master_rc_marker: ${{ contains(steps.master-version.outputs.version, '-rc.') }}
-            rollout_updated_by: ${{ steps.rollout-gate-state.outputs.rollout-updated-by }}
+            rollout_created_or_updated_by: ${{ steps.rollout-gate-state.outputs.rollout-created-or-updated-by }}
             retool_url: ${{ steps.rollout-gate-state.outputs.retool-url }}
             bypass_ack_checked: ${{ steps.bypass-state.outputs.approved }}
             ack_checkbox_text: ${{ env.ROLLOUT_ACK_CHECKBOX_TEXT }}

--- a/.github/workflows/connector-active-progressive-rollout-checks.yml
+++ b/.github/workflows/connector-active-progressive-rollout-checks.yml
@@ -195,15 +195,15 @@ jobs:
             retool_url="${retool_base_url}?actorDefinitionId=${actor_definition_id}"
           fi
           active_rollout='[.rollouts[]? | select(.state | IN("initialized", "workflow_started", "in_progress", "paused", "finalizing", "errored"))][0] // {}'
-          created_or_updated_by_name="$(jq -r "(${active_rollout}).created_or_updated_by_user_name // empty" <<< "${ROLLOUT_STATUS_JSON}")"
-          created_or_updated_by_email="$(jq -r "(${active_rollout}).created_or_updated_by_user_email // empty" <<< "${ROLLOUT_STATUS_JSON}")"
-          created_or_updated_by_display="unknown"
-          if [[ -n "${created_or_updated_by_name}" && -n "${created_or_updated_by_email}" ]]; then
-            created_or_updated_by_display="${created_or_updated_by_name} <${created_or_updated_by_email}>"
-          elif [[ -n "${created_or_updated_by_email}" ]]; then
-            created_or_updated_by_display="${created_or_updated_by_email}"
-          elif [[ -n "${created_or_updated_by_name}" ]]; then
-            created_or_updated_by_display="${created_or_updated_by_name}"
+          updated_by_name="$(jq -r "(${active_rollout}).updated_by_user_name // empty" <<< "${ROLLOUT_STATUS_JSON}")"
+          updated_by_email="$(jq -r "(${active_rollout}).updated_by_user_email // empty" <<< "${ROLLOUT_STATUS_JSON}")"
+          updated_by_display="unknown"
+          if [[ -n "${updated_by_name}" && -n "${updated_by_email}" ]]; then
+            updated_by_display="${updated_by_name} <${updated_by_email}>"
+          elif [[ -n "${updated_by_email}" ]]; then
+            updated_by_display="${updated_by_email}"
+          elif [[ -n "${updated_by_name}" ]]; then
+            updated_by_display="${updated_by_name}"
           fi
           has_active_rollout="$(jq -r '.has_active_rollout' <<< "${ROLLOUT_STATUS_JSON}")"
           has_master_rc_marker="false"
@@ -217,7 +217,7 @@ jobs:
           echo "has-active-rollout=${has_active_rollout}" | tee -a "${GITHUB_OUTPUT}"
           echo "has-master-rc-marker=${has_master_rc_marker}" | tee -a "${GITHUB_OUTPUT}"
           echo "requires-ack=${requires_ack}" | tee -a "${GITHUB_OUTPUT}"
-          echo "rollout-created-or-updated-by=${created_or_updated_by_display}" | tee -a "${GITHUB_OUTPUT}"
+          echo "rollout-updated-by=${updated_by_display}" | tee -a "${GITHUB_OUTPUT}"
           echo "retool-url=${retool_url}" | tee -a "${GITHUB_OUTPUT}"
 
       - name: Detect rollout bypass checkbox
@@ -391,7 +391,7 @@ jobs:
             rollout_state: ${{ fromJSON(steps.rollout-status.outputs.json).rollouts[0].state || 'none' }}
             master_version: ${{ steps.master-version.outputs.version }}
             master_rc_marker: ${{ contains(steps.master-version.outputs.version, '-rc.') }}
-            rollout_created_or_updated_by: ${{ steps.rollout-gate-state.outputs.rollout-created-or-updated-by }}
+            rollout_updated_by: ${{ steps.rollout-gate-state.outputs.rollout-updated-by }}
             retool_url: ${{ steps.rollout-gate-state.outputs.retool-url }}
             bypass_ack_checked: ${{ steps.bypass-state.outputs.approved }}
             ack_checkbox_text: ${{ env.ROLLOUT_ACK_CHECKBOX_TEXT }}


### PR DESCRIPTION
## What

Improve the progressive rollout gate warning requested by AJ Steers so PR readers can see the user recorded as last updating an active rollout, plus a direct Retool cleanup link. This keeps `initialized` rollouts treated as active.

Depends on https://github.com/airbytehq/airbyte-ops-mcp/pull/821 for the Ops CLI fields that populate the user details.

## How

- Add `rollout_updated_by` and `retool_url` values to the rollout gate workflow template variables.
- Build a Retool Connector Rollout Manager link from the rollout actor definition ID when available.
- Render the updated-by user and cleanup link in `.github/progressive-rollout-gate-comment.md`.
- Keep the active-state filter including `initialized`.

## Review guide

1. `.github/workflows/connector-active-progressive-rollout-checks.yml`
2. `.github/progressive-rollout-gate-comment.md`

## User Impact

Connector PR authors and reviewers get clearer rollout ownership and a direct cleanup path when this CI warning appears. No runtime user impact.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚
- [ ] NO ❌

## Testing

- [x] `git -C /home/ubuntu/repos/airbyte diff --check`
- [x] Local shell check of the `jq` expression used to format `Test User <test@airbyte.io>` and the actor-definition Retool URL
- [x] Live Ops MCP tool check via https://github.com/airbytehq/airbyte-ops-mcp/pull/821 returned the active MySQL `initialized` rollout and new nullable `updated_by_user_*` fields

Link to Devin session: https://app.devin.ai/sessions/475db32362894e14a0fad33d7fc1b5ab
Requested by: @aaronsteers