### PR TITLE
fix(source-twilio): resume incremental messages/recordings from saved cursor

### DIFF
--- a/airbyte-integrations/connectors/source-twilio/manifest.yaml
+++ b/airbyte-integrations/connectors/source-twilio/manifest.yaml
@@ -568,7 +568,7 @@ definitions:
     incremental_sync:
       $ref: "#/definitions/base_nested_incremental_from_accounts_stream/incremental_sync"
       datetime_format: "%Y-%m-%d %H:%M:%SZ"
-      cursor_granularity: PT0.000001S
+      cursor_granularity: PT1S
       start_datetime:
         type: MinMaxDatetime
         datetime: "{{ max(format_datetime(config.get('start_date', '1970-01-01T00:00:00Z'), '%Y-%m-%d %H:%M:%SZ'), day_delta(-400, format='%Y-%m-%d %H:%M:%SZ')) }}"
@@ -603,7 +603,7 @@ definitions:
     incremental_sync:
       $ref: "#/definitions/base_nested_incremental_from_accounts_stream/incremental_sync"
       datetime_format: "%Y-%m-%d %H:%M:%SZ"
-      cursor_granularity: PT0.000001S
+      cursor_granularity: PT1S
       start_datetime:
         type: MinMaxDatetime
         datetime: "{{ max(format_datetime(config.get('start_date', '1970-01-01T00:00:00Z'), '%Y-%m-%d %H:%M:%SZ'), day_delta(-400, format='%Y-%m-%d %H:%M:%SZ')) }}"

--- a/airbyte-integrations/connectors/source-twilio/metadata.yaml
+++ b/airbyte-integrations/connectors/source-twilio/metadata.yaml
@@ -14,7 +14,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: b9dc6155-672e-42ea-b10d-9f1f1fb95ab1
-  dockerImageTag: 1.0.3
+  dockerImageTag: 1.0.4
   dockerRepository: airbyte/source-twilio
   documentationUrl: https://docs.airbyte.com/integrations/sources/twilio
   githubIssueLabel: source-twilio

--- a/airbyte-integrations/connectors/source-twilio/unit_tests/test_streams.py
+++ b/airbyte-integrations/connectors/source-twilio/unit_tests/test_streams.py
@@ -216,13 +216,20 @@ class TestIncrementalTwilioStream:
         The per-partition cursor then never advances past the first window and the stream
         re-reads its whole history every sync. With a matching granularity (``PT1S``) the
         intervals merge and the cursor advances to the newest record.
+
+        The assertion checks the cursor lands on the *newest record across every window* (not
+        merely that it moved), so a partial-advance regression where only some slices merge
+        would still fail.
         """
         requests_mock.get(f"{BASE}/Accounts.json", json=ACCOUNTS_JSON, status_code=200)
 
         # Each monthly window returns one record dated at its lower bound (DateSent>),
         # echoed back in the ISO 'T' form the connector normalizes records to.
+        windows = []
+
         def _messages(request, context):
             lower = parse_qs(urlparse(request.url).query, keep_blank_values=True).get("DateSent>", ["1970-01-01 00:00:00Z"])[0]
+            windows.append(lower)
             context.status_code = 200
             return {"messages": [{"sid": "SM", "date_sent": lower.replace(" ", "T")}]}
 
@@ -250,10 +257,22 @@ class TestIncrementalTwilioStream:
 
         output = read_from_stream(TEST_CONFIG, "messages", SyncMode.incremental, state)
 
-        # Emitted per-partition cursor must advance past the saved value, not stay stuck on it.
+        # The sync must span several windows, otherwise the multi-slice merge isn't exercised.
+        assert len(set(windows)) >= 3, f"expected multiple date windows, got {sorted(set(windows))}"
+
+        # The newest record returned across all windows (records sit at each window's lower bound).
+        # Window bounds and the stored cursor share the second-precision format, so a string
+        # comparison is exact and order-preserving.
+        newest_record = max(windows)
+
+        # Emitted per-partition cursor must land on that newest record -- i.e. every slice merged
+        # and the cursor advanced fully, not just past the first window.
         final = output.most_recent_state.stream_state.__dict__
         partition_cursor = final["states"][0]["cursor"]["date_sent"]
-        assert partition_cursor > saved_cursor, f"per-partition cursor did not advance (stuck at {partition_cursor})"
+        assert partition_cursor == newest_record, (
+            f"per-partition cursor did not advance to the newest record: "
+            f"cursor={partition_cursor!r}, newest_record={newest_record!r}, saved={saved_cursor!r}"
+        )
 
     @freeze_time("2022-11-16 12:03:11+00:00")
     def test_alerts_pagination_limit_error_message(self, requests_mock):

--- a/airbyte-integrations/connectors/source-twilio/unit_tests/test_streams.py
+++ b/airbyte-integrations/connectors/source-twilio/unit_tests/test_streams.py
@@ -206,6 +206,56 @@ class TestIncrementalTwilioStream:
         assert sum(m.call_count for m in child_matchers) == len(windows)
 
     @freeze_time("2022-11-16 12:03:11+00:00")
+    def test_messages_cursor_advances_across_windows(self, requests_mock):
+        """Regression for the stuck-cursor bug (oncall #12688).
+
+        `messages` uses a second-precision ``datetime_format`` (``%Y-%m-%d %H:%M:%SZ``). If
+        ``cursor_granularity`` is finer than that (e.g. ``PT0.000001S``), each slice end
+        (``next_start - granularity``) is truncated to the second when formatted, opening a
+        ~1s gap between consecutive slice intervals that ``merge_intervals`` cannot bridge.
+        The per-partition cursor then never advances past the first window and the stream
+        re-reads its whole history every sync. With a matching granularity (``PT1S``) the
+        intervals merge and the cursor advances to the newest record.
+        """
+        requests_mock.get(f"{BASE}/Accounts.json", json=ACCOUNTS_JSON, status_code=200)
+
+        # Each monthly window returns one record dated at its lower bound (DateSent>),
+        # echoed back in the ISO 'T' form the connector normalizes records to.
+        def _messages(request, context):
+            lower = parse_qs(urlparse(request.url).query, keep_blank_values=True).get("DateSent>", ["1970-01-01 00:00:00Z"])[0]
+            context.status_code = 200
+            return {"messages": [{"sid": "SM", "date_sent": lower.replace(" ", "T")}]}
+
+        requests_mock.get(f"{BASE}/Accounts/AC123/Messages.json", json=_messages)
+
+        # Saved per-partition state a few months back -> several monthly windows are generated.
+        saved_cursor = "2022-08-16 00:00:00Z"
+        state = (
+            StateBuilder()
+            .with_stream_state(
+                "messages",
+                {
+                    "states": [
+                        {
+                            "partition": {"parent_slice": {}, "subresource_uri": "/2010-04-01/Accounts/AC123/Messages.json"},
+                            "cursor": {"date_sent": saved_cursor},
+                        }
+                    ],
+                    "state": {"date_sent": saved_cursor},
+                    "use_global_cursor": False,
+                },
+            )
+            .build()
+        )
+
+        output = read_from_stream(TEST_CONFIG, "messages", SyncMode.incremental, state)
+
+        # Emitted per-partition cursor must advance past the saved value, not stay stuck on it.
+        final = output.most_recent_state.stream_state.__dict__
+        partition_cursor = final["states"][0]["cursor"]["date_sent"]
+        assert partition_cursor > saved_cursor, f"per-partition cursor did not advance (stuck at {partition_cursor})"
+
+    @freeze_time("2022-11-16 12:03:11+00:00")
     def test_alerts_pagination_limit_error_message(self, requests_mock):
         requests_mock.get(
             f"{MONITOR_BASE}/Alerts",

--- a/docs/integrations/sources/twilio.md
+++ b/docs/integrations/sources/twilio.md
@@ -148,6 +148,7 @@ For programmatic configuration, use these parameter names:
 
 | Version | Date | Pull Request | Subject |
 | :------ | :--- | :----------- | :------ |
+| 1.0.4 | 2026-06-19 | [XXXXX](https://github.com/airbytehq/airbyte/pull/XXXXX) | Fix `messages` and `recordings` incremental state getting stuck near the start date by aligning `cursor_granularity` with the second-precision `datetime_format`. |
 | 1.0.3 | 2026-06-16 | [80075](https://github.com/airbytehq/airbyte/pull/80075) | Update dependencies |
 | 1.0.2 | 2026-06-09 | [79553](https://github.com/airbytehq/airbyte/pull/79553) | Update dependencies |
 | 1.0.1 | 2026-06-02 | [79027](https://github.com/airbytehq/airbyte/pull/79027) | Update dependencies |

--- a/docs/integrations/sources/twilio.md
+++ b/docs/integrations/sources/twilio.md
@@ -148,7 +148,7 @@ For programmatic configuration, use these parameter names:
 
 | Version | Date | Pull Request | Subject |
 | :------ | :--- | :----------- | :------ |
-| 1.0.4 | 2026-06-19 | [XXXXX](https://github.com/airbytehq/airbyte/pull/XXXXX) | Fix `messages` and `recordings` incremental state getting stuck near the start date by aligning `cursor_granularity` with the second-precision `datetime_format`. |
+| 1.0.4 | 2026-06-19 | [80282](https://github.com/airbytehq/airbyte/pull/80282) | Fix `messages` and `recordings` incremental state getting stuck near the start date by aligning `cursor_granularity` with the second-precision `datetime_format`. |
 | 1.0.3 | 2026-06-16 | [80075](https://github.com/airbytehq/airbyte/pull/80075) | Update dependencies |
 | 1.0.2 | 2026-06-09 | [79553](https://github.com/airbytehq/airbyte/pull/79553) | Update dependencies |
 | 1.0.1 | 2026-06-02 | [79027](https://github.com/airbytehq/airbyte/pull/79027) | Update dependencies |


### PR DESCRIPTION
## What

Resolves the Twilio `messages` (and `recordings`) incremental streams re-exporting their **entire history every sync** despite a recent saved cursor (oncall [#12688](https://github.com/airbytehq/oncall/issues/12688)).

## Root cause

Both streams use a **second-precision** `datetime_format` (`"%Y-%m-%d %H:%M:%SZ"`) but declared `cursor_granularity: PT0.000001S` (microseconds).

The concurrent cursor computes each slice end as `next_start - cursor_granularity` (e.g. `…19:08:06.999999`). When that value is serialized with the second-precision format it is **truncated** to `…19:08:06`, opening a ~1-second gap to the next slice's start (`…19:08:07`). Because the gap (1s) is larger than the increment used when merging intervals (the granularity, 1µs), the per-partition slice intervals **never merge**, so the persisted cursor stays pinned near the start date and the stream re-reads its whole window every sync. The global/fallback cursor advances normally (it tracks max-observed values, not merged intervals), which is why the symptom is "state looks recent but data is re-read".

## Why the current implementation fails (CDK references, pinned to `v7.23.1`, the CDK in `source-declarative-manifest:7.23.1`)

1. **Slice end = `next_start − cursor_granularity`, serialized with the cursor's `datetime_format`** — [`cursor.py` L494‑L508](https://github.com/airbytehq/airbyte-python-cdk/blob/v7.23.1/airbyte_cdk/sources/streams/concurrent/cursor.py#L494-L508). With a microsecond granularity and a second-precision format, `output_format(end)` drops the sub-second part.
2. **The end boundary is read back into state via `parse_value`** — [`cursor.py` L342‑L344](https://github.com/airbytehq/airbyte-python-cdk/blob/v7.23.1/airbyte_cdk/sources/streams/concurrent/cursor.py#L342-L344) → [`_extract_from_slice` L389‑L398](https://github.com/airbytehq/airbyte-python-cdk/blob/v7.23.1/airbyte_cdk/sources/streams/concurrent/cursor.py#L389-L398). This is the round-trip that turns `…06.999999` into `…06`, one full second earlier than the next slice's start.
3. **Intervals merge only if `increment(prev_end) >= next_start`** — [`abstract_stream_state_converter.py` L160‑L166](https://github.com/airbytehq/airbyte-python-cdk/blob/v7.23.1/airbyte_cdk/sources/streams/concurrent/state_converters/abstract_stream_state_converter.py#L160-L166), where `increment` adds exactly **one `cursor_granularity`** — [`datetime_stream_state_converter.py` L167‑L168](https://github.com/airbytehq/airbyte-python-cdk/blob/v7.23.1/airbyte_cdk/sources/streams/concurrent/state_converters/datetime_stream_state_converter.py#L167-L168). `prev_end + 1µs` (`…06.000001`) is still < `next_start` (`…07`), so the merge is skipped and the slices stay disjoint.
4. **The persisted cursor is the first interval's value** — [`_get_latest_complete_time` L54‑L65](https://github.com/airbytehq/airbyte-python-cdk/blob/v7.23.1/airbyte_cdk/sources/streams/concurrent/state_converters/abstract_stream_state_converter.py#L54-L65). With the intervals never merging, this returns the first (oldest) interval forever → the cursor never advances.

## Fix

Align `cursor_granularity` with the format resolution: `PT0.000001S` → **`PT1S`** for `messages_stream` and `recordings_stream`. The slice end becomes `next_start - 1s`, which survives second-precision formatting, so `increment(end) == next_start` and the intervals merge — the cursor advances.

No `global_substream_cursor` is used, so multi-account connections keep independent per-account cursors (no data-loss risk for lagging sub-accounts).

## Validation

- New unit regression test `test_messages_cursor_advances_across_windows` (fails on `PT0.000001S`, passes on `PT1S`).
- Real Twilio API, two consecutive incremental syncs (resume from sync-1 state): **before** → sync 2 re-reads all 19 records (cursor stuck); **after** → sync 2 reads 1 (cursor advanced).
- Reproduced and confirmed identically through the built Docker image.

## Note

This is one instance of a broader class of bug (`cursor_granularity` finer than `datetime_format`). Other affected connectors are tracked in oncall [#12926](https://github.com/airbytehq/oncall/issues/12926).