### PR TITLE
feat(source-salesforce): add granular OAuth scopes to consent URL

### DIFF
--- a/airbyte-integrations/connectors/source-salesforce/metadata.yaml
+++ b/airbyte-integrations/connectors/source-salesforce/metadata.yaml
@@ -10,7 +10,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: b117307c-14b6-41aa-9422-947e34922962
-  dockerImageTag: 2.7.22
+  dockerImageTag: 2.7.23
   releases:
     rolloutConfiguration:
       enableProgressiveRollout: false

--- a/airbyte-integrations/connectors/source-salesforce/pyproject.toml
+++ b/airbyte-integrations/connectors/source-salesforce/pyproject.toml
@@ -3,7 +3,7 @@ requires = [ "poetry-core>=1.0.0",]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
-version = "2.7.22"
+version = "2.7.23"
 name = "source-salesforce"
 description = "Source implementation for Salesforce."
 authors = [ "Airbyte <contact@airbyte.io>",]

--- a/airbyte-integrations/connectors/source-salesforce/source_salesforce/spec.yaml
+++ b/airbyte-integrations/connectors/source-salesforce/source_salesforce/spec.yaml
@@ -129,7 +129,7 @@ advanced_auth:
         - scope: "web"
         - scope: "refresh_token"
         - scope: "lightning"
-      consent_url: "https://{% if is_sandbox %}test{% else %}login{% endif %}.salesforce.com/services/oauth2/authorize?{{client_id_param}}&{{redirect_uri_param}}&response_type=code&{{state_param}}"
+      consent_url: "https://{% if is_sandbox %}test{% else %}login{% endif %}.salesforce.com/services/oauth2/authorize?{{client_id_param}}&{{redirect_uri_param}}&response_type=code&{{scopes_param}}&{{state_param}}"
       access_token_url: "https://{% if is_sandbox %}test{% else %}login{% endif %}.salesforce.com/services/oauth2/token"
       access_token_headers:
         Content-Type: "application/x-www-form-urlencoded"

--- a/airbyte-integrations/connectors/source-salesforce/source_salesforce/spec.yaml
+++ b/airbyte-integrations/connectors/source-salesforce/source_salesforce/spec.yaml
@@ -124,6 +124,11 @@ advanced_auth:
   predicate_value: Client
   oauth_config_specification:
     oauth_connector_input_specification:
+      scopes:
+        - scope: "api"
+        - scope: "web"
+        - scope: "refresh_token"
+        - scope: "lightning"
       consent_url: "https://{% if is_sandbox %}test{% else %}login{% endif %}.salesforce.com/services/oauth2/authorize?{{client_id_param}}&{{redirect_uri_param}}&response_type=code&{{state_param}}"
       access_token_url: "https://{% if is_sandbox %}test{% else %}login{% endif %}.salesforce.com/services/oauth2/token"
       access_token_headers:

--- a/docs/integrations/sources/salesforce.md
+++ b/docs/integrations/sources/salesforce.md
@@ -280,6 +280,7 @@ The lookback window uses the ISO 8601 duration format. The format is `PT<number>
 
 | Version     | Date       | Pull Request                                             | Subject                                                                                                                                                                |
 |:------------|:-----------|:---------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 2.7.23 | 2026-05-20 | [78339](https://github.com/airbytehq/airbyte/pull/78339) | Add granular OAuth scopes (api, web, refresh_token, lightning) to consent URL |
 | 2.7.22 | 2026-04-28 | [76978](https://github.com/airbytehq/airbyte/pull/76978) | Bump airbyte-cdk to ^7.17.4 |
 | 2.7.21 | 2026-04-28 | [77132](https://github.com/airbytehq/airbyte/pull/77132) | Promoted release candidate to GA |
 | 2.7.21-rc.1 | 2026-04-21 | [76389](https://github.com/airbytehq/airbyte/pull/76389) | Fix bulk job slicing by bypassing deprecated DeclarativeStream.stream_slices() after CDK 7.13+ upgrade |


### PR DESCRIPTION
## Summary

- Add granular OAuth scopes (`api`, `web`, `refresh_token`, `lightning`) to the Salesforce connector's `oauth_connector_input_specification`.
- Include `{{scopes_param}}` in the consent URL so the configured scopes are actually requested during the OAuth flow.
