### PR TITLE
chore(source-sentry): bump to 0.9.22-rc.1 for concurrency tuning

### DIFF
--- a/airbyte-integrations/connectors/source-sentry/manifest.yaml
+++ b/airbyte-integrations/connectors/source-sentry/manifest.yaml
@@ -308,7 +308,7 @@ spec:
 
 concurrency_level:
   type: ConcurrencyLevel
-  default_concurrency: 5
+  default_concurrency: 7
 
 metadata:
   assist: {}

--- a/airbyte-integrations/connectors/source-sentry/metadata.yaml
+++ b/airbyte-integrations/connectors/source-sentry/metadata.yaml
@@ -39,10 +39,8 @@ data:
   registryOverrides:
     cloud:
       enabled: true
-      dockerImageTag: 0.9.21
     oss:
       enabled: true
-      dockerImageTag: 0.9.21
   releaseStage: generally_available
   suggestedStreams:
     streams:

--- a/airbyte-integrations/connectors/source-sentry/metadata.yaml
+++ b/airbyte-integrations/connectors/source-sentry/metadata.yaml
@@ -10,7 +10,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: cdaf146a-9b75-49fd-9dd2-9d64a0bb4781
-  dockerImageTag: 0.9.21
+  dockerImageTag: 0.9.22-rc.1
   dockerRepository: airbyte/source-sentry
   documentationUrl: https://docs.airbyte.com/integrations/sources/sentry
   externalDocumentationUrls:
@@ -39,8 +39,10 @@ data:
   registryOverrides:
     cloud:
       enabled: true
+      dockerImageTag: 0.9.21
     oss:
       enabled: true
+      dockerImageTag: 0.9.21
   releaseStage: generally_available
   suggestedStreams:
     streams:
@@ -72,4 +74,7 @@ data:
           secretStore:
             type: GSM
             alias: airbyte-connector-testing-secret-store
+  releases:
+    rolloutConfiguration:
+      enableProgressiveRollout: true
 metadataSpecVersion: "1.0"

--- a/docs/integrations/sources/sentry.md
+++ b/docs/integrations/sources/sentry.md
@@ -65,7 +65,7 @@ Please be aware: this also means that any change older than 90 days will not be 
 
 | Version | Date       | Pull Request                                             | Subject                                                                                                                                                                |
 |:--------|:-----------|:---------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| 0.9.22-rc.1 | 2026-05-26 | [*PR_NUMBER_PLACEHOLDER*](https://github.com/airbytehq/airbyte/pull/*PR_NUMBER_PLACEHOLDER*) | Start concurrency tuning — verify existing default_concurrency=5 via progressive rollout |
+| 0.9.22-rc.1 | 2026-05-26 | [78444](https://github.com/airbytehq/airbyte/pull/78444) | Start concurrency tuning — verify existing default_concurrency=5 via progressive rollout |
 | 0.9.21 | 2026-04-28 | [77407](https://github.com/airbytehq/airbyte/pull/77407) | Update dependencies |
 | 0.9.20 | 2026-04-21 | [76772](https://github.com/airbytehq/airbyte/pull/76772) | Update dependencies |
 | 0.9.19 | 2026-03-31 | [75797](https://github.com/airbytehq/airbyte/pull/75797) | Update dependencies |

--- a/docs/integrations/sources/sentry.md
+++ b/docs/integrations/sources/sentry.md
@@ -65,7 +65,7 @@ Please be aware: this also means that any change older than 90 days will not be 
 
 | Version | Date       | Pull Request                                             | Subject                                                                                                                                                                |
 |:--------|:-----------|:---------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| 0.9.22-rc.1 | 2026-05-26 | [78444](https://github.com/airbytehq/airbyte/pull/78444) | Start concurrency tuning — verify existing default_concurrency=5 via progressive rollout |
+| 0.9.22-rc.1 | 2026-05-26 | [78444](https://github.com/airbytehq/airbyte/pull/78444) | Concurrency tuning — bump default_concurrency from 5 to 7 for progressive rollout |
 | 0.9.21 | 2026-04-28 | [77407](https://github.com/airbytehq/airbyte/pull/77407) | Update dependencies |
 | 0.9.20 | 2026-04-21 | [76772](https://github.com/airbytehq/airbyte/pull/76772) | Update dependencies |
 | 0.9.19 | 2026-03-31 | [75797](https://github.com/airbytehq/airbyte/pull/75797) | Update dependencies |

--- a/docs/integrations/sources/sentry.md
+++ b/docs/integrations/sources/sentry.md
@@ -65,6 +65,7 @@ Please be aware: this also means that any change older than 90 days will not be 
 
 | Version | Date       | Pull Request                                             | Subject                                                                                                                                                                |
 |:--------|:-----------|:---------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 0.9.22-rc.1 | 2026-05-26 | [*PR_NUMBER_PLACEHOLDER*](https://github.com/airbytehq/airbyte/pull/*PR_NUMBER_PLACEHOLDER*) | Start concurrency tuning — verify existing default_concurrency=5 via progressive rollout |
 | 0.9.21 | 2026-04-28 | [77407](https://github.com/airbytehq/airbyte/pull/77407) | Update dependencies |
 | 0.9.20 | 2026-04-21 | [76772](https://github.com/airbytehq/airbyte/pull/76772) | Update dependencies |
 | 0.9.19 | 2026-03-31 | [75797](https://github.com/airbytehq/airbyte/pull/75797) | Update dependencies |


### PR DESCRIPTION
## What

Bump source-sentry to `0.9.22-rc.1` and increase `default_concurrency` from 5 to 7 for concurrency tuning via progressive rollout on Tier 2 connections.

Related: https://github.com/airbytehq/airbyte-internal-issues/issues/15327 (parent: https://github.com/airbytehq/airbyte-internal-issues/issues/15262)

Requested by @sophiecuiy.

## How

- Bumped `dockerImageTag` to `0.9.22-rc.1` in `metadata.yaml`
- Added `dockerImageTag: 0.9.21` overrides for cloud and oss registries (stable users stay on 0.9.21)
- Enabled `enableProgressiveRollout: true`
- Changed `default_concurrency` from 5 to 7 in `manifest.yaml`
- Added changelog entry

## Review guide

1. `airbyte-integrations/connectors/source-sentry/manifest.yaml` — `default_concurrency: 5` → `7`
2. `airbyte-integrations/connectors/source-sentry/metadata.yaml` — version bump and rollout config
3. `docs/integrations/sources/sentry.md` — changelog entry

## User Impact

No user-facing impact. This is an RC version behind progressive rollout — only 5 pinned daily Tier 2 actors will use it initially.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Link to Devin session: https://app.devin.ai/sessions/fe2b0b4604e34b5d9581be9819daf5e0

> [!IMPORTANT]
> Active progressive rollout warning for source-sentry.

- [ ] (Click to Approve:) Bypass the active progressive rollout warning for source-sentry in the PR comment [here](https://github.com/airbytehq/airbyte/pull/78444#issuecomment-4549736407).