### PR TITLE
chore(source-airtable): upgrade CDK to 7.23.3

### DIFF
--- a/airbyte-integrations/connectors/source-airtable/metadata.yaml
+++ b/airbyte-integrations/connectors/source-airtable/metadata.yaml
@@ -7,11 +7,11 @@ data:
       - api.airtable.com
       - airtable.com
   connectorBuildOptions:
-    baseImage: docker.io/airbyte/source-declarative-manifest:7.23.2@sha256:19eb795baa82bad71c097a7388313c1fd9f36978f543a8c7a245bbedb0c9a153
+    baseImage: docker.io/airbyte/source-declarative-manifest:7.23.3@sha256:60bdf3b1b4384b2599a229445609a3a8f9ff11fefb8a62e3be9c62fc32485310
   connectorSubtype: api
   connectorType: source
   definitionId: 14c6e7ea-97ed-4f5e-a7b5-25e9a80b8212
-  dockerImageTag: 4.6.29
+  dockerImageTag: 4.6.30
   dockerRepository: airbyte/source-airtable
   documentationUrl: https://docs.airbyte.com/integrations/sources/airtable
   externalDocumentationUrls:

--- a/docs/integrations/sources/airtable.md
+++ b/docs/integrations/sources/airtable.md
@@ -148,6 +148,7 @@ If you use Airbyte Cloud and your organization restricts access to specific IPs,
 
 | Version    | Date       | Pull Request                                             | Subject                                                                                 |
 |:-----------|:-----------|:---------------------------------------------------------|:----------------------------------------------------------------------------------------|
+| 4.6.30 | 2026-06-24 | [80771](https://github.com/airbytehq/airbyte/pull/80771) | Upgrade CDK to 7.23.3 |
 | 4.6.29 | 2026-06-23 | [80374](https://github.com/airbytehq/airbyte/pull/80374) | Update dependencies |
 | 4.6.28 | 2026-06-16 | [79749](https://github.com/airbytehq/airbyte/pull/79749) | Update dependencies |
 | 4.6.27 | 2026-06-09 | [79201](https://github.com/airbytehq/airbyte/pull/79201) | Update dependencies |


### PR DESCRIPTION
## What

Upgrade source-airtable base image from `source-declarative-manifest:7.23.2` to `7.23.3` (CDK bump).

Resolves https://github.com/airbytehq/oncall/issues/11954

Requested by @darynaishchenko.

## How

- Bumped `connectorBuildOptions.baseImage` to `7.23.3` with updated sha256 digest in `metadata.yaml`
- Bumped `dockerImageTag` from `4.6.29` to `4.6.30`
- Added changelog entry

## Review guide

1. `airbyte-integrations/connectors/source-airtable/metadata.yaml`
2. `docs/integrations/sources/airtable.md`

## User Impact

Users get the latest CDK fixes/improvements. No breaking changes.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Link to Devin session: https://app.devin.ai/sessions/332ac24d898442bbba0f49b1c93ab87f