### PR TITLE
chore(source-datagen): dummy version bump for progressive rollout (autopilot) testing

### DIFF
--- a/airbyte-integrations/connectors/source-datagen/metadata.yaml
+++ b/airbyte-integrations/connectors/source-datagen/metadata.yaml
@@ -28,6 +28,11 @@ data:
   releases:
     rolloutConfiguration:
       enableProgressiveRollout: true
+      defaultRolloutMode: autopilot
+      autopilotConfig:
+        autoStart: true
+        autoPromoteStages: true
+        strategy: fast
   releaseStage: alpha
   supportLevel: community
   tags:

--- a/airbyte-integrations/connectors/source-datagen/metadata.yaml
+++ b/airbyte-integrations/connectors/source-datagen/metadata.yaml
@@ -6,7 +6,7 @@ data:
   connectorSubtype: database
   connectorType: source
   definitionId: f14d5125-dc0d-4f6c-abe5-acde821a2203
-  dockerImageTag: 0.2.1
+  dockerImageTag: 0.2.2
   dockerRepository: airbyte/source-datagen
   documentationUrl: https://docs.airbyte.com/integrations/sources/datagen
   githubIssueLabel: source-datagen

--- a/airbyte-integrations/connectors/source-datagen/metadata.yaml
+++ b/airbyte-integrations/connectors/source-datagen/metadata.yaml
@@ -1,5 +1,4 @@
 data:
-  # Dummy edit to trigger connector detection for progressive-rollout (autopilot) release testing. Rollout config + version bump are applied by the workflows.
   ab_internal:
     ql: 100
     sl: 100

--- a/airbyte-integrations/connectors/source-datagen/metadata.yaml
+++ b/airbyte-integrations/connectors/source-datagen/metadata.yaml
@@ -1,4 +1,5 @@
 data:
+  # Dummy edit to trigger connector detection for progressive-rollout (autopilot) release testing. Rollout config + version bump are applied by the workflows.
   ab_internal:
     ql: 100
     sl: 100

--- a/docs/integrations/sources/datagen.md
+++ b/docs/integrations/sources/datagen.md
@@ -64,13 +64,14 @@ If you use Airbyte Cloud and your organization restricts access to specific IPs,
 
 | Version | Date       | Pull Request                                             | Subject                            |
 |:--------|:-----------|:---------------------------------------------------------|:-----------------------------------|
-| 0.2.1   | 2026-06-09 | [79330](https://github.com/airbytehq/airbyte/pull/79330) | Progressive rollout e2e test     |
-| 0.2.0   | 2026-04-28 | [75542](https://github.com/airbytehq/airbyte/pull/75542) | Add wide schema flavor with configurable column count; fix null safety in partition reader; cache codec references; bump CDK to 1.1.6 |
-| 0.1.6   | 2025-10-23 | [68611](https://github.com/airbytehq/airbyte/pull/68611) | Update cdk version                 |
-| 0.1.5   | 2025-10-21 | [68581](https://github.com/airbytehq/airbyte/pull/68581) | Update dataChannel version         |
-| 0.1.4   | 2025-10-16 | [68131](https://github.com/airbytehq/airbyte/pull/68131) | Increment naming fix               |
-| 0.1.3   | 2025-10-16 | [68129](https://github.com/airbytehq/airbyte/pull/68129) | Increment encoding fix             |
-| 0.1.2   | 2025-10-14 | [67720](https://github.com/airbytehq/airbyte/pull/67720) | Removal of Array type              |
-| 0.1.1   | 2025-10-13 | [67110](https://github.com/airbytehq/airbyte/pull/67110) | Addition of proto types            |
-| 0.1.0   | 2025-09-29 | [66331](https://github.com/airbytehq/airbyte/pull/66331) | Creation of initial DataGen Source |
+| 0.2.2 | 2026-07-10 | [81656](https://github.com/airbytehq/airbyte/pull/81656) | chore(source-datagen): dummy version bump for progressive rollout (autopilot) testing |
+| 0.2.1 | 2026-06-09 | [79330](https://github.com/airbytehq/airbyte/pull/79330) | Progressive rollout e2e test |
+| 0.2.0 | 2026-04-28 | [75542](https://github.com/airbytehq/airbyte/pull/75542) | Add wide schema flavor with configurable column count; fix null safety in partition reader; cache codec references; bump CDK to 1.1.6 |
+| 0.1.6 | 2025-10-23 | [68611](https://github.com/airbytehq/airbyte/pull/68611) | Update cdk version |
+| 0.1.5 | 2025-10-21 | [68581](https://github.com/airbytehq/airbyte/pull/68581) | Update dataChannel version |
+| 0.1.4 | 2025-10-16 | [68131](https://github.com/airbytehq/airbyte/pull/68131) | Increment naming fix |
+| 0.1.3 | 2025-10-16 | [68129](https://github.com/airbytehq/airbyte/pull/68129) | Increment encoding fix |
+| 0.1.2 | 2025-10-14 | [67720](https://github.com/airbytehq/airbyte/pull/67720) | Removal of Array type |
+| 0.1.1 | 2025-10-13 | [67110](https://github.com/airbytehq/airbyte/pull/67110) | Addition of proto types |
+| 0.1.0 | 2025-09-29 | [66331](https://github.com/airbytehq/airbyte/pull/66331) | Creation of initial DataGen Source |
 </details>


### PR DESCRIPTION
## What

Version-bump PR for `source-datagen` to exercise the autopilot progressive-rollout release flow, requested by AJ Steers. Mirrors the source-faker (airbytehq/airbyte#81653) and source-pokeapi (airbytehq/airbyte#81655) test PRs.

Unlike pokeapi, `source-datagen` is not yet fully configured for autopilot — its `rolloutConfiguration` only has `enableProgressiveRollout: true` with no `defaultRolloutMode`/`autopilotConfig`. So this PR uses the `/enable-autopilot-rollouts` workflow (strategy `fast`) to write that config, plus the version-bump workflow for the release-test bump.

## How

- A dummy comment in `source-datagen/metadata.yaml` establishes the branch so the connector is detected as modified.
- The **enable-autopilot-rollouts workflow** (strategy `fast`) sets `defaultRolloutMode: autopilot` + `autopilotConfig` and keeps `enableProgressiveRollout: true`.
- The **version-bump workflow** (default `patch`) applies the version bump, using this PR title as the changelog line.

## Review guide

1. `airbyte-integrations/connectors/source-datagen/metadata.yaml`

## User Impact

None beyond a routine patch bump + enabling autopilot rollouts; used for release-flow testing.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

---
[Devin session](https://app.devin.ai/sessions/e262f7b87e604a2f877d2d64c7bc1504)

Requested by: @aaronsteers