### PR TITLE
fix(source-linkedin-ads): Harden adAnalytics rate-limit handling

### DIFF
--- a/airbyte-integrations/connectors/source-linkedin-ads/CONTRIBUTING.md
+++ b/airbyte-integrations/connectors/source-linkedin-ads/CONTRIBUTING.md
@@ -99,6 +99,16 @@ predict when a customer will hit limits. If customers report rate limiting, the 
 value is the primary lever to reduce pressure. The analytics property chunking (5 requests per record
 page) means the effective request rate is much higher than the visible concurrency level suggests.
 
+LinkedIn separately limits Ad Analytics requests to 45 million metric values across a rolling five-minute
+window. Metric values are calculated from the requested fields and returned records, so the call-count
+budget cannot predict this limit. `LinkedInAdsDataVolumeBackoffStrategy` detects the documented response
+message and waits 330 seconds before retrying. Analytics requests keep the existing five-retry limit but
+allow up to 30 minutes so each retry starts after the rolling window can clear.
+
+**Why this matters:** Do not replace the data-volume backoff with a faster generic 429 strategy. Count-based
+429 responses must continue using the exponential fallback, and unrecognized response bodies must not be
+treated as data-volume throttles.
+
 ## Incremental Stream Considerations
 
 The LinkedIn Marketing API supports date-based filtering on analytics and campaign/creative endpoints, which the connector already uses for 17 incremental streams. The single remaining FR parent stream (`accounts`) is a config-style endpoint listing ad accounts, which does not support date-based filtering on its list endpoint.

--- a/airbyte-integrations/connectors/source-linkedin-ads/components.py
+++ b/airbyte-integrations/connectors/source-linkedin-ads/components.py
@@ -20,7 +20,7 @@ from airbyte_cdk.sources.declarative.requesters.request_options.interpolated_req
     RequestInput,
 )
 from airbyte_cdk.sources.streams.http import HttpClient
-from airbyte_cdk.sources.streams.http.error_handlers import ErrorResolution, ResponseAction
+from airbyte_cdk.sources.streams.http.error_handlers import BackoffStrategy, ErrorResolution, ResponseAction
 from airbyte_cdk.sources.streams.http.exceptions import DefaultBackoffException, RequestBodyException, UserDefinedBackoffException
 from airbyte_cdk.sources.streams.http.http import BODY_REQUEST_METHODS
 from airbyte_cdk.utils.datetime_helpers import AirbyteDateTime, ab_datetime_parse
@@ -31,6 +31,24 @@ from airbyte_cdk.utils.datetime_helpers import AirbyteDateTime, ab_datetime_pars
 # on behalf of https://github.com/airbytehq/airbyte/issues/13018,
 # expand this list, if required.
 DESTINATION_RESERVED_KEYWORDS: list = ["pivot"]
+_DATA_VOLUME_RATE_LIMIT_BACKOFF_SECONDS = 330.0
+_DATA_VOLUME_RATE_LIMIT_MESSAGE_PARTS = (
+    "data request limit has been exceeded",
+    "45 million metric values",
+)
+
+
+def _is_data_volume_rate_limit(response_or_exception: Optional[Union[requests.Response, Exception]]) -> bool:
+    if not isinstance(response_or_exception, requests.Response) or response_or_exception.status_code != 429:
+        return False
+
+    try:
+        response_body = response_or_exception.json()
+        message = response_body.get("message", "")
+    except (AttributeError, ValueError):
+        return False
+
+    return isinstance(message, str) and all(part in message.casefold() for part in _DATA_VOLUME_RATE_LIMIT_MESSAGE_PARTS)
 
 
 class SafeHttpClient(HttpClient):
@@ -159,7 +177,33 @@ class LinkedInAdsErrorHandler(DefaultErrorHandler):
                 failure_type=FailureType.transient_error,
                 error_message="source-linkedin-ads has faced a temporary DNS resolution issue. Retrying...",
             )
+        if _is_data_volume_rate_limit(response_or_exception):
+            return ErrorResolution(
+                response_action=ResponseAction.RATE_LIMITED,
+                failure_type=FailureType.transient_error,
+                error_message="LinkedIn Ads metric-value rate limit is exceeded.",
+            )
+        if isinstance(response_or_exception, requests.Response) and response_or_exception.status_code == 414:
+            return ErrorResolution(
+                response_action=ResponseAction.FAIL,
+                failure_type=FailureType.system_error,
+                error_message="LinkedIn Ads request URL exceeds the API length limit.",
+            )
         return super().interpret_response(response_or_exception)
+
+
+@dataclass
+class LinkedInAdsDataVolumeBackoffStrategy(BackoffStrategy):
+    """Waits for the rolling metric-value window to clear after a data-volume throttle."""
+
+    def backoff_time(
+        self,
+        response_or_exception: Optional[Union[requests.Response, requests.RequestException]],
+        attempt_count: int,
+    ) -> Optional[float]:
+        if _is_data_volume_rate_limit(response_or_exception):
+            return _DATA_VOLUME_RATE_LIMIT_BACKOFF_SECONDS
+        return None
 
 
 def transform_change_audit_stamps(

--- a/airbyte-integrations/connectors/source-linkedin-ads/manifest.yaml
+++ b/airbyte-integrations/connectors/source-linkedin-ads/manifest.yaml
@@ -551,7 +551,8 @@ definitions:
           request_headers:
             Linkedin-Version: "202601"
             X-Restli-Protocol-Version: 2.0.0
-          error_handlers: "#/definitions/ad_analytics_error_handler"
+          error_handler:
+            $ref: "#/definitions/ad_analytics_error_handler"
         record_selector:
           type: RecordSelector
           extractor:
@@ -625,7 +626,8 @@ definitions:
           request_headers:
             Linkedin-Version: "202601"
             X-Restli-Protocol-Version: 2.0.0
-          error_handlers: "#/definitions/ad_analytics_error_handler"
+          error_handler:
+            $ref: "#/definitions/ad_analytics_error_handler"
         record_selector:
           type: RecordSelector
           extractor:
@@ -699,7 +701,8 @@ definitions:
           request_headers:
             Linkedin-Version: "202601"
             X-Restli-Protocol-Version: 2.0.0
-          error_handlers: "#/definitions/ad_analytics_error_handler"
+          error_handler:
+            $ref: "#/definitions/ad_analytics_error_handler"
         record_selector:
           type: RecordSelector
           extractor:
@@ -773,7 +776,8 @@ definitions:
           request_headers:
             Linkedin-Version: "202601"
             X-Restli-Protocol-Version: 2.0.0
-          error_handlers: "#/definitions/ad_analytics_error_handler"
+          error_handler:
+            $ref: "#/definitions/ad_analytics_error_handler"
         record_selector:
           type: RecordSelector
           extractor:
@@ -847,7 +851,8 @@ definitions:
           request_headers:
             Linkedin-Version: "202601"
             X-Restli-Protocol-Version: 2.0.0
-          error_handlers: "#/definitions/ad_analytics_error_handler"
+          error_handler:
+            $ref: "#/definitions/ad_analytics_error_handler"
         record_selector:
           type: RecordSelector
           extractor:
@@ -921,7 +926,8 @@ definitions:
           request_headers:
             Linkedin-Version: "202601"
             X-Restli-Protocol-Version: 2.0.0
-          error_handlers: "#/definitions/ad_analytics_error_handler"
+          error_handler:
+            $ref: "#/definitions/ad_analytics_error_handler"
         record_selector:
           type: RecordSelector
           extractor:
@@ -995,7 +1001,8 @@ definitions:
           request_headers:
             Linkedin-Version: "202601"
             X-Restli-Protocol-Version: 2.0.0
-          error_handlers: "#/definitions/ad_analytics_error_handler"
+          error_handler:
+            $ref: "#/definitions/ad_analytics_error_handler"
         record_selector:
           type: RecordSelector
           extractor:
@@ -1069,7 +1076,8 @@ definitions:
           request_headers:
             Linkedin-Version: "202601"
             X-Restli-Protocol-Version: 2.0.0
-          error_handlers: "#/definitions/ad_analytics_error_handler"
+          error_handler:
+            $ref: "#/definitions/ad_analytics_error_handler"
         record_selector:
           type: RecordSelector
           extractor:
@@ -1143,7 +1151,8 @@ definitions:
           request_headers:
             Linkedin-Version: "202601"
             X-Restli-Protocol-Version: 2.0.0
-          error_handlers: "#/definitions/ad_analytics_error_handler"
+          error_handler:
+            $ref: "#/definitions/ad_analytics_error_handler"
         record_selector:
           type: RecordSelector
           extractor:
@@ -1217,7 +1226,8 @@ definitions:
           request_headers:
             Linkedin-Version: "202601"
             X-Restli-Protocol-Version: 2.0.0
-          error_handlers: "#/definitions/ad_analytics_error_handler"
+          error_handler:
+            $ref: "#/definitions/ad_analytics_error_handler"
         record_selector:
           type: RecordSelector
           extractor:
@@ -1291,7 +1301,8 @@ definitions:
           request_headers:
             Linkedin-Version: "202601"
             X-Restli-Protocol-Version: 2.0.0
-          error_handlers: "#/definitions/ad_analytics_error_handler"
+          error_handler:
+            $ref: "#/definitions/ad_analytics_error_handler"
         record_selector:
           type: RecordSelector
           extractor:
@@ -1366,7 +1377,8 @@ definitions:
           request_headers:
             Linkedin-Version: "202601"
             X-Restli-Protocol-Version: 2.0.0
-          error_handlers: "#/definitions/ad_analytics_error_handler"
+          error_handler:
+            $ref: "#/definitions/ad_analytics_error_handler"
         record_selector:
           type: RecordSelector
           extractor:

--- a/airbyte-integrations/connectors/source-linkedin-ads/manifest.yaml
+++ b/airbyte-integrations/connectors/source-linkedin-ads/manifest.yaml
@@ -8,6 +8,16 @@ check:
     - accounts
 
 definitions:
+  ad_analytics_error_handler:
+    type: CustomErrorHandler
+    class_name: source_declarative_manifest.components.LinkedInAdsErrorHandler
+    max_retries: 5
+    max_time: 1800
+    backoff_strategies:
+      - type: CustomBackoffStrategy
+        class_name: source_declarative_manifest.components.LinkedInAdsDataVolumeBackoffStrategy
+      - type: ExponentialBackoffStrategy
+        factor: 5
   streams:
     accounts:
       type: DeclarativeStream
@@ -541,12 +551,7 @@ definitions:
           request_headers:
             Linkedin-Version: "202601"
             X-Restli-Protocol-Version: 2.0.0
-          error_handlers:
-            type: CustomErrorHandler
-            class_name: source_declarative_manifest.components.LinkedInAdsErrorHandler
-            backoff_strategies:
-              - type: ExponentialBackoffStrategy
-                factor: 5
+          error_handlers: "#/definitions/ad_analytics_error_handler"
         record_selector:
           type: RecordSelector
           extractor:
@@ -620,12 +625,7 @@ definitions:
           request_headers:
             Linkedin-Version: "202601"
             X-Restli-Protocol-Version: 2.0.0
-          error_handlers:
-            type: CustomErrorHandler
-            class_name: source_declarative_manifest.components.LinkedInAdsErrorHandler
-            backoff_strategies:
-              - type: ExponentialBackoffStrategy
-                factor: 5
+          error_handlers: "#/definitions/ad_analytics_error_handler"
         record_selector:
           type: RecordSelector
           extractor:
@@ -699,12 +699,7 @@ definitions:
           request_headers:
             Linkedin-Version: "202601"
             X-Restli-Protocol-Version: 2.0.0
-          error_handlers:
-            type: CustomErrorHandler
-            class_name: source_declarative_manifest.components.LinkedInAdsErrorHandler
-            backoff_strategies:
-              - type: ExponentialBackoffStrategy
-                factor: 5
+          error_handlers: "#/definitions/ad_analytics_error_handler"
         record_selector:
           type: RecordSelector
           extractor:
@@ -778,12 +773,7 @@ definitions:
           request_headers:
             Linkedin-Version: "202601"
             X-Restli-Protocol-Version: 2.0.0
-          error_handlers:
-            type: CustomErrorHandler
-            class_name: source_declarative_manifest.components.LinkedInAdsErrorHandler
-            backoff_strategies:
-              - type: ExponentialBackoffStrategy
-                factor: 5
+          error_handlers: "#/definitions/ad_analytics_error_handler"
         record_selector:
           type: RecordSelector
           extractor:
@@ -857,12 +847,7 @@ definitions:
           request_headers:
             Linkedin-Version: "202601"
             X-Restli-Protocol-Version: 2.0.0
-          error_handlers:
-            type: CustomErrorHandler
-            class_name: source_declarative_manifest.components.LinkedInAdsErrorHandler
-            backoff_strategies:
-              - type: ExponentialBackoffStrategy
-                factor: 5
+          error_handlers: "#/definitions/ad_analytics_error_handler"
         record_selector:
           type: RecordSelector
           extractor:
@@ -936,12 +921,7 @@ definitions:
           request_headers:
             Linkedin-Version: "202601"
             X-Restli-Protocol-Version: 2.0.0
-          error_handlers:
-            type: CustomErrorHandler
-            class_name: source_declarative_manifest.components.LinkedInAdsErrorHandler
-            backoff_strategies:
-              - type: ExponentialBackoffStrategy
-                factor: 5
+          error_handlers: "#/definitions/ad_analytics_error_handler"
         record_selector:
           type: RecordSelector
           extractor:
@@ -1015,12 +995,7 @@ definitions:
           request_headers:
             Linkedin-Version: "202601"
             X-Restli-Protocol-Version: 2.0.0
-          error_handlers:
-            type: CustomErrorHandler
-            class_name: source_declarative_manifest.components.LinkedInAdsErrorHandler
-            backoff_strategies:
-              - type: ExponentialBackoffStrategy
-                factor: 5
+          error_handlers: "#/definitions/ad_analytics_error_handler"
         record_selector:
           type: RecordSelector
           extractor:
@@ -1094,12 +1069,7 @@ definitions:
           request_headers:
             Linkedin-Version: "202601"
             X-Restli-Protocol-Version: 2.0.0
-          error_handlers:
-            type: CustomErrorHandler
-            class_name: source_declarative_manifest.components.LinkedInAdsErrorHandler
-            backoff_strategies:
-              - type: ExponentialBackoffStrategy
-                factor: 5
+          error_handlers: "#/definitions/ad_analytics_error_handler"
         record_selector:
           type: RecordSelector
           extractor:
@@ -1173,12 +1143,7 @@ definitions:
           request_headers:
             Linkedin-Version: "202601"
             X-Restli-Protocol-Version: 2.0.0
-          error_handlers:
-            type: CustomErrorHandler
-            class_name: source_declarative_manifest.components.LinkedInAdsErrorHandler
-            backoff_strategies:
-              - type: ExponentialBackoffStrategy
-                factor: 5
+          error_handlers: "#/definitions/ad_analytics_error_handler"
         record_selector:
           type: RecordSelector
           extractor:
@@ -1252,12 +1217,7 @@ definitions:
           request_headers:
             Linkedin-Version: "202601"
             X-Restli-Protocol-Version: 2.0.0
-          error_handlers:
-            type: CustomErrorHandler
-            class_name: source_declarative_manifest.components.LinkedInAdsErrorHandler
-            backoff_strategies:
-              - type: ExponentialBackoffStrategy
-                factor: 5
+          error_handlers: "#/definitions/ad_analytics_error_handler"
         record_selector:
           type: RecordSelector
           extractor:
@@ -1331,12 +1291,7 @@ definitions:
           request_headers:
             Linkedin-Version: "202601"
             X-Restli-Protocol-Version: 2.0.0
-          error_handlers:
-            type: CustomErrorHandler
-            class_name: source_declarative_manifest.components.LinkedInAdsErrorHandler
-            backoff_strategies:
-              - type: ExponentialBackoffStrategy
-                factor: 5
+          error_handlers: "#/definitions/ad_analytics_error_handler"
         record_selector:
           type: RecordSelector
           extractor:
@@ -1411,12 +1366,7 @@ definitions:
           request_headers:
             Linkedin-Version: "202601"
             X-Restli-Protocol-Version: 2.0.0
-          error_handlers:
-            type: CustomErrorHandler
-            class_name: source_declarative_manifest.components.LinkedInAdsErrorHandler
-            backoff_strategies:
-              - type: ExponentialBackoffStrategy
-                factor: 5
+          error_handlers: "#/definitions/ad_analytics_error_handler"
         record_selector:
           type: RecordSelector
           extractor:

--- a/airbyte-integrations/connectors/source-linkedin-ads/metadata.yaml
+++ b/airbyte-integrations/connectors/source-linkedin-ads/metadata.yaml
@@ -11,7 +11,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 137ece28-5434-455c-8f34-69dc3782f451
-  dockerImageTag: 5.6.9
+  dockerImageTag: 5.6.10
   dockerRepository: airbyte/source-linkedin-ads
   documentationUrl: https://docs.airbyte.com/integrations/sources/linkedin-ads
   externalDocumentationUrls:

--- a/airbyte-integrations/connectors/source-linkedin-ads/unit_tests/mock_server/test_ad_campaign_analytics.py
+++ b/airbyte-integrations/connectors/source-linkedin-ads/unit_tests/mock_server/test_ad_campaign_analytics.py
@@ -1,13 +1,16 @@
 # Copyright (c) 2025 Airbyte, Inc., all rights reserved.
 
+import json
 from datetime import datetime, timezone
 from unittest import TestCase
+from unittest.mock import patch
 
 import freezegun
+import pytest
 
-from airbyte_cdk.models import SyncMode
+from airbyte_cdk.models import FailureType, SyncMode
 from airbyte_cdk.test.catalog_builder import CatalogBuilder
-from airbyte_cdk.test.entrypoint_wrapper import read
+from airbyte_cdk.test.entrypoint_wrapper import ExpectedOutcome, read
 from airbyte_cdk.test.mock_http import HttpMocker, HttpResponse
 from airbyte_cdk.test.state_builder import StateBuilder
 from unit_tests.conftest import get_source
@@ -24,6 +27,9 @@ _NOW = datetime.now(timezone.utc)
 _STREAM_NAME = "ad_campaign_analytics"
 _PARENT_STREAM_NAME = "campaigns"
 _GRANDPARENT_STREAM_NAME = "accounts"
+_DATA_VOLUME_RATE_LIMIT_MESSAGE = (
+    "The data request limit has been exceeded. More than 45 million metric values were requested in a 5-minute window."
+)
 
 
 def _create_account_record(account_id: int, name: str = "Test Account") -> dict:
@@ -311,3 +317,93 @@ class TestAdCampaignAnalyticsStream(TestCase):
         # Note: dateRange is processed by the custom record extractor and converted to end_date/start_date
         assert "end_date" in record_data
         assert "start_date" in record_data
+
+
+def _configure_rate_limit_test_parents(http_mocker: HttpMocker) -> None:
+    http_mocker.get(
+        LinkedInAdsRequestBuilder.accounts_endpoint().with_q("search").with_page_size(500).build(),
+        LinkedInAdsPaginatedResponseBuilder.single_page([_create_account_record(111111111)]),
+    )
+    http_mocker.get(
+        LinkedInAdsRequestBuilder.campaigns_endpoint(111111111).with_any_query_params().build(),
+        LinkedInAdsPaginatedResponseBuilder.single_page([_create_campaign_record(1001, 111111111)]),
+    )
+
+
+def _read_campaign_analytics(config: dict, expected_outcome: ExpectedOutcome = ExpectedOutcome.EXPECT_SUCCESS):
+    source = get_source(config=config)
+    catalog = CatalogBuilder().with_stream(_STREAM_NAME, SyncMode.full_refresh).build()
+    return read(source, config=config, catalog=catalog, expected_outcome=expected_outcome)
+
+
+@freezegun.freeze_time("2024-06-15T00:00:00Z")
+def test_data_volume_rate_limit_retry() -> None:
+    config = ConfigBuilder().with_start_date("2024-06-01").build()
+    sleeps = []
+
+    with HttpMocker() as http_mocker, patch("time.sleep", side_effect=lambda seconds: sleeps.append(float(seconds))):
+        _configure_rate_limit_test_parents(http_mocker)
+        http_mocker.get(
+            LinkedInAdsRequestBuilder.ad_analytics_endpoint().with_any_query_params().build(),
+            [
+                HttpResponse(status_code=429, body=json.dumps({"message": _DATA_VOLUME_RATE_LIMIT_MESSAGE})),
+                LinkedInAdsAnalyticsResponseBuilder.single_page([_create_analytics_record(1001)]),
+            ],
+        )
+
+        output = _read_campaign_analytics(config)
+
+        assert len(output.records) == 1
+        assert output.records[0].record.stream == _STREAM_NAME
+        assert [seconds for seconds in sleeps if seconds > 0] == [331.0]
+        assert output.errors == []
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        pytest.param(json.dumps({"message": "Rate limit exceeded."}), id="generic_json"),
+        pytest.param("not-json", id="malformed_body"),
+    ],
+)
+@freezegun.freeze_time("2024-06-15T00:00:00Z")
+def test_non_data_volume_rate_limit_fallback(body: str) -> None:
+    config = ConfigBuilder().with_start_date("2024-06-01").build()
+    sleeps = []
+
+    with HttpMocker() as http_mocker, patch("time.sleep", side_effect=lambda seconds: sleeps.append(float(seconds))):
+        _configure_rate_limit_test_parents(http_mocker)
+        http_mocker.get(
+            LinkedInAdsRequestBuilder.ad_analytics_endpoint().with_any_query_params().build(),
+            [
+                HttpResponse(status_code=429, body=body),
+                LinkedInAdsAnalyticsResponseBuilder.single_page([_create_analytics_record(1001)]),
+            ],
+        )
+
+        output = _read_campaign_analytics(config)
+
+        assert len(output.records) == 1
+        assert [seconds for seconds in sleeps if seconds > 0] == [11.0]
+        assert output.errors == []
+
+
+@freezegun.freeze_time("2024-06-15T00:00:00Z")
+def test_uri_too_long_failure() -> None:
+    config = ConfigBuilder().with_start_date("2024-06-01").build()
+    sleeps = []
+
+    with HttpMocker() as http_mocker, patch("time.sleep", side_effect=lambda seconds: sleeps.append(float(seconds))):
+        _configure_rate_limit_test_parents(http_mocker)
+        http_mocker.get(
+            LinkedInAdsRequestBuilder.ad_analytics_endpoint().with_any_query_params().build(),
+            HttpResponse(status_code=414, body="{}"),
+        )
+
+        output = _read_campaign_analytics(config, expected_outcome=ExpectedOutcome.EXPECT_EXCEPTION)
+
+        errors = [message.trace.error for message in output.errors if message.trace.error.failure_type == FailureType.system_error]
+        assert output.records == []
+        assert len(errors) == 1
+        assert errors[0].message == "LinkedIn Ads request URL exceeds the API length limit."
+        assert [seconds for seconds in sleeps if seconds > 0] == []

--- a/airbyte-integrations/connectors/source-linkedin-ads/unit_tests/test_components.py
+++ b/airbyte-integrations/connectors/source-linkedin-ads/unit_tests/test_components.py
@@ -2,7 +2,9 @@
 # Copyright (c) 2024 Airbyte, Inc., all rights reserved.
 #
 
+import json
 import logging
+from typing import Mapping, Union
 from unittest.mock import MagicMock
 
 import pytest
@@ -15,6 +17,16 @@ from airbyte_cdk.sources.streams.http.error_handlers import ResponseAction
 
 
 logger = logging.getLogger("airbyte")
+_DATA_VOLUME_RATE_LIMIT_MESSAGE = (
+    "The data request limit has been exceeded. More than 45 million metric values were requested in a 5-minute window."
+)
+
+
+def _response(status_code: int, body: Union[Mapping[str, str], bytes]) -> Response:
+    response = Response()
+    response.status_code = status_code
+    response._content = body if isinstance(body, bytes) else json.dumps(body).encode()
+    return response
 
 
 @pytest.fixture
@@ -149,3 +161,59 @@ def test_linkedin_ads_error_handler_http_response(components_module):
 
     # For a successful response, DefaultErrorHandler returns SUCCESS action
     assert error_resolution.response_action == ResponseAction.SUCCESS
+
+
+@pytest.mark.parametrize(
+    "body,expected_message",
+    [
+        pytest.param(
+            {"message": _DATA_VOLUME_RATE_LIMIT_MESSAGE},
+            "LinkedIn Ads metric-value rate limit is exceeded.",
+            id="data_volume_throttle",
+        ),
+        pytest.param(
+            {"message": "Rate limit exceeded for LinkedIn API."},
+            "HTTP Status Code: 429. Error: Too many requests.",
+            id="count_throttle",
+        ),
+        pytest.param({}, "HTTP Status Code: 429. Error: Too many requests.", id="missing_message"),
+        pytest.param(b"not-json", "HTTP Status Code: 429. Error: Too many requests.", id="malformed_body"),
+    ],
+)
+def test_linkedin_ads_error_handler_rate_limit_response(components_module, body, expected_message):
+    error_handler = components_module.LinkedInAdsErrorHandler(parameters={}, config={})
+
+    error_resolution = error_handler.interpret_response(_response(429, body))
+
+    assert error_resolution.response_action == ResponseAction.RATE_LIMITED
+    assert error_resolution.failure_type == FailureType.transient_error
+    assert error_resolution.error_message == expected_message
+
+
+def test_linkedin_ads_error_handler_uri_too_long(components_module):
+    error_handler = components_module.LinkedInAdsErrorHandler(parameters={}, config={})
+
+    error_resolution = error_handler.interpret_response(_response(414, {}))
+
+    assert error_resolution.response_action == ResponseAction.FAIL
+    assert error_resolution.failure_type == FailureType.system_error
+    assert error_resolution.error_message == "LinkedIn Ads request URL exceeds the API length limit."
+
+
+@pytest.mark.parametrize(
+    "response_or_exception,expected_backoff",
+    [
+        pytest.param(
+            _response(429, {"message": _DATA_VOLUME_RATE_LIMIT_MESSAGE}),
+            330.0,
+            id="data_volume_throttle",
+        ),
+        pytest.param(_response(429, {"message": "Rate limit exceeded."}), None, id="count_throttle"),
+        pytest.param(_response(429, b"not-json"), None, id="malformed_body"),
+        pytest.param(InvalidURL("Invalid URL"), None, id="request_exception"),
+    ],
+)
+def test_linkedin_ads_data_volume_backoff_strategy(components_module, response_or_exception, expected_backoff):
+    strategy = components_module.LinkedInAdsDataVolumeBackoffStrategy()
+
+    assert strategy.backoff_time(response_or_exception=response_or_exception, attempt_count=1) == expected_backoff

--- a/airbyte-integrations/connectors/source-linkedin-ads/unit_tests/test_source.py
+++ b/airbyte-integrations/connectors/source-linkedin-ads/unit_tests/test_source.py
@@ -112,8 +112,7 @@ class TestAllStreams:
     def test_manifest_maps_429_to_rate_limited(self):
         """
         Verify the manifest configures HTTP 429 responses with RATE_LIMITED action
-        (not RETRY), so that rate-limited requests retry indefinitely with backoff
-        instead of failing after a limited number of retries.
+        (not RETRY) so rate-limited requests use the rate-limit backoff path.
 
         HTTP 500/503 should remain mapped to RETRY.
         """
@@ -133,10 +132,31 @@ class TestAllStreams:
         filter_429 = next(f for f in response_filters if 429 in f.get("http_codes", []))
         filter_5xx = next(f for f in response_filters if 500 in f.get("http_codes", []))
 
-        assert (
-            filter_429["action"] == "RATE_LIMITED"
-        ), f"HTTP 429 must use RATE_LIMITED action for indefinite retry, got {filter_429['action']}"
+        assert filter_429["action"] == "RATE_LIMITED", f"HTTP 429 must use RATE_LIMITED action, got {filter_429['action']}"
         assert filter_5xx["action"] == "RETRY", f"HTTP 500/503 should use RETRY action, got {filter_5xx['action']}"
+
+    def test_ad_analytics_error_handler_configuration(self):
+        manifest_path = Path(__file__).parent.parent / "manifest.yaml"
+        manifest = yaml.safe_load(manifest_path.read_text())
+        analytics_error_handler = manifest["definitions"]["ad_analytics_error_handler"]
+
+        assert analytics_error_handler["max_retries"] == 5
+        assert analytics_error_handler["max_time"] == 1800
+        assert analytics_error_handler["backoff_strategies"] == [
+            {
+                "type": "CustomBackoffStrategy",
+                "class_name": "source_declarative_manifest.components.LinkedInAdsDataVolumeBackoffStrategy",
+            },
+            {"type": "ExponentialBackoffStrategy", "factor": 5},
+        ]
+
+        analytics_requesters = [
+            stream["retriever"]["requester"]
+            for stream in manifest["definitions"]["streams"].values()
+            if stream.get("retriever", {}).get("requester", {}).get("path") == "adAnalytics"
+        ]
+        assert analytics_requesters
+        assert all(requester["error_handlers"] == "#/definitions/ad_analytics_error_handler" for requester in analytics_requesters)
 
     def test_custom_streams(self, requests_mock):
         config = {"ad_analytics_reports": [{"name": "ShareAdByMonth", "pivot_by": "COMPANY", "time_granularity": "MONTHLY"}], **TEST_CONFIG}

--- a/airbyte-integrations/connectors/source-linkedin-ads/unit_tests/test_source.py
+++ b/airbyte-integrations/connectors/source-linkedin-ads/unit_tests/test_source.py
@@ -156,7 +156,7 @@ class TestAllStreams:
             if stream.get("retriever", {}).get("requester", {}).get("path") == "adAnalytics"
         ]
         assert analytics_requesters
-        assert all(requester["error_handlers"] == "#/definitions/ad_analytics_error_handler" for requester in analytics_requesters)
+        assert all(requester["error_handler"] == {"$ref": "#/definitions/ad_analytics_error_handler"} for requester in analytics_requesters)
 
     def test_custom_streams(self, requests_mock):
         config = {"ad_analytics_reports": [{"name": "ShareAdByMonth", "pivot_by": "COMPANY", "time_granularity": "MONTHLY"}], **TEST_CONFIG}

--- a/docs/integrations/sources/linkedin-ads.md
+++ b/docs/integrations/sources/linkedin-ads.md
@@ -222,11 +222,12 @@ If you use Airbyte Cloud and your organization restricts access to specific IPs,
 
 | Version    | Date       | Pull Request                                             | Subject                                                                                                                                                                |
 |:-----------|:-----------|:---------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| 5.6.7 | 2026-04-06 | [76040](https://github.com/airbytehq/airbyte/pull/76040) | Replace deprecated MessageRepresentationAirbyteTracedErrors with AirbyteTracedException in tests |
-| 5.6.6 | 2026-04-06 | [75583](https://github.com/airbytehq/airbyte/pull/75583) | Add `oauth_connector_input_specification` with granular scopes |
+| 5.6.10 | 2026-07-10 | [81641](https://github.com/airbytehq/airbyte/pull/81641) | Improve adAnalytics resilience to data-volume throttling and fail fast on oversized request URLs |
 | 5.6.9 | 2026-04-21 | [73947](https://github.com/airbytehq/airbyte/pull/73947) | Update dependencies |
 | 5.6.8 | 2026-04-07 | [76120](https://github.com/airbytehq/airbyte/pull/76120) | Fix dynamic stream name field_path to avoid parent stream name collision |
+| 5.6.7 | 2026-04-06 | [76040](https://github.com/airbytehq/airbyte/pull/76040) | Replace deprecated MessageRepresentationAirbyteTracedErrors with AirbyteTracedException in tests |
 | 5.6.7 | 2026-04-02 | [76040](https://github.com/airbytehq/airbyte/pull/76040) | Replace deprecated MessageRepresentationAirbyteTracedErrors with AirbyteTracedException in tests |
+| 5.6.6 | 2026-04-06 | [75583](https://github.com/airbytehq/airbyte/pull/75583) | Add `oauth_connector_input_specification` with granular scopes |
 | 5.6.6 | 2026-04-01 | [75583](https://github.com/airbytehq/airbyte/pull/75583) | Add `oauth_connector_input_specification` with granular scopes |
 | 5.6.5 | 2026-03-30 | [75597](https://github.com/airbytehq/airbyte/pull/75597) | Map HTTP 429 responses to RATE_LIMITED instead of RETRY for rate-limit-specific backoff |
 | 5.6.4 | 2026-02-10 | [72831](https://github.com/airbytehq/airbyte/pull/72831) | Upgrade LinkedIn API version from 202502 to 202601 |

--- a/docs/integrations/sources/linkedin-ads.md
+++ b/docs/integrations/sources/linkedin-ads.md
@@ -228,7 +228,7 @@ If you use Airbyte Cloud and your organization restricts access to specific IPs,
 | 5.6.8 | 2026-04-07 | [76120](https://github.com/airbytehq/airbyte/pull/76120) | Fix dynamic stream name field_path to avoid parent stream name collision |
 | 5.6.7 | 2026-04-02 | [76040](https://github.com/airbytehq/airbyte/pull/76040) | Replace deprecated MessageRepresentationAirbyteTracedErrors with AirbyteTracedException in tests |
 | 5.6.6 | 2026-04-01 | [75583](https://github.com/airbytehq/airbyte/pull/75583) | Add `oauth_connector_input_specification` with granular scopes |
-| 5.6.5 | 2026-03-30 | [75597](https://github.com/airbytehq/airbyte/pull/75597) | Map HTTP 429 responses to RATE_LIMITED instead of RETRY for proper indefinite backoff on rate-limited requests |
+| 5.6.5 | 2026-03-30 | [75597](https://github.com/airbytehq/airbyte/pull/75597) | Map HTTP 429 responses to RATE_LIMITED instead of RETRY for rate-limit-specific backoff |
 | 5.6.4 | 2026-02-10 | [72831](https://github.com/airbytehq/airbyte/pull/72831) | Upgrade LinkedIn API version from 202502 to 202601 |
 | 5.6.3 | 2026-02-10 | [72768](https://github.com/airbytehq/airbyte/pull/72768) | Update dependencies |
 | 5.6.2 | 2026-01-20 | [72028](https://github.com/airbytehq/airbyte/pull/72028) | Update dependencies |


### PR DESCRIPTION
## What

Requested by @ZaneHyattAB for OC-11542.

Harden `source-linkedin-ads` against LinkedIn's data-volume throttle on `adAnalytics` endpoints without changing
analytics batching. Phase 1 established that the existing exponential strategy is bounded, that data-volume and
count-based 429s are distinguishable by response body, and that HTTP 414 currently consumes retries before failing
generically. Full findings:
https://github.com/airbytehq/airbyte/pull/74334#issuecomment-4936809669.

This remains orthogonal to the batching work in https://github.com/airbytehq/airbyte/pull/74334.

## How

```text
if status == 429 and body matches LinkedIn's 45M metric-value signature:
    classify as RATE_LIMITED
    wait 330 seconds
else if status == 429:
    preserve the existing exponential fallback
else if status == 414:
    fail immediately as a system error
```

The 12 `adAnalytics` streams share one handler definition through canonical `error_handler.$ref` wiring, with five
retries and a 30-minute elapsed-time ceiling. The 330-second delay starts each data-volume retry after the documented
five-minute rolling window can clear; malformed or unrecognized bodies retain existing behavior.

The connector guidance now documents this API-specific behavior. The connector is bumped to `5.6.10`, and the
changelog both records the resilience change and corrects the prior claim that 429 retries were indefinite.

## Review guide

1. `airbyte-integrations/connectors/source-linkedin-ads/components.py:34-51` — response-body detection
2. `airbyte-integrations/connectors/source-linkedin-ads/components.py:163-206` — 429/414 resolution and custom backoff
3. `airbyte-integrations/connectors/source-linkedin-ads/manifest.yaml:10-20` — shared analytics retry policy
4. `airbyte-integrations/connectors/source-linkedin-ads/manifest.yaml:551-1380` — canonical shared-handler references
5. `airbyte-integrations/connectors/source-linkedin-ads/unit_tests/mock_server/test_ad_campaign_analytics.py:317-409`
   — full connector-read retry and failure coverage
6. `airbyte-integrations/connectors/source-linkedin-ads/unit_tests/test_components.py:166-219` — focused
   classification/backoff tests
7. `airbyte-integrations/connectors/source-linkedin-ads/CONTRIBUTING.md:90-112` — unique behavior documentation
8. `airbyte-integrations/connectors/source-linkedin-ads/metadata.yaml:14` and
   `docs/integrations/sources/linkedin-ads.md:225` — `5.6.10` release metadata

## User Impact

Large-account analytics syncs that hit LinkedIn's metric-value limit wait for the rolling window instead of repeatedly
retrying too soon. Count-based 429 behavior is unchanged. HTTP 414 fails immediately with a deterministic connector
error instead of exhausting retries.

### Test plan

- Runtime mock-server resilience tests: 4 passed
- Full connector unit suite: 165 passed
- All 12 `adAnalytics` requesters instantiated the shared handler with the expected policy
- Changed-file pre-commit hooks, Ruff lint/format, and `git diff --check`: passed

## Can this PR be safely reverted and rolled back?

- [x] YES 💚
- [ ] NO ❌

---
[Devin session](https://app.devin.ai/sessions/2ea67fe220e64e7fbe24013dcdf03cbf)
