### PR TITLE
docs: add Airbyte 2.1.1 release notes

### DIFF
--- a/docs/release_notes/self-managed/v-2.1.md
+++ b/docs/release_notes/self-managed/v-2.1.md
@@ -164,6 +164,6 @@ This version includes security improvements and updated base images.
 
 ### Version 2.1.1
 
-Airbyte 2.1.1 was released on July 8, 2026.
+Airbyte 2.1.1 was released on July 13, 2026.
 
 - **Fixed an unintended 100-connection-per-organization limit**: A change in 2.1.0 inadvertently applied a 100-connection-per-organization cap to self-managed deployments when connections were created through the public API. This limit was never meant to apply to self-managed and has been removed, so you can once again create connections through the public API without hitting the cap.

--- a/docs/release_notes/self-managed/v-2.1.md
+++ b/docs/release_notes/self-managed/v-2.1.md
@@ -159,3 +159,11 @@ This version includes security improvements and updated base images.
 - **Updated contributor documentation link**: Fixed an outdated link to the GitHub token creation page in the documentation for contributing new connectors.
 
 - **Live connector docs from GitHub**: Connector documentation displayed in the UI is now fetched directly from GitHub (the source of truth for docs.airbyte.com) instead of the version bundled at the last connector publish. This means documentation updates — such as troubleshooting tips or corrected instructions — are visible immediately without waiting for a connector version bump. If GitHub is unreachable (for example, in air-gapped environments), the system falls back seamlessly to the previously bundled docs.
+
+## Patch releases
+
+### Version 2.1.1
+
+Airbyte 2.1.1 was released on July 8, 2026.
+
+- **100-connection-per-organization limit removed**: Version 2.1.0 capped organizations at 100 connections when you created connections through the public API. This release removes that cap, so you can once again create connections through the public API without hitting the limit.

--- a/docs/release_notes/self-managed/v-2.1.md
+++ b/docs/release_notes/self-managed/v-2.1.md
@@ -166,4 +166,4 @@ This version includes security improvements and updated base images.
 
 Airbyte 2.1.1 was released on July 8, 2026.
 
-- **100-connection-per-organization limit removed**: Version 2.1.0 capped organizations at 100 connections when you created connections through the public API. This release removes that cap, so you can once again create connections through the public API without hitting the limit.
+- **Fixed an unintended 100-connection-per-organization limit**: A change in 2.1.0 inadvertently applied a 100-connection-per-organization cap to self-managed deployments when connections were created through the public API. This limit was never meant to apply to self-managed and has been removed, so you can once again create connections through the public API without hitting the cap.


### PR DESCRIPTION
## What

Adds a `## Patch releases` → `### Version 2.1.1` section to the Self-Managed 2.1 release notes page (`docs/release_notes/self-managed/v-2.1.md`), following the per-patch pattern already used on `v-2.0.md` (2.0.1) and earlier pages. No new page or sidebar entry is needed for a patch release.

Produced via the `self-managed-release-notes` skill. Requested by Ian Alton (`@ian-at-airbyte`) in Slack. Tracking: [DOCS-30](https://linear.app/airbyteio/issue/DOCS-30/211-release-notes).

## How

Phase 1 — enumerated the merged changes between `release/2.1.0` and `release/2.1.1` in `airbytehq/airbyte-platform-internal`. The diff contains exactly one PR:

- `airbytehq/airbyte-platform-internal#19126` — `chore: remove connection check and unlimited connection entitlement, since its only for unified trial`

That PR removes the `UnlimitedConnectionsEntitlement` and the 100-connection-per-organization cap that was introduced in 2.1.0 (`airbytehq/airbyte-platform-internal#18293`). The cap was enforced on the public-API connection-creation path; in Community edition the default `NoEntitlementClient` reports not-entitled, so self-managed operators would hit the limit at 100 connections per org via the public API. Removing it is operator-notable, so it earns one bullet in the patch section.

The change also touches the Cloud-only wrapped controller (`cloud/airbyte-server-wrapped`), which is excluded per the skill's Cloud-only gate; the note is scoped to the self-managed-relevant public-API behavior only.

## Review guide

1. `docs/release_notes/self-managed/v-2.1.md` — new `## Patch releases` / `### Version 2.1.1` section at the end.

## User Impact

Documentation only. Informs self-managed operators that the 100-connection-per-organization cap on public-API connection creation (introduced in 2.1.0) is removed in 2.1.1.

## Can this PR be safely reverted and rolled back?
- [x] YES 💚
- [ ] NO ❌

Link to Devin session: https://app.devin.ai/sessions/16ccb344839641f4b12f600971c4b400

> [!IMPORTANT]
> ⚡ **Auto-merge enabled.**
> 
> _This PR is set to merge automatically when all requirements are met._