### PR TITLE
feat(source-monday): add subscription_tier spec field and tier-aware HTTPAPIBudget for concurrency tuning

### DIFF
--- a/airbyte-integrations/connectors/source-monday/manifest.yaml
+++ b/airbyte-integrations/connectors/source-monday/manifest.yaml
@@ -424,6 +424,16 @@ spec:
         default: 4
         examples: [1, 2, 3]
         description: The number of worker threads to use for the sync.
+      subscription_tier:
+        type: string
+        title: Subscription Tier
+        enum: [basic, pro, enterprise]
+        default: basic
+        description: >-
+          Your monday.com plan tier. Determines the applied rate-limit policy
+          at runtime. "basic" covers Free, Standard, and Basic plans.
+          Leave as "basic" if unsure — this is the safest default.
+        order: 99
   advanced_auth:
     auth_flow_type: oauth2.0
     predicate_key: ["credentials", "auth_type"]
@@ -480,11 +490,24 @@ check:
   stream_names:
     - "users"
 
-# The smallest limit for 1 minute is 250 queries, so set the default number of workers to 4. https://developer.monday.com/api-reference/docs/rate-limits#minute-limit
+# Monday.com rate limits per plan (https://developer.monday.com/api-reference/docs/rate-limits):
+#   Minute limit: Basic/Free/Standard = 1,000/min, Pro = 2,500/min, Enterprise = 5,000/min
+#   Concurrency limit: Basic/Free/Standard = 40, Pro = 100, Enterprise = 250
 concurrency_level:
   type: ConcurrencyLevel
   default_concurrency: "{{ config.get('num_workers', 4) }}"
   max_concurrency: 40 # Monday concurrency limit for lowest tier is 40. https://developer.monday.com/api-reference/docs/rate-limits#concurrency-limit
+
+# Tier-aware HTTP API budget — COMMENTED OUT during concurrency tuning (Phases 1–3).
+# Uncomment at Step 22.5 for GA. Values from https://developer.monday.com/api-reference/docs/rate-limits
+# api_budget:
+#   type: HTTPAPIBudget
+#   policies:
+#     - type: MovingWindowCallRatePolicy
+#       rates:
+#         - limit: "{{ {'basic': 1000, 'pro': 2500, 'enterprise': 5000}[config.get('subscription_tier', 'basic')] }}"
+#           interval: PT1M
+#   action_on_excess: WAIT
 
 schemas:
   activity_logs:

--- a/airbyte-integrations/connectors/source-monday/manifest.yaml
+++ b/airbyte-integrations/connectors/source-monday/manifest.yaml
@@ -421,8 +421,8 @@ spec:
         title: Number of concurrent threads
         minimum: 2
         maximum: 50
-        default: 4
-        examples: [1, 2, 3]
+        default: 6
+        examples: [2, 6, 10]
         description: The number of worker threads to use for the sync.
       subscription_tier:
         type: string
@@ -495,7 +495,7 @@ check:
 #   Concurrency limit: Basic/Free/Standard = 40, Pro = 100, Enterprise = 250
 concurrency_level:
   type: ConcurrencyLevel
-  default_concurrency: "{{ config.get('num_workers', 4) }}"
+  default_concurrency: "{{ config.get('num_workers', 6) }}"
   max_concurrency: 40 # Monday concurrency limit for lowest tier is 40. https://developer.monday.com/api-reference/docs/rate-limits#concurrency-limit
 
 # Tier-aware HTTP API budget — COMMENTED OUT during concurrency tuning (Phases 1–3).

--- a/airbyte-integrations/connectors/source-monday/metadata.yaml
+++ b/airbyte-integrations/connectors/source-monday/metadata.yaml
@@ -10,7 +10,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 80a54ea2-9959-4040-aac1-eee42423ec9b
-  dockerImageTag: 2.6.0-rc.1
+  dockerImageTag: 2.5.9-rc.1
   releases:
     rolloutConfiguration:
       enableProgressiveRollout: true

--- a/airbyte-integrations/connectors/source-monday/metadata.yaml
+++ b/airbyte-integrations/connectors/source-monday/metadata.yaml
@@ -44,10 +44,8 @@ data:
   registryOverrides:
     cloud:
       enabled: true
-      dockerImageTag: 2.5.8
     oss:
       enabled: true
-      dockerImageTag: 2.5.8
   releaseStage: generally_available
   suggestedStreams:
     streams:

--- a/airbyte-integrations/connectors/source-monday/metadata.yaml
+++ b/airbyte-integrations/connectors/source-monday/metadata.yaml
@@ -10,26 +10,17 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 80a54ea2-9959-4040-aac1-eee42423ec9b
-  dockerImageTag: 2.5.8
+  dockerImageTag: 2.6.0-rc.1
   releases:
     rolloutConfiguration:
-      enableProgressiveRollout: false
+      enableProgressiveRollout: true
     breakingChanges:
       2.0.0:
         message: "Source Monday has deprecated API version 2023-07. We have upgraded the connector to the latest API version 2024-01. In this new version, the Id field has changed from an integer to a string in the streams Boards, Items, Tags, Teams, Updates, Users and Workspaces. Please reset affected streams."
         upgradeDeadline: "2024-01-15"
         scopedImpact:
           - scopeType: stream
-            impactedScopes:
-              [
-                "boards",
-                "items",
-                "tags",
-                "teams",
-                "updates",
-                "users",
-                "workspaces",
-              ]
+            impactedScopes: ["boards", "items", "tags", "teams", "updates", "users", "workspaces"]
   dockerRepository: airbyte/source-monday
   documentationUrl: https://docs.airbyte.com/integrations/sources/monday
   githubIssueLabel: source-monday
@@ -44,8 +35,10 @@ data:
   registryOverrides:
     cloud:
       enabled: true
+      dockerImageTag: 2.5.8
     oss:
       enabled: true
+      dockerImageTag: 2.5.8
   releaseStage: generally_available
   suggestedStreams:
     streams:

--- a/airbyte-integrations/connectors/source-monday/metadata.yaml
+++ b/airbyte-integrations/connectors/source-monday/metadata.yaml
@@ -20,7 +20,16 @@ data:
         upgradeDeadline: "2024-01-15"
         scopedImpact:
           - scopeType: stream
-            impactedScopes: ["boards", "items", "tags", "teams", "updates", "users", "workspaces"]
+            impactedScopes:
+              [
+                "boards",
+                "items",
+                "tags",
+                "teams",
+                "updates",
+                "users",
+                "workspaces",
+              ]
   dockerRepository: airbyte/source-monday
   documentationUrl: https://docs.airbyte.com/integrations/sources/monday
   githubIssueLabel: source-monday

--- a/docs/integrations/sources/monday.md
+++ b/docs/integrations/sources/monday.md
@@ -86,7 +86,7 @@ The Monday connector should not run into Monday API limitations under normal usa
 
 | Version    | Date       | Pull Request                                              | Subject                                                                                                                                                                |
 |:-----------|:-----------|:----------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| 2.6.0-rc.1 | 2026-05-26 | [*PR_NUMBER_PLACEHOLDER*](https://github.com/airbytehq/airbyte/pull/*PR_NUMBER_PLACEHOLDER*) | Add subscription_tier spec field and tier-aware HTTPAPIBudget for concurrency tuning (Path B) |
+| 2.6.0-rc.1 | 2026-05-26 | [78442](https://github.com/airbytehq/airbyte/pull/78442) | Add subscription_tier spec field and tier-aware HTTPAPIBudget for concurrency tuning (Path B) |
 | 2.5.8 | 2026-04-28 | [77302](https://github.com/airbytehq/airbyte/pull/77302) | Update dependencies |
 | 2.5.7 | 2026-04-21 | [76675](https://github.com/airbytehq/airbyte/pull/76675) | Update dependencies |
 | 2.5.6 | 2026-04-13 | [76276](https://github.com/airbytehq/airbyte/pull/76276) | Rename "concurrent workers" to "concurrent threads" in connector spec |

--- a/docs/integrations/sources/monday.md
+++ b/docs/integrations/sources/monday.md
@@ -86,7 +86,7 @@ The Monday connector should not run into Monday API limitations under normal usa
 
 | Version    | Date       | Pull Request                                              | Subject                                                                                                                                                                |
 |:-----------|:-----------|:----------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| 2.6.0-rc.1 | 2026-05-26 | [78442](https://github.com/airbytehq/airbyte/pull/78442) | Add subscription_tier spec field and tier-aware HTTPAPIBudget for concurrency tuning (Path B) |
+| 2.5.9-rc.1 | 2026-05-26 | [78442](https://github.com/airbytehq/airbyte/pull/78442) | Add subscription_tier spec field and tier-aware HTTPAPIBudget for concurrency tuning (Path B) |
 | 2.5.8 | 2026-04-28 | [77302](https://github.com/airbytehq/airbyte/pull/77302) | Update dependencies |
 | 2.5.7 | 2026-04-21 | [76675](https://github.com/airbytehq/airbyte/pull/76675) | Update dependencies |
 | 2.5.6 | 2026-04-13 | [76276](https://github.com/airbytehq/airbyte/pull/76276) | Rename "concurrent workers" to "concurrent threads" in connector spec |

--- a/docs/integrations/sources/monday.md
+++ b/docs/integrations/sources/monday.md
@@ -86,6 +86,7 @@ The Monday connector should not run into Monday API limitations under normal usa
 
 | Version    | Date       | Pull Request                                              | Subject                                                                                                                                                                |
 |:-----------|:-----------|:----------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 2.6.0-rc.1 | 2026-05-26 | [*PR_NUMBER_PLACEHOLDER*](https://github.com/airbytehq/airbyte/pull/*PR_NUMBER_PLACEHOLDER*) | Add subscription_tier spec field and tier-aware HTTPAPIBudget for concurrency tuning (Path B) |
 | 2.5.8 | 2026-04-28 | [77302](https://github.com/airbytehq/airbyte/pull/77302) | Update dependencies |
 | 2.5.7 | 2026-04-21 | [76675](https://github.com/airbytehq/airbyte/pull/76675) | Update dependencies |
 | 2.5.6 | 2026-04-13 | [76276](https://github.com/airbytehq/airbyte/pull/76276) | Rename "concurrent workers" to "concurrent threads" in connector spec |


### PR DESCRIPTION
## What

Concurrency tuning setup for source-monday (Path B — tiered rate limits).

Tracking issue: https://github.com/airbytehq/airbyte-internal-issues/issues/15325
Epic: https://github.com/airbytehq/airbyte-internal-issues/issues/15262
Requested by: @sophiecuiy

## How

1. **`subscription_tier` spec field** (live, not commented out): enum `[basic, pro, enterprise]` with `default: basic`. Maps to monday.com plan tiers. "basic" covers Free/Standard/Basic plans — the safest default for unconfigured users.

2. **Tier-aware HTTPAPIBudget** (commented out during tuning Phases 1–3, to be uncommented at Step 22.5 for GA):
   - `basic`: 1,000 req/min
   - `pro`: 2,500 req/min
   - `enterprise`: 5,000 req/min
   - Values sourced from https://developer.monday.com/api-reference/docs/rate-limits

3. **Starting concurrency increased from 4 to 6** per Sophie's request — no rate-limiting signs observed at current concurrency=4, safe to start higher given monday.com basic-tier limits (1000/min, 40 concurrent).

4. **Progressive rollout enabled** in `metadata.yaml`.

5. **Version bumped to `2.6.0-rc.1`** for progressive rollout testing.

**Rate-limit research (monday.com API):**
- Minute limit: basic=1,000/min, pro=2,500/min, enterprise=5,000/min
- Concurrency limit: basic=40, pro=100, enterprise=250
- `max_rate_limit` = 16.67/sec (lowest tier), `starting_concurrency` = 6, `step` = 1

## Review guide

1. `airbyte-integrations/connectors/source-monday/manifest.yaml` — subscription_tier spec field, default_concurrency bumped to 6, commented-out tier-aware api_budget
2. `airbyte-integrations/connectors/source-monday/metadata.yaml` — version bump to 2.6.0-rc.1, enableProgressiveRollout: true
3. `docs/integrations/sources/monday.md` — changelog entry

## User Impact

- New optional `subscription_tier` field appears in the connector config UI (default: "basic")
- `num_workers` default increased from 4 to 6 (existing users with default config will see a concurrency increase from 4 to 6)
- No behavior change from HTTPAPIBudget until it is uncommented at GA

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Link to Devin session: https://app.devin.ai/sessions/aa22890a6dbf4747919ec4806087cfaf

> [!IMPORTANT]
> Active progressive rollout warning for source-monday.

- [ ] (Click to Approve:) Bypass the active progressive rollout warning for source-monday in the PR comment [here](https://github.com/airbytehq/airbyte/pull/78442#issuecomment-4549758461).