### PR TITLE
fix(docs): resolve duplicate Skills translation key blocking production deploys

### DIFF
--- a/docs/ai-agents/get-started/developer-quickstart/skills/_category_.json
+++ b/docs/ai-agents/get-started/developer-quickstart/skills/_category_.json
@@ -1,3 +1,4 @@
 {
+  "key": "developer-quickstart-skills",
   "description": "Install pre-packaged instructions into a coding agent so it can generate working code against Airbyte connectors."
 }


### PR DESCRIPTION
## What

Production docs deploys (Vercel) are failing with:

```
Multiple docs sidebar items produce the same translation key.
- `sidebar.defaultSidebar.category.Skills`: 2 duplicates found
```

The OpenAPI spec at `airbyte-sonar-prod.s3.us-east-2.amazonaws.com/openapi/latest/app.json` recently added a `Skills` tag, which generates an API sidebar category named "Skills" during the `prebuild` step. This conflicts with the existing folder-based "Skills" category at `docs/ai-agents/get-started/developer-quickstart/skills/`, since both end up in the same `defaultSidebar` and produce identical translation keys.

## How

Add a unique `key` field (`"developer-quickstart-skills"`) to the `_category_.json` of the developer-quickstart skills folder. This is the standard Docusaurus solution for disambiguating categories that share a label — it gives the category a distinct translation key without changing its display label.

## Review guide

1. `docs/ai-agents/get-started/developer-quickstart/skills/_category_.json` — one-line addition

## User Impact

Unblocks production docs deploys. No visible change to the docs site.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

---
[Devin session](https://app.devin.ai/sessions/21a6a4641e0f49e391e6d1e9c4458196)

Requested by: @ian-at-airbyte