### PR TITLE
docs: raise self-serve automatic invoice limit from $2,000 to $10,000

### DIFF
--- a/docs/ai-agents/admin/billing.md
+++ b/docs/ai-agents/admin/billing.md
@@ -109,17 +109,17 @@ If you can't pay with the card on file, [update your payment method](#update-you
 
 In the Invoices panel, click the download icon next to an invoice to save a copy.
 
-### Automatic invoice at $2,000 {#auto-bill}
+### Automatic invoice at $10,000 {#auto-bill}
 
-If your charges for a billing period reach $2,000, Airbyte automatically issues an invoice and bills the payment method on file. This is in addition to your regular monthly invoice. After the automatic invoice, charges continue to accrue normally for the rest of the billing period.
+If your charges for a billing period reach $10,000, Airbyte automatically issues an invoice and bills the payment method on file. This is in addition to your regular monthly invoice. After the automatic invoice, charges continue to accrue normally for the rest of the billing period.
 
-The $2,000 automatic invoice is independent of your [maximum bill](#maximum-bill). The automatic invoice is how Airbyte collects what you already owe. The maximum bill is how you tell Airbyte to stop adding charges.
+The $10,000 automatic invoice is independent of your [maximum bill](#maximum-bill). The automatic invoice is how Airbyte collects what you already owe. The maximum bill is how you tell Airbyte to stop adding charges.
 
 ## Avoid billing surprises
 
 To avoid billing surprises, Airbyte offers two capabilities. Airbyte strongly encourages you to rely on these tools to avoid unexpected charges.
 
-- If your charges reach $2,000 in a billing period, Airbyte [automatically generates an invoice and bills you](#auto-bill).
+- If your charges reach $10,000 in a billing period, Airbyte [automatically generates an invoice and bills you](#auto-bill).
 - You can set a [maximum bill](#maximum-bill) so you're never charged more than you're willing to pay in a billing period.
 
 ## Cancel your subscription

--- a/docs/platform/cloud/managing-airbyte-cloud/manage-credits.md
+++ b/docs/platform/cloud/managing-airbyte-cloud/manage-credits.md
@@ -31,7 +31,7 @@ All pricing is in USD.
 
 **If you run out of credits, Airbyte Cloud continues your syncs as it normally would and bills you in-arrears**. Airbyte does not stop in-progress syncs and does not pause scheduled ones. You're billed monthly for any additional credit usage, regardless of sync status.
 
-If you pass $2,000 (USD) in credit usage during a billing period, Airbyte automatically charges your saved payment method and issues an invoice.
+If you pass $10,000 (USD) in credit usage during a billing period, Airbyte automatically charges your saved payment method and issues an invoice.
 
 ## Purchase credits
 


### PR DESCRIPTION
## What

The self-serve automatic invoicing limit is being raised from $2,000 to $10,000. This updates the docs mentions of the old $2,000 figure. Requested by Ian Alton in [DOCS-29](https://linear.app/airbyteio/issue/DOCS-29/10k-billing-limit).

Follows the April change airbytehq/airbyte#75307 that introduced these figures.

## How

Text-only edits replacing `$2,000` with `$10,000`:

- `docs/platform/cloud/managing-airbyte-cloud/manage-credits.md` — 1 mention
- `docs/ai-agents/admin/billing.md` — 4 mentions (the `Automatic invoice at $10,000` heading + body)

The billing.md heading uses an explicit anchor `{#auto-bill}`, so `#auto-bill` links remain intact.

## Review guide
1. `docs/ai-agents/admin/billing.md`
2. `docs/platform/cloud/managing-airbyte-cloud/manage-credits.md`

## User Impact

Docs now reflect the $10,000 automatic invoicing threshold. The actual threshold is configured in the billing platform (Orb) and is out of scope for this docs PR. The companion product string change lives in a separate airbyte-platform-internal PR.

## Can this PR be safely reverted and rolled back?
- [x] YES 💚
- [ ] NO ❌

Link to Devin session: https://app.devin.ai/sessions/c1d952b036674feb983c684469c35c84
Requested by: @ian-at-airbyte