### PR TITLE
ci(ai-ready): make comment-id optional for programmatic triggers

### DIFF
--- a/.github/workflows/ai-ready-command.yml
+++ b/.github/workflows/ai-ready-command.yml
@@ -13,8 +13,8 @@ on:
         required: false
         type: string
       comment-id:
-        description: "The comment-id of the slash command. Used to resolve the issue or PR."
-        required: true
+        description: "The comment-id of the slash command. Used to update the comment with status. Optional for programmatic triggers."
+        required: false
         type: string
       pr:
         description: "PR number, if triggered from a PR"
@@ -47,7 +47,7 @@ jobs:
           private-key: ${{ secrets.OCTAVIA_BOT_PRIVATE_KEY }}
 
       - name: Require PR context
-        if: inputs.pr == ''
+        if: inputs.pr == '' && inputs.comment-id
         uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
         with:
           token: ${{ steps.get-app-token.outputs.token }}


### PR DESCRIPTION
## What

`ai-ready-command.yml` was the only slash-command workflow with `comment-id: required: true`. All other workflows (`ai-prove-fix`, `ai-review`, `ai-triage`) have `comment-id: required: false`. This inconsistency caused the daily hands-free triage bot to fail with HTTP 422 when dispatching `/ai-ready` programmatically (without a `comment-id`), since it uses the same dispatch pattern for all workflows.

The downstream `hydra-automerge.yml` already handles missing `comment-id` gracefully — it posts evaluation results as a new PR comment when no `comment-id` is provided.

Requested by @pedroslopez based on investigation of [session 5d48b9a9abab43e8](https://app.devin.ai/sessions/5d48b9a9abab43e892b5dd67f9d11de0) where 5 approved PRs were not advanced to `/ai-ready`.

## How

- Changed `comment-id` from `required: true` to `required: false` in `ai-ready-command.yml`
- Added `&& inputs.comment-id` guard to the error-reporting step that updates the command comment (line 50), so it doesn't try to update a nonexistent comment when triggered without one

## Review guide

1. `.github/workflows/ai-ready-command.yml` — the only file changed

## User Impact

- Human slash-command flow is unchanged (always provides `comment-id` via the dispatcher)
- Programmatic triggers (triage bot, API dispatch) can now omit `comment-id` without getting 422
- Evaluation results still posted as a new PR comment when no `comment-id` is provided (handled by `hydra-automerge.yml`)

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Link to Devin session: https://app.devin.ai/sessions/c19a2132219b42e8a4df90f116ceb1e4

> [!IMPORTANT]
> ⚡ **Auto-merge enabled.**
> 
> _This PR is set to merge automatically when all requirements are met._

> [!NOTE]
> **Auto-merge may have been disabled. Please check the PR status to confirm.**