### PR TITLE
docs(ai-agents): Add Agents IP allowlist

### DIFF
--- a/docs/ai-agents/admin/ip-allowlist.md
+++ b/docs/ai-agents/admin/ip-allowlist.md
@@ -9,7 +9,7 @@ import AirbyteCloudIps from '@site/static/_airbyte_cloud_ips.md';
 
 Airbyte Agents uses the Airbyte Cloud IP addresses, plus additional IP addresses for Agents-specific workloads. If your organization restricts inbound traffic by IP address, allow the following addresses in your firewall.
 
-<AirbyteCloudIps/>
+<AirbyteCloudIps />
 
 ## Airbyte Agents
 

--- a/docs/ai-agents/admin/ip-allowlist.md
+++ b/docs/ai-agents/admin/ip-allowlist.md
@@ -1,0 +1,20 @@
+---
+plan: all
+sidebar_label: IP allow list
+---
+
+import AirbyteCloudIps from '@site/static/_airbyte_cloud_ips.md';
+
+# IP allow list for Agents
+
+Airbyte Agents uses the Airbyte Cloud IP addresses, plus additional IP addresses for Agents-specific workloads. If your organization restricts inbound traffic by IP address, allow the following addresses in your firewall.
+
+<AirbyteCloudIps/>
+
+## Airbyte Agents
+
+| Geography     | Region    | IP address (CIDR) | IP addresses   |
+| ------------- | --------- | ----------------- | -------------- |
+| United States | us-west-2 | N/A               | 44.226.44.242  |
+| United States | us-west-2 | N/A               | 35.163.106.179 |
+| United States | us-west-2 | N/A               | 44.227.212.246 |

--- a/docs/ai-agents/admin/ip-allowlist.md
+++ b/docs/ai-agents/admin/ip-allowlist.md
@@ -7,7 +7,7 @@ import AirbyteCloudIps from '@site/static/_airbyte_cloud_ips.md';
 
 # IP allow list for Agents
 
-Airbyte Agents uses the Airbyte Cloud IP addresses to sync data from your sources, plus additional IP addresses for Agents-specific workloads. If your organization restricts inbound traffic by IP address, allow the following addresses in your firewall.
+Airbyte Agents uses the Airbyte Cloud IP addresses, plus additional IP addresses for Agents-specific workloads. If your organization restricts inbound traffic by IP address, allow the following addresses in your firewall.
 
 <AirbyteCloudIps />
 

--- a/docs/ai-agents/admin/ip-allowlist.md
+++ b/docs/ai-agents/admin/ip-allowlist.md
@@ -7,7 +7,7 @@ import AirbyteCloudIps from '@site/static/_airbyte_cloud_ips.md';
 
 # IP allow list for Agents
 
-Airbyte Agents uses the Airbyte Cloud IP addresses, plus additional IP addresses for Agents-specific workloads. If your organization restricts inbound traffic by IP address, allow the following addresses in your firewall.
+Airbyte Agents uses the Airbyte Cloud IP addresses to sync data from your sources, plus additional IP addresses for Agents-specific workloads. If your organization restricts inbound traffic by IP address, allow the following addresses in your firewall.
 
 <AirbyteCloudIps />
 

--- a/docs/ai-agents/admin/readme.md
+++ b/docs/ai-agents/admin/readme.md
@@ -5,4 +5,4 @@ sidebar_position: 7
 
 # Account and administration
 
-Manage your Airbyte Agents account. This section covers [billing](./billing.md), including plans, payments, usage monitoring, invoices, and subscription changes.
+Manage your Airbyte Agents account. This section covers [billing](./billing.md), including plans, payments, usage monitoring, invoices, and subscription changes. If your network restricts inbound traffic, see [IP allow list](./ip-allowlist.md).

--- a/docs/platform/operating-airbyte/ip-allowlist.md
+++ b/docs/platform/operating-airbyte/ip-allowlist.md
@@ -6,4 +6,8 @@ import AirbyteCloudIps from '@site/static/_airbyte_cloud_ips.md';
 
 # IP allow list for Cloud
 
-<AirbyteCloudIps/>
+Airbyte Cloud runs and syncs your data using a specific set of IP addresses. Allow these IPs in your firewall to ensure Airbyte users can correctly use the platform.
+
+Airbyte defaults to running syncs in the United States. To change this, or to check your data residency, see your [data residency](/platform/cloud/managing-airbyte-cloud/manage-data-residency) for each workspace.
+
+<AirbyteCloudIps />

--- a/docs/platform/operating-airbyte/ip-allowlist.md
+++ b/docs/platform/operating-airbyte/ip-allowlist.md
@@ -2,30 +2,8 @@
 products: cloud
 ---
 
+import AirbyteCloudIps from '@site/static/_airbyte_cloud_ips.md';
+
 # IP allow list for Cloud
 
-Airbyte Cloud runs and syncs your data using a specific set of IP addresses. Allow these IPs in your firewall to ensure Airbyte users can correctly use the platform.
-
-Airbyte defaults to running syncs in the United States. To change this, or to check your data residency, see your [data residency](/platform/cloud/managing-airbyte-cloud/manage-data-residency) for each workspace.
-
-## Google Cloud Platform
-
-| Geography     | Region       | IP address (CIDR) | IP addresses   |
-| ------------- |--------------|-------------------|----------------|
-| United States | us-west-3    | N/A               | 34.106.109.131 |
-| United States | us-west-3    | N/A               | 34.106.196.165 |
-| United States | us-west-3    | N/A               | 34.106.60.246  |
-| United States | us-west-3    | N/A               | 34.106.229.69  |
-| United States | us-west-3    | N/A               | 34.106.127.139 |
-| United States | us-west-3    | N/A               | 34.106.218.58  |
-| United States | us-west-3    | N/A               | 34.106.115.240 |
-| United States | us-west-3    | N/A               | 34.106.225.141 |
-| United States | us-central-1 | 34.33.7.0/29      | 34.33.7.[0,8]  |
-
-## AWS
-
-| Geography | Region    | IP address (CIDR) | IP addresses   |
-| --------- | --------- | ----------------- | -------------- |
-| France    | eu-west-3 | N/A               | 13.37.4.46     |
-| France    | eu-west-3 | N/A               | 13.37.142.60   |
-| France    | eu-west-3 | N/A               | 35.181.124.238 |
+<AirbyteCloudIps/>

--- a/docusaurus/static/_airbyte_cloud_ips.md
+++ b/docusaurus/static/_airbyte_cloud_ips.md
@@ -1,7 +1,3 @@
-Airbyte Cloud runs and syncs your data using a specific set of IP addresses. Allow these IPs in your firewall to ensure Airbyte users can correctly use the platform.
-
-Airbyte defaults to running syncs in the United States. To change this, or to check your data residency, see your [data residency](/platform/cloud/managing-airbyte-cloud/manage-data-residency) for each workspace.
-
 ## Google Cloud Platform
 
 | Geography     | Region       | IP address (CIDR) | IP addresses   |

--- a/docusaurus/static/_airbyte_cloud_ips.md
+++ b/docusaurus/static/_airbyte_cloud_ips.md
@@ -1,0 +1,25 @@
+Airbyte Cloud runs and syncs your data using a specific set of IP addresses. Allow these IPs in your firewall to ensure Airbyte users can correctly use the platform.
+
+Airbyte defaults to running syncs in the United States. To change this, or to check your data residency, see your [data residency](/platform/cloud/managing-airbyte-cloud/manage-data-residency) for each workspace.
+
+## Google Cloud Platform
+
+| Geography     | Region       | IP address (CIDR) | IP addresses   |
+| ------------- | ------------ | ----------------- | -------------- |
+| United States | us-west-3    | N/A               | 34.106.109.131 |
+| United States | us-west-3    | N/A               | 34.106.196.165 |
+| United States | us-west-3    | N/A               | 34.106.60.246  |
+| United States | us-west-3    | N/A               | 34.106.229.69  |
+| United States | us-west-3    | N/A               | 34.106.127.139 |
+| United States | us-west-3    | N/A               | 34.106.218.58  |
+| United States | us-west-3    | N/A               | 34.106.115.240 |
+| United States | us-west-3    | N/A               | 34.106.225.141 |
+| United States | us-central-1 | 34.33.7.0/29      | 34.33.7.[0,8]  |
+
+## AWS
+
+| Geography | Region    | IP address (CIDR) | IP addresses   |
+| --------- | --------- | ----------------- | -------------- |
+| France    | eu-west-3 | N/A               | 13.37.4.46     |
+| France    | eu-west-3 | N/A               | 13.37.142.60   |
+| France    | eu-west-3 | N/A               | 35.181.124.238 |


### PR DESCRIPTION
## Documentation Confidence Assessment

**Overall Confidence: 4/5**

| Dimension | Score | Rationale |
|-----------|-------|-----------|
| Code Comprehension | 5/5 | This is docs-only; the behavior documented comes from the existing Cloud page, Ian's requested Agents IP list, and AWS IP range verification. |
| Context Availability | 5/5 | Ian provided the exact desired page, sidebar label, shared-content refactor, and Agents-only IPs. |
| Existing Doc Quantity | 1/5 | The existing Cloud IP allowlist was short and Agents had no dedicated IP allowlist page. |
| Existing Doc Quality | 4/5 | The existing Cloud content was accurate and reusable, but not factored for Agents reuse. |
| Feature Area Maturity | 3/5 | Cloud IP allowlisting is established; Agents admin docs are newer and still growing. |
| Change Scope & Risk | 3/5 | Adds one new Agents admin page and refactors the Cloud IP table into shared content. |
| Inference Ratio | 5/5 | Core facts are directly sourced from the current Cloud docs, Ian's prompt, and AWS `ip-ranges.json` for region verification. |

### What I Verified vs. What I Inferred

Verified:
- The current Cloud IP list was extracted without changing the IP values.
- The Cloud-specific intro and data residency text remains only on the Cloud page.
- The Cloud page imports the shared `_airbyte_cloud_ips` content.
- The new Agents page imports the shared Cloud IP content and lists Ian's three Agents-specific IPs.
- The Agents page explains that Cloud IP addresses are needed for syncing data from sources.
- The three Agents-specific IPs map to AWS EC2 prefixes in `us-west-2` using AWS's public `ip-ranges.json`.
- The Agents admin docs sidebar is autogenerated, so the new file and `sidebar_label` are sufficient for placement.

Inferred:
- The Agents-only IPs should be shown in the same table shape as the Cloud AWS table for consistency.

Reviewer focus:
- Confirm the Agents-only IPs and whether `us-west-2` is the desired user-facing region label.
- Spot-check the new Agents admin page wording.

## What
<!--
* Describe what the change is solving. Link all GitHub issues related to this change.
-->
Ian Alton asked for a new Airbyte Agents admin docs topic that lists the IP addresses customers should allowlist when their network restricts inbound traffic.

This PR adds that page and keeps the existing Airbyte Cloud IP list reusable so the Cloud and Agents pages stay in sync.

## How
<!--
* Describe how code changes achieve the solution.
-->
- Extract the existing Airbyte Cloud IP address tables into `docusaurus/static/_airbyte_cloud_ips.md`.
- Keep the Cloud-specific intro and data residency text on the current Cloud page.
- Update the current Cloud IP allowlist page to import the shared snippet.
- Add `docs/ai-agents/admin/ip-allowlist.md` with `sidebar_label: IP allow list`, the shared Cloud IPs, and the three Agents-specific IPs:
  - `44.226.44.242`
  - `35.163.106.179`
  - `44.227.212.246`
- Clarify that Agents needs the Cloud IPs to sync data from sources.
- Link the new page from the Agents admin overview.

## Review guide
<!--
1. `x.py`
2. `y.py`
-->
1. `docs/ai-agents/admin/ip-allowlist.md`
2. `docusaurus/static/_airbyte_cloud_ips.md`
3. `docs/platform/operating-airbyte/ip-allowlist.md`
4. `docs/ai-agents/admin/readme.md`

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->
Customers using IP allowlisting can find one Agents admin page with both Airbyte Cloud IPs and the Agents-only IPs. The Cloud page keeps the existing Cloud-specific context and data residency link.

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌

## Verification
- [x] `git diff --check`
- [x] `cd docusaurus && corepack pnpm exec prettier --check ../docs/ai-agents/admin/readme.md static/_airbyte_cloud_ips.md`
- [x] `cd docusaurus && corepack pnpm exec docusaurus docs:version:ai-agents temp-mdx-check` then removed the generated temporary version files
- [x] `cd docusaurus && corepack pnpm clear && corepack pnpm build` (succeeded with existing broken-anchor warnings outside this PR)

---
[Devin session](https://app.devin.ai/sessions/828e9432e4e64a05a95f822405f94561)

Requested by: @ian-at-airbyte

> [!IMPORTANT]
> ⚡ **Auto-merge enabled.**
> 
> _This PR is set to merge automatically when all requirements are met._