### PR TITLE
ci: post Slack notification on successful hydra automerge

### DIFF
--- a/.github/workflows/hydra-automerge.yml
+++ b/.github/workflows/hydra-automerge.yml
@@ -558,6 +558,25 @@ jobs:
           echo "::error::Failed to merge PR #$PR_NUMBER after 3 attempts"
           exit 1
 
+      - name: Post automerge notification to Slack
+        if: steps.evaluate.outputs.result == 'PASS' && inputs.dry-run != 'true' && vars.ENABLE_CONNECTOR_AUTO_MERGE == 'true'
+        uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
+        with:
+          token: ${{ secrets.SLACK_BOT_TOKEN_AIRBYTE_TEAM }}
+          method: chat.postMessage
+          payload: |
+            channel: C0A30PKB8HK
+            text: "Hydra auto-merged PR #${{ inputs.pr }}: ${{ steps.pre-check.outputs.title }}"
+            blocks:
+              - type: section
+                text:
+                  type: mrkdwn
+                  text: ":robot_face: *Hydra Auto-Merge*\n<https://github.com/airbytehq/airbyte/pull/${{ inputs.pr }}|#${{ inputs.pr }} ${{ steps.pre-check.outputs.title }}>"
+              - type: context
+                elements:
+                  - type: mrkdwn
+                    text: "<https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|Workflow run> | <${{ steps.devin.outputs.session-url }}|Devin session>"
+
       - name: Dry-run notice (variable)
         if: steps.evaluate.outputs.result == 'PASS' && inputs.dry-run != 'true' && vars.ENABLE_CONNECTOR_AUTO_MERGE != 'true'
         run: echo "::notice::DRY RUN (ENABLE_CONNECTOR_AUTO_MERGE not set) -- would merge PR #${PR_NUMBER}"


### PR DESCRIPTION
## What

Adds a Slack audit log / notification to `<#C0A30PKB8HK>` whenever the hydra automerge workflow successfully merges a PR.

Requested by @pedroslopez.

## How

Adds a new step after the "Squash merge PR" step in `.github/workflows/hydra-automerge.yml`:

- Uses `slackapi/slack-github-action` (same version as the force-merge workflow) with `chat.postMessage`
- Authenticated via `SLACK_BOT_TOKEN_AIRBYTE_TEAM` (same token the force-merge workflow uses)
- Fires only when the merge actually happens (eval PASS, not dry-run, `ENABLE_CONNECTOR_AUTO_MERGE == 'true'`)
- If the merge step fails (exit 1), the job fails and the Slack step is skipped

The message includes the PR number, title, a link to the workflow run, and the Devin evaluation session.

## Review guide

1. `.github/workflows/hydra-automerge.yml` — new step at line 561

## User Impact

On-call and engineering teams get visibility into what gets automerged, directly in Slack.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Link to Devin session: https://app.devin.ai/sessions/c3fdb540d54544dc89283c9cf2a67183