### PR TITLE
feat(source-pylon): inject parent issue_id into issue_messages records

### DIFF
--- a/airbyte-integrations/connectors/source-pylon/manifest.yaml
+++ b/airbyte-integrations/connectors/source-pylon/manifest.yaml
@@ -151,6 +151,12 @@ definitions:
               partition_field: issue_id
               stream:
                 $ref: "#/definitions/streams/issues"
+      transformations:
+        - type: AddFields
+          fields:
+            - path:
+                - issue_id
+              value: "{{ stream_partition.issue_id }}"
       schema_loader:
         type: InlineSchemaLoader
         schema:
@@ -865,6 +871,10 @@ schemas:
     properties:
       id:
         type: string
+      issue_id:
+        type:
+          - "null"
+          - string
       message_html:
         type:
           - "null"

--- a/airbyte-integrations/connectors/source-pylon/metadata.yaml
+++ b/airbyte-integrations/connectors/source-pylon/metadata.yaml
@@ -17,7 +17,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: f2e53e88-3c6b-4e5a-b7c2-a1d9c5e8f4b6
-  dockerImageTag: 0.0.8
+  dockerImageTag: 0.0.9
   dockerRepository: airbyte/source-pylon
   githubIssueLabel: source-pylon
   icon: icon.svg


### PR DESCRIPTION
## Summary

The `issue_messages` stream is a child of `issues` (fetched via `GET /issues/{issue_id}/messages`) but does not include the parent `issue_id` on emitted records. This makes it impossible to join messages back to their parent issue in downstream warehouses — a common need for computing per-issue message counts by author type (customer vs staff).

**Changes:**
- Add an `AddFields` transformation to the `issue_messages` stream that stamps `issue_id` from the stream partition onto each record
- Update the inline JSON schema to declare the new `issue_id` field
- Version bump to 0.0.9

## Motivation

Without `issue_id` on message records, users cannot:
- Count messages per issue broken down by sender type
- Compute response times per issue
- Build support analytics dashboards that correlate message patterns with issue metadata

The `issue_threads` stream already includes `issue_id` in the API response, but `issue_messages` does not — the Pylon API returns messages as a sub-resource without echoing back the parent ID. Since the connector already knows the `issue_id` (it's the partition key used to build the request path), injecting it is a one-line declarative change.

## Test plan

- [x] Verify existing `issue_messages` sync still works (no schema change for existing fields)
- [x] Confirm new `issue_id` field appears on all synced message records
- [x] Validate `issue_id` values match the parent issue's `id` field


Made with [Cursor](https://cursor.com)