### PR TITLE
docs(community): fix dead connector-requests link

### DIFF
--- a/docs/community/getting-support.md
+++ b/docs/community/getting-support.md
@@ -23,6 +23,8 @@ Core users don't have access to paid support but can use the [Community Slack](#
 
 Connector support depends on the connector's support level. See [Connector Support Levels](/integrations/connector-support-levels) for details.
 
+If you don't see a connector you need, see [Custom or New Connector](/integrations/custom-connectors) to request or build one.
+
 ### GitHub discussions
 
 [GitHub discussions](https://github.com/airbytehq/airbyte/discussions) are a great way to propose, vote on, and discuss data replication improvements.

--- a/docs/community/getting-support.md
+++ b/docs/community/getting-support.md
@@ -23,8 +23,6 @@ Core users don't have access to paid support but can use the [Community Slack](#
 
 Connector support depends on the connector's support level. See [Connector Support Levels](/integrations/connector-support-levels) for details.
 
-If you don't see a connector you need, submit a [connector request](https://airbyte.com/connector-requests).
-
 ### GitHub discussions
 
 [GitHub discussions](https://github.com/airbytehq/airbyte/discussions) are a great way to propose, vote on, and discuss data replication improvements.


### PR DESCRIPTION
## What

The `airbyte.com/connector-requests` link on the Getting Support docs page is dead — Airbyte no longer accepts connector requests for data replication via the marketing site, and the URL now redirects to the connector catalog (`/connectors`) with no request form.

Requested by @ian-at-airbyte.

## How

In `docs/community/getting-support.md`, replace the dead marketing-site link with a pointer to the existing [Custom or New Connector](/integrations/custom-connectors) docs page, which covers requesting a connector via GitHub Discussions and building your own.

## Review guide

1. `docs/community/getting-support.md`

## User Impact

Users are no longer sent to a dead link; they're pointed to docs explaining how to request or build a connector.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Link to Devin session: https://app.devin.ai/sessions/55884f8ee4ec4a79b5bc6c809ff96876

> [!IMPORTANT]
> ⚡ **Auto-merge enabled.**
> 
> _This PR is set to merge automatically when all requirements are met._