### PR TITLE
fix(docs): resolve duplicate "Skills" sidebar key in Docusaurus build

### DIFF
--- a/docs/ai-agents/get-started/developer-quickstart/skills/_category_.json
+++ b/docs/ai-agents/get-started/developer-quickstart/skills/_category_.json
@@ -1,3 +1,4 @@
 {
+  "key": "developer-quickstart-skills",
   "description": "Install pre-packaged instructions into a coding agent so it can generate working code against Airbyte connectors."
 }


### PR DESCRIPTION
## What

Fixes the `sidebar.defaultSidebar.category.Skills: 2 duplicates found` Docusaurus build error that is breaking "Build Airbyte Docs" and "Vercel Preview" CI checks on every PR touching `docs/`.

The duplicate was introduced by airbytehq/airbyte#79665, which regenerated the cached Agent API spec. The new spec includes a `"Skills"` tag for `/api/v1/skills` endpoints, and `docusaurus-plugin-openapi-docs` auto-generates a sidebar category from it. This collides with the filesystem-generated "Skills" category from `docs/ai-agents/get-started/developer-quickstart/skills/`.

Reported by @YardenCarmeli in https://airbytehq-team.slack.com/archives/C043JHEEYKG/p1781194360131969. Requested by @aaronsteers.

## How

Added `"key": "developer-quickstart-skills"` to `docs/ai-agents/get-started/developer-quickstart/skills/_category_.json`. This follows the existing pattern used by `docs/ai-agents/interfaces/api/authentication/_category_.json` (`"key": "api-authentication"`) to disambiguate sidebar categories with the same display label.

## Review guide

1. `docs/ai-agents/get-started/developer-quickstart/skills/_category_.json` — the only change

## User Impact

Unblocks docs CI for all PRs. No user-facing change — the sidebar label remains "Skills" in both locations.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

---
[Devin session](https://app.devin.ai/sessions/203f2cf06a40446fa0d5dda2f4bcf04a)

> [!IMPORTANT]
> ⚡ **Auto-merge enabled.**
> 
> _This PR is set to merge automatically when all requirements are met._

> [!NOTE]
> **Auto-merge may have been disabled. Please check the PR status to confirm.**