### PR TITLE
fix: use CREATE TABLE IF NOT EXISTS for non-replace table creation in connectors

### DIFF
--- a/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/write/typing_deduping/direct_load_tables/BigqueryDirectLoadSqlGenerator.kt
+++ b/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/write/typing_deduping/direct_load_tables/BigqueryDirectLoadSqlGenerator.kt
@@ -76,10 +76,11 @@ class BigqueryDirectLoadSqlGenerator(
             } else {
                 emptyList()
             }
+        val createPrefix = if (replace) "CREATE TABLE" else "CREATE TABLE IF NOT EXISTS"
         val createTableStatement =
             listOf(
                 """
-                CREATE TABLE `$projectId`.$finalTableId (
+                $createPrefix `$projectId`.$finalTableId (
                   _airbyte_raw_id STRING NOT NULL,
                   _airbyte_extracted_at TIMESTAMP NOT NULL,
                   _airbyte_meta JSON NOT NULL,

--- a/airbyte-integrations/connectors/destination-clickhouse/src/main/kotlin/io/airbyte/integrations/destination/clickhouse/client/ClickhouseSqlGenerator.kt
+++ b/airbyte-integrations/connectors/destination-clickhouse/src/main/kotlin/io/airbyte/integrations/destination/clickhouse/client/ClickhouseSqlGenerator.kt
@@ -29,7 +29,7 @@ class ClickhouseSqlGenerator {
         tableSchema: StreamTableSchema,
         replace: Boolean,
     ): String {
-        val forceCreateTable = if (replace) "OR REPLACE" else ""
+        val createPrefix = if (replace) "CREATE OR REPLACE TABLE" else "CREATE TABLE IF NOT EXISTS"
 
         val finalSchema = tableSchema.columnSchema.finalSchema
         val columnDeclarations =
@@ -71,7 +71,7 @@ class ClickhouseSqlGenerator {
             }
 
         return """
-            CREATE $forceCreateTable TABLE `${tableName.namespace}`.`${tableName.name}` (
+            $createPrefix `${tableName.namespace}`.`${tableName.name}` (
               $COLUMN_NAME_AB_RAW_ID String NOT NULL,
               $COLUMN_NAME_AB_EXTRACTED_AT DateTime64(3) NOT NULL,
               $COLUMN_NAME_AB_META String NOT NULL,

--- a/airbyte-integrations/connectors/destination-snowflake/src/main/kotlin/io/airbyte/integrations/destination/snowflake/sql/SnowflakeDirectLoadSqlGenerator.kt
+++ b/airbyte-integrations/connectors/destination-snowflake/src/main/kotlin/io/airbyte/integrations/destination/snowflake/sql/SnowflakeDirectLoadSqlGenerator.kt
@@ -85,11 +85,11 @@ class SnowflakeDirectLoadSqlGenerator(
                 .joinToString(",\n    ")
 
         // Snowflake supports CREATE OR REPLACE TABLE, which is simpler than drop+recreate
-        val createOrReplace = if (replace) "CREATE OR REPLACE" else "CREATE"
+        val createPrefix = if (replace) "CREATE OR REPLACE TABLE" else "CREATE TABLE IF NOT EXISTS"
 
         val createTableStatement =
             """
-            |$createOrReplace TABLE ${fullyQualifiedName(tableName)} (
+            |$createPrefix ${fullyQualifiedName(tableName)} (
             |    $columnDeclarations
             |)
             """.trimMargin() // Something was tripping up trimIndent so we opt for trimMargin

--- a/airbyte-integrations/connectors/destination-snowflake/src/test/kotlin/io/airbyte/integrations/destination/snowflake/sql/SnowflakeDirectLoadSqlGeneratorTest.kt
+++ b/airbyte-integrations/connectors/destination-snowflake/src/test/kotlin/io/airbyte/integrations/destination/snowflake/sql/SnowflakeDirectLoadSqlGeneratorTest.kt
@@ -148,7 +148,7 @@ internal class SnowflakeDirectLoadSqlGeneratorTest {
         val expectedTableName = snowflakeDirectLoadSqlGenerator.fullyQualifiedName(tableName)
         val expectedSql =
             """
-            CREATE TABLE $expectedTableName (
+            CREATE TABLE IF NOT EXISTS $expectedTableName (
                 "_AIRBYTE_RAW_ID" VARCHAR NOT NULL,
                 "_AIRBYTE_EXTRACTED_AT" TIMESTAMP_TZ NOT NULL,
                 "_AIRBYTE_META" VARIANT NOT NULL,
@@ -506,7 +506,7 @@ internal class SnowflakeDirectLoadSqlGeneratorTest {
         val expectedTableName = snowflakeDirectLoadSqlGenerator.fullyQualifiedName(tableName)
         val expectedSql =
             """
-            CREATE TABLE $expectedTableName (
+            CREATE TABLE IF NOT EXISTS $expectedTableName (
                 "_AIRBYTE_RAW_ID" VARCHAR NOT NULL,
                 "_AIRBYTE_EXTRACTED_AT" TIMESTAMP_TZ NOT NULL,
                 "_AIRBYTE_META" VARIANT NOT NULL,
@@ -540,7 +540,7 @@ internal class SnowflakeDirectLoadSqlGeneratorTest {
         val expectedTableName = snowflakeDirectLoadSqlGenerator.fullyQualifiedName(tableName)
         val expectedSql =
             """
-            CREATE TABLE $expectedTableName (
+            CREATE TABLE IF NOT EXISTS $expectedTableName (
                 "_AIRBYTE_RAW_ID" VARCHAR NOT NULL,
                 "_AIRBYTE_EXTRACTED_AT" TIMESTAMP_TZ NOT NULL,
                 "_AIRBYTE_META" VARIANT NOT NULL,
@@ -575,7 +575,7 @@ internal class SnowflakeDirectLoadSqlGeneratorTest {
         val expectedTableName = snowflakeDirectLoadSqlGenerator.fullyQualifiedName(tableName)
         val expectedSql =
             """
-            CREATE TABLE $expectedTableName (
+            CREATE TABLE IF NOT EXISTS $expectedTableName (
                 "_AIRBYTE_RAW_ID" VARCHAR NOT NULL,
                 "_AIRBYTE_EXTRACTED_AT" TIMESTAMP_TZ NOT NULL,
                 "_AIRBYTE_META" VARIANT NOT NULL,


### PR DESCRIPTION
Part of https://github.com/airbytehq/oncall/issues/13059

## Summary
- Updates SQL generators for **destination-bigquery**, **destination-clickhouse**, and **destination-snowflake** to use `CREATE TABLE IF NOT EXISTS` when `replace=false`
- This prevents accidental data loss from dropping existing tables during non-replace table creation

## Dependency
This PR depends on #81549 (CDK change: `replace=true` -> `replace=false` in `DirectLoadTableStreamLoader`). Please merge #81549 first.