### PR TITLE
fix(source-hubspot): concurrency tuning RC - set default_concurrency=4, disable budget

### DIFF
--- a/airbyte-integrations/connectors/source-hubspot/manifest.yaml
+++ b/airbyte-integrations/connectors/source-hubspot/manifest.yaml
@@ -2519,33 +2519,35 @@ spec:
               - client_secret
 
 
-api_budget:
-  type: HTTPAPIBudget
-  policies:
-    # 1) CRM Search: special cap, separate from the global burst
-    - type: MovingWindowCallRatePolicy
-      rates:
-        - limit: 5         # 5 req/second
-          interval: PT1S
-        - limit: 300       # 300 req/min (same ceiling)
-          interval: PT1M
-      matchers:
-        - method: POST
-          url_path_pattern: "^/crm/v3/objects/[^/]+/search$"
-    # 2) General: public app burst = 110 per 10s per installed account
-    - type: MovingWindowCallRatePolicy
-      rates:
-        - limit: 10
-          interval: PT1S
-        - limit: 100
-          interval: PT10S
-      matchers: [ ]
-  status_codes_for_ratelimit_hit: [429]
+# api_budget commented out during concurrency tuning — original values preserved below.
+# Ref: https://developers.hubspot.com/docs/developer-tooling/platform/usage-guidelines
+# api_budget:
+#   type: HTTPAPIBudget
+#   policies:
+#     # 1) CRM Search: special cap, separate from the global burst
+#     - type: MovingWindowCallRatePolicy
+#       rates:
+#         - limit: 5         # 5 req/second
+#           interval: PT1S
+#         - limit: 300       # 300 req/min (same ceiling)
+#           interval: PT1M
+#       matchers:
+#         - method: POST
+#           url_path_pattern: "^/crm/v3/objects/[^/]+/search$"
+#     # 2) General: public app burst = 110 per 10s per installed account
+#     - type: MovingWindowCallRatePolicy
+#       rates:
+#         - limit: 10
+#           interval: PT1S
+#         - limit: 100
+#           interval: PT10S
+#       matchers: [ ]
+#   status_codes_for_ratelimit_hit: [429]
 
 # HubSpot account is limited to 110 requests every 10 seconds https://developers.hubspot.com/docs/guides/apps/api-usage/usage-details#rate-limits
 concurrency_level:
   type: ConcurrencyLevel
-  default_concurrency: "{{ config.get('num_workers', 10) }}"
+  default_concurrency: "{{ config.get('num_workers', 4) }}"
   max_concurrency: 40
 
 schemas:

--- a/airbyte-integrations/connectors/source-hubspot/metadata.yaml
+++ b/airbyte-integrations/connectors/source-hubspot/metadata.yaml
@@ -10,7 +10,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 36c891d9-4bd9-43ac-bad2-10e12756272c
-  dockerImageTag: 6.5.5
+  dockerImageTag: 6.5.6-rc.1
   dockerRepository: airbyte/source-hubspot
   documentationUrl: https://docs.airbyte.com/integrations/sources/hubspot
   resourceRequirements:
@@ -36,12 +36,14 @@ data:
   registryOverrides:
     cloud:
       enabled: true
+      dockerImageTag: 6.5.5
     oss:
       enabled: true
+      dockerImageTag: 6.5.5
   releaseStage: generally_available
   releases:
     rolloutConfiguration:
-      enableProgressiveRollout: false
+      enableProgressiveRollout: true
     breakingChanges:
       6.0.0:
         message: >-
@@ -67,13 +69,7 @@ data:
         deadlineAction: "auto_upgrade"
         scopedImpact:
           - scopeType: stream
-            impactedScopes:
-              [
-                "contact_lists",
-                "contacts_form_submissions",
-                "contacts_list_memberships",
-                "contacts_merged_audit",
-              ]
+            impactedScopes: ["contact_lists", "contacts_form_submissions", "contacts_list_memberships", "contacts_merged_audit"]
       4.0.0:
         message: >-
           This update brings extended schema with data type changes for the streams
@@ -82,8 +78,7 @@ data:
         upgradeDeadline: "2024-03-10"
         scopedImpact:
           - scopeType: stream
-            impactedScopes:
-              ["deals_property_history", "companies_property_history"]
+            impactedScopes: ["deals_property_history", "companies_property_history"]
       3.0.0:
         message: >-
           This update brings extended schema with data type changes for the Marketing

--- a/airbyte-integrations/connectors/source-hubspot/metadata.yaml
+++ b/airbyte-integrations/connectors/source-hubspot/metadata.yaml
@@ -69,7 +69,13 @@ data:
         deadlineAction: "auto_upgrade"
         scopedImpact:
           - scopeType: stream
-            impactedScopes: ["contact_lists", "contacts_form_submissions", "contacts_list_memberships", "contacts_merged_audit"]
+            impactedScopes:
+              [
+                "contact_lists",
+                "contacts_form_submissions",
+                "contacts_list_memberships",
+                "contacts_merged_audit",
+              ]
       4.0.0:
         message: >-
           This update brings extended schema with data type changes for the streams
@@ -78,7 +84,8 @@ data:
         upgradeDeadline: "2024-03-10"
         scopedImpact:
           - scopeType: stream
-            impactedScopes: ["deals_property_history", "companies_property_history"]
+            impactedScopes:
+              ["deals_property_history", "companies_property_history"]
       3.0.0:
         message: >-
           This update brings extended schema with data type changes for the Marketing

--- a/docs/integrations/sources/hubspot.md
+++ b/docs/integrations/sources/hubspot.md
@@ -354,6 +354,7 @@ If you use [custom properties](https://knowledge.hubspot.com/properties/create-a
 
 | Version     | Date       | Pull Request                                             | Subject                                                                                                                                                                                                                      |
 |:------------|:-----------|:---------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 6.5.6-rc.1 | 2026-05-26 | [*PR_NUMBER_PLACEHOLDER*](https://github.com/airbytehq/airbyte/pull/*PR_NUMBER_PLACEHOLDER*) | Concurrency tuning RC: set default_concurrency=4 (from 10), comment out HTTP API budget for empirical tuning via progressive rollout |
 | 6.5.5 | 2026-04-22 | [76323](https://github.com/airbytehq/airbyte/pull/76323) | Add failure_type classification to `list_memberships` error handler response filters |
 | 6.5.4 | 2026-04-21 | [76848](https://github.com/airbytehq/airbyte/pull/76848) | Fix OAuth optional_scopes to align with connector streams |
 | 6.5.3 | 2026-04-21 | [76073](https://github.com/airbytehq/airbyte/pull/76073) | Update CDK to pre-release with deadlock fix |


### PR DESCRIPTION
## What

Concurrency tuning RC for source-hubspot. This PR prepares a progressive rollout to empirically determine optimal concurrency for this connector.

- Related: https://github.com/airbytehq/airbyte-internal-issues/issues/15322
- Epic: https://github.com/airbytehq/airbyte-internal-issues/issues/15262

## How

1. **Comment out HTTP API budget** in `manifest.yaml` — original values preserved as comments so they can be restored after tuning completes.
2. **Set `default_concurrency` to 4** (from 10) — calculated via the concurrency tuning playbook formula: `max_rate_limit=10/s` → `floor(10/4)=2 ≤ 2` → special case override to 4, step=1.
3. **Enable progressive rollout** (`enableProgressiveRollout: true`) in `metadata.yaml`.
4. **Bump version to 6.5.6-rc.1** with registry overrides pinning OSS/Cloud GA users to 6.5.5.

### Rate limit research (Path A — single-tier)

| Auth Method | Burst Limit |
|---|---|
| OAuth Public App (all plans) | 110 req/10s |
| Private App Free/Starter | 100 req/10s |
| Private App Professional | 190 req/10s |
| Private App Enterprise | 190 req/10s |
| CRM Search (all methods) | 5 req/s |

Conservative floor: 100/10s = 10 req/s → `starting_concurrency=4`, `step=1`.

## Review guide

1. `airbyte-integrations/connectors/source-hubspot/manifest.yaml` — budget commented out, concurrency lowered
2. `airbyte-integrations/connectors/source-hubspot/metadata.yaml` — version bump + progressive rollout enabled
3. `docs/integrations/sources/hubspot.md` — changelog entry

## User Impact

- No immediate user impact. The RC version (6.5.6-rc.1) will only be deployed to a subset of Tier 2 actors via progressive rollout.
- GA users remain on 6.5.5 via registry overrides.
- After tuning completes, the optimal concurrency and re-enabled budget will be promoted to GA.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Link to Devin session: https://app.devin.ai/sessions/b11ad73c4ebc4eb786a3e60023485bfc
Requested by: @sophiecuiy