### PR TITLE
fix(source-google-ads): remove problematic response filter

### DIFF
--- a/airbyte-integrations/connectors/source-google-ads/metadata.yaml
+++ b/airbyte-integrations/connectors/source-google-ads/metadata.yaml
@@ -11,7 +11,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 253487c0-2246-43ba-a21f-5116b20a2c50
-  dockerImageTag: 5.0.1
+  dockerImageTag: 5.0.2
   dockerRepository: airbyte/source-google-ads
   documentationUrl: https://docs.airbyte.com/integrations/sources/google-ads
   externalDocumentationUrls:

--- a/airbyte-integrations/connectors/source-google-ads/pyproject.toml
+++ b/airbyte-integrations/connectors/source-google-ads/pyproject.toml
@@ -3,7 +3,7 @@ requires = [ "poetry-core>=1.0.0",]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
-version = "5.0.1"
+version = "5.0.2"
 name = "source-google-ads"
 description = "Source implementation for Google Ads."
 authors = [ "Airbyte <contact@airbyte.io>",]

--- a/airbyte-integrations/connectors/source-google-ads/source_google_ads/manifest.yaml
+++ b/airbyte-integrations/connectors/source-google-ads/source_google_ads/manifest.yaml
@@ -50,14 +50,6 @@ definitions:
     type: DefaultErrorHandler
     response_filters:
       - type: HttpResponseFilter
-        action: FAIL
-        failure_type: config_error
-        http_codes:
-          - 400
-        predicate: "{{ 'UNRECOGNIZED_FIELD' in (response | string) or 'Unrecognized field' in (response | string) }}"
-        error_message: >-
-          {{ (((response[0] if response is iterable and response is not mapping else response).get('error', {}).get('details', [{}])[0].get('errors', [{}])[0].get('message')) or (response[0] if response is iterable and response is not mapping else response).get('error', {}).get('message') or 'Google Ads query contains unrecognized fields.') }}
-      - type: HttpResponseFilter
         action: RETRY
         http_codes:
           - 500

--- a/airbyte-integrations/connectors/source-google-ads/unit_tests/mock_server/test_full_refresh_streams.py
+++ b/airbyte-integrations/connectors/source-google-ads/unit_tests/mock_server/test_full_refresh_streams.py
@@ -1,10 +1,8 @@
 # Copyright (c) 2025 Airbyte, Inc., all rights reserved.
 
 import json
-from collections import namedtuple
 
 import pytest
-from source_google_ads.components import CustomGAQuerySchemaLoader
 
 from airbyte_cdk.models import SyncMode
 from airbyte_cdk.test.catalog_builder import CatalogBuilder
@@ -15,7 +13,6 @@ from unit_tests.mock_server.conftest import create_source
 from unit_tests.mock_server.helpers import (
     API_BASE,
     build_full_refresh_query,
-    build_google_ads_query_error_response,
     build_stream_response,
     setup_full_refresh_parent_mocks,
 )
@@ -192,45 +189,3 @@ def test_full_refresh_403_ignored(stream_name):
         output = read(source, config=config, catalog=catalog)
 
     assert len(output.records) == 0
-
-
-def test_custom_query_unrecognized_field_error_fails_as_config_error(mocker):
-    query = "SELECT campaign.id, campaign.start_date, campaign.end_date FROM campaign"
-    stream_name = "custom_campaign_query"
-    config = ConfigBuilder().with_custom_queries([{"query": query, "table_name": stream_name}]).build()
-
-    data_type = namedtuple("DataType", ["name"])
-    node = namedtuple("Node", ["data_type", "enum_values", "is_repeated"])
-    fields_metadata = {
-        "campaign.id": node(data_type("INT64"), [], False),
-        "campaign.start_date": node(data_type("DATE"), [], False),
-        "campaign.end_date": node(data_type("DATE"), [], False),
-    }
-    mocker.patch.object(
-        CustomGAQuerySchemaLoader,
-        "google_ads_client",
-        return_value=mocker.Mock(get_fields_metadata=lambda fields: fields_metadata),
-    )
-
-    with HttpMocker() as http_mocker:
-        setup_full_refresh_parent_mocks(http_mocker)
-        http_mocker.post(
-            HttpRequest(
-                url=f"{API_BASE}/customers/{_CUSTOMER_ID}/googleAds:searchStream",
-                body=json.dumps({"query": query}),
-            ),
-            build_google_ads_query_error_response(
-                query_error="UNRECOGNIZED_FIELD",
-                message="Unrecognized fields in the query: 'campaign.start_date', 'campaign.end_date'.",
-            ),
-        )
-
-        catalog = CatalogBuilder().with_stream(stream_name, SyncMode.full_refresh).build()
-        source = create_source(config=config, catalog=catalog)
-        output = read(source, config=config, catalog=catalog)
-
-    assert len(output.records) == 0
-    assert output.errors
-    error = output.errors[0].trace.error
-    assert error.failure_type.value == "config_error"
-    assert error.message == "Unrecognized fields in the query: 'campaign.start_date', 'campaign.end_date'."

--- a/docs/integrations/sources/google-ads.md
+++ b/docs/integrations/sources/google-ads.md
@@ -364,16 +364,16 @@ In essence, the conversion window is a tool for measuring the effectiveness of a
 
 In the case of configuring the Google Ads source connector, each time a sync is run the connector will retrieve all conversions that were active within the specified conversion window. For example, if you set a conversion window of 30 days, each time a sync is run, the connector will pull all conversions that were active within the past 30 days. Due to this mechanism, it may seem like the same campaigns, ad groups, or ads have different conversion numbers. However, in reality, each data record accurately reflects the number of conversions for that particular resource at the time of extracting the data from the Google Ads API.
 
-## Performance considerations
+## IP allow list
+
+If you use Airbyte Cloud and your organization restricts access to specific IPs, add the [Airbyte Cloud IP addresses](https://docs.airbyte.com/platform/operating-airbyte/ip-allowlist) to your allow list.
+
+### Performance considerations
 
 This source is constrained by the [Google Ads API limits](https://developers.google.com/google-ads/api/docs/best-practices/quotas)
 
 Due to a limitation in the Google Ads API which does not allow getting performance data at a granularity level smaller than a day, the Google Ads connector usually pulls data up until the previous day. For example, if the sync runs on Wednesday at 5 PM, then data up until Tuesday midnight is pulled. Data for Wednesday is exported only if a sync runs after Wednesday (for example, 12:01 AM on Thursday) and so on. This avoids syncing partial performance data, only to have to resync it again once the full day's data has been recorded by Google. For example, without this functionality, a sync which runs on Wednesday at 5 PM would get ads performance data for Wednesday between 12:01 AM - 5 PM on Wednesday, then it would need to run again at the end of the day to get all of Wednesday's data.
 </HideInUI>
-
-## IP allow list
-
-If you use Airbyte Cloud and your organization restricts access to specific IPs, add the [Airbyte Cloud IP addresses](https://docs.airbyte.com/platform/operating-airbyte/ip-allowlist) to your allow list.
 
 ## Changelog
 

--- a/docs/integrations/sources/google-ads.md
+++ b/docs/integrations/sources/google-ads.md
@@ -382,6 +382,7 @@ If you use Airbyte Cloud and your organization restricts access to specific IPs,
 
 | Version     | Date       | Pull Request                                             | Subject                                                                                                                                                                |
 |:------------|:-----------|:---------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 5.0.2 | 2026-05-29 | [78508](https://github.com/airbytehq/airbyte/pull/78508) | Remove the Google Ads 400 response filter predicate to avoid buffering large streaming responses. |
 | 5.0.1 | 2026-05-26 | [78419](https://github.com/airbytehq/airbyte/pull/78419) | Classify unrecognized fields in custom GAQL queries as configuration errors. |
 | 5.0.0 | 2026-04-20 | [73722](https://github.com/airbytehq/airbyte/pull/73722) | Upgrade Google Ads API from v20 to v23 (field renames, removals, Performance Max ad network type support) and remove nullable `bidding_strategy.id` from primary keys of `campaign_bidding_strategy` and `ad_group_bidding_strategy` streams |
 | 4.2.6 | 2026-05-13 | [78065](https://github.com/airbytehq/airbyte/pull/78065) | Promoted release candidate to GA |


### PR DESCRIPTION
## What
Resolves https://github.com/airbytehq/oncall/issues/12742.

Requested by Daryna Ishchenko.

source-google-ads v5.0.1 added a 400 `HttpResponseFilter` with a response `predicate` for custom GAQL `UNRECOGNIZED_FIELD` errors. Per https://github.com/airbytehq/oncall/issues/12742#issuecomment-4575032472, that predicate can force response JSON parsing on large successful Google Ads streaming responses and cause OOMs.

## How
- Removed the problematic 400 response filter from `manifest.yaml`.
- Bumped source-google-ads from 5.0.1 to 5.0.2.
- Added a 5.0.2 changelog entry.

Breaking change evaluation: not breaking. This does not change connector config/spec, schemas, streams, primary keys, cursors, or state format. It removes an error handler that can buffer large streaming responses; the narrower 400 config-error handling can be restored later with a safer approach.

## Review guide
1. `airbyte-integrations/connectors/source-google-ads/source_google_ads/manifest.yaml`
2. `airbyte-integrations/connectors/source-google-ads/metadata.yaml`
3. `airbyte-integrations/connectors/source-google-ads/pyproject.toml`
4. `docs/integrations/sources/google-ads.md`

## User Impact
Users syncing large Google Ads streams should no longer hit OOMs caused by this response filter buffering streaming responses.

Invalid custom GAQL field errors may temporarily fall back to the connector's default error handling until the response filter is reintroduced safely.

## Can this PR be safely reverted and rolled back?
- [x] YES 💚
- [ ] NO ❌

---
[Devin session](https://app.devin.ai/sessions/83bc7f5212134e1eae563b6e433b9baf)

Requested by: @darynaishchenko