### PR TITLE
fix(destination-s3-data-lake): handle null AWS credentials in assume-role auth path

### DIFF
--- a/airbyte-integrations/connectors/destination-s3-data-lake/src/main/kotlin/io/airbyte/integrations/destination/s3_data_lake/catalog/GlueCredentialsProvider.kt
+++ b/airbyte-integrations/connectors/destination-s3-data-lake/src/main/kotlin/io/airbyte/integrations/destination/s3_data_lake/catalog/GlueCredentialsProvider.kt
@@ -41,7 +41,7 @@ class GlueCredentialsProvider private constructor(private val delegate: AwsCrede
             val provider =
                 when (mode) {
                     AWS_CREDENTIALS_MODE_STATIC_CREDS -> {
-                        if (accessKey != null && secretKey != null) {
+                        if (!accessKey.isNullOrBlank() && !secretKey.isNullOrBlank()) {
                             StaticCredentialsProvider.create(
                                 AwsBasicCredentials.create(accessKey, secretKey)
                             )
@@ -51,7 +51,7 @@ class GlueCredentialsProvider private constructor(private val delegate: AwsCrede
                     }
                     AWS_CREDENTIALS_MODE_ASSUME_ROLE -> {
                         val baseCredentials =
-                            if (accessKey != null && secretKey != null) {
+                            if (!accessKey.isNullOrBlank() && !secretKey.isNullOrBlank()) {
                                 StaticCredentialsProvider.create(
                                     AwsBasicCredentials.create(accessKey, secretKey)
                                 )

--- a/airbyte-integrations/connectors/destination-s3-data-lake/src/main/kotlin/io/airbyte/integrations/destination/s3_data_lake/catalog/GlueCredentialsProvider.kt
+++ b/airbyte-integrations/connectors/destination-s3-data-lake/src/main/kotlin/io/airbyte/integrations/destination/s3_data_lake/catalog/GlueCredentialsProvider.kt
@@ -50,14 +50,18 @@ class GlueCredentialsProvider private constructor(private val delegate: AwsCrede
                         }
                     }
                     AWS_CREDENTIALS_MODE_ASSUME_ROLE -> {
+                        val baseCredentials =
+                            if (accessKey != null && secretKey != null) {
+                                StaticCredentialsProvider.create(
+                                    AwsBasicCredentials.create(accessKey, secretKey)
+                                )
+                            } else {
+                                DefaultCredentialsProvider.create()
+                            }
                         StsAssumeRoleCredentialsProvider.builder()
                             .stsClient(
                                 StsClient.builder()
-                                    .credentialsProvider(
-                                        StaticCredentialsProvider.create(
-                                            AwsBasicCredentials.create(accessKey, secretKey)
-                                        )
-                                    )
+                                    .credentialsProvider(baseCredentials)
                                     .region(Region.of(properties[ASSUME_ROLE_REGION]))
                                     .build()
                             )


### PR DESCRIPTION
## Summary
- Fixes `NullPointerException: Access key ID cannot be blank` during CHECK when using Glue catalog with assume-role authentication
- The `ASSUME_ROLE` branch in `GlueCredentialsProvider.create()` unconditionally passed `accessKey`/`secretKey` to `AwsBasicCredentials.create()`, which threw NPE when credentials were null or blank
- Adds a null check mirroring the existing `STATIC_CREDS` branch, falling back to `DefaultCredentialsProvider` for the STS client bootstrap when explicit keys are unavailable (e.g. instance profiles, ECS task roles)

> [!IMPORTANT]
> Active progressive rollout warning for destination-s3-data-lake.

- [ ] (Click to Approve:) Bypass the active progressive rollout warning for destination-s3-data-lake in the PR comment [here](https://github.com/airbytehq/airbyte/pull/79188#issuecomment-4653341208).