### PR TITLE
fix(destination-s3-data-lake, destination-gcs-data-lake): replace deprecated NestedField.of() with optional()/required()

### DIFF
--- a/airbyte-integrations/connectors/destination-gcs-data-lake/src/main/kotlin/io/airbyte/integrations/destination/gcs_data_lake/write/GcsDataLakeStreamLoader.kt
+++ b/airbyte-integrations/connectors/destination-gcs-data-lake/src/main/kotlin/io/airbyte/integrations/destination/gcs_data_lake/write/GcsDataLakeStreamLoader.kt
@@ -78,13 +78,21 @@ class GcsDataLakeStreamLoader(
                         ?: originalName
 
                 if (mappedName != originalName) {
-                    Types.NestedField.of(
-                        field.fieldId(),
-                        field.isOptional,
-                        mappedName,
-                        field.type(),
-                        field.doc()
-                    )
+                    if (field.isOptional) {
+                        Types.NestedField.optional(
+                            field.fieldId(),
+                            mappedName,
+                            field.type(),
+                            field.doc()
+                        )
+                    } else {
+                        Types.NestedField.required(
+                            field.fieldId(),
+                            mappedName,
+                            field.type(),
+                            field.doc()
+                        )
+                    }
                 } else {
                     field
                 }

--- a/airbyte-integrations/connectors/destination-s3-data-lake/src/test/kotlin/io/airbyte/integrations/destination/s3_data_lake/write/S3DataLakeStreamLoaderTest.kt
+++ b/airbyte-integrations/connectors/destination-s3-data-lake/src/test/kotlin/io/airbyte/integrations/destination/s3_data_lake/write/S3DataLakeStreamLoaderTest.kt
@@ -422,7 +422,7 @@ internal class S3DataLakeStreamLoaderTest {
                     Types.StructType.of(
                         Types.NestedField.required(6, "sync_id", Types.LongType.get()),
                         Types.NestedField.required(
-                    7,
+                            7,
                             "changes",
                             Types.ListType.ofRequired(
                                 8,
@@ -666,7 +666,7 @@ internal class S3DataLakeStreamLoaderTest {
                     Types.StructType.of(
                         Types.NestedField.required(6, "sync_id", Types.LongType.get()),
                         Types.NestedField.required(
-                    7,
+                            7,
                             "changes",
                             Types.ListType.ofRequired(
                                 8,

--- a/airbyte-integrations/connectors/destination-s3-data-lake/src/test/kotlin/io/airbyte/integrations/destination/s3_data_lake/write/S3DataLakeStreamLoaderTest.kt
+++ b/airbyte-integrations/connectors/destination-s3-data-lake/src/test/kotlin/io/airbyte/integrations/destination/s3_data_lake/write/S3DataLakeStreamLoaderTest.kt
@@ -429,12 +429,12 @@ internal class S3DataLakeStreamLoaderTest {
                                 Types.StructType.of(
                                     Types.NestedField.required(9, "field", Types.StringType.get()),
                                     Types.NestedField.required(
-                    10,
+                                        10,
                                         "change",
                                         Types.StringType.get(),
                                     ),
                                     Types.NestedField.required(
-                    11,
+                                        11,
                                         "reason",
                                         Types.StringType.get(),
                                     ),
@@ -673,12 +673,12 @@ internal class S3DataLakeStreamLoaderTest {
                                 Types.StructType.of(
                                     Types.NestedField.required(9, "field", Types.StringType.get()),
                                     Types.NestedField.required(
-                    10,
+                                        10,
                                         "change",
                                         Types.StringType.get(),
                                     ),
                                     Types.NestedField.required(
-                    11,
+                                        11,
                                         "reason",
                                         Types.StringType.get(),
                                     ),

--- a/airbyte-integrations/connectors/destination-s3-data-lake/src/test/kotlin/io/airbyte/integrations/destination/s3_data_lake/write/S3DataLakeStreamLoaderTest.kt
+++ b/airbyte-integrations/connectors/destination-s3-data-lake/src/test/kotlin/io/airbyte/integrations/destination/s3_data_lake/write/S3DataLakeStreamLoaderTest.kt
@@ -404,43 +404,37 @@ internal class S3DataLakeStreamLoaderTest {
             )
         val icebergSchema =
             Schema(
-                Types.NestedField.of(1, true, "id", Types.LongType.get()),
-                Types.NestedField.of(2, true, "name", Types.StringType.get()),
-                Types.NestedField.of(
+                Types.NestedField.optional(1, "id", Types.LongType.get()),
+                Types.NestedField.optional(2, "name", Types.StringType.get()),
+                Types.NestedField.required(
                     3,
-                    false,
                     Meta.Companion.COLUMN_NAME_AB_RAW_ID,
                     Types.StringType.get()
                 ),
-                Types.NestedField.of(
+                Types.NestedField.required(
                     4,
-                    false,
                     Meta.Companion.COLUMN_NAME_AB_EXTRACTED_AT,
                     Types.LongType.get()
                 ),
-                Types.NestedField.of(
+                Types.NestedField.required(
                     5,
-                    false,
                     Meta.Companion.COLUMN_NAME_AB_META,
                     Types.StructType.of(
-                        Types.NestedField.of(6, false, "sync_id", Types.LongType.get()),
-                        Types.NestedField.of(
-                            7,
-                            false,
+                        Types.NestedField.required(6, "sync_id", Types.LongType.get()),
+                        Types.NestedField.required(
+                    7,
                             "changes",
                             Types.ListType.ofRequired(
                                 8,
                                 Types.StructType.of(
-                                    Types.NestedField.of(9, false, "field", Types.StringType.get()),
-                                    Types.NestedField.of(
-                                        10,
-                                        false,
+                                    Types.NestedField.required(9, "field", Types.StringType.get()),
+                                    Types.NestedField.required(
+                    10,
                                         "change",
                                         Types.StringType.get(),
                                     ),
-                                    Types.NestedField.of(
-                                        11,
-                                        false,
+                                    Types.NestedField.required(
+                    11,
                                         "reason",
                                         Types.StringType.get(),
                                     ),
@@ -449,9 +443,8 @@ internal class S3DataLakeStreamLoaderTest {
                         ),
                     ),
                 ),
-                Types.NestedField.of(
+                Types.NestedField.required(
                     12,
-                    false,
                     Meta.Companion.COLUMN_NAME_AB_GENERATION_ID,
                     Types.LongType.get()
                 ),
@@ -531,7 +524,7 @@ internal class S3DataLakeStreamLoaderTest {
             )
         val icebergSchema =
             Schema(
-                Types.NestedField.of(2, true, "name", Types.StringType.get()),
+                Types.NestedField.optional(2, "name", Types.StringType.get()),
             )
         val awsConfiguration: AWSAccessKeyConfiguration = mockk {
             every { accessKeyId } returns "access-key"
@@ -655,43 +648,37 @@ internal class S3DataLakeStreamLoaderTest {
             )
         val columns =
             listOf(
-                Types.NestedField.of(1, false, "id", Types.LongType.get()),
-                Types.NestedField.of(2, true, "name", Types.StringType.get()),
-                Types.NestedField.of(
+                Types.NestedField.required(1, "id", Types.LongType.get()),
+                Types.NestedField.optional(2, "name", Types.StringType.get()),
+                Types.NestedField.required(
                     3,
-                    false,
                     Meta.Companion.COLUMN_NAME_AB_RAW_ID,
                     Types.StringType.get()
                 ),
-                Types.NestedField.of(
+                Types.NestedField.required(
                     4,
-                    false,
                     Meta.Companion.COLUMN_NAME_AB_EXTRACTED_AT,
                     Types.LongType.get()
                 ),
-                Types.NestedField.of(
+                Types.NestedField.required(
                     5,
-                    false,
                     Meta.Companion.COLUMN_NAME_AB_META,
                     Types.StructType.of(
-                        Types.NestedField.of(6, false, "sync_id", Types.LongType.get()),
-                        Types.NestedField.of(
-                            7,
-                            false,
+                        Types.NestedField.required(6, "sync_id", Types.LongType.get()),
+                        Types.NestedField.required(
+                    7,
                             "changes",
                             Types.ListType.ofRequired(
                                 8,
                                 Types.StructType.of(
-                                    Types.NestedField.of(9, false, "field", Types.StringType.get()),
-                                    Types.NestedField.of(
-                                        10,
-                                        false,
+                                    Types.NestedField.required(9, "field", Types.StringType.get()),
+                                    Types.NestedField.required(
+                    10,
                                         "change",
                                         Types.StringType.get(),
                                     ),
-                                    Types.NestedField.of(
-                                        11,
-                                        false,
+                                    Types.NestedField.required(
+                    11,
                                         "reason",
                                         Types.StringType.get(),
                                     ),
@@ -700,9 +687,8 @@ internal class S3DataLakeStreamLoaderTest {
                         ),
                     ),
                 ),
-                Types.NestedField.of(
+                Types.NestedField.required(
                     12,
-                    false,
                     Meta.Companion.COLUMN_NAME_AB_GENERATION_ID,
                     Types.LongType.get()
                 ),


### PR DESCRIPTION
This PR targets the following PR:
- #79705

---

## What

Fixes pre-existing deprecation warnings that are treated as compilation errors with `-Werror`. The deprecated `Types.NestedField.of()` method was flagged after the Iceberg dependency update in v1.0.14.

## How

Replaced `Types.NestedField.of(id, isOptional, name, type, doc)` calls with the non-deprecated equivalents:
- `Types.NestedField.optional(id, name, type, doc)` when the field is optional
- `Types.NestedField.required(id, name, type, doc)` when the field is required

## Review guide

1. `airbyte-integrations/connectors/destination-gcs-data-lake/src/main/kotlin/.../GcsDataLakeStreamLoader.kt` — production code fix
2. `airbyte-integrations/connectors/destination-s3-data-lake/src/test/kotlin/.../S3DataLakeStreamLoaderTest.kt` — test code fix

## User Impact

No user-facing impact. This is a compile-time fix only — the runtime behavior is identical.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Link to Devin session: https://app.devin.ai/sessions/2665fe8e872b40c685a7d8622f228419
Requested by: @aaronsteers

> [!IMPORTANT]
> Active progressive rollout warning for destination-s3-data-lake.

- [ ] (Click to Approve:) Bypass the active progressive rollout warning for destination-s3-data-lake in the PR comment [here](https://github.com/airbytehq/airbyte/pull/79706#issuecomment-4703603487).