### PR TITLE
fix(source-paypal-transaction): preserve transaction IDs as strings

### DIFF
--- a/airbyte-integrations/connectors/source-paypal-transaction/manifest.yaml
+++ b/airbyte-integrations/connectors/source-paypal-transaction/manifest.yaml
@@ -102,6 +102,7 @@ definitions:
             - path:
                 - transaction_id
               value: "{{ record['transaction_info']['transaction_id'] }}"
+              value_type: string
       schema_loader:
         type: InlineSchemaLoader
         schema:

--- a/airbyte-integrations/connectors/source-paypal-transaction/metadata.yaml
+++ b/airbyte-integrations/connectors/source-paypal-transaction/metadata.yaml
@@ -11,7 +11,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: d913b0f2-cc51-4e55-a44c-8ba1697b9239
-  dockerImageTag: 2.6.44
+  dockerImageTag: 2.6.45
   dockerRepository: airbyte/source-paypal-transaction
   documentationUrl: https://docs.airbyte.com/integrations/sources/paypal-transaction
   githubIssueLabel: source-paypal-transaction

--- a/airbyte-integrations/connectors/source-paypal-transaction/metadata.yaml
+++ b/airbyte-integrations/connectors/source-paypal-transaction/metadata.yaml
@@ -11,7 +11,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: d913b0f2-cc51-4e55-a44c-8ba1697b9239
-  dockerImageTag: 2.6.43
+  dockerImageTag: 2.6.44
   dockerRepository: airbyte/source-paypal-transaction
   documentationUrl: https://docs.airbyte.com/integrations/sources/paypal-transaction
   githubIssueLabel: source-paypal-transaction

--- a/airbyte-integrations/connectors/source-paypal-transaction/unit_tests/test_components.py
+++ b/airbyte-integrations/connectors/source-paypal-transaction/unit_tests/test_components.py
@@ -3,10 +3,14 @@
 import logging
 import time
 from datetime import datetime
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
 import requests
+import yaml
+
+from airbyte_cdk.sources.declarative.transformations.add_fields import AddedFieldDefinition, AddFields
 
 
 @pytest.fixture
@@ -155,3 +159,68 @@ def test_date_formats_in_config(config):
 @pytest.fixture(name="logger_mock")
 def logger_mock_fixture():
     return patch("source_paypal_transactions.source.AirbyteLogger")
+
+
+@pytest.fixture(name="manifest")
+def manifest_fixture():
+    manifest_path = Path(__file__).parent.parent / "manifest.yaml"
+    return yaml.safe_load(manifest_path.read_text())
+
+
+def test_manifest_transaction_id_add_field_is_string(manifest):
+    transactions = manifest["definitions"]["streams"]["transactions"]
+    transaction_id_fields = [
+        field
+        for transformation in transactions["transformations"]
+        if transformation["type"] == "AddFields"
+        for field in transformation["fields"]
+        if field["path"] == ["transaction_id"]
+    ]
+
+    assert len(transaction_id_fields) == 1
+    assert transaction_id_fields[0]["value_type"] == "string"
+
+
+@pytest.mark.parametrize(
+    ("record", "expected_transaction_id"),
+    [
+        pytest.param(
+            {"transaction_info": {"transaction_id": "35E87645934406417"}},
+            "35E87645934406417",
+            id="scientific-notation-like-id",
+        ),
+        pytest.param(
+            {"transaction_info": {"transaction_id": "1E2"}},
+            "1E2",
+            id="short-scientific-notation-like-id",
+        ),
+        pytest.param(
+            {"transaction_info": {"transaction_id": "99999999999"}},
+            "99999999999",
+            id="numeric-string",
+        ),
+        pytest.param(
+            {"transaction_info": {"transaction_id": "ABC123DEF"}},
+            "ABC123DEF",
+            id="alphanumeric-string",
+        ),
+        pytest.param({"transaction_info": {}}, "", id="missing-transaction-id"),
+    ],
+)
+def test_transaction_id_add_field_preserves_string_values(record, expected_transaction_id):
+    transaction_id_transform = AddFields(
+        fields=[
+            AddedFieldDefinition(
+                path=["transaction_id"],
+                value="{{ record['transaction_info']['transaction_id'] }}",
+                value_type=str,
+                parameters={},
+            )
+        ],
+        parameters={},
+    )
+
+    transaction_id_transform.transform(record, config={})
+
+    assert record["transaction_id"] == expected_transaction_id
+    assert isinstance(record["transaction_id"], str)

--- a/docs/integrations/sources/paypal-transaction.md
+++ b/docs/integrations/sources/paypal-transaction.md
@@ -268,6 +268,7 @@ If you use Airbyte Cloud and your organization restricts access to specific IPs,
 
 | Version | Date       | Pull Request                                             | Subject                                                                                                                      |
 | :------ | :--------- | :------------------------------------------------------- | :--------------------------------------------------------------------------------------------------------------------------- |
+| 2.6.44 | 2026-08-06 | [80301](https://github.com/airbytehq/airbyte/pull/80301) | Fix `transaction_id` primary key emitted as null for IDs resembling scientific notation |
 | 2.6.43 | 2026-07-28 | [83194](https://github.com/airbytehq/airbyte/pull/83194) | Update to CDK 7.23.8 (fixes AirbyteCustomCodeNotPermittedError for bundled custom components) and remove the temporary Cloud version override |
 | 2.6.42 | 2026-07-28 | [1082](https://github.com/airbytehq/airbyte-python-cdk/issues/1082) | Roll Cloud back to 2.6.40 — 2.6.41 is built on SDM 7.23.7, which breaks bundled custom components |
 | 2.6.41 | 2026-07-28 | [83052](https://github.com/airbytehq/airbyte/pull/83052) | Update dependencies |

--- a/docs/integrations/sources/paypal-transaction.md
+++ b/docs/integrations/sources/paypal-transaction.md
@@ -268,6 +268,7 @@ If you use Airbyte Cloud and your organization restricts access to specific IPs,
 
 | Version | Date       | Pull Request                                             | Subject                                                                                                                      |
 | :------ | :--------- | :------------------------------------------------------- | :--------------------------------------------------------------------------------------------------------------------------- |
+| 2.6.45 | 2026-08-15 | [80301](https://github.com/airbytehq/airbyte/pull/80301) | Fix `transaction_id` primary key emitted as null for IDs resembling scientific notation |
 | 2.6.44 | 2026-08-11 | [84075](https://github.com/airbytehq/airbyte/pull/84075) | Update dependencies |
 | 2.6.43 | 2026-07-28 | [83194](https://github.com/airbytehq/airbyte/pull/83194) | Update to CDK 7.23.8 (fixes AirbyteCustomCodeNotPermittedError for bundled custom components) and remove the temporary Cloud version override |
 | 2.6.42 | 2026-07-28 | [1082](https://github.com/airbytehq/airbyte-python-cdk/issues/1082) | Roll Cloud back to 2.6.40 — 2.6.41 is built on SDM 7.23.7, which breaks bundled custom components |


### PR DESCRIPTION
## What
- Restores `value_type: string` on the PayPal transactions `transaction_id` AddFields transformation.
- Adds regression coverage for scientific-notation-like IDs, numeric strings, alphanumeric strings, and missing nested IDs.

Fixes #79674.
Supersedes #79676.

## Validation
- `ruff check airbyte-integrations/connectors/source-paypal-transaction/unit_tests/test_components.py`
- `ruff format --check airbyte-integrations/connectors/source-paypal-transaction/unit_tests/test_components.py`
- `env -u VIRTUAL_ENV uv run --python 3.11 --with pytest --with airbyte-cdk==6.10.0 --with PyYAML pytest unit_tests -q` from `airbyte-integrations/connectors/source-paypal-transaction`: 15 passed

Could not run `airbyte-ci connectors --name=source-paypal-transaction test` locally because the `airbyte-ci` command is not available in this checkout and is not installable via `uvx airbyte-ci`.