### PR TITLE
feat(source-google-sheets): set concurrency=2, add num_workers and API budget (0.12.28-rc.1)

### DIFF
--- a/airbyte-integrations/connectors/source-google-sheets/manifest.yaml
+++ b/airbyte-integrations/connectors/source-google-sheets/manifest.yaml
@@ -430,6 +430,17 @@ spec:
       - credentials
     additionalProperties: true
     properties:
+      num_workers:
+        type: integer
+        title: Number of Concurrent Threads
+        description: >-
+          Number of concurrent threads for syncing. Higher values can speed up syncs
+          for spreadsheets with multiple sheets, but may hit rate limits. Google Sheets
+          API limits to 300 read requests per minute (~5 req/sec).
+        default: 2
+        minimum: 1
+        maximum: 10
+        order: 9
       batch_size:
         type: integer
         title: Row Batch Size
@@ -650,7 +661,19 @@ spec:
               - client_secret
 
 
+# Rate limits: https://developers.google.com/sheets/api/limits
+# - 300 read requests per minute per project (~5 req/sec)
+api_budget:
+  type: HTTPAPIBudget
+  policies:
+    - type: MovingWindowCallRatePolicy
+      rates:
+        - limit: 300
+          interval: PT1M
+      matchers: []  # Applies to all endpoints
+  status_codes_for_ratelimit_hit: [429]
+
 concurrency_level:
   type: ConcurrencyLevel
-  default_concurrency: 4
-  max_concurrency: 4
+  default_concurrency: "{{ config.get('num_workers', 2) }}"
+  max_concurrency: 10

--- a/airbyte-integrations/connectors/source-google-sheets/metadata.yaml
+++ b/airbyte-integrations/connectors/source-google-sheets/metadata.yaml
@@ -10,7 +10,7 @@ data:
   connectorSubtype: file
   connectorType: source
   definitionId: 71607ba1-c0ac-4799-8049-7f4b90dd50f7
-  dockerImageTag: 0.12.27-rc.1
+  dockerImageTag: 0.12.28-rc.1
   dockerRepository: airbyte/source-google-sheets
   documentationUrl: https://docs.airbyte.com/integrations/sources/google-sheets
   externalDocumentationUrls:

--- a/docs/integrations/sources/google-sheets.md
+++ b/docs/integrations/sources/google-sheets.md
@@ -309,7 +309,7 @@ If you use Airbyte Cloud and your organization restricts access to specific IPs,
 
 | Version    | Date       | Pull Request                                             | Subject                                                                                                                                                                |
 |------------|------------|----------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| 0.12.28-rc.1 | 2026-05-29 | [*PR_NUMBER_PLACEHOLDER*](https://github.com/airbytehq/airbyte/pull/*PR_NUMBER_PLACEHOLDER*) | Set default_concurrency to 2, add num_workers spec field, add HTTP API budget |
+| 0.12.28-rc.1 | 2026-05-29 | [78519](https://github.com/airbytehq/airbyte/pull/78519) | Set default_concurrency to 2, add num_workers spec field, add HTTP API budget |
 | 0.12.27-rc.1 | 2026-05-26 | [78437](https://github.com/airbytehq/airbyte/pull/78437) | Set default_concurrency to 4 for concurrency tuning |
 | 0.12.26 | 2026-05-26 | [78443](https://github.com/airbytehq/airbyte/pull/78443) | Update dependencies |
 | 0.12.25 | 2026-04-28 | [77273](https://github.com/airbytehq/airbyte/pull/77273) | Update dependencies |

--- a/docs/integrations/sources/google-sheets.md
+++ b/docs/integrations/sources/google-sheets.md
@@ -309,6 +309,7 @@ If you use Airbyte Cloud and your organization restricts access to specific IPs,
 
 | Version    | Date       | Pull Request                                             | Subject                                                                                                                                                                |
 |------------|------------|----------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 0.12.28-rc.1 | 2026-05-29 | [*PR_NUMBER_PLACEHOLDER*](https://github.com/airbytehq/airbyte/pull/*PR_NUMBER_PLACEHOLDER*) | Set default_concurrency to 2, add num_workers spec field, add HTTP API budget |
 | 0.12.27-rc.1 | 2026-05-26 | [78437](https://github.com/airbytehq/airbyte/pull/78437) | Set default_concurrency to 4 for concurrency tuning |
 | 0.12.26 | 2026-05-26 | [78443](https://github.com/airbytehq/airbyte/pull/78443) | Update dependencies |
 | 0.12.25 | 2026-04-28 | [77273](https://github.com/airbytehq/airbyte/pull/77273) | Update dependencies |


### PR DESCRIPTION
## What

Concurrency tuning iteration 2 for `source-google-sheets`. Follows up on https://github.com/airbytehq/airbyte/pull/78437 (merged, concurrency=4).

Iteration 1 (concurrency=4) showed speed regressions on single-stream connections and no API budget to enforce rate limits. Per user direction, this iteration:
- Reduces `default_concurrency` from 4 to 2
- Adds `num_workers` as a user-configurable spec field (default=2, min=1, max=10)
- Adds an HTTP API budget enforcing the Google Sheets API limit (300 req/min)

Related issue: https://github.com/airbytehq/airbyte-internal-issues/issues/15321

## How

Changes to `manifest.yaml`:
1. `concurrency_level.default_concurrency` changed from `4` to `{{ config.get('num_workers', 2) }}` — reads from user spec, defaults to 2
2. `concurrency_level.max_concurrency` changed from `4` to `10` — allows users to go higher if needed
3. Added `api_budget` block with `HTTPAPIBudget` enforcing 300 req/min via `MovingWindowCallRatePolicy`
4. Added `num_workers` integer field to spec (default=2, min=1, max=10, order=9)

## Review guide

1. `airbyte-integrations/connectors/source-google-sheets/manifest.yaml` — all three changes
2. `airbyte-integrations/connectors/source-google-sheets/metadata.yaml` — version bump to 0.12.28-rc.1
3. `docs/integrations/sources/google-sheets.md` — changelog entry

## User Impact

Users gain a `num_workers` field to control concurrency and an API budget that respects Google Sheets rate limits. Default behavior changes from concurrency=4 (no budget) to concurrency=2 (with 300 req/min budget), which should reduce rate-limit-related slowdowns.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Link to Devin session: https://app.devin.ai/sessions/3cfd1c912163463ebf4825bcc2fdc681
Requested by: @sophiecuiy

> [!IMPORTANT]
> Active progressive rollout warning for source-google-sheets.

- [ ] (Click to Approve:) Bypass the active progressive rollout warning for source-google-sheets in the PR comment [here](https://github.com/airbytehq/airbyte/pull/78519#issuecomment-4578406796).