### PR TITLE
docs(source-oracle-enterprise): Document Oracle 12c CDC setup

### DIFF
--- a/docs/integrations/enterprise-connectors/source-oracle-enterprise.md
+++ b/docs/integrations/enterprise-connectors/source-oracle-enterprise.md
@@ -33,7 +33,7 @@ From the point of view of the Oracle database instance, the Enterprise Oracle so
 
 ### Requirements
 
-1. Oracle DB version 23ai, 21c or 19c.
+1. Oracle Database 12c or later.
 2. Dedicated read-only Airbyte user with access to all tables needed for replication.
 
 #### 1. Make sure your database is accessible from the machine running Airbyte
@@ -109,9 +109,14 @@ GRANT EXECUTE_CATALOG_ROLE TO airbyte;
 GRANT SELECT ANY TRANSACTION TO airbyte;
 GRANT LOGMINING TO airbyte;
 GRANT CREATE TABLE TO airbyte;
+GRANT UNLIMITED TABLESPACE TO airbyte;
 GRANT LOCK ANY TABLE TO airbyte;
 GRANT CREATE SEQUENCE TO airbyte;
 ```
+
+Debezium creates a `LOG_MINING_FLUSH` table for LogMiner. The CDC user needs either the
+`UNLIMITED TABLESPACE` privilege shown above or a sufficient quota on its default tablespace.
+Without a tablespace quota, CDC fails with `ORA-01950`.
 
 If the database instance is a multitenant CDB instance, then these grant statements need to be supplemented with the `CONTAINER=ALL` clause.
 Furthermore, an extra privilege is required:


### PR DESCRIPTION
## Triggering Context

**Run triggered by:** Manual request from Ryan Waskewich following live Oracle 12.2.0.1 validation.

**Relevant context:** https://github.com/airbytehq/airbyte-enterprise/pull/450

**Confidence impact:** The required setup was verified directly, but the related connector implementation is still an open PR, so Triggering Context scores 3/5.

## Documentation Confidence Assessment

**Overall Confidence: 2/5** *(capped: too much code inference)*

| Dimension | Score | Rationale |
|-----------|-------|-----------|
| Code Comprehension | 1/5 | This is a Java/Kotlin connector, although the relevant version gate and CDC delete mapping were directly inspected. |
| API Documentation Quality | 4/5 | Oracle and Debezium document LogMiner setup well, and the prerequisite was verified against Oracle 12.2.0.1. |
| Change Scope & Risk | 4/5 | The diff is a seven-line targeted prerequisite and supported-version correction. |
| Existing Doc Maturity | 4/5 | The existing 309-line guide already covers setup, CDC, and troubleshooting. |
| Connector Sensitivity | 4/5 | This is a certified Enterprise connector with metadata quality level 200 and support level 0. |
| Triggering Context | 3/5 | The request is grounded in live validation, but the related implementation PR remains open. |

### What I Verified vs. What I Inferred

- **Verified from code**: The connector accepts Oracle major version 12; delete records populate `_ab_cdc_deleted_at`; the existing CDC test fixture grants a default-tablespace quota.
- **Verified from database behavior**: On Oracle 12.2.0.1, Debezium failed with `ORA-01950` before the tablespace grant and successfully mined CDC changes after the grant. A committed delete emitted `_ab_cdc_deleted_at` and advanced the SCN.
- **Verified from API docs**: The configured stream exposes `_ab_cdc_scn`, `_ab_cdc_updated_at`, and `_ab_cdc_deleted_at` and uses `ID` as its primary key.
- **Inferred**: A sufficiently sized default-tablespace quota is preferable to `UNLIMITED TABLESPACE` when operators require least privilege.

### Areas of Concern

- Oracle 12c support depends on the related Enterprise connector change being released.
- Reviewers should confirm whether the broad `UNLIMITED TABLESPACE` example or a specific quota should be the primary recommendation.

---

## What

- Documents Oracle Database 12c as supported.
- Adds the tablespace privilege required for Debezium's `LOG_MINING_FLUSH` table.
- Explains the narrower default-tablespace quota alternative and the `ORA-01950` symptom.

## How

Updates the existing CDC grant sequence with `UNLIMITED TABLESPACE`. The document's existing multitenant guidance applies `CONTAINER=ALL` to this grant for common users.

## Review guide

1. `docs/integrations/enterprise-connectors/source-oracle-enterprise.md`

## User Impact

Oracle 12c users can complete LogMiner setup without CDC failing because the user can create tables but lacks a tablespace quota.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚
- [ ] NO ❌

---

> **Note**: I am an AI assistant (Devin) and have proposed these documentation updates based on a review of the connector source code, Oracle documentation, and live Oracle 12.2.0.1 validation. Reviewers may merge, modify, or close this PR as they see fit.

Link to Devin session: https://app.devin.ai/sessions/81971c26c4bf44de829215ea58867d42
Requested by: @rwask