### PR TITLE
test(source-faker): bump to 7.2.0-rc.2 with autopilot progressive rollout config

### DIFF
--- a/airbyte-integrations/connectors/source-faker/metadata.yaml
+++ b/airbyte-integrations/connectors/source-faker/metadata.yaml
@@ -9,7 +9,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: dfd88b22-b603-4c3d-aad7-3701784586b1
-  dockerImageTag: 7.2.0-rc.1
+  dockerImageTag: 7.2.0-rc.2
   dockerRepository: airbyte/source-faker
   documentationUrl: https://docs.airbyte.com/integrations/sources/faker
   externalDocumentationUrls:
@@ -32,6 +32,11 @@ data:
   releases:
     rolloutConfiguration:
       enableProgressiveRollout: true
+      defaultRolloutMode: autopilot
+      autopilotConfig:
+        autoStart: true
+        autoPromoteStages: true
+        strategy: fast
     breakingChanges:
       4.0.0:
         message: This is a breaking change message

--- a/airbyte-integrations/connectors/source-faker/pyproject.toml
+++ b/airbyte-integrations/connectors/source-faker/pyproject.toml
@@ -3,7 +3,7 @@ requires = [ "poetry-core>=1.0.0",]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
-version = "7.2.0-rc.1"
+version = "7.2.0-rc.2"
 name = "source-faker"
 description = "Source implementation for fake but realistic looking data."
 authors = [ "Airbyte <evan@airbyte.io>",]

--- a/docs/integrations/sources/faker.md
+++ b/docs/integrations/sources/faker.md
@@ -47,6 +47,7 @@ Each purchase record includes: `id`, `user_id`, `product_id`, `created_at`, `upd
 
 | Version     | Date       | Pull Request                                                                                                          | Subject                                                                                                         |
 |:------------|:-----------| :-------------------------------------------------------------------------------------------------------------------- |:----------------------------------------------------------------------------------------------------------------|
+| 7.2.0-rc.2 | 2026-06-24 | [*PR_NUMBER_PLACEHOLDER*](https://github.com/airbytehq/airbyte/pull/*PR_NUMBER_PLACEHOLDER*) | Test autopilot progressive rollout lifecycle |
 | 7.2.0-rc.1 | 2026-06-09 | [79331](https://github.com/airbytehq/airbyte/pull/79331) | Progressive rollout e2e test |
 | 7.1.1 | 2026-05-13 | [78075](https://github.com/airbytehq/airbyte/pull/78075) | Re-release to verify PyPI README publishing |
 | 7.1.0 | 2026-03-31 | [75941](https://github.com/airbytehq/airbyte/pull/75941) | Promoted release candidate to GA |


### PR DESCRIPTION
## What

E2E test of the autopilot progressive rollout lifecycle using source-faker as a guinea pig.

Tracking issue: https://github.com/airbytehq/airbyte-ops-mcp/issues/956

Bumps source-faker from `7.2.0-rc.1` → `7.2.0-rc.2` and enables full autopilot configuration so the rollout can be driven end-to-end via the `airbyte-ops cloud connector rollout autopilot` CLI.

## How

1. `metadata.yaml`: version bump + added autopilot config under `rolloutConfiguration`:
```yaml
rolloutConfiguration:
  enableProgressiveRollout: true
  defaultRolloutMode: autopilot
  autopilotConfig:
    autoStart: true
    autoPromoteStages: true
    strategy: fast
```
2. `pyproject.toml`: version → `7.2.0-rc.2`
3. `docs/integrations/sources/faker.md`: changelog entry for `7.2.0-rc.2`

## Review guide

1. `airbyte-integrations/connectors/source-faker/metadata.yaml` — autopilot config added
2. `airbyte-integrations/connectors/source-faker/pyproject.toml` — version bump
3. `docs/integrations/sources/faker.md` — changelog entry

## User Impact

No user impact. This is a test connector version bump to validate the autopilot rollout system. `strategy: fast` targets TIER_2 (non-sensitive) customers only during rollout.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚
- [ ] NO ❌

Link to Devin session: https://app.devin.ai/sessions/5c6e84bc516d49a79c60bd9c996028e8
Requested by: @aaronsteers

> [!IMPORTANT]
> Active progressive rollout warning for source-faker.

- [x] (Click to Approve:) Bypass the active progressive rollout warning for source-faker in the PR comment [here](https://github.com/airbytehq/airbyte/pull/80776#issuecomment-4792209465).