### PR TITLE
ci(connectors): notify GA rollout finalization

### DIFF
--- a/.github/workflows/finalize_rollout.yml
+++ b/.github/workflows/finalize_rollout.yml
@@ -281,7 +281,7 @@ jobs:
         with:
           payload: |
             {
-              "channel": "#connector-publish-failures",
+              "channel": "#connector-publish-updates",
               "username": "Connectors CI/CD Bot",
               "text": "↗️ Successfully finalized GA rollout for `${{ env.CONNECTOR_NAME }}` — registry recompiled:\n${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
             }

--- a/.github/workflows/finalize_rollout.yml
+++ b/.github/workflows/finalize_rollout.yml
@@ -273,7 +273,20 @@ jobs:
             --admin
 
       # --- Notifications ---
-      - name: Notify Slack on promote success
+      - name: Notify Slack on GA promote success
+        if: success() && steps.resolve-vars.outputs.is_rc == 'false'
+        uses: slackapi/slack-github-action@70cd7be8e40a46e8b0eced40b0de447bdb42f68e # v1.26.0
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.PUBLISH_ON_MERGE_SLACK_WEBHOOK }}
+        with:
+          payload: |
+            {
+              "channel": "#connector-publish-failures",
+              "username": "Connectors CI/CD Bot",
+              "text": "↗️ Successfully finalized GA rollout for `${{ env.CONNECTOR_NAME }}` — registry recompiled:\n${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            }
+
+      - name: Notify Slack on RC promote success
         if: success() && steps.create-pr.outputs.pull-request-number
         uses: slackapi/slack-github-action@70cd7be8e40a46e8b0eced40b0de447bdb42f68e # v1.26.0
         env:


### PR DESCRIPTION
## What
Follow-up to https://github.com/airbytehq/airbyte/pull/79608: successful GA rollout finalization now sends a Slack success notification instead of silently completing after registry marker finalization and registry compile.

Requested by: @aaronsteers

## How
- Add a GA-only success notification gated on `steps.resolve-vars.outputs.is_rc == 'false'`.
- Send that GA success notification to `#connector-publish-updates`, matching connector publish success notifications.
- Rename the existing promote success notification to the RC path, where a metadata finalization PR exists.
- Keep failure notification behavior unchanged.

## Review guide
1. `.github/workflows/finalize_rollout.yml`

## User Impact
Successful GA progressive rollout promotion is visible in the publish updates Slack channel. RC rollout promotion behavior remains unchanged.

## Can this PR be safely reverted and rolled back?
- [x] YES 💚
- [ ] NO ❌

Test plan:
- [x] `yq eval '.name' .github/workflows/finalize_rollout.yml`
- [x] Extracted `Resolve vars` and `Version bump and rollout finalization` shell blocks with `yq`; both pass `bash -n`.
- [x] Verified GA notification gate is `success() && steps.resolve-vars.outputs.is_rc == 'false'`.
- [x] Verified GA notification payload uses `#connector-publish-updates` and mentions `finalized GA rollout`.
- [x] Verified RC notification gate remains `success() && steps.create-pr.outputs.pull-request-number`.
- [x] `git diff --check -- .github/workflows/finalize_rollout.yml`

Link to Devin session: https://app.devin.ai/sessions/fedade004085404a9e71cfafb50c6438