### PR TITLE
fix(source-alloydb): Use registryOverrides metadata convention

### DIFF
--- a/airbyte-integrations/connectors/source-alloydb-strict-encrypt/metadata.yaml
+++ b/airbyte-integrations/connectors/source-alloydb-strict-encrypt/metadata.yaml
@@ -1,0 +1,24 @@
+data:
+  allowedHosts:
+    hosts:
+      - ${host}
+      - ${tunnel_method.tunnel_host}
+  registryOverrides:
+    cloud:
+      enabled: false # strict encrypt connectors are deployed to Cloud by their non strict encrypt sibling.
+    oss:
+      enabled: false # strict encrypt connectors are not used on OSS.
+  connectorSubtype: database
+  connectorType: source
+  definitionId: 1fa90628-2b9e-11ed-a261-0242ac120002
+  dockerImageTag: 3.1.5
+  dockerRepository: airbyte/source-alloydb-strict-encrypt
+  githubIssueLabel: source-alloydb
+  icon: alloydb.svg
+  license: MIT
+  name: AlloyDB for PostgreSQL
+  releaseStage: generally_available
+  documentationUrl: https://docs.airbyte.com/integrations/sources/alloydb
+  tags:
+    - language:java
+metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-alloydb/metadata.yaml
+++ b/airbyte-integrations/connectors/source-alloydb/metadata.yaml
@@ -1,0 +1,29 @@
+data:
+  allowedHosts:
+    hosts:
+      - ${host}
+      - ${tunnel_method.tunnel_host}
+  connectorSubtype: database
+  connectorType: source
+  definitionId: 1fa90628-2b9e-11ed-a261-0242ac120002
+  dockerImageTag: 3.1.8
+  dockerRepository: airbyte/source-alloydb
+  githubIssueLabel: source-alloydb
+  icon: alloydb.svg
+  license: MIT
+  name: AlloyDB for PostgreSQL
+  registryOverrides:
+    cloud:
+      enabled: false
+    oss:
+      enabled: false
+  releaseStage: generally_available
+  documentationUrl: https://docs.airbyte.com/integrations/sources/alloydb
+  tags:
+    - language:java
+    - deprecated:true
+  ab_internal:
+    sl: 200
+    ql: 400
+  supportLevel: certified
+metadataSpecVersion: "1.0"


### PR DESCRIPTION
## What
<!--
* Describe what the change is solving. Link all GitHub issues related to this change.
-->
AJ Steers asked for AlloyDB metadata to use the normal registry metadata convention so the legacy registry compile migration can recognize that these stale connector artifacts are disabled.

This restores only the removed AlloyDB metadata files needed for registry cleanup and uses `registryOverrides` instead of the old `registries` key.

## How
<!--
* Describe how code changes achieve the solution.
-->
- Restore `source-alloydb` metadata with `data.registryOverrides.cloud.enabled: false` and `data.registryOverrides.oss.enabled: false`.
- Restore `source-alloydb-strict-encrypt` metadata with the same `registryOverrides` disabled flags.
- Leave docs and icons removed; this PR is intended to let registry compile remove the dead connector entries rather than making AlloyDB visible again.

## Review guide
<!--
1. `x.py`
2. `y.py`
-->
1. `airbyte-integrations/connectors/source-alloydb/metadata.yaml`
2. `airbyte-integrations/connectors/source-alloydb-strict-encrypt/metadata.yaml`

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->
After this is merged and the registry compile workflow runs with `--with-legacy-migration v1`, AlloyDB should stop appearing on docs.airbyte.com/integrations with a missing icon and broken docs link.

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌

## Test plan
- [x] `python - <<'PY' ...` verified both AlloyDB metadata files use `registryOverrides` and no longer use `registries`.
- [x] `uv run --with pyyaml python - <<'PY' ...` parsed both metadata files and verified cloud/oss are disabled via `registryOverrides`.
- [x] `git diff --check`

---
[Devin session](https://app.devin.ai/sessions/d24cdf505002478ab78f026d277547e4)

Requested by: @ian-at-airbyte