### PR TITLE
ci(release-notes): add retry and Slack failure alert to daily workflow

### DIFF
--- a/.github/workflows/daily-sonar-release-notes.yml
+++ b/.github/workflows/daily-sonar-release-notes.yml
@@ -61,7 +61,7 @@ jobs:
           token: ${{ secrets.SLACK_BOT_TOKEN_AIRBYTE_TEAM }}
           method: chat.postMessage
           payload: |
-            channel: C08BHPUMEPJ
+            channel: C032Y32T065
             text: "Daily Sonar Release Notes workflow failed after 2 attempts"
             blocks:
               - type: section

--- a/.github/workflows/daily-sonar-release-notes.yml
+++ b/.github/workflows/daily-sonar-release-notes.yml
@@ -27,3 +27,44 @@ jobs:
             area/documentation
             team/documentation
             sonar-release-notes
+
+  retry:
+    name: "Retry: Generate Airbyte Agents release notes"
+    needs: generate-release-notes
+    if: ${{ always() && needs.generate-release-notes.result != 'success' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Trigger Devin session (retry)
+        uses: aaronsteers/devin-action@main
+        with:
+          devin-token: ${{ secrets.DEVIN_AI_API_KEY }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          playbook-macro: "!sonar_release_notes"
+          api-version: v3
+          org-id: ${{ vars.DEVIN_AI_ORG_ID }}
+          tags: |
+            area/documentation
+            team/documentation
+            sonar-release-notes
+
+  notify-failure:
+    name: Notify Slack on failure
+    needs: [generate-release-notes, retry]
+    if: ${{ always() && needs.generate-release-notes.result != 'success' && needs.retry.result != 'success' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Post failure alert to Slack
+        uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
+        with:
+          token: ${{ secrets.SLACK_BOT_TOKEN_AIRBYTE_TEAM }}
+          method: chat.postMessage
+          payload: |
+            channel: C08BHPUMEPJ
+            text: "Daily Sonar Release Notes workflow failed after 2 attempts"
+            blocks:
+              - type: section
+                text:
+                  type: mrkdwn
+                  text: ":warning: *Daily Sonar Release Notes* failed after 2 attempts.\n<https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|View workflow run>"


### PR DESCRIPTION
## What

The Daily Sonar Release Notes workflow ([run #3](https://github.com/airbytehq/airbyte/actions/runs/27215218113/job/80354857316)) was cancelled on 2026-06-09 because a GitHub Actions runner was never assigned. The workflow has no retry or alerting, so this went unnoticed until manual inspection.

Requested by @ian-at-airbyte.

## How

Adds two new jobs to `daily-sonar-release-notes.yml`:

1. **`retry`** — runs the same Devin session trigger if the primary job ends with any non-success result (failure *or* cancellation). Uses `always() && needs.generate-release-notes.result != 'success'` so it covers both runner-level and step-level failures.
2. **`notify-failure`** — posts a warning to `#ask-devin-ai` (`C08BHPUMEPJ`) via `slackapi/slack-github-action` if both attempts fail. Uses the existing `SLACK_BOT_TOKEN_AIRBYTE_TEAM` secret, matching the pattern in `hydra-automerge.yml`.

The primary job is left unchanged — no `continue-on-error`, no step duplication.

## Review guide

1. `.github/workflows/daily-sonar-release-notes.yml` — the only file changed.

## User Impact

On transient infrastructure failures, the workflow now self-heals with one automatic retry. If both attempts fail, a Slack message appears in `#ask-devin-ai` with a link to the workflow run so it can be investigated quickly.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Link to Devin session: https://app.devin.ai/sessions/02edd0854ebb46eb879fc0c282b53437