### PR TITLE
ci(hydra-automerge): Label successful automatic merges

### DIFF
--- a/.github/workflows/hydra-automerge.yml
+++ b/.github/workflows/hydra-automerge.yml
@@ -444,6 +444,47 @@ jobs:
           echo "::error::Failed to merge PR #$PR_NUMBER after 3 attempts"
           exit 1
 
+      - name: Label auto-merged PR
+        if: steps.evaluate.outputs.result == 'PASS' && inputs.dry-run != 'true' && vars.ENABLE_CONNECTOR_AUTO_MERGE == 'true'
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        with:
+          github-token: ${{ steps.get-hoard-token.outputs.token }}
+          script: |
+            const label = 'hyd-automerged';
+
+            try {
+              await github.rest.issues.getLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                name: label,
+              });
+            } catch (error) {
+              if (error.status !== 404) {
+                throw error;
+              }
+
+              try {
+                await github.rest.issues.createLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  name: label,
+                  color: '0e8a16',
+                  description: 'Merged automatically by Hydra',
+                });
+              } catch (createError) {
+                if (createError.status !== 422) {
+                  throw createError;
+                }
+              }
+            }
+
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: Number(process.env.PR_NUMBER),
+              labels: [label],
+            });
+
       - name: Post automerge notification to Slack
         if: steps.evaluate.outputs.result == 'PASS' && inputs.dry-run != 'true' && vars.ENABLE_CONNECTOR_AUTO_MERGE == 'true'
         uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1

--- a/.github/workflows/hydra-automerge.yml
+++ b/.github/workflows/hydra-automerge.yml
@@ -446,44 +446,9 @@ jobs:
 
       - name: Label auto-merged PR
         if: steps.evaluate.outputs.result == 'PASS' && inputs.dry-run != 'true' && vars.ENABLE_CONNECTOR_AUTO_MERGE == 'true'
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
-        with:
-          github-token: ${{ steps.get-hoard-token.outputs.token }}
-          script: |
-            const label = 'hyd-automerged';
-
-            try {
-              await github.rest.issues.getLabel({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                name: label,
-              });
-            } catch (error) {
-              if (error.status !== 404) {
-                throw error;
-              }
-
-              try {
-                await github.rest.issues.createLabel({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  name: label,
-                  color: '0e8a16',
-                  description: 'Merged automatically by Hydra',
-                });
-              } catch (createError) {
-                if (createError.status !== 422) {
-                  throw createError;
-                }
-              }
-            }
-
-            await github.rest.issues.addLabels({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: Number(process.env.PR_NUMBER),
-              labels: [label],
-            });
+        env:
+          GH_TOKEN: ${{ steps.get-hoard-token.outputs.token }}
+        run: gh issue edit "$PR_NUMBER" --repo airbytehq/airbyte --add-label hyd-automerged
 
       - name: Post automerge notification to Slack
         if: steps.evaluate.outputs.result == 'PASS' && inputs.dry-run != 'true' && vars.ENABLE_CONNECTOR_AUTO_MERGE == 'true'


### PR DESCRIPTION
## What

Add a `hyd-automerged` label after Hydra successfully auto-merges a pull request, enabling reliable tracking of actual automatic merges rather than all PRs that reach `hyd-ready`.

Requested by @pedroslopez.

## How

- Create `hyd-automerged` once in the repository with the description "Merged automatically by Hydra."
- Run the labeling step only after the squash-merge step succeeds and only when real auto-merge is enabled.
- Apply the existing label using the workflow's GitHub App token.

## Review guide

1. `.github/workflows/hydra-automerge.yml`

## User Impact

Successfully Hydra-auto-merged PRs can be queried using the `hyd-automerged` label. Dry runs and failed or ineligible merges remain unlabeled.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚
- [ ] NO ❌

## Validation

- `npx --yes prettier@3.0.3 --check .github/workflows/hydra-automerge.yml`
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7 .github/workflows/hydra-automerge.yml`
- Pre-commit hook passed for the changed workflow.
- Verified `hyd-automerged` exists via the GitHub API.

---
[Devin session](https://app.devin.ai/sessions/cd614c02c04140f1833775153ec48f8f)