### PR TITLE
ci(hydra-automerge): add net_new_stream_addition to automergeable scopes

### DIFF
--- a/.github/workflows/hydra-automerge.yml
+++ b/.github/workflows/hydra-automerge.yml
@@ -310,7 +310,16 @@ jobs:
                       reasoning:
                         type: string
                     required: [pass, reasoning]
-                required: [docs_only_change, comment_only_change, dependency_version_bump, metadata_only_change]
+                  net_new_stream_addition:
+                    type: object
+                    description: "Set pass to true ONLY if the PR exclusively adds net-new streams to an existing connector without modifying any existing streams or core connector logic. Allowed changes: new stream class definitions, new stream registrations, new tests for the new streams, new or updated documentation/changelogs for the new streams, version bumps in metadata.yaml, and new or updated schema files for the new streams. Set pass to false if any existing stream, existing schema, existing test, or core connector logic (e.g. auth, base classes, shared utilities, existing stream definitions) is modified."
+                    properties:
+                      pass:
+                        type: boolean
+                      reasoning:
+                        type: string
+                    required: [pass, reasoning]
+                required: [docs_only_change, comment_only_change, dependency_version_bump, metadata_only_change, net_new_stream_addition]
             required: [preconditions, change_scope]
 
       - name: Check for structured output
@@ -354,8 +363,9 @@ jobs:
           comment_only=$(echo "$STRUCTURED_OUTPUT" | jq -r '.change_scope.comment_only_change.pass')
           dep_bump=$(echo "$STRUCTURED_OUTPUT" | jq -r '.change_scope.dependency_version_bump.pass')
           metadata_only=$(echo "$STRUCTURED_OUTPUT" | jq -r '.change_scope.metadata_only_change.pass')
+          new_streams=$(echo "$STRUCTURED_OUTPUT" | jq -r '.change_scope.net_new_stream_addition.pass')
 
-          if [[ "$docs_only" == "true" || "$comment_only" == "true" || "$dep_bump" == "true" || "$metadata_only" == "true" ]]; then
+          if [[ "$docs_only" == "true" || "$comment_only" == "true" || "$dep_bump" == "true" || "$metadata_only" == "true" || "$new_streams" == "true" ]]; then
             scope_pass="true"
           else
             scope_pass="false"
@@ -415,7 +425,7 @@ jobs:
             echo ""
             scope_matched=false
             has_scope_row=false
-            for key in docs_only_change comment_only_change dependency_version_bump metadata_only_change; do
+            for key in docs_only_change comment_only_change dependency_version_bump metadata_only_change net_new_stream_addition; do
               pass=$(echo "$STRUCTURED_OUTPUT" | jq -r ".change_scope.${key}.pass")
               if [[ "$pass" == "true" ]]; then
                 if [[ "$has_scope_row" == "false" ]]; then

--- a/.github/workflows/hydra-automerge.yml
+++ b/.github/workflows/hydra-automerge.yml
@@ -312,7 +312,7 @@ jobs:
                     required: [pass, reasoning]
                   net_new_stream_addition:
                     type: object
-                    description: "Set pass to true ONLY if the PR exclusively adds net-new streams to an existing connector without modifying any existing streams or core connector logic. Allowed changes: new stream class definitions, new stream registrations, new tests for the new streams, new or updated documentation/changelogs for the new streams, version bumps in metadata.yaml, and new or updated schema files for the new streams. Set pass to false if any existing stream, existing schema, existing test, or core connector logic (e.g. auth, base classes, shared utilities, existing stream definitions) is modified."
+                    description: "Set pass to true ONLY if the PR exclusively adds net-new streams to an existing connector without modifying any existing streams or core connector logic. Allowed changes: new stream class definitions, new stream registrations, new tests for the new streams, new or updated documentation/changelogs for the new streams, version bumps in metadata.yaml, new or updated schema files for the new streams, and trivial updates to existing tests that are a direct mechanical consequence of adding the new stream (e.g. incrementing an expected stream count assertion). Set pass to false if any existing stream definition, existing schema, or core connector logic (e.g. auth, base classes, shared utilities) is modified, or if existing tests are changed in ways beyond trivial count updates."
                     properties:
                       pass:
                         type: boolean


### PR DESCRIPTION
## What

Adds `net_new_stream_addition` as a new automergeable change scope in the hydra automerge workflow, requested by @pedroslopez.

PRs that exclusively add net-new streams to an existing connector (without modifying existing streams or core logic) can now be auto-merged.

## How

Added `net_new_stream_addition` to all 4 relevant sections of `hydra-automerge.yml`:

1. **Structured output schema** — new scope with description guiding the Devin evaluator: pass only if the PR exclusively adds new streams (new class definitions, registrations, tests, schemas, docs/changelogs, version bumps) without modifying existing streams or core connector logic. Trivial mechanical test updates (e.g. incrementing expected stream count) are allowed.
2. **`required` array** — included in the change_scope required fields.
3. **Evaluate step** — extracted from structured output and added to the `ANY(scope)` OR condition.
4. **Report step** — added to the scope iteration loop for the evaluation comment.

### Test results against [PR #79640](https://github.com/airbytehq/airbyte/pull/79640) (source-zendesk-support `side_conversations` stream)

**Run 1** ([session](https://app.devin.ai/sessions/d3b3943286184dc59acb5ed6bc24a5a1)): `net_new_stream_addition: false` — original wording rejected the PR because `unit_test.py` updated `expected_n_streams` from 42→43. The description said "set pass to false if any existing test is modified," which was too strict.

**Run 2** ([session](https://app.devin.ai/sessions/76f8c69e68cc487d86708a87fd6f8bcb)): `net_new_stream_addition: true` — updated wording explicitly allows "trivial updates to existing tests that are a direct mechanical consequence of adding the new stream (e.g. incrementing an expected stream count assertion)." Evaluator correctly classified the stream count update as trivial and passed.

Both runs correctly identified preconditions (no breaking changes + AI review approved) and correctly rejected all other scopes.

## Review guide

1. `.github/workflows/hydra-automerge.yml` — single file, all changes

## User Impact

Connector PRs that only add new streams can now pass the auto-merge evaluation gate, reducing manual merge overhead for routine stream additions.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Link to Devin session: https://app.devin.ai/sessions/64310465a87e40fda3a7077225f9db17