### PR TITLE
docs: render boolean support markers from plain text instead of emoji

### DIFF
--- a/docs/integrations/enterprise-connectors/source-oracle-enterprise.md
+++ b/docs/integrations/enterprise-connectors/source-oracle-enterprise.md
@@ -2,6 +2,7 @@
 dockerRepository: airbyte/source-oracle-enterprise
 enterprise-connector: true
 ---
+
 # Source Oracle
 
 Airbyte's Oracle enterprise source connector offers the following features:
@@ -18,7 +19,7 @@ The required minimum platform version is v0.58.0 for this connector.
 ## Features
 
 | Feature                       | Supported | Notes              |
-| :---------------------------- |:----------| :----------------- |
+| :---------------------------- | :-------- | :----------------- |
 | Full Refresh Sync             | Yes       |                    |
 | Incremental Sync - Append     | Yes       |                    |
 | Replicate Incremental Deletes | Yes       |                    |
@@ -50,17 +51,20 @@ LogMiner is typically not enabled by default and requires some extra steps to en
 What form these steps take depends on whether the Oracle instance is managed via Amazon RDS or not.
 
 In the case of an Amazon RDS instance, the steps are as follows:
+
 1. Check that `SELECT LOG_MODE FROM V$DATABASE` returns `ARCHIVELOG`. If not, ensure that backups are enabled.
 2. Execute `exec rdsadmin.rdsadmin_util.set_configuration('archivelog retention hours',24)`, possibly replacing 24 with a more suitable value depending on the intended sync frequency. For instance, if the sync is intended to be run daily, then a retention period spanning multiple days is advisable.
 3. Execute `exec rdsadmin.rdsadmin_util.alter_supplemental_logging('ADD')` to enable supplemental logging on the database.
 
 In the case of any other Oracle instance, the steps are as follows:
+
 1. `CONNECT ... AS SYSDBA` using [SQL Plus](https://en.wikipedia.org/wiki/SQL_Plus) or equivalent.
 2. Provision the redo log files with something along the lines of `ALTER SYSTEM SET db_recovery_file_dest_size = 10G` and `ALTER SYSTEM SET db_recovery_file_dest = '/opt/oracle/oradata/recovery_area' SCOPE=SPFILE` but replacing the `10G` and directory path arguments with suitable values. Note that the directory in the path needs to exist.
 3. Shut down and restart the instance with `SHUTDOWN IMMEDIATE` and `STARTUP MOUNT`.
 4. `ALTER DATABASE ARCHIVELOG`, `ALTER DATABASE ADD SUPPLEMENTAL LOG DATA` and `ALTER DATABASE OPEN` to restart the database with supplemental logging enabled.
 
 At this point, RDS instance or not, all that remains to prepare the database for CDC incremental syncs is to enable supplemental logging on each of the relevant tables:
+
 ```sql
 ALTER TABLE ... ADD SUPPLEMENTAL LOG DATA (ALL) COLUMNS;
 ```
@@ -212,11 +216,13 @@ to the Airbyte connector configuration screen, so it may log in to the bastion.
 
 The Enterprise Oracle source connector supports incremental syncs using CDC with some limitations.
 Some of these are readily apparent in the database and user setup steps described above:
+
 - CDC availability is subject to a log retention period,
 - CDC requires more user privileges,
 - CDC requires supplemental logging and other settings at the Oracle instance level.
 
 In addition to these, LogMiner, which our CDC relies on, has a few quirks:
+
 - tables with names longer than 30 characters are simply ignored,
 - columns with names longer than 30 characters are simply ignored.
 
@@ -239,54 +245,54 @@ Increase this value if your database has long periods of inactivity between chan
 Oracle data types are mapped to the following data types when synchronizing data.
 
 | Oracle Type                      | Airbyte Type            | Notes                       | CDC |
-| :------------------------------- |:------------------------|:----------------------------|-----|
+| :------------------------------- | :---------------------- | :-------------------------- | --- |
 | `BFILE`                          | string                  | base-64 encoded binary data |     |
-| `BINARY_FLOAT`                   | number                  |                             | ✓   |
-| `BINARY_DOUBLE`                  | number                  |                             | ✓   |
+| `BINARY_FLOAT`                   | number                  |                             | Yes |
+| `BINARY_DOUBLE`                  | number                  |                             | Yes |
 | `BLOB`                           | string                  | base-64 encoded binary data |     |
 | `BOOL`                           | boolean                 |                             |     |
 | `BOOLEAN`                        | boolean                 |                             |     |
-| `CHAR`                           | string                  |                             | ✓   |
-| `CHAR VARYING`                   | string                  |                             | ✓   |
-| `CHARACTER`                      | string                  |                             | ✓   |
-| `CHARACTER VARYING`              | string                  |                             | ✓   |
+| `CHAR`                           | string                  |                             | Yes |
+| `CHAR VARYING`                   | string                  |                             | Yes |
+| `CHARACTER`                      | string                  |                             | Yes |
+| `CHARACTER VARYING`              | string                  |                             | Yes |
 | `CLOB`                           | string                  |                             |     |
-| `DATE`                           | timestamp               | surprisingly, not a date    | ✓   |
-| `DEC`                            | number                  | integer when scale is 0     | ✓   |
-| `DECIMAL`                        | number                  | integer when scale is 0     | ✓   |
-| `FLOAT`                          | number                  |                             | ✓   |
-| `DOUBLE PRECISION`               | number                  |                             | ✓   |
-| `REAL`                           | number                  |                             | ✓   |
-| `INT`                            | number                  | integer                     | ✓   |
-| `INTEGER`                        | number                  | integer                     | ✓   |
-| `INTERVAL YEAR TO MONTH`         | string                  |                             | ✓   |
-| `INTERVAL DAY TO SECOND`         | string                  |                             | ✓   |
-| `INTERVALDS`                     | string                  |                             | ✓   |
-| `INTERVALYM`                     | string                  |                             | ✓   |
+| `DATE`                           | timestamp               | surprisingly, not a date    | Yes |
+| `DEC`                            | number                  | integer when scale is 0     | Yes |
+| `DECIMAL`                        | number                  | integer when scale is 0     | Yes |
+| `FLOAT`                          | number                  |                             | Yes |
+| `DOUBLE PRECISION`               | number                  |                             | Yes |
+| `REAL`                           | number                  |                             | Yes |
+| `INT`                            | number                  | integer                     | Yes |
+| `INTEGER`                        | number                  | integer                     | Yes |
+| `INTERVAL YEAR TO MONTH`         | string                  |                             | Yes |
+| `INTERVAL DAY TO SECOND`         | string                  |                             | Yes |
+| `INTERVALDS`                     | string                  |                             | Yes |
+| `INTERVALYM`                     | string                  |                             | Yes |
 | `JSON`                           | object                  |                             |     |
 | `LONG`                           | string                  | base-64 encoded binary data |     |
 | `LONG RAW`                       | string                  | base-64 encoded binary data |     |
-| `NATIONAL CHAR`                  | string                  |                             | ✓   |
-| `NATIONAL CHAR VARYING`          | string                  |                             | ✓   |
-| `NATIONAL CHARACTER`             | string                  |                             | ✓   |
-| `NATIONAL CHARACTER VARYING`     | string                  |                             | ✓   |
-| `NCHAR`                          | string                  |                             | ✓   |
-| `NCHAR VARYING`                  | string                  |                             | ✓   |
+| `NATIONAL CHAR`                  | string                  |                             | Yes |
+| `NATIONAL CHAR VARYING`          | string                  |                             | Yes |
+| `NATIONAL CHARACTER`             | string                  |                             | Yes |
+| `NATIONAL CHARACTER VARYING`     | string                  |                             | Yes |
+| `NCHAR`                          | string                  |                             | Yes |
+| `NCHAR VARYING`                  | string                  |                             | Yes |
 | `NCLOB`                          | string                  |                             |     |
-| `NUMBER`                         | number                  | integer when scale is 0     | ✓   |
-| `NUMERIC`                        | number                  | integer when scale is 0     | ✓   |
-| `NVARCHAR2`                      | string                  |                             | ✓   |
+| `NUMBER`                         | number                  | integer when scale is 0     | Yes |
+| `NUMERIC`                        | number                  | integer when scale is 0     | Yes |
+| `NVARCHAR2`                      | string                  |                             | Yes |
 | `RAW`                            | string                  | base-64 encoded binary data |     |
 | `ROWID`                          | string                  | base-64 encoded binary data |     |
-| `SMALLINT`                       | number                  | integer                     | ✓   |
-| `TIMESTAMP`                      | timestamp               |                             | ✓   |
-| `TIMESTAMP WITH LOCAL TIME ZONE` | timestamp               |                             | ✓   |
-| `TIMESTAMP WITH LOCAL TZ`        | timestamp               |                             | ✓   |
-| `TIMESTAMP WITH TIME ZONE`       | timestamp with timezone |                             | ✓   |
-| `TIMESTAMP WITH TZ`              | timestamp with timezone |                             | ✓   |
+| `SMALLINT`                       | number                  | integer                     | Yes |
+| `TIMESTAMP`                      | timestamp               |                             | Yes |
+| `TIMESTAMP WITH LOCAL TIME ZONE` | timestamp               |                             | Yes |
+| `TIMESTAMP WITH LOCAL TZ`        | timestamp               |                             | Yes |
+| `TIMESTAMP WITH TIME ZONE`       | timestamp with timezone |                             | Yes |
+| `TIMESTAMP WITH TZ`              | timestamp with timezone |                             | Yes |
 | `UROWID`                         | string                  | base-64 encoded binary data |     |
-| `VARCHAR`                        | string                  |                             | ✓   |
-| `VARCHAR2`                       | string                  |                             | ✓   |
+| `VARCHAR`                        | string                  |                             | Yes |
+| `VARCHAR2`                       | string                  |                             | Yes |
 
 Varray types are mapped to the corresponding Airbyte array type.
 This applies also to multiple levels of nesting, i.e. VARRAYs of VARRAYs, and so forth.
@@ -301,9 +307,9 @@ We are happy to take feedback on preferred mappings.
 
 The connector is still incubating, this section only exists to satisfy Airbyte's QA checks.
 
-| Version | Date       | Pull Request                                                   | Subject                                               |
-|:--------|:-----------|:---------------------------------------------------------------|:------------------------------------------------------|
+| Version | Date       | Pull Request                                                    | Subject                                                               |
+| :------ | :--------- | :-------------------------------------------------------------- | :-------------------------------------------------------------------- |
 | 0.1.4   | 2026-06-16 | [443](https://github.com/airbytehq/airbyte-enterprise/pull/443) | Make CDC heartbeat timeout configurable via `initial_waiting_seconds` |
-| 0.1.3   | -          | -                                                              | Previous changes                                      |
+| 0.1.3   | -          | -                                                               | Previous changes                                                      |
 
 </details>

--- a/docs/integrations/enterprise-connectors/source-oracle-enterprise.md
+++ b/docs/integrations/enterprise-connectors/source-oracle-enterprise.md
@@ -2,7 +2,6 @@
 dockerRepository: airbyte/source-oracle-enterprise
 enterprise-connector: true
 ---
-
 # Source Oracle
 
 Airbyte's Oracle enterprise source connector offers the following features:
@@ -19,7 +18,7 @@ The required minimum platform version is v0.58.0 for this connector.
 ## Features
 
 | Feature                       | Supported | Notes              |
-| :---------------------------- | :-------- | :----------------- |
+| :---------------------------- |:----------| :----------------- |
 | Full Refresh Sync             | Yes       |                    |
 | Incremental Sync - Append     | Yes       |                    |
 | Replicate Incremental Deletes | Yes       |                    |
@@ -51,20 +50,17 @@ LogMiner is typically not enabled by default and requires some extra steps to en
 What form these steps take depends on whether the Oracle instance is managed via Amazon RDS or not.
 
 In the case of an Amazon RDS instance, the steps are as follows:
-
 1. Check that `SELECT LOG_MODE FROM V$DATABASE` returns `ARCHIVELOG`. If not, ensure that backups are enabled.
 2. Execute `exec rdsadmin.rdsadmin_util.set_configuration('archivelog retention hours',24)`, possibly replacing 24 with a more suitable value depending on the intended sync frequency. For instance, if the sync is intended to be run daily, then a retention period spanning multiple days is advisable.
 3. Execute `exec rdsadmin.rdsadmin_util.alter_supplemental_logging('ADD')` to enable supplemental logging on the database.
 
 In the case of any other Oracle instance, the steps are as follows:
-
 1. `CONNECT ... AS SYSDBA` using [SQL Plus](https://en.wikipedia.org/wiki/SQL_Plus) or equivalent.
 2. Provision the redo log files with something along the lines of `ALTER SYSTEM SET db_recovery_file_dest_size = 10G` and `ALTER SYSTEM SET db_recovery_file_dest = '/opt/oracle/oradata/recovery_area' SCOPE=SPFILE` but replacing the `10G` and directory path arguments with suitable values. Note that the directory in the path needs to exist.
 3. Shut down and restart the instance with `SHUTDOWN IMMEDIATE` and `STARTUP MOUNT`.
 4. `ALTER DATABASE ARCHIVELOG`, `ALTER DATABASE ADD SUPPLEMENTAL LOG DATA` and `ALTER DATABASE OPEN` to restart the database with supplemental logging enabled.
 
 At this point, RDS instance or not, all that remains to prepare the database for CDC incremental syncs is to enable supplemental logging on each of the relevant tables:
-
 ```sql
 ALTER TABLE ... ADD SUPPLEMENTAL LOG DATA (ALL) COLUMNS;
 ```
@@ -216,13 +212,11 @@ to the Airbyte connector configuration screen, so it may log in to the bastion.
 
 The Enterprise Oracle source connector supports incremental syncs using CDC with some limitations.
 Some of these are readily apparent in the database and user setup steps described above:
-
 - CDC availability is subject to a log retention period,
 - CDC requires more user privileges,
 - CDC requires supplemental logging and other settings at the Oracle instance level.
 
 In addition to these, LogMiner, which our CDC relies on, has a few quirks:
-
 - tables with names longer than 30 characters are simply ignored,
 - columns with names longer than 30 characters are simply ignored.
 
@@ -245,7 +239,7 @@ Increase this value if your database has long periods of inactivity between chan
 Oracle data types are mapped to the following data types when synchronizing data.
 
 | Oracle Type                      | Airbyte Type            | Notes                       | CDC |
-| :------------------------------- | :---------------------- | :-------------------------- | --- |
+| :------------------------------- |:------------------------|:----------------------------|-----|
 | `BFILE`                          | string                  | base-64 encoded binary data |     |
 | `BINARY_FLOAT`                   | number                  |                             | Yes |
 | `BINARY_DOUBLE`                  | number                  |                             | Yes |
@@ -260,7 +254,7 @@ Oracle data types are mapped to the following data types when synchronizing data
 | `DATE`                           | timestamp               | surprisingly, not a date    | Yes |
 | `DEC`                            | number                  | integer when scale is 0     | Yes |
 | `DECIMAL`                        | number                  | integer when scale is 0     | Yes |
-| `FLOAT`                          | number                  |                             | Yes |
+| `FLOAT`                           | number                  |                             | Yes |
 | `DOUBLE PRECISION`               | number                  |                             | Yes |
 | `REAL`                           | number                  |                             | Yes |
 | `INT`                            | number                  | integer                     | Yes |
@@ -307,9 +301,9 @@ We are happy to take feedback on preferred mappings.
 
 The connector is still incubating, this section only exists to satisfy Airbyte's QA checks.
 
-| Version | Date       | Pull Request                                                    | Subject                                                               |
-| :------ | :--------- | :-------------------------------------------------------------- | :-------------------------------------------------------------------- |
+| Version | Date       | Pull Request                                                   | Subject                                               |
+|:--------|:-----------|:---------------------------------------------------------------|:------------------------------------------------------|
 | 0.1.4   | 2026-06-16 | [443](https://github.com/airbytehq/airbyte-enterprise/pull/443) | Make CDC heartbeat timeout configurable via `initial_waiting_seconds` |
-| 0.1.3   | -          | -                                                               | Previous changes                                                      |
+| 0.1.3   | -          | -                                                              | Previous changes                                      |
 
 </details>

--- a/docs/integrations/sources/chargedesk.md
+++ b/docs/integrations/sources/chargedesk.md
@@ -1,8 +1,7 @@
 # Chargedesk
-
 This is the setup for the Chargedesk source that ingests data from the chargedesk API.
 
-[ChargeDesk](https://chargedesk.com/) integrates directly with many of the most popular payment gateways including Stripe, WooCommerce, PayPal, Braintree Payments, Recurly, Authorize.Net, Zuora and Shopify.
+[ChargeDesk](https://chargedesk.com/) integrates directly with many of the most popular payment gateways including Stripe, WooCommerce, PayPal, Braintree Payments, Recurly, Authorize.Net, Zuora and Shopify. 
 
 In order to use this source, you must first create an account. Once verified and logged in, head over to Setup -> API / Webhooks -> Issue New Key to generate your API key.
 
@@ -10,20 +9,19 @@ You can find more about the API here https://chargedesk.com/api-docs
 
 ## Configuration
 
-| Input        | Type      | Description                                                              | Default Value |
-| ------------ | --------- | ------------------------------------------------------------------------ | ------------- |
-| `password`   | `string`  | Password.                                                                |               |
-| `username`   | `string`  | Username.                                                                |               |
-| `start_date` | `integer` | Start Date. Date from when the sync should start in epoch Unix timestamp |               |
+| Input | Type | Description | Default Value |
+|-------|------|-------------|---------------|
+| `password` | `string` | Password.  |  |
+| `username` | `string` | Username.  |  |
+| `start_date` | `integer` | Start Date. Date from when the sync should start in epoch Unix timestamp |  |
 
 ## Streams
-
-| Stream Name   | Primary Key     | Pagination       | Supports Full Sync | Supports Incremental |
-| ------------- | --------------- | ---------------- | ------------------ | -------------------- |
-| charges       | charge_id       | DefaultPaginator | Supported          | Supported            |
-| customers     | customer_id     | DefaultPaginator | Supported          | Supported            |
-| subscriptions | subscription_id | DefaultPaginator | Supported          | Supported            |
-| products      | product_id      | DefaultPaginator | Supported          | Not supported        |
+| Stream Name | Primary Key | Pagination | Supports Full Sync | Supports Incremental |
+|-------------|-------------|------------|---------------------|----------------------|
+| charges | charge_id | DefaultPaginator | Supported | Supported |
+| customers | customer_id | DefaultPaginator | Supported | Supported |
+| subscriptions | subscription_id | DefaultPaginator | Supported | Supported |
+| products | product_id | DefaultPaginator | Supported | Not supported |
 
 ## IP allow list
 
@@ -34,68 +32,68 @@ If you use Airbyte Cloud and your organization restricts access to specific IPs,
 <details>
   <summary>Expand to review</summary>
 
-| Version | Date       | Pull Request                                             | Subject                                                                                                                                                                |
-| ------- | ---------- | -------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| 0.0.61  | 2026-07-21 | [82369](https://github.com/airbytehq/airbyte/pull/82369) | Update dependencies                                                                                                                                                    |
-| 0.0.60  | 2026-07-14 | [81777](https://github.com/airbytehq/airbyte/pull/81777) | Update dependencies                                                                                                                                                    |
-| 0.0.59  | 2026-06-30 | [80990](https://github.com/airbytehq/airbyte/pull/80990) | Update dependencies                                                                                                                                                    |
-| 0.0.58  | 2026-06-23 | [80412](https://github.com/airbytehq/airbyte/pull/80412) | Update dependencies                                                                                                                                                    |
-| 0.0.57  | 2026-06-16 | [79799](https://github.com/airbytehq/airbyte/pull/79799) | Update dependencies                                                                                                                                                    |
-| 0.0.56  | 2026-06-09 | [79262](https://github.com/airbytehq/airbyte/pull/79262) | Update dependencies                                                                                                                                                    |
-| 0.0.55  | 2026-06-02 | [78647](https://github.com/airbytehq/airbyte/pull/78647) | Update dependencies                                                                                                                                                    |
-| 0.0.54  | 2026-04-28 | [77190](https://github.com/airbytehq/airbyte/pull/77190) | Update dependencies                                                                                                                                                    |
-| 0.0.53  | 2026-04-21 | [75793](https://github.com/airbytehq/airbyte/pull/75793) | Update dependencies                                                                                                                                                    |
-| 0.0.52  | 2026-03-17 | [75103](https://github.com/airbytehq/airbyte/pull/75103) | Update dependencies                                                                                                                                                    |
-| 0.0.51  | 2026-03-10 | [74425](https://github.com/airbytehq/airbyte/pull/74425) | Update dependencies                                                                                                                                                    |
-| 0.0.50  | 2026-02-24 | [73819](https://github.com/airbytehq/airbyte/pull/73819) | Update dependencies                                                                                                                                                    |
-| 0.0.49  | 2026-02-17 | [73474](https://github.com/airbytehq/airbyte/pull/73474) | Update dependencies                                                                                                                                                    |
-| 0.0.48  | 2026-02-03 | [72697](https://github.com/airbytehq/airbyte/pull/72697) | Update dependencies                                                                                                                                                    |
-| 0.0.47  | 2026-01-20 | [72160](https://github.com/airbytehq/airbyte/pull/72160) | Update dependencies                                                                                                                                                    |
-| 0.0.46  | 2026-01-14 | [71705](https://github.com/airbytehq/airbyte/pull/71705) | Update dependencies                                                                                                                                                    |
-| 0.0.45  | 2025-12-18 | [70660](https://github.com/airbytehq/airbyte/pull/70660) | Update dependencies                                                                                                                                                    |
-| 0.0.44  | 2025-11-25 | [69905](https://github.com/airbytehq/airbyte/pull/69905) | Update dependencies                                                                                                                                                    |
-| 0.0.43  | 2025-11-18 | [69601](https://github.com/airbytehq/airbyte/pull/69601) | Update dependencies                                                                                                                                                    |
-| 0.0.42  | 2025-10-29 | [68864](https://github.com/airbytehq/airbyte/pull/68864) | Update dependencies                                                                                                                                                    |
-| 0.0.41  | 2025-10-21 | [68486](https://github.com/airbytehq/airbyte/pull/68486) | Update dependencies                                                                                                                                                    |
-| 0.0.40  | 2025-10-14 | [68070](https://github.com/airbytehq/airbyte/pull/68070) | Update dependencies                                                                                                                                                    |
-| 0.0.39  | 2025-10-07 | [67188](https://github.com/airbytehq/airbyte/pull/67188) | Update dependencies                                                                                                                                                    |
-| 0.0.38  | 2025-09-30 | [65854](https://github.com/airbytehq/airbyte/pull/65854) | Update dependencies                                                                                                                                                    |
-| 0.0.37  | 2025-08-23 | [65235](https://github.com/airbytehq/airbyte/pull/65235) | Update dependencies                                                                                                                                                    |
-| 0.0.36  | 2025-08-09 | [64681](https://github.com/airbytehq/airbyte/pull/64681) | Update dependencies                                                                                                                                                    |
-| 0.0.35  | 2025-08-02 | [64325](https://github.com/airbytehq/airbyte/pull/64325) | Update dependencies                                                                                                                                                    |
-| 0.0.34  | 2025-07-26 | [64027](https://github.com/airbytehq/airbyte/pull/64027) | Update dependencies                                                                                                                                                    |
-| 0.0.33  | 2025-07-19 | [63551](https://github.com/airbytehq/airbyte/pull/63551) | Update dependencies                                                                                                                                                    |
-| 0.0.32  | 2025-07-12 | [62955](https://github.com/airbytehq/airbyte/pull/62955) | Update dependencies                                                                                                                                                    |
-| 0.0.31  | 2025-07-05 | [62762](https://github.com/airbytehq/airbyte/pull/62762) | Update dependencies                                                                                                                                                    |
-| 0.0.30  | 2025-06-28 | [62309](https://github.com/airbytehq/airbyte/pull/62309) | Update dependencies                                                                                                                                                    |
-| 0.0.29  | 2025-06-21 | [61942](https://github.com/airbytehq/airbyte/pull/61942) | Update dependencies                                                                                                                                                    |
-| 0.0.28  | 2025-06-14 | [61170](https://github.com/airbytehq/airbyte/pull/61170) | Update dependencies                                                                                                                                                    |
-| 0.0.27  | 2025-05-24 | [60365](https://github.com/airbytehq/airbyte/pull/60365) | Update dependencies                                                                                                                                                    |
-| 0.0.26  | 2025-05-10 | [59989](https://github.com/airbytehq/airbyte/pull/59989) | Update dependencies                                                                                                                                                    |
-| 0.0.25  | 2025-05-03 | [59317](https://github.com/airbytehq/airbyte/pull/59317) | Update dependencies                                                                                                                                                    |
-| 0.0.24  | 2025-04-26 | [58716](https://github.com/airbytehq/airbyte/pull/58716) | Update dependencies                                                                                                                                                    |
-| 0.0.23  | 2025-04-19 | [58284](https://github.com/airbytehq/airbyte/pull/58284) | Update dependencies                                                                                                                                                    |
-| 0.0.22  | 2025-04-12 | [57600](https://github.com/airbytehq/airbyte/pull/57600) | Update dependencies                                                                                                                                                    |
-| 0.0.21  | 2025-04-05 | [57160](https://github.com/airbytehq/airbyte/pull/57160) | Update dependencies                                                                                                                                                    |
-| 0.0.20  | 2025-03-29 | [56566](https://github.com/airbytehq/airbyte/pull/56566) | Update dependencies                                                                                                                                                    |
-| 0.0.19  | 2025-03-22 | [56158](https://github.com/airbytehq/airbyte/pull/56158) | Update dependencies                                                                                                                                                    |
-| 0.0.18  | 2025-03-08 | [55397](https://github.com/airbytehq/airbyte/pull/55397) | Update dependencies                                                                                                                                                    |
-| 0.0.17  | 2025-03-01 | [54875](https://github.com/airbytehq/airbyte/pull/54875) | Update dependencies                                                                                                                                                    |
-| 0.0.16  | 2025-02-22 | [54210](https://github.com/airbytehq/airbyte/pull/54210) | Update dependencies                                                                                                                                                    |
-| 0.0.15  | 2025-02-15 | [53893](https://github.com/airbytehq/airbyte/pull/53893) | Update dependencies                                                                                                                                                    |
-| 0.0.14  | 2025-02-08 | [53420](https://github.com/airbytehq/airbyte/pull/53420) | Update dependencies                                                                                                                                                    |
-| 0.0.13  | 2025-02-01 | [52884](https://github.com/airbytehq/airbyte/pull/52884) | Update dependencies                                                                                                                                                    |
-| 0.0.12  | 2025-01-25 | [52173](https://github.com/airbytehq/airbyte/pull/52173) | Update dependencies                                                                                                                                                    |
-| 0.0.11  | 2025-01-18 | [51731](https://github.com/airbytehq/airbyte/pull/51731) | Update dependencies                                                                                                                                                    |
-| 0.0.10  | 2025-01-11 | [51278](https://github.com/airbytehq/airbyte/pull/51278) | Update dependencies                                                                                                                                                    |
-| 0.0.9   | 2024-12-28 | [50448](https://github.com/airbytehq/airbyte/pull/50448) | Update dependencies                                                                                                                                                    |
-| 0.0.8   | 2024-12-21 | [50170](https://github.com/airbytehq/airbyte/pull/50170) | Update dependencies                                                                                                                                                    |
-| 0.0.7   | 2024-12-14 | [49554](https://github.com/airbytehq/airbyte/pull/49554) | Update dependencies                                                                                                                                                    |
-| 0.0.6   | 2024-12-12 | [49309](https://github.com/airbytehq/airbyte/pull/49309) | Update dependencies                                                                                                                                                    |
-| 0.0.5   | 2024-12-11 | [49037](https://github.com/airbytehq/airbyte/pull/49037) | Starting with this version, the Docker image is now rootless. Please note that this and future versions will not be compatible with Airbyte versions earlier than 0.64 |
-| 0.0.4   | 2024-11-04 | [48205](https://github.com/airbytehq/airbyte/pull/48205) | Update dependencies                                                                                                                                                    |
-| 0.0.3   | 2024-10-29 | [47832](https://github.com/airbytehq/airbyte/pull/47832) | Update dependencies                                                                                                                                                    |
-| 0.0.2   | 2024-10-28 | [47560](https://github.com/airbytehq/airbyte/pull/47560) | Update dependencies                                                                                                                                                    |
-| 0.0.1   | 2024-10-18 |                                                          | Initial release by [@aazam-gh](https://github.com/aazam-gh) via Connector Builder                                                                                      |
+| Version          | Date              | Pull Request | Subject        |
+|------------------|-------------------|--------------|----------------|
+| 0.0.61 | 2026-07-21 | [82369](https://github.com/airbytehq/airbyte/pull/82369) | Update dependencies |
+| 0.0.60 | 2026-07-14 | [81777](https://github.com/airbytehq/airbyte/pull/81777) | Update dependencies |
+| 0.0.59 | 2026-06-30 | [80990](https://github.com/airbytehq/airbyte/pull/80990) | Update dependencies |
+| 0.0.58 | 2026-06-23 | [80412](https://github.com/airbytehq/airbyte/pull/80412) | Update dependencies |
+| 0.0.57 | 2026-06-16 | [79799](https://github.com/airbytehq/airbyte/pull/79799) | Update dependencies |
+| 0.0.56 | 2026-06-09 | [79262](https://github.com/airbytehq/airbyte/pull/79262) | Update dependencies |
+| 0.0.55 | 2026-06-02 | [78647](https://github.com/airbytehq/airbyte/pull/78647) | Update dependencies |
+| 0.0.54 | 2026-04-28 | [77190](https://github.com/airbytehq/airbyte/pull/77190) | Update dependencies |
+| 0.0.53 | 2026-04-21 | [75793](https://github.com/airbytehq/airbyte/pull/75793) | Update dependencies |
+| 0.0.52 | 2026-03-17 | [75103](https://github.com/airbytehq/airbyte/pull/75103) | Update dependencies |
+| 0.0.51 | 2026-03-10 | [74425](https://github.com/airbytehq/airbyte/pull/74425) | Update dependencies |
+| 0.0.50 | 2026-02-24 | [73819](https://github.com/airbytehq/airbyte/pull/73819) | Update dependencies |
+| 0.0.49 | 2026-02-17 | [73474](https://github.com/airbytehq/airbyte/pull/73474) | Update dependencies |
+| 0.0.48 | 2026-02-03 | [72697](https://github.com/airbytehq/airbyte/pull/72697) | Update dependencies |
+| 0.0.47 | 2026-01-20 | [72160](https://github.com/airbytehq/airbyte/pull/72160) | Update dependencies |
+| 0.0.46 | 2026-01-14 | [71705](https://github.com/airbytehq/airbyte/pull/71705) | Update dependencies |
+| 0.0.45 | 2025-12-18 | [70660](https://github.com/airbytehq/airbyte/pull/70660) | Update dependencies |
+| 0.0.44 | 2025-11-25 | [69905](https://github.com/airbytehq/airbyte/pull/69905) | Update dependencies |
+| 0.0.43 | 2025-11-18 | [69601](https://github.com/airbytehq/airbyte/pull/69601) | Update dependencies |
+| 0.0.42 | 2025-10-29 | [68864](https://github.com/airbytehq/airbyte/pull/68864) | Update dependencies |
+| 0.0.41 | 2025-10-21 | [68486](https://github.com/airbytehq/airbyte/pull/68486) | Update dependencies |
+| 0.0.40 | 2025-10-14 | [68070](https://github.com/airbytehq/airbyte/pull/68070) | Update dependencies |
+| 0.0.39 | 2025-10-07 | [67188](https://github.com/airbytehq/airbyte/pull/67188) | Update dependencies |
+| 0.0.38 | 2025-09-30 | [65854](https://github.com/airbytehq/airbyte/pull/65854) | Update dependencies |
+| 0.0.37 | 2025-08-23 | [65235](https://github.com/airbytehq/airbyte/pull/65235) | Update dependencies |
+| 0.0.36 | 2025-08-09 | [64681](https://github.com/airbytehq/airbyte/pull/64681) | Update dependencies |
+| 0.0.35 | 2025-08-02 | [64325](https://github.com/airbytehq/airbyte/pull/64325) | Update dependencies |
+| 0.0.34 | 2025-07-26 | [64027](https://github.com/airbytehq/airbyte/pull/64027) | Update dependencies |
+| 0.0.33 | 2025-07-19 | [63551](https://github.com/airbytehq/airbyte/pull/63551) | Update dependencies |
+| 0.0.32 | 2025-07-12 | [62955](https://github.com/airbytehq/airbyte/pull/62955) | Update dependencies |
+| 0.0.31 | 2025-07-05 | [62762](https://github.com/airbytehq/airbyte/pull/62762) | Update dependencies |
+| 0.0.30 | 2025-06-28 | [62309](https://github.com/airbytehq/airbyte/pull/62309) | Update dependencies |
+| 0.0.29 | 2025-06-21 | [61942](https://github.com/airbytehq/airbyte/pull/61942) | Update dependencies |
+| 0.0.28 | 2025-06-14 | [61170](https://github.com/airbytehq/airbyte/pull/61170) | Update dependencies |
+| 0.0.27 | 2025-05-24 | [60365](https://github.com/airbytehq/airbyte/pull/60365) | Update dependencies |
+| 0.0.26 | 2025-05-10 | [59989](https://github.com/airbytehq/airbyte/pull/59989) | Update dependencies |
+| 0.0.25 | 2025-05-03 | [59317](https://github.com/airbytehq/airbyte/pull/59317) | Update dependencies |
+| 0.0.24 | 2025-04-26 | [58716](https://github.com/airbytehq/airbyte/pull/58716) | Update dependencies |
+| 0.0.23 | 2025-04-19 | [58284](https://github.com/airbytehq/airbyte/pull/58284) | Update dependencies |
+| 0.0.22 | 2025-04-12 | [57600](https://github.com/airbytehq/airbyte/pull/57600) | Update dependencies |
+| 0.0.21 | 2025-04-05 | [57160](https://github.com/airbytehq/airbyte/pull/57160) | Update dependencies |
+| 0.0.20 | 2025-03-29 | [56566](https://github.com/airbytehq/airbyte/pull/56566) | Update dependencies |
+| 0.0.19 | 2025-03-22 | [56158](https://github.com/airbytehq/airbyte/pull/56158) | Update dependencies |
+| 0.0.18 | 2025-03-08 | [55397](https://github.com/airbytehq/airbyte/pull/55397) | Update dependencies |
+| 0.0.17 | 2025-03-01 | [54875](https://github.com/airbytehq/airbyte/pull/54875) | Update dependencies |
+| 0.0.16 | 2025-02-22 | [54210](https://github.com/airbytehq/airbyte/pull/54210) | Update dependencies |
+| 0.0.15 | 2025-02-15 | [53893](https://github.com/airbytehq/airbyte/pull/53893) | Update dependencies |
+| 0.0.14 | 2025-02-08 | [53420](https://github.com/airbytehq/airbyte/pull/53420) | Update dependencies |
+| 0.0.13 | 2025-02-01 | [52884](https://github.com/airbytehq/airbyte/pull/52884) | Update dependencies |
+| 0.0.12 | 2025-01-25 | [52173](https://github.com/airbytehq/airbyte/pull/52173) | Update dependencies |
+| 0.0.11 | 2025-01-18 | [51731](https://github.com/airbytehq/airbyte/pull/51731) | Update dependencies |
+| 0.0.10 | 2025-01-11 | [51278](https://github.com/airbytehq/airbyte/pull/51278) | Update dependencies |
+| 0.0.9 | 2024-12-28 | [50448](https://github.com/airbytehq/airbyte/pull/50448) | Update dependencies |
+| 0.0.8 | 2024-12-21 | [50170](https://github.com/airbytehq/airbyte/pull/50170) | Update dependencies |
+| 0.0.7 | 2024-12-14 | [49554](https://github.com/airbytehq/airbyte/pull/49554) | Update dependencies |
+| 0.0.6 | 2024-12-12 | [49309](https://github.com/airbytehq/airbyte/pull/49309) | Update dependencies |
+| 0.0.5 | 2024-12-11 | [49037](https://github.com/airbytehq/airbyte/pull/49037) | Starting with this version, the Docker image is now rootless. Please note that this and future versions will not be compatible with Airbyte versions earlier than 0.64 |
+| 0.0.4 | 2024-11-04 | [48205](https://github.com/airbytehq/airbyte/pull/48205) | Update dependencies |
+| 0.0.3 | 2024-10-29 | [47832](https://github.com/airbytehq/airbyte/pull/47832) | Update dependencies |
+| 0.0.2 | 2024-10-28 | [47560](https://github.com/airbytehq/airbyte/pull/47560) | Update dependencies |
+| 0.0.1 | 2024-10-18 | | Initial release by [@aazam-gh](https://github.com/aazam-gh) via Connector Builder |
 
 </details>

--- a/docs/integrations/sources/chargedesk.md
+++ b/docs/integrations/sources/chargedesk.md
@@ -1,7 +1,8 @@
 # Chargedesk
+
 This is the setup for the Chargedesk source that ingests data from the chargedesk API.
 
-[ChargeDesk](https://chargedesk.com/) integrates directly with many of the most popular payment gateways including Stripe, WooCommerce, PayPal, Braintree Payments, Recurly, Authorize.Net, Zuora and Shopify. 
+[ChargeDesk](https://chargedesk.com/) integrates directly with many of the most popular payment gateways including Stripe, WooCommerce, PayPal, Braintree Payments, Recurly, Authorize.Net, Zuora and Shopify.
 
 In order to use this source, you must first create an account. Once verified and logged in, head over to Setup -> API / Webhooks -> Issue New Key to generate your API key.
 
@@ -9,19 +10,20 @@ You can find more about the API here https://chargedesk.com/api-docs
 
 ## Configuration
 
-| Input | Type | Description | Default Value |
-|-------|------|-------------|---------------|
-| `password` | `string` | Password.  |  |
-| `username` | `string` | Username.  |  |
-| `start_date` | `integer` | Start Date. Date from when the sync should start in epoch Unix timestamp |  |
+| Input        | Type      | Description                                                              | Default Value |
+| ------------ | --------- | ------------------------------------------------------------------------ | ------------- |
+| `password`   | `string`  | Password.                                                                |               |
+| `username`   | `string`  | Username.                                                                |               |
+| `start_date` | `integer` | Start Date. Date from when the sync should start in epoch Unix timestamp |               |
 
 ## Streams
-| Stream Name | Primary Key | Pagination | Supports Full Sync | Supports Incremental |
-|-------------|-------------|------------|---------------------|----------------------|
-| charges | charge_id | DefaultPaginator | ✅ |  ✅  |
-| customers | customer_id | DefaultPaginator | ✅ |  ✅  |
-| subscriptions | subscription_id | DefaultPaginator | ✅ |  ✅  |
-| products | product_id | DefaultPaginator | ✅ |  ❌  |
+
+| Stream Name   | Primary Key     | Pagination       | Supports Full Sync | Supports Incremental |
+| ------------- | --------------- | ---------------- | ------------------ | -------------------- |
+| charges       | charge_id       | DefaultPaginator | Supported          | Supported            |
+| customers     | customer_id     | DefaultPaginator | Supported          | Supported            |
+| subscriptions | subscription_id | DefaultPaginator | Supported          | Supported            |
+| products      | product_id      | DefaultPaginator | Supported          | Not supported        |
 
 ## IP allow list
 
@@ -32,68 +34,68 @@ If you use Airbyte Cloud and your organization restricts access to specific IPs,
 <details>
   <summary>Expand to review</summary>
 
-| Version          | Date              | Pull Request | Subject        |
-|------------------|-------------------|--------------|----------------|
-| 0.0.61 | 2026-07-21 | [82369](https://github.com/airbytehq/airbyte/pull/82369) | Update dependencies |
-| 0.0.60 | 2026-07-14 | [81777](https://github.com/airbytehq/airbyte/pull/81777) | Update dependencies |
-| 0.0.59 | 2026-06-30 | [80990](https://github.com/airbytehq/airbyte/pull/80990) | Update dependencies |
-| 0.0.58 | 2026-06-23 | [80412](https://github.com/airbytehq/airbyte/pull/80412) | Update dependencies |
-| 0.0.57 | 2026-06-16 | [79799](https://github.com/airbytehq/airbyte/pull/79799) | Update dependencies |
-| 0.0.56 | 2026-06-09 | [79262](https://github.com/airbytehq/airbyte/pull/79262) | Update dependencies |
-| 0.0.55 | 2026-06-02 | [78647](https://github.com/airbytehq/airbyte/pull/78647) | Update dependencies |
-| 0.0.54 | 2026-04-28 | [77190](https://github.com/airbytehq/airbyte/pull/77190) | Update dependencies |
-| 0.0.53 | 2026-04-21 | [75793](https://github.com/airbytehq/airbyte/pull/75793) | Update dependencies |
-| 0.0.52 | 2026-03-17 | [75103](https://github.com/airbytehq/airbyte/pull/75103) | Update dependencies |
-| 0.0.51 | 2026-03-10 | [74425](https://github.com/airbytehq/airbyte/pull/74425) | Update dependencies |
-| 0.0.50 | 2026-02-24 | [73819](https://github.com/airbytehq/airbyte/pull/73819) | Update dependencies |
-| 0.0.49 | 2026-02-17 | [73474](https://github.com/airbytehq/airbyte/pull/73474) | Update dependencies |
-| 0.0.48 | 2026-02-03 | [72697](https://github.com/airbytehq/airbyte/pull/72697) | Update dependencies |
-| 0.0.47 | 2026-01-20 | [72160](https://github.com/airbytehq/airbyte/pull/72160) | Update dependencies |
-| 0.0.46 | 2026-01-14 | [71705](https://github.com/airbytehq/airbyte/pull/71705) | Update dependencies |
-| 0.0.45 | 2025-12-18 | [70660](https://github.com/airbytehq/airbyte/pull/70660) | Update dependencies |
-| 0.0.44 | 2025-11-25 | [69905](https://github.com/airbytehq/airbyte/pull/69905) | Update dependencies |
-| 0.0.43 | 2025-11-18 | [69601](https://github.com/airbytehq/airbyte/pull/69601) | Update dependencies |
-| 0.0.42 | 2025-10-29 | [68864](https://github.com/airbytehq/airbyte/pull/68864) | Update dependencies |
-| 0.0.41 | 2025-10-21 | [68486](https://github.com/airbytehq/airbyte/pull/68486) | Update dependencies |
-| 0.0.40 | 2025-10-14 | [68070](https://github.com/airbytehq/airbyte/pull/68070) | Update dependencies |
-| 0.0.39 | 2025-10-07 | [67188](https://github.com/airbytehq/airbyte/pull/67188) | Update dependencies |
-| 0.0.38 | 2025-09-30 | [65854](https://github.com/airbytehq/airbyte/pull/65854) | Update dependencies |
-| 0.0.37 | 2025-08-23 | [65235](https://github.com/airbytehq/airbyte/pull/65235) | Update dependencies |
-| 0.0.36 | 2025-08-09 | [64681](https://github.com/airbytehq/airbyte/pull/64681) | Update dependencies |
-| 0.0.35 | 2025-08-02 | [64325](https://github.com/airbytehq/airbyte/pull/64325) | Update dependencies |
-| 0.0.34 | 2025-07-26 | [64027](https://github.com/airbytehq/airbyte/pull/64027) | Update dependencies |
-| 0.0.33 | 2025-07-19 | [63551](https://github.com/airbytehq/airbyte/pull/63551) | Update dependencies |
-| 0.0.32 | 2025-07-12 | [62955](https://github.com/airbytehq/airbyte/pull/62955) | Update dependencies |
-| 0.0.31 | 2025-07-05 | [62762](https://github.com/airbytehq/airbyte/pull/62762) | Update dependencies |
-| 0.0.30 | 2025-06-28 | [62309](https://github.com/airbytehq/airbyte/pull/62309) | Update dependencies |
-| 0.0.29 | 2025-06-21 | [61942](https://github.com/airbytehq/airbyte/pull/61942) | Update dependencies |
-| 0.0.28 | 2025-06-14 | [61170](https://github.com/airbytehq/airbyte/pull/61170) | Update dependencies |
-| 0.0.27 | 2025-05-24 | [60365](https://github.com/airbytehq/airbyte/pull/60365) | Update dependencies |
-| 0.0.26 | 2025-05-10 | [59989](https://github.com/airbytehq/airbyte/pull/59989) | Update dependencies |
-| 0.0.25 | 2025-05-03 | [59317](https://github.com/airbytehq/airbyte/pull/59317) | Update dependencies |
-| 0.0.24 | 2025-04-26 | [58716](https://github.com/airbytehq/airbyte/pull/58716) | Update dependencies |
-| 0.0.23 | 2025-04-19 | [58284](https://github.com/airbytehq/airbyte/pull/58284) | Update dependencies |
-| 0.0.22 | 2025-04-12 | [57600](https://github.com/airbytehq/airbyte/pull/57600) | Update dependencies |
-| 0.0.21 | 2025-04-05 | [57160](https://github.com/airbytehq/airbyte/pull/57160) | Update dependencies |
-| 0.0.20 | 2025-03-29 | [56566](https://github.com/airbytehq/airbyte/pull/56566) | Update dependencies |
-| 0.0.19 | 2025-03-22 | [56158](https://github.com/airbytehq/airbyte/pull/56158) | Update dependencies |
-| 0.0.18 | 2025-03-08 | [55397](https://github.com/airbytehq/airbyte/pull/55397) | Update dependencies |
-| 0.0.17 | 2025-03-01 | [54875](https://github.com/airbytehq/airbyte/pull/54875) | Update dependencies |
-| 0.0.16 | 2025-02-22 | [54210](https://github.com/airbytehq/airbyte/pull/54210) | Update dependencies |
-| 0.0.15 | 2025-02-15 | [53893](https://github.com/airbytehq/airbyte/pull/53893) | Update dependencies |
-| 0.0.14 | 2025-02-08 | [53420](https://github.com/airbytehq/airbyte/pull/53420) | Update dependencies |
-| 0.0.13 | 2025-02-01 | [52884](https://github.com/airbytehq/airbyte/pull/52884) | Update dependencies |
-| 0.0.12 | 2025-01-25 | [52173](https://github.com/airbytehq/airbyte/pull/52173) | Update dependencies |
-| 0.0.11 | 2025-01-18 | [51731](https://github.com/airbytehq/airbyte/pull/51731) | Update dependencies |
-| 0.0.10 | 2025-01-11 | [51278](https://github.com/airbytehq/airbyte/pull/51278) | Update dependencies |
-| 0.0.9 | 2024-12-28 | [50448](https://github.com/airbytehq/airbyte/pull/50448) | Update dependencies |
-| 0.0.8 | 2024-12-21 | [50170](https://github.com/airbytehq/airbyte/pull/50170) | Update dependencies |
-| 0.0.7 | 2024-12-14 | [49554](https://github.com/airbytehq/airbyte/pull/49554) | Update dependencies |
-| 0.0.6 | 2024-12-12 | [49309](https://github.com/airbytehq/airbyte/pull/49309) | Update dependencies |
-| 0.0.5 | 2024-12-11 | [49037](https://github.com/airbytehq/airbyte/pull/49037) | Starting with this version, the Docker image is now rootless. Please note that this and future versions will not be compatible with Airbyte versions earlier than 0.64 |
-| 0.0.4 | 2024-11-04 | [48205](https://github.com/airbytehq/airbyte/pull/48205) | Update dependencies |
-| 0.0.3 | 2024-10-29 | [47832](https://github.com/airbytehq/airbyte/pull/47832) | Update dependencies |
-| 0.0.2 | 2024-10-28 | [47560](https://github.com/airbytehq/airbyte/pull/47560) | Update dependencies |
-| 0.0.1 | 2024-10-18 | | Initial release by [@aazam-gh](https://github.com/aazam-gh) via Connector Builder |
+| Version | Date       | Pull Request                                             | Subject                                                                                                                                                                |
+| ------- | ---------- | -------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 0.0.61  | 2026-07-21 | [82369](https://github.com/airbytehq/airbyte/pull/82369) | Update dependencies                                                                                                                                                    |
+| 0.0.60  | 2026-07-14 | [81777](https://github.com/airbytehq/airbyte/pull/81777) | Update dependencies                                                                                                                                                    |
+| 0.0.59  | 2026-06-30 | [80990](https://github.com/airbytehq/airbyte/pull/80990) | Update dependencies                                                                                                                                                    |
+| 0.0.58  | 2026-06-23 | [80412](https://github.com/airbytehq/airbyte/pull/80412) | Update dependencies                                                                                                                                                    |
+| 0.0.57  | 2026-06-16 | [79799](https://github.com/airbytehq/airbyte/pull/79799) | Update dependencies                                                                                                                                                    |
+| 0.0.56  | 2026-06-09 | [79262](https://github.com/airbytehq/airbyte/pull/79262) | Update dependencies                                                                                                                                                    |
+| 0.0.55  | 2026-06-02 | [78647](https://github.com/airbytehq/airbyte/pull/78647) | Update dependencies                                                                                                                                                    |
+| 0.0.54  | 2026-04-28 | [77190](https://github.com/airbytehq/airbyte/pull/77190) | Update dependencies                                                                                                                                                    |
+| 0.0.53  | 2026-04-21 | [75793](https://github.com/airbytehq/airbyte/pull/75793) | Update dependencies                                                                                                                                                    |
+| 0.0.52  | 2026-03-17 | [75103](https://github.com/airbytehq/airbyte/pull/75103) | Update dependencies                                                                                                                                                    |
+| 0.0.51  | 2026-03-10 | [74425](https://github.com/airbytehq/airbyte/pull/74425) | Update dependencies                                                                                                                                                    |
+| 0.0.50  | 2026-02-24 | [73819](https://github.com/airbytehq/airbyte/pull/73819) | Update dependencies                                                                                                                                                    |
+| 0.0.49  | 2026-02-17 | [73474](https://github.com/airbytehq/airbyte/pull/73474) | Update dependencies                                                                                                                                                    |
+| 0.0.48  | 2026-02-03 | [72697](https://github.com/airbytehq/airbyte/pull/72697) | Update dependencies                                                                                                                                                    |
+| 0.0.47  | 2026-01-20 | [72160](https://github.com/airbytehq/airbyte/pull/72160) | Update dependencies                                                                                                                                                    |
+| 0.0.46  | 2026-01-14 | [71705](https://github.com/airbytehq/airbyte/pull/71705) | Update dependencies                                                                                                                                                    |
+| 0.0.45  | 2025-12-18 | [70660](https://github.com/airbytehq/airbyte/pull/70660) | Update dependencies                                                                                                                                                    |
+| 0.0.44  | 2025-11-25 | [69905](https://github.com/airbytehq/airbyte/pull/69905) | Update dependencies                                                                                                                                                    |
+| 0.0.43  | 2025-11-18 | [69601](https://github.com/airbytehq/airbyte/pull/69601) | Update dependencies                                                                                                                                                    |
+| 0.0.42  | 2025-10-29 | [68864](https://github.com/airbytehq/airbyte/pull/68864) | Update dependencies                                                                                                                                                    |
+| 0.0.41  | 2025-10-21 | [68486](https://github.com/airbytehq/airbyte/pull/68486) | Update dependencies                                                                                                                                                    |
+| 0.0.40  | 2025-10-14 | [68070](https://github.com/airbytehq/airbyte/pull/68070) | Update dependencies                                                                                                                                                    |
+| 0.0.39  | 2025-10-07 | [67188](https://github.com/airbytehq/airbyte/pull/67188) | Update dependencies                                                                                                                                                    |
+| 0.0.38  | 2025-09-30 | [65854](https://github.com/airbytehq/airbyte/pull/65854) | Update dependencies                                                                                                                                                    |
+| 0.0.37  | 2025-08-23 | [65235](https://github.com/airbytehq/airbyte/pull/65235) | Update dependencies                                                                                                                                                    |
+| 0.0.36  | 2025-08-09 | [64681](https://github.com/airbytehq/airbyte/pull/64681) | Update dependencies                                                                                                                                                    |
+| 0.0.35  | 2025-08-02 | [64325](https://github.com/airbytehq/airbyte/pull/64325) | Update dependencies                                                                                                                                                    |
+| 0.0.34  | 2025-07-26 | [64027](https://github.com/airbytehq/airbyte/pull/64027) | Update dependencies                                                                                                                                                    |
+| 0.0.33  | 2025-07-19 | [63551](https://github.com/airbytehq/airbyte/pull/63551) | Update dependencies                                                                                                                                                    |
+| 0.0.32  | 2025-07-12 | [62955](https://github.com/airbytehq/airbyte/pull/62955) | Update dependencies                                                                                                                                                    |
+| 0.0.31  | 2025-07-05 | [62762](https://github.com/airbytehq/airbyte/pull/62762) | Update dependencies                                                                                                                                                    |
+| 0.0.30  | 2025-06-28 | [62309](https://github.com/airbytehq/airbyte/pull/62309) | Update dependencies                                                                                                                                                    |
+| 0.0.29  | 2025-06-21 | [61942](https://github.com/airbytehq/airbyte/pull/61942) | Update dependencies                                                                                                                                                    |
+| 0.0.28  | 2025-06-14 | [61170](https://github.com/airbytehq/airbyte/pull/61170) | Update dependencies                                                                                                                                                    |
+| 0.0.27  | 2025-05-24 | [60365](https://github.com/airbytehq/airbyte/pull/60365) | Update dependencies                                                                                                                                                    |
+| 0.0.26  | 2025-05-10 | [59989](https://github.com/airbytehq/airbyte/pull/59989) | Update dependencies                                                                                                                                                    |
+| 0.0.25  | 2025-05-03 | [59317](https://github.com/airbytehq/airbyte/pull/59317) | Update dependencies                                                                                                                                                    |
+| 0.0.24  | 2025-04-26 | [58716](https://github.com/airbytehq/airbyte/pull/58716) | Update dependencies                                                                                                                                                    |
+| 0.0.23  | 2025-04-19 | [58284](https://github.com/airbytehq/airbyte/pull/58284) | Update dependencies                                                                                                                                                    |
+| 0.0.22  | 2025-04-12 | [57600](https://github.com/airbytehq/airbyte/pull/57600) | Update dependencies                                                                                                                                                    |
+| 0.0.21  | 2025-04-05 | [57160](https://github.com/airbytehq/airbyte/pull/57160) | Update dependencies                                                                                                                                                    |
+| 0.0.20  | 2025-03-29 | [56566](https://github.com/airbytehq/airbyte/pull/56566) | Update dependencies                                                                                                                                                    |
+| 0.0.19  | 2025-03-22 | [56158](https://github.com/airbytehq/airbyte/pull/56158) | Update dependencies                                                                                                                                                    |
+| 0.0.18  | 2025-03-08 | [55397](https://github.com/airbytehq/airbyte/pull/55397) | Update dependencies                                                                                                                                                    |
+| 0.0.17  | 2025-03-01 | [54875](https://github.com/airbytehq/airbyte/pull/54875) | Update dependencies                                                                                                                                                    |
+| 0.0.16  | 2025-02-22 | [54210](https://github.com/airbytehq/airbyte/pull/54210) | Update dependencies                                                                                                                                                    |
+| 0.0.15  | 2025-02-15 | [53893](https://github.com/airbytehq/airbyte/pull/53893) | Update dependencies                                                                                                                                                    |
+| 0.0.14  | 2025-02-08 | [53420](https://github.com/airbytehq/airbyte/pull/53420) | Update dependencies                                                                                                                                                    |
+| 0.0.13  | 2025-02-01 | [52884](https://github.com/airbytehq/airbyte/pull/52884) | Update dependencies                                                                                                                                                    |
+| 0.0.12  | 2025-01-25 | [52173](https://github.com/airbytehq/airbyte/pull/52173) | Update dependencies                                                                                                                                                    |
+| 0.0.11  | 2025-01-18 | [51731](https://github.com/airbytehq/airbyte/pull/51731) | Update dependencies                                                                                                                                                    |
+| 0.0.10  | 2025-01-11 | [51278](https://github.com/airbytehq/airbyte/pull/51278) | Update dependencies                                                                                                                                                    |
+| 0.0.9   | 2024-12-28 | [50448](https://github.com/airbytehq/airbyte/pull/50448) | Update dependencies                                                                                                                                                    |
+| 0.0.8   | 2024-12-21 | [50170](https://github.com/airbytehq/airbyte/pull/50170) | Update dependencies                                                                                                                                                    |
+| 0.0.7   | 2024-12-14 | [49554](https://github.com/airbytehq/airbyte/pull/49554) | Update dependencies                                                                                                                                                    |
+| 0.0.6   | 2024-12-12 | [49309](https://github.com/airbytehq/airbyte/pull/49309) | Update dependencies                                                                                                                                                    |
+| 0.0.5   | 2024-12-11 | [49037](https://github.com/airbytehq/airbyte/pull/49037) | Starting with this version, the Docker image is now rootless. Please note that this and future versions will not be compatible with Airbyte versions earlier than 0.64 |
+| 0.0.4   | 2024-11-04 | [48205](https://github.com/airbytehq/airbyte/pull/48205) | Update dependencies                                                                                                                                                    |
+| 0.0.3   | 2024-10-29 | [47832](https://github.com/airbytehq/airbyte/pull/47832) | Update dependencies                                                                                                                                                    |
+| 0.0.2   | 2024-10-28 | [47560](https://github.com/airbytehq/airbyte/pull/47560) | Update dependencies                                                                                                                                                    |
+| 0.0.1   | 2024-10-18 |                                                          | Initial release by [@aazam-gh](https://github.com/aazam-gh) via Connector Builder                                                                                      |
 
 </details>

--- a/docs/integrations/sources/eventzilla.md
+++ b/docs/integrations/sources/eventzilla.md
@@ -1,21 +1,23 @@
 # Eventzilla
+
 The Airbyte connector for Eventzilla enables seamless integration between Eventzilla and various data destinations. It automates the extraction of event management data, such as attendee details, ticket sales, and event performance metrics, and syncs it with your preferred data warehouses or analytics tools. This connector helps organizations centralize and analyze their Eventzilla data for reporting, monitoring, and strategic insights.
 
 ## Configuration
 
-| Input | Type | Description | Default Value |
-|-------|------|-------------|---------------|
-| `x-api-key` | `string` | API Key. API key to use. Generate it by creating a new application within your Eventzilla account settings under Settings &gt; App Management. |  |
+| Input       | Type     | Description                                                                                                                                    | Default Value |
+| ----------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------- | ------------- |
+| `x-api-key` | `string` | API Key. API key to use. Generate it by creating a new application within your Eventzilla account settings under Settings &gt; App Management. |               |
 
 ## Streams
-| Stream Name | Primary Key | Pagination | Supports Full Sync | Supports Incremental |
-|-------------|-------------|------------|---------------------|----------------------|
-| events | id | DefaultPaginator | ✅ |  ❌  |
-| attendees | id | DefaultPaginator | ✅ |  ❌  |
-| categories |  | DefaultPaginator | ✅ |  ❌  |
-| tickets | id | DefaultPaginator | ✅ |  ❌  |
-| users | id | DefaultPaginator | ✅ |  ❌  |
-| transactions | refno | DefaultPaginator | ✅ |  ❌  |
+
+| Stream Name  | Primary Key | Pagination       | Supports Full Sync | Supports Incremental |
+| ------------ | ----------- | ---------------- | ------------------ | -------------------- |
+| events       | id          | DefaultPaginator | Supported          | Not supported        |
+| attendees    | id          | DefaultPaginator | Supported          | Not supported        |
+| categories   |             | DefaultPaginator | Supported          | Not supported        |
+| tickets      | id          | DefaultPaginator | Supported          | Not supported        |
+| users        | id          | DefaultPaginator | Supported          | Not supported        |
+| transactions | refno       | DefaultPaginator | Supported          | Not supported        |
 
 ## IP allow list
 
@@ -26,61 +28,61 @@ If you use Airbyte Cloud and your organization restricts access to specific IPs,
 <details>
   <summary>Expand to review</summary>
 
-| Version          | Date              | Pull Request | Subject        |
-|------------------|-------------------|--------------|----------------|
-| 0.0.54 | 2026-07-21 | [82390](https://github.com/airbytehq/airbyte/pull/82390) | Update dependencies |
-| 0.0.53 | 2026-07-14 | [81828](https://github.com/airbytehq/airbyte/pull/81828) | Update dependencies |
-| 0.0.52 | 2026-06-30 | [81057](https://github.com/airbytehq/airbyte/pull/81057) | Update dependencies |
-| 0.0.51 | 2026-06-23 | [80433](https://github.com/airbytehq/airbyte/pull/80433) | Update dependencies |
-| 0.0.50 | 2026-06-16 | [79846](https://github.com/airbytehq/airbyte/pull/79846) | Update dependencies |
-| 0.0.49 | 2026-06-09 | [79301](https://github.com/airbytehq/airbyte/pull/79301) | Update dependencies |
-| 0.0.48 | 2026-06-02 | [78704](https://github.com/airbytehq/airbyte/pull/78704) | Update dependencies |
-| 0.0.47 | 2026-04-28 | [77208](https://github.com/airbytehq/airbyte/pull/77208) | Update dependencies |
-| 0.0.46 | 2026-04-21 | [76554](https://github.com/airbytehq/airbyte/pull/76554) | Update dependencies |
-| 0.0.45 | 2026-03-24 | [75038](https://github.com/airbytehq/airbyte/pull/75038) | Update dependencies |
-| 0.0.44 | 2026-02-24 | [73904](https://github.com/airbytehq/airbyte/pull/73904) | Update dependencies |
-| 0.0.43 | 2026-02-17 | [73480](https://github.com/airbytehq/airbyte/pull/73480) | Update dependencies |
-| 0.0.42 | 2026-02-10 | [73013](https://github.com/airbytehq/airbyte/pull/73013) | Update dependencies |
-| 0.0.41 | 2026-02-03 | [72601](https://github.com/airbytehq/airbyte/pull/72601) | Update dependencies |
-| 0.0.40 | 2026-01-20 | [71900](https://github.com/airbytehq/airbyte/pull/71900) | Update dependencies |
-| 0.0.39 | 2026-01-14 | [71585](https://github.com/airbytehq/airbyte/pull/71585) | Update dependencies |
-| 0.0.38 | 2025-12-18 | [70579](https://github.com/airbytehq/airbyte/pull/70579) | Update dependencies |
-| 0.0.37 | 2025-11-25 | [70167](https://github.com/airbytehq/airbyte/pull/70167) | Update dependencies |
-| 0.0.36 | 2025-11-18 | [69361](https://github.com/airbytehq/airbyte/pull/69361) | Update dependencies |
-| 0.0.35 | 2025-10-29 | [68743](https://github.com/airbytehq/airbyte/pull/68743) | Update dependencies |
-| 0.0.34 | 2025-10-21 | [68550](https://github.com/airbytehq/airbyte/pull/68550) | Update dependencies |
-| 0.0.33 | 2025-10-14 | [67793](https://github.com/airbytehq/airbyte/pull/67793) | Update dependencies |
-| 0.0.32 | 2025-10-07 | [67284](https://github.com/airbytehq/airbyte/pull/67284) | Update dependencies |
-| 0.0.31 | 2025-09-30 | [65852](https://github.com/airbytehq/airbyte/pull/65852) | Update dependencies |
-| 0.0.30 | 2025-08-23 | [65271](https://github.com/airbytehq/airbyte/pull/65271) | Update dependencies |
-| 0.0.29 | 2025-08-09 | [64691](https://github.com/airbytehq/airbyte/pull/64691) | Update dependencies |
-| 0.0.28 | 2025-08-02 | [64336](https://github.com/airbytehq/airbyte/pull/64336) | Update dependencies |
-| 0.0.27 | 2025-07-26 | [64013](https://github.com/airbytehq/airbyte/pull/64013) | Update dependencies |
-| 0.0.26 | 2025-07-19 | [63603](https://github.com/airbytehq/airbyte/pull/63603) | Update dependencies |
-| 0.0.25 | 2025-07-12 | [62980](https://github.com/airbytehq/airbyte/pull/62980) | Update dependencies |
-| 0.0.24 | 2025-07-05 | [62818](https://github.com/airbytehq/airbyte/pull/62818) | Update dependencies |
-| 0.0.23 | 2025-06-28 | [62404](https://github.com/airbytehq/airbyte/pull/62404) | Update dependencies |
-| 0.0.22 | 2025-06-22 | [62005](https://github.com/airbytehq/airbyte/pull/62005) | Update dependencies |
-| 0.0.21 | 2025-06-14 | [61185](https://github.com/airbytehq/airbyte/pull/61185) | Update dependencies |
-| 0.0.20 | 2025-05-24 | [59450](https://github.com/airbytehq/airbyte/pull/59450) | Update dependencies |
-| 0.0.19 | 2025-04-26 | [58333](https://github.com/airbytehq/airbyte/pull/58333) | Update dependencies |
-| 0.0.18 | 2025-04-12 | [57782](https://github.com/airbytehq/airbyte/pull/57782) | Update dependencies |
-| 0.0.17 | 2025-04-05 | [57205](https://github.com/airbytehq/airbyte/pull/57205) | Update dependencies |
-| 0.0.16 | 2025-03-29 | [56539](https://github.com/airbytehq/airbyte/pull/56539) | Update dependencies |
-| 0.0.15 | 2025-03-22 | [55959](https://github.com/airbytehq/airbyte/pull/55959) | Update dependencies |
-| 0.0.14 | 2025-03-08 | [55334](https://github.com/airbytehq/airbyte/pull/55334) | Update dependencies |
-| 0.0.13 | 2025-03-01 | [54927](https://github.com/airbytehq/airbyte/pull/54927) | Update dependencies |
-| 0.0.12 | 2025-02-22 | [54450](https://github.com/airbytehq/airbyte/pull/54450) | Update dependencies |
-| 0.0.11 | 2025-02-15 | [53753](https://github.com/airbytehq/airbyte/pull/53753) | Update dependencies |
-| 0.0.10 | 2025-02-08 | [53375](https://github.com/airbytehq/airbyte/pull/53375) | Update dependencies |
-| 0.0.9 | 2025-02-01 | [52840](https://github.com/airbytehq/airbyte/pull/52840) | Update dependencies |
-| 0.0.8 | 2025-01-25 | [52334](https://github.com/airbytehq/airbyte/pull/52334) | Update dependencies |
-| 0.0.7 | 2025-01-18 | [51675](https://github.com/airbytehq/airbyte/pull/51675) | Update dependencies |
-| 0.0.6 | 2025-01-11 | [51083](https://github.com/airbytehq/airbyte/pull/51083) | Update dependencies |
-| 0.0.5 | 2024-12-28 | [50549](https://github.com/airbytehq/airbyte/pull/50549) | Update dependencies |
-| 0.0.4 | 2024-12-21 | [50047](https://github.com/airbytehq/airbyte/pull/50047) | Update dependencies |
-| 0.0.3 | 2024-12-14 | [49488](https://github.com/airbytehq/airbyte/pull/49488) | Update dependencies |
-| 0.0.2 | 2024-12-12 | [49198](https://github.com/airbytehq/airbyte/pull/49198) | Update dependencies |
-| 0.0.1 | 2024-10-23 | | Initial release by [@parthiv11](https://github.com/parthiv11) via Connector Builder |
+| Version | Date       | Pull Request                                             | Subject                                                                             |
+| ------- | ---------- | -------------------------------------------------------- | ----------------------------------------------------------------------------------- |
+| 0.0.54  | 2026-07-21 | [82390](https://github.com/airbytehq/airbyte/pull/82390) | Update dependencies                                                                 |
+| 0.0.53  | 2026-07-14 | [81828](https://github.com/airbytehq/airbyte/pull/81828) | Update dependencies                                                                 |
+| 0.0.52  | 2026-06-30 | [81057](https://github.com/airbytehq/airbyte/pull/81057) | Update dependencies                                                                 |
+| 0.0.51  | 2026-06-23 | [80433](https://github.com/airbytehq/airbyte/pull/80433) | Update dependencies                                                                 |
+| 0.0.50  | 2026-06-16 | [79846](https://github.com/airbytehq/airbyte/pull/79846) | Update dependencies                                                                 |
+| 0.0.49  | 2026-06-09 | [79301](https://github.com/airbytehq/airbyte/pull/79301) | Update dependencies                                                                 |
+| 0.0.48  | 2026-06-02 | [78704](https://github.com/airbytehq/airbyte/pull/78704) | Update dependencies                                                                 |
+| 0.0.47  | 2026-04-28 | [77208](https://github.com/airbytehq/airbyte/pull/77208) | Update dependencies                                                                 |
+| 0.0.46  | 2026-04-21 | [76554](https://github.com/airbytehq/airbyte/pull/76554) | Update dependencies                                                                 |
+| 0.0.45  | 2026-03-24 | [75038](https://github.com/airbytehq/airbyte/pull/75038) | Update dependencies                                                                 |
+| 0.0.44  | 2026-02-24 | [73904](https://github.com/airbytehq/airbyte/pull/73904) | Update dependencies                                                                 |
+| 0.0.43  | 2026-02-17 | [73480](https://github.com/airbytehq/airbyte/pull/73480) | Update dependencies                                                                 |
+| 0.0.42  | 2026-02-10 | [73013](https://github.com/airbytehq/airbyte/pull/73013) | Update dependencies                                                                 |
+| 0.0.41  | 2026-02-03 | [72601](https://github.com/airbytehq/airbyte/pull/72601) | Update dependencies                                                                 |
+| 0.0.40  | 2026-01-20 | [71900](https://github.com/airbytehq/airbyte/pull/71900) | Update dependencies                                                                 |
+| 0.0.39  | 2026-01-14 | [71585](https://github.com/airbytehq/airbyte/pull/71585) | Update dependencies                                                                 |
+| 0.0.38  | 2025-12-18 | [70579](https://github.com/airbytehq/airbyte/pull/70579) | Update dependencies                                                                 |
+| 0.0.37  | 2025-11-25 | [70167](https://github.com/airbytehq/airbyte/pull/70167) | Update dependencies                                                                 |
+| 0.0.36  | 2025-11-18 | [69361](https://github.com/airbytehq/airbyte/pull/69361) | Update dependencies                                                                 |
+| 0.0.35  | 2025-10-29 | [68743](https://github.com/airbytehq/airbyte/pull/68743) | Update dependencies                                                                 |
+| 0.0.34  | 2025-10-21 | [68550](https://github.com/airbytehq/airbyte/pull/68550) | Update dependencies                                                                 |
+| 0.0.33  | 2025-10-14 | [67793](https://github.com/airbytehq/airbyte/pull/67793) | Update dependencies                                                                 |
+| 0.0.32  | 2025-10-07 | [67284](https://github.com/airbytehq/airbyte/pull/67284) | Update dependencies                                                                 |
+| 0.0.31  | 2025-09-30 | [65852](https://github.com/airbytehq/airbyte/pull/65852) | Update dependencies                                                                 |
+| 0.0.30  | 2025-08-23 | [65271](https://github.com/airbytehq/airbyte/pull/65271) | Update dependencies                                                                 |
+| 0.0.29  | 2025-08-09 | [64691](https://github.com/airbytehq/airbyte/pull/64691) | Update dependencies                                                                 |
+| 0.0.28  | 2025-08-02 | [64336](https://github.com/airbytehq/airbyte/pull/64336) | Update dependencies                                                                 |
+| 0.0.27  | 2025-07-26 | [64013](https://github.com/airbytehq/airbyte/pull/64013) | Update dependencies                                                                 |
+| 0.0.26  | 2025-07-19 | [63603](https://github.com/airbytehq/airbyte/pull/63603) | Update dependencies                                                                 |
+| 0.0.25  | 2025-07-12 | [62980](https://github.com/airbytehq/airbyte/pull/62980) | Update dependencies                                                                 |
+| 0.0.24  | 2025-07-05 | [62818](https://github.com/airbytehq/airbyte/pull/62818) | Update dependencies                                                                 |
+| 0.0.23  | 2025-06-28 | [62404](https://github.com/airbytehq/airbyte/pull/62404) | Update dependencies                                                                 |
+| 0.0.22  | 2025-06-22 | [62005](https://github.com/airbytehq/airbyte/pull/62005) | Update dependencies                                                                 |
+| 0.0.21  | 2025-06-14 | [61185](https://github.com/airbytehq/airbyte/pull/61185) | Update dependencies                                                                 |
+| 0.0.20  | 2025-05-24 | [59450](https://github.com/airbytehq/airbyte/pull/59450) | Update dependencies                                                                 |
+| 0.0.19  | 2025-04-26 | [58333](https://github.com/airbytehq/airbyte/pull/58333) | Update dependencies                                                                 |
+| 0.0.18  | 2025-04-12 | [57782](https://github.com/airbytehq/airbyte/pull/57782) | Update dependencies                                                                 |
+| 0.0.17  | 2025-04-05 | [57205](https://github.com/airbytehq/airbyte/pull/57205) | Update dependencies                                                                 |
+| 0.0.16  | 2025-03-29 | [56539](https://github.com/airbytehq/airbyte/pull/56539) | Update dependencies                                                                 |
+| 0.0.15  | 2025-03-22 | [55959](https://github.com/airbytehq/airbyte/pull/55959) | Update dependencies                                                                 |
+| 0.0.14  | 2025-03-08 | [55334](https://github.com/airbytehq/airbyte/pull/55334) | Update dependencies                                                                 |
+| 0.0.13  | 2025-03-01 | [54927](https://github.com/airbytehq/airbyte/pull/54927) | Update dependencies                                                                 |
+| 0.0.12  | 2025-02-22 | [54450](https://github.com/airbytehq/airbyte/pull/54450) | Update dependencies                                                                 |
+| 0.0.11  | 2025-02-15 | [53753](https://github.com/airbytehq/airbyte/pull/53753) | Update dependencies                                                                 |
+| 0.0.10  | 2025-02-08 | [53375](https://github.com/airbytehq/airbyte/pull/53375) | Update dependencies                                                                 |
+| 0.0.9   | 2025-02-01 | [52840](https://github.com/airbytehq/airbyte/pull/52840) | Update dependencies                                                                 |
+| 0.0.8   | 2025-01-25 | [52334](https://github.com/airbytehq/airbyte/pull/52334) | Update dependencies                                                                 |
+| 0.0.7   | 2025-01-18 | [51675](https://github.com/airbytehq/airbyte/pull/51675) | Update dependencies                                                                 |
+| 0.0.6   | 2025-01-11 | [51083](https://github.com/airbytehq/airbyte/pull/51083) | Update dependencies                                                                 |
+| 0.0.5   | 2024-12-28 | [50549](https://github.com/airbytehq/airbyte/pull/50549) | Update dependencies                                                                 |
+| 0.0.4   | 2024-12-21 | [50047](https://github.com/airbytehq/airbyte/pull/50047) | Update dependencies                                                                 |
+| 0.0.3   | 2024-12-14 | [49488](https://github.com/airbytehq/airbyte/pull/49488) | Update dependencies                                                                 |
+| 0.0.2   | 2024-12-12 | [49198](https://github.com/airbytehq/airbyte/pull/49198) | Update dependencies                                                                 |
+| 0.0.1   | 2024-10-23 |                                                          | Initial release by [@parthiv11](https://github.com/parthiv11) via Connector Builder |
 
 </details>

--- a/docs/integrations/sources/eventzilla.md
+++ b/docs/integrations/sources/eventzilla.md
@@ -1,23 +1,21 @@
 # Eventzilla
-
 The Airbyte connector for Eventzilla enables seamless integration between Eventzilla and various data destinations. It automates the extraction of event management data, such as attendee details, ticket sales, and event performance metrics, and syncs it with your preferred data warehouses or analytics tools. This connector helps organizations centralize and analyze their Eventzilla data for reporting, monitoring, and strategic insights.
 
 ## Configuration
 
-| Input       | Type     | Description                                                                                                                                    | Default Value |
-| ----------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------- | ------------- |
-| `x-api-key` | `string` | API Key. API key to use. Generate it by creating a new application within your Eventzilla account settings under Settings &gt; App Management. |               |
+| Input | Type | Description | Default Value |
+|-------|------|-------------|---------------|
+| `x-api-key` | `string` | API Key. API key to use. Generate it by creating a new application within your Eventzilla account settings under Settings &gt; App Management. |  |
 
 ## Streams
-
-| Stream Name  | Primary Key | Pagination       | Supports Full Sync | Supports Incremental |
-| ------------ | ----------- | ---------------- | ------------------ | -------------------- |
-| events       | id          | DefaultPaginator | Supported          | Not supported        |
-| attendees    | id          | DefaultPaginator | Supported          | Not supported        |
-| categories   |             | DefaultPaginator | Supported          | Not supported        |
-| tickets      | id          | DefaultPaginator | Supported          | Not supported        |
-| users        | id          | DefaultPaginator | Supported          | Not supported        |
-| transactions | refno       | DefaultPaginator | Supported          | Not supported        |
+| Stream Name | Primary Key | Pagination | Supports Full Sync | Supports Incremental |
+|-------------|-------------|------------|---------------------|----------------------|
+| events | id | DefaultPaginator | Supported | Not supported |
+| attendees | id | DefaultPaginator | Supported | Not supported |
+| categories |  | DefaultPaginator | Supported | Not supported |
+| tickets | id | DefaultPaginator | Supported | Not supported |
+| users | id | DefaultPaginator | Supported | Not supported |
+| transactions | refno | DefaultPaginator | Supported | Not supported |
 
 ## IP allow list
 
@@ -28,61 +26,61 @@ If you use Airbyte Cloud and your organization restricts access to specific IPs,
 <details>
   <summary>Expand to review</summary>
 
-| Version | Date       | Pull Request                                             | Subject                                                                             |
-| ------- | ---------- | -------------------------------------------------------- | ----------------------------------------------------------------------------------- |
-| 0.0.54  | 2026-07-21 | [82390](https://github.com/airbytehq/airbyte/pull/82390) | Update dependencies                                                                 |
-| 0.0.53  | 2026-07-14 | [81828](https://github.com/airbytehq/airbyte/pull/81828) | Update dependencies                                                                 |
-| 0.0.52  | 2026-06-30 | [81057](https://github.com/airbytehq/airbyte/pull/81057) | Update dependencies                                                                 |
-| 0.0.51  | 2026-06-23 | [80433](https://github.com/airbytehq/airbyte/pull/80433) | Update dependencies                                                                 |
-| 0.0.50  | 2026-06-16 | [79846](https://github.com/airbytehq/airbyte/pull/79846) | Update dependencies                                                                 |
-| 0.0.49  | 2026-06-09 | [79301](https://github.com/airbytehq/airbyte/pull/79301) | Update dependencies                                                                 |
-| 0.0.48  | 2026-06-02 | [78704](https://github.com/airbytehq/airbyte/pull/78704) | Update dependencies                                                                 |
-| 0.0.47  | 2026-04-28 | [77208](https://github.com/airbytehq/airbyte/pull/77208) | Update dependencies                                                                 |
-| 0.0.46  | 2026-04-21 | [76554](https://github.com/airbytehq/airbyte/pull/76554) | Update dependencies                                                                 |
-| 0.0.45  | 2026-03-24 | [75038](https://github.com/airbytehq/airbyte/pull/75038) | Update dependencies                                                                 |
-| 0.0.44  | 2026-02-24 | [73904](https://github.com/airbytehq/airbyte/pull/73904) | Update dependencies                                                                 |
-| 0.0.43  | 2026-02-17 | [73480](https://github.com/airbytehq/airbyte/pull/73480) | Update dependencies                                                                 |
-| 0.0.42  | 2026-02-10 | [73013](https://github.com/airbytehq/airbyte/pull/73013) | Update dependencies                                                                 |
-| 0.0.41  | 2026-02-03 | [72601](https://github.com/airbytehq/airbyte/pull/72601) | Update dependencies                                                                 |
-| 0.0.40  | 2026-01-20 | [71900](https://github.com/airbytehq/airbyte/pull/71900) | Update dependencies                                                                 |
-| 0.0.39  | 2026-01-14 | [71585](https://github.com/airbytehq/airbyte/pull/71585) | Update dependencies                                                                 |
-| 0.0.38  | 2025-12-18 | [70579](https://github.com/airbytehq/airbyte/pull/70579) | Update dependencies                                                                 |
-| 0.0.37  | 2025-11-25 | [70167](https://github.com/airbytehq/airbyte/pull/70167) | Update dependencies                                                                 |
-| 0.0.36  | 2025-11-18 | [69361](https://github.com/airbytehq/airbyte/pull/69361) | Update dependencies                                                                 |
-| 0.0.35  | 2025-10-29 | [68743](https://github.com/airbytehq/airbyte/pull/68743) | Update dependencies                                                                 |
-| 0.0.34  | 2025-10-21 | [68550](https://github.com/airbytehq/airbyte/pull/68550) | Update dependencies                                                                 |
-| 0.0.33  | 2025-10-14 | [67793](https://github.com/airbytehq/airbyte/pull/67793) | Update dependencies                                                                 |
-| 0.0.32  | 2025-10-07 | [67284](https://github.com/airbytehq/airbyte/pull/67284) | Update dependencies                                                                 |
-| 0.0.31  | 2025-09-30 | [65852](https://github.com/airbytehq/airbyte/pull/65852) | Update dependencies                                                                 |
-| 0.0.30  | 2025-08-23 | [65271](https://github.com/airbytehq/airbyte/pull/65271) | Update dependencies                                                                 |
-| 0.0.29  | 2025-08-09 | [64691](https://github.com/airbytehq/airbyte/pull/64691) | Update dependencies                                                                 |
-| 0.0.28  | 2025-08-02 | [64336](https://github.com/airbytehq/airbyte/pull/64336) | Update dependencies                                                                 |
-| 0.0.27  | 2025-07-26 | [64013](https://github.com/airbytehq/airbyte/pull/64013) | Update dependencies                                                                 |
-| 0.0.26  | 2025-07-19 | [63603](https://github.com/airbytehq/airbyte/pull/63603) | Update dependencies                                                                 |
-| 0.0.25  | 2025-07-12 | [62980](https://github.com/airbytehq/airbyte/pull/62980) | Update dependencies                                                                 |
-| 0.0.24  | 2025-07-05 | [62818](https://github.com/airbytehq/airbyte/pull/62818) | Update dependencies                                                                 |
-| 0.0.23  | 2025-06-28 | [62404](https://github.com/airbytehq/airbyte/pull/62404) | Update dependencies                                                                 |
-| 0.0.22  | 2025-06-22 | [62005](https://github.com/airbytehq/airbyte/pull/62005) | Update dependencies                                                                 |
-| 0.0.21  | 2025-06-14 | [61185](https://github.com/airbytehq/airbyte/pull/61185) | Update dependencies                                                                 |
-| 0.0.20  | 2025-05-24 | [59450](https://github.com/airbytehq/airbyte/pull/59450) | Update dependencies                                                                 |
-| 0.0.19  | 2025-04-26 | [58333](https://github.com/airbytehq/airbyte/pull/58333) | Update dependencies                                                                 |
-| 0.0.18  | 2025-04-12 | [57782](https://github.com/airbytehq/airbyte/pull/57782) | Update dependencies                                                                 |
-| 0.0.17  | 2025-04-05 | [57205](https://github.com/airbytehq/airbyte/pull/57205) | Update dependencies                                                                 |
-| 0.0.16  | 2025-03-29 | [56539](https://github.com/airbytehq/airbyte/pull/56539) | Update dependencies                                                                 |
-| 0.0.15  | 2025-03-22 | [55959](https://github.com/airbytehq/airbyte/pull/55959) | Update dependencies                                                                 |
-| 0.0.14  | 2025-03-08 | [55334](https://github.com/airbytehq/airbyte/pull/55334) | Update dependencies                                                                 |
-| 0.0.13  | 2025-03-01 | [54927](https://github.com/airbytehq/airbyte/pull/54927) | Update dependencies                                                                 |
-| 0.0.12  | 2025-02-22 | [54450](https://github.com/airbytehq/airbyte/pull/54450) | Update dependencies                                                                 |
-| 0.0.11  | 2025-02-15 | [53753](https://github.com/airbytehq/airbyte/pull/53753) | Update dependencies                                                                 |
-| 0.0.10  | 2025-02-08 | [53375](https://github.com/airbytehq/airbyte/pull/53375) | Update dependencies                                                                 |
-| 0.0.9   | 2025-02-01 | [52840](https://github.com/airbytehq/airbyte/pull/52840) | Update dependencies                                                                 |
-| 0.0.8   | 2025-01-25 | [52334](https://github.com/airbytehq/airbyte/pull/52334) | Update dependencies                                                                 |
-| 0.0.7   | 2025-01-18 | [51675](https://github.com/airbytehq/airbyte/pull/51675) | Update dependencies                                                                 |
-| 0.0.6   | 2025-01-11 | [51083](https://github.com/airbytehq/airbyte/pull/51083) | Update dependencies                                                                 |
-| 0.0.5   | 2024-12-28 | [50549](https://github.com/airbytehq/airbyte/pull/50549) | Update dependencies                                                                 |
-| 0.0.4   | 2024-12-21 | [50047](https://github.com/airbytehq/airbyte/pull/50047) | Update dependencies                                                                 |
-| 0.0.3   | 2024-12-14 | [49488](https://github.com/airbytehq/airbyte/pull/49488) | Update dependencies                                                                 |
-| 0.0.2   | 2024-12-12 | [49198](https://github.com/airbytehq/airbyte/pull/49198) | Update dependencies                                                                 |
-| 0.0.1   | 2024-10-23 |                                                          | Initial release by [@parthiv11](https://github.com/parthiv11) via Connector Builder |
+| Version          | Date              | Pull Request | Subject        |
+|------------------|-------------------|--------------|----------------|
+| 0.0.54 | 2026-07-21 | [82390](https://github.com/airbytehq/airbyte/pull/82390) | Update dependencies |
+| 0.0.53 | 2026-07-14 | [81828](https://github.com/airbytehq/airbyte/pull/81828) | Update dependencies |
+| 0.0.52 | 2026-06-30 | [81057](https://github.com/airbytehq/airbyte/pull/81057) | Update dependencies |
+| 0.0.51 | 2026-06-23 | [80433](https://github.com/airbytehq/airbyte/pull/80433) | Update dependencies |
+| 0.0.50 | 2026-06-16 | [79846](https://github.com/airbytehq/airbyte/pull/79846) | Update dependencies |
+| 0.0.49 | 2026-06-09 | [79301](https://github.com/airbytehq/airbyte/pull/79301) | Update dependencies |
+| 0.0.48 | 2026-06-02 | [78704](https://github.com/airbytehq/airbyte/pull/78704) | Update dependencies |
+| 0.0.47 | 2026-04-28 | [77208](https://github.com/airbytehq/airbyte/pull/77208) | Update dependencies |
+| 0.0.46 | 2026-04-21 | [76554](https://github.com/airbytehq/airbyte/pull/76554) | Update dependencies |
+| 0.0.45 | 2026-03-24 | [75038](https://github.com/airbytehq/airbyte/pull/75038) | Update dependencies |
+| 0.0.44 | 2026-02-24 | [73904](https://github.com/airbytehq/airbyte/pull/73904) | Update dependencies |
+| 0.0.43 | 2026-02-17 | [73480](https://github.com/airbytehq/airbyte/pull/73480) | Update dependencies |
+| 0.0.42 | 2026-02-10 | [73013](https://github.com/airbytehq/airbyte/pull/73013) | Update dependencies |
+| 0.0.41 | 2026-02-03 | [72601](https://github.com/airbytehq/airbyte/pull/72601) | Update dependencies |
+| 0.0.40 | 2026-01-20 | [71900](https://github.com/airbytehq/airbyte/pull/71900) | Update dependencies |
+| 0.0.39 | 2026-01-14 | [71585](https://github.com/airbytehq/airbyte/pull/71585) | Update dependencies |
+| 0.0.38 | 2025-12-18 | [70579](https://github.com/airbytehq/airbyte/pull/70579) | Update dependencies |
+| 0.0.37 | 2025-11-25 | [70167](https://github.com/airbytehq/airbyte/pull/70167) | Update dependencies |
+| 0.0.36 | 2025-11-18 | [69361](https://github.com/airbytehq/airbyte/pull/69361) | Update dependencies |
+| 0.0.35 | 2025-10-29 | [68743](https://github.com/airbytehq/airbyte/pull/68743) | Update dependencies |
+| 0.0.34 | 2025-10-21 | [68550](https://github.com/airbytehq/airbyte/pull/68550) | Update dependencies |
+| 0.0.33 | 2025-10-14 | [67793](https://github.com/airbytehq/airbyte/pull/67793) | Update dependencies |
+| 0.0.32 | 2025-10-07 | [67284](https://github.com/airbytehq/airbyte/pull/67284) | Update dependencies |
+| 0.0.31 | 2025-09-30 | [65852](https://github.com/airbytehq/airbyte/pull/65852) | Update dependencies |
+| 0.0.30 | 2025-08-23 | [65271](https://github.com/airbytehq/airbyte/pull/65271) | Update dependencies |
+| 0.0.29 | 2025-08-09 | [64691](https://github.com/airbytehq/airbyte/pull/64691) | Update dependencies |
+| 0.0.28 | 2025-08-02 | [64336](https://github.com/airbytehq/airbyte/pull/64336) | Update dependencies |
+| 0.0.27 | 2025-07-26 | [64013](https://github.com/airbytehq/airbyte/pull/64013) | Update dependencies |
+| 0.0.26 | 2025-07-19 | [63603](https://github.com/airbytehq/airbyte/pull/63603) | Update dependencies |
+| 0.0.25 | 2025-07-12 | [62980](https://github.com/airbytehq/airbyte/pull/62980) | Update dependencies |
+| 0.0.24 | 2025-07-05 | [62818](https://github.com/airbytehq/airbyte/pull/62818) | Update dependencies |
+| 0.0.23 | 2025-06-28 | [62404](https://github.com/airbytehq/airbyte/pull/62404) | Update dependencies |
+| 0.0.22 | 2025-06-22 | [62005](https://github.com/airbytehq/airbyte/pull/62005) | Update dependencies |
+| 0.0.21 | 2025-06-14 | [61185](https://github.com/airbytehq/airbyte/pull/61185) | Update dependencies |
+| 0.0.20 | 2025-05-24 | [59450](https://github.com/airbytehq/airbyte/pull/59450) | Update dependencies |
+| 0.0.19 | 2025-04-26 | [58333](https://github.com/airbytehq/airbyte/pull/58333) | Update dependencies |
+| 0.0.18 | 2025-04-12 | [57782](https://github.com/airbytehq/airbyte/pull/57782) | Update dependencies |
+| 0.0.17 | 2025-04-05 | [57205](https://github.com/airbytehq/airbyte/pull/57205) | Update dependencies |
+| 0.0.16 | 2025-03-29 | [56539](https://github.com/airbytehq/airbyte/pull/56539) | Update dependencies |
+| 0.0.15 | 2025-03-22 | [55959](https://github.com/airbytehq/airbyte/pull/55959) | Update dependencies |
+| 0.0.14 | 2025-03-08 | [55334](https://github.com/airbytehq/airbyte/pull/55334) | Update dependencies |
+| 0.0.13 | 2025-03-01 | [54927](https://github.com/airbytehq/airbyte/pull/54927) | Update dependencies |
+| 0.0.12 | 2025-02-22 | [54450](https://github.com/airbytehq/airbyte/pull/54450) | Update dependencies |
+| 0.0.11 | 2025-02-15 | [53753](https://github.com/airbytehq/airbyte/pull/53753) | Update dependencies |
+| 0.0.10 | 2025-02-08 | [53375](https://github.com/airbytehq/airbyte/pull/53375) | Update dependencies |
+| 0.0.9 | 2025-02-01 | [52840](https://github.com/airbytehq/airbyte/pull/52840) | Update dependencies |
+| 0.0.8 | 2025-01-25 | [52334](https://github.com/airbytehq/airbyte/pull/52334) | Update dependencies |
+| 0.0.7 | 2025-01-18 | [51675](https://github.com/airbytehq/airbyte/pull/51675) | Update dependencies |
+| 0.0.6 | 2025-01-11 | [51083](https://github.com/airbytehq/airbyte/pull/51083) | Update dependencies |
+| 0.0.5 | 2024-12-28 | [50549](https://github.com/airbytehq/airbyte/pull/50549) | Update dependencies |
+| 0.0.4 | 2024-12-21 | [50047](https://github.com/airbytehq/airbyte/pull/50047) | Update dependencies |
+| 0.0.3 | 2024-12-14 | [49488](https://github.com/airbytehq/airbyte/pull/49488) | Update dependencies |
+| 0.0.2 | 2024-12-12 | [49198](https://github.com/airbytehq/airbyte/pull/49198) | Update dependencies |
+| 0.0.1 | 2024-10-23 | | Initial release by [@parthiv11](https://github.com/parthiv11) via Connector Builder |
 
 </details>

--- a/docusaurus/docusaurus.config.ts
+++ b/docusaurus/docusaurus.config.ts
@@ -152,7 +152,8 @@ const config: Config = {
         path: "../docs/platform",
         routeBasePath: "/platform",
         sidebarPath: "./sidebar-platform.js",
-        editUrl: "https://github.com/airbytehq/airbyte/blob/master/docs",
+        editUrl:
+          "https://github.com/airbytehq/airbyte/blob/master/docs",
         remarkPlugins: [
           plugins.productInformation,
           plugins.addButtonToTitle,
@@ -193,7 +194,8 @@ const config: Config = {
           // standalone landing pages that should not appear in navigation.
           const hiddenDocIds = new Set(["README", "slack-app"]);
           const itemsWithoutReadme = processedItems.filter(
-            (item: any) => !(item.type === "doc" && hiddenDocIds.has(item.id)),
+            (item: any) =>
+              !(item.type === "doc" && hiddenDocIds.has(item.id)),
           );
 
           return [

--- a/docusaurus/docusaurus.config.ts
+++ b/docusaurus/docusaurus.config.ts
@@ -17,6 +17,7 @@ const getRemarkPlugins = () => ({
   specDecoration: require("./src/remark/specDecoration"),
   docMetaTags: require("./src/remark/docMetaTags"),
   addButtonToTitle: require("./src/remark/addButtonToTitle"),
+  booleanTableIndicators: require("./src/remark/booleanTableIndicators"),
   npm2yarn: require("@docusaurus/remark-plugin-npm2yarn"),
   agentConnectorHeaderDecoration: require("./src/remark/agentConnectorHeaderDecoration"),
   planInformation: require("./src/remark/planInformation"),
@@ -151,11 +152,11 @@ const config: Config = {
         path: "../docs/platform",
         routeBasePath: "/platform",
         sidebarPath: "./sidebar-platform.js",
-        editUrl:
-          "https://github.com/airbytehq/airbyte/blob/master/docs",
+        editUrl: "https://github.com/airbytehq/airbyte/blob/master/docs",
         remarkPlugins: [
           plugins.productInformation,
           plugins.addButtonToTitle,
+          plugins.booleanTableIndicators,
         ],
       },
     ],
@@ -192,8 +193,7 @@ const config: Config = {
           // standalone landing pages that should not appear in navigation.
           const hiddenDocIds = new Set(["README", "slack-app"]);
           const itemsWithoutReadme = processedItems.filter(
-            (item: any) =>
-              !(item.type === "doc" && hiddenDocIds.has(item.id)),
+            (item: any) => !(item.type === "doc" && hiddenDocIds.has(item.id)),
           );
 
           return [
@@ -210,6 +210,7 @@ const config: Config = {
           plugins.agentConnectorHeaderDecoration,
           plugins.planInformation,
           plugins.addButtonToTitle,
+          plugins.booleanTableIndicators,
           [plugins.npm2yarn, { sync: true }],
           plugins.codeBlockTabs,
         ],
@@ -227,6 +228,7 @@ const config: Config = {
         remarkPlugins: [
           plugins.productInformation,
           plugins.addButtonToTitle,
+          plugins.booleanTableIndicators,
         ],
       },
     ],
@@ -249,6 +251,7 @@ const config: Config = {
           plugins.productInformation,
           plugins.connectorTypeBanner,
           plugins.docMetaTags,
+          plugins.booleanTableIndicators,
         ],
       },
     ],
@@ -264,6 +267,7 @@ const config: Config = {
         remarkPlugins: [
           plugins.productInformation,
           plugins.addButtonToTitle,
+          plugins.booleanTableIndicators,
         ],
       },
     ],
@@ -279,6 +283,7 @@ const config: Config = {
         remarkPlugins: [
           plugins.productInformation,
           plugins.addButtonToTitle,
+          plugins.booleanTableIndicators,
         ],
       },
     ],

--- a/docusaurus/src/components/BooleanTableIndicator.jsx
+++ b/docusaurus/src/components/BooleanTableIndicator.jsx
@@ -1,0 +1,27 @@
+import { faCheck, faXmark } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import classNames from "classnames";
+import React from "react";
+
+export const BooleanTableIndicator = ({ label, status }) => {
+  const isSupported = status === "supported";
+
+  return (
+    <span
+      className={classNames(
+        "boolean-table-indicator",
+        isSupported
+          ? "boolean-table-indicator--supported"
+          : "boolean-table-indicator--unsupported",
+      )}
+    >
+      <FontAwesomeIcon
+        aria-hidden="true"
+        className="boolean-table-indicator__icon"
+        focusable="false"
+        icon={isSupported ? faCheck : faXmark}
+      />
+      <span>{label}</span>
+    </span>
+  );
+};

--- a/docusaurus/src/components/ConnectorRegistry.jsx
+++ b/docusaurus/src/components/ConnectorRegistry.jsx
@@ -36,11 +36,7 @@ function buildCompositeEntry(entry, connectorType) {
     dockerRepository,
     dockerImageTag: entry.dockerImageTag || "",
     supportLevel: entry.supportLevel || "community",
-    iconUrl:
-      entry.iconUrl ||
-      (dockerRepository
-        ? `https://connectors.airbyte.com/files/metadata/${dockerRepository}/latest/icon.svg`
-        : ""),
+    iconUrl: entry.iconUrl || (dockerRepository ? `https://connectors.airbyte.com/files/metadata/${dockerRepository}/latest/icon.svg` : ""),
     documentationUrl: entry.documentationUrl || "",
   };
 }
@@ -83,11 +79,7 @@ function connectorSort(a, b) {
   if (a.name > b.name) return 1;
 }
 
-function ConnectorTable({
-  connectors,
-  connectorSupportLevel,
-  enterpriseConnectors = [],
-}) {
+function ConnectorTable({ connectors, connectorSupportLevel, enterpriseConnectors = [] }) {
   return (
     <table>
       <thead>
@@ -106,17 +98,12 @@ function ConnectorTable({
             if (connectorSupportLevel === "enterprise") {
               return true;
             }
-
+            
             const isEnterpriseConnector = enterpriseConnectors.some(
-              (ec) =>
-                ec &&
-                c &&
-                (ec.definitionId === c.definitionId || ec.name === c.name),
+              ec => ec && c && (ec.definitionId === c.definitionId || ec.name === c.name)
             );
-
-            return (
-              !isEnterpriseConnector && c.supportLevel === connectorSupportLevel
-            );
+            
+            return !isEnterpriseConnector && c.supportLevel === connectorSupportLevel;
           })
           .map((connector) => {
             const docsLink = connector.documentationUrl?.replace(
@@ -183,13 +170,13 @@ function ConnectorTable({
                 </td>
                 <td>
                   <BooleanTableIndicator
-                    label={connector.is_oss ? "Supported" : "Not supported"}
+                    label={connector.is_oss ? "Yes" : "No"}
                     status={connector.is_oss ? "supported" : "unsupported"}
                   />
                 </td>
                 <td>
                   <BooleanTableIndicator
-                    label={connector.is_cloud ? "Supported" : "Not supported"}
+                    label={connector.is_cloud ? "Yes" : "No"}
                     status={connector.is_cloud ? "supported" : "unsupported"}
                   />
                 </td>
@@ -197,8 +184,9 @@ function ConnectorTable({
                   <td>
                     <small>
                       <code>
-                        {connector.dockerRepository}:{connector.dockerImageTag}
-                      </code>
+                        {connector.dockerRepository}:
+                      {connector.dockerImageTag}
+                    </code>
                     </small>
                   </td>
                 )}
@@ -228,31 +216,25 @@ export default function ConnectorRegistry({ type }) {
           c.documentationUrl?.includes("/integrations/enterprise-connectors/"),
       );
 
-      const enterpriseFromPlugin =
-        pluginData.enterpriseConnectors.length > 0
-          ? pluginData.enterpriseConnectors
-              .filter((name) => name.includes(type))
-              .map((name) => {
-                const _name = name.replace(`${type}-`, "");
+      const enterpriseFromPlugin = pluginData.enterpriseConnectors.length > 0
+        ? pluginData.enterpriseConnectors
+            .filter((name) => name.includes(type))
+            .map((name) => {
+              const _name = name.replace(`${type}-`, "");
 
-                const info = registry.find(
-                  (c) =>
-                    c.name?.includes(_name) ||
-                    c.documentationUrl?.includes(_name),
-                );
-                return info;
-              })
-              .filter(Boolean)
-          : [];
+              const info = registry.find(
+                (c) =>
+                  c.name?.includes(_name) ||
+                  c.documentationUrl?.includes(_name),
+              );
+              return info;
+            })
+            .filter(Boolean)
+        : [];
 
-      const allEnterpriseConnectors = [
-        ...enterpriseFromRegistry,
-        ...enterpriseFromPlugin,
-      ];
+      const allEnterpriseConnectors = [...enterpriseFromRegistry, ...enterpriseFromPlugin];
       const uniqueEnterpriseConnectors = Array.from(
-        new Map(
-          allEnterpriseConnectors.map((c) => [c.definitionId, c]),
-        ).values(),
+        new Map(allEnterpriseConnectors.map(c => [c.definitionId, c])).values()
       );
 
       setEnterpriseConnectors(uniqueEnterpriseConnectors);
@@ -261,9 +243,7 @@ export default function ConnectorRegistry({ type }) {
 
   if (registry === null) return <div>{`Loading ${type}s...`}</div>;
   if (registry.length === 0)
-    return (
-      <div>{`Failed to load ${type}s. Check your network connection and try again.`}</div>
-    );
+    return <div>{`Failed to load ${type}s. Check your network connection and try again.`}</div>;
 
   const connectors = registry
     .filter((c) => c.connector_type === type)

--- a/docusaurus/src/components/ConnectorRegistry.jsx
+++ b/docusaurus/src/components/ConnectorRegistry.jsx
@@ -1,8 +1,11 @@
+import { faBookOpen, faBug, faCode } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { usePluginData } from "@docusaurus/useGlobalData";
 import TabItem from "@theme/TabItem";
 import Tabs from "@theme/Tabs";
 import { useEffect, useState } from "react";
 import { COMPOSITE_REGISTRY_URL } from "../constants";
+import { BooleanTableIndicator } from "./BooleanTableIndicator";
 import styles from "./ConnectorRegistry.module.css";
 
 const iconStyle = { maxWidth: 25, maxHeight: 25 };
@@ -33,7 +36,11 @@ function buildCompositeEntry(entry, connectorType) {
     dockerRepository,
     dockerImageTag: entry.dockerImageTag || "",
     supportLevel: entry.supportLevel || "community",
-    iconUrl: entry.iconUrl || (dockerRepository ? `https://connectors.airbyte.com/files/metadata/${dockerRepository}/latest/icon.svg` : ""),
+    iconUrl:
+      entry.iconUrl ||
+      (dockerRepository
+        ? `https://connectors.airbyte.com/files/metadata/${dockerRepository}/latest/icon.svg`
+        : ""),
     documentationUrl: entry.documentationUrl || "",
   };
 }
@@ -76,7 +83,11 @@ function connectorSort(a, b) {
   if (a.name > b.name) return 1;
 }
 
-function ConnectorTable({ connectors, connectorSupportLevel, enterpriseConnectors = [] }) {
+function ConnectorTable({
+  connectors,
+  connectorSupportLevel,
+  enterpriseConnectors = [],
+}) {
   return (
     <table>
       <thead>
@@ -95,12 +106,17 @@ function ConnectorTable({ connectors, connectorSupportLevel, enterpriseConnector
             if (connectorSupportLevel === "enterprise") {
               return true;
             }
-            
+
             const isEnterpriseConnector = enterpriseConnectors.some(
-              ec => ec && c && (ec.definitionId === c.definitionId || ec.name === c.name)
+              (ec) =>
+                ec &&
+                c &&
+                (ec.definitionId === c.definitionId || ec.name === c.name),
             );
-            
-            return !isEnterpriseConnector && c.supportLevel === connectorSupportLevel;
+
+            return (
+              !isEnterpriseConnector && c.supportLevel === connectorSupportLevel
+            );
           })
           .map((connector) => {
             const docsLink = connector.documentationUrl?.replace(
@@ -114,7 +130,12 @@ function ConnectorTable({ connectors, connectorSupportLevel, enterpriseConnector
                   <div className={styles.connectorName}>
                     {connector.iconUrl && (
                       <div className={styles.connectorIconBackground}>
-                        <img src={connector.iconUrl} style={iconStyle} />
+                        <img
+                          alt=""
+                          aria-hidden="true"
+                          src={connector.iconUrl}
+                          style={iconStyle}
+                        />
                       </div>
                     )}
 
@@ -130,27 +151,54 @@ function ConnectorTable({ connectors, connectorSupportLevel, enterpriseConnector
                       justifyContent: "center",
                     }}
                   >
-                    <a href={docsLink}>📕</a>
+                    <a
+                      aria-label={`${connector.name} documentation`}
+                      className={styles.connectorLink}
+                      href={docsLink}
+                    >
+                      <FontAwesomeIcon aria-hidden="true" icon={faBookOpen} />
+                    </a>
                     {connector.supportLevel != "archived" &&
-                    connector.github_url  ? (
-                      <a href={connector.github_url}>⚙️</a>
+                    connector.github_url ? (
+                      <a
+                        aria-label={`View ${connector.name} source code`}
+                        className={styles.connectorLink}
+                        href={connector.github_url}
+                      >
+                        <FontAwesomeIcon aria-hidden="true" icon={faCode} />
+                      </a>
                     ) : (
                       ""
                     )}
                     {connector.supportLevel != "archived" ? (
-                      <a href={connector.issue_url}>🐛</a>
+                      <a
+                        aria-label={`Report an issue with ${connector.name}`}
+                        className={styles.connectorLink}
+                        href={connector.issue_url}
+                      >
+                        <FontAwesomeIcon aria-hidden="true" icon={faBug} />
+                      </a>
                     ) : null}
                   </div>
                 </td>
-                <td>{connector.is_oss ? "✅" : "❌"}</td>
-                <td>{connector.is_cloud ? "✅" : "❌"}</td>
+                <td>
+                  <BooleanTableIndicator
+                    label={connector.is_oss ? "Supported" : "Not supported"}
+                    status={connector.is_oss ? "supported" : "unsupported"}
+                  />
+                </td>
+                <td>
+                  <BooleanTableIndicator
+                    label={connector.is_cloud ? "Supported" : "Not supported"}
+                    status={connector.is_cloud ? "supported" : "unsupported"}
+                  />
+                </td>
                 {connectorSupportLevel !== "enterprise" && (
                   <td>
                     <small>
                       <code>
-                        {connector.dockerRepository}:
-                      {connector.dockerImageTag}
-                    </code>
+                        {connector.dockerRepository}:{connector.dockerImageTag}
+                      </code>
                     </small>
                   </td>
                 )}
@@ -180,25 +228,31 @@ export default function ConnectorRegistry({ type }) {
           c.documentationUrl?.includes("/integrations/enterprise-connectors/"),
       );
 
-      const enterpriseFromPlugin = pluginData.enterpriseConnectors.length > 0
-        ? pluginData.enterpriseConnectors
-            .filter((name) => name.includes(type))
-            .map((name) => {
-              const _name = name.replace(`${type}-`, "");
+      const enterpriseFromPlugin =
+        pluginData.enterpriseConnectors.length > 0
+          ? pluginData.enterpriseConnectors
+              .filter((name) => name.includes(type))
+              .map((name) => {
+                const _name = name.replace(`${type}-`, "");
 
-              const info = registry.find(
-                (c) =>
-                  c.name?.includes(_name) ||
-                  c.documentationUrl?.includes(_name),
-              );
-              return info;
-            })
-            .filter(Boolean)
-        : [];
+                const info = registry.find(
+                  (c) =>
+                    c.name?.includes(_name) ||
+                    c.documentationUrl?.includes(_name),
+                );
+                return info;
+              })
+              .filter(Boolean)
+          : [];
 
-      const allEnterpriseConnectors = [...enterpriseFromRegistry, ...enterpriseFromPlugin];
+      const allEnterpriseConnectors = [
+        ...enterpriseFromRegistry,
+        ...enterpriseFromPlugin,
+      ];
       const uniqueEnterpriseConnectors = Array.from(
-        new Map(allEnterpriseConnectors.map(c => [c.definitionId, c])).values()
+        new Map(
+          allEnterpriseConnectors.map((c) => [c.definitionId, c]),
+        ).values(),
       );
 
       setEnterpriseConnectors(uniqueEnterpriseConnectors);
@@ -207,7 +261,9 @@ export default function ConnectorRegistry({ type }) {
 
   if (registry === null) return <div>{`Loading ${type}s...`}</div>;
   if (registry.length === 0)
-    return <div>{`Failed to load ${type}s. Check your network connection and try again.`}</div>;
+    return (
+      <div>{`Failed to load ${type}s. Check your network connection and try again.`}</div>
+    );
 
   const connectors = registry
     .filter((c) => c.connector_type === type)

--- a/docusaurus/src/components/ConnectorRegistry.module.css
+++ b/docusaurus/src/components/ConnectorRegistry.module.css
@@ -5,6 +5,14 @@
   font-weight: bold;
 }
 
+.connectorLink {
+  color: var(--ifm-color-content);
+}
+
+.connectorLink:hover {
+  color: var(--ifm-color-primary);
+}
+
 .connectorIconBackground {
   background-color: var(--icon-background);
   border-radius: 6px;

--- a/docusaurus/src/css/custom.css
+++ b/docusaurus/src/css/custom.css
@@ -30,7 +30,7 @@
   --ifm-table-head-background: var(--color-blue-30);
   --ifm-table-border-color: var(--ifm-color-primary-lightest);
   --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.2);
-  
+
   /* OpenAPI method badge colors */
   --openapi-code-green: #49cc90;
   --openapi-code-red: #f93e3e;
@@ -112,6 +112,35 @@ html.plugin-id-default nav.theme-doc-breadcrumbs {
   visibility: hidden;
 }
 
+.boolean-table-indicator {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  white-space: nowrap;
+  font-size: 0.9em;
+  line-height: 1.2;
+}
+
+.boolean-table-indicator__icon {
+  font-size: 0.85em;
+}
+
+.boolean-table-indicator--supported {
+  color: var(--color-green-800);
+}
+
+.boolean-table-indicator--unsupported {
+  color: var(--ifm-color-emphasis-600);
+}
+
+html[data-theme="dark"] .boolean-table-indicator--supported {
+  color: var(--ifm-color-emphasis-400);
+}
+
+html[data-theme="dark"] .boolean-table-indicator--unsupported {
+  color: var(--ifm-color-emphasis-500);
+}
+
 .admonition-icon,
 .iconExternalLink_wgqa,
 .iconExternalLink_node_modules-\@docusaurus-theme-classic-lib-next-theme-IconExternalLink-styles-module {
@@ -141,8 +170,9 @@ nav ul.dropdown__menu {
 }
 
 /* Hide some less important navbar items at medium resolutions */
-@media (max-width:1250px) {
-  nav a.header-github-link, nav a.cloudStatusLink {
+@media (max-width: 1250px) {
+  nav a.header-github-link,
+  nav a.cloudStatusLink {
     display: none;
   }
 }
@@ -194,7 +224,7 @@ nav.navbar {
   display: none;
 }
 
-@media (min-width:996px) {
+@media (min-width: 996px) {
   .navbar__link {
     display: flex;
     align-items: center;
@@ -351,7 +381,8 @@ table td code {
   border-radius: 4px;
 }
 
-table th, table td {
+table th,
+table td {
   vertical-align: top;
 }
 
@@ -475,4 +506,3 @@ li.api-method.patch .menu__link::before {
   content: "patch";
   background-color: var(--openapi-code-orange);
 }
-

--- a/docusaurus/src/css/custom.css
+++ b/docusaurus/src/css/custom.css
@@ -30,7 +30,7 @@
   --ifm-table-head-background: var(--color-blue-30);
   --ifm-table-border-color: var(--ifm-color-primary-lightest);
   --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.2);
-
+  
   /* OpenAPI method badge colors */
   --openapi-code-green: #49cc90;
   --openapi-code-red: #f93e3e;
@@ -134,11 +134,11 @@ html.plugin-id-default nav.theme-doc-breadcrumbs {
 }
 
 html[data-theme="dark"] .boolean-table-indicator--supported {
-  color: var(--ifm-color-emphasis-400);
+  color: var(--color-green-600);
 }
 
 html[data-theme="dark"] .boolean-table-indicator--unsupported {
-  color: var(--ifm-color-emphasis-500);
+  color: var(--ifm-color-emphasis-400);
 }
 
 .admonition-icon,
@@ -170,9 +170,8 @@ nav ul.dropdown__menu {
 }
 
 /* Hide some less important navbar items at medium resolutions */
-@media (max-width: 1250px) {
-  nav a.header-github-link,
-  nav a.cloudStatusLink {
+@media (max-width:1250px) {
+  nav a.header-github-link, nav a.cloudStatusLink {
     display: none;
   }
 }
@@ -224,7 +223,7 @@ nav.navbar {
   display: none;
 }
 
-@media (min-width: 996px) {
+@media (min-width:996px) {
   .navbar__link {
     display: flex;
     align-items: center;
@@ -381,8 +380,7 @@ table td code {
   border-radius: 4px;
 }
 
-table th,
-table td {
+table th, table td {
   vertical-align: top;
 }
 
@@ -506,3 +504,4 @@ li.api-method.patch .menu__link::before {
   content: "patch";
   background-color: var(--openapi-code-orange);
 }
+

--- a/docusaurus/src/remark/booleanTableIndicators.js
+++ b/docusaurus/src/remark/booleanTableIndicators.js
@@ -1,0 +1,66 @@
+const visit = require("unist-util-visit").visit;
+
+const BOOLEAN_MARKERS = new Map([
+  ["yes", { label: "Yes", status: "supported" }],
+  ["no", { label: "No", status: "unsupported" }],
+  ["supported", { label: "Supported", status: "supported" }],
+  ["not supported", { label: "Not supported", status: "unsupported" }],
+  ["✅", { label: "Supported", status: "supported" }],
+  ["❌", { label: "Not supported", status: "unsupported" }],
+]);
+
+const getMarker = (cell) => {
+  if (!cell || !Array.isArray(cell.children) || cell.children.length !== 1) {
+    return null;
+  }
+
+  const child = cell.children[0];
+  if (child.type !== "text" || typeof child.value !== "string") {
+    return null;
+  }
+
+  return BOOLEAN_MARKERS.get(child.value.trim().toLowerCase()) || null;
+};
+
+const plugin = () => {
+  const transformer = (ast) => {
+    visit(ast, "table", (table) => {
+      if (!Array.isArray(table.children)) return;
+
+      table.children.slice(1).forEach((row) => {
+        if (!row || !Array.isArray(row.children)) return;
+
+        row.children.forEach((cell) => {
+          if (!cell || cell.type !== "tableCell") return;
+
+          const marker = getMarker(cell);
+          if (!marker) return;
+
+          cell.children = [
+            {
+              type: "mdxJsxTextElement",
+              name: "BooleanTableIndicator",
+              attributes: [
+                {
+                  type: "mdxJsxAttribute",
+                  name: "label",
+                  value: marker.label,
+                },
+                {
+                  type: "mdxJsxAttribute",
+                  name: "status",
+                  value: marker.status,
+                },
+              ],
+              children: [],
+            },
+          ];
+        });
+      });
+    });
+  };
+
+  return transformer;
+};
+
+module.exports = plugin;

--- a/docusaurus/src/theme/MDXComponents/index.js
+++ b/docusaurus/src/theme/MDXComponents/index.js
@@ -1,6 +1,7 @@
 // Import the original mapper
 import { AgentConnectorTitle } from "@site/src/components/AgentConnectorTitle";
 import { AppliesTo } from "@site/src/components/AppliesTo";
+import { BooleanTableIndicator } from "@site/src/components/BooleanTableIndicator";
 import { ConnectorTypeBanner } from "@site/src/components/ConnectorTypeBanner";
 import { Arcade } from "@site/src/components/Arcade";
 import { FieldAnchor } from "@site/src/components/FieldAnchor";
@@ -27,6 +28,7 @@ export default {
   AgentConnectorTitle,
   Arcade,
   AppliesTo,
+  BooleanTableIndicator,
   ConnectorTypeBanner,
   FieldAnchor,
   HideInUI,


### PR DESCRIPTION
## What

Requested by Ian Alton (`@ian-at-airbyte`) to move public docs off emoji as boolean markers. Two problems with ✅/❌ in docs tables: they read informally for enterprise buyers, and they're unreliably interpreted by scrapers and AI answer engines that consume our raw Markdown.

Docs source now carries plain words; a build-time remark plugin adds a Font Awesome icon at render time. This keeps all three constituencies happy at once:

- **Scrapers / LLMs** — the raw `.md` (served by the Copy Page button and `@signalwire/docusaurus-plugin-llms-txt`) contains literal `Supported` / `Not supported`, never emoji or JSX.
- **Screen readers** — the visible text is the source of truth; the icon is decorative (`aria-hidden`), so nothing announces an icon or emoji name.
- **Writers** — they type a word in a table cell. No imports, no JSX, no component to remember, and the table still reads correctly on GitHub or if the plugin is ever removed.

This is a demo of the pattern, not the full migration. There are roughly 5,700 emoji cells across `docs/integrations/**`; three files are converted here.

## How

`docusaurus/src/remark/booleanTableIndicators.js` walks Markdown tables and, when a body cell's entire content is a recognized marker, swaps it for a `<BooleanTableIndicator>`:

```
tableCell["Yes"]  ->  BooleanTableIndicator label="Yes" status="supported"
tableCell["❌"]   ->  BooleanTableIndicator label="Not supported" status="unsupported"
tableCell["Yes, when *x*"]  ->  untouched
```

Recognized input is case-insensitive `Yes`/`No` and `Supported`/`Not supported`, plus legacy `✅`/`❌` so unconverted connector docs pick up the accessible rendering immediately, ahead of any bulk text pass. Only whole-cell matches transform; mixed content, prose, and code are untouched. Header rows are skipped — `source-oracle-enterprise.md` has a column literally headed `Supported`, which must stay plain text.

`BooleanTableIndicator` is registered globally in `MDXComponents`, so it also serves `ConnectorRegistry.jsx`, which previously rendered ✅/❌ and 📕/⚙️/🐛 at runtime. Those link icons are now Font Awesome with `aria-label`s, since they have no visible text.

## Review guide

1. `docusaurus/src/remark/booleanTableIndicators.js` — the transform and its guards
2. `docusaurus/src/components/BooleanTableIndicator.jsx` + `docusaurus/src/css/custom.css` — rendering, compact sizing for wide stream tables, dark-mode colors
3. `docusaurus/src/components/ConnectorRegistry.jsx` — de-emoji'd registry matrix; uses `Yes`/`No` since its columns are already headed "Self-managed" and "Cloud"
4. `docs/integrations/sources/chargedesk.md`, `eventzilla.md`, `enterprise-connectors/source-oracle-enterprise.md` — before/after in source (Oracle used `✓`)
5. `docusaurus/docusaurus.config.ts` — plugin wired into each docs instance

## User Impact

Support columns render as an icon plus a text label instead of a bare emoji. No content or URLs change. Pages that still contain ✅/❌ in source render through the plugin too, so the visual language is consistent during the transition — though their raw Markdown keeps the emoji until converted.

Known follow-ups, deliberately out of scope:

- The generator that emits connector stream tables (`| stream | key | DefaultPaginator | ✅ | ❌ |`) is not in this repo, `airbyte-python-cdk`, or `connector-builder-mcp` — evidence points at the Connector Builder submission path. Until it's fixed, new connector submissions will keep landing emoji in source.
- Bulk conversion of the remaining `docs/integrations/**` cells.
- Decorative emoji in changelogs and release-note headings (🎉/🐛/✨) are untouched.
- A Vale rule could enforce this going forward; markdownlint is a poor fit.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚
- [ ] NO ❌


Link to Devin session: https://app.devin.ai/sessions/eb897827a738496284bdcca4545a7c3e