### PR TITLE
fix(destination-s3-data-lake): fall back to default AWS credentials chain for STS bootstrap

### DIFF
--- a/airbyte-integrations/connectors/destination-s3-data-lake/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-s3-data-lake/metadata.yaml
@@ -37,7 +37,7 @@ data:
             alias: airbyte-connector-testing-secret-store
   connectorType: destination
   definitionId: 716ca874-520b-4902-9f80-9fad66754b89
-  dockerImageTag: 0.3.49
+  dockerImageTag: 0.3.50
   dockerRepository: airbyte/destination-s3-data-lake
   documentationUrl: https://docs.airbyte.com/integrations/destinations/s3-data-lake
   githubIssueLabel: destination-s3-data-lake

--- a/airbyte-integrations/connectors/destination-s3-data-lake/src/main/kotlin/io/airbyte/integrations/destination/s3_data_lake/catalog/GlueCredentialsProvider.kt
+++ b/airbyte-integrations/connectors/destination-s3-data-lake/src/main/kotlin/io/airbyte/integrations/destination/s3_data_lake/catalog/GlueCredentialsProvider.kt
@@ -50,14 +50,23 @@ class GlueCredentialsProvider private constructor(private val delegate: AwsCrede
                         }
                     }
                     AWS_CREDENTIALS_MODE_ASSUME_ROLE -> {
+                        // When the deployment doesn't provide system-level static
+                        // credentials, fall back to the default credentials chain so the
+                        // STS client can use the pod's IAM identity (IRSA, instance
+                        // profile, env vars, etc.) to perform AssumeRole. This mirrors
+                        // the behavior of the AWS_CREDENTIALS_MODE_STATIC_CREDS branch.
+                        val stsCredentialsProvider =
+                            if (accessKey != null && secretKey != null) {
+                                StaticCredentialsProvider.create(
+                                    AwsBasicCredentials.create(accessKey, secretKey)
+                                )
+                            } else {
+                                DefaultCredentialsProvider.create()
+                            }
                         StsAssumeRoleCredentialsProvider.builder()
                             .stsClient(
                                 StsClient.builder()
-                                    .credentialsProvider(
-                                        StaticCredentialsProvider.create(
-                                            AwsBasicCredentials.create(accessKey, secretKey)
-                                        )
-                                    )
+                                    .credentialsProvider(stsCredentialsProvider)
                                     .region(Region.of(properties[ASSUME_ROLE_REGION]))
                                     .build()
                             )

--- a/airbyte-integrations/connectors/destination-s3-data-lake/src/main/kotlin/io/airbyte/integrations/destination/s3_data_lake/catalog/S3DataLakeUtil.kt
+++ b/airbyte-integrations/connectors/destination-s3-data-lake/src/main/kotlin/io/airbyte/integrations/destination/s3_data_lake/catalog/S3DataLakeUtil.kt
@@ -244,18 +244,16 @@ class S3DataLakeUtil(
         config: S3DataLakeConfiguration
     ): Map<String, String> {
         val region = config.s3BucketConfiguration.s3BucketRegion
-        val (accessKeyId, secretAccessKey, externalId) =
-            if (assumeRoleCredentials != null) {
-                Triple(
-                    assumeRoleCredentials.accessKey,
-                    assumeRoleCredentials.secretKey,
-                    assumeRoleCredentials.externalId,
-                )
-            } else {
-                throw IllegalStateException(
-                    "Cannot assume role without system-provided credentials"
-                )
-            }
+        // System-provided assume-role credentials are optional. When they are not
+        // injected (e.g. OSS / privatelink deployments that authenticate the pod
+        // via IRSA or an instance profile instead of static Airbyte-system keys),
+        // we leave the access-key / secret-key entries off the property map and
+        // let GlueCredentialsProvider fall back to the default credentials chain
+        // for the STS client that performs AssumeRole. The external id is only
+        // surfaced when we actually have a system-provided one to use.
+        val accessKeyId = assumeRoleCredentials?.accessKey
+        val secretAccessKey = assumeRoleCredentials?.secretKey
+        val externalId = assumeRoleCredentials?.externalId
 
         return mapOfNotNull(
             // Note: no explicit credentials, whether on AwsProperties.REST_ACCESS_KEY_ID, or on

--- a/airbyte-integrations/connectors/destination-s3-data-lake/src/test/kotlin/io/airbyte/integrations/destination/s3_data_lake/catalog/GlueCredentialsProviderTest.kt
+++ b/airbyte-integrations/connectors/destination-s3-data-lake/src/test/kotlin/io/airbyte/integrations/destination/s3_data_lake/catalog/GlueCredentialsProviderTest.kt
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2026 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.integrations.destination.s3_data_lake.catalog
+
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
+import org.junit.jupiter.api.assertThrows
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider
+import software.amazon.awssdk.services.sts.auth.StsAssumeRoleCredentialsProvider
+
+internal class GlueCredentialsProviderTest {
+
+    @Test
+    fun `static creds mode returns a provider when keys are present`() {
+        val provider =
+            GlueCredentialsProvider.create(
+                mapOf(
+                    AWS_CREDENTIALS_MODE to AWS_CREDENTIALS_MODE_STATIC_CREDS,
+                    ACCESS_KEY_ID to "key",
+                    SECRET_ACCESS_KEY to "secret",
+                ),
+            )
+        Assertions.assertTrue(provider is AwsCredentialsProvider)
+    }
+
+    @Test
+    fun `static creds mode falls back to default chain when keys are missing`() {
+        // Building should not throw even though no access keys are present.
+        assertDoesNotThrow {
+            GlueCredentialsProvider.create(
+                mapOf(AWS_CREDENTIALS_MODE to AWS_CREDENTIALS_MODE_STATIC_CREDS),
+            )
+        }
+    }
+
+    @Test
+    fun `assume role mode returns an STS-backed provider when system keys are present`() {
+        val provider =
+            GlueCredentialsProvider.create(
+                mapOf(
+                    AWS_CREDENTIALS_MODE to AWS_CREDENTIALS_MODE_ASSUME_ROLE,
+                    ACCESS_KEY_ID to "key",
+                    SECRET_ACCESS_KEY to "secret",
+                    ASSUME_ROLE_ARN to "arn:aws:iam::123456789012:role/test",
+                    ASSUME_ROLE_EXTERNAL_ID to "ext",
+                    ASSUME_ROLE_REGION to "us-east-1",
+                ),
+            )
+        Assertions.assertTrue(provider is AwsCredentialsProvider)
+    }
+
+    @Test
+    fun `assume role mode falls back to default chain for the STS client when system keys are missing`() {
+        // Reproduces the privatelink / IRSA scenario where the connector pod has
+        // no system-provided static keys to bootstrap the STS client. Building
+        // the provider must not NPE on AwsBasicCredentials.create(null, null);
+        // instead the STS client should be configured with the default chain so
+        // it can use the pod's IAM identity to perform AssumeRole.
+        assertDoesNotThrow {
+            GlueCredentialsProvider.create(
+                mapOf(
+                    AWS_CREDENTIALS_MODE to AWS_CREDENTIALS_MODE_ASSUME_ROLE,
+                    ASSUME_ROLE_ARN to "arn:aws:iam::123456789012:role/test",
+                    ASSUME_ROLE_REGION to "us-east-1",
+                ),
+            )
+        }
+    }
+
+    @Test
+    fun `unknown mode raises a descriptive error`() {
+        val error =
+            assertThrows<IllegalArgumentException> {
+                GlueCredentialsProvider.create(mapOf(AWS_CREDENTIALS_MODE to "bogus"))
+            }
+        Assertions.assertTrue(error.message!!.contains("bogus"))
+    }
+
+    // Sanity check that the underlying STS provider type is what we expect, so
+    // future refactors that swap the implementation are caught loudly.
+    @Test
+    fun `assume role mode delegates to StsAssumeRoleCredentialsProvider`() {
+        val provider =
+            GlueCredentialsProvider.create(
+                mapOf(
+                    AWS_CREDENTIALS_MODE to AWS_CREDENTIALS_MODE_ASSUME_ROLE,
+                    ASSUME_ROLE_ARN to "arn:aws:iam::123456789012:role/test",
+                    ASSUME_ROLE_REGION to "us-east-1",
+                ),
+            )
+        val delegateField = GlueCredentialsProvider::class.java.getDeclaredField("delegate")
+        delegateField.isAccessible = true
+        Assertions.assertTrue(delegateField.get(provider) is StsAssumeRoleCredentialsProvider)
+    }
+}

--- a/airbyte-integrations/connectors/destination-s3-data-lake/src/test/kotlin/io/airbyte/integrations/destination/s3_data_lake/catalog/S3DataLakeUtilTest.kt
+++ b/airbyte-integrations/connectors/destination-s3-data-lake/src/test/kotlin/io/airbyte/integrations/destination/s3_data_lake/catalog/S3DataLakeUtilTest.kt
@@ -11,6 +11,7 @@ import io.airbyte.cdk.load.command.ImportType
 import io.airbyte.cdk.load.command.NamespaceMapper
 import io.airbyte.cdk.load.command.aws.AWSAccessKeyConfiguration
 import io.airbyte.cdk.load.command.aws.AWSArnRoleConfiguration
+import io.airbyte.cdk.load.command.aws.AwsAssumeRoleCredentials
 import io.airbyte.cdk.load.command.iceberg.parquet.GlueCatalogConfiguration
 import io.airbyte.cdk.load.command.iceberg.parquet.IcebergCatalogConfiguration
 import io.airbyte.cdk.load.command.iceberg.parquet.NessieCatalogConfiguration
@@ -406,6 +407,81 @@ internal class S3DataLakeUtilTest {
         Assertions.assertEquals(
             "aws-creds-static-creds",
             catalogProperties["client.credentials-provider.aws-creds-mode"]
+        )
+    }
+
+    @Test
+    fun `testGlueCatalogPropertiesWithRoleArnAndSystemCredentials`() {
+        // When a role ARN is configured and the deployment injects system-provided
+        // assume-role credentials, the resulting Iceberg property map carries the
+        // static keys + external id that GlueCredentialsProvider needs to bootstrap
+        // the STS client.
+        val s3DataLakeUtilWithCreds =
+            S3DataLakeUtil(
+                icebergUtil,
+                assumeRoleCredentials =
+                    AwsAssumeRoleCredentials(
+                        accessKey = "system-access-key",
+                        secretKey = "system-secret-key",
+                        externalId = "system-external-id",
+                    ),
+            )
+        val config = createGlueTestConfiguration(roleArn = "arn:aws:iam::123456789012:role/test")
+        val catalogProperties = s3DataLakeUtilWithCreds.toCatalogProperties(config)
+
+        Assertions.assertEquals(
+            "aws-creds-assume-role",
+            catalogProperties["client.credentials-provider.aws-creds-mode"]
+        )
+        Assertions.assertEquals(
+            "system-access-key",
+            catalogProperties["client.credentials-provider.access-key-id"]
+        )
+        Assertions.assertEquals(
+            "system-secret-key",
+            catalogProperties["client.credentials-provider.secret-access-key"]
+        )
+        Assertions.assertEquals(
+            "system-external-id",
+            catalogProperties["client.credentials-provider.external-id"]
+        )
+        Assertions.assertEquals(
+            "arn:aws:iam::123456789012:role/test",
+            catalogProperties["client.credentials-provider.role-arn"]
+        )
+    }
+
+    @Test
+    fun `testGlueCatalogPropertiesWithRoleArnAndNoSystemCredentials`() {
+        // When a role ARN is configured but the deployment does NOT inject
+        // assume-role credentials (e.g. OSS / privatelink running with IRSA),
+        // the role-arn / region entries must still be emitted so we land in the
+        // ASSUME_ROLE branch of GlueCredentialsProvider, but the static-key and
+        // external-id entries must be absent so the provider falls through to
+        // the default credentials chain instead of NPEing on null keys.
+        val config = createGlueTestConfiguration(roleArn = "arn:aws:iam::123456789012:role/test")
+        val catalogProperties = s3DataLakeUtil.toCatalogProperties(config)
+
+        Assertions.assertEquals(
+            "aws-creds-assume-role",
+            catalogProperties["client.credentials-provider.aws-creds-mode"]
+        )
+        Assertions.assertEquals(
+            "arn:aws:iam::123456789012:role/test",
+            catalogProperties["client.credentials-provider.role-arn"]
+        )
+        Assertions.assertEquals(
+            S3BucketRegion.`us-east-1`.region,
+            catalogProperties["client.credentials-provider.region"]
+        )
+        Assertions.assertFalse(
+            catalogProperties.containsKey("client.credentials-provider.access-key-id")
+        )
+        Assertions.assertFalse(
+            catalogProperties.containsKey("client.credentials-provider.secret-access-key")
+        )
+        Assertions.assertFalse(
+            catalogProperties.containsKey("client.credentials-provider.external-id")
         )
     }
 

--- a/docs/integrations/destinations/s3-data-lake.md
+++ b/docs/integrations/destinations/s3-data-lake.md
@@ -395,6 +395,7 @@ This destination supports [namespaces](https://docs.airbyte.com/platform/using-a
 
 | Version     | Date       | Pull Request                                               | Subject                                                                                                                         |
 |:------------|:-----------|:-----------------------------------------------------------|:--------------------------------------------------------------------------------------------------------------------------------|
+| 0.3.50      | 2026-06-04 |                                                            | Fix `Access key ID cannot be blank` NPE during check when using Glue + role ARN without system-provided assume-role credentials; fall back to the default AWS credentials chain (IRSA / instance profile / env) for the STS bootstrap client. |
 | 0.3.49      | 2026-05-19 | [78232](https://github.com/airbytehq/airbyte/pull/78232)  | Upgrade CDK to 1.0.13 |
 | 0.3.48      | 2026-05-01 | [77677](https://github.com/airbytehq/airbyte/pull/77677)  | Add configurable flush batch size for aggregate publishing.                                                                     |
 | 0.3.47      | 2026-04-16 | [76410](https://github.com/airbytehq/airbyte/pull/76410) | Upgrade CDK to 1.0.9.                                                  |


### PR DESCRIPTION
## What

When the S3 Data Lake destination runs with a Glue catalog + role ARN but no system-provided assume-role credentials (most commonly: OSS or privatelink deployments where the connector pod authenticates via IRSA / instance profile rather than static keys), the check operation crashes with:

```
Could not connect with provided configuration. Error: Access key ID cannot be blank.
  at io.airbyte.integrations.destination.s3_data_lake.catalog.GlueCredentialsProvider$Companion.create(GlueCredentialsProvider.kt:58)
```

Two problems combined to produce that NPE:

1. `S3DataLakeUtil.buildRoleBasedClientProperties` hard-required the `AwsAssumeRoleCredentials` Micronaut bean, throwing `IllegalStateException("Cannot assume role without system-provided credentials")` when it was absent. That made it impossible to authenticate via the pod's IAM identity even when the deployment had IRSA set up correctly.
2. `GlueCredentialsProvider`'s `AWS_CREDENTIALS_MODE_ASSUME_ROLE` branch unconditionally called `AwsBasicCredentials.create(accessKey, secretKey)` without the null guard that was added to the `AWS_CREDENTIALS_MODE_STATIC_CREDS` branch in #50876 ("support aws instance profile auth"). If the property map didn't carry the static keys, the assume-role branch NPE'd inside the AWS SDK.

## How

Apply the same null guard to the assume-role branch that #50876 applied to the static-creds branch:

- `GlueCredentialsProvider`: when `accessKey` / `secretKey` are absent, build the STS client with `DefaultCredentialsProvider.create()` so it can use IRSA / instance profile / env-var credentials to perform `AssumeRole`, instead of NPEing on `AwsBasicCredentials.create(null, null)`.
- `S3DataLakeUtil.buildRoleBasedClientProperties`: stop throwing when the `AwsAssumeRoleCredentials` bean is missing — read fields with the null-safe `?.` operator so `mapOfNotNull` drops the access-key-id / secret-access-key / external-id entries from the Iceberg property map. The provider's new fallback then takes over.

The static-keys-present path is unchanged: when the deployment does inject `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` / `AWS_ASSUME_ROLE_EXTERNAL_ID`, the property map still carries them and the STS client still uses `StaticCredentialsProvider`.

Unit tests cover the four combinations (static creds present/absent, assume-role with system keys present/absent) and a new `GlueCredentialsProviderTest` asserts that the assume-role branch no longer throws when keys are missing.

## Review guide

1. `airbyte-integrations/connectors/destination-s3-data-lake/src/main/kotlin/io/airbyte/integrations/destination/s3_data_lake/catalog/GlueCredentialsProvider.kt`
2. `airbyte-integrations/connectors/destination-s3-data-lake/src/main/kotlin/io/airbyte/integrations/destination/s3_data_lake/catalog/S3DataLakeUtil.kt`
3. `airbyte-integrations/connectors/destination-s3-data-lake/src/test/kotlin/io/airbyte/integrations/destination/s3_data_lake/catalog/GlueCredentialsProviderTest.kt`
4. `airbyte-integrations/connectors/destination-s3-data-lake/src/test/kotlin/io/airbyte/integrations/destination/s3_data_lake/catalog/S3DataLakeUtilTest.kt`

## User Impact

- **Self-hosted / privatelink deployments with IRSA or instance profile**: `check` and `sync` now succeed against Glue + role ARN configurations without requiring the operator to also inject Airbyte-system static keys via `AWS_ASSUME_ROLE_SECRET_NAME`.
- **Airbyte Cloud and OSS deployments that do inject system keys**: no behavior change; the static keys are still used to bootstrap the STS client.
- **Error message regression**: the `IllegalStateException("Cannot assume role without system-provided credentials")` is gone. Misconfigured pods will now produce whatever auth error the underlying AWS SDK returns from `AssumeRole` (`InvalidClientTokenId`, `AccessDenied`, etc.), which is more informative anyway.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

> [!IMPORTANT]
> Active progressive rollout warning for destination-s3-data-lake.

- [ ] (Click to Approve:) Bypass the active progressive rollout warning for destination-s3-data-lake in the PR comment [here](https://github.com/airbytehq/airbyte/pull/79131#issuecomment-4624593506).