### PR TITLE
chore(source-jira): adjust default concurrency to 7, enable progressive rollout

### DIFF
--- a/airbyte-integrations/connectors/source-jira/manifest.yaml
+++ b/airbyte-integrations/connectors/source-jira/manifest.yaml
@@ -14696,10 +14696,9 @@ check:
   stream_names:
   - projects
 
-# Defining a value here is difficult because the Jira API documentation mentions "REST API rate limits are not published because the computation logic is evolving continuously to maximize reliability and performance for customers" regarding the API budget. Hence, we will need to empirically validate the values that are set here.
 concurrency_level:
   type: ConcurrencyLevel
-  default_concurrency: "{{ config.get('num_workers', 5) }}"
+  default_concurrency: "{{ config.get('num_workers', 4) }}"
   max_concurrency: 40
 
 spec:
@@ -14913,11 +14912,11 @@ spec:
         title: Number of concurrent threads
         minimum: 1
         maximum: 40
-        default: 3
+        default: 4
         examples:
         - 1
         - 2
-        - 3
+        - 4
         description: The number of worker threads to use for the sync.
         order: 6
   advanced_auth:

--- a/airbyte-integrations/connectors/source-jira/manifest.yaml
+++ b/airbyte-integrations/connectors/source-jira/manifest.yaml
@@ -14698,7 +14698,7 @@ check:
 
 concurrency_level:
   type: ConcurrencyLevel
-  default_concurrency: "{{ config.get('num_workers', 4) }}"
+  default_concurrency: "{{ config.get('num_workers', 6) }}"
   max_concurrency: 40
 
 spec:
@@ -14912,11 +14912,11 @@ spec:
         title: Number of concurrent threads
         minimum: 1
         maximum: 40
-        default: 4
+        default: 6
         examples:
         - 1
         - 2
-        - 4
+        - 6
         description: The number of worker threads to use for the sync.
         order: 6
   advanced_auth:

--- a/airbyte-integrations/connectors/source-jira/manifest.yaml
+++ b/airbyte-integrations/connectors/source-jira/manifest.yaml
@@ -14698,7 +14698,7 @@ check:
 
 concurrency_level:
   type: ConcurrencyLevel
-  default_concurrency: "{{ config.get('num_workers', 6) }}"
+  default_concurrency: "{{ config.get('num_workers', 7) }}"
   max_concurrency: 40
 
 spec:
@@ -14912,11 +14912,11 @@ spec:
         title: Number of concurrent threads
         minimum: 1
         maximum: 40
-        default: 6
+        default: 7
         examples:
         - 1
         - 2
-        - 6
+        - 7
         description: The number of worker threads to use for the sync.
         order: 6
   advanced_auth:

--- a/airbyte-integrations/connectors/source-jira/metadata.yaml
+++ b/airbyte-integrations/connectors/source-jira/metadata.yaml
@@ -12,7 +12,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 68e63de2-bb83-4c7e-93fa-a8a9051e3993
-  dockerImageTag: 5.1.0
+  dockerImageTag: 5.1.1
   dockerRepository: airbyte/source-jira
   documentationUrl: https://docs.airbyte.com/integrations/sources/jira
   externalDocumentationUrls:
@@ -75,7 +75,7 @@ data:
           - scopeType: stream
             impactedScopes: ["board_issues"]
     rolloutConfiguration:
-      enableProgressiveRollout: false
+      enableProgressiveRollout: true
   suggestedStreams:
     streams:
       - issues

--- a/airbyte-integrations/connectors/source-jira/metadata.yaml
+++ b/airbyte-integrations/connectors/source-jira/metadata.yaml
@@ -12,7 +12,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 68e63de2-bb83-4c7e-93fa-a8a9051e3993
-  dockerImageTag: 5.1.1
+  dockerImageTag: 5.1.1-rc.1
   dockerRepository: airbyte/source-jira
   documentationUrl: https://docs.airbyte.com/integrations/sources/jira
   externalDocumentationUrls:

--- a/docs/integrations/sources/jira.md
+++ b/docs/integrations/sources/jira.md
@@ -247,6 +247,7 @@ The connector uses these configuration fields for programmatic setup with PyAirb
 
 | Version    | Date       | Pull Request                                               | Subject                                                                                                                                                                |
 |:-----------|:-----------|:-----------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 5.1.1 | 2026-05-26 | [](https://github.com/airbytehq/airbyte/pull/) | Adjust default concurrency to 4 and enable progressive rollout for concurrency tuning |
 | 5.1.0 | 2026-05-20 | [78130](https://github.com/airbytehq/airbyte/pull/78130) | Add Service Account authentication support |
 | 5.0.0 | 2026-05-20 | [70448](https://github.com/airbytehq/airbyte/pull/70448) | Migrate the `workflows` stream from the deprecated `/rest/api/3/workflow/search` endpoint to its replacement `/rest/api/3/workflows/search`. Primary key changes from `[entityId, name]` to `[id]`, and the record schema is updated to match the new endpoint. |
 | 4.4.1 | 2026-05-14 | [78088](https://github.com/airbytehq/airbyte/pull/78088) | Fix domain validation regression: auto-normalize domains with https:// prefix or trailing slashes |

--- a/docs/integrations/sources/jira.md
+++ b/docs/integrations/sources/jira.md
@@ -247,7 +247,7 @@ The connector uses these configuration fields for programmatic setup with PyAirb
 
 | Version    | Date       | Pull Request                                               | Subject                                                                                                                                                                |
 |:-----------|:-----------|:-----------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| 5.1.1 | 2026-05-26 | [](https://github.com/airbytehq/airbyte/pull/) | Adjust default concurrency to 4 and enable progressive rollout for concurrency tuning |
+| 5.1.1 | 2026-05-26 | [78441](https://github.com/airbytehq/airbyte/pull/78441) | Adjust default concurrency to 4 and enable progressive rollout for concurrency tuning |
 | 5.1.0 | 2026-05-20 | [78130](https://github.com/airbytehq/airbyte/pull/78130) | Add Service Account authentication support |
 | 5.0.0 | 2026-05-20 | [70448](https://github.com/airbytehq/airbyte/pull/70448) | Migrate the `workflows` stream from the deprecated `/rest/api/3/workflow/search` endpoint to its replacement `/rest/api/3/workflows/search`. Primary key changes from `[entityId, name]` to `[id]`, and the record schema is updated to match the new endpoint. |
 | 4.4.1 | 2026-05-14 | [78088](https://github.com/airbytehq/airbyte/pull/78088) | Fix domain validation regression: auto-normalize domains with https:// prefix or trailing slashes |

--- a/docs/integrations/sources/jira.md
+++ b/docs/integrations/sources/jira.md
@@ -247,7 +247,7 @@ The connector uses these configuration fields for programmatic setup with PyAirb
 
 | Version    | Date       | Pull Request                                               | Subject                                                                                                                                                                |
 |:-----------|:-----------|:-----------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| 5.1.1 | 2026-05-26 | [78441](https://github.com/airbytehq/airbyte/pull/78441) | Adjust default concurrency to 4 and enable progressive rollout for concurrency tuning |
+| 5.1.1 | 2026-05-26 | [78441](https://github.com/airbytehq/airbyte/pull/78441) | Adjust default concurrency to 6 and enable progressive rollout for concurrency tuning |
 | 5.1.0 | 2026-05-20 | [78130](https://github.com/airbytehq/airbyte/pull/78130) | Add Service Account authentication support |
 | 5.0.0 | 2026-05-20 | [70448](https://github.com/airbytehq/airbyte/pull/70448) | Migrate the `workflows` stream from the deprecated `/rest/api/3/workflow/search` endpoint to its replacement `/rest/api/3/workflows/search`. Primary key changes from `[entityId, name]` to `[id]`, and the record schema is updated to match the new endpoint. |
 | 4.4.1 | 2026-05-14 | [78088](https://github.com/airbytehq/airbyte/pull/78088) | Fix domain validation regression: auto-normalize domains with https:// prefix or trailing slashes |

--- a/docs/integrations/sources/jira.md
+++ b/docs/integrations/sources/jira.md
@@ -247,7 +247,7 @@ The connector uses these configuration fields for programmatic setup with PyAirb
 
 | Version    | Date       | Pull Request                                               | Subject                                                                                                                                                                |
 |:-----------|:-----------|:-----------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| 5.1.1-rc.1 | 2026-05-26 | [78441](https://github.com/airbytehq/airbyte/pull/78441) | Adjust default concurrency to 6 and enable progressive rollout for concurrency tuning |
+| 5.1.1-rc.1 | 2026-05-26 | [78441](https://github.com/airbytehq/airbyte/pull/78441) | Adjust default concurrency to 7 and enable progressive rollout for concurrency tuning |
 | 5.1.0 | 2026-05-20 | [78130](https://github.com/airbytehq/airbyte/pull/78130) | Add Service Account authentication support |
 | 5.0.0 | 2026-05-20 | [70448](https://github.com/airbytehq/airbyte/pull/70448) | Migrate the `workflows` stream from the deprecated `/rest/api/3/workflow/search` endpoint to its replacement `/rest/api/3/workflows/search`. Primary key changes from `[entityId, name]` to `[id]`, and the record schema is updated to match the new endpoint. |
 | 4.4.1 | 2026-05-14 | [78088](https://github.com/airbytehq/airbyte/pull/78088) | Fix domain validation regression: auto-normalize domains with https:// prefix or trailing slashes |

--- a/docs/integrations/sources/jira.md
+++ b/docs/integrations/sources/jira.md
@@ -247,7 +247,7 @@ The connector uses these configuration fields for programmatic setup with PyAirb
 
 | Version    | Date       | Pull Request                                               | Subject                                                                                                                                                                |
 |:-----------|:-----------|:-----------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| 5.1.1 | 2026-05-26 | [78441](https://github.com/airbytehq/airbyte/pull/78441) | Adjust default concurrency to 6 and enable progressive rollout for concurrency tuning |
+| 5.1.1-rc.1 | 2026-05-26 | [78441](https://github.com/airbytehq/airbyte/pull/78441) | Adjust default concurrency to 6 and enable progressive rollout for concurrency tuning |
 | 5.1.0 | 2026-05-20 | [78130](https://github.com/airbytehq/airbyte/pull/78130) | Add Service Account authentication support |
 | 5.0.0 | 2026-05-20 | [70448](https://github.com/airbytehq/airbyte/pull/70448) | Migrate the `workflows` stream from the deprecated `/rest/api/3/workflow/search` endpoint to its replacement `/rest/api/3/workflows/search`. Primary key changes from `[entityId, name]` to `[id]`, and the record schema is updated to match the new endpoint. |
 | 4.4.1 | 2026-05-14 | [78088](https://github.com/airbytehq/airbyte/pull/78088) | Fix domain validation regression: auto-normalize domains with https:// prefix or trailing slashes |


### PR DESCRIPTION
## What

Adjust source-jira's default concurrency from 5 to 7 and enable progressive rollout for concurrency tuning.

Closes https://github.com/airbytehq/airbyte-internal-issues/issues/15324
Part of epic https://github.com/airbytehq/airbyte-internal-issues/issues/15262

## How

Concurrency tuning playbook — Path A (single-tier burst rate limits, not tiered by Jira plan).

**Rate limit research:** Jira Cloud has 3 independent rate-limiting systems. API token users (source-jira's primary auth method) are governed only by burst rate limits (~10 req/s estimated steady-state), which are not tiered by plan. No 429 errors or throttling observed in Datadog over the last 7 days at the current effective concurrency of 3-5, so starting at 7.

**Tuning parameters:**
- `max_rate_limit`: 10
- `starting_concurrency`: 7 (raised from formula default, justified by zero throttling evidence)
- `step`: 1

**Code changes:**
1. `manifest.yaml`: `default_concurrency` fallback changed from 5 → 7
2. `manifest.yaml`: spec `num_workers` default changed from 3 → 7, example updated
3. `metadata.yaml`: version bumped 5.1.0 → 5.1.1-rc.1, `enableProgressiveRollout: true`
4. `docs/integrations/sources/jira.md`: changelog entry for 5.1.1-rc.1

## Review guide

1. `airbyte-integrations/connectors/source-jira/manifest.yaml` — concurrency_level and spec num_workers changes
2. `airbyte-integrations/connectors/source-jira/metadata.yaml` — version bump to RC and progressive rollout flag
3. `docs/integrations/sources/jira.md` — changelog entry

## User Impact

Users who have not explicitly set `num_workers` in their config will now default to 7 concurrent threads instead of 3-5. This should improve sync speed for most users. If any user experiences rate limiting, they can lower `num_workers` in their connection settings.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Reverts concurrency to previous default (5) and disables progressive rollout.

---
[Devin session](https://app.devin.ai/sessions/aa87e469be384b64acc0f6bc45c00093)

Requested by: @sophiecuiy