### PR TITLE
chore(source-pokeapi): dummy version bump for progressive rollout (autopilot) testing

### DIFF
--- a/airbyte-integrations/connectors/source-pokeapi/metadata.yaml
+++ b/airbyte-integrations/connectors/source-pokeapi/metadata.yaml
@@ -1,4 +1,5 @@
 data:
+  # Dummy edit to trigger connector detection for progressive-rollout (autopilot) release testing. Superseded by the version-bump workflow commit.
   allowedHosts:
     hosts:
       - "*"

--- a/airbyte-integrations/connectors/source-pokeapi/metadata.yaml
+++ b/airbyte-integrations/connectors/source-pokeapi/metadata.yaml
@@ -1,5 +1,4 @@
 data:
-  # Dummy edit to trigger connector detection for progressive-rollout (autopilot) release testing. Superseded by the version-bump workflow commit.
   allowedHosts:
     hosts:
       - "*"

--- a/airbyte-integrations/connectors/source-pokeapi/metadata.yaml
+++ b/airbyte-integrations/connectors/source-pokeapi/metadata.yaml
@@ -28,7 +28,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 6371b14b-bc68-4236-bfbd-468e8df8e968
-  dockerImageTag: 0.3.60
+  dockerImageTag: 0.3.61
   dockerRepository: airbyte/source-pokeapi
   githubIssueLabel: source-pokeapi
   icon: pokeapi.svg

--- a/docs/integrations/sources/pokeapi.md
+++ b/docs/integrations/sources/pokeapi.md
@@ -51,6 +51,7 @@ If you use Airbyte Cloud and your organization restricts access to specific IPs,
 
 | Version | Date       | Pull Request                                             | Subject                                         |
 | :------ | :--------- | :------------------------------------------------------- | :---------------------------------------------- |
+| 0.3.61 | 2026-07-10 | [81655](https://github.com/airbytehq/airbyte/pull/81655) | chore(source-pokeapi): dummy version bump for progressive rollout (autopilot) testing |
 | 0.3.60 | 2026-06-30 | [81200](https://github.com/airbytehq/airbyte/pull/81200) | Update dependencies |
 | 0.3.59 | 2026-06-25 | [80885](https://github.com/airbytehq/airbyte/pull/80885) | POC: Test autopilot rollout pipeline |
 | 0.3.58 | 2026-06-23 | [80588](https://github.com/airbytehq/airbyte/pull/80588) | Update dependencies |


### PR DESCRIPTION
## What

Version-bump PR for `source-pokeapi` to exercise the autopilot progressive-rollout release flow, requested by AJ Steers. Mirrors the source-faker test PR (airbytehq/airbyte#81653).

`source-pokeapi` already has the correct rollout settings (`enableProgressiveRollout: true`, `defaultRolloutMode: autopilot`, `autopilotConfig.strategy: fast`), so no rollout config change is needed here — this PR just carries a version bump for release testing.

## How

- A dummy comment in `source-pokeapi/metadata.yaml` establishes the branch so the connector is detected as modified.
- The version bump itself is applied by the **version-bump workflow** (default `patch`), which uses this PR title as the changelog line.

## Review guide

1. `airbyte-integrations/connectors/source-pokeapi/metadata.yaml`

## User Impact

None beyond a routine patch bump; used for release-flow testing.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

---
[Devin session](https://app.devin.ai/sessions/e262f7b87e604a2f877d2d64c7bc1504)

Requested by: @aaronsteers