### PR TITLE
fix(destination-mssql): Fix timestamp conversion regression for sub-millisecond precision values

### DIFF
--- a/airbyte-integrations/connectors/destination-mssql/src/main/kotlin/io/airbyte/integrations/destination/mssql/v2/MSSQLQueryBuilder.kt
+++ b/airbyte-integrations/connectors/destination-mssql/src/main/kotlin/io/airbyte/integrations/destination/mssql/v2/MSSQLQueryBuilder.kt
@@ -404,7 +404,7 @@ class MSSQLQueryBuilder(
                     )
                 TimestampTypeWithoutTimezone ->
                     LIMITS.validateTimestamp(value)?.let {
-                        statement.setObject(statementIndex, it.toString())
+                        statement.setObject(statementIndex, it)
                     }
                         ?: statement.setAsNullValue(statementIndex, field.type.type)
 


### PR DESCRIPTION
## Description

Version 2.2.17 introduced a regression in `MSSQLQueryBuilder.kt` where `TimestampTypeWithoutTimezone` values are bound as **strings** to the JDBC prepared statement via `it.toString()`. This breaks when the `LocalDateTime` value has sub-millisecond precision (which is common with `datetime2(7)` source columns).

## Root Cause

`LocalDateTime.toString()` on a value with nanosecond precision produces strings like:

```
2026-03-11T16:55:33.476611200
2019-10-20T10:11:45.030000000
```

SQL Server's `DATETIME` column only accepts string representations with up to **3 decimal places**. Any string with 4+ decimal places causes:

```
com.microsoft.sqlserver.jdbc.SQLServerException: Conversion failed when converting date and/or time from character string.
```

## Fix

Pass the `LocalDateTime` object directly to `statement.setObject()` instead of its string representation. The JDBC driver correctly handles type binding for `LocalDateTime` to `DATETIME`, including implicit rounding to the precision of the target column type.

**Change in `MSSQLQueryBuilder.kt` (line 407):**

```diff
- statement.setObject(statementIndex, it.toString())
+ statement.setObject(statementIndex, it)
```

This also aligns with how other temporal types are already handled in the same method:
- `TimestampTypeWithTimezone` → `statement.setObject(statementIndex, (value.abValue as TimestampWithTimezoneValue).value)`
- `TimeTypeWithTimezone` → `statement.setObject(statementIndex, (value.abValue as TimeWithTimezoneValue).value)`
- `TimeTypeWithoutTimezone` → `statement.setObject(statementIndex, (value.abValue as TimeWithoutTimezoneValue).value)`

All of these pass the temporal object directly and rely on the JDBC driver for correct type binding.

## Testing

1. Create a source MSSQL table with a `datetime2` column containing values with sub-millisecond precision (e.g., `2023-01-15T10:30:00.1234567`)
2. Set up an Airbyte connection with destination-mssql
3. Run a full refresh sync
4. Verify that the sync completes successfully without `Conversion failed when converting date and/or time from character string` errors

## What

Fixes a regression introduced in v2.2.17 where MSSQL destination syncs fail when processing timestamps with sub-millisecond precision (which is common with `datetime2(7)` source columns). 

**Root Cause:**
`LocalDateTime.toString()` on a value with nanosecond precision produces strings with up to 9 decimal places. However, SQL Server's `DATETIME` column only accepts string representations with up to 3 decimal places. Any string with 4+ decimal places causes: `SQLServerException: Conversion failed when converting date and/or time from character string.`

Closes #79193

## How

In `MSSQLQueryBuilder.kt`, stopped binding `TimestampTypeWithoutTimezone` values as strings. 

Instead, passed the `LocalDateTime` object directly to `statement.setObject(statementIndex, it)`. The JDBC driver correctly handles type binding for `LocalDateTime` to `DATETIME`, including implicit rounding to the precision of the target column type.

This also aligns with how other temporal types (`TimestampTypeWithTimezone`, `TimeTypeWithTimezone`, etc.) are already handled safely in the same method.

## Review guide

1. `MSSQLQueryBuilder.kt`

## User Impact

* **End result:** Users syncing data with high-precision timestamps to MSSQL will no longer experience sync failures/crashes caused by formatting conversion errors.
* **Negative side effects:** None expected. The JDBC driver handles the implicit rounding down to the database column's supported precision natively.


## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [ ] YES 💚
- [ ] NO ❌
