### PR TITLE
fix(destination-redshift): remove invalid link from v4 breaking change message

### DIFF
--- a/airbyte-integrations/connectors/destination-redshift/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-redshift/metadata.yaml
@@ -101,9 +101,8 @@ data:
           more `_airbyte_raw_*` tables). Oversized or out-of-range values are
           nullified before insertion and tracked in `_airbyte_meta`. If you have
           downstream dbt models or SQL queries referencing `_airbyte_raw_*` tables,
-          update them before upgrading. See the [migration guide](https://docs.airbyte.com/integrations/destinations/redshift-v2-migrations)
-          for details. Selecting `Upgrade` will upgrade **all** connections using
-          this destination at their next sync.
+          update them before upgrading. Selecting `Upgrade` will upgrade **all**
+          connections using this destination at their next sync.
 
           "
         upgradeDeadline: "2026-08-31"

--- a/airbyte-integrations/connectors/destination-redshift/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-redshift/metadata.yaml
@@ -106,6 +106,7 @@ data:
 
           "
         upgradeDeadline: "2026-08-31"
+        deadlineAction: "auto_upgrade"
   resourceRequirements:
     jobSpecific:
       - jobType: sync

--- a/airbyte-integrations/connectors/destination-redshift/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-redshift/metadata.yaml
@@ -101,8 +101,7 @@ data:
           more `_airbyte_raw_*` tables). Oversized or out-of-range values are
           nullified before insertion and tracked in `_airbyte_meta`. If you have
           downstream dbt models or SQL queries referencing `_airbyte_raw_*` tables,
-          update them before upgrading. Selecting `Upgrade` will upgrade **all**
-          connections using this destination at their next sync.
+          update them before upgrading.
 
           "
         upgradeDeadline: "2026-08-31"


### PR DESCRIPTION
## What

The v4.0.0 breaking change entry for `destination-redshift` in `metadata.yaml` had two issues:
1. An invalid migration guide link (`https://docs.airbyte.com/integrations/destinations/redshift-v2-migrations`) that doesn't need to be included since links are added automatically.
2. Missing `deadlineAction: "auto_upgrade"` to explicitly set auto-upgrade behavior at the deadline.

Requested by @pedroslopez.

## How

- Removed the `See the [migration guide](...) for details.` sentence from the v4.0.0 breaking change message.
- Added `deadlineAction: "auto_upgrade"` to the v4.0.0 breaking change entry.

## Review guide

1. `airbyte-integrations/connectors/destination-redshift/metadata.yaml`

## User Impact

Users will no longer see a broken link in the v4.0.0 breaking change upgrade notification, and the deadline will correctly trigger auto-upgrade.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

---
[Devin session](https://app.devin.ai/sessions/8258df087cbf41b39e0c1ed53b799c83)