### PR TITLE
feat(source-postgres,source-mysql): add local e2e prove-fix test harness skills

### DIFF
--- a/airbyte-integrations/connectors/source-mysql/.agents/skills/source-mysql-e2e-tests/SKILL.md
+++ b/airbyte-integrations/connectors/source-mysql/.agents/skills/source-mysql-e2e-tests/SKILL.md
@@ -1,0 +1,171 @@
+---
+name: source-mysql-e2e-tests
+description: Stand up a local MySQL backend, apply SQL fixtures, and run airbyte-ops protocol commands (spec / check / discover / read) against airbyte/source-mysql:<tag> for ad-hoc end-to-end testing and prove-fix comparisons. Use when you need a deterministic, throwaway local environment for any source-mysql test, repro, or target-vs-control fix validation.
+---
+
+# source-mysql-e2e-tests
+
+Local end-to-end test harness for `source-mysql`. Stands up a MySQL
+container named `source-mysql-db-backend`, lets you apply arbitrary SQL
+fixtures, and runs Airbyte protocol commands against any
+`airbyte/source-mysql:<tag>` image via
+`airbyte-ops cloud connector regression-test` — in single-version mode
+for repros, or comparison mode (target vs control) for `/ai-prove-fix`.
+
+Modeled on
+[`source-mssql-e2e-tests`](../../../source-mssql/.agents/skills/source-mssql-e2e-tests/SKILL.md);
+the script contract is identical so driver scripts port across engines.
+
+## When to use this skill
+
+- Reproducing a `source-mysql` bug locally (type mapping, discovery,
+  incremental cursor, `tinyint(1)` handling, null/edge-value handling,
+  identifier quoting).
+- Running `spec` / `check` / `discover` / `read` against any
+  `airbyte/source-mysql:<tag>` for connector development.
+- Proving a fix: comparing a PR image (`--test-image`) against a
+  known-bad or latest control (`--control-image`) — see the
+  `db_prove_fix` playbook in `airbytehq/ai-skills`.
+
+## Prerequisites
+
+- Docker.
+- [`uv`](https://docs.astral.sh/uv/). `uv tool install airbyte-internal-ops`
+  puts `airbyte-ops` on `$PATH`; alternatively prefix every call with
+  `uvx airbyte-internal-ops`.
+- `jq`.
+- A clone of `airbytehq/airbyte`.
+
+You do not need GSM or Cloud admin credentials. Local-only mode (no
+`--connection-id`) reads everything from local files.
+
+## Layout
+
+```
+source-mysql-e2e-tests/
+├── SKILL.md
+├── scripts/
+│   ├── start-backend.sh        # docker run mysql:8.0 (binlog ROW + GTID) as source-mysql-db-backend
+│   ├── stop-backend.sh         # docker rm -f source-mysql-db-backend
+│   ├── apply-sql.sh            # docker exec mysql (stdin)
+│   ├── render-config.sh        # jq the backend bridge IP into a config template
+│   └── run-protocol-cmd.sh     # thin wrapper around `airbyte-ops … regression-test`
+└── fixtures/
+    ├── configs/
+    │   └── base.template.json  # STANDARD (non-CDC) config; host placeholder
+    └── sql/
+        └── 00-init-base.sql    # sample table with three rows
+```
+
+The skill expects all script paths relative to the skill root.
+
+## Conventions
+
+- Container name: `source-mysql-db-backend`. Override via
+  `BACKEND_NAME=…` only for parallel test isolation; don't use customer
+  connection names.
+- Working directory for rendered configs and run output:
+  `${REPRO_OUT:-/tmp/source-mysql-repro}`. Each `regression-test` run
+  writes artifacts under `$REPRO_OUT/<step-name>/`. Use a fresh
+  subdirectory per step so artifacts don't get clobbered.
+- Both containers (the MySQL backend and the connector launched by
+  `airbyte-ops`) share Docker's default `bridge` network. The connector
+  resolves the backend by its bridge IP, which `render-config.sh`
+  substitutes into the working config at runtime. Tracked upstream in
+  [`airbytehq/airbyte-ops-mcp#765`](https://github.com/airbytehq/airbyte-ops-mcp/issues/765);
+  once `--network` is supported the bridge-IP dance can collapse.
+- Image is pinned to `mysql:8.0` (override with `BACKEND_IMAGE=…` to
+  reproduce a version-specific bug — e.g. `mysql:5.7`).
+- The backend starts with `--binlog-format=ROW`, `--binlog-row-image=FULL`,
+  and GTIDs on, so a CDC repro can read the binlog on the same container
+  without a restart.
+
+## Usage
+
+```bash
+SKILL=airbyte-integrations/connectors/source-mysql/.agents/skills/source-mysql-e2e-tests
+export REPRO_OUT=/tmp/source-mysql-repro
+
+# 1. Start the backend.
+"$SKILL/scripts/start-backend.sh"
+
+# 2. Apply a SQL fixture.
+"$SKILL/scripts/apply-sql.sh" "$SKILL/fixtures/sql/00-init-base.sql"
+
+# 3. Render a working config from a template, substituting the backend IP.
+"$SKILL/scripts/render-config.sh" \
+  "$SKILL/fixtures/configs/base.template.json" \
+  "$REPRO_OUT/working/base.json"
+
+# 4a. Single-version run. Output lands under $REPRO_OUT/check-baseline/.
+"$SKILL/scripts/run-protocol-cmd.sh" check baseline 3.53.1 \
+  --config-path="$REPRO_OUT/working/base.json"
+
+# 4b. Prove-fix comparison: PR image (dev) vs known-bad control (3.53.0).
+CONTROL_VERSION=3.53.0 "$SKILL/scripts/run-protocol-cmd.sh" read prove dev \
+  --config-path="$REPRO_OUT/working/base.json" \
+  --catalog-path="$REPRO_OUT/working/catalog.json"
+
+# 5. Tear down.
+"$SKILL/scripts/stop-backend.sh"
+```
+
+`run-protocol-cmd.sh <command> <step-name> <version> [extra-args…]`
+maps to (single-version, default):
+
+```
+airbyte-ops cloud connector regression-test \
+  --skip-compare=True \
+  --command=<command> \
+  --test-image=airbyte/source-mysql:<version> \
+  --output-dir=$REPRO_OUT/<step-name> \
+  <extra-args…>
+```
+
+Set `CONTROL_VERSION=<tag>` to switch to comparison mode: `--skip-compare`
+is dropped and `--control-image=airbyte/source-mysql:$CONTROL_VERSION`
+is added so airbyte-ops emits a side-by-side SPEC/CHECK/DISCOVER/READ
+diff — the evidence engine the `db_prove_fix` playbook relies on.
+
+## Asserting on output
+
+Inline assertions in driver scripts. Suggested helpers:
+
+- Exit code: check `$?` immediately after the call.
+- AirbyteMessage shape: `jq -e 'select(.type == "RECORD")' $REPRO_OUT/<step>/stdout.txt`.
+- Discovered types: inspect the `DISCOVER` catalog JSON for the field's `json_schema`.
+- Connector-side log shape: `grep -c '<expected substring>' $REPRO_OUT/<step>/stderr.txt`.
+- Connection status: `jq -e 'select(.type == "CONNECTION_STATUS" and .connectionStatus.status == "SUCCEEDED")' $REPRO_OUT/<step>/stdout.txt`.
+
+`run-protocol-cmd.sh` accepts `--enable-debug-logs=True` as an extra arg
+to set `LOG_LEVEL=DEBUG` on the connector container. That surfaces the
+Debezium / bulk-CDK debug lines that some assertions rely on.
+
+## Common gotchas
+
+- _CDC needs ROW binlog_ → `start-backend.sh` sets `--binlog-format=ROW`
+  and a `--server-id`. A CDC repro switches the config
+  `replication_method` to `{"method": "CDC"}` and reads the binlog; the
+  connecting user needs `REPLICATION SLAVE` / `REPLICATION CLIENT`
+  (root has them). MySQL 8.0 has binlog on by default; the explicit
+  flags make the format deterministic.
+- _`ssl_mode` shape_ → MySQL uses `preferred / required / verify_ca /
+  verify_identity` (the base config uses `preferred` so the local
+  plaintext backend connects), not the Postgres `disable`/`require`
+  strings or the mssql `unencrypted` shape.
+- _`replication_method.method` is `STANDARD` / `CDC`_ (all caps), like
+  mssql — not the Postgres `Standard`.
+- _`tinyint(1)`_ → by default the connector maps `TINYINT(1)` to boolean;
+  `treat_tinyint1_as_integer: true` in the config forces integer. Set it
+  in a fixture config when reproducing a `tinyint` typing bug.
+
+## Tear-down
+
+`stop-backend.sh` is idempotent: `docker rm -f` is a no-op if the
+container doesn't exist. To wipe everything:
+
+```bash
+"$SKILL/scripts/stop-backend.sh"
+rm -rf "$REPRO_OUT"
+unset REPRO_OUT
+```

--- a/airbyte-integrations/connectors/source-mysql/.agents/skills/source-mysql-e2e-tests/fixtures/configs/base.template.json
+++ b/airbyte-integrations/connectors/source-mysql/.agents/skills/source-mysql-e2e-tests/fixtures/configs/base.template.json
@@ -1,0 +1,16 @@
+{
+  "host": "source-mysql-db-backend",
+  "port": 3306,
+  "database": "test_db",
+  "username": "root",
+  "password": "test_password",
+  "ssl_mode": {
+    "mode": "preferred"
+  },
+  "tunnel_method": {
+    "tunnel_method": "NO_TUNNEL"
+  },
+  "replication_method": {
+    "method": "STANDARD"
+  }
+}

--- a/airbyte-integrations/connectors/source-mysql/.agents/skills/source-mysql-e2e-tests/fixtures/sql/00-init-base.sql
+++ b/airbyte-integrations/connectors/source-mysql/.agents/skills/source-mysql-e2e-tests/fixtures/sql/00-init-base.sql
@@ -1,0 +1,15 @@
+-- Idempotent base init for source-mysql e2e tests (non-CDC).
+-- The test_db database is created by the container (MYSQL_DATABASE); this
+-- fixture just (re)creates a small sample table with three rows.
+
+DROP TABLE IF EXISTS sample;
+
+CREATE TABLE sample (
+  id    INT          NOT NULL PRIMARY KEY,
+  label VARCHAR(64)  NOT NULL
+);
+
+INSERT INTO sample (id, label) VALUES
+  (1, 'alpha'),
+  (2, 'beta'),
+  (3, 'gamma');

--- a/airbyte-integrations/connectors/source-mysql/.agents/skills/source-mysql-e2e-tests/scripts/apply-sql.sh
+++ b/airbyte-integrations/connectors/source-mysql/.agents/skills/source-mysql-e2e-tests/scripts/apply-sql.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Apply a .sql file to the e2e backend via `docker exec mysql` on stdin.
+#
+# Usage:  apply-sql.sh <path/to/file.sql>
+#
+# Env:
+#   BACKEND_NAME        container name (default: source-mysql-db-backend)
+#   BACKEND_PASSWORD    root password (default: test_password)
+#   BACKEND_DB          database to apply against (default: test_db)
+set -euo pipefail
+
+BACKEND_NAME="${BACKEND_NAME:-source-mysql-db-backend}"
+BACKEND_PASSWORD="${BACKEND_PASSWORD:-test_password}"
+BACKEND_DB="${BACKEND_DB:-test_db}"
+
+if [[ $# -lt 1 ]]; then
+  echo "usage: $(basename "$0") <path/to/file.sql>" >&2
+  exit 2
+fi
+SQL_FILE="$1"
+if [[ ! -f "$SQL_FILE" ]]; then
+  echo "[apply-sql] not a file: $SQL_FILE" >&2
+  exit 2
+fi
+
+# MYSQL_PWD avoids the "password on the command line is insecure" warning.
+docker exec -i -e MYSQL_PWD="$BACKEND_PASSWORD" "$BACKEND_NAME" \
+  mysql -uroot "$BACKEND_DB" < "$SQL_FILE"
+echo "[apply-sql] applied $SQL_FILE." >&2

--- a/airbyte-integrations/connectors/source-mysql/.agents/skills/source-mysql-e2e-tests/scripts/render-config.sh
+++ b/airbyte-integrations/connectors/source-mysql/.agents/skills/source-mysql-e2e-tests/scripts/render-config.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Substitute the e2e backend's bridge IP into a config template.
+#
+# Usage:  render-config.sh <template.json> <output.json>
+#
+# The connector container launched by `airbyte-ops` is on the default
+# `bridge` network and cannot resolve a user-defined network's container
+# names. Until airbytehq/airbyte-ops-mcp#765 lands `--network` support,
+# we render a working config that pins .host to the bridge IP that
+# Docker assigned to the backend container at runtime.
+#
+# Env:
+#   BACKEND_NAME        container name (default: source-mysql-db-backend)
+set -euo pipefail
+
+BACKEND_NAME="${BACKEND_NAME:-source-mysql-db-backend}"
+
+if [[ $# -lt 2 ]]; then
+  echo "usage: $(basename "$0") <template.json> <output.json>" >&2
+  exit 2
+fi
+TEMPLATE="$1"
+OUTPUT="$2"
+if [[ ! -f "$TEMPLATE" ]]; then
+  echo "[render-config] template not found: $TEMPLATE" >&2
+  exit 2
+fi
+
+BACKEND_IP=$(docker inspect "$BACKEND_NAME" \
+  --format '{{.NetworkSettings.Networks.bridge.IPAddress}}')
+if [[ -z "$BACKEND_IP" ]]; then
+  echo "[render-config] could not resolve bridge IP for $BACKEND_NAME." >&2
+  echo "[render-config] is the container running on the default bridge network?" >&2
+  exit 1
+fi
+
+mkdir -p "$(dirname "$OUTPUT")"
+jq --arg h "$BACKEND_IP" '.host = $h' "$TEMPLATE" > "$OUTPUT"
+echo "[render-config] $TEMPLATE → $OUTPUT (host=$BACKEND_IP)" >&2

--- a/airbyte-integrations/connectors/source-mysql/.agents/skills/source-mysql-e2e-tests/scripts/run-protocol-cmd.sh
+++ b/airbyte-integrations/connectors/source-mysql/.agents/skills/source-mysql-e2e-tests/scripts/run-protocol-cmd.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# Run an Airbyte protocol command against airbyte/source-mysql:<version>
+# via `airbyte-ops cloud connector regression-test`.
+#
+# Usage:  run-protocol-cmd.sh <command> <step-name> <version> [extra-args…]
+#
+#   <command>     spec | check | discover | read
+#   <step-name>   subdirectory under $REPRO_OUT to write artifacts to
+#   <version>     image tag, e.g. 3.53.1 / dev / latest
+#   [extra-args]  any additional flags forwarded verbatim
+#
+# Modes:
+#   Single-version (default): runs <version> alone with --skip-compare=True
+#     and returns the connector's own exit code (derived from report.md).
+#   Comparison (prove-fix): set CONTROL_VERSION=<tag> to compare <version>
+#     (--test-image) against airbyte/source-mysql:$CONTROL_VERSION
+#     (--control-image). --skip-compare is dropped so airbyte-ops produces
+#     a side-by-side SPEC/CHECK/DISCOVER/READ diff.
+#
+# Output:
+#   $REPRO_OUT/<step-name>/…  (stdout.txt, stderr.txt, report.md, diff)
+#
+# Env:
+#   REPRO_OUT        parent output directory (default: /tmp/source-mysql-repro)
+#   CONTROL_VERSION  when set, enables comparison mode against this tag
+#   AIRBYTE_OPS      command to invoke airbyte-ops. Default picks the binary
+#                    on $PATH (`airbyte-ops`) if `uv tool install
+#                    airbyte-internal-ops` was run, else falls back to
+#                    `uvx airbyte-internal-ops`.
+set -euo pipefail
+
+REPRO_OUT="${REPRO_OUT:-/tmp/source-mysql-repro}"
+CONNECTOR_IMAGE="airbyte/source-mysql"
+if [[ -z "${AIRBYTE_OPS:-}" ]]; then
+  if command -v airbyte-ops >/dev/null 2>&1; then
+    AIRBYTE_OPS="airbyte-ops"
+  else
+    AIRBYTE_OPS="uvx airbyte-internal-ops"
+  fi
+fi
+
+if [[ $# -lt 3 ]]; then
+  echo "usage: $(basename "$0") <command> <step-name> <version> [extra-args…]" >&2
+  exit 2
+fi
+COMMAND="$1"; shift
+STEP_NAME="$1"; shift
+VERSION="$1"; shift
+
+OUT_DIR="$REPRO_OUT/$STEP_NAME"
+rm -rf "$OUT_DIR"
+mkdir -p "$OUT_DIR"
+
+# `airbyte-ops cloud connector regression-test` in single-version mode
+# prints "Error: Single-version regression test failed …" when the
+# underlying connector exits non-zero, but the CLI itself returns 0.
+# Run it with `set +e` so a non-zero CLI exit also doesn't abort the
+# script, then derive the connector's actual exit code from report.md so
+# the caller's `RC` is meaningful.
+set +e
+if [[ -n "${CONTROL_VERSION:-}" ]]; then
+  # shellcheck disable=SC2086
+  $AIRBYTE_OPS cloud connector regression-test \
+    --command="$COMMAND" \
+    --test-image="$CONNECTOR_IMAGE:$VERSION" \
+    --control-image="$CONNECTOR_IMAGE:$CONTROL_VERSION" \
+    --output-dir="$OUT_DIR" \
+    "$@"
+else
+  # shellcheck disable=SC2086
+  $AIRBYTE_OPS cloud connector regression-test \
+    --skip-compare=True \
+    --command="$COMMAND" \
+    --test-image="$CONNECTOR_IMAGE:$VERSION" \
+    --output-dir="$OUT_DIR" \
+    "$@"
+fi
+set -e
+
+CONNECTOR_RC="$(
+  grep -E '^- \*\*Exit Code:\*\*' "$OUT_DIR/report.md" 2>/dev/null \
+    | head -n 1 \
+    | grep -oE '[0-9]+' \
+    | head -n 1
+)"
+exit "${CONNECTOR_RC:-1}"

--- a/airbyte-integrations/connectors/source-mysql/.agents/skills/source-mysql-e2e-tests/scripts/start-backend.sh
+++ b/airbyte-integrations/connectors/source-mysql/.agents/skills/source-mysql-e2e-tests/scripts/start-backend.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Start a throwaway MySQL container for source-mysql e2e tests.
+# Idempotent: succeeds whether or not the container already exists.
+#
+# Started with ROW-format binary logging + GTIDs so the same backend can
+# be reused by a CDC repro (binlog) without a restart.
+#
+# Env:
+#   BACKEND_NAME        container name (default: source-mysql-db-backend)
+#   BACKEND_PASSWORD    root password (default: test_password)
+#   BACKEND_DB          initial database (default: test_db)
+#   BACKEND_PORT        host port mapped to 3306/tcp (default: 3306)
+#   BACKEND_IMAGE       image (default: mysql:8.0)
+set -euo pipefail
+
+BACKEND_NAME="${BACKEND_NAME:-source-mysql-db-backend}"
+BACKEND_PASSWORD="${BACKEND_PASSWORD:-test_password}"
+BACKEND_DB="${BACKEND_DB:-test_db}"
+BACKEND_PORT="${BACKEND_PORT:-3306}"
+BACKEND_IMAGE="${BACKEND_IMAGE:-mysql:8.0}"
+
+if docker inspect "$BACKEND_NAME" >/dev/null 2>&1; then
+  echo "[start-backend] $BACKEND_NAME already exists; reusing." >&2
+else
+  docker run -d --rm \
+    --name "$BACKEND_NAME" \
+    -e MYSQL_ROOT_PASSWORD="$BACKEND_PASSWORD" \
+    -e MYSQL_DATABASE="$BACKEND_DB" \
+    -p "$BACKEND_PORT:3306" \
+    "$BACKEND_IMAGE" \
+    --server-id=223344 \
+    --log-bin=mysql-bin \
+    --binlog-format=ROW \
+    --binlog-row-image=FULL \
+    --gtid-mode=ON \
+    --enforce-gtid-consistency=ON >/dev/null
+fi
+
+echo "[start-backend] waiting for $BACKEND_NAME to accept connections…" >&2
+for _ in $(seq 1 60); do
+  if docker exec -e MYSQL_PWD="$BACKEND_PASSWORD" "$BACKEND_NAME" \
+       mysql -uroot -N -e "SELECT 1" >/dev/null 2>&1; then
+    echo "[start-backend] $BACKEND_NAME ready." >&2
+    exit 0
+  fi
+  sleep 2
+done
+
+echo "[start-backend] timed out waiting for $BACKEND_NAME after 120s." >&2
+exit 1

--- a/airbyte-integrations/connectors/source-mysql/.agents/skills/source-mysql-e2e-tests/scripts/stop-backend.sh
+++ b/airbyte-integrations/connectors/source-mysql/.agents/skills/source-mysql-e2e-tests/scripts/stop-backend.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Stop and remove the source-mysql e2e backend container.
+# Idempotent: a no-op if the container doesn't exist.
+#
+# Env:
+#   BACKEND_NAME        container name (default: source-mysql-db-backend)
+set -euo pipefail
+
+BACKEND_NAME="${BACKEND_NAME:-source-mysql-db-backend}"
+
+docker rm -f "$BACKEND_NAME" >/dev/null 2>&1 || true
+echo "[stop-backend] $BACKEND_NAME removed." >&2

--- a/airbyte-integrations/connectors/source-postgres/.agents/skills/source-postgres-e2e-tests/SKILL.md
+++ b/airbyte-integrations/connectors/source-postgres/.agents/skills/source-postgres-e2e-tests/SKILL.md
@@ -1,0 +1,169 @@
+---
+name: source-postgres-e2e-tests
+description: Stand up a local PostgreSQL backend, apply SQL fixtures, and run airbyte-ops protocol commands (spec / check / discover / read) against airbyte/source-postgres:<tag> for ad-hoc end-to-end testing and prove-fix comparisons. Use when you need a deterministic, throwaway local environment for any source-postgres test, repro, or target-vs-control fix validation.
+---
+
+# source-postgres-e2e-tests
+
+Local end-to-end test harness for `source-postgres`. Stands up a
+PostgreSQL container named `source-postgres-db-backend`, lets you apply
+arbitrary SQL fixtures, and runs Airbyte protocol commands against any
+`airbyte/source-postgres:<tag>` image via
+`airbyte-ops cloud connector regression-test` — in single-version mode
+for repros, or comparison mode (target vs control) for `/ai-prove-fix`.
+
+Modeled on
+[`source-mssql-e2e-tests`](../../../source-mssql/.agents/skills/source-mssql-e2e-tests/SKILL.md);
+the script contract is identical so driver scripts port across engines.
+
+## When to use this skill
+
+- Reproducing a `source-postgres` bug locally (type mapping, discovery,
+  incremental cursor, null/edge-value handling, identifier quoting).
+- Running `spec` / `check` / `discover` / `read` against any
+  `airbyte/source-postgres:<tag>` for connector development.
+- Proving a fix: comparing a PR image (`--test-image`) against a
+  known-bad or latest control (`--control-image`) — see the
+  `db_prove_fix` playbook in `airbytehq/ai-skills`.
+
+## Prerequisites
+
+- Docker.
+- [`uv`](https://docs.astral.sh/uv/). `uv tool install airbyte-internal-ops`
+  puts `airbyte-ops` on `$PATH`; alternatively prefix every call with
+  `uvx airbyte-internal-ops`.
+- `jq`.
+- A clone of `airbytehq/airbyte`.
+
+You do not need GSM or Cloud admin credentials. Local-only mode (no
+`--connection-id`) reads everything from local files.
+
+## Layout
+
+```
+source-postgres-e2e-tests/
+├── SKILL.md
+├── scripts/
+│   ├── start-backend.sh        # docker run postgres:16 (wal_level=logical) as source-postgres-db-backend
+│   ├── stop-backend.sh         # docker rm -f source-postgres-db-backend
+│   ├── apply-sql.sh            # docker exec psql -f (stdin)
+│   ├── render-config.sh        # jq the backend bridge IP into a config template
+│   └── run-protocol-cmd.sh     # thin wrapper around `airbyte-ops … regression-test`
+└── fixtures/
+    ├── configs/
+    │   └── base.template.json  # Standard (non-CDC) config; host placeholder
+    └── sql/
+        └── 00-init-base.sql    # public.sample table with three rows
+```
+
+The skill expects all script paths relative to the skill root.
+
+## Conventions
+
+- Container name: `source-postgres-db-backend`. Override via
+  `BACKEND_NAME=…` only for parallel test isolation; don't use customer
+  connection names.
+- Working directory for rendered configs and run output:
+  `${REPRO_OUT:-/tmp/source-postgres-repro}`. Each `regression-test` run
+  writes artifacts under `$REPRO_OUT/<step-name>/`. Use a fresh
+  subdirectory per step so artifacts don't get clobbered.
+- Both containers (the Postgres backend and the connector launched by
+  `airbyte-ops`) share Docker's default `bridge` network. The connector
+  resolves the backend by its bridge IP, which `render-config.sh`
+  substitutes into the working config at runtime. Tracked upstream in
+  [`airbytehq/airbyte-ops-mcp#765`](https://github.com/airbytehq/airbyte-ops-mcp/issues/765);
+  once `--network` is supported the bridge-IP dance can collapse.
+- Image is pinned to `postgres:16` (override with `BACKEND_IMAGE=…` to
+  reproduce a version-specific bug — e.g. `postgres:13`).
+- The backend starts with `wal_level=logical`, `max_wal_senders`, and
+  `max_replication_slots` set so a CDC repro can create a replication
+  slot + publication on the same container without a restart.
+
+## Usage
+
+```bash
+SKILL=airbyte-integrations/connectors/source-postgres/.agents/skills/source-postgres-e2e-tests
+export REPRO_OUT=/tmp/source-postgres-repro
+
+# 1. Start the backend.
+"$SKILL/scripts/start-backend.sh"
+
+# 2. Apply a SQL fixture.
+"$SKILL/scripts/apply-sql.sh" "$SKILL/fixtures/sql/00-init-base.sql"
+
+# 3. Render a working config from a template, substituting the backend IP.
+"$SKILL/scripts/render-config.sh" \
+  "$SKILL/fixtures/configs/base.template.json" \
+  "$REPRO_OUT/working/base.json"
+
+# 4a. Single-version run. Output lands under $REPRO_OUT/check-baseline/.
+"$SKILL/scripts/run-protocol-cmd.sh" check baseline 3.8.1 \
+  --config-path="$REPRO_OUT/working/base.json"
+
+# 4b. Prove-fix comparison: PR image (dev) vs known-bad control (3.8.0).
+CONTROL_VERSION=3.8.0 "$SKILL/scripts/run-protocol-cmd.sh" read prove dev \
+  --config-path="$REPRO_OUT/working/base.json" \
+  --catalog-path="$REPRO_OUT/working/catalog.json"
+
+# 5. Tear down.
+"$SKILL/scripts/stop-backend.sh"
+```
+
+`run-protocol-cmd.sh <command> <step-name> <version> [extra-args…]`
+maps to (single-version, default):
+
+```
+airbyte-ops cloud connector regression-test \
+  --skip-compare=True \
+  --command=<command> \
+  --test-image=airbyte/source-postgres:<version> \
+  --output-dir=$REPRO_OUT/<step-name> \
+  <extra-args…>
+```
+
+Set `CONTROL_VERSION=<tag>` to switch to comparison mode: `--skip-compare`
+is dropped and `--control-image=airbyte/source-postgres:$CONTROL_VERSION`
+is added so airbyte-ops emits a side-by-side SPEC/CHECK/DISCOVER/READ
+diff — the evidence engine the `db_prove_fix` playbook relies on.
+
+## Asserting on output
+
+Inline assertions in driver scripts. Suggested helpers:
+
+- Exit code: check `$?` immediately after the call.
+- AirbyteMessage shape: `jq -e 'select(.type == "RECORD")' $REPRO_OUT/<step>/stdout.txt`.
+- Discovered types: inspect the `DISCOVER` catalog JSON for the field's `json_schema`.
+- Connector-side log shape: `grep -c '<expected substring>' $REPRO_OUT/<step>/stderr.txt`.
+- Connection status: `jq -e 'select(.type == "CONNECTION_STATUS" and .connectionStatus.status == "SUCCEEDED")' $REPRO_OUT/<step>/stdout.txt`.
+
+`run-protocol-cmd.sh` accepts `--enable-debug-logs=True` as an extra arg
+to set `LOG_LEVEL=DEBUG` on the connector container. That surfaces the
+Debezium / bulk-CDK debug lines that some assertions rely on.
+
+## Common gotchas
+
+- _CDC needs logical decoding_ → `start-backend.sh` sets
+  `wal_level=logical`. A CDC repro still has to `CREATE PUBLICATION` and
+  a logical replication slot (`pg_create_logical_replication_slot`) in
+  its SQL fixture, and the config must switch `replication_method` to
+  `{"method": "CDC", "replication_slot": "…", "publication": "…"}`.
+- _`schemas` is case-sensitive_ → the base config selects `["public"]`.
+  If a fixture creates objects in another schema, add it to `schemas` or
+  discovery won't see them.
+- _`ssl_mode` values differ from other engines_ → Postgres uses
+  `disable / allow / prefer / require / verify-ca / verify-full` (the
+  base config uses `disable` for the local plaintext backend), not the
+  mssql `unencrypted` shape.
+- _`replication_method.method` is `Standard` / `Xmin` / `CDC`_ (capital
+  S), not the mssql `STANDARD`.
+
+## Tear-down
+
+`stop-backend.sh` is idempotent: `docker rm -f` is a no-op if the
+container doesn't exist. To wipe everything:
+
+```bash
+"$SKILL/scripts/stop-backend.sh"
+rm -rf "$REPRO_OUT"
+unset REPRO_OUT
+```

--- a/airbyte-integrations/connectors/source-postgres/.agents/skills/source-postgres-e2e-tests/fixtures/configs/base.template.json
+++ b/airbyte-integrations/connectors/source-postgres/.agents/skills/source-postgres-e2e-tests/fixtures/configs/base.template.json
@@ -1,0 +1,17 @@
+{
+  "host": "source-postgres-db-backend",
+  "port": 5432,
+  "database": "test_db",
+  "username": "postgres",
+  "password": "test_password",
+  "schemas": ["public"],
+  "ssl_mode": {
+    "mode": "disable"
+  },
+  "tunnel_method": {
+    "tunnel_method": "NO_TUNNEL"
+  },
+  "replication_method": {
+    "method": "Standard"
+  }
+}

--- a/airbyte-integrations/connectors/source-postgres/.agents/skills/source-postgres-e2e-tests/fixtures/sql/00-init-base.sql
+++ b/airbyte-integrations/connectors/source-postgres/.agents/skills/source-postgres-e2e-tests/fixtures/sql/00-init-base.sql
@@ -1,0 +1,15 @@
+-- Idempotent base init for source-postgres e2e tests (non-CDC).
+-- The test_db database is created by the container (POSTGRES_DB); this
+-- fixture just (re)creates a small public.sample table with three rows.
+
+DROP TABLE IF EXISTS public.sample;
+
+CREATE TABLE public.sample (
+  id    INTEGER     NOT NULL PRIMARY KEY,
+  label VARCHAR(64) NOT NULL
+);
+
+INSERT INTO public.sample (id, label) VALUES
+  (1, 'alpha'),
+  (2, 'beta'),
+  (3, 'gamma');

--- a/airbyte-integrations/connectors/source-postgres/.agents/skills/source-postgres-e2e-tests/scripts/apply-sql.sh
+++ b/airbyte-integrations/connectors/source-postgres/.agents/skills/source-postgres-e2e-tests/scripts/apply-sql.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Apply a .sql file to the e2e backend via `docker exec psql` on stdin.
+#
+# Usage:  apply-sql.sh <path/to/file.sql>
+#
+# Env:
+#   BACKEND_NAME        container name (default: source-postgres-db-backend)
+#   BACKEND_DB          database to apply against (default: test_db)
+set -euo pipefail
+
+BACKEND_NAME="${BACKEND_NAME:-source-postgres-db-backend}"
+BACKEND_DB="${BACKEND_DB:-test_db}"
+
+if [[ $# -lt 1 ]]; then
+  echo "usage: $(basename "$0") <path/to/file.sql>" >&2
+  exit 2
+fi
+SQL_FILE="$1"
+if [[ ! -f "$SQL_FILE" ]]; then
+  echo "[apply-sql] not a file: $SQL_FILE" >&2
+  exit 2
+fi
+
+# psql connects over the local unix socket as the postgres superuser
+# (trust auth in the stock image), so no password is needed here.
+docker exec -i "$BACKEND_NAME" \
+  psql -v ON_ERROR_STOP=1 -U postgres -d "$BACKEND_DB" < "$SQL_FILE"
+echo "[apply-sql] applied $SQL_FILE." >&2

--- a/airbyte-integrations/connectors/source-postgres/.agents/skills/source-postgres-e2e-tests/scripts/render-config.sh
+++ b/airbyte-integrations/connectors/source-postgres/.agents/skills/source-postgres-e2e-tests/scripts/render-config.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Substitute the e2e backend's bridge IP into a config template.
+#
+# Usage:  render-config.sh <template.json> <output.json>
+#
+# The connector container launched by `airbyte-ops` is on the default
+# `bridge` network and cannot resolve a user-defined network's container
+# names. Until airbytehq/airbyte-ops-mcp#765 lands `--network` support,
+# we render a working config that pins .host to the bridge IP that
+# Docker assigned to the backend container at runtime.
+#
+# Env:
+#   BACKEND_NAME        container name (default: source-postgres-db-backend)
+set -euo pipefail
+
+BACKEND_NAME="${BACKEND_NAME:-source-postgres-db-backend}"
+
+if [[ $# -lt 2 ]]; then
+  echo "usage: $(basename "$0") <template.json> <output.json>" >&2
+  exit 2
+fi
+TEMPLATE="$1"
+OUTPUT="$2"
+if [[ ! -f "$TEMPLATE" ]]; then
+  echo "[render-config] template not found: $TEMPLATE" >&2
+  exit 2
+fi
+
+BACKEND_IP=$(docker inspect "$BACKEND_NAME" \
+  --format '{{.NetworkSettings.Networks.bridge.IPAddress}}')
+if [[ -z "$BACKEND_IP" ]]; then
+  echo "[render-config] could not resolve bridge IP for $BACKEND_NAME." >&2
+  echo "[render-config] is the container running on the default bridge network?" >&2
+  exit 1
+fi
+
+mkdir -p "$(dirname "$OUTPUT")"
+jq --arg h "$BACKEND_IP" '.host = $h' "$TEMPLATE" > "$OUTPUT"
+echo "[render-config] $TEMPLATE → $OUTPUT (host=$BACKEND_IP)" >&2

--- a/airbyte-integrations/connectors/source-postgres/.agents/skills/source-postgres-e2e-tests/scripts/run-protocol-cmd.sh
+++ b/airbyte-integrations/connectors/source-postgres/.agents/skills/source-postgres-e2e-tests/scripts/run-protocol-cmd.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# Run an Airbyte protocol command against airbyte/source-postgres:<version>
+# via `airbyte-ops cloud connector regression-test`.
+#
+# Usage:  run-protocol-cmd.sh <command> <step-name> <version> [extra-args…]
+#
+#   <command>     spec | check | discover | read
+#   <step-name>   subdirectory under $REPRO_OUT to write artifacts to
+#   <version>     image tag, e.g. 3.8.1 / dev / latest
+#   [extra-args]  any additional flags forwarded verbatim
+#
+# Modes:
+#   Single-version (default): runs <version> alone with --skip-compare=True
+#     and returns the connector's own exit code (derived from report.md).
+#   Comparison (prove-fix): set CONTROL_VERSION=<tag> to compare <version>
+#     (--test-image) against airbyte/source-postgres:$CONTROL_VERSION
+#     (--control-image). --skip-compare is dropped so airbyte-ops produces
+#     a side-by-side SPEC/CHECK/DISCOVER/READ diff.
+#
+# Output:
+#   $REPRO_OUT/<step-name>/…  (stdout.txt, stderr.txt, report.md, diff)
+#
+# Env:
+#   REPRO_OUT        parent output directory (default: /tmp/source-postgres-repro)
+#   CONTROL_VERSION  when set, enables comparison mode against this tag
+#   AIRBYTE_OPS      command to invoke airbyte-ops. Default picks the binary
+#                    on $PATH (`airbyte-ops`) if `uv tool install
+#                    airbyte-internal-ops` was run, else falls back to
+#                    `uvx airbyte-internal-ops`.
+set -euo pipefail
+
+REPRO_OUT="${REPRO_OUT:-/tmp/source-postgres-repro}"
+CONNECTOR_IMAGE="airbyte/source-postgres"
+if [[ -z "${AIRBYTE_OPS:-}" ]]; then
+  if command -v airbyte-ops >/dev/null 2>&1; then
+    AIRBYTE_OPS="airbyte-ops"
+  else
+    AIRBYTE_OPS="uvx airbyte-internal-ops"
+  fi
+fi
+
+if [[ $# -lt 3 ]]; then
+  echo "usage: $(basename "$0") <command> <step-name> <version> [extra-args…]" >&2
+  exit 2
+fi
+COMMAND="$1"; shift
+STEP_NAME="$1"; shift
+VERSION="$1"; shift
+
+OUT_DIR="$REPRO_OUT/$STEP_NAME"
+rm -rf "$OUT_DIR"
+mkdir -p "$OUT_DIR"
+
+# `airbyte-ops cloud connector regression-test` in single-version mode
+# prints "Error: Single-version regression test failed …" when the
+# underlying connector exits non-zero, but the CLI itself returns 0.
+# Run it with `set +e` so a non-zero CLI exit also doesn't abort the
+# script, then derive the connector's actual exit code from report.md so
+# the caller's `RC` is meaningful.
+set +e
+if [[ -n "${CONTROL_VERSION:-}" ]]; then
+  # shellcheck disable=SC2086
+  $AIRBYTE_OPS cloud connector regression-test \
+    --command="$COMMAND" \
+    --test-image="$CONNECTOR_IMAGE:$VERSION" \
+    --control-image="$CONNECTOR_IMAGE:$CONTROL_VERSION" \
+    --output-dir="$OUT_DIR" \
+    "$@"
+else
+  # shellcheck disable=SC2086
+  $AIRBYTE_OPS cloud connector regression-test \
+    --skip-compare=True \
+    --command="$COMMAND" \
+    --test-image="$CONNECTOR_IMAGE:$VERSION" \
+    --output-dir="$OUT_DIR" \
+    "$@"
+fi
+set -e
+
+CONNECTOR_RC="$(
+  grep -E '^- \*\*Exit Code:\*\*' "$OUT_DIR/report.md" 2>/dev/null \
+    | head -n 1 \
+    | grep -oE '[0-9]+' \
+    | head -n 1
+)"
+exit "${CONNECTOR_RC:-1}"

--- a/airbyte-integrations/connectors/source-postgres/.agents/skills/source-postgres-e2e-tests/scripts/start-backend.sh
+++ b/airbyte-integrations/connectors/source-postgres/.agents/skills/source-postgres-e2e-tests/scripts/start-backend.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Start a throwaway PostgreSQL container for source-postgres e2e tests.
+# Idempotent: succeeds whether or not the container already exists.
+#
+# Started with `wal_level=logical` so the same backend can be reused by
+# the CDC variant (logical replication slots + publications) without a
+# restart.
+#
+# Env:
+#   BACKEND_NAME        container name (default: source-postgres-db-backend)
+#   BACKEND_PASSWORD    postgres superuser password (default: test_password)
+#   BACKEND_DB          initial database (default: test_db)
+#   BACKEND_PORT        host port mapped to 5432/tcp (default: 5432)
+#   BACKEND_IMAGE       image (default: postgres:16)
+set -euo pipefail
+
+BACKEND_NAME="${BACKEND_NAME:-source-postgres-db-backend}"
+BACKEND_PASSWORD="${BACKEND_PASSWORD:-test_password}"
+BACKEND_DB="${BACKEND_DB:-test_db}"
+BACKEND_PORT="${BACKEND_PORT:-5432}"
+BACKEND_IMAGE="${BACKEND_IMAGE:-postgres:16}"
+
+if docker inspect "$BACKEND_NAME" >/dev/null 2>&1; then
+  echo "[start-backend] $BACKEND_NAME already exists; reusing." >&2
+else
+  docker run -d --rm \
+    --name "$BACKEND_NAME" \
+    -e POSTGRES_PASSWORD="$BACKEND_PASSWORD" \
+    -e POSTGRES_DB="$BACKEND_DB" \
+    -p "$BACKEND_PORT:5432" \
+    "$BACKEND_IMAGE" \
+    -c wal_level=logical \
+    -c max_wal_senders=10 \
+    -c max_replication_slots=10 >/dev/null
+fi
+
+echo "[start-backend] waiting for $BACKEND_NAME to accept connections…" >&2
+for _ in $(seq 1 60); do
+  if docker exec "$BACKEND_NAME" pg_isready -U postgres -d "$BACKEND_DB" >/dev/null 2>&1; then
+    echo "[start-backend] $BACKEND_NAME ready." >&2
+    exit 0
+  fi
+  sleep 2
+done
+
+echo "[start-backend] timed out waiting for $BACKEND_NAME after 120s." >&2
+exit 1

--- a/airbyte-integrations/connectors/source-postgres/.agents/skills/source-postgres-e2e-tests/scripts/stop-backend.sh
+++ b/airbyte-integrations/connectors/source-postgres/.agents/skills/source-postgres-e2e-tests/scripts/stop-backend.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Stop and remove the source-postgres e2e backend container.
+# Idempotent: a no-op if the container doesn't exist.
+#
+# Env:
+#   BACKEND_NAME        container name (default: source-postgres-db-backend)
+set -euo pipefail
+
+BACKEND_NAME="${BACKEND_NAME:-source-postgres-db-backend}"
+
+docker rm -f "$BACKEND_NAME" >/dev/null 2>&1 || true
+echo "[stop-backend] $BACKEND_NAME removed." >&2


### PR DESCRIPTION
## What

Adds connector-local e2e test-harness skills for `source-postgres` and `source-mysql`, modeled on the existing `source-mssql-e2e-tests` harness. These are the per-engine evidence engine for the new **database-source `/ai-prove-fix`** playbook (`db_prove_fix.md` in `airbytehq/ai-skills`: https://github.com/airbytehq/ai-skills/pull/608) — they let Devin (or a maintainer) stand up a throwaway local DB, apply an authored SQL fixture, and run protocol commands against a PR image vs a control image to prove a fix, without touching customer data.

Requested by Sophie Cui (@sophiecuiy).

Each skill lives under `airbyte-integrations/connectors/source-<engine>/.agents/skills/source-<engine>-e2e-tests/` with the same script contract as mssql:

```
scripts/start-backend.sh    # throwaway DB container (postgres:16 / mysql:8.0)
scripts/stop-backend.sh     # docker rm -f
scripts/apply-sql.sh        # load a .sql fixture
scripts/render-config.sh    # jq the backend bridge IP into a config template
scripts/run-protocol-cmd.sh # wrapper over `airbyte-ops … regression-test`
fixtures/configs/base.template.json
fixtures/sql/00-init-base.sql
```

## How

Faithful ports of the mssql scripts, adapted per engine:

- **Postgres backend** starts `postgres:16` with `wal_level=logical` + WAL sender/slot headroom so a CDC repro can add a logical replication slot without a restart. Readiness via `pg_isready`; `apply-sql.sh` pipes into `psql` over the trust-auth unix socket.
- **MySQL backend** starts `mysql:8.0` with `--binlog-format=ROW --binlog-row-image=FULL` + GTIDs for CDC; readiness via a `SELECT 1` probe; `apply-sql.sh` uses `MYSQL_PWD` to avoid the plaintext-password warning.
- **Config templates** use each engine's real spec shape (verified against the connectors): Postgres `ssl_mode: {mode: disable}` + `replication_method: {method: Standard}`; MySQL `ssl_mode: {mode: preferred}` + `replication_method: {method: STANDARD}`.
- **`run-protocol-cmd.sh` adds comparison mode** on top of the mssql single-version wrapper: setting `CONTROL_VERSION=<tag>` drops `--skip-compare=True` and adds `--control-image=airbyte/source-<engine>:<tag>`, producing the side-by-side `SPEC/CHECK/DISCOVER/READ` diff the prove-fix playbook consumes. Default (no `CONTROL_VERSION`) is single-version, exactly like mssql.

Docs-only/harness files — no connector runtime code changes.

## Review guide

1. `source-postgres/.agents/skills/source-postgres-e2e-tests/SKILL.md` and `source-mysql/.agents/skills/source-mysql-e2e-tests/SKILL.md` — the two skill entrypoints; engine-specific gotchas are documented at the bottom of each.
2. `scripts/run-protocol-cmd.sh` (both) — the only script that diverges from mssql (adds `CONTROL_VERSION` comparison mode).
3. `scripts/start-backend.sh` (both) — CDC-ready backend flags.

**Local verification** (both engines, against published images on this machine):
- `start-backend.sh` → container healthy; direct `psql` / `mysql` query returns the 3 fixture rows.
- `render-config.sh` → bridge IP substituted into a valid config.
- `run-protocol-cmd.sh check` → `airbyte/source-postgres:3.8.1` and `airbyte/source-mysql:3.53.1` both return `CONNECTION_STATUS: SUCCEEDED`, wrapper exit code 0.
- `run-protocol-cmd.sh discover` (postgres) → `sample` stream discovered with `id`/`label`.

## Note on versioning

The merged mssql harness PR (#77775) added `.agents/skills/` with **no** `dockerImageTag` bump or changelog row, so this PR follows that precedent (no runtime change, no release intended). Happy to add a patch bump + changelog rows to both connectors if the connector-CI matrix detector requires it.

## User Impact

None for end users — this only adds maintainer/agent test tooling under `.agents/`.

## Can this PR be safely reverted and rolled back?
- [x] YES 💚
- [ ] NO ❌


Link to Devin session: https://app.devin.ai/sessions/33ca2c4f3fe040659c79757d590f2c30