### PR TITLE
docs(connector-builder): warn about zero-record syncs when auto-detect schema is disabled

### DIFF
--- a/docs/platform/connector-development/connector-builder-ui/record-processing.mdx
+++ b/docs/platform/connector-development/connector-builder-ui/record-processing.mdx
@@ -778,6 +778,8 @@ This behavior can be toggled off by disabling the `Automatically import declared
 If you disable `Automatically import declared schema`, you **must** manually define a valid schema for each stream. Without a declared schema, the connector has no field definitions for the stream, so syncs produce **zero records** and the connection fails with a generic platform error such as _"Warning from airbyte_platform: Something went wrong within the airbyte platform"_. This is a common cause of unexpected zero-record sync failures for custom connectors built with the Connector Builder.
 
 If you prefer to manage schemas manually, run at least one test read with auto-import enabled to generate a baseline schema, then disable auto-import and make your edits from there.
+
+If you are already experiencing this issue, re-import the schema in the Connector Builder with `Automatically import detected schema` enabled, then save and publish the connector. Once published, refresh the source schema in the connection's Schema tab, verify that the fields are detected and selected for each stream, and re-run the sync.
 :::
 
 For example the following test records:

--- a/docs/platform/connector-development/connector-builder-ui/record-processing.mdx
+++ b/docs/platform/connector-development/connector-builder-ui/record-processing.mdx
@@ -774,6 +774,12 @@ This information is used by the Airbyte system for different purposes:
 When doing test reads, the connector builder analyzes the test records and shows the derived schema in the "Detected schema" tab. By default, new streams are configured to automatically import the detected schema into the declared schema on every test read.
 This behavior can be toggled off by disabling the `Automatically import declared schema` switch, in which case the declared schema can be manually edited in the UI and it will no longer be automatically updated when triggering test reads.
 
+:::caution
+If you disable `Automatically import declared schema`, you **must** manually define a valid schema for each stream. Without a declared schema, the connector has no field definitions for the stream. This means syncs will complete successfully but produce **zero records**, because Airbyte cannot map the source data to a destination schema. This is a common cause of unexpected zero-record syncs for custom connectors built with the Connector Builder.
+
+If you prefer to manage schemas manually, run at least one test read with auto-import enabled to generate a baseline schema, then disable auto-import and make your edits from there.
+:::
+
 For example the following test records:
 
 ```

--- a/docs/platform/connector-development/connector-builder-ui/record-processing.mdx
+++ b/docs/platform/connector-development/connector-builder-ui/record-processing.mdx
@@ -779,7 +779,7 @@ If you disable `Automatically import declared schema`, you **must** manually def
 
 If you prefer to manage schemas manually, run at least one test read with auto-import enabled to generate a baseline schema, then disable auto-import and make your edits from there.
 
-If you are already experiencing this issue, re-import the schema in the Connector Builder with `Automatically import detected schema` enabled, then save and publish the connector. Once published, refresh the source schema in the connection's Schema tab, verify that the fields are detected and selected for each stream, and re-run the sync.
+If you are already experiencing this issue, re-import the schema in the Connector Builder with `Automatically import declared schema` enabled, then save and publish the connector. Once published, refresh the source schema in the connection's Schema tab, verify that the fields are detected and selected for each stream, and re-run the sync.
 :::
 
 For example the following test records:

--- a/docs/platform/connector-development/connector-builder-ui/record-processing.mdx
+++ b/docs/platform/connector-development/connector-builder-ui/record-processing.mdx
@@ -775,7 +775,7 @@ When doing test reads, the connector builder analyzes the test records and shows
 This behavior can be toggled off by disabling the `Automatically import declared schema` switch, in which case the declared schema can be manually edited in the UI and it will no longer be automatically updated when triggering test reads.
 
 :::caution
-If you disable `Automatically import declared schema`, you **must** manually define a valid schema for each stream. Without a declared schema, the connector has no field definitions for the stream. This means syncs will complete successfully but produce **zero records**, because Airbyte cannot map the source data to a destination schema. This is a common cause of unexpected zero-record syncs for custom connectors built with the Connector Builder.
+If you disable `Automatically import declared schema`, you **must** manually define a valid schema for each stream. Without a declared schema, the connector has no field definitions for the stream, so syncs produce **zero records** and the connection fails with a generic platform error such as _"Warning from airbyte_platform: Something went wrong within the airbyte platform"_. This is a common cause of unexpected zero-record sync failures for custom connectors built with the Connector Builder.
 
 If you prefer to manage schemas manually, run at least one test read with auto-import enabled to generate a baseline schema, then disable auto-import and make your edits from there.
 :::


### PR DESCRIPTION
## What

Adds a `:::caution` admonition to the Connector Builder "Declared schema" documentation warning users that disabling `Automatically import declared schema` without manually defining a valid schema results in zero-record syncs and a misleading platform error (`"Warning from airbyte_platform: Something went wrong within the airbyte platform"`).

This addresses a pattern observed across multiple support tickets where users building custom connectors in the Connector Builder disabled auto-detect schema but did not provide a manual schema, leading to confusing sync failures.

Requested by @Airbyte-Support (syed.khadeer@airbyte.io).

## How

Single addition to `docs/platform/connector-development/connector-builder-ui/record-processing.mdx` — a `:::caution` block immediately after the paragraph describing the `Automatically import declared schema` toggle. The warning:
- Explains that a missing schema causes zero-record syncs
- Mentions the specific misleading error message users see so they can self-diagnose
- Recommends running a test read with auto-import first to generate a baseline schema

## Review guide

1. `docs/platform/connector-development/connector-builder-ui/record-processing.mdx` — the only change

## User Impact

Users who disable auto-detect schema in the Connector Builder will now see a clear warning explaining that they must manually define a schema, with the specific error message they'd encounter and a recommended workflow.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

---
[Devin session](https://app.devin.ai/sessions/a5f3bc87ec1f47ee93b1a2ed8aa0fd48)