### PR TITLE
chore: cut release.

### DIFF
--- a/airbyte-integrations/connectors/destination-s3/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-s3/metadata.yaml
@@ -2,7 +2,7 @@ data:
   connectorSubtype: file
   connectorType: destination
   definitionId: 4816b78f-1489-44c1-9060-4b19d5fa9362
-  dockerImageTag: 1.9.8-rc.1
+  dockerImageTag: 1.9.8
   dockerRepository: airbyte/destination-s3
   githubIssueLabel: destination-s3
   icon: s3.svg
@@ -32,7 +32,7 @@ data:
           **This release includes breaking changes, including major revisions to the schema of stored data. Do not upgrade without reviewing the migration guide.**
         upgradeDeadline: "2024-10-08"
     rolloutConfiguration:
-      enableProgressiveRollout: true
+      enableProgressiveRollout: false
   resourceRequirements:
     jobSpecific:
       - jobType: sync

--- a/docs/integrations/destinations/s3.md
+++ b/docs/integrations/destinations/s3.md
@@ -546,6 +546,7 @@ This destination supports [namespaces](https://docs.airbyte.com/platform/using-a
 
 | Version     | Date       | Pull Request                                               | Subject                                                                                                                                              |
 |:------------|:-----------|:-----------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------|
+| 1.9.8       | 2026-05-21 | [78240](https://github.com/airbytehq/airbyte/pull/78240) | Promoting release candidate 1.9.8-rc.1 to a main version. |
 | 1.9.8-rc.1  | 2026-05-19 | [78240](https://github.com/airbytehq/airbyte/pull/78240) | Upgrade CDK to 1.0.13. Progressive rollout. |
 | 1.9.7       | 2026-01-26 | [72354](https://github.com/airbytehq/airbyte/pull/72354) | Fix sync failures for sources with empty schemas by upgrading CDK to 0.2.1                                                                           |
 | 1.9.6       | 2026-01-26 | [72298](https://github.com/airbytehq/airbyte/pull/72298) | Upgrade CDK to 0.2.0                                                                                                                                 |


### PR DESCRIPTION
## What
Cuts s3 release since the progressive rollout tool isn't working

> [!IMPORTANT]
> Active progressive rollout warning for destination-s3.

- [ ] (Click to Approve:) Bypass the active progressive rollout warning for destination-s3 in the PR comment [here](https://github.com/airbytehq/airbyte/pull/78332#issuecomment-4511848633).