### PR TITLE
chore(source-microsoft-dataverse): extend breaking change deadline by 2 weeks

### DIFF
--- a/airbyte-integrations/connectors/source-microsoft-dataverse/metadata.yaml
+++ b/airbyte-integrations/connectors/source-microsoft-dataverse/metadata.yaml
@@ -25,7 +25,7 @@ data:
           DateOnly fields require a schema refresh and data reset after upgrading. Please refer
           to the [migration guide](https://docs.airbyte.com/integrations/sources/microsoft-dataverse-migrations)
           for more information.
-        upgradeDeadline: "2026-06-05"
+        upgradeDeadline: "2026-06-19"
         deadlineAction: "auto_upgrade"
   releaseStage: alpha
   documentationUrl: https://docs.airbyte.com/integrations/sources/microsoft-dataverse


### PR DESCRIPTION
## What

Extends the `source-microsoft-dataverse` v1.0.0 breaking change upgrade deadline from `2026-06-05` to `2026-06-19` (+2 weeks) to give users more time to perform schema refresh and data reset.

Requested by @davinchia.

## How

Single-line change in `metadata.yaml`: `upgradeDeadline: "2026-06-05"` → `"2026-06-19"`.

## Review guide

1. `airbyte-integrations/connectors/source-microsoft-dataverse/metadata.yaml` — deadline date change only

## User Impact

Users with DateOnly fields in their Dataverse streams get an additional 2 weeks before the auto-upgrade is applied.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

---
[Devin session](https://app.devin.ai/sessions/8a36c0798c9e45baba095b18a2f11d3d)