### PR TITLE
Add opt-in staging branch deletion for data lake destinations

### DIFF
--- a/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/kotlin/io/airbyte/cdk/load/command/iceberg/parquet/IcebergCatalogConfiguration.kt
+++ b/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/kotlin/io/airbyte/cdk/load/command/iceberg/parquet/IcebergCatalogConfiguration.kt
@@ -31,7 +31,12 @@ data class IcebergCatalogConfiguration(
     @JsonPropertyDescription(
         "The specific configuration details of the chosen Iceberg catalog type."
     )
-    val catalogConfiguration: CatalogConfiguration
+    val catalogConfiguration: CatalogConfiguration,
+    @JsonSchemaTitle("Delete Staging Branch on Successful Sync")
+    @JsonPropertyDescription(
+        "Whether to delete the Iceberg staging branch after a successful committed sync."
+    )
+    val deleteStagingBranchOnSuccess: Boolean = false
 )
 
 /**

--- a/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/kotlin/io/airbyte/cdk/load/command/iceberg/parquet/IcebergCatalogSpecifications.kt
+++ b/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/kotlin/io/airbyte/cdk/load/command/iceberg/parquet/IcebergCatalogSpecifications.kt
@@ -54,6 +54,18 @@ interface IcebergCatalogSpecifications {
     val mainBranchName: String
 
     /**
+     * Whether to delete the staging branch after a successful sync has been fully committed to the
+     * main branch.
+     */
+    @get:JsonSchemaTitle("Delete Staging Branch on Successful Sync")
+    @get:JsonPropertyDescription(
+        "Deletes the Iceberg staging branch only after a successful committed sync. This can be useful when external compaction rewrites the main branch."
+    )
+    @get:JsonProperty("delete_staging_branch_on_success", required = false)
+    val deleteStagingBranchOnSuccess: Boolean?
+        get() = false
+
+    /**
      * The catalog type.
      *
      * Indicates the type of catalog used (e.g., NESSIE, GLUE, REST) and provides configuration
@@ -103,7 +115,12 @@ interface IcebergCatalogSpecifications {
                     )
             }
 
-        return IcebergCatalogConfiguration(warehouseLocation, mainBranchName, catalogConfiguration)
+        return IcebergCatalogConfiguration(
+            warehouseLocation,
+            mainBranchName,
+            catalogConfiguration,
+            deleteStagingBranchOnSuccess ?: false,
+        )
     }
 }
 

--- a/airbyte-integrations/connectors/destination-gcs-data-lake/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-gcs-data-lake/metadata.yaml
@@ -21,7 +21,7 @@ data:
             alias: airbyte-connector-testing-secret-store
   connectorType: destination
   definitionId: 8c8a2d3e-1b4f-4a9c-9e7d-6f5a4b3c2d1e
-  dockerImageTag: 1.0.10
+  dockerImageTag: 1.0.11
   dockerRepository: airbyte/destination-gcs-data-lake
   documentationUrl: https://docs.airbyte.com/integrations/destinations/gcs-data-lake
   githubIssueLabel: destination-gcs-data-lake

--- a/airbyte-integrations/connectors/destination-gcs-data-lake/src/main/kotlin/io/airbyte/integrations/destination/gcs_data_lake/spec/GcsCatalogConfiguration.kt
+++ b/airbyte-integrations/connectors/destination-gcs-data-lake/src/main/kotlin/io/airbyte/integrations/destination/gcs_data_lake/spec/GcsCatalogConfiguration.kt
@@ -7,6 +7,7 @@ package io.airbyte.integrations.destination.gcs_data_lake.spec
 data class GcsCatalogConfiguration(
     val warehouseLocation: String,
     val mainBranchName: String,
+    val deleteStagingBranchOnSuccess: Boolean,
     val catalogConfiguration: GcsCatalogConfig
 )
 

--- a/airbyte-integrations/connectors/destination-gcs-data-lake/src/main/kotlin/io/airbyte/integrations/destination/gcs_data_lake/spec/GcsDataLakeConfiguration.kt
+++ b/airbyte-integrations/connectors/destination-gcs-data-lake/src/main/kotlin/io/airbyte/integrations/destination/gcs_data_lake/spec/GcsDataLakeConfiguration.kt
@@ -24,6 +24,7 @@ data class GcsDataLakeConfiguration(
     val gcsEndpoint: String?,
     val namespace: String,
     val gcsCatalogConfiguration: GcsCatalogConfiguration,
+    val deleteStagingBranchOnSuccess: Boolean,
 ) : DestinationConfiguration() {
 
     // Lazy-loaded credentials from service account JSON with proper OAuth scopes
@@ -72,6 +73,7 @@ class GcsDataLakeConfigurationFactory :
             gcsEndpoint = pojo.gcsEndpoint,
             namespace = pojo.namespace,
             gcsCatalogConfiguration = pojo.toGcsCatalogConfiguration(),
+            deleteStagingBranchOnSuccess = pojo.deleteStagingBranchOnSuccess ?: false,
         )
     }
 }

--- a/airbyte-integrations/connectors/destination-gcs-data-lake/src/main/kotlin/io/airbyte/integrations/destination/gcs_data_lake/spec/GcsDataLakeSpecification.kt
+++ b/airbyte-integrations/connectors/destination-gcs-data-lake/src/main/kotlin/io/airbyte/integrations/destination/gcs_data_lake/spec/GcsDataLakeSpecification.kt
@@ -115,6 +115,14 @@ class GcsDataLakeSpecification : ConfigurationSpecification() {
     @get:JsonSchemaInject(json = """{"order": 8}""")
     val gcsEndpoint: String? = null
 
+    @get:JsonSchemaTitle("Delete Staging Branch on Successful Sync")
+    @get:JsonPropertyDescription(
+        "Deletes the Iceberg staging branch only after a successful committed sync. This is useful when external compaction rewrites the main branch so the next staging branch is recreated from compacted main lineage."
+    )
+    @get:JsonProperty("delete_staging_branch_on_success", required = false)
+    @get:JsonSchemaInject(json = """{"group": "advanced", "order": 9, "default": false}""")
+    val deleteStagingBranchOnSuccess: Boolean? = false
+
     fun toGcsCatalogConfiguration(): GcsCatalogConfiguration {
         val catalogConfig =
             when (catalogType) {
@@ -139,6 +147,7 @@ class GcsDataLakeSpecification : ConfigurationSpecification() {
         return GcsCatalogConfiguration(
             warehouseLocation = warehouseLocation,
             mainBranchName = mainBranchName,
+            deleteStagingBranchOnSuccess = deleteStagingBranchOnSuccess ?: false,
             catalogConfiguration = catalogConfig
         )
     }
@@ -153,4 +162,8 @@ class GcsDataLakeSpecificationExtension : DestinationSpecificationExtension {
             DestinationSyncMode.APPEND_DEDUP
         )
     override val supportsIncremental = true
+    override val groups =
+        listOf(
+            DestinationSpecificationExtension.Group("advanced", "Advanced"),
+        )
 }

--- a/airbyte-integrations/connectors/destination-gcs-data-lake/src/main/kotlin/io/airbyte/integrations/destination/gcs_data_lake/write/GcsDataLakeStreamLoader.kt
+++ b/airbyte-integrations/connectors/destination-gcs-data-lake/src/main/kotlin/io/airbyte/integrations/destination/gcs_data_lake/write/GcsDataLakeStreamLoader.kt
@@ -33,6 +33,7 @@ class GcsDataLakeStreamLoader(
     private val icebergUtil: IcebergUtil,
     private val stagingBranchName: String,
     private val mainBranchName: String,
+    private val deleteStagingBranchOnSuccess: Boolean,
     private val streamStateStore: StreamStateStore<GcsDataLakeStreamState>,
 ) : StreamLoader {
     private lateinit var table: Table
@@ -181,16 +182,7 @@ class GcsDataLakeStreamLoader(
             "Final target schema has ${targetSchema.identifierFieldIds().size} identifier fields: ${targetSchema.identifierFieldIds()}"
         }
 
-        try {
-            logger.info {
-                "maybe creating branch $stagingBranchName for stream ${stream.mappedDescriptor}"
-            }
-            table.manageSnapshots().createBranch(stagingBranchName).commit()
-        } catch (e: IllegalArgumentException) {
-            logger.info {
-                "branch $stagingBranchName already exists for stream ${stream.mappedDescriptor}"
-            }
-        }
+        createStagingBranchIfAbsent()
 
         val state =
             GcsDataLakeStreamState(
@@ -205,7 +197,7 @@ class GcsDataLakeStreamLoader(
             // Doing it first to make sure that data coming in the current batch is written to the
             // main branch
             logger.info {
-                "No stream failure detected. Committing changes from staging branch '$stagingBranchName' to main branch '$mainBranchName."
+                "No stream failure detected. Committing changes from staging branch '$stagingBranchName' to main branch '$mainBranchName'."
             }
             // We've modified the table over the sync (i.e. adding new snapshots)
             // so we need to refresh here to get the latest table metadata.
@@ -230,6 +222,7 @@ class GcsDataLakeStreamLoader(
                     throw e
                 }
             }
+            table.refresh()
             table.manageSnapshots().replaceBranch(mainBranchName, stagingBranchName).commit()
 
             if (stream.isSingleGenerationTruncate()) {
@@ -243,7 +236,12 @@ class GcsDataLakeStreamLoader(
                     "Deleted obsolete generation IDs up to ${stream.minimumGenerationId - 1}. " +
                         "Pushing these updates to the '$mainBranchName' branch."
                 }
+                table.refresh()
                 table.manageSnapshots().replaceBranch(mainBranchName, stagingBranchName).commit()
+            }
+
+            if (deleteStagingBranchOnSuccess) {
+                removeStagingBranchIfPresent()
             }
         }
     }
@@ -264,4 +262,58 @@ class GcsDataLakeStreamLoader(
             // in a single transaction, even with different field IDs.
             requireSeparateCommitsForColumnReplace = true,
         )
+
+    private fun createStagingBranchIfAbsent() {
+        table.refresh()
+        if (table.refs().containsKey(stagingBranchName)) {
+            logger.info {
+                "Branch '$stagingBranchName' already exists for stream ${stream.mappedDescriptor}; skipping create."
+            }
+            return
+        }
+
+        try {
+            logger.info {
+                "Creating branch '$stagingBranchName' for stream ${stream.mappedDescriptor}."
+            }
+            table.manageSnapshots().createBranch(stagingBranchName).commit()
+        } catch (e: IllegalArgumentException) {
+            table.refresh()
+            if (table.refs().containsKey(stagingBranchName)) {
+                logger.info(e) {
+                    "Branch '$stagingBranchName' was created concurrently for stream ${stream.mappedDescriptor}; continuing."
+                }
+            } else {
+                throw e
+            }
+        }
+    }
+
+    private fun removeStagingBranchIfPresent() {
+        if (stagingBranchName == mainBranchName) {
+            logger.warn {
+                "Skipping deletion of staging branch '$stagingBranchName' for stream ${stream.mappedDescriptor} because it matches the main branch."
+            }
+            return
+        }
+
+        try {
+            table.refresh()
+            if (!table.refs().containsKey(stagingBranchName)) {
+                logger.info {
+                    "Branch '$stagingBranchName' is absent for stream ${stream.mappedDescriptor}; skipping delete."
+                }
+                return
+            }
+
+            logger.info {
+                "Deleting branch '$stagingBranchName' for stream ${stream.mappedDescriptor} after successful commit."
+            }
+            table.manageSnapshots().removeBranch(stagingBranchName).commit()
+        } catch (e: Exception) {
+            logger.warn(e) {
+                "Failed to delete branch '$stagingBranchName' for stream ${stream.mappedDescriptor} after successful commit; leaving sync successful."
+            }
+        }
+    }
 }

--- a/airbyte-integrations/connectors/destination-gcs-data-lake/src/main/kotlin/io/airbyte/integrations/destination/gcs_data_lake/write/GcsDataLakeWriter.kt
+++ b/airbyte-integrations/connectors/destination-gcs-data-lake/src/main/kotlin/io/airbyte/integrations/destination/gcs_data_lake/write/GcsDataLakeWriter.kt
@@ -71,6 +71,7 @@ class GcsDataLakeWriter(
             stagingBranchName =
                 io.airbyte.integrations.destination.gcs_data_lake.spec.DEFAULT_STAGING_BRANCH,
             mainBranchName = icebergConfiguration.gcsCatalogConfiguration.mainBranchName,
+            deleteStagingBranchOnSuccess = icebergConfiguration.deleteStagingBranchOnSuccess,
             streamStateStore = streamStateStore,
         )
     }

--- a/airbyte-integrations/connectors/destination-gcs-data-lake/src/test-integration/kotlin/io/airbyte/integrations/destination/gcs_data_lake/GcsDataLakeWriteTest.kt
+++ b/airbyte-integrations/connectors/destination-gcs-data-lake/src/test-integration/kotlin/io/airbyte/integrations/destination/gcs_data_lake/GcsDataLakeWriteTest.kt
@@ -58,9 +58,11 @@ class BigLakeWriteTest :
                                             GcsCatalogConfiguration(
                                                 warehouseLocation = "",
                                                 mainBranchName = "",
+                                                deleteStagingBranchOnSuccess = false,
                                                 catalogConfiguration =
                                                     BigLakeCatalogConfiguration("", "")
                                             ),
+                                        deleteStagingBranchOnSuccess = false,
                                     ),
                                     tempTableNameGenerator = DefaultTempTableNameGenerator(),
                                 )

--- a/airbyte-integrations/connectors/destination-gcs-data-lake/src/test-integration/resources/expected-spec-cloud.json
+++ b/airbyte-integrations/connectors/destination-gcs-data-lake/src/test-integration/resources/expected-spec-cloud.json
@@ -132,9 +132,21 @@
         "description" : "Optional custom GCS endpoint URL. Use this for testing with local GCS emulators.",
         "title" : "GCS Endpoint (Optional)",
         "order" : 8
+      },
+      "delete_staging_branch_on_success" : {
+        "type" : "boolean",
+        "description" : "Deletes the Iceberg staging branch only after a successful committed sync. This is useful when external compaction rewrites the main branch so the next staging branch is recreated from compacted main lineage.",
+        "title" : "Delete Staging Branch on Successful Sync",
+        "group" : "advanced",
+        "order" : 9,
+        "default" : false
       }
     },
-    "required" : [ "gcs_bucket_name", "service_account_json", "gcp_location", "warehouse_location", "main_branch_name", "namespace", "catalog_type" ]
+    "required" : [ "gcs_bucket_name", "service_account_json", "gcp_location", "warehouse_location", "main_branch_name", "namespace", "catalog_type" ],
+    "groups" : [ {
+      "id" : "advanced",
+      "title" : "Advanced"
+    } ]
   },
   "supportsIncremental" : true,
   "supportsNormalization" : false,

--- a/airbyte-integrations/connectors/destination-gcs-data-lake/src/test-integration/resources/expected-spec-oss.json
+++ b/airbyte-integrations/connectors/destination-gcs-data-lake/src/test-integration/resources/expected-spec-oss.json
@@ -132,9 +132,21 @@
         "description" : "Optional custom GCS endpoint URL. Use this for testing with local GCS emulators.",
         "title" : "GCS Endpoint (Optional)",
         "order" : 8
+      },
+      "delete_staging_branch_on_success" : {
+        "type" : "boolean",
+        "description" : "Deletes the Iceberg staging branch only after a successful committed sync. This is useful when external compaction rewrites the main branch so the next staging branch is recreated from compacted main lineage.",
+        "title" : "Delete Staging Branch on Successful Sync",
+        "group" : "advanced",
+        "order" : 9,
+        "default" : false
       }
     },
-    "required" : [ "gcs_bucket_name", "service_account_json", "gcp_location", "warehouse_location", "main_branch_name", "namespace", "catalog_type" ]
+    "required" : [ "gcs_bucket_name", "service_account_json", "gcp_location", "warehouse_location", "main_branch_name", "namespace", "catalog_type" ],
+    "groups" : [ {
+      "id" : "advanced",
+      "title" : "Advanced"
+    } ]
   },
   "supportsIncremental" : true,
   "supportsNormalization" : false,

--- a/airbyte-integrations/connectors/destination-gcs-data-lake/src/test/kotlin/io/airbyte/integrations/destination/gcs_data_lake/write/GcsDataLakeStreamLoaderTest.kt
+++ b/airbyte-integrations/connectors/destination-gcs-data-lake/src/test/kotlin/io/airbyte/integrations/destination/gcs_data_lake/write/GcsDataLakeStreamLoaderTest.kt
@@ -1,0 +1,180 @@
+/*
+ * Copyright (c) 2026 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.integrations.destination.gcs_data_lake.write
+
+import io.airbyte.cdk.load.command.Append
+import io.airbyte.cdk.load.command.DestinationStream
+import io.airbyte.cdk.load.command.NamespaceMapper
+import io.airbyte.cdk.load.config.NamespaceDefinitionType
+import io.airbyte.cdk.load.schema.model.ColumnSchema
+import io.airbyte.cdk.load.schema.model.StreamTableSchema
+import io.airbyte.cdk.load.schema.model.TableName
+import io.airbyte.cdk.load.schema.model.TableNames
+import io.airbyte.cdk.load.toolkits.iceberg.parquet.ColumnTypeChangeBehavior
+import io.airbyte.cdk.load.toolkits.iceberg.parquet.IcebergTableSynchronizer
+import io.airbyte.cdk.load.toolkits.iceberg.parquet.SchemaUpdateResult
+import io.airbyte.cdk.load.toolkits.iceberg.parquet.io.IcebergUtil
+import io.airbyte.cdk.load.write.StreamStateStore
+import io.airbyte.integrations.destination.gcs_data_lake.catalog.GcsDataLakeCatalogUtil
+import io.airbyte.integrations.destination.gcs_data_lake.spec.DEFAULT_STAGING_BRANCH
+import io.airbyte.integrations.destination.gcs_data_lake.spec.GcsDataLakeConfiguration
+import io.mockk.clearMocks
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.runs
+import io.mockk.verify
+import io.mockk.verifyOrder
+import kotlinx.coroutines.runBlocking
+import org.apache.iceberg.ManageSnapshots
+import org.apache.iceberg.Schema
+import org.apache.iceberg.SnapshotRef
+import org.apache.iceberg.Table
+import org.apache.iceberg.catalog.Catalog
+import org.apache.iceberg.types.Types
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
+
+internal class GcsDataLakeStreamLoaderTest {
+    private val streamStateStore: StreamStateStore<GcsDataLakeStreamState> = mockk {
+        every { put(any(), any()) } returns Unit
+    }
+
+    private val emptyTableSchema =
+        StreamTableSchema(
+            columnSchema =
+                ColumnSchema(
+                    inputSchema = mapOf(),
+                    inputToFinalColumnNames = mapOf(),
+                    finalSchema = mapOf(),
+                ),
+            importType = Append,
+            tableNames = TableNames(finalTableName = TableName("namespace", "test")),
+        )
+
+    @Test
+    fun testOptInDeletesStagingBranchAfterSuccessfulTeardown() {
+        val fixture = createMinimalStartedLoader(deleteStagingBranchOnSuccess = true)
+
+        runBlocking { fixture.streamLoader.teardown(true) }
+
+        verifyOrder {
+            fixture.table.refresh()
+            fixture.manageSnapshots.replaceBranch("main", DEFAULT_STAGING_BRANCH)
+            fixture.manageSnapshots.commit()
+            fixture.table.refresh()
+            fixture.manageSnapshots.removeBranch(DEFAULT_STAGING_BRANCH)
+            fixture.manageSnapshots.commit()
+        }
+    }
+
+    @Test
+    fun testDefaultLeavesStagingBranchAfterSuccessfulTeardown() {
+        val fixture = createMinimalStartedLoader(deleteStagingBranchOnSuccess = false)
+
+        runBlocking { fixture.streamLoader.teardown(true) }
+
+        verify(exactly = 0) {
+            fixture.manageSnapshots.removeBranch(any())
+        }
+    }
+
+    @Test
+    fun testFailedSyncLeavesStagingBranch() {
+        val fixture = createMinimalStartedLoader(deleteStagingBranchOnSuccess = true)
+
+        runBlocking { fixture.streamLoader.teardown(false) }
+
+        verify(exactly = 0) {
+            fixture.manageSnapshots.removeBranch(any())
+        }
+        verify(exactly = 0) { fixture.manageSnapshots.replaceBranch(any<String>(), any<String>()) }
+    }
+
+    @Test
+    fun testStagingBranchDeletionFailureDoesNotFailTeardown() {
+        val fixture = createMinimalStartedLoader(deleteStagingBranchOnSuccess = true)
+        every { fixture.manageSnapshots.removeBranch(DEFAULT_STAGING_BRANCH) } throws
+            RuntimeException("catalog failure")
+
+        assertDoesNotThrow { runBlocking { fixture.streamLoader.teardown(true) } }
+
+        verify(exactly = 1) { fixture.manageSnapshots.removeBranch(DEFAULT_STAGING_BRANCH) }
+    }
+
+    private data class MinimalLoaderFixture(
+        val streamLoader: GcsDataLakeStreamLoader,
+        val table: Table,
+        val manageSnapshots: ManageSnapshots,
+    )
+
+    private fun createMinimalStartedLoader(
+        deleteStagingBranchOnSuccess: Boolean
+    ): MinimalLoaderFixture {
+        val schema = Schema(Types.NestedField.of(1, true, "id", Types.LongType.get()))
+        val stream =
+            DestinationStream(
+                generationId = 1,
+                minimumGenerationId = 0,
+                syncId = 1,
+                unmappedNamespace = "namespace",
+                unmappedName = "name",
+                namespaceMapper =
+                    NamespaceMapper(namespaceDefinitionType = NamespaceDefinitionType.SOURCE),
+                tableSchema = emptyTableSchema,
+            )
+        val catalog: Catalog = mockk()
+        val manageSnapshots: ManageSnapshots = mockk()
+        val table: Table = mockk {
+            every { schema() } returns schema
+            every { refresh() } just runs
+            every { refs() } returnsMany
+                listOf(emptyMap(), mapOf(DEFAULT_STAGING_BRANCH to mockk<SnapshotRef>()))
+            every { manageSnapshots() } returns manageSnapshots
+        }
+        every { manageSnapshots.createBranch(DEFAULT_STAGING_BRANCH) } returns manageSnapshots
+        every { manageSnapshots.replaceBranch("main", DEFAULT_STAGING_BRANCH) } returns
+            manageSnapshots
+        every { manageSnapshots.removeBranch(DEFAULT_STAGING_BRANCH) } returns manageSnapshots
+        every { manageSnapshots.commit() } just runs
+
+        val gcsDataLakeCatalogUtil: GcsDataLakeCatalogUtil = mockk {
+            every { createNamespace(any(), any()) } just runs
+            every { toCatalogProperties(any()) } returns mapOf()
+        }
+        val icebergUtil: IcebergUtil = mockk {
+            every { createCatalog(any(), any()) } returns catalog
+            every { createTable(any(), any(), any()) } returns table
+            every { toIcebergSchema(any()) } returns schema
+        }
+        val icebergTableSynchronizer: IcebergTableSynchronizer = mockk {
+            every {
+                maybeApplySchemaChanges(
+                    any(),
+                    any(),
+                    ColumnTypeChangeBehavior.SAFE_SUPERTYPE,
+                    true
+                )
+            } returns SchemaUpdateResult(schema, emptyList())
+        }
+        val streamLoader =
+            GcsDataLakeStreamLoader(
+                icebergConfiguration = mockk<GcsDataLakeConfiguration>(),
+                stream = stream,
+                icebergTableSynchronizer = icebergTableSynchronizer,
+                gcsDataLakeCatalogUtil = gcsDataLakeCatalogUtil,
+                icebergUtil = icebergUtil,
+                stagingBranchName = DEFAULT_STAGING_BRANCH,
+                mainBranchName = "main",
+                deleteStagingBranchOnSuccess = deleteStagingBranchOnSuccess,
+                streamStateStore = streamStateStore,
+            )
+        runBlocking { streamLoader.start() }
+        clearMocks(table, manageSnapshots, answers = false)
+        every { table.refs() } returns mapOf(DEFAULT_STAGING_BRANCH to mockk<SnapshotRef>())
+
+        return MinimalLoaderFixture(streamLoader, table, manageSnapshots)
+    }
+}

--- a/airbyte-integrations/connectors/destination-s3-data-lake/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-s3-data-lake/metadata.yaml
@@ -37,7 +37,7 @@ data:
             alias: airbyte-connector-testing-secret-store
   connectorType: destination
   definitionId: 716ca874-520b-4902-9f80-9fad66754b89
-  dockerImageTag: 0.3.49
+  dockerImageTag: 0.3.50
   dockerRepository: airbyte/destination-s3-data-lake
   documentationUrl: https://docs.airbyte.com/integrations/destinations/s3-data-lake
   githubIssueLabel: destination-s3-data-lake

--- a/airbyte-integrations/connectors/destination-s3-data-lake/src/main/kotlin/io/airbyte/integrations/destination/s3_data_lake/spec/S3DataLakeConfiguration.kt
+++ b/airbyte-integrations/connectors/destination-s3-data-lake/src/main/kotlin/io/airbyte/integrations/destination/s3_data_lake/spec/S3DataLakeConfiguration.kt
@@ -22,6 +22,7 @@ data class S3DataLakeConfiguration(
     override val s3BucketConfiguration: S3BucketConfiguration,
     override val icebergCatalogConfiguration: IcebergCatalogConfiguration,
     val flushBatchSizeMb: Long?,
+    val deleteStagingBranchOnSuccess: Boolean,
 ) :
     DestinationConfiguration(),
     AWSAccessKeyConfigurationProvider,
@@ -59,6 +60,7 @@ class S3DataLakeConfigurationFactory :
             s3BucketConfiguration = pojo.toS3BucketConfiguration(),
             icebergCatalogConfiguration = pojo.toIcebergCatalogConfiguration(),
             flushBatchSizeMb = pojo.flushBatchSizeMb,
+            deleteStagingBranchOnSuccess = pojo.deleteStagingBranchOnSuccess ?: false,
         )
     }
 }

--- a/airbyte-integrations/connectors/destination-s3-data-lake/src/main/kotlin/io/airbyte/integrations/destination/s3_data_lake/spec/S3DataLakeSpecification.kt
+++ b/airbyte-integrations/connectors/destination-s3-data-lake/src/main/kotlin/io/airbyte/integrations/destination/s3_data_lake/spec/S3DataLakeSpecification.kt
@@ -71,6 +71,14 @@ class S3DataLakeSpecification :
     @get:JsonSchemaInject(json = """{"always_show": true,"order":7}""")
     override val catalogType: CatalogType = GlueCatalogSpecification(glueId = "", databaseName = "")
 
+    @get:JsonSchemaTitle("Delete Staging Branch on Successful Sync")
+    @get:JsonPropertyDescription(
+        "Deletes the Iceberg staging branch only after a successful committed sync. This is useful when external compaction rewrites the main branch so the next staging branch is recreated from compacted main lineage."
+    )
+    @get:JsonProperty("delete_staging_branch_on_success", required = false)
+    @get:JsonSchemaInject(json = """{"group": "advanced", "order": 8, "default": false}""")
+    val deleteStagingBranchOnSuccess: Boolean? = false
+
     @get:JsonSchemaTitle("Flush Batch Size (MB)")
     @get:JsonPropertyDescription(
         "The approximate size in megabytes of each batch of data written to Iceberg. " +
@@ -80,7 +88,7 @@ class S3DataLakeSpecification :
     )
     @get:JsonProperty("flush_batch_size_mb", required = false)
     @get:JsonSchemaInject(
-        json = """{"examples":[200], "default": 200, "order": 8, "airbyte_hidden": true}"""
+        json = """{"examples":[200], "default": 200, "order": 9, "airbyte_hidden": true}"""
     )
     val flushBatchSizeMb: Long? = null
 }
@@ -94,4 +102,8 @@ class S3DataLakeSpecificationExtension : DestinationSpecificationExtension {
             DestinationSyncMode.APPEND_DEDUP
         )
     override val supportsIncremental = true
+    override val groups =
+        listOf(
+            DestinationSpecificationExtension.Group("advanced", "Advanced"),
+        )
 }

--- a/airbyte-integrations/connectors/destination-s3-data-lake/src/main/kotlin/io/airbyte/integrations/destination/s3_data_lake/write/S3DataLakeStreamLoader.kt
+++ b/airbyte-integrations/connectors/destination-s3-data-lake/src/main/kotlin/io/airbyte/integrations/destination/s3_data_lake/write/S3DataLakeStreamLoader.kt
@@ -14,7 +14,6 @@ import io.airbyte.cdk.load.write.StreamLoader
 import io.airbyte.cdk.load.write.StreamStateStore
 import io.airbyte.integrations.destination.s3_data_lake.catalog.S3DataLakeUtil
 import io.airbyte.integrations.destination.s3_data_lake.spec.DEFAULT_CATALOG_NAME
-import io.airbyte.integrations.destination.s3_data_lake.spec.DEFAULT_STAGING_BRANCH
 import io.airbyte.integrations.destination.s3_data_lake.spec.S3DataLakeConfiguration
 import io.github.oshai.kotlinlogging.KotlinLogging
 import org.apache.iceberg.Schema
@@ -32,6 +31,7 @@ class S3DataLakeStreamLoader(
     private val icebergUtil: IcebergUtil,
     private val stagingBranchName: String,
     private val mainBranchName: String,
+    private val deleteStagingBranchOnSuccess: Boolean,
     private val streamStateStore: StreamStateStore<S3DataLakeStreamState>,
 ) : StreamLoader {
     private lateinit var table: Table
@@ -72,16 +72,7 @@ class S3DataLakeStreamLoader(
         // incrementally, and if the entire sync is in a transaction, we might crash before we can
         // commit that transaction.
         targetSchema = computeOrExecuteSchemaUpdate().schema
-        try {
-            logger.info {
-                "maybe creating branch $DEFAULT_STAGING_BRANCH for stream ${stream.mappedDescriptor}"
-            }
-            table.manageSnapshots().createBranch(DEFAULT_STAGING_BRANCH).commit()
-        } catch (e: IllegalArgumentException) {
-            logger.info {
-                "branch $DEFAULT_STAGING_BRANCH already exists for stream ${stream.mappedDescriptor}"
-            }
-        }
+        createStagingBranchIfAbsent()
 
         val state =
             S3DataLakeStreamState(
@@ -96,7 +87,7 @@ class S3DataLakeStreamLoader(
             // Doing it first to make sure that data coming in the current batch is written to the
             // main branch
             logger.info {
-                "No stream failure detected. Committing changes from staging branch '$stagingBranchName' to main branch '$mainBranchName."
+                "No stream failure detected. Committing changes from staging branch '$stagingBranchName' to main branch '$mainBranchName'."
             }
             // We've modified the table over the sync (i.e. adding new snapshots)
             // so we need to refresh here to get the latest table metadata.
@@ -105,6 +96,7 @@ class S3DataLakeStreamLoader(
             table.refresh()
             // Commit all pending schema updates in order (important for two-phase commits)
             computeOrExecuteSchemaUpdate().pendingUpdates.forEach { it.commit() }
+            table.refresh()
             table.manageSnapshots().replaceBranch(mainBranchName, stagingBranchName).commit()
 
             if (stream.isSingleGenerationTruncate()) {
@@ -118,7 +110,12 @@ class S3DataLakeStreamLoader(
                     "Deleted obsolete generation IDs up to ${stream.minimumGenerationId - 1}. " +
                         "Pushing these updates to the '$mainBranchName' branch."
                 }
+                table.refresh()
                 table.manageSnapshots().replaceBranch(mainBranchName, stagingBranchName).commit()
+            }
+
+            if (deleteStagingBranchOnSuccess) {
+                removeStagingBranchIfPresent()
             }
         }
     }
@@ -135,4 +132,58 @@ class S3DataLakeStreamLoader(
             incomingSchema,
             columnTypeChangeBehavior,
         )
+
+    private fun createStagingBranchIfAbsent() {
+        table.refresh()
+        if (table.refs().containsKey(stagingBranchName)) {
+            logger.info {
+                "Branch '$stagingBranchName' already exists for stream ${stream.mappedDescriptor}; skipping create."
+            }
+            return
+        }
+
+        try {
+            logger.info {
+                "Creating branch '$stagingBranchName' for stream ${stream.mappedDescriptor}."
+            }
+            table.manageSnapshots().createBranch(stagingBranchName).commit()
+        } catch (e: IllegalArgumentException) {
+            table.refresh()
+            if (table.refs().containsKey(stagingBranchName)) {
+                logger.info(e) {
+                    "Branch '$stagingBranchName' was created concurrently for stream ${stream.mappedDescriptor}; continuing."
+                }
+            } else {
+                throw e
+            }
+        }
+    }
+
+    private fun removeStagingBranchIfPresent() {
+        if (stagingBranchName == mainBranchName) {
+            logger.warn {
+                "Skipping deletion of staging branch '$stagingBranchName' for stream ${stream.mappedDescriptor} because it matches the main branch."
+            }
+            return
+        }
+
+        try {
+            table.refresh()
+            if (!table.refs().containsKey(stagingBranchName)) {
+                logger.info {
+                    "Branch '$stagingBranchName' is absent for stream ${stream.mappedDescriptor}; skipping delete."
+                }
+                return
+            }
+
+            logger.info {
+                "Deleting branch '$stagingBranchName' for stream ${stream.mappedDescriptor} after successful commit."
+            }
+            table.manageSnapshots().removeBranch(stagingBranchName).commit()
+        } catch (e: Exception) {
+            logger.warn(e) {
+                "Failed to delete branch '$stagingBranchName' for stream ${stream.mappedDescriptor} after successful commit; leaving sync successful."
+            }
+        }
+    }
 }

--- a/airbyte-integrations/connectors/destination-s3-data-lake/src/main/kotlin/io/airbyte/integrations/destination/s3_data_lake/write/S3DataLakeWriter.kt
+++ b/airbyte-integrations/connectors/destination-s3-data-lake/src/main/kotlin/io/airbyte/integrations/destination/s3_data_lake/write/S3DataLakeWriter.kt
@@ -71,6 +71,7 @@ class S3DataLakeWriter(
             icebergUtil,
             stagingBranchName = DEFAULT_STAGING_BRANCH,
             mainBranchName = icebergConfiguration.icebergCatalogConfiguration.mainBranchName,
+            deleteStagingBranchOnSuccess = icebergConfiguration.deleteStagingBranchOnSuccess,
             streamStateStore = streamStateStore,
         )
     }

--- a/airbyte-integrations/connectors/destination-s3-data-lake/src/test-integration/resources/expected-spec-cloud.json
+++ b/airbyte-integrations/connectors/destination-s3-data-lake/src/test-integration/resources/expected-spec-cloud.json
@@ -215,17 +215,29 @@
         "order" : 7,
         "type" : "object"
       },
+      "delete_staging_branch_on_success" : {
+        "type" : "boolean",
+        "description" : "Deletes the Iceberg staging branch only after a successful committed sync. This is useful when external compaction rewrites the main branch so the next staging branch is recreated from compacted main lineage.",
+        "title" : "Delete Staging Branch on Successful Sync",
+        "group" : "advanced",
+        "order" : 8,
+        "default" : false
+      },
       "flush_batch_size_mb" : {
         "type" : "integer",
         "description" : "The approximate size in megabytes of each batch of data written to Iceberg. Smaller values flush more frequently, improving data freshness and reducing data loss on failure, but will create more small files that require compaction. Must be between 1 and 500 MB. Default is 200 MB.",
         "title" : "Flush Batch Size (MB)",
         "examples" : [ 200 ],
         "default" : 200,
-        "order" : 8,
+        "order" : 9,
         "airbyte_hidden" : true
       }
     },
-    "required" : [ "s3_bucket_name", "s3_bucket_region", "warehouse_location", "main_branch_name", "catalog_type" ]
+    "required" : [ "s3_bucket_name", "s3_bucket_region", "warehouse_location", "main_branch_name", "catalog_type" ],
+    "groups" : [ {
+      "id" : "advanced",
+      "title" : "Advanced"
+    } ]
   },
   "supportsIncremental" : true,
   "supportsNormalization" : false,

--- a/airbyte-integrations/connectors/destination-s3-data-lake/src/test-integration/resources/expected-spec-oss.json
+++ b/airbyte-integrations/connectors/destination-s3-data-lake/src/test-integration/resources/expected-spec-oss.json
@@ -215,17 +215,29 @@
         "order" : 7,
         "type" : "object"
       },
+      "delete_staging_branch_on_success" : {
+        "type" : "boolean",
+        "description" : "Deletes the Iceberg staging branch only after a successful committed sync. This is useful when external compaction rewrites the main branch so the next staging branch is recreated from compacted main lineage.",
+        "title" : "Delete Staging Branch on Successful Sync",
+        "group" : "advanced",
+        "order" : 8,
+        "default" : false
+      },
       "flush_batch_size_mb" : {
         "type" : "integer",
         "description" : "The approximate size in megabytes of each batch of data written to Iceberg. Smaller values flush more frequently, improving data freshness and reducing data loss on failure, but will create more small files that require compaction. Must be between 1 and 500 MB. Default is 200 MB.",
         "title" : "Flush Batch Size (MB)",
         "examples" : [ 200 ],
         "default" : 200,
-        "order" : 8,
+        "order" : 9,
         "airbyte_hidden" : true
       }
     },
-    "required" : [ "s3_bucket_name", "s3_bucket_region", "warehouse_location", "main_branch_name", "catalog_type" ]
+    "required" : [ "s3_bucket_name", "s3_bucket_region", "warehouse_location", "main_branch_name", "catalog_type" ],
+    "groups" : [ {
+      "id" : "advanced",
+      "title" : "Advanced"
+    } ]
   },
   "supportsIncremental" : true,
   "supportsNormalization" : false,

--- a/airbyte-integrations/connectors/destination-s3-data-lake/src/test/kotlin/io/airbyte/integrations/destination/s3_data_lake/catalog/S3DataLakeUtilTest.kt
+++ b/airbyte-integrations/connectors/destination-s3-data-lake/src/test/kotlin/io/airbyte/integrations/destination/s3_data_lake/catalog/S3DataLakeUtilTest.kt
@@ -239,6 +239,7 @@ internal class S3DataLakeUtilTest {
                 icebergCatalogConfiguration = icebergCatalogConfiguration,
                 s3BucketConfiguration = s3BucketConfiguration,
                 flushBatchSizeMb = null,
+                deleteStagingBranchOnSuccess = false,
             )
         val catalogProperties = s3DataLakeUtil.toCatalogProperties(config = configuration)
         Assertions.assertEquals(
@@ -352,6 +353,7 @@ internal class S3DataLakeUtilTest {
                         )
                 ),
             flushBatchSizeMb = null,
+            deleteStagingBranchOnSuccess = false,
         )
     }
 

--- a/airbyte-integrations/connectors/destination-s3-data-lake/src/test/kotlin/io/airbyte/integrations/destination/s3_data_lake/write/S3DataLakeStreamLoaderTest.kt
+++ b/airbyte-integrations/connectors/destination-s3-data-lake/src/test/kotlin/io/airbyte/integrations/destination/s3_data_lake/write/S3DataLakeStreamLoaderTest.kt
@@ -28,6 +28,7 @@ import io.airbyte.cdk.load.toolkits.iceberg.parquet.ColumnTypeChangeBehavior
 import io.airbyte.cdk.load.toolkits.iceberg.parquet.IcebergSuperTypeFinder
 import io.airbyte.cdk.load.toolkits.iceberg.parquet.IcebergTableSynchronizer
 import io.airbyte.cdk.load.toolkits.iceberg.parquet.IcebergTypesComparator
+import io.airbyte.cdk.load.toolkits.iceberg.parquet.SchemaUpdateResult
 import io.airbyte.cdk.load.toolkits.iceberg.parquet.io.IcebergUtil
 import io.airbyte.cdk.load.write.StreamStateStore
 import io.airbyte.integrations.destination.s3_data_lake.catalog.S3DataLakeUtil
@@ -35,15 +36,19 @@ import io.airbyte.integrations.destination.s3_data_lake.spec.DEFAULT_STAGING_BRA
 import io.airbyte.integrations.destination.s3_data_lake.spec.S3BucketConfiguration
 import io.airbyte.integrations.destination.s3_data_lake.spec.S3BucketRegion
 import io.airbyte.integrations.destination.s3_data_lake.spec.S3DataLakeConfiguration
+import io.mockk.clearMocks
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
 import io.mockk.just
 import io.mockk.mockk
 import io.mockk.runs
 import io.mockk.verify
+import io.mockk.verifyOrder
 import kotlin.test.assertEquals
 import kotlinx.coroutines.runBlocking
+import org.apache.iceberg.ManageSnapshots
 import org.apache.iceberg.Schema
+import org.apache.iceberg.SnapshotRef
 import org.apache.iceberg.SortOrder
 import org.apache.iceberg.Table
 import org.apache.iceberg.UpdateSchema
@@ -54,6 +59,7 @@ import org.apache.iceberg.types.Types
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
 
 internal class S3DataLakeStreamLoaderTest {
     @MockK(relaxed = true)
@@ -88,6 +94,56 @@ internal class S3DataLakeStreamLoaderTest {
     @BeforeEach
     fun setup() {
         every { streamStateStore.put(any(), any()) } returns Unit
+    }
+
+    @Test
+    fun testOptInDeletesStagingBranchAfterSuccessfulTeardown() {
+        val fixture = createMinimalStartedLoader(deleteStagingBranchOnSuccess = true)
+
+        runBlocking { fixture.streamLoader.teardown(true) }
+
+        verifyOrder {
+            fixture.table.refresh()
+            fixture.manageSnapshots.replaceBranch("main", DEFAULT_STAGING_BRANCH)
+            fixture.manageSnapshots.commit()
+            fixture.table.refresh()
+            fixture.manageSnapshots.removeBranch(DEFAULT_STAGING_BRANCH)
+            fixture.manageSnapshots.commit()
+        }
+    }
+
+    @Test
+    fun testDefaultLeavesStagingBranchAfterSuccessfulTeardown() {
+        val fixture = createMinimalStartedLoader(deleteStagingBranchOnSuccess = false)
+
+        runBlocking { fixture.streamLoader.teardown(true) }
+
+        verify(exactly = 0) {
+            fixture.manageSnapshots.removeBranch(any())
+        }
+    }
+
+    @Test
+    fun testFailedSyncLeavesStagingBranch() {
+        val fixture = createMinimalStartedLoader(deleteStagingBranchOnSuccess = true)
+
+        runBlocking { fixture.streamLoader.teardown(false) }
+
+        verify(exactly = 0) {
+            fixture.manageSnapshots.removeBranch(any())
+        }
+        verify(exactly = 0) { fixture.manageSnapshots.replaceBranch(any<String>(), any<String>()) }
+    }
+
+    @Test
+    fun testStagingBranchDeletionFailureDoesNotFailTeardown() {
+        val fixture = createMinimalStartedLoader(deleteStagingBranchOnSuccess = true)
+        every { fixture.manageSnapshots.removeBranch(DEFAULT_STAGING_BRANCH) } throws
+            RuntimeException("catalog failure")
+
+        assertDoesNotThrow { runBlocking { fixture.streamLoader.teardown(true) } }
+
+        verify(exactly = 1) { fixture.manageSnapshots.removeBranch(DEFAULT_STAGING_BRANCH) }
     }
 
     @Test
@@ -212,6 +268,7 @@ internal class S3DataLakeStreamLoaderTest {
                 icebergUtil,
                 stagingBranchName = DEFAULT_STAGING_BRANCH,
                 mainBranchName = "main",
+                deleteStagingBranchOnSuccess = false,
                 streamStateStore = streamStateStore,
             )
         Assertions.assertNotNull(streamLoader)
@@ -285,6 +342,7 @@ internal class S3DataLakeStreamLoaderTest {
         every { updateSchema.commit() } just runs
         every { updateSchema.apply() } returns icebergSchema
         every { table.refresh() } just runs
+        every { table.refs() } returns mapOf(DEFAULT_STAGING_BRANCH to mockk<SnapshotRef>())
         every { table.manageSnapshots().createBranch(any()).commit() } throws
             IllegalArgumentException("branch already exists")
         every {
@@ -316,6 +374,7 @@ internal class S3DataLakeStreamLoaderTest {
                 icebergUtil,
                 stagingBranchName = DEFAULT_STAGING_BRANCH,
                 mainBranchName = "main",
+                deleteStagingBranchOnSuccess = false,
                 streamStateStore = streamStateStore,
             )
         runBlocking { streamLoader.start() }
@@ -461,6 +520,7 @@ internal class S3DataLakeStreamLoaderTest {
         every { updateSchema.commit() } just runs
         every { updateSchema.apply() } returns icebergSchema
         every { table.refresh() } just runs
+        every { table.refs() } returns emptyMap()
         every { table.manageSnapshots().createBranch(any()).commit() } just runs
         every {
             table.manageSnapshots().replaceBranch("main", DEFAULT_STAGING_BRANCH).commit()
@@ -491,6 +551,7 @@ internal class S3DataLakeStreamLoaderTest {
                 icebergUtil,
                 stagingBranchName = DEFAULT_STAGING_BRANCH,
                 mainBranchName = "main",
+                deleteStagingBranchOnSuccess = false,
                 streamStateStore = streamStateStore,
             )
         runBlocking { streamLoader.start() }
@@ -549,6 +610,7 @@ internal class S3DataLakeStreamLoaderTest {
                 icebergUtil,
                 stagingBranchName = DEFAULT_STAGING_BRANCH,
                 mainBranchName = "main",
+                deleteStagingBranchOnSuccess = false,
                 streamStateStore = streamStateStore,
             )
 
@@ -556,5 +618,75 @@ internal class S3DataLakeStreamLoaderTest {
             ColumnTypeChangeBehavior.SAFE_SUPERTYPE,
             streamLoader.columnTypeChangeBehavior,
         )
+    }
+
+    private data class MinimalLoaderFixture(
+        val streamLoader: S3DataLakeStreamLoader,
+        val table: Table,
+        val manageSnapshots: ManageSnapshots,
+    )
+
+    private fun createMinimalStartedLoader(
+        deleteStagingBranchOnSuccess: Boolean
+    ): MinimalLoaderFixture {
+        val schema = Schema(Types.NestedField.of(1, true, "id", Types.LongType.get()))
+        val stream =
+            DestinationStream(
+                generationId = 1,
+                minimumGenerationId = 0,
+                syncId = 1,
+                unmappedNamespace = "namespace",
+                unmappedName = "name",
+                namespaceMapper =
+                    NamespaceMapper(namespaceDefinitionType = NamespaceDefinitionType.SOURCE),
+                tableSchema = emptyTableSchema,
+            )
+        val catalog: Catalog = mockk()
+        val manageSnapshots: ManageSnapshots = mockk()
+        val table: Table = mockk {
+            every { schema() } returns schema
+            every { refresh() } just runs
+            every { refs() } returnsMany
+                listOf(emptyMap(), mapOf(DEFAULT_STAGING_BRANCH to mockk<SnapshotRef>()))
+            every { manageSnapshots() } returns manageSnapshots
+        }
+        every { manageSnapshots.createBranch(DEFAULT_STAGING_BRANCH) } returns manageSnapshots
+        every { manageSnapshots.replaceBranch("main", DEFAULT_STAGING_BRANCH) } returns
+            manageSnapshots
+        every { manageSnapshots.removeBranch(DEFAULT_STAGING_BRANCH) } returns manageSnapshots
+        every { manageSnapshots.commit() } just runs
+
+        val s3DataLakeUtil: S3DataLakeUtil = mockk {
+            every { createNamespaceWithGlueHandling(any(), any()) } just runs
+            every { toCatalogProperties(any()) } returns mapOf()
+        }
+        val icebergUtil: IcebergUtil = mockk {
+            every { createCatalog(any(), any()) } returns catalog
+            every { createTable(any(), any(), any()) } returns table
+            every { toIcebergSchema(any()) } returns schema
+        }
+        val icebergTableSynchronizer: IcebergTableSynchronizer = mockk {
+            every { maybeApplySchemaChanges(any(), any(), any()) } returns
+                SchemaUpdateResult(schema, emptyList())
+            every { maybeApplySchemaChanges(any(), any(), any(), any()) } returns
+                SchemaUpdateResult(schema, emptyList())
+        }
+        val streamLoader =
+            S3DataLakeStreamLoader(
+                icebergConfiguration = mockk(),
+                stream = stream,
+                icebergTableSynchronizer = icebergTableSynchronizer,
+                s3DataLakeUtil = s3DataLakeUtil,
+                icebergUtil = icebergUtil,
+                stagingBranchName = DEFAULT_STAGING_BRANCH,
+                mainBranchName = "main",
+                deleteStagingBranchOnSuccess = deleteStagingBranchOnSuccess,
+                streamStateStore = streamStateStore,
+        )
+        runBlocking { streamLoader.start() }
+        clearMocks(table, manageSnapshots, answers = false)
+        every { table.refs() } returns mapOf(DEFAULT_STAGING_BRANCH to mockk<SnapshotRef>())
+
+        return MinimalLoaderFixture(streamLoader, table, manageSnapshots)
     }
 }

--- a/docs/integrations/destinations/gcs-data-lake.md
+++ b/docs/integrations/destinations/gcs-data-lake.md
@@ -96,6 +96,7 @@ In Airbyte, configure the following fields:
 | **Catalog Type**         | Yes        | Select the type of Iceberg catalog to use: `BigLake` or `Polaris`            |
 | **Main Branch Name**     | No         | Iceberg branch name (default: `main`)                                        |
 | **Default Namespace**    | No         | Default namespace for tables (for example: `default`, `airbyte_data`)        |
+| **Delete Staging Branch on Successful Sync** | No | Advanced option. Deletes `airbyte_staging` only after a successful committed sync, so the next staging branch can be recreated from compacted main lineage when you run external compaction. Airbyte doesn't perform compaction. |
 
 ### BigLake-specific fields
 
@@ -198,6 +199,8 @@ At the end of stream sync, the current `main` branch is replaced with the `airby
 
 **Important Warning**: any changes made to the `main` branch outside of Airbyte's operations after a sync begins is going to be lost during this process.
 
+The advanced **Delete Staging Branch on Successful Sync** option deletes the `airbyte_staging` branch only after Airbyte has successfully committed the stream to `main`. This is disabled by default. Enable it when an external compaction process rewrites the `main` branch and you want the next sync to recreate `airbyte_staging` from the compacted main lineage. Airbyte doesn't perform compaction.
+
 ## Compaction
 
 :::caution
@@ -221,6 +224,7 @@ This destination supports [namespaces](https://docs.airbyte.com/platform/using-a
 
 | Version | Date       | Pull Request                                                 | Subject                                                                               |
 |:--------|:-----------|:-------------------------------------------------------------|:--------------------------------------------------------------------------------------|
+| 1.0.11  | 2026-05-26 |                                                              | Add opt-in deletion of the Iceberg staging branch after successful committed syncs.   |
 | 1.0.10  | 2026-05-19 | [78235](https://github.com/airbytehq/airbyte/pull/78235)     | Upgrade CDK to 1.0.13 |
 | 1.0.9   | 2026-04-16 | [76406](https://github.com/airbytehq/airbyte/pull/76406)     | Upgrade CDK to 1.0.9.                                                                 |
 | 1.0.8   | 2026-03-30 | [75630](https://github.com/airbytehq/airbyte/pull/75630)     | Upgrade CDK to 1.0.7: fix sort order handling during schema evolution.                |

--- a/docs/integrations/destinations/s3-data-lake.md
+++ b/docs/integrations/destinations/s3-data-lake.md
@@ -342,6 +342,8 @@ Iceberg supports [Git-like semantics](https://iceberg.apache.org/docs/latest/bra
 At the end of stream sync, we replace the current `main` branch with the `airbyte_staging` branch we were working on. We intentionally avoid fast-forwarding to better handle potential compaction issues.
 **Important Warning**: Any changes made to the `main` branch outside of Airbyte's operations after a sync begins will be lost during this process.
 
+The advanced **Delete Staging Branch on Successful Sync** option deletes the `airbyte_staging` branch only after Airbyte has successfully committed the stream to `main`. This is disabled by default. Enable it when an external compaction process rewrites the `main` branch and you want the next sync to recreate `airbyte_staging` from the compacted main lineage. Airbyte doesn't perform compaction.
+
 ## Compaction
 
 :::caution
@@ -395,6 +397,7 @@ This destination supports [namespaces](https://docs.airbyte.com/platform/using-a
 
 | Version     | Date       | Pull Request                                               | Subject                                                                                                                         |
 |:------------|:-----------|:-----------------------------------------------------------|:--------------------------------------------------------------------------------------------------------------------------------|
+| 0.3.50      | 2026-05-26 |                                                            | Add opt-in deletion of the Iceberg staging branch after successful committed syncs.                                             |
 | 0.3.49      | 2026-05-19 | [78232](https://github.com/airbytehq/airbyte/pull/78232)  | Upgrade CDK to 1.0.13 |
 | 0.3.48      | 2026-05-01 | [77677](https://github.com/airbytehq/airbyte/pull/77677)  | Add configurable flush batch size for aggregate publishing.                                                                     |
 | 0.3.47      | 2026-04-16 | [76410](https://github.com/airbytehq/airbyte/pull/76410) | Upgrade CDK to 1.0.9.                                                  |


### PR DESCRIPTION
## Summary
- Add an opt-in `delete_staging_branch_on_success` advanced config for S3 and GCS Data Lake destinations.
- Delete the Iceberg staging branch after a successful committed sync when the option is enabled, so the next sync can recreate staging from compacted main lineage.
- Keep the default behavior unchanged and leave syncs successful if post-commit staging branch deletion fails.
- Update connector specs, docs, metadata versions, and focused stream loader tests.

## Tests
- `./gradlew :airbyte-integrations:connectors:destination-s3-data-lake:test :airbyte-integrations:connectors:destination-gcs-data-lake:test`

Draft while validating whether we want an additional real-catalog integration test for branch ref behavior.

> [!IMPORTANT]
> Active progressive rollout warning for destination-s3-data-lake.

- [ ] (Click to Approve:) Bypass the active progressive rollout warning for destination-s3-data-lake in the PR comment [here](https://github.com/airbytehq/airbyte/pull/78483#issuecomment-4565942386).