### PR TITLE
chore(destination-snowflake): bump version 4.0.46 → 4.0.47

### DIFF
--- a/airbyte-integrations/connectors/destination-snowflake/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-snowflake/metadata.yaml
@@ -6,7 +6,7 @@ data:
   connectorSubtype: database
   connectorType: destination
   definitionId: 424892c4-daac-4491-b35d-c6688ba547ba
-  dockerImageTag: 4.0.46
+  dockerImageTag: 4.0.47
   dockerRepository: airbyte/destination-snowflake
   documentationUrl: https://docs.airbyte.com/integrations/destinations/snowflake
   githubIssueLabel: destination-snowflake

--- a/docs/integrations/destinations/snowflake.md
+++ b/docs/integrations/destinations/snowflake.md
@@ -288,6 +288,7 @@ This destination supports [namespaces](https://docs.airbyte.com/platform/using-a
 
 | Version         | Date       | Pull Request                                               | Subject                                                                                                                                                                                |
 |:----------------|:-----------|:-----------------------------------------------------------|:---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 4.0.47          | 2026-07-23 | [82294](https://github.com/airbytehq/airbyte/pull/82294)   | Replace ALTER TABLE SWAP WITH with CREATE OR REPLACE TABLE CLONE COPY GRANTS to preserve table grants |
 | 4.0.46          | 2026-07-15 | [82104](https://github.com/airbytehq/airbyte/pull/82104)   | Use CREATE TABLE IF NOT EXISTS for non-replace table creation to prevent accidental data loss |
 | 4.0.45          | 2026-07-10 | [81530](https://github.com/airbytehq/airbyte/pull/81530)   | Restore NULL-safe primary-key matching in dedup MERGE to fix duplicate rows when composite PKs contain NULLs |
 | 4.0.44          | 2026-06-30 | [81346](https://github.com/airbytehq/airbyte/pull/81346)   | Remove unnecessary NULL PK equality checks from merge SQL |


### PR DESCRIPTION
## Summary

Bumps `destination-snowflake` version from `4.0.46` to `4.0.47` for the fix in #82294 which was merged without a version bump.

The fix replaces `ALTER TABLE ... SWAP WITH` with `CREATE OR REPLACE TABLE ... CLONE ... COPY GRANTS` to preserve table grants during Full Refresh Overwrite syncs.

## Changes

- **`metadata.yaml`** — `dockerImageTag: 4.0.46` → `4.0.47`
- **`docs/integrations/destinations/snowflake.md`** — Added changelog entry for `4.0.47`

> [!IMPORTANT]
> Active progressive rollout warning for destination-snowflake.

- [x] (Click to Approve:) Bypass the active progressive rollout warning for destination-snowflake in the PR comment [here](https://github.com/airbytehq/airbyte/pull/82718#issuecomment-5062696600).