### PR TITLE
fix(destination-aws-datalake): handle array of objects with empty properties in Glue type inference

### DIFF
--- a/airbyte-integrations/connectors/destination-aws-datalake/destination_aws_datalake/stream_writer.py
+++ b/airbyte-integrations/connectors/destination-aws-datalake/destination_aws_datalake/stream_writer.py
@@ -339,7 +339,7 @@ class StreamWriter:
                     json_columns.add(col)
                     result_typ = "string"
 
-                # if array with objects
+                # if array with objects that have defined properties
                 elif isinstance(items, dict) and item_properties:
                     # Check if nested object has properties and no mixed type objects
                     if self._is_invalid_struct_or_array(item_properties):
@@ -349,6 +349,11 @@ class StreamWriter:
                     else:
                         json_columns.add(col)
                         result_typ = "string"
+
+                # array of objects with empty or no properties (e.g., additionalProperties: true)
+                elif isinstance(items, dict) and item_type == "object":
+                    json_columns.add(col)
+                    result_typ = "string"
 
                 elif item_type and self._json_schema_type_has_mixed_types(raw_item_type):
                     json_columns.add(col)

--- a/airbyte-integrations/connectors/destination-aws-datalake/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-aws-datalake/metadata.yaml
@@ -4,7 +4,7 @@ data:
   definitionId: 99878c90-0fbd-46d3-9d98-ffde879d17fc
   connectorBuildOptions:
     baseImage: docker.io/airbyte/python-connector-base:4.0.0@sha256:d9894b6895923b379f3006fa251147806919c62b7d9021b5cd125bb67d7bbe22
-  dockerImageTag: 0.1.58
+  dockerImageTag: 0.1.59
   dockerRepository: airbyte/destination-aws-datalake
   githubIssueLabel: destination-aws-datalake
   icon: awsdatalake.svg

--- a/airbyte-integrations/connectors/destination-aws-datalake/pyproject.toml
+++ b/airbyte-integrations/connectors/destination-aws-datalake/pyproject.toml
@@ -3,7 +3,7 @@ requires = [ "poetry-core>=1.0.0",]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
-version = "0.1.58"
+version = "0.1.59"
 name = "destination-aws-datalake"
 description = "Destination Implementation for AWS Datalake."
 authors = [ "Airbyte <contact@airbyte.io>",]

--- a/airbyte-integrations/connectors/destination-aws-datalake/unit_tests/stream_writer_test.py
+++ b/airbyte-integrations/connectors/destination-aws-datalake/unit_tests/stream_writer_test.py
@@ -183,6 +183,14 @@ def get_big_schema_configured_stream():
                 "properties": {"id": {"type": ["null", "integer"]}, "name": {"type": ["null", "string"]}},
                 "additionalProperties": False,
             },
+            "array_of_objects_empty_properties": {
+                "type": ["null", "array"],
+                "items": {
+                    "type": ["null", "object"],
+                    "properties": {},
+                    "additionalProperties": True,
+                },
+            },
         },
     }
 
@@ -374,6 +382,7 @@ def test_get_glue_dtypes_from_json_schema():
         "nested_nested_bad_object": "string",
         "object_with_additional_properties": "string",
         "object_no_additional_properties": "struct<id:bigint,name:string>",
+        "array_of_objects_empty_properties": "string",
         "percentage": "double",
         "phone_number_ids": "string",
         "questions": "array<struct<id:bigint,question:string,answer:string>>",
@@ -394,6 +403,7 @@ def test_get_glue_dtypes_from_json_schema():
         "nested_nested_bad_object",
         "phone_number_ids",
         "object_with_additional_properties",
+        "array_of_objects_empty_properties",
     }
 
 

--- a/docs/integrations/destinations/aws-datalake.md
+++ b/docs/integrations/destinations/aws-datalake.md
@@ -99,6 +99,7 @@ This destination supports [namespaces](https://docs.airbyte.com/platform/using-a
 
 | Version | Date       | Pull Request                                               | Subject                                              |
 |:--------| :--------- | :--------------------------------------------------------- | :--------------------------------------------------- |
+| 0.1.59 | 2025-07-03 | [XXXXX](https://github.com/airbytehq/airbyte/pull/XXXXX) | Fix KeyError when syncing arrays of objects with empty properties |
 | 0.1.58 | 2025-05-24 | [59824](https://github.com/airbytehq/airbyte/pull/59824) | Update dependencies |
 | 0.1.57 | 2025-05-03 | [59366](https://github.com/airbytehq/airbyte/pull/59366) | Update dependencies |
 | 0.1.56 | 2025-04-26 | [58711](https://github.com/airbytehq/airbyte/pull/58711) | Update dependencies |

--- a/docs/integrations/destinations/aws-datalake.md
+++ b/docs/integrations/destinations/aws-datalake.md
@@ -99,7 +99,7 @@ This destination supports [namespaces](https://docs.airbyte.com/platform/using-a
 
 | Version | Date       | Pull Request                                               | Subject                                              |
 |:--------| :--------- | :--------------------------------------------------------- | :--------------------------------------------------- |
-| 0.1.59 | 2025-07-03 | [XXXXX](https://github.com/airbytehq/airbyte/pull/XXXXX) | Fix KeyError when syncing arrays of objects with empty properties |
+| 0.1.59 | 2025-07-03 | [81414](https://github.com/airbytehq/airbyte/pull/81414) | Fix KeyError when syncing arrays of objects with empty properties |
 | 0.1.58 | 2025-05-24 | [59824](https://github.com/airbytehq/airbyte/pull/59824) | Update dependencies |
 | 0.1.57 | 2025-05-03 | [59366](https://github.com/airbytehq/airbyte/pull/59366) | Update dependencies |
 | 0.1.56 | 2025-04-26 | [58711](https://github.com/airbytehq/airbyte/pull/58711) | Update dependencies |


### PR DESCRIPTION
## What

Fixes `KeyError: 'object'` crash in the AWS Datalake destination when syncing streams that contain arrays of objects with empty `properties: {}` and `additionalProperties: true` (e.g., Zendesk Support `ticket_audits.attachments[*].thumbnails[*]`).

Requested by @Airbyte-Support.

## How

In `_get_glue_dtypes_from_json_schema`, when processing an array column:

1. The existing check `elif isinstance(items, dict) and item_properties:` requires `item_properties` to be truthy — an empty dict `{}` is falsy, so the branch is skipped.
2. Execution falls through to `result_typ = f"array<{type_mapper[item_type]}>"` where `item_type='object'`, but `'object'` is not a key in `GLUE_TYPE_MAPPING_DOUBLE`.

The fix adds a new `elif` branch between the "array with object properties" check and the "mixed types" check:

```python
# array of objects with empty or no properties (e.g., additionalProperties: true)
elif isinstance(items, dict) and item_type == "object":
    json_columns.add(col)
    result_typ = "string"
```

This serializes the array as a JSON string, consistent with how objects with `additionalProperties: true` are already handled at the top-level object branch (line 311-319).

## Review guide

1. `destination_aws_datalake/stream_writer.py` — new elif branch at line 353-356
2. `unit_tests/stream_writer_test.py` — added `array_of_objects_empty_properties` field to the big schema fixture and corresponding expected results

## User Impact

Streams containing arrays of objects with empty properties (like Zendesk `ticket_audits` with `attachments[*].thumbnails[*]`) will sync successfully instead of crashing with `KeyError: 'object'`. The problematic nested array is serialized as a JSON string column.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

---
[Devin session](https://app.devin.ai/sessions/4d33868c28dc44a2a0ee5d0d9d178b12)