### PR TITLE
docs(enterprise-connectors): update 'no longer sold' admonitions

### DIFF
--- a/docs/integrations/enterprise-connectors/destination-salesforce.md
+++ b/docs/integrations/enterprise-connectors/destination-salesforce.md
@@ -5,14 +5,6 @@ enterprise-connector: true
 
 # Salesforce destination
 
-<HideInUI>
-
-:::warning
-Airbyte no longer maintains or supports the Salesforce destination connector. It may continue to function but is not actively developed, and no future updates or bug fixes are planned. Use at your own discretion.
-:::
-
-</HideInUI>
-
 The Salesforce destination connector enables [data activation](/platform/move-data/elt-data-activation) by syncing data from your data warehouse to Salesforce objects. This connector is designed for operational workflows where you need to deliver modeled data directly to your CRM for sales, marketing, and customer success teams.
 
 The connector uses the [Salesforce Bulk API v62.0](https://developer.salesforce.com/docs/atlas.en-us.api_asynch.meta/api_asynch/asynch_api_intro.htm) for efficient data loading and supports OAuth 2.0 authentication with comprehensive error handling through [rejected records](/platform/move-data/rejected-records) functionality.

--- a/docs/integrations/enterprise-connectors/source-db2-enterprise.md
+++ b/docs/integrations/enterprise-connectors/source-db2-enterprise.md
@@ -4,11 +4,15 @@ enterprise-connector: true
 ---
 # Source Db2
 
+<HideInUI>
+
 :::info We no longer sell this connector
 
 Airbyte no longer sells this connector, but we continue to support it if you purchased it in the past.
 
 :::
+
+</HideInUI>
 
 The Enterprise Db2 source connector reads data from your Db2 database. To use CDC, your database must have triggers and tracking tables provisioned in advance by your DBA. During CDC syncs, the connector reads from these tracking tables and deletes processed change rows.
 

--- a/docs/integrations/enterprise-connectors/source-db2-enterprise.md
+++ b/docs/integrations/enterprise-connectors/source-db2-enterprise.md
@@ -4,6 +4,12 @@ enterprise-connector: true
 ---
 # Source Db2
 
+:::info We no longer sell this connector
+
+Airbyte no longer sells this connector, but we continue to support it if you purchased it in the past.
+
+:::
+
 The Enterprise Db2 source connector reads data from your Db2 database. To use CDC, your database must have triggers and tracking tables provisioned in advance by your DBA. During CDC syncs, the connector reads from these tracking tables and deletes processed change rows.
 
 ## Features

--- a/docs/integrations/enterprise-connectors/source-sap-hana.md
+++ b/docs/integrations/enterprise-connectors/source-sap-hana.md
@@ -5,11 +5,15 @@ enterprise-connector: true
 
 # Source SAP HANA
 
+<HideInUI>
+
 :::info We no longer sell this connector
 
 Airbyte no longer sells this connector, but we continue to support it if you purchased it in the past.
 
 :::
+
+</HideInUI>
 
 Airbyte's incubating SAP HANA enterprise source connector currently offers Full Refresh and Incrementals syncs for streams. Support for Change Data Capture (CDC) is available using a trigger-based approach.
 

--- a/docs/integrations/enterprise-connectors/source-sap-hana.md
+++ b/docs/integrations/enterprise-connectors/source-sap-hana.md
@@ -5,6 +5,12 @@ enterprise-connector: true
 
 # Source SAP HANA
 
+:::info We no longer sell this connector
+
+Airbyte no longer sells this connector, but we continue to support it if you purchased it in the past.
+
+:::
+
 Airbyte's incubating SAP HANA enterprise source connector currently offers Full Refresh and Incrementals syncs for streams. Support for Change Data Capture (CDC) is available using a trigger-based approach.
 
 ## Features

--- a/docs/integrations/enterprise-connectors/source-service-now.md
+++ b/docs/integrations/enterprise-connectors/source-service-now.md
@@ -4,6 +4,12 @@ enterprise-connector: true
 ---
 # Source ServiceNow
 
+:::info We no longer sell this connector
+
+Airbyte no longer sells this connector, but we continue to support it if you purchased it in the past.
+
+:::
+
 Airbyte’s incubating ServiceNow enterprise source connector currently offers Full Refresh syncs for streams that are part of Software Asset Management and Configuration Management Database applications.
 
 ## Features

--- a/docs/integrations/enterprise-connectors/source-service-now.md
+++ b/docs/integrations/enterprise-connectors/source-service-now.md
@@ -4,11 +4,15 @@ enterprise-connector: true
 ---
 # Source ServiceNow
 
+<HideInUI>
+
 :::info We no longer sell this connector
 
 Airbyte no longer sells this connector, but we continue to support it if you purchased it in the past.
 
 :::
+
+</HideInUI>
 
 Airbyte’s incubating ServiceNow enterprise source connector currently offers Full Refresh syncs for streams that are part of Software Asset Management and Configuration Management Database applications.
 

--- a/docs/integrations/enterprise-connectors/source-sharepoint-enterprise.md
+++ b/docs/integrations/enterprise-connectors/source-sharepoint-enterprise.md
@@ -5,6 +5,12 @@ enterprise-connector: true
 
 # SharePoint Enterprise
 
+:::info We no longer sell this connector
+
+Airbyte no longer sells this connector, but we continue to support it if you purchased it in the past.
+
+:::
+
 <HideInUI>
 
 This page contains the setup guide and reference information for the [SharePoint Enterprise](https://portal.azure.com) source connector.

--- a/docs/integrations/enterprise-connectors/source-sharepoint-enterprise.md
+++ b/docs/integrations/enterprise-connectors/source-sharepoint-enterprise.md
@@ -5,11 +5,15 @@ enterprise-connector: true
 
 # SharePoint Enterprise
 
+<HideInUI>
+
 :::info We no longer sell this connector
 
 Airbyte no longer sells this connector, but we continue to support it if you purchased it in the past.
 
 :::
+
+</HideInUI>
 
 <HideInUI>
 

--- a/docs/integrations/enterprise-connectors/source-sharepoint-lists-enterprise.md
+++ b/docs/integrations/enterprise-connectors/source-sharepoint-lists-enterprise.md
@@ -5,11 +5,15 @@ enterprise-connector: true
 
 # SharePoint Lists Enterprise
 
+<HideInUI>
+
 :::info We no longer sell this connector
 
 Airbyte no longer sells this connector, but we continue to support it if you purchased it in the past.
 
 :::
+
+</HideInUI>
 
 <HideInUI>
 

--- a/docs/integrations/enterprise-connectors/source-sharepoint-lists-enterprise.md
+++ b/docs/integrations/enterprise-connectors/source-sharepoint-lists-enterprise.md
@@ -5,6 +5,12 @@ enterprise-connector: true
 
 # SharePoint Lists Enterprise
 
+:::info We no longer sell this connector
+
+Airbyte no longer sells this connector, but we continue to support it if you purchased it in the past.
+
+:::
+
 <HideInUI>
 
 This page contains the setup guide and reference information for the [SharePoint Lists Enterprise](https://portal.azure.com) source connector.

--- a/docs/integrations/enterprise-connectors/source-workday-rest.md
+++ b/docs/integrations/enterprise-connectors/source-workday-rest.md
@@ -4,6 +4,12 @@ enterprise-connector: true
 ---
 # Source Workday REST
 
+:::info We no longer sell this connector
+
+Airbyte no longer sells this connector, but we continue to support it if you purchased it in the past.
+
+:::
+
 Airbyte's [Workday](https://workday.com) enterprise source connector currently offers the following features:
 
 - Incremental as well as Full Refresh [sync modes](https://docs.airbyte.com/cloud/core-concepts#connection-sync-modes). Note that incremental syncs are only supported for specific streams.

--- a/docs/integrations/enterprise-connectors/source-workday-rest.md
+++ b/docs/integrations/enterprise-connectors/source-workday-rest.md
@@ -4,11 +4,15 @@ enterprise-connector: true
 ---
 # Source Workday REST
 
+<HideInUI>
+
 :::info We no longer sell this connector
 
 Airbyte no longer sells this connector, but we continue to support it if you purchased it in the past.
 
 :::
+
+</HideInUI>
 
 Airbyte's [Workday](https://workday.com) enterprise source connector currently offers the following features:
 

--- a/docs/integrations/enterprise-connectors/source-workday.md
+++ b/docs/integrations/enterprise-connectors/source-workday.md
@@ -4,6 +4,12 @@ enterprise-connector: true
 ---
 # Source Workday
 
+:::info We no longer sell this connector
+
+Airbyte no longer sells this connector, but we continue to support it if you purchased it in the past.
+
+:::
+
 Airbyte's [Workday](https://workday.com) enterprise source connector currently offers the following features:
 
 - Full Refresh [sync modes](https://docs.airbyte.com/cloud/core-concepts#connection-sync-modes). Note that incremental syncs are only supported for specific streams.

--- a/docs/integrations/enterprise-connectors/source-workday.md
+++ b/docs/integrations/enterprise-connectors/source-workday.md
@@ -4,11 +4,15 @@ enterprise-connector: true
 ---
 # Source Workday
 
+<HideInUI>
+
 :::info We no longer sell this connector
 
 Airbyte no longer sells this connector, but we continue to support it if you purchased it in the past.
 
 :::
+
+</HideInUI>
 
 Airbyte's [Workday](https://workday.com) enterprise source connector currently offers the following features:
 


### PR DESCRIPTION
## What

Updates enterprise connector documentation to reflect which connectors are still sold:
- Adds an `:::info` admonition ("We no longer sell this connector") to 7 connectors that are no longer sold
- Removes the outdated deprecation warning from `destination-salesforce` (still actively sold)

Requested by @ian-at-airbyte.

## How

Added this admonition below the page title on each unsold connector doc:

```
:::info We no longer sell this connector

Airbyte no longer sells this connector, but we continue to support it if you purchased it in the past.

:::
```

**Connectors marked as no longer sold:**
- source-sharepoint-enterprise
- source-sharepoint-lists-enterprise
- source-db2-enterprise
- source-sap-hana
- source-service-now
- source-workday
- source-workday-rest

**Connectors with admonition removed:**
- destination-salesforce (removed `:::warning` block that incorrectly stated it was no longer maintained)

## Review guide

All changes are in `docs/integrations/enterprise-connectors/`:
1. 7 source connector docs — added info admonition after the title heading
2. `destination-salesforce.md` — removed the `<HideInUI>` wrapped `:::warning` block

## User Impact

Users visiting these docs pages will see a clear info banner indicating the connector is no longer sold but still supported for existing customers. The destination-salesforce page will no longer show an incorrect deprecation warning.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

---
[Devin session](https://app.devin.ai/sessions/fdd3ab18d5874a0f91e79fe778d4ea0e)