### PR TITLE
fix(docs): remove data worker page from Plus plan product badges

### DIFF
--- a/docs/platform/cloud/managing-airbyte-cloud/manage-data-workers.md
+++ b/docs/platform/cloud/managing-airbyte-cloud/manage-data-workers.md
@@ -1,5 +1,5 @@
 ---
-products: cloud-plus
+products: cloud-teams
 ---
 
 # Monitor data worker usage

--- a/docs/platform/readme.md
+++ b/docs/platform/readme.md
@@ -77,7 +77,7 @@ Airbyte's data replication platform is available as a self-managed, hybrid, or f
 
 <CardWithIcon title="Standard" description="A cloud solution that provides a fully managed experience for data replication. Focus on moving data while Airbyte manages the infrastructure. Free 30-day trial." ctaText="Sign up" ctaLink="https://cloud.airbyte.com/signup" icon="fa-cloud" />
 
-<CardWithIcon title="Plus" description="A cloud solution with all the capabilities of Standard, plus higher priority support and predictable, capacity-based annual pricing." ctaText="Talk to Sales" ctaLink="https://airbyte.com/company/talk-to-sales" icon="fa-lock" />
+<CardWithIcon title="Plus" description="A cloud solution with all the capabilities of Standard, plus higher priority support and predictable annual pricing." ctaText="Talk to Sales" ctaLink="https://airbyte.com/company/talk-to-sales" icon="fa-lock" />
 
 <CardWithIcon title="Pro" description="A cloud solution for organizations looking to scale efficiently. Role based access control, single sign on, and more ensure Pro is a robust solution that can grow with your team." ctaText="Talk to Sales" ctaLink="https://airbyte.com/company/talk-to-sales" icon="fa-lock" />
 

--- a/docusaurus/platform_versioned_docs/version-2.1/cloud/managing-airbyte-cloud/manage-data-workers.md
+++ b/docusaurus/platform_versioned_docs/version-2.1/cloud/managing-airbyte-cloud/manage-data-workers.md
@@ -1,5 +1,5 @@
 ---
-products: cloud-plus
+products: cloud-teams
 ---
 
 # Monitor data worker usage

--- a/docusaurus/platform_versioned_docs/version-2.1/readme.md
+++ b/docusaurus/platform_versioned_docs/version-2.1/readme.md
@@ -73,7 +73,7 @@ Airbyte's data replication platform is available as a self-managed, hybrid, or f
 
 <CardWithIcon title="Standard" description="A cloud solution that provides a fully managed experience for data replication. Focus on moving data while Airbyte manages the infrastructure. Free 30-day trial." ctaText="Sign up" ctaLink="https://cloud.airbyte.com/signup" icon="fa-cloud" />
 
-<CardWithIcon title="Plus" description="A cloud solution with all the capabilities of Standard, plus higher priority support and predictable, capacity-based annual pricing." ctaText="Talk to Sales" ctaLink="https://airbyte.com/company/talk-to-sales" icon="fa-lock" />
+<CardWithIcon title="Plus" description="A cloud solution with all the capabilities of Standard, plus higher priority support and predictable annual pricing." ctaText="Talk to Sales" ctaLink="https://airbyte.com/company/talk-to-sales" icon="fa-lock" />
 
 <CardWithIcon title="Pro" description="A cloud solution for organizations looking to scale efficiently. Role based access control, single sign on, and more ensure Pro is a robust solution that can grow with your team." ctaText="Talk to Sales" ctaLink="https://airbyte.com/company/talk-to-sales" icon="fa-lock" />
 


### PR DESCRIPTION
## What

Plus is a credit/volume-based plan, not a capacity-based plan with data workers. The data workers docs page (`manage-data-workers.md`) incorrectly used `products: cloud-plus` frontmatter, causing it to display for Plus users. Only Pro and Enterprise Flex are capacity-based plans.

Additionally, the Plus plan card on the platform homepage described Plus as having "capacity-based annual pricing," which is inaccurate.

Resolves [DOCS-25](https://linear.app/airbyteio/issue/DOCS-25/investigate-data-worker-capacity-on-plus-plans).

## How

- Changed `products: cloud-plus` → `products: cloud-teams` in `manage-data-workers.md` (current and v2.1 versioned docs). `cloud-teams` shows the page only for Pro and Enterprise Flex via the existing badge inheritance logic in `ProductInformation.jsx`.
- Removed \"capacity-based\" from the Plus plan description in `readme.md` (current and v2.1 versioned docs).

Evidence that Plus is not capacity-based:
- `airbyte-platform-internal`: `DataWorkerUsageService.VALID_PLANS` = `PRO`, `FLEX`, `SME` — Plus excluded
- Plus lacks `CommittedDataWorkersEntitlement`
- `understand-airbyte-cloud-limits.md` explicitly says \"Organizations on capacity-based plans (Pro, Enterprise Flex)\"
- Webapp: `AllowDataWorkerCapacity` feature flag controls credits vs data workers; Plus orgs see credits

## Review guide

1. `docs/platform/cloud/managing-airbyte-cloud/manage-data-workers.md` — frontmatter change
2. `docs/platform/readme.md` — Plus plan description wording
3. Same two changes mirrored in `docusaurus/platform_versioned_docs/version-2.1/`

## User Impact

Plus plan users will no longer see the data workers documentation page (which was irrelevant to them). The Plus plan description no longer incorrectly claims capacity-based pricing.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚"

Link to Devin session: https://app.devin.ai/sessions/e3242dd983684fd3ae043d7331011644
Requested by: @ian-at-airbyte