### PR TITLE
test(source-faker): create progressive rollout rc2 (do not merge)

### DIFF
--- a/airbyte-integrations/connectors/source-faker/.progressive-rollout-rc2-marker
+++ b/airbyte-integrations/connectors/source-faker/.progressive-rollout-rc2-marker
@@ -1,0 +1,1 @@
+temporary marker for draft PR creation

--- a/airbyte-integrations/connectors/source-faker/.progressive-rollout-rc2-marker
+++ b/airbyte-integrations/connectors/source-faker/.progressive-rollout-rc2-marker
@@ -1,1 +1,0 @@
-temporary marker for draft PR creation

--- a/airbyte-integrations/connectors/source-faker/metadata.yaml
+++ b/airbyte-integrations/connectors/source-faker/metadata.yaml
@@ -9,7 +9,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: dfd88b22-b603-4c3d-aad7-3701784586b1
-  dockerImageTag: 7.2.0-rc.1
+  dockerImageTag: 7.2.0-rc.2
   dockerRepository: airbyte/source-faker
   documentationUrl: https://docs.airbyte.com/integrations/sources/faker
   externalDocumentationUrls:

--- a/airbyte-integrations/connectors/source-faker/pyproject.toml
+++ b/airbyte-integrations/connectors/source-faker/pyproject.toml
@@ -3,7 +3,7 @@ requires = [ "poetry-core>=1.0.0",]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
-version = "7.2.0-rc.1"
+version = "7.2.0-rc.2"
 name = "source-faker"
 description = "Source implementation for fake but realistic looking data."
 authors = [ "Airbyte <evan@airbyte.io>",]

--- a/docs/integrations/sources/faker.md
+++ b/docs/integrations/sources/faker.md
@@ -47,6 +47,7 @@ Each purchase record includes: `id`, `user_id`, `product_id`, `created_at`, `upd
 
 | Version     | Date       | Pull Request                                                                                                          | Subject                                                                                                         |
 |:------------|:-----------| :-------------------------------------------------------------------------------------------------------------------- |:----------------------------------------------------------------------------------------------------------------|
+| 7.2.0-rc.2 | 2026-06-09 | [79454](https://github.com/airbytehq/airbyte/pull/79454) | Progressive rollout e2e test |
 | 7.2.0-rc.1 | 2026-06-09 | [79331](https://github.com/airbytehq/airbyte/pull/79331) | Progressive rollout e2e test |
 | 7.1.1 | 2026-05-13 | [78075](https://github.com/airbytehq/airbyte/pull/78075) | Re-release to verify PyPI README publishing |
 | 7.1.0 | 2026-03-31 | [75941](https://github.com/airbytehq/airbyte/pull/75941) | Promoted release candidate to GA |


### PR DESCRIPTION
## What
Create the second `source-faker` release-candidate draft PR for the progressive rollout E2E test requested by AJ Steers.

This follows the successful rollback of RC1 (`7.2.0-rc.1`) and prepares RC2 (`7.2.0-rc.2`) for the next publish/rollout initialization phase.

## How
- Bumps `source-faker` from `7.2.0-rc.1` to `7.2.0-rc.2` with `bump_version_in_repo`
- Keeps `releases.rolloutConfiguration.enableProgressiveRollout: true`
- Preserves the pin-free RC path: no `registryOverrides.*.dockerImageTag` pins are added
- Adds the changelog row with the actual draft PR URL

## Review guide
1. `airbyte-integrations/connectors/source-faker/metadata.yaml`
2. `airbyte-integrations/connectors/source-faker/pyproject.toml`
3. `docs/integrations/sources/faker.md`

## User Impact
No user-facing impact intended yet; this is a controlled rollout E2E test PR and must remain draft until explicitly approved.

## Can this PR be safely reverted and rolled back?
- [x] YES 💚
- [ ] NO ❌

---
[Devin session](https://app.devin.ai/sessions/679eb4cb91a646aa8a39d0d449623fd5)

Requested by: @aaronsteers

> [!IMPORTANT]
> Active progressive rollout warning for source-faker.

- [ ] (Click to Approve:) Bypass the active progressive rollout warning for source-faker in the PR comment [here](https://github.com/airbytehq/airbyte/pull/79454#issuecomment-4657567829).