### PR TITLE
docs(ai-agents): Remove changelog links

### DIFF
--- a/docusaurus/src/components/AgentConnectorRegistry.jsx
+++ b/docusaurus/src/components/AgentConnectorRegistry.jsx
@@ -1,10 +1,7 @@
 import { usePluginData } from "@docusaurus/useGlobalData";
 import styles from "./AgentConnectorRegistry.module.css";
 
-const ICON_BASE_URL =
-  "https://connectors.airbyte.com/files/metadata/airbyte";
-const CHANGELOG_BASE_URL =
-  "https://github.com/airbytehq/airbyte-agent-connectors/blob/main/connectors";
+const ICON_BASE_URL = "https://connectors.airbyte.com/files/metadata/airbyte";
 
 const iconStyle = { maxWidth: 25, maxHeight: 25 };
 
@@ -73,15 +70,6 @@ export default function AgentConnectorRegistry() {
                 <span className={styles.linkSeparator}>|</span>
                 <a href={`${connector.href}REFERENCE`} title="API Reference">
                   Reference
-                </a>
-                <span className={styles.linkSeparator}>|</span>
-                <a
-                  href={`${CHANGELOG_BASE_URL}/${connector.slug}/CHANGELOG.md`}
-                  title="Changelog"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  Changelog
                 </a>
               </div>
             </td>


### PR DESCRIPTION
## What
Remove the external Changelog links from the AI agents connector catalog page, requested by Ian Alton in Slack: https://airbytehq-team.slack.com/archives/C08BHPUMEPJ/p1779900228875819?thread_ts=1779900228.875819&cid=C08BHPUMEPJ

## How
Delete the Changelog column entry from `AgentConnectorRegistry`, leaving Overview, Auth, and Reference links for each agent connector.

## Review guide
1. `docusaurus/src/components/AgentConnectorRegistry.jsx`

## User Impact
Users browsing https://docs.airbyte.com/ai-agents/connectors/ will no longer see Changelog links for each connector. Overview, Auth, and Reference links remain unchanged.

## Can this PR be safely reverted and rolled back?
- [x] YES 💚
- [ ] NO ❌

## Test plan
- [x] `corepack pnpm --dir /home/ubuntu/repos/airbyte/docusaurus install`
- [x] `corepack pnpm --dir /home/ubuntu/repos/airbyte/docusaurus exec prettier --check src/components/AgentConnectorRegistry.jsx`
- [x] `corepack pnpm --dir /home/ubuntu/repos/airbyte/docusaurus build` (passes; reports pre-existing broken anchor warnings in generated AI agents docs)
- [x] Browser-tested deployed docs preview: catalog table loads, visible rows show `Overview`, `Auth`, and `Reference` only, browser find reports `0/0` for `Changelog`, and Airtable `Reference` opens `/ai-agents/connectors/airtable/REFERENCE`.

Link to Devin session: https://app.devin.ai/sessions/1ccd9f7ef363440da3a96afc913c6bf1
Requested by: @ian-at-airbyte