### PR TITLE
ci(codeql): split security and quality query coverage

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,8 +1,5 @@
 name: "Airbyte CodeQL config"
 
-queries:
-  - uses: security-and-quality
-
 # Compiled languages are scoped by their build steps. These filters primarily
 # reduce interpreted-language indexing of tests and local build outputs.
 paths-ignore:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -113,6 +113,7 @@ jobs:
           languages: java-kotlin
           build-mode: manual
           config-file: ./.github/codeql/codeql-config.yml
+          queries: security-and-quality
 
       - name: Build (compile only, continue past failures)
         # Preserve partial extraction when an unrelated monorepo module fails.
@@ -150,6 +151,7 @@ jobs:
           languages: python
           build-mode: none
           config-file: ./.github/codeql/codeql-config.yml
+          queries: security-extended
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
@@ -176,6 +178,7 @@ jobs:
           languages: javascript-typescript
           build-mode: none
           config-file: ./.github/codeql/codeql-config.yml
+          queries: security-extended
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
@@ -202,6 +205,7 @@ jobs:
           languages: actions
           build-mode: none
           config-file: ./.github/codeql/codeql-config.yml
+          queries: security-and-quality
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3


### PR DESCRIPTION
## What

Requested by AJ Steers (`@aaronsteers`) as a follow-up to https://github.com/airbytehq/airbyte/pull/81543. Separates the repository workflow's security query coverage from GitHub's dynamic Code Quality analysis so Python and JavaScript/TypeScript quality findings are not produced by both systems.

## How

- Moves query-suite selection from the shared CodeQL config into each language job.
- Runs `security-extended` for Python and JavaScript/TypeScript; GitHub Code Quality remains responsible for their quality findings and bot-authored Autofix suggestions.
- Retains `security-and-quality` for Java/Kotlin and GitHub Actions, where dynamic Code Quality is not currently providing equivalent coverage.
- Keeps shared indexing exclusions in `.github/codeql/codeql-config.yml`.

The pull request will still show separate security and Code Quality check groups, but their query responsibilities no longer overlap for Python and JavaScript/TypeScript.

## Review guide

1. `.github/workflows/codeql.yml` — per-language query-suite selection.
2. `.github/codeql/codeql-config.yml` — shared path exclusions only.

## User Impact

None. CI-only change that preserves security coverage while keeping GitHub Code Quality's richer pull-request feedback for Python and JavaScript/TypeScript.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚
- [ ] NO ❌

---
[Devin session](https://app.devin.ai/sessions/8d8be37c10934d038630d37a86f751e0)