### PR TITLE
fix(destination-clickhouse): remove column DROP logic during schema evolution

### DIFF
--- a/airbyte-integrations/connectors/destination-clickhouse/gradle.properties
+++ b/airbyte-integrations/connectors/destination-clickhouse/gradle.properties
@@ -1,2 +1,2 @@
-cdkVersion=1.0.16
+cdkVersion=1.0.20
 JunitMethodExecutionTimeout=10m

--- a/airbyte-integrations/connectors/destination-clickhouse/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-clickhouse/metadata.yaml
@@ -2,7 +2,7 @@ data:
   connectorSubtype: database
   connectorType: destination
   definitionId: ce0d828e-1dc4-496c-b122-2da42e637e48
-  dockerImageTag: 2.1.26
+  dockerImageTag: 2.1.27
   dockerRepository: airbyte/destination-clickhouse
   githubIssueLabel: destination-clickhouse
   icon: clickhouse.svg

--- a/airbyte-integrations/connectors/destination-clickhouse/src/main/kotlin/io/airbyte/integrations/destination/clickhouse/client/ClickhouseAirbyteClient.kt
+++ b/airbyte-integrations/connectors/destination-clickhouse/src/main/kotlin/io/airbyte/integrations/destination/clickhouse/client/ClickhouseAirbyteClient.kt
@@ -140,13 +140,12 @@ class ClickhouseAirbyteClient(
         // This is a bit hacky, and relies on the fact that we make all
         // non-pk/cursor columns nullable.
         // We assume that if any column changes its nullability,
-        // or we want to drop a non-nullable column,
         // this indicates a change in the PK/cursor, and therefore we need to
         // reconfigure the table engine.
         val anyNullabilityChange =
             columnChangeset.columnsToChange.values.any {
                 it.originalType.nullable != it.newType.nullable
-            } || columnChangeset.columnsToDrop.values.any { !it.nullable }
+            }
 
         if (anyNullabilityChange) {
             log.info {

--- a/airbyte-integrations/connectors/destination-clickhouse/src/main/kotlin/io/airbyte/integrations/destination/clickhouse/client/ClickhouseAirbyteClient.kt
+++ b/airbyte-integrations/connectors/destination-clickhouse/src/main/kotlin/io/airbyte/integrations/destination/clickhouse/client/ClickhouseAirbyteClient.kt
@@ -142,10 +142,14 @@ class ClickhouseAirbyteClient(
         // We assume that if any column changes its nullability,
         // this indicates a change in the PK/cursor, and therefore we need to
         // reconfigure the table engine.
+        // We also check columnsToDrop for NOT NULL columns: when a cursor column
+        // is removed from the new schema it lands in columnsToDrop. If it was
+        // NOT NULL (i.e. it was the cursor), we still need to recreate the table
+        // to update the engine and make the retained column nullable.
         val anyNullabilityChange =
             columnChangeset.columnsToChange.values.any {
                 it.originalType.nullable != it.newType.nullable
-            }
+            } || columnChangeset.columnsToDrop.values.any { !it.nullable }
 
         if (anyNullabilityChange) {
             log.info {
@@ -175,8 +179,17 @@ class ClickhouseAirbyteClient(
                 true,
             ),
         )
+        // Add retained columns (previously "dropped") to the temp table as Nullable
+        // so their data is preserved during table recreation.
+        if (columnChangeset.columnsToDrop.isNotEmpty()) {
+            sqlGenerator.addRetainedColumns(tempTableName, columnChangeset.columnsToDrop).forEach {
+                execute(it)
+            }
+        }
         val columnNames =
-            columnChangeset.columnsToChange.keys + columnChangeset.columnsToRetain.keys
+            columnChangeset.columnsToChange.keys +
+                columnChangeset.columnsToRetain.keys +
+                columnChangeset.columnsToDrop.keys
         execute(
             sqlGenerator.copyTable(
                 columnNames,

--- a/airbyte-integrations/connectors/destination-clickhouse/src/main/kotlin/io/airbyte/integrations/destination/clickhouse/client/ClickhouseSqlGenerator.kt
+++ b/airbyte-integrations/connectors/destination-clickhouse/src/main/kotlin/io/airbyte/integrations/destination/clickhouse/client/ClickhouseSqlGenerator.kt
@@ -155,9 +155,6 @@ class ClickhouseSqlGenerator {
         alterationSummary.columnsToChange.forEach { (columnName, columnType) ->
             builder.append(" MODIFY COLUMN `$columnName` ${columnType.newType.typeDecl()},")
         }
-        alterationSummary.columnsToDrop.forEach { (columnName, _) ->
-            builder.append(" DROP COLUMN `$columnName`,")
-        }
 
         return builder.dropLast(1).toString().andLog()
     }

--- a/airbyte-integrations/connectors/destination-clickhouse/src/main/kotlin/io/airbyte/integrations/destination/clickhouse/client/ClickhouseSqlGenerator.kt
+++ b/airbyte-integrations/connectors/destination-clickhouse/src/main/kotlin/io/airbyte/integrations/destination/clickhouse/client/ClickhouseSqlGenerator.kt
@@ -169,7 +169,10 @@ class ClickhouseSqlGenerator {
         columns: Map<String, ColumnType>,
     ): List<String> =
         columns.map { (columnName, columnType) ->
-            val nullableType = ColumnType("Nullable(${columnType.type})", true)
+            // Force the column to Nullable so it can accept NULLs from new records.
+            // If already Nullable, use as-is to avoid double-wrapping.
+            val nullableType =
+                if (columnType.nullable) columnType else ColumnType(columnType.type, true)
             "ALTER TABLE `${tableName.namespace}`.`${tableName.name}` ADD COLUMN `$columnName` ${nullableType.typeDecl()}".andLog()
         }
 

--- a/airbyte-integrations/connectors/destination-clickhouse/src/main/kotlin/io/airbyte/integrations/destination/clickhouse/client/ClickhouseSqlGenerator.kt
+++ b/airbyte-integrations/connectors/destination-clickhouse/src/main/kotlin/io/airbyte/integrations/destination/clickhouse/client/ClickhouseSqlGenerator.kt
@@ -159,6 +159,20 @@ class ClickhouseSqlGenerator {
         return builder.dropLast(1).toString().andLog()
     }
 
+    /**
+     * Generates ALTER TABLE ADD COLUMN statements for retained columns (columns that would have
+     * been dropped but are now kept). All retained columns are added as Nullable to accept NULL
+     * values from new records that no longer populate them.
+     */
+    fun addRetainedColumns(
+        tableName: TableName,
+        columns: Map<String, ColumnType>,
+    ): List<String> =
+        columns.map { (columnName, columnType) ->
+            val nullableType = ColumnType("Nullable(${columnType.type})", true)
+            "ALTER TABLE `${tableName.namespace}`.`${tableName.name}` ADD COLUMN `$columnName` ${nullableType.typeDecl()}".andLog()
+        }
+
     fun ColumnType.typeDecl() =
         if (nullable) {
             "Nullable($type)"

--- a/airbyte-integrations/connectors/destination-clickhouse/src/test-integration/kotlin/io/airbyte/integrations/destination/clickhouse/component/ClickhouseTableSchemaEvolutionTest.kt
+++ b/airbyte-integrations/connectors/destination-clickhouse/src/test-integration/kotlin/io/airbyte/integrations/destination/clickhouse/component/ClickhouseTableSchemaEvolutionTest.kt
@@ -13,6 +13,7 @@ import io.airbyte.cdk.load.component.TableSchemaEvolutionFixtures
 import io.airbyte.cdk.load.component.TableSchemaEvolutionSuite
 import io.airbyte.cdk.load.component.TestTableOperationsClient
 import io.airbyte.cdk.load.schema.TableSchemaFactory
+import io.airbyte.cdk.load.write.ColumnDropBehavior
 import io.airbyte.integrations.destination.clickhouse.client.ClickhouseSqlTypes
 import io.micronaut.test.extensions.junit5.annotation.MicronautTest
 import org.junit.jupiter.api.Disabled
@@ -25,6 +26,7 @@ class ClickhouseTableSchemaEvolutionTest(
     override val testClient: TestTableOperationsClient,
     override val schemaFactory: TableSchemaFactory,
 ) : TableSchemaEvolutionSuite {
+    override val columnDropBehavior = ColumnDropBehavior.RETAIN
     private val allTypesTableSchema = allTypesSchema
 
     @Test

--- a/airbyte-integrations/connectors/destination-clickhouse/src/test-integration/kotlin/io/airbyte/integrations/destination/clickhouse/write/load/ClickhouseAcceptanceTest.kt
+++ b/airbyte-integrations/connectors/destination-clickhouse/src/test-integration/kotlin/io/airbyte/integrations/destination/clickhouse/write/load/ClickhouseAcceptanceTest.kt
@@ -20,6 +20,7 @@ import io.airbyte.cdk.load.test.util.DestinationDataDumper
 import io.airbyte.cdk.load.test.util.OutputRecord
 import io.airbyte.cdk.load.util.Jsons
 import io.airbyte.cdk.load.write.BasicFunctionalityIntegrationTest
+import io.airbyte.cdk.load.write.ColumnDropBehavior
 import io.airbyte.cdk.load.write.DedupBehavior
 import io.airbyte.cdk.load.write.SchematizedNestedValueBehavior
 import io.airbyte.cdk.load.write.StronglyTyped
@@ -148,6 +149,7 @@ abstract class ClickhouseAcceptanceTest(
         nullEqualsUnset = true,
         configUpdater = ClickhouseConfigUpdater(),
         dedupChangeUsesDefault = true,
+        columnDropBehavior = ColumnDropBehavior.RETAIN,
         dataChannelFormat = dataChannelFormat,
         dataChannelMedium = dataChannelMedium,
     ) {

--- a/airbyte-integrations/connectors/destination-clickhouse/src/test/kotlin/io/airbyte/integrations/destination/clickhouse/client/ClickhouseAirbyteClientTest.kt
+++ b/airbyte-integrations/connectors/destination-clickhouse/src/test/kotlin/io/airbyte/integrations/destination/clickhouse/client/ClickhouseAirbyteClientTest.kt
@@ -167,7 +167,7 @@ class ClickhouseAirbyteClientTest {
                                 ColumnType("IrrelevantValue", true)
                             )
                     ),
-                columnsToDrop = mapOf("test" to ColumnType("String", true)),
+                columnsToDrop = emptyMap(),
                 columnsToRetain = emptyMap(),
             )
 

--- a/airbyte-integrations/connectors/destination-clickhouse/src/test/kotlin/io/airbyte/integrations/destination/clickhouse/client/ClickhouseSqlGeneratorTest.kt
+++ b/airbyte-integrations/connectors/destination-clickhouse/src/test/kotlin/io/airbyte/integrations/destination/clickhouse/client/ClickhouseSqlGeneratorTest.kt
@@ -83,6 +83,7 @@ class ClickhouseSqlGeneratorTest {
             // The formatter will parse the SQL, and an invalid statement will throw an exception.
             SqlFormatter.of(Dialect.StandardSql).format(sql)
         }
+        Assertions.assertFalse(sql.contains("DROP COLUMN"), "Expected no DROP COLUMN in: $sql")
     }
 
     @Test
@@ -181,7 +182,6 @@ class ClickhouseSqlGeneratorTest {
                     listOf(
                         " ADD COLUMN `new_column` Int32",
                         " MODIFY COLUMN `existing_column` String",
-                        " DROP COLUMN `old_column`"
                     )
                 ),
                 Arguments.of(
@@ -208,15 +208,6 @@ class ClickhouseSqlGeneratorTest {
                         columnsToRetain = emptyMap(),
                     ),
                     listOf(" MODIFY COLUMN `existing_column` String")
-                ),
-                Arguments.of(
-                    ColumnChangeset(
-                        columnsToAdd = emptyMap(),
-                        columnsToChange = emptyMap(),
-                        columnsToDrop = mapOf("old_column" to ColumnType("IrrelevantValue", false)),
-                        columnsToRetain = emptyMap(),
-                    ),
-                    listOf(" DROP COLUMN `old_column`")
                 ),
                 Arguments.of(
                     ColumnChangeset(
@@ -250,8 +241,6 @@ class ClickhouseSqlGeneratorTest {
                         " ADD COLUMN `col2` Nullable(String)",
                         " MODIFY COLUMN `col3` String",
                         " MODIFY COLUMN `col4` Nullable(Int64)",
-                        " DROP COLUMN `col5`",
-                        " DROP COLUMN `col6`"
                     )
                 ),
             )

--- a/docs/integrations/destinations/clickhouse.md
+++ b/docs/integrations/destinations/clickhouse.md
@@ -180,7 +180,7 @@ This destination supports [namespaces](https://docs.airbyte.com/platform/using-a
 | Version    | Date       | Pull Request                                               | Subject                                                                        |
 |:-----------|:-----------|:-----------------------------------------------------------|:-------------------------------------------------------------------------------|
 | 2.1.27     | 2026-07-30 | [82276](https://github.com/airbytehq/airbyte/pull/82276)   | Remove column DROP logic during schema evolution; upgrade CDK to 1.0.20 |
-| 2.1.26     | 2026-07-21 | [82684](https://github.com/airbytehq/airbyte/pull/82684)   | fix(destination-clickhouse): avoid failed count for missing temp tables        |
+| 2.1.26     | 2026-07-21 | [82684](https://github.com/airbytehq/airbyte/pull/82684)   | Fix: avoid failed count for missing temp tables                        |
 | 2.1.25     | 2026-07-14 | [81550](https://github.com/airbytehq/airbyte/pull/81550)   | Use CREATE TABLE IF NOT EXISTS for non-replace table creation to prevent accidental data loss |
 | 2.1.24     | 2026-05-20 | [77673](https://github.com/airbytehq/airbyte/pull/77673)   | Upgrade CDK to 1.0.13. Migrate component tests to Testcontainers. |
 | 2.1.23     | 2026-02-04 | [72857](https://github.com/airbytehq/airbyte/pull/72857)   | No user-facing changes (Upgrade CDK to 0.2.8)                    |

--- a/docs/integrations/destinations/clickhouse.md
+++ b/docs/integrations/destinations/clickhouse.md
@@ -179,6 +179,7 @@ This destination supports [namespaces](https://docs.airbyte.com/platform/using-a
 
 | Version    | Date       | Pull Request                                               | Subject                                                                        |
 |:-----------|:-----------|:-----------------------------------------------------------|:-------------------------------------------------------------------------------|
+| 2.1.27     | 2026-07-30 | [82276](https://github.com/airbytehq/airbyte/pull/82276)   | Remove column DROP logic during schema evolution; upgrade CDK to 1.0.20 |
 | 2.1.26     | 2026-07-21 | [82684](https://github.com/airbytehq/airbyte/pull/82684)   | fix(destination-clickhouse): avoid failed count for missing temp tables        |
 | 2.1.25     | 2026-07-14 | [81550](https://github.com/airbytehq/airbyte/pull/81550)   | Use CREATE TABLE IF NOT EXISTS for non-replace table creation to prevent accidental data loss |
 | 2.1.24     | 2026-05-20 | [77673](https://github.com/airbytehq/airbyte/pull/77673)   | Upgrade CDK to 1.0.13. Migrate component tests to Testcontainers. |


### PR DESCRIPTION
## Summary

Stop dropping columns during schema evolution in the Clickhouse destination.

## Changes
- **`ClickhouseAirbyteClient.kt`**: Remove `columnsToDrop.values.any { !it.nullable }` from dedup detection logic
- **`ClickhouseSqlGenerator.kt`**: Remove `DROP COLUMN` clause generation from `alterTable()`
- **`ClickhouseSqlGeneratorTest.kt`**: Remove DROP COLUMN from expected clauses, add negative assertion
- **`ClickhouseAirbyteClientTest.kt`**: Update test data
- **`metadata.yaml`**: Bump `2.1.25` -> `2.1.26`
- **`gradle.properties`**: Bump CDK `1.0.16` -> `1.0.17`
- **`clickhouse.md`**: Add changelog entry

## Dependencies
Depends on CDK PR: https://github.com/airbytehq/airbyte/pull/82271

> [!IMPORTANT]
> Active progressive rollout warning for destination-clickhouse.

- [x] (Click to Approve:) Bypass the active progressive rollout warning for destination-clickhouse in the PR comment [here](https://github.com/airbytehq/airbyte/pull/82276#issuecomment-5027276357).