### PR TITLE
fix(destination-mssql): validate timestamp values against DATETIME lower bound

### DIFF
--- a/airbyte-integrations/connectors/destination-mssql/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-mssql/metadata.yaml
@@ -17,7 +17,7 @@ data:
             type: GSM
   connectorType: destination
   definitionId: d4353156-9217-4cad-8dd7-c108fd4f74cf
-  dockerImageTag: 2.2.16
+  dockerImageTag: 2.2.17
   dockerRepository: airbyte/destination-mssql
   documentationUrl: https://docs.airbyte.com/integrations/destinations/mssql
   githubIssueLabel: destination-mssql

--- a/airbyte-integrations/connectors/destination-mssql/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-mssql/metadata.yaml
@@ -17,7 +17,7 @@ data:
             type: GSM
   connectorType: destination
   definitionId: d4353156-9217-4cad-8dd7-c108fd4f74cf
-  dockerImageTag: 2.2.17
+  dockerImageTag: 2.2.16
   dockerRepository: airbyte/destination-mssql
   documentationUrl: https://docs.airbyte.com/integrations/destinations/mssql
   githubIssueLabel: destination-mssql

--- a/airbyte-integrations/connectors/destination-mssql/src/main/kotlin/io/airbyte/integrations/destination/mssql/v2/MSSQLCsvRowGenerator.kt
+++ b/airbyte-integrations/connectors/destination-mssql/src/main/kotlin/io/airbyte/integrations/destination/mssql/v2/MSSQLCsvRowGenerator.kt
@@ -27,6 +27,7 @@ import io.airbyte.cdk.load.util.serializeToString
 import io.airbyte.protocol.models.v0.AirbyteRecordMessageMetaChange.Reason
 import java.math.BigDecimal
 import java.math.BigInteger
+import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 
 object LIMITS {
@@ -39,8 +40,21 @@ object LIMITS {
     val MAX_NUMERIC: BigDecimal = BigDecimal("1e38").minus(BigDecimal.ONE).divide(NUMERIC_SCALE)
     val MIN_NUMERIC: BigDecimal = BigDecimal("-1e38").plus(BigDecimal.ONE).divide(NUMERIC_SCALE)
 
+    // Minimum value for DATETIME in SQL Server (1753-01-01 00:00:00.000)
+    val MIN_DATETIME: LocalDateTime = LocalDateTime.of(1753, 1, 1, 0, 0, 0)
+
     val TRUE = IntegerValue(1)
     val FALSE = IntegerValue(0)
+
+    fun validateTimestamp(value: EnrichedAirbyteValue): LocalDateTime? {
+        val tsValue = (value.abValue as TimestampWithoutTimezoneValue).value
+        return if (tsValue < MIN_DATETIME) {
+            value.nullify(Reason.DESTINATION_FIELD_SIZE_LIMITATION)
+            null
+        } else {
+            tsValue
+        }
+    }
 
     fun validateNumber(value: EnrichedAirbyteValue): BigDecimal? {
         val numValue = (value.abValue as NumberValue).value
@@ -105,13 +119,16 @@ class MSSQLCsvRowGenerator(private val validateValuesPreLoad: Boolean) {
                                     .value
                                     .format(DateTimeFormatter.ISO_OFFSET_DATE_TIME)
                             )
-                    is TimestampTypeWithoutTimezone ->
+                    is TimestampTypeWithoutTimezone -> {
+                        LIMITS.validateTimestamp(value)
+                            ?: return@forEach // nullified; skip formatting
                         value.abValue =
                             StringValue(
                                 (actualValue as TimestampWithoutTimezoneValue)
                                     .value
                                     .format(DateTimeFormatter.ISO_DATE_TIME)
                             )
+                    }
 
                     // serialize complex types to string
                     is ArrayType,

--- a/airbyte-integrations/connectors/destination-mssql/src/main/kotlin/io/airbyte/integrations/destination/mssql/v2/MSSQLQueryBuilder.kt
+++ b/airbyte-integrations/connectors/destination-mssql/src/main/kotlin/io/airbyte/integrations/destination/mssql/v2/MSSQLQueryBuilder.kt
@@ -379,10 +379,12 @@ class MSSQLQueryBuilder(
                     LIMITS.validateInteger(value)?.let {
                         statement.setLong(statementIndex, it.longValueExact())
                     }
+                        ?: statement.setAsNullValue(statementIndex, field.type.type)
                 NumberType ->
                     LIMITS.validateNumber(value)?.let {
                         statement.setBigDecimal(statementIndex, it)
                     }
+                        ?: statement.setAsNullValue(statementIndex, field.type.type)
                 StringType ->
                     statement.setString(statementIndex, (value.abValue as StringValue).value)
                 TimeTypeWithTimezone ->
@@ -404,6 +406,7 @@ class MSSQLQueryBuilder(
                     LIMITS.validateTimestamp(value)?.let {
                         statement.setObject(statementIndex, it.toString())
                     }
+                        ?: statement.setAsNullValue(statementIndex, field.type.type)
 
                 // Serialize complex types to string
                 is ArrayType,

--- a/airbyte-integrations/connectors/destination-mssql/src/main/kotlin/io/airbyte/integrations/destination/mssql/v2/MSSQLQueryBuilder.kt
+++ b/airbyte-integrations/connectors/destination-mssql/src/main/kotlin/io/airbyte/integrations/destination/mssql/v2/MSSQLQueryBuilder.kt
@@ -36,7 +36,6 @@ import io.airbyte.cdk.load.data.TimeWithoutTimezoneValue
 import io.airbyte.cdk.load.data.TimestampTypeWithTimezone
 import io.airbyte.cdk.load.data.TimestampTypeWithoutTimezone
 import io.airbyte.cdk.load.data.TimestampWithTimezoneValue
-import io.airbyte.cdk.load.data.TimestampWithoutTimezoneValue
 import io.airbyte.cdk.load.data.UnionType
 import io.airbyte.cdk.load.data.UnknownType
 import io.airbyte.cdk.load.message.DestinationRecordRaw
@@ -402,10 +401,9 @@ class MSSQLQueryBuilder(
                         (value.abValue as TimestampWithTimezoneValue).value
                     )
                 TimestampTypeWithoutTimezone ->
-                    statement.setObject(
-                        statementIndex,
-                        (value.abValue as TimestampWithoutTimezoneValue).value
-                    )
+                    LIMITS.validateTimestamp(value)?.let {
+                        statement.setObject(statementIndex, it.toString())
+                    }
 
                 // Serialize complex types to string
                 is ArrayType,

--- a/airbyte-integrations/connectors/destination-mssql/src/test-integration/kotlin/io/airbyte/integrations/destination/mssql/v2/MSSQLTimestampValidationIntegrationTest.kt
+++ b/airbyte-integrations/connectors/destination-mssql/src/test-integration/kotlin/io/airbyte/integrations/destination/mssql/v2/MSSQLTimestampValidationIntegrationTest.kt
@@ -1,0 +1,207 @@
+/*
+ * Copyright (c) 2026 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.integrations.destination.mssql.v2
+
+import io.airbyte.cdk.load.command.Append
+import io.airbyte.cdk.load.command.DestinationStream
+import io.airbyte.cdk.load.command.NamespaceMapper
+import io.airbyte.cdk.load.data.FieldType
+import io.airbyte.cdk.load.data.IntegerType
+import io.airbyte.cdk.load.data.NullValue
+import io.airbyte.cdk.load.data.ObjectType
+import io.airbyte.cdk.load.data.TimestampTypeWithoutTimezone
+import io.airbyte.cdk.load.message.DestinationRecordJsonSource
+import io.airbyte.cdk.load.message.DestinationRecordRaw
+import io.airbyte.cdk.load.util.deserializeToNode
+import io.airbyte.protocol.models.v0.AirbyteMessage
+import io.airbyte.protocol.models.v0.AirbyteRecordMessage
+import java.sql.Connection
+import java.sql.DriverManager
+import java.util.*
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+
+/**
+ * Integration test that verifies the full round-trip through [MSSQLQueryBuilder.populateStatement]
+ * when a pre-1753 timestamp is sent. The [LIMITS.validateTimestamp] function should nullify the
+ * value and `setAsNullValue` should set the parameter to SQL NULL, allowing the INSERT to succeed.
+ */
+class MSSQLTimestampValidationIntegrationTest {
+
+    companion object {
+        private const val TEST_SCHEMA = "ts_validation_test"
+        private const val TABLE_NAME = "timestamp_nullify_test"
+
+        private val columns =
+            linkedMapOf(
+                "id" to FieldType(IntegerType, true),
+                "ts_col" to FieldType(TimestampTypeWithoutTimezone, true),
+            )
+
+        @JvmStatic
+        @BeforeAll
+        fun beforeAll() {
+            MSSQLContainerHelper.start()
+            getConnection().use { conn ->
+                conn.createStatement().use { stmt ->
+                    stmt.execute(
+                        """
+                        IF NOT EXISTS (SELECT name FROM sys.schemas WHERE name = '$TEST_SCHEMA')
+                        BEGIN
+                            EXEC ('CREATE SCHEMA [$TEST_SCHEMA]');
+                        END
+                        """.trimIndent(),
+                    )
+                }
+            }
+        }
+
+        @JvmStatic
+        @AfterAll
+        fun afterAll() {
+            getConnection().use { conn ->
+                conn.createStatement().use { stmt ->
+                    stmt.execute(
+                        """
+                        DECLARE @sql NVARCHAR(MAX) = N'';
+                        SELECT @sql += 'DROP TABLE ' + QUOTENAME(s.name) + '.' + QUOTENAME(t.name) + ';'
+                        FROM sys.schemas s
+                        JOIN sys.tables t ON s.schema_id = t.schema_id
+                        WHERE s.name = '$TEST_SCHEMA';
+                        EXEC sp_executesql @sql;
+                        """.trimIndent(),
+                    )
+                    stmt.execute("DROP SCHEMA IF EXISTS [$TEST_SCHEMA]")
+                }
+            }
+        }
+
+        private fun getConnection(): Connection {
+            val host = MSSQLContainerHelper.getHost()
+            val port = MSSQLContainerHelper.getPort()
+            val user = MSSQLContainerHelper.getUsername()
+            val password = MSSQLContainerHelper.getPassword()
+            return DriverManager.getConnection(
+                "jdbc:sqlserver://$host:$port;encrypt=false;trustServerCertificate=true",
+                user,
+                password,
+            )
+        }
+
+        private fun makeStream(): DestinationStream {
+            return DestinationStream(
+                unmappedNamespace = TEST_SCHEMA,
+                unmappedName = TABLE_NAME,
+                importType = Append,
+                schema = ObjectType(properties = columns),
+                generationId = 1,
+                minimumGenerationId = 0,
+                syncId = 42,
+                namespaceMapper = NamespaceMapper(),
+            )
+        }
+
+        private fun makeRecord(stream: DestinationStream, jsonData: String): DestinationRecordRaw {
+            val recordMessage =
+                AirbyteRecordMessage()
+                    .withNamespace(TEST_SCHEMA)
+                    .withStream(TABLE_NAME)
+                    .withData(jsonData.deserializeToNode())
+                    .withEmittedAt(System.currentTimeMillis())
+
+            val airbyteMessage =
+                AirbyteMessage().withType(AirbyteMessage.Type.RECORD).withRecord(recordMessage)
+
+            return DestinationRecordRaw(
+                stream = stream,
+                rawData = DestinationRecordJsonSource(airbyteMessage),
+                serializedSizeBytes = jsonData.length.toLong(),
+                airbyteRawId = UUID.randomUUID(),
+            )
+        }
+    }
+
+    @Test
+    fun `pre-1753 timestamp is nullified and INSERT succeeds via populateStatement`() {
+        val stream = makeStream()
+        val builder = MSSQLQueryBuilder(defaultSchema = TEST_SCHEMA, stream = stream)
+
+        getConnection().use { conn ->
+            // 1. Create the table
+            builder.createTableIfNotExists(conn)
+
+            // 2. Build a record with a pre-1753 timestamp (the value that originally crashed)
+            val record = makeRecord(stream, """{"id": 1, "ts_col": "0001-01-01T00:00:00"}""")
+
+            // 3. Insert via populateStatement -- this should NOT throw
+            val insertSql = builder.getFinalTableInsertColumnHeader()
+            conn.prepareStatement(insertSql).use { stmt ->
+                builder.populateStatement(stmt, record, builder.finalTableSchema)
+                stmt.executeUpdate()
+            }
+
+            // 4. Read back the record and verify ts_col is NULL
+            conn
+                .prepareStatement(
+                    "SELECT * FROM [$TEST_SCHEMA].[$TABLE_NAME] WHERE [id] = 1",
+                )
+                .use { stmt ->
+                    stmt.executeQuery().use { rs ->
+                        assertTrue(rs.next(), "Expected one row in result set")
+                        val result = builder.readResult(rs, builder.finalTableSchema)
+
+                        // ts_col should have been nullified by validateTimestamp
+                        val tsValue = result.values["ts_col"]
+                        assertEquals(
+                            NullValue,
+                            tsValue,
+                            "Pre-1753 timestamp should be nullified to NULL in the database",
+                        )
+                    }
+                }
+        }
+    }
+
+    @Test
+    fun `valid timestamp passes through populateStatement and round-trips correctly`() {
+        val stream = makeStream()
+        val builder = MSSQLQueryBuilder(defaultSchema = TEST_SCHEMA, stream = stream)
+
+        getConnection().use { conn ->
+            // Table already created by previous test, but ensure it exists
+            builder.createTableIfNotExists(conn)
+
+            // Insert a record with a valid timestamp
+            val record = makeRecord(stream, """{"id": 2, "ts_col": "2023-06-15T12:34:56"}""")
+
+            val insertSql = builder.getFinalTableInsertColumnHeader()
+            conn.prepareStatement(insertSql).use { stmt ->
+                builder.populateStatement(stmt, record, builder.finalTableSchema)
+                stmt.executeUpdate()
+            }
+
+            // Read back and verify the timestamp value is present
+            conn
+                .prepareStatement(
+                    "SELECT * FROM [$TEST_SCHEMA].[$TABLE_NAME] WHERE [id] = 2",
+                )
+                .use { stmt ->
+                    stmt.executeQuery().use { rs ->
+                        assertTrue(rs.next(), "Expected one row in result set")
+                        val result = builder.readResult(rs, builder.finalTableSchema)
+
+                        val tsValue = result.values["ts_col"]
+                        assertTrue(
+                            tsValue !is NullValue && tsValue != NullValue,
+                            "Valid timestamp should not be null, got: $tsValue",
+                        )
+                    }
+                }
+        }
+    }
+}

--- a/airbyte-integrations/connectors/destination-mssql/src/test/kotlin/io/airbyte/integrations/destination/mssql/v2/LimitsTest.kt
+++ b/airbyte-integrations/connectors/destination-mssql/src/test/kotlin/io/airbyte/integrations/destination/mssql/v2/LimitsTest.kt
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2026 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.integrations.destination.mssql.v2
+
+import io.airbyte.cdk.load.data.EnrichedAirbyteValue
+import io.airbyte.cdk.load.data.NullValue
+import io.airbyte.cdk.load.data.TimestampTypeWithoutTimezone
+import io.airbyte.cdk.load.data.TimestampWithoutTimezoneValue
+import java.time.LocalDateTime
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class LimitsTest {
+
+    private fun makeTimestampValue(ts: LocalDateTime): EnrichedAirbyteValue =
+        EnrichedAirbyteValue(
+            abValue = TimestampWithoutTimezoneValue(ts),
+            type = TimestampTypeWithoutTimezone,
+            name = "test_timestamp",
+            airbyteMetaField = null,
+        )
+
+    @Test
+    fun `validateTimestamp passes through value within DATETIME range`() {
+        val value = makeTimestampValue(LocalDateTime.of(2023, 6, 15, 12, 34, 56))
+        val result = LIMITS.validateTimestamp(value)
+        assertNotNull(result)
+        assertEquals(LocalDateTime.of(2023, 6, 15, 12, 34, 56), result)
+        assertTrue(value.abValue is TimestampWithoutTimezoneValue)
+    }
+
+    @Test
+    fun `validateTimestamp passes through value at exact lower boundary`() {
+        val value = makeTimestampValue(LocalDateTime.of(1753, 1, 1, 0, 0, 0))
+        val result = LIMITS.validateTimestamp(value)
+        assertNotNull(result)
+        assertEquals(LocalDateTime.of(1753, 1, 1, 0, 0, 0), result)
+        assertTrue(value.abValue is TimestampWithoutTimezoneValue)
+    }
+
+    @Test
+    fun `validateTimestamp nullifies value below DATETIME lower boundary`() {
+        val value = makeTimestampValue(LocalDateTime.of(1752, 12, 31, 23, 59, 59))
+        val result = LIMITS.validateTimestamp(value)
+        assertNull(result)
+        assertTrue(value.abValue is NullValue)
+        assertEquals(1, value.changes.size)
+    }
+
+    @Test
+    fun `validateTimestamp nullifies pre-1753 date`() {
+        val value = makeTimestampValue(LocalDateTime.of(1, 1, 1, 0, 0, 0))
+        val result = LIMITS.validateTimestamp(value)
+        assertNull(result)
+        assertTrue(value.abValue is NullValue)
+        assertEquals(1, value.changes.size)
+    }
+}

--- a/docs/integrations/destinations/mssql.md
+++ b/docs/integrations/destinations/mssql.md
@@ -165,32 +165,33 @@ This destination supports [namespaces](https://docs.airbyte.com/platform/using-a
 
 | Version    | Date       | Pull Request                                               | Subject                                                                                             |
 |:-----------|:-----------|:-----------------------------------------------------------|:----------------------------------------------------------------------------------------------------|
+| 2.2.17 | 2026-06-05 | [79154](https://github.com/airbytehq/airbyte/pull/79154) | fix(destination-mssql): validate timestamp values against DATETIME lower bound |
 | 2.2.16 | 2026-04-23 | [76946](https://github.com/airbytehq/airbyte/pull/76946) | Upgrade Bulk CDK to 1.0.11 and fix `_ab_cdc_deleted_at` column type so the secondary index on CDC streams can be created. |
 | 2.2.15 | 2026-01-26 | [72297](https://github.com/airbytehq/airbyte/pull/72297) | Upgrade CDK to 0.2.0 |
 | 2.2.14 | 2025-11-05 | [69130](https://github.com/airbytehq/airbyte/pull/69130) | Upgrade to Bulk CDK 0.1.61. |
-| 2.2.13     | 2025-09-24 | [66684](https://github.com/airbytehq/airbyte/pull/66684)   | Pin to CDK artifact                                                                                 |
-| 2.2.12     | 2025-06-26 | [62078](https://github.com/airbytehq/airbyte/pull/62078)   | Add SSH tunnel support                                                                              |
-| 2.2.11     | 2025-05-30 | [61017](https://github.com/airbytehq/airbyte/pull/61017)   | Integration test fixes                                                                              |
-| 2.2.10     | 2025-05-29 | [60897](https://github.com/airbytehq/airbyte/pull/60897)   | Internal fixes                                                                                      |
-| 2.2.9      | 2025-05-19 | [60791](https://github.com/airbytehq/airbyte/pull/60791)   | Fix bug in detecting schema change when stream has no columns                                       |
-| 2.2.8      | 2025-05-08 | [59735](https://github.com/airbytehq/airbyte/pull/59735)   | Cleanup: Remove unused code                                                                         |
-| 2.2.7      | 2025-05-07 | [56444](https://github.com/airbytehq/airbyte/pull/56444)   | CDK: Internal refactor; perf improvements                                                           |
-| 2.2.6      | 2025-04-21 | [58146](https://github.com/airbytehq/airbyte/pull/58146)   | Fix numeric bounds-handling                                                                         |
-| 2.2.5      | 2025-04-18 | [58140](https://github.com/airbytehq/airbyte/pull/58140)   | Upgrade to latest CDK                                                                               |
-| 2.2.4      | 2025-04-11 | [57563](https://github.com/airbytehq/airbyte/pull/57563)   | Improve BULK INSERT documentation.                                                                  |
-| 2.2.3      | 2025-04-16 | [58085](https://github.com/airbytehq/airbyte/pull/58085)   | Internal refactoring                                                                                |
-| 2.2.2      | 2025-04-07 | [56391](https://github.com/airbytehq/airbyte/pull/56391)   | Add support for Azure blob storage auth via storage account key.                                    |
-| 2.2.1      | 2025-03-27 | [56402](https://github.com/airbytehq/airbyte/pull/56402)   | Improve Azure blob storage load logic.                                                              |
-| 2.2.0      | 2025-03-23 | [56353](https://github.com/airbytehq/airbyte/pull/56353)   | Bulk Load performance improvements                                                                  |
-| 2.1.2      | 2025-03-25 | [56346](https://github.com/airbytehq/airbyte/pull/56346)   | Internal refactor                                                                                   |
-| 2.1.1      | 2025-03-24 | [56355](https://github.com/airbytehq/airbyte/pull/56355)   | Upgrade to airbyte/java-connector-base:2.0.1 to be M4 compatible.                                   |
-| 2.1.0      | 2025-03-24 | [55849](https://github.com/airbytehq/airbyte/pull/55849)   | Misc. bugfixes in type-handling (esp. in complex types)                                             |
-| 2.0.5      | 2025-03-24 | [55904](https://github.com/airbytehq/airbyte/pull/55904)   | Fix handling of invalid schemas (correctly JSON-serialize values)                                   |
-| 2.0.4      | 2025-03-20 | [55886](https://github.com/airbytehq/airbyte/pull/55886)   | Internal refactor                                                                                   |
-| 2.0.3      | 2025-03-18 | [55811](https://github.com/airbytehq/airbyte/pull/55811)   | CDK: Pass DestinationStream around vs Descriptor                                                    |
-| 2.0.2      | 2025-03-12 | [55720](https://github.com/airbytehq/airbyte/pull/55720)   | Restore definition ID                                                                               |
-| 2.0.1      | 2025-03-12 | [55718](https://github.com/airbytehq/airbyte/pull/55718)   | Fix breaking change information in metadata.yaml                                                    |
-| 2.0.0      | 2025-03-11 | [55684](https://github.com/airbytehq/airbyte/pull/55684)   | Release 2.0.0                                                                                       |
+| 2.2.13 | 2025-09-24 | [66684](https://github.com/airbytehq/airbyte/pull/66684) | Pin to CDK artifact |
+| 2.2.12 | 2025-06-26 | [62078](https://github.com/airbytehq/airbyte/pull/62078) | Add SSH tunnel support |
+| 2.2.11 | 2025-05-30 | [61017](https://github.com/airbytehq/airbyte/pull/61017) | Integration test fixes |
+| 2.2.10 | 2025-05-29 | [60897](https://github.com/airbytehq/airbyte/pull/60897) | Internal fixes |
+| 2.2.9 | 2025-05-19 | [60791](https://github.com/airbytehq/airbyte/pull/60791) | Fix bug in detecting schema change when stream has no columns |
+| 2.2.8 | 2025-05-08 | [59735](https://github.com/airbytehq/airbyte/pull/59735) | Cleanup: Remove unused code |
+| 2.2.7 | 2025-05-07 | [56444](https://github.com/airbytehq/airbyte/pull/56444) | CDK: Internal refactor; perf improvements |
+| 2.2.6 | 2025-04-21 | [58146](https://github.com/airbytehq/airbyte/pull/58146) | Fix numeric bounds-handling |
+| 2.2.5 | 2025-04-18 | [58140](https://github.com/airbytehq/airbyte/pull/58140) | Upgrade to latest CDK |
+| 2.2.4 | 2025-04-11 | [57563](https://github.com/airbytehq/airbyte/pull/57563) | Improve BULK INSERT documentation. |
+| 2.2.3 | 2025-04-16 | [58085](https://github.com/airbytehq/airbyte/pull/58085) | Internal refactoring |
+| 2.2.2 | 2025-04-07 | [56391](https://github.com/airbytehq/airbyte/pull/56391) | Add support for Azure blob storage auth via storage account key. |
+| 2.2.1 | 2025-03-27 | [56402](https://github.com/airbytehq/airbyte/pull/56402) | Improve Azure blob storage load logic. |
+| 2.2.0 | 2025-03-23 | [56353](https://github.com/airbytehq/airbyte/pull/56353) | Bulk Load performance improvements |
+| 2.1.2 | 2025-03-25 | [56346](https://github.com/airbytehq/airbyte/pull/56346) | Internal refactor |
+| 2.1.1 | 2025-03-24 | [56355](https://github.com/airbytehq/airbyte/pull/56355) | Upgrade to airbyte/java-connector-base:2.0.1 to be M4 compatible. |
+| 2.1.0 | 2025-03-24 | [55849](https://github.com/airbytehq/airbyte/pull/55849) | Misc. bugfixes in type-handling (esp. in complex types) |
+| 2.0.5 | 2025-03-24 | [55904](https://github.com/airbytehq/airbyte/pull/55904) | Fix handling of invalid schemas (correctly JSON-serialize values) |
+| 2.0.4 | 2025-03-20 | [55886](https://github.com/airbytehq/airbyte/pull/55886) | Internal refactor |
+| 2.0.3 | 2025-03-18 | [55811](https://github.com/airbytehq/airbyte/pull/55811) | CDK: Pass DestinationStream around vs Descriptor |
+| 2.0.2 | 2025-03-12 | [55720](https://github.com/airbytehq/airbyte/pull/55720) | Restore definition ID |
+| 2.0.1 | 2025-03-12 | [55718](https://github.com/airbytehq/airbyte/pull/55718) | Fix breaking change information in metadata.yaml |
+| 2.0.0 | 2025-03-11 | [55684](https://github.com/airbytehq/airbyte/pull/55684) | Release 2.0.0 |
 | 2.0.0.rc13 | 2025-03-07 | [55252](https://github.com/airbytehq/airbyte/pull/55252)   | RC13: Bugfix for OOM on Bulk Load                                                                   |
 | 2.0.0.rc12 | 2025-03-05 | [54159](https://github.com/airbytehq/airbyte/pull/54159)   | RC12: Support For Bulk Insert Using Azure Blob Storage                                              |
 | 2.0.0.rc11 | 2025-03-04 | [55193](https://github.com/airbytehq/airbyte/pull/55193)   | RC11: Increase decimal precision                                                                    |


### PR DESCRIPTION


## Summary

Request from: https://airbytehq-team.slack.com/archives/C043JHEEYKG/p1780668502416749

- Adds `MIN_DATETIME` (`1753-01-01 00:00:00.000`) validation for `TimestampWithoutTimezone` values in destination-mssql
- Out-of-range timestamps (pre-1753) are gracefully nullified with `DESTINATION_FIELD_SIZE_LIMITATION` instead of crashing with `BatchUpdateException`
- Validation is applied in both the bulk load (CSV) and standard insert (PreparedStatement) paths

## Problem

Connections hitting `java.sql.BatchUpdateException: The conversion of a datetime2 data type to a datetime data type resulted in an out-of-range value` when source data contains dates before 1753-01-01. MSSQL's `DATETIME` type only supports 1753-01-01 through 9999-12-31, but no validation existed to catch this.

## Solution

Added `LIMITS.validateTimestamp()` following the same pattern as the existing `validateInteger()` and `validateNumber()` functions. Values below the DATETIME lower bound are nullified and a `DESTINATION_FIELD_SIZE_LIMITATION` change is recorded in `_airbyte_meta`.

## Changes

| File | Change |
|------|--------|
| `MSSQLCsvRowGenerator.kt` | Added `MIN_DATETIME`, `validateTimestamp()` to `LIMITS` object; wired into bulk load path |
| `MSSQLQueryBuilder.kt` | Wired validation into standard insert (PreparedStatement) path |
| `LimitsTest.kt` | 4 unit tests: in-range, exact boundary, below boundary, pre-1753 |
| `metadata.yaml` | Version bump `2.2.16` → `2.2.17` |