### PR TITLE
perf(source-instagram): promote concurrency tuning to GA (4.2.29)

### DIFF
--- a/airbyte-integrations/connectors/source-instagram/manifest.yaml
+++ b/airbyte-integrations/connectors/source-instagram/manifest.yaml
@@ -741,19 +741,6 @@ concurrency_level:
   default_concurrency: "{{ config.get('num_workers', 20) }}"
   max_concurrency: 50
 
-# Facebook Graph API BUC (Business Use Case) rate limits are dynamic and impression-based.
-# This budget acts as a safety net to prevent excessive request bursts.
-api_budget:
-  type: HTTPAPIBudget
-  policies:
-    - type: MovingWindowCallRatePolicy
-      rates:
-        - limit: 200
-          interval: PT1M
-      matchers: []
-  status_codes_for_ratelimit_hit:
-    - 429
-
 metadata:
   autoImportSchema:
     Media: true

--- a/airbyte-integrations/connectors/source-instagram/metadata.yaml
+++ b/airbyte-integrations/connectors/source-instagram/metadata.yaml
@@ -7,7 +7,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 6acf6b55-4f1e-4fca-944e-1a3caef8aba8
-  dockerImageTag: 4.2.29-rc.2
+  dockerImageTag: 4.2.29
   dockerRepository: airbyte/source-instagram
   githubIssueLabel: source-instagram
   icon: instagram.svg
@@ -25,8 +25,6 @@ data:
       enabled: true
   releaseStage: generally_available
   releases:
-    rolloutConfiguration:
-      enableProgressiveRollout: true
     breakingChanges:
       4.0.0:
         message: "This release removes deprecated metrics - `clips_replays_count`, `ig_reels_aggregated_all_plays_count`, `impressions`, and `plays` from `media_insights` stream, and `impressions` from `user_insights` and `story_insights` streams. Customers who these streams must take action with their connections. For more details, see our <a href='https://docs.airbyte.com/integrations/sources/instagram-migrations'>migration guide</a>."

--- a/docs/integrations/sources/instagram.md
+++ b/docs/integrations/sources/instagram.md
@@ -119,6 +119,7 @@ If you use Airbyte Cloud and your organization restricts access to specific IPs,
 
 | Version    | Date       | Pull Request                                             | Subject                                                                                                                                                                |
 |:-----------|:-----------|:---------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 4.2.29 | 2026-06-02 | [*PR_NUMBER_PLACEHOLDER*](https://github.com/airbytehq/airbyte/pull/*PR_NUMBER_PLACEHOLDER*) | Promote concurrency tuning to GA: default_concurrency=20 with user-configurable num_workers. Removes HTTPAPIBudget that caused regressions during tuning. |
 | 4.2.29-rc.2 | 2026-05-26 | [78440](https://github.com/airbytehq/airbyte/pull/78440) | Add HTTPAPIBudget for rate limit protection |
 | 4.2.29-rc.1 | 2026-05-26 | [78440](https://github.com/airbytehq/airbyte/pull/78440) | Enable progressive rollout for concurrency tuning |
 | 4.2.28 | 2026-04-28 | [77272](https://github.com/airbytehq/airbyte/pull/77272) | Update dependencies |


### PR DESCRIPTION
## What

Promotes source-instagram concurrency tuning from RC to GA (4.2.29). This is the final step of the progressive rollout that has been running across Tier 1 and Tier 2 customers.

Related issue: https://github.com/airbytehq/airbyte-internal-issues/issues/15323
Epic: https://github.com/airbytehq/airbyte-internal-issues/issues/15262

Requested by @sophiecuiy.

## How

1. **Remove HTTPAPIBudget** — The `MovingWindowCallRatePolicy` (200 calls/min) was added in rc.2 but caused a +15.1% duration regression. It was removed during tuning (reverted to rc.1) and this PR cleans up the leftover code from master.
2. **Bump version** from `4.2.29-rc.2` → `4.2.29` (GA).
3. **Remove `enableProgressiveRollout`** from `metadata.yaml` since the rollout is being finalized.

No changes to concurrency settings — `default_concurrency=20` with user-configurable `num_workers` (default 20) remains as tuned.

## Review guide

1. `airbyte-integrations/connectors/source-instagram/manifest.yaml` — HTTPAPIBudget section removed
2. `airbyte-integrations/connectors/source-instagram/metadata.yaml` — version bump + progressive rollout config removed
3. `docs/integrations/sources/instagram.md` — changelog entry added

## User Impact

- Concurrency tuning results become GA for all users (not just rollout participants)
- ~16% faster sync durations, ~22% faster source read times observed during rollout
- `num_workers` remains user-configurable (default 20, range 2-40)
- No breaking changes

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

---
[Devin session](https://app.devin.ai/sessions/e52d4b4f076e4bd984b93eb313068f9f)

> [!IMPORTANT]
> Active progressive rollout warning for source-instagram.

- [x] (Click to Approve:) Bypass the active progressive rollout warning for source-instagram in the PR comment [here](https://github.com/airbytehq/airbyte/pull/79097#issuecomment-4605075741).