### PR TITLE
docs: clarify refresh API limitation

### DIFF
--- a/docs/platform/operator-guides/refreshes.md
+++ b/docs/platform/operator-guides/refreshes.md
@@ -23,7 +23,13 @@ Depending on the sync mode you’ve selected, you’ll be able to choose between
 | Full Refresh \| Append         | Not available                     | Not available                     | Available |
 | Incremental \| Append          | Not available                     | Available                         | Available |
 
-For supported destinations, and depending on the sync mode you have selected, there are two types of refreshes - "retaining history" and "removing history". Both kinds of Refresh Syncs can be triggered from the UI and via the Airbyte API at either the stream or connection levels (although both might not be available depending on your sync mode).
+For supported destinations, and depending on the sync mode you have selected, there are two types of refreshes - "retaining history" and "removing history". Both kinds of Refresh Syncs can be triggered from the UI at either the stream or connection levels (although both might not be available depending on your sync mode).
+
+:::note
+
+The public `POST /v1/jobs` API currently supports starting `sync` and `reset` jobs, but not `refresh` jobs. Use the UI for refreshes unless you are using an API surface that explicitly documents refresh support.
+
+:::
 
 ![Are you sure you want to refresh data](/.gitbook/assets/refreshes/are-you-sure-refresh.png)
 


### PR DESCRIPTION
## What

Closes #75459.

Clarifies the refresh operator guide so it no longer says Refresh Syncs can be triggered through the public Jobs API.

## How

Keeps the UI guidance for refreshes and adds a short note that `POST /v1/jobs` currently supports `sync` and `reset` jobs, but not `refresh` jobs.

## Review guide

1. `docs/platform/operator-guides/refreshes.md`

## User Impact

Users looking for a programmatic refresh path will not try `POST /v1/jobs` with `jobType=REFRESH` based on this page.

## Can this PR be safely reverted and rolled back?

- [x] YES
- [ ] NO