### PR TITLE
chore(source-amplitude): bump SDM base image

### DIFF
--- a/airbyte-integrations/connectors/source-amplitude/metadata.yaml
+++ b/airbyte-integrations/connectors/source-amplitude/metadata.yaml
@@ -7,11 +7,11 @@ data:
       - amplitude.com
       - analytics.eu.amplitude.com
   connectorBuildOptions:
-    baseImage: docker.io/airbyte/source-declarative-manifest:7.17.4@sha256:f85ae668c118cc9a42dae007325b916d63c2df72d6809677582b4fa8a1c65bbb
+    baseImage: docker.io/airbyte/source-declarative-manifest:7.19.3@sha256:b4796c8ad8a6b1918bbd2bdf9e874f149309194f5c2f5a23e05b51e6172d9b78
   connectorSubtype: api
   connectorType: source
   definitionId: fa9f58c6-2d03-4237-aaa4-07d75e0c1396
-  dockerImageTag: 0.7.31
+  dockerImageTag: 0.7.32
   dockerRepository: airbyte/source-amplitude
   documentationUrl: https://docs.airbyte.com/integrations/sources/amplitude
   githubIssueLabel: source-amplitude

--- a/docs/integrations/sources/amplitude.md
+++ b/docs/integrations/sources/amplitude.md
@@ -67,6 +67,7 @@ If you use Airbyte Cloud and your organization restricts access to specific IPs,
 
 | Version    | Date       | Pull Request                                             | Subject                                                                                                                                                                |
 |:-----------|:-----------| :------------------------------------------------------- |:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 0.7.32 | 2026-05-26 | [TBD](https://github.com/airbytehq/airbyte/pull/TBD) | Update dependencies |
 | 0.7.31 | 2026-04-28 | [72688](https://github.com/airbytehq/airbyte/pull/72688) | Update dependencies |
 | 0.7.30 | 2026-03-31 | [75406](https://github.com/airbytehq/airbyte/pull/75406) | Upgrade CDK to v7.14.0 and use weight-based rate limiting for Dashboard REST API streams |
 | 0.7.29 | 2026-03-03 | [70841](https://github.com/airbytehq/airbyte/pull/70841) | Add HTTPAPIBudget and concurrency_level |

--- a/docs/integrations/sources/amplitude.md
+++ b/docs/integrations/sources/amplitude.md
@@ -67,7 +67,7 @@ If you use Airbyte Cloud and your organization restricts access to specific IPs,
 
 | Version    | Date       | Pull Request                                             | Subject                                                                                                                                                                |
 |:-----------|:-----------| :------------------------------------------------------- |:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| 0.7.32 | 2026-05-26 | [TBD](https://github.com/airbytehq/airbyte/pull/TBD) | Update dependencies |
+| 0.7.32 | 2026-05-26 | [78456](https://github.com/airbytehq/airbyte/pull/78456) | Update dependencies |
 | 0.7.31 | 2026-04-28 | [72688](https://github.com/airbytehq/airbyte/pull/72688) | Update dependencies |
 | 0.7.30 | 2026-03-31 | [75406](https://github.com/airbytehq/airbyte/pull/75406) | Upgrade CDK to v7.14.0 and use weight-based rate limiting for Dashboard REST API streams |
 | 0.7.29 | 2026-03-03 | [70841](https://github.com/airbytehq/airbyte/pull/70841) | Add HTTPAPIBudget and concurrency_level |


### PR DESCRIPTION
## What
Updates the manifest-only `source-amplitude` connector to use `source-declarative-manifest:7.19.3` and bumps the connector image tag from `0.7.31` to `0.7.32`.

This replaces the previous Mixpanel PR because Mixpanel is not an SDM connector and should remain on the Python connector base image.

## How
- Updates `airbyte-integrations/connectors/source-amplitude/metadata.yaml` to use `docker.io/airbyte/source-declarative-manifest:7.19.3@sha256:b4796c8ad8a6b1918bbd2bdf9e874f149309194f5c2f5a23e05b51e6172d9b78`.
- Bumps `dockerImageTag` to `0.7.32`.
- Adds the corresponding changelog entry in the Amplitude source docs.

## Review guide
1. `airbyte-integrations/connectors/source-amplitude/metadata.yaml`
2. `docs/integrations/sources/amplitude.md`

## User Impact
The Amplitude source connector will build from SDM `7.19.3`. No connector configuration changes are expected.

## Can this PR be safely reverted and rolled back?
- [x] YES 💚
- [ ] NO ❌

Link to Devin session: https://app.devin.ai/sessions/692a714acba648d89e40aa18a4a33b66
Requested by: @sophiecuiy