### PR TITLE
chore(source-faker): dummy version bump for progressive rollout (autopilot) testing

### DIFF
--- a/airbyte-integrations/connectors/source-faker/metadata.yaml
+++ b/airbyte-integrations/connectors/source-faker/metadata.yaml
@@ -37,7 +37,7 @@ data:
       autopilotConfig:
         autoStart: true
         autoPromoteStages: true
-        strategy: fast
+        strategy: slow
     breakingChanges:
       4.0.0:
         message: This is a breaking change message

--- a/airbyte-integrations/connectors/source-faker/metadata.yaml
+++ b/airbyte-integrations/connectors/source-faker/metadata.yaml
@@ -10,7 +10,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: dfd88b22-b603-4c3d-aad7-3701784586b1
-  dockerImageTag: 7.2.0
+  dockerImageTag: 7.2.1
   dockerRepository: airbyte/source-faker
   documentationUrl: https://docs.airbyte.com/integrations/sources/faker
   externalDocumentationUrls:

--- a/airbyte-integrations/connectors/source-faker/metadata.yaml
+++ b/airbyte-integrations/connectors/source-faker/metadata.yaml
@@ -32,7 +32,7 @@ data:
   releaseStage: beta
   releases:
     rolloutConfiguration:
-      enableProgressiveRollout: false
+      enableProgressiveRollout: true
       defaultRolloutMode: autopilot
       autopilotConfig:
         autoStart: true

--- a/airbyte-integrations/connectors/source-faker/metadata.yaml
+++ b/airbyte-integrations/connectors/source-faker/metadata.yaml
@@ -1,4 +1,5 @@
 data:
+  # Dummy edit to exercise the /enable-autopilot-rollouts slash command workflow. Not for merge.
   ab_internal:
     ql: 300
     sl: 100

--- a/airbyte-integrations/connectors/source-faker/pyproject.toml
+++ b/airbyte-integrations/connectors/source-faker/pyproject.toml
@@ -3,7 +3,7 @@ requires = [ "poetry-core>=1.0.0",]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
-version = "7.2.0"
+version = "7.2.1"
 name = "source-faker"
 description = "Source implementation for fake but realistic looking data."
 authors = [ "Airbyte <evan@airbyte.io>",]

--- a/docs/integrations/sources/faker.md
+++ b/docs/integrations/sources/faker.md
@@ -47,6 +47,7 @@ Each purchase record includes: `id`, `user_id`, `product_id`, `created_at`, `upd
 
 | Version     | Date       | Pull Request                                                                                                          | Subject                                                                                                         |
 |:------------|:-----------| :-------------------------------------------------------------------------------------------------------------------- |:----------------------------------------------------------------------------------------------------------------|
+| 7.2.1 | 2026-07-10 | [81653](https://github.com/airbytehq/airbyte/pull/81653) | chore(source-faker): dummy version bump for progressive rollout (autopilot) testing |
 | 7.2.0 | 2026-07-09 | [81556](https://github.com/airbytehq/airbyte/pull/81556) | Promoted release candidate to GA |
 | 7.2.0-rc.2 | 2026-06-24 | [80776](https://github.com/airbytehq/airbyte/pull/80776) | Test autopilot progressive rollout lifecycle |
 | 7.2.0-rc.1 | 2026-06-09 | [79331](https://github.com/airbytehq/airbyte/pull/79331) | Progressive rollout e2e test |


### PR DESCRIPTION
## What

**Do not merge.** Throwaway PR to end-to-end test the `/enable-autopilot-rollouts` slash command workflow (#81570) against a real connector, requested by AJ Steers.

`source-faker` currently has `releases.rolloutConfiguration.enableProgressiveRollout: false` with `defaultRolloutMode: autopilot`. Running enable should flip the toggle to `true` and push a commit to this branch.

## How

The only change here is a dummy comment in `source-faker/metadata.yaml` so the workflow detects the connector as modified. The workflow (dispatched from the #81570 branch via the Ops MCP CI trigger) then runs `airbyte-ops local connector rollouts enable` and commits the metadata edit back to this branch.

## Review guide

1. `airbyte-integrations/connectors/source-faker/metadata.yaml` — dummy comment only (pre-run); the enable step's commit will follow.

## User Impact

None — test-only, not for merge.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

---
[Devin session](https://app.devin.ai/sessions/e262f7b87e604a2f877d2d64c7bc1504)

Requested by: @aaronsteers