### PR TITLE
feat(source-intercom): Expose conversation handling time stats

### DIFF
--- a/airbyte-integrations/connectors/source-intercom/manifest.yaml
+++ b/airbyte-integrations/connectors/source-intercom/manifest.yaml
@@ -500,7 +500,7 @@ definitions:
     conversations:
       type: DeclarativeStream
       description: >-
-        https://developers.intercom.com/docs/references/2.11/rest-api/api.intercom.io/conversations/searchconversations
+        https://developers.intercom.com/docs/references/2.14/rest-api/api.intercom.io/conversations/searchconversations
       name: conversations
       retriever:
         type: SimpleRetriever
@@ -510,7 +510,7 @@ definitions:
           http_method: POST
           request_headers:
             Accept: application/json
-            Intercom-Version: "2.11"
+            Intercom-Version: "2.14"
           request_body_json:
             sort: "{\"field\": \"updated_at\", \"order\": \"ascending\"}"
             # Intercom Search API timestamps are date-indexed. Keep incremental_sync second-precise for state/client-side filtering,
@@ -2680,6 +2680,31 @@ schemas:
               - "null"
               - integer
             description: The total count of conversation reopens
+          adjusted_handling_time:
+            type:
+              - "null"
+              - integer
+            description: The active handling time excluding idle periods when teammates are not actively working on the conversation.
+          assigned_team_first_response_time:
+            type:
+              - "null"
+              - array
+            description: Response time details for the assigned team.
+            items:
+              type:
+                - "null"
+                - object
+              additionalProperties: true
+          assigned_team_first_response_time_in_office_hours:
+            type:
+              - "null"
+              - array
+            description: Response time details for the assigned team within office hours.
+            items:
+              type:
+                - "null"
+                - object
+              additionalProperties: true
           first_admin_reply_at:
             type:
               - "null"
@@ -2730,6 +2755,11 @@ schemas:
               - "null"
               - integer
             description: Timestamp of the last contact reply
+          handling_time:
+            type:
+              - "null"
+              - integer
+            description: Time from conversation assignment to conversation close in seconds.
           median_time_to_reply:
             type:
               - "null"

--- a/airbyte-integrations/connectors/source-intercom/metadata.yaml
+++ b/airbyte-integrations/connectors/source-intercom/metadata.yaml
@@ -10,7 +10,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: d8313939-3782-41b0-be29-b3ca20d8dd3a
-  dockerImageTag: 0.13.24
+  dockerImageTag: 0.14.0
   dockerRepository: airbyte/source-intercom
   documentationUrl: https://docs.airbyte.com/integrations/sources/intercom
   externalDocumentationUrls:

--- a/docs/integrations/sources/intercom.md
+++ b/docs/integrations/sources/intercom.md
@@ -134,6 +134,7 @@ If you use Airbyte Cloud and your organization restricts access to specific IPs,
 
 | Version      | Date       | Pull Request                                             | Subject                                                                                                                              |
 |:-------------|:-----------|:---------------------------------------------------------|:-------------------------------------------------------------------------------------------------------------------------------------|
+| 0.14.0 | 2026-05-29 | [*PR_NUMBER_PLACEHOLDER*](https://github.com/airbytehq/airbyte/pull/*PR_NUMBER_PLACEHOLDER*) | Update the conversations stream to Intercom API v2.14 and add conversation handling time statistics. |
 | 0.13.24 | 2026-05-21 | | Fix sub-daily incremental syncs for `contacts`, `conversations`, and `tickets` |
 | 0.13.23 | 2026-05-19 | [78171](https://github.com/airbytehq/airbyte/pull/78171) | Promoted release candidate to GA |
 | 0.13.23-rc.1 | 2026-05-12 | [78023](https://github.com/airbytehq/airbyte/pull/78023) | Bump CDK to 7.18.1.post8.dev25490693965 for block_simultaneous_read regression validation |


### PR DESCRIPTION
## What

Link: https://github.com/airbytehq/oncall/issues/11689

Zane Hyatt asked for the recommended narrow Intercom connector update after triage showed that a full v2.11 to v2.15 upgrade would pull in a breaking `tickets.ticket_state` response-shape change.

This PR exposes Intercom conversation handling-time statistics without upgrading the `tickets` stream.

## How

- Updates only the `conversations` stream request header from Intercom API v2.11 to v2.14.
- Adds the v2.13+ `conversation.statistics` fields to the inline schema:
  - `adjusted_handling_time`
  - `handling_time`
  - `assigned_team_first_response_time`
  - `assigned_team_first_response_time_in_office_hours`
- Bumps `source-intercom` from `0.13.24` to `0.14.0` and adds a changelog entry.
- Leaves all other stream headers, including `tickets`, on v2.11 to avoid the known `ticket_state` string-to-object change.

## Review guide

1. `airbyte-integrations/connectors/source-intercom/manifest.yaml`
2. `airbyte-integrations/connectors/source-intercom/metadata.yaml`
3. `docs/integrations/sources/intercom.md`

## User Impact

Users syncing the `conversations` stream can receive the Intercom v2.14 conversation handling-time statistics, including `adjusted_handling_time`, when Intercom returns them.

This should not require a breaking-change migration because it is scoped to additive fields on `conversations`; the `tickets` stream remains on v2.11.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚
- [ ] NO ❌

## Testing

- `git diff --check`
- Manifest text assertions verified:
  - exactly one `Intercom-Version: "2.14"`
  - remaining 12 stream headers still use `Intercom-Version: "2.11"`
  - new conversation statistics fields are present

I did not run live acceptance tests because this change needs Intercom credentials/secrets and eligible conversation data for the new statistics fields.

Link to Devin session: https://app.devin.ai/sessions/30d4f162a5fc4ed7a1267ccd12885f58
Requested by: @ZaneHyattAB