### PR TITLE
docs: document /enable-autopilot-rollouts in internal PR welcome

### DIFF
--- a/.github/pr-welcome-internal.md
+++ b/.github/pr-welcome-internal.md
@@ -26,6 +26,9 @@ Airbyte Maintainers (that's you!) can execute the following slash commands on yo
   - `/ai-create-docs-pr` - Creates a documentation PR for connector changes, stacked on the current PR.
 - 🚀 Connector Releases:
   - `/publish-connectors-prerelease` - Publishes pre-release connector builds (tagged as `{version}-preview.{git-sha}`) for all modified connectors in the PR.
+  - `/enable-autopilot-rollouts` - Enables autopilot progressive rollouts for the modified connector(s) in the PR, remediating "autopilot rollouts not enabled for `{connector-name}`" auto-merge blockers. Sets `defaultRolloutMode: autopilot` and `enableProgressiveRollout: true`, preserving any existing `autopilotConfig`.
+    - Optional args: `connector=<CONNECTOR_NAME>` (defaults to the modified connectors in the PR), `strategy=fast|slow|default` (defaults to `fast`).
+    - Example: `/enable-autopilot-rollouts` or `/enable-autopilot-rollouts connector=source-faker strategy=slow`
 - ☕️ JVM connectors:
   - `/update-connector-cdk-version connector=<CONNECTOR_NAME>` - Updates the specified connector to the latest CDK version.
     Example: `/update-connector-cdk-version connector=destination-bigquery`


### PR DESCRIPTION
## What

Documents the newly-added `/enable-autopilot-rollouts` slash command (workflow added in #81570) in the internal PR welcome message, so maintainers can discover it. Requested by AJ Steers.

## How

Adds a bullet under the "🚀 Connector Releases" section of `.github/pr-welcome-internal.md` describing what the command does (enables autopilot progressive rollouts to remediate the "autopilot rollouts not enabled" auto-merge blocker), its optional `connector=` / `strategy=` args, and examples.

## Review guide

1. `.github/pr-welcome-internal.md`

## User Impact

Maintainers see the command documented in the PR welcome comment. No behavioral change.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

---
[Devin session](https://app.devin.ai/sessions/e262f7b87e604a2f877d2d64c7bc1504)

Requested by: @aaronsteers