### PR TITLE
ci: fix dependency_version_bump scope in auto-merge evaluation

### DIFF
--- a/.github/workflows/hydra-automerge.yml
+++ b/.github/workflows/hydra-automerge.yml
@@ -323,7 +323,7 @@ jobs:
                     required: [pass, reasoning]
                   dependency_version_bump:
                     type: object
-                    description: "Set pass to true ONLY if the PR exclusively bumps dependency versions (e.g. changes to pyproject.toml, setup.py, build.gradle, package.json version pins, or lockfiles) without any other functional code changes. The version bump must be a patch or minor version increment, NOT a major version bump. If the PR includes any other changes beyond the version bump and its lockfile updates, set pass to false."
+                    description: "Set pass to true if the PR is a dependency version bump with no functional code changes. Allowed files: dependency manifests (pyproject.toml, setup.py, build.gradle, package.json), lockfiles (poetry.lock, package-lock.json, yarn.lock), connector version metadata (metadata.yaml version/dockerImageTag fields), and changelog entries (docs/integrations/**/*.md). Any size of dependency version jump is acceptable (patch, minor, or major) -- the magnitude of the dependency version change does not affect this classification. Set pass to false ONLY if the PR also modifies source code, test files, or other functional files beyond the categories listed above."
                     properties:
                       pass:
                         type: boolean

--- a/.github/workflows/hydra-automerge.yml
+++ b/.github/workflows/hydra-automerge.yml
@@ -323,7 +323,7 @@ jobs:
                     required: [pass, reasoning]
                   dependency_version_bump:
                     type: object
-                    description: "Set pass to true if the PR is a dependency version bump with no functional code changes. Allowed files: dependency manifests (pyproject.toml, setup.py, build.gradle, package.json), lockfiles (poetry.lock, package-lock.json, yarn.lock), connector version metadata (metadata.yaml version/dockerImageTag fields), and changelog entries (docs/integrations/**/*.md). Any size of dependency version jump is acceptable (patch, minor, or major) -- the magnitude of the dependency version change does not affect this classification. Set pass to false ONLY if the PR also modifies source code, test files, or other functional files beyond the categories listed above."
+                    description: "Set pass to true if the PR is a dependency version bump with no functional code changes. Allowed files: dependency manifests (pyproject.toml, setup.py, build.gradle, package.json), lockfiles (poetry.lock, package-lock.json, yarn.lock), connector version metadata (metadata.yaml version/dockerImageTag fields), and changelog entries (docs/integrations/**/*.md). Set pass to false ONLY if the PR also modifies source code, test files, or other functional files beyond the categories listed above."
                     properties:
                       pass:
                         type: boolean


### PR DESCRIPTION
## What

Fixes false negatives in the Hydra auto-merge evaluation for legitimate dependency bump PRs.

The `dependency_version_bump` structured output schema description in `hydra-automerge.yml` had two issues that caused [this session](https://app.devin.ai/sessions/8ec37bfed28140a497f0c35d7f556639) to incorrectly reject [PR #79196](https://github.com/airbytehq/airbyte/pull/79196) (a cryptography CVE bump for source-github):

1. **Major dependency version restriction**: The description required "patch or minor version increment, NOT a major version bump." A major *dependency* version jump (cryptography 44→46) is not a *connector* breaking change — the `no_breaking_changes` precondition already handles that concern separately.

2. **Changelog exclusion**: "any other changes beyond the version bump and its lockfile updates" excluded changelog entries in `docs/integrations/`, which are standard practice for every connector version bump.

## How

Updated the `dependency_version_bump` field description to:
- Explicitly enumerate allowed file categories: dependency manifests, lockfiles, connector version metadata (`metadata.yaml`), and changelog entries (`docs/integrations/**/*.md`)
- Accept any dependency version jump size (patch, minor, or major)
- Only set `pass: false` when actual source code or test files are modified

## Review guide

1. `.github/workflows/hydra-automerge.yml` — single description string change on the `dependency_version_bump` field (line ~326)

## User Impact

Dependency bump PRs (including those with major dependency jumps like CVE fixes) that only touch expected files will now correctly pass the auto-merge scope gate instead of being rejected.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Link to Devin session: https://app.devin.ai/sessions/b330e11a0c33499898f483a7fc3b4c64
Requested by: @pedroslopez