### PR TITLE
ci(codeql): add custom CodeQL workflow with resilient build

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,69 @@
+name: "CodeQL"
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - "**.java"
+      - "**.kt"
+      - "**.kts"
+      - "**/build.gradle"
+      - "buildSrc/**"
+      - "settings.gradle"
+  pull_request:
+    branches: [master]
+    paths:
+      - "**.java"
+      - "**.kt"
+      - "**.kts"
+      - "**/build.gradle"
+      - "buildSrc/**"
+      - "settings.gradle"
+  schedule:
+    # Run weekly on Monday at 00:00 UTC
+    - cron: "0 0 * * 1"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: Analyze Java/Kotlin
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    permissions:
+      security-events: write
+      contents: read
+      actions: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Java environment
+        uses: ./.github/actions/install-java-environment
+        with:
+          gradle_cache_read_only: true
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: java-kotlin
+          # Extend default queries with security-and-quality
+          queries: security-and-quality
+
+      - name: Build (compile only, continue past failures)
+        # Use --continue so a single connector's dependency failure
+        # does not block analysis of the rest of the codebase.
+        run: |
+          ./gradlew compileJava compileKotlin \
+            --continue \
+            -x test \
+            -x integrationTestJava \
+            -x performanceTestJava \
+            -Dorg.gradle.jvmargs="-Xmx4g"
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:java-kotlin"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -55,6 +55,9 @@ jobs:
       - name: Build (compile only, continue past failures)
         # Use --continue so a single connector's dependency failure
         # does not block analysis of the rest of the codebase.
+        # continue-on-error because --continue still exits non-zero
+        # when any task fails, which would skip the analysis step.
+        continue-on-error: true
         run: |
           ./gradlew compileJava compileKotlin \
             --continue \


### PR DESCRIPTION
## What

The default CodeQL setup for `java-kotlin` has been broken since Jan 2026. The autobuild fails when any single connector's dependency resolution fails (currently `source-e2e-test:compileClasspath` due to transient JitPack unavailability), which blocks the entire code scanning analysis.

Resolves the code scanning blockage visible at: https://github.com/airbytehq/airbyte/security/code-scanning/tools/CodeQL/status/

Requested by @aaronsteers.

## How

Adds a custom CodeQL workflow (`.github/workflows/codeql.yml`) that replaces the default autobuild with a manual Gradle compilation step:

```
./gradlew compileJava compileKotlin --continue -x test
```

Key difference from the default setup: `--continue` tells Gradle to keep building other subprojects even when one fails, so a single connector's dependency issue no longer blocks analysis of the entire codebase.

The workflow:
- Reuses the repo's `install-java-environment` composite action (Java 21 Corretto + Gradle cache)
- Scopes triggers to JVM-related file changes (`.java`, `.kt`, `.kts`, `build.gradle`, `buildSrc/`, `settings.gradle`)
- Runs on push/PR to `master` and weekly on Monday
- Uses `security-and-quality` query suite

## Admin action required after merge

After merging, disable the default CodeQL setup in the repo settings so both don't run simultaneously:
**Settings → Code security → Code scanning → CodeQL analysis → switch from "Default" to "Not configured"**

The custom workflow will then be the sole CodeQL configuration.

## Review guide

1. `.github/workflows/codeql.yml` — the entire change is this new workflow file

## User Impact

Restores CodeQL code scanning, which has been non-functional for ~6 months.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

---
[Devin session](https://app.devin.ai/sessions/ffd77f4affd7478a9a16529be759e59f)