### PR TITLE
docs(platform): expand dynamic streams section in beginners guide to catalog

### DIFF
--- a/docs/platform/understanding-airbyte/beginners-guide-to-catalog.md
+++ b/docs/platform/understanding-airbyte/beginners-guide-to-catalog.md
@@ -194,7 +194,18 @@ The `ConfiguredAirbyteCatalog` follows the same rules as we described in the [Da
 
 Now let's build a stock ticker source that handles returning ticker data for _multiple_ stocks. The name of each stream will be the stock symbol that it represents.
 
+In this example, the source is configured with a list of stock symbols. When the source runs `discover`, it reads `symbols` from the config and emits one `AirbyteStream` for each symbol.
+
+```json
+{
+  "api_key": "super_secret_key",
+  "symbols": ["TSLA", "FB"]
+}
+```
+
 #### AirbyteCatalog
+
+Here is what the `AirbyteCatalog` might look like.
 
 ```javascript
 {
@@ -248,6 +259,76 @@ Now let's build a stock ticker source that handles returning ticker data for _mu
 ```
 
 This example provides another way of thinking about exposing data in a source. As a developer building a source, you can model the `AirbyteCatalog` for a source however makes most sense to the use case you are trying to fulfill.
+
+#### ConfiguredAirbyteCatalog
+
+Because each dynamic stream is a separate `AirbyteStream`, you can configure each one individually. For example, you might want to replicate `TSLA` as a `FULL_REFRESH` and `FB` as an `INCREMENTAL` sync using `date` as the cursor.
+
+We also set `destination_sync_mode` to tell the destination how to write the data (`overwrite` for `FULL_REFRESH`, `append` for `INCREMENTAL`).
+
+```javascript
+{
+  "streams": [
+    {
+      "sync_mode": "FULL_REFRESH",
+      "destination_sync_mode": "overwrite",
+      "stream": {
+        "name": "TSLA",
+        "supported_sync_modes": [
+          "full_refresh",
+          "incremental"
+        ],
+        "source_defined_cursor": false,
+        "json_schema": {
+          "type": "object",
+          "properties": {
+            "symbol": {
+              "type": "string"
+            },
+            "price": {
+              "type": "number"
+            },
+            "date": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    {
+      "sync_mode": "INCREMENTAL",
+      "cursor_field": ["date"],
+      "destination_sync_mode": "append",
+      "stream": {
+        "name": "FB",
+        "supported_sync_modes": [
+          "full_refresh",
+          "incremental"
+        ],
+        "source_defined_cursor": false,
+        "json_schema": {
+          "type": "object",
+          "properties": {
+            "symbol": {
+              "type": "string"
+            },
+            "price": {
+              "type": "number"
+            },
+            "date": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    }
+  ]
+}
+```
+
+Dynamic streams are a good fit when the set of top-level data sets depends on the source configuration or the upstream API. Each dynamic stream becomes its own table in the destination. If the data is better modeled as a single table with a filter column, a static stream with a `symbol` field is usually simpler.
+
+For more information on how `discover` builds a catalog from a source's configuration, see the [Airbyte Protocol catalog section](airbyte-protocol.md#catalog). If each dynamic stream needs a different schema, see the [CDK dynamic schemas guide](../connector-development/cdk-python/schemas.md#dynamic-schemas).
 
 ## Nested Schema Example
 


### PR DESCRIPTION
## Documentation Confidence Assessment

**Overall Confidence: 3/5** — moderate confidence; standard review recommended.

| Dimension | Score | Rationale |
|-----------|-------|-----------|
| Code Comprehension | 5/5 | Docs-only change to the platform catalog guide; behavior is documented in the Airbyte Protocol spec and CDK docs. |
| Context Availability | 4/5 | The internal docs request called out the Dynamic Streams Example as sparse and asked for improvements. |
| Existing Doc Quantity | 3/5 | The dynamic streams section existed but was only ~50 lines with one unexplained example. |
| Existing Doc Quality | 3/5 | Existing content was technically accurate but incomplete; it did not explain where stream names come from or how to configure dynamic streams. |
| Feature Area Maturity | 5/5 | `AirbyteCatalog` and `discover` are core, mature platform concepts. |
| Change Scope & Risk | 3/5 | A focused ~80-line addition to one docs page; low risk but substantive enough to need a factual review. |
| Inference Ratio | 3/5 | The example and `ConfiguredAirbyteCatalog` structure are grounded in the protocol spec and existing doc patterns; the `symbols` config example is illustrative. |

### What I Verified vs. What I Inferred

- **Verified from code/docs**: The `AirbyteCatalog`/`ConfiguredAirbyteCatalog` fields and requirements come from `docs/platform/understanding-airbyte/airbyte-protocol.md` (e.g., `destination_sync_mode` and `cursor_field` behavior). Dynamic schema generation is covered in `docs/platform/connector-development/cdk-python/schemas.md`.
- **Verified from issue context**: The request specifically pointed to the `#dynamic-streams-example` anchor and stated there was not enough information there.
- **Inferred**: The stock-ticker `symbols` config snippet and the choice of `FULL_REFRESH`/`INCREMENTAL` sync modes are illustrative examples intended to show how `discover` produces one stream per configured entity. The same-schema-per-stream assumption is also illustrative; real connectors may need dynamic schemas for per-stream shapes.

### Reviewer Focus Areas

1. Verify the new `ConfiguredAirbyteCatalog` example correctly reflects the protocol requirements for `sync_mode`, `cursor_field`, and `destination_sync_mode` in `docs/platform/understanding-airbyte/beginners-guide-to-catalog.md`.
2. Confirm the guidance on when to use dynamic streams vs. a static `symbol` column is accurate and in line with current connector best practices.
3. Check that the relative links to `airbyte-protocol.md#catalog` and `../connector-development/cdk-python/schemas.md#dynamic-schemas` resolve in the Docusaurus build.

### Areas of Concern

None identified, but this is a docs interpretation of the catalog protocol rather than a code-verified feature change.

---

## What

Expands the Dynamic Streams Example in the Beginner's Guide to the AirbyteCatalog to explain where dynamic stream names come from, how a `ConfiguredAirbyteCatalog` selects them, and when to choose dynamic streams over a static stream. Requested in [airbytehq/Support-Ops-and-Projects#60](https://github.com/airbytehq/Support-Ops-and-Projects/issues/60).

## How

- Added a source config snippet showing `symbols` feeding `discover`.
- Added a `ConfiguredAirbyteCatalog` example for the dynamic streams, including `sync_mode`, `cursor_field`, and `destination_sync_mode`.
- Added guidance on when dynamic streams are appropriate and a comparison to static streams.
- Cross-linked to the Airbyte Protocol catalog section and CDK dynamic schemas docs.

## Review guide

- `docs/platform/understanding-airbyte/beginners-guide-to-catalog.md`

## User Impact

Readers of the catalog guide will now see a complete dynamic-streams example instead of only an `AirbyteCatalog` with two unexplained stock symbols.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

---

> **Note**: I am an AI assistant (Devin) and have proposed these documentation updates based on a review of platform source code changes. All platform documentation PRs require human review. Reviewers may merge, modify, or close this PR as they see fit.

---
[Devin session](https://app.devin.ai/sessions/6a5969ccf45e4216a3ef0426bde436df)


Requested by: @vikram661