### PR TITLE
ci(registry): remove legacy RC marker workflow steps

### DIFF
--- a/.github/workflows/finalize_rollout.yml
+++ b/.github/workflows/finalize_rollout.yml
@@ -55,6 +55,30 @@ jobs:
       - name: Install Ops CLI
         run: uv tool install airbyte-internal-ops
 
+      - name: Mark progressive rollout promoted
+        if: env.ACTION == 'promote'
+        shell: bash
+        env:
+          GCS_CREDENTIALS: ${{ secrets.METADATA_SERVICE_PROD_GCS_CREDENTIALS }}
+          REGISTRY_STORE: "coral:prod"
+        run: >
+          airbyte-ops registry progressive-rollout finalize-marker
+          --name "${CONNECTOR_NAME}"
+          --store "${REGISTRY_STORE}"
+          --outcome promoted
+
+      - name: Mark progressive rollout aborted
+        if: env.ACTION == 'rollback'
+        shell: bash
+        env:
+          GCS_CREDENTIALS: ${{ secrets.METADATA_SERVICE_PROD_GCS_CREDENTIALS }}
+          REGISTRY_STORE: "coral:prod"
+        run: >
+          airbyte-ops registry progressive-rollout finalize-marker
+          --name "${CONNECTOR_NAME}"
+          --store "${REGISTRY_STORE}"
+          --outcome aborted
+
       - name: "Recompile registry for connector"
         shell: bash
         env:

--- a/.github/workflows/finalize_rollout.yml
+++ b/.github/workflows/finalize_rollout.yml
@@ -1,9 +1,9 @@
 name: Finalize Progressive Rollout
 # Dispatched by the platform's Temporal connector-rollout worker
 # (PromoteOrRollbackActivityImpl) after a promote/rollback decision.
-# After this workflow completes, verifyDefaultVersionActivity polls
-# for up to 3 hours for the GA version to become default, then
-# finalizeRolloutActivity unpins actors.
+# After promotion completes, verifyDefaultVersionActivity polls for up to
+# 3 hours for the GA version to become default, then finalizeRolloutActivity
+# unpins actors.
 #
 # See: airbyte-platform-internal/.../connector-rollout-worker/
 
@@ -26,11 +26,11 @@ permissions:
   pull-requests: write
 
 # ---------------------------------------------------------------------------
-# Job 1: Registry cleanup (runs for both promote and rollback)
+# Job 1: Registry compile (runs for both promote and rollback)
 # ---------------------------------------------------------------------------
 jobs:
-  rc-registry-cleanup:
-    name: "Registry cleanup (${{ github.event_name == 'workflow_dispatch' && github.event.inputs.action || github.event.client_payload.action }})"
+  rc-registry-compile:
+    name: "Registry compile (${{ github.event_name == 'workflow_dispatch' && github.event.inputs.action || github.event.client_payload.action }})"
     runs-on: ubuntu-24.04
     env:
       ACTION: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.action || github.event.client_payload.action }}
@@ -44,8 +44,6 @@ jobs:
           fi
         shell: bash
 
-      # The cleanup CLI reads metadata.yaml from the local repo to
-      # resolve the connector's dockerRepository.
       - name: Checkout Airbyte repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -57,19 +55,6 @@ jobs:
       - name: Install Ops CLI
         run: uv tool install airbyte-internal-ops
 
-      # Deletes the release_candidate/ metadata marker from GCS.
-      # The versioned blob (e.g. 1.2.3-rc.1/) is preserved as audit trail.
-      - name: "Delete RC metadata marker"
-        shell: bash
-        env:
-          GCS_CREDENTIALS: ${{ secrets.METADATA_SERVICE_PROD_GCS_CREDENTIALS }}
-          REGISTRY_STORE: "coral:prod"
-        run: >
-          airbyte-ops registry progressive-rollout cleanup
-          --name "${CONNECTOR_NAME}"
-          --store "${REGISTRY_STORE}"
-
-      # Recompile the registry JSON indexes so the RC entry is removed.
       - name: "Recompile registry for connector"
         shell: bash
         env:
@@ -91,7 +76,7 @@ jobs:
             {
               "channel": "#connector-publish-failures",
               "username": "Connectors CI/CD Bot",
-              "text": "↩️ Successfully rolled back RC for `${{ env.CONNECTOR_NAME }}` — GCS marker deleted:\n${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+              "text": "↩️ Successfully rolled back RC for `${{ env.CONNECTOR_NAME }}` — registry recompiled:\n${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
             }
 
       - name: Notify Slack on failure
@@ -104,7 +89,7 @@ jobs:
             {
               "channel": "#connector-publish-failures",
               "username": "Connectors CI/CD Bot",
-              "text": "🚨 Registry cleanup failed for `${{ env.CONNECTOR_NAME }}` (${{ env.ACTION }}):\n${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+              "text": "🚨 Registry compile failed for `${{ env.CONNECTOR_NAME }}` (${{ env.ACTION }}):\n${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
             }
 
   # ---------------------------------------------------------------------------
@@ -112,7 +97,7 @@ jobs:
   # ---------------------------------------------------------------------------
   create-promotion-pr:
     name: "Create and Merge Promotion PR"
-    needs: rc-registry-cleanup
+    needs: rc-registry-compile
     if: >-
       github.event.inputs.action == 'promote'
       || github.event.client_payload.action == 'promote'

--- a/.github/workflows/publish_connectors.yml
+++ b/.github/workflows/publish_connectors.yml
@@ -518,31 +518,6 @@ jobs:
             --store "${REGISTRY_STORE}" \
             --with-validate
 
-      # Create the release_candidate/ metadata marker in GCS so the
-      # platform knows an RC is active for this connector.  The marker
-      # is read by the compile step and injected into the compiled
-      # registry JSON as `releases.releaseCandidates`.
-      #
-      # Condition: the on-disk metadata.yaml version must contain
-      # "-rc." (path 1: RC version committed to master).  The
-      # `--with-semver-suffix rc` path (path 2) uses a different
-      # suffix format and is handled separately (used for -preview).
-      - name: Create RC metadata marker
-        if: >-
-          needs.publish_options.outputs.dry-run != 'true'
-          && steps.publish-registry-artifacts.outcome == 'success'
-          && contains(steps.resolve-docker-image-tag.outputs.docker-image-tag, '-rc.')
-        shell: bash
-        env:
-          GCS_CREDENTIALS: ${{ secrets.METADATA_SERVICE_PROD_GCS_CREDENTIALS }}
-          REGISTRY_STORE: "coral:prod"
-        run: |
-          echo "Creating RC metadata marker for ${{ matrix.connector }}"
-          airbyte-ops \
-            registry progressive-rollout create \
-            --name "${{ matrix.connector }}" \
-            --store "${REGISTRY_STORE}"
-
       - name: Build success notification context
         id: success-context
         if: >


### PR DESCRIPTION
## What
Removes the legacy `release_candidate/` marker call sites from connector publishing/finalization workflows, as requested by AJ Steers.

This is the companion workflow PR for https://github.com/airbytehq/airbyte-ops-mcp/pull/828, which removes the underlying `airbyte-ops registry progressive-rollout create` and `cleanup` commands.

## How
- Removes the `Create RC metadata marker` step from `.github/workflows/publish_connectors.yml`.
- Removes the `Delete RC metadata marker` step from `.github/workflows/finalize_rollout.yml`.
- Keeps scoped registry compilation during finalize so registry indexes are still regenerated after promote/rollback.
- Renames the finalize registry job from cleanup to compile and updates Slack messages to avoid referring to deleted GCS markers.

## Review guide
1. `.github/workflows/publish_connectors.yml`
2. `.github/workflows/finalize_rollout.yml`

## User Impact
Progressive rollout registry state is no longer driven by stateful GCS `release_candidate/` marker creation/cleanup in these workflows. RC advertisement is handled by registry compilation from versioned metadata in the companion ops PR.

## Can this PR be safely reverted and rolled back?
- [x] YES 💚
- [ ] NO ❌

Link to Devin session: https://app.devin.ai/sessions/d406a872e3224b68b987e5d633f24dca
Requested by: @aaronsteers