### PR TITLE
fix(extract-cdk): upgrade Debezium version for UUID failures

### DIFF
--- a/airbyte-cdk/bulk/core/extract/src/test/kotlin/io/airbyte/cdk/fakesource/FakeSourceConfigurationSpecification.kt
+++ b/airbyte-cdk/bulk/core/extract/src/test/kotlin/io/airbyte/cdk/fakesource/FakeSourceConfigurationSpecification.kt
@@ -121,7 +121,7 @@ class FakeSourceConfigurationSpecification : ConfigurationSpecification() {
 
     @JsonIgnore var additionalPropertiesMap = mutableMapOf<String, Any>()
 
-    @JsonAnyGetter fun getAdditionalProperties(): Map<String, Any> = additionalPropertiesMap
+    @JsonIgnore fun getAdditionalProperties(): Map<String, Any> = additionalPropertiesMap
 
     @JsonAnySetter
     fun setAdditionalProperty(

--- a/airbyte-cdk/bulk/toolkits/extract-cdc/build.gradle
+++ b/airbyte-cdk/bulk/toolkits/extract-cdc/build.gradle
@@ -1,5 +1,5 @@
 dependencies {
-    api platform('io.debezium:debezium-bom:3.1.2.Final')
+    api platform('io.debezium:debezium-bom:3.3.2.Final')
     api 'io.debezium:debezium-api'
     api 'io.debezium:debezium-embedded'
 

--- a/airbyte-integrations/connectors/source-mysql/gradle.properties
+++ b/airbyte-integrations/connectors/source-mysql/gradle.properties
@@ -1,3 +1,3 @@
 testExecutionConcurrency=1
 JunitMethodExecutionTimeout=5m
-cdkVersion=1.1.8
+cdkVersion=local

--- a/airbyte-integrations/connectors/source-mysql/src/main/kotlin/io/airbyte/integrations/source/mysql/MySqlSourceConfigurationSpecification.kt
+++ b/airbyte-integrations/connectors/source-mysql/src/main/kotlin/io/airbyte/integrations/source/mysql/MySqlSourceConfigurationSpecification.kt
@@ -198,7 +198,12 @@ class MySqlSourceConfigurationSpecification : ConfigurationSpecification() {
 
     @JsonIgnore var additionalPropertiesMap: MutableMap<String, Any>? = mutableMapOf<String, Any>()
 
-    @JsonAnyGetter fun getAdditionalProperties(): Map<String, Any>? = additionalPropertiesMap
+    // The Debezium 3.3.2 migration pulled Jackson up to 2.19.0. Under this newer Jackson,
+    // getAdditionalProperties() is enumerated as a serializable bean property named "additionalProperties" into the
+    // generated spec. @JsonIgnore keeps the method  callable (the SSH tunnel config reads it) but hides it from
+    // Jackson's property introspection, so mbknor no longer emits it.
+    @JsonIgnore
+    fun getAdditionalProperties(): Map<String, Any>? = additionalPropertiesMap
 
     @JsonAnySetter
     fun setAdditionalProperty(

--- a/airbyte-integrations/connectors/source-mysql/src/main/kotlin/io/airbyte/integrations/source/mysql/MySqlSourceDebeziumOperations.kt
+++ b/airbyte-integrations/connectors/source-mysql/src/main/kotlin/io/airbyte/integrations/source/mysql/MySqlSourceDebeziumOperations.kt
@@ -539,7 +539,7 @@ class MySqlSourceDebeziumOperations(
             val offsetNode: ObjectNode = stateNode[MYSQL_CDC_OFFSET] as ObjectNode
             val offsetMap: Map<JsonNode, JsonNode> =
                 offsetNode
-                    .fields()
+                    .properties()
                     .asSequence()
                     .map { (k, v) -> Jsons.readTree(k) to Jsons.readTree(v.textValue()) }
                     .toMap()


### PR DESCRIPTION
## What
Fixes [12810](https://github.com/airbytehq/oncall/issues/12810)

## How
- Upgrade Debezium to `3.3.2` to include the fix for UUIDSet entries that exist only in the left operand ([ref](https://redhat.atlassian.net/browse/DBZ-9682)). 
- As part of this upgrade, the Jackson version was also upgraded to `2.19`.  
     - Add @JsonIgnore to `MySqlSourceConfigurationSpecification.getAdditionalProperties()`, since the new Jackson version now populates `additionalProperties` in the spec, which is not needed.
     - Replace `fields()` with `properties()` since `fields()` was depracted in `2.19`([ref](https://javadoc.io/static/com.fasterxml.jackson.core/jackson-databind/2.19.1/com/fasterxml/jackson/databind/JsonNode.html#fields--))

## Review guide
<!--
1. `x.py`
2. `y.py`
-->

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [ ] YES 💚
- [ ] NO ❌
