### PR TITLE
Test S3 Data Lake equality delete Bloom filter

### DIFF
--- a/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/build.gradle
+++ b/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/build.gradle
@@ -8,6 +8,8 @@ dependencies {
     implementation project(':airbyte-cdk:bulk:core:bulk-cdk-core-base')
     implementation project(':airbyte-cdk:bulk:core:bulk-cdk-core-load')
 
+    implementation 'org.apache.commons:commons-collections4:4.5.0'
+
     // Hadoop Configuration class used by Iceberg
     implementation 'org.apache.hadoop:hadoop-common:3.4.1'
 

--- a/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/java/io/airbyte/cdk/load/toolkits/iceberg/parquet/io/BaseDeltaTaskWriter.java
+++ b/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/java/io/airbyte/cdk/load/toolkits/iceberg/parquet/io/BaseDeltaTaskWriter.java
@@ -43,6 +43,7 @@ public abstract class BaseDeltaTaskWriter extends BaseTaskWriter<Record> {
   private final Schema deleteSchema;
   private final InternalRecordWrapper wrapper;
   private final InternalRecordWrapper keyWrapper;
+  private final EqualityDeleteKeyTracker equalityDeleteKeyTracker;
 
   public BaseDeltaTaskWriter(final Table table,
                              final PartitionSpec spec,
@@ -53,12 +54,27 @@ public abstract class BaseDeltaTaskWriter extends BaseTaskWriter<Record> {
                              final long targetFileSize,
                              final Schema schema,
                              final Set<Integer> identifierFieldIds) {
+    this(table, spec, format, appenderFactory, fileFactory, io, targetFileSize, schema,
+        identifierFieldIds, null);
+  }
+
+  public BaseDeltaTaskWriter(final Table table,
+                             final PartitionSpec spec,
+                             final FileFormat format,
+                             final FileAppenderFactory<Record> appenderFactory,
+                             final OutputFileFactory fileFactory,
+                             final FileIO io,
+                             final long targetFileSize,
+                             final Schema schema,
+                             final Set<Integer> identifierFieldIds,
+                             final EqualityDeleteKeyTracker equalityDeleteKeyTracker) {
     super(spec, format, appenderFactory, fileFactory, io, targetFileSize);
     this.table = table;
     this.schema = schema;
     this.deleteSchema = TypeUtil.select(schema, identifierFieldIds);
     this.wrapper = new InternalRecordWrapper(schema.asStruct());
     this.keyWrapper = new InternalRecordWrapper(deleteSchema.asStruct());
+    this.equalityDeleteKeyTracker = equalityDeleteKeyTracker;
   }
 
   public abstract RowDataDeltaWriter route(final Record row);
@@ -90,11 +106,21 @@ public abstract class BaseDeltaTaskWriter extends BaseTaskWriter<Record> {
     if (rowOperation == Operation.INSERT) {
       writer.write(row);
     } else if (rowOperation == Operation.DELETE) {
-      writer.deleteKey(constructIdentifierRecord(row));
+      final Record identifierRecord = constructIdentifierRecord(row);
+      if (shouldDeleteKey(identifierRecord)) {
+        writer.deleteKey(identifierRecord);
+      }
     } else {
-      writer.deleteKey(constructIdentifierRecord(row));
+      final Record identifierRecord = constructIdentifierRecord(row);
+      if (shouldDeleteKey(identifierRecord)) {
+        writer.deleteKey(identifierRecord);
+      }
       writer.write(row);
     }
+  }
+
+  private boolean shouldDeleteKey(final Record identifierRecord) {
+    return equalityDeleteKeyTracker == null || equalityDeleteKeyTracker.shouldDelete(identifierRecord);
   }
 
   private Operation getOperation(final Record row) {

--- a/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/kotlin/io/airbyte/cdk/load/toolkits/iceberg/parquet/io/EqualityDeleteBloomFilter.kt
+++ b/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/kotlin/io/airbyte/cdk/load/toolkits/iceberg/parquet/io/EqualityDeleteBloomFilter.kt
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2026 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.cdk.load.toolkits.iceberg.parquet.io
+
+import io.github.oshai.kotlinlogging.KotlinLogging
+import java.io.ByteArrayOutputStream
+import java.io.DataOutputStream
+import java.nio.ByteBuffer
+import java.nio.charset.StandardCharsets
+import java.security.MessageDigest
+import org.apache.commons.collections4.bloomfilter.EnhancedDoubleHasher
+import org.apache.commons.collections4.bloomfilter.Shape
+import org.apache.commons.collections4.bloomfilter.SimpleBloomFilter
+import org.apache.iceberg.Schema
+import org.apache.iceberg.data.Record
+
+interface EqualityDeleteKeyTracker {
+    fun shouldDelete(identifierRecord: Record): Boolean
+    fun logSummary(reason: String)
+}
+
+class EqualityDeleteBloomFilter(
+    private val streamName: String,
+    private val deleteSchema: Schema,
+    expectedItems: Int,
+    numberOfBits: Int,
+    numberOfHashFunctions: Int,
+    private val logIntervalRecords: Long,
+) : EqualityDeleteKeyTracker {
+    private val log = KotlinLogging.logger {}
+    private val shape = Shape.fromNMK(expectedItems, numberOfBits, numberOfHashFunctions)
+    private val bloomFilter = SimpleBloomFilter(shape)
+    private val digest = MessageDigest.getInstance("SHA-256")
+
+    private var checkedKeys = 0L
+    private var missesAdded = 0L
+    private var probableHits = 0L
+    private var equalityDeletesEmitted = 0L
+    private var equalityDeletesSkipped = 0L
+
+    init {
+        log.info {
+            "Enabled primary key Bloom filter for stream $streamName " +
+                "(expectedItems=$expectedItems, numberOfBits=$numberOfBits, " +
+                "numberOfHashFunctions=$numberOfHashFunctions, " +
+                "configuredFalsePositiveProbability=${shape.getProbability(expectedItems)})"
+        }
+    }
+
+    @Synchronized
+    override fun shouldDelete(identifierRecord: Record): Boolean {
+        checkedKeys += 1
+        val hasher = EnhancedDoubleHasher(digest.digest(serializeIdentifierRecord(identifierRecord)))
+        val probableHit = bloomFilter.contains(hasher)
+
+        if (probableHit) {
+            probableHits += 1
+            equalityDeletesEmitted += 1
+        } else {
+            bloomFilter.merge(hasher)
+            missesAdded += 1
+            equalityDeletesSkipped += 1
+        }
+
+        if (logIntervalRecords > 0 && checkedKeys % logIntervalRecords == 0L) {
+            logStats("periodic")
+        }
+
+        return probableHit
+    }
+
+    @Synchronized
+    override fun logSummary(reason: String) {
+        logStats(reason)
+    }
+
+    private fun logStats(reason: String) {
+        val estimatedItems = bloomFilter.estimateN()
+        log.info {
+            "Primary key Bloom filter stats for stream $streamName ($reason): " +
+                "checkedKeys=$checkedKeys, missesAdded=$missesAdded, " +
+                "probableHits=$probableHits, equalityDeletesEmitted=$equalityDeletesEmitted, " +
+                "equalityDeletesSkipped=$equalityDeletesSkipped, cardinality=${bloomFilter.cardinality()}, " +
+                "estimatedItems=$estimatedItems, " +
+                "estimatedFalsePositiveProbability=${shape.getProbability(estimatedItems)}, " +
+                "numberOfBits=${shape.numberOfBits}, " +
+                "numberOfHashFunctions=${shape.numberOfHashFunctions}"
+        }
+    }
+
+    private fun serializeIdentifierRecord(identifierRecord: Record): ByteArray {
+        val output = ByteArrayOutputStream()
+        DataOutputStream(output).use { data ->
+            data.writeInt(deleteSchema.columns().size)
+            deleteSchema.columns().forEach { field ->
+                val value = identifierRecord.getField(field.name())
+                data.writeInt(field.fieldId())
+                data.writeUTF(field.name())
+                data.writeUTF(value.javaClass.name)
+                val bytes = serializeValue(value)
+                data.writeInt(bytes.size)
+                data.write(bytes)
+            }
+        }
+        return output.toByteArray()
+    }
+
+    private fun serializeValue(value: Any): ByteArray {
+        return when (value) {
+            is ByteArray -> value
+            is ByteBuffer -> {
+                val duplicate = value.duplicate()
+                val bytes = ByteArray(duplicate.remaining())
+                duplicate.get(bytes)
+                bytes
+            }
+            else -> value.toString().toByteArray(StandardCharsets.UTF_8)
+        }
+    }
+}

--- a/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/kotlin/io/airbyte/cdk/load/toolkits/iceberg/parquet/io/IcebergTableWriterFactory.kt
+++ b/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/kotlin/io/airbyte/cdk/load/toolkits/iceberg/parquet/io/IcebergTableWriterFactory.kt
@@ -55,7 +55,8 @@ class IcebergTableWriterFactory {
         table: Table,
         generationId: String,
         importType: ImportType,
-        schema: Schema
+        schema: Schema,
+        equalityDeleteKeyTracker: EqualityDeleteKeyTracker? = null,
     ): BaseTaskWriter<Record> {
         assertGenerationIdSuffixIsOfValidFormat(generationId)
         val format =
@@ -99,7 +100,8 @@ class IcebergTableWriterFactory {
                     appenderFactory = appenderFactory,
                     targetFileSize = targetFileSize,
                     outputFileFactory = outputFileFactory,
-                    format = format
+                    format = format,
+                    equalityDeleteKeyTracker = equalityDeleteKeyTracker,
                 )
             else -> throw IllegalArgumentException("Unsupported import type $importType")
         }
@@ -171,7 +173,8 @@ class IcebergTableWriterFactory {
         appenderFactory: GenericAppenderFactory,
         outputFileFactory: OutputFileFactory,
         targetFileSize: Long,
-        identifierFieldIds: Set<Int>
+        identifierFieldIds: Set<Int>,
+        equalityDeleteKeyTracker: EqualityDeleteKeyTracker?,
     ): BaseTaskWriter<Record> {
         return if (table.spec().isUnpartitioned) {
             UnpartitionedDeltaWriter(
@@ -183,7 +186,8 @@ class IcebergTableWriterFactory {
                 io = table.io(),
                 targetFileSize = targetFileSize,
                 schema = schema,
-                identifierFieldIds = identifierFieldIds
+                identifierFieldIds = identifierFieldIds,
+                equalityDeleteKeyTracker = equalityDeleteKeyTracker,
             )
         } else {
             PartitionedDeltaWriter(
@@ -195,7 +199,8 @@ class IcebergTableWriterFactory {
                 io = table.io(),
                 targetFileSize = targetFileSize,
                 schema = schema,
-                identifierFieldIds = identifierFieldIds
+                identifierFieldIds = identifierFieldIds,
+                equalityDeleteKeyTracker = equalityDeleteKeyTracker,
             )
         }
     }

--- a/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/kotlin/io/airbyte/cdk/load/toolkits/iceberg/parquet/io/PartitionedWriters.kt
+++ b/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/kotlin/io/airbyte/cdk/load/toolkits/iceberg/parquet/io/PartitionedWriters.kt
@@ -33,6 +33,7 @@ class PartitionedDeltaWriter(
     targetFileSize: Long,
     schema: Schema,
     identifierFieldIds: Set<Int>,
+    equalityDeleteKeyTracker: EqualityDeleteKeyTracker? = null,
 ) :
     BaseDeltaTaskWriter(
         table,
@@ -43,7 +44,8 @@ class PartitionedDeltaWriter(
         io,
         targetFileSize,
         schema,
-        identifierFieldIds
+        identifierFieldIds,
+        equalityDeleteKeyTracker
     ) {
 
     private val partitionKey = PartitionKey(spec, schema)

--- a/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/kotlin/io/airbyte/cdk/load/toolkits/iceberg/parquet/io/UnpartitionedWriters.kt
+++ b/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/kotlin/io/airbyte/cdk/load/toolkits/iceberg/parquet/io/UnpartitionedWriters.kt
@@ -28,6 +28,7 @@ class UnpartitionedDeltaWriter(
     targetFileSize: Long,
     schema: Schema,
     identifierFieldIds: Set<Int>,
+    equalityDeleteKeyTracker: EqualityDeleteKeyTracker? = null,
 ) :
     BaseDeltaTaskWriter(
         table,
@@ -38,7 +39,8 @@ class UnpartitionedDeltaWriter(
         io,
         targetFileSize,
         schema,
-        identifierFieldIds
+        identifierFieldIds,
+        equalityDeleteKeyTracker
     ) {
 
     private val writer = RowDataDeltaWriter(null)

--- a/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/test/kotlin/io/airbyte/cdk/load/toolkits/iceberg/parquet/io/BaseDeltaTaskWriterTest.kt
+++ b/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/test/kotlin/io/airbyte/cdk/load/toolkits/iceberg/parquet/io/BaseDeltaTaskWriterTest.kt
@@ -12,11 +12,15 @@ import org.apache.iceberg.PartitionSpec
 import org.apache.iceberg.Schema
 import org.apache.iceberg.Table
 import org.apache.iceberg.TableProperties.WRITE_TARGET_FILE_SIZE_BYTES_DEFAULT
+import org.apache.iceberg.data.GenericRecord
 import org.apache.iceberg.data.Record
 import org.apache.iceberg.io.FileAppenderFactory
 import org.apache.iceberg.io.FileIO
 import org.apache.iceberg.io.OutputFileFactory
+import org.apache.iceberg.types.TypeUtil
 import org.apache.iceberg.types.Types
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.EnumSource
@@ -114,6 +118,132 @@ internal class BaseDeltaTaskWriterTest {
         verify(exactly = 0) { deltaWriter.deleteKey(record) }
     }
 
+    @Test
+    fun `bloom filter skips first update delete and emits repeated update delete`() {
+        val columns =
+            mutableListOf(
+                Types.NestedField.required(1, "id", Types.IntegerType.get()),
+                Types.NestedField.required(2, "name", Types.StringType.get()),
+            )
+        val primaryKeyIds = setOf(1)
+        val schema = Schema(columns, primaryKeyIds)
+        val deltaWriter = mockDeltaWriter()
+        val writer =
+            testWriter(
+                schema = schema,
+                primaryKeyIds = primaryKeyIds,
+                deltaWriter = deltaWriter,
+                equalityDeleteKeyTracker = testBloomFilter(schema, primaryKeyIds),
+            )
+
+        writer.write(RecordWrapper(record(schema, 1, "first"), Operation.UPDATE))
+        writer.write(RecordWrapper(record(schema, 1, "second"), Operation.UPDATE))
+
+        verify(exactly = 1) { deltaWriter.deleteKey(any()) }
+        verify(exactly = 2) { deltaWriter.write(any()) }
+    }
+
+    @Test
+    fun `bloom filter skips first delete and emits repeated delete`() {
+        val columns =
+            mutableListOf(
+                Types.NestedField.required(1, "id", Types.IntegerType.get()),
+                Types.NestedField.required(2, "name", Types.StringType.get()),
+            )
+        val primaryKeyIds = setOf(1)
+        val schema = Schema(columns, primaryKeyIds)
+        val deltaWriter = mockDeltaWriter()
+        val writer =
+            testWriter(
+                schema = schema,
+                primaryKeyIds = primaryKeyIds,
+                deltaWriter = deltaWriter,
+                equalityDeleteKeyTracker = testBloomFilter(schema, primaryKeyIds),
+            )
+
+        writer.write(RecordWrapper(record(schema, 1, "first"), Operation.DELETE))
+        writer.write(RecordWrapper(record(schema, 1, "second"), Operation.DELETE))
+
+        verify(exactly = 1) { deltaWriter.deleteKey(any()) }
+        verify(exactly = 0) { deltaWriter.write(any()) }
+    }
+
+    @Test
+    fun `bloom filter distinguishes composite primary key values`() {
+        val columns =
+            mutableListOf(
+                Types.NestedField.required(1, "first", Types.StringType.get()),
+                Types.NestedField.required(2, "second", Types.StringType.get()),
+            )
+        val primaryKeyIds = setOf(1, 2)
+        val schema = Schema(columns, primaryKeyIds)
+        val deleteSchema = TypeUtil.select(schema, primaryKeyIds)
+        val bloomFilter = testBloomFilter(schema, primaryKeyIds)
+
+        assertFalse(bloomFilter.shouldDelete(record(deleteSchema, "ab", "c")))
+        assertFalse(bloomFilter.shouldDelete(record(deleteSchema, "a", "bc")))
+        assertTrue(bloomFilter.shouldDelete(record(deleteSchema, "ab", "c")))
+    }
+
+    private fun mockDeltaWriter(): BaseDeltaTaskWriter.RowDataDeltaWriter =
+        mockk {
+            every { deleteKey(any()) } returns Unit
+            every { write(any()) } returns Unit
+        }
+
+    private fun testBloomFilter(
+        schema: Schema,
+        primaryKeyIds: Set<Int>
+    ): EqualityDeleteBloomFilter =
+        EqualityDeleteBloomFilter(
+            streamName = "test",
+            deleteSchema = TypeUtil.select(schema, primaryKeyIds),
+            expectedItems = 100,
+            numberOfBits = 1024,
+            numberOfHashFunctions = 3,
+            logIntervalRecords = 0,
+        )
+
+    private fun record(schema: Schema, id: Int, name: String): GenericRecord {
+        val record = GenericRecord.create(schema)
+        record.setField("id", id)
+        record.setField("name", name)
+        return record
+    }
+
+    private fun record(schema: Schema, first: String, second: String): GenericRecord {
+        val record = GenericRecord.create(schema)
+        record.setField("first", first)
+        record.setField("second", second)
+        return record
+    }
+
+    private fun testWriter(
+        schema: Schema,
+        primaryKeyIds: Set<Int>,
+        deltaWriter: BaseDeltaTaskWriter.RowDataDeltaWriter,
+        equalityDeleteKeyTracker: EqualityDeleteKeyTracker?,
+    ): BaseDeltaTaskWriter {
+        val spec: PartitionSpec = mockk()
+        val outputFileFactory: OutputFileFactory = mockk()
+        val appenderFactory: FileAppenderFactory<Record> = mockk {
+            every { newDataWriter(any(), any(), any()) } returns mockk()
+        }
+        val io: FileIO = mockk { every { newOutputFile(any()) } returns mockk() }
+        return TestDeltaWriter(
+            spec = spec,
+            format = FileFormat.PARQUET,
+            appenderFactory = appenderFactory,
+            outputFileFactory = outputFileFactory,
+            io = io,
+            targetFileSize = WRITE_TARGET_FILE_SIZE_BYTES_DEFAULT,
+            schema = schema,
+            primaryKeyIds = primaryKeyIds,
+            deltaWriter = deltaWriter,
+            equalityDeleteKeyTracker = equalityDeleteKeyTracker,
+        )
+    }
+
     private class TestDeltaWriter(
         spec: PartitionSpec,
         format: FileFormat,
@@ -124,6 +254,7 @@ internal class BaseDeltaTaskWriterTest {
         schema: Schema,
         primaryKeyIds: Set<Int>,
         val deltaWriter: RowDataDeltaWriter,
+        equalityDeleteKeyTracker: EqualityDeleteKeyTracker? = null,
     ) :
         BaseDeltaTaskWriter(
             mockk<Table>(),
@@ -134,7 +265,8 @@ internal class BaseDeltaTaskWriterTest {
             io,
             targetFileSize,
             schema,
-            primaryKeyIds
+            primaryKeyIds,
+            equalityDeleteKeyTracker,
         ) {
         override fun close() {}
 

--- a/airbyte-integrations/connectors/destination-s3-data-lake/build.gradle
+++ b/airbyte-integrations/connectors/destination-s3-data-lake/build.gradle
@@ -36,6 +36,8 @@ configurations.configureEach {
 //}
 
 dependencies {
+    implementation project(':airbyte-cdk:bulk:toolkits:bulk-cdk-toolkit-load-iceberg-parquet')
+
     implementation("org.apache.iceberg:iceberg-api:${project.ext.apacheIcebergVersion}")
     implementation("org.apache.iceberg:iceberg-core:${project.ext.apacheIcebergVersion}")
     implementation("org.apache.iceberg:iceberg-data:${project.ext.apacheIcebergVersion}")

--- a/airbyte-integrations/connectors/destination-s3-data-lake/src/main/kotlin/io/airbyte/integrations/destination/s3_data_lake/dataflow/S3DataLakeAggregateFactory.kt
+++ b/airbyte-integrations/connectors/destination-s3-data-lake/src/main/kotlin/io/airbyte/integrations/destination/s3_data_lake/dataflow/S3DataLakeAggregateFactory.kt
@@ -32,7 +32,8 @@ class S3DataLakeAggregateFactory(
                 table = state.table,
                 generationId = icebergUtil.constructGenerationIdSuffix(stream),
                 importType = stream.tableSchema.importType,
-                schema = state.schema
+                schema = state.schema,
+                equalityDeleteKeyTracker = state.equalityDeleteKeyTracker,
             )
 
         return S3DataLakeAggregate(

--- a/airbyte-integrations/connectors/destination-s3-data-lake/src/main/kotlin/io/airbyte/integrations/destination/s3_data_lake/spec/S3DataLakeConfiguration.kt
+++ b/airbyte-integrations/connectors/destination-s3-data-lake/src/main/kotlin/io/airbyte/integrations/destination/s3_data_lake/spec/S3DataLakeConfiguration.kt
@@ -4,6 +4,10 @@
 
 package io.airbyte.integrations.destination.s3_data_lake.spec
 
+import com.fasterxml.jackson.annotation.JsonProperty
+import com.fasterxml.jackson.annotation.JsonPropertyDescription
+import com.kjetland.jackson.jsonSchema.annotations.JsonSchemaInject
+import com.kjetland.jackson.jsonSchema.annotations.JsonSchemaTitle
 import io.airbyte.cdk.load.command.DestinationConfiguration
 import io.airbyte.cdk.load.command.DestinationConfigurationFactory
 import io.airbyte.cdk.load.command.aws.AWSAccessKeyConfiguration
@@ -22,6 +26,8 @@ data class S3DataLakeConfiguration(
     override val s3BucketConfiguration: S3BucketConfiguration,
     override val icebergCatalogConfiguration: IcebergCatalogConfiguration,
     val flushBatchSizeMb: Long?,
+    val primaryKeyBloomFilter: PrimaryKeyBloomFilterConfiguration =
+        PrimaryKeyBloomFilterConfiguration(),
 ) :
     DestinationConfiguration(),
     AWSAccessKeyConfigurationProvider,
@@ -47,6 +53,65 @@ data class S3DataLakeConfiguration(
         }
 }
 
+data class PrimaryKeyBloomFilterConfiguration(
+    @get:JsonSchemaTitle("Enabled")
+    @get:JsonPropertyDescription(
+        "Whether to enable the experimental primary-key Bloom filter optimization."
+    )
+    @get:JsonSchemaInject(json = """{"default": false, "order": 0}""")
+    val enabled: Boolean = false,
+
+    @get:JsonSchemaTitle("Expected Items")
+    @get:JsonPropertyDescription(
+        "Expected number of unique primary keys to add to the Bloom filter during one sync."
+    )
+    @param:JsonProperty("expected_items")
+    @get:JsonProperty("expected_items")
+    @get:JsonSchemaInject(json = """{"default": 10000000, "order": 1}""")
+    val expectedItems: Int = Defaults.EXPECTED_ITEMS,
+
+    @get:JsonSchemaTitle("Number of Bits")
+    @get:JsonPropertyDescription("Number of bits in the Bloom filter.")
+    @param:JsonProperty("num_bits")
+    @get:JsonProperty("num_bits")
+    @get:JsonSchemaInject(json = """{"default": 100000000, "order": 2}""")
+    val numberOfBits: Int = Defaults.NUMBER_OF_BITS,
+
+    @get:JsonSchemaTitle("Number of Hash Functions")
+    @get:JsonPropertyDescription("Number of hash functions to use for each primary key.")
+    @param:JsonProperty("num_hash_functions")
+    @get:JsonProperty("num_hash_functions")
+    @get:JsonSchemaInject(json = """{"default": 7, "order": 3}""")
+    val numberOfHashFunctions: Int = Defaults.NUMBER_OF_HASH_FUNCTIONS,
+
+    @get:JsonSchemaTitle("Log Interval Records")
+    @get:JsonPropertyDescription(
+        "How often to log Bloom filter counters by number of checked keys. Set to 0 to disable periodic logging."
+    )
+    @param:JsonProperty("log_interval_records")
+    @get:JsonProperty("log_interval_records")
+    @get:JsonSchemaInject(json = """{"default": 1000000, "order": 4}""")
+    val logIntervalRecords: Long = Defaults.LOG_INTERVAL_RECORDS,
+) {
+    object Defaults {
+        const val EXPECTED_ITEMS = 10_000_000
+        const val NUMBER_OF_BITS = 100_000_000
+        const val NUMBER_OF_HASH_FUNCTIONS = 7
+        const val LOG_INTERVAL_RECORDS = 1_000_000L
+    }
+
+    init {
+        require(expectedItems > 0) { "primary_key_bloom_filter.expected_items must be positive" }
+        require(numberOfBits > 0) { "primary_key_bloom_filter.num_bits must be positive" }
+        require(numberOfHashFunctions > 0) {
+            "primary_key_bloom_filter.num_hash_functions must be positive"
+        }
+        require(logIntervalRecords >= 0) {
+            "primary_key_bloom_filter.log_interval_records must be non-negative"
+        }
+    }
+}
+
 @Singleton
 class S3DataLakeConfigurationFactory :
     DestinationConfigurationFactory<S3DataLakeSpecification, S3DataLakeConfiguration> {
@@ -59,6 +124,8 @@ class S3DataLakeConfigurationFactory :
             s3BucketConfiguration = pojo.toS3BucketConfiguration(),
             icebergCatalogConfiguration = pojo.toIcebergCatalogConfiguration(),
             flushBatchSizeMb = pojo.flushBatchSizeMb,
+            primaryKeyBloomFilter =
+                pojo.primaryKeyBloomFilter ?: PrimaryKeyBloomFilterConfiguration(),
         )
     }
 }

--- a/airbyte-integrations/connectors/destination-s3-data-lake/src/main/kotlin/io/airbyte/integrations/destination/s3_data_lake/spec/S3DataLakeSpecification.kt
+++ b/airbyte-integrations/connectors/destination-s3-data-lake/src/main/kotlin/io/airbyte/integrations/destination/s3_data_lake/spec/S3DataLakeSpecification.kt
@@ -83,6 +83,14 @@ class S3DataLakeSpecification :
         json = """{"examples":[200], "default": 200, "order": 8, "airbyte_hidden": true}"""
     )
     val flushBatchSizeMb: Long? = null
+
+    @get:JsonSchemaTitle("Primary Key Bloom Filter")
+    @get:JsonPropertyDescription(
+        "Experimental Bloom filter used to skip first-seen primary-key equality deletes in dedupe mode."
+    )
+    @get:JsonProperty("primary_key_bloom_filter", required = false)
+    @get:JsonSchemaInject(json = """{"order": 9, "airbyte_hidden": true}""")
+    val primaryKeyBloomFilter: PrimaryKeyBloomFilterConfiguration? = null
 }
 
 @Singleton

--- a/airbyte-integrations/connectors/destination-s3-data-lake/src/main/kotlin/io/airbyte/integrations/destination/s3_data_lake/write/S3DataLakeStreamLoader.kt
+++ b/airbyte-integrations/connectors/destination-s3-data-lake/src/main/kotlin/io/airbyte/integrations/destination/s3_data_lake/write/S3DataLakeStreamLoader.kt
@@ -5,9 +5,12 @@
 package io.airbyte.integrations.destination.s3_data_lake.write
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings
+import io.airbyte.cdk.load.command.Dedupe
 import io.airbyte.cdk.load.command.DestinationStream
 import io.airbyte.cdk.load.toolkits.iceberg.parquet.ColumnTypeChangeBehavior
 import io.airbyte.cdk.load.toolkits.iceberg.parquet.IcebergTableSynchronizer
+import io.airbyte.cdk.load.toolkits.iceberg.parquet.io.EqualityDeleteBloomFilter
+import io.airbyte.cdk.load.toolkits.iceberg.parquet.io.EqualityDeleteKeyTracker
 import io.airbyte.cdk.load.toolkits.iceberg.parquet.io.IcebergTableCleaner
 import io.airbyte.cdk.load.toolkits.iceberg.parquet.io.IcebergUtil
 import io.airbyte.cdk.load.write.StreamLoader
@@ -20,6 +23,7 @@ import io.github.oshai.kotlinlogging.KotlinLogging
 import org.apache.iceberg.Schema
 import org.apache.iceberg.Table
 import org.apache.iceberg.UpdateSchema
+import org.apache.iceberg.types.TypeUtil
 
 private val logger = KotlinLogging.logger {}
 
@@ -36,6 +40,7 @@ class S3DataLakeStreamLoader(
 ) : StreamLoader {
     private lateinit var table: Table
     private lateinit var targetSchema: Schema
+    private var equalityDeleteKeyTracker: EqualityDeleteKeyTracker? = null
 
     // If we're executing a truncate, then force the schema change.
     internal val columnTypeChangeBehavior: ColumnTypeChangeBehavior =
@@ -83,43 +88,49 @@ class S3DataLakeStreamLoader(
             }
         }
 
+        equalityDeleteKeyTracker = createEqualityDeleteKeyTracker()
         val state =
             S3DataLakeStreamState(
                 table = table,
                 schema = targetSchema,
+                equalityDeleteKeyTracker = equalityDeleteKeyTracker,
             )
         streamStateStore.put(stream.mappedDescriptor, state)
     }
 
     override suspend fun teardown(completedSuccessfully: Boolean) {
-        if (completedSuccessfully) {
-            // Doing it first to make sure that data coming in the current batch is written to the
-            // main branch
-            logger.info {
-                "No stream failure detected. Committing changes from staging branch '$stagingBranchName' to main branch '$mainBranchName."
-            }
-            // We've modified the table over the sync (i.e. adding new snapshots)
-            // so we need to refresh here to get the latest table metadata.
-            // In principle, this doesn't matter, but the iceberg SDK throws an error about
-            // stale table metadata without this.
-            table.refresh()
-            // Commit all pending schema updates in order (important for two-phase commits)
-            computeOrExecuteSchemaUpdate().pendingUpdates.forEach { it.commit() }
-            table.manageSnapshots().replaceBranch(mainBranchName, stagingBranchName).commit()
-
-            if (stream.isSingleGenerationTruncate()) {
+        try {
+            if (completedSuccessfully) {
+                // Doing it first to make sure that data coming in the current batch is written to
+                // the main branch
                 logger.info {
-                    "Detected a minimum generation ID (${stream.minimumGenerationId}). Preparing to delete obsolete generation IDs."
+                    "No stream failure detected. Committing changes from staging branch '$stagingBranchName' to main branch '$mainBranchName."
                 }
-                val icebergTableCleaner = IcebergTableCleaner(icebergUtil = icebergUtil)
-                icebergTableCleaner.deleteOldGenerationData(table, stagingBranchName, stream)
-                //  Doing it again to push the deletes from the staging to main branch
-                logger.info {
-                    "Deleted obsolete generation IDs up to ${stream.minimumGenerationId - 1}. " +
-                        "Pushing these updates to the '$mainBranchName' branch."
-                }
+                // We've modified the table over the sync (i.e. adding new snapshots)
+                // so we need to refresh here to get the latest table metadata.
+                // In principle, this doesn't matter, but the iceberg SDK throws an error about
+                // stale table metadata without this.
+                table.refresh()
+                // Commit all pending schema updates in order (important for two-phase commits)
+                computeOrExecuteSchemaUpdate().pendingUpdates.forEach { it.commit() }
                 table.manageSnapshots().replaceBranch(mainBranchName, stagingBranchName).commit()
+
+                if (stream.isSingleGenerationTruncate()) {
+                    logger.info {
+                        "Detected a minimum generation ID (${stream.minimumGenerationId}). Preparing to delete obsolete generation IDs."
+                    }
+                    val icebergTableCleaner = IcebergTableCleaner(icebergUtil = icebergUtil)
+                    icebergTableCleaner.deleteOldGenerationData(table, stagingBranchName, stream)
+                    //  Doing it again to push the deletes from the staging to main branch
+                    logger.info {
+                        "Deleted obsolete generation IDs up to ${stream.minimumGenerationId - 1}. " +
+                            "Pushing these updates to the '$mainBranchName' branch."
+                    }
+                    table.manageSnapshots().replaceBranch(mainBranchName, stagingBranchName).commit()
+                }
             }
+        } finally {
+            equalityDeleteKeyTracker?.logSummary("stream teardown")
         }
     }
 
@@ -135,4 +146,22 @@ class S3DataLakeStreamLoader(
             incomingSchema,
             columnTypeChangeBehavior,
         )
+
+    private fun createEqualityDeleteKeyTracker(): EqualityDeleteKeyTracker? {
+        val bloomFilterConfig = icebergConfiguration.primaryKeyBloomFilter
+        val isDedupe = stream.tableSchema.importType is Dedupe
+        val identifierFieldIds = targetSchema.identifierFieldIds()
+        if (!bloomFilterConfig.enabled || !isDedupe || identifierFieldIds.isEmpty()) {
+            return null
+        }
+
+        return EqualityDeleteBloomFilter(
+            streamName = stream.mappedDescriptor.toString(),
+            deleteSchema = TypeUtil.select(targetSchema, identifierFieldIds),
+            expectedItems = bloomFilterConfig.expectedItems,
+            numberOfBits = bloomFilterConfig.numberOfBits,
+            numberOfHashFunctions = bloomFilterConfig.numberOfHashFunctions,
+            logIntervalRecords = bloomFilterConfig.logIntervalRecords,
+        )
+    }
 }

--- a/airbyte-integrations/connectors/destination-s3-data-lake/src/main/kotlin/io/airbyte/integrations/destination/s3_data_lake/write/S3DataLakeStreamState.kt
+++ b/airbyte-integrations/connectors/destination-s3-data-lake/src/main/kotlin/io/airbyte/integrations/destination/s3_data_lake/write/S3DataLakeStreamState.kt
@@ -4,10 +4,12 @@
 
 package io.airbyte.integrations.destination.s3_data_lake.write
 
+import io.airbyte.cdk.load.toolkits.iceberg.parquet.io.EqualityDeleteKeyTracker
 import org.apache.iceberg.Schema
 import org.apache.iceberg.Table
 
 class S3DataLakeStreamState(
     val table: Table,
     val schema: Schema,
+    val equalityDeleteKeyTracker: EqualityDeleteKeyTracker? = null,
 )

--- a/airbyte-integrations/connectors/destination-s3-data-lake/src/test-integration/resources/expected-spec-cloud.json
+++ b/airbyte-integrations/connectors/destination-s3-data-lake/src/test-integration/resources/expected-spec-cloud.json
@@ -223,6 +223,52 @@
         "default" : 200,
         "order" : 8,
         "airbyte_hidden" : true
+      },
+      "primary_key_bloom_filter" : {
+        "description" : "Experimental Bloom filter used to skip first-seen primary-key equality deletes in dedupe mode.",
+        "title" : "Primary Key Bloom Filter",
+        "order" : 9,
+        "airbyte_hidden" : true,
+        "type" : "object",
+        "additionalProperties" : true,
+        "properties" : {
+          "enabled" : {
+            "type" : "boolean",
+            "description" : "Whether to enable the experimental primary-key Bloom filter optimization.",
+            "title" : "Enabled",
+            "default" : false,
+            "order" : 0
+          },
+          "expected_items" : {
+            "type" : "integer",
+            "description" : "Expected number of unique primary keys to add to the Bloom filter during one sync.",
+            "title" : "Expected Items",
+            "default" : 10000000,
+            "order" : 1
+          },
+          "num_bits" : {
+            "type" : "integer",
+            "description" : "Number of bits in the Bloom filter.",
+            "title" : "Number of Bits",
+            "default" : 100000000,
+            "order" : 2
+          },
+          "num_hash_functions" : {
+            "type" : "integer",
+            "description" : "Number of hash functions to use for each primary key.",
+            "title" : "Number of Hash Functions",
+            "default" : 7,
+            "order" : 3
+          },
+          "log_interval_records" : {
+            "type" : "integer",
+            "description" : "How often to log Bloom filter counters by number of checked keys. Set to 0 to disable periodic logging.",
+            "title" : "Log Interval Records",
+            "default" : 1000000,
+            "order" : 4
+          }
+        },
+        "required" : [ "enabled", "expected_items", "num_bits", "num_hash_functions", "log_interval_records" ]
       }
     },
     "required" : [ "s3_bucket_name", "s3_bucket_region", "warehouse_location", "main_branch_name", "catalog_type" ]

--- a/airbyte-integrations/connectors/destination-s3-data-lake/src/test-integration/resources/expected-spec-oss.json
+++ b/airbyte-integrations/connectors/destination-s3-data-lake/src/test-integration/resources/expected-spec-oss.json
@@ -223,6 +223,52 @@
         "default" : 200,
         "order" : 8,
         "airbyte_hidden" : true
+      },
+      "primary_key_bloom_filter" : {
+        "description" : "Experimental Bloom filter used to skip first-seen primary-key equality deletes in dedupe mode.",
+        "title" : "Primary Key Bloom Filter",
+        "order" : 9,
+        "airbyte_hidden" : true,
+        "type" : "object",
+        "additionalProperties" : true,
+        "properties" : {
+          "enabled" : {
+            "type" : "boolean",
+            "description" : "Whether to enable the experimental primary-key Bloom filter optimization.",
+            "title" : "Enabled",
+            "default" : false,
+            "order" : 0
+          },
+          "expected_items" : {
+            "type" : "integer",
+            "description" : "Expected number of unique primary keys to add to the Bloom filter during one sync.",
+            "title" : "Expected Items",
+            "default" : 10000000,
+            "order" : 1
+          },
+          "num_bits" : {
+            "type" : "integer",
+            "description" : "Number of bits in the Bloom filter.",
+            "title" : "Number of Bits",
+            "default" : 100000000,
+            "order" : 2
+          },
+          "num_hash_functions" : {
+            "type" : "integer",
+            "description" : "Number of hash functions to use for each primary key.",
+            "title" : "Number of Hash Functions",
+            "default" : 7,
+            "order" : 3
+          },
+          "log_interval_records" : {
+            "type" : "integer",
+            "description" : "How often to log Bloom filter counters by number of checked keys. Set to 0 to disable periodic logging.",
+            "title" : "Log Interval Records",
+            "default" : 1000000,
+            "order" : 4
+          }
+        },
+        "required" : [ "enabled", "expected_items", "num_bits", "num_hash_functions", "log_interval_records" ]
       }
     },
     "required" : [ "s3_bucket_name", "s3_bucket_region", "warehouse_location", "main_branch_name", "catalog_type" ]

--- a/airbyte-integrations/connectors/destination-s3-data-lake/src/test/kotlin/io/airbyte/integrations/destination/s3_data_lake/write/S3DataLakeStreamLoaderTest.kt
+++ b/airbyte-integrations/connectors/destination-s3-data-lake/src/test/kotlin/io/airbyte/integrations/destination/s3_data_lake/write/S3DataLakeStreamLoaderTest.kt
@@ -32,6 +32,7 @@ import io.airbyte.cdk.load.toolkits.iceberg.parquet.io.IcebergUtil
 import io.airbyte.cdk.load.write.StreamStateStore
 import io.airbyte.integrations.destination.s3_data_lake.catalog.S3DataLakeUtil
 import io.airbyte.integrations.destination.s3_data_lake.spec.DEFAULT_STAGING_BRANCH
+import io.airbyte.integrations.destination.s3_data_lake.spec.PrimaryKeyBloomFilterConfiguration
 import io.airbyte.integrations.destination.s3_data_lake.spec.S3BucketConfiguration
 import io.airbyte.integrations.destination.s3_data_lake.spec.S3BucketRegion
 import io.airbyte.integrations.destination.s3_data_lake.spec.S3DataLakeConfiguration
@@ -184,6 +185,7 @@ internal class S3DataLakeStreamLoaderTest {
             every { awsAccessKeyConfiguration } returns awsConfiguration
             every { icebergCatalogConfiguration } returns icebergCatalogConfig
             every { s3BucketConfiguration } returns bucketConfiguration
+            every { primaryKeyBloomFilter } returns PrimaryKeyBloomFilterConfiguration()
         }
         val catalog: Catalog = mockk()
         val table: Table = mockk { every { schema() } returns icebergSchema }
@@ -260,6 +262,7 @@ internal class S3DataLakeStreamLoaderTest {
             every { awsAccessKeyConfiguration } returns awsConfiguration
             every { icebergCatalogConfiguration } returns icebergCatalogConfig
             every { s3BucketConfiguration } returns bucketConfiguration
+            every { primaryKeyBloomFilter } returns PrimaryKeyBloomFilterConfiguration()
         }
         val catalog: Catalog = mockk()
         val table: Table = mockk {
@@ -435,6 +438,7 @@ internal class S3DataLakeStreamLoaderTest {
             every { awsAccessKeyConfiguration } returns awsConfiguration
             every { icebergCatalogConfiguration } returns icebergCatalogConfig
             every { s3BucketConfiguration } returns bucketConfiguration
+            every { primaryKeyBloomFilter } returns PrimaryKeyBloomFilterConfiguration()
         }
         val catalog: Catalog = mockk()
         val table: Table = mockk {


### PR DESCRIPTION
Builds an experimental hidden Bloom filter config for `destination-s3-data-lake` to reduce first-pull equality deletes during MotherDuck cloud testing.

Focused verification run locally:
- `./gradlew :airbyte-cdk:bulk:toolkits:bulk-cdk-toolkit-load-iceberg-parquet:test --tests io.airbyte.cdk.load.toolkits.iceberg.parquet.io.BaseDeltaTaskWriterTest`
- `./gradlew :airbyte-integrations:connectors:destination-s3-data-lake:compileKotlin`
- `./gradlew :airbyte-integrations:connectors:destination-s3-data-lake:integrationTestNonDocker --tests io.airbyte.integrations.destination.s3_data_lake.S3DataLakeSpecTest`
- `./gradlew :airbyte-integrations:connectors:destination-s3-data-lake:test --tests io.airbyte.integrations.destination.s3_data_lake.write.S3DataLakeStreamLoaderTest`

> [!IMPORTANT]
> Active progressive rollout warning for destination-s3-data-lake.

- [ ] (Click to Approve:) Bypass the active progressive rollout warning for destination-s3-data-lake in the PR comment [here](https://github.com/airbytehq/airbyte/pull/78547#issuecomment-4596859201).