### PR TITLE
ci: allow backtick-wrapped scopes in semantic PR title check

### DIFF
--- a/.github/workflows/semantic-pr-check.yml
+++ b/.github/workflows/semantic-pr-check.yml
@@ -5,6 +5,7 @@
 #
 # Valid formats:
 # - feat(source-postgres): add new stream
+# - feat(`source-postgres`): backtick-wrapped scope is also valid
 # - fix(destination-bigquery): handle null values
 # - chore(source-github): update dependencies [2026-01-15]
 # - release(source-stripe): promote 5.15.18
@@ -41,6 +42,10 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
+          # Allow backticks in scope so titles like feat(`source-foo`): ... pass.
+          # The scope capture trims leading/trailing backticks if present.
+          headerPattern: '^(\w*)(?:\(`?([\w\$\.\-\*/ ]+)`?\))?!?: (.+)$'
+          headerPatternCorrespondence: type, scope, subject
           # Configure which types are allowed (newline-delimited).
           # Comparison is case-insensitive, so only lowercase variants are needed.
           # See: https://github.com/commitizen/conventional-commit-types/blob/master/index.json


### PR DESCRIPTION
## What

Connector Builder now generates PR titles with backtick-wrapped scopes:
```
feat(`source-app-store-connection`): 🎉 New source connector contribution from `@Ella6882`
```

The default `headerPattern` in `amannn/action-semantic-pull-request@v6` doesn't allow backticks in the scope, so these titles fail the semantic PR title check.

Companion to https://github.com/airbytehq/airbyte-platform-internal/pull/19129 which updates the Builder scaffolding to generate these titles.

Requested by @aaronsteers.

## How

Added a custom `headerPattern` that makes backticks optional around the scope: `` `?  `` before and after the scope capture group. Both `feat(source-foo)` and `` feat(`source-foo`) `` are accepted. The backticks are outside the capture group so they're trimmed from the parsed scope value.

## Review guide
1. `.github/workflows/semantic-pr-check.yml`

## User Impact

Builder-generated PRs with backtick-wrapped scopes will pass the semantic PR title check instead of failing.

## Can this PR be safely reverted and rolled back?
- [x] YES 💚
- [ ] NO ❌

---
[Devin session](https://app.devin.ai/sessions/cace59173afd491b93cc5768e86c87b6)