### PR TITLE
chore(source-pokeapi): bump to 0.3.59 with autopilot rollout config

### DIFF
--- a/airbyte-integrations/connectors/source-pokeapi/metadata.yaml
+++ b/airbyte-integrations/connectors/source-pokeapi/metadata.yaml
@@ -9,7 +9,12 @@ data:
       enabled: true
   releases:
     rolloutConfiguration:
-      enableProgressiveRollout: false
+      enableProgressiveRollout: true
+      defaultRolloutMode: autopilot
+      autopilotConfig:
+        autoStart: true
+        autoPromoteStages: true
+        strategy: fast
   remoteRegistries:
     pypi:
       enabled: false
@@ -22,7 +27,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 6371b14b-bc68-4236-bfbd-468e8df8e968
-  dockerImageTag: 0.3.58
+  dockerImageTag: 0.3.59
   dockerRepository: airbyte/source-pokeapi
   githubIssueLabel: source-pokeapi
   icon: pokeapi.svg

--- a/docs/integrations/sources/pokeapi.md
+++ b/docs/integrations/sources/pokeapi.md
@@ -43,7 +43,7 @@ If you use Airbyte Cloud and your organization restricts access to specific IPs,
 
 | Version | Date       | Pull Request                                             | Subject                                         |
 | :------ | :--------- | :------------------------------------------------------- | :---------------------------------------------- |
-| 0.3.59 | 2026-06-25 | [TBD](https://github.com/airbytehq/airbyte/pull/TBD) | POC: Test autopilot rollout pipeline |
+| 0.3.59 | 2026-06-25 | [80885](https://github.com/airbytehq/airbyte/pull/80885) | POC: Test autopilot rollout pipeline |
 | 0.3.58 | 2026-06-23 | [80588](https://github.com/airbytehq/airbyte/pull/80588) | Update dependencies |
 | 0.3.57 | 2026-06-16 | [79995](https://github.com/airbytehq/airbyte/pull/79995) | Update dependencies |
 | 0.3.56 | 2026-06-09 | [79458](https://github.com/airbytehq/airbyte/pull/79458) | Update dependencies |

--- a/docs/integrations/sources/pokeapi.md
+++ b/docs/integrations/sources/pokeapi.md
@@ -43,6 +43,7 @@ If you use Airbyte Cloud and your organization restricts access to specific IPs,
 
 | Version | Date       | Pull Request                                             | Subject                                         |
 | :------ | :--------- | :------------------------------------------------------- | :---------------------------------------------- |
+| 0.3.59 | 2026-06-25 | [TBD](https://github.com/airbytehq/airbyte/pull/TBD) | POC: Test autopilot rollout pipeline |
 | 0.3.58 | 2026-06-23 | [80588](https://github.com/airbytehq/airbyte/pull/80588) | Update dependencies |
 | 0.3.57 | 2026-06-16 | [79995](https://github.com/airbytehq/airbyte/pull/79995) | Update dependencies |
 | 0.3.56 | 2026-06-09 | [79458](https://github.com/airbytehq/airbyte/pull/79458) | Update dependencies |


### PR DESCRIPTION
## What

POC: Enable autopilot progressive rollout pipeline for `source-pokeapi` (version 0.3.59) to validate the end-to-end autopilot rollout lifecycle.

Tracking issue: https://github.com/airbytehq/airbyte-ops-mcp/issues/969
Requested by: @aaronsteers

## How

- Bumped `dockerImageTag` from `0.3.58` → `0.3.59`
- Changed `enableProgressiveRollout: false` → `true`
- Added autopilot config:
  ```yaml
  defaultRolloutMode: autopilot
  autopilotConfig:
    autoStart: true
    autoPromoteStages: true
    strategy: fast
  ```
- Added changelog entry

## Review guide

1. `airbyte-integrations/connectors/source-pokeapi/metadata.yaml` — version bump + rollout config
2. `docs/integrations/sources/pokeapi.md` — changelog entry

## User Impact

No user-facing impact. This is a no-op version bump to validate the autopilot rollout pipeline. Source-pokeapi is a low-risk community connector used primarily for tutorials.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Link to Devin session: https://app.devin.ai/sessions/cd8838912e7b4f9ba59e90dd58a96340

> [!IMPORTANT]
> Active progressive rollout warning for source-pokeapi.

- [ ] (Click to Approve:) Bypass the active progressive rollout warning for source-pokeapi in the PR comment [here](https://github.com/airbytehq/airbyte/pull/80885#issuecomment-4803638544).