### PR TITLE
feat(destination-mssql): add connectorIPCOptions to enable speed mode

### DIFF
--- a/airbyte-integrations/connectors/destination-mssql/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-mssql/metadata.yaml
@@ -5,6 +5,15 @@ data:
     requireVersionIncrementsInPullRequests: false
   connectorBuildOptions:
     baseImage: docker.io/airbyte/java-connector-base:2.0.1@sha256:ec89bd1a89e825514dd2fc8730ba299a3ae1544580a078df0e35c5202c2085b3
+  connectorIPCOptions:
+    dataChannel:
+      version: 0.0.2
+      supportedSerialization:
+        - JSONL
+        - PROTOBUF
+      supportedTransport:
+        - SOCKET
+        - STDIO
   connectorSubtype: database
   connectorTestSuitesOptions:
     - suite: unitTests


### PR DESCRIPTION
## Summary

- Adds `connectorIPCOptions` block to `destination-mssql` `metadata.yaml` to enable speed mode (SOCKET-based IPC transport) for this connector.
- `destination-mssql` is a certified, Bulk CDK destination but was the only one missing this configuration. All other Bulk CDK destinations (snowflake, bigquery, redshift, postgres, s3, databricks, clickhouse, etc.) already have this declared.

## Change

Adds the following to `metadata.yaml`:

```yaml
connectorIPCOptions:
  dataChannel:
    version: 0.0.2
    supportedSerialization:
      - JSONL
      - PROTOBUF
    supportedTransport:
      - SOCKET
      - STDIO
```

This enables the platform to route data directly from source to destination via SOCKET IPC (speed mode) instead of the standard STDIO pipeline, improving sync performance.