### PR TITLE
feat(connectors): Add hotfix prerelease suffix

### DIFF
--- a/.github/actions/connector-image-build-push/action.yml
+++ b/.github/actions/connector-image-build-push/action.yml
@@ -13,7 +13,7 @@ inputs:
     required: false
     default: "docker.io/airbyte"
   with-semver-suffix:
-    description: "Semver suffix mode: 'none', 'preview', or 'rc'. Determines tagging and latest push behavior."
+    description: "Semver suffix mode: 'none', 'preview', 'hotfix', or 'rc'. Determines tagging and latest push behavior."
     required: false
     default: "preview"
   tag-override:
@@ -142,6 +142,11 @@ runs:
           hash=$(git rev-parse --short=7 HEAD)
           CONNECTOR_VERSION_TAG="${CONNECTOR_VERSION}-preview.${hash}"
           echo "🏷 Using preview tag: $CONNECTOR_VERSION_TAG"
+        elif [[ "${{ inputs.with-semver-suffix }}" == "hotfix" ]]; then
+          date_suffix=$(date -u +%m%d)
+          hash=$(git rev-parse --short=3 HEAD)
+          CONNECTOR_VERSION_TAG="${CONNECTOR_VERSION}-hotfix.${date_suffix}.${hash}"
+          echo "🏷 Using hotfix tag: $CONNECTOR_VERSION_TAG"
         elif [[ "${{ inputs.with-semver-suffix }}" == "rc" ]]; then
           CONNECTOR_VERSION_TAG="${CONNECTOR_VERSION}-rc1"
           echo "🏷 Using RC tag: $CONNECTOR_VERSION_TAG"
@@ -162,7 +167,7 @@ runs:
             echo "🏷 Will push with latest tag for production release"
           else
             PUSH_LATEST_TAG="false"
-            echo "🏷 Skipping latest tag for preview, RC, or release candidate build"
+            echo "🏷 Skipping latest tag for preview, hotfix, RC, or release candidate build"
           fi
         fi
 

--- a/.github/pr-welcome-community.md
+++ b/.github/pr-welcome-community.md
@@ -17,7 +17,7 @@ As needed or by request, Airbyte Maintainers can execute the following slash com
 - `/run-cat-tests` - Runs CAT tests.
 - `/run-regression-tests` - Runs regression tests for the modified connector(s).
 - `/build-connector-images` - Builds and publishes a pre-release docker image for the modified connector(s).
-- `/publish-connectors-prerelease` - Publishes pre-release connector builds (tagged as `{version}-preview.{git-sha}`) for all modified connectors in the PR.
+- `/publish-connectors-prerelease` - Publishes pre-release connector builds (tagged as `{version}-preview.{git-sha}` by default, or `{version}-hotfix.{mmdd}.{sha}` when requested) for all modified connectors in the PR.
 - `/ai-review` - AI-powered PR review for connector safety and quality gates.
 - `/ai-docs-review` - AI-powered documentation review for PRs with connector changes.
 - `/ai-create-docs-pr` - Creates a documentation PR for connector changes.

--- a/.github/pr-welcome-internal.md
+++ b/.github/pr-welcome-internal.md
@@ -25,7 +25,7 @@ Airbyte Maintainers (that's you!) can execute the following slash commands on yo
   - `/ai-docs-review` - AI-powered documentation review for PRs with connector changes.
   - `/ai-create-docs-pr` - Creates a documentation PR for connector changes, stacked on the current PR.
 - 🚀 Connector Releases:
-  - `/publish-connectors-prerelease` - Publishes pre-release connector builds (tagged as `{version}-preview.{git-sha}`) for all modified connectors in the PR.
+  - `/publish-connectors-prerelease` - Publishes pre-release connector builds (tagged as `{version}-preview.{git-sha}` by default, or `{version}-hotfix.{mmdd}.{sha}` when requested) for all modified connectors in the PR.
 - ☕️ JVM connectors:
   - `/update-connector-cdk-version connector=<CONNECTOR_NAME>` - Updates the specified connector to the latest CDK version.
     Example: `/update-connector-cdk-version connector=destination-bigquery`

--- a/.github/workflows/publish-connectors-prerelease-command.yml
+++ b/.github/workflows/publish-connectors-prerelease-command.yml
@@ -3,13 +3,14 @@ name: Publish Connectors Pre-release
 # It can be triggered via the /publish-connectors-prerelease slash command from PR comments,
 # or via the MCP tool `publish_connector_to_airbyte_registry`.
 #
-# Pre-release versions are tagged with the format: {version}-preview.{7-char-git-sha}
+# Pre-release versions are tagged with the format: {version}-preview.{7-char-git-sha} by default, or {version}-hotfix.{mmdd}.{3-char-git-sha} when requested
 # These versions are NOT eligible for semver auto-advancement but ARE available
 # for version pinning via the scoped_configuration API.
 #
 # Usage:
 #   /publish-connectors-prerelease                    # Auto-detects single modified connector
 #   /publish-connectors-prerelease connector=source-github  # Explicit connector name
+#   /publish-connectors-prerelease version-suffix=hotfix connector=source-github
 #
 # If no connector is specified, the workflow auto-detects modified connectors.
 # It will fail if 0 or 2+ connectors are modified (only single-connector publishing is supported).
@@ -39,6 +40,11 @@ on:
         description: "Single connector name to publish (e.g., destination-pinecone). If not provided, auto-detects from PR changes (fails if 0 or 2+ connectors modified)."
         required: false
         type: string
+      version-suffix:
+        description: "Pre-release suffix format: preview or hotfix. Hotfix tags include current UTC MMDD and 3 SHA chars."
+        required: false
+        default: "preview"
+        type: string
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.inputs.pr || github.run_id }}
@@ -55,6 +61,8 @@ jobs:
       short-sha: ${{ steps.get-sha.outputs.short-sha }}
       connector-name: ${{ steps.resolve-connector.outputs.connector-name }}
       connector-version: ${{ steps.connector-version.outputs.connector-version }}
+      version-suffix: ${{ steps.resolve-version-suffix.outputs.version-suffix }}
+      tag-format: ${{ steps.resolve-version-suffix.outputs.tag-format }}
     steps:
       - name: Checkout to get commit SHA
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -67,7 +75,7 @@ jobs:
         id: get-sha
         run: |
           SHORT_SHA=$(git rev-parse --short=7 HEAD)
-          echo "short-sha=$SHORT_SHA" >> $GITHUB_OUTPUT
+          echo "short-sha=$SHORT_SHA" | tee -a $GITHUB_OUTPUT
 
       - name: Get job variables
         id: job-vars
@@ -77,16 +85,23 @@ jobs:
           if [[ -n "${{ inputs.pr }}" ]]; then
             RUN_URL="${RUN_URL}?pr=${{ inputs.pr }}"
           fi
-          echo "run-url=$RUN_URL" >> $GITHUB_OUTPUT
-          echo "pr-number=${{ inputs.pr }}" >> $GITHUB_OUTPUT
+          echo "run-url=$RUN_URL" | tee -a $GITHUB_OUTPUT
+          echo "pr-number=${{ inputs.pr }}" | tee -a $GITHUB_OUTPUT
 
       - name: Resolve connector name
         id: resolve-connector
+        env:
+          CONNECTOR_INPUT: ${{ inputs.connector }}
         run: |
           set -euo pipefail
-          if [[ -n "${{ inputs.connector }}" ]]; then
-            echo "Connector explicitly provided: ${{ inputs.connector }}"
-            echo "connector-name=${{ inputs.connector }}" >> "$GITHUB_OUTPUT"
+          if [[ -n "$CONNECTOR_INPUT" && "$CONNECTOR_INPUT" == *"version-suffix="* ]]; then
+            echo "::error::Received version-suffix inside the connector input. Use '/publish-connectors-prerelease version-suffix=<preview|hotfix> connector=<name>' instead of adding version-suffix to the connector value."
+            exit 1
+          fi
+
+          if [[ -n "$CONNECTOR_INPUT" ]]; then
+            echo "Connector explicitly provided: $CONNECTOR_INPUT"
+            echo "connector-name=$CONNECTOR_INPUT" | tee -a $GITHUB_OUTPUT
             exit 0
           fi
 
@@ -109,7 +124,32 @@ jobs:
 
           CONNECTOR_NAME=$(echo "$CONNECTORS" | head -n1)
           echo "Auto-detected single modified connector: $CONNECTOR_NAME"
-          echo "connector-name=$CONNECTOR_NAME" >> "$GITHUB_OUTPUT"
+          echo "connector-name=$CONNECTOR_NAME" | tee -a $GITHUB_OUTPUT
+
+      - name: Resolve version suffix
+        id: resolve-version-suffix
+        env:
+          VERSION_SUFFIX: ${{ inputs.version-suffix }}
+        run: |
+          set -euo pipefail
+          VERSION_SUFFIX="${VERSION_SUFFIX:-preview}"
+          VERSION_SUFFIX="${VERSION_SUFFIX,,}"
+          case "$VERSION_SUFFIX" in
+            preview)
+              TAG_FORMAT="{version}-preview.${{ steps.get-sha.outputs.short-sha }}"
+              ;;
+            hotfix)
+              SHORT_SHA=$(git rev-parse --short=3 HEAD)
+              DATE_SUFFIX=$(date -u +%m%d)
+              TAG_FORMAT="{version}-hotfix.${DATE_SUFFIX}.${SHORT_SHA}"
+              ;;
+            *)
+              echo "::error::Invalid version-suffix '$VERSION_SUFFIX'. Valid options are 'preview' or 'hotfix'."
+              exit 1
+              ;;
+          esac
+          echo "version-suffix=$VERSION_SUFFIX" | tee -a $GITHUB_OUTPUT
+          echo "tag-format=$TAG_FORMAT" | tee -a $GITHUB_OUTPUT
 
       - name: Determine connector version
         id: connector-version
@@ -124,7 +164,7 @@ jobs:
           if [[ -z "$VERSION" ]] && [[ -f "$CONNECTOR_DIR/metadata.yaml" ]]; then
             VERSION=$(grep -E '^\s*dockerImageTag:' "$CONNECTOR_DIR/metadata.yaml" | head -n1 | awk '{print $2}' | tr -d '"')
           fi
-          echo "connector-version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "connector-version=$VERSION" | tee -a $GITHUB_OUTPUT
 
       - name: Append start comment
         id: append-start-comment
@@ -140,7 +180,7 @@ jobs:
             > Publishing pre-release build for connector `${{ steps.resolve-connector.outputs.connector-name }}`.
             > PR: [#${{ inputs.pr }}](https://github.com/${{ inputs.repo || github.repository }}/pull/${{ inputs.pr }})
             >
-            > Pre-release versions will be tagged as `{version}-preview.${{ steps.get-sha.outputs.short-sha }}`
+            > Pre-release versions will be tagged as `${{ steps.resolve-version-suffix.outputs.tag-format }}`
             > and are available for version pinning via the scoped_configuration API.
             >
             > [View workflow run](${{ steps.job-vars.outputs.run-url }})
@@ -151,7 +191,7 @@ jobs:
     uses: ./.github/workflows/publish_connectors.yml
     with:
       connectors: ${{ format('--name={0}', needs.init.outputs.connector-name) }}
-      with-semver-suffix: preview
+      with-semver-suffix: ${{ needs.init.outputs.version-suffix }}
       gitref: refs/pull/${{ inputs.pr }}/head
       pr: ${{ format('{0}', inputs.pr) }}
     secrets: inherit

--- a/.github/workflows/publish_connectors.yml
+++ b/.github/workflows/publish_connectors.yml
@@ -18,6 +18,7 @@ on:
           - default: Resolves to 'none' on push to master, 'preview' on manual trigger
           - none: Use exact version from metadata.yaml (for production releases)
           - preview: Append '-preview.{sha}' suffix (for development builds)
+          - hotfix: Append '-hotfix.{mmdd}.{sha}' suffix (for tested bug/customer fixes)
           - rc: Append '-rc1' suffix (for release candidates)
         default: default
         type: string
@@ -55,6 +56,7 @@ on:
           - default: Resolves to 'none' on push to master, 'preview' on manual trigger
           - none: Use exact version from metadata.yaml (for production releases)
           - preview: Append '-preview.{sha}' suffix (for development builds)
+          - hotfix: Append '-hotfix.{mmdd}.{sha}' suffix (for tested bug/customer fixes)
           - rc: Append '-rc1' suffix (for release candidates)
         default: default
         type: choice
@@ -62,6 +64,7 @@ on:
           - default
           - none
           - preview
+          - hotfix
           - rc
       publish-java-tars:
         description: "Whether to publish Java connector tar files."
@@ -302,11 +305,12 @@ jobs:
 
           # Generate docker image tag based on semver suffix mode
           case "$SEMVER_SUFFIX" in
-            preview)
+            preview|hotfix)
               DOCKER_TAG=$(airbyte-ops registry connector-version next \
                 --name "${{ matrix.connector }}" \
                 --sha "$(git rev-parse HEAD)" \
-                --base-version "${CONNECTOR_VERSION}")
+                --base-version "${CONNECTOR_VERSION}" \
+                --suffix "${SEMVER_SUFFIX}")
               echo "docker-image-tag=${DOCKER_TAG}" | tee -a $GITHUB_OUTPUT
               echo "release-type-flag=--pre-release" | tee -a $GITHUB_OUTPUT
               ;;
@@ -451,15 +455,13 @@ jobs:
           echo "Progressive rollout enabled in metadata.yaml"
 
       # --- Ephemeral version bump for pre-release builds ---
-      # For preview builds, the metadata.yaml still contains the base version (e.g. 3.2.3)
-      # but the actual published tag is the preview version (e.g. 3.2.3-preview.820ce48).
       # The artifact generator reads dockerImageTag from metadata.yaml, so we need to
       # bump it in-place before generating artifacts. This is ephemeral — not committed.
       # See: https://github.com/airbytehq/airbyte-ops-mcp/issues/604
       - name: Ephemeral version bump for pre-release
         if: >
           steps.check-release-block.outputs.blocked != 'true' &&
-          needs.publish_options.outputs.with-semver-suffix == 'preview'
+          contains(fromJson('["preview", "hotfix"]'), needs.publish_options.outputs.with-semver-suffix)
         run: |
           echo "Bumping metadata.yaml version to ${{ steps.resolve-docker-image-tag.outputs.docker-image-tag }}"
           airbyte-ops local connector bump-version \

--- a/poe-tasks/build-and-publish-java-connectors-with-tag.sh
+++ b/poe-tasks/build-and-publish-java-connectors-with-tag.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # This script builds and optionally publishes Java connector Docker images.
-# Usage: ./build-and-publish-java-connectors-with-tag.sh --name <name> --with-semver-suffix [none | preview | rc] [--publish]
+# Usage: ./build-and-publish-java-connectors-with-tag.sh --name <name> --with-semver-suffix [none | preview | hotfix | rc] [--publish]
 #
 # Flag descriptions:
 #   --name <name>:    Specifies the connector name (e.g., destination-bigquery).
@@ -9,6 +9,7 @@
 #   --with-semver-suffix:   Specifies the semver suffix mode:
 #                     - none: Builds with the exact version from metadata.yaml.
 #                     - preview: Builds with a preview tag (version-preview.githash).
+#                     - hotfix: Builds with a hotfix tag (version-hotfix.MMDD.githash).
 #                     - rc: Builds with an RC tag (version-rc1).
 #                     Defaults to preview if not specified.
 #
@@ -102,11 +103,14 @@ else
     preview)
       docker_tag=$(generate_dev_tag "$base_tag")
       ;;
+    hotfix)
+      docker_tag=$(generate_hotfix_tag "$base_tag")
+      ;;
     rc)
       docker_tag=$(generate_rc_tag "$base_tag")
       ;;
     *)
-      echo "Error: Invalid semver_suffix '$semver_suffix'. Valid options are 'none', 'preview', or 'rc'." >&2
+      echo "Error: Invalid semver_suffix '$semver_suffix'. Valid options are 'none', 'preview', 'hotfix', or 'rc'." >&2
       exit 1
       ;;
   esac

--- a/poe-tasks/lib/parse_args.sh
+++ b/poe-tasks/lib/parse_args.sh
@@ -1,8 +1,8 @@
 # Parse the command-line args that we care about.
 # Scripts sourcing this script can be invoked as either:
-# ./foo.sh [--with-semver-suffix=<none|preview|rc>] [--publish] [--name=<source/destination-foo>]* [--name <source/destination-foo>]*
+# ./foo.sh [--with-semver-suffix=<none|preview|hotfix|rc>] [--publish] [--name=<source/destination-foo>]* [--name <source/destination-foo>]*
 # Or, if invoked with no `--name` flags:
-# ./get-modified-connectors.sh --json | ./foo.sh [--with-semver-suffix=<none|preview|rc>] [--publish]
+# ./get-modified-connectors.sh --json | ./foo.sh [--with-semver-suffix=<none|preview|hotfix|rc>] [--publish]
 semver_suffix="preview"
 do_publish=false
 connectors=()

--- a/poe-tasks/lib/util.sh
+++ b/poe-tasks/lib/util.sh
@@ -62,6 +62,16 @@ generate_dev_tag() {
   echo "${base}-preview.${hash}"
 }
 
+# Generate the hotfix image tag (e.g. `1.2.3-hotfix.0522.abc`).
+generate_hotfix_tag() {
+  local base="$1"
+  local date_suffix
+  local hash
+  date_suffix=$(date -u +%m%d)
+  hash=$(git rev-parse --short=3 HEAD)
+  echo "${base}-hotfix.${date_suffix}.${hash}"
+}
+
 # Generate the release candidate image tag (e.g. `1.2.3-rc1`).
 generate_rc_tag() {
   local base="$1"

--- a/poe-tasks/publish-python-registry.sh
+++ b/poe-tasks/publish-python-registry.sh
@@ -18,7 +18,7 @@ Options:
     -n, --name CONNECTOR_NAME     Connector name (required)
     -t, --token TOKEN             PyPI token (optional, specify this or set PYTHON_REGISTRY_TOKEN environment variable)
     -v, --version VERSION         Override version (optional)
-    --with-semver-suffix TYPE     Semver suffix (optional): 'none', 'preview', or 'rc' (default is 'preview')
+    --with-semver-suffix TYPE     Semver suffix (optional): 'none', 'preview', 'hotfix', or 'rc' (default is 'preview')
     --test-registry               Use the test PyPI registry (default is production registry)
     --dry-run                     Build the package and skip upload
     -h, --help                    Show this help message
@@ -126,8 +126,8 @@ if [[ -z "$CONNECTOR_NAME" ]]; then
     exit 1
 fi
 
-if [[ "$SEMVER_SUFFIX" != "none" && "$SEMVER_SUFFIX" != "preview" && "$SEMVER_SUFFIX" != "rc" ]]; then
-    echo "Error: Invalid semver suffix '$SEMVER_SUFFIX'. Valid options are 'none', 'preview', or 'rc'." >&2
+if [[ "$SEMVER_SUFFIX" != "none" && "$SEMVER_SUFFIX" != "preview" && "$SEMVER_SUFFIX" != "hotfix" && "$SEMVER_SUFFIX" != "rc" ]]; then
+    echo "Error: Invalid semver suffix '$SEMVER_SUFFIX'. Valid options are 'none', 'preview', 'hotfix', or 'rc'." >&2
     usage >&2
     exit 1
 fi
@@ -182,8 +182,8 @@ if [[ -n "$VERSION_OVERRIDE" ]]; then
 elif [[ -n "${CONNECTOR_VERSION_TAG:-}" ]]; then
     # When set by the publish workflow, use the pre-resolved tag directly.
     VERSION="$CONNECTOR_VERSION_TAG"
-elif [[ "$SEMVER_SUFFIX" == "preview" ]]; then
-    # Add current timestamp for preview builds.
+elif [[ "$SEMVER_SUFFIX" == "preview" || "$SEMVER_SUFFIX" == "hotfix" ]]; then
+    # Add current timestamp for pre-release builds.
     # we can't use the git revision because not all python registries allow local version identifiers. 
     # Public version identifiers must conform to PEP 440 and only allow digits.
     TIMESTAMP=$(date +"%Y%m%d%H%M")

--- a/poe-tasks/upload-java-connector-tar-file.sh
+++ b/poe-tasks/upload-java-connector-tar-file.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # Uploads the java tar for java connectors.
-# Usage: ./poe-tasks/upload-java-connector-tar-file.sh --name destination-bigquery --with-semver-suffix <none|preview|rc>
+# Usage: ./poe-tasks/upload-java-connector-tar-file.sh --name destination-bigquery --with-semver-suffix <none|preview|hotfix|rc>
 # You must have set the env var GCS_CREDENTIALS, which contains a JSON-formatted GCP service account key.
 # GCS_CREDENTIALS needs write access to `gs://$metadata_bucket/resources/java`.
 set -euo pipefail
@@ -36,11 +36,14 @@ else
     preview)
       docker_tag=$(generate_dev_tag "$base_tag")
       ;;
+    hotfix)
+      docker_tag=$(generate_hotfix_tag "$base_tag")
+      ;;
     rc)
       docker_tag=$(generate_rc_tag "$base_tag")
       ;;
     *)
-      echo "Error: Invalid semver_suffix '$semver_suffix'. Valid options are 'none', 'preview', or 'rc'." >&2
+      echo "Error: Invalid semver_suffix '$semver_suffix'. Valid options are 'none', 'preview', 'hotfix', or 'rc'." >&2
       exit 1
       ;;
   esac


### PR DESCRIPTION
## What
Add an explicit `hotfix` prerelease suffix mode for connector prerelease publishes requested by AJ Steers.

Default prerelease tags stay unchanged as `{version}-preview.{7-char-git-sha}`. Hotfix prerelease tags are opt-in and use `{version}-hotfix.{UTC-MMDD}.{3-char-git-sha}` to make tested bug or customer-fix builds easier to recognize before pins are removed.

This does not change connector semver bump policy. The hotfix suffix is only an ephemeral publish tag format applied to the version already declared in PR metadata.

## How
- Add `version-suffix` input handling to `/publish-connectors-prerelease` and pass it through to `publish_connectors.yml` as `with-semver-suffix`.
- Add `hotfix` as an accepted `with-semver-suffix` value in publish workflows and connector image build/push actions.
- Generate hotfix Docker tags with UTC `MMDD` and the 3-character short SHA.
- Extend helper scripts for Java image publishing, Java tar upload, and Python registry publishing to accept `hotfix` consistently.
- Update PR welcome text to document the new suffix option.

## Review guide
1. `.github/workflows/publish-connectors-prerelease-command.yml`
2. `.github/workflows/publish_connectors.yml`
3. `.github/actions/connector-image-build-push/action.yml`
4. `poe-tasks/lib/util.sh`
5. `.github/pr-welcome-community.md` and `.github/pr-welcome-internal.md`

## User Impact
Maintainers can request a connector prerelease with `/publish-connectors-prerelease version-suffix=hotfix connector=<name>` and get a tag like `4.4.8-hotfix.0522.e2b`. Existing preview prerelease behavior remains the default.

## Can this PR be safely reverted and rolled back?
- [x] YES
- [ ] NO

Verified locally:
- `yq eval '.'` on changed workflow/action YAML files
- `bash -n` on changed poe task shell scripts

Companion PRs:
- https://github.com/airbytehq/airbyte-ops-mcp/pull/825
- https://github.com/airbytehq/airbyte-enterprise/pull/438

Link to Devin session: https://app.devin.ai/sessions/84a7bbf9d4384bbea49ae497f8da8216
Requested by: @aaronsteers