### PR TITLE
chore(source-xkcd): bump SDM base image

### DIFF
--- a/airbyte-integrations/connectors/source-xkcd/metadata.yaml
+++ b/airbyte-integrations/connectors/source-xkcd/metadata.yaml
@@ -5,7 +5,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 80fddd16-17bd-4c0c-bf4a-80df7863fc9d
-  dockerImageTag: 0.2.40
+  dockerImageTag: 0.2.41
   dockerRepository: airbyte/source-xkcd
   githubIssueLabel: source-xkcd
   icon: xkcd.svg
@@ -40,7 +40,7 @@ data:
             type: GSM
             alias: airbyte-connector-testing-secret-store
   connectorBuildOptions:
-    baseImage: docker.io/airbyte/source-declarative-manifest:7.17.4@sha256:f85ae668c118cc9a42dae007325b916d63c2df72d6809677582b4fa8a1c65bbb
+    baseImage: docker.io/airbyte/source-declarative-manifest:7.19.3@sha256:b4796c8ad8a6b1918bbd2bdf9e874f149309194f5c2f5a23e05b51e6172d9b78
   externalDocumentationUrls:
     - title: xkcd JSON API
       url: https://xkcd.com/json.html

--- a/docs/integrations/sources/xkcd.md
+++ b/docs/integrations/sources/xkcd.md
@@ -27,6 +27,7 @@ If you use Airbyte Cloud and your organization restricts access to specific IPs,
 
 | Version | Date       | Pull Request                                             | Subject                                   |
 | :------ | :--------- | :------------------------------------------------------- | :---------------------------------------- |
+| 0.2.41 | 2026-05-26 | [TBD](https://github.com/airbytehq/airbyte/pull/TBD) | Update base image to source-declarative-manifest 7.19.3. |
 | 0.2.40 | 2026-04-28 | [77482](https://github.com/airbytehq/airbyte/pull/77482) | Update dependencies |
 | 0.2.39 | 2026-04-21 | [76803](https://github.com/airbytehq/airbyte/pull/76803) | Update dependencies |
 | 0.2.38 | 2026-03-17 | [75100](https://github.com/airbytehq/airbyte/pull/75100) | Update dependencies |

--- a/docs/integrations/sources/xkcd.md
+++ b/docs/integrations/sources/xkcd.md
@@ -27,7 +27,7 @@ If you use Airbyte Cloud and your organization restricts access to specific IPs,
 
 | Version | Date       | Pull Request                                             | Subject                                   |
 | :------ | :--------- | :------------------------------------------------------- | :---------------------------------------- |
-| 0.2.41 | 2026-05-26 | [78454](https://github.com/airbytehq/airbyte/pull/78454) | Update base image to source-declarative-manifest 7.19.3. |
+| 0.2.41 | 2026-05-26 | [78454](https://github.com/airbytehq/airbyte/pull/78454) | Update dependencies |
 | 0.2.40 | 2026-04-28 | [77482](https://github.com/airbytehq/airbyte/pull/77482) | Update dependencies |
 | 0.2.39 | 2026-04-21 | [76803](https://github.com/airbytehq/airbyte/pull/76803) | Update dependencies |
 | 0.2.38 | 2026-03-17 | [75100](https://github.com/airbytehq/airbyte/pull/75100) | Update dependencies |

--- a/docs/integrations/sources/xkcd.md
+++ b/docs/integrations/sources/xkcd.md
@@ -27,7 +27,7 @@ If you use Airbyte Cloud and your organization restricts access to specific IPs,
 
 | Version | Date       | Pull Request                                             | Subject                                   |
 | :------ | :--------- | :------------------------------------------------------- | :---------------------------------------- |
-| 0.2.41 | 2026-05-26 | [TBD](https://github.com/airbytehq/airbyte/pull/TBD) | Update base image to source-declarative-manifest 7.19.3. |
+| 0.2.41 | 2026-05-26 | [78454](https://github.com/airbytehq/airbyte/pull/78454) | Update base image to source-declarative-manifest 7.19.3. |
 | 0.2.40 | 2026-04-28 | [77482](https://github.com/airbytehq/airbyte/pull/77482) | Update dependencies |
 | 0.2.39 | 2026-04-21 | [76803](https://github.com/airbytehq/airbyte/pull/76803) | Update dependencies |
 | 0.2.38 | 2026-03-17 | [75100](https://github.com/airbytehq/airbyte/pull/75100) | Update dependencies |


### PR DESCRIPTION
## What

Updates the `source-xkcd` manifest-only connector to use `source-declarative-manifest:7.19.3` and bumps the connector image tag from `0.2.40` to `0.2.41`.

This replaces the earlier `source-smoke-test` choice with a non-smoke-test source connector that does not have `acceptance-test-config.yml`.

## How

- Updates `airbyte-integrations/connectors/source-xkcd/metadata.yaml` to use `docker.io/airbyte/source-declarative-manifest:7.19.3@sha256:b4796c8ad8a6b1918bbd2bdf9e874f149309194f5c2f5a23e05b51e6172d9b78`
- Bumps `dockerImageTag` to `0.2.41`
- Adds the corresponding changelog entry in the Xkcd source docs

## Review guide

1. `airbyte-integrations/connectors/source-xkcd/metadata.yaml`
2. `docs/integrations/sources/xkcd.md`

## User Impact

The Xkcd source connector will build from SDM `7.19.3`. No connector configuration changes are expected.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚
- [ ] NO ❌

Link to Devin session: https://app.devin.ai/sessions/692a714acba648d89e40aa18a4a33b66
Requested by: @sophiecuiy