### PR TITLE
feat(source-mixpanel): Add opt-in raw export stream

### DIFF
--- a/airbyte-integrations/connectors/source-mixpanel/metadata.yaml
+++ b/airbyte-integrations/connectors/source-mixpanel/metadata.yaml
@@ -11,7 +11,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 12928b32-bf0a-4f1e-964f-07e12e37153a
-  dockerImageTag: 4.0.1
+  dockerImageTag: 4.1.0
   dockerRepository: airbyte/source-mixpanel
   documentationUrl: https://docs.airbyte.com/integrations/sources/mixpanel
   githubIssueLabel: source-mixpanel

--- a/airbyte-integrations/connectors/source-mixpanel/pyproject.toml
+++ b/airbyte-integrations/connectors/source-mixpanel/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
-version = "4.0.1"
+version = "4.1.0"
 name = "source-mixpanel"
 description = "Source implementation for Mixpanel."
 authors = ["Airbyte <contact@airbyte.io>"]

--- a/airbyte-integrations/connectors/source-mixpanel/source_mixpanel/manifest.yaml
+++ b/airbyte-integrations/connectors/source-mixpanel/source_mixpanel/manifest.yaml
@@ -1,4 +1,4 @@
-version: 0.80.0
+version: 0.81.0
 type: DeclarativeSource
 
 definitions:

--- a/airbyte-integrations/connectors/source-mixpanel/source_mixpanel/source.py
+++ b/airbyte-integrations/connectors/source-mixpanel/source_mixpanel/source.py
@@ -145,12 +145,17 @@ class SourceMixpanel(YamlDeclarativeSource):
             else:
                 credentials["option_title"] = "Service Account"
 
-        streams = super().streams(config=config)
+        selected_streams = config.get("streams")
+
+        all_streams = super().streams(config=config)
 
         config_transformed = copy.deepcopy(config)
         config_transformed = self._validate_and_transform(config_transformed)
         auth = self.get_authenticator(config)
 
-        streams.append(Export(authenticator=auth, **config_transformed))
+        all_streams.append(Export(authenticator=auth, **config_transformed))
 
-        return streams
+        if selected_streams:
+            all_streams = [s for s in all_streams if s.name in selected_streams]
+
+        return all_streams

--- a/airbyte-integrations/connectors/source-mixpanel/source_mixpanel/source.py
+++ b/airbyte-integrations/connectors/source-mixpanel/source_mixpanel/source.py
@@ -16,7 +16,7 @@ from airbyte_cdk.sources.source import TState
 from airbyte_cdk.sources.streams import Stream
 from airbyte_cdk.sources.streams.http.requests_native_auth import BasicHttpAuthenticator, TokenAuthenticator
 from airbyte_cdk.utils import AirbyteTracedException
-from source_mixpanel.streams import Export
+from source_mixpanel.streams import Export, ExportRaw
 
 
 def adapt_validate_if_testing(func):
@@ -159,6 +159,8 @@ class SourceMixpanel(YamlDeclarativeSource):
         auth = self.get_authenticator(config)
 
         all_streams.append(Export(authenticator=auth, **config_transformed))
+        if config.get("enable_export_raw", False):
+            all_streams.append(ExportRaw(authenticator=auth, **config_transformed))
 
         if selected_streams:
             all_streams = [s for s in all_streams if s.name in selected_streams]

--- a/airbyte-integrations/connectors/source-mixpanel/source_mixpanel/source.py
+++ b/airbyte-integrations/connectors/source-mixpanel/source_mixpanel/source.py
@@ -6,7 +6,7 @@ import copy
 import logging
 import os
 from functools import wraps
-from typing import Any, List, Mapping, MutableMapping, Optional
+from typing import Any, List, Mapping, MutableMapping, Optional, Tuple
 
 import pendulum
 
@@ -136,6 +136,11 @@ class SourceMixpanel(YamlDeclarativeSource):
         if username and secret:
             return BasicHttpAuthenticator(username=username, password=secret)
         return TokenAuthenticatorBase64(token=credentials["api_secret"])
+
+    def check_connection(self, logger: logging.Logger, config: Mapping[str, Any]) -> Tuple[bool, Any]:
+        check_config: MutableMapping[str, Any] = copy.deepcopy(dict(config))
+        check_config["streams"] = ["cohorts"]
+        return super().check_connection(logger, check_config)
 
     def streams(self, config: Mapping[str, Any]) -> List[Stream]:
         credentials = config.get("credentials")

--- a/airbyte-integrations/connectors/source-mixpanel/source_mixpanel/spec.json
+++ b/airbyte-integrations/connectors/source-mixpanel/source_mixpanel/spec.json
@@ -159,7 +159,8 @@
             "annotations",
             "cohort_members",
             "funnels",
-            "export"
+            "export",
+            "export_raw"
           ]
         },
         "uniqueItems": true
@@ -185,6 +186,14 @@
           "minLength": 1
         },
         "uniqueItems": true
+      },
+      "enable_export_raw": {
+        "order": 15,
+        "title": "Enable Raw Export Stream",
+        "description": "Adds an export_raw stream that preserves the complete typed Mixpanel properties object. The existing export stream remains unchanged.",
+        "type": "boolean",
+        "default": false,
+        "airbyte_hidden": true
       }
     }
   }

--- a/airbyte-integrations/connectors/source-mixpanel/source_mixpanel/spec.json
+++ b/airbyte-integrations/connectors/source-mixpanel/source_mixpanel/spec.json
@@ -167,7 +167,7 @@
       "export_events": {
         "order": 13,
         "title": "Export Events",
-        "description": "Optional event names to replicate from the Export stream. When provided, the connector also limits dynamic Export schema discovery to these events. If left empty, all events are replicated.",
+        "description": "Optional event names to replicate from the Export stream. When provided, the connector filters the raw Export sync to these events and scopes dynamic schema discovery to them. Note: this does NOT skip Mixpanel's schema discovery request (events/properties/top) — it still runs, just per selected event, so it can still be slow or time out on large projects. To skip discovery entirely, set Export Properties instead. If left empty, all events are replicated.",
         "type": "array",
         "items": {
           "type": "string",
@@ -178,7 +178,7 @@
       "export_properties": {
         "order": 14,
         "title": "Export Properties",
-        "description": "Optional event property names to include in the Export schema. When provided, the connector skips Mixpanel's dynamic property discovery request. This setting does not remove other properties from exported records or reduce the raw response size.",
+        "description": "Optional event property names to include in the Export schema. When provided, the connector builds the Export schema directly from this list and completely skips Mixpanel's dynamic property discovery request (events/properties/top) — this is the setting to use if schema discovery is timing out. This setting does not remove other properties from exported records or reduce the raw response size.",
         "type": "array",
         "items": {
           "type": "string",

--- a/airbyte-integrations/connectors/source-mixpanel/source_mixpanel/spec.json
+++ b/airbyte-integrations/connectors/source-mixpanel/source_mixpanel/spec.json
@@ -163,6 +163,28 @@
           ]
         },
         "uniqueItems": true
+      },
+      "export_events": {
+        "order": 13,
+        "title": "Export Events",
+        "description": "Optional event names to replicate from the Export stream. When provided, the connector also limits dynamic Export schema discovery to these events. If left empty, all events are replicated.",
+        "type": "array",
+        "items": {
+          "type": "string",
+          "minLength": 1
+        },
+        "uniqueItems": true
+      },
+      "export_properties": {
+        "order": 14,
+        "title": "Export Properties",
+        "description": "Optional event property names to include in the Export schema. When provided, the connector skips Mixpanel's dynamic property discovery request. This setting does not remove other properties from exported records or reduce the raw response size.",
+        "type": "array",
+        "items": {
+          "type": "string",
+          "minLength": 1
+        },
+        "uniqueItems": true
       }
     }
   }

--- a/airbyte-integrations/connectors/source-mixpanel/source_mixpanel/spec.json
+++ b/airbyte-integrations/connectors/source-mixpanel/source_mixpanel/spec.json
@@ -145,6 +145,24 @@
         "default": 3,
         "examples": [1, 2, 3],
         "description": "The number of worker threads to use for the sync. The performance upper boundary is based on the limit of your Mixpanel pricing plan. More info about the rate limit tiers can be found on Mixpanel's API <a href=\"https://developer.mixpanel.com/reference/raw-event-e xport#api-export-endpoint-rate-limits\">docs</a>."
+      },
+      "streams": {
+        "order": 12,
+        "title": "Streams to Discover",
+        "description": "Select specific streams to discover and sync. If left empty, all streams will be available. Use this to speed up schema discovery when you only need specific data and discovery is timing out.",
+        "type": "array",
+        "items": {
+          "type": "string",
+          "enum": [
+            "cohorts",
+            "engage",
+            "annotations",
+            "cohort_members",
+            "funnels",
+            "export"
+          ]
+        },
+        "uniqueItems": true
       }
     }
   }

--- a/airbyte-integrations/connectors/source-mixpanel/source_mixpanel/streams.py
+++ b/airbyte-integrations/connectors/source-mixpanel/source_mixpanel/streams.py
@@ -307,8 +307,23 @@ class ExportSchema(MixpanelStream):
     data_field: str = None
     reqs_per_hour_limit: int = 0  # see the docstring
 
+    def __init__(self, *args, event: Optional[str] = None, **kwargs):
+        self.event = event
+        super().__init__(*args, **kwargs)
+
     def path(self, **kwargs) -> str:
         return "events/properties/top"
+
+    def request_params(
+        self,
+        stream_state: Mapping[str, Any],
+        stream_slice: Mapping[str, Any] = None,
+        next_page_token: Mapping[str, Any] = None,
+    ) -> MutableMapping[str, Any]:
+        params = super().request_params(stream_state, stream_slice, next_page_token)
+        if self.event:
+            params["event"] = self.event
+        return params
 
     def process_response(self, response: requests.Response, **kwargs) -> Iterable[str]:
         """
@@ -386,6 +401,17 @@ class Export(DateSlicesMixin, IncrementalMixpanelStream):
 
     transformer = TypeTransformer(TransformConfig.DefaultSchemaNormalization)
 
+    def __init__(
+        self,
+        *args,
+        export_events: Optional[List[str]] = None,
+        export_properties: Optional[List[str]] = None,
+        **kwargs,
+    ):
+        self.export_events = export_events or []
+        self.export_properties = export_properties or []
+        super().__init__(*args, **kwargs)
+
     @property
     def url_base(self):
         prefix = "-eu" if self.region == "EU" else ""
@@ -458,6 +484,11 @@ class Export(DateSlicesMixin, IncrementalMixpanelStream):
 
             yield item
 
+    def _read_schema_properties(self, event: Optional[str] = None) -> Iterable[str]:
+        for property_name in ExportSchema(event=event, **self.get_stream_params()).read_records(sync_mode=SyncMode.full_refresh):
+            if isinstance(property_name, str):
+                yield property_name
+
     @cache
     def get_json_schema(self) -> Mapping[str, Any]:
         """
@@ -467,15 +498,23 @@ class Export(DateSlicesMixin, IncrementalMixpanelStream):
         Override as needed.
         """
 
-        schema = super().get_json_schema()
+        schema = dict(super().get_json_schema())
 
         # Set whether to allow additional properties for engage and export endpoints
         # Event and Engage properties are dynamic and depend on the properties provided on upload,
         #   when the Event or Engage (user/person) was created.
         schema["additionalProperties"] = self.additional_properties
 
-        # read existing Export schema from API
-        schema_properties = ExportSchema(**self.get_stream_params()).read_records(sync_mode=SyncMode.full_refresh)
+        schema_properties: Iterable[str]
+        if self.export_properties:
+            schema_properties = self.export_properties
+        elif self.export_events:
+            schema_properties = (
+                property_name for event in self.export_events for property_name in self._read_schema_properties(event=event)
+            )
+        else:
+            schema_properties = self._read_schema_properties()
+
         for result in transform_property_names(schema_properties):
             # Schema does not provide exact property type
             # string ONLY for event properties (no other datatypes)
@@ -493,6 +532,8 @@ class Export(DateSlicesMixin, IncrementalMixpanelStream):
         if cursor_param:
             timestamp = int(pendulum.parse(cursor_param).timestamp())
             params["where"] = f'properties["$time"]>=datetime({timestamp})'
+        if self.export_events:
+            params["event"] = json.dumps(self.export_events)
         return params
 
     def request_kwargs(

--- a/airbyte-integrations/connectors/source-mixpanel/source_mixpanel/streams.py
+++ b/airbyte-integrations/connectors/source-mixpanel/source_mixpanel/streams.py
@@ -540,3 +540,41 @@ class Export(DateSlicesMixin, IncrementalMixpanelStream):
         self, stream_state: Mapping[str, Any], stream_slice: Mapping[str, Any] = None, next_page_token: Mapping[str, Any] = None
     ) -> Mapping[str, Any]:
         return {"stream": True}
+
+
+class ExportRaw(Export):
+    name = "export_raw"
+
+    def process_response(self, response: requests.Response, **kwargs) -> Iterable[Mapping]:
+        for record in self.iter_dicts(response.iter_lines(decode_unicode=True)):
+            properties = record["properties"]
+            timestamp = properties["time"] if "time" in properties else properties["$time"]
+            yield {
+                "event": record["event"],
+                "time": pendulum.from_timestamp(int(timestamp), tz="UTC").to_iso8601_string(),
+                "properties": properties,
+            }
+
+    @cache
+    def get_json_schema(self) -> Mapping[str, Any]:
+        return {
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "type": "object",
+            "additionalProperties": False,
+            "properties": {
+                "event": {
+                    "description": "Event type captured",
+                    "type": ["null", "string"],
+                },
+                "time": {
+                    "description": "Timestamp of the event",
+                    "type": ["null", "string"],
+                    "format": "date-time",
+                },
+                "properties": {
+                    "description": "Complete typed Mixpanel event properties",
+                    "type": ["null", "object"],
+                    "additionalProperties": True,
+                },
+            },
+        }

--- a/airbyte-integrations/connectors/source-mixpanel/unit_tests/test_source.py
+++ b/airbyte-integrations/connectors/source-mixpanel/unit_tests/test_source.py
@@ -68,6 +68,47 @@ def test_streams(requests_mock, config_raw):
     assert "revenue" not in [stream.name for stream in streams]
 
 
+@pytest.mark.parametrize(
+    "selected_streams,expected_count,expected_names",
+    [
+        pytest.param(None, 6, None, id="no_filter_returns_all"),
+        pytest.param([], 6, None, id="empty_list_returns_all"),
+        pytest.param(["cohorts", "annotations"], 2, {"cohorts", "annotations"}, id="subset_filter"),
+        pytest.param(["export"], 1, {"export"}, id="single_stream_filter"),
+        pytest.param(
+            ["cohorts", "engage", "annotations", "cohort_members", "funnels", "export"],
+            6,
+            {"cohorts", "engage", "annotations", "cohort_members", "funnels", "export"},
+            id="all_streams_explicit",
+        ),
+    ],
+)
+def test_streams_filtering(requests_mock, config_raw, selected_streams, expected_count, expected_names):
+    requests_mock.register_uri("POST", "https://mixpanel.com/api/query/engage?page_size=1000", setup_response(200, {}))
+    requests_mock.register_uri("GET", "https://mixpanel.com/api/query/engage/properties", setup_response(200, {}))
+    requests_mock.register_uri("GET", "https://mixpanel.com/api/query/events/properties/top", setup_response(200, {}))
+    requests_mock.register_uri("GET", "https://mixpanel.com/api/query/annotations", setup_response(200, {}))
+    requests_mock.register_uri("GET", "https://mixpanel.com/api/query/cohorts/list", setup_response(200, {"id": 123}))
+    requests_mock.register_uri("GET", "https://mixpanel.com/api/query/funnels", setup_response(200, {}))
+    requests_mock.register_uri(
+        "GET", "https://mixpanel.com/api/query/funnels/list", setup_response(200, {"funnel_id": 123, "name": "name"})
+    )
+    requests_mock.register_uri(
+        "GET",
+        "https://data.mixpanel.com/api/2.0/export",
+        setup_response(200, {"event": "some event", "properties": {"event": 124, "time": 124124}}),
+    )
+
+    config = copy.deepcopy(config_raw)
+    if selected_streams is not None:
+        config["streams"] = selected_streams
+
+    streams = SourceMixpanel(MagicMock(), config, MagicMock()).streams(config)
+    assert len(streams) == expected_count
+    if expected_names:
+        assert {s.name for s in streams} == expected_names
+
+
 def test_streams_string_date(requests_mock, config_raw):
     requests_mock.register_uri("GET", "https://mixpanel.com/api/query/engage/properties", setup_response(200, {}))
     requests_mock.register_uri("GET", "https://mixpanel.com/api/query/events/properties/top", setup_response(200, {}))

--- a/airbyte-integrations/connectors/source-mixpanel/unit_tests/test_source.py
+++ b/airbyte-integrations/connectors/source-mixpanel/unit_tests/test_source.py
@@ -32,6 +32,28 @@ def test_check_connection(requests_mock, check_connection_url, config_raw, respo
     assert ok == expect_success
 
 
+@pytest.mark.parametrize(
+    "selected_streams",
+    [
+        pytest.param(["export"], id="export_only"),
+        pytest.param(["annotations"], id="declarative_stream_only"),
+    ],
+)
+def test_check_connection_with_filtered_catalog(requests_mock, config_raw, selected_streams):
+    requests_mock.get("https://mixpanel.com/api/query/cohorts/list", status_code=200, json=[])
+    config = {
+        **config_raw,
+        "start_date": "2024-01-25T00:00:00Z",
+        "end_date": "2024-02-25T00:00:00Z",
+        "streams": selected_streams,
+    }
+
+    ok, error = SourceMixpanel(MagicMock(), config, MagicMock()).check_connection(logger, config)
+
+    assert ok is True
+    assert error is None
+
+
 def test_check_connection_bad_config():
     config = {}
     source = SourceMixpanel(MagicMock(), config, MagicMock())

--- a/airbyte-integrations/connectors/source-mixpanel/unit_tests/test_source.py
+++ b/airbyte-integrations/connectors/source-mixpanel/unit_tests/test_source.py
@@ -131,6 +131,38 @@ def test_streams_filtering(requests_mock, config_raw, selected_streams, expected
         assert {s.name for s in streams} == expected_names
 
 
+@pytest.mark.parametrize(
+    "enable_export_raw,selected_streams,expected_names",
+    [
+        pytest.param(False, ["export"], {"export"}, id="disabled"),
+        pytest.param(True, ["export"], {"export"}, id="enabled_but_filtered"),
+        pytest.param(True, ["export_raw"], {"export_raw"}, id="enabled_and_selected"),
+        pytest.param(
+            True, None, {"cohorts", "engage", "annotations", "cohort_members", "funnels", "export", "export_raw"}, id="enabled_all"
+        ),
+    ],
+)
+def test_export_raw_stream_selection(requests_mock, config_raw, enable_export_raw, selected_streams, expected_names):
+    requests_mock.register_uri("POST", "https://mixpanel.com/api/query/engage?page_size=1000", setup_response(200, {}))
+    requests_mock.register_uri("GET", "https://mixpanel.com/api/query/engage/properties", setup_response(200, {}))
+    requests_mock.register_uri("GET", "https://mixpanel.com/api/query/events/properties/top", setup_response(200, {}))
+    requests_mock.register_uri("GET", "https://mixpanel.com/api/query/annotations", setup_response(200, {}))
+    requests_mock.register_uri("GET", "https://mixpanel.com/api/query/cohorts/list", setup_response(200, {"id": 123}))
+    requests_mock.register_uri("GET", "https://mixpanel.com/api/query/funnels", setup_response(200, {}))
+    requests_mock.register_uri(
+        "GET", "https://mixpanel.com/api/query/funnels/list", setup_response(200, {"funnel_id": 123, "name": "name"})
+    )
+
+    config = copy.deepcopy(config_raw)
+    config["enable_export_raw"] = enable_export_raw
+    if selected_streams is not None:
+        config["streams"] = selected_streams
+
+    streams = SourceMixpanel(MagicMock(), config, MagicMock()).streams(config)
+
+    assert {stream.name for stream in streams} == expected_names
+
+
 def test_streams_string_date(requests_mock, config_raw):
     requests_mock.register_uri("GET", "https://mixpanel.com/api/query/engage/properties", setup_response(200, {}))
     requests_mock.register_uri("GET", "https://mixpanel.com/api/query/events/properties/top", setup_response(200, {}))

--- a/airbyte-integrations/connectors/source-mixpanel/unit_tests/test_streams.py
+++ b/airbyte-integrations/connectors/source-mixpanel/unit_tests/test_streams.py
@@ -15,7 +15,7 @@ import responses
 import source_mixpanel
 from source_mixpanel import SourceMixpanel
 from source_mixpanel.components import iter_dicts
-from source_mixpanel.streams import Export, ExportSchema
+from source_mixpanel.streams import Export, ExportRaw, ExportSchema
 from source_mixpanel.utils import read_full_refresh
 
 from airbyte_cdk.models import (
@@ -651,8 +651,15 @@ def test_export_schema_request_params(config):
         pytest.param(["Signup", "Purchase"], '["Signup", "Purchase"]', id="selected_events"),
     ],
 )
-def test_export_request_params(config, export_events, expected_event):
-    stream = Export(authenticator=MagicMock(), export_events=export_events, **config)
+@pytest.mark.parametrize(
+    "stream_class",
+    [
+        pytest.param(Export, id="flattened"),
+        pytest.param(ExportRaw, id="raw"),
+    ],
+)
+def test_export_request_params(config, export_events, expected_event, stream_class):
+    stream = stream_class(authenticator=MagicMock(), export_events=export_events, **config)
     stream_slice = {
         "start_date": "2024-01-25",
         "end_date": "2024-01-26",
@@ -687,6 +694,71 @@ def test_export_explicit_properties_do_not_filter_records(config):
 
     assert records[0]["selected_property"] == "selected"
     assert records[0]["unselected_property"] == "retained"
+
+
+def test_export_raw_process_response_preserves_typed_properties(config):
+    stream = ExportRaw(authenticator=MagicMock(), **config)
+    properties = {
+        "time": 1623860880,
+        "$insert_id": "insert-id",
+        "$browser": "Chrome",
+        "nested": {"enabled": True, "values": [1, "two", None]},
+        "boolean": False,
+        "null": None,
+    }
+    response = MagicMock()
+    response.iter_lines.return_value = [json.dumps({"event": "Signup", "properties": properties})]
+
+    records = list(stream.process_response(response))
+
+    assert records == [
+        {
+            "event": "Signup",
+            "time": "2021-06-16T16:28:00Z",
+            "properties": properties,
+        }
+    ]
+    assert stream.get_updated_state({}, records[0]) == {"time": "2021-06-16T16:28:00Z"}
+
+
+def test_export_raw_get_json_schema_skips_dynamic_discovery(requests_mock, config):
+    stream = ExportRaw(authenticator=MagicMock(), **config)
+
+    schema = stream.get_json_schema()
+
+    assert not requests_mock.called
+    assert schema["additionalProperties"] is False
+    assert schema["properties"]["properties"] == {
+        "description": "Complete typed Mixpanel event properties",
+        "type": ["null", "object"],
+        "additionalProperties": True,
+    }
+
+
+def test_export_raw_read_records_preserves_typed_properties(requests_mock, config):
+    stream = ExportRaw(authenticator=MagicMock(), **config)
+    properties = {
+        "time": 1623860880,
+        "$insert_id": "insert-id",
+        "array": [1, 2],
+        "object": {"nested": True},
+        "boolean": True,
+        "null": None,
+    }
+    requests_mock.register_uri(
+        "GET",
+        get_url_to_mock(stream),
+        text=json.dumps({"event": "Signup", "properties": properties}),
+    )
+
+    records = list(
+        stream.read_records(
+            sync_mode=SyncMode.incremental,
+            stream_slice={"start_date": "2021-06-16", "end_date": "2021-06-16"},
+        )
+    )
+
+    assert records == [{"event": "Signup", "time": "2021-06-16T16:28:00Z", "properties": properties}]
 
 
 @pytest.fixture

--- a/airbyte-integrations/connectors/source-mixpanel/unit_tests/test_streams.py
+++ b/airbyte-integrations/connectors/source-mixpanel/unit_tests/test_streams.py
@@ -15,7 +15,7 @@ import responses
 import source_mixpanel
 from source_mixpanel import SourceMixpanel
 from source_mixpanel.components import iter_dicts
-from source_mixpanel.streams import Export
+from source_mixpanel.streams import Export, ExportSchema
 from source_mixpanel.utils import read_full_refresh
 
 from airbyte_cdk.models import (
@@ -588,13 +588,105 @@ def test_export_schema(requests_mock, export_schema_response, config_raw):
     assert schema["properties"]["browser_version"]["type"] == ["null", "string"]
 
 
-def test_export_get_json_schema(requests_mock, export_schema_response, config_raw):
+@pytest.mark.parametrize(
+    "extra_config",
+    [
+        pytest.param({}, id="omitted"),
+        pytest.param({"export_events": []}, id="empty_events"),
+        pytest.param({"export_properties": []}, id="empty_properties"),
+    ],
+)
+def test_export_get_json_schema(requests_mock, export_schema_response, config_raw, extra_config):
     requests_mock.register_uri("GET", "https://mixpanel.com/api/query/events/properties/top", export_schema_response)
 
-    stream = init_stream("export", config_raw)
+    stream = init_stream("export", {**config_raw, **extra_config})
     schema = stream.get_json_schema()
 
     assert "DYNAMIC_FIELD" in schema["properties"]
+
+
+def test_export_get_json_schema_with_explicit_properties(requests_mock, config_raw):
+    stream = init_stream(
+        "export",
+        {**config_raw, "export_properties": ["$configured_property", "AnotherConfiguredProperty"]},
+    )
+
+    schema = stream.get_json_schema()
+
+    assert not requests_mock.called
+    assert schema["properties"]["configured_property"]["type"] == ["null", "string"]
+    assert schema["properties"]["AnotherConfiguredProperty"]["type"] == ["null", "string"]
+
+
+def test_export_get_json_schema_with_events(requests_mock, config_raw):
+    requests_mock.register_uri(
+        "GET",
+        "https://mixpanel.com/api/query/events/properties/top",
+        [
+            {"json": {"$signup_property": {"count": 2}}, "status_code": 200},
+            {"json": {"purchase_property": {"count": 3}}, "status_code": 200},
+        ],
+    )
+    stream = init_stream("export", {**config_raw, "export_events": ["Signup", "Purchase"]})
+
+    schema = stream.get_json_schema()
+
+    assert schema["properties"]["signup_property"]["type"] == ["null", "string"]
+    assert schema["properties"]["purchase_property"]["type"] == ["null", "string"]
+    assert [request.query for request in requests_mock.request_history] == ["event=signup", "event=purchase"]
+
+
+def test_export_schema_request_params(config):
+    stream = ExportSchema(authenticator=MagicMock(), event="Signup", **config)
+
+    params = stream.request_params(stream_state={})
+
+    assert params["event"] == "Signup"
+
+
+@pytest.mark.parametrize(
+    "export_events,expected_event",
+    [
+        pytest.param([], None, id="all_events"),
+        pytest.param(["Signup", "Purchase"], '["Signup", "Purchase"]', id="selected_events"),
+    ],
+)
+def test_export_request_params(config, export_events, expected_event):
+    stream = Export(authenticator=MagicMock(), export_events=export_events, **config)
+    stream_slice = {
+        "start_date": "2024-01-25",
+        "end_date": "2024-01-26",
+        "time": "2024-01-25T12:00:00Z",
+    }
+
+    params = stream.request_params(stream_state={}, stream_slice=stream_slice)
+
+    assert params["from_date"] == "2024-01-25"
+    assert params["to_date"] == "2024-01-26"
+    assert params["where"] == 'properties["$time"]>=datetime(1706184000)'
+    assert params.get("event") == expected_event
+
+
+def test_export_explicit_properties_do_not_filter_records(config):
+    stream = Export(authenticator=MagicMock(), export_properties=["selected_property"], **config)
+    response = MagicMock()
+    response.iter_lines.return_value = [
+        json.dumps(
+            {
+                "event": "Signup",
+                "properties": {
+                    "time": 1623860880,
+                    "selected_property": "selected",
+                    "unselected_property": "retained",
+                },
+            }
+        )
+    ]
+
+    records = list(stream.process_response(response))
+
+    assert records[0]["selected_property"] == "selected"
+    assert records[0]["unselected_property"] == "retained"
 
 
 @pytest.fixture

--- a/docs/integrations/sources/mixpanel.md
+++ b/docs/integrations/sources/mixpanel.md
@@ -97,7 +97,7 @@ If you use Airbyte Cloud and your organization restricts access to specific IPs,
 
 | Version | Date | Pull Request | Subject |
 | :--- | :--- | :--- | :--- |
-| 4.1.0 | 2026-07-16 | [TBD](https://github.com/airbytehq/airbyte/pull/TBD) | Add optional stream and Export filters plus an opt-in raw Export stream with typed nested properties |
+| 4.1.0 | 2026-07-16 | [82227](https://github.com/airbytehq/airbyte/pull/82227) | Add optional stream and Export filters plus an opt-in raw Export stream with typed nested properties |
 | 4.0.1 | 2026-07-02 | [81392](https://github.com/airbytehq/airbyte/pull/81392) | Bump h11 0.14.0 to 0.16.0 to resolve GHSA-vqfr-h8mv-ghfj |
 | 4.0.0 | 2026-05-22 | [78271](https://github.com/airbytehq/airbyte/pull/78271) | Removed the Revenue stream because Mixpanel no longer provides a documented or working revenue Query API endpoint. |
 | 3.6.3 | 2026-04-13 | [76276](https://github.com/airbytehq/airbyte/pull/76276) | Rename "concurrent workers" to "concurrent threads" in connector spec |

--- a/docs/integrations/sources/mixpanel.md
+++ b/docs/integrations/sources/mixpanel.md
@@ -33,7 +33,8 @@ The connector also supports [Project Secret](https://developer.mixpanel.com/refe
 14. For **Page Size**, enter the number of records to fetch per request for the Engage stream. The default is 1000.
 15. For **Export Lookback Window**, enter the number of seconds to look back from the last synced timestamp during incremental syncs of the Export stream. This helps avoid missed data due to delays in event recording. The default is 0 seconds.
 16. For **Number of concurrent threads**, enter the number of worker threads for the sync. The default is 3. Higher values may improve performance but are constrained by your Mixpanel plan's [rate limits](https://developer.mixpanel.com/reference/rate-limits).
-17. Click **Set up source**.
+17. (Optional) For **Streams to Discover**, select the specific streams you want to discover and sync. If left empty, all streams are available. Use this to speed up schema discovery when your account has access to many endpoints and discovery is timing out. Available streams: `cohorts`, `engage`, `annotations`, `cohort_members`, `funnels`, `export`.
+18. Click **Set up source**.
 
 ## Supported sync modes
 
@@ -87,6 +88,7 @@ If you use Airbyte Cloud and your organization restricts access to specific IPs,
 
 | Version | Date | Pull Request | Subject |
 | :--- | :--- | :--- | :--- |
+| 4.1.0 | 2026-06-30 | [TBD](https://github.com/airbytehq/airbyte/pull/TBD) | Add optional `streams` config parameter to filter which streams are discovered and synced, improving schema discovery performance for accounts with broad access |
 | 4.0.1 | 2026-07-02 | [81392](https://github.com/airbytehq/airbyte/pull/81392) | Bump h11 0.14.0 to 0.16.0 to resolve GHSA-vqfr-h8mv-ghfj |
 | 4.0.0 | 2026-05-22 | [78271](https://github.com/airbytehq/airbyte/pull/78271) | Removed the Revenue stream because Mixpanel no longer provides a documented or working revenue Query API endpoint. |
 | 3.6.3 | 2026-04-13 | [76276](https://github.com/airbytehq/airbyte/pull/76276) | Rename "concurrent workers" to "concurrent threads" in connector spec |

--- a/docs/integrations/sources/mixpanel.md
+++ b/docs/integrations/sources/mixpanel.md
@@ -34,7 +34,9 @@ The connector also supports [Project Secret](https://developer.mixpanel.com/refe
 15. For **Export Lookback Window**, enter the number of seconds to look back from the last synced timestamp during incremental syncs of the Export stream. This helps avoid missed data due to delays in event recording. The default is 0 seconds.
 16. For **Number of concurrent threads**, enter the number of worker threads for the sync. The default is 3. Higher values may improve performance but are constrained by your Mixpanel plan's [rate limits](https://developer.mixpanel.com/reference/rate-limits).
 17. (Optional) For **Streams to Discover**, select the specific streams you want to discover and sync. If left empty, all streams are available. Use this to speed up schema discovery when your account has access to many endpoints and discovery is timing out. Available streams: `cohorts`, `engage`, `annotations`, `cohort_members`, `funnels`, `export`.
-18. Click **Set up source**.
+18. (Optional) For **Export Events**, enter the exact, case-sensitive event names to replicate from the Export stream. If left empty, all events are replicated. This setting also scopes dynamic Export schema discovery to the selected events.
+19. (Optional) For **Export Properties**, enter the exact event property names to include in the Export schema. When provided, the connector skips Mixpanel's dynamic property-discovery request. This setting doesn't remove other properties from exported records or reduce the raw response size.
+20. Click **Set up source**.
 
 ## Supported sync modes
 
@@ -71,7 +73,7 @@ Mixpanel enforces separate rate limits for different API endpoints:
 - **Query API** (Cohorts, Engage, Funnels, Annotations, Cohort Members): 5 concurrent queries, 60 queries per hour.
 - **Raw Data Export API** (Export): 100 concurrent queries, 60 queries per hour, 3 queries per second.
 
-Syncing large date windows may take longer due to these rate limits. You can adjust the **Date slicing window** and **Number of concurrent threads** settings to tune performance within your plan's limits.
+Syncing large date windows may take longer due to these rate limits. You can adjust the **Date slicing window** and **Number of concurrent threads** settings to tune performance within your plan's limits. Use **Export Events** to reduce the number of events returned by Mixpanel. If Export schema discovery times out, use **Export Properties** to define the required schema fields without querying Mixpanel for every available event property.
 
 ## Limitations
 
@@ -88,7 +90,7 @@ If you use Airbyte Cloud and your organization restricts access to specific IPs,
 
 | Version | Date | Pull Request | Subject |
 | :--- | :--- | :--- | :--- |
-| 4.1.0 | 2026-06-30 | [TBD](https://github.com/airbytehq/airbyte/pull/TBD) | Add optional `streams` config parameter to filter which streams are discovered and synced, improving schema discovery performance for accounts with broad access |
+| 4.1.0 | 2026-06-30 | [TBD](https://github.com/airbytehq/airbyte/pull/TBD) | Add optional stream, Export event, and Export property filters to reduce schema discovery and sync volume |
 | 4.0.1 | 2026-07-02 | [81392](https://github.com/airbytehq/airbyte/pull/81392) | Bump h11 0.14.0 to 0.16.0 to resolve GHSA-vqfr-h8mv-ghfj |
 | 4.0.0 | 2026-05-22 | [78271](https://github.com/airbytehq/airbyte/pull/78271) | Removed the Revenue stream because Mixpanel no longer provides a documented or working revenue Query API endpoint. |
 | 3.6.3 | 2026-04-13 | [76276](https://github.com/airbytehq/airbyte/pull/76276) | Rename "concurrent workers" to "concurrent threads" in connector spec |

--- a/docs/integrations/sources/mixpanel.md
+++ b/docs/integrations/sources/mixpanel.md
@@ -34,8 +34,8 @@ The connector also supports [Project Secret](https://developer.mixpanel.com/refe
 15. For **Export Lookback Window**, enter the number of seconds to look back from the last synced timestamp during incremental syncs of the Export stream. This helps avoid missed data due to delays in event recording. The default is 0 seconds.
 16. For **Number of concurrent threads**, enter the number of worker threads for the sync. The default is 3. Higher values may improve performance but are constrained by your Mixpanel plan's [rate limits](https://developer.mixpanel.com/reference/rate-limits).
 17. (Optional) For **Streams to Discover**, select the specific streams you want to discover and sync. If left empty, all streams are available. Use this to speed up schema discovery when your account has access to many endpoints and discovery is timing out. Available streams: `cohorts`, `engage`, `annotations`, `cohort_members`, `funnels`, `export`.
-18. (Optional) For **Export Events**, enter the exact, case-sensitive event names to replicate from the Export stream. If left empty, all events are replicated. This setting also scopes dynamic Export schema discovery to the selected events.
-19. (Optional) For **Export Properties**, enter the exact event property names to include in the Export schema. When provided, the connector skips Mixpanel's dynamic property-discovery request. This setting doesn't remove other properties from exported records or reduce the raw response size.
+18. (Optional) For **Export Events**, enter the exact, case-sensitive event names to replicate from the Export stream. If left empty, all events are replicated. This setting also scopes dynamic Export schema discovery to the selected events, but it does **not** skip discovery — the connector still calls Mixpanel's property-discovery request (`events/properties/top`) once per selected event, so discovery can still be slow or time out. To skip discovery entirely, set **Export Properties**.
+19. (Optional) For **Export Properties**, enter the exact event property names to include in the Export schema. When provided, the connector builds the Export schema directly from this list and completely skips Mixpanel's dynamic property-discovery request (`events/properties/top`) — use this setting if Export schema discovery is timing out. This setting doesn't remove other properties from exported records or reduce the raw response size.
 20. Click **Set up source**.
 
 ## Supported sync modes
@@ -73,7 +73,7 @@ Mixpanel enforces separate rate limits for different API endpoints:
 - **Query API** (Cohorts, Engage, Funnels, Annotations, Cohort Members): 5 concurrent queries, 60 queries per hour.
 - **Raw Data Export API** (Export): 100 concurrent queries, 60 queries per hour, 3 queries per second.
 
-Syncing large date windows may take longer due to these rate limits. You can adjust the **Date slicing window** and **Number of concurrent threads** settings to tune performance within your plan's limits. Use **Export Events** to reduce the number of events returned by Mixpanel. If Export schema discovery times out, use **Export Properties** to define the required schema fields without querying Mixpanel for every available event property.
+Syncing large date windows may take longer due to these rate limits. You can adjust the **Date slicing window** and **Number of concurrent threads** settings to tune performance within your plan's limits. Use **Export Events** to reduce the number of events returned by Mixpanel during syncs. Note that **Export Events** alone does not fix a schema-discovery timeout — the connector still queries `events/properties/top` for each selected event. If Export schema discovery times out, use **Export Properties** to define the required schema fields directly; this is the only setting that skips the discovery request entirely.
 
 ## Limitations
 

--- a/docs/integrations/sources/mixpanel.md
+++ b/docs/integrations/sources/mixpanel.md
@@ -33,7 +33,7 @@ The connector also supports [Project Secret](https://developer.mixpanel.com/refe
 14. For **Page Size**, enter the number of records to fetch per request for the Engage stream. The default is 1000.
 15. For **Export Lookback Window**, enter the number of seconds to look back from the last synced timestamp during incremental syncs of the Export stream. This helps avoid missed data due to delays in event recording. The default is 0 seconds.
 16. For **Number of concurrent threads**, enter the number of worker threads for the sync. The default is 3. Higher values may improve performance but are constrained by your Mixpanel plan's [rate limits](https://developer.mixpanel.com/reference/rate-limits).
-17. (Optional) For **Streams to Discover**, select the specific streams you want to discover and sync. If left empty, all streams are available. Use this to speed up schema discovery when your account has access to many endpoints and discovery is timing out. Available streams: `cohorts`, `engage`, `annotations`, `cohort_members`, `funnels`, `export`.
+17. (Optional) For **Streams to Discover**, select the specific streams you want to discover and sync. If left empty, all streams are available. Use this to speed up schema discovery when your account has access to many endpoints and discovery is timing out. Available streams: `cohorts`, `engage`, `annotations`, `cohort_members`, `funnels`, `export`, and the opt-in `export_raw`.
 18. (Optional) For **Export Events**, enter the exact, case-sensitive event names to replicate from the Export stream. If left empty, all events are replicated. This setting also scopes dynamic Export schema discovery to the selected events, but it does **not** skip discovery — the connector still calls Mixpanel's property-discovery request (`events/properties/top`) once per selected event, so discovery can still be slow or time out. To skip discovery entirely, set **Export Properties**.
 19. (Optional) For **Export Properties**, enter the exact event property names to include in the Export schema. When provided, the connector builds the Export schema directly from this list and completely skips Mixpanel's dynamic property-discovery request (`events/properties/top`) — use this setting if Export schema discovery is timing out. This setting doesn't remove other properties from exported records or reduce the raw response size.
 20. Click **Set up source**.
@@ -56,6 +56,7 @@ Incremental syncs may return duplicate records for the state date because the Mi
 | Stream | Sync mode | Primary key |
 | --- | --- | --- |
 | [Export](https://developer.mixpanel.com/reference/raw-event-export) | Incremental | User-defined (see below) |
+| Export Raw | Incremental | User-defined (see below) |
 | [Engage](https://developer.mixpanel.com/reference/engage-query) | Incremental | `distinct_id` |
 | [Funnels](https://developer.mixpanel.com/reference/funnels-query) | Incremental | `funnel_id`, `date` |
 | [Annotations](https://developer.mixpanel.com/reference/list-all-annotations-for-project) | Full Refresh | `id` |
@@ -64,7 +65,13 @@ Incremental syncs may return duplicate records for the state date because the Mi
 
 ### Primary key for the Export stream
 
-The Export stream has no default primary key. Mixpanel recommends using `insert_id`, `time`, `event`, and `distinct_id` together as the primary key. Some rows may lack an `insert_id`, so verify that your chosen key combination uniquely identifies your data.
+The Export streams have no default primary key. Mixpanel recommends using `insert_id`, `time`, `event`, and `distinct_id` together as the primary key. Some rows may lack an `insert_id`, so verify that your chosen key combination uniquely identifies your data. In `export_raw`, `insert_id` and `distinct_id` remain nested under `properties`.
+
+### Raw Export stream
+
+The opt-in `export_raw` stream preserves Mixpanel's complete typed `properties` object, including `$`-prefixed keys, arrays, nested objects, booleans, and nulls. It also emits `event` and a top-level ISO 8601 `time` field for incremental cursor tracking. This separate stream leaves the existing flattened `export` stream unchanged and skips dynamic property discovery.
+
+To enable it through programmatic configuration, set the hidden `enable_export_raw` property to `true`. To sync only nested records, also set `streams` to `["export_raw"]`.
 
 ## Performance considerations
 
@@ -90,7 +97,7 @@ If you use Airbyte Cloud and your organization restricts access to specific IPs,
 
 | Version | Date | Pull Request | Subject |
 | :--- | :--- | :--- | :--- |
-| 4.1.0 | 2026-06-30 | [TBD](https://github.com/airbytehq/airbyte/pull/TBD) | Add optional stream, Export event, and Export property filters to reduce schema discovery and sync volume |
+| 4.1.0 | 2026-07-16 | [TBD](https://github.com/airbytehq/airbyte/pull/TBD) | Add optional stream and Export filters plus an opt-in raw Export stream with typed nested properties |
 | 4.0.1 | 2026-07-02 | [81392](https://github.com/airbytehq/airbyte/pull/81392) | Bump h11 0.14.0 to 0.16.0 to resolve GHSA-vqfr-h8mv-ghfj |
 | 4.0.0 | 2026-05-22 | [78271](https://github.com/airbytehq/airbyte/pull/78271) | Removed the Revenue stream because Mixpanel no longer provides a documented or working revenue Query API endpoint. |
 | 3.6.3 | 2026-04-13 | [76276](https://github.com/airbytehq/airbyte/pull/76276) | Rename "concurrent workers" to "concurrent threads" in connector spec |


### PR DESCRIPTION
## Triggering Context

**Run triggered by:** Ryan's manual request to implement and document an opt-in raw Mixpanel Export stream.

**Relevant context:** [Devin implementation session](https://app.devin.ai/sessions/28cc51a3e1894fa7946bbe70694a26e7) and https://github.com/airbytehq/airbyte/issues/73493

**Confidence impact:** The requested behavior and compatibility constraints are explicit, but the feature remains in this open draft PR, so the documentation scope may still change after review.

## Documentation Confidence Assessment

**Overall Confidence: 3/5**

| Dimension | Score | Rationale |
|-----------|-------|-----------|
| Code Comprehension | 3/5 | The relevant Python CDK Export path is straightforward and was exercised through unit and image-level protocol tests. |
| API Documentation Quality | 4/5 | Mixpanel provides official Export, authentication, and rate-limit documentation, including an OpenAPI definition. |
| Change Scope & Risk | 4/5 | The documentation diff is a targeted 17-line update covering the new stream, filters, and changelog. |
| Existing Doc Maturity | 3/5 | The baseline 196-line connector guide already covered setup, streams, performance, limitations, and releases. |
| Connector Sensitivity | 4/5 | This is a community connector with high quality level but the new behavior is opt-in and additive. |
| Triggering Context | 3/5 | Documentation accompanies an open, unmerged feature PR with clear requirements. |

### What I Verified vs. What I Inferred

- **Verified from code**: the flag defaults to disabled; `export_raw` is additive; the existing `export` path is unchanged; raw records preserve typed nested properties; top-level `time`, state, event filtering, and cursor filtering work.
- **Verified from API docs**: Mixpanel's Export API returns JSONL with complete event properties and supports the documented `event` and `where` request filters.
- **Inferred**: the exact destination-side table presentation can vary by destination and normalization configuration; Snowflake's object mapping was verified from destination code rather than a live end-to-end sync.

### Areas of Concern

- Live authenticated success could not be validated because the available non-production Mixpanel project rejects API calls with HTTP 402.
- The current docs intentionally describe programmatic enablement because the field is `airbyte_hidden`; they must be updated if review changes it to an Advanced-visible UI option.

---

## What

Adds an opt-in `export_raw` stream for Mixpanel events that preserves the complete typed `properties` object, including `$`-prefixed keys, arrays, nested objects, booleans, numbers, and nulls.

This also carries forward the optional stream, Export event, and Export property filters from https://github.com/airbytehq/airbyte/pull/81343.

## How

- A hidden `enable_export_raw` source setting exposes the additive `export_raw` stream.
- `export_raw` reuses Export authentication, endpoint, date slicing, event filtering, lookback, and top-level `time` cursor behavior.
- Records are emitted as `{event, time, properties}`; `time` is normalized to ISO 8601 while `properties` is passed through without flattening, renaming, or string conversion.
- The static schema declares `properties` as an open object and skips Mixpanel's dynamic property-discovery requests.
- The existing `export` implementation and schema remain unchanged.

## Review Guide

1. `source_mixpanel/streams.py`: additive `ExportRaw` record and schema behavior.
2. `source_mixpanel/source.py` and `spec.json`: opt-in and stream selection.
3. `unit_tests/test_streams.py` and `unit_tests/test_source.py`: compatibility, typed-property, cursor, filtering, and discovery coverage.
4. `docs/integrations/sources/mixpanel.md`: configuration, output shape, and compatibility guidance.

Local validation:
- `poetry run pytest unit_tests -q` — 69 passed.
- Ruff format and lint checks pass for all changed Python files.

Prerelease:
- `airbyte/source-mixpanel:4.1.0-preview.8b75715`
- Digest: `sha256:8a6113a373747a9b452360bc011f48a86293a7f87b8d882c2612bb01065783c9`

Exact-image protocol validation:
- SPEC, disabled/enabled DISCOVER, and incremental `export_raw` READ passed against a deterministic internal HTTPS endpoint.
- READ preserved property names and native numbers, arrays, nested objects, booleans, and nulls.
- The request retained configured event and incremental `where` filters.
- The emitted top-level `time` and final state matched.
- A regression CHECK reached the available non-production Mixpanel project but returned HTTP 402 (`Your plan does not allow API calls`); live READ therefore could not run. No production resources were accessed.

## User Impact

Default behavior is unchanged: existing configurations continue to expose and sync the flattened `export` stream exactly as before. Enabling `export_raw` adds a separate incremental stream, so users can write nested records to a new destination table without changing or resetting the existing flattened stream.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚
- [ ] NO ❌

---

> **Note**: I am an AI assistant (Devin) and have proposed these documentation updates based on a review of the connector source code and third-party API documentation. Reviewers may merge, modify, or close this PR as they see fit.

---
[Devin session](https://app.devin.ai/sessions/28cc51a3e1894fa7946bbe70694a26e7)
