### PR TITLE
docs(ai-agents): remove broken link to authentication-module on billing page

### DIFF
--- a/docs/ai-agents/admin/billing.md
+++ b/docs/ai-agents/admin/billing.md
@@ -182,7 +182,7 @@ A plan for teams running more automations.
 
 A plan for large companies and embedded products. Airbyte tailors pricing, usage limits, and feature access to your needs. Custom plans include:
 
-- An [authentication module](/ai-agents/interfaces/api/authentication-module) for embedding connector authentication in your app.
+- An authentication module for embedding connector authentication in your app.
 - A dedicated account manager.
 - Service level agreements.
 - Dedicated human support.


### PR DESCRIPTION
## What

Fixes a broken Docusaurus link that is blocking production deploys on Vercel for docs.airbyte.com.

The billing page (`/ai-agents/admin/billing`) linked to `/ai-agents/interfaces/api/authentication-module`, which Docusaurus cannot resolve during the build. Requested by @ian-at-airbyte.

## How

Removed the markdown link from the "authentication module" text on line 185 of `docs/ai-agents/admin/billing.md`, keeping the text intact.

## Review guide

1. `docs/ai-agents/admin/billing.md` — single line change, link removed.

## User Impact

Unblocks production Vercel deploys for docs.airbyte.com. No user-facing content change — the text remains, only the non-functional link is removed.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚
- [ ] NO ❌

Link to Devin session: https://app.devin.ai/sessions/d903dbf60f284848b41ef14cd937770a