### PR TITLE
fix(destination-clickhouse): avoid failed count for missing temp tables

### DIFF
--- a/airbyte-integrations/connectors/destination-clickhouse/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-clickhouse/metadata.yaml
@@ -2,7 +2,7 @@ data:
   connectorSubtype: database
   connectorType: destination
   definitionId: ce0d828e-1dc4-496c-b122-2da42e637e48
-  dockerImageTag: 2.1.25
+  dockerImageTag: 2.1.26
   dockerRepository: airbyte/destination-clickhouse
   githubIssueLabel: destination-clickhouse
   icon: clickhouse.svg

--- a/airbyte-integrations/connectors/destination-clickhouse/src/main/kotlin/io/airbyte/integrations/destination/clickhouse/client/ClickhouseAirbyteClient.kt
+++ b/airbyte-integrations/connectors/destination-clickhouse/src/main/kotlin/io/airbyte/integrations/destination/clickhouse/client/ClickhouseAirbyteClient.kt
@@ -191,6 +191,12 @@ class ClickhouseAirbyteClient(
 
     override suspend fun countTable(tableName: TableName): Long? {
         try {
+            // The direct-load status gatherer probes generated temporary tables on every
+            // sync. Those tables are normally absent after a successful cleanup, so avoid
+            // issuing a failing COUNT query just to discover that expected state.
+            if (!tableExists(tableName)) {
+                return null
+            }
             val sql = sqlGenerator.countTable(tableName, "cnt")
             val response = query(sql)
             val reader: ClickHouseBinaryFormatReader = client.newBinaryFormatReader(response)

--- a/airbyte-integrations/connectors/destination-clickhouse/src/test/kotlin/io/airbyte/integrations/destination/clickhouse/client/ClickhouseAirbyteClientTest.kt
+++ b/airbyte-integrations/connectors/destination-clickhouse/src/test/kotlin/io/airbyte/integrations/destination/clickhouse/client/ClickhouseAirbyteClientTest.kt
@@ -72,6 +72,19 @@ class ClickhouseAirbyteClientTest {
         coVerify { client.query(DUMMY_SENTENCE) }
     }
 
+    @Test
+    fun `test count table skips query when table is absent`() = runTest {
+        val tableName = TableName("namespace", "temporary_table")
+        coEvery { clickhouseAirbyteClient.tableExists(tableName) } returns false
+
+        val count = clickhouseAirbyteClient.countTable(tableName)
+
+        Assertions.assertNull(count)
+        coVerify(exactly = 1) { clickhouseAirbyteClient.tableExists(tableName) }
+        verify(exactly = 0) { clickhouseSqlGenerator.countTable(any(), any()) }
+        coVerify(exactly = 0) { client.query(any()) }
+    }
+
     private fun mockCHSchemaWithAirbyteColumns() {
         every { client.getTableSchema(any(), any()) } returns
             mockk {

--- a/docs/integrations/destinations/clickhouse.md
+++ b/docs/integrations/destinations/clickhouse.md
@@ -179,6 +179,7 @@ This destination supports [namespaces](https://docs.airbyte.com/platform/using-a
 
 | Version    | Date       | Pull Request                                               | Subject                                                                        |
 |:-----------|:-----------|:-----------------------------------------------------------|:-------------------------------------------------------------------------------|
+| 2.1.26     | 2026-07-20 | [81670](https://github.com/airbytehq/airbyte/pull/81670)   | fix(destination-clickhouse): avoid failed count for missing temp tables        |
 | 2.1.25     | 2026-07-14 | [81550](https://github.com/airbytehq/airbyte/pull/81550)   | Use CREATE TABLE IF NOT EXISTS for non-replace table creation to prevent accidental data loss |
 | 2.1.24     | 2026-05-20 | [77673](https://github.com/airbytehq/airbyte/pull/77673)   | Upgrade CDK to 1.0.13. Migrate component tests to Testcontainers. |
 | 2.1.23     | 2026-02-04 | [72857](https://github.com/airbytehq/airbyte/pull/72857)   | No user-facing changes (Upgrade CDK to 0.2.8)                    |


### PR DESCRIPTION
## Summary
- Check table existence before counting it in the ClickHouse destination. 
- WHy: customers don't like to see failing queries in their mertrics
- Preserve the existing missing-table return value (`null`).
- Avoid emitting a ClickHouse `UNKNOWN_TABLE` error for the normal direct-load temporary-table cleanup path.

## Validation
- `./gradlew :airbyte-integrations:connectors:destination-clickhouse:test --tests io.airbyte.integrations.destination.clickhouse.client.ClickhouseAirbyteClientTest`

> [!IMPORTANT]
> ⚡ **Auto-merge enabled.**
> 
> _This PR is set to merge automatically when all requirements are met._

> [!NOTE]
> **Auto-merge may have been disabled. Please check the PR status to confirm.**