### PR TITLE
feat(source-xero): pace requests under rate limits, honor Retry-After, and use a lightweight connection check

### DIFF
--- a/airbyte-integrations/connectors/source-xero/manifest.yaml
+++ b/airbyte-integrations/connectors/source-xero/manifest.yaml
@@ -1,11 +1,31 @@
-version: 5.14.0
+version: 6.61.6
 
 type: DeclarativeSource
 
 check:
   type: CheckStream
   stream_names:
-    - bank_transactions
+    # Use the cheapest possible stream for the connection check. `organisations`
+    # returns a single record and never paginates, so testing/starting a connection
+    # costs one API call and cannot be starved by rate limits (unlike the previous
+    # `bank_transactions`, a heavy paginated stream that 429'd and failed the check).
+    - organisations
+
+# Proactively pace requests under Xero's published limits so the connector never
+# thrashes against a 429. Xero allows 60 calls/minute per tenant; we cap at 55 to
+# leave headroom for clock skew and token-refresh traffic. The budget is shared
+# across all (concurrent) streams, so total throughput stays within the limit.
+# See https://developer.xero.com/documentation/guides/oauth2/limits/
+api_budget:
+  type: HTTPAPIBudget
+  policies:
+    - type: MovingWindowCallRatePolicy
+      rates:
+        - limit: 55
+          interval: PT1M
+      matchers:
+        - method: GET
+          url_base: "https://api.xero.com"
 
 definitions:
   streams:
@@ -444,38 +464,27 @@ definitions:
         - credentials
         - auth_type
     error_handler:
-      type: CompositeErrorHandler
-      error_handlers:
-        - type: DefaultErrorHandler
-          backoff_strategies:
-            - type: ConstantBackoffStrategy
-              backoff_time_in_seconds: 30
-          response_filters:
-            - type: HttpResponseFilter
-              action: FAIL
-              http_codes: [401]
-              error_message: "Failed to authorize request"
-        - type: DefaultErrorHandler
-          response_filters:
-            - type: HttpResponseFilter
-              action: IGNORE
-              http_codes: [403]
-        # Stop immediately if Daily Limit reached
-        - type: DefaultErrorHandler
-          response_filters:
-            - type: HttpResponseFilter
-              action: FAIL
-              http_codes: [429]
-              error_message: "daily limit"
-        # Retry standard rate limits (e.g. 60/min)
-        - type: DefaultErrorHandler
-          backoff_strategies:
-            - type: ExponentialBackoffStrategy
-              factor: 2
-          response_filters:
-            - type: HttpResponseFilter
-              action: RETRY
-              http_codes: [429]
+      type: DefaultErrorHandler
+      response_filters:
+        # Authentication failures are terminal — surface them clearly.
+        - type: HttpResponseFilter
+          action: FAIL
+          http_codes: [401]
+          error_message: "Failed to authorize request. Verify your Xero credentials and that the tenant is still connected."
+        # A tenant may lack the scope for a given stream — skip it instead of failing the whole sync.
+        - type: HttpResponseFilter
+          action: IGNORE
+          http_codes: [403]
+      # 429 (and transient 5xx) are retried honoring Xero's Retry-After header.
+      # A per-minute limit returns a small Retry-After and is retried in place.
+      # The daily limit (5,000/tenant) returns a very large Retry-After (seconds
+      # until the window resets); that exceeds max_waiting_time_in_seconds, which
+      # stops the stream cleanly so the next scheduled sync resumes from saved
+      # state rather than blocking a worker for hours or hammering the API.
+      backoff_strategies:
+        - type: WaitTimeFromHeader
+          header: "Retry-After"
+          max_waiting_time_in_seconds: 300
 
 streams:
   - $ref: "#/definitions/streams/bank_transactions"

--- a/airbyte-integrations/connectors/source-xero/metadata.yaml
+++ b/airbyte-integrations/connectors/source-xero/metadata.yaml
@@ -31,7 +31,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 6fd1e833-dd6e-45ec-a727-ab917c5be892
-  dockerImageTag: 2.1.6
+  dockerImageTag: 2.2.0
   dockerRepository: airbyte/source-xero
   githubIssueLabel: source-xero
   icon: xero.svg

--- a/docs/integrations/sources/xero.md
+++ b/docs/integrations/sources/xero.md
@@ -125,6 +125,7 @@ If you use Airbyte Cloud and your organization restricts access to specific IPs,
 
 | Version | Date       | Pull Request                                             | Subject                                                   |
 |:--------|:-----------|:---------------------------------------------------------|:----------------------------------------------------------|
+| 2.2.0 | 2026-07-08 | [81522](https://github.com/airbytehq/airbyte/pull/81522) | Pace requests under Xero's rate limits (API budget), honor `Retry-After` on 429s, and use a lightweight connection check |
 | 2.1.6 | 2026-06-30 | [79089](https://github.com/airbytehq/airbyte/pull/79089) | Update dependencies |
 | 2.1.5 | 2026-02-25 | [71340](https://github.com/airbytehq/airbyte/pull/71340) | Resolve the generator returned from JsonDecoder into dictionary |
 | 2.1.4 | 2025-03-01 | [55142](https://github.com/airbytehq/airbyte/pull/55142) | Update dependencies |


### PR DESCRIPTION
## What

The Xero source has no proactive rate limiting. It issues requests (across concurrent streams) until Xero returns `429 Too Many Requests`, then retries with a blind fixed/exponential backoff. On tenants with large data volumes this thrashes against Xero's **60 requests/minute** limit. It also breaks the **connection check**: `CheckStream` reads the heavy, paginated `bank_transactions` stream, which gets `429`'d and raises `UserDefinedBackoffException`, so the check (and therefore the sync) fails before any data is read.

Xero's documented limits are 60 calls/min, 5,000 calls/day, and 5 concurrent per tenant, with a `Retry-After` header returned on 429s:
- https://developer.xero.com/documentation/guides/oauth2/limits/
- https://developer.xero.com/documentation/api/efficient-data-retrieval

## How

- **Add an `api_budget`** (`HTTPAPIBudget` + `MovingWindowCallRatePolicy`) that caps GET traffic to `api.xero.com` at **55/min** (headroom under the 60/min limit). The budget is shared across the connector's concurrent streams, so total throughput stays within Xero's limit and 429s are avoided proactively instead of reacted to.
- **Replace the `CompositeErrorHandler`** — which used a fixed 30s + exponential backoff and could not distinguish a per-minute 429 from the daily-limit 429 — with a `DefaultErrorHandler` that honors Xero's **`Retry-After`** header via `WaitTimeFromHeader`. `max_waiting_time_in_seconds: 300` retries a per-minute limit in place, while the daily limit (whose `Retry-After` is the time until the window resets) cleanly stops the stream so the next sync resumes from saved state rather than blocking a worker for hours.
- **Point the connection `check`** at the lightweight `organisations` stream (single record, no pagination) instead of `bank_transactions`, so testing/starting a connection costs one API call and cannot be starved by rate limits.
- Bump the manifest `version` to `6.61.6` (for `api_budget` support; matches the connector base image) and the connector to **2.2.0**.

## Review guide

The functional change is entirely in `manifest.yaml`: the top-of-file `api_budget` and `check`, plus `definitions.base_requester.error_handler`. The large inline stream schemas are unchanged.

## User Impact

No breaking changes. Existing connections keep the same streams, cursor fields, and state. Syncs on large tenants stop failing on rate limits, and the connection check no longer fails under load.

## Testing

Acceptance tests are disabled for this connector (`metadata.yaml`). Validated locally against `airbyte-cdk==6.61.6` (the base-image CDK):
- The edited manifest passes declarative-schema validation and all 21 streams build.
- Confirmed the resulting `HTTPAPIBudget` (with its `MovingWindowCallRatePolicy` and request matcher) is attached to the streams' `HttpClient`, i.e. the budget is enforced at request time and not silently dropped.

## Notes for reviewers

- `page_size` is already at Xero's maximum (1,000); pagination is unchanged.
- Date-based request windowing was considered for the >100k-document "high volume" endpoints but does not apply here: Xero's incremental filter is the lower-bound-only `If-Modified-Since` header (there is no "modified-before"), so a `DatetimeBasedCursor` `step` cannot bound the upper end of a slice. If a specific stream hits a `400 HighVolumeException`, the appropriate follow-up is a `ListPartitionRouter` over an optimized Xero filter (e.g. Invoices by `Statuses`/`Type`), added per-stream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
