### PR TITLE
fix(source-tiktok-marketing): classify app_id mismatch and 40001 errors as config_error

### DIFF
--- a/airbyte-integrations/connectors/source-tiktok-marketing/manifest.yaml
+++ b/airbyte-integrations/connectors/source-tiktok-marketing/manifest.yaml
@@ -34,11 +34,11 @@ definitions:
         - predicate: "{{ response.get('code') == 40001 }}"
           action: FAIL
           failure_type: config_error
-          error_message: "Insufficient permissions for this endpoint (error 40001). Verify that the access token has the required scopes and that the TikTok developer application is approved. {{ response.get('message', '') }}"
+          error_message: "Access token has insufficient permissions (error 40001). {{ response.get('message', '') }}"
         - predicate: "{{ 'app_id' in response.get('message', '').lower() and 'inconsistent' in response.get('message', '').lower() }}"
           action: FAIL
           failure_type: config_error
-          error_message: "TikTok app_id does not match the access token. The app_id, secret, and access_token must all belong to the same TikTok developer application. If using Airbyte Cloud OAuth, do not manually override the app_id or access_token after authenticating. {{ response.get('message', '') }}"
+          error_message: "App ID does not match the access token application. {{ response.get('message', '') }}"
         - predicate: "{{ response.get('code') != 0 }}"
           action: FAIL
           error_message: "{{ response['message'] }}"

--- a/airbyte-integrations/connectors/source-tiktok-marketing/manifest.yaml
+++ b/airbyte-integrations/connectors/source-tiktok-marketing/manifest.yaml
@@ -31,6 +31,14 @@ definitions:
         - predicate: "{{ response.get('code') == 40002 }}"
           action: IGNORE
           error_message: "Resource not accessible or does not exist (error 40002). {{ response.get('message', '') }}"
+        - predicate: "{{ response.get('code') == 40001 }}"
+          action: FAIL
+          failure_type: config_error
+          error_message: "Insufficient permissions for this endpoint (error 40001). Verify that the access token has the required scopes and that the TikTok developer application is approved. {{ response.get('message', '') }}"
+        - predicate: "{{ 'app_id' in response.get('message', '').lower() and 'inconsistent' in response.get('message', '').lower() }}"
+          action: FAIL
+          failure_type: config_error
+          error_message: "TikTok app_id does not match the access token. The app_id, secret, and access_token must all belong to the same TikTok developer application. If using Airbyte Cloud OAuth, do not manually override the app_id or access_token after authenticating. {{ response.get('message', '') }}"
         - predicate: "{{ response.get('code') != 0 }}"
           action: FAIL
           error_message: "{{ response['message'] }}"
@@ -158,7 +166,7 @@ definitions:
         $ref: "#/definitions/requester"
         request_parameters:
           secret: "{{ config.get('credentials', config.get('environment', {})).get('secret') }}"
-          app_id: "{{ config.get('credentials', config.get('environment', {})).get('app_id', 0) }}"
+          app_id: "{{ config.get('credentials', config.get('environment', {})).get('app_id', '') }}"
         request_headers: {}
       record_selector:
         $ref: "#/definitions/record_selector"

--- a/airbyte-integrations/connectors/source-tiktok-marketing/metadata.yaml
+++ b/airbyte-integrations/connectors/source-tiktok-marketing/metadata.yaml
@@ -11,7 +11,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 4bfac00d-ce15-44ff-95b9-9e3c3e8fbd35
-  dockerImageTag: 5.0.11
+  dockerImageTag: 5.0.12
   dockerRepository: airbyte/source-tiktok-marketing
   documentationUrl: https://docs.airbyte.com/integrations/sources/tiktok-marketing
   externalDocumentationUrls:

--- a/docs/integrations/sources/tiktok-marketing.md
+++ b/docs/integrations/sources/tiktok-marketing.md
@@ -163,6 +163,7 @@ If you use Airbyte Cloud and your organization restricts access to specific IPs,
 
 | Version    | Date       | Pull Request                                              | Subject                                                                                                                                                                |
 |:-----------|:-----------|:----------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 5.0.12 | 2026-06-18 | [80240](https://github.com/airbytehq/airbyte/pull/80240) | Classify app_id/access_token mismatch and error 40001 as config_error with actionable guidance |
 | 5.0.11 | 2026-06-16 | [80094](https://github.com/airbytehq/airbyte/pull/80094) | Update dependencies |
 | 5.0.10 | 2026-06-09 | [79549](https://github.com/airbytehq/airbyte/pull/79549) | Update dependencies |
 | 5.0.9 | 2026-06-02 | [78999](https://github.com/airbytehq/airbyte/pull/78999) | Update dependencies |


### PR DESCRIPTION
## What

Fixes https://github.com/airbytehq/airbyte/issues/80210

Users setting up the TikTok Marketing source with manual credentials see an unhelpful generic error when `app_id` doesn't match the `access_token`'s application, or when `app_id` is missing from the config (defaults to `0`). The error is classified as a system error instead of a configuration error, giving no actionable guidance.

Requested by @Airbyte-Support (Syed Khadeer).

## How

**Error handlers** — add two targeted response filters in the main requester, before the catch-all:

```yaml
# 40001 → config_error with permissions guidance
- predicate: "{{ response.get('code') == 40001 }}"
  failure_type: config_error

# message-based match for app_id/token mismatch
- predicate: "{{ 'app_id' in message and 'inconsistent' in message }}"
  failure_type: config_error
```

**Default fix** — change `app_id` fallback from `0` to `''` so a missing `app_id` produces a clear "required parameter" error from TikTok instead of the misleading "inconsistent" message.

## Review guide

1. `airbyte-integrations/connectors/source-tiktok-marketing/manifest.yaml` — error handler additions (lines 34-41) and `app_id` default change (line 169)
2. `airbyte-integrations/connectors/source-tiktok-marketing/metadata.yaml` — version bump 5.0.11 → 5.0.12

## User Impact

- Users with mismatched `app_id`/`access_token` now see a clear `config_error` explaining that all three credentials must belong to the same TikTok developer application.
- Users with insufficient permissions (error 40001) now see a `config_error` with guidance to check scopes.
- No behavioral change for users with correctly configured credentials.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Link to Devin session: https://app.devin.ai/sessions/fd23d061560a4829b7bd562d0f5dcb3f