### PR TITLE
docs(destination-databricks): improve spec documentation and reorganize field groups

### DIFF
--- a/airbyte-integrations/connectors/destination-databricks/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-databricks/metadata.yaml
@@ -48,6 +48,7 @@ data:
           If you do not interact with the raw tables, you can safely upgrade. If you do, update any downstream
           dbt models or SQL queries to reference the final tables instead, then drop old raw tables after verifying.
         upgradeDeadline: "2026-10-01"
+        deadlineAction: "auto_upgrade"
   documentationUrl: https://docs.airbyte.com/integrations/destinations/databricks
   resourceRequirements:
     jobSpecific:

--- a/airbyte-integrations/connectors/destination-databricks/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-databricks/metadata.yaml
@@ -40,6 +40,14 @@ data:
           This version adds an `_airbyte_generation_id` column to the raw and final tables. If you ran a sync using 2.0.0, you MUST manually drop the
           raw and final tables and then clear (reset) your connection; this release will not automatically upgrade your tables.
         upgradeDeadline: "2025-01-31"
+      4.0.0:
+        message: >
+          This version upgrades Destination Databricks to the
+          [Direct-Load](https://docs.airbyte.com/platform/using-airbyte/core-concepts/direct-load-tables) paradigm,
+          which improves performance and reduces warehouse spend. Raw tables (`_airbyte_raw_*`) are no longer produced.
+          If you do not interact with the raw tables, you can safely upgrade. If you do, update any downstream
+          dbt models or SQL queries to reference the final tables instead, then drop old raw tables after verifying.
+        upgradeDeadline: "2026-10-01"
   documentationUrl: https://docs.airbyte.com/integrations/destinations/databricks
   resourceRequirements:
     jobSpecific:

--- a/airbyte-integrations/connectors/destination-databricks/src/main/kotlin/io/airbyte/integrations/destination/databricks/check/DatabricksChecker.kt
+++ b/airbyte-integrations/connectors/destination-databricks/src/main/kotlin/io/airbyte/integrations/destination/databricks/check/DatabricksChecker.kt
@@ -37,11 +37,6 @@ class DatabricksChecker(
     private var checkTableName: TableName? = null
 
     override fun check() {
-        require(config.acceptTerms) {
-            "You must agree to the Databricks JDBC Driver Terms & Conditions to use this connector. " +
-                "Set 'accept_terms' to true in the connector configuration."
-        }
-
         val namespace = config.schema.lowercase()
         val tableName = "_airbyte_check_${Instant.now().epochSecond}"
         val table = TableName(namespace = namespace, name = tableName)

--- a/airbyte-integrations/connectors/destination-databricks/src/main/kotlin/io/airbyte/integrations/destination/databricks/spec/DatabricksSpecification.kt
+++ b/airbyte-integrations/connectors/destination-databricks/src/main/kotlin/io/airbyte/integrations/destination/databricks/spec/DatabricksSpecification.kt
@@ -20,45 +20,55 @@ import jakarta.inject.Singleton
 @Singleton
 open class DatabricksSpecification : ConfigurationSpecification() {
     @get:JsonSchemaTitle("Server Hostname")
-    @get:JsonPropertyDescription("Databricks Cluster Server Hostname.")
+    @get:JsonPropertyDescription(
+        "Enter your Databricks workspace <a href=\"https://docs.databricks.com/en/integrations/compute-details.html\">server hostname</a> (e.g., abc-12345678-wxyz.cloud.databricks.com). You can find this in your cluster or SQL warehouse connection details."
+    )
     @get:JsonProperty("hostname")
     @get:JsonSchemaInject(
         json =
-            """{"group": "connection", "order": 2, "examples": ["abc-12345678-wxyz.cloud.databricks.com"]}"""
+            """{"group": "connection", "order": 1, "examples": ["abc-12345678-wxyz.cloud.databricks.com"]}"""
     )
     val hostname: String = ""
 
     @get:JsonSchemaTitle("HTTP Path")
-    @get:JsonPropertyDescription("Databricks Cluster HTTP Path.")
+    @get:JsonPropertyDescription(
+        "Enter the <a href=\"https://docs.databricks.com/en/integrations/compute-details.html\">HTTP path</a> for your Databricks SQL warehouse or cluster. You can find this in the connection details of your compute resource."
+    )
     @get:JsonProperty("http_path")
     @get:JsonSchemaInject(
         json =
-            """{"group": "connection", "order": 3, "examples": ["sql/1.0/warehouses/0000-1111111-abcd90"]}"""
+            """{"group": "connection", "order": 2, "examples": ["sql/1.0/warehouses/0000-1111111-abcd90"]}"""
     )
     val httpPath: String = ""
 
     @get:JsonSchemaTitle("Port")
-    @get:JsonPropertyDescription("Databricks Cluster Port.")
+    @get:JsonPropertyDescription(
+        "Enter the port number for the Databricks cluster connection. The default port is 443 (HTTPS)."
+    )
     @get:JsonProperty("port")
     @get:JsonSchemaInject(
-        json = """{"group": "advanced", "order": 4, "default": "443", "examples": ["443"]}""",
+        json = """{"group": "advanced", "order": 9, "default": "443", "examples": ["443"]}""",
     )
     val port: String? = "443"
 
     @get:JsonSchemaTitle("Databricks Unity Catalog Name")
-    @get:JsonPropertyDescription("The name of the unity catalog for the database")
+    @get:JsonPropertyDescription(
+        "Enter the name of the <a href=\"https://docs.databricks.com/en/data-governance/unity-catalog/index.html\">Unity Catalog</a> that you want to sync data into."
+    )
     @get:JsonProperty("database")
-    @get:JsonSchemaInject(json = """{"group": "connection", "order": 5}""")
+    @get:JsonSchemaInject(
+        json = """{"group": "connection", "order": 3, "examples": ["AIRBYTE_DATABASE"]}"""
+    )
     val database: String = ""
 
     @get:JsonSchemaTitle("Default Schema")
     @get:JsonPropertyDescription(
-        """The default schema tables are written. If not specified otherwise, the "default" will be used."""
+        """Enter the name of the default <a href="https://docs.databricks.com/en/sql/language-manual/sql-ref-schema.html">schema</a> where tables will be written. If not specified, "default" will be used."""
     )
     @get:JsonProperty("schema")
     @get:JsonSchemaInject(
         json =
-            """{"group": "advanced", "order": 6, "default": "default", "examples": ["default"]}""",
+            """{"group": "connection", "order": 4, "default": "default", "examples": ["AIRBYTE_SCHEMA"]}""",
     )
     val schema: String? = "default"
 
@@ -67,19 +77,23 @@ open class DatabricksSpecification : ConfigurationSpecification() {
         """Whether to execute CDC deletions as hard deletes (i.e. propagate source deletions to the destination), or soft deletes (i.e. leave a tombstone record in the destination). Defaults to hard deletes.""",
     )
     @get:JsonProperty("cdc_deletion_mode", defaultValue = "Hard delete")
-    @get:JsonSchemaInject(json = """{"group": "advanced", "order": 7, "always_show": true}""")
+    @get:JsonSchemaInject(json = """{"group": "sync_behavior", "order": 7, "always_show": true}""")
     val cdcDeletionMode: CdcDeletionMode? = null
 
     @get:JsonSchemaTitle("Authentication")
-    @get:JsonSchemaDescription("Authentication mechanism for Staging files and running queries")
+    @get:JsonSchemaDescription(
+        "Determines the type of authentication used to connect to Databricks. OAuth2 is recommended for production use."
+    )
     @get:JsonProperty("authentication")
-    @get:JsonSchemaInject(json = """{"group": "connection", "order": 8}""")
+    @get:JsonSchemaInject(json = """{"group": "connection", "order": 5}""")
     val authentication: DatabricksAuthSpecification = OAuthSpecification()
 
     @get:JsonSchemaTitle("Purge Staging Files and Tables")
-    @get:JsonPropertyDescription("Default to 'true'. Switch it to 'false' for debugging purpose.")
+    @get:JsonPropertyDescription(
+        "Whether to delete staging files and tables after data has been loaded. Disable this option for debugging purposes."
+    )
     @get:JsonProperty("purge_staging_data")
-    @get:JsonSchemaInject(json = """{"group": "advanced", "order": 9, "default": true}""")
+    @get:JsonSchemaInject(json = """{"group": "sync_behavior", "order": 8, "default": true}""")
     @Suppress("RedundantNullableReturnType")
     val purgeStagingData: Boolean? = true
 
@@ -88,7 +102,9 @@ open class DatabricksSpecification : ConfigurationSpecification() {
         """You must agree to the Databricks JDBC Driver <a href="https://databricks.com/jdbc-odbc-driver-license">Terms & Conditions</a> to use this connector.""",
     )
     @get:JsonProperty("accept_terms")
-    @get:JsonSchemaInject(json = """{"group": "connection", "order": 10, "default": false}""")
+    @get:JsonSchemaInject(
+        json = """{"group": "connection", "order": 6, "default": false, "const": true}"""
+    )
     val acceptTerms: Boolean = false
 }
 
@@ -104,6 +120,7 @@ open class DatabricksSpecification : ConfigurationSpecification() {
 sealed class DatabricksAuthSpecification(
     @Suppress("PropertyName") @param:JsonProperty("auth_type") val auth_type: Type
 ) {
+    /** Enumeration of possible authentication types. */
     enum class Type(@get:JsonValue val authTypeName: String) {
         OAUTH("OAUTH"),
         BASIC("BASIC"),
@@ -114,10 +131,14 @@ sealed class DatabricksAuthSpecification(
 @JsonSchemaDescription("Authentication using OAuth2 client credentials.")
 class OAuthSpecification(
     @get:JsonSchemaTitle("Client ID")
+    @get:JsonPropertyDescription(
+        "Enter the OAuth2 client ID for your Databricks <a href=\"https://docs.databricks.com/en/dev-tools/auth/oauth-m2m.html\">service principal</a>."
+    )
     @get:JsonProperty("client_id")
     @get:JsonSchemaInject(json = """{"order": 1}""")
     val clientId: String = "",
     @get:JsonSchemaTitle("Secret")
+    @get:JsonPropertyDescription("Enter the OAuth2 secret associated with the client ID.")
     @get:JsonProperty("secret")
     @get:JsonSchemaInject(json = """{"order": 2, "airbyte_secret": true}""")
     val secret: String = "",
@@ -127,11 +148,15 @@ class OAuthSpecification(
 @JsonSchemaDescription("Authentication using a personal access token.")
 class PersonalAccessTokenSpecification(
     @get:JsonSchemaTitle("Personal Access Token")
+    @get:JsonPropertyDescription(
+        "Enter your Databricks <a href=\"https://docs.databricks.com/en/dev-tools/auth/pat.html\">personal access token</a>."
+    )
     @get:JsonProperty("personal_access_token")
     @get:JsonSchemaInject(json = """{"order": 1, "airbyte_secret": true}""")
     val personalAccessToken: String = "",
 ) : DatabricksAuthSpecification(Type.BASIC)
 
+/** Determines how CDC deletions are handled at the destination. */
 enum class CdcDeletionMode(@get:JsonValue val cdcDeletionMode: String) {
     HARD_DELETE("Hard delete"),
     SOFT_DELETE("Soft delete"),
@@ -149,6 +174,7 @@ class DatabricksSpecificationExtension : DestinationSpecificationExtension {
     override val groups =
         listOf(
             DestinationSpecificationExtension.Group("connection", "Connection"),
-            DestinationSpecificationExtension.Group("advanced", "Optional Fields"),
+            DestinationSpecificationExtension.Group("sync_behavior", "Sync Behavior"),
+            DestinationSpecificationExtension.Group("advanced", "Advanced"),
         )
 }

--- a/airbyte-integrations/connectors/destination-databricks/src/test-integration/resources/expected-spec-cloud.json
+++ b/airbyte-integrations/connectors/destination-databricks/src/test-integration/resources/expected-spec-cloud.json
@@ -8,44 +8,45 @@
     "properties" : {
       "hostname" : {
         "type" : "string",
-        "description" : "Databricks Cluster Server Hostname.",
+        "description" : "Enter your Databricks workspace <a href=\"https://docs.databricks.com/en/integrations/compute-details.html\">server hostname</a> (e.g., abc-12345678-wxyz.cloud.databricks.com). You can find this in your cluster or SQL warehouse connection details.",
         "title" : "Server Hostname",
         "group" : "connection",
-        "order" : 2,
+        "order" : 1,
         "examples" : [ "abc-12345678-wxyz.cloud.databricks.com" ]
       },
       "http_path" : {
         "type" : "string",
-        "description" : "Databricks Cluster HTTP Path.",
+        "description" : "Enter the <a href=\"https://docs.databricks.com/en/integrations/compute-details.html\">HTTP path</a> for your Databricks SQL warehouse or cluster. You can find this in the connection details of your compute resource.",
         "title" : "HTTP Path",
         "group" : "connection",
-        "order" : 3,
+        "order" : 2,
         "examples" : [ "sql/1.0/warehouses/0000-1111111-abcd90" ]
       },
       "port" : {
         "type" : "string",
-        "description" : "Databricks Cluster Port.",
+        "description" : "Enter the port number for the Databricks cluster connection. The default port is 443 (HTTPS).",
         "title" : "Port",
         "group" : "advanced",
-        "order" : 4,
+        "order" : 9,
         "default" : "443",
         "examples" : [ "443" ]
       },
       "database" : {
         "type" : "string",
-        "description" : "The name of the unity catalog for the database",
+        "description" : "Enter the name of the <a href=\"https://docs.databricks.com/en/data-governance/unity-catalog/index.html\">Unity Catalog</a> that you want to sync data into.",
         "title" : "Databricks Unity Catalog Name",
         "group" : "connection",
-        "order" : 5
+        "order" : 3,
+        "examples" : [ "AIRBYTE_DATABASE" ]
       },
       "schema" : {
         "type" : "string",
-        "description" : "The default schema tables are written. If not specified otherwise, the \"default\" will be used.",
+        "description" : "Enter the name of the default <a href=\"https://docs.databricks.com/en/sql/language-manual/sql-ref-schema.html\">schema</a> where tables will be written. If not specified, \"default\" will be used.",
         "title" : "Default Schema",
-        "group" : "advanced",
-        "order" : 6,
+        "group" : "connection",
+        "order" : 4,
         "default" : "default",
-        "examples" : [ "default" ]
+        "examples" : [ "AIRBYTE_SCHEMA" ]
       },
       "cdc_deletion_mode" : {
         "type" : "string",
@@ -53,7 +54,7 @@
         "enum" : [ "Hard delete", "Soft delete" ],
         "description" : "Whether to execute CDC deletions as hard deletes (i.e. propagate source deletions to the destination), or soft deletes (i.e. leave a tombstone record in the destination). Defaults to hard deletes.",
         "title" : "CDC deletion mode",
-        "group" : "advanced",
+        "group" : "sync_behavior",
         "order" : 7,
         "always_show" : true
       },
@@ -71,11 +72,13 @@
             },
             "client_id" : {
               "type" : "string",
+              "description" : "Enter the OAuth2 client ID for your Databricks <a href=\"https://docs.databricks.com/en/dev-tools/auth/oauth-m2m.html\">service principal</a>.",
               "title" : "Client ID",
               "order" : 1
             },
             "secret" : {
               "type" : "string",
+              "description" : "Enter the OAuth2 secret associated with the client ID.",
               "title" : "Secret",
               "order" : 2,
               "airbyte_secret" : true
@@ -95,6 +98,7 @@
             },
             "personal_access_token" : {
               "type" : "string",
+              "description" : "Enter your Databricks <a href=\"https://docs.databricks.com/en/dev-tools/auth/pat.html\">personal access token</a>.",
               "title" : "Personal Access Token",
               "order" : 1,
               "airbyte_secret" : true
@@ -102,18 +106,18 @@
           },
           "required" : [ "auth_type", "personal_access_token" ]
         } ],
-        "description" : "Authentication mechanism for Staging files and running queries",
+        "description" : "Determines the type of authentication used to connect to Databricks. OAuth2 is recommended for production use.",
         "title" : "Authentication",
         "group" : "connection",
-        "order" : 8,
+        "order" : 5,
         "type" : "object"
       },
       "purge_staging_data" : {
         "type" : "boolean",
-        "description" : "Default to 'true'. Switch it to 'false' for debugging purpose.",
+        "description" : "Whether to delete staging files and tables after data has been loaded. Disable this option for debugging purposes.",
         "title" : "Purge Staging Files and Tables",
-        "group" : "advanced",
-        "order" : 9,
+        "group" : "sync_behavior",
+        "order" : 8,
         "default" : true
       },
       "accept_terms" : {
@@ -121,8 +125,9 @@
         "description" : "You must agree to the Databricks JDBC Driver <a href=\"https://databricks.com/jdbc-odbc-driver-license\">Terms & Conditions</a> to use this connector.",
         "title" : "Agree to the Databricks JDBC Driver Terms & Conditions",
         "group" : "connection",
-        "order" : 10,
-        "default" : false
+        "order" : 6,
+        "default" : false,
+        "const" : true
       }
     },
     "required" : [ "hostname", "http_path", "database", "authentication", "accept_terms" ],
@@ -130,8 +135,11 @@
       "id" : "connection",
       "title" : "Connection"
     }, {
+      "id" : "sync_behavior",
+      "title" : "Sync Behavior"
+    }, {
       "id" : "advanced",
-      "title" : "Optional Fields"
+      "title" : "Advanced"
     } ]
   },
   "supportsIncremental" : true,

--- a/airbyte-integrations/connectors/destination-databricks/src/test-integration/resources/expected-spec-oss.json
+++ b/airbyte-integrations/connectors/destination-databricks/src/test-integration/resources/expected-spec-oss.json
@@ -8,44 +8,45 @@
     "properties" : {
       "hostname" : {
         "type" : "string",
-        "description" : "Databricks Cluster Server Hostname.",
+        "description" : "Enter your Databricks workspace <a href=\"https://docs.databricks.com/en/integrations/compute-details.html\">server hostname</a> (e.g., abc-12345678-wxyz.cloud.databricks.com). You can find this in your cluster or SQL warehouse connection details.",
         "title" : "Server Hostname",
         "group" : "connection",
-        "order" : 2,
+        "order" : 1,
         "examples" : [ "abc-12345678-wxyz.cloud.databricks.com" ]
       },
       "http_path" : {
         "type" : "string",
-        "description" : "Databricks Cluster HTTP Path.",
+        "description" : "Enter the <a href=\"https://docs.databricks.com/en/integrations/compute-details.html\">HTTP path</a> for your Databricks SQL warehouse or cluster. You can find this in the connection details of your compute resource.",
         "title" : "HTTP Path",
         "group" : "connection",
-        "order" : 3,
+        "order" : 2,
         "examples" : [ "sql/1.0/warehouses/0000-1111111-abcd90" ]
       },
       "port" : {
         "type" : "string",
-        "description" : "Databricks Cluster Port.",
+        "description" : "Enter the port number for the Databricks cluster connection. The default port is 443 (HTTPS).",
         "title" : "Port",
         "group" : "advanced",
-        "order" : 4,
+        "order" : 9,
         "default" : "443",
         "examples" : [ "443" ]
       },
       "database" : {
         "type" : "string",
-        "description" : "The name of the unity catalog for the database",
+        "description" : "Enter the name of the <a href=\"https://docs.databricks.com/en/data-governance/unity-catalog/index.html\">Unity Catalog</a> that you want to sync data into.",
         "title" : "Databricks Unity Catalog Name",
         "group" : "connection",
-        "order" : 5
+        "order" : 3,
+        "examples" : [ "AIRBYTE_DATABASE" ]
       },
       "schema" : {
         "type" : "string",
-        "description" : "The default schema tables are written. If not specified otherwise, the \"default\" will be used.",
+        "description" : "Enter the name of the default <a href=\"https://docs.databricks.com/en/sql/language-manual/sql-ref-schema.html\">schema</a> where tables will be written. If not specified, \"default\" will be used.",
         "title" : "Default Schema",
-        "group" : "advanced",
-        "order" : 6,
+        "group" : "connection",
+        "order" : 4,
         "default" : "default",
-        "examples" : [ "default" ]
+        "examples" : [ "AIRBYTE_SCHEMA" ]
       },
       "cdc_deletion_mode" : {
         "type" : "string",
@@ -53,7 +54,7 @@
         "enum" : [ "Hard delete", "Soft delete" ],
         "description" : "Whether to execute CDC deletions as hard deletes (i.e. propagate source deletions to the destination), or soft deletes (i.e. leave a tombstone record in the destination). Defaults to hard deletes.",
         "title" : "CDC deletion mode",
-        "group" : "advanced",
+        "group" : "sync_behavior",
         "order" : 7,
         "always_show" : true
       },
@@ -71,11 +72,13 @@
             },
             "client_id" : {
               "type" : "string",
+              "description" : "Enter the OAuth2 client ID for your Databricks <a href=\"https://docs.databricks.com/en/dev-tools/auth/oauth-m2m.html\">service principal</a>.",
               "title" : "Client ID",
               "order" : 1
             },
             "secret" : {
               "type" : "string",
+              "description" : "Enter the OAuth2 secret associated with the client ID.",
               "title" : "Secret",
               "order" : 2,
               "airbyte_secret" : true
@@ -95,6 +98,7 @@
             },
             "personal_access_token" : {
               "type" : "string",
+              "description" : "Enter your Databricks <a href=\"https://docs.databricks.com/en/dev-tools/auth/pat.html\">personal access token</a>.",
               "title" : "Personal Access Token",
               "order" : 1,
               "airbyte_secret" : true
@@ -102,18 +106,18 @@
           },
           "required" : [ "auth_type", "personal_access_token" ]
         } ],
-        "description" : "Authentication mechanism for Staging files and running queries",
+        "description" : "Determines the type of authentication used to connect to Databricks. OAuth2 is recommended for production use.",
         "title" : "Authentication",
         "group" : "connection",
-        "order" : 8,
+        "order" : 5,
         "type" : "object"
       },
       "purge_staging_data" : {
         "type" : "boolean",
-        "description" : "Default to 'true'. Switch it to 'false' for debugging purpose.",
+        "description" : "Whether to delete staging files and tables after data has been loaded. Disable this option for debugging purposes.",
         "title" : "Purge Staging Files and Tables",
-        "group" : "advanced",
-        "order" : 9,
+        "group" : "sync_behavior",
+        "order" : 8,
         "default" : true
       },
       "accept_terms" : {
@@ -121,8 +125,9 @@
         "description" : "You must agree to the Databricks JDBC Driver <a href=\"https://databricks.com/jdbc-odbc-driver-license\">Terms & Conditions</a> to use this connector.",
         "title" : "Agree to the Databricks JDBC Driver Terms & Conditions",
         "group" : "connection",
-        "order" : 10,
-        "default" : false
+        "order" : 6,
+        "default" : false,
+        "const" : true
       }
     },
     "required" : [ "hostname", "http_path", "database", "authentication", "accept_terms" ],
@@ -130,8 +135,11 @@
       "id" : "connection",
       "title" : "Connection"
     }, {
+      "id" : "sync_behavior",
+      "title" : "Sync Behavior"
+    }, {
       "id" : "advanced",
-      "title" : "Optional Fields"
+      "title" : "Advanced"
     } ]
   },
   "supportsIncremental" : true,

--- a/airbyte-integrations/connectors/destination-databricks/src/test/kotlin/io/airbyte/integrations/destination/databricks/check/DatabricksCheckerTest.kt
+++ b/airbyte-integrations/connectors/destination-databricks/src/test/kotlin/io/airbyte/integrations/destination/databricks/check/DatabricksCheckerTest.kt
@@ -123,17 +123,6 @@ class DatabricksCheckerTest {
     }
 
     @Test
-    fun `check fails when terms are not accepted`() {
-        val noTermsConfig = config.copy(acceptTerms = false)
-        val noTermsChecker = DatabricksChecker(databricksClient, noTermsConfig)
-
-        val exception = assertThrows<IllegalArgumentException> { noTermsChecker.check() }
-
-        assertTrue(exception.message!!.contains("accept_terms"))
-        coVerify(exactly = 0) { databricksClient.createNamespace(any()) }
-    }
-
-    @Test
     fun `check uses lowercased schema from config`() {
         val upperConfig = config.copy(schema = "MySchema")
         val upperChecker = DatabricksChecker(databricksClient, upperConfig)

--- a/docs/integrations/destinations/databricks-migrations.md
+++ b/docs/integrations/destinations/databricks-migrations.md
@@ -1,5 +1,18 @@
 # Databricks Lakehouse Migration Guide
 
+## Upgrading to 4.0.0
+
+This version upgrades Destination Databricks to the [Direct-Load](/platform/using-airbyte/core-concepts/direct-load-tables) paradigm, which improves performance and reduces warehouse spend. If you have unusual requirements around record visibility or schema evolution, read that document for more information about how Direct-Load differs from Typing and Deduping.
+
+If you do not interact with the raw tables, you can safely upgrade. There is no breakage for this use case. But if you interact with the raw tables, follow the migration steps below.
+
+### Migration steps
+
+1. Raw tables (`_airbyte_raw_*`) are no longer produced. Update any downstream dbt models or SQL queries to reference the final tables instead.
+2. Upgrade the destination to version 4.0.0
+3. Verify data in the final tables
+4. Optional: Drop old raw tables (`_airbyte_raw_*`) after verifying the new tables
+
 ## Upgrading to 3.0.0
 
 This version adds an `_airbyte_generation_id` column to the raw and final tables and a `sync_id` entry in `_airbyte_meta`.

--- a/docs/integrations/destinations/databricks.md
+++ b/docs/integrations/destinations/databricks.md
@@ -1,25 +1,19 @@
 # Databricks Lakehouse
 
-## Overview
+:::info Direct Load
 
-This destination syncs data to Delta Lake on Databricks Lakehouse. Each stream is written to its own
-[delta-table](https://delta.io/).
+Starting with version 4.0.0, the Databricks Lakehouse destination uses **Direct Load** architecture. This means data is written directly to final tables without using intermediate raw tables, providing improved performance and reduced storage costs.
 
-:::caution
-You **must** be using Unity Catalog to use this connector.
+For migration details and backward compatibility options, see the [Databricks Migration Guide](databricks-migrations.md#upgrading-to-400).
+
 :::
 
-:::info
-Please note, at this time OAuth2 authentication is only supported in AWS
-deployments. If you are running Databricks in GCP, you **must** use an access
-token.
-:::
+## Prerequisites
 
-This connector requires a JDBC driver to connect to the Databricks cluster. By using the driver and
-the connector, you must agree to the
-[JDBC ODBC driver license](https://databricks.com/jdbc-odbc-driver-license). This means that you can
-only use this connector to connect third party applications to Apache Spark SQL within a Databricks
-offering using the ODBC and/or JDBC protocols.
+- A Databricks workspace with [Unity Catalog](https://docs.databricks.com/en/data-governance/unity-catalog/index.html) enabled.
+- A SQL warehouse or compute cluster to run queries against.
+- Authentication credentials: OAuth client ID and secret (AWS only), or a personal access token.
+- Acceptance of the Databricks [JDBC ODBC driver license](https://databricks.com/jdbc-odbc-driver-license). By using this connector, you agree that it may only be used to connect third-party applications to Apache Spark SQL within a Databricks offering using the ODBC and/or JDBC protocols.
 
 ## Network access
 
@@ -27,9 +21,9 @@ If you're using Airbyte Cloud and this destination uses IP-based access controls
 add Airbyte's [IP addresses](/platform/operating-airbyte/ip-allowlist) to your
 allowlist.
 
-## Airbyte Setup
+## Step 1: Set up Databricks
 
-When setting up a Databricks destination, you need these pieces of information:
+You will need the following information from your Databricks workspace:
 
 ### Server Hostname / HTTP Path / Port
 
@@ -42,9 +36,16 @@ When setting up a Databricks destination, you need these pieces of information:
 
    ![](/.gitbook/assets/destination/databricks/databricks_sql_warehouse_connection_details.png)
 
-4. Finally, you'll need to provide the `Databricks Unity Catalog Path`, which is the path to the database you wish to use within the Unity Catalog. This is often the same as the workspace name.
+4. Note the **Server Hostname**, **HTTP Path**, and **Port** values.
+
+5. Finally, you'll need to note the **Databricks Unity Catalog Path**, which is the path to the database you wish to use within the Unity Catalog. This is often the same as the workspace name.
+
 
 ### Authentication
+
+:::info
+At this time, OAuth2 authentication is only supported in AWS deployments. If you are running Databricks in GCP, you **must** use a personal access token.
+:::
 
 #### OAuth (Recommended for AWS deployments of Databricks)
 
@@ -62,10 +63,17 @@ to generate a client ID and secret.
 
    ![](/.gitbook/assets/destination/databricks/databricks_generate_token.png)
 
-### Other Options
+## Step 2: Set up the Databricks destination in Airbyte
 
-- `Default Schema` - The schema that will contain your data. You can later override this on a per-connection basis.
-- `Purge Staging Files and Tables` - Whether Airbyte should delete files after loading them into tables. Note: if deselected, Databricks will still delete your files after your retention period has passed (default - 7 days).
+1. Log in to your Airbyte account.
+2. In the left navigation bar, click **Destinations**. In the top-right corner, click **+ New destination**.
+3. Find and select **Databricks Lakehouse** from the list of available destinations.
+4. Enter the **Server Hostname**, **HTTP Path**, **Port**, and **Databricks Unity Catalog Path** from Step 1.
+5. Select your **Authentication** method and enter the required credentials.
+6. Configure the remaining options:
+   - `Default Schema` - The schema that will contain your data. You can later override this on a per-connection basis.
+   - `Purge Staging Files and Tables` - Whether Airbyte should delete files after loading them into tables. Note: if deselected, Databricks will still delete your files after your retention period has passed (default - 7 days).
+7. Click **Set up destination**.
 
 ## Supported sync modes
 
@@ -79,17 +87,39 @@ to generate a client ID and secret.
 
 ## Output Schema
 
-Each table will have the following columns, in addition to your whatever columns were in your data:
+### Output Schema (Direct Load)
 
-| Column                   |   Type    | Notes                                                                  |
-| :----------------------- | :-------: | :--------------------------------------------------------------------- |
-| `_airbyte_raw_id`        |  string   | A random UUID.                                                         |
-| `_airbyte_extracted_at`  | timestamp | Timestamp when the source read the record.                             |
-| `_airbyte_loaded_at`     | timestamp | Timestamp when the record was written to the destination               |
-| `_airbyte_generation_id` |  bigint   | See the [refreshes](../../platform/operator-guides/refreshes) documentation. |
+The Databricks destination uses Direct Load architecture. Each stream is written directly to a final table in your configured schema. The table includes your data columns plus the following Airbyte metadata columns:
 
-Airbyte will also produce "raw tables" (by default in the `airbyte_internal` schema). We do not recommend directly interacting
-with the raw tables, and their format is subject to change without notice.
+| Column                   |   Type      | Notes                                                                    |
+| :----------------------- | :---------: | :----------------------------------------------------------------------- |
+| `_airbyte_raw_id`        |  `STRING`   | A UUID assigned by Airbyte to each processed event.                      |
+| `_airbyte_extracted_at`  | `TIMESTAMP` | Timestamp when the event was pulled from the data source.                |
+| `_airbyte_meta`          |  `STRING`   | JSON metadata about the record, including sync information.              |
+| `_airbyte_generation_id` |  `LONG`     | See the [refreshes](../../platform/operator-guides/refreshes) documentation. |
+
+## Data type map
+
+| Airbyte Type                 | Databricks Type   | Notes                                                  |
+| :--------------------------- | :---------------- | :----------------------------------------------------- |
+| `string`                     | `STRING`          |                                                        |
+| `number`                     | `DECIMAL(38, 10)` | Max 28 integer digits, 10 fractional                   |
+| `integer`                    | `LONG`            | 64-bit integer                                         |
+| `boolean`                    | `BOOLEAN`         |                                                        |
+| `object`                     | `STRING`          | Serialized as JSON                                     |
+| `array`                      | `STRING`          | Serialized as JSON                                     |
+| `timestamp_with_timezone`    | `TIMESTAMP`       | Microsecond precision                                  |
+| `timestamp_without_timezone` | `TIMESTAMP_NTZ`   | Microsecond precision, no timezone                     |
+| `time_with_timezone`         | `STRING`          | No native Databricks equivalent                        |
+| `time_without_timezone`      | `STRING`          | No native Databricks equivalent                        |
+| `date`                       | `DATE`            |                                                        |
+
+## Naming conventions
+
+Databricks uses [Unity Catalog](https://docs.databricks.com/en/data-governance/unity-catalog/index.html) identifiers with the following rules:
+
+- Identifiers are **case-insensitive**. Stream and namespace names are lowercased when creating tables and schemas.
+- Special characters and mixed-case names are handled by the connector automatically.
 
 ## Namespace support
 
@@ -102,6 +132,7 @@ This destination supports [namespaces](https://docs.airbyte.com/platform/using-a
 
 | Version | Date       | Pull Request                                                                                                        | Subject                                                                                                                                                                                |
 |:--------|:-----------|:--------------------------------------------------------------------------------------------------------------------|:---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 4.0.0   | 2026-06-29 | [80823](https://github.com/airbytehq/airbyte/pull/80823)                                                            | Complete rewrite: removed v1 connector and promoted v2 as the main destination-databricks; upgraded base image from 2.0.1 to 2.0.4                                                     |
 | 3.3.8   | 2026-03-11 | [74732](https://github.com/airbytehq/airbyte/pull/74732)                                                            | Add JDBC ConnectTimeout and SocketTimeout to prevent indefinite hangs when Databricks SQL warehouse is paused or unresponsive                                                          |
 | 3.3.7   | 2025-07-15 | [63311](https://github.com/airbytehq/airbyte/pull/63311)                                                            | Support arbitrary number of streams in findExisitngTable query                                                                                                                         |
 | 3.3.6   | 2025-03-24 | [56355](https://github.com/airbytehq/airbyte/pull/56355)                                                            | Upgrade to airbyte/java-connector-base:2.0.1 to be M4 compatible.                                                                                                                      |

--- a/docs/integrations/destinations/databricks.md
+++ b/docs/integrations/destinations/databricks.md
@@ -40,7 +40,6 @@ You will need the following information from your Databricks workspace:
 
 5. Finally, you'll need to note the **Databricks Unity Catalog Path**, which is the path to the database you wish to use within the Unity Catalog. This is often the same as the workspace name.
 
-
 ### Authentication
 
 :::info


### PR DESCRIPTION
## Summary

- Improve `DatabricksSpecification.kt` documentation to match Snowflake's quality standard, adding action-oriented field descriptions with links to official Databricks docs (compute details, Unity Catalog, schema, OAuth M2M, PAT)
- Reorganize spec fields into 3 groups — **Connection**, **Sync Behavior**, **Advanced** — with sequential ordering starting from 1
- Add schema-level `const: true` enforcement for `accept_terms` and remove the now-redundant runtime `require()` check from `DatabricksChecker`

### Docs (`databricks.md`, `databricks-migrations.md`, `metadata.yaml`)
- Pre-existing v4.0.0 documentation updates (included in this branch)