### PR TITLE
test(source-datagen): GA rollout e2e

### DIFF
--- a/airbyte-integrations/connectors/source-datagen/metadata.yaml
+++ b/airbyte-integrations/connectors/source-datagen/metadata.yaml
@@ -5,7 +5,7 @@ data:
   connectorSubtype: database
   connectorType: source
   definitionId: f14d5125-dc0d-4f6c-abe5-acde821a2203
-  dockerImageTag: 0.2.0
+  dockerImageTag: 0.2.1
   dockerRepository: airbyte/source-datagen
   documentationUrl: https://docs.airbyte.com/integrations/sources/datagen
   githubIssueLabel: source-datagen

--- a/airbyte-integrations/connectors/source-datagen/metadata.yaml
+++ b/airbyte-integrations/connectors/source-datagen/metadata.yaml
@@ -24,6 +24,9 @@ data:
       enabled: true
     oss:
       enabled: true
+  releases:
+    rolloutConfiguration:
+      enableProgressiveRollout: true
   releaseStage: alpha
   supportLevel: community
   tags:

--- a/docs/integrations/sources/datagen.md
+++ b/docs/integrations/sources/datagen.md
@@ -64,13 +64,13 @@ If you use Airbyte Cloud and your organization restricts access to specific IPs,
 
 | Version | Date       | Pull Request                                             | Subject                            |
 |:--------|:-----------|:---------------------------------------------------------|:-----------------------------------|
-| 0.2.1 | 2026-06-09 | [79330](https://github.com/airbytehq/airbyte/pull/79330) | Progressive rollout e2e test |
-| 0.2.0 | 2026-04-28 | [75542](https://github.com/airbytehq/airbyte/pull/75542) | Add wide schema flavor with configurable column count; fix null safety in partition reader; cache codec references; bump CDK to 1.1.6 |
-| 0.1.6 | 2025-10-23 | [68611](https://github.com/airbytehq/airbyte/pull/68611) | Update cdk version |
-| 0.1.5 | 2025-10-21 | [68581](https://github.com/airbytehq/airbyte/pull/68581) | Update dataChannel version |
-| 0.1.4 | 2025-10-16 | [68131](https://github.com/airbytehq/airbyte/pull/68131) | Increment naming fix |
-| 0.1.3 | 2025-10-16 | [68129](https://github.com/airbytehq/airbyte/pull/68129) | Increment encoding fix |
-| 0.1.2 | 2025-10-14 | [67720](https://github.com/airbytehq/airbyte/pull/67720) | Removal of Array type |
-| 0.1.1 | 2025-10-13 | [67110](https://github.com/airbytehq/airbyte/pull/67110) | Addition of proto types |
-| 0.1.0 | 2025-09-29 | [66331](https://github.com/airbytehq/airbyte/pull/66331) | Creation of initial DataGen Source |
+| 0.2.1   | 2026-06-09 | [79330](https://github.com/airbytehq/airbyte/pull/79330) | Progressive rollout e2e test     |
+| 0.2.0   | 2026-04-28 | [75542](https://github.com/airbytehq/airbyte/pull/75542) | Add wide schema flavor with configurable column count; fix null safety in partition reader; cache codec references; bump CDK to 1.1.6 |
+| 0.1.6   | 2025-10-23 | [68611](https://github.com/airbytehq/airbyte/pull/68611) | Update cdk version                 |
+| 0.1.5   | 2025-10-21 | [68581](https://github.com/airbytehq/airbyte/pull/68581) | Update dataChannel version         |
+| 0.1.4   | 2025-10-16 | [68131](https://github.com/airbytehq/airbyte/pull/68131) | Increment naming fix               |
+| 0.1.3   | 2025-10-16 | [68129](https://github.com/airbytehq/airbyte/pull/68129) | Increment encoding fix             |
+| 0.1.2   | 2025-10-14 | [67720](https://github.com/airbytehq/airbyte/pull/67720) | Removal of Array type              |
+| 0.1.1   | 2025-10-13 | [67110](https://github.com/airbytehq/airbyte/pull/67110) | Addition of proto types            |
+| 0.1.0   | 2025-09-29 | [66331](https://github.com/airbytehq/airbyte/pull/66331) | Creation of initial DataGen Source |
 </details>

--- a/docs/integrations/sources/datagen.md
+++ b/docs/integrations/sources/datagen.md
@@ -64,12 +64,13 @@ If you use Airbyte Cloud and your organization restricts access to specific IPs,
 
 | Version | Date       | Pull Request                                             | Subject                            |
 |:--------|:-----------|:---------------------------------------------------------|:-----------------------------------|
-| 0.2.0   | 2026-04-28 | [75542](https://github.com/airbytehq/airbyte/pull/75542) | Add wide schema flavor with configurable column count; fix null safety in partition reader; cache codec references; bump CDK to 1.1.6 |
-| 0.1.6   | 2025-10-23 | [68611](https://github.com/airbytehq/airbyte/pull/68611) | Update cdk version                 |
-| 0.1.5   | 2025-10-21 | [68581](https://github.com/airbytehq/airbyte/pull/68581) | Update dataChannel version         |
-| 0.1.4   | 2025-10-16 | [68131](https://github.com/airbytehq/airbyte/pull/68131) | Increment naming fix               |
-| 0.1.3   | 2025-10-16 | [68129](https://github.com/airbytehq/airbyte/pull/68129) | Increment encoding fix             |
-| 0.1.2   | 2025-10-14 | [67720](https://github.com/airbytehq/airbyte/pull/67720) | Removal of Array type              |
-| 0.1.1   | 2025-10-13 | [67110](https://github.com/airbytehq/airbyte/pull/67110) | Addition of proto types            |
-| 0.1.0   | 2025-09-29 | [66331](https://github.com/airbytehq/airbyte/pull/66331) | Creation of initial DataGen Source |
+| 0.2.1 | 2026-06-09 | [79330](https://github.com/airbytehq/airbyte/pull/79330) | Progressive rollout e2e test |
+| 0.2.0 | 2026-04-28 | [75542](https://github.com/airbytehq/airbyte/pull/75542) | Add wide schema flavor with configurable column count; fix null safety in partition reader; cache codec references; bump CDK to 1.1.6 |
+| 0.1.6 | 2025-10-23 | [68611](https://github.com/airbytehq/airbyte/pull/68611) | Update cdk version |
+| 0.1.5 | 2025-10-21 | [68581](https://github.com/airbytehq/airbyte/pull/68581) | Update dataChannel version |
+| 0.1.4 | 2025-10-16 | [68131](https://github.com/airbytehq/airbyte/pull/68131) | Increment naming fix |
+| 0.1.3 | 2025-10-16 | [68129](https://github.com/airbytehq/airbyte/pull/68129) | Increment encoding fix |
+| 0.1.2 | 2025-10-14 | [67720](https://github.com/airbytehq/airbyte/pull/67720) | Removal of Array type |
+| 0.1.1 | 2025-10-13 | [67110](https://github.com/airbytehq/airbyte/pull/67110) | Addition of proto types |
+| 0.1.0 | 2025-09-29 | [66331](https://github.com/airbytehq/airbyte/pull/66331) | Creation of initial DataGen Source |
 </details>


### PR DESCRIPTION
## What

Draft human-in-the-loop test PR for the new-style regular GA progressive rollout path on `source-datagen`.

Requested by AJ Steers.

## How

- Bumps `source-datagen` from `0.2.0` to the normal GA patch version `0.2.1` with no `-rc` suffix.
- Enables `releases.rolloutConfiguration.enableProgressiveRollout: true`, so publish should create rollout candidate metadata from a regular GA version.
- Adds the `0.2.1` changelog row with this draft PR number.
- Does not add generated prior-version `registryOverrides.*.dockerImageTag` pins.

## Review guide

1. `airbyte-integrations/connectors/source-datagen/metadata.yaml`
2. `docs/integrations/sources/datagen.md`

## User Impact

This is a draft rollout validation PR and should not be marked ready or merged until AJ explicitly approves the test gate. If merged later, it will exercise the progressive rollout pipeline for `airbyte/source-datagen` using the normal GA patch version `0.2.1`.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚
- [ ] NO ❌

---
[Devin session](https://app.devin.ai/sessions/fedade004085404a9e71cfafb50c6438)

Requested by: @aaronsteers