### PR TITLE
ci(release-notes): rename workflow, add Cloud release notes job, and allow auto-merge

### DIFF
--- a/.github/workflows/auto-merge-cron.yml
+++ b/.github/workflows/auto-merge-cron.yml
@@ -123,6 +123,7 @@ jobs:
               docs/ai-agents/connectors/*) ;;
               docs/ai-agents/reference/*) ;;
               docs/developers/pyairbyte/*) ;;
+              docs/release_notes/*) ;;
               docusaurus/src/data/*) ;;
               *) valid=false; echo "::warning::Non-connector file: $file"; break ;;
             esac

--- a/.github/workflows/daily-release-notes.yml
+++ b/.github/workflows/daily-release-notes.yml
@@ -1,4 +1,4 @@
-name: Daily Sonar Release Notes
+name: Daily Release Notes
 
 on:
   schedule:
@@ -10,7 +10,7 @@ permissions:
   contents: read
 
 jobs:
-  generate-release-notes:
+  generate-agents-release-notes:
     name: Generate Airbyte Agents release notes
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -27,3 +27,21 @@ jobs:
             area/documentation
             team/documentation
             sonar-release-notes
+
+  generate-cloud-release-notes:
+    name: Generate Airbyte Cloud release notes
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Trigger Devin session
+        uses: aaronsteers/devin-action@main
+        with:
+          devin-token: ${{ secrets.DEVIN_AI_API_KEY }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          playbook-macro: "!cloud_release_notes"
+          api-version: v3
+          org-id: ${{ vars.DEVIN_AI_ORG_ID }}
+          tags: |
+            area/documentation
+            team/documentation
+            cloud-release-notes

--- a/.github/workflows/hydra-automerge.yml
+++ b/.github/workflows/hydra-automerge.yml
@@ -108,6 +108,7 @@ jobs:
               docs/integrations/destinations/*) ;;
               docs/ai-agents/connectors/*) ;;
               docs/developers/pyairbyte/*) ;;
+              docs/release_notes/*) ;;
               docusaurus/src/data/*) ;;
               *) valid=false; echo "::warning::Non-connector file: $file"; break ;;
             esac

--- a/docs/release_notes/cloud/readme.md
+++ b/docs/release_notes/cloud/readme.md
@@ -1,0 +1,1 @@
+# Airbyte Cloud release notes

--- a/docs/release_notes/cloud/readme.md
+++ b/docs/release_notes/cloud/readme.md
@@ -1,1 +1,3 @@
 # Airbyte Cloud release notes
+
+Airbyte Cloud is updated continuously. You always have the latest features and fixes.

--- a/docusaurus/sidebar-release_notes.js
+++ b/docusaurus/sidebar-release_notes.js
@@ -70,6 +70,15 @@ export default {
         },
         {
           type: "category",
+          label: "Cloud",
+          link: {
+            type: "doc",
+            id: "cloud/readme",
+          },
+          items: [],
+        },
+        {
+          type: "category",
           label: "Agents",
           link: {
             type: "doc",


### PR DESCRIPTION
## What

Expanding the daily release notes automation to cover Airbyte Cloud in addition to Airbyte Agents, and enabling the auto-merge path for release notes PRs. Requested by @ian-at-airbyte.

## How

- Renamed `daily-sonar-release-notes.yml` → `daily-release-notes.yml` and the workflow name from "Daily Sonar Release Notes" → "Daily Release Notes"
- Renamed existing job `generate-release-notes` → `generate-agents-release-notes`
- Added a new `generate-cloud-release-notes` job that triggers a separate Devin session with the `!cloud_release_notes` playbook macro
- Created `docs/release_notes/cloud/readme.md` as the target page for Cloud release notes
- Added a "Cloud" sidebar category in `docusaurus/sidebar-release_notes.js` between Self-Managed and Agents
- Added `docs/release_notes/*` to the path allowlist in both `auto-merge-cron.yml` and `hydra-automerge.yml` so release notes PRs qualify for auto-merge

## Review guide

1. `.github/workflows/daily-release-notes.yml` — workflow rename + new job
2. `docs/release_notes/cloud/readme.md` — empty release notes page
3. `docusaurus/sidebar-release_notes.js` — sidebar entry
4. `.github/workflows/auto-merge-cron.yml` — added `docs/release_notes/*` to path allowlist
5. `.github/workflows/hydra-automerge.yml` — added `docs/release_notes/*` to path allowlist

## User Impact

Airbyte Cloud will get daily public release notes alongside Agents. Release notes PRs can now be auto-merged via the HITL workflow. No impact on existing Agents release notes behavior.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

---
[Devin session](https://app.devin.ai/sessions/476e1f759e4a4bb1bd51349b3e1f7037)