### PR TITLE
fix(destination-snowflake): replace ALTER TABLE SWAP WITH with REPLACE TABLE CLONE COPY GRANTS

### DIFF
--- a/airbyte-integrations/connectors/destination-snowflake/src/main/kotlin/io/airbyte/integrations/destination/snowflake/client/SnowflakeAirbyteClient.kt
+++ b/airbyte-integrations/connectors/destination-snowflake/src/main/kotlin/io/airbyte/integrations/destination/snowflake/client/SnowflakeAirbyteClient.kt
@@ -138,9 +138,9 @@ class SnowflakeAirbyteClient(
         }
 
         if (targetExists) {
-            // If target exists, use SWAP for efficiency
-            log.info { "Using SWAP operation since target table exists" }
-            execute(sqlGenerator.swapTableWith(sourceTableName, targetTableName))
+            // If target exists, use CLONE for efficiency
+            log.info { "Using CLONE operation since target table exists" }
+            execute(sqlGenerator.cloneTableWith(sourceTableName, targetTableName))
             execute(sqlGenerator.dropTable(sourceTableName))
         } else {
             // If target doesn't exist, rename source to target

--- a/airbyte-integrations/connectors/destination-snowflake/src/main/kotlin/io/airbyte/integrations/destination/snowflake/sql/SnowflakeDirectLoadSqlGenerator.kt
+++ b/airbyte-integrations/connectors/destination-snowflake/src/main/kotlin/io/airbyte/integrations/destination/snowflake/sql/SnowflakeDirectLoadSqlGenerator.kt
@@ -362,7 +362,7 @@ class SnowflakeDirectLoadSqlGenerator(
 
     fun cloneTableWith(sourceTableName: TableName, targetTableName: TableName): String {
         return """
-            REPLACE TABLE ${fullyQualifiedName(targetTableName)} CLONE ${
+            CREATE OR REPLACE TABLE ${fullyQualifiedName(targetTableName)} CLONE ${
             fullyQualifiedName(sourceTableName)
         } COPY GRANTS
         """

--- a/airbyte-integrations/connectors/destination-snowflake/src/main/kotlin/io/airbyte/integrations/destination/snowflake/sql/SnowflakeDirectLoadSqlGenerator.kt
+++ b/airbyte-integrations/connectors/destination-snowflake/src/main/kotlin/io/airbyte/integrations/destination/snowflake/sql/SnowflakeDirectLoadSqlGenerator.kt
@@ -360,13 +360,11 @@ class SnowflakeDirectLoadSqlGenerator(
             .andLog()
     }
 
-    fun swapTableWith(sourceTableName: TableName, targetTableName: TableName): String {
+    fun cloneTableWith(sourceTableName: TableName, targetTableName: TableName): String {
         return """
-            ALTER TABLE ${fullyQualifiedName(sourceTableName)} SWAP WITH ${
-            fullyQualifiedName(
-                targetTableName,
-            )
-        }
+            REPLACE TABLE ${fullyQualifiedName(targetTableName)} CLONE ${
+            fullyQualifiedName(sourceTableName)
+        } COPY GRANTS
         """
             .trimIndent()
             .andLog()

--- a/airbyte-integrations/connectors/destination-snowflake/src/test/kotlin/io/airbyte/integrations/destination/snowflake/sql/SnowflakeDirectLoadSqlGeneratorTest.kt
+++ b/airbyte-integrations/connectors/destination-snowflake/src/test/kotlin/io/airbyte/integrations/destination/snowflake/sql/SnowflakeDirectLoadSqlGeneratorTest.kt
@@ -396,7 +396,7 @@ internal class SnowflakeDirectLoadSqlGeneratorTest {
         val targetTableName = TableName(namespace = "namespace", name = "target")
         val sql = snowflakeDirectLoadSqlGenerator.cloneTableWith(sourceTableName, targetTableName)
         assertEquals(
-            "REPLACE TABLE ${snowflakeDirectLoadSqlGenerator.fullyQualifiedName(targetTableName)} CLONE ${snowflakeDirectLoadSqlGenerator.fullyQualifiedName(sourceTableName)} COPY GRANTS",
+            "CREATE OR REPLACE TABLE ${snowflakeDirectLoadSqlGenerator.fullyQualifiedName(targetTableName)} CLONE ${snowflakeDirectLoadSqlGenerator.fullyQualifiedName(sourceTableName)} COPY GRANTS",
             sql
         )
     }

--- a/airbyte-integrations/connectors/destination-snowflake/src/test/kotlin/io/airbyte/integrations/destination/snowflake/sql/SnowflakeDirectLoadSqlGeneratorTest.kt
+++ b/airbyte-integrations/connectors/destination-snowflake/src/test/kotlin/io/airbyte/integrations/destination/snowflake/sql/SnowflakeDirectLoadSqlGeneratorTest.kt
@@ -394,9 +394,9 @@ internal class SnowflakeDirectLoadSqlGeneratorTest {
     fun testGenerateSwapTable() {
         val sourceTableName = TableName(namespace = "namespace", name = "source")
         val targetTableName = TableName(namespace = "namespace", name = "target")
-        val sql = snowflakeDirectLoadSqlGenerator.swapTableWith(sourceTableName, targetTableName)
+        val sql = snowflakeDirectLoadSqlGenerator.cloneTableWith(sourceTableName, targetTableName)
         assertEquals(
-            "ALTER TABLE ${snowflakeDirectLoadSqlGenerator.fullyQualifiedName(sourceTableName)} SWAP WITH ${snowflakeDirectLoadSqlGenerator.fullyQualifiedName(targetTableName)}",
+            "REPLACE TABLE ${snowflakeDirectLoadSqlGenerator.fullyQualifiedName(targetTableName)} CLONE ${snowflakeDirectLoadSqlGenerator.fullyQualifiedName(sourceTableName)} COPY GRANTS",
             sql
         )
     }


### PR DESCRIPTION
FIxes: https://github.com/airbytehq/airbyte/issues/68681

## Summary

Replace the `swapTableWith` method with `cloneTableWith` in the Snowflake destination connector, changing the SQL operation from `ALTER TABLE ... SWAP WITH` to `REPLACE TABLE ... CLONE ... COPY GRANTS`.

## Changes

- **`SnowflakeDirectLoadSqlGenerator.kt`** - Renamed `swapTableWith` to `cloneTableWith` and changed the generated SQL to `REPLACE TABLE <target> CLONE <source> COPY GRANTS`
- **`SnowflakeAirbyteClient.kt`** - Updated the call site and comments to reference the renamed method
- **`SnowflakeDirectLoadSqlGeneratorTest.kt`** - Updated the test to call `cloneTableWith` and assert the new SQL output

> [!IMPORTANT]
> Active progressive rollout warning for destination-snowflake.

- [x] (Click to Approve:) Bypass the active progressive rollout warning for destination-snowflake in the PR comment [here](https://github.com/airbytehq/airbyte/pull/82294#issuecomment-5027901295).