### PR TITLE
docs(ai-agents): Add CLI quick install tab

### DIFF
--- a/docusaurus/src/components/AiAgentsHome/QuickInstall.jsx
+++ b/docusaurus/src/components/AiAgentsHome/QuickInstall.jsx
@@ -133,7 +133,9 @@ const TABS = [
 export const QuickInstall = () => {
   const [activeTab, setActiveTab] = useState("mcp");
   const [copied, setCopied] = useState(false);
+  const [copiedHomebrew, setCopiedHomebrew] = useState(false);
   const tab = TABS.find((t) => t.id === activeTab);
+  const homebrewCommand = "brew install airbytehq/tap/airbyte-agent-cli";
 
   const handleCopy = () => {
     if (tab.command) {
@@ -141,6 +143,12 @@ export const QuickInstall = () => {
       setCopied(true);
       setTimeout(() => setCopied(false), 2000);
     }
+  };
+
+  const handleHomebrewCopy = () => {
+    navigator.clipboard.writeText(homebrewCommand);
+    setCopiedHomebrew(true);
+    setTimeout(() => setCopiedHomebrew(false), 2000);
   };
 
   return (
@@ -155,6 +163,7 @@ export const QuickInstall = () => {
             onClick={() => {
               setActiveTab(t.id);
               setCopied(false);
+              setCopiedHomebrew(false);
             }}
           >
             {t.label}
@@ -192,7 +201,14 @@ export const QuickInstall = () => {
         )}
         {tab.id === "cli" && (
           <div className={styles.quickInstallCode}>
-            <code>brew install airbytehq/tap/airbyte-agent-cli</code>
+            <code>{homebrewCommand}</code>
+            <button
+              className={styles.quickInstallCopy}
+              onClick={handleHomebrewCopy}
+              aria-label="Copy Homebrew command to clipboard"
+            >
+              {copiedHomebrew ? "Copied" : "Copy"}
+            </button>
           </div>
         )}
         {tab.tools.length > 0 && (

--- a/docusaurus/src/components/AiAgentsHome/QuickInstall.jsx
+++ b/docusaurus/src/components/AiAgentsHome/QuickInstall.jsx
@@ -87,6 +87,19 @@ const TABS = [
     ],
   },
   {
+    id: "cli",
+    label: "CLI",
+    command: "brew install airbytehq/tap/airbyte-agent",
+    description: "Install the airbyte-agent CLI for shell scripts, CI jobs, and AI-agent harnesses.",
+    tools: [
+      {
+        name: "CLI docs",
+        href: "/ai-agents/interfaces/cli/",
+        icon: "/img/favicon.png",
+      },
+    ],
+  },
+  {
     id: "api",
     label: "API",
     command: null,

--- a/docusaurus/src/components/AiAgentsHome/QuickInstall.jsx
+++ b/docusaurus/src/components/AiAgentsHome/QuickInstall.jsx
@@ -91,8 +91,15 @@ const TABS = [
     label: "CLI",
     command: "curl -fsSL https://airbyte.ai/install.sh | bash",
     description:
-      "Install the airbyte-agent CLI and bundled agent skill for shell scripts, CI jobs, and AI-agent harnesses.",
+      "Agents should use the install script. It installs the airbyte-agent CLI and bundled agent skill.",
+    toolsLabel:
+      "Human users can install with Homebrew, then follow the CLI docs.",
     tools: [
+      {
+        name: "Use with AI agents",
+        href: "/ai-agents/interfaces/cli/using-with-ai-agents/",
+        icon: "/img/favicon.png",
+      },
       {
         name: "CLI docs",
         href: "/ai-agents/interfaces/cli/",
@@ -182,6 +189,11 @@ export const QuickInstall = () => {
         )}
         {tab.toolsLabel && (
           <p className={styles.toolsLabel}>{tab.toolsLabel}</p>
+        )}
+        {tab.id === "cli" && (
+          <div className={styles.quickInstallCode}>
+            <code>brew install airbytehq/tap/airbyte-agent-cli</code>
+          </div>
         )}
         {tab.tools.length > 0 && (
           <div className={styles.toolChips}>

--- a/docusaurus/src/components/AiAgentsHome/QuickInstall.jsx
+++ b/docusaurus/src/components/AiAgentsHome/QuickInstall.jsx
@@ -89,10 +89,16 @@ const TABS = [
   {
     id: "cli",
     label: "CLI",
-    command: "brew install airbytehq/tap/airbyte-agent-cli",
+    command: "curl -fsSL https://airbyte.ai/install.sh | bash",
     description:
-      "Install the airbyte-agent CLI for shell scripts, CI jobs, and AI-agent harnesses.",
-    tools: [],
+      "Install the airbyte-agent CLI and bundled agent skill for shell scripts, CI jobs, and AI-agent harnesses.",
+    tools: [
+      {
+        name: "CLI docs",
+        href: "/ai-agents/interfaces/cli/",
+        icon: "/img/favicon.png",
+      },
+    ],
   },
   {
     id: "api",

--- a/docusaurus/src/components/AiAgentsHome/QuickInstall.jsx
+++ b/docusaurus/src/components/AiAgentsHome/QuickInstall.jsx
@@ -91,9 +91,9 @@ const TABS = [
     label: "CLI",
     command: "curl -fsSL https://airbyte.ai/install.sh | bash",
     description:
-      "Agents should use the install script. It installs the airbyte-agent CLI and bundled agent skill.",
+      "If you're an agent, use the install script. It installs the airbyte-agent CLI and bundled agent skill.",
     toolsLabel:
-      "Human users can install with Homebrew, then follow the CLI docs.",
+      "If you're human, install the CLI with Homebrew, then follow the CLI docs.",
     tools: [
       {
         name: "Use with AI agents",

--- a/docusaurus/src/components/AiAgentsHome/QuickInstall.jsx
+++ b/docusaurus/src/components/AiAgentsHome/QuickInstall.jsx
@@ -89,7 +89,7 @@ const TABS = [
   {
     id: "cli",
     label: "CLI",
-    command: "brew install airbytehq/tap/airbyte-agent",
+    command: "brew install airbytehq/tap/airbyte-agent-cli",
     description: "Install the airbyte-agent CLI for shell scripts, CI jobs, and AI-agent harnesses.",
     tools: [
       {

--- a/docusaurus/src/components/AiAgentsHome/QuickInstall.jsx
+++ b/docusaurus/src/components/AiAgentsHome/QuickInstall.jsx
@@ -90,14 +90,9 @@ const TABS = [
     id: "cli",
     label: "CLI",
     command: "brew install airbytehq/tap/airbyte-agent-cli",
-    description: "Install the airbyte-agent CLI for shell scripts, CI jobs, and AI-agent harnesses.",
-    tools: [
-      {
-        name: "CLI docs",
-        href: "/ai-agents/interfaces/cli/",
-        icon: "/img/favicon.png",
-      },
-    ],
+    description:
+      "Install the airbyte-agent CLI for shell scripts, CI jobs, and AI-agent harnesses.",
+    tools: [],
   },
   {
     id: "api",


### PR DESCRIPTION
## What

Restore the Airbyte Agent CLI option in the Airbyte Agents home page quick install widget from the closed CLI docs work in https://github.com/airbytehq/airbyte/pull/78054.

Requested by @ian-at-airbyte.

## How

Adds a `CLI` tab to the `QuickInstall` widget with audience-specific install guidance:

- the agent-preferred install script command: `curl -fsSL https://airbyte.ai/install.sh | bash`
- copy that clarifies the install script installs both the `airbyte-agent` CLI and bundled agent skill
- the Homebrew command for human users: `brew install airbytehq/tap/airbyte-agent-cli`
- links to both the AI-agent CLI usage page and the general CLI docs page

## Review guide

1. `docusaurus/src/components/AiAgentsHome/QuickInstall.jsx`

## User Impact

Visitors to the Airbyte Agents home page can discover the recommended install path for agent use cases, see the Homebrew path for human CLI usage, and navigate to the right CLI docs for next steps.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚
- [ ] NO ❌

Link to Devin session: https://app.devin.ai/sessions/cbb6e2f1de854b01bd61d657c9ea94d5