### PR TITLE
feat(source-facebook-marketing): Add attribution_spec field to AdSets stream

### DIFF
--- a/airbyte-integrations/connectors/source-facebook-marketing/metadata.yaml
+++ b/airbyte-integrations/connectors/source-facebook-marketing/metadata.yaml
@@ -10,7 +10,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: e7778cfc-e97c-4458-9ecb-b4f2bba8946c
-  dockerImageTag: 5.2.12
+  dockerImageTag: 5.3.0
   dockerRepository: airbyte/source-facebook-marketing
   documentationUrl: https://docs.airbyte.com/integrations/sources/facebook-marketing
   externalDocumentationUrls:

--- a/airbyte-integrations/connectors/source-facebook-marketing/pyproject.toml
+++ b/airbyte-integrations/connectors/source-facebook-marketing/pyproject.toml
@@ -3,7 +3,7 @@ requires = [ "poetry-core>=1.0.0",]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
-version = "5.2.12"
+version = "5.3.0"
 name = "source-facebook-marketing"
 description = "Source implementation for Facebook Marketing."
 authors = [ "Airbyte <contact@airbyte.io>",]

--- a/airbyte-integrations/connectors/source-facebook-marketing/source_facebook_marketing/schemas/ad_sets.json
+++ b/airbyte-integrations/connectors/source-facebook-marketing/source_facebook_marketing/schemas/ad_sets.json
@@ -187,6 +187,23 @@
           }
         }
       }
+    },
+    "attribution_spec": {
+      "description": "Conversion attribution spec used for attributing conversions for optimization. Supported window lengths differ by optimization goal and campaign objective.",
+      "type": ["null", "array"],
+      "items": {
+        "type": "object",
+        "properties": {
+          "event_type": {
+            "description": "The type of conversion event to which the attribution applies.",
+            "type": "string"
+          },
+          "window_days": {
+            "description": "The attribution window in days. Common values: 1, 7, or 28 depending on the event type.",
+            "type": "integer"
+          }
+        }
+      }
     }
   }
 }

--- a/airbyte-integrations/connectors/source-facebook-marketing/unit_tests/integration/test_include_deleted.py
+++ b/airbyte-integrations/connectors/source-facebook-marketing/unit_tests/integration/test_include_deleted.py
@@ -179,6 +179,7 @@ class TestIncludeDeleted(TestCase):
             "bid_constraints",
             "adlabels",
             "learning_stage_info",
+            "attribution_spec",
         ]
 
         http_mocker.get(

--- a/airbyte-integrations/connectors/source-facebook-marketing/unit_tests/resource/http/response/ad_sets.json
+++ b/airbyte-integrations/connectors/source-facebook-marketing/unit_tests/resource/http/response/ad_sets.json
@@ -40,7 +40,13 @@
         "conversions": 12,
         "last_sig_edit_ts": 1734947501,
         "attribution_windows": ["7d_click", "1d_view"]
-      }
+      },
+      "attribution_spec": [
+        {
+          "event_type": "OFFSITE_CONVERSIONS",
+          "window_days": 7
+        }
+      ]
     }
   ]
 }

--- a/docs/integrations/sources/facebook-marketing.md
+++ b/docs/integrations/sources/facebook-marketing.md
@@ -480,6 +480,7 @@ If you use Airbyte Cloud and your organization restricts access to specific IPs,
 
 | Version    | Date       | Pull Request                                             | Subject                                                                                                                                                                                                                                                                                           |
 |:-----------|:-----------|:---------------------------------------------------------|:--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 5.3.0 | 2026-06-01 | [59655](https://github.com/airbytehq/airbyte/pull/59655) | Add `attribution_spec` field to `ad_sets` stream |
 | 5.2.12 | 2026-05-27 | [78451](https://github.com/airbytehq/airbyte/pull/78451) | Promoted release candidate to GA |
 | 5.2.12-rc.1 | 2026-05-20 | [75457](https://github.com/airbytehq/airbyte/pull/75457) | Bump facebook-business SDK from v23 to v25 to support Marketing API v25.0 before v23.0 sunset on June 9, 2026 |
 | 5.2.11 | 2026-04-28 | [76977](https://github.com/airbytehq/airbyte/pull/76977) | Bump airbyte-cdk to ^7.17.4; facebook-business updated to 23.0.3 via lockfile refresh |


### PR DESCRIPTION
## What

Adds the `attribution_spec` field to the AdSets stream in `source-facebook-marketing` when it is available. Rebased on current `master` (5.2.12, Marketing API v25); supersedes the previously-closed #59655.

## How

The `ad_sets` stream schema is extended with a new top-level `attribution_spec` property (nullable array of `{event_type, window_days}`). Version bumped to 5.3.0.

## Review guide

1. `airbyte-integrations/connectors/source-facebook-marketing/source_facebook_marketing/schemas/ad_sets.json`

## User Impact

Users can now see the configured conversion attribution window per ad set.

## Can this PR be safely reverted and rolled back?
- [x] YES 💚
- [ ] NO ❌