### PR TITLE
docs(ai-agents): add dedicated semantic search page for agent connectors

### DIFF
--- a/docs/ai-agents/concepts/context-store.md
+++ b/docs/ai-agents/concepts/context-store.md
@@ -94,11 +94,11 @@ Semantic search is an evolving capability and is available for a limited set of 
 | Linear | Issues | Description |
 | Linear | Comments | Body |
 
-More connectors and fields will gain semantic search over time.
+Airbyte continues to add semantic search to more connectors and fields.
 
 ### Calling semantic search with the SDK or API
 
-If you build agents with the SDK or API, you can request semantic search directly by passing a `semantic` object to `context_store_search`:
+If you build agents with the SDK or API, you can request semantic search directly by passing a `semantic` object to `context_store_search`. In the SDK, use the generic `connector.execute(entity, "context_store_search", params)` method — the typed per-entity `context_store_search` helper accepts only a structured `query`, not a `semantic` object.
 
 ```json
 {
@@ -123,7 +123,7 @@ Keep these rules in mind when constructing a request:
 - **`semantic` and `query` are mutually exclusive.** Pass one or the other, never both in the same request.
 - **Results are ranked by similarity, so `sort` isn't supported.** To filter results, put the filter inside `semantic.filter` using the same operators as `query.filter`.
 - **`dedup` controls per-record deduplication.** `max` (the default) returns only the single best-scoring passage per source record. `none` returns multiple passages from the same record, still ranked by similarity and capped by `limit`.
-- **`context_size` controls how many characters of surrounding context are returned per hit,** up to the field's configured window.
+- **`context_size` controls how many characters of surrounding context are returned per hit,** up to the field's configured window. Omit it to return the full configured window.
 
 For the entities and fields available on each connector, see the individual [connector reference pages](../connectors).
 

--- a/docs/ai-agents/concepts/context-store.md
+++ b/docs/ai-agents/concepts/context-store.md
@@ -82,17 +82,27 @@ If you build agents with the SDK or API, you can call `context_store_search` dir
 
 Structured search matches records by exact or fuzzy field values. Some connectors also support **semantic search**: a similarity search that finds relevant passages by meaning rather than by keyword. Instead of matching a filter, Airbyte embeds your natural-language query and returns the most similar chunks of text, ranked by relevance.
 
-Semantic search is useful for long, unstructured text fields, such as call transcripts or issue descriptions, where the exact wording of a match isn't known in advance. For example, an agent can answer "find call passages where a customer raised pricing concerns" by searching the meaning of the transcript text, not a specific phrase.
+Semantic search is useful for long, unstructured text, such as call transcripts, issue descriptions, or the contents of a document, where the exact wording of a match isn't known in advance. For example, an agent can answer "find call passages where a customer raised pricing concerns" by searching the meaning of the transcript text, not a specific phrase.
 
 Semantic search is an evolving capability and is available for a limited set of connectors and fields today. Agents choose it automatically when a prompt calls for meaning-based retrieval over a supported field. As with structured search, you don't need to specify the search mode in your prompts.
 
+### Record text vs. file content
+
+Semantic search comes in two flavors, depending on the connector:
+
+- **Record text.** Data connectors (such as Gong and Linear) embed a text field of a structured record — a transcript, an issue description, a comment body. Each hit is a passage of that field, attributed to the record it came from.
+- **File content.** File connectors (such as Google Drive) embed the extracted text of the files they sync. Each hit is a passage of a document's content, attributed to its source file (name, path, and other file metadata).
+
+Both flavors use the same request shape — a `semantic` object passed to `context_store_search` — so agents call them the same way. The difference is what a passage represents: a field of a record, or a span of a file's contents.
+
 ### Connectors and fields that support semantic search
 
-| Connector | Entity | Field |
-| --------- | ------ | ----- |
-| Gong | Call transcripts | Transcript text |
-| Linear | Issues | Description |
-| Linear | Comments | Body |
+| Connector | Entity | Field | Searches |
+| --------- | ------ | ----- | -------- |
+| Gong | Call transcripts | Transcript text | Record text |
+| Linear | Issues | Description | Record text |
+| Linear | Comments | Body | Record text |
+| Google Drive | Files | Content | File content |
 
 Airbyte continues to add semantic search to more connectors and fields.
 

--- a/docs/ai-agents/concepts/context-store.md
+++ b/docs/ai-agents/concepts/context-store.md
@@ -78,13 +78,13 @@ The Context Store supports structured search with filter operators, field select
 
 If you build agents with the SDK or API, you can call `context_store_search` directly and pass structured filters. For details on the query model, see the individual [connector reference pages](../connectors), which document the available entities, filter fields, and search parameters for each connector.
 
-## Semantic search
+### Semantic search
 
 Structured search matches records by exact or fuzzy field values. Some connectors also support **semantic search**: a similarity search that finds relevant passages by meaning rather than by keyword. Instead of matching a filter, Airbyte embeds your natural-language prompt and returns the most similar passages of text, ranked by relevance. It suits long, unstructured text such as call transcripts, issue descriptions, or the contents of a document, where you don't know the exact wording of a match in advance.
 
 Agents choose semantic search automatically when a prompt calls for meaning-based retrieval over a supported field, so you don't need to specify the search mode in your prompts. If you build agents with the CLI, API, or SDK, you can also request it directly.
 
-For how semantic search works, which connectors and fields support it, and complete CLI, API, and SDK examples, see [Semantic search](./semantic-search).
+To learn how semantic search works, which connectors and fields support it, and to see complete CLI, API, and SDK examples, see [Semantic search](./semantic-search).
 
 ## Initial index
 

--- a/docs/ai-agents/concepts/context-store.md
+++ b/docs/ai-agents/concepts/context-store.md
@@ -80,62 +80,11 @@ If you build agents with the SDK or API, you can call `context_store_search` dir
 
 ## Semantic search
 
-Structured search matches records by exact or fuzzy field values. Some connectors also support **semantic search**: a similarity search that finds relevant passages by meaning rather than by keyword. Instead of matching a filter, Airbyte embeds your natural-language query and returns the most similar chunks of text, ranked by relevance.
+Structured search matches records by exact or fuzzy field values. Some connectors also support **semantic search**: a similarity search that finds relevant passages by meaning rather than by keyword. Instead of matching a filter, Airbyte embeds your natural-language prompt and returns the most similar passages of text, ranked by relevance. It suits long, unstructured text such as call transcripts, issue descriptions, or the contents of a document, where you don't know the exact wording of a match in advance.
 
-Semantic search is useful for long, unstructured text, such as call transcripts, issue descriptions, or the contents of a document, where the exact wording of a match isn't known in advance. For example, an agent can answer "find call passages where a customer raised pricing concerns" by searching the meaning of the transcript text, not a specific phrase.
+Agents choose semantic search automatically when a prompt calls for meaning-based retrieval over a supported field, so you don't need to specify the search mode in your prompts. If you build agents with the CLI, API, or SDK, you can also request it directly.
 
-Semantic search is an evolving capability and is available for a limited set of connectors and fields today. Agents choose it automatically when a prompt calls for meaning-based retrieval over a supported field. As with structured search, you don't need to specify the search mode in your prompts.
-
-### Record text vs. file content
-
-Semantic search comes in two flavors, depending on the connector:
-
-- **Record text.** Data connectors (such as Gong and Linear) embed a text field of a structured record — a transcript, an issue description, a comment body. Each hit is a passage of that field, attributed to the record it came from.
-- **File content.** File connectors (such as Google Drive) embed the extracted text of the files they sync. Each hit is a passage of a document's content, attributed to its source file (name, path, and other file metadata).
-
-Both flavors use the same request shape — a `semantic` object passed to `context_store_search` — so agents call them the same way. The difference is what a passage represents: a field of a record, or a span of a file's contents.
-
-### Connectors and fields that support semantic search
-
-| Connector | Entity | Field | Searches |
-| --------- | ------ | ----- | -------- |
-| Gong | Call transcripts | Transcript text | Record text |
-| Linear | Issues | Description | Record text |
-| Linear | Comments | Body | Record text |
-| Google Drive | Files | Content | File content |
-
-Airbyte continues to add semantic search to more connectors and fields.
-
-### Calling semantic search with the SDK or API
-
-If you build agents with the SDK or API, you can request semantic search directly by passing a `semantic` object to `context_store_search`. In the SDK, use the generic `connector.execute(entity, "context_store_search", params)` method — the typed per-entity `context_store_search` helper accepts only a structured `query`, not a `semantic` object.
-
-```json
-{
-  "entity": "call_transcripts",
-  "action": "context_store_search",
-  "params": {
-    "semantic": {
-      "field": "transcript",
-      "prompt": "customer raised pricing concerns",
-      "context_size": 2048,
-      "dedup": "max"
-    },
-    "limit": 20
-  }
-}
-```
-
-Each hit is returned as an `{entity, metadata}` object, where `metadata` includes the similarity `score`, the matched `context` text, and connector-specific attribution fields.
-
-Keep these rules in mind when constructing a request:
-
-- **`semantic` and `query` are mutually exclusive.** Pass one or the other, never both in the same request.
-- **Results are ranked by similarity, so `sort` isn't supported.** To filter results, put the filter inside `semantic.filter` using the same operators as `query.filter`.
-- **`dedup` controls per-record deduplication.** `max` (the default) returns only the single best-scoring passage per source record. `none` returns multiple passages from the same record, still ranked by similarity and capped by `limit`.
-- **`context_size` controls how many characters of surrounding context are returned per hit,** up to the field's configured window. Omit it to return the full configured window.
-
-For the entities and fields available on each connector, see the individual [connector reference pages](../connectors).
+For how semantic search works, which connectors and fields support it, and complete CLI, API, and SDK examples, see [Semantic search](./semantic-search).
 
 ## Initial index
 

--- a/docs/ai-agents/concepts/context-store.md
+++ b/docs/ai-agents/concepts/context-store.md
@@ -78,6 +78,55 @@ The Context Store supports structured search with filter operators, field select
 
 If you build agents with the SDK or API, you can call `context_store_search` directly and pass structured filters. For details on the query model, see the individual [connector reference pages](../connectors), which document the available entities, filter fields, and search parameters for each connector.
 
+## Semantic search
+
+Structured search matches records by exact or fuzzy field values. Some connectors also support **semantic search**: a similarity search that finds relevant passages by meaning rather than by keyword. Instead of matching a filter, Airbyte embeds your natural-language query and returns the most similar chunks of text, ranked by relevance.
+
+Semantic search is useful for long, unstructured text fields, such as call transcripts or issue descriptions, where the exact wording of a match isn't known in advance. For example, an agent can answer "find call passages where a customer raised pricing concerns" by searching the meaning of the transcript text, not a specific phrase.
+
+Semantic search is an evolving capability and is available for a limited set of connectors and fields today. Agents choose it automatically when a prompt calls for meaning-based retrieval over a supported field. As with structured search, you don't need to specify the search mode in your prompts.
+
+### Connectors and fields that support semantic search
+
+| Connector | Entity | Field |
+| --------- | ------ | ----- |
+| Gong | Call transcripts | Transcript text |
+| Linear | Issues | Description |
+| Linear | Comments | Body |
+
+More connectors and fields will gain semantic search over time.
+
+### Calling semantic search with the SDK or API
+
+If you build agents with the SDK or API, you can request semantic search directly by passing a `semantic` object to `context_store_search`:
+
+```json
+{
+  "entity": "call_transcripts",
+  "action": "context_store_search",
+  "params": {
+    "semantic": {
+      "field": "transcript",
+      "prompt": "customer raised pricing concerns",
+      "context_size": 2048,
+      "dedup": "max"
+    },
+    "limit": 20
+  }
+}
+```
+
+Each hit is returned as an `{entity, metadata}` object, where `metadata` includes the similarity `score`, the matched `context` text, and connector-specific attribution fields.
+
+Keep these rules in mind when constructing a request:
+
+- **`semantic` and `query` are mutually exclusive.** Pass one or the other, never both in the same request.
+- **Results are ranked by similarity, so `sort` isn't supported.** To filter results, put the filter inside `semantic.filter` using the same operators as `query.filter`.
+- **`dedup` controls per-record deduplication.** `max` (the default) returns only the single best-scoring passage per source record. `none` returns multiple passages from the same record, still ranked by similarity and capped by `limit`.
+- **`context_size` controls how many characters of surrounding context are returned per hit,** up to the field's configured window.
+
+For the entities and fields available on each connector, see the individual [connector reference pages](../connectors).
+
 ## Initial index
 
 When the Context Store populates data for a connector, Airbyte runs an initial index. Indexing time depends on the amount of data and third-party API rate limits, and can range from minutes to days.

--- a/docs/ai-agents/concepts/semantic-search.md
+++ b/docs/ai-agents/concepts/semantic-search.md
@@ -35,7 +35,7 @@ Semantic search comes in two flavors, depending on the connector. Both use the s
 
 ## Supported connectors and fields
 
-Semantic search is available on a growing set of connectors and fields, so this page doesn't maintain a fixed list. To check whether a connector supports it, open its [connector reference page](../connectors): an entity supports semantic search when its reference lists a **Semantic Search** action, which documents the exact field, request, and response for that connector.
+Semantic search is available on a growing set of connectors and fields, so this page doesn't maintain a fixed list. To check whether a connector supports it, open its [connector documentation](../connectors): an entity supports semantic search when a **Semantic Search** action appears in its list of actions. This action shows up in the entity table on the connector's overview page and in its full reference, which documents the exact field, request, and response.
 
 The examples on this page use Gong (a data connector) and Google Drive (a file connector).
 

--- a/docs/ai-agents/concepts/semantic-search.md
+++ b/docs/ai-agents/concepts/semantic-search.md
@@ -1,0 +1,324 @@
+---
+plan: all
+sidebar_position: 3
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+# Semantic search
+
+Structured [Context Store](./context-store) search matches records by exact or fuzzy field values. Semantic search is a different mode: a similarity search that finds relevant passages by *meaning* rather than by keyword. Instead of matching a filter, Airbyte embeds your natural-language prompt as a vector, compares it against the stored text, and returns the most similar passages, ranked by relevance.
+
+Semantic search suits long, unstructured text, such as call transcripts, issue descriptions, or the contents of a document, where you don't know the exact wording of a match in advance. For example, an agent can answer "find call passages where a customer raised pricing concerns" by searching the meaning of the transcript text, not a specific phrase.
+
+:::note Alpha
+Semantic search is an alpha capability. The request and response shapes described here can change, and it's available for a limited set of connectors and fields today. See [Supported connectors and fields](#supported-connectors-and-fields).
+:::
+
+## How it works
+
+Airbyte indexes each supported text field ahead of time:
+
+1. **Extract and split.** Airbyte takes the source text (a record field or the extracted contents of a file) and splits it into passages, such as speaker turns, paragraphs, or document chunks.
+2. **Embed.** Each passage is converted into a numeric vector (an embedding) that captures its meaning, and stored in the Context Store.
+3. **Rank at query time.** When you search, Airbyte embeds your `prompt` the same way and returns the passages whose vectors are most similar, each with a relevance `score` and the surrounding `context` text.
+
+Because similarity determines the order, results come back ranked from most to least relevant. You don't sort them yourself.
+
+## Record text vs. file content
+
+Semantic search comes in two flavors, depending on the connector. Both use the same request shape, so agents call them the same way. What differs is what a passage represents.
+
+- **Data connectors (record text).** Connectors such as Gong and Linear embed a text field of a structured record: a transcript, an issue description, a comment body. Each hit is a passage of that field, attributed to the record it came from.
+- **File connectors (file content).** Connectors such as Google Drive embed the extracted text of the files they sync. Each hit is a passage of a document's content, attributed to its source file, such as name, path, and MIME type.
+
+## Supported connectors and fields
+
+| Connector | Type | Entity | Field | A hit is |
+| --------- | ---- | ------ | ----- | -------- |
+| Gong | Data | `call_transcripts` | `transcript` | A passage of a call transcript |
+| Linear | Data | `issues` | `description` | A passage of an issue description |
+| Linear | Data | `comments` | `body` | A passage of a comment |
+| Google Drive | File | `files` | `content` | A passage of a file's contents |
+
+Airbyte continues to add semantic search to more connectors and fields. The [connector reference pages](../connectors) are the source of truth for which entities and fields a connector indexes; look for the **Semantic Search** action on an entity.
+
+## How you invoke it
+
+- **Web app.** In the agent chat, ask in natural language. The agent uses semantic search automatically when it's available for the data you're asking about; you don't choose the mode. Supported entities show a **Semantic search** badge so you can see which data is indexed.
+- **Agent MCP.** Same as the web app. Semantic search isn't a separate MCP tool. Your agent calls the connector's `context_store_search` action with a `semantic` object when your prompt calls for meaning-based retrieval.
+- **CLI, API, and SDK.** You build the request yourself by passing a `semantic` object to the `context_store_search` action. The two sections below show complete examples for each.
+
+## Request shape
+
+Whether the connector is a data connector or a file connector, a semantic search is a `context_store_search` call whose `params` carry a `semantic` object instead of a structured `query`.
+
+| Field | Type | Required | Description |
+| ----- | ---- | -------- | ----------- |
+| `semantic.field` | `string` | Sometimes | The indexed field to search. Optional when the connector indexes a single field (for example, a file `content` field), which Airbyte selects automatically. Set it explicitly to choose among multiple indexed fields. |
+| `semantic.prompt` | `string` | Yes | The natural-language query. Airbyte embeds it and compares it against the field's stored passages. |
+| `semantic.filter` | `object` | No | A filter applied alongside the similarity match, using the same operators and dot notation as `query.filter`. |
+| `semantic.context_size` | `integer` | No | Characters of surrounding context to return per hit, centered on the match and capped at the field's configured window. Omit it to return the full window. |
+| `semantic.dedup` | `string` | No | `max` (the default) returns the single best-scoring passage per source record or file. `none` returns multiple passages from the same source, still ranked by similarity and capped by `limit`. |
+| `fields` | `array` | No | Field paths to include in each hit's `entity`, using dot notation for nested fields. |
+| `limit` | `integer` | No | Maximum number of hits to return. Defaults to 10, with a maximum of 100. |
+
+Keep these rules in mind:
+
+- **`semantic` and `query` are mutually exclusive.** Pass one or the other, never both in the same request.
+- **`sort` isn't supported.** Results are always ranked by similarity. To narrow them, use `semantic.filter`.
+
+## Response shape
+
+A semantic search returns a `data` array of hits and a `meta` object. Each hit separates the source from the match:
+
+- `data[].entity` holds the source record's or source file's own fields.
+- `data[].metadata` holds everything that describes the match: the similarity `score`, the matched `context` text, and any per-passage attribution or [enrichment](../connectors) fields the connector adds. Enrichment outputs are returned only and can't be filtered.
+
+```json title="Search result"
+{
+  "data": [
+    {
+      "entity": { "...": "source record or file fields" },
+      "metadata": {
+        "score": 0.82,
+        "context": "...the matched passage of text..."
+      }
+    }
+  ],
+  "meta": {
+    "has_more": false,
+    "cursor": null,
+    "took_ms": 42
+  }
+}
+```
+
+The CLI and API wrap this object in the standard [execute envelope](../interfaces/api/execute#response-format): the `{data, meta}` result lands in the response's `result` field.
+
+## Search data connectors
+
+Data connectors search a text field of a structured record. The example below searches Gong call transcripts for passages about pricing concerns. Each hit is attributed to its call, and Gong enriches hits with the speaker's name, title, and affiliation under `metadata`.
+
+<Tabs groupId="interface">
+<TabItem value="cli" label="CLI" default>
+
+```bash
+airbyte-agent connectors execute --json '{
+  "workspace": "default",
+  "name": "Gong",
+  "entity": "call_transcripts",
+  "action": "context_store_search",
+  "params": {
+    "semantic": {
+      "field": "transcript",
+      "prompt": "customer raised concerns about pricing"
+    },
+    "limit": 10
+  }
+}'
+```
+
+</TabItem>
+<TabItem value="api" label="API">
+
+```bash title="Request"
+curl -X POST 'https://api.airbyte.ai/api/v1/integrations/connectors/<connector_id>/execute' \
+  --header 'Authorization: Bearer <your_application_token>' \
+  --header 'Content-Type: application/json' \
+  --data '{
+    "entity": "call_transcripts",
+    "action": "context_store_search",
+    "params": {
+      "semantic": {
+        "field": "transcript",
+        "prompt": "customer raised concerns about pricing"
+      },
+      "limit": 10
+    }
+  }'
+```
+
+</TabItem>
+<TabItem value="sdk" label="SDK">
+
+Pass the `semantic` object through the generic `execute` method. The typed `call_transcripts.context_store_search` helper accepts only a structured `query`, not a `semantic` object.
+
+```python title="agent.py"
+import asyncio
+from airbyte_agent_sdk import connect
+
+async def main():
+    gong = connect("gong")
+    try:
+        result = await gong.execute(
+            "call_transcripts",
+            "context_store_search",
+            {
+                "semantic": {
+                    "field": "transcript",
+                    "prompt": "customer raised concerns about pricing",
+                },
+                "limit": 10,
+            },
+        )
+        for hit in result.data:
+            print(hit["metadata"]["score"], hit["metadata"]["context"])
+    finally:
+        await gong.close()
+
+asyncio.run(main())
+```
+
+</TabItem>
+<TabItem value="mcp" label="Agent MCP">
+
+Ask your agent in natural language, for example *"find Gong calls where a customer raised pricing concerns."* The agent calls `context_store_search` with a `semantic` object automatically when it fits your prompt. There's no separate semantic-search tool.
+
+</TabItem>
+<TabItem value="webapp" label="Web app">
+
+In the agent chat, ask in natural language. The agent uses semantic search automatically when it's available for the data you're asking about.
+
+</TabItem>
+</Tabs>
+
+A hit looks like this. The call's own fields are under `entity`; the score, matched context, and speaker enrichment are under `metadata`.
+
+```json title="Search result"
+{
+  "data": [
+    {
+      "entity": {
+        "callId": "7830000000000000000",
+        "started": "2024-05-14T17:00:00Z"
+      },
+      "metadata": {
+        "score": 0.79,
+        "context": "...honestly the current pricing is a stretch for a team our size...",
+        "speakerName": "Jordan Lee",
+        "speakerTitle": "VP Finance",
+        "speakerAffiliation": "external"
+      }
+    }
+  ],
+  "meta": { "has_more": false, "cursor": null, "took_ms": 51 }
+}
+```
+
+## Search file connectors
+
+File connectors search the extracted text content of the files they sync. The example below searches a Google Drive connector for passages about renewal terms. Each hit is a passage of a document's content, attributed to its source file. Because Google Drive indexes a single field (`content`), you can omit `semantic.field` and pass only a `prompt`; it's shown below for clarity.
+
+<Tabs groupId="interface">
+<TabItem value="cli" label="CLI" default>
+
+```bash
+airbyte-agent connectors execute --json '{
+  "workspace": "default",
+  "name": "Google Drive",
+  "entity": "files",
+  "action": "context_store_search",
+  "params": {
+    "semantic": {
+      "field": "content",
+      "prompt": "auto-renewal terms in our vendor agreements"
+    },
+    "limit": 10
+  }
+}'
+```
+
+</TabItem>
+<TabItem value="api" label="API">
+
+```bash title="Request"
+curl -X POST 'https://api.airbyte.ai/api/v1/integrations/connectors/<connector_id>/execute' \
+  --header 'Authorization: Bearer <your_application_token>' \
+  --header 'Content-Type: application/json' \
+  --data '{
+    "entity": "files",
+    "action": "context_store_search",
+    "params": {
+      "semantic": {
+        "field": "content",
+        "prompt": "auto-renewal terms in our vendor agreements"
+      },
+      "limit": 10
+    }
+  }'
+```
+
+</TabItem>
+<TabItem value="sdk" label="SDK">
+
+Pass the `semantic` object through the generic `execute` method. The typed `files.context_store_search` helper accepts only a structured `query`, not a `semantic` object.
+
+```python title="agent.py"
+import asyncio
+from airbyte_agent_sdk import connect
+
+async def main():
+    google_drive = connect("google-drive")
+    try:
+        result = await google_drive.execute(
+            "files",
+            "context_store_search",
+            {
+                "semantic": {
+                    "field": "content",
+                    "prompt": "auto-renewal terms in our vendor agreements",
+                },
+                "limit": 10,
+            },
+        )
+        for hit in result.data:
+            print(hit["entity"]["file_name"], hit["metadata"]["score"])
+    finally:
+        await google_drive.close()
+
+asyncio.run(main())
+```
+
+</TabItem>
+<TabItem value="mcp" label="Agent MCP">
+
+Ask your agent in natural language, for example *"search Google Drive for the auto-renewal terms in the vendor agreements."* The agent calls `context_store_search` with a `semantic` object automatically when it fits your prompt. There's no separate semantic-search tool.
+
+</TabItem>
+<TabItem value="webapp" label="Web app">
+
+In the agent chat, ask in natural language. The agent uses semantic search automatically when it's available for the data you're asking about.
+
+</TabItem>
+</Tabs>
+
+A hit looks like this. The source file's attribution fields are under `entity`; the score and matched passage are under `metadata`.
+
+```json title="Search result"
+{
+  "data": [
+    {
+      "entity": {
+        "id": "1AbC...",
+        "file_name": "2024-vendor-agreement.pdf",
+        "file_path": "/Contracts/2024-vendor-agreement.pdf",
+        "mime_type": "application/pdf",
+        "updated_at": "2024-06-02T09:12:00Z"
+      },
+      "metadata": {
+        "score": 0.84,
+        "context": "...this agreement auto-renews for successive one-year terms unless either party..."
+      }
+    }
+  ],
+  "meta": { "has_more": false, "cursor": null, "took_ms": 63 }
+}
+```
+
+## Related
+
+- **[Context Store](./context-store).** How Airbyte indexes and serves your data.
+- **[Agent connectors](../connectors).** Per-connector reference for the entities and fields that support semantic search.
+- **[Execute operations](../interfaces/api/execute).** The execute request and response envelope shared by every action.

--- a/docs/ai-agents/concepts/semantic-search.md
+++ b/docs/ai-agents/concepts/semantic-search.md
@@ -35,18 +35,13 @@ Semantic search comes in two flavors, depending on the connector. Both use the s
 
 ## Supported connectors and fields
 
-| Connector | Type | Entity | Field | A hit is |
-| --------- | ---- | ------ | ----- | -------- |
-| Gong | Data | `call_transcripts` | `transcript` | A passage of a call transcript |
-| Linear | Data | `issues` | `description` | A passage of an issue description |
-| Linear | Data | `comments` | `body` | A passage of a comment |
-| Google Drive | File | `files` | `content` | A passage of a file's contents |
+Semantic search is available on a growing set of connectors and fields, so this page doesn't maintain a fixed list. To check whether a connector supports it, open its [connector reference page](../connectors): an entity supports semantic search when its reference lists a **Semantic Search** action, which documents the exact field, request, and response for that connector.
 
-Airbyte continues to add semantic search to more connectors and fields. The [connector reference pages](../connectors) are the source of truth for which entities and fields a connector indexes; look for the **Semantic Search** action on an entity.
+The examples on this page use Gong (a data connector) and Google Drive (a file connector).
 
 ## How you invoke it
 
-- **Web app.** In the agent chat, ask in natural language. The agent uses semantic search automatically when it's available for the data you're asking about; you don't choose the mode. Supported entities show a **Semantic search** badge so you can see which data is indexed.
+- **Web app.** In the agent chat, ask in natural language. The agent uses semantic search automatically when it's available for the data you're asking about.
 - **Agent MCP.** Same as the web app. Semantic search isn't a separate MCP tool. Your agent calls the connector's `context_store_search` action with a `semantic` object when your prompt calls for meaning-based retrieval.
 - **CLI, API, and SDK.** You build the request yourself by passing a `semantic` object to the `context_store_search` action. The two sections below show complete examples for each.
 
@@ -56,7 +51,7 @@ Whether the connector is a data connector or a file connector, a semantic search
 
 | Field | Type | Required | Description |
 | ----- | ---- | -------- | ----------- |
-| `semantic.field` | `string` | Sometimes | The indexed field to search. Optional when the connector indexes a single field (for example, a file `content` field), which Airbyte selects automatically. Set it explicitly to choose among multiple indexed fields. |
+| `semantic.field` | `string` | Yes | The indexed field to search, as listed on the connector's reference page. |
 | `semantic.prompt` | `string` | Yes | The natural-language query. Airbyte embeds it and compares it against the field's stored passages. |
 | `semantic.filter` | `object` | No | A filter applied alongside the similarity match, using the same operators and dot notation as `query.filter`. |
 | `semantic.context_size` | `integer` | No | Characters of surrounding context to return per hit, centered on the match and capped at the field's configured window. Omit it to return the full window. |
@@ -104,7 +99,7 @@ Data connectors search a text field of a structured record. The example below se
 <Tabs groupId="interface">
 <TabItem value="cli" label="CLI" default>
 
-```bash
+```bash title="Request"
 airbyte-agent connectors execute --json '{
   "workspace": "default",
   "name": "Gong",
@@ -196,7 +191,7 @@ A hit looks like this. The call's own fields are under `entity`; the score, matc
       },
       "metadata": {
         "score": 0.79,
-        "context": "...honestly the current pricing is a stretch for a team our size...",
+        "context": "...honestly that number is more than we budgeted for a team our size...",
         "speakerName": "Jordan Lee",
         "speakerTitle": "VP Finance",
         "speakerAffiliation": "external"
@@ -209,12 +204,12 @@ A hit looks like this. The call's own fields are under `entity`; the score, matc
 
 ## Search file connectors
 
-File connectors search the extracted text content of the files they sync. The example below searches a Google Drive connector for passages about renewal terms. Each hit is a passage of a document's content, attributed to its source file. Because Google Drive indexes a single field (`content`), you can omit `semantic.field` and pass only a `prompt`; it's shown below for clarity.
+File connectors search the extracted text content of the files they sync. The example below searches a Google Drive connector for passages about renewal terms. Each hit is a passage of a document's content, attributed to its source file.
 
 <Tabs groupId="interface">
 <TabItem value="cli" label="CLI" default>
 
-```bash
+```bash title="Request"
 airbyte-agent connectors execute --json '{
   "workspace": "default",
   "name": "Google Drive",
@@ -309,7 +304,7 @@ A hit looks like this. The source file's attribution fields are under `entity`; 
       },
       "metadata": {
         "score": 0.84,
-        "context": "...this agreement auto-renews for successive one-year terms unless either party..."
+        "context": "...this agreement continues for successive one-year periods unless either party gives written notice 30 days beforehand..."
       }
     }
   ],

--- a/docs/ai-agents/concepts/semantic-search.md
+++ b/docs/ai-agents/concepts/semantic-search.md
@@ -158,7 +158,7 @@ async def main():
                 "limit": 10,
             },
         )
-        for hit in result.data:
+        for hit in result.data["data"]:
             print(hit["metadata"]["score"], hit["metadata"]["context"])
     finally:
         await gong.close()
@@ -268,7 +268,7 @@ async def main():
                 "limit": 10,
             },
         )
-        for hit in result.data:
+        for hit in result.data["data"]:
             print(hit["entity"]["file_name"], hit["metadata"]["score"])
     finally:
         await google_drive.close()


### PR DESCRIPTION
## What

We lack public documentation about semantic search in agent connectors. This adds a dedicated **Semantic search** concept page (`docs/ai-agents/concepts/semantic-search.md`) and slims the Context Store page down to a short intro that links out to it.

Requested by Ian Alton.

The new page covers:
- **What semantic search is and how it works** — embedding the prompt, ranking passages by similarity, and returning `score` + `context` per hit.
- **Record text vs. file content** — the interface is shared, but a "passage" differs by connector kind:
  - **Data connectors** (Gong `call_transcripts.transcript`, Linear `issues.description` / `comments.body`) search a text field of a structured record; each hit is attributed to its record.
  - **File connectors** (Google Drive `files.content`) search the extracted text of synced files; each hit is attributed to its source file (name, path, MIME type).
- **Supported connectors and fields** — Gong, Linear, and Google Drive, pointing at the autogenerated connector reference pages as the source of truth.
- **Two practical sections, one per connector kind**, each with **CLI / API / SDK / Agent MCP / Web app** tabs:
  - CLI, API, and SDK show complete, copy-pasteable requests (generic `execute` with a `semantic` object, since the typed `context_store_search` helper only accepts a structured `query`).
  - Agent MCP and Web app are one-liners: the agent invokes semantic search automatically when it's available — there's no separate MCP tool and no manual search form.
- **Shared request/response contract** — the `semantic.{field, prompt, filter, context_size, dedup}` params, `fields`/`limit`, `semantic`/`query` exclusivity, no `sort`, and the `{data:[{entity, metadata}], meta}` result shape (with the note that CLI/API wrap it in the standard execute envelope's `result`).

Framed as an alpha capability available for a limited set of connectors today.

## How

- Added `docs/ai-agents/concepts/semantic-search.md` (autogenerated sidebar picks it up via `sidebar_position: 3`).
- Replaced the large inline semantic-search section in `docs/ai-agents/concepts/context-store.md` with a two-paragraph summary and a link to the new page.
- Request/response shapes were verified against the backend (`SemanticQuery`, `SemanticSearchResponse`, `SemanticHit`, and the `ConnectorExecuteResponse` envelope) rather than inferred.

## Review guide

1. `docs/ai-agents/concepts/semantic-search.md` (new page)
2. `docs/ai-agents/concepts/context-store.md` (slimmed section + link)

Local checks: MarkdownLint clean; Vale (Google/write-good/airbyte styles) reports 0 errors / 0 warnings on both files (style suggestions only, below CI's warning gate).

## User Impact

Users building or operating agents get a single, practical reference for semantic search: what it is, which connectors/fields support it, how it differs between structured records and files, and exactly how to call it from the CLI, API, and SDK. Docs-only change; no runtime impact.

A companion sonar PR (airbytehq/sonar#5812) updates the connector-reference-page generator to surface semantically-searchable fields — including the FILES/document flavor — on autogenerated connector pages.

## Can this PR be safely reverted and rolled back?
- [x] YES 💚

Link to Devin session: https://app.devin.ai/sessions/3816b113b0574003a1ec3ed7d290a16b
Requested by: @ian-at-airbyte