### PR TITLE
fix(source-zendesk-talk): stop infinite pagination loop on call_legs and calls

### DIFF
--- a/airbyte-integrations/connectors/source-zendesk-talk/manifest.yaml
+++ b/airbyte-integrations/connectors/source-zendesk-talk/manifest.yaml
@@ -254,7 +254,13 @@ definitions:
           pagination_strategy:
             type: CursorPagination
             cursor_value: "{{ response.get(\"next_page\", {}) }}"
-            stop_condition: "{{ response.get(\"count\", {}) <= 1 }}"
+            # Zendesk Talk incremental exports always return a `next_page` URL and filter
+            # `start_time` inclusively, so once caught up the paginator keeps re-requesting
+            # `start_time=end_time` and receiving the same boundary record(s). Stop when a page
+            # is not full (fewer than the 1000-record page size) — Zendesk's documented signal
+            # that no more items are available. A count-based "caught up" check is unsafe here
+            # because a single call can have several legs sharing the same `updated_at` second.
+            stop_condition: "{{ response.get(\"count\", 0) < 1000 }}"
       name: call_legs
       primary_key:
         - id
@@ -306,7 +312,13 @@ definitions:
           pagination_strategy:
             type: CursorPagination
             cursor_value: "{{ response.get(\"next_page\", {}) }}"
-            stop_condition: "{{ response.get(\"count\", {}) <= 1 }}"
+            # Zendesk Talk incremental exports always return a `next_page` URL and filter
+            # `start_time` inclusively, so once caught up the paginator keeps re-requesting
+            # `start_time=end_time` and receiving the same boundary record(s). Stop when a page
+            # is not full (fewer than the 1000-record page size) — Zendesk's documented signal
+            # that no more items are available. A count-based "caught up" check is unsafe here
+            # because a single call can have several legs sharing the same `updated_at` second.
+            stop_condition: "{{ response.get(\"count\", 0) < 1000 }}"
       name: calls
       primary_key:
         - id

--- a/airbyte-integrations/connectors/source-zendesk-talk/metadata.yaml
+++ b/airbyte-integrations/connectors/source-zendesk-talk/metadata.yaml
@@ -11,7 +11,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: c8630570-086d-4a40-99ae-ea5b18673071
-  dockerImageTag: 2.0.16
+  dockerImageTag: 2.0.17
   dockerRepository: airbyte/source-zendesk-talk
   documentationUrl: https://docs.airbyte.com/integrations/sources/zendesk-talk
   externalDocumentationUrls:

--- a/airbyte-integrations/connectors/source-zendesk-talk/unit_tests/test_pagination.py
+++ b/airbyte-integrations/connectors/source-zendesk-talk/unit_tests/test_pagination.py
@@ -1,0 +1,64 @@
+# Copyright (c) 2023 Airbyte, Inc., all rights reserved.
+
+"""
+Regression tests for the incremental-export pagination stop condition.
+
+Zendesk Talk incremental exports (`call_legs`, `calls`) always return a `next_page` URL and
+filter `start_time` inclusively, so once a sync catches up the paginator keeps re-requesting
+`start_time=end_time` and receiving the same boundary record(s). A single call can produce
+several legs sharing the same `updated_at` second, so the terminal page can hold >= 2 records.
+
+The stream must therefore stop when a page is not full (`count < 1000`, the export page size),
+not when the page holds a single record. The previous `count <= 1` condition looped forever
+whenever the newest second held two or more legs (oncall #13012).
+"""
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from airbyte_cdk.sources.declarative.interpolation.interpolated_boolean import InterpolatedBoolean
+
+
+MANIFEST_PATH = Path(__file__).resolve().parent.parent / "manifest.yaml"
+INCREMENTAL_EXPORT_STREAMS = ["call_legs", "calls"]
+PAGE_SIZE = 1000
+
+
+def _stop_condition(stream_name: str) -> str:
+    manifest = yaml.safe_load(MANIFEST_PATH.read_text())
+    stream = manifest["definitions"]["streams"][stream_name]
+    return stream["retriever"]["paginator"]["pagination_strategy"]["stop_condition"]
+
+
+def _should_stop(stream_name: str, response: dict) -> bool:
+    condition = InterpolatedBoolean(condition=_stop_condition(stream_name), parameters={})
+    return condition.eval(config={}, response=response)
+
+
+@pytest.mark.parametrize("stream_name", INCREMENTAL_EXPORT_STREAMS)
+@pytest.mark.parametrize(
+    "response, expected_stop, scenario",
+    [
+        ({"count": PAGE_SIZE, "next_page": "url?start_time=2"}, False, "full page -> keep paginating"),
+        ({"count": 20, "next_page": "url?start_time=2"}, True, "partial page -> caught up, stop"),
+        # The exact #13012 loop: two legs of one call share the newest updated_at second.
+        # Zendesk returns them forever with an unchanged next_page; `count <= 1` never stopped.
+        ({"count": 2, "next_page": "url?start_time=2"}, True, "two-record boundary page -> stop (regression)"),
+        ({"count": 1, "next_page": "url?start_time=2"}, True, "single-record boundary page -> stop"),
+        ({"count": 0, "next_page": "url?start_time=2"}, True, "empty page -> stop"),
+        ({"next_page": "url?start_time=2"}, True, "missing count -> stop (safe default)"),
+    ],
+)
+def test_incremental_export_pagination_stops_on_non_full_page(stream_name, response, expected_stop, scenario):
+    assert _should_stop(stream_name, response) is expected_stop, scenario
+
+
+@pytest.mark.parametrize("stream_name", INCREMENTAL_EXPORT_STREAMS)
+def test_stop_condition_is_page_size_based_not_single_record(stream_name):
+    # Guard against regressing to a count-based "one record left" heuristic (e.g. `count <= 1`),
+    # which loops when the boundary second holds multiple legs.
+    condition = _stop_condition(stream_name)
+    assert "< 1000" in condition, condition
+    assert "<= 1" not in condition, condition

--- a/docs/integrations/sources/zendesk-talk.md
+++ b/docs/integrations/sources/zendesk-talk.md
@@ -95,6 +95,7 @@ If you use Airbyte Cloud and your organization restricts access to specific IPs,
 
 | Version | Date | Pull Request | Subject |
 |:--|:--|:--|:--|
+| 2.0.17 | 2026-07-08 | [81516](https://github.com/airbytehq/airbyte/pull/81516) | Fix infinite pagination loop on `call_legs` and `calls` incremental streams |
 | 2.0.16 | 2026-06-30 | [81319](https://github.com/airbytehq/airbyte/pull/81319) | Update dependencies |
 | 2.0.15 | 2026-06-23 | [80706](https://github.com/airbytehq/airbyte/pull/80706) | Update dependencies |
 | 2.0.14 | 2026-06-16 | [80118](https://github.com/airbytehq/airbyte/pull/80118) | Update dependencies |


### PR DESCRIPTION
## What

Fix an infinite pagination loop on the `call_legs` and `calls` incremental-export streams that caused an unexpected full re-read of `call_legs` (oncall [#13012](https://github.com/airbytehq/oncall/issues/13012)).

Both streams changed their `CursorPagination` termination from `count <= 1` to `count < 1000` (the export page size).

## Why

The `/stats/incremental/legs` and `/stats/incremental/calls` endpoints:

- **always return a `next_page` URL** (never null), and
- filter `start_time` **inclusively** (`>=`), so `next_page` points at `start_time=end_time`.

The paginator was configured to stop when `count <= 1`. Once the sync catches up to the newest data, re-requesting `start_time=end_time` keeps returning the record(s) sitting exactly on that boundary timestamp. A single call routinely produces **multiple legs that share the same `updated_at` second**, so the boundary page has `count >= 2`, `end_time` never advances, and `next_page` is identical every time. `count <= 1` therefore never becomes true and the connector loops forever, re-emitting the same handful of boundary records until the sync is cancelled by its time limit.

This is why the issue hit `call_legs` but not `calls`: two distinct calls rarely land in the same second, so `calls` usually reaches `count == 1` and terminates, whereas `call_legs` (many legs per call) almost always has `count >= 2` at the boundary. It is not related to data volume.

### Origin

This is a regression from the original low-code migration. The pre-low-code Python connector terminated when the pagination cursor stopped advancing (the response's next `start_time` equalled the current one). The declarative `stop_condition` could not express "did the cursor token change", and since the endpoints never return a null `next_page`, `count <= 1` was substituted as a "caught up" heuristic. That heuristic only holds when the trailing timestamp is unique.

## Fix

Stop when a page is not full (`count < 1000`), which is Zendesk's documented signal for "no more items available immediately" and reproduces the original termination semantics. A partial page means all remaining records have been returned; a full page (1000) means more data follows.

## Testing

Verified against a live Zendesk Talk account by running `read` on `call_legs` with an incremental state positioned just before the boundary:

- **Before:** the run never terminated — the same 2 boundary records (two legs of one call, identical `updated_at`) were re-emitted 900+ times each and the same `next_page` was requested thousands of times.
- **After:** the run terminates on its own, emitting only the real delta (distinct records, no duplicates) and advancing the cursor correctly.

Direct API checks confirmed the mechanism: requesting `start_time=<boundary>` returns `count = 2` with `end_time == start_time` and an unchanged `next_page`, so `count <= 1` can never be satisfied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)