### PR TITLE
feat(destination-s3): add JSONL stringify option for Hive JsonSerDe

### DIFF
--- a/airbyte-cdk/bulk/toolkits/legacy-task-load-object-storage/src/main/kotlin/io/airbyte/cdk/load/command/object_storage/DeprecatedObjectStorageFormatSpecification.kt
+++ b/airbyte-cdk/bulk/toolkits/legacy-task-load-object-storage/src/main/kotlin/io/airbyte/cdk/load/command/object_storage/DeprecatedObjectStorageFormatSpecification.kt
@@ -39,11 +39,15 @@ interface DeprecatedObjectStorageFormatSpecificationProvider {
     fun toObjectStorageFormatConfiguration(): ObjectStorageFormatConfiguration {
         return when (format) {
             is DeprecatedJsonFormatSpecification ->
-                JsonFormatConfiguration(
-                    rootLevelFlattening =
-                        (format as DeprecatedJsonFormatSpecification).flattening ==
-                            FlatteningSpecificationProvider.Flattening.ROOT_LEVEL_FLATTENING
-                )
+                (format as DeprecatedJsonFormatSpecification).let {
+                    JsonFormatConfiguration(
+                        rootLevelFlattening =
+                            it.flattening ==
+                                FlatteningSpecificationProvider.Flattening.ROOT_LEVEL_FLATTENING,
+                        stringifyObjects =
+                            it.stringify == StringifySpecificationProvider.Stringify.STRINGIFY,
+                    )
+                }
             is DeprecatedCSVFormatSpecification ->
                 CSVFormatConfiguration(
                     rootLevelFlattening =
@@ -132,9 +136,12 @@ class DeprecatedJsonFormatSpecification(
 ) :
     DeprecatedObjectStorageFormatSpecification(formatType),
     FlatteningSpecificationProvider,
+    StringifySpecificationProvider,
     ObjectStorageCompressionSpecificationProvider {
     override val flattening: FlatteningSpecificationProvider.Flattening? =
         FlatteningSpecificationProvider.Flattening.NO_FLATTENING
+    override val stringify: StringifySpecificationProvider.Stringify? =
+        StringifySpecificationProvider.Stringify.DEFAULT
     override val compression: ObjectStorageCompressionSpecification? =
         GZIPCompressionSpecification()
 }

--- a/airbyte-cdk/bulk/toolkits/legacy-task-load-object-storage/src/main/kotlin/io/airbyte/cdk/load/command/object_storage/ObjectStorageFormatSpecification.kt
+++ b/airbyte-cdk/bulk/toolkits/legacy-task-load-object-storage/src/main/kotlin/io/airbyte/cdk/load/command/object_storage/ObjectStorageFormatSpecification.kt
@@ -26,11 +26,15 @@ interface ObjectStorageFormatSpecificationProvider {
     fun toObjectStorageFormatConfiguration(): ObjectStorageFormatConfiguration {
         return when (format) {
             is JsonFormatSpecification ->
-                JsonFormatConfiguration(
-                    rootLevelFlattening =
-                        (format as JsonFormatSpecification).flattening ==
-                            FlatteningSpecificationProvider.Flattening.ROOT_LEVEL_FLATTENING
-                )
+                (format as JsonFormatSpecification).let {
+                    JsonFormatConfiguration(
+                        rootLevelFlattening =
+                            it.flattening ==
+                                FlatteningSpecificationProvider.Flattening.ROOT_LEVEL_FLATTENING,
+                        stringifyObjects =
+                            it.stringify == StringifySpecificationProvider.Stringify.STRINGIFY,
+                    )
+                }
             is CSVFormatSpecification ->
                 CSVFormatConfiguration(
                     rootLevelFlattening =
@@ -76,8 +80,13 @@ class JsonFormatSpecification(
     @JsonProperty("format_type")
     override val formatType: Type = Type.JSONL,
     override val flattening: FlatteningSpecificationProvider.Flattening? =
-        FlatteningSpecificationProvider.Flattening.NO_FLATTENING
-) : ObjectStorageFormatSpecification(formatType), FlatteningSpecificationProvider
+        FlatteningSpecificationProvider.Flattening.NO_FLATTENING,
+    override val stringify: StringifySpecificationProvider.Stringify? =
+        StringifySpecificationProvider.Stringify.DEFAULT,
+) :
+    ObjectStorageFormatSpecification(formatType),
+    FlatteningSpecificationProvider,
+    StringifySpecificationProvider
 
 interface FlatteningSpecificationProvider {
     @get:JsonSchemaTitle("Flattening")
@@ -87,6 +96,20 @@ interface FlatteningSpecificationProvider {
     enum class Flattening(@get:JsonValue val flatteningName: String) {
         NO_FLATTENING("No flattening"),
         ROOT_LEVEL_FLATTENING("Root level flattening")
+    }
+}
+
+interface StringifySpecificationProvider {
+    @get:JsonSchemaTitle("Stringify JSON")
+    @get:JsonPropertyDescription(
+        "Whether root-level objects in the JSONL output (including _airbyte_data) should be converted to JSON strings. Useful for Hive JsonSerDe compatibility. Default preserves objects as objects.",
+    )
+    @get:JsonProperty("stringify", defaultValue = "Default")
+    val stringify: Stringify?
+
+    enum class Stringify(@get:JsonValue val stringifyName: String) {
+        DEFAULT("Default"),
+        STRINGIFY("Stringify")
     }
 }
 
@@ -102,7 +125,8 @@ sealed interface ObjectStorageFormatConfiguration {
 
 data class JsonFormatConfiguration(
     override val extension: String = "jsonl",
-    override val rootLevelFlattening: Boolean = false
+    override val rootLevelFlattening: Boolean = false,
+    val stringifyObjects: Boolean = false,
 ) : ObjectStorageFormatConfiguration {}
 
 data class CSVFormatConfiguration(

--- a/airbyte-cdk/bulk/toolkits/legacy-task-load-object-storage/src/main/kotlin/io/airbyte/cdk/load/file/object_storage/ObjectStorageFormattingWriter.kt
+++ b/airbyte-cdk/bulk/toolkits/legacy-task-load-object-storage/src/main/kotlin/io/airbyte/cdk/load/file/object_storage/ObjectStorageFormattingWriter.kt
@@ -14,10 +14,14 @@ import io.airbyte.cdk.load.command.object_storage.ParquetFormatConfiguration
 import io.airbyte.cdk.load.config.DataChannelFormat
 import io.airbyte.cdk.load.config.DataChannelMedium
 import io.airbyte.cdk.load.data.ObjectType
+import io.airbyte.cdk.load.data.ObjectValue
+import io.airbyte.cdk.load.data.AirbyteValue
+import io.airbyte.cdk.load.data.StringValue
 import io.airbyte.cdk.load.data.avro.toAvroRecord
 import io.airbyte.cdk.load.data.avro.toAvroSchema
 import io.airbyte.cdk.load.data.csv.toCsvRecord
 import io.airbyte.cdk.load.data.dataWithAirbyteMeta
+import io.airbyte.cdk.load.data.json.toJson
 import io.airbyte.cdk.load.data.withAirbyteMeta
 import io.airbyte.cdk.load.file.StreamProcessor
 import io.airbyte.cdk.load.file.avro.toAvroWriter
@@ -72,20 +76,25 @@ class DefaultObjectStorageFormattingWriterFactory(
         // TODO: FileWriter
 
         return when (formatConfigProvider.objectStorageFormatConfiguration) {
-            is JsonFormatConfiguration ->
+            is JsonFormatConfiguration -> {
+                val jsonConfig =
+                    formatConfigProvider.objectStorageFormatConfiguration as JsonFormatConfiguration
                 if (dataChannelFormat == DataChannelFormat.PROTOBUF) {
                     ProtoToJsonFormatter(
                         stream = stream,
                         outputStream = outputStream,
                         rootLevelFlattening = flatten,
+                        stringifyObjects = jsonConfig.stringifyObjects,
                     )
                 } else {
                     JsonFormattingWriter(
                         stream = stream,
                         outputStream = outputStream,
                         rootLevelFlattening = flatten,
+                        stringifyObjects = jsonConfig.stringifyObjects,
                     )
                 }
+            }
             is AvroFormatConfiguration ->
                 if (dataChannelFormat == DataChannelFormat.PROTOBUF) {
                     ProtoToAvroFormatter(
@@ -150,10 +159,11 @@ class JsonFormattingWriter(
     private val stream: DestinationStream,
     private val outputStream: OutputStream,
     private val rootLevelFlattening: Boolean,
+    private val stringifyObjects: Boolean = false,
 ) : ObjectStorageFormattingWriter {
 
     override fun accept(record: DestinationRecordRaw) {
-        val data =
+        var data =
             record
                 .asDestinationRecordAirbyteValue()
                 .dataWithAirbyteMeta(
@@ -161,9 +171,13 @@ class JsonFormattingWriter(
                     flatten = rootLevelFlattening,
                     airbyteRawId = record.airbyteRawId,
                 )
-                .toJson()
-                .serializeToString()
-        outputStream.write(data)
+
+        if (stringifyObjects) {
+            data = stringifyRootLevelObjects(data)
+        }
+
+        val serialized = data.toJson().serializeToString()
+        outputStream.write(serialized)
         outputStream.write("\n")
     }
 
@@ -173,6 +187,30 @@ class JsonFormattingWriter(
 
     override fun close() {
         outputStream.close()
+    }
+
+    companion object {
+        /**
+         * Converts root-level [ObjectValue] fields to JSON strings. This is useful for Hive
+         * JsonSerDe compatibility, which otherwise mishandles nested objects (including
+         * `_airbyte_data`).
+         */
+        fun stringifyRootLevelObjects(value: ObjectValue): ObjectValue {
+            val converted = linkedMapOf<String, AirbyteValue>()
+            for ((key, fieldValue) in value.values) {
+                converted[key] =
+                    when (fieldValue) {
+                        is ObjectValue -> {
+                            // Use AirbyteValue receiver so the JsonNode toJson() extension is
+                            // selected (ObjectValue also has a @JsonValue member).
+                            val asAirbyteValue: AirbyteValue = fieldValue
+                            StringValue(asAirbyteValue.toJson().serializeToString())
+                        }
+                        else -> fieldValue
+                    }
+            }
+            return ObjectValue(converted)
+        }
     }
 }
 

--- a/airbyte-cdk/bulk/toolkits/legacy-task-load-object-storage/src/main/kotlin/io/airbyte/cdk/load/file/object_storage/ProtoToJsonFormatter.kt
+++ b/airbyte-cdk/bulk/toolkits/legacy-task-load-object-storage/src/main/kotlin/io/airbyte/cdk/load/file/object_storage/ProtoToJsonFormatter.kt
@@ -14,11 +14,16 @@ import java.io.OutputStream
 class ProtoToJsonFormatter(
     stream: DestinationStream,
     private val outputStream: OutputStream,
-    rootLevelFlattening: Boolean
+    rootLevelFlattening: Boolean,
+    stringifyObjects: Boolean = false,
 ) : ObjectStorageFormattingWriter {
 
     private val fastWriter =
-        ProtoToJsonWriter(stream.airbyteValueProxyFieldAccessors, rootLevelFlattening)
+        ProtoToJsonWriter(
+            stream.airbyteValueProxyFieldAccessors,
+            rootLevelFlattening,
+            stringifyObjects,
+        )
     private val unknownColumnChanges = stream.unknownColumnChanges
 
     private val generator =

--- a/airbyte-cdk/bulk/toolkits/legacy-task-load-object-storage/src/main/kotlin/io/airbyte/cdk/load/file/object_storage/ProtoToJsonWriter.kt
+++ b/airbyte-cdk/bulk/toolkits/legacy-task-load-object-storage/src/main/kotlin/io/airbyte/cdk/load/file/object_storage/ProtoToJsonWriter.kt
@@ -4,6 +4,7 @@
 package io.airbyte.cdk.load.file.object_storage
 
 import com.fasterxml.jackson.core.JsonGenerator
+import com.fasterxml.jackson.databind.node.ObjectNode
 import io.airbyte.cdk.load.data.*
 import io.airbyte.cdk.load.message.DestinationRecordProtobufSource
 import io.airbyte.cdk.load.message.DestinationRecordRaw
@@ -13,12 +14,14 @@ import io.airbyte.cdk.load.message.Meta.Companion.COLUMN_NAME_AB_GENERATION_ID
 import io.airbyte.cdk.load.message.Meta.Companion.COLUMN_NAME_AB_META
 import io.airbyte.cdk.load.message.Meta.Companion.COLUMN_NAME_AB_RAW_ID
 import io.airbyte.cdk.load.message.Meta.Companion.COLUMN_NAME_DATA
+import io.airbyte.cdk.util.Jsons
 import java.math.BigDecimal
 import java.math.BigInteger
 
 class ProtoToJsonWriter(
     private val columns: Array<AirbyteValueProxy.FieldAccessor>,
-    private val flatten: Boolean
+    private val flatten: Boolean,
+    private val stringifyObjects: Boolean = false,
 ) {
 
     fun writeMeta(gen: JsonGenerator, record: DestinationRecordRaw, changes: List<Meta.Change>) =
@@ -27,21 +30,25 @@ class ProtoToJsonWriter(
             writeNumberField(COLUMN_NAME_AB_EXTRACTED_AT, record.rawData.emittedAtMs)
 
             // _airbyte_meta
-            writeFieldName(COLUMN_NAME_AB_META)
-            writeStartObject()
-            writeNumberField("sync_id", record.stream.syncId)
-
-            writeFieldName("changes")
-            writeStartArray()
-            for (c in changes) {
+            if (stringifyObjects) {
+                writeStringField(COLUMN_NAME_AB_META, buildMetaJson(record, changes))
+            } else {
+                writeFieldName(COLUMN_NAME_AB_META)
                 writeStartObject()
-                writeStringField("field", c.field)
-                writeStringField("change", c.change.name)
-                writeStringField("reason", c.reason.name)
-                writeEndObject()
+                writeNumberField("sync_id", record.stream.syncId)
+
+                writeFieldName("changes")
+                writeStartArray()
+                for (c in changes) {
+                    writeStartObject()
+                    writeStringField("field", c.field)
+                    writeStringField("change", c.change.name)
+                    writeStringField("reason", c.reason.name)
+                    writeEndObject()
+                }
+                writeEndArray()
+                writeEndObject() // _airbyte_meta
             }
-            writeEndArray()
-            writeEndObject() // _airbyte_meta
 
             writeNumberField(COLUMN_NAME_AB_GENERATION_ID, record.stream.generationId)
         }
@@ -51,18 +58,99 @@ class ProtoToJsonWriter(
 
         if (!flatten) {
             gen.writeFieldName(COLUMN_NAME_DATA)
+            if (stringifyObjects) {
+                gen.writeString(buildDataObject(proxy).toString())
+                return
+            }
             gen.writeStartObject()
         }
 
-        for (column in columns) writeValue(gen, column, proxy)
+        for (column in columns) writeValue(gen, column, proxy, stringifyObjects && flatten)
 
         if (!flatten) gen.writeEndObject()
+    }
+
+    private fun buildMetaJson(record: DestinationRecordRaw, changes: List<Meta.Change>): String {
+        val meta = Jsons.objectNode()
+        meta.put("sync_id", record.stream.syncId)
+        val changesArray = meta.putArray("changes")
+        for (c in changes) {
+            val changeNode = changesArray.addObject()
+            changeNode.put("field", c.field)
+            changeNode.put("change", c.change.name)
+            changeNode.put("reason", c.reason.name)
+        }
+        return meta.toString()
+    }
+
+    private fun buildDataObject(proxy: AirbyteValueProxy): ObjectNode {
+        val data = Jsons.objectNode()
+        for (column in columns) {
+            putValue(data, column, proxy)
+        }
+        return data
+    }
+
+    private fun putValue(
+        node: ObjectNode,
+        field: AirbyteValueProxy.FieldAccessor,
+        proxy: AirbyteValueProxy
+    ) {
+        when (field.type) {
+            is ArrayType,
+            is ArrayTypeWithoutSchema,
+            is UnionType,
+            is ObjectType,
+            is ObjectTypeWithEmptySchema,
+            is ObjectTypeWithoutSchema -> {
+                val json = proxy.getJsonNode(field)
+                if (json == null) node.putNull(field.name) else node.set(field.name, json)
+            }
+            is BooleanType -> {
+                val value = proxy.getBoolean(field)
+                if (value == null) node.putNull(field.name) else node.put(field.name, value)
+            }
+            is IntegerType -> {
+                val value = proxy.getInteger(field)
+                if (value == null) node.putNull(field.name) else node.put(field.name, value)
+            }
+            is NumberType -> {
+                val value = proxy.getNumber(field)
+                if (value == null) node.putNull(field.name) else node.put(field.name, value)
+            }
+            is DateType -> {
+                val value = proxy.getDate(field)
+                if (value == null) node.putNull(field.name) else node.put(field.name, value)
+            }
+            is StringType -> {
+                val value = proxy.getString(field)
+                if (value == null) node.putNull(field.name) else node.put(field.name, value)
+            }
+            is TimeTypeWithTimezone -> {
+                val value = proxy.getTimeWithTimezone(field)
+                if (value == null) node.putNull(field.name) else node.put(field.name, value)
+            }
+            is TimeTypeWithoutTimezone -> {
+                val value = proxy.getTimeWithoutTimezone(field)
+                if (value == null) node.putNull(field.name) else node.put(field.name, value)
+            }
+            is TimestampTypeWithTimezone -> {
+                val value = proxy.getTimestampWithTimezone(field)
+                if (value == null) node.putNull(field.name) else node.put(field.name, value)
+            }
+            is TimestampTypeWithoutTimezone -> {
+                val value = proxy.getTimestampWithoutTimezone(field)
+                if (value == null) node.putNull(field.name) else node.put(field.name, value)
+            }
+            is UnknownType -> node.putNull(field.name)
+        }
     }
 
     private fun writeValue(
         gen: JsonGenerator,
         field: AirbyteValueProxy.FieldAccessor,
-        proxy: AirbyteValueProxy
+        proxy: AirbyteValueProxy,
+        stringifyObjects: Boolean,
     ) =
         when (field.type) {
             is ArrayType,
@@ -70,7 +158,8 @@ class ProtoToJsonWriter(
             is UnionType,
             is ObjectType,
             is ObjectTypeWithEmptySchema,
-            is ObjectTypeWithoutSchema -> gen.writeTreeOrNull(field, proxy.getJsonNode(field))
+            is ObjectTypeWithoutSchema ->
+                gen.writeTreeOrNull(field, proxy.getJsonNode(field), stringifyObjects)
             is BooleanType -> gen.writeBooleanOrNull(field, proxy.getBoolean(field))
             is IntegerType -> gen.writeNumberOrNull(field, proxy.getInteger(field))
             is NumberType -> gen.writeNumberOrNull(field, proxy.getNumber(field))
@@ -98,12 +187,15 @@ class ProtoToJsonWriter(
 
     private fun JsonGenerator.writeTreeOrNull(
         field: AirbyteValueProxy.FieldAccessor,
-        node: com.fasterxml.jackson.databind.JsonNode?
+        node: com.fasterxml.jackson.databind.JsonNode?,
+        stringifyObjects: Boolean,
     ) {
         if (node == null) writeNullField(field.name)
         else {
             writeFieldName(field.name)
-            writeTree(node) // requires codec: generator created from ObjectMapper
+            // Only stringify JSON objects; leave arrays as arrays (matches issue scope).
+            if (stringifyObjects && node.isObject) writeString(node.toString())
+            else writeTree(node) // requires codec: generator created from ObjectMapper
         }
     }
 

--- a/airbyte-cdk/bulk/toolkits/legacy-task-load-object-storage/src/test/kotlin/io/airbyte/cdk/load/file/object_storage/ProtoToJsonFormattingTest.kt
+++ b/airbyte-cdk/bulk/toolkits/legacy-task-load-object-storage/src/test/kotlin/io/airbyte/cdk/load/file/object_storage/ProtoToJsonFormattingTest.kt
@@ -65,6 +65,32 @@ class ProtoToJsonFormattingTest : ProtoFixtures(true) {
     }
 
     @Test
+    fun `formatter stringifies root-level objects when enabled`() {
+        val out = ByteArrayOutputStream()
+        val formatter =
+            ProtoToJsonFormatter(
+                stream,
+                out,
+                rootLevelFlattening = false,
+                stringifyObjects = true,
+            )
+
+        formatter.accept(record)
+        formatter.flush()
+
+        val lines = out.toString(Charsets.UTF_8).split('\n')
+        assertEquals(2, lines.size)
+
+        val expectedJson =
+            """
+            {"_airbyte_raw_id":"11111111-1111-1111-1111-111111111111","_airbyte_extracted_at":1724438400000,"_airbyte_meta":"{\"sync_id\":42,\"changes\":[{\"field\":\"x\",\"change\":\"NULLED\",\"reason\":\"DESTINATION_SERIALIZATION_ERROR\"},{\"field\":\"y\",\"change\":\"NULLED\",\"reason\":\"SOURCE_SERIALIZATION_ERROR\"},{\"field\":\"z\",\"change\":\"TRUNCATED\",\"reason\":\"SOURCE_RECORD_SIZE_LIMITATION\"},{\"field\":\"unknown_col\",\"change\":\"NULLED\",\"reason\":\"DESTINATION_SERIALIZATION_ERROR\"}]}","_airbyte_generation_id":314,"_airbyte_data":"{\"bool_col\":true,\"int_col\":123,\"num_col\":12.34,\"string_col\":\"hello\",\"date_col\":\"2025-06-17\",\"time_tz_col\":\"23:59:59+02:00\",\"time_no_tz_col\":\"23:59:59\",\"ts_tz_col\":\"2025-06-17T23:59:59+02:00\",\"ts_no_tz_col\":\"2025-06-17T23:59:59\",\"array_col\":[\"a\",\"b\"],\"obj_col\":{\"k\":\"v\"},\"union_col\":{\"u\":1},\"unknown_col\":null}"}
+        """.trimIndent()
+
+        assertEquals(expectedJson, lines[0])
+        assertEquals("", lines[1])
+    }
+
+    @Test
     fun `formatter throws on non-protobuf record`() {
         val nonProtoRecord =
             mockk<DestinationRecordRaw> {

--- a/airbyte-cdk/bulk/toolkits/legacy-task-load-object-storage/src/test/kotlin/io/airbyte/cdk/load/write/object_storage/ObjectStorageFormattingWriterTest.kt
+++ b/airbyte-cdk/bulk/toolkits/legacy-task-load-object-storage/src/test/kotlin/io/airbyte/cdk/load/write/object_storage/ObjectStorageFormattingWriterTest.kt
@@ -84,6 +84,27 @@ private val stream =
         namespaceMapper = NamespaceMapper(namespaceDefinitionType = NamespaceDefinitionType.SOURCE),
     )
 
+private val nestedStream =
+    DestinationStream(
+        unmappedNamespace = "test_ns",
+        unmappedName = "test_name",
+        Append,
+        ObjectType(
+            linkedMapOf(
+                "foo" to FieldType(StringType, nullable = true),
+                "nested" to
+                    FieldType(
+                        ObjectType(linkedMapOf("a" to FieldType(StringType, nullable = true))),
+                        nullable = true,
+                    ),
+            )
+        ),
+        generationId = 42,
+        minimumGenerationId = 0,
+        syncId = 123,
+        namespaceMapper = NamespaceMapper(namespaceDefinitionType = NamespaceDefinitionType.SOURCE),
+    )
+
 private val record =
     DestinationRecordRaw(
         stream,
@@ -96,6 +117,24 @@ private val record =
                         .withNamespace("test_ns")
                         .withEmittedAt(1234)
                         .withData(Jsons.deserialize("""{"foo": "bar"}""")),
+                ),
+        ),
+        serializedSizeBytes = 42,
+        airbyteRawId = UUID.fromString("0197604b-ca2e-7e7c-9126-dacc18b68e8e"),
+    )
+
+private val recordWithNestedObject =
+    DestinationRecordRaw(
+        nestedStream,
+        DestinationRecordJsonSource(
+            AirbyteMessage()
+                .withType(AirbyteMessage.Type.RECORD)
+                .withRecord(
+                    AirbyteRecordMessage()
+                        .withStream("test_name")
+                        .withNamespace("test_ns")
+                        .withEmittedAt(1234)
+                        .withData(Jsons.deserialize("""{"foo": "bar", "nested": {"a": 1}}""")),
                 ),
         ),
         serializedSizeBytes = 42,
@@ -125,6 +164,46 @@ class JsonFormattingWriterTest {
         assertEquals(
             """
             {"_airbyte_raw_id":"0197604b-ca2e-7e7c-9126-dacc18b68e8e","_airbyte_extracted_at":1234,"_airbyte_meta":{"sync_id":123,"changes":[]},"_airbyte_generation_id":42,"foo":"bar"}
+            
+            """.trimIndent(),
+            os.toByteArray().decodeToString(),
+        )
+    }
+
+    @Test
+    fun testAcceptWithStringifyNoFlattening() {
+        val os = ByteArrayOutputStream()
+        val writer =
+            JsonFormattingWriter(
+                stream,
+                os,
+                rootLevelFlattening = false,
+                stringifyObjects = true,
+            )
+        writer.accept(recordWithNestedObject)
+        assertEquals(
+            """
+            {"_airbyte_raw_id":"0197604b-ca2e-7e7c-9126-dacc18b68e8e","_airbyte_extracted_at":1234,"_airbyte_meta":"{\"sync_id\":123,\"changes\":[]}","_airbyte_generation_id":42,"_airbyte_data":"{\"foo\":\"bar\",\"nested\":{\"a\":1}}"}
+            
+            """.trimIndent(),
+            os.toByteArray().decodeToString(),
+        )
+    }
+
+    @Test
+    fun testAcceptWithStringifyAndFlattening() {
+        val os = ByteArrayOutputStream()
+        val writer =
+            JsonFormattingWriter(
+                nestedStream,
+                os,
+                rootLevelFlattening = true,
+                stringifyObjects = true,
+            )
+        writer.accept(recordWithNestedObject)
+        assertEquals(
+            """
+            {"_airbyte_raw_id":"0197604b-ca2e-7e7c-9126-dacc18b68e8e","_airbyte_extracted_at":1234,"_airbyte_meta":"{\"sync_id\":123,\"changes\":[]}","_airbyte_generation_id":42,"foo":"bar","nested":"{\"a\":1}"}
             
             """.trimIndent(),
             os.toByteArray().decodeToString(),

--- a/airbyte-integrations/connectors/destination-azure-blob-storage/src/test-integration/resources/expected-spec-cloud.json
+++ b/airbyte-integrations/connectors/destination-azure-blob-storage/src/test-integration/resources/expected-spec-cloud.json
@@ -101,7 +101,15 @@
               "default" : "No flattening",
               "enum" : [ "No flattening", "Root level flattening" ],
               "title" : "Flattening"
+            },
+            "stringify" : {
+              "type" : "string",
+              "description" : "Whether root-level objects in the JSONL output (including _airbyte_data) should be converted to JSON strings. Useful for Hive JsonSerDe compatibility. Default preserves objects as objects.",
+              "default" : "Default",
+              "enum" : [ "Default", "Stringify" ],
+              "title" : "Stringify JSON"
             }
+
           },
           "required" : [ "format_type" ]
         } ],

--- a/airbyte-integrations/connectors/destination-azure-blob-storage/src/test-integration/resources/expected-spec-oss.json
+++ b/airbyte-integrations/connectors/destination-azure-blob-storage/src/test-integration/resources/expected-spec-oss.json
@@ -101,7 +101,15 @@
               "default" : "No flattening",
               "enum" : [ "No flattening", "Root level flattening" ],
               "title" : "Flattening"
+            },
+            "stringify" : {
+              "type" : "string",
+              "description" : "Whether root-level objects in the JSONL output (including _airbyte_data) should be converted to JSON strings. Useful for Hive JsonSerDe compatibility. Default preserves objects as objects.",
+              "default" : "Default",
+              "enum" : [ "Default", "Stringify" ],
+              "title" : "Stringify JSON"
             }
+
           },
           "required" : [ "format_type" ]
         } ],

--- a/airbyte-integrations/connectors/destination-customer-io/src/test-integration/resources/expected-spec-cloud.json
+++ b/airbyte-integrations/connectors/destination-customer-io/src/test-integration/resources/expected-spec-cloud.json
@@ -144,7 +144,15 @@
                     "default" : "No flattening",
                     "enum" : [ "No flattening", "Root level flattening" ],
                     "title" : "Flattening"
+                  },
+                  "stringify" : {
+                    "type" : "string",
+                    "description" : "Whether root-level objects in the JSONL output (including _airbyte_data) should be converted to JSON strings. Useful for Hive JsonSerDe compatibility. Default preserves objects as objects.",
+                    "default" : "Default",
+                    "enum" : [ "Default", "Stringify" ],
+                    "title" : "Stringify JSON"
                   }
+
                 },
                 "required" : [ "format_type" ]
               } ],

--- a/airbyte-integrations/connectors/destination-customer-io/src/test-integration/resources/expected-spec-oss.json
+++ b/airbyte-integrations/connectors/destination-customer-io/src/test-integration/resources/expected-spec-oss.json
@@ -144,7 +144,15 @@
                     "default" : "No flattening",
                     "enum" : [ "No flattening", "Root level flattening" ],
                     "title" : "Flattening"
+                  },
+                  "stringify" : {
+                    "type" : "string",
+                    "description" : "Whether root-level objects in the JSONL output (including _airbyte_data) should be converted to JSON strings. Useful for Hive JsonSerDe compatibility. Default preserves objects as objects.",
+                    "default" : "Default",
+                    "enum" : [ "Default", "Stringify" ],
+                    "title" : "Stringify JSON"
                   }
+
                 },
                 "required" : [ "format_type" ]
               } ],

--- a/airbyte-integrations/connectors/destination-gcs/src/test-integration/resources/expected-spec-cloud.json
+++ b/airbyte-integrations/connectors/destination-gcs/src/test-integration/resources/expected-spec-cloud.json
@@ -129,6 +129,13 @@
               "enum" : [ "No flattening", "Root level flattening" ],
               "title" : "Flattening"
             },
+            "stringify" : {
+              "type" : "string",
+              "description" : "Whether root-level objects in the JSONL output (including _airbyte_data) should be converted to JSON strings. Useful for Hive JsonSerDe compatibility. Default preserves objects as objects.",
+              "default" : "Default",
+              "enum" : [ "Default", "Stringify" ],
+              "title" : "Stringify JSON"
+            },
             "compression" : {
               "oneOf" : [ {
                 "title" : "No Compression",

--- a/airbyte-integrations/connectors/destination-gcs/src/test-integration/resources/expected-spec-oss.json
+++ b/airbyte-integrations/connectors/destination-gcs/src/test-integration/resources/expected-spec-oss.json
@@ -129,6 +129,13 @@
               "enum" : [ "No flattening", "Root level flattening" ],
               "title" : "Flattening"
             },
+            "stringify" : {
+              "type" : "string",
+              "description" : "Whether root-level objects in the JSONL output (including _airbyte_data) should be converted to JSON strings. Useful for Hive JsonSerDe compatibility. Default preserves objects as objects.",
+              "default" : "Default",
+              "enum" : [ "Default", "Stringify" ],
+              "title" : "Stringify JSON"
+            },
             "compression" : {
               "oneOf" : [ {
                 "title" : "No Compression",

--- a/airbyte-integrations/connectors/destination-hubspot/src/test-integration/resources/expected-spec-cloud.json
+++ b/airbyte-integrations/connectors/destination-hubspot/src/test-integration/resources/expected-spec-cloud.json
@@ -117,7 +117,15 @@
                     "default" : "No flattening",
                     "enum" : [ "No flattening", "Root level flattening" ],
                     "title" : "Flattening"
+                  },
+                  "stringify" : {
+                    "type" : "string",
+                    "description" : "Whether root-level objects in the JSONL output (including _airbyte_data) should be converted to JSON strings. Useful for Hive JsonSerDe compatibility. Default preserves objects as objects.",
+                    "default" : "Default",
+                    "enum" : [ "Default", "Stringify" ],
+                    "title" : "Stringify JSON"
                   }
+
                 },
                 "required" : [ "format_type" ]
               } ],

--- a/airbyte-integrations/connectors/destination-hubspot/src/test-integration/resources/expected-spec-oss.json
+++ b/airbyte-integrations/connectors/destination-hubspot/src/test-integration/resources/expected-spec-oss.json
@@ -117,7 +117,15 @@
                     "default" : "No flattening",
                     "enum" : [ "No flattening", "Root level flattening" ],
                     "title" : "Flattening"
+                  },
+                  "stringify" : {
+                    "type" : "string",
+                    "description" : "Whether root-level objects in the JSONL output (including _airbyte_data) should be converted to JSON strings. Useful for Hive JsonSerDe compatibility. Default preserves objects as objects.",
+                    "default" : "Default",
+                    "enum" : [ "Default", "Stringify" ],
+                    "title" : "Stringify JSON"
                   }
+
                 },
                 "required" : [ "format_type" ]
               } ],

--- a/airbyte-integrations/connectors/destination-s3/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-s3/metadata.yaml
@@ -2,7 +2,7 @@ data:
   connectorSubtype: file
   connectorType: destination
   definitionId: 4816b78f-1489-44c1-9060-4b19d5fa9362
-  dockerImageTag: 1.9.8
+  dockerImageTag: 1.9.9
   dockerRepository: airbyte/destination-s3
   githubIssueLabel: destination-s3
   icon: s3.svg

--- a/airbyte-integrations/connectors/destination-s3/src/test-integration/resources/expected-spec-cloud.json
+++ b/airbyte-integrations/connectors/destination-s3/src/test-integration/resources/expected-spec-cloud.json
@@ -119,6 +119,13 @@
               "enum" : [ "No flattening", "Root level flattening" ],
               "title" : "Flattening"
             },
+            "stringify" : {
+              "type" : "string",
+              "description" : "Whether root-level objects in the JSONL output (including _airbyte_data) should be converted to JSON strings. Useful for Hive JsonSerDe compatibility. Default preserves objects as objects.",
+              "default" : "Default",
+              "enum" : [ "Default", "Stringify" ],
+              "title" : "Stringify JSON"
+            },
             "compression" : {
               "oneOf" : [ {
                 "title" : "No Compression",

--- a/airbyte-integrations/connectors/destination-s3/src/test-integration/resources/expected-spec-oss.json
+++ b/airbyte-integrations/connectors/destination-s3/src/test-integration/resources/expected-spec-oss.json
@@ -119,6 +119,13 @@
               "enum" : [ "No flattening", "Root level flattening" ],
               "title" : "Flattening"
             },
+            "stringify" : {
+              "type" : "string",
+              "description" : "Whether root-level objects in the JSONL output (including _airbyte_data) should be converted to JSON strings. Useful for Hive JsonSerDe compatibility. Default preserves objects as objects.",
+              "default" : "Default",
+              "enum" : [ "Default", "Stringify" ],
+              "title" : "Stringify JSON"
+            },
             "compression" : {
               "oneOf" : [ {
                 "title" : "No Compression",

--- a/docs/integrations/destinations/s3.md
+++ b/docs/integrations/destinations/s3.md
@@ -483,6 +483,8 @@ They will be like this in the output file:
 Output files can be compressed. The default option is GZIP compression. If compression is selected,
 the output filename will have an extra extension (GZIP: `.jsonl.gz`).
 
+If your data has nested objects and you query the files with Hive `JsonSerDe`, enable the **Stringify JSON** option under JSONL output format. When set to `Stringify`, root-level objects (including `_airbyte_data` and `_airbyte_meta`) are written as JSON strings instead of nested objects. The default (`Default`) preserves the existing object serialization.
+
 ### Parquet
 
 #### Configuration
@@ -546,6 +548,7 @@ This destination supports [namespaces](https://docs.airbyte.com/platform/using-a
 
 | Version     | Date       | Pull Request                                               | Subject                                                                                                                                              |
 |:------------|:-----------|:-----------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------|
+| 1.9.9       | 2026-07-21 | | Add optional JSONL `stringify` setting to serialize root-level objects as JSON strings (Hive JsonSerDe compatibility). |
 | 1.9.8       | 2026-05-21 | [78240](https://github.com/airbytehq/airbyte/pull/78240) | Promoting release candidate 1.9.8-rc.1 to a main version. |
 | 1.9.8-rc.1  | 2026-05-19 | [78240](https://github.com/airbytehq/airbyte/pull/78240) | Upgrade CDK to 1.0.13. Progressive rollout. |
 | 1.9.7       | 2026-01-26 | [72354](https://github.com/airbytehq/airbyte/pull/72354) | Fix sync failures for sources with empty schemas by upgrading CDK to 0.2.1                                                                           |


### PR DESCRIPTION
## What
Adds an optional JSONL `stringify` setting (`Default` / `Stringify`) so root-level objects (including `_airbyte_data`) can be written as JSON strings for Hive JsonSerDe compatibility.

## Why
Nested objects in S3 JSONL are mishandled by Hive JsonSerDe (records show as `{`).

Closes #27171

## How
- Add `stringify` to JSONL format spec (default preserves current behavior)
- Thread through `JsonFormatConfiguration`
- Apply in `JsonFormattingWriter` / `ProtoToJsonWriter`
- Unit tests + docs + version bump to 1.9.9

## Test plan
- [x] Unit tests for stringify on/off
- [ ] Spec snapshot / CI checks