### PR TITLE
fix(destination-snowflake, destination-bigquery): remove NULL PK equality checks from merge SQL

### DIFF
--- a/airbyte-integrations/connectors/destination-bigquery/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-bigquery/metadata.yaml
@@ -6,7 +6,7 @@ data:
   connectorSubtype: database
   connectorType: destination
   definitionId: 22f6c74f-5699-40ff-833c-4a879ea40133
-  dockerImageTag: 3.0.20
+  dockerImageTag: 3.0.21
   dockerRepository: airbyte/destination-bigquery
   documentationUrl: https://docs.airbyte.com/integrations/destinations/bigquery
   githubIssueLabel: destination-bigquery

--- a/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/write/typing_deduping/direct_load_tables/BigqueryDirectLoadSqlGenerator.kt
+++ b/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/write/typing_deduping/direct_load_tables/BigqueryDirectLoadSqlGenerator.kt
@@ -140,7 +140,7 @@ class BigqueryDirectLoadSqlGenerator(
             importType.primaryKey.joinToString(" AND ") { fieldPath ->
                 val fieldName = fieldPath.first()
                 val columnName = columnNameMapping[fieldName]!!
-                """(target_table.`$columnName` = new_record.`$columnName` OR (target_table.`$columnName` IS NULL AND new_record.`$columnName` IS NULL))"""
+                """target_table.`$columnName` = new_record.`$columnName`"""
             }
 
         val columnList: String =

--- a/airbyte-integrations/connectors/destination-snowflake/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-snowflake/metadata.yaml
@@ -6,7 +6,7 @@ data:
   connectorSubtype: database
   connectorType: destination
   definitionId: 424892c4-daac-4491-b35d-c6688ba547ba
-  dockerImageTag: 4.0.43
+  dockerImageTag: 4.0.44
   dockerRepository: airbyte/destination-snowflake
   documentationUrl: https://docs.airbyte.com/integrations/destinations/snowflake
   githubIssueLabel: destination-snowflake

--- a/airbyte-integrations/connectors/destination-snowflake/src/main/kotlin/io/airbyte/integrations/destination/snowflake/sql/SnowflakeDirectLoadSqlGenerator.kt
+++ b/airbyte-integrations/connectors/destination-snowflake/src/main/kotlin/io/airbyte/integrations/destination/snowflake/sql/SnowflakeDirectLoadSqlGenerator.kt
@@ -134,7 +134,7 @@ class SnowflakeDirectLoadSqlGenerator(
                 pks.joinToString(" AND ") { columnName ->
                     val targetTableColumnName = "target_table.${columnName.quote()}"
                     val newRecordColumnName = "new_record.${columnName.quote()}"
-                    """($targetTableColumnName = $newRecordColumnName OR ($targetTableColumnName IS NULL AND $newRecordColumnName IS NULL))"""
+                    """$targetTableColumnName = $newRecordColumnName"""
                 }
             } else {
                 // If no primary key, we can't perform a meaningful upsert

--- a/airbyte-integrations/connectors/destination-snowflake/src/test/kotlin/io/airbyte/integrations/destination/snowflake/sql/SnowflakeDirectLoadSqlGeneratorTest.kt
+++ b/airbyte-integrations/connectors/destination-snowflake/src/test/kotlin/io/airbyte/integrations/destination/snowflake/sql/SnowflakeDirectLoadSqlGeneratorTest.kt
@@ -941,7 +941,7 @@ internal class SnowflakeDirectLoadSqlGeneratorTest {
                 |  FROM numbered_rows
                 |  WHERE row_number = 1
                 |) AS new_record
-                |ON (target_table."ID" = new_record."ID" OR (target_table."ID" IS NULL AND new_record."ID" IS NULL))
+                |ON target_table."ID" = new_record."ID"
                 |WHEN MATCHED AND (
                 |  target_table."UPDATED_AT" < new_record."UPDATED_AT"
                 |  OR (target_table."UPDATED_AT" = new_record."UPDATED_AT" AND target_table."_AIRBYTE_EXTRACTED_AT" < new_record."_AIRBYTE_EXTRACTED_AT")

--- a/docs/integrations/destinations/bigquery.md
+++ b/docs/integrations/destinations/bigquery.md
@@ -252,6 +252,7 @@ This destination supports [namespaces](https://docs.airbyte.com/platform/using-a
 
 | Version     | Date       | Pull Request                                               | Subject                                                                                                                                                                           |
 |:------------|:-----------|:-----------------------------------------------------------|:----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 3.0.21 | 2026-06-30 | [81346](https://github.com/airbytehq/airbyte/pull/81346) | Remove unnecessary NULL PK equality checks from merge SQL |
 | 3.0.20 | 2026-06-26 | [80932](https://github.com/airbytehq/airbyte/pull/80932) | Handle BigQueryException in getGenerationId() for legacy tables without _airbyte_generation_id column. |
 | 3.0.19 | 2026-05-21 | [78239](https://github.com/airbytehq/airbyte/pull/78239) | Promoting release candidate 3.0.19-rc.1 to a main version. |
 | 3.0.19-rc.1 | 2026-05-19 | [78239](https://github.com/airbytehq/airbyte/pull/78239) | Upgrade CDK to 1.0.13. Progressive rollout. |

--- a/docs/integrations/destinations/snowflake.md
+++ b/docs/integrations/destinations/snowflake.md
@@ -288,6 +288,7 @@ This destination supports [namespaces](https://docs.airbyte.com/platform/using-a
 
 | Version         | Date       | Pull Request                                               | Subject                                                                                                                                                                                |
 |:----------------|:-----------|:-----------------------------------------------------------|:---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 4.0.44          | 2026-06-30 | [81346](https://github.com/airbytehq/airbyte/pull/81346)   | Remove unnecessary NULL PK equality checks from merge SQL |
 | 4.0.43          | 2026-05-19 | [78231](https://github.com/airbytehq/airbyte/pull/78231)   | Upgrade CDK to 1.0.13 |
 | 4.0.42          | 2026-05-11 | [77978](https://github.com/airbytehq/airbyte/pull/77978)   | Improve encrypted key-pair private key handling and error messages                                                                                                                     |
 | 4.0.41          | 2026-05-06 | [77795](https://github.com/airbytehq/airbyte/pull/77795)   | Add option to preserve Snowflake whitespace                                                                                                                                            |


### PR DESCRIPTION
Fixes https://github.com/airbytehq/oncall/issues/13023, https://github.com/airbytehq/airbyte/issues/81347
## Summary
- Remove the redundant NULL-safe PK matching pattern `(a = b OR (a IS NULL AND b IS NULL))` from MERGE ON clauses in destination-snowflake and destination-bigquery SQL generators
- Primary keys should not contain NULL values, so the NULL equivalence fallback is unnecessary and creates inconsistency with other destinations (postgres, redshift, mssql) that use simple equality (`a = b`)
- Updated the Snowflake SQL generator test assertion to match the simplified ON clause

Closes #81347

## Changed Files
- `destination-snowflake/.../SnowflakeDirectLoadSqlGenerator.kt` — simplified PK matching in `upsertTable()`
- `destination-snowflake/.../SnowflakeDirectLoadSqlGeneratorTest.kt` — updated expected SQL in `testGenerateUpdateTable()`
- `destination-bigquery/.../BigqueryDirectLoadSqlGenerator.kt` — simplified PK matching in `upsertTable()`

> [!IMPORTANT]
> Active progressive rollout warning for destination-snowflake.

- [x] (Click to Approve:) Bypass the active progressive rollout warning for destination-snowflake in the PR comment [here](https://github.com/airbytehq/airbyte/pull/81346#issuecomment-4848259529).

> [!IMPORTANT]
> ⚡ **Auto-merge enabled.**
> 
> _This PR is set to merge automatically when all requirements are met._