### PR TITLE
ci: add /hydra-failure slash command dispatch

### DIFF
--- a/.github/workflows/hydra-failure-command.yml
+++ b/.github/workflows/hydra-failure-command.yml
@@ -1,0 +1,74 @@
+name: Hydra Failure Command
+
+on:
+  workflow_dispatch:
+    inputs:
+      pr:
+        description: "Pull request number (if triggered from a PR)"
+        type: number
+        required: false
+      comment-id:
+        description: "The comment-id of the slash command. Used to update the comment with the status."
+        required: false
+      repo:
+        description: "Repo (passed by slash command dispatcher)"
+        required: false
+        default: "airbytehq/airbyte"
+      gitref:
+        description: "Git ref (passed by slash command dispatcher)"
+        required: false
+
+run-name: "Hydra Failure for PR #${{ github.event.inputs.pr }}"
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: read
+
+jobs:
+  hydra-failure:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get job variables
+        id: job-vars
+        run: |
+          echo "run-url=https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" >> $GITHUB_OUTPUT
+
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Authenticate as GitHub App
+        uses: actions/create-github-app-token@v3.0.0
+        id: get-app-token
+        with:
+          owner: "airbytehq"
+          repositories: "airbyte,oncall"
+          app-id: ${{ secrets.OCTAVIA_BOT_APP_ID }}
+          private-key: ${{ secrets.OCTAVIA_BOT_PRIVATE_KEY }}
+
+      - name: Post start comment
+        if: inputs.comment-id != ''
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          token: ${{ steps.get-app-token.outputs.token }}
+          comment-id: ${{ inputs.comment-id }}
+          issue-number: ${{ inputs.pr }}
+          body: |
+            > **Hydra Failure Started**
+            >
+            > Turning the reported playbook failure into a regression eval, then fixing the playbook so the eval passes.
+            > [View workflow run](${{ steps.job-vars.outputs.run-url }})
+
+      - name: Run Hydra Failure
+        uses: aaronsteers/devin-action@main
+        with:
+          comment-id: ${{ inputs.comment-id }}
+          issue-number: ${{ inputs.pr }}
+          playbook-macro: "!hydra_failure"
+          devin-token: ${{ secrets.DEVIN_AI_API_KEY }}
+          github-token: ${{ steps.get-app-token.outputs.token }}
+          api-version: v3
+          org-id: ${{ vars.DEVIN_AI_ORG_ID }}
+          start-message: "🐍 **Hydra Failure session starting...** Reproducing the reported playbook failure as a failing eval, then fixing the playbook so the same eval passes. [View playbook](https://github.com/airbytehq/ai-skills/blob/main/devin/playbooks/hydra_failure.md)"
+          tags: |
+            ai-oncall

--- a/.github/workflows/hydra-failure-command.yml
+++ b/.github/workflows/hydra-failure-command.yml
@@ -38,7 +38,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Authenticate as GitHub App
-        uses: actions/create-github-app-token@v3.0.0
+        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
         id: get-app-token
         with:
           owner: "airbytehq"
@@ -48,7 +48,7 @@ jobs:
 
       - name: Post start comment
         if: inputs.comment-id != ''
-        uses: peter-evans/create-or-update-comment@v4
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
         with:
           token: ${{ steps.get-app-token.outputs.token }}
           comment-id: ${{ inputs.comment-id }}

--- a/.github/workflows/hydra-failure-command.yml
+++ b/.github/workflows/hydra-failure-command.yml
@@ -18,7 +18,7 @@ on:
         description: "Git ref (passed by slash command dispatcher)"
         required: false
 
-run-name: "Hydra Failure for PR #${{ github.event.inputs.pr }}"
+run-name: "Hydra Failure (comment ${{ github.event.inputs.comment-id }})"
 
 permissions:
   contents: read
@@ -46,13 +46,45 @@ jobs:
           app-id: ${{ secrets.OCTAVIA_BOT_APP_ID }}
           private-key: ${{ secrets.OCTAVIA_BOT_PRIVATE_KEY }}
 
+      - name: Resolve issue number
+        id: resolve
+        env:
+          INPUT_PR_NUMBER: ${{ inputs.pr }}
+          INPUT_COMMENT_ID: ${{ inputs.comment-id }}
+          GH_TOKEN: ${{ steps.get-app-token.outputs.token }}
+        run: |
+          set -euo pipefail
+
+          issue_number="$INPUT_PR_NUMBER"
+          comment_id="$INPUT_COMMENT_ID"
+
+          # The dispatcher passes an empty `pr` when the command is invoked from
+          # an issue (not a PR). Resolve the issue number from the comment-id in
+          # that case so the start comment and Devin session target the right thread.
+          if [[ -z "$issue_number" || "$issue_number" == "0" ]] && [[ -n "$comment_id" ]]; then
+            echo "Resolving issue number from comment-id..."
+            issue_number=$(curl -s \
+              -H "Authorization: Bearer $GH_TOKEN" \
+              -H "Accept: application/vnd.github+json" \
+              "https://api.github.com/repos/$GITHUB_REPOSITORY/issues/comments/$comment_id" \
+              | jq -r '.issue_url | split("/") | last')
+            if [[ -z "$issue_number" || "$issue_number" == "null" ]]; then
+              echo "::warning::Could not resolve issue number from comment-id $comment_id"
+              issue_number=""
+            else
+              echo "Resolved issue number: $issue_number"
+            fi
+          fi
+
+          echo "issue_number=${issue_number}" >> $GITHUB_OUTPUT
+
       - name: Post start comment
         if: inputs.comment-id != ''
         uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
         with:
           token: ${{ steps.get-app-token.outputs.token }}
           comment-id: ${{ inputs.comment-id }}
-          issue-number: ${{ inputs.pr }}
+          issue-number: ${{ steps.resolve.outputs.issue_number }}
           body: |
             > **Hydra Failure Started**
             >
@@ -63,7 +95,7 @@ jobs:
         uses: aaronsteers/devin-action@main
         with:
           comment-id: ${{ inputs.comment-id }}
-          issue-number: ${{ inputs.pr }}
+          issue-number: ${{ steps.resolve.outputs.issue_number }}
           playbook-macro: "!hydra_failure"
           devin-token: ${{ secrets.DEVIN_AI_API_KEY }}
           github-token: ${{ steps.get-app-token.outputs.token }}

--- a/.github/workflows/slash-commands.yml
+++ b/.github/workflows/slash-commands.yml
@@ -72,6 +72,7 @@ jobs:
             enable-autopilot-rollouts
             force-merge
             format-fix
+            hydra-failure
             poe
             publish-connectors-prerelease
             publish-java-cdk


### PR DESCRIPTION
## What

Wires up the `/hydra-failure` slash command so it can be invoked from `airbytehq/airbyte` — on a connector PR **or** an issue in this repo — the place where a `prove_fix` misjudgment is actually observed. Requested by @sophiecuiy for [HYD-52](https://linear.app/airbyteio/issue/HYD-52/prove-fix-playbook-enforce-retry-loop-before-declaring-fix-not).

The `/hydra-failure` playbook turns an observed playbook failure into a reproducible `prove_fix` eval and then fixes the playbook so the same eval passes (playbook lives at [ai-skills/devin/playbooks/hydra_failure.md](https://github.com/airbytehq/ai-skills/blob/main/devin/playbooks/hydra_failure.md)). Until now it had no dispatch entry point in this repo.

## How

- `slash-commands.yml`: added `hydra-failure` to the dispatched `commands:` list (alphabetical slot between `format-fix` and `poe`).
- `hydra-failure-command.yml` (new): `workflow_dispatch` command handler modeled on `ai-prove-fix-command.yml` — authenticates as the Octavia app, resolves the issue/PR number from `comment-id` when the command is invoked from an issue (empty `pr`), posts a start comment on the triggering thread, and starts a Devin session via `aaronsteers/devin-action@main` with `playbook-macro: "!hydra_failure"`.

```diff
  commands: |
    ...
    force-merge
    format-fix
+   hydra-failure
    poe
    ...
```

## Review guide

1. `.github/workflows/slash-commands.yml` — one-line list addition.
2. `.github/workflows/hydra-failure-command.yml` — new command workflow (mirror of `ai-prove-fix-command.yml`, plus the `Resolve issue number` step from `ai-dev-command.yml` so issue-triggered invocations work).

## User Impact

Maintainers can comment `/hydra-failure` on an airbyte connector PR or issue to kick off the loop; the session does its reproduction/fix work in `airbytehq/ai-skills` and reports back on the originating comment.

**Scope:** this PR wires dispatch for issues/PRs **in `airbytehq/airbyte` only**. Invoking `/hydra-failure` from `airbytehq/oncall` would require a separate dispatcher in that repo (follow-up, not included here).

**Dependency:** the `!hydra_failure` macro only resolves once the playbook is live in Devin — i.e. after ai-skills#581 (which adds `hydra_failure.md`) merges and syncs. Until then this command will dispatch but the session macro won't be found. This PR is the airbyte-side wiring only.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Link to Devin session: https://app.devin.ai/sessions/052d1f575f614f73ac7cfb29ada56aa7