### PR TITLE
fix(source-clickhouse): add JSON Schema format hints for temporal types (0.3.1)

### DIFF
--- a/airbyte-integrations/connectors/source-clickhouse/metadata.yaml
+++ b/airbyte-integrations/connectors/source-clickhouse/metadata.yaml
@@ -14,7 +14,7 @@ data:
     - suite: acceptanceTests
   connectorType: source
   definitionId: bad83517-5e54-4a3d-9b53-63e85fbd4d7c
-  dockerImageTag: 0.3.0
+  dockerImageTag: 0.3.1
   dockerRepository: airbyte/source-clickhouse
   documentationUrl: https://docs.airbyte.com/integrations/sources/clickhouse
   githubIssueLabel: source-clickhouse

--- a/airbyte-integrations/connectors/source-clickhouse/src/main/java/io/airbyte/integrations/source/clickhouse/ClickHouseSource.java
+++ b/airbyte-integrations/connectors/source-clickhouse/src/main/java/io/airbyte/integrations/source/clickhouse/ClickHouseSource.java
@@ -90,7 +90,7 @@ public class ClickHouseSource extends AbstractJdbcSource<JDBCType> implements So
   }
 
   public ClickHouseSource(final FeatureFlags featureFlags) {
-    super(DRIVER_CLASS, NoOpStreamingQueryConfig::new, JdbcUtils.getDefaultSourceOperations());
+    super(DRIVER_CLASS, NoOpStreamingQueryConfig::new, new ClickHouseSourceOperations());
     this.featureFlags = featureFlags;
   }
 

--- a/airbyte-integrations/connectors/source-clickhouse/src/main/java/io/airbyte/integrations/source/clickhouse/ClickHouseSourceOperations.java
+++ b/airbyte-integrations/connectors/source-clickhouse/src/main/java/io/airbyte/integrations/source/clickhouse/ClickHouseSourceOperations.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2026 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.integrations.source.clickhouse;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.airbyte.cdk.db.jdbc.JdbcConstants;
+import io.airbyte.cdk.db.jdbc.JdbcSourceOperations;
+import io.airbyte.cdk.db.jdbc.JdbcUtils;
+import io.airbyte.protocol.models.JsonSchemaType;
+import java.sql.JDBCType;
+import java.sql.Types;
+
+/**
+ * Custom source operations for ClickHouse that handles type mapping differences.
+ *
+ * <p>
+ * The ClickHouse JDBC driver 0.9.x returns JDBCType.OTHER for large integer types that don't have
+ * exact JDBC equivalents (UInt64, Int128, Int256, UInt128, UInt256). This class maps those types to
+ * NUMERIC so they can be used as cursor columns for incremental sync.
+ */
+public class ClickHouseSourceOperations extends JdbcSourceOperations {
+
+  @Override
+  public JDBCType getDatabaseFieldType(final JsonNode field) {
+    final int columnType = field.get(JdbcConstants.INTERNAL_COLUMN_TYPE).asInt();
+
+    // If the driver returns OTHER, look at the type name and map it appropriately
+    if (columnType == Types.OTHER) {
+      final String typeName = field.get(JdbcConstants.INTERNAL_COLUMN_TYPE_NAME).asText();
+      return mapOtherTypeToJdbcType(typeName);
+    }
+
+    // For standard JDBC types, use the parent implementation
+    return super.getDatabaseFieldType(field);
+  }
+
+  /**
+   * Maps ClickHouse type names to standard JDBC types when the driver returns JDBCType.OTHER. Only
+   * handles types that actually return as OTHER (large integers without JDBC equivalents).
+   */
+  private JDBCType mapOtherTypeToJdbcType(final String rawTypeName) {
+    final String typeName = rawTypeName.toLowerCase();
+
+    // Large integers that don't have standard JDBC equivalents return as OTHER
+    // UInt64 can't fit in signed BIGINT, and Int128/Int256/UInt128/UInt256 have no JDBC equivalent
+    if (typeName.startsWith("uint64") || typeName.startsWith("int128") ||
+        typeName.startsWith("int256") || typeName.startsWith("uint128") ||
+        typeName.startsWith("uint256")) {
+      return JDBCType.NUMERIC;
+    }
+
+    // Default to VARCHAR for any other types that unexpectedly return as OTHER
+    return JDBCType.VARCHAR;
+  }
+
+  @Override
+  public JsonSchemaType getAirbyteType(final JDBCType sourceType) {
+    return switch (sourceType) {
+      case BIT, BOOLEAN -> JsonSchemaType.BOOLEAN;
+      case TINYINT, SMALLINT, INTEGER, BIGINT -> JsonSchemaType.INTEGER;
+      case FLOAT, DOUBLE, REAL, NUMERIC, DECIMAL -> JsonSchemaType.NUMBER;
+      case BLOB, BINARY, VARBINARY, LONGVARBINARY -> JsonSchemaType.STRING_BASE_64;
+      case ARRAY -> JsonSchemaType.ARRAY;
+      case DATE -> JsonSchemaType.STRING_DATE;
+      case TIME -> JsonSchemaType.STRING_TIME_WITHOUT_TIMEZONE;
+      case TIME_WITH_TIMEZONE -> JsonSchemaType.STRING_TIME_WITH_TIMEZONE;
+      case TIMESTAMP -> JsonSchemaType.STRING_TIMESTAMP_WITHOUT_TIMEZONE;
+      case TIMESTAMP_WITH_TIMEZONE -> JsonSchemaType.STRING_TIMESTAMP_WITH_TIMEZONE;
+      default -> JsonSchemaType.STRING;
+    };
+  }
+
+  @Override
+  public boolean isCursorType(final JDBCType type) {
+    return JdbcUtils.ALLOWED_CURSOR_TYPES.contains(type);
+  }
+
+}

--- a/airbyte-integrations/connectors/source-clickhouse/src/main/resources/spec.json
+++ b/airbyte-integrations/connectors/source-clickhouse/src/main/resources/spec.json
@@ -1,5 +1,5 @@
 {
-  "documentationUrl": "https://docs.airbyte.com/integrations/destinations/clickhouse",
+  "documentationUrl": "https://docs.airbyte.com/integrations/sources/clickhouse",
   "connectionSpecification": {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "ClickHouse Source Spec",

--- a/airbyte-integrations/connectors/source-clickhouse/src/test/java/io/airbyte/integrations/source/clickhouse/ClickHouseSourceOperationsTest.java
+++ b/airbyte-integrations/connectors/source-clickhouse/src/test/java/io/airbyte/integrations/source/clickhouse/ClickHouseSourceOperationsTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2026 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.integrations.source.clickhouse;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.airbyte.protocol.models.JsonSchemaType;
+import java.sql.JDBCType;
+import org.junit.jupiter.api.Test;
+
+class ClickHouseSourceOperationsTest {
+
+  private final ClickHouseSourceOperations operations = new ClickHouseSourceOperations();
+
+  @Test
+  void testTemporalTypesWithFormatHints() {
+    assertEquals(JsonSchemaType.STRING_DATE, operations.getAirbyteType(JDBCType.DATE));
+    assertEquals(JsonSchemaType.STRING_TIME_WITHOUT_TIMEZONE, operations.getAirbyteType(JDBCType.TIME));
+    assertEquals(JsonSchemaType.STRING_TIME_WITH_TIMEZONE, operations.getAirbyteType(JDBCType.TIME_WITH_TIMEZONE));
+    assertEquals(JsonSchemaType.STRING_TIMESTAMP_WITHOUT_TIMEZONE, operations.getAirbyteType(JDBCType.TIMESTAMP));
+    assertEquals(JsonSchemaType.STRING_TIMESTAMP_WITH_TIMEZONE, operations.getAirbyteType(JDBCType.TIMESTAMP_WITH_TIMEZONE));
+  }
+
+  @Test
+  void testNumericTypes() {
+    assertEquals(JsonSchemaType.BOOLEAN, operations.getAirbyteType(JDBCType.BOOLEAN));
+    assertEquals(JsonSchemaType.BOOLEAN, operations.getAirbyteType(JDBCType.BIT));
+    assertEquals(JsonSchemaType.INTEGER, operations.getAirbyteType(JDBCType.INTEGER));
+    assertEquals(JsonSchemaType.INTEGER, operations.getAirbyteType(JDBCType.BIGINT));
+    assertEquals(JsonSchemaType.INTEGER, operations.getAirbyteType(JDBCType.SMALLINT));
+    assertEquals(JsonSchemaType.INTEGER, operations.getAirbyteType(JDBCType.TINYINT));
+    assertEquals(JsonSchemaType.NUMBER, operations.getAirbyteType(JDBCType.FLOAT));
+    assertEquals(JsonSchemaType.NUMBER, operations.getAirbyteType(JDBCType.DOUBLE));
+    assertEquals(JsonSchemaType.NUMBER, operations.getAirbyteType(JDBCType.DECIMAL));
+    assertEquals(JsonSchemaType.NUMBER, operations.getAirbyteType(JDBCType.NUMERIC));
+    assertEquals(JsonSchemaType.NUMBER, operations.getAirbyteType(JDBCType.REAL));
+  }
+
+  @Test
+  void testOtherTypes() {
+    assertEquals(JsonSchemaType.STRING, operations.getAirbyteType(JDBCType.VARCHAR));
+    assertEquals(JsonSchemaType.STRING_BASE_64, operations.getAirbyteType(JDBCType.BLOB));
+    assertEquals(JsonSchemaType.STRING_BASE_64, operations.getAirbyteType(JDBCType.BINARY));
+    assertEquals(JsonSchemaType.ARRAY, operations.getAirbyteType(JDBCType.ARRAY));
+    assertEquals(JsonSchemaType.STRING, operations.getAirbyteType(JDBCType.OTHER));
+  }
+
+  @Test
+  void testCursorTypes() {
+    assertTrue(operations.isCursorType(JDBCType.TIMESTAMP));
+    assertTrue(operations.isCursorType(JDBCType.DATE));
+    assertTrue(operations.isCursorType(JDBCType.INTEGER));
+    assertTrue(operations.isCursorType(JDBCType.BIGINT));
+    assertTrue(operations.isCursorType(JDBCType.VARCHAR));
+    assertFalse(operations.isCursorType(JDBCType.BLOB));
+    assertFalse(operations.isCursorType(JDBCType.ARRAY));
+  }
+
+}

--- a/docs/integrations/sources/clickhouse.md
+++ b/docs/integrations/sources/clickhouse.md
@@ -84,6 +84,7 @@ If you use Airbyte Cloud and your organization restricts access to specific IPs,
 
 | Version | Date       | Pull Request                                               | Subject                                                                                                   |
 |:--------|:-----------|:-----------------------------------------------------------|:----------------------------------------------------------------------------------------------------------|
+| 0.3.1   | 2026-06-29 | [72484](https://github.com/airbytehq/airbyte/pull/72484)   | Add JSON Schema format hints for temporal types (DateTime, Date) and fix documentation URL                |
 | 0.3.0   | 2026-01-27 | [75298](https://github.com/airbytehq/airbyte/pull/75298)   | Fold source-clickhouse-strict-encrypt into source-clickhouse                                              |
 | 0.2.6   | 2025-11-03 | [66714](https://github.com/airbytehq/airbyte/pull/66714)   | Revert JDBC driver upgrade                                                                                |
 | 0.2.5   | 2025-09-25 | [66482](https://github.com/airbytehq/airbyte/pull/66482)   | Upgrade ClickHouse JDBC driver from 0.3.2-patch10 to 0.9.0                                                |


### PR DESCRIPTION
## What

Rebased version of #72484 by @hkhan925 — resolving merge conflicts with master.

Fixes #72483

The ClickHouse source connector emits plain `{"type": "string"}` for temporal columns (DateTime, DateTime64, Date, Date32) without JSON Schema format hints. This causes downstream systems to treat timestamps as plain strings.

Also fixes the documentation URL in `spec.json` (pointed to destinations instead of sources).

## How

1. Re-added `ClickHouseSourceOperations` (removed in #75298) with:
   - `getDatabaseFieldType()` — maps ClickHouse large integer types (UInt64, Int128, etc.) that return as `JDBCType.OTHER` to `NUMERIC`
   - `getAirbyteType()` — maps temporal JDBC types to format-hinted JSON Schema types:
     - `TIMESTAMP` → `STRING_TIMESTAMP_WITHOUT_TIMEZONE` (format: "date-time")
     - `TIMESTAMP_WITH_TIMEZONE` → `STRING_TIMESTAMP_WITH_TIMEZONE` (format: "date-time")
     - `DATE` → `STRING_DATE` (format: "date")
     - `TIME` → `STRING_TIME_WITHOUT_TIMEZONE` (format: "time")
     - `TIME_WITH_TIMEZONE` → `STRING_TIME_WITH_TIMEZONE` (format: "time")
   - `isCursorType()` — validates cursor-compatible types
2. Updated `ClickHouseSource` constructor: `JdbcUtils.getDefaultSourceOperations()` → `new ClickHouseSourceOperations()`
3. Fixed `spec.json` documentation URL
4. Bumped version `0.3.0` → `0.3.1`

## Review guide

1. `ClickHouseSourceOperations.java` — new file, core type mapping logic
2. `ClickHouseSource.java` — one-line constructor change
3. `spec.json` — documentation URL fix
4. `ClickHouseSourceOperationsTest.java` — unit tests for type mappings and cursor types
5. `metadata.yaml` — version bump
6. `clickhouse.md` — changelog entry

## User Impact

- ClickHouse DateTime/DateTime64 columns will now be recognized as timestamps by downstream systems
- ClickHouse Date/Date32 columns will now be recognized as dates
- Large integer types (UInt64, Int128, etc.) can be used as cursor columns for incremental sync
- No breaking changes — only adds metadata that was previously missing

## Can this PR be safely reverted and rolled back?

- [x] YES 💚


Link to Devin session: https://app.devin.ai/sessions/24c7674a3da046059cb58e89963dfcc7
Requested by: @sophiecuiy

> [!IMPORTANT]
> Active progressive rollout warning for source-clickhouse.

- [ ] (Click to Approve:) Bypass the active progressive rollout warning for source-clickhouse in the PR comment [here](https://github.com/airbytehq/airbyte/pull/80944#issuecomment-4835548137).