### PR TITLE
fix(source-hubspot): continue CRM search pagination on short pages

### DIFF
--- a/airbyte-integrations/connectors/source-hubspot/components.py
+++ b/airbyte-integrations/connectors/source-hubspot/components.py
@@ -809,12 +809,16 @@ class HubspotCRMSearchPaginationStrategy(PaginationStrategy):
         # for any given query. Attempting to page beyond 10,000 will result in a 400 error.
         # https://developers.hubspot.com/docs/api/crm/search. We stop getting data at 10,000 and
         # start a new search query with the latest id that has been collected.
-        if last_page_token_value and last_page_token_value.get("after", 0) + last_page_size >= self.RECORDS_LIMIT:
+        current_after = int(last_page_token_value.get("after", 0)) if last_page_token_value else 0
+
+        if last_page_token_value and current_after + last_page_size >= self.RECORDS_LIMIT:
             return {"after": 0, "id": last_record[self.primary_key]}
 
         after = response.json().get("paging", {}).get("next", {}).get("after")
         if after is None:
             return None
+
+        after = int(after)
 
         last_id_of_previous_chunk = last_page_token_value.get("id")
         if last_id_of_previous_chunk:

--- a/airbyte-integrations/connectors/source-hubspot/components.py
+++ b/airbyte-integrations/connectors/source-hubspot/components.py
@@ -812,15 +812,18 @@ class HubspotCRMSearchPaginationStrategy(PaginationStrategy):
         if last_page_token_value and last_page_token_value.get("after", 0) + last_page_size >= self.RECORDS_LIMIT:
             return {"after": 0, "id": last_record[self.primary_key]}
 
-        # Stop paginating when there are fewer records than the page size or the current page has no records
-        if (last_page_size < self.page_size) or last_page_size == 0 or not response.json().get("paging"):
+        after = response.json().get("paging", {}).get("next", {}).get("after")
+        if after is None:
             return None
 
         last_id_of_previous_chunk = last_page_token_value.get("id")
         if last_id_of_previous_chunk:
-            return {"after": last_page_token_value["after"] + last_page_size, self.primary_key: last_id_of_previous_chunk}
-        else:
-            return {"after": last_page_token_value["after"] + last_page_size}
+            return {
+                "after": after,
+                self.primary_key: last_id_of_previous_chunk,
+            }
+
+        return {"after": after}
 
     def get_page_size(self) -> Optional[int]:
         return self.page_size

--- a/airbyte-integrations/connectors/source-hubspot/unit_tests/test_components.py
+++ b/airbyte-integrations/connectors/source-hubspot/unit_tests/test_components.py
@@ -679,20 +679,37 @@ def test_entity_schema_normalization(components_module, original_value, field_sc
     "json_response,last_page_size,last_record,last_page_token_value,expected_next_page_token",
     [
         pytest.param(
-            {"paging": {"next": {"after": 1200}}}, 200, {"id": 5000}, {"after": 1000}, {"after": 1200}, id="test_next_page_on_first_chunk"
+            {"paging": {"next": {"after": 1200}}},
+            200,
+            {"id": 5000},
+            {"after": 1000},
+            {"after": 1200},
+            id="test_next_page_on_first_chunk",
         ),
         pytest.param(
             {"paging": {"next": {"after": 1200}}},
             100,
             {"id": 5000},
             {"after": 1000},
-            None,
-            id="test_stop_paging_when_last_page_is_less_than_page_size",
+            {"after": 1200},
+            id="test_continue_paging_when_last_page_is_less_than_page_size_but_after_exists",
         ),
         pytest.param(
-            {"paging": {"next": {"after": 1200}}}, 0, {"id": 5000}, {"after": 1000}, None, id="test_stop_paging_when_last_page_size_is_zero"
+            {"paging": {"next": {"after": 1200}}},
+            0,
+            {"id": 5000},
+            {"after": 1000},
+            {"after": 1200},
+            id="test_continue_paging_when_last_page_size_is_zero_but_after_exists",
         ),
-        pytest.param({}, 200, {"id": 5000}, {"after": 1000}, None, id="test_stop_paging_when_no_after_in_response"),
+        pytest.param(
+            {},
+            200,
+            {"id": 5000},
+            {"after": 1000},
+            None,
+            id="test_stop_paging_when_no_after_in_response",
+        ),
         pytest.param(
             {"paging": {"next": {"after": 10000}}},
             200,

--- a/airbyte-integrations/connectors/source-hubspot/unit_tests/test_components.py
+++ b/airbyte-integrations/connectors/source-hubspot/unit_tests/test_components.py
@@ -742,6 +742,14 @@ def test_entity_schema_normalization(components_module, original_value, field_sc
             {"after": 200, "id": 25000},
             id="test_next_page_on_next_chunk_of_records",
         ),
+        pytest.param(
+            {"paging": {"next": {"after": "400"}}},
+            200,
+            {"id": "5000"},
+            {"after": "200"},
+            {"after": 400},
+            id="test_handles_string_after_cursor_from_hubspot",
+        ),
     ],
 )
 def test_crm_search_pagination_strategy(


### PR DESCRIPTION
Fixes CRM Search pagination so the connector follows HubSpot's returned paging.next.after cursor instead of stopping when a page is underfilled or empty. Adds regression coverage for both cases. Local validation: 38 component tests and 94 stream tests passed.