### PR TITLE
chore(source-chargebee): disable progressive rollout flag

### DIFF
--- a/airbyte-integrations/connectors/source-chargebee/metadata.yaml
+++ b/airbyte-integrations/connectors/source-chargebee/metadata.yaml
@@ -37,7 +37,7 @@ data:
   releaseStage: generally_available
   releases:
     rolloutConfiguration:
-      enableProgressiveRollout: true
+      enableProgressiveRollout: false
   suggestedStreams:
     streams:
       - subscription


### PR DESCRIPTION
## What

The cancelled RC cleanup PR (#79604) missed setting `enableProgressiveRollout` to `false`. This fixes that.

Requested by @sophiecuiy.

## How

- **`metadata.yaml`** — `enableProgressiveRollout` set from `true` to `false`.

## Review guide

1. `airbyte-integrations/connectors/source-chargebee/metadata.yaml`

## User Impact

None — metadata-only change.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

---
[Devin session](https://app.devin.ai/sessions/36de5890f41044ab8eb9fcf8b38f2fd3)

> [!IMPORTANT]
> Active progressive rollout warning for source-chargebee.

- [ ] (Click to Approve:) Bypass the active progressive rollout warning for source-chargebee in the PR comment [here](https://github.com/airbytehq/airbyte/pull/79607#issuecomment-4662378015).