### PR TITLE
chore(destination-mssql): bump version to 2.2.20 for connectorIPCOptions change

### DIFF
--- a/airbyte-integrations/connectors/destination-mssql/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-mssql/metadata.yaml
@@ -31,7 +31,7 @@ data:
             type: GSM
   connectorType: destination
   definitionId: d4353156-9217-4cad-8dd7-c108fd4f74cf
-  dockerImageTag: 2.2.19
+  dockerImageTag: 2.2.20
   dockerRepository: airbyte/destination-mssql
   documentationUrl: https://docs.airbyte.com/integrations/destinations/mssql
   githubIssueLabel: destination-mssql

--- a/docs/integrations/destinations/mssql.md
+++ b/docs/integrations/destinations/mssql.md
@@ -178,6 +178,7 @@ This destination supports [namespaces](https://docs.airbyte.com/platform/using-a
 
 | Version    | Date       | Pull Request                                               | Subject                                                                                                                   |
 |:-----------|:-----------|:-----------------------------------------------------------|:--------------------------------------------------------------------------------------------------------------------------|
+| 2.2.20     | 2026-07-10 | [81536](https://github.com/airbytehq/airbyte/pull/81536)   | Add connectorIPCOptions to enable speed mode                                                                              |
 | 2.2.19     | 2026-06-30 | [80269](https://github.com/airbytehq/airbyte/pull/80269)   | Extract shared value coercion into MSSQLValueCoercer; enable acceptance tests                                             |
 | 2.2.18     | 2026-06-09 | [79602](https://github.com/airbytehq/airbyte/pull/79602)   | Fix bulk load — schema-qualified staging tables, always serialize booleans as 0/1                                         |
 | 2.2.17     | 2026-06-08 | [79154](https://github.com/airbytehq/airbyte/pull/79154)   | Nullify timestamp-without-timezone values before 1753-01-01 instead of failing the sync                                   |


### PR DESCRIPTION
## Summary
- Bumps `dockerImageTag` from `2.2.19` to `2.2.20` in `metadata.yaml`
- Adds changelog entry in `docs/integrations/destinations/mssql.md`

Version bump was missed in #81536 (feat: add connectorIPCOptions to enable speed mode).

> [!IMPORTANT]
> ⚡ **Auto-merge enabled.**
> 
> _This PR is set to merge automatically when all requirements are met._