### PR TITLE
feat(source-xero): add declarative OAuth 2.0 flow and enable on Cloud

### DIFF
--- a/airbyte-integrations/connectors/source-xero/manifest.yaml
+++ b/airbyte-integrations/connectors/source-xero/manifest.yaml
@@ -417,6 +417,16 @@ definitions:
         oauth2_access_token:
           type: BearerAuthenticator
           api_token: "{{ config['credentials']['access_token'] }}"
+        oauth2_authorization_code:
+          type: OAuthAuthenticator
+          client_id: "{{ config['credentials']['client_id'] }}"
+          client_secret: "{{ config['credentials']['client_secret'] }}"
+          refresh_token: "{{ config['credentials']['refresh_token'] }}"
+          grant_type: refresh_token
+          expires_in_name: expires_in
+          access_token_name: access_token
+          refresh_request_body: {}
+          token_refresh_endpoint: https://identity.xero.com/connect/token
         oauth2_confidential_application:
           type: OAuthAuthenticator
           scopes:
@@ -531,6 +541,34 @@ spec:
         type: object
         oneOf:
           - type: object
+            title: Authenticate via Xero (OAuth)
+            required:
+              - auth_type
+              - client_id
+              - client_secret
+              - refresh_token
+            properties:
+              auth_type:
+                type: string
+                const: oauth2_authorization_code
+                order: 0
+                title: Authentication Method
+              client_id:
+                type: string
+                description: Your Xero application's Client ID.
+                title: Client ID
+                airbyte_secret: true
+              client_secret:
+                type: string
+                description: Your Xero application's Client Secret.
+                title: Client Secret
+                airbyte_secret: true
+              refresh_token:
+                type: string
+                description: The refresh token used to renew the expired access token.
+                title: Refresh Token
+                airbyte_secret: true
+          - type: object
             title: OAuth Custom Connection
             required:
               - auth_type
@@ -576,6 +614,64 @@ spec:
         order: 2
         title: Authentication Method
     additionalProperties: true
+  advanced_auth:
+    auth_flow_type: oauth2.0
+    predicate_key:
+      - credentials
+      - auth_type
+    predicate_value: oauth2_authorization_code
+    oauth_config_specification:
+      oauth_connector_input_specification:
+        consent_url: >-
+          https://login.xero.com/identity/connect/authorize?{{client_id_param}}&{{redirect_uri_param}}&{{scope_param}}&{{state_param}}&response_type=code
+        scope: >-
+          offline_access accounting.transactions.read accounting.reports.read
+          accounting.budgets.read accounting.reports.tenninetynine.read
+          accounting.journals.read accounting.settings.read
+          accounting.contacts.read accounting.attachments.read assets.read
+          files.read projects.read openid
+        access_token_url: https://identity.xero.com/connect/token
+        access_token_headers:
+          Content-Type: application/x-www-form-urlencoded
+        access_token_params:
+          grant_type: authorization_code
+          code: "{{ auth_code_value }}"
+          client_id: "{{ client_id_value }}"
+          client_secret: "{{ client_secret_value }}"
+          redirect_uri: "{{ redirect_uri_value }}"
+        extract_output:
+          - refresh_token
+      complete_oauth_output_specification:
+        type: object
+        additionalProperties: false
+        properties:
+          refresh_token:
+            type: string
+            path_in_connector_config:
+              - credentials
+              - refresh_token
+      complete_oauth_server_input_specification:
+        type: object
+        additionalProperties: false
+        properties:
+          client_id:
+            type: string
+          client_secret:
+            type: string
+      complete_oauth_server_output_specification:
+        type: object
+        additionalProperties: false
+        properties:
+          client_id:
+            type: string
+            path_in_connector_config:
+              - credentials
+              - client_id
+          client_secret:
+            type: string
+            path_in_connector_config:
+              - credentials
+              - client_secret
 
 metadata:
   autoImportSchema:

--- a/airbyte-integrations/connectors/source-xero/manifest.yaml
+++ b/airbyte-integrations/connectors/source-xero/manifest.yaml
@@ -623,13 +623,21 @@ spec:
     oauth_config_specification:
       oauth_connector_input_specification:
         consent_url: >-
-          https://login.xero.com/identity/connect/authorize?{{client_id_param}}&{{redirect_uri_param}}&{{scope_param}}&{{state_param}}&response_type=code
-        scope: >-
-          offline_access accounting.transactions.read accounting.reports.read
-          accounting.budgets.read accounting.reports.tenninetynine.read
-          accounting.journals.read accounting.settings.read
-          accounting.contacts.read accounting.attachments.read assets.read
-          files.read projects.read openid
+          https://login.xero.com/identity/connect/authorize?{{client_id_param}}&{{redirect_uri_param}}&{{scopes_param}}&{{state_param}}&response_type=code
+        scopes:
+          - scope: offline_access
+          - scope: accounting.transactions.read
+          - scope: accounting.reports.read
+          - scope: accounting.budgets.read
+          - scope: accounting.reports.tenninetynine.read
+          - scope: accounting.journals.read
+          - scope: accounting.settings.read
+          - scope: accounting.contacts.read
+          - scope: accounting.attachments.read
+          - scope: assets.read
+          - scope: files.read
+          - scope: projects.read
+          - scope: openid
         access_token_url: https://identity.xero.com/connect/token
         access_token_headers:
           Content-Type: application/x-www-form-urlencoded

--- a/airbyte-integrations/connectors/source-xero/metadata.yaml
+++ b/airbyte-integrations/connectors/source-xero/metadata.yaml
@@ -49,15 +49,13 @@ data:
     ql: 300
   connectorTestSuitesOptions:
     - suite: unitTests
-    # Disabling acceptance tests
-    # No/Low Airbyte Cloud Usage
-    # - suite: acceptanceTests
-    #   testSecrets:
-    #     - name: SECRET_SOURCE-XERO__CREDS
-    #       fileName: config.json
-    #       secretStore:
-    #         type: GSM
-    #         alias: airbyte-connector-testing-secret-store
+    - suite: acceptanceTests
+      testSecrets:
+        - name: SECRET_SOURCE-XERO__CREDS
+          fileName: config.json
+          secretStore:
+            type: GSM
+            alias: airbyte-connector-testing-secret-store
   externalDocumentationUrls:
     - title: Xero API reference
       url: https://developer.xero.com/documentation/

--- a/airbyte-integrations/connectors/source-xero/metadata.yaml
+++ b/airbyte-integrations/connectors/source-xero/metadata.yaml
@@ -2,6 +2,7 @@ data:
   allowedHosts:
     hosts:
       - api.xero.com
+      - identity.xero.com
   registryOverrides:
     oss:
       enabled: true

--- a/airbyte-integrations/connectors/source-xero/metadata.yaml
+++ b/airbyte-integrations/connectors/source-xero/metadata.yaml
@@ -6,7 +6,7 @@ data:
     oss:
       enabled: true
     cloud:
-      enabled: false
+      enabled: true
   remoteRegistries:
     pypi:
       enabled: false
@@ -31,7 +31,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 6fd1e833-dd6e-45ec-a727-ab917c5be892
-  dockerImageTag: 2.1.5
+  dockerImageTag: 2.2.0
   dockerRepository: airbyte/source-xero
   githubIssueLabel: source-xero
   icon: xero.svg

--- a/airbyte-integrations/connectors/source-xero/unit_tests/test_oauth_config.py
+++ b/airbyte-integrations/connectors/source-xero/unit_tests/test_oauth_config.py
@@ -53,10 +53,7 @@ def _get_authenticators(manifest):
 )
 def test_spec_credentials_oneof_contains_auth_type(manifest, auth_type, expected_title, expected_required):
     credentials = _get_spec(manifest)["properties"]["credentials"]
-    matching = [
-        opt for opt in credentials["oneOf"]
-        if opt["properties"]["auth_type"].get("const") == auth_type
-    ]
+    matching = [opt for opt in credentials["oneOf"] if opt["properties"]["auth_type"].get("const") == auth_type]
     assert len(matching) == 1, f"Expected exactly one oneOf entry for {auth_type}"
     option = matching[0]
     assert option["title"] == expected_title
@@ -65,14 +62,9 @@ def test_spec_credentials_oneof_contains_auth_type(manifest, auth_type, expected
 
 def test_oauth2_authorization_code_secrets_are_marked(manifest):
     credentials = _get_spec(manifest)["properties"]["credentials"]
-    oauth_option = [
-        opt for opt in credentials["oneOf"]
-        if opt["properties"]["auth_type"].get("const") == "oauth2_authorization_code"
-    ][0]
+    oauth_option = [opt for opt in credentials["oneOf"] if opt["properties"]["auth_type"].get("const") == "oauth2_authorization_code"][0]
     for secret_field in ("client_id", "client_secret", "refresh_token"):
-        assert oauth_option["properties"][secret_field].get("airbyte_secret") is True, (
-            f"{secret_field} must be marked airbyte_secret"
-        )
+        assert oauth_option["properties"][secret_field].get("airbyte_secret") is True, f"{secret_field} must be marked airbyte_secret"
 
 
 def test_selective_authenticator_has_oauth2_authorization_code_branch(manifest):

--- a/airbyte-integrations/connectors/source-xero/unit_tests/test_oauth_config.py
+++ b/airbyte-integrations/connectors/source-xero/unit_tests/test_oauth_config.py
@@ -84,7 +84,7 @@ def test_advanced_auth_block_configured(manifest):
 
     oauth_spec = advanced_auth["oauth_config_specification"]
     input_spec = oauth_spec["oauth_connector_input_specification"]
-    assert "login.xero.com" in input_spec["consent_url"]
+    assert input_spec["consent_url"].startswith("https://login.xero.com/identity/connect/authorize")
     assert input_spec["access_token_url"] == "https://identity.xero.com/connect/token"
     scope_values = [s["scope"] for s in input_spec["scopes"]]
     assert "offline_access" in scope_values

--- a/airbyte-integrations/connectors/source-xero/unit_tests/test_oauth_config.py
+++ b/airbyte-integrations/connectors/source-xero/unit_tests/test_oauth_config.py
@@ -94,7 +94,8 @@ def test_advanced_auth_block_configured(manifest):
     input_spec = oauth_spec["oauth_connector_input_specification"]
     assert "login.xero.com" in input_spec["consent_url"]
     assert input_spec["access_token_url"] == "https://identity.xero.com/connect/token"
-    assert "offline_access" in input_spec["scope"]
+    scope_values = [s["scope"] for s in input_spec["scopes"]]
+    assert "offline_access" in scope_values
     assert "refresh_token" in input_spec["extract_output"]
 
     output_spec = oauth_spec["complete_oauth_output_specification"]

--- a/airbyte-integrations/connectors/source-xero/unit_tests/test_oauth_config.py
+++ b/airbyte-integrations/connectors/source-xero/unit_tests/test_oauth_config.py
@@ -1,0 +1,104 @@
+#
+# Copyright (c) 2026 Airbyte, Inc., all rights reserved.
+#
+
+import pathlib
+
+import pytest
+import yaml
+
+
+MANIFEST_PATH = pathlib.Path(__file__).resolve().parents[1] / "manifest.yaml"
+
+
+@pytest.fixture(scope="module")
+def manifest():
+    return yaml.safe_load(MANIFEST_PATH.read_text())
+
+
+def _get_spec(manifest):
+    return manifest["spec"]["connection_specification"]
+
+
+def _get_advanced_auth(manifest):
+    return manifest["spec"]["advanced_auth"]
+
+
+def _get_authenticators(manifest):
+    return manifest["definitions"]["base_requester"]["authenticator"]["authenticators"]
+
+
+@pytest.mark.parametrize(
+    "auth_type,expected_title,expected_required",
+    [
+        pytest.param(
+            "oauth2_authorization_code",
+            "Authenticate via Xero (OAuth)",
+            ["auth_type", "client_id", "client_secret", "refresh_token"],
+            id="oauth2_authorization_code",
+        ),
+        pytest.param(
+            "oauth2_confidential_application",
+            "OAuth Custom Connection",
+            ["auth_type", "client_id", "client_secret"],
+            id="oauth2_confidential_application",
+        ),
+        pytest.param(
+            "oauth2_access_token",
+            "Bearer Access Token",
+            ["access_token", "auth_type"],
+            id="oauth2_access_token",
+        ),
+    ],
+)
+def test_spec_credentials_oneof_contains_auth_type(manifest, auth_type, expected_title, expected_required):
+    credentials = _get_spec(manifest)["properties"]["credentials"]
+    matching = [
+        opt for opt in credentials["oneOf"]
+        if opt["properties"]["auth_type"].get("const") == auth_type
+    ]
+    assert len(matching) == 1, f"Expected exactly one oneOf entry for {auth_type}"
+    option = matching[0]
+    assert option["title"] == expected_title
+    assert sorted(option["required"]) == sorted(expected_required)
+
+
+def test_oauth2_authorization_code_secrets_are_marked(manifest):
+    credentials = _get_spec(manifest)["properties"]["credentials"]
+    oauth_option = [
+        opt for opt in credentials["oneOf"]
+        if opt["properties"]["auth_type"].get("const") == "oauth2_authorization_code"
+    ][0]
+    for secret_field in ("client_id", "client_secret", "refresh_token"):
+        assert oauth_option["properties"][secret_field].get("airbyte_secret") is True, (
+            f"{secret_field} must be marked airbyte_secret"
+        )
+
+
+def test_selective_authenticator_has_oauth2_authorization_code_branch(manifest):
+    authenticators = _get_authenticators(manifest)
+    assert "oauth2_authorization_code" in authenticators
+    branch = authenticators["oauth2_authorization_code"]
+    assert branch["type"] == "OAuthAuthenticator"
+    assert branch["token_refresh_endpoint"] == "https://identity.xero.com/connect/token"
+    assert branch["grant_type"] == "refresh_token"
+
+
+def test_advanced_auth_block_configured(manifest):
+    advanced_auth = _get_advanced_auth(manifest)
+    assert advanced_auth["auth_flow_type"] == "oauth2.0"
+    assert advanced_auth["predicate_key"] == ["credentials", "auth_type"]
+    assert advanced_auth["predicate_value"] == "oauth2_authorization_code"
+
+    oauth_spec = advanced_auth["oauth_config_specification"]
+    input_spec = oauth_spec["oauth_connector_input_specification"]
+    assert "login.xero.com" in input_spec["consent_url"]
+    assert input_spec["access_token_url"] == "https://identity.xero.com/connect/token"
+    assert "offline_access" in input_spec["scope"]
+    assert "refresh_token" in input_spec["extract_output"]
+
+    output_spec = oauth_spec["complete_oauth_output_specification"]
+    assert output_spec["properties"]["refresh_token"]["path_in_connector_config"] == [
+        "credentials",
+        "refresh_token",
+    ]

--- a/docs/integrations/sources/xero.md
+++ b/docs/integrations/sources/xero.md
@@ -27,14 +27,17 @@ For multi-tenant Xero accounts, you'll need to select which organization to conn
 There are three currently supported ways to authenticate with Xero:
 
 For OAuth (recommended on Airbyte Cloud), authorize the connection through Xero's standard [OAuth 2.0 flow](https://developer.xero.com/documentation/guides/oauth2/auth-flow/). On Airbyte Cloud you can authenticate with the **Authenticate via Xero (OAuth)** button. When configuring the connector yourself you provide:
+
 - Client ID
 - Client Secret
 - Refresh Token
 
 For the bearer token strategy, please follow [instructions](https://developer.xero.com/documentation/guides/oauth2/pkce-flow/) to obtain all requirements:
+
 - Client ID
 
 For the OAuth client credentials, please follow [instructions](https://developer.xero.com/documentation/guides/oauth2/custom-connections) to obtain all requirements:
+
 - Client ID
 - Client Secret
 

--- a/docs/integrations/sources/xero.md
+++ b/docs/integrations/sources/xero.md
@@ -130,7 +130,7 @@ If you use Airbyte Cloud and your organization restricts access to specific IPs,
 
 | Version | Date       | Pull Request                                             | Subject                                                   |
 |:--------|:-----------|:---------------------------------------------------------|:----------------------------------------------------------|
-| 2.2.0 | 2026-06-22 | [00000](https://github.com/airbytehq/airbyte/pull/00000) | Add standard OAuth 2.0 authorization flow and enable on Airbyte Cloud |
+| 2.2.0 | 2026-06-22 | [80344](https://github.com/airbytehq/airbyte/pull/80344) | Add standard OAuth 2.0 authorization flow and enable on Airbyte Cloud |
 | 2.1.5 | 2026-02-25 | [71340](https://github.com/airbytehq/airbyte/pull/71340) | Resolve the generator returned from JsonDecoder into dictionary |
 | 2.1.4 | 2025-03-01 | [55142](https://github.com/airbytehq/airbyte/pull/55142) | Update dependencies |
 | 2.1.3 | 2025-02-22 | [54526](https://github.com/airbytehq/airbyte/pull/54526) | Update dependencies |

--- a/docs/integrations/sources/xero.md
+++ b/docs/integrations/sources/xero.md
@@ -24,7 +24,12 @@ For multi-tenant Xero accounts, you'll need to select which organization to conn
 
 ## Authentication
 
-There are two currently supported ways to authenticate with Xero:
+There are three currently supported ways to authenticate with Xero:
+
+For OAuth (recommended on Airbyte Cloud), authorize the connection through Xero's standard [OAuth 2.0 flow](https://developer.xero.com/documentation/guides/oauth2/auth-flow/). On Airbyte Cloud you can authenticate with the **Authenticate via Xero (OAuth)** button. When configuring the connector yourself you provide:
+- Client ID
+- Client Secret
+- Refresh Token
 
 For the bearer token strategy, please follow [instructions](https://developer.xero.com/documentation/guides/oauth2/pkce-flow/) to obtain all requirements:
 - Client ID
@@ -125,6 +130,7 @@ If you use Airbyte Cloud and your organization restricts access to specific IPs,
 
 | Version | Date       | Pull Request                                             | Subject                                                   |
 |:--------|:-----------|:---------------------------------------------------------|:----------------------------------------------------------|
+| 2.2.0 | 2026-06-22 | [00000](https://github.com/airbytehq/airbyte/pull/00000) | Add standard OAuth 2.0 authorization flow and enable on Airbyte Cloud |
 | 2.1.5 | 2026-02-25 | [71340](https://github.com/airbytehq/airbyte/pull/71340) | Resolve the generator returned from JsonDecoder into dictionary |
 | 2.1.4 | 2025-03-01 | [55142](https://github.com/airbytehq/airbyte/pull/55142) | Update dependencies |
 | 2.1.3 | 2025-02-22 | [54526](https://github.com/airbytehq/airbyte/pull/54526) | Update dependencies |


### PR DESCRIPTION
## What

Requested by Ryan (@rwask) to make `source-xero` available on Airbyte Cloud.

`source-xero` is OSS-only because its `metadata.yaml` sets `registryOverrides.cloud.enabled: false`. It was pulled from Cloud in #32476 ("remove source-xero from Cloud", batch-disabling "connectors with oauth issues"). The underlying gap: the connector only offered a user-supplied OAuth `client_credentials` ("Custom Connection") flow and a manually-pasted Bearer token — neither is the hosted 3-legged authorization-code OAuth flow that Cloud's "Authenticate your account" button drives (no `advanced_auth` block in the spec).

This PR adds that hosted OAuth option and flips `cloud.enabled: true`.

## How

In `manifest.yaml`:
- Added an `OAuthAuthenticator` branch (`oauth2_authorization_code`, `grant_type: refresh_token`) to the existing `SelectiveAuthenticator`, pointing at Xero's token endpoint `https://identity.xero.com/connect/token`.
- Added a new first `credentials` oneOf, **"Authenticate via Xero (OAuth)"** (`client_id` / `client_secret` / `refresh_token`, all `airbyte_secret`). The existing "OAuth Custom Connection" and "Bearer Access Token" options are unchanged for backward compatibility.
- Added an `advanced_auth` / `oauth_config_specification` block (consent URL `https://login.xero.com/identity/connect/authorize`, token URL, `offline_access` + accounting/assets/files/projects scopes, `refresh_token` extracted to `[credentials, refresh_token]`).

In `metadata.yaml`:
- `registryOverrides.cloud.enabled: false → true`
- `dockerImageTag: 2.1.5 → 2.2.0` (additive, non-breaking)
- Re-enabled acceptance tests with GSM secret `SECRET_SOURCE-XERO__CREDS` (updated with fresh `oauth2_authorization_code` refresh-token credentials)

Docs: documented the new OAuth option, fixed markdownlint issues, and added the 2.2.0 changelog row.

```yaml
advanced_auth:
  auth_flow_type: oauth2.0
  predicate_key: [credentials, auth_type]
  predicate_value: oauth2_authorization_code
  oauth_config_specification:
    oauth_connector_input_specification:
      consent_url: https://login.xero.com/identity/connect/authorize?...&response_type=code
      access_token_url: https://identity.xero.com/connect/token
      extract_output: [refresh_token]
```

## Review guide

1. `airbyte-integrations/connectors/source-xero/manifest.yaml` — new authenticator branch, new credentials oneOf, `advanced_auth` block.
2. `airbyte-integrations/connectors/source-xero/metadata.yaml` — cloud flag + version bump + acceptance tests re-enabled.
3. `docs/integrations/sources/xero.md` — auth docs + changelog.

## User Impact

Cloud users can authenticate Xero with the standard "Authenticate your account" button instead of bringing their own Xero app. Existing OSS configs (Custom Connection / Bearer Token) are untouched.

**Caveat (not code):** actually serving this on Cloud requires Airbyte to register + store an Airbyte-owned Xero OAuth app's `client_id`/`client_secret` in Cloud's OAuth secret store. Xero standard OAuth apps are also capped at 25 connected organisations until the app passes Xero App Store certification — the original business blocker. This provisioning/certification must be completed before the connector actually serves OAuth on Cloud.

Verified locally: ran the connector `check` against a live Xero org using the new `oauth2_authorization_code` (refresh-token) path → `SUCCEEDED`.

## Can this PR be safely reverted and rolled back?
- [x] YES 💚
- [ ] NO ❌

Link to Devin session: https://app.devin.ai/sessions/6aa01007b50643a9be8edcb7e7638203

## AI PR Review Justification

### Code Security
This PR adds a standard OAuth 2.0 authorization-code flow to source-xero using the CDK's built-in `OAuthAuthenticator` declarative component — no custom authentication logic was written. All secret fields (`client_id`, `client_secret`, `refresh_token`) are marked `airbyte_secret: true` in the spec. The `advanced_auth` block follows the standard Airbyte pattern used across dozens of other connectors (e.g., source-hubspot, source-google-analytics). The consent URL points to Xero's official identity endpoint (`login.xero.com`) and the token endpoint is Xero's standard `identity.xero.com/connect/token`. No credentials are logged, hardcoded, or transmitted outside the standard CDK OAuth flow. Requesting human security sign-off to confirm.
