### PR TITLE
perf(source-instagram): increase default_concurrency to 20 for concurrency tuning (4.2.29-rc.1)

### DIFF
--- a/airbyte-integrations/connectors/source-instagram/manifest.yaml
+++ b/airbyte-integrations/connectors/source-instagram/manifest.yaml
@@ -738,7 +738,7 @@ streams:
 # Instagram Rate limits are per app and our app have advanced access for Instagram endpoints.
 concurrency_level:
   type: ConcurrencyLevel
-  default_concurrency: "{{ config.get('num_workers', 15) }}"
+  default_concurrency: "{{ config.get('num_workers', 20) }}"
   max_concurrency: 50
 
 metadata:
@@ -810,7 +810,7 @@ spec:
         title: Number of concurrent threads
         minimum: 2
         maximum: 40
-        default: 15
+        default: 20
         examples:
           - 1
           - 2

--- a/airbyte-integrations/connectors/source-instagram/metadata.yaml
+++ b/airbyte-integrations/connectors/source-instagram/metadata.yaml
@@ -21,10 +21,8 @@ data:
   registryOverrides:
     cloud:
       enabled: true
-      dockerImageTag: 4.2.28
     oss:
       enabled: true
-      dockerImageTag: 4.2.28
   releaseStage: generally_available
   releases:
     rolloutConfiguration:

--- a/airbyte-integrations/connectors/source-instagram/metadata.yaml
+++ b/airbyte-integrations/connectors/source-instagram/metadata.yaml
@@ -35,13 +35,19 @@ data:
         upgradeDeadline: "2025-04-21"
         scopedImpact:
           - scopeType: stream
-            impactedScopes: ["media_insights", "user_insights", "story_insights"]
+            impactedScopes:
+              - "media_insights"
+              - "user_insights"
+              - "story_insights"
       3.0.0:
         message: "The existing Instagram API (v11) has been deprecated. Customers who use streams `Media Insights`, `Story Insights` or `User Lifetime Insights` must take action with their connections. Please follow the to update to the latest Instagram API (v18). For more details, see our <a href='https://docs.airbyte.com/integrations/sources/instagram-migrations'>migration guide</a>."
         upgradeDeadline: "2024-01-05"
         scopedImpact:
           - scopeType: stream
-            impactedScopes: ["media_insights", "story_insights", "user_lifetime_insights"]
+            impactedScopes:
+              - "media_insights"
+              - "story_insights"
+              - "user_lifetime_insights"
       2.0.0:
         message: This release introduces a default primary key for the streams UserLifetimeInsights and UserInsights. Additionally, the format of timestamp fields has been updated in the UserLifetimeInsights, UserInsights, Media and Stories streams to include timezone information.
         upgradeDeadline: "2023-12-11"

--- a/airbyte-integrations/connectors/source-instagram/metadata.yaml
+++ b/airbyte-integrations/connectors/source-instagram/metadata.yaml
@@ -7,7 +7,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 6acf6b55-4f1e-4fca-944e-1a3caef8aba8
-  dockerImageTag: 4.2.28
+  dockerImageTag: 4.2.29-rc.1
   dockerRepository: airbyte/source-instagram
   githubIssueLabel: source-instagram
   icon: instagram.svg
@@ -21,27 +21,27 @@ data:
   registryOverrides:
     cloud:
       enabled: true
+      dockerImageTag: 4.2.28
     oss:
       enabled: true
+      dockerImageTag: 4.2.28
   releaseStage: generally_available
   releases:
     rolloutConfiguration:
-      enableProgressiveRollout: false
+      enableProgressiveRollout: true
     breakingChanges:
       4.0.0:
         message: "This release removes deprecated metrics - `clips_replays_count`, `ig_reels_aggregated_all_plays_count`, `impressions`, and `plays` from `media_insights` stream, and `impressions` from `user_insights` and `story_insights` streams. Customers who these streams must take action with their connections. For more details, see our <a href='https://docs.airbyte.com/integrations/sources/instagram-migrations'>migration guide</a>."
         upgradeDeadline: "2025-04-21"
         scopedImpact:
           - scopeType: stream
-            impactedScopes:
-              ["media_insights", "user_insights", "story_insights"]
+            impactedScopes: ["media_insights", "user_insights", "story_insights"]
       3.0.0:
         message: "The existing Instagram API (v11) has been deprecated. Customers who use streams `Media Insights`, `Story Insights` or `User Lifetime Insights` must take action with their connections. Please follow the to update to the latest Instagram API (v18). For more details, see our <a href='https://docs.airbyte.com/integrations/sources/instagram-migrations'>migration guide</a>."
         upgradeDeadline: "2024-01-05"
         scopedImpact:
           - scopeType: stream
-            impactedScopes:
-              ["media_insights", "story_insights", "user_lifetime_insights"]
+            impactedScopes: ["media_insights", "story_insights", "user_lifetime_insights"]
       2.0.0:
         message: This release introduces a default primary key for the streams UserLifetimeInsights and UserInsights. Additionally, the format of timestamp fields has been updated in the UserLifetimeInsights, UserInsights, Media and Stories streams to include timezone information.
         upgradeDeadline: "2023-12-11"

--- a/docs/integrations/sources/instagram.md
+++ b/docs/integrations/sources/instagram.md
@@ -115,6 +115,7 @@ For accounts in UTC+ timezones, the Instagram API returns `end_time` values at t
 
 | Version    | Date       | Pull Request                                             | Subject                                                                                                                                                                |
 |:-----------|:-----------|:---------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 4.2.29-rc.1 | 2026-05-26 | [*PR_NUMBER_PLACEHOLDER*](https://github.com/airbytehq/airbyte/pull/*PR_NUMBER_PLACEHOLDER*) | Enable progressive rollout for concurrency tuning |
 | 4.2.28 | 2026-04-28 | [77272](https://github.com/airbytehq/airbyte/pull/77272) | Update dependencies |
 | 4.2.27 | 2026-04-21 | [76627](https://github.com/airbytehq/airbyte/pull/76627) | Update dependencies |
 | 4.2.26 | 2026-04-13 | [76276](https://github.com/airbytehq/airbyte/pull/76276) | Rename "concurrent workers" to "concurrent threads" in connector spec |

--- a/docs/integrations/sources/instagram.md
+++ b/docs/integrations/sources/instagram.md
@@ -115,7 +115,7 @@ For accounts in UTC+ timezones, the Instagram API returns `end_time` values at t
 
 | Version    | Date       | Pull Request                                             | Subject                                                                                                                                                                |
 |:-----------|:-----------|:---------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| 4.2.29-rc.1 | 2026-05-26 | [*PR_NUMBER_PLACEHOLDER*](https://github.com/airbytehq/airbyte/pull/*PR_NUMBER_PLACEHOLDER*) | Enable progressive rollout for concurrency tuning |
+| 4.2.29-rc.1 | 2026-05-26 | [78440](https://github.com/airbytehq/airbyte/pull/78440) | Enable progressive rollout for concurrency tuning |
 | 4.2.28 | 2026-04-28 | [77272](https://github.com/airbytehq/airbyte/pull/77272) | Update dependencies |
 | 4.2.27 | 2026-04-21 | [76627](https://github.com/airbytehq/airbyte/pull/76627) | Update dependencies |
 | 4.2.26 | 2026-04-13 | [76276](https://github.com/airbytehq/airbyte/pull/76276) | Rename "concurrent workers" to "concurrent threads" in connector spec |


### PR DESCRIPTION
## What

Enable progressive rollout and increase default concurrency for source-instagram to begin concurrency tuning via the [Connector Concurrency Tuning & Rollout playbook](https://github.com/airbytehq/airbyte-internal-issues/issues/15323).

Resolves https://github.com/airbytehq/airbyte-internal-issues/issues/15323
Parent epic: https://github.com/airbytehq/airbyte-internal-issues/issues/15262

Requested by @sophiecuiy.

**Phase 0 summary:**
- **Current state**: source-instagram already has `concurrency_level` (was default 15, exposed as `num_workers` in spec) and `max_concurrency: 50`, but is missing `HTTPAPIBudget`
- **Rate limits**: Instagram Graph API uses Meta's Business Use Case (BUC) rate limits, which are dynamic and impression-based per account. No fixed per-second rate limit is publicly documented. The Airbyte app has "advanced access" for Instagram endpoints. No rate limiting signs at current concurrency levels.
- **Path**: A (single-tier — Instagram API has no user-selectable subscription tiers)
- **Starting concurrency**: 20 (increased from previous default of 15; no rate limiting observed at 15)
- **Step**: 3
- **Eligible Tier 2 actors**: 116 unique actors, 35 connections with daily+ sync frequency
- **Tier 1**: 1 connection; **Tier 0**: 0 connections
- **HTTP API budget**: None currently — will be added after concurrency tuning completes

## How

- Bump version from 4.2.28 to 4.2.29-rc.1
- Set `enableProgressiveRollout: true` in metadata.yaml
- Pin cloud and oss registries to stable 4.2.28 during rollout
- Increase `default_concurrency` from 15 to 20 in manifest.yaml
- Update `num_workers` spec default from 15 to 20

## Review guide

1. `airbyte-integrations/connectors/source-instagram/metadata.yaml` — version bump and rollout config
2. `airbyte-integrations/connectors/source-instagram/manifest.yaml` — concurrency default increase (15 → 20)
3. `docs/integrations/sources/instagram.md` — changelog entry

## User Impact

No user impact during progressive rollout. Only actors explicitly pinned to the RC version will use it. After successful tuning and GA promotion, users may see improved sync performance with higher default concurrency.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Link to Devin session: https://app.devin.ai/sessions/e52d4b4f076e4bd984b93eb313068f9f