### PR TITLE
docs(ai-agents): document multi-workspace management and cross-workspace views

### DIFF
--- a/docs/ai-agents/admin/sessions.md
+++ b/docs/ai-agents/admin/sessions.md
@@ -23,6 +23,7 @@ Airbyte logs sessions for work initiated in the web app. Work initiated through 
 The Sessions table lists the most recent sessions first. Each row represents one session, and the columns describe what the agent did and how much work it took.
 
 - **Source**: A descriptive name for the session. For automations, this is the automation's name. For chats, this is the chat's title.
+- **Workspace**: The workspace the session ran in. If that workspace has since been deleted, this shows an em dash (—). On Free and Individual plans, every session runs in the `default` workspace.
 - **Type**: Whether the session is a [Chat](#chat), an [Automation](#automation), or an **Automation Builder Chat**.
 - **Status**: Notes Active or Deleted. Active chats are resumable.
 - **Connectors**: The connectors the agent used during the session. Hover over a connector icon to see its name.
@@ -35,7 +36,9 @@ The Sessions table lists the most recent sessions first. Each row represents one
   - Click the **View** icon to open the session and see its messages and tool calls.
   - Click the **Chat** icon to jump to the chat or automation the session belongs to.
 
-Use the **Type**, **Status**, and **Connectors** filters above the table to narrow the list. The Type filter scopes to chats or automations. The Status filter scopes to Active, which you can resume, or Deleted. The Connectors filter scopes to sessions that used one or more specific connectors.
+Use the filters above the table to narrow the list. The Type filter scopes to chats or automations. The Status filter scopes to Active, which you can resume, or Deleted. The Connectors filter scopes to sessions that used one or more specific connectors. On the [Team and Custom plans](./billing.md#team), a **Workspace** filter also scopes the list to one or more workspaces.
+
+Administrators see sessions from every workspace in the organization. Members see sessions from the workspaces they belong to. On Free and Individual plans there is only the `default` workspace, so this distinction doesn't apply.
 
 ## Session types {#session-types}
 

--- a/docs/ai-agents/admin/tool-calls.md
+++ b/docs/ai-agents/admin/tool-calls.md
@@ -49,6 +49,8 @@ Use the filters above the table to narrow the activity to a specific subset:
 - **Tool Type**: Show only Direct tool calls, only Search tool calls, or both.
 - **Status**: Show only successful calls, only failed calls, or both.
 
+Administrators see tool calls from every workspace in the organization; members see tool calls from the workspaces they belong to. Tool calls made in a workspace that was later deleted are preserved and still appear in the table.
+
 #### Columns
 
 Each row in the table includes the following information:

--- a/docs/ai-agents/admin/users.md
+++ b/docs/ai-agents/admin/users.md
@@ -56,12 +56,12 @@ Removing a user revokes their access to the organization immediately. To cancel 
 
 ## Workspace membership
 
-On the Team plan, administrators control which workspaces each member can access.
+On the Team and Custom plans, administrators control which workspaces each member can access.
 
-- **Administrators** can see and manage all workspaces in the organization.
-- **Members** can be assigned to specific workspaces by an administrator.
+- **Administrators** can see and manage every workspace in the organization, and always keep access to all of them.
+- **Members** can be added to specific workspaces by an administrator, and see only the workspaces they belong to.
 
-Administrators can manage workspace membership from the workspace members page. For details on workspace structure, see [Workspaces](../concepts/architecture/workspaces.md).
+Everyone in the organization can access the `default` workspace. Administrators manage membership for other workspaces from the workspace picker in the sidebar: open a workspace's edit dialog and add or remove members there. For details on workspace structure and management, see [Workspaces](../concepts/architecture/workspaces.md).
 
 ## Related topics
 

--- a/docs/ai-agents/concepts/architecture/workspaces.md
+++ b/docs/ai-agents/concepts/architecture/workspaces.md
@@ -34,8 +34,16 @@ The UUID is the durable identifier. The name is a convenience for routing, but i
 
 There are two ways to create a workspace:
 
-- **Web app** ([Team and Custom plans](../../admin/billing.md#team)): Open the workspace picker in the sidebar and click **New workspace**. Enter a name and click **Create**.
+- **Web app** ([Team and Custom plans](../../admin/billing.md#team)): Only administrators can create workspaces. Open the workspace picker in the sidebar, click **New workspace**, enter a name, pick a color, and click **Create**. Airbyte switches you to the new workspace and adds you as a member automatically.
 - **API**: The first time you mint a [scoped token](../../interfaces/api/authentication#scoped-token) against a new `workspace_name`, Airbyte creates the workspace for you. Use any stable string that makes sense in your app, for example an internal tenant ID or team slug.
+
+## Workspace properties
+
+Each workspace has the following properties:
+
+- **Name**: A human-readable label, unique within the organization. You can rename a workspace later, except the default workspace.
+- **Color**: A swatch chosen from a fixed palette. The color appears next to the workspace name in the picker and helps you tell workspaces apart at a glance.
+- **Context Store region**: Where the workspace's [Context Store](../context-store) data is stored. This is currently the United States for every workspace and can't be changed.
 
 ## Scoped tokens
 
@@ -47,16 +55,36 @@ For details on generating and using scoped tokens, see [Authentication](../../in
 
 On [Team and Custom plans](../../admin/billing.md#team), administrators control which workspaces each member can access.
 
-- **Administrators** can see and manage all workspaces.
-- **Members** can be assigned to specific workspaces by an administrator.
+- **Administrators** can see and manage every workspace in the organization. They always keep access to every workspace and can't be removed as members.
+- **Members** can be added to specific workspaces by an administrator. A member sees only the workspaces they belong to.
 
-Chats and connectors are workspace-specific. Workspace membership lets administrators control which members can access which workspaces.
+Everyone in the organization has access to the `default` workspace. This can't be changed.
 
-For details on managing users and assigning workspace membership, see [Users](../../admin/users.md).
+Chats and connectors are shared within a workspace: any member of a workspace can view, use, and edit the connectors it contains. Workspace membership is what lets administrators control who can access which set of chats and connectors.
 
 ## Manage workspaces
 
-Workspace management (listing, updating, and deleting workspaces) is available through the web app and the API. The SDK `Workspace` class covers day-to-day operations like listing connectors and executing operations.
+Administrators manage workspaces from the workspace picker in the sidebar. Open the picker, hover a workspace, and use the edit or delete controls. Non-administrators don't see these controls, and the `default` workspace can't be edited or deleted.
+
+### Edit a workspace
+
+Click the edit (pencil) icon next to a workspace to open its settings. You can:
+
+- **Rename** the workspace and change its **color**.
+- **Manage members**: add any active organization member, or remove a member you added earlier. Administrators always appear as members and can't be removed. Search by name or email to find people.
+- **Copy the workspace ID** for use in API calls.
+
+Click **Save** to apply your changes. The Context Store region is fixed and can't be edited.
+
+### Delete a workspace
+
+Click the delete (trash) icon next to a workspace, then type the workspace name to confirm. Deleting a workspace permanently removes the workspace along with all chats and connectors inside it. This can't be undone.
+
+Historical [session](../../admin/sessions.md) and [tool call](../../admin/tool-calls.md) records that ran in a deleted workspace are preserved, but the workspace no longer appears as a place you can open or add connectors to.
+
+### Programmatic access
+
+Workspace management is also available through the API. The SDK `Workspace` class covers day-to-day operations like listing connectors and executing operations.
 
 - [Manage workspaces (API)](../../interfaces/api/workspaces): List, update, and delete workspaces.
 - [Manage workspaces (SDK)](../../interfaces/sdk/workspaces): Target a workspace, list connectors, and execute operations.

--- a/docs/ai-agents/concepts/architecture/workspaces.md
+++ b/docs/ai-agents/concepts/architecture/workspaces.md
@@ -72,9 +72,10 @@ Click the edit (pencil) icon next to a workspace to open its settings. You can:
 
 - **Rename** the workspace and change its **color**.
 - **Manage members**: add any active organization member, or remove a member you added earlier. Administrators always appear as members and can't be removed. Search by name or email to find people.
-- **Copy the workspace ID** for use in API calls.
 
 Click **Save** to apply your changes. The Context Store region is fixed and can't be edited.
+
+To grab a workspace's ID for use in API calls, open the picker and use the **Copy workspace ID** control on the workspace's row. You don't need to open the edit dialog to do this.
 
 ### Delete a workspace
 
@@ -84,7 +85,7 @@ Historical [session](../../admin/sessions.md) and [tool call](../../admin/tool-c
 
 ### Programmatic access
 
-Workspace management is also available through the API. The SDK `Workspace` class covers day-to-day operations like listing connectors and executing operations.
+Workspace management is also available through the [API](../../interfaces/api/workspaces). The [SDK `Workspace` class](../../interfaces/sdk/workspaces) covers day-to-day operations like listing connectors and executing operations.
 
 - [Manage workspaces (API)](../../interfaces/api/workspaces): List, update, and delete workspaces.
 - [Manage workspaces (SDK)](../../interfaces/sdk/workspaces): Target a workspace, list connectors, and execute operations.

--- a/docs/ai-agents/interfaces/ui/add-connector.md
+++ b/docs/ai-agents/interfaces/ui/add-connector.md
@@ -22,7 +22,9 @@ Adding a connector is a one-time setup step per workspace. You don't need to pic
 
 ## Workspaces and connectors
 
-A **workspace** is the scope that a connector lives in. Every organization starts with a `default` workspace and a `Test Environment` workspace, and you can create more. Use workspaces to separate credentials that shouldn't mix. For example, separate production data from sandbox data, or one customer's credentials from another customer's.
+A **workspace** is the scope that a connector lives in. Every organization starts with a `default` workspace, and on the [Team and Custom plans](../../admin/billing.md#team) administrators can create more. Use workspaces to separate credentials that shouldn't mix. For example, separate production data from sandbox data, or one customer's credentials from another customer's.
+
+Connectors are shared within a workspace. Any user with access to the workspace can use a connector in chats, and can edit or delete it. Keep this in mind when you add credentials to a shared workspace.
 
 A workspace can hold as many connectors as you need:
 

--- a/docs/ai-agents/interfaces/ui/chats.md
+++ b/docs/ai-agents/interfaces/ui/chats.md
@@ -25,6 +25,8 @@ Suggestions are starting points, not fixed templates. The agent treats the text 
 
 Every chat you start is saved. To return to a chat, open the sidebar and click the chat under **Recent Chats**. The sidebar shows your five most recent chats by default. Click **Show more** to expand the list, or open the Sessions page from Settings to browse every chat and automation run in your organization.
 
+On the [Team and Custom plans](../../admin/billing.md#team), **Recent Chats** lists only the chats in the workspace you're currently viewing. To see chats from another workspace, switch to it in the workspace picker. Opening a chat that lives in a different workspace switches you to that workspace automatically.
+
 When you reopen a chat, the full history loads in place and you can continue the conversation by sending another message. Older messages stay available. Scroll up or click **Load older messages** to page through the history.
 
 Only the person who started a chat can send messages in it. If another member of your organization opens the chat (for example, via a link to its URL), they see the full conversation in read-only mode and can't post new messages.

--- a/docs/ai-agents/interfaces/ui/readme.md
+++ b/docs/ai-agents/interfaces/ui/readme.md
@@ -27,7 +27,14 @@ Administrators can add connectors from the web app.
 
 ## Workspaces
 
-On the [Team and Custom plans](../../admin/billing.md#team), a workspace picker appears in the sidebar. Use it to switch between workspaces, create new ones, and see which workspace is currently active. Chats and connectors are scoped to the active workspace. See [Workspaces](../../concepts/architecture/workspaces) for details.
+On the [Team and Custom plans](../../admin/billing.md#team), a workspace picker appears at the top of the sidebar. Each workspace has a name and a color swatch, and the picker shows which workspace is currently active. Chats and connectors are scoped to the active workspace.
+
+- **Switch workspaces**: Open the picker and select another workspace. Airbyte navigates to that workspace and shows a confirmation toast.
+- **Create a workspace** (administrators only): Click **New workspace**, enter a name, and pick a color. The Context Store region is fixed to the United States. Airbyte switches you to the new workspace and adds you as a member.
+- **Edit a workspace** (administrators only): Hover a workspace and click the edit icon to rename it, change its color, manage members, or copy its ID.
+- **Delete a workspace** (administrators only): Hover a workspace and click the delete icon, then type the name to confirm.
+
+The `default` workspace can't be renamed, recolored, or deleted, and everyone in the organization can access it. See [Workspaces](../../concepts/architecture/workspaces) for details.
 
 ## Related administration
 


### PR DESCRIPTION
This PR targets PR #79704:
- #79704

---

## What

Updates the Agent docs to reflect user-facing changes shipped in the [Agent Governance](https://linear.app/airbyteio/project/agent-governance-5dd666d04055) project (multi-workspace management + Team plan bug bash). Requested by Ian Alton (ian.alton@airbyte.io). Tracks [DOCS-23](https://linear.app/airbyteio/issue/DOCS-23/update-documentation-for-team-plan).

Per-user **private workspaces are intentionally omitted** — that work was canceled (PLAT-872) and is not shipped.

## How

Eight files updated:

- **`concepts/architecture/workspaces.md`** — new *Workspace properties* section (name, color, US-only Context Store region); create is admin-only and auto-adds the creator as a member; expanded membership model (admins always retain access; everyone can access `default`; connectors are shared within a workspace); new *Edit a workspace*, *Delete a workspace* (type-to-confirm; chats/connectors removed; session & tool-call history preserved), and *Programmatic access* subsections.
- **`interfaces/ui/readme.md`** — expanded workspace picker section: switch (confirmation toast), admin-only create/edit/delete, colors, default-workspace protections.
- **`interfaces/ui/chats.md`** — Recent Chats is scoped to the active workspace; opening a chat in another workspace switches to it.
- **`interfaces/ui/add-connector.md`** — fixed inaccurate "starts with a `default` and a `Test Environment` workspace" claim (only `default` is standard); added shared-workspace disclaimer (any member can use/edit/delete a workspace's connectors).
- **`admin/sessions.md`** — documented the **Workspace** column and filter, admin-vs-member cross-workspace visibility, and deleted-workspace behavior (column shows an em dash; row preserved).
- **`admin/tool-calls.md`** — admin-vs-member visibility and deleted-workspace behavior (records preserved).
- **`admin/users.md`** — corrected workspace-membership management to point at the workspace picker's edit dialog (there is no separate "workspace members page").
- **`admin/billing.md`** — no change needed; Team plan already links Multiple workspaces (verified).

All UI terminology was verified against the sonar frontend locale strings and workspace picker / dialog components.

## Review guide

1. `docs/ai-agents/concepts/architecture/workspaces.md` — the substantive additions.
2. `docs/ai-agents/interfaces/ui/add-connector.md` — the factual fix (Test Environment claim).
3. `docs/ai-agents/admin/sessions.md` — new Workspace column/visibility docs.
4. Remaining files — smaller cross-workspace notes.

## User Impact

Docs-only. Users and admins on Team/Custom plans get accurate guidance on creating, editing, deleting, and sharing workspaces, and on cross-workspace visibility in Sessions and Tool Calls. No product/runtime changes.

## Can this PR be safely reverted and rolled back?
- [x] YES 💚
- [ ] NO ❌

---
[Devin session](https://app.devin.ai/sessions/2b99cf83cd8046f2925b5df2032cabba)

Requested by: @ian-at-airbyte