### PR TITLE
docs(ai-agents): promote skill docs as recommended introspection pattern

### DIFF
--- a/docs/ai-agents/concepts/connect-ask-act.md
+++ b/docs/ai-agents/concepts/connect-ask-act.md
@@ -47,6 +47,14 @@ execute(entity, action, params)
 
 This pattern is the same across every connector and every interface. Agents call the same entities and actions with the same parameters from any interface.
 
+Before an agent executes, it needs to know which entities and actions a connector supports. Rather than loading the entire connector schema into the prompt up front, agents introspect the connector just in time through **skill docs** — concise, chunked guidance the platform generates for each connector:
+
+1. **Inspect the connector** to discover its metadata and Context Store readiness.
+2. **Read skill docs** for an outline of entities and actions, then read the specific section for the operation the agent is about to run.
+3. **Execute** the chosen entity and action.
+
+This progressive flow keeps the agent's context small and its calls accurate. The `build_connector_tools` helper wires these steps up as ready-to-use tools; see [Execute operations](../interfaces/sdk/execute) for the code.
+
 Airbyte Agents act through [**Chats**](../interfaces/ui/chats) — interactive, conversational sessions where an agent responds to prompts in real time.
 
 Airbyte logs every action an agent takes. You can review what happened, when, and why in the [Sessions](../admin/sessions) and [Tool calls](../admin/tool-calls) views.

--- a/docs/ai-agents/get-started/developer-quickstart/tutorial-fastmcp.md
+++ b/docs/ai-agents/get-started/developer-quickstart/tutorial-fastmcp.md
@@ -71,21 +71,17 @@ my-mcp-agent/
 2. Create a `server.py` file with the following imports:
 
    ```python title="server.py"
-   import json
-
    from dotenv import load_dotenv
    from fastmcp import FastMCP
-   from airbyte_agent_sdk import connect
-   from airbyte_agent_sdk.connectors.github import GithubConnector
+   from airbyte_agent_sdk import build_connector_tools, connect
    ```
 
    These imports provide:
 
-   - `json`: Serialize connector results for the MCP tool return value.
    - `load_dotenv`: Load environment variables from your `.env` file.
    - `FastMCP`: The FastMCP server class that handles MCP protocol communication.
    - `connect`: The Agent SDK entry point. One call returns a typed connector bound to your workspace.
-   - `GithubConnector`: The connector class. You reference it when decorating the tool so the SDK can describe the connector's entities and actions to the agent.
+   - `build_connector_tools`: Turns a connector into ready-to-bind agent tools that inspect the connector and read its skill docs before executing.
 
 ## Part 3: Add a .env file with your secrets
 
@@ -143,24 +139,22 @@ github = connect("github")
 
 If you want to connect to a different workspace or pass credentials explicitly, use `connect("github", workspace_name="my-workspace", client_id=..., client_secret=...)` or pass an `AirbyteAuthConfig`. See the [SDK reference](https://github.com/airbytehq/airbyte-agent-sdk) for details.
 
-### Register the tool
+### Register the tools
 
-Rather than one tool per GitHub endpoint, the Agent SDK exposes the entire GitHub API through a single `execute(entity, action, params)` entry point. This one-tool-per-connector model is context-efficient: instead of registering dozens of tools that consume the agent's context window, a single tool with a compact entity/action catalog gives the agent full connector coverage with minimal overhead.
+Rather than one tool per GitHub endpoint, `build_connector_tools` returns three tools bound to your connector: `inspect_connector`, `read_skill_docs`, and `execute`. This model is context-efficient: instead of registering dozens of endpoint tools that consume the client's context window, the agent inspects the connector and reads its skill docs on demand, then executes.
 
-The `@GithubConnector.tool_utils` decorator fills in the entity and action catalog as part of the tool description, so the agent knows what's available without you writing a schema. It also enables automatic fallback to the `list` action when the Context Store is not yet ready, so your tool works immediately even before the first replication completes.
+`tools.as_list()` returns plain async callables. Register each one with the server:
 
 ```python title="server.py"
-@mcp.tool()
-@GithubConnector.tool_utils
-async def github_execute(entity: str, action: str, params: dict | None = None) -> str:
-    """Execute GitHub connector operations."""
-    result = await github.execute(entity, action, params or {})
-    return json.dumps(result, default=str)
+tools = build_connector_tools(github, framework="mcp")
+
+for tool in tools.as_list():
+    mcp.tool(tool)
 ```
 
-The decorator stack is the whole tool definition. No per-action `docstring`, no `GITHUB_LIST_COMMITS` or `GITHUB_GET_PR` sprawl, one entry point that covers the full connector. `@GithubConnector.tool_utils` appends the full entity and action catalog to the tool description so the MCP client sees every entity, action, and enum value the connector supports. As the connector grows, the tool signature stays the same.
+Passing `framework="mcp"` makes runtime errors surface in a form the MCP client can act on. Each callable carries its own name, docstring, and signature, so `mcp.tool` registers it with the right schema. Because the agent reads the connector's skill docs before it executes, the MCP client discovers the entities, actions, and enum values the connector supports without a hand-written schema.
 
-Each `execute` call returns a structured result with `data` (the records) and `meta` (pagination cursors). MCP tools return strings, so this tutorial serializes the whole result with `json.dumps` so the MCP client can reason about both the records and the pagination state.
+Each `execute` call returns a structured result with `data` (the records) and `meta` (pagination cursors). FastMCP serializes the result for the MCP client, so it can reason about both the records and the pagination state.
 
 ### Add the server entry point
 

--- a/docs/ai-agents/get-started/developer-quickstart/tutorial-langchain.md
+++ b/docs/ai-agents/get-started/developer-quickstart/tutorial-langchain.md
@@ -73,25 +73,21 @@ You create `.env` and `uv.lock` files in later steps, so don't worry about them 
 2. Create an `agent.py` file with the following imports:
 
    ```python title="agent.py"
-   import json
-
    from dotenv import load_dotenv
    from langchain.agents import create_agent
-   from langchain.tools import tool
+   from langchain_core.tools import StructuredTool
    from langchain_openai import ChatOpenAI
-   from airbyte_agent_sdk import connect
-   from airbyte_agent_sdk.connectors.github import GithubConnector
+   from airbyte_agent_sdk import build_connector_tools, connect
    ```
 
    These imports provide:
 
-   - `json`: Serialize connector results for the LangChain tool return value.
    - `load_dotenv`: Load environment variables from your `.env` file.
    - `create_agent`: LangChain's function for creating an agent that can call tools.
-   - `tool`: LangChain's decorator for converting a function into a tool.
+   - `StructuredTool`: LangChain's wrapper for turning a function into a tool.
    - `ChatOpenAI`: LangChain's OpenAI chat model integration.
    - `connect`: The Agent SDK entry point. One call returns a typed connector bound to your workspace.
-   - `GithubConnector`: The connector class. You reference it when decorating the tool so the SDK can describe the connector's entities and actions to the agent.
+   - `build_connector_tools`: Turns a connector into ready-to-bind agent tools that inspect the connector and read its skill docs before executing.
 
 ## Part 3: Add a .env file with your secrets
 
@@ -150,22 +146,24 @@ One line does four things for you:
 
 If you want to connect to a different workspace or pass credentials explicitly, use `connect("github", workspace_name="my-workspace", client_id=..., client_secret=...)` or pass an `AirbyteAuthConfig`. See the [SDK reference](https://github.com/airbytehq/airbyte-agent-sdk) for details.
 
-### Define the tool
+### Build the tools
 
-Rather than one tool per GitHub endpoint, the Agent SDK exposes the entire GitHub API through a single `execute(entity, action, params)` entry point. The `@GithubConnector.tool_utils` decorator fills in the entity and action catalog as the tool description, so the agent knows what's available without you writing a schema.
+Rather than one tool per GitHub endpoint, `build_connector_tools` returns three tools bound to your connector: `inspect_connector`, `read_skill_docs`, and `execute`. The agent inspects the connector and reads its skill docs to learn the available entities and actions, then executes, so you don't write a schema by hand.
+
+`tools.as_list()` returns plain async callables. Wrap each one as a LangChain `StructuredTool`:
 
 ```python title="agent.py"
-@tool
-@GithubConnector.tool_utils
-async def github_execute(entity: str, action: str, params: dict | None = None) -> str:
-    """Execute GitHub connector operations."""
-    result = await github.execute(entity, action, params or {})
-    return json.dumps(result, default=str)
+tools = build_connector_tools(github, framework="langchain")
+
+lc_tools = [
+    StructuredTool.from_function(coroutine=tool, name=tool.__name__, description=tool.__doc__)
+    for tool in tools.as_list()
+]
 ```
 
-The decorator stack is the whole tool definition. No per-action `docstring`, no `GITHUB_LIST_COMMITS` or `GITHUB_GET_PR` sprawl, one entry point that covers the full connector. `@GithubConnector.tool_utils` appends the full entity and action catalog to the tool description, and caps oversized responses. As the connector grows, the tool signature stays the same.
+Passing `framework="langchain"` makes runtime errors surface as LangChain tool errors so the agent can retry. `StructuredTool.from_function` reads each tool's name, docstring, and signature to build the tool schema.
 
-Each `execute` call returns a structured result with `data` (the records) and `meta` (pagination cursors). LangChain tools return strings, so this tutorial serializes the whole result with `json.dumps` so the agent can reason about both the records and the pagination state.
+Each `execute` call returns a structured result with `data` (the records) and `meta` (pagination cursors). LangChain serializes the tool result for the model, so you can reason about both the records and the pagination state.
 
 ### Define the agent
 
@@ -176,17 +174,18 @@ llm = ChatOpenAI(model="gpt-4o")
 
 agent = create_agent(
     model=llm,
-    tools=[github_execute],
+    tools=lc_tools,
     system_prompt=(
-        "You are a helpful assistant that can access GitHub data through the "
-        "github_execute tool. Be concise and accurate."
+        "You are a helpful assistant that can access GitHub data. Before your first "
+        "execute call, inspect the connector and read its skill docs to learn the "
+        "available entities, actions, and parameters. Be concise and accurate."
     ),
 )
 ```
 
 - `ChatOpenAI(model="gpt-4o")` creates an OpenAI chat model. You can use a different model by changing the model string. For example, use `"gpt-4o-mini"` to lower costs. LangChain also supports [other providers](https://python.langchain.com/docs/integrations/chat/) like Anthropic and Google.
 - `create_agent` creates an agent that reasons about which tools to call based on your input. LangChain's agent runtime is built on LangGraph, but you don't need to import LangGraph directly for this quickstart.
-- The `system_prompt` parameter is where you encode any API idiosyncrasies the model can't see in the tool schema. The Agent SDK already exposes entity names, actions, and enum values through the tool description, so the system prompt only needs to carry domain constraints (pagination defaults, date formats, preferred streams) as your agent grows.
+- The `system_prompt` parameter is where you encode any API idiosyncrasies the model can't see in the tool schema. Because the agent reads skill docs at runtime, the system prompt only needs to carry domain constraints (pagination defaults, date formats, preferred streams) as your agent grows.
 
 ## Part 6: Run your project
 

--- a/docs/ai-agents/get-started/developer-quickstart/tutorial-langchain.md
+++ b/docs/ai-agents/get-started/developer-quickstart/tutorial-langchain.md
@@ -75,7 +75,9 @@ You create `.env` and `uv.lock` files in later steps, so don't worry about them 
    ```python title="agent.py"
    from dotenv import load_dotenv
    from langchain.agents import create_agent
-   from langchain_core.tools import StructuredTool
+   from langchain.agents.middleware import wrap_tool_call
+   from langchain_core.messages import ToolMessage
+   from langchain_core.tools import StructuredTool, ToolException
    from langchain_openai import ChatOpenAI
    from airbyte_agent_sdk import build_connector_tools, connect
    ```
@@ -84,7 +86,10 @@ You create `.env` and `uv.lock` files in later steps, so don't worry about them 
 
    - `load_dotenv`: Load environment variables from your `.env` file.
    - `create_agent`: LangChain's function for creating an agent that can call tools.
+   - `wrap_tool_call`: LangChain middleware helper for intercepting tool calls. You'll use it to feed tool errors back to the model.
+   - `ToolMessage`: LangChain's message type for returning a tool result (or error) to the model.
    - `StructuredTool`: LangChain's wrapper for turning a function into a tool.
+   - `ToolException`: The error type the Agent SDK raises when a tool call fails.
    - `ChatOpenAI`: LangChain's OpenAI chat model integration.
    - `connect`: The Agent SDK entry point. One call returns a typed connector bound to your workspace.
    - `build_connector_tools`: Turns a connector into ready-to-bind agent tools that inspect the connector and read its skill docs before executing.
@@ -161,9 +166,24 @@ lc_tools = [
 ]
 ```
 
-Passing `framework="langchain"` makes runtime errors surface as LangChain tool errors so the agent can retry. `StructuredTool.from_function` reads each tool's name, docstring, and signature to build the tool schema.
+Passing `framework="langchain"` makes runtime errors surface as LangChain `ToolException`s. `StructuredTool.from_function` reads each tool's name, docstring, and signature to build the tool schema.
 
 Each `execute` call returns a structured result with `data` (the records) and `meta` (pagination cursors). LangChain serializes the tool result for the model, so you can reason about both the records and the pagination state.
+
+### Surface tool errors back to the model
+
+When the agent calls a tool with invalid arguments—for example, guessing a `read_skill_docs` section id—the SDK raises a `ToolException` whose message carries the correction (such as the valid section outline). LangChain 1.x's `create_agent` re-raises tool exceptions by default, which ends the run before the agent can act on the correction. Add a small middleware that returns the error to the model as a `ToolMessage` instead, so the agent can read it and retry:
+
+```python title="agent.py"
+@wrap_tool_call
+async def surface_tool_errors(request, handler):
+    try:
+        return await handler(request)
+    except ToolException as exc:
+        return ToolMessage(content=str(exc), tool_call_id=request.tool_call["id"])
+```
+
+You'll pass this middleware to `create_agent` in the next step. The `async` form is required because the connector tools are async coroutines.
 
 ### Define the agent
 
@@ -175,6 +195,7 @@ llm = ChatOpenAI(model="gpt-4o")
 agent = create_agent(
     model=llm,
     tools=lc_tools,
+    middleware=[surface_tool_errors],
     system_prompt=(
         "You are a helpful assistant that can access GitHub data. Before your first "
         "execute call, inspect the connector and read its skill docs to learn the "

--- a/docs/ai-agents/get-started/developer-quickstart/tutorial-pydantic.md
+++ b/docs/ai-agents/get-started/developer-quickstart/tutorial-pydantic.md
@@ -80,8 +80,7 @@ You create `.env` and `uv.lock` files in later steps, so don't worry about them 
    ```python title="agent.py"
    from dotenv import load_dotenv
    from pydantic_ai import Agent
-   from airbyte_agent_sdk import connect
-   from airbyte_agent_sdk.connectors.github import GithubConnector
+   from airbyte_agent_sdk import build_connector_tools, connect
    ```
 
    These imports provide:
@@ -89,7 +88,7 @@ You create `.env` and `uv.lock` files in later steps, so don't worry about them 
    - `load_dotenv`: Load environment variables from your `.env` file.
    - `Agent`: The Pydantic AI agent class that orchestrates LLM interactions and tool calls.
    - `connect`: The Agent SDK entry point. One call returns a typed connector bound to your workspace.
-   - `GithubConnector`: The connector class. You reference it when decorating the tool so the SDK can describe the connector's entities and actions to the agent.
+   - `build_connector_tools`: Turns a connector into ready-to-bind agent tools that inspect the connector and read its skill docs before executing.
 
 ## Part 3: Add a .env file with your secrets
 
@@ -148,40 +147,39 @@ One line does four things for you:
 
 If you want to connect to a different workspace or pass credentials explicitly, use `connect("github", workspace_name="my-workspace", client_id=..., client_secret=...)` or pass an `AirbyteAuthConfig`. See the [SDK reference](https://github.com/airbytehq/airbyte-agent-sdk) for details.
 
-### Define the agent
+### Build the tools and agent
 
-Create a Pydantic AI agent with a system prompt that describes its purpose:
+Build the connector's tools, then create a Pydantic AI agent that uses them:
 
 ```python title="agent.py"
+tools = build_connector_tools(github, framework="pydantic_ai")
+
 agent = Agent(
     "openai:gpt-4o",
+    tools=tools.as_list(),
     system_prompt=(
-        "You are a helpful assistant that can access GitHub data through the "
-        "github_execute tool. Be concise and accurate."
+        "You are a helpful assistant that can access GitHub data. Before your first "
+        "execute call, inspect the connector and read its skill docs to learn the "
+        "available entities, actions, and parameters. Be concise and accurate."
     ),
 )
 ```
 
+- `build_connector_tools(github, framework="pydantic_ai")` returns three tools bound to your connector: `inspect_connector`, `read_skill_docs`, and `execute`. Passing `framework="pydantic_ai"` makes runtime errors surface as Pydantic AI retry signals, and `tools.as_list()` registers all three at once.
 - The `"openai:gpt-4o"` string specifies the model to use. You can use a different model by changing the model string. For example, use `"openai:gpt-4o-mini"` to lower costs, or see the [Pydantic AI models documentation](https://ai.pydantic.dev/models/) for other providers like Anthropic or Google.
-- The `system_prompt` parameter is where you encode any API idiosyncrasies the model can't see in the tool schema. The Agent SDK already exposes entity names, actions, and enum values through the tool description, so the prompt only needs to carry domain constraints (pagination defaults, date formats, preferred streams) as your agent grows.
-- The prompt references a `github_execute` tool. You register that tool in the next part.
+- The `system_prompt` parameter is where you encode any API idiosyncrasies the model can't see in the tool schema. Because the agent reads skill docs at runtime, the prompt only needs to carry domain constraints (pagination defaults, date formats, preferred streams) as your agent grows.
 
-## Part 6: Add a tool to your agent
+## Part 6: How the agent uses the connector
 
-Rather than one tool per GitHub endpoint, the Agent SDK exposes the entire GitHub API through a single `execute(entity, action, params)` entry point. The `tool_utils` decorator fills in the entity and action catalog as the tool description, so the model knows what's available without you writing a schema.
+You don't wire up one tool per GitHub endpoint. `build_connector_tools` gave the agent three tools that work together, so the agent discovers what the connector supports at runtime instead of relying on a schema baked into the prompt:
 
-Add the following to `agent.py`:
+1. `inspect_connector()` reports the connector's metadata and Context Store readiness.
+2. `read_skill_docs()` returns an outline of the connector's entities and actions. `read_skill_docs(section="...")` drills into the exact guidance for the operation the agent is about to run.
+3. `execute(entity, action, params)` runs the operation.
 
-```python title="agent.py"
-@agent.tool_plain
-@GithubConnector.tool_utils
-async def github_execute(entity: str, action: str, params: dict | None = None):
-    return await github.execute(entity, action, params or {})
-```
+This progressive flow keeps the agent's context small: it reads only the section it needs before executing, rather than loading the entire connector schema up front. Airbyte serves the skill docs from the same connector definition the SDK is generated from, so they stay accurate as the connector grows.
 
-The decorator stack is the whole tool definition. No per-action `docstring`, no `GITHUB_LIST_COMMITS` or `GITHUB_GET_PR` sprawl, one entry point that covers the full connector. `@GithubConnector.tool_utils` appends the full entity and action catalog to the tool description, and caps oversized responses. As the connector grows, the tool signature stays the same.
-
-Each `execute` call returns a structured result with `data` (the records) and `meta` (pagination cursors). Pydantic AI serializes the dict for the model automatically, so you don't need to call `json.dumps` here. You can keep the result as-is, filter it in Python, or page through it using `meta.end_cursor`.
+Each `execute` call returns a structured result with `data` (the records) and `meta` (pagination cursors). Pydantic AI serializes the result for the model automatically. You can keep it as-is, filter it in Python, or page through it using `meta.end_cursor`.
 
 ## Part 7: Run your project
 
@@ -250,7 +248,7 @@ In this tutorial, you learned how to:
 - Set up a new Python project with uv
 - Add Pydantic AI and Airbyte's GitHub agent connector to your project
 - Configure environment variables for your Airbyte Agents credentials
-- Register a single tool that covers the entire GitHub API
+- Equip the agent with connector tools that introspect and execute against the entire GitHub API
 - Run your project and use natural language to interact with GitHub data through Airbyte
 
 ## Next steps

--- a/docs/ai-agents/interfaces/api/execute.md
+++ b/docs/ai-agents/interfaces/api/execute.md
@@ -26,6 +26,33 @@ curl 'https://api.airbyte.ai/api/v1/integrations/connectors?workspace_name=defau
 
 The Agent SDK can resolve a connector by its slug (for example, `"hubspot"`) without any IDs. Consider using the [SDK](../sdk/execute) if you want to avoid managing connector IDs in application code.
 
+## Discover what to execute
+
+Before you execute, discover which entities and actions a connector supports and how to call them. Rather than hard-coding a schema, fetch the connector's **skill docs** — concise, chunked usage guidance the platform generates for each connector.
+
+First, inspect the connector to get its `docs_skill_id` and Context Store readiness:
+
+```bash title="Request"
+curl 'https://api.airbyte.ai/api/v1/integrations/connectors/<connector_id>/inspect' \
+  --header 'Authorization: Bearer <your_application_token>'
+```
+
+The response includes a `docs_skill_id` of the form `connector-source:<connector_id>`. Pass it to the skill docs endpoint. Omit `section` to get an outline with the connector's entities, actions, and the available section IDs:
+
+```bash title="Request"
+curl 'https://api.airbyte.ai/api/v1/skills/docs?id=<docs_skill_id>' \
+  --header 'Authorization: Bearer <your_application_token>'
+```
+
+Then request a specific section for the operation you're about to run:
+
+```bash title="Request"
+curl 'https://api.airbyte.ai/api/v1/skills/docs?id=<docs_skill_id>&section=<section_id>' \
+  --header 'Authorization: Bearer <your_application_token>'
+```
+
+The full flow is inspect → read skill docs (outline) → read skill docs (section) → execute. To browse or search skills across a workspace, use `GET /api/v1/skills` and `GET /api/v1/skills/search?query=...`. See the [API reference](/ai-agents/reference/api) for full response schemas.
+
 ## Execute an operation
 
 To execute an operation against a connector, send a POST request to the execute endpoint with the entity, action, and any required parameters.

--- a/docs/ai-agents/interfaces/api/readme.md
+++ b/docs/ai-agents/interfaces/api/readme.md
@@ -29,7 +29,7 @@ The four pages in this section are designed to map one-to-one with the [SDK](../
 
 2. **[Add a connector](./add-connector)**: Create a connector from a `definition_id` plus the credentials for the third-party service.
 
-3. **[Execute operations](./execute)**: Call `POST /integrations/connectors/<connector_id>/execute` to read from or take action on the connected service.
+3. **[Execute operations](./execute)**: First introspect the connector (`GET /integrations/connectors/<connector_id>/inspect`, then `GET /skills/docs`) to discover its entities, actions, and usage guidance, then call `POST /integrations/connectors/<connector_id>/execute` to read from or take action on the connected service.
 
 4. **[Manage workspaces](./workspaces)**: Administer workspaces (list, update, delete). These are operations the SDK defers to the API. Most apps use the `default` workspace and don't need this page.
 

--- a/docs/ai-agents/interfaces/cli/describe-connector.md
+++ b/docs/ai-agents/interfaces/cli/describe-connector.md
@@ -9,6 +9,10 @@ Use `connectors describe` to inspect a configured connector before executing act
 
 Run this command before executing. Entity names, action names, parameters, and field names vary by connector.
 
+:::note describe vs. skill docs
+`describe` returns the connector's raw `schema` — the machine-readable entity, action, and parameter contract you use when writing `execute` calls by hand or in a script. This is different from the connector's **skill docs**, which are prose guidance written for an AI agent to read at runtime. When you build an agent, prefer skill docs (through `build_connector_tools` in the [SDK](../sdk/execute), or the inspect and read-docs steps in the [API](../api/execute) and [MCP](../mcp)). Reach for `describe` when you want the schema itself.
+:::
+
 ## Describe by name
 
 ```bash

--- a/docs/ai-agents/interfaces/mcp/readme.md
+++ b/docs/ai-agents/interfaces/mcp/readme.md
@@ -342,6 +342,16 @@ How many Zendesk tickets are in "open" status?
 
 The agent uses field selection to return only the data you need, which reduces token usage and improves response quality.
 
+### How the agent introspects a connector
+
+Under the hood, the agent uses a small set of skill-docs tools to learn a connector before it acts, so it doesn't need every entity and action loaded into its context up front:
+
+- `inspect_connector` reports a connector's metadata, its `docs_skill_id`, and Context Store readiness.
+- `read_skill_docs` returns a connector's usage docs — an outline of entities and actions, or a specific section when the agent passes one.
+- `list_skills` and `search_skills` browse and search the skills available to your agent.
+
+The agent inspects the connector, reads the relevant skill docs, then executes — the same inspect → read docs → execute flow the [SDK](../sdk/execute) and [API](../api/execute) expose. Most clients call these tools automatically, so you just prompt in natural language.
+
 ## How authentication works
 
 The Agent MCP uses a two-layer authentication model: one layer to authenticate you with the Airbyte Agents, and a second layer to authenticate with each third-party service you connect.

--- a/docs/ai-agents/interfaces/sdk/execute.md
+++ b/docs/ai-agents/interfaces/sdk/execute.md
@@ -93,7 +93,7 @@ The SDK binds the skill-doc ID internally, so the model only passes an optional 
 `connect("github")` returns a typed connector when a generated submodule exists, but `build_connector_tools` also accepts a generic `HostedExecutor` for YAML-only connectors. Either works with the same three tools.
 
 :::note
-Skill docs are hosted by Airbyte and served by the platform. If you point the SDK at a local or offline connector (no hosted backend), `build_connector_tools` still returns the same three tools, but `inspect_connector` reports `"mode": "local"` and `read_skill_docs` falls back to the connector's generated (YAML-derived) description instead of hosted section docs. `execute` still runs directly against the connector.
+Skill docs are hosted by Airbyte and served by the platform. If you point the SDK at a connector running in open source mode (no hosted backend), `build_connector_tools` still returns the same three tools, but `inspect_connector` reports `"mode": "local"` and `read_skill_docs` falls back to the connector's generated (YAML-derived) description instead of hosted section docs. `execute` still runs directly against the connector.
 :::
 
 To expose only `execute` with a single generated description instead of the progressive flow, pass `use_progressive_docs=False`. `tools.as_list()` then returns just the `execute` tool.

--- a/docs/ai-agents/interfaces/sdk/execute.md
+++ b/docs/ai-agents/interfaces/sdk/execute.md
@@ -113,6 +113,10 @@ lc_tools = [
 ]
 ```
 
+:::note
+LangChain 1.x re-raises tool errors by default, so a wrong `read_skill_docs` section guess aborts the run before the agent can self-correct from the returned outline. To let the agent recover, add the `wrap_tool_call` middleware shown in [Surface tool errors back to the model](../../get-started/developer-quickstart/tutorial-langchain#surface-tool-errors-back-to-the-model) in the LangChain quickstart.
+:::
+
 FastMCP registers each callable as a tool:
 
 ```python title="server.py"

--- a/docs/ai-agents/interfaces/sdk/execute.md
+++ b/docs/ai-agents/interfaces/sdk/execute.md
@@ -92,6 +92,10 @@ The SDK binds the skill-doc ID internally, so the model only passes an optional 
 
 `connect("github")` returns a typed connector when a generated submodule exists, but `build_connector_tools` also accepts a generic `HostedExecutor` for YAML-only connectors. Either works with the same three tools.
 
+:::note
+Skill docs are hosted by Airbyte and served by the platform. If you point the SDK at a local or offline connector (no hosted backend), `build_connector_tools` still returns the same three tools, but `inspect_connector` reports `"mode": "local"` and `read_skill_docs` falls back to the connector's generated (YAML-derived) description instead of hosted section docs. `execute` still runs directly against the connector.
+:::
+
 To expose only `execute` with a single generated description instead of the progressive flow, pass `use_progressive_docs=False`. `tools.as_list()` then returns just the `execute` tool.
 
 #### Other frameworks

--- a/docs/ai-agents/interfaces/sdk/execute.md
+++ b/docs/ai-agents/interfaces/sdk/execute.md
@@ -62,9 +62,75 @@ For patterns that look up a connector ID without hard-coding it, see [Get a conn
 
 ## Expose a connector as an agent tool
 
-When you wrap a connector as a tool for an AI agent, the agent needs to know which entities and actions exist, what parameters each takes, and how pagination works. The SDK supports two styles.
+When you wrap a connector as a tool for an AI agent, the agent needs to know which entities and actions exist, what parameters each takes, and how pagination works. The recommended pattern is `build_connector_tools`, which binds ready-to-use tools that let the agent read just-in-time skill docs before it executes.
 
-### Manual docstrings
+### Recommended: build_connector_tools
+
+`build_connector_tools(connector)` returns a `ConnectorTools` object with three callables bound to one connector: `inspect_connector`, `read_skill_docs`, and `execute`. Pass `framework=` so runtime errors surface as that framework's retry signal, then register all three with `tools.as_list()`.
+
+```python title="agent.py"
+from pydantic_ai import Agent
+from airbyte_agent_sdk import build_connector_tools, connect
+
+github = connect("github")
+tools = build_connector_tools(github, framework="pydantic_ai")
+
+agent = Agent("openai:gpt-4o", tools=tools.as_list())
+```
+
+Instead of packing the whole connector schema into one static tool description, the agent works through a progressive introspection flow:
+
+```text
+inspect_connector() -> read_skill_docs() -> read_skill_docs(section="...") -> execute(entity, action, params)
+```
+
+- `inspect_connector()` returns the connector's hosted metadata and Context Store readiness, and resolves the skill-doc ID the other tools use.
+- `read_skill_docs()` with no section returns the outline and general guidance. `read_skill_docs(section="<id>")` returns the exact entity and action guidance the agent needs before it executes.
+- `execute(entity, action, params)` runs the operation.
+
+The SDK binds the skill-doc ID internally, so the model only passes an optional `section`. This keeps the agent's context small: it reads the outline, drills into the one section it needs, then executes, instead of loading every entity and action up front. Skill docs are served by Airbyte from the same connector definition the SDK is generated from, so they stay in sync with the connector.
+
+`connect("github")` returns a typed connector when a generated submodule exists, but `build_connector_tools` also accepts a generic `HostedExecutor` for YAML-only connectors. Either works with the same three tools.
+
+To expose only `execute` with a single generated description instead of the progressive flow, pass `use_progressive_docs=False`. `tools.as_list()` then returns just the `execute` tool.
+
+#### Other frameworks
+
+`tools.as_list()` returns plain async callables, so you can register them with any framework. Set `framework=` to match.
+
+LangChain wraps each callable as a `StructuredTool`:
+
+```python title="agent.py"
+from langchain_core.tools import StructuredTool
+from airbyte_agent_sdk import build_connector_tools, connect
+
+github = connect("github")
+tools = build_connector_tools(github, framework="langchain")
+
+lc_tools = [
+    StructuredTool.from_function(coroutine=tool, name=tool.__name__, description=tool.__doc__)
+    for tool in tools.as_list()
+]
+```
+
+FastMCP registers each callable as a tool:
+
+```python title="server.py"
+from fastmcp import FastMCP
+from airbyte_agent_sdk import build_connector_tools, connect
+
+mcp = FastMCP("github-tools")
+github = connect("github")
+
+for tool in build_connector_tools(github, framework="mcp").as_list():
+    mcp.tool(tool)
+```
+
+### Alternatives
+
+The decorator patterns below predate `build_connector_tools`. They bind a single `execute` tool with the connector's full catalog baked into the description up front, rather than letting the agent read skill docs on demand. Prefer `build_connector_tools` for new agents. Reach for these when you want to expose a narrow set of operations, need full control over the tool description, or run a local connector without hosted skill docs.
+
+#### Manual docstrings
 
 Define one tool per operation with a hand-written docstring. Use this when you want to expose a narrow set of operations or need full control over parameters.
 
@@ -84,7 +150,7 @@ async def list_issues(owner: str, repo: str, limit: int = 10) -> str:
 
 The docstring becomes the tool description the LLM sees. Function parameters become the tool's input schema.
 
-### Auto-generated tool descriptions
+#### Auto-generated tool descriptions
 
 For broad coverage, use the `tool_utils` decorator on a typed connector. The decorator replaces the wrapped function's docstring with a generated description that includes every entity, action, required and optional parameter, and response shape. The LLM then sees every operation the connector supports with no extra wiring.
 
@@ -102,7 +168,7 @@ async def github_execute(entity: str, action: str, params: dict | None = None):
     return await github.execute(entity, action, params or {})
 ```
 
-#### Decorator order matters
+##### Decorator order matters
 
 The framework decorator (for example, `@agent.tool_plain` or FastMCP's `@mcp.tool`) captures `__doc__` at decoration time. `@Connector.tool_utils` must be the inner decorator so it can rewrite `__doc__` before the framework reads it.
 
@@ -115,7 +181,7 @@ async def github_execute(entity, action, params=None):
 
 If you reverse the order, the framework captures the original empty docstring and the LLM loses the generated documentation.
 
-#### Custom docstrings
+##### Custom docstrings
 
 Generated docstrings are almost always the right choice. Override them only when your agent specifically misuses the tool and a custom description fixes it.
 

--- a/docs/ai-agents/interfaces/sdk/execute.md
+++ b/docs/ai-agents/interfaces/sdk/execute.md
@@ -3,6 +3,9 @@ plan: all
 sidebar_position: 3
 ---
 
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
 # Execute operations
 
 Once you've added a connector to your workspace, you can run operations against it from Python. The SDK offers direct execution and patterns for exposing a connector as a tool to an AI agent framework.
@@ -68,16 +71,6 @@ When you wrap a connector as a tool for an AI agent, the agent needs to know whi
 
 `build_connector_tools(connector)` returns a `ConnectorTools` object with three callables bound to one connector: `inspect_connector`, `read_skill_docs`, and `execute`. Pass `framework=` so runtime errors surface as that framework's retry signal, then register all three with `tools.as_list()`.
 
-```python title="agent.py"
-from pydantic_ai import Agent
-from airbyte_agent_sdk import build_connector_tools, connect
-
-github = connect("github")
-tools = build_connector_tools(github, framework="pydantic_ai")
-
-agent = Agent("openai:gpt-4o", tools=tools.as_list())
-```
-
 Instead of packing the whole connector schema into one static tool description, the agent works through a progressive introspection flow:
 
 ```text
@@ -98,11 +91,50 @@ Skill docs are hosted by Airbyte and served by the platform. If you point the SD
 
 To expose only `execute` with a single generated description instead of the progressive flow, pass `use_progressive_docs=False`. `tools.as_list()` then returns just the `execute` tool.
 
-#### Other frameworks
+#### Register the tools with your framework
 
-`tools.as_list()` returns plain async callables, so you can register them with any framework. Set `framework=` to match.
+`tools.as_list()` returns plain async callables, so you can register them with any framework. Set `framework=` to match the one you use.
 
-LangChain wraps each callable as a `StructuredTool`:
+<Tabs groupId="agent-framework">
+<TabItem value="pydantic_ai" label="Pydantic AI" default>
+
+Pass `tools.as_list()` straight to the agent:
+
+```python title="agent.py"
+from pydantic_ai import Agent
+from airbyte_agent_sdk import build_connector_tools, connect
+
+github = connect("github")
+tools = build_connector_tools(github, framework="pydantic_ai")
+
+agent = Agent("openai:gpt-4o", tools=tools.as_list())
+```
+
+</TabItem>
+<TabItem value="openai_agents" label="OpenAI Agents SDK">
+
+Wrap each callable with `function_tool`:
+
+```python title="agent.py"
+from agents import Agent, function_tool
+from airbyte_agent_sdk import build_connector_tools, connect
+
+github = connect("github")
+tools = build_connector_tools(github, framework="openai_agents")
+
+oai_tools = [function_tool(tool, strict_mode=False) for tool in tools.as_list()]
+
+agent = Agent(name="github-agent", model="gpt-4o", tools=oai_tools)
+```
+
+:::note
+The OpenAI Agents SDK enforces a strict JSON schema by default, which rejects `execute`'s open-ended `params` object. Pass `strict_mode=False` to `function_tool` so the tools register.
+:::
+
+</TabItem>
+<TabItem value="langchain" label="LangChain">
+
+Wrap each callable as a `StructuredTool`:
 
 ```python title="agent.py"
 from langchain_core.tools import StructuredTool
@@ -121,7 +153,10 @@ lc_tools = [
 LangChain 1.x re-raises tool errors by default, so a wrong `read_skill_docs` section guess aborts the run before the agent can self-correct from the returned outline. To let the agent recover, add the `wrap_tool_call` middleware shown in [Surface tool errors back to the model](../../get-started/developer-quickstart/tutorial-langchain#surface-tool-errors-back-to-the-model) in the LangChain quickstart.
 :::
 
-FastMCP registers each callable as a tool:
+</TabItem>
+<TabItem value="mcp" label="FastMCP">
+
+Register each callable as an MCP tool:
 
 ```python title="server.py"
 from fastmcp import FastMCP
@@ -133,6 +168,9 @@ github = connect("github")
 for tool in build_connector_tools(github, framework="mcp").as_list():
     mcp.tool(tool)
 ```
+
+</TabItem>
+</Tabs>
 
 ### Alternatives
 

--- a/docs/vale-styles/config/vocabularies/Airbyte/accept.txt
+++ b/docs/vale-styles/config/vocabularies/Airbyte/accept.txt
@@ -173,4 +173,9 @@ httpx
 async
 Automations
 enum
+
+# Agent SDK terms
+
+build_connector_tools
+[Cc]allable(s)?
 uv


### PR DESCRIPTION
## What

Resolves [DOCS-31](https://linear.app/airbyteio/issue/DOCS-31/docs-promote-agent-connector-skill-docs-as-the-recommended). Requested by Ian Alton (@ian-at-airbyte) via the Linear ticket.

The agent-connector docs still teach `@Connector.tool_utils` / manual docstrings and `describe` as the way an agent learns a connector, even though the recommended pattern is now the progressive **skill docs** flow (`inspect_connector` → `read_skill_docs` → `read_skill_docs(section=...)` → `execute`), exposed via the SDK's `build_connector_tools`, the REST `inspect` + `/skills/docs` endpoints, and the MCP skill-docs tools. This PR makes skill docs the recommended pattern everywhere and demotes the decorator/docstring approaches to clearly-labeled alternatives (docs-only; no code or contract changes).

## How

Six documentation changes across `docs/ai-agents/`:

- **`concepts/connect-ask-act.md`** — added the inspect → read skill docs → execute progression to the "Act" section.
- **`interfaces/sdk/execute.md`** — lead the "Expose a connector as an agent tool" section with `build_connector_tools` (+ Pydantic AI / LangChain `StructuredTool` / FastMCP registration). The `tool_utils` and manual-docstring approaches are preserved **in full** under a new "Alternatives" subsection (per ticket discussion — accuracy over real-estate).
- **`interfaces/api/execute.md`** + **`api/readme.md`** — documented the `GET /integrations/connectors/{id}/inspect` (returns `docs_skill_id`) and `GET /skills/docs?id=&section=` steps before `execute`.
- **`interfaces/mcp/readme.md`** — documented the `inspect_connector` / `read_skill_docs` / `list_skills` / `search_skills` tools the agent uses under the hood.
- **`interfaces/cli/describe-connector.md`** — one clarifying note that `describe` returns the raw schema (for hand-written `execute` calls) vs. skill docs (agent-facing guidance). No new CLI commands invented.
- **`docs/vale-styles/.../Airbyte/accept.txt`** — added `build_connector_tools` and `callable(s)` to the Vale vocabulary.

Every REST endpoint, query param, tool name, and `docs_skill_id` format was verified against the `sonar` backend and `agent-engine-mcp` source.

## Review guide

1. `docs/ai-agents/interfaces/sdk/execute.md` — the biggest change; confirm the Alternatives section keeps the full original `tool_utils` docs.
2. `docs/ai-agents/get-started/developer-quickstart/tutorial-{pydantic,langchain,fastmcp}.md` — each tutorial now registers the three tools for its framework instead of a single `@tool_utils`-decorated `execute`.
3. `docs/ai-agents/interfaces/api/execute.md` and `mcp/readme.md` — endpoint/tool names.

## User Impact

Docs-only. Developers building agents are guided to the recommended, context-efficient skill-docs pattern first, while the previous decorator/docstring approaches remain documented as alternatives.

Notes for reviewers:
- Pre-existing `markdownlint` MD024 errors exist in `mcp/readme.md` (duplicate "Option 1/2/3" install headings) on lines I did not touch; left as-is to keep scope focused. CI's markdownlint uses `filter_mode: added`, so they aren't newly introduced.
- Remaining Vale flags on changed lines are `Google.EmDash` on spaced em-dashes, which match the established style throughout these docs. Vale runs advisory in CI (`reporter: local`, `fail_on_error: false`).

## Can this PR be safely reverted and rolled back?
- [x] YES 💚
- [ ] NO ❌

Link to Devin session: https://app.devin.ai/sessions/5b69d8fea36f4c8995764379c326da42