### PR TITLE
fix(destination-bigquery): restore null primary key checks in SQL generator

### DIFF
--- a/airbyte-integrations/connectors/destination-bigquery/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-bigquery/metadata.yaml
@@ -6,7 +6,7 @@ data:
   connectorSubtype: database
   connectorType: destination
   definitionId: 22f6c74f-5699-40ff-833c-4a879ea40133
-  dockerImageTag: 3.0.21
+  dockerImageTag: 3.0.22
   dockerRepository: airbyte/destination-bigquery
   documentationUrl: https://docs.airbyte.com/integrations/destinations/bigquery
   githubIssueLabel: destination-bigquery

--- a/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/write/typing_deduping/direct_load_tables/BigqueryDirectLoadSqlGenerator.kt
+++ b/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/write/typing_deduping/direct_load_tables/BigqueryDirectLoadSqlGenerator.kt
@@ -140,7 +140,7 @@ class BigqueryDirectLoadSqlGenerator(
             importType.primaryKey.joinToString(" AND ") { fieldPath ->
                 val fieldName = fieldPath.first()
                 val columnName = columnNameMapping[fieldName]!!
-                """target_table.`$columnName` = new_record.`$columnName`"""
+                """(target_table.`$columnName` = new_record.`$columnName` OR (target_table.`$columnName` IS NULL AND new_record.`$columnName` IS NULL))"""
             }
 
         val columnList: String =

--- a/docs/integrations/destinations/bigquery.md
+++ b/docs/integrations/destinations/bigquery.md
@@ -252,6 +252,7 @@ This destination supports [namespaces](https://docs.airbyte.com/platform/using-a
 
 | Version     | Date       | Pull Request                                               | Subject                                                                                                                                                                           |
 |:------------|:-----------|:-----------------------------------------------------------|:----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 3.0.22 | 2026-07-10 | [81635](https://github.com/airbytehq/airbyte/pull/81635) | Restore PK NULL equality checks |
 | 3.0.21 | 2026-06-30 | [81346](https://github.com/airbytehq/airbyte/pull/81346) | Remove unnecessary NULL PK equality checks from merge SQL |
 | 3.0.20 | 2026-06-26 | [80932](https://github.com/airbytehq/airbyte/pull/80932) | Handle BigQueryException in getGenerationId() for legacy tables without _airbyte_generation_id column. |
 | 3.0.19 | 2026-05-21 | [78239](https://github.com/airbytehq/airbyte/pull/78239) | Promoting release candidate 3.0.19-rc.1 to a main version. |


### PR DESCRIPTION
## What

Restores the NULL-safe primary key matching pattern in the destination-bigquery MERGE/upsert ON clause, reverting the destination-bigquery portion of #81346.

That change replaced `(target_table.PK = new_record.PK OR (target_table.PK IS NULL AND new_record.PK IS NULL))` with simple equality (`target_table.PK = new_record.PK`) on the assumption that primary keys never contain NULLs. In practice, some Marketing API source connectors can emit records with NULL primary key values when upstream fields are incompatible or absent. Since `NULL = NULL` never matches in SQL, those records never match an existing row in the MERGE ON clause — they are re-inserted on every incremental sync, producing unbounded duplicates in dedup mode.

Related: #81346, #81347
Fixes: #81634 

## How

- Restore the NULL-safe PK matching pattern in `upsertTable()` in `BigqueryDirectLoadSqlGenerator.kt`, so the MERGE ON clause once again treats NULL PK values as equal:

```sql
(target_table.PK = new_record.PK OR (target_table.PK IS NULL AND new_record.PK IS NULL))
```

## Review guide

1. `destination-bigquery/.../direct_load_tables/BigqueryDirectLoadSqlGenerator.kt` — `upsertTable()` PK matching in the MERGE ON clause

## User Impact

- Dedup syncs into BigQuery correctly update (rather than duplicate) records whose primary key values are NULL.
- No impact for streams whose primary keys are always non-NULL: the added `OR (... IS NULL AND ... IS NULL)` branch never matches for them.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚
- [ ] NO ❌

> [!IMPORTANT]
> ⚡ **Auto-merge enabled.**
> 
> _This PR is set to merge automatically when all requirements are met._