### PR TITLE
ci(hydra): auto-enable autopilot rollouts before auto-merge

### DIFF
--- a/.github/workflows/hydra-automerge.yml
+++ b/.github/workflows/hydra-automerge.yml
@@ -539,8 +539,9 @@ jobs:
           echo "branch=$(echo "$pr_json" | jq -r .head.ref)" >> "$GITHUB_OUTPUT"
 
       # PAT (not a GitHub App token) is required so that pushing the autopilot
-      # commit re-triggers the PR's required CI checks. Also works on forks where
-      # the app is installed.
+      # commit re-triggers the PR's required CI checks. Pushing to fork PR
+      # branches additionally requires the PAT to have push access to the head
+      # branch (e.g. "Allow edits from maintainers" enabled on the fork PR).
       - name: Checkout PR head for autopilot
         if: steps.evaluate.outputs.result == 'PASS' && inputs.dry-run != 'true' && vars.ENABLE_CONNECTOR_AUTO_MERGE == 'true'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/hydra-automerge.yml
+++ b/.github/workflows/hydra-automerge.yml
@@ -607,7 +607,8 @@ jobs:
           done
 
           # Drop any files that are now gitignored (mirrors the slash command).
-          git ls-files -i -c --exclude-from=.gitignore | xargs -r git rm --cached
+          # NUL-delimited so unusual paths can't be split or option-injected.
+          git ls-files -z -i -c --exclude-from=.gitignore | xargs -0 -r git rm --cached --
           git add -A
           if git diff --cached --quiet; then
             echo "No metadata changes produced by autopilot enable; nothing to push."
@@ -638,7 +639,7 @@ jobs:
 
       - name: Wait for required checks after autopilot commit
         if: steps.evaluate.outputs.result == 'PASS' && inputs.dry-run != 'true' && vars.ENABLE_CONNECTOR_AUTO_MERGE == 'true' && steps.autopilot-enable.outputs.pushed == 'true'
-        uses: actions/github-script@v7
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         env:
           REQUIRED_CHECKS_JSON: ${{ steps.required-checks.outputs.checks }}
           EXPECTED_SHA: ${{ steps.autopilot-enable.outputs.sha }}

--- a/.github/workflows/hydra-automerge.yml
+++ b/.github/workflows/hydra-automerge.yml
@@ -521,6 +521,183 @@ jobs:
           GH_TOKEN: ${{ steps.get-hoard-token.outputs.token }}
         run: gh pr ready "$PR_NUMBER" --repo airbytehq/airbyte
 
+      # ── Autopilot rollouts (enable if missing, then wait for CI) ────
+      # Every auto-merged connector PR should ship with autopilot progressive
+      # rollouts enabled. If any modified connector is missing it, enable it via
+      # the same `airbyte-ops` command as the /enable-autopilot-rollouts slash
+      # command, commit to the PR branch (which re-triggers required CI), and
+      # wait for those checks to pass on the new commit before merging.
+      - name: Resolve PR head for autopilot
+        if: steps.evaluate.outputs.result == 'PASS' && inputs.dry-run != 'true' && vars.ENABLE_CONNECTOR_AUTO_MERGE == 'true'
+        id: autopilot-head
+        env:
+          GH_TOKEN: ${{ steps.get-hoard-token.outputs.token }}
+        run: |
+          set -euo pipefail
+          pr_json=$(gh api "repos/airbytehq/airbyte/pulls/$PR_NUMBER")
+          echo "repo=$(echo "$pr_json" | jq -r .head.repo.full_name)" >> "$GITHUB_OUTPUT"
+          echo "branch=$(echo "$pr_json" | jq -r .head.ref)" >> "$GITHUB_OUTPUT"
+
+      # PAT (not a GitHub App token) is required so that pushing the autopilot
+      # commit re-triggers the PR's required CI checks. Also works on forks where
+      # the app is installed.
+      - name: Checkout PR head for autopilot
+        if: steps.evaluate.outputs.result == 'PASS' && inputs.dry-run != 'true' && vars.ENABLE_CONNECTOR_AUTO_MERGE == 'true'
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: ${{ steps.autopilot-head.outputs.repo }}
+          ref: ${{ steps.autopilot-head.outputs.branch }}
+          fetch-depth: 1
+          token: ${{ secrets.GH_PAT_APPROVINGTON_OCTAVIA }}
+
+      - name: Install uv
+        if: steps.evaluate.outputs.result == 'PASS' && inputs.dry-run != 'true' && vars.ENABLE_CONNECTOR_AUTO_MERGE == 'true'
+        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
+        with:
+          ignore-empty-workdir: true
+
+      - name: Install airbyte-ops CLI
+        if: steps.evaluate.outputs.result == 'PASS' && inputs.dry-run != 'true' && vars.ENABLE_CONNECTOR_AUTO_MERGE == 'true'
+        run: uv tool install 'airbyte-internal-ops>=0.77.0'
+
+      - name: Detect connectors without autopilot rollouts
+        if: steps.evaluate.outputs.result == 'PASS' && inputs.dry-run != 'true' && vars.ENABLE_CONNECTOR_AUTO_MERGE == 'true'
+        id: autopilot-detect
+        env:
+          GH_TOKEN: ${{ steps.get-hoard-token.outputs.token }}
+        run: |
+          set -euo pipefail
+          CONNECTORS="$(
+            airbyte-ops local connector list \
+              --repo-path . \
+              --modified-only \
+              --pr "$PR_NUMBER" \
+              --gh-token "$GH_TOKEN" \
+              --autopilot-enabled=false \
+              --output-format lines
+          )"
+          if [ -z "$CONNECTORS" ]; then
+            echo "All modified connectors already have autopilot rollouts enabled."
+          else
+            echo "Connectors missing autopilot rollouts:"
+            echo "$CONNECTORS"
+            EOF="$(dd if=/dev/urandom bs=15 count=1 status=none | base64)"
+            echo "connectors<<$EOF" >> "$GITHUB_OUTPUT"
+            echo "$CONNECTORS" >> "$GITHUB_OUTPUT"
+            echo "$EOF" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Enable autopilot rollouts and push
+        if: steps.evaluate.outputs.result == 'PASS' && inputs.dry-run != 'true' && vars.ENABLE_CONNECTOR_AUTO_MERGE == 'true' && steps.autopilot-detect.outputs.connectors != ''
+        id: autopilot-enable
+        env:
+          CONNECTORS: ${{ steps.autopilot-detect.outputs.connectors }}
+          CONTRIBUTOR_REPO: ${{ steps.autopilot-head.outputs.repo }}
+          HEAD_BRANCH: ${{ steps.autopilot-head.outputs.branch }}
+        run: |
+          set -euo pipefail
+          echo "$CONNECTORS" | while IFS= read -r connector; do
+            [ -z "$connector" ] && continue
+            echo "--- Enabling autopilot rollouts for $connector ---"
+            airbyte-ops local connector rollouts enable \
+              --name "$connector" \
+              --repo-path . \
+              --strategy fast
+          done
+
+          # Drop any files that are now gitignored (mirrors the slash command).
+          git ls-files -i -c --exclude-from=.gitignore | xargs -r git rm --cached
+          git add -A
+          if git diff --cached --quiet; then
+            echo "No metadata changes produced by autopilot enable; nothing to push."
+            echo "pushed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          git config --global user.name "Octavia Squidington III"
+          git config --global user.email "octavia-squidington-iii@users.noreply.github.com"
+          git commit -m "chore: enable autopilot rollouts"
+          sha="$(git rev-parse HEAD)"
+          git remote add contributor "https://github.com/$CONTRIBUTOR_REPO.git"
+          git push contributor "HEAD:$HEAD_BRANCH"
+          echo "sha=$sha" | tee -a "$GITHUB_OUTPUT"
+          echo "pushed=true" >> "$GITHUB_OUTPUT"
+
+      - name: Note autopilot enablement on PR
+        if: steps.evaluate.outputs.result == 'PASS' && inputs.dry-run != 'true' && vars.ENABLE_CONNECTOR_AUTO_MERGE == 'true' && steps.autopilot-enable.outputs.pushed == 'true'
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
+        with:
+          token: ${{ steps.get-hoard-token.outputs.token }}
+          issue-number: ${{ inputs.pr }}
+          body: |
+            > **Autopilot rollouts enabled** (`${{ steps.autopilot-enable.outputs.sha }}`).
+            > Waiting for required checks to re-run on the new commit before auto-merging.
+            >
+            > [Workflow run](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})
+
+      - name: Wait for required checks after autopilot commit
+        if: steps.evaluate.outputs.result == 'PASS' && inputs.dry-run != 'true' && vars.ENABLE_CONNECTOR_AUTO_MERGE == 'true' && steps.autopilot-enable.outputs.pushed == 'true'
+        uses: actions/github-script@v7
+        env:
+          REQUIRED_CHECKS_JSON: ${{ steps.required-checks.outputs.checks }}
+          EXPECTED_SHA: ${{ steps.autopilot-enable.outputs.sha }}
+        with:
+          github-token: ${{ steps.get-hoard-token.outputs.token }}
+          script: |
+            const prNum = Number(process.env.PR_NUMBER);
+            const requiredChecks = new Set(JSON.parse(process.env.REQUIRED_CHECKS_JSON || '[]'));
+            const expectedSha = process.env.EXPECTED_SHA;
+            const maxMinutes = 60;
+            const intervalMs = 60000;
+            const deadline = Date.now() + maxMinutes * 60000;
+            const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+            while (true) {
+              const { data: pr } = await github.rest.pulls.get({
+                owner: 'airbytehq', repo: 'airbyte', pull_number: prNum,
+              });
+              const sha = pr.head.sha;
+              if (expectedSha && sha !== expectedSha) {
+                throw new Error(
+                  `PR head moved to ${sha} (expected ${expectedSha}); aborting auto-merge.`
+                );
+              }
+
+              const statuses = await github.paginate(
+                github.rest.repos.listCommitStatusesForRef,
+                { owner: 'airbytehq', repo: 'airbyte', ref: sha, per_page: 100 }
+              );
+              const successStatuses = new Set(
+                statuses.filter(s => s.state === 'success').map(s => s.context)
+              );
+
+              const checkRuns = await github.paginate(
+                github.rest.checks.listForRef,
+                { owner: 'airbytehq', repo: 'airbyte', ref: sha, per_page: 100 },
+                (response) => response.data
+              );
+              const successChecks = new Set(
+                checkRuns
+                  .filter(cr => cr.conclusion === 'success' || cr.conclusion === 'skipped')
+                  .map(cr => cr.name)
+              );
+
+              const allPassing = new Set([...successStatuses, ...successChecks]);
+              const missing = [...requiredChecks].filter(c => !allPassing.has(c));
+
+              if (missing.length === 0) {
+                core.info('All required checks passing on autopilot commit.');
+                return;
+              }
+              if (Date.now() > deadline) {
+                throw new Error(
+                  `Timed out after ${maxMinutes}m waiting for required checks: ${missing.join(', ')}`
+                );
+              }
+              core.info(`Waiting on required checks: ${missing.join(', ')}`);
+              await sleep(intervalMs);
+            }
+
       - name: Approve PR with admin bot
         if: steps.evaluate.outputs.result == 'PASS' && inputs.dry-run != 'true'
         env:

--- a/.github/workflows/hydra-automerge.yml
+++ b/.github/workflows/hydra-automerge.yml
@@ -667,8 +667,19 @@ jobs:
                 github.rest.repos.listCommitStatusesForRef,
                 { owner: 'airbytehq', repo: 'airbyte', ref: sha, per_page: 100 }
               );
+              // listCommitStatusesForRef returns historical entries; only the
+              // latest status per context reflects the current state.
+              const latestStatusByContext = new Map();
+              for (const s of statuses) {
+                const prev = latestStatusByContext.get(s.context);
+                if (!prev || new Date(s.updated_at) > new Date(prev.updated_at)) {
+                  latestStatusByContext.set(s.context, s);
+                }
+              }
               const successStatuses = new Set(
-                statuses.filter(s => s.state === 'success').map(s => s.context)
+                [...latestStatusByContext.values()]
+                  .filter(s => s.state === 'success')
+                  .map(s => s.context)
               );
 
               const checkRuns = await github.paginate(

--- a/.github/workflows/hydra-automerge.yml
+++ b/.github/workflows/hydra-automerge.yml
@@ -256,6 +256,9 @@ jobs:
               owner: 'airbytehq', repo: 'airbyte', pull_number: prNum,
             });
             const sha = pr.head.sha;
+            // Export the evaluated head SHA so the autopilot/merge steps can
+            // pin the whole eval->merge chain to the SHA that was checked here.
+            core.setOutput('sha', sha);
 
             const statuses = await github.paginate(
               github.rest.repos.listCommitStatusesForRef,
@@ -532,9 +535,18 @@ jobs:
         id: autopilot-head
         env:
           GH_TOKEN: ${{ steps.get-hoard-token.outputs.token }}
+          EVALUATED_SHA: ${{ steps.verify-checks.outputs.sha }}
         run: |
           set -euo pipefail
           pr_json=$(gh api "repos/airbytehq/airbyte/pulls/$PR_NUMBER")
+          head_sha=$(echo "$pr_json" | jq -r .head.sha)
+          # Pin the eval->merge chain to the SHA verify-checks evaluated. If the
+          # contributor pushed a new commit after the Devin eval, abort rather
+          # than enabling autopilot on / merging code the eval never saw.
+          if [ -n "$EVALUATED_SHA" ] && [ "$head_sha" != "$EVALUATED_SHA" ]; then
+            echo "::error::PR head moved from evaluated $EVALUATED_SHA to $head_sha since the Devin eval; aborting auto-merge."
+            exit 1
+          fi
           echo "repo=$(echo "$pr_json" | jq -r .head.repo.full_name)" >> "$GITHUB_OUTPUT"
           echo "branch=$(echo "$pr_json" | jq -r .head.ref)" >> "$GITHUB_OUTPUT"
 
@@ -769,3 +781,18 @@ jobs:
       - name: Dry-run notice (flag)
         if: steps.evaluate.outputs.result == 'PASS' && inputs.dry-run == 'true'
         run: echo "::notice::DRY RUN (dry-run flag) -- would merge PR #${PR_NUMBER}"
+
+      # If anything in the post-eval autopilot/merge phase fails (head moved,
+      # push rejected, CLI flake, check wait timeout, merge failure), the eval
+      # comment still says PASS and the "enabled... waiting for CI" note never
+      # resolves. Leave a visible abort note so the stalled PR isn't missed.
+      - name: Note auto-merge aborted on failure
+        if: failure() && steps.evaluate.outputs.result == 'PASS' && inputs.dry-run != 'true' && vars.ENABLE_CONNECTOR_AUTO_MERGE == 'true'
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
+        with:
+          token: ${{ steps.get-hoard-token.outputs.token }}
+          issue-number: ${{ inputs.pr }}
+          body: |
+            > :red_circle: **Auto-merge aborted.** The Devin evaluation passed, but a step in the autopilot-enable / merge phase failed, so this PR was **not** merged. Please check the run and re-trigger auto-merge once resolved.
+            >
+            > [Workflow run](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})

--- a/.github/workflows/hydra-automerge.yml
+++ b/.github/workflows/hydra-automerge.yml
@@ -554,12 +554,16 @@ jobs:
       # commit re-triggers the PR's required CI checks. Pushing to fork PR
       # branches additionally requires the PAT to have push access to the head
       # branch (e.g. "Allow edits from maintainers" enabled on the fork PR).
+      # Check out the exact SHA verify-checks evaluated (not the mutable branch
+      # ref) so a push landing between the resolve step and here can't sneak
+      # unevaluated code into the autopilot commit. HEAD_BRANCH is used only as
+      # the push destination; a non-fast-forward push then fails safely.
       - name: Checkout PR head for autopilot
         if: steps.evaluate.outputs.result == 'PASS' && inputs.dry-run != 'true' && vars.ENABLE_CONNECTOR_AUTO_MERGE == 'true'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: ${{ steps.autopilot-head.outputs.repo }}
-          ref: ${{ steps.autopilot-head.outputs.branch }}
+          ref: ${{ steps.verify-checks.outputs.sha }}
           fetch-depth: 1
           token: ${{ secrets.GH_PAT_APPROVINGTON_OCTAVIA }}
 


### PR DESCRIPTION
## What

Requested by @suisuixia42.

Every connector PR that goes through the AI-gated auto-merge path (`hydra-automerge.yml`, triggered by `/ai-ready`) should ship with autopilot progressive rollouts enabled, so those merged connectors get automatic rollout. Today autopilot is only enabled manually via the `/enable-autopilot-rollouts` slash command; nothing guarantees auto-merged PRs have it on.

This makes the auto-merge path enforce it: after the Devin scope eval passes and before the squash-merge, if any modified connector is missing autopilot, the workflow enables it, commits to the PR branch, waits for the required checks to re-pass on the new commit, and then merges.

## How

New steps inserted in the `evaluate-and-merge` job between "Mark draft PR as ready" and "Approve PR with admin bot", all gated on `result == 'PASS' && dry-run != 'true' && vars.ENABLE_CONNECTOR_AUTO_MERGE == 'true'`:

1. **Resolve PR head** (repo + branch) via `gh api`.
2. **Checkout PR head** using the `GH_PAT_APPROVINGTON_OCTAVIA` PAT — a PAT (not an App token) is required so the autopilot commit re-triggers required CI.
3. **Install `airbyte-ops` CLI** (`airbyte-internal-ops>=0.77.0`).
4. **Detect** connectors missing autopilot: `airbyte-ops local connector list --modified-only --pr N --autopilot-enabled=false`.
5. **Enable + push** (only if any missing): `airbyte-ops local connector rollouts enable --name <c> --strategy fast`, commit `chore: enable autopilot rollouts`, push to the PR branch. Sets `pushed=true` and the new `sha`. If enable produced no diff, `pushed=false` and it's a no-op.
6. **Comment** on the PR noting autopilot was enabled and that it's waiting for CI.
7. **Wait for required checks** on the new SHA (reuses the same required-checks list + success/skipped logic as the earlier verify step, in a poll loop, 60m timeout; aborts if the PR head moves).

This mirrors the mechanics of the existing `enable-autopilot-rollouts-command.yml` (same CLI, same commit author, same PAT-push-to-re-trigger-CI pattern) and the detection flag from `autopilot-rollout-suggestion.yml`.

Approve + squash-merge steps are unchanged and now naturally run against the SHA that includes the autopilot commit.

## Review guide

1. `.github/workflows/hydra-automerge.yml` — the inserted block (Resolve head → Checkout → Install → Detect → Enable+push → Comment → Wait-for-checks) before the existing Approve/Merge steps.

Scope decisions per requester:
- **Way 1 (wait for CI)** chosen over admin-bypass: the autopilot commit's required checks actually run and must pass before merge.
- **hydra path only**: the cron path (`auto-merge-cron.yml`, merges `auto-merge`-labeled PRs without a Devin eval) is intentionally not touched.
- If all modified connectors already have autopilot on, no commit is pushed and merge proceeds immediately as before.

## User Impact

Connector PRs auto-merged by Hydra will have `defaultRolloutMode: autopilot` + `enableProgressiveRollout: true` in `metadata.yaml`, enabling automatic progressive rollout. Trade-off: when autopilot must be enabled, the auto-merge is delayed until the new commit's required checks re-pass (up to ~60m). No effect in dry-run (`inputs.dry-run`) or when `ENABLE_CONNECTOR_AUTO_MERGE` isn't `true`.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚


Link to Devin session: https://app.devin.ai/sessions/88e167392a5c4458a2335d68df1dedc2