### PR TITLE
fix(source-zendesk-support): skip streams on permission-denied 403 instead of failing sync

### DIFF
--- a/airbyte-integrations/connectors/source-zendesk-support/manifest.yaml
+++ b/airbyte-integrations/connectors/source-zendesk-support/manifest.yaml
@@ -81,10 +81,13 @@ definitions:
       error_handler:
         type: DefaultErrorHandler
         response_filters:
+          - error_message_contains: "You do not have access"
+            action: IGNORE
+            error_message: "Skipping stream '{{ parameters.get('name') }}' because the authenticated user lacks permission to access this resource. This is expected for non-admin accounts on admin-only endpoints. Other streams will still sync. Details: {{ response.get('error') }}"
           - http_codes: [403, 404]
             action: FAIL
             failure_type: config_error
-            error_message: "Unable to read data for stream {{ parameters.get('name') }} due to an issue with permissions. Please ensure that your account has the necessary access level. You can try to re-authenticate on the Set Up Connector page or you can disable stream {{ parameters.get('name') }} on the Schema Tab. Error message: {{ response.get('error') }}"
+            error_message: "Unable to read data for stream '{{ parameters.get('name') }}'. The endpoint returned an error indicating a configuration issue. Please ensure that your account has the necessary access level and that the endpoint is available. Error message: {{ response.get('error') }}"
         backoff_strategies:
           - type: WaitTimeFromHeader
             header: Retry-After

--- a/airbyte-integrations/connectors/source-zendesk-support/metadata.yaml
+++ b/airbyte-integrations/connectors/source-zendesk-support/metadata.yaml
@@ -11,7 +11,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 79c1aa37-dae3-42ae-b333-d1c105477715
-  dockerImageTag: 5.2.9
+  dockerImageTag: 5.2.10
   dockerRepository: airbyte/source-zendesk-support
   documentationUrl: https://docs.airbyte.com/integrations/sources/zendesk-support
   githubIssueLabel: source-zendesk-support

--- a/airbyte-integrations/connectors/source-zendesk-support/unit_tests/mock_server/test_organizations.py
+++ b/airbyte-integrations/connectors/source-zendesk-support/unit_tests/mock_server/test_organizations.py
@@ -5,13 +5,12 @@ from unittest import TestCase
 
 import freezegun
 
+from airbyte_cdk.models import Level as LogLevel
 from airbyte_cdk.models import SyncMode
 from airbyte_cdk.test.mock_http import HttpMocker
 from airbyte_cdk.test.mock_http.response_builder import FieldPath
 from airbyte_cdk.test.state_builder import StateBuilder
 from airbyte_cdk.utils.datetime_helpers import ab_datetime_now
-
-from airbyte_cdk.models import Level as LogLevel
 
 from .config import ConfigBuilder
 from .request_builder import ApiTokenAuthenticator, ZendeskSupportRequestBuilder

--- a/airbyte-integrations/connectors/source-zendesk-support/unit_tests/mock_server/test_organizations.py
+++ b/airbyte-integrations/connectors/source-zendesk-support/unit_tests/mock_server/test_organizations.py
@@ -162,7 +162,9 @@ class TestOrganizationsStreamIncremental(TestCase):
             .with_any_query_params()
             .build(),
             ErrorResponseBuilder.response_with_status(403)
-            .with_error_message("You do not have access to this page. You do not have permission to access this page. Please contact the account owner of this help desk for further help.")
+            .with_error_message(
+                "You do not have access to this page. You do not have permission to access this page. Please contact the account owner of this help desk for further help."
+            )
             .build(),
         )
 
@@ -181,9 +183,7 @@ class TestOrganizationsStreamIncremental(TestCase):
             .with_start_time(self._config["start_date"])
             .with_any_query_params()
             .build(),
-            ErrorResponseBuilder.response_with_status(403)
-            .with_error_message("Forbidden")
-            .build(),
+            ErrorResponseBuilder.response_with_status(403).with_error_message("Forbidden").build(),
         )
 
         output = read_stream("organizations", SyncMode.incremental, self._config, expecting_exception=True)

--- a/airbyte-integrations/connectors/source-zendesk-support/unit_tests/mock_server/test_organizations.py
+++ b/airbyte-integrations/connectors/source-zendesk-support/unit_tests/mock_server/test_organizations.py
@@ -11,10 +11,12 @@ from airbyte_cdk.test.mock_http.response_builder import FieldPath
 from airbyte_cdk.test.state_builder import StateBuilder
 from airbyte_cdk.utils.datetime_helpers import ab_datetime_now
 
+from airbyte_cdk.models import Level as LogLevel
+
 from .config import ConfigBuilder
 from .request_builder import ApiTokenAuthenticator, ZendeskSupportRequestBuilder
-from .response_builder import OrganizationsRecordBuilder, OrganizationsResponseBuilder
-from .utils import datetime_to_string, read_stream, string_to_datetime
+from .response_builder import ErrorResponseBuilder, OrganizationsRecordBuilder, OrganizationsResponseBuilder
+from .utils import datetime_to_string, get_log_messages_by_log_level, read_stream, string_to_datetime
 
 
 _NOW = ab_datetime_now()
@@ -149,3 +151,62 @@ class TestOrganizationsStreamIncremental(TestCase):
         assert len(output.records) == 1
         assert output.most_recent_state is not None
         assert output.most_recent_state.stream_descriptor.name == "organizations"
+
+    @HttpMocker()
+    def test_given_403_permission_denied_when_read_organizations_then_ignore_and_skip_stream(self, http_mocker):
+        """When Zendesk returns 403 with 'You do not have access', the stream should be skipped."""
+        api_token_authenticator = self._get_authenticator(self._config)
+        http_mocker.get(
+            ZendeskSupportRequestBuilder.organizations_endpoint(api_token_authenticator)
+            .with_start_time(self._config["start_date"])
+            .with_any_query_params()
+            .build(),
+            ErrorResponseBuilder.response_with_status(403)
+            .with_error_message("You do not have access to this page. You do not have permission to access this page. Please contact the account owner of this help desk for further help.")
+            .build(),
+        )
+
+        output = read_stream("organizations", SyncMode.incremental, self._config)
+
+        assert len(output.records) == 0
+        error_logs = list(get_log_messages_by_log_level(output.logs, LogLevel.ERROR))
+        assert not any("403" in msg for msg in error_logs), "403 permission-denied should not produce ERROR logs"
+
+    @HttpMocker()
+    def test_given_403_other_error_when_read_organizations_then_fail(self, http_mocker):
+        """When Zendesk returns 403 without the permission-denied message, the sync should fail."""
+        api_token_authenticator = self._get_authenticator(self._config)
+        http_mocker.get(
+            ZendeskSupportRequestBuilder.organizations_endpoint(api_token_authenticator)
+            .with_start_time(self._config["start_date"])
+            .with_any_query_params()
+            .build(),
+            ErrorResponseBuilder.response_with_status(403)
+            .with_error_message("Forbidden")
+            .build(),
+        )
+
+        output = read_stream("organizations", SyncMode.incremental, self._config, expecting_exception=True)
+
+        assert len(output.records) == 0
+        error_logs = list(get_log_messages_by_log_level(output.logs, LogLevel.ERROR))
+        assert any("403" in msg for msg in error_logs), "Expected 403 error code in logs"
+        assert any("Forbidden" in msg for msg in error_logs), "Expected error message in logs"
+
+    @HttpMocker()
+    def test_given_404_error_when_read_organizations_then_fail(self, http_mocker):
+        """404 errors should still fail the sync."""
+        api_token_authenticator = self._get_authenticator(self._config)
+        http_mocker.get(
+            ZendeskSupportRequestBuilder.organizations_endpoint(api_token_authenticator)
+            .with_start_time(self._config["start_date"])
+            .with_any_query_params()
+            .build(),
+            ErrorResponseBuilder.response_with_status(404).build(),
+        )
+
+        output = read_stream("organizations", SyncMode.incremental, self._config, expecting_exception=True)
+
+        assert len(output.records) == 0
+        error_logs = list(get_log_messages_by_log_level(output.logs, LogLevel.ERROR))
+        assert any("404" in msg for msg in error_logs), "Expected 404 error code in logs"

--- a/docs/integrations/sources/zendesk-support.md
+++ b/docs/integrations/sources/zendesk-support.md
@@ -224,6 +224,7 @@ If you use Airbyte Cloud and your organization restricts access to specific IPs,
 
 | Version     | Date       | Pull Request                                             | Subject                                                                                                                                                                                                                            |
 |:------------|:-----------|:---------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 5.2.10 | 2026-06-11 | []() | Gracefully skip streams when Zendesk returns permission-denied error instead of failing the entire sync |
 | 5.2.9 | 2026-06-09 | [79583](https://github.com/airbytehq/airbyte/pull/79583) | Update dependencies |
 | 5.2.8 | 2026-06-02 | [77507](https://github.com/airbytehq/airbyte/pull/77507) | Update dependencies |
 | 5.2.7 | 2026-05-15 | [78120](https://github.com/airbytehq/airbyte/pull/78120) | Promoted release candidate to GA |

--- a/docs/integrations/sources/zendesk-support.md
+++ b/docs/integrations/sources/zendesk-support.md
@@ -224,7 +224,7 @@ If you use Airbyte Cloud and your organization restricts access to specific IPs,
 
 | Version     | Date       | Pull Request                                             | Subject                                                                                                                                                                                                                            |
 |:------------|:-----------|:---------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| 5.2.10 | 2026-06-11 | []() | Gracefully skip streams when Zendesk returns permission-denied error instead of failing the entire sync |
+| 5.2.10 | 2026-06-11 | [79684](https://github.com/airbytehq/airbyte/pull/79684) | Gracefully skip streams when Zendesk returns permission-denied error instead of failing the entire sync |
 | 5.2.9 | 2026-06-09 | [79583](https://github.com/airbytehq/airbyte/pull/79583) | Update dependencies |
 | 5.2.8 | 2026-06-02 | [77507](https://github.com/airbytehq/airbyte/pull/77507) | Update dependencies |
 | 5.2.7 | 2026-05-15 | [78120](https://github.com/airbytehq/airbyte/pull/78120) | Promoted release candidate to GA |


### PR DESCRIPTION
## What

Resolves https://github.com/airbytehq/oncall/issues/12843

Non-admin Zendesk accounts get HTTP 403 on admin-only incremental export endpoints (`/api/v2/incremental/*`). The existing global error handler maps `[403, 404]` to `action: FAIL`, terminating the entire sync instead of skipping just the inaccessible streams.

This is an alternative to https://github.com/airbytehq/airbyte/pull/79668, which blanket-ignores all 403s and 404s. That approach is too broad — a 403 isn't always a permissions issue (could be expired token, IP restriction, etc.), and 404 usually means the endpoint doesn't exist, which is a real error.

## How

Added a targeted `error_message_contains` filter **above** the existing `403/404 → FAIL` filter in the global error handler:

```yaml
response_filters:
  # Match only Zendesk's permission-denied response body
  - error_message_contains: "You do not have access"
    action: IGNORE
    error_message: "Skipping stream '...' because the authenticated user lacks permission..."
  # All other 403/404s still fail as before
  - http_codes: [403, 404]
    action: FAIL
    failure_type: config_error
    error_message: "Unable to read data for stream '...'..."
```

The CDK's `HttpResponseFilter` evaluates `http_codes`, `predicate`, and `error_message_contains` as OR conditions (see [HubSpot manifest L149-153](https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/connectors/source-hubspot/manifest.yaml#L149-L153)). Using `error_message_contains` alone (without `http_codes`) ensures only responses whose body contains "You do not have access" are matched — other 403s and all 404s fall through to the existing FAIL filter.

## Review guide

1. `manifest.yaml` L84-90 — the new `error_message_contains` IGNORE filter + updated FAIL filter message
2. `test_organizations.py` — three new tests:
   - `test_given_403_permission_denied_when_read_organizations_then_ignore_and_skip_stream` — 403 with "You do not have access" → IGNORE
   - `test_given_403_other_error_when_read_organizations_then_fail` — 403 with "Forbidden" → FAIL
   - `test_given_404_error_when_read_organizations_then_fail` — 404 still FAILs

## User Impact

Non-admin Zendesk accounts can now sync all streams they have access to. Streams behind admin-only endpoints are gracefully skipped with an informative log message. Other 403 errors (bad credentials, expired tokens) and 404 errors still fail the sync as expected. Check connection still correctly detects invalid credentials.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Requested by @suisuixia42.

---
[Devin session](https://app.devin.ai/sessions/c4b016a959054289b1bd83071168d826)