### PR TITLE
perf(source-instagram): add HTTPAPIBudget for rate limit protection (4.2.29-rc.2)

### DIFF
--- a/airbyte-integrations/connectors/source-instagram/manifest.yaml
+++ b/airbyte-integrations/connectors/source-instagram/manifest.yaml
@@ -741,6 +741,19 @@ concurrency_level:
   default_concurrency: "{{ config.get('num_workers', 20) }}"
   max_concurrency: 50
 
+# Facebook Graph API BUC (Business Use Case) rate limits are dynamic and impression-based.
+# This budget acts as a safety net to prevent excessive request bursts.
+api_budget:
+  type: HTTPAPIBudget
+  policies:
+    - type: MovingWindowCallRatePolicy
+      rates:
+        - limit: 200
+          interval: PT1M
+      matchers: []
+  status_codes_for_ratelimit_hit:
+    - 429
+
 metadata:
   autoImportSchema:
     Media: true

--- a/airbyte-integrations/connectors/source-instagram/metadata.yaml
+++ b/airbyte-integrations/connectors/source-instagram/metadata.yaml
@@ -7,7 +7,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 6acf6b55-4f1e-4fca-944e-1a3caef8aba8
-  dockerImageTag: 4.2.29-rc.1
+  dockerImageTag: 4.2.29-rc.2
   dockerRepository: airbyte/source-instagram
   githubIssueLabel: source-instagram
   icon: instagram.svg

--- a/docs/integrations/sources/instagram.md
+++ b/docs/integrations/sources/instagram.md
@@ -119,6 +119,7 @@ If you use Airbyte Cloud and your organization restricts access to specific IPs,
 
 | Version    | Date       | Pull Request                                             | Subject                                                                                                                                                                |
 |:-----------|:-----------|:---------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 4.2.29-rc.2 | 2026-05-26 | [78440](https://github.com/airbytehq/airbyte/pull/78440) | Add HTTPAPIBudget for rate limit protection |
 | 4.2.29-rc.1 | 2026-05-26 | [78440](https://github.com/airbytehq/airbyte/pull/78440) | Enable progressive rollout for concurrency tuning |
 | 4.2.28 | 2026-04-28 | [77272](https://github.com/airbytehq/airbyte/pull/77272) | Update dependencies |
 | 4.2.27 | 2026-04-21 | [76627](https://github.com/airbytehq/airbyte/pull/76627) | Update dependencies |


### PR DESCRIPTION
## What

Add an `HTTPAPIBudget` to source-instagram as part of the ongoing concurrency tuning rollout (Phase 1). Bump RC version from 4.2.29-rc.1 to 4.2.29-rc.2.

Related: https://github.com/airbytehq/airbyte-internal-issues/issues/15323
Epic: https://github.com/airbytehq/airbyte-internal-issues/issues/15262
Requested by: @sophiecuiy

## How

- Added `api_budget` block with `HTTPAPIBudget` and `MovingWindowCallRatePolicy` (200 calls/min) to `manifest.yaml` as a safety net against excessive request bursts
- Bumped `dockerImageTag` from `4.2.29-rc.1` to `4.2.29-rc.2` in `metadata.yaml`
- Concurrency remains at 20 (unchanged from rc.1)
- Updated changelog

## Review guide

1. `airbyte-integrations/connectors/source-instagram/manifest.yaml` — new `api_budget` block
2. `airbyte-integrations/connectors/source-instagram/metadata.yaml` — version bump
3. `docs/integrations/sources/instagram.md` — changelog entry

## User Impact

Rate limit protection via HTTPAPIBudget. No user-facing config changes. This is an RC version for progressive rollout testing only.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Link to Devin session: https://app.devin.ai/sessions/e52d4b4f076e4bd984b93eb313068f9f

> [!IMPORTANT]
> Active progressive rollout warning for source-instagram.

- [ ] (Click to Approve:) Bypass the active progressive rollout warning for source-instagram in the PR comment [here](https://github.com/airbytehq/airbyte/pull/78520#issuecomment-4578458877).