### PR TITLE
ci(hydra-automerge): fix shell quoting in structured output check

### DIFF
--- a/.github/workflows/hydra-automerge.yml
+++ b/.github/workflows/hydra-automerge.yml
@@ -345,8 +345,10 @@ jobs:
       - name: Check for structured output
         if: steps.devin.outputs.session-id
         id: check-output
+        env:
+          STRUCTURED_OUTPUT: ${{ steps.devin.outputs.structured-output }}
         run: |
-          if [[ -n '${{ steps.devin.outputs.structured-output }}' ]]; then
+          if [[ -n "$STRUCTURED_OUTPUT" ]]; then
             echo "success=true" >> "$GITHUB_OUTPUT"
           else
             echo "::error::Devin session completed but did not produce structured output."


### PR DESCRIPTION
## What

Fixes a bash syntax error in the `hydra-automerge.yml` workflow that causes the "Check for structured output" step to fail when Devin's structured output JSON contains single quotes.

Observed failure: https://github.com/airbytehq/airbyte/actions/runs/27045970234/job/79831888128#step:14:1

Related oncall ticket: https://github.com/airbytehq/oncall/issues/12799

## How

The step used inline single-quoted interpolation:
```bash
if [[ -n '${{ steps.devin.outputs.structured-output }}' ]]; then
```

When the structured output contained single quotes in reasoning fields (e.g. `'# Connector description for source-outlook'`), the shell saw unbalanced quotes and errored with `syntax error in conditional expression`.

Fix: pass the value through an `env` variable and test it with double-quoted expansion — the same pattern already used by the subsequent "Evaluate auto-merge gates" step.

## Review guide

1. `.github/workflows/hydra-automerge.yml` — the only change is in the "Check for structured output" step (added `env:` block, switched from `'${{ ... }}'` to `"$STRUCTURED_OUTPUT"`).

## User Impact

The hydra auto-merge pipeline will no longer fail when Devin's structured output reasoning includes single quotes. PRs that pass all gates will correctly proceed to merge.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Link to Devin session: https://app.devin.ai/sessions/57c91f93940243cb9c3298ae3a245deb
Requested by: @pedroslopez