### PR TITLE
ci(hydra-automerge): post all status updates on a single dedicated comment

### DIFF
--- a/.github/workflows/ai-ready-command.yml
+++ b/.github/workflows/ai-ready-command.yml
@@ -71,6 +71,5 @@ jobs:
     uses: ./.github/workflows/hydra-automerge.yml
     with:
       pr: ${{ inputs.pr }}
-      comment-id: ${{ inputs.comment-id }}
       dry-run: ${{ inputs.dry-run }}
     secrets: inherit

--- a/.github/workflows/hydra-automerge.yml
+++ b/.github/workflows/hydra-automerge.yml
@@ -82,12 +82,13 @@ jobs:
             echo "::warning::PR #$PR_NUMBER is no longer open (state=$state). Skipping."
           fi
 
-      - name: Update command comment with progress
-        if: inputs.comment-id && steps.pre-check.outputs.state == 'OPEN'
+      - name: Post status comment
+        if: steps.pre-check.outputs.state == 'OPEN'
+        id: status-comment
         uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
         with:
           token: ${{ steps.get-hoard-token.outputs.token }}
-          comment-id: ${{ inputs.comment-id }}
+          issue-number: ${{ inputs.pr }}
           body: |
             > **Auto-merge evaluation in progress...**
             > [Workflow run](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})
@@ -119,7 +120,8 @@ jobs:
         uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
         with:
           token: ${{ steps.get-hoard-token.outputs.token }}
-          comment-id: ${{ inputs.comment-id }}
+          comment-id: ${{ steps.status-comment.outputs.comment-id }}
+          edit-mode: replace
           body: |
             > **Auto-merge evaluation: SKIPPED**
             >
@@ -127,17 +129,6 @@ jobs:
             > Auto-merge is only available for PRs that exclusively touch connector-related files.
             >
             > [Workflow run](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})
-
-      - name: Post new comment if no command comment (path fail)
-        if: steps.pre-check.outputs.state == 'OPEN' && steps.validate-paths.outputs.valid == 'false' && !inputs.comment-id
-        env:
-          GH_TOKEN: ${{ steps.get-hoard-token.outputs.token }}
-        run: |
-          gh pr comment "$PR_NUMBER" --repo airbytehq/airbyte --body "## Auto-merge evaluation: **SKIPPED**
-
-          This PR modifies files outside the allowed connector paths. Auto-merge is only available for PRs that exclusively touch connector-related files.
-
-          > [Workflow run](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})"
 
       - name: Fetch required checks for master branch
         if: steps.pre-check.outputs.state == 'OPEN' && steps.validate-paths.outputs.valid == 'true'
@@ -215,25 +206,14 @@ jobs:
         uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
         with:
           token: ${{ steps.get-hoard-token.outputs.token }}
-          comment-id: ${{ inputs.comment-id }}
+          comment-id: ${{ steps.status-comment.outputs.comment-id }}
+          edit-mode: replace
           body: |
             > **Auto-merge evaluation: BLOCKED**
             >
             > Required status checks are not passing. Missing: `${{ steps.verify-checks.outputs.missing }}`
             >
             > [Workflow run](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})
-
-      - name: Post new comment if no command comment (checks fail)
-        if: steps.pre-check.outputs.state == 'OPEN' && steps.validate-paths.outputs.valid == 'true' && steps.verify-checks.outputs.ready == 'false' && !inputs.comment-id
-        env:
-          GH_TOKEN: ${{ steps.get-hoard-token.outputs.token }}
-          MISSING_CHECKS: ${{ steps.verify-checks.outputs.missing }}
-        run: |
-          gh pr comment "$PR_NUMBER" --repo airbytehq/airbyte --body "## Auto-merge evaluation: **BLOCKED**
-
-          Required status checks are not passing. Missing: \`${MISSING_CHECKS}\`
-
-          > [Workflow run](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})"
 
       # ── Devin AI evaluation ────────────────────────────────────────
       - name: Checkout code
@@ -254,12 +234,10 @@ jobs:
           devin-token: ${{ secrets.DEVIN_AI_API_KEY }}
           github-token: ${{ steps.get-hoard-token.outputs.token }}
           org-id: ${{ vars.DEVIN_AI_ORG_ID }}
-          issue-number: ${{ inputs.pr }}
           max-acu-limit: "2"
           wait-for-stopped-status: "true"
           wait-minutes-max: "10"
           structured-output-required: "true"
-          start-message: "**Auto-merge evaluation** starting..."
           tags: |
             auto-merge-eval
             hyd-ready
@@ -474,46 +452,28 @@ jobs:
             echo "EVAL_EOF"
           } >> "$GITHUB_OUTPUT"
 
-      - name: Update command comment with results
-        if: steps.report.outputs.comment && inputs.comment-id
+      - name: Update status comment with results
+        if: steps.report.outputs.comment && steps.status-comment.outputs.comment-id
         uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
         with:
           token: ${{ steps.get-hoard-token.outputs.token }}
-          comment-id: ${{ inputs.comment-id }}
+          comment-id: ${{ steps.status-comment.outputs.comment-id }}
+          edit-mode: replace
           body: ${{ steps.report.outputs.comment }}
 
-      - name: Post new comment with results (no command comment)
-        if: steps.report.outputs.comment && !inputs.comment-id
-        env:
-          GH_TOKEN: ${{ steps.get-hoard-token.outputs.token }}
-          EVAL_COMMENT: ${{ steps.report.outputs.comment }}
-        run: |
-          gh pr comment "$PR_NUMBER" --repo airbytehq/airbyte --body "$EVAL_COMMENT"
-
-      - name: Update command comment on Devin error
-        if: always() && steps.check-output.outcome != 'skipped' && steps.check-output.outputs.success != 'true' && inputs.comment-id
+      - name: Update status comment on Devin error
+        if: always() && steps.check-output.outcome != 'skipped' && steps.check-output.outputs.success != 'true' && steps.status-comment.outputs.comment-id
         uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
         with:
           token: ${{ steps.get-hoard-token.outputs.token }}
-          comment-id: ${{ inputs.comment-id }}
+          comment-id: ${{ steps.status-comment.outputs.comment-id }}
+          edit-mode: replace
           body: |
             > **Auto-merge evaluation: ERROR**
             >
             > The Devin AI evaluation session did not produce structured output.
             >
             > [Devin session](${{ steps.devin.outputs.session-url }}) | [Workflow run](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})
-
-      - name: Post new comment on Devin error (no command comment)
-        if: always() && steps.check-output.outcome != 'skipped' && steps.check-output.outputs.success != 'true' && !inputs.comment-id
-        env:
-          GH_TOKEN: ${{ steps.get-hoard-token.outputs.token }}
-          SESSION_URL: ${{ steps.devin.outputs.session-url }}
-        run: |
-          gh pr comment "$PR_NUMBER" --repo airbytehq/airbyte --body "## Auto-merge evaluation: **ERROR**
-
-          The Devin AI evaluation session did not produce structured output.
-
-          > [Devin session](${SESSION_URL}) | [Workflow run](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})"
 
       # ── Merge (if evaluation passed and not dry-run) ────────────────
       - name: Authenticate as 'octavia-bot-admin' GitHub App

--- a/.github/workflows/hydra-automerge.yml
+++ b/.github/workflows/hydra-automerge.yml
@@ -20,9 +20,6 @@ on:
       pr:
         description: "PR number"
         required: true
-      comment-id:
-        description: "Comment ID (from slash command dispatcher)"
-        required: false
       dry-run:
         description: "If 'true', evaluate only -- do not approve or merge"
         required: false
@@ -32,10 +29,6 @@ on:
       pr:
         description: "PR number"
         required: true
-        type: string
-      comment-id:
-        description: "Comment ID"
-        required: false
         type: string
       dry-run:
         description: "If 'true', evaluate only -- do not approve or merge"


### PR DESCRIPTION
## What

Fixes the bug where hydra-automerge was appending evaluation results to an unrelated comment (e.g. the ai-review comment) instead of the "Auto-merge evaluation starting..." comment.

Example: https://github.com/airbytehq/airbyte/pull/79183

Root cause was two-layered:
1. **Caller**: The `daily_hands_free_triage` playbook passed a wrong `comment-id` (e.g. the ai-review comment's ID) when dispatching `/ai-ready` programmatically
2. **Workflow**: `hydra-automerge.yml` blindly trusted `inputs.comment-id` for status updates, while the devin-action created a separate "Auto-merge evaluation starting..." comment (because it received `issue-number` but no `comment-id`)

## How

`hydra-automerge.yml`:
- Creates a dedicated status comment at the start (`id: status-comment`) via `issue-number`
- All subsequent updates (progress, early exits, results, errors) use `steps.status-comment.outputs.comment-id`
- Removed the `comment-id` input entirely — the workflow no longer accepts or uses it
- Stopped passing `issue-number` to the devin-action, so it no longer creates a separate comment

`ai-ready-command.yml`:
- Stopped forwarding `comment-id` to `hydra-automerge.yml`

Companion playbook update: https://github.com/airbytehq/ai-skills/pull/492

Requested by @pedroslopez.

## Review guide

1. `.github/workflows/hydra-automerge.yml` — core fix: own status comment, removed `comment-id` input
2. `.github/workflows/ai-ready-command.yml` — stopped passing `comment-id`

## User Impact

All auto-merge status (progress, results, errors) now appears on a single dedicated comment. No more polluting unrelated comments.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Link to Devin session: https://app.devin.ai/sessions/c923eb966ffa48a59c96411c2d7d29ca