### PR TITLE
feat(source-google-sheets): set default_concurrency to 4 for concurrency tuning (0.12.26-rc.1)

### DIFF
--- a/airbyte-integrations/connectors/source-google-sheets/manifest.yaml
+++ b/airbyte-integrations/connectors/source-google-sheets/manifest.yaml
@@ -652,5 +652,5 @@ spec:
 
 concurrency_level:
   type: ConcurrencyLevel
-  default_concurrency: 1
-  max_concurrency: 1
+  default_concurrency: 75
+  max_concurrency: 75

--- a/airbyte-integrations/connectors/source-google-sheets/manifest.yaml
+++ b/airbyte-integrations/connectors/source-google-sheets/manifest.yaml
@@ -652,5 +652,5 @@ spec:
 
 concurrency_level:
   type: ConcurrencyLevel
-  default_concurrency: 75
-  max_concurrency: 75
+  default_concurrency: 4
+  max_concurrency: 4

--- a/airbyte-integrations/connectors/source-google-sheets/metadata.yaml
+++ b/airbyte-integrations/connectors/source-google-sheets/metadata.yaml
@@ -32,10 +32,8 @@ data:
   registryOverrides:
     cloud:
       enabled: true
-      dockerImageTag: 0.12.25
     oss:
       enabled: true
-      dockerImageTag: 0.12.25
   releaseStage: generally_available
   releases:
     rolloutConfiguration:

--- a/airbyte-integrations/connectors/source-google-sheets/metadata.yaml
+++ b/airbyte-integrations/connectors/source-google-sheets/metadata.yaml
@@ -10,7 +10,7 @@ data:
   connectorSubtype: file
   connectorType: source
   definitionId: 71607ba1-c0ac-4799-8049-7f4b90dd50f7
-  dockerImageTag: 0.12.25
+  dockerImageTag: 0.12.26-rc.1
   dockerRepository: airbyte/source-google-sheets
   documentationUrl: https://docs.airbyte.com/integrations/sources/google-sheets
   externalDocumentationUrls:
@@ -32,12 +32,14 @@ data:
   registryOverrides:
     cloud:
       enabled: true
+      dockerImageTag: 0.12.25
     oss:
       enabled: true
+      dockerImageTag: 0.12.25
   releaseStage: generally_available
   releases:
     rolloutConfiguration:
-      enableProgressiveRollout: false
+      enableProgressiveRollout: true
   supportLevel: certified
   tags:
     - language:manifest-only

--- a/docs/integrations/sources/google-sheets.md
+++ b/docs/integrations/sources/google-sheets.md
@@ -305,7 +305,7 @@ Airbyte batches requests to the API in order to efficiently pull data and respec
 
 | Version    | Date       | Pull Request                                             | Subject                                                                                                                                                                |
 |------------|------------|----------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| 0.12.26-rc.1 | 2026-05-26 | [*PR_NUMBER_PLACEHOLDER*](https://github.com/airbytehq/airbyte/pull/*PR_NUMBER_PLACEHOLDER*) | Set default_concurrency to 75 for concurrency tuning |
+| 0.12.26-rc.1 | 2026-05-26 | [78437](https://github.com/airbytehq/airbyte/pull/78437) | Set default_concurrency to 75 for concurrency tuning |
 | 0.12.25 | 2026-04-28 | [77273](https://github.com/airbytehq/airbyte/pull/77273) | Update dependencies |
 | 0.12.24 | 2026-04-21 | [76629](https://github.com/airbytehq/airbyte/pull/76629) | Update dependencies |
 | 0.12.23 | 2026-04-02 | [75578](https://github.com/airbytehq/airbyte/pull/75578) | Add `oauth_connector_input_specification` with granular scopes |

--- a/docs/integrations/sources/google-sheets.md
+++ b/docs/integrations/sources/google-sheets.md
@@ -305,6 +305,7 @@ Airbyte batches requests to the API in order to efficiently pull data and respec
 
 | Version    | Date       | Pull Request                                             | Subject                                                                                                                                                                |
 |------------|------------|----------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 0.12.26-rc.1 | 2026-05-26 | [*PR_NUMBER_PLACEHOLDER*](https://github.com/airbytehq/airbyte/pull/*PR_NUMBER_PLACEHOLDER*) | Set default_concurrency to 75 for concurrency tuning |
 | 0.12.25 | 2026-04-28 | [77273](https://github.com/airbytehq/airbyte/pull/77273) | Update dependencies |
 | 0.12.24 | 2026-04-21 | [76629](https://github.com/airbytehq/airbyte/pull/76629) | Update dependencies |
 | 0.12.23 | 2026-04-02 | [75578](https://github.com/airbytehq/airbyte/pull/75578) | Add `oauth_connector_input_specification` with granular scopes |

--- a/docs/integrations/sources/google-sheets.md
+++ b/docs/integrations/sources/google-sheets.md
@@ -305,7 +305,7 @@ Airbyte batches requests to the API in order to efficiently pull data and respec
 
 | Version    | Date       | Pull Request                                             | Subject                                                                                                                                                                |
 |------------|------------|----------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| 0.12.26-rc.1 | 2026-05-26 | [78437](https://github.com/airbytehq/airbyte/pull/78437) | Set default_concurrency to 75 for concurrency tuning |
+| 0.12.26-rc.1 | 2026-05-26 | [78437](https://github.com/airbytehq/airbyte/pull/78437) | Set default_concurrency to 4 for concurrency tuning |
 | 0.12.25 | 2026-04-28 | [77273](https://github.com/airbytehq/airbyte/pull/77273) | Update dependencies |
 | 0.12.24 | 2026-04-21 | [76629](https://github.com/airbytehq/airbyte/pull/76629) | Update dependencies |
 | 0.12.23 | 2026-04-02 | [75578](https://github.com/airbytehq/airbyte/pull/75578) | Add `oauth_connector_input_specification` with granular scopes |


### PR DESCRIPTION
## What

Set `default_concurrency` to 4 for source-google-sheets as part of the Connector Concurrency Tuning & Rollout playbook. This is the first RC (0.12.26-rc.1) for Phase 1 tuning.

Related:
- Epic: https://github.com/airbytehq/airbyte-internal-issues/issues/15262
- Connector issue: https://github.com/airbytehq/airbyte-internal-issues/issues/15321
- Slack thread: https://airbytehq-team.slack.com/archives/C08BHPUMEPJ/p1779829206176219

Requested by @sophiecuiy.

## How

- Updated `manifest.yaml`: changed `default_concurrency` from 1 → 4 and `max_concurrency` from 1 → 4
- Updated `metadata.yaml`: enabled progressive rollout (`enableProgressiveRollout: true`), bumped version to `0.12.26-rc.1`, pinned cloud/oss registries to stable 0.12.25
- No existing HTTP API budget to comment out (none present in manifest)

### Rate limit research (Path A — single-tier)

Google Sheets API v4 enforces **300 read requests per minute per project** = **5 req/sec** (https://developers.google.com/workspace/sheets/api/limits). No tiered rate limits — same quota for all Google Workspace editions. Write limit is 60/min but irrelevant for a source connector.

- `max_rate_limit = 5` (per second)
- `floor(5/4) = 1` ≤ 2 → **special case**: `starting_concurrency = 4`, `step = 1`

### Eligible actors

120 eligible Tier 2 actors with recent successful syncs found (2 internal Airbyte). Tuning cohort will be max(floor(120 * 0.5), 20) = 60 actors.

## Review guide

1. `airbyte-integrations/connectors/source-google-sheets/manifest.yaml` — concurrency change
2. `airbyte-integrations/connectors/source-google-sheets/metadata.yaml` — version bump + progressive rollout enablement
3. `docs/integrations/sources/google-sheets.md` — changelog entry

## User Impact

Concurrency tuning will be validated via progressive rollout on Tier 2 actors before GA. No user-facing impact until rollout completes successfully.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Link to Devin session: https://app.devin.ai/sessions/3cfd1c912163463ebf4825bcc2fdc681

> [!IMPORTANT]
> Active progressive rollout warning for source-google-sheets.

- [ ] (Click to Approve:) Bypass the active progressive rollout warning for source-google-sheets in the PR comment [here](https://github.com/airbytehq/airbyte/pull/78437#issuecomment-4549716822).