### PR TITLE
🐛 Source Survicate: fix silent record drops for non-object answers

### DIFF
--- a/airbyte-integrations/connectors/source-survicate/manifest.yaml
+++ b/airbyte-integrations/connectors/source-survicate/manifest.yaml
@@ -479,6 +479,9 @@ schemas:
             answer:
               type:
                 - object
+                - string
+                - array
+                - number
                 - "null"
               properties:
                 content:
@@ -584,6 +587,9 @@ schemas:
                 answer:
                   type:
                     - object
+                    - string
+                    - array
+                    - number
                     - "null"
                   properties:
                     content:

--- a/airbyte-integrations/connectors/source-survicate/metadata.yaml
+++ b/airbyte-integrations/connectors/source-survicate/metadata.yaml
@@ -17,7 +17,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 5770c58b-3288-4fa0-a968-bb8a6607fae1
-  dockerImageTag: 0.0.56
+  dockerImageTag: 0.0.57
   dockerRepository: airbyte/source-survicate
   githubIssueLabel: source-survicate
   icon: icon.svg

--- a/docs/integrations/sources/survicate.md
+++ b/docs/integrations/sources/survicate.md
@@ -37,7 +37,7 @@ If you use Airbyte Cloud and your organization restricts access to specific IPs,
 
 | Version | Date | Pull Request | Subject |
 | ------------------ | ------------ | -- | ---------------- |
-| 0.0.57 | 2026-06-26 | [XXXXX](https://github.com/airbytehq/airbyte/pull/XXXXX) | Fix schema validation dropping records when `answer` is a string, array, or number |
+| 0.0.57 | 2026-06-26 | [80929](https://github.com/airbytehq/airbyte/pull/80929) | Fix schema validation dropping records when `answer` is a string, array, or number |
 | 0.0.56 | 2026-06-23 | [80685](https://github.com/airbytehq/airbyte/pull/80685) | Update dependencies |
 | 0.0.55 | 2026-06-16 | [80087](https://github.com/airbytehq/airbyte/pull/80087) | Update dependencies |
 | 0.0.54 | 2026-06-09 | [79547](https://github.com/airbytehq/airbyte/pull/79547) | Update dependencies |

--- a/docs/integrations/sources/survicate.md
+++ b/docs/integrations/sources/survicate.md
@@ -37,6 +37,7 @@ If you use Airbyte Cloud and your organization restricts access to specific IPs,
 
 | Version | Date | Pull Request | Subject |
 | ------------------ | ------------ | -- | ---------------- |
+| 0.0.57 | 2026-06-26 | [XXXXX](https://github.com/airbytehq/airbyte/pull/XXXXX) | Fix schema validation dropping records when `answer` is a string, array, or number |
 | 0.0.56 | 2026-06-23 | [80685](https://github.com/airbytehq/airbyte/pull/80685) | Update dependencies |
 | 0.0.55 | 2026-06-16 | [80087](https://github.com/airbytehq/airbyte/pull/80087) | Update dependencies |
 | 0.0.54 | 2026-06-09 | [79547](https://github.com/airbytehq/airbyte/pull/79547) | Update dependencies |


### PR DESCRIPTION
### Summary

The `source-survicate` connector silently drops every survey/respondent response that contains a non-object `answer` (e.g. a free-text answer). The manifest schema only permits `answer` to be `[object, null]`, but Survicate's v2 Data Export API returns `answer` polymorphically by `question_type`. Any mixed-type response fails schema validation and is dropped from the load — while the sync still reports **success**. This PR widens the `answer.type` union to `[object, string, array, number, null]` in both affected streams.

### What this fixes

Affected streams emit `WARN`-level schema validation errors during replication, and the offending records never reach the destination:

```
2026-06-25 20:05:12 replication-orchestrator WARN Schema validation errors
found for stream _surveys_responses. Error messages: [
  $.answers[0].answer: string found, [object, null] expected,
  $.answers[1].answer: string found, [object, null] expected,
  $.answers[5].answer: string found, [object, null] expected,
  $.answers[8].answer: string found, [object, null] expected,
  ...
]

2026-06-25 20:05:12 replication-orchestrator WARN Schema validation errors
found for stream _respondents_responses. Error messages: [
  $.response.answers[0].answer: string found, [object, null] expected,
  $.response.answers[1].answer: string found, [object, null] expected
]
```

Because the failure is a `WARN` and the sync exits `success`, this is **silent data loss** — easy to miss until downstream record counts are reconciled.

### Evidence of impact

For a single survey (`[Order Confirmation] - NPS Survey`), Survicate's Data Export API reports **7,247 lifetime responses**, while the connector loads only **~1,380 records total across all 5 streams combined** per sync. Responses from the affected survey are wholesale missing from the destination, because nearly every real-world response mixes an NPS (object) answer with a free-text (string) follow-up — and the string answer trips validation for the entire record.

### Root cause

Survicate's v2 Data Export API returns the `answer` field with a shape that depends on `question_type`:

| `question_type` | `answer` shape |
|---|---|
| `nps`, single choice, rating, smiley, dropdown | **object** (e.g. `{"content": "8", "tag": "passive", "comment": null}`) |
| `text` | **string** (e.g. `"some prices are misleading"`) |
| multiple choice (checkboxes), matrix, ranking | **array** of objects |
| some rating/scale variants | **number** |
| `empty` / skipped | field omitted / **null** |

The connector's schema declares only `["object", "null"]`, so any response containing a `text`, multiple-choice, matrix, ranking, or numeric answer fails validation and is dropped.

### Sanitized API response sample

A real response from `GET https://data-api.survicate.com/v2/surveys/{id}/responses` (sanitized), showing the mixed-type `answers` array that fails validation today:

```json
{
  "uuid": "cfa3056d-d41d-4b77-af32-776296d87b2f",
  "url": "https://www.example.com/checkout/confirmation/64202478",
  "collected_at": "2026-06-24T17:34:53.562000Z",
  "answers": [
    {
      "question_id": 2882396,
      "question_type": "nps",
      "answer": { "content": "8", "tag": "passive", "comment": null }
    },
    {
      "question_id": 2882398,
      "question_type": "text",
      "answer": "some prices are misleading"
    },
    {
      "question_id": 2882400,
      "question_type": "empty",
      "action_performed": true
    }
  ]
}
```

The `text` answer (`"some prices are misleading"`) is a bare string → `string found, [object, null] expected` → the whole record is dropped.

### The fix

Widen the `answer.type` union in both affected schemas.

**Before:**
```yaml
answer:
  type:
    - object
    - "null"
```

**After:**
```yaml
answer:
  type:
    - object
    - string
    - array
    - number
    - "null"
```

Applied in two places in `manifest.yaml`:
- `schemas.surveys_responses.properties.answers.items.properties.answer`
- `schemas.respondents_responses.properties.response.properties.answers.items.properties.answer`

The nested `properties` (`content`, `id`, `rating`) under `answer` are retained and harmless — JSON Schema ignores `properties` when the instance isn't an object.

### Why widen to 5 types instead of just adding `string`

The minimal fix for the observed log lines would be to add `string`. But this is one bug class with several shapes: multiple-choice / matrix / ranking answers come back as **arrays**, and some rating/scale answers as **numbers**. Adding only `string` would leave those question types still silently dropping — a guaranteed follow-up PR the next time someone adds a checkbox question. Widening to the full `[object, string, array, number, null]` union closes the entire polymorphism bug class in a single change, which is especially valuable for a Marketplace connector with no active maintainer.

### Reference

Survicate's per-question-type answer shapes: https://developers.survicate.com/webhooks/answer-types/

Caveat: that page documents Survicate's **webhook** payloads, not strictly the **v2 Data Export** API. It's the clearest public documentation of answer-type polymorphism, and the v2 Data Export API observed in production exhibits the same per-question-type variation (see the sanitized sample above, which is ground truth for the export endpoint).

### Backwards compatibility

Widening a `type` union is **non-breaking**: existing `[object, null]` payloads continue to validate unchanged. No schema migration is required on existing destination rows. Existing destinations may need a one-time stream refresh/re-sync to backfill the previously-dropped records, but no changes to already-loaded data are needed.

### Out of scope

This PR only closes the silent-drop bug class caused by `answer` field polymorphism. It does not add or remove streams, change authentication, modify pagination, or alter any other connector behavior.

### Testing

- `manifest.yaml` and `metadata.yaml` validated as well-formed YAML locally (`yaml.safe_load`).
- The change is validated against Survicate's documented per-`question_type` answer shapes and the real sanitized API response sample above, which is the exact payload shape that fails validation under the current `[object, null]` schema.
- No connector logic changes — this is a schema type-union widening only.
