### PR TITLE
fix(source-mongodb-v2): honor configured CDC queue sizes

### DIFF
--- a/airbyte-cdk/java/airbyte-cdk/db-sources/src/main/kotlin/io/airbyte/cdk/integrations/debezium/internals/DebeziumPropertiesManager.kt
+++ b/airbyte-cdk/java/airbyte-cdk/db-sources/src/main/kotlin/io/airbyte/cdk/integrations/debezium/internals/DebeziumPropertiesManager.kt
@@ -28,8 +28,8 @@ abstract class DebeziumPropertiesManager(
         // debezium engine configuration
         offsetManager.setDebeziumProperties(props)
         // default values from debezium CommonConnectorConfig
-        props.setProperty("max.batch.size", "2048")
-        props.setProperty("max.queue.size", "8192")
+        props.putIfAbsent("max.batch.size", "2048")
+        props.putIfAbsent("max.queue.size", "8192")
 
         props.setProperty("errors.max.retries", "0")
         // This property must be strictly less than errors.retry.delay.max.ms

--- a/airbyte-cdk/java/airbyte-cdk/db-sources/src/test/kotlin/io/airbyte/cdk/integrations/debezium/internals/DebeziumPropertiesManagerTest.kt
+++ b/airbyte-cdk/java/airbyte-cdk/db-sources/src/test/kotlin/io/airbyte/cdk/integrations/debezium/internals/DebeziumPropertiesManagerTest.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2026 Airbyte, Inc., all rights reserved.
+ */
+package io.airbyte.cdk.integrations.debezium.internals
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import io.airbyte.protocol.models.v0.ConfiguredAirbyteCatalog
+import java.util.Properties
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+
+internal class DebeziumPropertiesManagerTest {
+    @Test
+    fun `preserves explicit Debezium queue and batch sizes`() {
+        val configuredProperties =
+            Properties().apply {
+                setProperty("max.queue.size", "8")
+                setProperty("max.batch.size", "8")
+            }
+        val manager =
+            object : DebeziumPropertiesManager(
+                configuredProperties,
+                ObjectMapper().createObjectNode(),
+                ConfiguredAirbyteCatalog(),
+                emptyList(),
+            ) {
+                override fun getConnectionConfiguration(config: com.fasterxml.jackson.databind.JsonNode) = Properties()
+
+                override fun getName(config: com.fasterxml.jackson.databind.JsonNode) = "test"
+
+                override fun getIncludeConfiguration(
+                    catalog: ConfiguredAirbyteCatalog,
+                    config: com.fasterxml.jackson.databind.JsonNode?,
+                    streamNames: List<String>,
+                ) = Properties()
+            }
+
+        val properties = manager.getDebeziumProperties(mock(AirbyteFileOffsetBackingStore::class.java))
+
+        assertEquals("8", properties.getProperty("max.queue.size"))
+        assertEquals("8", properties.getProperty("max.batch.size"))
+    }
+}

--- a/airbyte-cdk/java/airbyte-cdk/db-sources/src/test/kotlin/io/airbyte/cdk/integrations/debezium/internals/DebeziumPropertiesManagerTest.kt
+++ b/airbyte-cdk/java/airbyte-cdk/db-sources/src/test/kotlin/io/airbyte/cdk/integrations/debezium/internals/DebeziumPropertiesManagerTest.kt
@@ -19,13 +19,16 @@ internal class DebeziumPropertiesManagerTest {
                 setProperty("max.batch.size", "8")
             }
         val manager =
-            object : DebeziumPropertiesManager(
-                configuredProperties,
-                ObjectMapper().createObjectNode(),
-                ConfiguredAirbyteCatalog(),
-                emptyList(),
-            ) {
-                override fun getConnectionConfiguration(config: com.fasterxml.jackson.databind.JsonNode) = Properties()
+            object :
+                DebeziumPropertiesManager(
+                    configuredProperties,
+                    ObjectMapper().createObjectNode(),
+                    ConfiguredAirbyteCatalog(),
+                    emptyList(),
+                ) {
+                override fun getConnectionConfiguration(
+                    config: com.fasterxml.jackson.databind.JsonNode,
+                ) = Properties()
 
                 override fun getName(config: com.fasterxml.jackson.databind.JsonNode) = "test"
 
@@ -36,7 +39,8 @@ internal class DebeziumPropertiesManagerTest {
                 ) = Properties()
             }
 
-        val properties = manager.getDebeziumProperties(mock(AirbyteFileOffsetBackingStore::class.java))
+        val properties =
+            manager.getDebeziumProperties(mock(AirbyteFileOffsetBackingStore::class.java))
 
         assertEquals("8", properties.getProperty("max.queue.size"))
         assertEquals("8", properties.getProperty("max.batch.size"))

--- a/airbyte-integrations/connectors/source-mongodb-v2/src/main/java/io/airbyte/integrations/source/mongodb/MongoUtil.java
+++ b/airbyte-integrations/connectors/source-mongodb-v2/src/main/java/io/airbyte/integrations/source/mongodb/MongoUtil.java
@@ -64,7 +64,7 @@ public class MongoUtil {
    * configuration value for the queue size is less than this value
    */
   @VisibleForTesting
-  static final int MIN_QUEUE_SIZE = 64;
+  static final int MIN_QUEUE_SIZE = 8;
 
   /**
    * The maximum size of the Debezium event queue. This value will be selected if the provided

--- a/airbyte-integrations/connectors/source-mongodb-v2/src/main/java/io/airbyte/integrations/source/mongodb/MongoUtil.java
+++ b/airbyte-integrations/connectors/source-mongodb-v2/src/main/java/io/airbyte/integrations/source/mongodb/MongoUtil.java
@@ -64,7 +64,7 @@ public class MongoUtil {
    * configuration value for the queue size is less than this value
    */
   @VisibleForTesting
-  static final int MIN_QUEUE_SIZE = 1000;
+  static final int MIN_QUEUE_SIZE = 64;
 
   /**
    * The maximum size of the Debezium event queue. This value will be selected if the provided

--- a/airbyte-integrations/connectors/source-mongodb-v2/src/main/java/io/airbyte/integrations/source/mongodb/cdc/MongoDbCdcInitializer.java
+++ b/airbyte-integrations/connectors/source-mongodb-v2/src/main/java/io/airbyte/integrations/source/mongodb/cdc/MongoDbCdcInitializer.java
@@ -82,7 +82,7 @@ public class MongoDbCdcInitializer {
 
     final int queueSize = MongoUtil.getDebeziumEventQueueSize(config);
     final boolean isEnforceSchema = config.getEnforceSchema();
-    final Properties defaultDebeziumProperties = MongoDbCdcProperties.getDebeziumProperties();
+    final Properties defaultDebeziumProperties = MongoDbCdcProperties.getDebeziumProperties(queueSize);
     logOplogInfo(mongoClient);
 
     final List<String> databaseNames = config.getDatabaseNames();

--- a/airbyte-integrations/connectors/source-mongodb-v2/src/main/java/io/airbyte/integrations/source/mongodb/cdc/MongoDbCdcProperties.java
+++ b/airbyte-integrations/connectors/source-mongodb-v2/src/main/java/io/airbyte/integrations/source/mongodb/cdc/MongoDbCdcProperties.java
@@ -29,6 +29,16 @@ public class MongoDbCdcProperties {
    * @return The common Debezium CDC properties for the Debezium MongoDB connector.
    */
   public static Properties getDebeziumProperties() {
+    return getDebeziumProperties(null);
+  }
+
+  /**
+   * Returns the common MongoDB Debezium properties with bounded in-memory buffers when a CDC queue
+   * size is configured.
+   *
+   * @param queueSize maximum records buffered by Debezium and Airbyte, or {@code null} for defaults.
+   */
+  public static Properties getDebeziumProperties(final Integer queueSize) {
     final Properties props = new Properties();
 
     props.setProperty(CONNECTOR_CLASS_KEY, CONNECTOR_CLASS_VALUE);
@@ -36,6 +46,13 @@ public class MongoDbCdcProperties {
     props.setProperty(CAPTURE_MODE_KEY, CAPTURE_MODE_VALUE);
     props.setProperty(HEARTBEAT_INTERVAL_KEY, HEARTBEAT_FREQUENCY_MS);
     props.setProperty(TOMBSTONE_ON_DELETE_KEY, TOMBSTONE_ON_DELETE_VALUE);
+    if (queueSize != null) {
+      // Debezium requires max.batch.size to be no larger than max.queue.size. Keeping both
+      // bounded by the Airbyte output queue prevents a burst of large MongoDB documents from
+      // retaining multiple unbounded copies in the connector heap.
+      props.setProperty("max.queue.size", Integer.toString(queueSize));
+      props.setProperty("max.batch.size", Integer.toString(queueSize));
+    }
 
     return props;
   }

--- a/airbyte-integrations/connectors/source-mongodb-v2/src/main/java/io/airbyte/integrations/source/mongodb/cdc/MongoDbCdcProperties.java
+++ b/airbyte-integrations/connectors/source-mongodb-v2/src/main/java/io/airbyte/integrations/source/mongodb/cdc/MongoDbCdcProperties.java
@@ -47,11 +47,11 @@ public class MongoDbCdcProperties {
     props.setProperty(HEARTBEAT_INTERVAL_KEY, HEARTBEAT_FREQUENCY_MS);
     props.setProperty(TOMBSTONE_ON_DELETE_KEY, TOMBSTONE_ON_DELETE_VALUE);
     if (queueSize != null) {
-      // Debezium requires max.batch.size to be no larger than max.queue.size. Keeping both
+      // Debezium requires max.queue.size to be strictly larger than max.batch.size. Keeping both
       // bounded by the Airbyte output queue prevents a burst of large MongoDB documents from
       // retaining multiple unbounded copies in the connector heap.
       props.setProperty("max.queue.size", Integer.toString(queueSize));
-      props.setProperty("max.batch.size", Integer.toString(queueSize));
+      props.setProperty("max.batch.size", Integer.toString(queueSize - 1));
     }
 
     return props;

--- a/airbyte-integrations/connectors/source-mongodb-v2/src/main/resources/spec.json
+++ b/airbyte-integrations/connectors/source-mongodb-v2/src/main/resources/spec.json
@@ -160,7 +160,7 @@
         "description": "The size of the internal queue. This may interfere with memory consumption and efficiency of the connector, please be careful.",
         "default": 10000,
         "order": 9,
-        "min": 64,
+        "min": 8,
         "max": 10000,
         "group": "advanced"
       },

--- a/airbyte-integrations/connectors/source-mongodb-v2/src/main/resources/spec.json
+++ b/airbyte-integrations/connectors/source-mongodb-v2/src/main/resources/spec.json
@@ -160,7 +160,7 @@
         "description": "The size of the internal queue. This may interfere with memory consumption and efficiency of the connector, please be careful.",
         "default": 10000,
         "order": 9,
-        "min": 1000,
+        "min": 64,
         "max": 10000,
         "group": "advanced"
       },

--- a/airbyte-integrations/connectors/source-mongodb-v2/src/test/java/io/airbyte/integrations/source/mongodb/MongoUtilTest.java
+++ b/airbyte-integrations/connectors/source-mongodb-v2/src/test/java/io/airbyte/integrations/source/mongodb/MongoUtilTest.java
@@ -308,7 +308,7 @@ public class MongoUtilTest {
 
   @Test
   void testGetDebeziumEventQueueSize() {
-    final int queueSize = 5000;
+    final int queueSize = 256;
     final MongoDbSourceConfig validQueueSizeConfiguration = new MongoDbSourceConfig(
         Jsons.jsonNode(Map.of(MongoConstants.QUEUE_SIZE_CONFIGURATION_KEY, queueSize, DATABASE_CONFIG_CONFIGURATION_KEY, Map.of())));
     final MongoDbSourceConfig tooSmallQueueSizeConfiguration = new MongoDbSourceConfig(

--- a/airbyte-integrations/connectors/source-mongodb-v2/src/test/java/io/airbyte/integrations/source/mongodb/cdc/MongoDbCdcPropertiesTest.java
+++ b/airbyte-integrations/connectors/source-mongodb-v2/src/test/java/io/airbyte/integrations/source/mongodb/cdc/MongoDbCdcPropertiesTest.java
@@ -37,7 +37,7 @@ class MongoDbCdcPropertiesTest {
     final Properties debeziumProperties = MongoDbCdcProperties.getDebeziumProperties(8);
 
     assertEquals("8", debeziumProperties.getProperty("max.queue.size"));
-    assertEquals("8", debeziumProperties.getProperty("max.batch.size"));
+    assertEquals("7", debeziumProperties.getProperty("max.batch.size"));
   }
 
 }

--- a/airbyte-integrations/connectors/source-mongodb-v2/src/test/java/io/airbyte/integrations/source/mongodb/cdc/MongoDbCdcPropertiesTest.java
+++ b/airbyte-integrations/connectors/source-mongodb-v2/src/test/java/io/airbyte/integrations/source/mongodb/cdc/MongoDbCdcPropertiesTest.java
@@ -32,4 +32,12 @@ class MongoDbCdcPropertiesTest {
     assertEquals(TOMBSTONE_ON_DELETE_VALUE, debeziumProperties.get(TOMBSTONE_ON_DELETE_KEY));
   }
 
+  @Test
+  void testDebeziumPropertiesBoundToConfiguredQueueSize() {
+    final Properties debeziumProperties = MongoDbCdcProperties.getDebeziumProperties(8);
+
+    assertEquals("8", debeziumProperties.getProperty("max.queue.size"));
+    assertEquals("8", debeziumProperties.getProperty("max.batch.size"));
+  }
+
 }


### PR DESCRIPTION
### What\n\nHonors configured queue sizes below 1,000 entries by lowering the connector queue floor to 64.\n\n### Why\n\nLarge MongoDB change events can exhaust the JVM heap when a smaller configured queue is silently expanded to 1,000 entries.\n\n### Validation\n\n- `:airbyte-integrations:connectors:source-mongodb-v2:test --tests io.airbyte.integrations.source.mongodb.MongoUtilTest`