### PR TITLE
fix(docs): add descriptive text labels to connector metric icons

### DIFF
--- a/docusaurus/src/components/HeaderDecoration.jsx
+++ b/docusaurus/src/components/HeaderDecoration.jsx
@@ -218,9 +218,13 @@ const MetricIcon = ({ iconComponent, level }) => {
 
   if (!Object.keys(iconComponent).includes(level.toLowerCase())) return null;
 
+  const displayLabel =
+    level.charAt(0).toUpperCase() + level.slice(1).toLowerCase();
+
   return (
     <div className={styles.metricIcon} title={level}>
       {iconComponent[level?.toLowerCase()]}
+      <span className={styles.metricLabel}>{displayLabel}</span>
     </div>
   );
 };

--- a/docusaurus/src/components/HeaderDecoration.module.css
+++ b/docusaurus/src/components/HeaderDecoration.module.css
@@ -131,9 +131,15 @@ html[data-theme="dark"] .connectorMetadata .availability .unavailable {
   display: flex;
   align-items: center;
   justify-content: center;
+  gap: 6px;
 }
 
 .metricIcon svg {
   height: 12px;
   width: auto;
+}
+
+.metricLabel {
+  font-size: 12px;
+  text-transform: capitalize;
 }


### PR DESCRIPTION
## What

Adds descriptive text labels ("Low", "Medium", "High") after the Sync Success Rate and Usage Rate icons on connector documentation pages. Previously these metrics only showed icons (checkmark circles and person silhouettes) without any text, making them confusing to interpret.

Requested by @ian-at-airbyte in [Slack thread](https://airbytehq-team.slack.com/archives/C032KEED342/p1782759716804589?thread_ts=1782759716.804589&cid=C032KEED342).

## How

- Modified the `MetricIcon` component in `HeaderDecoration.jsx` to render a `<span>` with the capitalized level text (e.g., "High") alongside the existing SVG icon.
- Added a `.metricLabel` CSS class and a `gap` to `.metricIcon` in `HeaderDecoration.module.css` for spacing between icon and text.

## Review guide

1. `docusaurus/src/components/HeaderDecoration.jsx` — `MetricIcon` component now renders a text label
2. `docusaurus/src/components/HeaderDecoration.module.css` — styling for the new label and icon spacing

## User Impact

Connector docs pages now display "Low", "Medium", or "High" text next to the Sync Success Rate and Usage Rate icons, making the metrics immediately understandable at a glance.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

---
[Devin session](https://app.devin.ai/sessions/6ef8fc8f5919472695fe79573df1d75f)