### PR TITLE
test(source-faker): create progressive rollout rc

### DIFF
--- a/airbyte-integrations/connectors/source-faker/metadata.yaml
+++ b/airbyte-integrations/connectors/source-faker/metadata.yaml
@@ -9,7 +9,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: dfd88b22-b603-4c3d-aad7-3701784586b1
-  dockerImageTag: 7.1.1
+  dockerImageTag: 7.2.0-rc.1
   dockerRepository: airbyte/source-faker
   documentationUrl: https://docs.airbyte.com/integrations/sources/faker
   externalDocumentationUrls:
@@ -31,7 +31,7 @@ data:
   releaseStage: beta
   releases:
     rolloutConfiguration:
-      enableProgressiveRollout: false
+      enableProgressiveRollout: true
     breakingChanges:
       4.0.0:
         message: This is a breaking change message

--- a/airbyte-integrations/connectors/source-faker/progressive_rollout_e2e_marker.txt
+++ b/airbyte-integrations/connectors/source-faker/progressive_rollout_e2e_marker.txt
@@ -1,1 +1,0 @@
-temporary marker for source-faker progressive rollout e2e draft PR creation

--- a/airbyte-integrations/connectors/source-faker/progressive_rollout_e2e_marker.txt
+++ b/airbyte-integrations/connectors/source-faker/progressive_rollout_e2e_marker.txt
@@ -1,0 +1,1 @@
+temporary marker for source-faker progressive rollout e2e draft PR creation

--- a/airbyte-integrations/connectors/source-faker/pyproject.toml
+++ b/airbyte-integrations/connectors/source-faker/pyproject.toml
@@ -3,7 +3,7 @@ requires = [ "poetry-core>=1.0.0",]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
-version = "7.1.1"
+version = "7.2.0-rc.1"
 name = "source-faker"
 description = "Source implementation for fake but realistic looking data."
 authors = [ "Airbyte <evan@airbyte.io>",]

--- a/docs/integrations/sources/faker.md
+++ b/docs/integrations/sources/faker.md
@@ -51,6 +51,7 @@ If you use Airbyte Cloud and your organization restricts access to specific IPs,
 
 | Version     | Date       | Pull Request                                                                                                          | Subject                                                                                                         |
 |:------------|:-----------| :-------------------------------------------------------------------------------------------------------------------- |:----------------------------------------------------------------------------------------------------------------|
+| 7.2.0-rc.1 | 2026-06-09 | [79331](https://github.com/airbytehq/airbyte/pull/79331) | Progressive rollout e2e test |
 | 7.1.1 | 2026-05-13 | [78075](https://github.com/airbytehq/airbyte/pull/78075) | Re-release to verify PyPI README publishing |
 | 7.1.0 | 2026-03-31 | [75941](https://github.com/airbytehq/airbyte/pull/75941) | Promoted release candidate to GA |
 | 7.1.0-rc.2 | 2026-03-31 | [75926](https://github.com/airbytehq/airbyte/pull/75926) | Bump source-faker to RC2 for progressive rollout e2e test |


### PR DESCRIPTION
## What
Draft test PR for the traditional release-candidate progressive rollout E2E test on `source-faker`.

Context:
- Existing draft test PR https://github.com/airbytehq/airbyte/pull/78100 is closed, so this is the replacement draft.
- Parent Devin session: https://app.devin.ai/sessions/f405dc912cdf44fead4aac65eec0d4e1
- Child Devin session: https://app.devin.ai/sessions/679eb4cb91a646aa8a39d0d449623fd5
- Related airbyte-ops-mcp PRs: https://github.com/airbytehq/airbyte-ops-mcp/pull/802 and https://github.com/airbytehq/airbyte-ops-mcp/pull/828
- Related Airbyte marker-file PR: https://github.com/airbytehq/airbyte/pull/78418

Do not merge this PR unless AJ explicitly approves. This is intended to remain draft until the human merge gate.

## How
- Bumps `source-faker` from `7.1.1` to release candidate `7.2.0-rc.1` using the `airbyte-ops-mcp` `bump_version_in_repo` flow.
- Enables `releases.rolloutConfiguration.enableProgressiveRollout` for the RC.
- Does not add generated prior-version `registryOverrides.*.dockerImageTag` pins; this PR validates the no-RC-override behavior from the updated rollout flow.
- Updates the generated docs changelog with this PR URL.

## Review guide
1. `airbyte-integrations/connectors/source-faker/metadata.yaml`
2. `airbyte-integrations/connectors/source-faker/pyproject.toml`
3. `docs/integrations/sources/faker.md`

## User Impact
No intended production user impact unless this draft test PR is explicitly approved, marked ready, merged, and published as part of the rollout E2E. If merged, it validates that RC rollout metadata can keep the stable GA version as default without generated registry override pins.

## Can this PR be safely reverted and rolled back?
- [x] YES 💚
- [ ] NO ❌

Requested by: @aaronsteers