### PR TITLE
ci(registry): add version yank command workflow

### DIFF
--- a/.github/workflows/generate-connector-registries.yml
+++ b/.github/workflows/generate-connector-registries.yml
@@ -77,32 +77,10 @@ jobs:
       - name: Install Ops CLI
         run: uv tool install airbyte-internal-ops
 
-      - name: Resolve registry credentials
-        env:
-          INPUT_STORE: ${{ inputs.store || 'coral:prod' }}
-          PROD_REGISTRY_GCS_CREDENTIALS: ${{ secrets.METADATA_SERVICE_PROD_GCS_CREDENTIALS }}
-          NON_PROD_REGISTRY_GCS_CREDENTIALS: ${{ secrets.GCP_GSM_CREDENTIALS }}
-        run: |
-          if [ "$INPUT_STORE" = "coral:prod" ]; then
-            REGISTRY_GCS_CREDENTIALS="$PROD_REGISTRY_GCS_CREDENTIALS"
-          else
-            REGISTRY_GCS_CREDENTIALS="$NON_PROD_REGISTRY_GCS_CREDENTIALS"
-          fi
-
-          if [ -z "$REGISTRY_GCS_CREDENTIALS" ]; then
-            echo "::error::Registry GCS credentials are not configured for $INPUT_STORE."
-            exit 1
-          fi
-
-          {
-            echo "GCS_CREDENTIALS<<GCS_CREDENTIALS_EOF"
-            printf '%s\n' "$REGISTRY_GCS_CREDENTIALS"
-            echo "GCS_CREDENTIALS_EOF"
-          } >> "$GITHUB_ENV"
-
       - name: Compile Registries
         id: compile-registries
         env:
+          GCS_CREDENTIALS: ${{ secrets.METADATA_SERVICE_PROD_GCS_CREDENTIALS }}
           FORCE_FLAG: ${{ inputs.force == true && '--force' || '' }}
           CONNECTOR_NAME_FLAG: ${{ inputs.connector-name && format('--connector-name {0}', inputs.connector-name) || '' }}
         shell: bash

--- a/.github/workflows/generate-connector-registries.yml
+++ b/.github/workflows/generate-connector-registries.yml
@@ -16,6 +16,11 @@ on:
         description: "A connector name to limit the latest/ resync scope (e.g. 'source-faker'). Leave empty to compile all connectors."
         required: false
         type: string
+      store:
+        description: "Registry store to compile."
+        required: false
+        type: string
+        default: "coral:prod"
       pr:
         description: "Associated pull request number, for linking in notifications."
         required: false
@@ -35,6 +40,11 @@ on:
         description: "A connector name to limit the latest/ resync scope (e.g. 'source-faker'). Leave empty to compile all connectors."
         required: false
         type: string
+      store:
+        description: "Registry store to compile."
+        required: false
+        type: string
+        default: "coral:prod"
 
 permissions:
   contents: read
@@ -52,7 +62,7 @@ jobs:
     name: Compile Registries (ops CLI)
     runs-on: ubuntu-24.04
     env:
-      REGISTRY_STORE: "coral:prod"
+      REGISTRY_STORE: ${{ inputs.store || 'coral:prod' }}
 
     steps:
       - name: Checkout Airbyte
@@ -67,10 +77,32 @@ jobs:
       - name: Install Ops CLI
         run: uv tool install airbyte-internal-ops
 
+      - name: Resolve registry credentials
+        env:
+          INPUT_STORE: ${{ inputs.store || 'coral:prod' }}
+          PROD_REGISTRY_GCS_CREDENTIALS: ${{ secrets.METADATA_SERVICE_PROD_GCS_CREDENTIALS }}
+          NON_PROD_REGISTRY_GCS_CREDENTIALS: ${{ secrets.GCP_GSM_CREDENTIALS }}
+        run: |
+          if [ "$INPUT_STORE" = "coral:prod" ]; then
+            REGISTRY_GCS_CREDENTIALS="$PROD_REGISTRY_GCS_CREDENTIALS"
+          else
+            REGISTRY_GCS_CREDENTIALS="$NON_PROD_REGISTRY_GCS_CREDENTIALS"
+          fi
+
+          if [ -z "$REGISTRY_GCS_CREDENTIALS" ]; then
+            echo "::error::Registry GCS credentials are not configured for $INPUT_STORE."
+            exit 1
+          fi
+
+          {
+            echo "GCS_CREDENTIALS<<GCS_CREDENTIALS_EOF"
+            printf '%s\n' "$REGISTRY_GCS_CREDENTIALS"
+            echo "GCS_CREDENTIALS_EOF"
+          } >> "$GITHUB_ENV"
+
       - name: Compile Registries
         id: compile-registries
         env:
-          GCS_CREDENTIALS: ${{ secrets.METADATA_SERVICE_PROD_GCS_CREDENTIALS }}
           FORCE_FLAG: ${{ inputs.force == true && '--force' || '' }}
           CONNECTOR_NAME_FLAG: ${{ inputs.connector-name && format('--connector-name {0}', inputs.connector-name) || '' }}
         shell: bash
@@ -89,6 +121,7 @@ jobs:
           RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           PR_NUMBER="${{ inputs.pr }}"
           CONNECTOR_NAME="${{ inputs.connector-name }}"
+          REGISTRY_STORE="${{ inputs.store || 'coral:prod' }}"
           FORCE="${{ inputs.force }}"
 
           if [[ -n "$PR_NUMBER" && "$PR_NUMBER" != "0" ]]; then
@@ -99,6 +132,7 @@ jobs:
           fi
 
           DETAILS=""
+          DETAILS="${DETAILS}\nStore: \`${REGISTRY_STORE}\`"
           if [[ -n "$CONNECTOR_NAME" ]]; then
             DETAILS="${DETAILS}\nConnector: \`${CONNECTOR_NAME}\`"
           fi

--- a/.github/workflows/registry-yank.yml
+++ b/.github/workflows/registry-yank.yml
@@ -74,10 +74,31 @@ jobs:
           print(f"Validated Slack approval from {approver}.")
           PY
 
-      - name: Yank connector version (prod)
-        if: ${{ !inputs.unyank && inputs.store == 'coral:prod' }}
+      - name: Resolve prod registry credentials
+        if: ${{ inputs.store == 'coral:prod' }}
         env:
-          GCS_CREDENTIALS: ${{ secrets.METADATA_SERVICE_PROD_GCS_CREDENTIALS }}
+          REGISTRY_GCS_CREDENTIALS: ${{ secrets.METADATA_SERVICE_PROD_GCS_CREDENTIALS }}
+        run: |
+          {
+            echo "GCS_CREDENTIALS<<GCS_CREDENTIALS_EOF"
+            printf '%s\n' "$REGISTRY_GCS_CREDENTIALS"
+            echo "GCS_CREDENTIALS_EOF"
+          } >> "$GITHUB_ENV"
+
+      - name: Resolve non-prod registry credentials
+        if: ${{ inputs.store != 'coral:prod' }}
+        env:
+          REGISTRY_GCS_CREDENTIALS: ${{ secrets.GCP_GSM_CREDENTIALS }}
+        run: |
+          {
+            echo "GCS_CREDENTIALS<<GCS_CREDENTIALS_EOF"
+            printf '%s\n' "$REGISTRY_GCS_CREDENTIALS"
+            echo "GCS_CREDENTIALS_EOF"
+          } >> "$GITHUB_ENV"
+
+      - name: Yank connector version
+        if: ${{ !inputs.unyank }}
+        env:
           INPUT_CONNECTOR_NAME: ${{ inputs.connector_name }}
           INPUT_VERSION: ${{ inputs.version }}
           INPUT_STORE: ${{ inputs.store }}
@@ -89,38 +110,9 @@ jobs:
             --store "$INPUT_STORE" \
             --reason "$INPUT_REASON"
 
-      - name: Yank connector version (non-prod)
-        if: ${{ !inputs.unyank && inputs.store != 'coral:prod' }}
+      - name: Unyank connector version
+        if: ${{ inputs.unyank }}
         env:
-          GCS_CREDENTIALS: ${{ secrets.GCP_GSM_CREDENTIALS }}
-          INPUT_CONNECTOR_NAME: ${{ inputs.connector_name }}
-          INPUT_VERSION: ${{ inputs.version }}
-          INPUT_STORE: ${{ inputs.store }}
-          INPUT_REASON: ${{ inputs.reason }}
-        run: |
-          airbyte-ops registry connector-version yank \
-            --name "$INPUT_CONNECTOR_NAME" \
-            --version "$INPUT_VERSION" \
-            --store "$INPUT_STORE" \
-            --reason "$INPUT_REASON"
-
-      - name: Unyank connector version (prod)
-        if: ${{ inputs.unyank && inputs.store == 'coral:prod' }}
-        env:
-          GCS_CREDENTIALS: ${{ secrets.METADATA_SERVICE_PROD_GCS_CREDENTIALS }}
-          INPUT_CONNECTOR_NAME: ${{ inputs.connector_name }}
-          INPUT_VERSION: ${{ inputs.version }}
-          INPUT_STORE: ${{ inputs.store }}
-        run: |
-          airbyte-ops registry connector-version unyank \
-            --name "$INPUT_CONNECTOR_NAME" \
-            --version "$INPUT_VERSION" \
-            --store "$INPUT_STORE"
-
-      - name: Unyank connector version (non-prod)
-        if: ${{ inputs.unyank && inputs.store != 'coral:prod' }}
-        env:
-          GCS_CREDENTIALS: ${{ secrets.GCP_GSM_CREDENTIALS }}
           INPUT_CONNECTOR_NAME: ${{ inputs.connector_name }}
           INPUT_VERSION: ${{ inputs.version }}
           INPUT_STORE: ${{ inputs.store }}
@@ -133,7 +125,6 @@ jobs:
       - name: Compile registry (non-prod)
         if: ${{ inputs.store != 'coral:prod' }}
         env:
-          GCS_CREDENTIALS: ${{ secrets.GCP_GSM_CREDENTIALS }}
           INPUT_CONNECTOR_NAME: ${{ inputs.connector_name }}
           INPUT_STORE: ${{ inputs.store }}
         run: |

--- a/.github/workflows/registry-yank.yml
+++ b/.github/workflows/registry-yank.yml
@@ -25,10 +25,6 @@ on:
         required: false
         type: boolean
         default: false
-      approval_comment_url:
-        description: "Approval URL authorizing this yank/unyank operation."
-        required: true
-        type: string
 
 permissions:
   contents: read
@@ -58,21 +54,8 @@ jobs:
       - name: Install Ops CLI
         run: uv tool install airbyte-internal-ops
 
-      - name: Validate Slack approval
-        env:
-          INPUT_APPROVAL_COMMENT_URL: ${{ inputs.approval_comment_url }}
-          SLACK_BOT_TOKEN: ${{ secrets.SLACK_HYDRA_BOT_TOKEN || secrets.SLACK_BOT_TOKEN_HITL || secrets.SLACK_BOT_TOKEN_AIRBYTE_TEAM }}
-        run: |
-          uv run --with airbyte-internal-ops python - <<'PY'
-          import os
-
-          from airbyte_ops_mcp.approval_resolution import resolve_admin_email_from_approval
-
-          approver = resolve_admin_email_from_approval(
-              approval_comment_url=os.environ["INPUT_APPROVAL_COMMENT_URL"],
-          )
-          print(f"Validated Slack approval from {approver}.")
-          PY
+      - name: Resolve workflow variables
+        run: echo "REGISTRY_ACTION=${{ inputs.unyank && 'unyank' || 'yank' }}" | tee -a "$GITHUB_ENV"
 
       - name: Resolve prod registry credentials
         if: ${{ inputs.store == 'coral:prod' }}
@@ -96,41 +79,22 @@ jobs:
             echo "GCS_CREDENTIALS_EOF"
           } >> "$GITHUB_ENV"
 
-      - name: Yank connector version
-        if: ${{ !inputs.unyank }}
+      - name: Update connector version yank marker
         env:
           INPUT_CONNECTOR_NAME: ${{ inputs.connector_name }}
           INPUT_VERSION: ${{ inputs.version }}
           INPUT_STORE: ${{ inputs.store }}
           INPUT_REASON: ${{ inputs.reason }}
         run: |
-          airbyte-ops registry connector-version yank \
-            --name "$INPUT_CONNECTOR_NAME" \
-            --version "$INPUT_VERSION" \
-            --store "$INPUT_STORE" \
-            --reason "$INPUT_REASON"
-
-      - name: Unyank connector version
-        if: ${{ inputs.unyank }}
-        env:
-          INPUT_CONNECTOR_NAME: ${{ inputs.connector_name }}
-          INPUT_VERSION: ${{ inputs.version }}
-          INPUT_STORE: ${{ inputs.store }}
-        run: |
-          airbyte-ops registry connector-version unyank \
-            --name "$INPUT_CONNECTOR_NAME" \
-            --version "$INPUT_VERSION" \
+          args=(
+            --name "$INPUT_CONNECTOR_NAME"
+            --version "$INPUT_VERSION"
             --store "$INPUT_STORE"
-
-      - name: Compile registry (non-prod)
-        if: ${{ inputs.store != 'coral:prod' }}
-        env:
-          INPUT_CONNECTOR_NAME: ${{ inputs.connector_name }}
-          INPUT_STORE: ${{ inputs.store }}
-        run: |
-          airbyte-ops registry store compile \
-            --store "$INPUT_STORE" \
-            --connector-name "$INPUT_CONNECTOR_NAME"
+          )
+          if [ "$REGISTRY_ACTION" = "yank" ] && [ -n "$INPUT_REASON" ]; then
+            args+=(--reason "$INPUT_REASON")
+          fi
+          airbyte-ops registry connector-version "$REGISTRY_ACTION" "${args[@]}"
 
   compile-prod-registry:
     name: Compile prod registry
@@ -140,3 +104,30 @@ jobs:
     with:
       connector-name: ${{ inputs.connector_name }}
     secrets: inherit
+
+  compile-non-prod-registry:
+    name: Compile non-prod registry
+    needs: yank-version
+    if: ${{ inputs.store != 'coral:prod' }}
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout Airbyte
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 1
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
+
+      - name: Install Ops CLI
+        run: uv tool install airbyte-internal-ops
+
+      - name: Compile non-prod registry
+        env:
+          GCS_CREDENTIALS: ${{ secrets.GCP_GSM_CREDENTIALS }}
+          INPUT_CONNECTOR_NAME: ${{ inputs.connector_name }}
+          INPUT_STORE: ${{ inputs.store }}
+        run: |
+          airbyte-ops registry store compile \
+            --store "$INPUT_STORE" \
+            --connector-name "$INPUT_CONNECTOR_NAME"

--- a/.github/workflows/registry-yank.yml
+++ b/.github/workflows/registry-yank.yml
@@ -34,11 +34,11 @@ permissions:
   contents: read
 
 concurrency:
-  group: registry-yank-${{ inputs.connector_name }}
+  group: registry-yank-${{ inputs.connector_name }}-${{ inputs.store }}
   cancel-in-progress: false
 
 jobs:
-  yank-and-compile:
+  yank-version:
     name: "${{ inputs.unyank && 'Unyank' || 'Yank' }} ${{ inputs.connector_name }}@${{ inputs.version }}"
     runs-on: ubuntu-24.04
     steps:
@@ -130,17 +130,6 @@ jobs:
             --version "$INPUT_VERSION" \
             --store "$INPUT_STORE"
 
-      - name: Compile registry (prod)
-        if: ${{ inputs.store == 'coral:prod' }}
-        env:
-          GCS_CREDENTIALS: ${{ secrets.METADATA_SERVICE_PROD_GCS_CREDENTIALS }}
-          INPUT_CONNECTOR_NAME: ${{ inputs.connector_name }}
-          INPUT_STORE: ${{ inputs.store }}
-        run: |
-          airbyte-ops registry store compile \
-            --store "$INPUT_STORE" \
-            --connector-name "$INPUT_CONNECTOR_NAME"
-
       - name: Compile registry (non-prod)
         if: ${{ inputs.store != 'coral:prod' }}
         env:
@@ -151,3 +140,12 @@ jobs:
           airbyte-ops registry store compile \
             --store "$INPUT_STORE" \
             --connector-name "$INPUT_CONNECTOR_NAME"
+
+  compile-prod-registry:
+    name: Compile prod registry
+    needs: yank-version
+    if: ${{ inputs.store == 'coral:prod' }}
+    uses: ./.github/workflows/generate-connector-registries.yml
+    with:
+      connector-name: ${{ inputs.connector_name }}
+    secrets: inherit

--- a/.github/workflows/registry-yank.yml
+++ b/.github/workflows/registry-yank.yml
@@ -51,10 +51,7 @@ jobs:
 
       - name: Resolve workflow variables
         env:
-          INPUT_STORE: ${{ inputs.store }}
           INPUT_UNYANK: ${{ inputs.unyank }}
-          PROD_REGISTRY_GCS_CREDENTIALS: ${{ secrets.METADATA_SERVICE_PROD_GCS_CREDENTIALS }}
-          NON_PROD_REGISTRY_GCS_CREDENTIALS: ${{ secrets.GCP_GSM_CREDENTIALS }}
         run: |
           if [ "$INPUT_UNYANK" = "true" ]; then
             echo "REGISTRY_ACTION=unyank" | tee -a "$GITHUB_ENV"
@@ -62,25 +59,9 @@ jobs:
             echo "REGISTRY_ACTION=yank" | tee -a "$GITHUB_ENV"
           fi
 
-          if [ "$INPUT_STORE" = "coral:prod" ]; then
-            REGISTRY_GCS_CREDENTIALS="$PROD_REGISTRY_GCS_CREDENTIALS"
-          else
-            REGISTRY_GCS_CREDENTIALS="$NON_PROD_REGISTRY_GCS_CREDENTIALS"
-          fi
-
-          if [ -z "$REGISTRY_GCS_CREDENTIALS" ]; then
-            echo "::error::Registry GCS credentials are not configured for $INPUT_STORE."
-            exit 1
-          fi
-
-          {
-            echo "GCS_CREDENTIALS<<GCS_CREDENTIALS_EOF"
-            printf '%s\n' "$REGISTRY_GCS_CREDENTIALS"
-            echo "GCS_CREDENTIALS_EOF"
-          } >> "$GITHUB_ENV"
-
       - name: Update connector version yank marker
         env:
+          GCS_CREDENTIALS: ${{ secrets.METADATA_SERVICE_PROD_GCS_CREDENTIALS }}
           INPUT_CONNECTOR_NAME: ${{ inputs.connector_name }}
           INPUT_VERSION: ${{ inputs.version }}
           INPUT_STORE: ${{ inputs.store }}

--- a/.github/workflows/registry-yank.yml
+++ b/.github/workflows/registry-yank.yml
@@ -46,11 +46,6 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
 
-      - name: Set up Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
-        with:
-          python-version: "3.11"
-
       - name: Install Ops CLI
         run: uv tool install airbyte-internal-ops
 

--- a/.github/workflows/registry-yank.yml
+++ b/.github/workflows/registry-yank.yml
@@ -26,7 +26,7 @@ on:
         type: boolean
         default: false
       approval_comment_url:
-        description: "Slack approval record URL authorizing this yank/unyank operation."
+        description: "Approval URL authorizing this yank/unyank operation."
         required: true
         type: string
 

--- a/.github/workflows/registry-yank.yml
+++ b/.github/workflows/registry-yank.yml
@@ -1,0 +1,153 @@
+name: "Registry: Yank Connector Version"
+
+on:
+  workflow_dispatch:
+    inputs:
+      connector_name:
+        description: "Connector name (e.g., 'source-faker')."
+        required: true
+        type: string
+      version:
+        description: "Version to yank (e.g., '1.2.3')."
+        required: true
+        type: string
+      store:
+        description: "Store target (e.g., 'coral:dev', 'coral:prod')."
+        required: true
+        type: string
+      reason:
+        description: "Reason for yanking this version."
+        required: false
+        type: string
+        default: ""
+      unyank:
+        description: "Set to true to unyank (restore) the version instead of yanking it."
+        required: false
+        type: boolean
+        default: false
+      approval_comment_url:
+        description: "Slack approval record URL authorizing this yank/unyank operation."
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: registry-yank-${{ inputs.connector_name }}
+  cancel-in-progress: false
+
+jobs:
+  yank-and-compile:
+    name: "${{ inputs.unyank && 'Unyank' || 'Yank' }} ${{ inputs.connector_name }}@${{ inputs.version }}"
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout Airbyte
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 1
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.11"
+
+      - name: Install Ops CLI
+        run: uv tool install airbyte-internal-ops
+
+      - name: Validate Slack approval
+        env:
+          INPUT_APPROVAL_COMMENT_URL: ${{ inputs.approval_comment_url }}
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_HYDRA_BOT_TOKEN || secrets.SLACK_BOT_TOKEN_HITL || secrets.SLACK_BOT_TOKEN_AIRBYTE_TEAM }}
+        run: |
+          uv run --with airbyte-internal-ops python - <<'PY'
+          import os
+
+          from airbyte_ops_mcp.approval_resolution import resolve_admin_email_from_approval
+
+          approver = resolve_admin_email_from_approval(
+              approval_comment_url=os.environ["INPUT_APPROVAL_COMMENT_URL"],
+          )
+          print(f"Validated Slack approval from {approver}.")
+          PY
+
+      - name: Yank connector version (prod)
+        if: ${{ !inputs.unyank && inputs.store == 'coral:prod' }}
+        env:
+          GCS_CREDENTIALS: ${{ secrets.METADATA_SERVICE_PROD_GCS_CREDENTIALS }}
+          INPUT_CONNECTOR_NAME: ${{ inputs.connector_name }}
+          INPUT_VERSION: ${{ inputs.version }}
+          INPUT_STORE: ${{ inputs.store }}
+          INPUT_REASON: ${{ inputs.reason }}
+        run: |
+          airbyte-ops registry connector-version yank \
+            --name "$INPUT_CONNECTOR_NAME" \
+            --version "$INPUT_VERSION" \
+            --store "$INPUT_STORE" \
+            --reason "$INPUT_REASON"
+
+      - name: Yank connector version (non-prod)
+        if: ${{ !inputs.unyank && inputs.store != 'coral:prod' }}
+        env:
+          GCS_CREDENTIALS: ${{ secrets.GCP_GSM_CREDENTIALS }}
+          INPUT_CONNECTOR_NAME: ${{ inputs.connector_name }}
+          INPUT_VERSION: ${{ inputs.version }}
+          INPUT_STORE: ${{ inputs.store }}
+          INPUT_REASON: ${{ inputs.reason }}
+        run: |
+          airbyte-ops registry connector-version yank \
+            --name "$INPUT_CONNECTOR_NAME" \
+            --version "$INPUT_VERSION" \
+            --store "$INPUT_STORE" \
+            --reason "$INPUT_REASON"
+
+      - name: Unyank connector version (prod)
+        if: ${{ inputs.unyank && inputs.store == 'coral:prod' }}
+        env:
+          GCS_CREDENTIALS: ${{ secrets.METADATA_SERVICE_PROD_GCS_CREDENTIALS }}
+          INPUT_CONNECTOR_NAME: ${{ inputs.connector_name }}
+          INPUT_VERSION: ${{ inputs.version }}
+          INPUT_STORE: ${{ inputs.store }}
+        run: |
+          airbyte-ops registry connector-version unyank \
+            --name "$INPUT_CONNECTOR_NAME" \
+            --version "$INPUT_VERSION" \
+            --store "$INPUT_STORE"
+
+      - name: Unyank connector version (non-prod)
+        if: ${{ inputs.unyank && inputs.store != 'coral:prod' }}
+        env:
+          GCS_CREDENTIALS: ${{ secrets.GCP_GSM_CREDENTIALS }}
+          INPUT_CONNECTOR_NAME: ${{ inputs.connector_name }}
+          INPUT_VERSION: ${{ inputs.version }}
+          INPUT_STORE: ${{ inputs.store }}
+        run: |
+          airbyte-ops registry connector-version unyank \
+            --name "$INPUT_CONNECTOR_NAME" \
+            --version "$INPUT_VERSION" \
+            --store "$INPUT_STORE"
+
+      - name: Compile registry (prod)
+        if: ${{ inputs.store == 'coral:prod' }}
+        env:
+          GCS_CREDENTIALS: ${{ secrets.METADATA_SERVICE_PROD_GCS_CREDENTIALS }}
+          INPUT_CONNECTOR_NAME: ${{ inputs.connector_name }}
+          INPUT_STORE: ${{ inputs.store }}
+        run: |
+          airbyte-ops registry store compile \
+            --store "$INPUT_STORE" \
+            --connector-name "$INPUT_CONNECTOR_NAME"
+
+      - name: Compile registry (non-prod)
+        if: ${{ inputs.store != 'coral:prod' }}
+        env:
+          GCS_CREDENTIALS: ${{ secrets.GCP_GSM_CREDENTIALS }}
+          INPUT_CONNECTOR_NAME: ${{ inputs.connector_name }}
+          INPUT_STORE: ${{ inputs.store }}
+        run: |
+          airbyte-ops registry store compile \
+            --store "$INPUT_STORE" \
+            --connector-name "$INPUT_CONNECTOR_NAME"

--- a/.github/workflows/registry-yank.yml
+++ b/.github/workflows/registry-yank.yml
@@ -96,38 +96,11 @@ jobs:
           fi
           airbyte-ops registry connector-version "$REGISTRY_ACTION" "${args[@]}"
 
-  compile-prod-registry:
-    name: Compile prod registry
+  compile-registry:
+    name: Compile registry
     needs: yank-version
-    if: ${{ inputs.store == 'coral:prod' }}
     uses: ./.github/workflows/generate-connector-registries.yml
     with:
       connector-name: ${{ inputs.connector_name }}
+      store: ${{ inputs.store }}
     secrets: inherit
-
-  compile-non-prod-registry:
-    name: Compile non-prod registry
-    needs: yank-version
-    if: ${{ inputs.store != 'coral:prod' }}
-    runs-on: ubuntu-24.04
-    steps:
-      - name: Checkout Airbyte
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          fetch-depth: 1
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
-
-      - name: Install Ops CLI
-        run: uv tool install airbyte-internal-ops
-
-      - name: Compile non-prod registry
-        env:
-          GCS_CREDENTIALS: ${{ secrets.GCP_GSM_CREDENTIALS }}
-          INPUT_CONNECTOR_NAME: ${{ inputs.connector_name }}
-          INPUT_STORE: ${{ inputs.store }}
-        run: |
-          airbyte-ops registry store compile \
-            --store "$INPUT_STORE" \
-            --connector-name "$INPUT_CONNECTOR_NAME"

--- a/.github/workflows/registry-yank.yml
+++ b/.github/workflows/registry-yank.yml
@@ -50,24 +50,29 @@ jobs:
         run: uv tool install airbyte-internal-ops
 
       - name: Resolve workflow variables
-        run: echo "REGISTRY_ACTION=${{ inputs.unyank && 'unyank' || 'yank' }}" | tee -a "$GITHUB_ENV"
-
-      - name: Resolve prod registry credentials
-        if: ${{ inputs.store == 'coral:prod' }}
         env:
-          REGISTRY_GCS_CREDENTIALS: ${{ secrets.METADATA_SERVICE_PROD_GCS_CREDENTIALS }}
+          INPUT_STORE: ${{ inputs.store }}
+          INPUT_UNYANK: ${{ inputs.unyank }}
+          PROD_REGISTRY_GCS_CREDENTIALS: ${{ secrets.METADATA_SERVICE_PROD_GCS_CREDENTIALS }}
+          NON_PROD_REGISTRY_GCS_CREDENTIALS: ${{ secrets.GCP_GSM_CREDENTIALS }}
         run: |
-          {
-            echo "GCS_CREDENTIALS<<GCS_CREDENTIALS_EOF"
-            printf '%s\n' "$REGISTRY_GCS_CREDENTIALS"
-            echo "GCS_CREDENTIALS_EOF"
-          } >> "$GITHUB_ENV"
+          if [ "$INPUT_UNYANK" = "true" ]; then
+            echo "REGISTRY_ACTION=unyank" | tee -a "$GITHUB_ENV"
+          else
+            echo "REGISTRY_ACTION=yank" | tee -a "$GITHUB_ENV"
+          fi
 
-      - name: Resolve non-prod registry credentials
-        if: ${{ inputs.store != 'coral:prod' }}
-        env:
-          REGISTRY_GCS_CREDENTIALS: ${{ secrets.GCP_GSM_CREDENTIALS }}
-        run: |
+          if [ "$INPUT_STORE" = "coral:prod" ]; then
+            REGISTRY_GCS_CREDENTIALS="$PROD_REGISTRY_GCS_CREDENTIALS"
+          else
+            REGISTRY_GCS_CREDENTIALS="$NON_PROD_REGISTRY_GCS_CREDENTIALS"
+          fi
+
+          if [ -z "$REGISTRY_GCS_CREDENTIALS" ]; then
+            echo "::error::Registry GCS credentials are not configured for $INPUT_STORE."
+            exit 1
+          fi
+
           {
             echo "GCS_CREDENTIALS<<GCS_CREDENTIALS_EOF"
             printf '%s\n' "$REGISTRY_GCS_CREDENTIALS"

--- a/.github/workflows/slash-commands.yml
+++ b/.github/workflows/slash-commands.yml
@@ -79,6 +79,7 @@ jobs:
             run-regression-tests
             test-performance
             update-connector-cdk-version
+            version-yank
 
           # Notes regarding static-args:
           # - Slash commands can be invoked from both issues and comments.

--- a/.github/workflows/version-yank-command.yml
+++ b/.github/workflows/version-yank-command.yml
@@ -43,6 +43,10 @@ on:
         required: false
         type: string
         default: ""
+      approval-url:
+        description: "Approval URL for the yank audit trail."
+        required: false
+        type: string
       unyank:
         description: "Set to true to unyank (restore) the version instead of yanking it."
         required: false
@@ -90,6 +94,21 @@ jobs:
             echo "REGISTRY_ACTION=yank" | tee -a "$GITHUB_ENV"
           fi
 
+      - name: Resolve approval URL
+        env:
+          INPUT_APPROVAL_URL: ${{ inputs.approval-url }}
+          INPUT_COMMENT_ID: ${{ inputs.comment-id }}
+          INPUT_PR: ${{ inputs.pr }}
+          INPUT_REPOSITORY: ${{ github.repository }}
+        run: |
+          if [ -n "$INPUT_APPROVAL_URL" ]; then
+            echo "APPROVAL_URL=$INPUT_APPROVAL_URL" | tee -a "$GITHUB_ENV"
+          elif [ -n "$INPUT_COMMENT_ID" ] && [ -n "$INPUT_PR" ]; then
+            echo "APPROVAL_URL=https://github.com/$INPUT_REPOSITORY/pull/$INPUT_PR#issuecomment-$INPUT_COMMENT_ID" | tee -a "$GITHUB_ENV"
+          else
+            echo "APPROVAL_URL=" | tee -a "$GITHUB_ENV"
+          fi
+
       - name: Update connector version yank marker
         env:
           GCS_CREDENTIALS: ${{ secrets.METADATA_SERVICE_PROD_GCS_CREDENTIALS }}
@@ -104,6 +123,9 @@ jobs:
           )
           if [ "$REGISTRY_ACTION" = "yank" ] && [ -n "$INPUT_REASON" ]; then
             args+=(--reason "$INPUT_REASON")
+          fi
+          if [ "$REGISTRY_ACTION" = "yank" ] && [ -n "$APPROVAL_URL" ]; then
+            args+=(--approval-url "$APPROVAL_URL")
           fi
           airbyte-ops registry connector-version "$REGISTRY_ACTION" "${args[@]}"
 

--- a/.github/workflows/version-yank-command.yml
+++ b/.github/workflows/version-yank-command.yml
@@ -22,13 +22,9 @@ on:
         required: false
         type: string
       # Custom inputs for this workflow:
-      connector_name:
-        description: "Connector name (e.g., 'source-faker')."
-        required: false
-        type: string
       connector-name:
-        description: "Connector name, for slash command usage (e.g., 'source-faker')."
-        required: false
+        description: "Connector name (e.g., 'source-faker')."
+        required: true
         type: string
       version:
         description: "Version to yank (e.g., '1.2.3')."
@@ -57,12 +53,12 @@ permissions:
   contents: read
 
 concurrency:
-  group: version-yank-${{ inputs.connector_name || inputs.connector-name }}-${{ inputs.store }}
+  group: version-yank-${{ inputs.connector-name }}-${{ inputs.store }}
   cancel-in-progress: false
 
 jobs:
   yank-version:
-    name: "${{ inputs.unyank && 'Unyank' || 'Yank' }} ${{ inputs.connector_name || inputs.connector-name }}@${{ inputs.version }}"
+    name: "${{ inputs.unyank && 'Unyank' || 'Yank' }} ${{ inputs.connector-name }}@${{ inputs.version }}"
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout Airbyte
@@ -78,14 +74,9 @@ jobs:
 
       - name: Resolve workflow variables
         env:
-          INPUT_CONNECTOR_NAME: ${{ inputs.connector_name || inputs.connector-name }}
+          INPUT_CONNECTOR_NAME: ${{ inputs.connector-name }}
           INPUT_UNYANK: ${{ inputs.unyank }}
         run: |
-          if [ -z "$INPUT_CONNECTOR_NAME" ]; then
-            echo "::error::connector_name or connector-name is required."
-            exit 1
-          fi
-
           echo "INPUT_CONNECTOR_NAME=$INPUT_CONNECTOR_NAME" | tee -a "$GITHUB_ENV"
 
           if [ "$INPUT_UNYANK" = "true" ]; then
@@ -134,6 +125,6 @@ jobs:
     needs: yank-version
     uses: ./.github/workflows/generate-connector-registries.yml
     with:
-      connector-name: ${{ inputs.connector_name || inputs.connector-name }}
+      connector-name: ${{ inputs.connector-name }}
       store: ${{ inputs.store }}
     secrets: inherit

--- a/.github/workflows/version-yank-command.yml
+++ b/.github/workflows/version-yank-command.yml
@@ -3,9 +3,30 @@ name: "Registry: Yank Connector Version"
 on:
   workflow_dispatch:
     inputs:
+      repo:
+        description: "Repo (passed by slash command dispatcher; ignored)"
+        required: false
+        default: "airbytehq/airbyte"
+        type: string
+      gitref:
+        description: "Git ref (passed by slash command dispatcher; ignored)"
+        required: false
+        type: string
+      comment-id:
+        description: "The comment-id of the slash command."
+        required: false
+        type: string
+      pr:
+        description: "PR number, if triggered from a PR comment."
+        required: false
+        type: string
       connector_name:
         description: "Connector name (e.g., 'source-faker')."
-        required: true
+        required: false
+        type: string
+      connector-name:
+        description: "Connector name, for slash command usage (e.g., 'source-faker')."
+        required: false
         type: string
       version:
         description: "Version to yank (e.g., '1.2.3')."
@@ -30,12 +51,12 @@ permissions:
   contents: read
 
 concurrency:
-  group: registry-yank-${{ inputs.connector_name }}-${{ inputs.store }}
+  group: version-yank-${{ inputs.connector_name || inputs.connector-name }}-${{ inputs.store }}
   cancel-in-progress: false
 
 jobs:
   yank-version:
-    name: "${{ inputs.unyank && 'Unyank' || 'Yank' }} ${{ inputs.connector_name }}@${{ inputs.version }}"
+    name: "${{ inputs.unyank && 'Unyank' || 'Yank' }} ${{ inputs.connector_name || inputs.connector-name }}@${{ inputs.version }}"
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout Airbyte
@@ -51,8 +72,16 @@ jobs:
 
       - name: Resolve workflow variables
         env:
+          INPUT_CONNECTOR_NAME: ${{ inputs.connector_name || inputs.connector-name }}
           INPUT_UNYANK: ${{ inputs.unyank }}
         run: |
+          if [ -z "$INPUT_CONNECTOR_NAME" ]; then
+            echo "::error::connector_name or connector-name is required."
+            exit 1
+          fi
+
+          echo "INPUT_CONNECTOR_NAME=$INPUT_CONNECTOR_NAME" | tee -a "$GITHUB_ENV"
+
           if [ "$INPUT_UNYANK" = "true" ]; then
             echo "REGISTRY_ACTION=unyank" | tee -a "$GITHUB_ENV"
           else
@@ -62,7 +91,6 @@ jobs:
       - name: Update connector version yank marker
         env:
           GCS_CREDENTIALS: ${{ secrets.METADATA_SERVICE_PROD_GCS_CREDENTIALS }}
-          INPUT_CONNECTOR_NAME: ${{ inputs.connector_name }}
           INPUT_VERSION: ${{ inputs.version }}
           INPUT_STORE: ${{ inputs.store }}
           INPUT_REASON: ${{ inputs.reason }}
@@ -82,6 +110,6 @@ jobs:
     needs: yank-version
     uses: ./.github/workflows/generate-connector-registries.yml
     with:
-      connector-name: ${{ inputs.connector_name }}
+      connector-name: ${{ inputs.connector_name || inputs.connector-name }}
       store: ${{ inputs.store }}
     secrets: inherit

--- a/.github/workflows/version-yank-command.yml
+++ b/.github/workflows/version-yank-command.yml
@@ -3,6 +3,7 @@ name: "Registry: Yank Connector Version"
 on:
   workflow_dispatch:
     inputs:
+      # Generic slash command inputs:
       repo:
         description: "Repo (passed by slash command dispatcher; ignored)"
         required: false
@@ -20,6 +21,7 @@ on:
         description: "PR number, if triggered from a PR comment."
         required: false
         type: string
+      # Custom inputs for this workflow:
       connector_name:
         description: "Connector name (e.g., 'source-faker')."
         required: false


### PR DESCRIPTION
## What
Adds `version-yank-command.yml` in `airbyte` as the canonical workflow for approved registry yank/unyank mutations. This keeps the mutating registry path in the repo that already owns prod registry publish/compile credentials, while merged `airbytehq/airbyte-ops-mcp#867` dispatches to it after MCP-level Slack/HITL approval.

This PR also registers `/version-yank` with the existing slash-command dispatcher and extends `generate-connector-registries.yml` with an optional `store` input so yank-triggered compiles reuse the existing registry generation workflow.

## How
- Adds `.github/workflows/version-yank-command.yml` with one connector input: `connector-name`.
- Accepts an explicit `approval-url` from the MCP path, or resolves a fallback PR-comment URL from `comment-id` + `pr` for slash-command invocations.
- Runs `airbyte-ops registry connector-version yank|unyank` against the selected `store`; for yank, forwards `--approval-url "$APPROVAL_URL"` so the marker records audit evidence.
- Calls `generate-connector-registries.yml` for compile, passing the selected `store` and inheriting secrets.
- Uses `METADATA_SERVICE_PROD_GCS_CREDENTIALS` as `GCS_CREDENTIALS` for both marker writes and registry compiles.
- Leaves Slack/HITL approval validation in `yank_connector_version`; the workflow records approval evidence but does not revalidate it.

## Review guide
1. `.github/workflows/version-yank-command.yml`
2. `.github/workflows/slash-commands.yml`
3. `.github/workflows/generate-connector-registries.yml`

## User Impact
Approved registry yank/unyank requests can run from `airbyte`, where canonical registry credentials and compile workflows live. Maintainers can also invoke the same workflow through `/version-yank` using the existing slash-command dispatcher.

No real yank/unyank workflow dispatch was performed while testing this PR.

## Validation
- `git diff --check`
- `yq eval` on `.github/workflows/version-yank-command.yml`, `.github/workflows/slash-commands.yml`, and `.github/workflows/generate-connector-registries.yml`
- `actionlint` on `.github/workflows/version-yank-command.yml`, `.github/workflows/slash-commands.yml`, and `.github/workflows/generate-connector-registries.yml`
- Static assertions that `version-yank-command.yml` uses one `connector-name` input for both MCP and slash-command dispatch
- Static assertions that `approval-url` is resolved from explicit input or PR comment fallback and forwarded to marker creation for yank
- Static assertions that both registry workflows use `METADATA_SERVICE_PROD_GCS_CREDENTIALS` directly with no prod/non-prod credential swap logic
- In `airbyte-ops-mcp`: `uv run --group dev ruff check && uv run --group dev ruff format --check`
- In `airbyte-ops-mcp`: `uv run --group dev pytest tests/test_mcp_registry.py tests/test_registry_yank.py tests/test_cli_registry.py::test_yank_connector_version_response_model -q`
- CI: 30 passed, 0 failed, 0 pending

## Can this PR be safely reverted and rolled back?
- [ ] YES 💚
- [x] NO ❌

The matching ops MCP dispatch change has merged, so reverting this workflow without also reverting `airbytehq/airbyte-ops-mcp#867` would break approved yank/unyank dispatches.

Link to Devin session: https://app.devin.ai/sessions/92fcd84318a14c95aa34ed40656fb276
Requested by: @aaronsteers