### PR TITLE
fix(source-mixpanel): serialize nested export properties as JSON

### DIFF
--- a/airbyte-integrations/connectors/source-mixpanel/metadata.yaml
+++ b/airbyte-integrations/connectors/source-mixpanel/metadata.yaml
@@ -11,7 +11,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 12928b32-bf0a-4f1e-964f-07e12e37153a
-  dockerImageTag: 4.0.1
+  dockerImageTag: 4.0.2
   dockerRepository: airbyte/source-mixpanel
   documentationUrl: https://docs.airbyte.com/integrations/sources/mixpanel
   githubIssueLabel: source-mixpanel

--- a/airbyte-integrations/connectors/source-mixpanel/pyproject.toml
+++ b/airbyte-integrations/connectors/source-mixpanel/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
-version = "4.0.1"
+version = "4.0.2"
 name = "source-mixpanel"
 description = "Source implementation for Mixpanel."
 authors = ["Airbyte <contact@airbyte.io>"]

--- a/airbyte-integrations/connectors/source-mixpanel/source_mixpanel/streams.py
+++ b/airbyte-integrations/connectors/source-mixpanel/source_mixpanel/streams.py
@@ -451,7 +451,8 @@ class Export(DateSlicesMixin, IncrementalMixpanelStream):
             for result in transform_property_names(properties.keys()):
                 # Convert all values to string (this is default property type)
                 # because API does not provide properties type information
-                item[result.transformed_name] = str(properties[result.source_name])
+                value = properties[result.source_name]
+                item[result.transformed_name] = json.dumps(value) if isinstance(value, (dict, list)) else str(value)
 
             # convert timestamp to datetime string
             item["time"] = pendulum.from_timestamp(int(item["time"]), tz="UTC").to_iso8601_string()

--- a/airbyte-integrations/connectors/source-mixpanel/unit_tests/test_streams.py
+++ b/airbyte-integrations/connectors/source-mixpanel/unit_tests/test_streams.py
@@ -631,6 +631,47 @@ def test_export_stream(requests_mock, export_response, config):
     assert records_length == 1
 
 
+def test_export_stream_serializes_nested_properties_as_json(requests_mock, config):
+    stream = Export(authenticator=MagicMock(), **config)
+    requests_mock.register_uri(
+        "GET",
+        get_url_to_mock(stream),
+        setup_response(
+            200,
+            {
+                "event": "Nested Properties",
+                "properties": {
+                    "time": 1623860880,
+                    "distinct_id": "1d694fd9-31a5-4b99-9eef-ae63112063ed",
+                    "$nested": {"flag": True, "missing": None},
+                    "$list": ["alpha", {"beta": False}],
+                    "$browser": "Chrome",
+                    "scalar_bool": True,
+                    "scalar_null": None,
+                    "scalar_number": 42,
+                },
+            },
+        ),
+    )
+    stream_slice = {"start_date": "2017-01-25T00:00:00Z", "end_date": "2017-02-25T00:00:00Z"}
+
+    records = list(stream.read_records(sync_mode=SyncMode.incremental, stream_slice=stream_slice))
+
+    assert records == [
+        {
+            "event": "Nested Properties",
+            "time": "2021-06-16T16:28:00Z",
+            "distinct_id": "1d694fd9-31a5-4b99-9eef-ae63112063ed",
+            "browser": "Chrome",
+            "nested": json.dumps({"flag": True, "missing": None}),
+            "list": json.dumps(["alpha", {"beta": False}]),
+            "scalar_bool": "True",
+            "scalar_null": "None",
+            "scalar_number": "42",
+        }
+    ]
+
+
 def test_export_stream_fail(requests_mock, export_response, config):
     stream = Export(authenticator=MagicMock(), **config)
     error_message = ""

--- a/docs/integrations/sources/mixpanel.md
+++ b/docs/integrations/sources/mixpanel.md
@@ -87,6 +87,7 @@ If you use Airbyte Cloud and your organization restricts access to specific IPs,
 
 | Version | Date | Pull Request | Subject |
 | :--- | :--- | :--- | :--- |
+| 4.0.2 | 2026-07-03 | [80302](https://github.com/airbytehq/airbyte/pull/80302) | Serialize nested Export stream properties as JSON strings |
 | 4.0.1 | 2026-07-02 | [81392](https://github.com/airbytehq/airbyte/pull/81392) | Bump h11 0.14.0 to 0.16.0 to resolve GHSA-vqfr-h8mv-ghfj |
 | 4.0.0 | 2026-05-22 | [78271](https://github.com/airbytehq/airbyte/pull/78271) | Removed the Revenue stream because Mixpanel no longer provides a documented or working revenue Query API endpoint. |
 | 3.6.3 | 2026-04-13 | [76276](https://github.com/airbytehq/airbyte/pull/76276) | Rename "concurrent workers" to "concurrent threads" in connector spec |


### PR DESCRIPTION
## What
- Serializes Export stream dict/list property values with `json.dumps` so nested objects/lists are emitted as valid JSON strings.
- Keeps scalar values on the existing `str(...)` path.
- Adds regression coverage for nested dict/list properties, nested booleans/nulls, normalized Mixpanel property names, and unchanged scalar behavior.

Fixes #73493.
Supersedes #73502.

## Validation
- `ruff check airbyte-integrations/connectors/source-mixpanel/source_mixpanel/streams.py airbyte-integrations/connectors/source-mixpanel/unit_tests/test_streams.py`
- `ruff format --check airbyte-integrations/connectors/source-mixpanel/source_mixpanel/streams.py airbyte-integrations/connectors/source-mixpanel/unit_tests/test_streams.py`
- `env -u VIRTUAL_ENV PYTHONPATH=. uv run --python 3.11 --with pytest --with pytest-mock --with requests-mock --with responses==0.25.7 --with pendulum==2.1.2 --with airbyte-cdk==6.45.0 pytest unit_tests -q` from `airbyte-integrations/connectors/source-mixpanel`: 46 passed

Could not run `airbyte-ci connectors --name=source-mixpanel test` locally because the `airbyte-ci` command is not available in this checkout and is not installable via `uvx airbyte-ci`.