### PR TITLE
ci(hydra): accept airbyte-support-bot as valid AI review author in auto-merge

### DIFF
--- a/.github/workflows/hydra-automerge.yml
+++ b/.github/workflows/hydra-automerge.yml
@@ -262,7 +262,7 @@ jobs:
                     required: [pass, reasoning]
                   ai_review_passed:
                     type: object
-                    description: "Set pass to true ONLY if the PR has a comment from devin-ai-integration[bot] containing the HTML marker '<!-- pr_ai_review_result: APPROVE' (exactly that string). Look through all PR comments to find this marker. If no such comment exists, or if the marker says FAIL, UNKNOWN, or SKIP, set pass to false."
+                    description: "Set pass to true ONLY if the PR has a comment from devin-ai-integration[bot] OR airbyte-support-bot containing the HTML marker '<!-- pr_ai_review_result: APPROVE' (exactly that string). Look through all PR comments to find this marker. Either author is valid — the AI review playbook posts as airbyte-support-bot so the PR-owning Devin session recognizes it as an external comment. If no such comment exists from either author, or if the marker says FAIL, UNKNOWN, or SKIP, set pass to false."
                     properties:
                       pass:
                         type: boolean

--- a/.github/workflows/pr-ai-review-submit.yml
+++ b/.github/workflows/pr-ai-review-submit.yml
@@ -16,7 +16,7 @@ jobs:
     # Only run on PR comments from Devin bot that contain the review result marker
     if: |
       github.event.issue.pull_request &&
-      github.event.comment.user.login == 'devin-ai-integration[bot]' &&
+      (github.event.comment.user.login == 'devin-ai-integration[bot]' || github.event.comment.user.login == 'airbyte-support-bot') &&
       contains(github.event.comment.body, '<!-- pr_ai_review_result:')
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## What
Fixes a false positive in the Hydra auto-merge evaluation where the `ai_review_passed` precondition fails because the `<!-- pr_ai_review_result: APPROVE` marker is posted by `airbyte-support-bot` rather than `devin-ai-integration[bot]`.

The AI review playbook (`pr_ai_review.md`) explicitly posts as `airbyte-support-bot` so the PR-owning Devin session recognizes it as an external comment. Neither the auto-merge evaluator prompt nor the review-submit workflow accounted for this.

Example false positive: https://github.com/airbytehq/airbyte/pull/81395#issuecomment-4869830289

Requested by @aaronsteers.

## How
1. Updated the `ai_review_passed` description in the structured output schema prompt in `hydra-automerge.yml` to accept comments from either `devin-ai-integration[bot]` or `airbyte-support-bot`.
2. Updated the `pr-ai-review-submit.yml` trigger condition to also fire for `airbyte-support-bot` comments containing the review marker (so FAIL markers from `airbyte-support-bot` correctly submit `REQUEST_CHANGES` reviews).

## Review guide
1. `.github/workflows/hydra-automerge.yml` — prompt text update
2. `.github/workflows/pr-ai-review-submit.yml` — trigger condition update

## User Impact
Auto-merge evaluations will no longer falsely fail when the AI review approval was posted by `airbyte-support-bot`. FAIL markers from `airbyte-support-bot` will also correctly trigger blocking reviews.

## Can this PR be safely reverted and rolled back?
- [x] YES 💚

Link to Devin session: https://app.devin.ai/sessions/f26511561475418b815d848a12bd8fcd