### PR TITLE
fix(destination-bigquery): use CREATE TABLE IF NOT EXISTS for non-replace table creation

### DIFF
--- a/airbyte-integrations/connectors/destination-bigquery/gradle.properties
+++ b/airbyte-integrations/connectors/destination-bigquery/gradle.properties
@@ -1,3 +1,3 @@
 testExecutionConcurrency=-1
 JunitMethodExecutionTimeout=10m
-cdkVersion=1.0.13
+cdkVersion=1.0.16

--- a/airbyte-integrations/connectors/destination-bigquery/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-bigquery/metadata.yaml
@@ -6,7 +6,7 @@ data:
   connectorSubtype: database
   connectorType: destination
   definitionId: 22f6c74f-5699-40ff-833c-4a879ea40133
-  dockerImageTag: 3.0.22
+  dockerImageTag: 3.0.23
   dockerRepository: airbyte/destination-bigquery
   documentationUrl: https://docs.airbyte.com/integrations/destinations/bigquery
   githubIssueLabel: destination-bigquery

--- a/airbyte-integrations/connectors/destination-bigquery/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-bigquery/metadata.yaml
@@ -39,7 +39,12 @@ data:
         message: "If you never interact with the raw tables, you can upgrade without taking any action. Otherwise, make sure to read the migration guide for more details."
         upgradeDeadline: "2026-07-31"
     rolloutConfiguration:
-      enableProgressiveRollout: false
+      enableProgressiveRollout: true
+      defaultRolloutMode: autopilot
+      autopilotConfig:
+        autoStart: true
+        autoPromoteStages: true
+        strategy: fast
   resourceRequirements:
     jobSpecific:
       - jobType: sync

--- a/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/write/typing_deduping/direct_load_tables/BigqueryDirectLoadSqlGenerator.kt
+++ b/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/write/typing_deduping/direct_load_tables/BigqueryDirectLoadSqlGenerator.kt
@@ -76,10 +76,13 @@ class BigqueryDirectLoadSqlGenerator(
             } else {
                 emptyList()
             }
+        // Use CREATE TABLE IF NOT EXISTS when not replacing, to safely handle
+        // cases where the table already exists (e.g. non-truncate sync modes).
+        val createPrefix = if (replace) "CREATE TABLE" else "CREATE TABLE IF NOT EXISTS"
         val createTableStatement =
             listOf(
                 """
-                CREATE TABLE `$projectId`.$finalTableId (
+                $createPrefix `$projectId`.$finalTableId (
                   _airbyte_raw_id STRING NOT NULL,
                   _airbyte_extracted_at TIMESTAMP NOT NULL,
                   _airbyte_meta JSON NOT NULL,

--- a/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/write/typing_deduping/direct_load_tables/BigqueryDirectLoadSqlGenerator.kt
+++ b/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/write/typing_deduping/direct_load_tables/BigqueryDirectLoadSqlGenerator.kt
@@ -76,8 +76,6 @@ class BigqueryDirectLoadSqlGenerator(
             } else {
                 emptyList()
             }
-        // Use CREATE TABLE IF NOT EXISTS when not replacing, to safely handle
-        // cases where the table already exists (e.g. non-truncate sync modes).
         val createPrefix = if (replace) "CREATE TABLE" else "CREATE TABLE IF NOT EXISTS"
         val createTableStatement =
             listOf(

--- a/docs/integrations/destinations/bigquery.md
+++ b/docs/integrations/destinations/bigquery.md
@@ -252,6 +252,7 @@ This destination supports [namespaces](https://docs.airbyte.com/platform/using-a
 
 | Version     | Date       | Pull Request                                               | Subject                                                                                                                                                                           |
 |:------------|:-----------|:-----------------------------------------------------------|:----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 3.0.23 | 2026-07-14 | [81550](https://github.com/airbytehq/airbyte/pull/81550) | Use CREATE TABLE IF NOT EXISTS for non-replace table creation to prevent accidental data loss |
 | 3.0.22 | 2026-07-10 | [81635](https://github.com/airbytehq/airbyte/pull/81635) | Restore PK NULL equality checks |
 | 3.0.21 | 2026-06-30 | [81346](https://github.com/airbytehq/airbyte/pull/81346) | Remove unnecessary NULL PK equality checks from merge SQL |
 | 3.0.20 | 2026-06-26 | [80932](https://github.com/airbytehq/airbyte/pull/80932) | Handle BigQueryException in getGenerationId() for legacy tables without _airbyte_generation_id column. |


### PR DESCRIPTION
## Summary
- Uses `CREATE TABLE IF NOT EXISTS` instead of `CREATE TABLE` when `replace=false` in `BigqueryDirectLoadSqlGenerator`
- This prevents errors when the table already exists during non-truncate sync modes (Append, Dedup)
- Complements the CDK change in #81549 which switched non-truncate modes to pass `replace=false`

Part of https://github.com/airbytehq/oncall/issues/13059
Supersedes #81550 (for BigQuery portion)

> [!IMPORTANT]
> ⚡ **Auto-merge enabled.**
> 
> _This PR is set to merge automatically when all requirements are met._