### PR TITLE
chore(source-bing-ads): promote 2.23.17 GA — add num_workers config

### DIFF
--- a/airbyte-integrations/connectors/source-bing-ads/manifest.yaml
+++ b/airbyte-integrations/connectors/source-bing-ads/manifest.yaml
@@ -17472,16 +17472,6 @@ schemas:
           - "null"
           - number
 
-api_budget:
-  type: HTTPAPIBudget
-  policies:
-    - type: MovingWindowCallRatePolicy
-      rates:
-        - limit: 100
-          interval: PT1M
-      matchers: []
-  status_codes_for_ratelimit_hit: [429]
-
 concurrency_level:
   type: ConcurrencyLevel
   default_concurrency: "{{ config.get('num_workers', 10) }}"

--- a/airbyte-integrations/connectors/source-bing-ads/metadata.yaml
+++ b/airbyte-integrations/connectors/source-bing-ads/metadata.yaml
@@ -16,7 +16,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 47f25999-dd5e-4636-8c39-e7cea2453331
-  dockerImageTag: 2.23.17-rc.2
+  dockerImageTag: 2.23.17
   dockerRepository: airbyte/source-bing-ads
   documentationUrl: https://docs.airbyte.com/integrations/sources/bing-ads
   externalDocumentationUrls:
@@ -44,7 +44,7 @@ data:
   releaseStage: generally_available
   releases:
     rolloutConfiguration:
-      enableProgressiveRollout: true
+      enableProgressiveRollout: false
     breakingChanges:
       1.0.0:
         message: Version 1.0.0 removes the primary keys from the geographic performance report streams. This will prevent the connector from losing data in the incremental append+dedup sync mode because of deduplication and incorrect primary keys. A data reset and schema refresh of all the affected streams is required for the changes to take effect.

--- a/docs/integrations/sources/bing-ads.md
+++ b/docs/integrations/sources/bing-ads.md
@@ -317,7 +317,7 @@ If you use Airbyte Cloud and your organization restricts access to specific IPs,
 
 | Version     | Date       | Pull Request                                                                                                                     | Subject                                                                                                                                                                |
 |:------------|:-----------|:---------------------------------------------------------------------------------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| 2.23.17 | 2026-05-29 | [*PR_NUMBER_PLACEHOLDER*](https://github.com/airbytehq/airbyte/pull/*PR_NUMBER_PLACEHOLDER*) | Add num_workers config for user-adjustable concurrency |
+| 2.23.17 | 2026-05-29 | [78518](https://github.com/airbytehq/airbyte/pull/78518) | Add num_workers config for user-adjustable concurrency |
 | 2.23.17-rc.2 | 2026-05-27 | [78438](https://github.com/airbytehq/airbyte/pull/78438) | Revert concurrency to 10, add num_workers config and HTTP API budget |
 | 2.23.17-rc.1 | 2026-05-26 | [78438](https://github.com/airbytehq/airbyte/pull/78438) | Enable progressive rollout for concurrency tuning |
 | 2.23.16 | 2026-04-21 | [76515](https://github.com/airbytehq/airbyte/pull/76515) | Update dependencies |

--- a/docs/integrations/sources/bing-ads.md
+++ b/docs/integrations/sources/bing-ads.md
@@ -317,6 +317,7 @@ If you use Airbyte Cloud and your organization restricts access to specific IPs,
 
 | Version     | Date       | Pull Request                                                                                                                     | Subject                                                                                                                                                                |
 |:------------|:-----------|:---------------------------------------------------------------------------------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 2.23.17 | 2026-05-29 | [*PR_NUMBER_PLACEHOLDER*](https://github.com/airbytehq/airbyte/pull/*PR_NUMBER_PLACEHOLDER*) | Add num_workers config for user-adjustable concurrency |
 | 2.23.17-rc.2 | 2026-05-27 | [78438](https://github.com/airbytehq/airbyte/pull/78438) | Revert concurrency to 10, add num_workers config and HTTP API budget |
 | 2.23.17-rc.1 | 2026-05-26 | [78438](https://github.com/airbytehq/airbyte/pull/78438) | Enable progressive rollout for concurrency tuning |
 | 2.23.16 | 2026-04-21 | [76515](https://github.com/airbytehq/airbyte/pull/76515) | Update dependencies |


### PR DESCRIPTION
## What

Promote source-bing-ads from 2.23.17-rc.2 to 2.23.17 GA. Removes the `api_budget` (HTTPAPIBudget) that was causing duration regressions for a subset of connections, and keeps the `num_workers` user-configurable concurrency setting.

Relates to: https://github.com/airbytehq/airbyte-internal-issues/issues/15318

## How

- Removed the `api_budget` block from the manifest (100 req/min rate limiter was throttling connections with many accounts/reports)
- Promoted version from `2.23.17-rc.2` to `2.23.17` in metadata.yaml
- Updated changelog

The `num_workers` spec property (integer, default=10, min=1, max=20) and its reference in `concurrency_level.default_concurrency` are retained, allowing users to tune concurrency via `config.get('num_workers', 10)`.

## Review guide

1. `airbyte-integrations/connectors/source-bing-ads/manifest.yaml` — api_budget block removed
2. `airbyte-integrations/connectors/source-bing-ads/metadata.yaml` — version bump to 2.23.17
3. `docs/integrations/sources/bing-ads.md` — changelog entry

## User Impact

Users gain a `num_workers` config option to adjust sync concurrency (default remains 10). No behavioral change for existing users unless they explicitly set `num_workers`.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚"

Link to Devin session: https://app.devin.ai/sessions/921816ac374845158c01bcf57ce882e1
Requested by: @sophiecuiy

> [!IMPORTANT]
> Active progressive rollout warning for source-bing-ads.

- [ ] (Click to Approve:) Bypass the active progressive rollout warning for source-bing-ads in the PR comment [here](https://github.com/airbytehq/airbyte/pull/78518#issuecomment-4578235687).