### PR TITLE
ci(connectors): Relax no-creds community connector tests

### DIFF
--- a/.github/workflows/connector-ci-checks.yml
+++ b/.github/workflows/connector-ci-checks.yml
@@ -203,7 +203,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          SUPPORT_LEVEL=$(yq -r '.data.supportLevel // "community"' metadata.yaml 2>/dev/null || echo "community")
+          SUPPORT_LEVEL=$(yq -r '.data.supportLevel // "unknown"' metadata.yaml 2>/dev/null || echo "unknown")
           SECRET_COUNT=0
           if [[ -d secrets ]]; then
             SECRET_COUNT=$(find secrets -maxdepth 1 -type f -name '*.json' | wc -l | tr -d ' ')
@@ -214,6 +214,7 @@ jobs:
           fi
 
           ALLOW_TEST_FAILURES=false
+          # Only treat zero secrets as intentional when GSM fetch completed; fetch errors must keep tests blocking.
           if [[ "$SUPPORT_LEVEL" == "community" &&
                 "$FETCH_SECRETS_OUTCOME" == "success" &&
                 "$SECRET_COUNT" == "0" ]]; then
@@ -333,7 +334,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          SUPPORT_LEVEL=$(yq -r '.data.supportLevel // "community"' metadata.yaml 2>/dev/null || echo "community")
+          SUPPORT_LEVEL=$(yq -r '.data.supportLevel // "unknown"' metadata.yaml 2>/dev/null || echo "unknown")
           SECRET_COUNT=0
           if [[ -d secrets ]]; then
             SECRET_COUNT=$(find secrets -maxdepth 1 -type f -name '*.json' | wc -l | tr -d ' ')
@@ -344,6 +345,7 @@ jobs:
           fi
 
           ALLOW_TEST_FAILURES=false
+          # Only treat zero secrets as intentional when GSM fetch completed; fetch errors must keep tests blocking.
           if [[ "$SUPPORT_LEVEL" == "community" &&
                 "$FETCH_SECRETS_OUTCOME" == "success" &&
                 "$SECRET_COUNT" == "0" ]]; then

--- a/.github/workflows/connector-ci-checks.yml
+++ b/.github/workflows/connector-ci-checks.yml
@@ -186,12 +186,45 @@ jobs:
         run: poe install
 
       - name: Fetch connector secrets
+        id: fetch-secrets
         # This will be skipped if the repo or fork does not set GCP_PROJECT_ID, or if it is set to an empty value.
         # Later integration tests will likely fail in this case, but we at least let them run.
         if: matrix.connector && needs.generate-matrix.outputs.creds-available == 'true'
         run: |
           airbyte-ops secrets fetch ${{ matrix.connector }} \
             --print-ci-secrets-masks
+
+      - name: Resolve connector test policy
+        id: connector-test-policy
+        if: matrix.connector
+        working-directory: airbyte-integrations/connectors/${{ matrix.connector }}
+        env:
+          FETCH_SECRETS_OUTCOME: ${{ steps.fetch-secrets.outcome }}
+          IS_UP_TO_DATE_PR: ${{ github.event_name == 'pull_request' && github.event.pull_request.user.login == 'octavia-bot-hoard[bot]' && (startsWith(github.head_ref, 'up-to-date/') || contains(github.event.pull_request.labels.*.name, 'up-to-date')) }}
+        run: |
+          set -euo pipefail
+
+          SUPPORT_LEVEL=$(yq -r '.data.supportLevel // "community"' metadata.yaml 2>/dev/null || echo "community")
+          SECRET_COUNT=0
+          if [[ -d secrets ]]; then
+            SECRET_COUNT=$(find secrets -maxdepth 1 -type f -name '*.json' | wc -l | tr -d ' ')
+          fi
+
+          if [[ "${FETCH_SECRETS_OUTCOME:-skipped}" != "success" ]]; then
+            SECRET_COUNT=unknown
+          fi
+
+          ALLOW_TEST_FAILURES=false
+          if [[ "$IS_UP_TO_DATE_PR" == "true" &&
+                "$SUPPORT_LEVEL" == "community" &&
+                "$FETCH_SECRETS_OUTCOME" == "success" &&
+                "$SECRET_COUNT" == "0" ]]; then
+            ALLOW_TEST_FAILURES=true
+          fi
+
+          echo "support-level=${SUPPORT_LEVEL}" | tee -a $GITHUB_OUTPUT
+          echo "secret-count=${SECRET_COUNT}" | tee -a $GITHUB_OUTPUT
+          echo "allow-test-failures=${ALLOW_TEST_FAILURES}" | tee -a $GITHUB_OUTPUT
 
       - name: Run Unit Tests ${{ needs.generate-matrix.outputs.creds-available == 'false' && '[Non-Blocking (Unprivileged) Test From Fork, pls run `/run-connector-tests`]' || '' }}
         if: matrix.connector
@@ -200,6 +233,7 @@ jobs:
 
       - name: Run Integration Tests ${{ needs.generate-matrix.outputs.creds-available == 'false' && '[Non-Blocking (Unprivileged) Test From Fork, pls run `/run-connector-tests`]' || '' }}
         if: matrix.connector
+        continue-on-error: ${{ steps.connector-test-policy.outputs.allow-test-failures == 'true' }}
         working-directory: airbyte-integrations/connectors/${{ matrix.connector }}
         run: poe test-integration-tests
 
@@ -288,10 +322,41 @@ jobs:
         # This will be skipped if the repo or fork does not set GCP_PROJECT_ID, or if it is set to an empty value.
         # Later integration tests will likely fail in this case, but we at least let them run.
         if: matrix.connector && env.GCP_PROJECT_ID != ''
-        continue-on-error: true
         run: |
           airbyte-ops secrets fetch ${{ matrix.connector }} \
             --print-ci-secrets-masks
+
+      - name: Resolve connector test policy
+        id: connector-test-policy
+        if: matrix.connector
+        working-directory: airbyte-integrations/connectors/${{ matrix.connector }}
+        env:
+          FETCH_SECRETS_OUTCOME: ${{ steps.fetch-secrets.outcome }}
+          IS_UP_TO_DATE_PR: ${{ github.event_name == 'pull_request' && github.event.pull_request.user.login == 'octavia-bot-hoard[bot]' && (startsWith(github.head_ref, 'up-to-date/') || contains(github.event.pull_request.labels.*.name, 'up-to-date')) }}
+        run: |
+          set -euo pipefail
+
+          SUPPORT_LEVEL=$(yq -r '.data.supportLevel // "community"' metadata.yaml 2>/dev/null || echo "community")
+          SECRET_COUNT=0
+          if [[ -d secrets ]]; then
+            SECRET_COUNT=$(find secrets -maxdepth 1 -type f -name '*.json' | wc -l | tr -d ' ')
+          fi
+
+          if [[ "${FETCH_SECRETS_OUTCOME:-skipped}" != "success" ]]; then
+            SECRET_COUNT=unknown
+          fi
+
+          ALLOW_TEST_FAILURES=false
+          if [[ "$IS_UP_TO_DATE_PR" == "true" &&
+                "$SUPPORT_LEVEL" == "community" &&
+                "$FETCH_SECRETS_OUTCOME" == "success" &&
+                "$SECRET_COUNT" == "0" ]]; then
+            ALLOW_TEST_FAILURES=true
+          fi
+
+          echo "support-level=${SUPPORT_LEVEL}" | tee -a $GITHUB_OUTPUT
+          echo "secret-count=${SECRET_COUNT}" | tee -a $GITHUB_OUTPUT
+          echo "allow-test-failures=${ALLOW_TEST_FAILURES}" | tee -a $GITHUB_OUTPUT
 
       - name: Run Unit Tests ${{ needs.generate-matrix.outputs.creds-available == 'false' && '[Non-Blocking (Unprivileged) Test From Fork, pls run `/run-connector-tests`]' || '' }}
         if: matrix.connector
@@ -300,11 +365,13 @@ jobs:
 
       - name: Run Integration Tests ${{ needs.generate-matrix.outputs.creds-available == 'false' && '[Non-Blocking (Unprivileged) Test From Fork, pls run `/run-connector-tests`]' || '' }}
         if: matrix.connector
+        continue-on-error: ${{ steps.connector-test-policy.outputs.allow-test-failures == 'true' }}
         working-directory: airbyte-integrations/connectors/${{ matrix.connector }}
         run: poe test-integration-tests
 
       - name: Container Tests
         if: matrix.connector
+        continue-on-error: ${{ steps.connector-test-policy.outputs.allow-test-failures == 'true' }}
         working-directory: airbyte-integrations/connectors/${{ matrix.connector }}
         run: |
           airbyte-cdk image test

--- a/.github/workflows/connector-ci-checks.yml
+++ b/.github/workflows/connector-ci-checks.yml
@@ -200,7 +200,6 @@ jobs:
         working-directory: airbyte-integrations/connectors/${{ matrix.connector }}
         env:
           FETCH_SECRETS_OUTCOME: ${{ steps.fetch-secrets.outcome }}
-          IS_UP_TO_DATE_PR: ${{ github.event_name == 'pull_request' && github.event.pull_request.user.login == 'octavia-bot-hoard[bot]' && (startsWith(github.head_ref, 'up-to-date/') || contains(github.event.pull_request.labels.*.name, 'up-to-date')) }}
         run: |
           set -euo pipefail
 
@@ -215,8 +214,7 @@ jobs:
           fi
 
           ALLOW_TEST_FAILURES=false
-          if [[ "$IS_UP_TO_DATE_PR" == "true" &&
-                "$SUPPORT_LEVEL" == "community" &&
+          if [[ "$SUPPORT_LEVEL" == "community" &&
                 "$FETCH_SECRETS_OUTCOME" == "success" &&
                 "$SECRET_COUNT" == "0" ]]; then
             ALLOW_TEST_FAILURES=true
@@ -332,7 +330,6 @@ jobs:
         working-directory: airbyte-integrations/connectors/${{ matrix.connector }}
         env:
           FETCH_SECRETS_OUTCOME: ${{ steps.fetch-secrets.outcome }}
-          IS_UP_TO_DATE_PR: ${{ github.event_name == 'pull_request' && github.event.pull_request.user.login == 'octavia-bot-hoard[bot]' && (startsWith(github.head_ref, 'up-to-date/') || contains(github.event.pull_request.labels.*.name, 'up-to-date')) }}
         run: |
           set -euo pipefail
 
@@ -347,8 +344,7 @@ jobs:
           fi
 
           ALLOW_TEST_FAILURES=false
-          if [[ "$IS_UP_TO_DATE_PR" == "true" &&
-                "$SUPPORT_LEVEL" == "community" &&
+          if [[ "$SUPPORT_LEVEL" == "community" &&
                 "$FETCH_SECRETS_OUTCOME" == "success" &&
                 "$SECRET_COUNT" == "0" ]]; then
             ALLOW_TEST_FAILURES=true

--- a/docs/platform/connector-development/testing-connectors/README.md
+++ b/docs/platform/connector-development/testing-connectors/README.md
@@ -18,7 +18,7 @@ To run Connector Acceptance tests locally, you must provide connector configurat
 Connector tests are automatically and remotely triggered on your branch according to the changes made in your branch.
 **Passing tests are required to merge a connector pull request.**
 
-Automated `up-to-date/*` dependency update pull requests for community connectors have one exception: if Airbyte's CI can successfully check Google Secret Manager and finds no sandbox or test credentials for the connector, integration tests and standard connector tests are allowed to be non-blocking. This exception only applies to bot-created `up-to-date/*` pull requests. For all other connector pull requests, available connector tests must pass before merge.
+Automated `up-to-date/*` dependency update pull requests for community connectors have one exception: if Airbyte's CI can successfully fetch connector secrets and finds no sandbox or test credentials, integration tests and non-Java container tests are allowed to be non-blocking. This exception only applies to pull requests opened by `octavia-bot-hoard[bot]` from an `up-to-date/*` branch or with the `up-to-date` label. Unit tests remain blocking. For all other connector pull requests, available connector tests must pass before merge.
 
 ## Connector specific tests
 

--- a/docs/platform/connector-development/testing-connectors/README.md
+++ b/docs/platform/connector-development/testing-connectors/README.md
@@ -18,7 +18,7 @@ To run Connector Acceptance tests locally, you must provide connector configurat
 Connector tests are automatically and remotely triggered on your branch according to the changes made in your branch.
 **Passing tests are required to merge a connector pull request.**
 
-Automated `up-to-date/*` dependency update pull requests for community connectors have one exception: if Airbyte's CI can successfully fetch connector secrets and finds no sandbox or test credentials, integration tests and non-Java container tests are allowed to be non-blocking. This exception only applies to pull requests opened by `octavia-bot-hoard[bot]` from an `up-to-date/*` branch or with the `up-to-date` label. Unit tests remain blocking. For all other connector pull requests, available connector tests must pass before merge.
+Community connector pull requests have one exception: if Airbyte's CI can successfully fetch connector secrets and finds no sandbox or test credentials, integration tests and non-Java container tests are allowed to be non-blocking. Unit tests remain blocking. For all other connector pull requests, available connector tests must pass before merge.
 
 ## Connector specific tests
 

--- a/docs/platform/connector-development/testing-connectors/README.md
+++ b/docs/platform/connector-development/testing-connectors/README.md
@@ -10,7 +10,6 @@ Multiple tests suites compose the Airbyte connector testing pyramid
 - [Connector Acceptance Tests](https://docs.airbyte.com/connector-development/testing-connectors/connector-acceptance-tests-reference/): Connector-agnostic tests that verify that a connector adheres to the [Airbyte protocol](https://docs.airbyte.com/understanding-airbyte/airbyte-protocol). Credentials to a source/destination sandbox account are **required**.
 - Regression Tests (deprecated): Connector-agnostic tests that verified the behavior of a connector between versions. Previously available for API source connectors.
 
-
 ## 🤖 CI
 
 CI will run all the tests that are available for a connector. This can include all of the tests listed above, if we have the appropriate credentials. At a minimum, it will include the Connector QA checks and any tests that exist in a connector's `unit_tests` and `integration_tests` directories.
@@ -18,6 +17,8 @@ To run Connector Acceptance tests locally, you must provide connector configurat
 
 Connector tests are automatically and remotely triggered on your branch according to the changes made in your branch.
 **Passing tests are required to merge a connector pull request.**
+
+Automated `up-to-date/*` dependency update pull requests for community connectors have one exception: if Airbyte's CI can successfully check Google Secret Manager and finds no sandbox or test credentials for the connector, integration tests and standard connector tests are allowed to be non-blocking. This exception only applies to bot-created `up-to-date/*` pull requests. For all other connector pull requests, available connector tests must pass before merge.
 
 ## Connector specific tests
 
@@ -46,4 +47,3 @@ We run Java connector tests with gradle.
 ```
 
 Please note that according to the test implementation you might have to provide connector configurations as a `config.json` file in a `.secrets` folder in the connector code directory.
-


### PR DESCRIPTION
## What
<!--
* Describe what the change is solving. Link all GitHub issues related to this change.
-->

Requested by Sophie Cui for Linear issue https://linear.app/airbyteio/issue/HYD-39/gate-community-connectors-with-sandboxtest-creds-on-integration-and.

This updates Connector CI so community connector PRs without sandbox/test credentials can merge without being blocked by integration or non-Java container test failures, while connectors with fetched test credentials remain fully gated.

## How
<!--
* Describe how code changes achieve the solution.
-->

- Add a connector test policy step to both JVM and non-JVM connector test jobs.
- Treat integration test failures as non-blocking only when the connector is explicitly `supportLevel: community`, GSM lookup succeeded, and no secret JSON files were fetched.
- Fail closed by using `supportLevel: unknown` when `metadata.yaml` is missing, unparseable, or omits `data.supportLevel`.
- Apply the same non-blocking policy to non-Java container tests; Java connector unit tests and all unit tests remain blocking.
- Make non-JVM secret fetch strict so auth/GSM failures do not get mistaken for missing credentials.
- Document the limited exception in the connector testing docs.

## Review guide
<!--
1. `x.py`
2. `y.py`
-->

1. `.github/workflows/connector-ci-checks.yml`
2. `docs/platform/connector-development/testing-connectors/README.md`

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->

Community connector PRs without sandbox/test credentials can proceed without being blocked by tests they cannot run meaningfully. Community connector PRs with fetched test credentials, or connectors without an explicit community support level, still require available tests to pass.

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌

## Validation

- `git diff --check`
- `yq eval '.' .github/workflows/connector-ci-checks.yml`
- `/home/ubuntu/go/bin/actionlint -shellcheck= .github/workflows/connector-ci-checks.yml`
- `npx --yes markdownlint-cli2 docs/platform/connector-development/testing-connectors/README.md`
- `vale` local check skipped because Vale is not installed in this VM; Docs / Vale runs in CI

---
[Devin session](https://app.devin.ai/sessions/20259aae56bb4e589a6480684653a77c)

Requested by: @sophiecuiy