### PR TITLE
fix(source-amazon-ads): fix off-by-one in 60-day report retention cap and skip out-of-retention slices

### DIFF
--- a/airbyte-integrations/connectors/source-amazon-ads/manifest.yaml
+++ b/airbyte-integrations/connectors/source-amazon-ads/manifest.yaml
@@ -56,9 +56,6 @@ definitions:
         action: FAIL
         failure_type: config_error
         error_message: "{{ response.details }}"
-      - predicate: "{{ 'must be equal to or after report type data retention start date' in response.details }}"
-        action: IGNORE
-        error_message: "Skipping report slice because the requested date range falls outside Amazon's data retention window for this report type. {{ response.details }}"
       - type: HttpResponseFilter
         http_codes: [ 425 ]
         action: FAIL
@@ -3406,11 +3403,10 @@ definitions:
     lookback_window: P{{ config.get('look_back_window', 3) }}D
     start_datetime:
       type: MinMaxDatetime
-      datetime: >-
-        {%- set today = today_utc() -%}
-        {%- set user_start_date = config.get('start_date', today.strftime('%Y-%m-%d')) -%}
-        {%- set fifty_nine_days_ago = today - duration('P59D') -%}
-        "{{ max(user_start_date, fifty_nine_days_ago.strftime('%Y-%m-%d')) }}"
+      datetime: "{{ config.get('start_date', today_utc().strftime('%Y-%m-%d')) }}"
+      # Amazon Ads Sponsored Brands reports have a 60-day data retention limit.
+      # https://advertising.amazon.com/API/docs/en-us/guides/reporting/v3/report-types
+      min_datetime: "{{ today_utc() - duration('P60D') }}"
       datetime_format: "%Y-%m-%d"
     end_datetime:
       datetime: "{{ today_utc() }}"

--- a/airbyte-integrations/connectors/source-amazon-ads/manifest.yaml
+++ b/airbyte-integrations/connectors/source-amazon-ads/manifest.yaml
@@ -56,6 +56,9 @@ definitions:
         action: FAIL
         failure_type: config_error
         error_message: "{{ response.details }}"
+      - predicate: "{{ 'must be equal to or after report type data retention start date' in response.details }}"
+        action: IGNORE
+        error_message: "Skipping report slice because the requested date range falls outside Amazon's data retention window for this report type. {{ response.details }}"
       - type: HttpResponseFilter
         http_codes: [ 425 ]
         action: FAIL
@@ -3404,10 +3407,10 @@ definitions:
     start_datetime:
       type: MinMaxDatetime
       datetime: >-
-        {%- set today = today_utc() - duration('P1D') -%}
+        {%- set today = today_utc() -%}
         {%- set user_start_date = config.get('start_date', today.strftime('%Y-%m-%d')) -%}
-        {%- set sixty_days_ago = today - duration('P60D') -%}
-        "{{ max(user_start_date, sixty_days_ago.strftime('%Y-%m-%d')) }}"
+        {%- set fifty_nine_days_ago = today - duration('P59D') -%}
+        "{{ max(user_start_date, fifty_nine_days_ago.strftime('%Y-%m-%d')) }}"
       datetime_format: "%Y-%m-%d"
     end_datetime:
       datetime: "{{ today_utc() }}"

--- a/airbyte-integrations/connectors/source-amazon-ads/manifest.yaml
+++ b/airbyte-integrations/connectors/source-amazon-ads/manifest.yaml
@@ -3403,7 +3403,7 @@ definitions:
     lookback_window: P{{ config.get('look_back_window', 3) }}D
     start_datetime:
       type: MinMaxDatetime
-      datetime: "{{ config.get('start_date', today_utc().strftime('%Y-%m-%d')) }}"
+      datetime: "{{ config.get('start_date', (today_utc() - duration('P1D')).strftime('%Y-%m-%d')) }}"
       # Amazon Ads Sponsored Brands reports have a 60-day data retention limit.
       # https://advertising.amazon.com/API/docs/en-us/guides/reporting/v3/report-types
       min_datetime: "{{ today_utc() - duration('P60D') }}"

--- a/airbyte-integrations/connectors/source-amazon-ads/metadata.yaml
+++ b/airbyte-integrations/connectors/source-amazon-ads/metadata.yaml
@@ -13,7 +13,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: c6b0a29e-1da9-4512-9002-7bfd0cba2246
-  dockerImageTag: 9.0.2
+  dockerImageTag: 9.0.3
   dockerRepository: airbyte/source-amazon-ads
   documentationUrl: https://docs.airbyte.com/integrations/sources/amazon-ads
   githubIssueLabel: source-amazon-ads

--- a/docs/integrations/sources/amazon-ads.md
+++ b/docs/integrations/sources/amazon-ads.md
@@ -185,6 +185,7 @@ If you use Airbyte Cloud and your organization restricts access to specific IPs,
 
 | Version    | Date       | Pull Request                                             | Subject                                                                                                                                                                |
 |:-----------|:-----------|:---------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 9.0.3 | 2026-06-30 | []() | Fix off-by-one in 60-day report date retention cap (requested 61 days back) and skip slices outside Amazon's per-report-type data retention window instead of failing the stream |
 | 9.0.2 | 2026-06-30 | [80957](https://github.com/airbytehq/airbyte/pull/80957) | Update dependencies |
 | 9.0.1 | 2026-06-23 | [80363](https://github.com/airbytehq/airbyte/pull/80363) | Update dependencies |
 | 9.0.0 | 2026-06-18 | [80201](https://github.com/airbytehq/airbyte/pull/80201) | Migrate `sponsored_product_ad_group_suggested_keywords` stream from deprecated V2 Suggested Keywords API to Keyword Recommendations API (`/sp/targets/keywords/recommendations`). |

--- a/docs/integrations/sources/amazon-ads.md
+++ b/docs/integrations/sources/amazon-ads.md
@@ -185,7 +185,7 @@ If you use Airbyte Cloud and your organization restricts access to specific IPs,
 
 | Version    | Date       | Pull Request                                             | Subject                                                                                                                                                                |
 |:-----------|:-----------|:---------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| 9.0.3 | 2026-06-30 | []() | Fix off-by-one in 60-day report date retention cap (requested 61 days back) and skip slices outside Amazon's per-report-type data retention window instead of failing the stream |
+| 9.0.3 | 2026-06-30 | [81333](https://github.com/airbytehq/airbyte/pull/81333) | Fix off-by-one in 60-day report date retention cap (requested 61 days back) and skip slices outside Amazon's per-report-type data retention window instead of failing the stream |
 | 9.0.2 | 2026-06-30 | [80957](https://github.com/airbytehq/airbyte/pull/80957) | Update dependencies |
 | 9.0.1 | 2026-06-23 | [80363](https://github.com/airbytehq/airbyte/pull/80363) | Update dependencies |
 | 9.0.0 | 2026-06-18 | [80201](https://github.com/airbytehq/airbyte/pull/80201) | Migrate `sponsored_product_ad_group_suggested_keywords` stream from deprecated V2 Suggested Keywords API to Keyword Recommendations API (`/sp/targets/keywords/recommendations`). |

--- a/docs/integrations/sources/amazon-ads.md
+++ b/docs/integrations/sources/amazon-ads.md
@@ -185,7 +185,7 @@ If you use Airbyte Cloud and your organization restricts access to specific IPs,
 
 | Version    | Date       | Pull Request                                             | Subject                                                                                                                                                                |
 |:-----------|:-----------|:---------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| 9.0.3 | 2026-06-30 | [81333](https://github.com/airbytehq/airbyte/pull/81333) | Fix off-by-one in 60-day report date retention cap (requested 61 days back) and skip slices outside Amazon's per-report-type data retention window instead of failing the stream |
+| 9.0.3 | 2026-06-30 | [81333](https://github.com/airbytehq/airbyte/pull/81333) | Use `min_datetime` to cap report start date to Amazon's 60-day data retention limit, fixing off-by-one that requested 61 days back |
 | 9.0.2 | 2026-06-30 | [80957](https://github.com/airbytehq/airbyte/pull/80957) | Update dependencies |
 | 9.0.1 | 2026-06-23 | [80363](https://github.com/airbytehq/airbyte/pull/80363) | Update dependencies |
 | 9.0.0 | 2026-06-18 | [80201](https://github.com/airbytehq/airbyte/pull/80201) | Migrate `sponsored_product_ad_group_suggested_keywords` stream from deprecated V2 Suggested Keywords API to Keyword Recommendations API (`/sp/targets/keywords/recommendations`). |


### PR DESCRIPTION
## What

Fixes `source-amazon-ads` 9.0.2 hard-failing the Sponsored Brands daily report stream (`sponsored_brands_campaigns_report_stream_daily`) on every sync due to requesting a `startDate` outside Amazon's 60-day data retention window.

Related: https://github.com/airbytehq/oncall/issues/13022

## How

The `incremental_sync_report_datetime_cursor` previously computed `start_datetime` as `today_utc() - P1D - P60D` = 61 days ago via Jinja. Amazon's SB retention floor is exactly 60 days, so the first slice always 400'd.

Fix: Use the CDK's built-in `min_datetime` field on `MinMaxDatetime` to clamp `start_datetime` to `today_utc() - P60D`. This cleanly prevents slices from ever requesting dates outside the retention window — regardless of user `start_date`, stale cursor state, or lookback window. The `datetime` field now simply passes through the user's configured `start_date` (or defaults to today).

```yaml
start_datetime:
  type: MinMaxDatetime
  datetime: "{{ config.get('start_date', today_utc().strftime('%Y-%m-%d')) }}"
  # Amazon Ads Sponsored Brands reports have a 60-day data retention limit.
  # https://advertising.amazon.com/API/docs/en-us/guides/reporting/v3/report-types
  min_datetime: "{{ today_utc() - duration('P60D') }}"
  datetime_format: "%Y-%m-%d"
```

## Review guide

1. `airbyte-integrations/connectors/source-amazon-ads/manifest.yaml` — `start_datetime` rewritten to use `min_datetime`; removed IGNORE error handler filter (per reviewer feedback)
2. `airbyte-integrations/connectors/source-amazon-ads/metadata.yaml` — version bump 9.0.2 → 9.0.3
3. `docs/integrations/sources/amazon-ads.md` — changelog entry

## User Impact

SB daily report streams that previously hard-failed on every sync (0 records) will now succeed. No config changes needed from users.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

---
[Devin session](https://app.devin.ai/sessions/ee511282ef2e48dda4d026af68160c96)

Requested by: @iherdt-airbyte