### PR TITLE
chore(source-bing-ads): enable progressive rollout for concurrency tuning

### DIFF
--- a/airbyte-integrations/connectors/source-bing-ads/manifest.yaml
+++ b/airbyte-integrations/connectors/source-bing-ads/manifest.yaml
@@ -17474,7 +17474,7 @@ schemas:
 
 concurrency_level:
   type: ConcurrencyLevel
-  default_concurrency: 10
+  default_concurrency: 12
   max_concurrency: 20
 
 spec:

--- a/airbyte-integrations/connectors/source-bing-ads/metadata.yaml
+++ b/airbyte-integrations/connectors/source-bing-ads/metadata.yaml
@@ -16,7 +16,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 47f25999-dd5e-4636-8c39-e7cea2453331
-  dockerImageTag: 2.23.16
+  dockerImageTag: 2.23.17-rc.1
   dockerRepository: airbyte/source-bing-ads
   documentationUrl: https://docs.airbyte.com/integrations/sources/bing-ads
   externalDocumentationUrls:
@@ -39,12 +39,14 @@ data:
   registryOverrides:
     cloud:
       enabled: true
+      dockerImageTag: 2.23.16
     oss:
       enabled: true
+      dockerImageTag: 2.23.16
   releaseStage: generally_available
   releases:
     rolloutConfiguration:
-      enableProgressiveRollout: false
+      enableProgressiveRollout: true
     breakingChanges:
       1.0.0:
         message: Version 1.0.0 removes the primary keys from the geographic performance report streams. This will prevent the connector from losing data in the incremental append+dedup sync mode because of deduplication and incorrect primary keys. A data reset and schema refresh of all the affected streams is required for the changes to take effect.

--- a/airbyte-integrations/connectors/source-bing-ads/metadata.yaml
+++ b/airbyte-integrations/connectors/source-bing-ads/metadata.yaml
@@ -39,10 +39,8 @@ data:
   registryOverrides:
     cloud:
       enabled: true
-      dockerImageTag: 2.23.16
     oss:
       enabled: true
-      dockerImageTag: 2.23.16
   releaseStage: generally_available
   releases:
     rolloutConfiguration:

--- a/docs/integrations/sources/bing-ads.md
+++ b/docs/integrations/sources/bing-ads.md
@@ -313,7 +313,7 @@ Bulk streams (Ad Group Labels, App Install Ads, App Install Ad Labels, Campaign 
 
 | Version     | Date       | Pull Request                                                                                                                     | Subject                                                                                                                                                                |
 |:------------|:-----------|:---------------------------------------------------------------------------------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| 2.23.17-rc.1 | 2026-05-26 | [*PR_NUMBER_PLACEHOLDER*](https://github.com/airbytehq/airbyte/pull/*PR_NUMBER_PLACEHOLDER*) | Enable progressive rollout for concurrency tuning |
+| 2.23.17-rc.1 | 2026-05-26 | [78438](https://github.com/airbytehq/airbyte/pull/78438) | Enable progressive rollout for concurrency tuning |
 | 2.23.16 | 2026-04-21 | [76515](https://github.com/airbytehq/airbyte/pull/76515) | Update dependencies |
 | 2.23.15 | 2026-04-08 | [76165](https://github.com/airbytehq/airbyte/pull/76165) | Promote 2.23.15-rc.3 to GA — fixes SAS token expiry during report downloads |
 | 2.23.15-rc.3 | 2026-04-02 | [76053](https://github.com/airbytehq/airbyte/pull/76053) | Fix SAS token expiry during report downloads by re-polling for fresh URL before each download |

--- a/docs/integrations/sources/bing-ads.md
+++ b/docs/integrations/sources/bing-ads.md
@@ -313,6 +313,7 @@ Bulk streams (Ad Group Labels, App Install Ads, App Install Ad Labels, Campaign 
 
 | Version     | Date       | Pull Request                                                                                                                     | Subject                                                                                                                                                                |
 |:------------|:-----------|:---------------------------------------------------------------------------------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 2.23.17-rc.1 | 2026-05-26 | [*PR_NUMBER_PLACEHOLDER*](https://github.com/airbytehq/airbyte/pull/*PR_NUMBER_PLACEHOLDER*) | Enable progressive rollout for concurrency tuning |
 | 2.23.16 | 2026-04-21 | [76515](https://github.com/airbytehq/airbyte/pull/76515) | Update dependencies |
 | 2.23.15 | 2026-04-08 | [76165](https://github.com/airbytehq/airbyte/pull/76165) | Promote 2.23.15-rc.3 to GA — fixes SAS token expiry during report downloads |
 | 2.23.15-rc.3 | 2026-04-02 | [76053](https://github.com/airbytehq/airbyte/pull/76053) | Fix SAS token expiry during report downloads by re-polling for fresh URL before each download |


### PR DESCRIPTION
## What

Enable progressive rollout for `source-bing-ads` and increase `default_concurrency` from 10 to 12 to test whether additional parallelism improves sync speeds for the async report pipeline.

Relates to: https://github.com/airbytehq/airbyte-internal-issues/issues/15318
Epic: https://github.com/airbytehq/airbyte-internal-issues/issues/15262

## How

- Bumps `dockerImageTag` to `2.23.17-rc.1`
- Pins cloud and OSS overrides to `2.23.16` (current stable)
- Sets `enableProgressiveRollout: true`
- Increases `default_concurrency` from 10 to 12 (step_size=2 per tuning playbook)

## Review guide

1. `airbyte-integrations/connectors/source-bing-ads/metadata.yaml` — version bump + progressive rollout config
2. `airbyte-integrations/connectors/source-bing-ads/manifest.yaml` — concurrency increase (10 → 12)
3. `docs/integrations/sources/bing-ads.md` — changelog entry

## User Impact

No user-facing impact initially. The RC will only be deployed to a controlled subset of Tier 2 connections via progressive rollout. The stable version (2.23.16) remains the default for all users. If tuning is successful, the increased concurrency may result in faster sync times.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

---
[Devin session](https://app.devin.ai/sessions/921816ac374845158c01bcf57ce882e1)
Requested by: sophie.cui@airbyte.io

Requested by: @sophiecuiy

> [!IMPORTANT]
> Active progressive rollout warning for source-bing-ads.

- [ ] (Click to Approve:) Bypass the active progressive rollout warning for source-bing-ads in the PR comment [here](https://github.com/airbytehq/airbyte/pull/78438#issuecomment-4549708184).