### PR TITLE
fix(source-microsoft-dataverse): revert base image to 4.0.0 (4.1.0 breaks build)

### DIFF
--- a/airbyte-integrations/connectors/source-microsoft-dataverse/metadata.yaml
+++ b/airbyte-integrations/connectors/source-microsoft-dataverse/metadata.yaml
@@ -2,7 +2,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 9220e3de-3b60-4bb2-a46f-046d59ea235a
-  dockerImageTag: 1.0.1
+  dockerImageTag: 1.0.2
   dockerRepository: airbyte/source-microsoft-dataverse
   githubIssueLabel: source-microsoft-dataverse
   icon: microsoftdataverse.svg
@@ -39,7 +39,7 @@ data:
   connectorTestSuitesOptions:
     - suite: unitTests
   connectorBuildOptions:
-    baseImage: docker.io/airbyte/python-connector-base:4.1.0@sha256:1d1aa21d34e851df4e8a87b391c27724c06e2597608e7161f4d167be853bd7b6
+    baseImage: docker.io/airbyte/python-connector-base:4.0.0@sha256:d9894b6895923b379f3006fa251147806919c62b7d9021b5cd125bb67d7bbe22
   externalDocumentationUrls:
     - title: Microsoft Dataverse Web API
       url: https://learn.microsoft.com/en-us/power-apps/developer/data-platform/webapi/overview

--- a/airbyte-integrations/connectors/source-microsoft-dataverse/pyproject.toml
+++ b/airbyte-integrations/connectors/source-microsoft-dataverse/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
-version = "1.0.1"
+version = "1.0.2"
 name = "source-microsoft-dataverse"
 description = "Source implementation for Microsoft Dataverse."
 authors = ["Airbyte <contact@airbyte.io>"]

--- a/docs/integrations/sources/microsoft-dataverse.md
+++ b/docs/integrations/sources/microsoft-dataverse.md
@@ -68,6 +68,7 @@ If you use Airbyte Cloud and your organization restricts access to specific IPs,
 
 | Version | Date       | Pull Request                                             | Subject                                                                                |
 | :------ | :--------- | :------------------------------------------------------- | :------------------------------------------------------------------------------------- |
+| 1.0.2 | 2026-06-05 | [79143](https://github.com/airbytehq/airbyte/pull/79143) | Revert connector base image to 4.0.0 (4.1.0 ships Python 3.13, incompatible with the connector's pinned CDK). |
 | 1.0.1 | 2026-06-02 | [78805](https://github.com/airbytehq/airbyte/pull/78805) | Update dependencies |
 | 1.0.0 | 2026-05-06 | [77565](https://github.com/airbytehq/airbyte/pull/77565) | Map DateOnly fields to `date` format instead of `date-time`. Add `$select` projection to discovery to reduce metadata payload size. Streams with DateOnly fields require a schema refresh and data reset. |
 | 0.1.32 | 2025-05-10 | [60052](https://github.com/airbytehq/airbyte/pull/60052) | Update dependencies |


### PR DESCRIPTION
## Summary

Revert `source-microsoft-dataverse`'s base image from `python-connector-base:4.1.0` back to `4.0.0` and bump the connector to `1.0.2`.

The 2026-06-02 dependency-bot PR (#78805) bumped the base image `4.0.0 → 4.1.0` and the version `1.0.0 → 1.0.1` in one commit. The 4.1.0 base image ships **Python 3.13**, but this connector is pinned to **`airbyte-cdk==0.80.0`**, which pulls in `pendulum<3.0.0` (resolves to `2.1.2`). Pendulum 2.1.2's `build.py` imports `distutils`, removed from the stdlib in Python 3.12 (PEP 632), so `poetry install` fails during the image build:

```
The currently activated Python version 3.13.9 is not supported by the project (^3.9,<3.12).
poetry install ... did not complete successfully: exit code: 1
```

As a result **1.0.1 never published** — the registry is still on 1.0.0 (base 4.0.0) — and every publish since has failed (e.g. run 26804497581 on merge of #78805, and again when extending the breaking-change deadline). The `<3.12` constraint is correct and required for CDK 0.80.0, so the fix is to revert the base image rather than relax the constraint. A proper move to a 3.12+ base image requires upgrading the connector off CDK 0.80.0, which is out of scope here.

Note: the dependency bot will attempt to re-bump the base image to 4.1.0 on its next run; a lasting fix needs the CDK upgrade.

## Changes

- `metadata.yaml`: base image `4.1.0` → `4.0.0` (original pinned digest), `dockerImageTag` `1.0.1` → `1.0.2`
- `pyproject.toml`: version `1.0.1` → `1.0.2`
- changelog: add `1.0.2` entry

## Test plan

- [x] Reproduced the failure: installing `airbyte-cdk==0.80.0` under Python 3.13 fails building `pendulum==2.1.2` (`No module named 'distutils'`); the same install succeeds under Python 3.11 (the interpreter shipped by base image 4.0.0).
- [ ] CI `Build and Verify Artifacts (source-microsoft-dataverse)` builds the image successfully on the reverted base.
- [ ] On merge, `Publish Connectors` publishes 1.0.2.

> [!IMPORTANT]
> ⚡ **Auto-merge enabled.**
> 
> _This PR is set to merge automatically when all requirements are met._

> [!NOTE]
> **Auto-merge may have been disabled. Please check the PR status to confirm.**