### PR TITLE
fix(docs): add iconUrl fallback for connectors missing iconUrl in composite registry

### DIFF
--- a/docusaurus/src/components/ConnectorRegistry.jsx
+++ b/docusaurus/src/components/ConnectorRegistry.jsx
@@ -33,7 +33,7 @@ function buildCompositeEntry(entry, connectorType) {
     dockerRepository,
     dockerImageTag: entry.dockerImageTag || "",
     supportLevel: entry.supportLevel || "community",
-    iconUrl: entry.iconUrl || "",
+    iconUrl: entry.iconUrl || (dockerRepository ? `https://connectors.airbyte.com/files/metadata/${dockerRepository}/latest/icon.svg` : ""),
     documentationUrl: entry.documentationUrl || "",
   };
 }

--- a/docusaurus/src/helpers/clientRegistryUtils.js
+++ b/docusaurus/src/helpers/clientRegistryUtils.js
@@ -41,7 +41,7 @@ function buildCompositeEntry(entry, connectorType) {
     dockerRepository,
     dockerImageTag: entry.dockerImageTag || "",
     supportLevel: entry.supportLevel || "community",
-    iconUrl: entry.iconUrl || "",
+    iconUrl: entry.iconUrl || (dockerRepository ? `https://connectors.airbyte.com/files/metadata/${dockerRepository}/latest/icon.svg` : ""),
     documentationUrl: entry.documentationUrl || "",
   };
 }

--- a/docusaurus/src/scripts/fetch-registry.js
+++ b/docusaurus/src/scripts/fetch-registry.js
@@ -83,7 +83,7 @@ function buildCompositeEntry(entry, connectorType) {
     dockerImageTag: entry.dockerImageTag || "",
     supportLevel: entry.supportLevel || "community",
     sourceType: entry.sourceType || "",
-    iconUrl: entry.iconUrl || "",
+    iconUrl: entry.iconUrl || (dockerRepository ? `https://connectors.airbyte.com/files/metadata/${dockerRepository}/latest/icon.svg` : ""),
     documentationUrl: entry.documentationUrl || "",
     spec: entry.spec || null,
     remoteRegistries: entry.remoteRegistries || {},


### PR DESCRIPTION
## What

Many Marketplace connectors (31 of 56 destinations, 41 of 592 sources) no longer render a logo on the catalog listing page or on individual connector doc pages. The composite registry at `connectors.airbyte.com` has two icon-related fields: `iconUrl` (full CDN URL) and `icon` (just the filename). Many connectors only have `icon` set — they lack `iconUrl` entirely.

The icon files *do* exist at the CDN at the predictable path `https://connectors.airbyte.com/files/metadata/{dockerRepository}/latest/icon.svg`, but the code was falling back to an empty string when `iconUrl` was absent.

Reported in [Slack thread](https://airbytehq-team.slack.com/archives/C032KEED342/p1781819814162849).

## How

When `iconUrl` is missing from a registry entry, construct it from `dockerRepository` using the same CDN path pattern that `buildArchivedRegistryEntry` already uses. Applied in all three `buildCompositeEntry` functions:

```js
// Before
iconUrl: entry.iconUrl || "",

// After
iconUrl: entry.iconUrl || (dockerRepository
  ? `https://connectors.airbyte.com/files/metadata/${dockerRepository}/latest/icon.svg`
  : ""),
```

## Review guide

1. `docusaurus/src/scripts/fetch-registry.js` — build-time registry (remark plugins, sidebar)
2. `docusaurus/src/components/ConnectorRegistry.jsx` — client-side catalog page
3. `docusaurus/src/helpers/clientRegistryUtils.js` — client-side individual connector pages

## User Impact

Connector logos will render on both the catalog listing page and individual connector doc pages for all connectors that have an `icon.svg` hosted on the CDN, even when the composite registry omits `iconUrl`.

## Can this PR be safely reverted and rolled back?

- [x] YES

---
[Devin session](https://app.devin.ai/sessions/797ee013a6234e19ac7142e31bb51de9)

Requested by: @ian-at-airbyte

> [!IMPORTANT]
> ⚡ **Auto-merge enabled.**
> 
> _This PR is set to merge automatically when all requirements are met._