### PR TITLE
docs(ai-agents): document multi-org limitation for MCP server

### DIFF
--- a/docs/ai-agents/concepts/architecture/organizations.md
+++ b/docs/ai-agents/concepts/architecture/organizations.md
@@ -19,7 +19,21 @@ Each organization has:
 
 ## One organization per account
 
-When you sign up at [app.airbyte.ai](https://app.airbyte.ai), Airbyte creates an organization for you automatically. Your account belongs to that organization. If you need to work across multiple organizations, your Airbyte account can be associated with more than one. Pass the `organization_id` to the SDK or API to target a specific organization. See [Multiple organizations](../../interfaces/sdk/authenticate#multiple-organizations).
+When you sign up at [app.airbyte.ai](https://app.airbyte.ai), Airbyte creates an organization for you automatically. Your account belongs to that organization. If you need to work across multiple organizations, your Airbyte account can be associated with more than one.
+
+### Interface support for multiple organizations
+
+Not all interfaces support accounts that belong to more than one organization:
+
+| Interface | Multiple organizations |
+| --------- | --------------------- |
+| [Web app](../../interfaces/ui) | ✓ Supported |
+| [SDK](../../interfaces/sdk) | ✓ Supported — pass `organization_id`. See [Multiple organizations](../../interfaces/sdk/authenticate#multiple-organizations). |
+| [CLI](../../interfaces/cli) | ✓ Supported — use `organizations use` or `--org-id`. See [Authenticate](../../interfaces/cli/authenticate). |
+| [API](../../interfaces/api) | ✓ Supported — each set of client credentials is scoped to one organization. |
+| [MCP server](../../interfaces/mcp) | ✗ Not supported |
+
+If your account belongs to a single organization, all interfaces work without additional configuration.
 
 ## Related topics
 

--- a/docs/ai-agents/interfaces/mcp/readme.md
+++ b/docs/ai-agents/interfaces/mcp/readme.md
@@ -24,7 +24,7 @@ Before you begin, make sure you have the following:
 - **Credentials for the connectors you want to use.** Each service requires its own authentication. For example, you need a Linear API key to connect Linear, or Salesforce OAuth credentials to connect Salesforce.
 
 :::note Multiple organizations not supported
-The Agent MCP does not support accounts that belong to more than one organization. If your account is associated with multiple organizations, use the [SDK](../sdk), [CLI](../cli), or [API](../api) instead.
+The Agent MCP doesn't support accounts that belong to more than one organization. If your account is associated with multiple organizations, use the [SDK](../sdk), [CLI](../cli), or [API](../api) instead.
 :::
 
 ## Add the Agent MCP to your agent

--- a/docs/ai-agents/interfaces/mcp/readme.md
+++ b/docs/ai-agents/interfaces/mcp/readme.md
@@ -23,6 +23,10 @@ Before you begin, make sure you have the following:
 
 - **Credentials for the connectors you want to use.** Each service requires its own authentication. For example, you need a Linear API key to connect Linear, or Salesforce OAuth credentials to connect Salesforce.
 
+:::note Multiple organizations not supported
+The Agent MCP does not support accounts that belong to more than one organization. If your account is associated with multiple organizations, use the [SDK](../sdk), [CLI](../cli), or [API](../api) instead.
+:::
+
 ## Add the Agent MCP to your agent
 
 Select your client below for setup instructions. Each client requires you to authenticate with your Airbyte account before you can use the MCP server.


### PR DESCRIPTION
## What

Documents that the Agent MCP does not support accounts belonging to multiple organizations. Adds a support matrix to the Organizations concept page showing which interfaces handle multi-org accounts.

Resolves [DOCS-28](https://linear.app/airbyteio/issue/DOCS-28/document-the-interfaces-that-dont-support-multiple-orgs).

## How

1. Added an admonition to `docs/ai-agents/interfaces/mcp/readme.md` under Requirements stating the limitation and directing users to SDK/CLI/API.
2. Updated `docs/ai-agents/concepts/architecture/organizations.md` to replace the single-sentence multi-org guidance with a table showing per-interface support.

## Review guide

1. `docs/ai-agents/interfaces/mcp/readme.md` — new `:::note` admonition after Requirements list
2. `docs/ai-agents/concepts/architecture/organizations.md` — new table under \"One organization per account\"

## User Impact

Users belonging to multiple organizations now see a clear note that the MCP server doesn't support their setup, with links to interfaces that do.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

---
[Devin session](https://app.devin.ai/sessions/5aa26cab5449497dbfd711347910c684)

Requested by: @ian-at-airbyte