### PR TITLE
fix(source-snowflake): fix silent record loss at cursor upper bound in incremental sync

### DIFF
--- a/airbyte-integrations/connectors/source-snowflake/metadata.yaml
+++ b/airbyte-integrations/connectors/source-snowflake/metadata.yaml
@@ -8,7 +8,7 @@ data:
   connectorSubtype: database
   connectorType: source
   definitionId: e2d65910-8c8b-40a1-ae7d-ee2416b2bfa2
-  dockerImageTag: 1.1.0
+  dockerImageTag: 1.1.1
   dockerRepository: airbyte/source-snowflake
   documentationUrl: https://docs.airbyte.com/integrations/sources/snowflake
   githubIssueLabel: source-snowflake

--- a/airbyte-integrations/connectors/source-snowflake/src/main/kotlin/io/airbyte/integrations/source/snowflake/SnowflakeFieldTypes.kt
+++ b/airbyte-integrations/connectors/source-snowflake/src/main/kotlin/io/airbyte/integrations/source/snowflake/SnowflakeFieldTypes.kt
@@ -18,20 +18,25 @@ import java.time.LocalDateTime
 import java.time.OffsetDateTime
 import java.time.ZoneOffset
 
-// Custom LocalDateTime accessor that truncates to 6 decimal places (microseconds).
 // Snowflake timestamps can have up to 9 decimal places (nanoseconds), but destinations may only
-// support 6 decimal places.
+// support 6 (microseconds). Rounded up, not down: this value is also used as a cursor bound for
+// incremental sync, and flooring it can make it compare as less than the row it should include.
+private fun roundUpToMicros(localDateTime: LocalDateTime): LocalDateTime {
+    val remainderNanos = localDateTime.nano % 1000
+    return if (remainderNanos == 0) {
+        localDateTime
+    } else {
+        localDateTime.plusNanos((1000 - remainderNanos).toLong())
+    }
+}
+
 object SnowflakeLocalDateTimeAccessor : JdbcAccessor<LocalDateTime> {
     override fun get(
         rs: ResultSet,
         colIdx: Int,
     ): LocalDateTime? {
         val timestamp = rs.getTimestamp(colIdx)?.takeUnless { rs.wasNull() } ?: return null
-        val localDateTime = timestamp.toLocalDateTime()
-        // Truncate to microseconds (6 decimal places) by zeroing out the nanoseconds beyond
-        // microseconds
-        val truncatedNanos = (localDateTime.nano / 1000) * 1000
-        return localDateTime.withNano(truncatedNanos)
+        return roundUpToMicros(timestamp.toLocalDateTime())
     }
 
     override fun set(
@@ -43,7 +48,7 @@ object SnowflakeLocalDateTimeAccessor : JdbcAccessor<LocalDateTime> {
     }
 }
 
-/** Custom field type for Snowflake TIMESTAMP_NTZ / DATETIME types, truncated to microseconds. */
+/** Custom field type for Snowflake TIMESTAMP_NTZ / DATETIME types, rounded to microseconds. */
 object SnowflakeLocalDateTimeFieldType :
     SymmetricJdbcFieldType<LocalDateTime>(
         LeafAirbyteSchemaType.TIMESTAMP_WITHOUT_TIMEZONE,
@@ -58,7 +63,7 @@ object SnowflakeLocalDateTimeFieldType :
  * exception. This implementation works around that limitation by retrieving the timestamp as
  * LocalDateTime and converting it to OffsetDateTime with UTC timezone.
  *
- * Nanoseconds are truncated to microsecond precision (6 decimal places).
+ * Nanoseconds are rounded up to microsecond precision (6 decimal places), see [roundUpToMicros].
  *
  * Related Snowflake issue: SNOW-895829
  */
@@ -69,8 +74,7 @@ object SnowflakeOffsetDateTimeFieldType :
         { rs, colIdx ->
             val localDateTime = TimestampAccessor.get(rs, colIdx)
             if (localDateTime != null) {
-                val truncatedNanos = (localDateTime.nano / 1000) * 1000
-                localDateTime.withNano(truncatedNanos).atOffset(ZoneOffset.UTC)
+                roundUpToMicros(localDateTime).atOffset(ZoneOffset.UTC)
             } else {
                 null
             }

--- a/airbyte-integrations/connectors/source-snowflake/src/main/kotlin/io/airbyte/integrations/source/snowflake/SnowflakeFieldTypes.kt
+++ b/airbyte-integrations/connectors/source-snowflake/src/main/kotlin/io/airbyte/integrations/source/snowflake/SnowflakeFieldTypes.kt
@@ -18,18 +18,9 @@ import java.time.LocalDateTime
 import java.time.OffsetDateTime
 import java.time.ZoneOffset
 
-// Snowflake timestamps can have up to 9 decimal places (nanoseconds), but destinations may only
-// support 6 (microseconds). Rounded up, not down: this value is also used as a cursor bound for
-// incremental sync, and flooring it can make it compare as less than the row it should include.
-private fun roundUpToMicros(localDateTime: LocalDateTime): LocalDateTime {
-    val remainderNanos = localDateTime.nano % 1000
-    return if (remainderNanos == 0) {
-        localDateTime
-    } else {
-        localDateTime.plusNanos((1000 - remainderNanos).toLong())
-    }
-}
-
+/**
+ * Nanoseconds are rounded up to microsecond precision (6 decimal places). See [roundUpToMicros].
+ */
 object SnowflakeLocalDateTimeAccessor : JdbcAccessor<LocalDateTime> {
     override fun get(
         rs: ResultSet,
@@ -89,3 +80,16 @@ object SnowflakeOffsetDateTimeFieldType :
             stmt.setTimestamp(paramIdx, timestamp)
         }
     )
+
+// Snowflake timestamps can have up to 9 decimal places (nanoseconds), but the Airbyte
+// protocol only supports 6 (microseconds). Round up, never down. This value is also used as a
+// cursor bound for incremental syncs, and reducing it can make it compare as less than a row with
+// higher value that we should include in the WHERE clause of the subsequent sync.
+private fun roundUpToMicros(localDateTime: LocalDateTime): LocalDateTime {
+    val remainderNanos = localDateTime.nano % 1000
+    return if (remainderNanos == 0) {
+        localDateTime
+    } else {
+        localDateTime.plusNanos((1000 - remainderNanos).toLong())
+    }
+}

--- a/airbyte-integrations/connectors/source-snowflake/src/test/kotlin/io/airbyte/integrations/source/snowflake/SnowflakeFieldTypesTest.kt
+++ b/airbyte-integrations/connectors/source-snowflake/src/test/kotlin/io/airbyte/integrations/source/snowflake/SnowflakeFieldTypesTest.kt
@@ -11,6 +11,7 @@ import java.time.OffsetDateTime
 import java.time.ZoneOffset
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.`when`
@@ -20,7 +21,7 @@ class SnowflakeFieldTypesTest {
     // --- SnowflakeLocalDateTimeAccessor tests ---
 
     @Test
-    fun `SnowflakeLocalDateTimeAccessor truncates 9 decimal places to 6`() {
+    fun `SnowflakeLocalDateTimeAccessor rounds up 9 decimal places to 6`() {
         val dateTimeWith9Decimals = LocalDateTime.of(2025, 11, 6, 22, 30, 46, 123456789)
         val timestamp = Timestamp.valueOf(dateTimeWith9Decimals)
 
@@ -30,7 +31,36 @@ class SnowflakeFieldTypesTest {
 
         val result = SnowflakeLocalDateTimeAccessor.get(rs, 1)
 
-        val expected = LocalDateTime.of(2025, 11, 6, 22, 30, 46, 123456000)
+        val expected = LocalDateTime.of(2025, 11, 6, 22, 30, 46, 123457000)
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun `SnowflakeLocalDateTimeAccessor rounding up never produces a value less than the original`() {
+        val dateTimeWith9Decimals = LocalDateTime.of(2025, 11, 6, 22, 30, 46, 123456789)
+        val timestamp = Timestamp.valueOf(dateTimeWith9Decimals)
+
+        val rs = mock(ResultSet::class.java)
+        `when`(rs.getTimestamp(1)).thenReturn(timestamp)
+        `when`(rs.wasNull()).thenReturn(false)
+
+        val result = SnowflakeLocalDateTimeAccessor.get(rs, 1)
+
+        assertTrue(result!! >= dateTimeWith9Decimals)
+    }
+
+    @Test
+    fun `SnowflakeLocalDateTimeAccessor rounding up carries into the next second`() {
+        val dateTimeNearSecondBoundary = LocalDateTime.of(2025, 11, 6, 22, 30, 46, 999999999)
+        val timestamp = Timestamp.valueOf(dateTimeNearSecondBoundary)
+
+        val rs = mock(ResultSet::class.java)
+        `when`(rs.getTimestamp(1)).thenReturn(timestamp)
+        `when`(rs.wasNull()).thenReturn(false)
+
+        val result = SnowflakeLocalDateTimeAccessor.get(rs, 1)
+
+        val expected = LocalDateTime.of(2025, 11, 6, 22, 30, 47, 0)
         assertEquals(expected, result)
     }
 
@@ -76,7 +106,7 @@ class SnowflakeFieldTypesTest {
     // --- SnowflakeOffsetDateTimeFieldType tests ---
 
     @Test
-    fun `SnowflakeOffsetDateTimeFieldType truncates 9 decimal places to 6`() {
+    fun `SnowflakeOffsetDateTimeFieldType rounds up 9 decimal places to 6`() {
         val dateTimeWith9Decimals = LocalDateTime.of(2025, 11, 6, 22, 30, 46, 123456789)
         val timestamp = Timestamp.valueOf(dateTimeWith9Decimals)
 
@@ -86,9 +116,9 @@ class SnowflakeFieldTypesTest {
 
         val result = SnowflakeOffsetDateTimeFieldType.jdbcGetter.get(rs, 1)
 
-        val expected = OffsetDateTime.of(2025, 11, 6, 22, 30, 46, 123456000, ZoneOffset.UTC)
+        val expected = OffsetDateTime.of(2025, 11, 6, 22, 30, 46, 123457000, ZoneOffset.UTC)
         assertEquals(expected, result)
-        assertEquals(123456000, result?.nano)
+        assertEquals(123457000, result?.nano)
     }
 
     @Test
@@ -129,6 +159,6 @@ class SnowflakeFieldTypesTest {
         val result = SnowflakeOffsetDateTimeFieldType.jdbcGetter.get(rs, 1)
 
         assertEquals(ZoneOffset.UTC, result?.offset)
-        assertEquals(500000000, result?.nano) // nanos truncated to microsecond precision
+        assertEquals(500001000, result?.nano) // rounded up to microsecond precision
     }
 }

--- a/docs/integrations/sources/snowflake.md
+++ b/docs/integrations/sources/snowflake.md
@@ -242,6 +242,7 @@ If you use Airbyte Cloud and your organization restricts access to specific IPs,
 
 | Version | Date       | Pull Request                                             | Subject                                                                                                                                   |
 |:--------|:-----------|:---------------------------------------------------------|:------------------------------------------------------------------------------------------------------------------------------------------|
+| 1.1.1 | 2026-07-21 | [XXXXX](https://github.com/airbytehq/airbyte/pull/XXXXX) | Fix incremental sync silently dropping rows at the cursor's upper bound by rounding timestamp precision up instead of down |
 | 1.1.0 | 2026-05-28 | [78481](https://github.com/airbytehq/airbyte/pull/78481) | Support Snowflake Programmatic Access Token authentication. |
 | 1.0.11 | 2026-05-05 | [77787](https://github.com/airbytehq/airbyte/pull/77787) | Make the hidden additional properties fields in spec optional. No functional change. |
 | 1.0.10 | 2026-03-13 | [74834](https://github.com/airbytehq/airbyte/pull/74834) | Truncate timestamp precision to 6 digits (microseconds) to prevent precision errors in destinations |

--- a/docs/integrations/sources/snowflake.md
+++ b/docs/integrations/sources/snowflake.md
@@ -242,7 +242,7 @@ If you use Airbyte Cloud and your organization restricts access to specific IPs,
 
 | Version | Date       | Pull Request                                             | Subject                                                                                                                                   |
 |:--------|:-----------|:---------------------------------------------------------|:------------------------------------------------------------------------------------------------------------------------------------------|
-| 1.1.1 | 2026-07-21 | [XXXXX](https://github.com/airbytehq/airbyte/pull/XXXXX) | Fix incremental sync silently dropping rows at the cursor's upper bound by rounding timestamp precision up instead of down |
+| 1.1.1 | 2026-07-21 | [82705](https://github.com/airbytehq/airbyte/pull/82705) | Fix incremental sync silently dropping rows at the cursor's upper bound by rounding timestamp precision up instead of down |
 | 1.1.0 | 2026-05-28 | [78481](https://github.com/airbytehq/airbyte/pull/78481) | Support Snowflake Programmatic Access Token authentication. |
 | 1.0.11 | 2026-05-05 | [77787](https://github.com/airbytehq/airbyte/pull/77787) | Make the hidden additional properties fields in spec optional. No functional change. |
 | 1.0.10 | 2026-03-13 | [74834](https://github.com/airbytehq/airbyte/pull/74834) | Truncate timestamp precision to 6 digits (microseconds) to prevent precision errors in destinations |


### PR DESCRIPTION
## What
Incremental syncs on `source-snowflake` can silently drop rows whose cursor value sits exactly at the query window's upper bound, whenever that row's real timestamp has non-zero digits below microsecond precision. This isn't limited to any particular sync outcome: in a normal sync with a wide cursor range, it silently drops just the specific row(s) sitting at the batch's true max, an easy-to-miss loss buried among many successfully synced records. It becomes fully visible when the cursor window collapses to a single point (stored checkpoint equals current `MAX(cursor_field)`, a common case right after a batch insert), where the entire matching batch shares that one boundary and the whole sync silently returns 0 records instead.

## How
Timestamps are rounded to microsecond precision when read from Snowflake (`SnowflakeLocalDateTimeAccessor` / `SnowflakeOffsetDateTimeFieldType`), since destinations may not support the full 9-digit nanosecond precision Snowflake stores. That rounding was a floor (round down). The same rounded value is also used to build the cursor bound for the incremental sync's WHERE clause. A floored upper bound can end up strictly less than the real value of the row(s) it's meant to include, so the WHERE clause silently excludes them, regardless of how wide the overall query range is.

Rounding up instead (`roundUpToMicros`) means the value used for both the emitted record and the cursor bound is never less than the real database value, while still respecting the microsecond precision destinations expect. Handles the second-boundary carry correctly (e.g. `.999999999` rounds into the next second at `.000000`).

## Review guide
1. `SnowflakeFieldTypes.kt` - the `roundUpToMicros` helper and its two call sites
2. `SnowflakeFieldTypesTest.kt` - updated expectations plus new regression and boundary-carry tests

## Note on related issues
This PR was previously linked to #70257. On closer investigation, #70257's actual reported symptom (confirmed via its full logs) matches a different, already-fixed bug (a random-sampling issue resolved by #66200 in v1.0.7), not this truncation bug, which was introduced later, in v1.0.10 (#74834). The two are unrelated. A standalone issue documenting this truncation bug specifically will be filed separately if needed.

## User Impact
Fixes silent, undetected data loss in incremental syncs. Existing connections don't need any config changes; the next sync after upgrading will pick up any previously-dropped rows since the cursor lower bound comparison is inclusive.

## Can this PR be safely reverted and rolled back?
- [x] YES 💚
