### PR TITLE
ci(ai-ready): freeze auto-merge on weekends with force override

### DIFF
--- a/.github/workflows/ai-ready-command.yml
+++ b/.github/workflows/ai-ready-command.yml
@@ -93,7 +93,7 @@ jobs:
             > **`/ai-ready` blocked: weekend freeze**
             >
             > Auto-merge is paused over the weekend, so no `hyd-ready` label was applied.
-            > If this is urgent, re-run `/ai-ready force=true` to bypass the freeze. Otherwise, please wait until Monday.
+            > If this is urgent, re-run `/ai-ready force=true` to bypass the freeze. Otherwise, please wait until after the weekend.
 
       - name: Apply ready label
         if: inputs.pr != '' && steps.weekend-check.outputs.blocked != 'true'

--- a/.github/workflows/ai-ready-command.yml
+++ b/.github/workflows/ai-ready-command.yml
@@ -72,10 +72,10 @@ jobs:
         env:
           FORCE: ${{ inputs.force }}
         run: |
-          # Day of week in UTC: 6 = Saturday, 7 = Sunday.
-          dow=$(date -u +%u)
+          # Day of week in US Pacific time: 6 = Saturday, 7 = Sunday.
+          dow=$(TZ="America/Los_Angeles" date +%u)
           if [[ ( "$dow" == "6" || "$dow" == "7" ) && "$FORCE" != "true" ]]; then
-            echo "::notice::Weekend freeze in effect (UTC day-of-week=$dow). Skipping auto-merge."
+            echo "::notice::Weekend freeze in effect (Pacific day-of-week=$dow). Skipping auto-merge."
             echo "blocked=true" | tee -a "$GITHUB_OUTPUT"
           else
             echo "blocked=false" | tee -a "$GITHUB_OUTPUT"

--- a/.github/workflows/ai-ready-command.yml
+++ b/.github/workflows/ai-ready-command.yml
@@ -25,6 +25,11 @@ on:
         required: false
         default: ""
         type: string
+      force:
+        description: "If 'true', bypass the weekend freeze and evaluate anyway"
+        required: false
+        default: ""
+        type: string
 
 run-name: "AI Ready for #${{ inputs.pr || inputs.comment-id }}"
 
@@ -36,6 +41,8 @@ permissions:
 jobs:
   validate:
     runs-on: ubuntu-24.04
+    outputs:
+      blocked: ${{ steps.weekend-check.outputs.blocked }}
     steps:
       - name: Authenticate as GitHub App
         uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
@@ -59,8 +66,37 @@ jobs:
         if: inputs.pr == ''
         run: exit 1
 
-      - name: Apply ready label
+      - name: Check for weekend freeze
         if: inputs.pr != ''
+        id: weekend-check
+        env:
+          FORCE: ${{ inputs.force }}
+        run: |
+          # Day of week in UTC: 6 = Saturday, 7 = Sunday.
+          dow=$(date -u +%u)
+          if [[ ( "$dow" == "6" || "$dow" == "7" ) && "$FORCE" != "true" ]]; then
+            echo "::notice::Weekend freeze in effect (UTC day-of-week=$dow). Skipping auto-merge."
+            echo "blocked=true" | tee -a "$GITHUB_OUTPUT"
+          else
+            echo "blocked=false" | tee -a "$GITHUB_OUTPUT"
+          fi
+
+      - name: Weekend freeze notice
+        if: inputs.pr != '' && steps.weekend-check.outputs.blocked == 'true'
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
+        with:
+          token: ${{ steps.get-app-token.outputs.token }}
+          issue-number: ${{ inputs.pr }}
+          comment-id: ${{ inputs.comment-id }}
+          edit-mode: replace
+          body: |
+            > **`/ai-ready` blocked: weekend freeze**
+            >
+            > Auto-merge is paused over the weekend, so no `hyd-ready` label was applied.
+            > Re-run `/ai-ready force=true` (or dispatch this workflow with `force` set to `true`) to bypass the freeze.
+
+      - name: Apply ready label
+        if: inputs.pr != '' && steps.weekend-check.outputs.blocked != 'true'
         env:
           GH_TOKEN: ${{ steps.get-app-token.outputs.token }}
           PR_NUMBER: ${{ inputs.pr }}
@@ -68,6 +104,7 @@ jobs:
 
   hydra-automerge:
     needs: validate
+    if: needs.validate.outputs.blocked != 'true'
     uses: ./.github/workflows/hydra-automerge.yml
     with:
       pr: ${{ inputs.pr }}

--- a/.github/workflows/ai-ready-command.yml
+++ b/.github/workflows/ai-ready-command.yml
@@ -93,7 +93,7 @@ jobs:
             > **`/ai-ready` blocked: weekend freeze**
             >
             > Auto-merge is paused over the weekend, so no `hyd-ready` label was applied.
-            > Re-run `/ai-ready force=true` (or dispatch this workflow with `force` set to `true`) to bypass the freeze.
+            > If this is urgent, re-run `/ai-ready force=true` to bypass the freeze. Otherwise, please wait until Monday.
 
       - name: Apply ready label
         if: inputs.pr != '' && steps.weekend-check.outputs.blocked != 'true'


### PR DESCRIPTION
## What

Adds a weekend freeze to the `/ai-ready` auto-merge flow (`ai-ready-command.yml`).

When `/ai-ready` runs on a Saturday or Sunday (US Pacific time), the workflow now:
- Posts a comment explaining auto-merge is paused for the weekend
- **Skips applying the `hyd-ready` label**
- **Skips calling `hydra-automerge.yml`** entirely

A `force` input bypasses the freeze.

## How to bypass

- Slash command: `/ai-ready force=true`
- Manual dispatch: set the `force` input to `true`

## Notes

- The guard lives only in `ai-ready-command.yml` (the slash-command entry point), not in `hydra-automerge.yml`. `ai-ready` is the only `workflow_call` caller of the merger, and the merger's other entry point is deliberate manual dispatch — so a single guard at the entry point keeps it as one source of truth without dead code.
- Weekend is determined in **US Pacific time** (`TZ="America/Los_Angeles" date +%u`, Sat/Sun).