### PR TITLE
test(extract-cdk): add speed mode decoration tests for StateManager

### DIFF
--- a/airbyte-cdk/bulk/core/extract/src/main/kotlin/io/airbyte/cdk/read/StateManagerFactory.kt
+++ b/airbyte-cdk/bulk/core/extract/src/main/kotlin/io/airbyte/cdk/read/StateManagerFactory.kt
@@ -97,7 +97,6 @@ class StateManagerFactory(
                 when (inputState) {
                     is StreamInputState ->
                         throw ConfigErrorException("input state unexpectedly of type STREAM")
-
                     is GlobalInputState -> forGlobal(mq, allStreams, inputState)
                     is EmptyInputState -> forGlobal(mq, allStreams)
                 }
@@ -133,7 +132,10 @@ class StateManagerFactory(
                             // sorting.
                             // Output here needs to match Discover's JdbcAirbyteStreamFactory
                             SOCKET to PROTOBUF ->
-                                if (metadataQuerier.primaryKey(stream.id).isNotEmpty() && stream.configuredPrimaryKey?.isNotEmpty() == true) {
+                                if (
+                                    metadataQuerier.primaryKey(stream.id).isNotEmpty() &&
+                                        stream.configuredPrimaryKey?.isNotEmpty() == true
+                                ) {
                                     stream.copy(
                                         schema =
                                             stream.schema + metaFieldDecorator.globalMetaFields,

--- a/airbyte-cdk/bulk/core/extract/src/test/kotlin/io/airbyte/cdk/read/StateManagerSpeedModeDecorationTest.kt
+++ b/airbyte-cdk/bulk/core/extract/src/test/kotlin/io/airbyte/cdk/read/StateManagerSpeedModeDecorationTest.kt
@@ -25,8 +25,8 @@ import org.junit.jupiter.api.Test
  * The edge case this guards against: a table with no source-defined primary key (hence ineligible
  * for CDC incremental) that is configured as full refresh append+dedup. Such a stream has a
  * configured primary key but no source-defined one, and its catalog schema does NOT contain the
- * meta fields. Decorating its records would misalign fields the destination cannot resolve in
- * speed mode.
+ * meta fields. Decorating its records would misalign fields the destination cannot resolve in speed
+ * mode.
  */
 @MicronautTest(rebuildContext = true)
 @Property(name = "airbyte.connector.config.host", value = "localhost")
@@ -65,7 +65,9 @@ class StateManagerSpeedModeDecorationTest {
         assertNotDecorated("NO_PK")
     }
 
-    /** SOCKET/PROTOBUF full refresh stream with both source and configured primary keys: decorated. */
+    /**
+     * SOCKET/PROTOBUF full refresh stream with both source and configured primary keys: decorated.
+     */
     @Test
     @Property(name = "airbyte.connector.state.json", value = "[]")
     @Property(

--- a/airbyte-cdk/bulk/core/extract/src/test/kotlin/io/airbyte/cdk/read/StateManagerSpeedModeDecorationTest.kt
+++ b/airbyte-cdk/bulk/core/extract/src/test/kotlin/io/airbyte/cdk/read/StateManagerSpeedModeDecorationTest.kt
@@ -1,0 +1,287 @@
+/* Copyright (c) 2026 Airbyte, Inc., all rights reserved. */
+package io.airbyte.cdk.read
+
+import io.airbyte.cdk.command.InputState
+import io.airbyte.cdk.command.SourceConfiguration
+import io.airbyte.cdk.output.BufferingCatalogValidationFailureHandler
+import io.airbyte.cdk.output.CatalogValidationFailure
+import io.airbyte.protocol.models.v0.ConfiguredAirbyteCatalog
+import io.micronaut.context.annotation.Property
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest
+import jakarta.inject.Inject
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+
+/**
+ * Tests for meta field decoration of full refresh streams in a global (CDC) sync, across the
+ * various data channel medium/format combinations.
+ *
+ * The key behavior under test is the "speed mode" (`SOCKET` + `PROTOBUF`) branch of
+ * [StateManagerFactory.forGlobal], where records do not carry field names and therefore must match
+ * the catalog schema exactly. A full refresh stream is only decorated with the global meta fields
+ * (`_ab_cdc_lsn`, `_ab_cdc_updated_at`, `_ab_cdc_deleted_at`) when the stream has BOTH a
+ * source-defined primary key AND a configured primary key.
+ *
+ * The edge case this guards against: a table with no source-defined primary key (hence ineligible
+ * for CDC incremental) that is configured as full refresh append+dedup. Such a stream has a
+ * configured primary key but no source-defined one, and its catalog schema does NOT contain the
+ * meta fields. Decorating its records would misalign fields the destination cannot resolve in
+ * speed mode.
+ */
+@MicronautTest(rebuildContext = true)
+@Property(name = "airbyte.connector.config.host", value = "localhost")
+@Property(name = "airbyte.connector.config.database", value = "testdb")
+@Property(name = "airbyte.connector.config.cursor.cursor_method", value = "cdc")
+@Property(name = "metadata.resource", value = "discover/metadata-speed-mode.json")
+@Property(name = "airbyte.connector.data-channel.medium", value = "SOCKET")
+@Property(name = "airbyte.connector.data-channel.format", value = "PROTOBUF")
+class StateManagerSpeedModeDecorationTest {
+    @Inject lateinit var config: SourceConfiguration
+
+    @Inject lateinit var configuredCatalog: ConfiguredAirbyteCatalog
+
+    @Inject lateinit var inputState: InputState
+
+    @Inject lateinit var stateManagerFactory: StateManagerFactory
+
+    @Inject lateinit var handler: BufferingCatalogValidationFailureHandler
+
+    val stateManager: StateManager by lazy {
+        stateManagerFactory.create(config, configuredCatalog, inputState)
+    }
+
+    /**
+     * The edge case from the PR: SOCKET/PROTOBUF full refresh stream with a configured primary key
+     * but NO source-defined primary key must NOT be decorated.
+     */
+    @Test
+    @Property(name = "airbyte.connector.state.json", value = "[]")
+    @Property(
+        name = "airbyte.connector.catalog.json",
+        value = FULL_REFRESH_NO_PK_WITH_CONFIGURED_PK,
+    )
+    fun testProtobufFullRefreshNoSourcePkNotDecorated() {
+        assertNoValidationFailures()
+        assertNotDecorated("NO_PK")
+    }
+
+    /** SOCKET/PROTOBUF full refresh stream with both source and configured primary keys: decorated. */
+    @Test
+    @Property(name = "airbyte.connector.state.json", value = "[]")
+    @Property(
+        name = "airbyte.connector.catalog.json",
+        value = FULL_REFRESH_WITH_SOURCE_AND_CONFIGURED_PK,
+    )
+    fun testProtobufFullRefreshWithBothPksDecorated() {
+        assertNoValidationFailures()
+        assertDecorated("EVENTS")
+    }
+
+    /**
+     * SOCKET/PROTOBUF full refresh stream with a source-defined primary key but no configured
+     * primary key must NOT be decorated.
+     */
+    @Test
+    @Property(name = "airbyte.connector.state.json", value = "[]")
+    @Property(
+        name = "airbyte.connector.catalog.json",
+        value = FULL_REFRESH_WITH_SOURCE_PK_NO_CONFIGURED_PK,
+    )
+    fun testProtobufFullRefreshNoConfiguredPkNotDecorated() {
+        assertNoValidationFailures()
+        assertNotDecorated("EVENTS")
+    }
+
+    /** SOCKET/PROTOBUF full refresh stream with neither primary key must NOT be decorated. */
+    @Test
+    @Property(name = "airbyte.connector.state.json", value = "[]")
+    @Property(
+        name = "airbyte.connector.catalog.json",
+        value = FULL_REFRESH_NO_PK_NO_CONFIGURED_PK,
+    )
+    fun testProtobufFullRefreshNoPksNotDecorated() {
+        assertNoValidationFailures()
+        assertNotDecorated("NO_PK")
+    }
+
+    /**
+     * Control: an incremental stream in global mode is always decorated regardless of medium/format
+     * or the source-defined primary key check.
+     */
+    @Test
+    @Property(
+        name = "airbyte.connector.state.json",
+        value = """{"type": "GLOBAL", "global": { "shared_state": { "cdc": "starting" } } }""",
+    )
+    @Property(name = "airbyte.connector.catalog.json", value = INCREMENTAL_KV)
+    fun testProtobufIncrementalAlwaysDecorated() {
+        assertNoValidationFailures()
+        assertDecorated("KV")
+    }
+
+    /**
+     * SOCKET/JSONL keys decoration off the configured primary key ONLY (the source-defined primary
+     * key is not consulted). This documents the intentional divergence from PROTOBUF for the edge
+     * case above.
+     */
+    @Test
+    @Property(name = "airbyte.connector.data-channel.format", value = "JSONL")
+    @Property(name = "airbyte.connector.state.json", value = "[]")
+    @Property(
+        name = "airbyte.connector.catalog.json",
+        value = FULL_REFRESH_NO_PK_WITH_CONFIGURED_PK,
+    )
+    fun testJsonlFullRefreshNoSourcePkStillDecorated() {
+        assertNoValidationFailures()
+        assertDecorated("NO_PK")
+    }
+
+    /** Legacy STDIO/JSONL never decorates full refresh streams. */
+    @Test
+    @Property(name = "airbyte.connector.data-channel.medium", value = "STDIO")
+    @Property(name = "airbyte.connector.data-channel.format", value = "JSONL")
+    @Property(name = "airbyte.connector.state.json", value = "[]")
+    @Property(
+        name = "airbyte.connector.catalog.json",
+        value = FULL_REFRESH_WITH_SOURCE_AND_CONFIGURED_PK,
+    )
+    fun testStdioFullRefreshNotDecorated() {
+        assertNoValidationFailures()
+        assertNotDecorated("EVENTS")
+    }
+
+    private fun assertNoValidationFailures() {
+        Assertions.assertEquals(listOf<CatalogValidationFailure>(), handler.get())
+    }
+
+    private fun streamByName(name: String): Stream =
+        stateManager.feeds.mapNotNull { it as? Stream }.first { it.name == name }
+
+    private fun schemaIds(name: String): List<String> = streamByName(name).schema.map { it.id }
+
+    private fun assertDecorated(name: String) {
+        val ids = schemaIds(name)
+        Assertions.assertTrue(
+            ids.containsAll(META_FIELD_IDS),
+            "expected stream $name schema $ids to contain meta fields $META_FIELD_IDS",
+        )
+    }
+
+    private fun assertNotDecorated(name: String) {
+        val ids = schemaIds(name)
+        Assertions.assertTrue(
+            META_FIELD_IDS.none { it in ids },
+            "expected stream $name schema $ids to contain no meta fields $META_FIELD_IDS",
+        )
+    }
+
+    companion object {
+        val META_FIELD_IDS = listOf("_ab_cdc_lsn", "_ab_cdc_updated_at", "_ab_cdc_deleted_at")
+
+        // EVENTS has a source-defined primary key ([["ID"]]) in the metadata resource.
+        const val FULL_REFRESH_WITH_SOURCE_AND_CONFIGURED_PK =
+            """{"streams": [{
+    "stream": {
+        "name": "EVENTS",
+        "json_schema": { "type": "object", "properties": {
+            "MSG": { "type": "string" },
+            "ID": { "type": "string" },
+            "TS": { "type": "string", "format": "date-time", "airbyte_type": "timestamp_with_timezone" }
+        }},
+        "supported_sync_modes": ["full_refresh", "incremental"],
+        "source_defined_cursor": false,
+        "default_cursor_field": [],
+        "source_defined_primary_key": [["ID"]],
+        "namespace": "PUBLIC"
+    },
+    "sync_mode": "full_refresh",
+    "cursor_field": [],
+    "destination_sync_mode": "append_dedup",
+    "primary_key": [["ID"]]
+}]}"""
+
+        const val FULL_REFRESH_WITH_SOURCE_PK_NO_CONFIGURED_PK =
+            """{"streams": [{
+    "stream": {
+        "name": "EVENTS",
+        "json_schema": { "type": "object", "properties": {
+            "MSG": { "type": "string" },
+            "ID": { "type": "string" },
+            "TS": { "type": "string", "format": "date-time", "airbyte_type": "timestamp_with_timezone" }
+        }},
+        "supported_sync_modes": ["full_refresh", "incremental"],
+        "source_defined_cursor": false,
+        "default_cursor_field": [],
+        "source_defined_primary_key": [["ID"]],
+        "namespace": "PUBLIC"
+    },
+    "sync_mode": "full_refresh",
+    "cursor_field": [],
+    "destination_sync_mode": "overwrite",
+    "primary_key": []
+}]}"""
+
+        // NO_PK has no source-defined primary key ([]) in the metadata resource.
+        const val FULL_REFRESH_NO_PK_WITH_CONFIGURED_PK =
+            """{"streams": [{
+    "stream": {
+        "name": "NO_PK",
+        "json_schema": { "type": "object", "properties": {
+            "MSG": { "type": "string" },
+            "ID": { "type": "string" },
+            "TS": { "type": "string", "format": "date-time", "airbyte_type": "timestamp_with_timezone" }
+        }},
+        "supported_sync_modes": ["full_refresh", "incremental"],
+        "source_defined_cursor": false,
+        "default_cursor_field": [],
+        "source_defined_primary_key": [],
+        "namespace": "PUBLIC"
+    },
+    "sync_mode": "full_refresh",
+    "cursor_field": [],
+    "destination_sync_mode": "append_dedup",
+    "primary_key": [["ID"]]
+}]}"""
+
+        const val FULL_REFRESH_NO_PK_NO_CONFIGURED_PK =
+            """{"streams": [{
+    "stream": {
+        "name": "NO_PK",
+        "json_schema": { "type": "object", "properties": {
+            "MSG": { "type": "string" },
+            "ID": { "type": "string" },
+            "TS": { "type": "string", "format": "date-time", "airbyte_type": "timestamp_with_timezone" }
+        }},
+        "supported_sync_modes": ["full_refresh", "incremental"],
+        "source_defined_cursor": false,
+        "default_cursor_field": [],
+        "source_defined_primary_key": [],
+        "namespace": "PUBLIC"
+    },
+    "sync_mode": "full_refresh",
+    "cursor_field": [],
+    "destination_sync_mode": "overwrite",
+    "primary_key": []
+}]}"""
+
+        const val INCREMENTAL_KV =
+            """{"streams": [{
+    "stream": {
+        "name": "KV",
+        "json_schema": { "type": "object", "properties": {
+            "V": { "type": "string" },
+            "K": { "type": "number", "airbyte_type": "integer" }
+        }},
+        "supported_sync_modes": ["full_refresh", "incremental"],
+        "source_defined_cursor": false,
+        "default_cursor_field": [],
+        "source_defined_primary_key": [["K"]],
+        "namespace": "PUBLIC"
+    },
+    "sync_mode": "incremental",
+    "cursor_field": ["_ab_cdc_lsn"],
+    "destination_sync_mode": "append_dedup",
+    "primary_key": [["K"]]
+}]}"""
+    }
+}

--- a/airbyte-cdk/bulk/core/extract/src/testFixtures/resources/discover/metadata-speed-mode.json
+++ b/airbyte-cdk/bulk/core/extract/src/testFixtures/resources/discover/metadata-speed-mode.json
@@ -1,0 +1,37 @@
+[
+  {
+    "name": "EVENTS",
+    "namespace": "PUBLIC",
+    "metadata": {
+      "columns": {
+        "ID": "io.airbyte.cdk.discover.StringFieldType",
+        "TS": "io.airbyte.cdk.discover.OffsetDateTimeFieldType",
+        "MSG": "io.airbyte.cdk.discover.StringFieldType"
+      },
+      "primaryKeys": [["ID"]]
+    }
+  },
+  {
+    "name": "NO_PK",
+    "namespace": "PUBLIC",
+    "metadata": {
+      "columns": {
+        "ID": "io.airbyte.cdk.discover.StringFieldType",
+        "TS": "io.airbyte.cdk.discover.OffsetDateTimeFieldType",
+        "MSG": "io.airbyte.cdk.discover.StringFieldType"
+      },
+      "primaryKeys": []
+    }
+  },
+  {
+    "name": "KV",
+    "namespace": "PUBLIC",
+    "metadata": {
+      "columns": {
+        "K": "io.airbyte.cdk.discover.IntFieldType",
+        "V": "io.airbyte.cdk.discover.StringFieldType"
+      },
+      "primaryKeys": [["K"]]
+    }
+  }
+]


### PR DESCRIPTION
## What
Add comprehensive test coverage for the "speed mode" (SOCKET + PROTOBUF) branch of `StateManagerFactory.forGlobal`, specifically validating the meta field decoration behavior for full refresh streams in global (CDC) syncs.

This test suite guards against an edge case where a full refresh stream with a configured primary key but no source-defined primary key would be incorrectly decorated with CDC meta fields (`_ab_cdc_lsn`, `_ab_cdc_updated_at`, `_ab_cdc_deleted_at`). In speed mode, records don't carry field names and must match the catalog schema exactly, so decorating such streams would cause field misalignment that the destination cannot resolve.

## How
- Added `StateManagerSpeedModeDecorationTest` with 7 test cases covering:
  - Full refresh with both source and configured primary keys (should be decorated)
  - Full refresh with only configured primary key, no source-defined key (should NOT be decorated) - the edge case
  - Full refresh with only source-defined primary key, no configured key (should NOT be decorated)
  - Full refresh with neither primary key (should NOT be decorated)
  - Incremental streams (always decorated, control case)
  - SOCKET/JSONL format behavior (decorates based on configured PK only, diverging from PROTOBUF)
  - Legacy STDIO/JSONL behavior (never decorates full refresh)

- Added `metadata-speed-mode.json` test fixture defining source-defined primary keys for test streams (EVENTS with PK, NO_PK without PK, KV with PK)

## Review guide
1. `StateManagerSpeedModeDecorationTest.kt` - Review test cases and assertions for correctness
2. `metadata-speed-mode.json` - Verify metadata fixture matches test expectations

## User Impact
No user-facing changes. This is test-only coverage that validates existing behavior and prevents regressions in the speed mode decoration logic.

## Can this PR be safely reverted and rolled back?
- [x] YES 💚

https://claude.ai/code/session_01CK5NruRc9hakWbFkkkSWp7