### PR TITLE
fix(source-airtable): add fallback type mapping for lookup, rollup, and multipleLookupValues fields

### DIFF
--- a/airbyte-integrations/connectors/source-airtable/manifest.yaml
+++ b/airbyte-integrations/connectors/source-airtable/manifest.yaml
@@ -314,6 +314,11 @@ definitions:
               target_type:
                 field_type: array
                 items: string
+              current_type: lookup
+            - type: TypesMap
+              target_type:
+                field_type: array
+                items: string
               current_type: rollup
               condition: "{{ raw_schema['options']['result']['type'] in ['multipleAttachments', 'barcode', 'button', 'singleCollaborator', 'createdBy', 'email', 'lastModifiedBy', 'multilineText', 'phoneNumber', 'richText', 'singleLineText', 'singleSelect', 'externalSyncSource', 'url', 'simpleText'] }}"
             - type: TypesMap
@@ -358,6 +363,11 @@ definitions:
               target_type:
                 field_type: array
                 items: string
+              current_type: rollup
+            - type: TypesMap
+              target_type:
+                field_type: array
+                items: string
               current_type: multipleLookupValues
               condition: "{{ raw_schema['options']['result']['type'] in ['multipleAttachments', 'barcode', 'button', 'singleCollaborator', 'createdBy', 'email', 'lastModifiedBy', 'multilineText', 'phoneNumber', 'richText', 'singleLineText', 'singleSelect', 'externalSyncSource', 'url', 'simpleText'] }}"
             - type: TypesMap
@@ -398,6 +408,11 @@ definitions:
                 items: string
               current_type: multipleLookupValues
               condition: "{{ not raw_schema['options']['result'] }}"
+            - type: TypesMap
+              target_type:
+                field_type: array
+                items: string
+              current_type: multipleLookupValues
             - type: TypesMap
               target_type: number
               current_type: formula

--- a/airbyte-integrations/connectors/source-airtable/metadata.yaml
+++ b/airbyte-integrations/connectors/source-airtable/metadata.yaml
@@ -11,7 +11,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 14c6e7ea-97ed-4f5e-a7b5-25e9a80b8212
-  dockerImageTag: 4.6.28
+  dockerImageTag: 4.6.29
   dockerRepository: airbyte/source-airtable
   documentationUrl: https://docs.airbyte.com/integrations/sources/airtable
   externalDocumentationUrls:

--- a/docs/integrations/sources/airtable.md
+++ b/docs/integrations/sources/airtable.md
@@ -148,6 +148,7 @@ If you use Airbyte Cloud and your organization restricts access to specific IPs,
 
 | Version    | Date       | Pull Request                                             | Subject                                                                                 |
 |:-----------|:-----------|:---------------------------------------------------------|:----------------------------------------------------------------------------------------|
+| 4.6.29 | 2026-06-19 | [*PR_NUMBER_PLACEHOLDER*](https://github.com/airbytehq/airbyte/pull/*PR_NUMBER_PLACEHOLDER*) | Add fallback type mapping for lookup, rollup, and multipleLookupValues fields with unrecognized result types |
 | 4.6.28 | 2026-06-16 | [79749](https://github.com/airbytehq/airbyte/pull/79749) | Update dependencies |
 | 4.6.27 | 2026-06-09 | [79201](https://github.com/airbytehq/airbyte/pull/79201) | Update dependencies |
 | 4.6.26 | 2026-06-02 | [76518](https://github.com/airbytehq/airbyte/pull/76518) | Update dependencies |

--- a/docs/integrations/sources/airtable.md
+++ b/docs/integrations/sources/airtable.md
@@ -148,7 +148,7 @@ If you use Airbyte Cloud and your organization restricts access to specific IPs,
 
 | Version    | Date       | Pull Request                                             | Subject                                                                                 |
 |:-----------|:-----------|:---------------------------------------------------------|:----------------------------------------------------------------------------------------|
-| 4.6.29 | 2026-06-19 | [*PR_NUMBER_PLACEHOLDER*](https://github.com/airbytehq/airbyte/pull/*PR_NUMBER_PLACEHOLDER*) | Add fallback type mapping for lookup, rollup, and multipleLookupValues fields with unrecognized result types |
+| 4.6.29 | 2026-06-19 | [80272](https://github.com/airbytehq/airbyte/pull/80272) | Add fallback type mapping for lookup, rollup, and multipleLookupValues fields with unrecognized result types |
 | 4.6.28 | 2026-06-16 | [79749](https://github.com/airbytehq/airbyte/pull/79749) | Update dependencies |
 | 4.6.27 | 2026-06-09 | [79201](https://github.com/airbytehq/airbyte/pull/79201) | Update dependencies |
 | 4.6.26 | 2026-06-02 | [76518](https://github.com/airbytehq/airbyte/pull/76518) | Update dependencies |


### PR DESCRIPTION
## What

Schema discovery fails with `ValueError: Invalid Airbyte data type: multipleLookupValues` when an Airtable base contains `lookup`, `rollup`, or `multipleLookupValues` fields whose result type is not explicitly handled by any conditional `TypesMap` entry.

This happens because the manifest's type mappings only cover a fixed set of known Airtable result types (e.g., `singleLineText`, `number`, `checkbox`, etc.). If the underlying field has a result type not in any list (e.g., `formula`, `rollup`, another `multipleLookupValues`, or any future Airtable type), or if `options.result` is missing/malformed, none of the conditions match. The raw Airtable type passes through to `_get_airbyte_type()`, which raises `ValueError` because it's not a valid Airbyte data type.

Reported via support: a customer's Airtable base has a field with `multipleLookupValues` type that triggers this during discovery, blocking all connection configuration and syncing.

## How

Added unconditional (no `condition`) fallback `TypesMap` entries for `lookup`, `rollup`, and `multipleLookupValues`, each defaulting to `array of string`. These are placed *after* all conditional entries for each type, so they only match when no specific condition has already matched (the CDK iterates in order and returns the first match).

```yaml
# After all conditional multipleLookupValues entries:
- type: TypesMap
  target_type:
    field_type: array
    items: string
  current_type: multipleLookupValues
  # no condition = always matches as fallback
```

## Review guide

1. `airbyte-integrations/connectors/source-airtable/manifest.yaml` — three new fallback `TypesMap` entries (one each for `lookup`, `rollup`, `multipleLookupValues`)

## User Impact

Users with Airtable bases containing lookup/rollup/multipleLookupValues fields that reference unsupported result types will no longer have schema discovery hang or fail. Those fields will be typed as `array of string` instead.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Link to Devin session: https://app.devin.ai/sessions/4daa0728f63740619268ae522515f15f
Requested by: @Airbyte-Support