### PR TITLE
fix(destination-clickhouse): use CREATE TABLE IF NOT EXISTS for non-replace table creation

### DIFF
--- a/airbyte-integrations/connectors/destination-clickhouse/gradle.properties
+++ b/airbyte-integrations/connectors/destination-clickhouse/gradle.properties
@@ -1,2 +1,2 @@
-cdkVersion=1.0.13
+cdkVersion=1.0.16
 JunitMethodExecutionTimeout=10m

--- a/airbyte-integrations/connectors/destination-clickhouse/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-clickhouse/metadata.yaml
@@ -2,7 +2,7 @@ data:
   connectorSubtype: database
   connectorType: destination
   definitionId: ce0d828e-1dc4-496c-b122-2da42e637e48
-  dockerImageTag: 2.1.24
+  dockerImageTag: 2.1.25
   dockerRepository: airbyte/destination-clickhouse
   githubIssueLabel: destination-clickhouse
   icon: clickhouse.svg

--- a/airbyte-integrations/connectors/destination-clickhouse/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-clickhouse/metadata.yaml
@@ -27,7 +27,12 @@ data:
   releaseStage: generally_available
   releases:
     rolloutConfiguration:
-      enableProgressiveRollout: false
+      enableProgressiveRollout: true
+      defaultRolloutMode: autopilot
+      autopilotConfig:
+        autoStart: true
+        autoPromoteStages: true
+        strategy: fast
     breakingChanges:
       2.0.0:
         message: "This connector has been re-written from scratch. Data will now be typed and stored in final (non-raw) tables. The connector may require changes to its configuration to function properly and downstream pipelines may be affected. Warning: SSH tunneling is in Beta."

--- a/airbyte-integrations/connectors/destination-clickhouse/src/main/kotlin/io/airbyte/integrations/destination/clickhouse/client/ClickhouseSqlGenerator.kt
+++ b/airbyte-integrations/connectors/destination-clickhouse/src/main/kotlin/io/airbyte/integrations/destination/clickhouse/client/ClickhouseSqlGenerator.kt
@@ -29,7 +29,10 @@ class ClickhouseSqlGenerator {
         tableSchema: StreamTableSchema,
         replace: Boolean,
     ): String {
-        val forceCreateTable = if (replace) "OR REPLACE" else ""
+        // Use CREATE OR REPLACE TABLE when replacing, and CREATE TABLE IF NOT EXISTS
+        // when not replacing to safely handle cases where the table already exists
+        // (e.g. non-truncate sync modes).
+        val createPrefix = if (replace) "CREATE OR REPLACE TABLE" else "CREATE TABLE IF NOT EXISTS"
 
         val finalSchema = tableSchema.columnSchema.finalSchema
         val columnDeclarations =
@@ -71,7 +74,7 @@ class ClickhouseSqlGenerator {
             }
 
         return """
-            CREATE $forceCreateTable TABLE `${tableName.namespace}`.`${tableName.name}` (
+            $createPrefix `${tableName.namespace}`.`${tableName.name}` (
               $COLUMN_NAME_AB_RAW_ID String NOT NULL,
               $COLUMN_NAME_AB_EXTRACTED_AT DateTime64(3) NOT NULL,
               $COLUMN_NAME_AB_META String NOT NULL,

--- a/airbyte-integrations/connectors/destination-clickhouse/src/main/kotlin/io/airbyte/integrations/destination/clickhouse/client/ClickhouseSqlGenerator.kt
+++ b/airbyte-integrations/connectors/destination-clickhouse/src/main/kotlin/io/airbyte/integrations/destination/clickhouse/client/ClickhouseSqlGenerator.kt
@@ -29,9 +29,6 @@ class ClickhouseSqlGenerator {
         tableSchema: StreamTableSchema,
         replace: Boolean,
     ): String {
-        // Use CREATE OR REPLACE TABLE when replacing, and CREATE TABLE IF NOT EXISTS
-        // when not replacing to safely handle cases where the table already exists
-        // (e.g. non-truncate sync modes).
         val createPrefix = if (replace) "CREATE OR REPLACE TABLE" else "CREATE TABLE IF NOT EXISTS"
 
         val finalSchema = tableSchema.columnSchema.finalSchema

--- a/docs/integrations/destinations/clickhouse.md
+++ b/docs/integrations/destinations/clickhouse.md
@@ -179,6 +179,7 @@ This destination supports [namespaces](https://docs.airbyte.com/platform/using-a
 
 | Version    | Date       | Pull Request                                               | Subject                                                                        |
 |:-----------|:-----------|:-----------------------------------------------------------|:-------------------------------------------------------------------------------|
+| 2.1.25     | 2026-07-14 | [81550](https://github.com/airbytehq/airbyte/pull/81550)   | Use CREATE TABLE IF NOT EXISTS for non-replace table creation to prevent accidental data loss |
 | 2.1.24     | 2026-05-20 | [77673](https://github.com/airbytehq/airbyte/pull/77673)   | Upgrade CDK to 1.0.13. Migrate component tests to Testcontainers. |
 | 2.1.23     | 2026-02-04 | [72857](https://github.com/airbytehq/airbyte/pull/72857)   | No user-facing changes (Upgrade CDK to 0.2.8)                    |
 | 2.1.22     | 2026-01-26 | [71784](https://github.com/airbytehq/airbyte/pull/71784)   | No user-facing changes (internal refactor SSH tunnel logic)                    |


### PR DESCRIPTION
## Summary
- Uses `CREATE TABLE IF NOT EXISTS` instead of `CREATE TABLE` when `replace=false` in `ClickhouseSqlGenerator`
- This prevents errors when the table already exists during non-truncate sync modes (Append, Dedup)
- Complements the CDK change in #81549 which switched non-truncate modes to pass `replace=false`

Part of https://github.com/airbytehq/oncall/issues/13059
Supersedes #81550 (for ClickHouse portion)