### PR TITLE
docs: enable llms-full.txt generation for docs site

### DIFF
--- a/docusaurus/docusaurus.config.ts
+++ b/docusaurus/docusaurus.config.ts
@@ -311,6 +311,7 @@ const config: Config = {
           "Airbyte is an open source platform designed for building and managing data pipelines, offering extensive connector options to facilitate data movement from various sources to destinations efficiently and effectively.",
         depth: 4,
         content: {
+          enableLlmsFullTxt: true,
           includePages: true,
           excludeRoutes: ["./api-docs/**", "./ai-agents/slack-app"],
         },


### PR DESCRIPTION
## What

Enables the `@signalwire/docusaurus-plugin-llms-txt` plugin to emit a combined full-text file (`build/llms-full.txt`) in addition to the existing `build/llms.txt` index. Requested by @dee-airbyte to produce full rendered docs text for use as NotebookLM source material.

## How

The plugin does not emit `llms-full.txt` by default (`content.enableLlmsFullTxt` defaults to `false`). Added that flag to the plugin's `content` block in `docusaurus/docusaurus.config.ts`:

```diff
 content: {
+  enableLlmsFullTxt: true,
   includePages: true,
   excludeRoutes: ["./api-docs/**", "./ai-agents/slack-app"],
 },
```

Option name confirmed against the installed plugin's types (`node_modules/@signalwire/docusaurus-plugin-llms-txt/lib/types/public.d.ts`) and README. Existing `excludeRoutes` and `includePages: true` are unchanged.

## Review guide

1. `docusaurus/docusaurus.config.ts` — single-line addition inside the llms-txt plugin `content` object.

## User Impact

`pnpm build` now additionally generates `build/llms-full.txt` (index + full page body content). Verified locally: build succeeds and the file is ~43 MB / ~4.4M words containing actual rendered page bodies across all top-level sections. No change to site behavior or other build outputs.

## Can this PR be safely reverted and rolled back?
- [x] YES 💚


Link to Devin session: https://app.devin.ai/sessions/069b9bf9449e4421984b55fc95dbcb4a