### PR TITLE
chore(source-google-ads): remove scopedImpact from 5.0.0 breaking change

### DIFF
--- a/airbyte-integrations/connectors/source-google-ads/metadata.yaml
+++ b/airbyte-integrations/connectors/source-google-ads/metadata.yaml
@@ -54,22 +54,6 @@ data:
       5.0.0:
         message: This release upgrades the Google Ads API from v20 to v23. Several built-in stream schemas have renamed fields (e.g., video metrics renamed to TrueView equivalents, `campaign.start_date` / `end_date` renamed to `start_date_time` / `end_date_time`) and removed fields (`CallAd` / `CallAdInfo` on `ad_group_ad`). It also removes the nullable `bidding_strategy.id` field from the primary keys of the `campaign_bidding_strategy` and `ad_group_bidding_strategy` streams. Users should refresh the source schema and reset affected streams after upgrading to ensure uninterrupted syncs. See the migration guide for full details.
         upgradeDeadline: "2026-06-09"
-        scopedImpact:
-          - scopeType: stream
-            impactedScopes:
-              [
-                "campaign",
-                "campaign_budget",
-                "account_performance_report",
-                "ad_group_ad",
-                "ad_group_ad_legacy",
-                "display_keyword_view",
-                "geographic_view_with_metrics",
-                "topic_view",
-                "user_location_view",
-                "ad_group_bidding_strategy",
-                "campaign_bidding_strategy",
-              ]
   suggestedStreams:
     streams:
       - campaigns


### PR DESCRIPTION
## Summary
- Remove the `scopedImpact` block from the 5.0.0 breaking change entry in `source-google-ads` `metadata.yaml` so the upgrade applies broadly rather than only to the previously enumerated stream subset.

## Test plan
- [ ] CI metadata validation passes for `source-google-ads`.
- [ ] Confirm the 5.0.0 breaking change still renders correctly without the scopedImpact section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)