### PR TITLE
ci: add /enable-autopilot-rollouts slash command workflow

### DIFF
--- a/.github/workflows/enable-autopilot-rollouts-command.yml
+++ b/.github/workflows/enable-autopilot-rollouts-command.yml
@@ -1,0 +1,204 @@
+name: Enable autopilot rollouts for connectors in a PR
+
+on:
+  workflow_dispatch:
+    inputs:
+      pr:
+        description: "Pull request number. The connector metadata edit is committed to this PR's branch."
+        type: number
+        required: false
+      comment-id:
+        description: "Optional. The comment-id of the slash command. Used to update the comment with the status."
+        required: false
+      connector:
+        description: "Optional. Explicit connector name (e.g. source-github). If omitted, modified connectors in the PR are detected."
+        required: false
+        default: ""
+      strategy:
+        description: "Optional. Autopilot pacing strategy: fast, slow, or default. Defaults to fast."
+        required: false
+        default: "fast"
+
+      # These must be declared, but they are unused and ignored.
+      # TODO: Infer 'repo' and 'gitref' from PR number on other workflows, so we can remove these.
+      repo:
+        description: "Repo (Ignored)"
+        required: false
+        default: "airbytehq/airbyte"
+      gitref:
+        description: "Ref (Ignored)"
+        required: false
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+run-name: "Enable autopilot rollouts in PR: #${{ github.event.inputs.pr }}"
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.inputs.pr }}
+  # Cancel any previous runs on the same branch if they are still in progress
+  cancel-in-progress: true
+
+jobs:
+  enable-autopilot-rollouts:
+    name: "Enable autopilot rollouts for connectors in this PR"
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Get job variables
+        id: job-vars
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.inputs.pr }}
+        shell: bash
+        run: |
+          PR_JSON=$(gh api "repos/${{ github.repository }}/pulls/$PR_NUMBER")
+          echo "repo=$(echo "$PR_JSON" | jq -r .head.repo.full_name)" >> $GITHUB_OUTPUT
+          echo "branch=$(echo "$PR_JSON" | jq -r .head.ref)" >> $GITHUB_OUTPUT
+          echo "run-url=https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" >> $GITHUB_OUTPUT
+
+      # NOTE: We still use a PAT here (rather than a GitHub App) because the workflow needs
+      # permissions to add commits to our main repo as well as forks. This will only work on
+      # forks if the user installs the app into their fork. Until we document this as a clear
+      # path, we will have to keep using the PAT.
+      - name: Checkout Airbyte
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: ${{ steps.job-vars.outputs.repo }}
+          ref: ${{ steps.job-vars.outputs.branch }}
+          fetch-depth: 1
+          # Important that token is a PAT so that CI checks are triggered again.
+          # Without this we would be forever waiting on required checks to pass.
+          token: ${{ secrets.GH_PAT_APPROVINGTON_OCTAVIA }}
+
+      - name: Append comment with job run link
+        # If comment-id is not provided, this will create a new
+        # comment with the job run link.
+        id: first-comment-action
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
+        with:
+          comment-id: ${{ github.event.inputs.comment-id }}
+          issue-number: ${{ github.event.inputs.pr }}
+          body: |
+
+            > Enable Autopilot Rollouts job started... [Check job output.][1]
+
+            [1]: ${{ steps.job-vars.outputs.run-url }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
+
+      - name: Install airbyte-ops CLI
+        run: uv tool install airbyte-internal-ops
+
+      - name: Resolve target connectors
+        id: detect-connectors
+        env:
+          PR_NUMBER: ${{ github.event.inputs.pr }}
+          EXPLICIT_CONNECTOR: ${{ github.event.inputs.connector }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if [ -n "$EXPLICIT_CONNECTOR" ]; then
+            echo "Using explicitly requested connector: $EXPLICIT_CONNECTOR"
+            CONNECTORS="$EXPLICIT_CONNECTOR"
+          else
+            echo "No connector specified; detecting modified connectors in PR #$PR_NUMBER."
+            CONNECTORS=$(
+              airbyte-ops local connector list \
+                --repo-path "$GITHUB_WORKSPACE" \
+                --modified-only \
+                --pr "$PR_NUMBER" \
+                --gh-token "$GH_TOKEN" \
+                --output-format lines
+            )
+          fi
+
+          if [ -z "$CONNECTORS" ]; then
+            echo "No connectors to update."
+          else
+            echo "Target connectors:"
+            echo "$CONNECTORS"
+          fi
+
+          # Pass the connector list to the next step via GITHUB_OUTPUT.
+          # Only set the multiline output when CONNECTORS is non-empty so that
+          # the downstream `if:` reliably evaluates to false for empty lists.
+          if [ -n "$CONNECTORS" ]; then
+            EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
+            echo "connectors<<$EOF" >> $GITHUB_OUTPUT
+            echo "$CONNECTORS" >> $GITHUB_OUTPUT
+            echo "$EOF" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Enable autopilot rollouts for target connectors
+        if: steps.detect-connectors.outputs.connectors != ''
+        env:
+          STRATEGY: ${{ github.event.inputs.strategy }}
+          CONNECTORS: ${{ steps.detect-connectors.outputs.connectors }}
+        run: |
+          echo "Strategy: $STRATEGY"
+          echo ""
+
+          echo "$CONNECTORS" | while IFS= read -r connector; do
+            [ -z "$connector" ] && continue
+            echo "--- Enabling autopilot rollouts for $connector ---"
+            airbyte-ops local connector enable-autopilot \
+              --name "$connector" \
+              --repo-path "$GITHUB_WORKSPACE" \
+              --strategy "$STRATEGY"
+          done
+
+      # This is helpful in the case that we change a previously committed generated file to be ignored by git.
+      - name: Remove any files that have been gitignored
+        run: git ls-files -i -c --exclude-from=.gitignore | xargs -r git rm --cached
+
+      # Check for changes in git
+      - name: Check for changes
+        id: git-diff
+        run: |
+          git diff --quiet && echo "No changes to commit" || echo "changes=true" >> $GITHUB_OUTPUT
+        shell: bash
+
+      # Commit changes (if any)
+      - name: Commit changes
+        id: commit-step
+        if: steps.git-diff.outputs.changes == 'true'
+        run: |
+          git config --global user.name "Octavia Squidington III"
+          git config --global user.email "octavia-squidington-iii@users.noreply.github.com"
+          git add .
+          git commit -m "chore: enable autopilot rollouts"
+          echo "sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
+
+      - name: Push changes to '(${{ steps.job-vars.outputs.repo }})'
+        if: steps.git-diff.outputs.changes == 'true'
+        run: |
+          git remote add contributor https://github.com/${{ steps.job-vars.outputs.repo }}.git
+          git push contributor HEAD:'${{ steps.job-vars.outputs.branch }}'
+
+      - name: Append success comment
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
+        if: steps.git-diff.outputs.changes == 'true'
+        with:
+          comment-id: ${{ steps.first-comment-action.outputs.comment-id }}
+          reactions: hooray
+          body: |
+            > ✅ Autopilot rollouts enabled. (${{ steps.commit-step.outputs.sha }})
+
+      - name: Append success comment (no-op)
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
+        if: steps.git-diff.outputs.changes != 'true'
+        with:
+          comment-id: ${{ steps.first-comment-action.outputs.comment-id }}
+          reactions: eyes
+          body: |
+            > ℹ️ No changes applied — autopilot rollouts already enabled for the target connector(s).
+
+      - name: Append failure comment
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
+        if: failure()
+        with:
+          comment-id: ${{ steps.first-comment-action.outputs.comment-id }}
+          reactions: confused
+          body: |
+            > 🔴 Job failed.

--- a/.github/workflows/enable-autopilot-rollouts-command.yml
+++ b/.github/workflows/enable-autopilot-rollouts-command.yml
@@ -142,7 +142,7 @@ jobs:
           echo "$CONNECTORS" | while IFS= read -r connector; do
             [ -z "$connector" ] && continue
             echo "--- Enabling autopilot rollouts for $connector ---"
-            airbyte-ops local connector enable-autopilot \
+            airbyte-ops local connector rollouts enable \
               --name "$connector" \
               --repo-path "$GITHUB_WORKSPACE" \
               --strategy "$STRATEGY"

--- a/.github/workflows/enable-autopilot-rollouts-command.yml
+++ b/.github/workflows/enable-autopilot-rollouts-command.yml
@@ -172,9 +172,12 @@ jobs:
 
       - name: Push changes to '(${{ steps.job-vars.outputs.repo }})'
         if: steps.git-diff.outputs.changes == 'true'
+        env:
+          CONTRIBUTOR_REPO: ${{ steps.job-vars.outputs.repo }}
+          HEAD_BRANCH: ${{ steps.job-vars.outputs.branch }}
         run: |
-          git remote add contributor https://github.com/${{ steps.job-vars.outputs.repo }}.git
-          git push contributor HEAD:'${{ steps.job-vars.outputs.branch }}'
+          git remote add contributor "https://github.com/$CONTRIBUTOR_REPO.git"
+          git push contributor "HEAD:$HEAD_BRANCH"
 
       - name: Append success comment
         uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0

--- a/.github/workflows/slash-commands.yml
+++ b/.github/workflows/slash-commands.yml
@@ -69,6 +69,7 @@ jobs:
             build-connector-images
             bump-progressive-rollout-version
             bump-version
+            enable-autopilot-rollouts
             force-merge
             format-fix
             poe


### PR DESCRIPTION
## What

Adds a `/enable-autopilot-rollouts` PR slash command that enables autopilot rollout on the connector(s) in a PR and commits the `metadata.yaml` edits back to the same PR branch.

This streamlines remediating the auto-merge blocker "can't auto-merge because autopilot rollouts not enabled for {connector-name}" — instead of hand-editing `metadata.yaml`, a maintainer comments `/enable-autopilot-rollouts` on the PR.

Depends on the CLI command added in airbytehq/airbyte-ops-mcp#1058 (`airbyte-ops local connector rollouts enable`), which is what actually mutates the metadata. This PR is the thin GitHub Actions wrapper.

## How

- New workflow `.github/workflows/enable-autopilot-rollouts-command.yml`, modeled on `bump-version-command.yml`:
  - Resolves the PR's head repo/branch via the GitHub API, checks it out with the Octavia PAT (so CI re-triggers on the pushed commit, and forks work).
  - Installs the ops CLI via `uv tool install airbyte-internal-ops`.
  - Resolves target connectors: uses the explicit `connector=` arg if given, else detects modified connectors via `airbyte-ops local connector list --modified-only --pr <n>`.
  - Runs `airbyte-ops local connector rollouts enable --name <c> --repo-path <ws> --strategy <strategy>` for each.
  - Commits + pushes to the PR branch only if there's a diff; updates the slash-command comment with success / no-op / failure status.
- Registered `enable-autopilot-rollouts` in the `slash-commands.yml` dispatcher command list.

`enable` sets `defaultRolloutMode: autopilot`, fills in default `autopilotConfig`, and flips `enableProgressiveRollout: true` — the toggle the autopilot cron gates on. Existing `autopilotConfig` values are preserved (defaults only fill absent fields). See airbytehq/airbyte-ops-mcp#1058 for the full config-vs-toggle semantics.

Args (all optional):
- `connector=source-foo` — target a specific connector instead of detecting changed ones.
- `strategy=fast|slow|default` — autopilot pacing; defaults to `fast`.

## Review guide
1. `.github/workflows/enable-autopilot-rollouts-command.yml`
2. `.github/workflows/slash-commands.yml`

## User Impact

Maintainers get a one-line remediation for the "autopilot rollouts not enabled" auto-merge block. No behavior change unless the command is invoked. Validated with `actionlint` (clean).

## Can this PR be safely reverted and rolled back?
- [x] YES 💚

Link to Devin session: https://app.devin.ai/sessions/e262f7b87e604a2f877d2d64c7bc1504
Requested by: @aaronsteers