### PR TITLE
docs: update S3 secrets to use AWS standard environment variable naming

### DIFF
--- a/docs/platform/deploying-airbyte/integrations/storage.md
+++ b/docs/platform/deploying-airbyte/integrations/storage.md
@@ -25,8 +25,8 @@ metadata:
 type: Opaque
 stringData:
   # AWS S3 Secrets
-  s3-access-key-id: ## e.g. AKIAIOSFODNN7EXAMPLE
-  s3-secret-access-key: ## e.g. wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+  AWS_ACCESS_KEY_ID: ## e.g. AKIAIOSFODNN7EXAMPLE
+  AWS_SECRET_ACCESS_KEY: ## e.g. wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
 
 ```
 
@@ -81,7 +81,7 @@ stringData:
 <Tabs >
 <TabItem value="S3" label="S3" default>
 
-Ensure you've already created a Kubernetes secret containing both your S3 access key ID, and secret access key. By default, secrets are expected in the `airbyte-config-secrets` Kubernetes secret, under the `s3-access-key-id` and `s3-secret-access-key` keys. Steps to configure these are in the above [prerequisites](#secrets).
+Ensure you've already created a Kubernetes secret containing both your S3 access key ID, and secret access key. By default, secrets are expected in the `airbyte-config-secrets` Kubernetes secret, under the `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` keys. Steps to configure these are in the above [prerequisites](#secrets).
 
 ```yaml title="values.yaml"
 global:


### PR DESCRIPTION
## What
* Updated S3 secrets configuration in the storage documentation to use AWS standard environment variable names (`AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`) instead of kebab-case variants.

## Why
The original kebab-case naming (`s3-access-key-id`, `s3-secret-access-key`) causes deployment failures because:
- Kubernetes secret keys with hyphens cannot be properly mapped to environment variables in pods
- AWS tools and SDKs expect standard environment variable names (`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`)
- Users following the current documentation encounter failures when attempting to configure S3 logging storage

Using AWS standard naming conventions ensures proper environment variable binding and eliminates configuration errors.

## How
* Updated the S3 Secrets example in `docs/platform/deploying-airbyte/integrations/storage.md` to reflect the correct Kubernetes secret key names that work with Airbyte's S3 integration
* Changed from kebab-case to AWS standard naming to match what users would naturally use when configuring AWS credentials

## User Impact
**Before**: Users following the documentation would experience failures when deploying Airbyte with S3 storage, as the hyphenated secret keys wouldn't be recognized as valid environment variables.

**After**: Users can now successfully deploy Airbyte with S3 storage by following the corrected documentation that uses proper AWS environment variable conventions.

## Testing
* This change was validated during S3 configuration setup where using the corrected secret names resolved deployment issues

## Can this PR be safely reverted and rolled back?
- [x] YES 💚
- [ ] NO ❌

## Review guide
* `docs/platform/deploying-airbyte/integrations/storage.md` - S3 Secrets section