### PR TITLE
docs: fix typos in airbyte-protocol.md

### DIFF
--- a/docs/platform/understanding-airbyte/airbyte-protocol.md
+++ b/docs/platform/understanding-airbyte/airbyte-protocol.md
@@ -874,7 +874,7 @@ Syncs can fail for multiple reasons, and therefore multiple `AirbyteErrorTraceMe
 
 #### AirbyteEstimateTraceMessage
 
-Estimate Trace Messages are used by connectors to inform the orchestrator about how much data they expect to move within the sync. This ise useful to present the user with estimates of the time remaining in the sync, or percentage complete. An example of this would be for every stream about to be synced from a databse to provde a `COUNT (*) from {table_name} where updated_at > {state}` to provide an estimate of the rows to be sent in this sync.
+Estimate Trace Messages are used by connectors to inform the orchestrator about how much data they expect to move within the sync. This is useful to present the user with estimates of the time remaining in the sync, or percentage complete. An example of this would be for every stream about to be synced from a database to provide a `COUNT (*) from {table_name} where updated_at > {state}` to provide an estimate of the rows to be sent in this sync.
 
 `AirbyteEstimateTraceMessage` should be emitted early in the sync to provide an early estimate of the sync's duration. Multiple `AirbyteEstimateTraceMessage`s can be sent for the same stream, and an updated estimate will replace the previous value.
 


### PR DESCRIPTION
## What

Fixes three typos in one sentence of the `AirbyteEstimateTraceMessage` section of the protocol documentation:

- "This ise useful" → "This is useful"
- "a databse" → "a database"
- "to provde" → "to provide"

## How

Documentation-only change, no code affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
