### PR TITLE
fix(source-mixpanel): encode nested object properties as JSON in Export stream

### DIFF
--- a/airbyte-integrations/connectors/source-mixpanel/metadata.yaml
+++ b/airbyte-integrations/connectors/source-mixpanel/metadata.yaml
@@ -11,7 +11,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 12928b32-bf0a-4f1e-964f-07e12e37153a
-  dockerImageTag: 4.0.0
+  dockerImageTag: 4.0.1
   dockerRepository: airbyte/source-mixpanel
   documentationUrl: https://docs.airbyte.com/integrations/sources/mixpanel
   githubIssueLabel: source-mixpanel

--- a/airbyte-integrations/connectors/source-mixpanel/source_mixpanel/streams.py
+++ b/airbyte-integrations/connectors/source-mixpanel/source_mixpanel/streams.py
@@ -450,8 +450,13 @@ class Export(DateSlicesMixin, IncrementalMixpanelStream):
             properties = record["properties"]
             for result in transform_property_names(properties.keys()):
                 # Convert all values to string (this is default property type)
-                # because API does not provide properties type information
-                item[result.transformed_name] = str(properties[result.source_name])
+                # because API does not provide properties type information.
+                # Nested objects/arrays are JSON-encoded instead of passed through
+                # str(), which would emit invalid Python-dict syntax (e.g.
+                # "{'enabled': False}") that downstream destinations cannot parse.
+                # See https://github.com/airbytehq/airbyte/issues/73493.
+                value = properties[result.source_name]
+                item[result.transformed_name] = json.dumps(value) if isinstance(value, (dict, list)) else str(value)
 
             # convert timestamp to datetime string
             item["time"] = pendulum.from_timestamp(int(item["time"]), tz="UTC").to_iso8601_string()

--- a/airbyte-integrations/connectors/source-mixpanel/unit_tests/test_streams.py
+++ b/airbyte-integrations/connectors/source-mixpanel/unit_tests/test_streams.py
@@ -631,6 +631,42 @@ def test_export_stream(requests_mock, export_response, config):
     assert records_length == 1
 
 
+def test_export_stream_nested_objects_are_json_encoded(requests_mock, config):
+    """Nested object/array event properties must be JSON-encoded, not stringified
+    with str() (which emits invalid Python-dict syntax like "{'enabled': False}"
+    that downstream destinations cannot parse).
+
+    Regression test for https://github.com/airbytehq/airbyte/issues/73493.
+    """
+    response = setup_response(
+        200,
+        {
+            "event": "Viewed E-commerce Page",
+            "properties": {
+                "time": 1623860880,
+                "distinct_id": "1d694fd9-31a5-4b99-9eef-ae63112063ed",
+                "$browser": "Chrome",
+                "feature_flags": {"activation": {"enabled": False}, "variant": "new"},
+                "tags": ["a", "b"],
+            },
+        },
+    )
+    stream = Export(authenticator=MagicMock(), **config)
+    requests_mock.register_uri("GET", get_url_to_mock(stream), response)
+    stream_slice = {"start_date": "2017-01-25T00:00:00Z", "end_date": "2017-02-25T00:00:00Z"}
+
+    records = list(stream.read_records(sync_mode=SyncMode.incremental, stream_slice=stream_slice))
+
+    assert len(records) == 1
+    record = records[0]
+    # Nested object -> valid JSON that round-trips back to the original structure.
+    assert json.loads(record["feature_flags"]) == {"activation": {"enabled": False}, "variant": "new"}
+    # Array -> valid JSON.
+    assert json.loads(record["tags"]) == ["a", "b"]
+    # Scalar values keep the existing string coercion.
+    assert record["browser"] == "Chrome"
+
+
 def test_export_stream_fail(requests_mock, export_response, config):
     stream = Export(authenticator=MagicMock(), **config)
     error_message = ""

--- a/docs/integrations/sources/mixpanel.md
+++ b/docs/integrations/sources/mixpanel.md
@@ -87,6 +87,7 @@ If you use Airbyte Cloud and your organization restricts access to specific IPs,
 
 | Version | Date | Pull Request | Subject |
 | :--- | :--- | :--- | :--- |
+| 4.0.1 | 2026-06-19 | [80304](https://github.com/airbytehq/airbyte/pull/80304) | Encode nested object/array event properties as JSON instead of Python-dict strings in the Export stream |
 | 4.0.0 | 2026-05-22 | [78271](https://github.com/airbytehq/airbyte/pull/78271) | Removed the Revenue stream because Mixpanel no longer provides a documented or working revenue Query API endpoint. |
 | 3.6.3 | 2026-04-13 | [76276](https://github.com/airbytehq/airbyte/pull/76276) | Rename "concurrent workers" to "concurrent threads" in connector spec |
 | 3.6.2 | 2026-04-03 | [76039](https://github.com/airbytehq/airbyte/pull/76039) | Replace deprecated MessageRepresentationAirbyteTracedErrors with AirbyteTracedException in tests |


### PR DESCRIPTION
## What

The Mixpanel **Export** stream stringifies nested object/array event properties with `str()`, which produces invalid Python-dict syntax (e.g. `"{'enabled': False}"`) instead of JSON. Downstream destinations cannot parse those values as JSON, which makes them hard to consume in databases.

Fixes #73493.

## How

In `Export.process_response`, JSON-encode `dict`/`list` property values with `json.dumps()`. Scalar values keep the existing `str()` coercion, because the Export API does not provide property type information (string is the default property type).

Before:
```
Feature_flags: "{activation: {enabled: False}, activation-popup: {enabled: True, variant: new}}"
```
After:
```
Feature_flags: "{\"activation\": {\"enabled\": false}, \"activation-popup\": {\"enabled\": true, \"variant\": \"new\"}}"
```

## Supersedes

This supersedes the stale AI-triage draft #73502 (a draft since 2026-03-09, with no test, no version bump, and no changelog). This PR adds a regression unit test, the version bump, and the changelog entry.

## Testing

Added `test_export_stream_nested_objects_are_json_encoded` to `unit_tests/test_streams.py`, which verifies that nested object and array properties round-trip as valid JSON while scalar values stay strings. Verified the test fails without the fix and passes with it, against `airbyte-cdk` 6.x. `ruff` clean.

- Bumped `dockerImageTag` 4.0.0 → 4.0.1 (a patch fix; 3.6.3 and 4.0.0 already exist on `master`)
- Added a changelog entry to `docs/integrations/sources/mixpanel.md`

---

##### Was generative AI tooling used to author this PR?

Yes — Claude Code (Opus 4.8). Generated-by: Claude Code (Opus 4.8)
