### PR TITLE
feat(source-google-ads): add service account auth

### DIFF
--- a/airbyte-integrations/connectors/source-google-ads/metadata.yaml
+++ b/airbyte-integrations/connectors/source-google-ads/metadata.yaml
@@ -5,6 +5,8 @@ data:
   allowedHosts:
     hosts:
       - accounts.google.com
+      - oauth2.googleapis.com
+      - www.googleapis.com
       - googleads.googleapis.com
   connectorBuildOptions:
     baseImage: docker.io/airbyte/python-connector-base:4.0.2@sha256:9fdb1888c4264cf6fee473649ecb593f56f58e5d0096a87ee0b231777e2e3e73

--- a/airbyte-integrations/connectors/source-google-ads/metadata.yaml
+++ b/airbyte-integrations/connectors/source-google-ads/metadata.yaml
@@ -11,7 +11,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 253487c0-2246-43ba-a21f-5116b20a2c50
-  dockerImageTag: 6.1.1
+  dockerImageTag: 6.2.0-rc.1
   dockerRepository: airbyte/source-google-ads
   documentationUrl: https://docs.airbyte.com/integrations/sources/google-ads
   externalDocumentationUrls:

--- a/airbyte-integrations/connectors/source-google-ads/metadata.yaml
+++ b/airbyte-integrations/connectors/source-google-ads/metadata.yaml
@@ -11,7 +11,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 253487c0-2246-43ba-a21f-5116b20a2c50
-  dockerImageTag: 6.1.0
+  dockerImageTag: 6.2.0
   dockerRepository: airbyte/source-google-ads
   documentationUrl: https://docs.airbyte.com/integrations/sources/google-ads
   externalDocumentationUrls:

--- a/airbyte-integrations/connectors/source-google-ads/pyproject.toml
+++ b/airbyte-integrations/connectors/source-google-ads/pyproject.toml
@@ -3,7 +3,7 @@ requires = [ "poetry-core>=1.0.0",]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
-version = "6.1.1"
+version = "6.2.0-rc.1"
 name = "source-google-ads"
 description = "Source implementation for Google Ads."
 authors = [ "Airbyte <contact@airbyte.io>",]

--- a/airbyte-integrations/connectors/source-google-ads/pyproject.toml
+++ b/airbyte-integrations/connectors/source-google-ads/pyproject.toml
@@ -3,7 +3,7 @@ requires = [ "poetry-core>=1.0.0",]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
-version = "6.1.0"
+version = "6.2.0"
 name = "source-google-ads"
 description = "Source implementation for Google Ads."
 authors = [ "Airbyte <contact@airbyte.io>",]

--- a/airbyte-integrations/connectors/source-google-ads/source_google_ads/components.py
+++ b/airbyte-integrations/connectors/source-google-ads/source_google_ads/components.py
@@ -7,16 +7,19 @@ import json
 import logging
 import re
 import threading
-from dataclasses import dataclass, field
+from dataclasses import InitVar, dataclass, field
 from datetime import datetime, timedelta
 from itertools import groupby
 from typing import Any, Callable, ClassVar, Dict, Generator, Iterable, List, Mapping, MutableMapping, Optional, Set, Tuple, Union
 
 import anyascii
 import requests
+from google.auth.transport.requests import Request as GoogleAuthRequest
+from google.oauth2 import service_account
 from requests.adapters import HTTPAdapter
 
 from airbyte_cdk import AirbyteTracedException, FailureType, InterpolatedString
+from airbyte_cdk.sources.declarative.auth.declarative_authenticator import DeclarativeAuthenticator
 from airbyte_cdk.sources.declarative.decoders.composite_raw_decoder import JsonParser
 from airbyte_cdk.sources.declarative.decoders.decoder import Decoder
 from airbyte_cdk.sources.declarative.extractors.dpath_extractor import DpathExtractor
@@ -41,6 +44,7 @@ logger = logging.getLogger("airbyte")
 # This is an idle timeout per recv() call, not a total request timeout,
 # so streaming responses that keep sending data are unaffected.
 DEFAULT_HTTP_TIMEOUT = 300  # 5 minutes
+GOOGLE_ADS_OAUTH_SCOPE = "https://www.googleapis.com/auth/adwords"
 
 
 class TimeoutHTTPAdapter(HTTPAdapter):
@@ -56,6 +60,62 @@ class TimeoutHTTPAdapter(HTTPAdapter):
     def send(self, request: requests.PreparedRequest, **kwargs: Any) -> requests.Response:  # type: ignore[override]
         kwargs.setdefault("timeout", self.timeout)
         return super().send(request, **kwargs)
+
+
+@dataclass
+class GoogleAdsServiceAccountAuthenticator(DeclarativeAuthenticator):
+    config: Mapping[str, Any]
+    parameters: InitVar[Mapping[str, Any]]
+
+    def __post_init__(self, parameters: Mapping[str, Any]) -> None:
+        self._credentials: Optional[service_account.Credentials] = None
+        self._lock = threading.Lock()
+        self._request = GoogleAuthRequest()
+
+    @property
+    def auth_header(self) -> str:
+        return "Authorization"
+
+    @property
+    def token(self) -> str:
+        credentials = self._get_or_refresh_credentials()
+        return f"Bearer {credentials.token}"
+
+    def _get_or_refresh_credentials(self) -> service_account.Credentials:
+        with self._lock:
+            if self._credentials is None:
+                self._credentials = self._build_credentials()
+            if not self._credentials.valid:
+                self._credentials.refresh(self._request)
+            return self._credentials
+
+    def _build_credentials(self) -> service_account.Credentials:
+        credentials_config = self.config["credentials"]
+        info = credentials_config.get("service_account_info")
+        if info is None:
+            raise AirbyteTracedException(
+                message="Service account credentials are missing the `service_account_info` field.",
+                failure_type=FailureType.config_error,
+            )
+        if isinstance(info, str):
+            try:
+                info = json.loads(info)
+            except json.JSONDecodeError as e:
+                raise AirbyteTracedException(
+                    message="The `service_account_info` field is not valid JSON.",
+                    failure_type=FailureType.config_error,
+                ) from e
+        if not isinstance(info, Mapping):
+            raise AirbyteTracedException(
+                message="The `service_account_info` field must be a JSON object.",
+                failure_type=FailureType.config_error,
+            )
+
+        credentials = service_account.Credentials.from_service_account_info(info, scopes=[GOOGLE_ADS_OAUTH_SCOPE])
+        impersonated_email = credentials_config.get("impersonated_email")
+        if impersonated_email:
+            credentials = credentials.with_subject(impersonated_email)
+        return credentials
 
 
 def _mount_timeout_adapter(requester: Any) -> None:

--- a/airbyte-integrations/connectors/source-google-ads/source_google_ads/components.py
+++ b/airbyte-integrations/connectors/source-google-ads/source_google_ads/components.py
@@ -8,16 +8,19 @@ import json
 import logging
 import re
 import threading
-from dataclasses import dataclass, field
+from dataclasses import InitVar, dataclass, field
 from datetime import datetime, timedelta
 from itertools import groupby
 from typing import Any, Callable, ClassVar, Dict, Generator, Iterable, List, Mapping, MutableMapping, Optional, Set, Tuple, Union
 
 import anyascii
 import requests
+from google.auth.transport.requests import Request as GoogleAuthRequest
+from google.oauth2 import service_account
 from requests.adapters import HTTPAdapter
 
 from airbyte_cdk import AirbyteTracedException, FailureType, InterpolatedString
+from airbyte_cdk.sources.declarative.auth.declarative_authenticator import DeclarativeAuthenticator
 from airbyte_cdk.sources.declarative.decoders.composite_raw_decoder import JsonParser
 from airbyte_cdk.sources.declarative.decoders.decoder import Decoder
 from airbyte_cdk.sources.declarative.extractors.dpath_extractor import DpathExtractor
@@ -42,6 +45,7 @@ logger = logging.getLogger("airbyte")
 # This is an idle timeout per recv() call, not a total request timeout,
 # so streaming responses that keep sending data are unaffected.
 DEFAULT_HTTP_TIMEOUT = 300  # 5 minutes
+GOOGLE_ADS_OAUTH_SCOPE = "https://www.googleapis.com/auth/adwords"
 
 
 class TimeoutHTTPAdapter(HTTPAdapter):
@@ -57,6 +61,62 @@ class TimeoutHTTPAdapter(HTTPAdapter):
     def send(self, request: requests.PreparedRequest, **kwargs: Any) -> requests.Response:  # type: ignore[override]
         kwargs.setdefault("timeout", self.timeout)
         return super().send(request, **kwargs)
+
+
+@dataclass
+class GoogleAdsServiceAccountAuthenticator(DeclarativeAuthenticator):
+    config: Mapping[str, Any]
+    parameters: InitVar[Mapping[str, Any]]
+
+    def __post_init__(self, parameters: Mapping[str, Any]) -> None:
+        self._credentials: Optional[service_account.Credentials] = None
+        self._lock = threading.Lock()
+        self._request = GoogleAuthRequest()
+
+    @property
+    def auth_header(self) -> str:
+        return "Authorization"
+
+    @property
+    def token(self) -> str:
+        credentials = self._get_or_refresh_credentials()
+        return f"Bearer {credentials.token}"
+
+    def _get_or_refresh_credentials(self) -> service_account.Credentials:
+        with self._lock:
+            if self._credentials is None:
+                self._credentials = self._build_credentials()
+            if not self._credentials.valid:
+                self._credentials.refresh(self._request)
+            return self._credentials
+
+    def _build_credentials(self) -> service_account.Credentials:
+        credentials_config = self.config["credentials"]
+        info = credentials_config.get("service_account_info")
+        if info is None:
+            raise AirbyteTracedException(
+                message="Service account credentials are missing the `service_account_info` field.",
+                failure_type=FailureType.config_error,
+            )
+        if isinstance(info, str):
+            try:
+                info = json.loads(info)
+            except json.JSONDecodeError as e:
+                raise AirbyteTracedException(
+                    message="The `service_account_info` field is not valid JSON.",
+                    failure_type=FailureType.config_error,
+                ) from e
+        if not isinstance(info, Mapping):
+            raise AirbyteTracedException(
+                message="The `service_account_info` field must be a JSON object.",
+                failure_type=FailureType.config_error,
+            )
+
+        credentials = service_account.Credentials.from_service_account_info(info, scopes=[GOOGLE_ADS_OAUTH_SCOPE])
+        impersonated_email = credentials_config.get("impersonated_email")
+        if impersonated_email:
+            credentials = credentials.with_subject(impersonated_email)
+        return credentials
 
 
 def _mount_timeout_adapter(requester: Any) -> None:

--- a/airbyte-integrations/connectors/source-google-ads/source_google_ads/components.py
+++ b/airbyte-integrations/connectors/source-google-ads/source_google_ads/components.py
@@ -15,6 +15,7 @@ from typing import Any, Callable, ClassVar, Dict, Generator, Iterable, List, Map
 
 import anyascii
 import requests
+from google.auth import exceptions as google_auth_exceptions
 from google.auth.transport.requests import Request as GoogleAuthRequest
 from google.oauth2 import service_account
 from requests.adapters import HTTPAdapter
@@ -36,7 +37,7 @@ from airbyte_cdk.sources.streams.concurrent.default_stream import DefaultStream
 from airbyte_cdk.sources.types import Config, Record, StreamSlice, StreamState
 from airbyte_cdk.sources.utils.transform import TransformConfig, TypeTransformer
 
-from .google_ads import GoogleAds
+from .google_ads import GoogleAds, build_service_account_credentials
 
 
 logger = logging.getLogger("airbyte")
@@ -45,7 +46,6 @@ logger = logging.getLogger("airbyte")
 # This is an idle timeout per recv() call, not a total request timeout,
 # so streaming responses that keep sending data are unaffected.
 DEFAULT_HTTP_TIMEOUT = 300  # 5 minutes
-GOOGLE_ADS_OAUTH_SCOPE = "https://www.googleapis.com/auth/adwords"
 
 
 class TimeoutHTTPAdapter(HTTPAdapter):
@@ -65,6 +65,12 @@ class TimeoutHTTPAdapter(HTTPAdapter):
 
 @dataclass
 class GoogleAdsServiceAccountAuthenticator(DeclarativeAuthenticator):
+    """Mints Google Ads bearer tokens from a service account key.
+
+    Selected by the manifest's `SelectiveAuthenticator` when `credentials.auth_type` is
+    `Service`. Credentials are built once and refreshed on expiry.
+    """
+
     config: Mapping[str, Any]
     parameters: InitVar[Mapping[str, Any]]
 
@@ -87,36 +93,20 @@ class GoogleAdsServiceAccountAuthenticator(DeclarativeAuthenticator):
             if self._credentials is None:
                 self._credentials = self._build_credentials()
             if not self._credentials.valid:
-                self._credentials.refresh(self._request)
+                try:
+                    self._credentials.refresh(self._request)
+                except google_auth_exceptions.RefreshError as e:
+                    # Google rejected the key or the delegation, e.g. the service account was never
+                    # added to the Google Ads account, or domain-wide delegation is not granted for
+                    # the adwords scope. That is a config problem, not a transient system failure.
+                    raise AirbyteTracedException(
+                        message="Could not obtain an access token for the service account. Confirm the service account has access to the Google Ads account, and that `Impersonated Email` is only set when domain-wide delegation is configured.",
+                        failure_type=FailureType.config_error,
+                    ) from e
             return self._credentials
 
     def _build_credentials(self) -> service_account.Credentials:
-        credentials_config = self.config["credentials"]
-        info = credentials_config.get("service_account_info")
-        if info is None:
-            raise AirbyteTracedException(
-                message="Service account credentials are missing the `service_account_info` field.",
-                failure_type=FailureType.config_error,
-            )
-        if isinstance(info, str):
-            try:
-                info = json.loads(info)
-            except json.JSONDecodeError as e:
-                raise AirbyteTracedException(
-                    message="The `service_account_info` field is not valid JSON.",
-                    failure_type=FailureType.config_error,
-                ) from e
-        if not isinstance(info, Mapping):
-            raise AirbyteTracedException(
-                message="The `service_account_info` field must be a JSON object.",
-                failure_type=FailureType.config_error,
-            )
-
-        credentials = service_account.Credentials.from_service_account_info(info, scopes=[GOOGLE_ADS_OAUTH_SCOPE])
-        impersonated_email = credentials_config.get("impersonated_email")
-        if impersonated_email:
-            credentials = credentials.with_subject(impersonated_email)
-        return credentials
+        return build_service_account_credentials(self.config["credentials"])
 
 
 def _mount_timeout_adapter(requester: Any) -> None:

--- a/airbyte-integrations/connectors/source-google-ads/source_google_ads/config_migrations.py
+++ b/airbyte-integrations/connectors/source-google-ads/source_google_ads/config_migrations.py
@@ -25,6 +25,37 @@ FULL_REFRESH_CUSTOM_TABLE = [
 ]
 
 
+class MigrateAuthType:
+    OAUTH_AUTH_TYPE = "Client"
+    message_repository: MessageRepository = InMemoryMessageRepository()
+
+    @classmethod
+    def should_migrate(cls, config: Mapping[str, Any]) -> bool:
+        credentials = config.get("credentials")
+        if not isinstance(credentials, Mapping):
+            return False
+        return "auth_type" not in credentials
+
+    @classmethod
+    def update_config(cls, config: Mapping[str, Any]) -> Mapping[str, Any]:
+        config["credentials"]["auth_type"] = cls.OAUTH_AUTH_TYPE
+        return config
+
+    @classmethod
+    def modify_and_save(cls, config_path: str, source: Source, config: Mapping[str, Any]) -> Mapping[str, Any]:
+        migrated_config = cls.update_config(config)
+        source.write_config(migrated_config, config_path)
+        return migrated_config
+
+    @classmethod
+    def migrate(cls, args: List[str], source: Source) -> None:
+        config_path = AirbyteEntrypoint(source).extract_config(args)
+        if config_path:
+            config = source.read_config(config_path)
+            if cls.should_migrate(config):
+                emit_configuration_as_airbyte_control_message(cls.modify_and_save(config_path, source, config))
+
+
 class MigrateCustomQuery:
     """
     This class stands for migrating the config at runtime.

--- a/airbyte-integrations/connectors/source-google-ads/source_google_ads/config_migrations.py
+++ b/airbyte-integrations/connectors/source-google-ads/source_google_ads/config_migrations.py
@@ -26,6 +26,17 @@ FULL_REFRESH_CUSTOM_TABLE = [
 
 
 class MigrateAuthType:
+    """
+    Backfills `credentials.auth_type` for configs that pre-date the OAuth / Service Account
+    `oneOf` split in `spec.json`.
+
+    Legacy configs only carry the OAuth fields (`client_id`, `client_secret`, `refresh_token`)
+    and no discriminator, so this sets `auth_type: "Client"` and emits a control message so the
+    platform persists it. This is only about persistence: a legacy config still validates against
+    the OAuth branch (which does not require `auth_type`), and `SourceGoogleAds._backfill_auth_type`
+    covers the in-memory config for the current invocation.
+    """
+
     OAUTH_AUTH_TYPE = "Client"
     message_repository: MessageRepository = InMemoryMessageRepository()
 

--- a/airbyte-integrations/connectors/source-google-ads/source_google_ads/google_ads.py
+++ b/airbyte-integrations/connectors/source-google-ads/source_google_ads/google_ads.py
@@ -3,6 +3,10 @@
 #
 
 
+import atexit
+import json
+import os
+import tempfile
 from enum import Enum
 from typing import Any, Iterable, Iterator, List, Mapping, MutableMapping
 
@@ -22,6 +26,65 @@ from .utils import logger
 
 
 API_VERSION = "v23"
+SERVICE_ACCOUNT_AUTH_TYPE = "Service"
+
+
+def _remove_temp_file(path: str) -> None:
+    try:
+        os.remove(path)
+    except FileNotFoundError:
+        pass
+
+
+def _materialize_service_account_credentials(credentials: MutableMapping[str, Any]) -> MutableMapping[str, Any]:
+    if "json_key_file_path" in credentials:
+        return credentials
+
+    info = credentials.get("service_account_info")
+    if info is None:
+        raise AirbyteTracedException(
+            message="Service account credentials are missing the `service_account_info` field. Please provide the JSON key contents in the connector configuration.",
+            failure_type=FailureType.config_error,
+        )
+
+    if isinstance(info, str):
+        try:
+            info_dict = json.loads(info)
+        except json.JSONDecodeError as e:
+            raise AirbyteTracedException(
+                message="The `service_account_info` field is not valid JSON. Paste the full contents of your service account key file.",
+                failure_type=FailureType.config_error,
+            ) from e
+        if not isinstance(info_dict, Mapping):
+            raise AirbyteTracedException(
+                message="The `service_account_info` field must be a JSON object containing service account key material.",
+                failure_type=FailureType.config_error,
+            )
+    elif isinstance(info, Mapping):
+        info_dict = dict(info)
+    else:
+        raise AirbyteTracedException(
+            message="The `service_account_info` field must be a JSON string or object containing service account key material.",
+            failure_type=FailureType.config_error,
+        )
+
+    key_file = tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False)
+    try:
+        os.chmod(key_file.name, 0o600)
+        json.dump(info_dict, key_file)
+    finally:
+        key_file.close()
+
+    credentials["json_key_file_path"] = key_file.name
+    credentials.pop("service_account_info", None)
+    atexit.register(_remove_temp_file, key_file.name)
+    return credentials
+
+
+def _prepare_credentials_for_sdk(credentials: MutableMapping[str, Any]) -> MutableMapping[str, Any]:
+    if credentials.get("auth_type") == SERVICE_ACCOUNT_AUTH_TYPE or "service_account_info" in credentials:
+        credentials = _materialize_service_account_credentials(credentials)
+    return {key: value for key, value in credentials.items() if key != "auth_type"}
 
 
 def on_give_up(details):
@@ -67,7 +130,7 @@ class GoogleAds:
     @staticmethod
     def get_google_ads_client(credentials) -> GoogleAdsClient:
         try:
-            return GoogleAdsClient.load_from_dict(credentials, version=API_VERSION)
+            return GoogleAdsClient.load_from_dict(_prepare_credentials_for_sdk(credentials), version=API_VERSION)
         except exceptions.RefreshError as e:
             message = "The authentication to Google Ads has expired. Re-authenticate to restore access to Google Ads."
             raise AirbyteTracedException(message=message, failure_type=FailureType.config_error) from e

--- a/airbyte-integrations/connectors/source-google-ads/source_google_ads/google_ads.py
+++ b/airbyte-integrations/connectors/source-google-ads/source_google_ads/google_ads.py
@@ -3,6 +3,10 @@
 #
 
 
+import atexit
+import json
+import os
+import tempfile
 from enum import Enum
 from typing import Any, Iterable, Iterator, List, Mapping, MutableMapping
 
@@ -22,6 +26,67 @@ from .utils import logger
 
 
 API_VERSION = "v23"
+SERVICE_ACCOUNT_AUTH_TYPE = "Service"
+
+
+def _remove_temp_file(path: str) -> None:
+    try:
+        os.remove(path)
+    except FileNotFoundError:
+        # Best-effort atexit cleanup: the materialized key file may already have
+        # been unlinked by an earlier explicit delete or a previous cleanup hook.
+        logger.debug("Service account temp key file already removed: %s", path)
+
+
+def _materialize_service_account_credentials(credentials: MutableMapping[str, Any]) -> MutableMapping[str, Any]:
+    if "json_key_file_path" in credentials:
+        return credentials
+
+    info = credentials.get("service_account_info")
+    if info is None:
+        raise AirbyteTracedException(
+            message="Service account credentials are missing the `service_account_info` field. Please provide the JSON key contents in the connector configuration.",
+            failure_type=FailureType.config_error,
+        )
+
+    if isinstance(info, str):
+        try:
+            info_dict = json.loads(info)
+        except json.JSONDecodeError as e:
+            raise AirbyteTracedException(
+                message="The `service_account_info` field is not valid JSON. Paste the full contents of your service account key file.",
+                failure_type=FailureType.config_error,
+            ) from e
+        if not isinstance(info_dict, Mapping):
+            raise AirbyteTracedException(
+                message="The `service_account_info` field must be a JSON object containing service account key material.",
+                failure_type=FailureType.config_error,
+            )
+    elif isinstance(info, Mapping):
+        info_dict = dict(info)
+    else:
+        raise AirbyteTracedException(
+            message="The `service_account_info` field must be a JSON string or object containing service account key material.",
+            failure_type=FailureType.config_error,
+        )
+
+    key_file = tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False)
+    try:
+        os.chmod(key_file.name, 0o600)
+        json.dump(info_dict, key_file)
+    finally:
+        key_file.close()
+
+    credentials["json_key_file_path"] = key_file.name
+    credentials.pop("service_account_info", None)
+    atexit.register(_remove_temp_file, key_file.name)
+    return credentials
+
+
+def _prepare_credentials_for_sdk(credentials: MutableMapping[str, Any]) -> MutableMapping[str, Any]:
+    if credentials.get("auth_type") == SERVICE_ACCOUNT_AUTH_TYPE or "service_account_info" in credentials:
+        credentials = _materialize_service_account_credentials(credentials)
+    return {key: value for key, value in credentials.items() if key != "auth_type"}
 
 
 def on_give_up(details):
@@ -67,7 +132,7 @@ class GoogleAds:
     @staticmethod
     def get_google_ads_client(credentials) -> GoogleAdsClient:
         try:
-            return GoogleAdsClient.load_from_dict(credentials, version=API_VERSION)
+            return GoogleAdsClient.load_from_dict(_prepare_credentials_for_sdk(credentials), version=API_VERSION)
         except exceptions.RefreshError as e:
             message = "The authentication to Google Ads has expired. Re-authenticate to restore access to Google Ads."
             raise AirbyteTracedException(message=message, failure_type=FailureType.config_error) from e

--- a/airbyte-integrations/connectors/source-google-ads/source_google_ads/google_ads.py
+++ b/airbyte-integrations/connectors/source-google-ads/source_google_ads/google_ads.py
@@ -3,10 +3,7 @@
 #
 
 
-import atexit
 import json
-import os
-import tempfile
 from enum import Enum
 from typing import Any, Iterable, Iterator, List, Mapping, MutableMapping
 
@@ -15,6 +12,8 @@ from google.ads.googleads.client import GoogleAdsClient
 from google.ads.googleads.v23.services.types.google_ads_service import GoogleAdsRow, SearchGoogleAdsResponse
 from google.api_core.exceptions import InternalServerError, ServerError, ServiceUnavailable, TooManyRequests
 from google.auth import exceptions
+from google.auth.transport.requests import Request as GoogleAuthRequest
+from google.oauth2 import service_account
 from google.protobuf import json_format
 from google.protobuf.message import Message
 from proto.marshal.collections import Repeated, RepeatedComposite
@@ -27,21 +26,25 @@ from .utils import logger
 
 API_VERSION = "v23"
 SERVICE_ACCOUNT_AUTH_TYPE = "Service"
+# Matches `google.ads.googleads.oauth2._SERVICE_ACCOUNT_SCOPES`.
+GOOGLE_ADS_OAUTH_SCOPE = "https://www.googleapis.com/auth/adwords"
 
 
-def _remove_temp_file(path: str) -> None:
-    try:
-        os.remove(path)
-    except FileNotFoundError:
-        # Best-effort atexit cleanup: the materialized key file may already have
-        # been unlinked by an earlier explicit delete or a previous cleanup hook.
-        logger.debug("Service account temp key file already removed: %s", path)
+def uses_service_account_auth(credentials: Mapping[str, Any]) -> bool:
+    return credentials.get("auth_type") == SERVICE_ACCOUNT_AUTH_TYPE or "service_account_info" in credentials
 
 
-def _materialize_service_account_credentials(credentials: MutableMapping[str, Any]) -> MutableMapping[str, Any]:
-    if "json_key_file_path" in credentials:
-        return credentials
+def build_service_account_credentials(credentials: Mapping[str, Any]) -> service_account.Credentials:
+    """Build (optionally subject-delegated) Google service account credentials from the connector config.
 
+    Shared by the Google Ads SDK client below and by the declarative
+    `GoogleAdsServiceAccountAuthenticator` in `components.py`, so both auth paths parse
+    `service_account_info` and classify bad key material identically.
+
+    The key never touches disk. `GoogleAdsClient.load_from_dict` only supports service
+    accounts via a `json_key_file_path` on disk, but `GoogleAdsClient` itself accepts a
+    credentials object directly, so the private key stays in memory.
+    """
     info = credentials.get("service_account_info")
     if info is None:
         raise AirbyteTracedException(
@@ -51,41 +54,33 @@ def _materialize_service_account_credentials(credentials: MutableMapping[str, An
 
     if isinstance(info, str):
         try:
-            info_dict = json.loads(info)
+            info = json.loads(info)
         except json.JSONDecodeError as e:
             raise AirbyteTracedException(
                 message="The `service_account_info` field is not valid JSON. Paste the full contents of your service account key file.",
                 failure_type=FailureType.config_error,
             ) from e
-        if not isinstance(info_dict, Mapping):
-            raise AirbyteTracedException(
-                message="The `service_account_info` field must be a JSON object containing service account key material.",
-                failure_type=FailureType.config_error,
-            )
-    elif isinstance(info, Mapping):
-        info_dict = dict(info)
-    else:
+
+    if not isinstance(info, Mapping):
         raise AirbyteTracedException(
-            message="The `service_account_info` field must be a JSON string or object containing service account key material.",
+            message="The `service_account_info` field must be a JSON object containing service account key material.",
             failure_type=FailureType.config_error,
         )
 
-    key_file = tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False)
     try:
-        os.chmod(key_file.name, 0o600)
-        json.dump(info_dict, key_file)
-    finally:
-        key_file.close()
+        account_credentials = service_account.Credentials.from_service_account_info(dict(info), scopes=[GOOGLE_ADS_OAUTH_SCOPE])
+    except ValueError as e:
+        raise AirbyteTracedException(
+            message="The `service_account_info` field is not a usable service account key. Paste the full, unmodified contents of your service account key file.",
+            failure_type=FailureType.config_error,
+        ) from e
 
-    credentials["json_key_file_path"] = key_file.name
-    credentials.pop("service_account_info", None)
-    atexit.register(_remove_temp_file, key_file.name)
-    return credentials
+    impersonated_email = credentials.get("impersonated_email")
+    return account_credentials.with_subject(impersonated_email) if impersonated_email else account_credentials
 
 
-def _prepare_credentials_for_sdk(credentials: MutableMapping[str, Any]) -> MutableMapping[str, Any]:
-    if credentials.get("auth_type") == SERVICE_ACCOUNT_AUTH_TYPE or "service_account_info" in credentials:
-        credentials = _materialize_service_account_credentials(credentials)
+def _prepare_credentials_for_sdk(credentials: Mapping[str, Any]) -> MutableMapping[str, Any]:
+    """Drop the Airbyte-only `auth_type` discriminator before handing the config to the SDK."""
     return {key: value for key, value in credentials.items() if key != "auth_type"}
 
 
@@ -132,6 +127,18 @@ class GoogleAds:
     @staticmethod
     def get_google_ads_client(credentials) -> GoogleAdsClient:
         try:
+            if uses_service_account_auth(credentials):
+                account_credentials = build_service_account_credentials(credentials)
+                # `load_from_dict` refreshes credentials eagerly, which is what surfaces unusable
+                # key material as a `RefreshError` here rather than mid-sync. Match that.
+                account_credentials.refresh(GoogleAuthRequest())
+                return GoogleAdsClient(
+                    credentials=account_credentials,
+                    developer_token=credentials["developer_token"],
+                    login_customer_id=credentials.get("login_customer_id"),
+                    use_proto_plus=credentials.get("use_proto_plus", True),
+                    version=API_VERSION,
+                )
             return GoogleAdsClient.load_from_dict(_prepare_credentials_for_sdk(credentials), version=API_VERSION)
         except exceptions.RefreshError as e:
             message = "The authentication to Google Ads has expired. Re-authenticate to restore access to Google Ads."

--- a/airbyte-integrations/connectors/source-google-ads/source_google_ads/manifest.yaml
+++ b/airbyte-integrations/connectors/source-google-ads/source_google_ads/manifest.yaml
@@ -9,7 +9,7 @@ check:
 
 definitions:
   # Authenticator Definitions
-  authenticator:
+  oauth_authenticator:
     type: OAuthAuthenticator
     refresh_request_body: {}
     token_refresh_endpoint: https://www.googleapis.com/oauth2/v3/token
@@ -17,6 +17,19 @@ definitions:
     client_id: '{{ config["credentials"]["client_id"] }}'
     client_secret: '{{ config["credentials"]["client_secret"] }}'
     refresh_token: '{{ config["credentials"]["refresh_token"] }}'
+
+  service_account_authenticator:
+    type: CustomAuthenticator
+    class_name: source_google_ads.components.GoogleAdsServiceAccountAuthenticator
+
+  authenticator:
+    type: SelectiveAuthenticator
+    authenticator_selection_path: ["credentials", "auth_type"]
+    authenticators:
+      Client:
+        $ref: "#/definitions/oauth_authenticator"
+      Service:
+        $ref: "#/definitions/service_account_authenticator"
 
   base_requester:
     type: HttpRequester

--- a/airbyte-integrations/connectors/source-google-ads/source_google_ads/run.py
+++ b/airbyte-integrations/connectors/source-google-ads/source_google_ads/run.py
@@ -12,6 +12,7 @@ from orjson import orjson
 from airbyte_cdk.entrypoint import AirbyteEntrypoint, launch, logger
 from airbyte_cdk.exception_handler import init_uncaught_exception_handler
 from airbyte_cdk.models import AirbyteErrorTraceMessage, AirbyteMessage, AirbyteMessageSerializer, AirbyteTraceMessage, TraceType, Type
+from source_google_ads.config_migrations import MigrateAuthType
 from source_google_ads.source import SourceGoogleAds
 
 
@@ -51,4 +52,5 @@ def run() -> None:
     _args = sys.argv[1:]
     source = _get_source(_args)
     if source:
+        MigrateAuthType.migrate(_args, source)
         launch(source, _args)

--- a/airbyte-integrations/connectors/source-google-ads/source_google_ads/source.py
+++ b/airbyte-integrations/connectors/source-google-ads/source_google_ads/source.py
@@ -21,10 +21,21 @@ from .streams import (
 
 class SourceGoogleAds(YamlDeclarativeSource):
     def __init__(self, catalog: Optional[ConfiguredAirbyteCatalog], config: Optional[Mapping[str, Any]], state: TState, **kwargs):
+        if config is not None:
+            config = self._backfill_auth_type(dict(config))
         super().__init__(catalog=catalog, config=config, state=state, **{"path_to_yaml": "manifest.yaml"})
 
     # Raise exceptions on missing streams
     raise_exception_on_missing_stream = True
+
+    @staticmethod
+    def _backfill_auth_type(config: Mapping[str, Any]) -> Mapping[str, Any]:
+        credentials = config.get("credentials")
+        if isinstance(credentials, Mapping) and "auth_type" not in credentials:
+            credentials = dict(credentials)
+            credentials["auth_type"] = "Client"
+            config["credentials"] = credentials
+        return config
 
     @staticmethod
     def _validate_and_transform(config: Mapping[str, Any]):

--- a/airbyte-integrations/connectors/source-google-ads/source_google_ads/source.py
+++ b/airbyte-integrations/connectors/source-google-ads/source_google_ads/source.py
@@ -30,6 +30,15 @@ class SourceGoogleAds(YamlDeclarativeSource):
 
     @staticmethod
     def _backfill_auth_type(config: Mapping[str, Any]) -> Mapping[str, Any]:
+        """Default `credentials.auth_type` to `Client` for legacy OAuth-only configs.
+
+        `MigrateAuthType` in `run.py` persists the same change on disk, but it cannot help
+        the config already loaded into this instance: the source is constructed before the
+        migration runs, and any caller that instantiates `SourceGoogleAds` directly skips
+        `run.py` entirely. Without this in-memory backfill the manifest's
+        `SelectiveAuthenticator` has no branch to resolve and stream building fails - which
+        is what broke DISCOVER in the earlier attempt at this feature (#77530).
+        """
         credentials = config.get("credentials")
         if isinstance(credentials, Mapping) and "auth_type" not in credentials:
             credentials = dict(credentials)

--- a/airbyte-integrations/connectors/source-google-ads/source_google_ads/spec.json
+++ b/airbyte-integrations/connectors/source-google-ads/source_google_ads/spec.json
@@ -9,51 +9,104 @@
     "properties": {
       "credentials": {
         "type": "object",
-        "description": "",
         "title": "Google Credentials",
+        "description": "Choose how to authenticate to Google Ads. Most users should use OAuth. Service Account is intended for server-to-server environments that already have Google Ads service account access configured.",
         "order": 0,
-        "required": [
-          "developer_token",
-          "client_id",
-          "client_secret",
-          "refresh_token"
-        ],
-        "properties": {
-          "developer_token": {
-            "type": "string",
-            "title": "Developer Token",
-            "order": 0,
-            "description": "The Developer Token granted by Google to use their APIs. For detailed instructions on finding this value, refer to our <a href=\"https://docs.airbyte.com/integrations/sources/google-ads#setup-guide\">documentation</a>.",
-            "airbyte_secret": true
+        "oneOf": [
+          {
+            "title": "OAuth Credentials",
+            "type": "object",
+            "required": [
+              "developer_token",
+              "client_id",
+              "client_secret",
+              "refresh_token"
+            ],
+            "properties": {
+              "auth_type": {
+                "type": "string",
+                "const": "Client",
+                "default": "Client",
+                "order": 0
+              },
+              "developer_token": {
+                "type": "string",
+                "title": "Developer Token",
+                "order": 1,
+                "description": "The Developer Token granted by Google to use their APIs. For detailed instructions on finding this value, refer to our <a href=\"https://docs.airbyte.com/integrations/sources/google-ads#setup-guide\">documentation</a>.",
+                "airbyte_secret": true
+              },
+              "client_id": {
+                "type": "string",
+                "title": "Client ID",
+                "order": 2,
+                "description": "The Client ID of your Google Ads developer application. For detailed instructions on finding this value, refer to our <a href=\"https://docs.airbyte.com/integrations/sources/google-ads#setup-guide\">documentation</a>."
+              },
+              "client_secret": {
+                "type": "string",
+                "title": "Client Secret",
+                "order": 3,
+                "description": "The Client Secret of your Google Ads developer application. For detailed instructions on finding this value, refer to our <a href=\"https://docs.airbyte.com/integrations/sources/google-ads#setup-guide\">documentation</a>.",
+                "airbyte_secret": true
+              },
+              "refresh_token": {
+                "type": "string",
+                "title": "Refresh Token",
+                "order": 4,
+                "description": "The token used to obtain a new Access Token. For detailed instructions on finding this value, refer to our <a href=\"https://docs.airbyte.com/integrations/sources/google-ads#setup-guide\">documentation</a>.",
+                "airbyte_secret": true
+              },
+              "access_token": {
+                "type": "string",
+                "title": "Access Token",
+                "order": 5,
+                "description": "The Access Token for making authenticated requests. For detailed instructions on finding this value, refer to our <a href=\"https://docs.airbyte.com/integrations/sources/google-ads#setup-guide\">documentation</a>.",
+                "airbyte_secret": true
+              }
+            }
           },
-          "client_id": {
-            "type": "string",
-            "title": "Client ID",
-            "order": 1,
-            "description": "The Client ID of your Google Ads developer application. For detailed instructions on finding this value, refer to our <a href=\"https://docs.airbyte.com/integrations/sources/google-ads#setup-guide\">documentation</a>."
-          },
-          "client_secret": {
-            "type": "string",
-            "title": "Client Secret",
-            "order": 2,
-            "description": "The Client Secret of your Google Ads developer application. For detailed instructions on finding this value, refer to our <a href=\"https://docs.airbyte.com/integrations/sources/google-ads#setup-guide\">documentation</a>.",
-            "airbyte_secret": true
-          },
-          "refresh_token": {
-            "type": "string",
-            "title": "Refresh Token",
-            "order": 3,
-            "description": "The token used to obtain a new Access Token. For detailed instructions on finding this value, refer to our <a href=\"https://docs.airbyte.com/integrations/sources/google-ads#setup-guide\">documentation</a>.",
-            "airbyte_secret": true
-          },
-          "access_token": {
-            "type": "string",
-            "title": "Access Token",
-            "order": 4,
-            "description": "The Access Token for making authenticated requests. For detailed instructions on finding this value, refer to our <a href=\"https://docs.airbyte.com/integrations/sources/google-ads#setup-guide\">documentation</a>.",
-            "airbyte_secret": true
+          {
+            "title": "Service Account Key Authentication",
+            "type": "object",
+            "required": [
+              "auth_type",
+              "developer_token",
+              "service_account_info"
+            ],
+            "properties": {
+              "auth_type": {
+                "type": "string",
+                "const": "Service",
+                "order": 0
+              },
+              "developer_token": {
+                "type": "string",
+                "title": "Developer Token",
+                "order": 1,
+                "description": "The Developer Token granted by Google to use their APIs. For detailed instructions on finding this value, refer to our <a href=\"https://docs.airbyte.com/integrations/sources/google-ads#setup-guide\">documentation</a>.",
+                "airbyte_secret": true
+              },
+              "service_account_info": {
+                "type": "string",
+                "title": "Service Account JSON Key",
+                "order": 2,
+                "description": "The full JSON content of the service account key file. For detailed instructions, refer to <a href=\"https://developers.google.com/google-ads/api/docs/oauth/service-accounts\">Google's documentation</a>.",
+                "airbyte_secret": true,
+                "multiline": true,
+                "examples": [
+                  "{ \"type\": \"service_account\", \"project_id\": \"YOUR_PROJECT_ID\", \"private_key_id\": \"YOUR_PRIVATE_KEY_ID\", \"private_key\": \"-----BEGIN PRIVATE KEY-----\\n...\\n-----END PRIVATE KEY-----\\n\", \"client_email\": \"name@project.iam.gserviceaccount.com\", ... }"
+                ]
+              },
+              "impersonated_email": {
+                "type": "string",
+                "title": "Impersonated Email",
+                "order": 3,
+                "description": "Optional email of the Google Ads user to impersonate via domain-wide delegation. Leave blank when the service account itself has direct access to the Google Ads account.",
+                "examples": ["user@example.com"]
+              }
+            }
           }
-        }
+        ]
       },
       "customer_id": {
         "title": "Customer ID(s)",
@@ -146,6 +199,8 @@
   },
   "advanced_auth": {
     "auth_flow_type": "oauth2.0",
+    "predicate_key": ["credentials", "auth_type"],
+    "predicate_value": "Client",
     "oauth_config_specification": {
       "complete_oauth_output_specification": {
         "type": "object",

--- a/airbyte-integrations/connectors/source-google-ads/unit_tests/conftest.py
+++ b/airbyte-integrations/connectors/source-google-ads/unit_tests/conftest.py
@@ -36,7 +36,7 @@ _YAML_FILE_PATH = "manifest.yaml"
 def get_source(config, state=None) -> YamlDeclarativeSource:
     catalog = CatalogBuilder().build()
     state = StateBuilder().build() if not state else state
-    return YamlDeclarativeSource(path_to_yaml=str(_SOURCE_FOLDER_PATH / _YAML_FILE_PATH), catalog=catalog, config=config, state=state)
+    return SourceGoogleAds(catalog=catalog, config=config, state=state)
 
 
 def find_stream(stream_name, config, state=None):

--- a/airbyte-integrations/connectors/source-google-ads/unit_tests/conftest.py
+++ b/airbyte-integrations/connectors/source-google-ads/unit_tests/conftest.py
@@ -36,6 +36,8 @@ _YAML_FILE_PATH = "manifest.yaml"
 def get_source(config, state=None) -> YamlDeclarativeSource:
     catalog = CatalogBuilder().build()
     state = StateBuilder().build() if not state else state
+    # `SourceGoogleAds` rather than a bare `YamlDeclarativeSource`, so `_backfill_auth_type` runs
+    # for the legacy fixtures here that pre-date the OAuth / Service Account `oneOf` split.
     return SourceGoogleAds(catalog=catalog, config=config, state=state)
 
 

--- a/airbyte-integrations/connectors/source-google-ads/unit_tests/test_components.py
+++ b/airbyte-integrations/connectors/source-google-ads/unit_tests/test_components.py
@@ -15,6 +15,7 @@ from source_google_ads.components import (
     CustomGAQuerySchemaLoader,
     FlattenNestedDictsTransformation,
     GoogleAdsRetriever,
+    GoogleAdsServiceAccountAuthenticator,
     GoogleAdsStreamingDecoder,
     SerializeMessageFieldsTransformation,
     TimeoutHTTPAdapter,
@@ -834,9 +835,9 @@ def test_custom_retriever_streams_have_expected_date_format(stream_name, datetim
 def test_default_streams_use_streaming_decoder_in_extractor(stream_name, retriever):
     extractor = retriever.record_selector.extractor
     assert isinstance(extractor, DpathExtractor), f"Stream {stream_name}: expected DpathExtractor, got {type(extractor).__name__}"
-    assert isinstance(
-        extractor.decoder, GoogleAdsStreamingDecoder
-    ), f"Stream {stream_name}: expected GoogleAdsStreamingDecoder on extractor, got {type(extractor.decoder).__name__}"
+    assert isinstance(extractor.decoder, GoogleAdsStreamingDecoder), (
+        f"Stream {stream_name}: expected GoogleAdsStreamingDecoder on extractor, got {type(extractor.decoder).__name__}"
+    )
 
 
 @pytest.mark.parametrize(
@@ -850,9 +851,9 @@ def test_default_streams_use_streaming_decoder_in_extractor(stream_name, retriev
 def test_dynamic_streams_use_streaming_decoder_in_extractor(stream_name, retriever):
     extractor = retriever.record_selector.extractor
     assert isinstance(extractor, DpathExtractor), f"Dynamic stream {stream_name}: expected DpathExtractor, got {type(extractor).__name__}"
-    assert isinstance(
-        extractor.decoder, GoogleAdsStreamingDecoder
-    ), f"Dynamic stream {stream_name}: expected GoogleAdsStreamingDecoder on extractor, got {type(extractor.decoder).__name__}"
+    assert isinstance(extractor.decoder, GoogleAdsStreamingDecoder), (
+        f"Dynamic stream {stream_name}: expected GoogleAdsStreamingDecoder on extractor, got {type(extractor.decoder).__name__}"
+    )
 
 
 class TestSerializeMessageFieldsTransformation:
@@ -1112,9 +1113,9 @@ def test_every_stream_has_timeout_adapter_mounted(stream_name, retriever):
     requester = retriever.requester
     session = requester._http_client._session
     adapter = session.adapters.get("https://")
-    assert isinstance(
-        adapter, TimeoutHTTPAdapter
-    ), f"Stream {stream_name}: expected TimeoutHTTPAdapter on `https://`, got {type(adapter).__name__}"
+    assert isinstance(adapter, TimeoutHTTPAdapter), (
+        f"Stream {stream_name}: expected TimeoutHTTPAdapter on `https://`, got {type(adapter).__name__}"
+    )
 
 
 @pytest.mark.parametrize(
@@ -1126,6 +1127,121 @@ def test_dynamic_streams_have_timeout_adapter_mounted(stream_name, retriever):
     requester = retriever.requester
     session = requester._http_client._session
     adapter = session.adapters.get("https://")
-    assert isinstance(
-        adapter, TimeoutHTTPAdapter
-    ), f"Dynamic stream {stream_name}: expected TimeoutHTTPAdapter on `https://`, got {type(adapter).__name__}"
+    assert isinstance(adapter, TimeoutHTTPAdapter), (
+        f"Dynamic stream {stream_name}: expected TimeoutHTTPAdapter on `https://`, got {type(adapter).__name__}"
+    )
+
+
+_SERVICE_ACCOUNT_KEY_DICT = {
+    "type": "service_account",
+    "project_id": "test-project",
+    "private_key_id": "key-id",
+    "private_key": "-----BEGIN PRIVATE KEY-----\nfake\n-----END PRIVATE KEY-----\n",
+    "client_email": "sa@test-project.iam.gserviceaccount.com",
+    "client_id": "1234567890",
+    "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+    "token_uri": "https://oauth2.googleapis.com/token",
+}
+
+
+@patch("source_google_ads.components.service_account.Credentials")
+def test_service_account_authenticator_emits_bearer_token_with_subject(mock_credentials_cls):
+    delegated = MagicMock()
+    delegated.valid = False
+    delegated.token = "ya29.test"
+
+    base = MagicMock()
+    base.with_subject.return_value = delegated
+    mock_credentials_cls.from_service_account_info.return_value = base
+
+    authenticator = GoogleAdsServiceAccountAuthenticator(
+        config={
+            "credentials": {
+                "auth_type": "Service",
+                "developer_token": "developer_token",
+                "service_account_info": json.dumps(_SERVICE_ACCOUNT_KEY_DICT),
+                "impersonated_email": "user@example.com",
+            }
+        },
+        parameters={},
+    )
+
+    assert authenticator.auth_header == "Authorization"
+    assert authenticator.token == "Bearer ya29.test"
+    mock_credentials_cls.from_service_account_info.assert_called_once_with(
+        _SERVICE_ACCOUNT_KEY_DICT, scopes=["https://www.googleapis.com/auth/adwords"]
+    )
+    base.with_subject.assert_called_once_with("user@example.com")
+    delegated.refresh.assert_called_once()
+
+
+@patch("source_google_ads.components.service_account.Credentials")
+def test_service_account_authenticator_skips_subject_when_not_configured(mock_credentials_cls):
+    credentials = MagicMock()
+    credentials.valid = True
+    credentials.token = "ya29.direct"
+    mock_credentials_cls.from_service_account_info.return_value = credentials
+
+    authenticator = GoogleAdsServiceAccountAuthenticator(
+        config={
+            "credentials": {
+                "auth_type": "Service",
+                "developer_token": "developer_token",
+                "service_account_info": _SERVICE_ACCOUNT_KEY_DICT,
+            }
+        },
+        parameters={},
+    )
+
+    assert authenticator.token == "Bearer ya29.direct"
+    credentials.with_subject.assert_not_called()
+    credentials.refresh.assert_not_called()
+
+
+def test_service_account_authenticator_rejects_missing_info():
+    authenticator = GoogleAdsServiceAccountAuthenticator(
+        config={"credentials": {"auth_type": "Service", "developer_token": "x", "impersonated_email": "u@example.com"}},
+        parameters={},
+    )
+
+    with pytest.raises(AirbyteTracedException) as exc_info:
+        _ = authenticator.token
+
+    assert "service_account_info" in exc_info.value.message
+
+
+def test_service_account_authenticator_rejects_invalid_json():
+    authenticator = GoogleAdsServiceAccountAuthenticator(
+        config={
+            "credentials": {
+                "auth_type": "Service",
+                "developer_token": "x",
+                "service_account_info": "not-json",
+                "impersonated_email": "u@example.com",
+            }
+        },
+        parameters={},
+    )
+
+    with pytest.raises(AirbyteTracedException) as exc_info:
+        _ = authenticator.token
+
+    assert "service_account_info" in exc_info.value.message
+
+
+def test_service_account_authenticator_rejects_non_object_json():
+    authenticator = GoogleAdsServiceAccountAuthenticator(
+        config={
+            "credentials": {
+                "auth_type": "Service",
+                "developer_token": "x",
+                "service_account_info": "[]",
+            }
+        },
+        parameters={},
+    )
+
+    with pytest.raises(AirbyteTracedException) as exc_info:
+        _ = authenticator.token
+
+    assert "JSON object" in exc_info.value.message

--- a/airbyte-integrations/connectors/source-google-ads/unit_tests/test_components.py
+++ b/airbyte-integrations/connectors/source-google-ads/unit_tests/test_components.py
@@ -835,9 +835,9 @@ def test_custom_retriever_streams_have_expected_date_format(stream_name, datetim
 def test_default_streams_use_streaming_decoder_in_extractor(stream_name, retriever):
     extractor = retriever.record_selector.extractor
     assert isinstance(extractor, DpathExtractor), f"Stream {stream_name}: expected DpathExtractor, got {type(extractor).__name__}"
-    assert isinstance(extractor.decoder, GoogleAdsStreamingDecoder), (
-        f"Stream {stream_name}: expected GoogleAdsStreamingDecoder on extractor, got {type(extractor.decoder).__name__}"
-    )
+    assert isinstance(
+        extractor.decoder, GoogleAdsStreamingDecoder
+    ), f"Stream {stream_name}: expected GoogleAdsStreamingDecoder on extractor, got {type(extractor.decoder).__name__}"
 
 
 @pytest.mark.parametrize(
@@ -851,9 +851,9 @@ def test_default_streams_use_streaming_decoder_in_extractor(stream_name, retriev
 def test_dynamic_streams_use_streaming_decoder_in_extractor(stream_name, retriever):
     extractor = retriever.record_selector.extractor
     assert isinstance(extractor, DpathExtractor), f"Dynamic stream {stream_name}: expected DpathExtractor, got {type(extractor).__name__}"
-    assert isinstance(extractor.decoder, GoogleAdsStreamingDecoder), (
-        f"Dynamic stream {stream_name}: expected GoogleAdsStreamingDecoder on extractor, got {type(extractor.decoder).__name__}"
-    )
+    assert isinstance(
+        extractor.decoder, GoogleAdsStreamingDecoder
+    ), f"Dynamic stream {stream_name}: expected GoogleAdsStreamingDecoder on extractor, got {type(extractor.decoder).__name__}"
 
 
 class TestSerializeMessageFieldsTransformation:
@@ -1113,9 +1113,9 @@ def test_every_stream_has_timeout_adapter_mounted(stream_name, retriever):
     requester = retriever.requester
     session = requester._http_client._session
     adapter = session.adapters.get("https://")
-    assert isinstance(adapter, TimeoutHTTPAdapter), (
-        f"Stream {stream_name}: expected TimeoutHTTPAdapter on `https://`, got {type(adapter).__name__}"
-    )
+    assert isinstance(
+        adapter, TimeoutHTTPAdapter
+    ), f"Stream {stream_name}: expected TimeoutHTTPAdapter on `https://`, got {type(adapter).__name__}"
 
 
 @pytest.mark.parametrize(
@@ -1127,9 +1127,9 @@ def test_dynamic_streams_have_timeout_adapter_mounted(stream_name, retriever):
     requester = retriever.requester
     session = requester._http_client._session
     adapter = session.adapters.get("https://")
-    assert isinstance(adapter, TimeoutHTTPAdapter), (
-        f"Dynamic stream {stream_name}: expected TimeoutHTTPAdapter on `https://`, got {type(adapter).__name__}"
-    )
+    assert isinstance(
+        adapter, TimeoutHTTPAdapter
+    ), f"Dynamic stream {stream_name}: expected TimeoutHTTPAdapter on `https://`, got {type(adapter).__name__}"
 
 
 _SERVICE_ACCOUNT_KEY_DICT = {

--- a/airbyte-integrations/connectors/source-google-ads/unit_tests/test_components.py
+++ b/airbyte-integrations/connectors/source-google-ads/unit_tests/test_components.py
@@ -8,6 +8,7 @@ from typing import List
 from unittest.mock import MagicMock, patch
 
 import pytest
+from google.auth import exceptions as google_auth_exceptions
 from requests.exceptions import ChunkedEncodingError, StreamConsumedError
 from source_google_ads.components import (
     ClickViewHttpRequester,
@@ -22,6 +23,7 @@ from source_google_ads.components import (
 )
 
 from airbyte_cdk import AirbyteTracedException
+from airbyte_cdk.models import FailureType
 from airbyte_cdk.sources.declarative.extractors.dpath_extractor import DpathExtractor
 from airbyte_cdk.sources.declarative.partition_routers.substream_partition_router import SubstreamPartitionRouter
 from airbyte_cdk.sources.declarative.retrievers import SimpleRetriever
@@ -1173,7 +1175,7 @@ _SERVICE_ACCOUNT_KEY_DICT = {
 }
 
 
-@patch("source_google_ads.components.service_account.Credentials")
+@patch("source_google_ads.google_ads.service_account.Credentials")
 def test_service_account_authenticator_emits_bearer_token_with_subject(mock_credentials_cls):
     delegated = MagicMock()
     delegated.valid = False
@@ -1204,7 +1206,7 @@ def test_service_account_authenticator_emits_bearer_token_with_subject(mock_cred
     delegated.refresh.assert_called_once()
 
 
-@patch("source_google_ads.components.service_account.Credentials")
+@patch("source_google_ads.google_ads.service_account.Credentials")
 def test_service_account_authenticator_skips_subject_when_not_configured(mock_credentials_cls):
     credentials = MagicMock()
     credentials.valid = True
@@ -1274,3 +1276,44 @@ def test_service_account_authenticator_rejects_non_object_json():
         _ = authenticator.token
 
     assert "JSON object" in exc_info.value.message
+
+
+@patch("source_google_ads.google_ads.service_account.Credentials")
+def test_service_account_authenticator_reports_refresh_failure_as_config_error(mock_credentials_cls):
+    """A rejected key or missing delegation is a config problem, not a system failure."""
+    credentials = MagicMock()
+    credentials.valid = False
+    credentials.refresh.side_effect = google_auth_exceptions.RefreshError("unauthorized_client")
+    mock_credentials_cls.from_service_account_info.return_value = credentials
+
+    authenticator = GoogleAdsServiceAccountAuthenticator(
+        config={
+            "credentials": {
+                "auth_type": "Service",
+                "developer_token": "x",
+                "service_account_info": _SERVICE_ACCOUNT_KEY_DICT,
+            }
+        },
+        parameters={},
+    )
+
+    with pytest.raises(AirbyteTracedException) as exc_info:
+        _ = authenticator.token
+
+    assert exc_info.value.failure_type == FailureType.config_error
+
+
+@patch("source_google_ads.google_ads.service_account.Credentials")
+def test_service_account_authenticator_rejects_unusable_key_material(mock_credentials_cls):
+    """`from_service_account_info` raises ValueError for an incomplete key; classify it."""
+    mock_credentials_cls.from_service_account_info.side_effect = ValueError("No key could be detected.")
+
+    authenticator = GoogleAdsServiceAccountAuthenticator(
+        config={"credentials": {"auth_type": "Service", "developer_token": "x", "service_account_info": '{"type": "service_account"}'}},
+        parameters={},
+    )
+
+    with pytest.raises(AirbyteTracedException) as exc_info:
+        _ = authenticator.token
+
+    assert exc_info.value.failure_type == FailureType.config_error

--- a/airbyte-integrations/connectors/source-google-ads/unit_tests/test_components.py
+++ b/airbyte-integrations/connectors/source-google-ads/unit_tests/test_components.py
@@ -15,6 +15,7 @@ from source_google_ads.components import (
     CustomGAQuerySchemaLoader,
     FlattenNestedDictsTransformation,
     GoogleAdsRetriever,
+    GoogleAdsServiceAccountAuthenticator,
     GoogleAdsStreamingDecoder,
     SerializeMessageFieldsTransformation,
     TimeoutHTTPAdapter,
@@ -1158,3 +1159,118 @@ def test_dynamic_streams_have_timeout_adapter_mounted(stream_name, retriever):
     assert isinstance(
         adapter, TimeoutHTTPAdapter
     ), f"Dynamic stream {stream_name}: expected TimeoutHTTPAdapter on `https://`, got {type(adapter).__name__}"
+
+
+_SERVICE_ACCOUNT_KEY_DICT = {
+    "type": "service_account",
+    "project_id": "test-project",
+    "private_key_id": "key-id",
+    "private_key": "-----BEGIN PRIVATE KEY-----\nfake\n-----END PRIVATE KEY-----\n",
+    "client_email": "sa@test-project.iam.gserviceaccount.com",
+    "client_id": "1234567890",
+    "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+    "token_uri": "https://oauth2.googleapis.com/token",
+}
+
+
+@patch("source_google_ads.components.service_account.Credentials")
+def test_service_account_authenticator_emits_bearer_token_with_subject(mock_credentials_cls):
+    delegated = MagicMock()
+    delegated.valid = False
+    delegated.token = "ya29.test"
+
+    base = MagicMock()
+    base.with_subject.return_value = delegated
+    mock_credentials_cls.from_service_account_info.return_value = base
+
+    authenticator = GoogleAdsServiceAccountAuthenticator(
+        config={
+            "credentials": {
+                "auth_type": "Service",
+                "developer_token": "developer_token",
+                "service_account_info": json.dumps(_SERVICE_ACCOUNT_KEY_DICT),
+                "impersonated_email": "user@example.com",
+            }
+        },
+        parameters={},
+    )
+
+    assert authenticator.auth_header == "Authorization"
+    assert authenticator.token == "Bearer ya29.test"
+    mock_credentials_cls.from_service_account_info.assert_called_once_with(
+        _SERVICE_ACCOUNT_KEY_DICT, scopes=["https://www.googleapis.com/auth/adwords"]
+    )
+    base.with_subject.assert_called_once_with("user@example.com")
+    delegated.refresh.assert_called_once()
+
+
+@patch("source_google_ads.components.service_account.Credentials")
+def test_service_account_authenticator_skips_subject_when_not_configured(mock_credentials_cls):
+    credentials = MagicMock()
+    credentials.valid = True
+    credentials.token = "ya29.direct"
+    mock_credentials_cls.from_service_account_info.return_value = credentials
+
+    authenticator = GoogleAdsServiceAccountAuthenticator(
+        config={
+            "credentials": {
+                "auth_type": "Service",
+                "developer_token": "developer_token",
+                "service_account_info": _SERVICE_ACCOUNT_KEY_DICT,
+            }
+        },
+        parameters={},
+    )
+
+    assert authenticator.token == "Bearer ya29.direct"
+    credentials.with_subject.assert_not_called()
+    credentials.refresh.assert_not_called()
+
+
+def test_service_account_authenticator_rejects_missing_info():
+    authenticator = GoogleAdsServiceAccountAuthenticator(
+        config={"credentials": {"auth_type": "Service", "developer_token": "x", "impersonated_email": "u@example.com"}},
+        parameters={},
+    )
+
+    with pytest.raises(AirbyteTracedException) as exc_info:
+        _ = authenticator.token
+
+    assert "service_account_info" in exc_info.value.message
+
+
+def test_service_account_authenticator_rejects_invalid_json():
+    authenticator = GoogleAdsServiceAccountAuthenticator(
+        config={
+            "credentials": {
+                "auth_type": "Service",
+                "developer_token": "x",
+                "service_account_info": "not-json",
+                "impersonated_email": "u@example.com",
+            }
+        },
+        parameters={},
+    )
+
+    with pytest.raises(AirbyteTracedException) as exc_info:
+        _ = authenticator.token
+
+    assert "service_account_info" in exc_info.value.message
+
+
+def test_service_account_authenticator_rejects_non_object_json():
+    authenticator = GoogleAdsServiceAccountAuthenticator(
+        config={
+            "credentials": {
+                "auth_type": "Service",
+                "developer_token": "x",
+                "service_account_info": "[]",
+            }
+        },
+        parameters={},
+    )
+
+    with pytest.raises(AirbyteTracedException) as exc_info:
+        _ = authenticator.token
+
+    assert "JSON object" in exc_info.value.message

--- a/airbyte-integrations/connectors/source-google-ads/unit_tests/test_config_migrations.py
+++ b/airbyte-integrations/connectors/source-google-ads/unit_tests/test_config_migrations.py
@@ -6,7 +6,7 @@
 import json
 from typing import Any, Mapping
 
-from source_google_ads.config_migrations import MigrateCustomQuery
+from source_google_ads.config_migrations import MigrateAuthType, MigrateCustomQuery
 from source_google_ads.source import SourceGoogleAds
 
 from airbyte_cdk.models import OrchestratorType, Type
@@ -80,3 +80,79 @@ def test_should_not_migrate_new_config():
     new_config = load_config(NEW_TEST_CONFIG_PATH)
     migration_instance = MigrateCustomQuery()
     assert not migration_instance.should_migrate(new_config)
+
+
+def test_migrate_auth_type_adds_client_marker_for_legacy_oauth_config():
+    legacy_config = {
+        "credentials": {
+            "developer_token": "dev",
+            "client_id": "client",
+            "client_secret": "secret",
+            "refresh_token": "refresh",
+        }
+    }
+
+    assert MigrateAuthType.should_migrate(legacy_config)
+    migrated = MigrateAuthType.update_config(legacy_config)
+    assert migrated["credentials"]["auth_type"] == "Client"
+
+
+def test_migrate_auth_type_skips_already_migrated_configs():
+    oauth_config = {
+        "credentials": {
+            "auth_type": "Client",
+            "developer_token": "dev",
+            "client_id": "client",
+            "client_secret": "secret",
+            "refresh_token": "refresh",
+        }
+    }
+    service_config = {
+        "credentials": {
+            "auth_type": "Service",
+            "developer_token": "dev",
+            "service_account_info": "{}",
+            "impersonated_email": "user@example.com",
+        }
+    }
+
+    assert not MigrateAuthType.should_migrate(oauth_config)
+    assert not MigrateAuthType.should_migrate(service_config)
+
+
+def test_migrate_auth_type_skips_configs_without_credentials():
+    assert not MigrateAuthType.should_migrate({})
+
+
+def test_source_init_backfills_auth_type_for_legacy_in_memory_config():
+    legacy_config = {
+        "credentials": {
+            "developer_token": "dev",
+            "client_id": "client",
+            "client_secret": "secret",
+            "refresh_token": "refresh",
+        },
+        "customer_id": "1234567890",
+        "start_date": "2021-01-01",
+    }
+
+    source = SourceGoogleAds(catalog=None, config=legacy_config, state=None)
+
+    assert source._config["credentials"]["auth_type"] == "Client"
+
+
+def test_legacy_oauth_config_can_build_streams_after_in_memory_backfill():
+    legacy_config = {
+        "credentials": {
+            "developer_token": "dev",
+            "client_id": "client",
+            "client_secret": "secret",
+            "refresh_token": "refresh",
+        },
+        "customer_id": "1234567890",
+        "start_date": "2021-01-01",
+    }
+
+    source = SourceGoogleAds(catalog=None, config=legacy_config, state=None)
+
+    assert source.streams(config=legacy_config)

--- a/airbyte-integrations/connectors/source-google-ads/unit_tests/test_config_migrations.py
+++ b/airbyte-integrations/connectors/source-google-ads/unit_tests/test_config_migrations.py
@@ -4,8 +4,11 @@
 
 
 import json
+import logging
 from typing import Any, Mapping
+from unittest.mock import patch
 
+import pytest
 from source_google_ads.config_migrations import MigrateAuthType, MigrateCustomQuery
 from source_google_ads.source import SourceGoogleAds
 
@@ -141,8 +144,9 @@ def test_source_init_backfills_auth_type_for_legacy_in_memory_config():
     assert source._config["credentials"]["auth_type"] == "Client"
 
 
-def test_legacy_oauth_config_can_build_streams_after_in_memory_backfill():
-    legacy_config = {
+def _legacy_oauth_config():
+    """An on-disk config from before the OAuth / Service Account `oneOf` split: no `auth_type`."""
+    return {
         "credentials": {
             "developer_token": "dev",
             "client_id": "client",
@@ -153,6 +157,29 @@ def test_legacy_oauth_config_can_build_streams_after_in_memory_backfill():
         "start_date": "2021-01-01",
     }
 
-    source = SourceGoogleAds(catalog=None, config=legacy_config, state=None)
 
+def test_legacy_oauth_config_can_discover_after_in_memory_backfill():
+    legacy_config = _legacy_oauth_config()
+
+    source = SourceGoogleAds(catalog=None, config=legacy_config, state=None)
+    catalog = source.discover(logging.getLogger("airbyte"), legacy_config)
+
+    assert catalog.streams
     assert source.streams(config=legacy_config)
+    # The caller's config is left alone; only the source's own copy is backfilled.
+    assert "auth_type" not in legacy_config["credentials"]
+
+
+def test_legacy_oauth_config_fails_discover_without_the_in_memory_backfill():
+    """Negative control for the test above.
+
+    The manifest resolves auth through a `SelectiveAuthenticator` keyed on
+    `credentials.auth_type`, and the CDK raises when that path is absent. Without
+    `_backfill_auth_type`, every legacy OAuth config breaks on DISCOVER - the regression that
+    sank the first attempt at this feature. This test fails if the backfill is ever dropped.
+    """
+    with patch.object(SourceGoogleAds, "_backfill_auth_type", staticmethod(lambda config: config)):
+        source = SourceGoogleAds(catalog=None, config=_legacy_oauth_config(), state=None)
+
+        with pytest.raises(ValueError, match="authenticator_selection_path"):
+            source.discover(logging.getLogger("airbyte"), _legacy_oauth_config())

--- a/airbyte-integrations/connectors/source-google-ads/unit_tests/test_google_ads.py
+++ b/airbyte-integrations/connectors/source-google-ads/unit_tests/test_google_ads.py
@@ -4,6 +4,9 @@
 
 
 import json
+import os
+import stat
+from copy import deepcopy
 from datetime import date
 
 import pendulum
@@ -56,11 +59,119 @@ EXPECTED_CRED = {
     "use_proto_plus": True,
 }
 
+SERVICE_ACCOUNT_KEY_DICT = {
+    "type": "service_account",
+    "project_id": "test-project",
+    "private_key_id": "key-id",
+    "private_key": "-----BEGIN PRIVATE KEY-----\nfake\n-----END PRIVATE KEY-----\n",
+    "client_email": "sa@test-project.iam.gserviceaccount.com",
+    "client_id": "1234567890",
+    "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+    "token_uri": "https://oauth2.googleapis.com/token",
+}
+
+SAMPLE_SERVICE_ACCOUNT_CONFIG = {
+    "credentials": {
+        "auth_type": "Service",
+        "developer_token": "developer_token",
+        "service_account_info": json.dumps(SERVICE_ACCOUNT_KEY_DICT),
+        "impersonated_email": "user@example.com",
+    }
+}
+
 
 def test_google_ads_init(mocker):
     google_client_mocker = mocker.patch("source_google_ads.google_ads.GoogleAdsClient", return_value=MockGoogleAdsClient)
     _ = GoogleAds(**SAMPLE_CONFIG)
     assert google_client_mocker.load_from_dict.call_args[0][0] == EXPECTED_CRED
+
+
+def test_google_ads_init_with_service_account_credentials(mocker):
+    google_client_mocker = mocker.patch("source_google_ads.google_ads.GoogleAdsClient", return_value=MockGoogleAdsClient)
+    cleanup_register = mocker.patch("source_google_ads.google_ads.atexit.register")
+
+    _ = GoogleAds(**deepcopy(SAMPLE_SERVICE_ACCOUNT_CONFIG))
+
+    sdk_credentials = google_client_mocker.load_from_dict.call_args[0][0]
+    assert "auth_type" not in sdk_credentials
+    assert "service_account_info" not in sdk_credentials
+    assert sdk_credentials["developer_token"] == "developer_token"
+    assert sdk_credentials["impersonated_email"] == "user@example.com"
+    assert sdk_credentials["use_proto_plus"] is True
+
+    json_key_file_path = sdk_credentials["json_key_file_path"]
+    try:
+        with open(json_key_file_path) as key_file:
+            assert json.load(key_file) == SERVICE_ACCOUNT_KEY_DICT
+        assert stat.S_IMODE(os.stat(json_key_file_path).st_mode) == 0o600
+        cleanup_register.assert_called_once()
+        assert cleanup_register.call_args.args[1] == json_key_file_path
+    finally:
+        os.remove(json_key_file_path)
+
+
+def test_service_account_credentials_temp_file_reused_across_clients(mocker):
+    google_client_mocker = mocker.patch("source_google_ads.google_ads.GoogleAdsClient", return_value=MockGoogleAdsClient)
+
+    google_ads_client = GoogleAds(**deepcopy(SAMPLE_SERVICE_ACCOUNT_CONFIG))
+    first_key_file = google_client_mocker.load_from_dict.call_args[0][0]["json_key_file_path"]
+    google_ads_client.get_client("9999999999")
+    second_key_file = google_client_mocker.load_from_dict.call_args[0][0]["json_key_file_path"]
+
+    try:
+        assert first_key_file == second_key_file
+    finally:
+        os.remove(first_key_file)
+
+
+def test_service_account_credentials_invalid_json_raises_config_error(mocker):
+    mocker.patch("source_google_ads.google_ads.GoogleAdsClient", return_value=MockGoogleAdsClient)
+
+    with pytest.raises(AirbyteTracedException) as exc_info:
+        GoogleAds(
+            credentials={
+                "auth_type": "Service",
+                "developer_token": "developer_token",
+                "service_account_info": "not json",
+                "impersonated_email": "user@example.com",
+            }
+        )
+
+    assert exc_info.value.failure_type == FailureType.config_error
+    assert "service_account_info" in exc_info.value.message
+
+
+def test_service_account_credentials_non_object_json_raises_config_error(mocker):
+    mocker.patch("source_google_ads.google_ads.GoogleAdsClient", return_value=MockGoogleAdsClient)
+
+    with pytest.raises(AirbyteTracedException) as exc_info:
+        GoogleAds(
+            credentials={
+                "auth_type": "Service",
+                "developer_token": "developer_token",
+                "service_account_info": "[]",
+                "impersonated_email": "user@example.com",
+            }
+        )
+
+    assert exc_info.value.failure_type == FailureType.config_error
+    assert "service_account_info" in exc_info.value.message
+
+
+def test_service_account_credentials_missing_info_raises_config_error(mocker):
+    mocker.patch("source_google_ads.google_ads.GoogleAdsClient", return_value=MockGoogleAdsClient)
+
+    with pytest.raises(AirbyteTracedException) as exc_info:
+        GoogleAds(
+            credentials={
+                "auth_type": "Service",
+                "developer_token": "developer_token",
+                "impersonated_email": "user@example.com",
+            }
+        )
+
+    assert exc_info.value.failure_type == FailureType.config_error
+    assert "service_account_info" in exc_info.value.message
 
 
 def test_google_ads_wrong_permissions(mocker):

--- a/airbyte-integrations/connectors/source-google-ads/unit_tests/test_google_ads.py
+++ b/airbyte-integrations/connectors/source-google-ads/unit_tests/test_google_ads.py
@@ -4,8 +4,6 @@
 
 
 import json
-import os
-import stat
 from copy import deepcopy
 from datetime import date
 
@@ -87,41 +85,45 @@ def test_google_ads_init(mocker):
 
 
 def test_google_ads_init_with_service_account_credentials(mocker):
-    google_client_mocker = mocker.patch("source_google_ads.google_ads.GoogleAdsClient", return_value=MockGoogleAdsClient)
-    cleanup_register = mocker.patch("source_google_ads.google_ads.atexit.register")
+    """The service account key is handed to the SDK in memory - never written to disk."""
+    google_client_mocker = mocker.patch("source_google_ads.google_ads.GoogleAdsClient")
+    service_account_mocker = mocker.patch("source_google_ads.google_ads.service_account.Credentials")
+    delegated = service_account_mocker.from_service_account_info.return_value.with_subject.return_value
 
     _ = GoogleAds(**deepcopy(SAMPLE_SERVICE_ACCOUNT_CONFIG))
 
-    sdk_credentials = google_client_mocker.load_from_dict.call_args[0][0]
-    assert "auth_type" not in sdk_credentials
-    assert "service_account_info" not in sdk_credentials
-    assert sdk_credentials["developer_token"] == "developer_token"
-    assert sdk_credentials["impersonated_email"] == "user@example.com"
-    assert sdk_credentials["use_proto_plus"] is True
+    # No `load_from_dict`, so no `json_key_file_path` and no temp file to leak.
+    google_client_mocker.load_from_dict.assert_not_called()
+    service_account_mocker.from_service_account_info.assert_called_once_with(
+        SERVICE_ACCOUNT_KEY_DICT, scopes=["https://www.googleapis.com/auth/adwords"]
+    )
+    service_account_mocker.from_service_account_info.return_value.with_subject.assert_called_once_with("user@example.com")
+    delegated.refresh.assert_called_once()
 
-    json_key_file_path = sdk_credentials["json_key_file_path"]
-    try:
-        with open(json_key_file_path) as key_file:
-            assert json.load(key_file) == SERVICE_ACCOUNT_KEY_DICT
-        assert stat.S_IMODE(os.stat(json_key_file_path).st_mode) == 0o600
-        cleanup_register.assert_called_once()
-        assert cleanup_register.call_args.args[1] == json_key_file_path
-    finally:
-        os.remove(json_key_file_path)
+    kwargs = google_client_mocker.call_args.kwargs
+    assert kwargs["credentials"] is delegated
+    assert kwargs["developer_token"] == "developer_token"
+    assert kwargs["use_proto_plus"] is True
+    assert kwargs["login_customer_id"] is None
 
 
-def test_service_account_credentials_temp_file_reused_across_clients(mocker):
-    google_client_mocker = mocker.patch("source_google_ads.google_ads.GoogleAdsClient", return_value=MockGoogleAdsClient)
+def test_service_account_credentials_are_not_mutated_or_persisted(mocker):
+    """Building the SDK client must not rewrite the live config.
 
-    google_ads_client = GoogleAds(**deepcopy(SAMPLE_SERVICE_ACCOUNT_CONFIG))
-    first_key_file = google_client_mocker.load_from_dict.call_args[0][0]["json_key_file_path"]
+    `components.GoogleAdsServiceAccountAuthenticator` reads `credentials.service_account_info`
+    lazily from the same config mapping, so dropping the key here would break the declarative
+    HTTP auth path for any config that also uses custom GAQL queries.
+    """
+    google_client_mocker = mocker.patch("source_google_ads.google_ads.GoogleAdsClient")
+    mocker.patch("source_google_ads.google_ads.service_account.Credentials")
+    config = deepcopy(SAMPLE_SERVICE_ACCOUNT_CONFIG)
+
+    google_ads_client = GoogleAds(**config)
     google_ads_client.get_client("9999999999")
-    second_key_file = google_client_mocker.load_from_dict.call_args[0][0]["json_key_file_path"]
 
-    try:
-        assert first_key_file == second_key_file
-    finally:
-        os.remove(first_key_file)
+    assert config["credentials"]["service_account_info"] == json.dumps(SERVICE_ACCOUNT_KEY_DICT)
+    assert "json_key_file_path" not in config["credentials"]
+    assert google_client_mocker.call_args.kwargs["login_customer_id"] == "9999999999"
 
 
 def test_service_account_credentials_invalid_json_raises_config_error(mocker):

--- a/docs/integrations/sources/google-ads.md
+++ b/docs/integrations/sources/google-ads.md
@@ -12,7 +12,7 @@ This page contains the setup guide and reference information for the [Google Ads
 <!-- env:oss -->
 - (For Airbyte Open Source):
   - A Developer Token
-  - OAuth credentials to authenticate your Google account
+  - OAuth credentials or a service account key to authenticate your Google account
   <!-- /env:oss -->
 
 ## Setup guide
@@ -39,9 +39,11 @@ To set up the Google Ads source connector with Airbyte Open Source, you will nee
 You will _not_ be able to access your data via the Google Ads API until this token is approved. You cannot use a test developer token; it has to be at least a basic developer token. The approval process typically takes around 24 hours.
 :::
 
-#### Step 2: (For Airbyte Open Source) Obtain your OAuth credentials
+#### Step 2: (For Airbyte Open Source) Choose an authentication method
 
-If you are using Airbyte Open Source, you will need to obtain the following OAuth credentials to authenticate your Google Ads account:
+If you are using Airbyte Open Source, you can authenticate with either OAuth credentials or a service account key.
+
+To use OAuth, obtain the following credentials:
 
 - Client ID
 - Client Secret
@@ -54,6 +56,8 @@ A single access token can grant varying degrees of access to multiple APIs. A va
 The scope for the Google Ads API is: https://www.googleapis.com/auth/adwords
 
 Each Google Ads API developer token is assigned an access level and "permissible use". The access level determines whether you can affect production accounts and the number of operations and requests that you can execute daily. Permissible use determines the specific Google Ads API features that the developer token is allowed to use. Read more about it and apply for higher access [here](https://developers.google.com/google-ads/api/docs/access-levels#access_levels_2).
+
+To use a service account, create a Google Cloud service account and download its JSON key file. Paste the full JSON key into **Service Account Info**. If your Google Ads account requires domain-wide delegation, enter the delegated user email in **Impersonated Email**. The connector uses the Google Ads API scope `https://www.googleapis.com/auth/adwords`.
 
 ### Step 3: Set up the Google Ads connector in Airbyte
 
@@ -133,7 +137,7 @@ If you are accessing your account through a Google Ads Manager account, you must
 3. Find and select **Google Ads** from the list of available sources.
 4. Enter a **Source name** of your choosing.
 5. Enter the **Developer Token** you obtained from Google.
-6. To authenticate your Google account, enter your Google application's **Client ID**, **Client Secret**, **Refresh Token**, and optionally, the **Access Token**.
+6. Select **OAuth Credentials** or **Service Account Key Authentication**. For OAuth, enter your Google application's **Client ID**, **Client Secret**, **Refresh Token**, and optionally, the **Access Token**. For service account authentication, paste the full service account JSON key into **Service Account Info** and optionally enter an **Impersonated Email**.
 7. (Optional) Enter a comma-separated list of the **Customer ID(s)** for your account. These IDs are 10-digit numbers that uniquely identify your account. To find your Customer ID, please follow [Google's instructions](https://support.google.com/google-ads/answer/1704344). Leaving this field blank will replicate data from all connected accounts.
 8. (Optional) Enter customer statuses to filter customers. Leaving this field blank will replicate data from all accounts. Check [Google Ads documentation](https://developers.google.com/google-ads/api/reference/rpc/v23/CustomerStatusEnum.CustomerStatus) for more info.
 9. (Optional) Enter a **Start Date** using the provided datepicker, or by programmatically entering the date in YYYY-MM-DD format. The data added on and after this date will be replicated. (Default start date is 2 years ago)
@@ -396,6 +400,7 @@ Due to a limitation in the Google Ads API which does not allow getting performan
 
 | Version     | Date       | Pull Request                                             | Subject                                                                                                                                                                |
 |:------------|:-----------|:---------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 6.2.0-rc.1 | 2026-08-28 | [80305](https://github.com/airbytehq/airbyte/pull/80305) | Add service account key authentication. |
 | 6.1.1 | 2026-08-25 | [85023](https://github.com/airbytehq/airbyte/pull/85023) | Fixed multi-byte UTF-8 characters being corrupted at chunk boundaries in large streamed responses. |
 | 6.1.0 | 2026-07-06 | [80952](https://github.com/airbytehq/airbyte/pull/80952) | Add `ad_performance` and `geo_performance` streams. |
 | 6.0.0 | 2026-05-29 | [78504](https://github.com/airbytehq/airbyte/pull/78504) | Clamp incremental report dates to Google Ads' 37-month granular data retention window. |

--- a/docs/integrations/sources/google-ads.md
+++ b/docs/integrations/sources/google-ads.md
@@ -57,7 +57,15 @@ The scope for the Google Ads API is: https://www.googleapis.com/auth/adwords
 
 Each Google Ads API developer token is assigned an access level and "permissible use". The access level determines whether you can affect production accounts and the number of operations and requests that you can execute daily. Permissible use determines the specific Google Ads API features that the developer token is allowed to use. Read more about it and apply for higher access [here](https://developers.google.com/google-ads/api/docs/access-levels#access_levels_2).
 
-To use a service account, create a Google Cloud service account and download its JSON key file. Paste the full JSON key into **Service Account Info**. If your Google Ads account requires domain-wide delegation, enter the delegated user email in **Impersonated Email**. The connector uses the Google Ads API scope `https://www.googleapis.com/auth/adwords`.
+To use a service account instead:
+
+1. Create a Google Cloud service account and download its JSON key file. See [Google's service account guide](https://developers.google.com/google-ads/api/docs/oauth/service-accounts) for details.
+2. Grant the service account access to your Google Ads account. Either:
+   - **Direct access (recommended)**: sign in to Google Ads as an administrator, go to **Admin > Access and security**, and add the service account email (`name@project.iam.gserviceaccount.com`) as a user. Leave **Impersonated Email** blank.
+   - **Domain-wide delegation**: if you use a Google Workspace domain and prefer to act on behalf of an existing Google Ads user, [delegate domain-wide authority](https://developers.google.com/identity/protocols/oauth2/service-account#delegatingauthority) to the service account for the `https://www.googleapis.com/auth/adwords` scope, then enter that user's address in **Impersonated Email**.
+3. Paste the full JSON key into **Service Account JSON Key**.
+
+A Developer Token is still required for service account authentication, exactly as it is for OAuth. The connector requests the Google Ads API scope `https://www.googleapis.com/auth/adwords`.
 
 ### Step 3: Set up the Google Ads connector in Airbyte
 
@@ -136,8 +144,8 @@ If you are accessing your account through a Google Ads Manager account, you must
 2. In the left navigation bar, click **Sources**. In the top-right corner, click **+ New source**.
 3. Find and select **Google Ads** from the list of available sources.
 4. Enter a **Source name** of your choosing.
-5. Enter the **Developer Token** you obtained from Google.
-6. Select **OAuth Credentials** or **Service Account Key Authentication**. For OAuth, enter your Google application's **Client ID**, **Client Secret**, **Refresh Token**, and optionally, the **Access Token**. For service account authentication, paste the full service account JSON key into **Service Account Info** and optionally enter an **Impersonated Email**.
+5. Select **OAuth Credentials** or **Service Account Key Authentication**.
+6. Enter the **Developer Token** you obtained from Google. Then, for OAuth, enter your Google application's **Client ID**, **Client Secret**, **Refresh Token**, and optionally, the **Access Token**. For service account authentication, paste the full service account JSON key into **Service Account JSON Key**, and enter an **Impersonated Email** only if you are using domain-wide delegation.
 7. (Optional) Enter a comma-separated list of the **Customer ID(s)** for your account. These IDs are 10-digit numbers that uniquely identify your account. To find your Customer ID, please follow [Google's instructions](https://support.google.com/google-ads/answer/1704344). Leaving this field blank will replicate data from all connected accounts.
 8. (Optional) Enter customer statuses to filter customers. Leaving this field blank will replicate data from all accounts. Check [Google Ads documentation](https://developers.google.com/google-ads/api/reference/rpc/v23/CustomerStatusEnum.CustomerStatus) for more info.
 9. (Optional) Enter a **Start Date** using the provided datepicker, or by programmatically entering the date in YYYY-MM-DD format. The data added on and after this date will be replicated. (Default start date is 2 years ago)

--- a/docs/integrations/sources/google-ads.md
+++ b/docs/integrations/sources/google-ads.md
@@ -12,7 +12,7 @@ This page contains the setup guide and reference information for the [Google Ads
 <!-- env:oss -->
 - (For Airbyte Open Source):
   - A Developer Token
-  - OAuth credentials to authenticate your Google account
+  - OAuth credentials or a service account key to authenticate your Google account
   <!-- /env:oss -->
 
 ## Setup guide
@@ -39,9 +39,11 @@ To set up the Google Ads source connector with Airbyte Open Source, you will nee
 You will _not_ be able to access your data via the Google Ads API until this token is approved. You cannot use a test developer token; it has to be at least a basic developer token. The approval process typically takes around 24 hours.
 :::
 
-#### Step 2: (For Airbyte Open Source) Obtain your OAuth credentials
+#### Step 2: (For Airbyte Open Source) Choose an authentication method
 
-If you are using Airbyte Open Source, you will need to obtain the following OAuth credentials to authenticate your Google Ads account:
+If you are using Airbyte Open Source, you can authenticate with either OAuth credentials or a service account key.
+
+To use OAuth, obtain the following credentials:
 
 - Client ID
 - Client Secret
@@ -54,6 +56,8 @@ A single access token can grant varying degrees of access to multiple APIs. A va
 The scope for the Google Ads API is: https://www.googleapis.com/auth/adwords
 
 Each Google Ads API developer token is assigned an access level and "permissible use". The access level determines whether you can affect production accounts and the number of operations and requests that you can execute daily. Permissible use determines the specific Google Ads API features that the developer token is allowed to use. Read more about it and apply for higher access [here](https://developers.google.com/google-ads/api/docs/access-levels#access_levels_2).
+
+To use a service account, create a Google Cloud service account and download its JSON key file. Paste the full JSON key into **Service Account Info**. If your Google Ads account requires domain-wide delegation, enter the delegated user email in **Impersonated Email**. The connector uses the Google Ads API scope `https://www.googleapis.com/auth/adwords`.
 
 ### Step 3: Set up the Google Ads connector in Airbyte
 
@@ -133,7 +137,7 @@ If you are accessing your account through a Google Ads Manager account, you must
 3. Find and select **Google Ads** from the list of available sources.
 4. Enter a **Source name** of your choosing.
 5. Enter the **Developer Token** you obtained from Google.
-6. To authenticate your Google account, enter your Google application's **Client ID**, **Client Secret**, **Refresh Token**, and optionally, the **Access Token**.
+6. Select **OAuth Credentials** or **Service Account Key Authentication**. For OAuth, enter your Google application's **Client ID**, **Client Secret**, **Refresh Token**, and optionally, the **Access Token**. For service account authentication, paste the full service account JSON key into **Service Account Info** and optionally enter an **Impersonated Email**.
 7. (Optional) Enter a comma-separated list of the **Customer ID(s)** for your account. These IDs are 10-digit numbers that uniquely identify your account. To find your Customer ID, please follow [Google's instructions](https://support.google.com/google-ads/answer/1704344). Leaving this field blank will replicate data from all connected accounts.
 8. (Optional) Enter customer statuses to filter customers. Leaving this field blank will replicate data from all accounts. Check [Google Ads documentation](https://developers.google.com/google-ads/api/reference/rpc/v23/CustomerStatusEnum.CustomerStatus) for more info.
 9. (Optional) Enter a **Start Date** using the provided datepicker, or by programmatically entering the date in YYYY-MM-DD format. The data added on and after this date will be replicated. (Default start date is 2 years ago)
@@ -396,6 +400,7 @@ Due to a limitation in the Google Ads API which does not allow getting performan
 
 | Version     | Date       | Pull Request                                             | Subject                                                                                                                                                                |
 |:------------|:-----------|:---------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 6.2.0 | 2026-08-06 | [80305](https://github.com/airbytehq/airbyte/pull/80305) | Add service account key authentication. |
 | 6.1.0 | 2026-07-06 | [80952](https://github.com/airbytehq/airbyte/pull/80952) | Add `ad_performance` and `geo_performance` streams. |
 | 6.0.0 | 2026-05-29 | [78504](https://github.com/airbytehq/airbyte/pull/78504) | Clamp incremental report dates to Google Ads' 37-month granular data retention window. |
 | 5.0.2 | 2026-05-29 | [78514](https://github.com/airbytehq/airbyte/pull/78514) | Remove the Google Ads 400 response filter predicate to avoid buffering large streaming responses. |


### PR DESCRIPTION
## Summary
- add Service Account Key Authentication alongside existing OAuth credentials
- use the service account credentials for both low-code REST requests and the google-ads SDK client
- backfill legacy OAuth configs with `auth_type: Client` during runtime migration and in-memory source initialization so existing configs continue to discover/sync
- document the new authentication option and bump the connector to 6.1.0

Closes #77529.
Supersedes #77530 and #77710 with the DISCOVER/backward-compatibility regression covered.

## Tests
- `python -m json.tool airbyte-integrations/connectors/source-google-ads/source_google_ads/spec.json >/tmp/source-google-ads-spec.json`
- `ruff check --fix airbyte-integrations/connectors/source-google-ads/source_google_ads/components.py airbyte-integrations/connectors/source-google-ads/source_google_ads/config_migrations.py airbyte-integrations/connectors/source-google-ads/source_google_ads/google_ads.py airbyte-integrations/connectors/source-google-ads/source_google_ads/run.py airbyte-integrations/connectors/source-google-ads/source_google_ads/source.py airbyte-integrations/connectors/source-google-ads/unit_tests/conftest.py airbyte-integrations/connectors/source-google-ads/unit_tests/test_components.py airbyte-integrations/connectors/source-google-ads/unit_tests/test_config_migrations.py airbyte-integrations/connectors/source-google-ads/unit_tests/test_google_ads.py`
- `ruff format --check airbyte-integrations/connectors/source-google-ads/source_google_ads/components.py airbyte-integrations/connectors/source-google-ads/source_google_ads/config_migrations.py airbyte-integrations/connectors/source-google-ads/source_google_ads/google_ads.py airbyte-integrations/connectors/source-google-ads/source_google_ads/run.py airbyte-integrations/connectors/source-google-ads/source_google_ads/source.py airbyte-integrations/connectors/source-google-ads/unit_tests/conftest.py airbyte-integrations/connectors/source-google-ads/unit_tests/test_components.py airbyte-integrations/connectors/source-google-ads/unit_tests/test_config_migrations.py airbyte-integrations/connectors/source-google-ads/unit_tests/test_google_ads.py`
- `env -u VIRTUAL_ENV PYTHONPATH=. uv run --python 3.11 --with pytest --with pytest-mock --with requests-mock --with freezegun==1.4.0 --with google-ads==29.1.0 --with 'airbyte-cdk==7.19.2' --with 'pendulum<3.0.0' pytest unit_tests/test_google_ads.py::test_google_ads_init_with_service_account_credentials unit_tests/test_google_ads.py::test_service_account_credentials_temp_file_reused_across_clients unit_tests/test_google_ads.py::test_service_account_credentials_invalid_json_raises_config_error unit_tests/test_google_ads.py::test_service_account_credentials_non_object_json_raises_config_error unit_tests/test_google_ads.py::test_service_account_credentials_missing_info_raises_config_error unit_tests/test_components.py::test_service_account_authenticator_emits_bearer_token_with_subject unit_tests/test_components.py::test_service_account_authenticator_skips_subject_when_not_configured unit_tests/test_components.py::test_service_account_authenticator_rejects_missing_info unit_tests/test_components.py::test_service_account_authenticator_rejects_invalid_json unit_tests/test_components.py::test_service_account_authenticator_rejects_non_object_json -q` (10 passed)
- `env -u VIRTUAL_ENV PYTHONPATH=. uv run --python 3.11 --with pytest --with pytest-mock --with requests-mock --with freezegun==1.4.0 --with google-ads==29.1.0 --with 'airbyte-cdk==7.19.2' --with 'pendulum<3.0.0' pytest unit_tests/test_google_ads.py unit_tests/test_config_migrations.py unit_tests/test_components.py -q` (178 passed)
- `env -u VIRTUAL_ENV PYTHONPATH=. uv run --python 3.11 --with pytest --with pytest-mock --with requests-mock --with freezegun==1.4.0 --with google-ads==29.1.0 --with 'airbyte-cdk==7.19.2' --with 'pendulum<3.0.0' pytest unit_tests -q` (335 passed, 2 failed in `unit_tests/test_empty_streams.py`; the same two tests fail on clean `origin/master` because expected GAQL dates predate the current 37-month retention window)
- `env -u VIRTUAL_ENV PYTHONPATH=. uv run --python 3.11 --with pytest --with pytest-mock --with requests-mock --with freezegun==1.4.0 --with google-ads==29.1.0 --with 'airbyte-cdk==7.19.2' --with 'pendulum<3.0.0' pytest unit_tests/test_empty_streams.py::test_query_shopping_performance_view_stream unit_tests/test_empty_streams.py::test_custom_query_stream -q` on clean `origin/master` (2 failed, same baseline date-window assertion)
- `airbyte-ci connectors --name=source-google-ads test` (failed: `airbyte-ci: command not found`)
- `uvx airbyte-ci --help` (failed: `airbyte-ci` not found in package registry)