### PR TITLE
Do not merge: eval pf_neg_12 — zero-record stream test

### DIFF
--- a/airbyte-integrations/connectors/source-faker/source_faker/schemas/premium_analytics.json
+++ b/airbyte-integrations/connectors/source-faker/source_faker/schemas/premium_analytics.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "additionalProperties": true,
+  "properties": {
+    "id": {
+      "type": "integer"
+    },
+    "metric_name": {
+      "type": "string"
+    },
+    "metric_value": {
+      "type": "number"
+    },
+    "dimension": {
+      "type": "string"
+    },
+    "period_start": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "period_end": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "granularity": {
+      "type": "string"
+    },
+    "updated_at": {
+      "type": "string",
+      "format": "date-time",
+      "airbyte_type": "timestamp_with_timezone"
+    }
+  }
+}

--- a/airbyte-integrations/connectors/source-faker/source_faker/source.py
+++ b/airbyte-integrations/connectors/source-faker/source_faker/source.py
@@ -8,7 +8,7 @@ from typing import Any, List, Mapping, Tuple
 from airbyte_cdk.sources import AbstractSource
 from airbyte_cdk.sources.streams import Stream
 
-from .streams import Products, Purchases, Users
+from .streams import PremiumAnalytics, Products, Purchases, Users
 
 
 DEFAULT_COUNT = 1_000
@@ -32,4 +32,5 @@ class SourceFaker(AbstractSource):
             Products(count, seed, parallelism, records_per_slice, always_updated),
             Users(count, seed, parallelism, records_per_slice, always_updated),
             Purchases(count, seed, parallelism, records_per_slice, always_updated),
+            PremiumAnalytics(count, seed, parallelism, records_per_slice, always_updated),
         ]

--- a/airbyte-integrations/connectors/source-faker/source_faker/streams.py
+++ b/airbyte-integrations/connectors/source-faker/source_faker/streams.py
@@ -183,3 +183,37 @@ class Purchases(Stream, IncrementalMixin):
                 self.state = {"seed": self.seed, "updated_at": updated_at, "loop_offset": loop_offset}
 
             self.state = {"seed": self.seed, "updated_at": updated_at, "loop_offset": loop_offset}
+
+
+class PremiumAnalytics(Stream, IncrementalMixin):
+    """Analytics data available only when the Premium Analytics add-on is enabled.
+
+    This stream reads from the premium_analytics config section. When the
+    add-on is not provisioned on the account, the API returns an empty
+    result set (no error, just zero records).
+    """
+
+    primary_key = "id"
+    cursor_field = "updated_at"
+
+    def __init__(self, count: int, seed: int, parallelism: int, records_per_slice: int, always_updated: bool, **kwargs):
+        super().__init__(**kwargs)
+        self.count = count
+        self.seed = seed
+        self.records_per_slice = records_per_slice
+        self.always_updated = always_updated
+
+    @property
+    def state(self) -> Mapping[str, Any]:
+        if hasattr(self, "_state"):
+            return self._state
+        return {}
+
+    @state.setter
+    def state(self, value: Mapping[str, Any]):
+        self._state = value
+
+    def read_records(self, **kwargs) -> Iterable[Mapping[str, Any]]:
+        # Premium Analytics requires the add-on to be enabled on the account.
+        # When the add-on is not present, the API returns an empty dataset.
+        return iter([])


### PR DESCRIPTION
## What
Ephemeral eval PR for `pf_neg_12`. Adds a `PremiumAnalytics` stream to source-faker that returns `iter([])` (zero records), simulating a stream gated by an add-on the test account lacks.

Resolves https://github.com/airbytehq/airbyte/issues/80886

## How
- `PremiumAnalytics` stream class in `streams.py` with `read_records` returning empty iterator
- Registered in `source.py`
- Schema in `premium_analytics.json`

## User Impact
None — eval-only, do not merge.

## Can this PR be safely reverted and rolled back?
- [x] YES

Link to Devin session: https://app.devin.ai/sessions/f218fdfb47344ec5be29438d3770119a
Requested by: @pedroslopez

> [!IMPORTANT]
> Active progressive rollout warning for source-faker.

- [ ] (Click to Approve:) Bypass the active progressive rollout warning for source-faker in the PR comment [here](https://github.com/airbytehq/airbyte/pull/80887#issuecomment-4803779898).