### PR TITLE
chore(source-sentry): bump to 0.9.22-rc.2 for concurrency tuning iteration 2

### DIFF
--- a/airbyte-integrations/connectors/source-sentry/manifest.yaml
+++ b/airbyte-integrations/connectors/source-sentry/manifest.yaml
@@ -308,7 +308,7 @@ spec:
 
 concurrency_level:
   type: ConcurrencyLevel
-  default_concurrency: 7
+  default_concurrency: 8
 
 metadata:
   assist: {}

--- a/airbyte-integrations/connectors/source-sentry/metadata.yaml
+++ b/airbyte-integrations/connectors/source-sentry/metadata.yaml
@@ -10,7 +10,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: cdaf146a-9b75-49fd-9dd2-9d64a0bb4781
-  dockerImageTag: 0.9.22-rc.1
+  dockerImageTag: 0.9.22-rc.2
   dockerRepository: airbyte/source-sentry
   documentationUrl: https://docs.airbyte.com/integrations/sources/sentry
   externalDocumentationUrls:

--- a/docs/integrations/sources/sentry.md
+++ b/docs/integrations/sources/sentry.md
@@ -70,7 +70,7 @@ If you use Airbyte Cloud and your organization restricts access to specific IPs,
 
 | Version | Date       | Pull Request                                             | Subject                                                                                                                                                                |
 |:--------|:-----------|:---------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| 0.9.22-rc.2 | 2026-05-27 | [*PR_NUMBER_PLACEHOLDER*](https://github.com/airbytehq/airbyte/pull/*PR_NUMBER_PLACEHOLDER*) | Concurrency tuning iteration 2 — bump default_concurrency from 7 to 8 |
+| 0.9.22-rc.2 | 2026-05-27 | [78468](https://github.com/airbytehq/airbyte/pull/78468) | Concurrency tuning iteration 2 — bump default_concurrency from 7 to 8 |
 | 0.9.22-rc.1 | 2026-05-26 | [78444](https://github.com/airbytehq/airbyte/pull/78444) | Concurrency tuning — bump default_concurrency from 5 to 7 for progressive rollout |
 | 0.9.21 | 2026-04-28 | [77407](https://github.com/airbytehq/airbyte/pull/77407) | Update dependencies |
 | 0.9.20 | 2026-04-21 | [76772](https://github.com/airbytehq/airbyte/pull/76772) | Update dependencies |

--- a/docs/integrations/sources/sentry.md
+++ b/docs/integrations/sources/sentry.md
@@ -70,6 +70,7 @@ If you use Airbyte Cloud and your organization restricts access to specific IPs,
 
 | Version | Date       | Pull Request                                             | Subject                                                                                                                                                                |
 |:--------|:-----------|:---------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 0.9.22-rc.2 | 2026-05-27 | [*PR_NUMBER_PLACEHOLDER*](https://github.com/airbytehq/airbyte/pull/*PR_NUMBER_PLACEHOLDER*) | Concurrency tuning iteration 2 — bump default_concurrency from 7 to 8 |
 | 0.9.22-rc.1 | 2026-05-26 | [78444](https://github.com/airbytehq/airbyte/pull/78444) | Concurrency tuning — bump default_concurrency from 5 to 7 for progressive rollout |
 | 0.9.21 | 2026-04-28 | [77407](https://github.com/airbytehq/airbyte/pull/77407) | Update dependencies |
 | 0.9.20 | 2026-04-21 | [76772](https://github.com/airbytehq/airbyte/pull/76772) | Update dependencies |


### PR DESCRIPTION
## What

Concurrency tuning iteration 2 for source-sentry. Bumps `default_concurrency` from 7 to 8 and version from `0.9.22-rc.1` to `0.9.22-rc.2`.

Related: https://github.com/airbytehq/airbyte-internal-issues/issues/15327 (parent: https://github.com/airbytehq/airbyte-internal-issues/issues/15262)

Requested by @sophiecuiy.

## How

- Bumped `dockerImageTag` to `0.9.22-rc.2` in `metadata.yaml`
- Changed `default_concurrency` from 7 to 8 in `manifest.yaml`
- Added changelog entry

## Context

Iteration 1 (c=7, rc.1) passed 24h health check:
- 0% failure rate across 5 pinned daily Tier 2 actors
- Aggregate duration 10.8% faster than stable baseline (159s vs 178s)
- No 429 errors, no retries
- Approved by Sophie to increase concurrency

## Review guide

1. `airbyte-integrations/connectors/source-sentry/manifest.yaml` — `default_concurrency: 7` → `8`
2. `airbyte-integrations/connectors/source-sentry/metadata.yaml` — version bump `0.9.22-rc.1` → `0.9.22-rc.2`
3. `docs/integrations/sources/sentry.md` — changelog entry

## User Impact

No user-facing impact. RC version behind progressive rollout for 5 pinned Tier 2 actors only.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

- [x] (Click to Approve:) Bypass the active progressive rollout warning for source-sentry in the PR comment [here](https://github.com/airbytehq/airbyte/pull/78468#issuecomment-4559680128).

Link to Devin session: https://app.devin.ai/sessions/fe2b0b4604e34b5d9581be9819daf5e0