### PR TITLE
chore(source-sentry): GA 0.9.22 — add num_workers, default_concurrency=5, no apibudget

### DIFF
--- a/airbyte-integrations/connectors/source-sentry/manifest.yaml
+++ b/airbyte-integrations/connectors/source-sentry/manifest.yaml
@@ -320,6 +320,7 @@ spec:
 concurrency_level:
   type: ConcurrencyLevel
   default_concurrency: "{{ config.get('num_workers', 5) }}"
+  max_concurrency: 20
 
 metadata:
   assist: {}

--- a/airbyte-integrations/connectors/source-sentry/manifest.yaml
+++ b/airbyte-integrations/connectors/source-sentry/manifest.yaml
@@ -304,11 +304,22 @@ spec:
         item: string
         order: 4
         title: Discover Event Fields
+      num_workers:
+        type: integer
+        title: Number of concurrent workers
+        description: >-
+          The number of worker threads to use for the sync. The default of 5 is
+          safe for all Sentry API plans. Testing showed concurrency of 7 is
+          optimal; increase if your Sentry plan supports higher rate limits.
+        minimum: 1
+        maximum: 20
+        default: 5
+        order: 5
     additionalProperties: true
 
 concurrency_level:
   type: ConcurrencyLevel
-  default_concurrency: 8
+  default_concurrency: "{{ config.get('num_workers', 5) }}"
 
 metadata:
   assist: {}

--- a/airbyte-integrations/connectors/source-sentry/metadata.yaml
+++ b/airbyte-integrations/connectors/source-sentry/metadata.yaml
@@ -10,7 +10,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: cdaf146a-9b75-49fd-9dd2-9d64a0bb4781
-  dockerImageTag: 0.9.22-rc.2
+  dockerImageTag: 0.9.22
   dockerRepository: airbyte/source-sentry
   documentationUrl: https://docs.airbyte.com/integrations/sources/sentry
   externalDocumentationUrls:
@@ -74,5 +74,5 @@ data:
             alias: airbyte-connector-testing-secret-store
   releases:
     rolloutConfiguration:
-      enableProgressiveRollout: true
+      enableProgressiveRollout: false
 metadataSpecVersion: "1.0"

--- a/docs/integrations/sources/sentry.md
+++ b/docs/integrations/sources/sentry.md
@@ -70,6 +70,7 @@ If you use Airbyte Cloud and your organization restricts access to specific IPs,
 
 | Version | Date       | Pull Request                                             | Subject                                                                                                                                                                |
 |:--------|:-----------|:---------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 0.9.22 | 2026-06-01 | [*PR_NUMBER_PLACEHOLDER*](https://github.com/airbytehq/airbyte/pull/*PR_NUMBER_PLACEHOLDER*) | Add user-configurable `num_workers` concurrency setting (default 5, tested optimal at 7) |
 | 0.9.22-rc.2 | 2026-05-27 | [78468](https://github.com/airbytehq/airbyte/pull/78468) | Concurrency tuning iteration 2 — bump default_concurrency from 7 to 8 |
 | 0.9.22-rc.1 | 2026-05-26 | [78444](https://github.com/airbytehq/airbyte/pull/78444) | Concurrency tuning — bump default_concurrency from 5 to 7 for progressive rollout |
 | 0.9.21 | 2026-04-28 | [77407](https://github.com/airbytehq/airbyte/pull/77407) | Update dependencies |

--- a/docs/integrations/sources/sentry.md
+++ b/docs/integrations/sources/sentry.md
@@ -70,7 +70,7 @@ If you use Airbyte Cloud and your organization restricts access to specific IPs,
 
 | Version | Date       | Pull Request                                             | Subject                                                                                                                                                                |
 |:--------|:-----------|:---------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| 0.9.22 | 2026-06-01 | [*PR_NUMBER_PLACEHOLDER*](https://github.com/airbytehq/airbyte/pull/*PR_NUMBER_PLACEHOLDER*) | Add user-configurable `num_workers` concurrency setting (default 5, tested optimal at 7) |
+| 0.9.22 | 2026-06-01 | [78537](https://github.com/airbytehq/airbyte/pull/78537) | Add user-configurable `num_workers` concurrency setting (default 5, tested optimal at 7) |
 | 0.9.22-rc.2 | 2026-05-27 | [78468](https://github.com/airbytehq/airbyte/pull/78468) | Concurrency tuning iteration 2 — bump default_concurrency from 7 to 8 |
 | 0.9.22-rc.1 | 2026-05-26 | [78444](https://github.com/airbytehq/airbyte/pull/78444) | Concurrency tuning — bump default_concurrency from 5 to 7 for progressive rollout |
 | 0.9.21 | 2026-04-28 | [77407](https://github.com/airbytehq/airbyte/pull/77407) | Update dependencies |


### PR DESCRIPTION
## What

GA release for source-sentry concurrency tuning. Requested by @sophiecuiy.

Closes https://github.com/airbytehq/airbyte-internal-issues/issues/15327

Changes:
- Promote version from `0.9.22-rc.2` to `0.9.22` (GA)
- Set `default_concurrency` to 5 (via `config.get('num_workers', 5)`)
- Add user-configurable `num_workers` to the connector spec (default=5, min=1, max=20)
- No `HttpAPIBudget` added (Path A, zero 429 errors observed across all tuning iterations)
- Disable progressive rollout (`enableProgressiveRollout: false`)

## How

- `manifest.yaml`: Changed `default_concurrency: 8` → `"{{ config.get('num_workers', 5) }}"` so the spec value overrides the manifest default
- `manifest.yaml`: Added `num_workers` integer field to the spec with default=5, description noting c=7 was tested optimal
- `metadata.yaml`: Version promoted from `0.9.22-rc.2` → `0.9.22`, progressive rollout disabled
- `docs/integrations/sources/sentry.md`: Changelog entry added

**Tuning summary (Phases 0-3):**
- c=5 (stable baseline): 178s aggregate mean
- c=7 (rc.1): 159s aggregate mean (-10.8%) — PASS
- c=8 (rc.2): 215s aggregate mean (+35.4% vs rc.1) — FAIL, reverted
- Full Tier 2 rollout on rc.1 (c=7): 0% failure rate, 0 rate-limit errors, -1.0% vs stable
- No Tier 1/Tier 0 actors exist for this connector

## Review guide

1. `airbyte-integrations/connectors/source-sentry/manifest.yaml` — `num_workers` spec field + concurrency_level Jinja expression
2. `airbyte-integrations/connectors/source-sentry/metadata.yaml` — version promote + rollout disable
3. `docs/integrations/sources/sentry.md` — changelog

## User Impact

Users get a new optional `num_workers` configuration field. Default concurrency is 5; users can increase up to 20 for faster syncs if their Sentry API plan supports it.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

- [x] (Click to Approve:) Bypass the active progressive rollout warning for source-sentry in the PR comment

Link to Devin session: https://app.devin.ai/sessions/fe2b0b4604e34b5d9581be9819daf5e0