### PR TITLE
ci(connectors-up-to-date): pin dep-bump commit author to octavia-bot-hoard[bot]

### DIFF
--- a/.github/workflows/connectors-up-to-date.yml
+++ b/.github/workflows/connectors-up-to-date.yml
@@ -312,10 +312,6 @@ jobs:
         uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0 # v8.1.0
         with:
           token: ${{ steps.get-app-token.outputs.token }}
-          # Pin author/committer to the octavia-bot-hoard App identity. Otherwise
-          # peter-evans defaults the author to ${{ github.actor }}, which for scheduled
-          # runs is whoever last enabled the workflow — leaking a real user into the
-          # Co-authored-by trailer on merge.
           author: "octavia-bot-hoard[bot] <230633153+octavia-bot-hoard[bot]@users.noreply.github.com>"
           committer: "octavia-bot-hoard[bot] <230633153+octavia-bot-hoard[bot]@users.noreply.github.com>"
           commit-message: "deps(${{ env.CONNECTOR_NAME }}): update dependencies [skip ci]"

--- a/.github/workflows/connectors-up-to-date.yml
+++ b/.github/workflows/connectors-up-to-date.yml
@@ -312,12 +312,12 @@ jobs:
         uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0 # v8.1.0
         with:
           token: ${{ steps.get-app-token.outputs.token }}
-          # Pin author/committer to the octavia-bot-hoard App identity (matching the
-          # "Configure git author" step). Otherwise peter-evans defaults the author to
-          # ${{ github.actor }}, which for scheduled runs is whoever last enabled the
-          # workflow — leaking a real user into the Co-authored-by trailer on merge.
-          author: "${{ steps.get-app-token.outputs.app-slug }}[bot] <${{ steps.get-user-id.outputs.user-id }}+${{ steps.get-app-token.outputs.app-slug }}[bot]@users.noreply.github.com>"
-          committer: "${{ steps.get-app-token.outputs.app-slug }}[bot] <${{ steps.get-user-id.outputs.user-id }}+${{ steps.get-app-token.outputs.app-slug }}[bot]@users.noreply.github.com>"
+          # Pin author/committer to the octavia-bot-hoard App identity. Otherwise
+          # peter-evans defaults the author to ${{ github.actor }}, which for scheduled
+          # runs is whoever last enabled the workflow — leaking a real user into the
+          # Co-authored-by trailer on merge.
+          author: "octavia-bot-hoard[bot] <230633153+octavia-bot-hoard[bot]@users.noreply.github.com>"
+          committer: "octavia-bot-hoard[bot] <230633153+octavia-bot-hoard[bot]@users.noreply.github.com>"
           commit-message: "deps(${{ env.CONNECTOR_NAME }}): update dependencies [skip ci]"
           branch: "up-to-date/${{ env.CONNECTOR_NAME }}"
           base: ${{ github.event.repository.default_branch }}

--- a/.github/workflows/connectors-up-to-date.yml
+++ b/.github/workflows/connectors-up-to-date.yml
@@ -312,6 +312,12 @@ jobs:
         uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0 # v8.1.0
         with:
           token: ${{ steps.get-app-token.outputs.token }}
+          # Pin author/committer to the octavia-bot-hoard App identity (matching the
+          # "Configure git author" step). Otherwise peter-evans defaults the author to
+          # ${{ github.actor }}, which for scheduled runs is whoever last enabled the
+          # workflow — leaking a real user into the Co-authored-by trailer on merge.
+          author: "${{ steps.get-app-token.outputs.app-slug }}[bot] <${{ steps.get-user-id.outputs.user-id }}+${{ steps.get-app-token.outputs.app-slug }}[bot]@users.noreply.github.com>"
+          committer: "${{ steps.get-app-token.outputs.app-slug }}[bot] <${{ steps.get-user-id.outputs.user-id }}+${{ steps.get-app-token.outputs.app-slug }}[bot]@users.noreply.github.com>"
           commit-message: "deps(${{ env.CONNECTOR_NAME }}): update dependencies [skip ci]"
           branch: "up-to-date/${{ env.CONNECTOR_NAME }}"
           base: ${{ github.event.repository.default_branch }}


### PR DESCRIPTION
## What

The automated weekly connector dependency-bump PRs (from `.github/workflows/connectors-up-to-date.yml`) land squash commits with a stray `Co-authored-by:` trailer pointing at a real person (e.g. `sophiecuiy`, previously `aaronsteers`) who did nothing.

Requested by Pedro (@pedroslopez).

## How

The `peter-evans/create-pull-request` step didn't set `author:`/`committer:`, so it fell back to its defaults:

```yaml
author:    '${{ github.actor }} <${{ github.actor_id }}+${{ github.actor }}@users.noreply.github.com>'
committer: 'github-actions[bot] <...>'
```

For a `schedule` run, `github.actor` is whoever last enabled the scheduled workflow, so the dep-bump commit gets authored by that human. The separate `bump version and update changelog` commit is authored by `octavia-bot-hoard[bot]` (git config), so the squash merge rolls both distinct authors into `Co-authored-by:` trailers.

This hardcodes `author`/`committer` to the `octavia-bot-hoard[bot]` App identity:

```yaml
author:    "octavia-bot-hoard[bot] <230633153+octavia-bot-hoard[bot]@users.noreply.github.com>"
committer: "octavia-bot-hoard[bot] <230633153+octavia-bot-hoard[bot]@users.noreply.github.com>"
```

## Review guide

1. `.github/workflows/connectors-up-to-date.yml` — the `Create or update PR` step.

## User Impact

Future automated dep-bump commits are authored/committed solely by `octavia-bot-hoard[bot]`; no human gets stamped as a co-author. No runtime/connector behavior change.

## Can this PR be safely reverted and rolled back?
- [x] YES 💚
- [ ] NO ❌


Link to Devin session: https://app.devin.ai/sessions/873a542376aa4ac993f801665874f3bb