### PR TITLE
feat(destination-bigquery): add per-stream table layout overrides

### DIFF
--- a/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/BigqueryBeansFactory.kt
+++ b/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/BigqueryBeansFactory.kt
@@ -27,6 +27,7 @@ import io.airbyte.cdk.load.write.StreamStateStore
 import io.airbyte.cdk.load.write.WriteOperation
 import io.airbyte.integrations.destination.bigquery.check.BigqueryCheckCleaner
 import io.airbyte.integrations.destination.bigquery.spec.BigqueryConfiguration
+import io.airbyte.integrations.destination.bigquery.stream.StreamConfigProvider
 import io.airbyte.integrations.destination.bigquery.write.bulk_loader.BigQueryBulkOneShotUploader
 import io.airbyte.integrations.destination.bigquery.write.bulk_loader.BigQueryBulkOneShotUploaderStep
 import io.airbyte.integrations.destination.bigquery.write.bulk_loader.BigqueryBulkLoadConfiguration
@@ -97,6 +98,7 @@ class BigqueryBeansFactory {
         bigquery: BigQuery,
         config: BigqueryConfiguration,
         names: TableCatalog,
+        streamConfigProvider: StreamConfigProvider,
         // micronaut will only instantiate a single instance of StreamStateStore,
         // so accept it as a * generic and cast as needed.
         // we use a different type depending on whether we're in legacy raw tables vs
@@ -127,6 +129,7 @@ class BigqueryBeansFactory {
                         BigqueryDirectLoadSqlGenerator(
                             projectId = config.projectId,
                             cdcDeletionMode = config.cdcDeletionMode,
+                            streamConfigProvider = streamConfigProvider,
                         ),
                         destinationHandler,
                     ),
@@ -154,6 +157,7 @@ class BigqueryBeansFactory {
                         destinationHandler,
                         projectId = config.projectId,
                         tempTableNameGenerator,
+                        streamConfigProvider,
                     ),
                 sqlTableOperations = sqlTableOperations,
                 streamStateStore = streamStateStore,

--- a/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/check/BigqueryCheckCleaner.kt
+++ b/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/check/BigqueryCheckCleaner.kt
@@ -8,6 +8,7 @@ import io.airbyte.cdk.load.check.CheckCleaner
 import io.airbyte.cdk.load.command.DestinationStream
 import io.airbyte.integrations.destination.bigquery.BigqueryBeansFactory
 import io.airbyte.integrations.destination.bigquery.spec.BigqueryConfiguration
+import io.airbyte.integrations.destination.bigquery.stream.StreamConfigProvider
 import io.airbyte.integrations.destination.bigquery.write.typing_deduping.BigqueryFinalTableNameGenerator
 import io.airbyte.integrations.destination.bigquery.write.typing_deduping.BigqueryRawTableNameGenerator
 import io.airbyte.integrations.destination.bigquery.write.typing_deduping.toTableId
@@ -15,6 +16,7 @@ import io.airbyte.integrations.destination.bigquery.write.typing_deduping.toTabl
 class BigqueryCheckCleaner : CheckCleaner<BigqueryConfiguration> {
     override fun cleanup(config: BigqueryConfiguration, stream: DestinationStream) {
         val bq = BigqueryBeansFactory().getBigqueryClient(config)
+        val streamConfigProvider = StreamConfigProvider(config)
         bq.getTable(
                 BigqueryRawTableNameGenerator(config)
                     .getTableName(stream.mappedDescriptor)
@@ -22,7 +24,7 @@ class BigqueryCheckCleaner : CheckCleaner<BigqueryConfiguration> {
             )
             ?.delete()
         bq.getTable(
-                BigqueryFinalTableNameGenerator(config)
+                BigqueryFinalTableNameGenerator(config, streamConfigProvider)
                     .getTableName(stream.mappedDescriptor)
                     .toTableId()
             )

--- a/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/spec/BigqueryConfiguration.kt
+++ b/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/spec/BigqueryConfiguration.kt
@@ -4,6 +4,7 @@
 
 package io.airbyte.integrations.destination.bigquery.spec
 
+import io.airbyte.cdk.ConfigErrorException
 import io.airbyte.cdk.load.command.DestinationConfiguration
 import io.airbyte.cdk.load.command.DestinationConfigurationFactory
 import io.airbyte.cdk.load.command.gcs.GcsClientConfiguration
@@ -19,12 +20,15 @@ data class BigqueryConfiguration(
     val cdcDeletionMode: CdcDeletionMode,
     val internalTableDataset: String,
     val legacyRawTablesOnly: Boolean,
+    val streamConfigurations: Map<StreamSelector, BigqueryStreamConfiguration>,
 ) : DestinationConfiguration() {
     override val numOpenStreamWorkers = 3
     // currently the base cdk declares 0.2 as the default.
     // use 0.4 so that we support 20MiB records.
     override val maxMessageQueueMemoryUsageRatio = 0.4
 }
+
+data class StreamSelector(val namespace: String?, val name: String)
 
 sealed interface LoadingMethodConfiguration
 
@@ -39,6 +43,20 @@ data class GcsStagingConfiguration(
 class BigqueryConfigurationFactory :
     DestinationConfigurationFactory<BigquerySpecification, BigqueryConfiguration> {
     override fun makeWithoutExceptionHandling(pojo: BigquerySpecification): BigqueryConfiguration {
+        val streamConfigurations = pojo.streamConfigurations.orEmpty()
+        streamConfigurations.forEach(::validateStreamConfiguration)
+        val duplicateSelectors =
+            streamConfigurations
+                .groupingBy { StreamSelector(it.streamNamespace, it.streamName) }
+                .eachCount()
+                .filterValues { it > 1 }
+                .keys
+        if (duplicateSelectors.isNotEmpty()) {
+            throw ConfigErrorException(
+                "Duplicate BigQuery stream configurations: ${duplicateSelectors.joinToString()}",
+            )
+        }
+
         val loadingMethodConfig =
             when (pojo.loadingMethod) {
                 is GcsStagingSpecification -> {
@@ -66,6 +84,53 @@ class BigqueryConfigurationFactory :
                     pojo.internalTableDataset!!
                 },
             legacyRawTablesOnly = pojo.legacyRawTablesOnly ?: false,
+            streamConfigurations =
+                streamConfigurations.associateBy {
+                    StreamSelector(it.streamNamespace, it.streamName)
+                },
         )
+    }
+
+    private fun validateStreamConfiguration(stream: BigqueryStreamConfiguration) {
+        if (stream.streamName.isBlank()) {
+            throw ConfigErrorException("BigQuery stream configuration requires a stream name.")
+        }
+        if (stream.streamNamespace?.isBlank() == true) {
+            throw ConfigErrorException(
+                "Stream ${stream.streamName}: stream namespace cannot be blank.",
+            )
+        }
+        if (stream.destinationDataset?.isBlank() == true) {
+            throw ConfigErrorException(
+                "Stream ${stream.streamName}: destination dataset cannot be blank.",
+            )
+        }
+        if (stream.destinationTable?.isBlank() == true) {
+            throw ConfigErrorException(
+                "Stream ${stream.streamName}: destination table cannot be blank.",
+            )
+        }
+        if (stream.partitioningField?.isBlank() == true) {
+            throw ConfigErrorException(
+                "Stream ${stream.streamName}: partitioning field cannot be blank.",
+            )
+        }
+        if (stream.partitioningGranularity != null && stream.partitioningField == null) {
+            throw ConfigErrorException(
+                "Stream ${stream.streamName}: partitioning granularity requires a partitioning field.",
+            )
+        }
+        stream.clusteringFields?.let { fields ->
+            if (fields.isEmpty() || fields.size > 4 || fields.any { it.isBlank() }) {
+                throw ConfigErrorException(
+                    "Stream ${stream.streamName}: clustering_fields must contain one to four non-blank field names.",
+                )
+            }
+            if (fields.distinctBy { it.lowercase() }.size != fields.size) {
+                throw ConfigErrorException(
+                    "Stream ${stream.streamName}: clustering_fields cannot contain duplicates.",
+                )
+            }
+        }
     }
 }

--- a/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/spec/BigquerySpecification.kt
+++ b/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/spec/BigquerySpecification.kt
@@ -105,7 +105,65 @@ class BigquerySpecification : ConfigurationSpecification() {
     @get:JsonProperty("raw_data_dataset")
     @get:JsonSchemaInject(json = """{"group": "advanced", "order": 8}""")
     val internalTableDataset: String? = null
+
+    @get:JsonSchemaTitle("Per-stream table configuration")
+    @get:JsonPropertyDescription(
+        """Optional overrides for the destination dataset and table name, time-unit partitioning, and clustering of individual streams. A configuration with no namespace matches that stream name in any namespace.""",
+    )
+    @get:JsonProperty("stream_configurations")
+    @get:JsonSchemaInject(json = """{"group": "advanced", "order": 9}""")
+    val streamConfigurations: List<BigqueryStreamConfiguration>? = null
 }
+
+data class BigqueryStreamConfiguration(
+    @get:JsonSchemaTitle("Stream name")
+    @get:JsonPropertyDescription(
+        "The effective destination stream name after Airbyte's stream-name mapping.",
+    )
+    @JsonProperty("stream_name")
+    val streamName: String = "",
+    @get:JsonSchemaTitle("Stream namespace")
+    @get:JsonPropertyDescription(
+        "Optional destination namespace used to disambiguate streams with the same name.",
+    )
+    @JsonProperty("stream_namespace")
+    val streamNamespace: String? = null,
+    @get:JsonSchemaTitle("Destination dataset")
+    @get:JsonPropertyDescription(
+        "Optional BigQuery dataset override. The connector creates the dataset when permitted.",
+    )
+    @JsonProperty("destination_dataset")
+    val destinationDataset: String? = null,
+    @get:JsonSchemaTitle("Destination table")
+    @get:JsonPropertyDescription(
+        "Optional final-table name override. The table suffix is appended after this value.",
+    )
+    @JsonProperty("destination_table")
+    val destinationTable: String? = null,
+    @get:JsonSchemaTitle("Table suffix")
+    @get:JsonPropertyDescription("Optional suffix appended to the destination table name.")
+    @JsonProperty("table_suffix")
+    val tableSuffix: String? = null,
+    @get:JsonSchemaTitle("Partitioning field")
+    @get:JsonPropertyDescription(
+        "Optional top-level DATE, TIMESTAMP, or DATETIME field used for time-unit partitioning.",
+    )
+    @JsonProperty("partitioning_field")
+    val partitioningField: String? = null,
+    @get:JsonSchemaTitle("Partitioning granularity")
+    @get:JsonPropertyDescription(
+        "Partition granularity. HOUR is supported for TIMESTAMP and DATETIME fields; DATE fields support DAY, MONTH, and YEAR.",
+    )
+    @JsonProperty("partitioning_granularity")
+    val partitioningGranularity: PartitioningGranularity? = null,
+    @get:JsonSchemaTitle("Clustering fields")
+    @get:JsonPropertyDescription(
+        "One to four top-level fields used for clustering, in clustering sort order.",
+    )
+    @get:JsonSchemaInject(json = """{"minItems": 1, "maxItems": 4}""")
+    @JsonProperty("clustering_fields")
+    val clusteringFields: List<String>? = null,
+)
 
 @JsonTypeInfo(
     use = JsonTypeInfo.Id.NAME,
@@ -212,6 +270,13 @@ enum class TransformationPriority(@get:JsonValue val transformationPriority: Str
 enum class CdcDeletionMode(@get:JsonValue val cdcDeletionMode: String) {
     HARD_DELETE("Hard delete"),
     SOFT_DELETE("Soft delete"),
+}
+
+enum class PartitioningGranularity(@get:JsonValue val value: String) {
+    HOUR("HOUR"),
+    DAY("DAY"),
+    MONTH("MONTH"),
+    YEAR("YEAR"),
 }
 
 @Singleton

--- a/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/stream/StreamConfigProvider.kt
+++ b/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/stream/StreamConfigProvider.kt
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2026 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.integrations.destination.bigquery.stream
+
+import io.airbyte.cdk.load.command.DestinationStream
+import io.airbyte.integrations.destination.bigquery.spec.BigqueryConfiguration
+import io.airbyte.integrations.destination.bigquery.spec.BigqueryStreamConfiguration
+import io.airbyte.integrations.destination.bigquery.spec.PartitioningGranularity
+import io.airbyte.integrations.destination.bigquery.spec.StreamSelector
+import jakarta.inject.Singleton
+
+@Singleton
+class StreamConfigProvider(private val config: BigqueryConfiguration) {
+    /**
+     * Namespace-specific entries take precedence over name-only entries. Descriptors are the mapped
+     * destination descriptors supplied by the CDK, so a namespace selector refers to the effective
+     * destination namespace.
+     */
+    fun getStreamConfig(
+        descriptor: DestinationStream.Descriptor,
+    ): BigqueryStreamConfiguration? =
+        config.streamConfigurations[StreamSelector(descriptor.namespace, descriptor.name)]
+            ?: config.streamConfigurations[StreamSelector(null, descriptor.name)]
+
+    fun getDestinationDataset(descriptor: DestinationStream.Descriptor): String =
+        getStreamConfig(descriptor)?.destinationDataset ?: descriptor.namespace ?: config.datasetId
+
+    fun getDestinationTable(descriptor: DestinationStream.Descriptor): String =
+        getStreamConfig(descriptor)?.destinationTable ?: descriptor.name
+
+    fun getTableSuffix(descriptor: DestinationStream.Descriptor): String =
+        getStreamConfig(descriptor)?.tableSuffix ?: ""
+
+    fun getPartitioningField(descriptor: DestinationStream.Descriptor): String =
+        getStreamConfig(descriptor)?.partitioningField ?: DEFAULT_PARTITIONING_FIELD
+
+    fun getPartitioningGranularity(
+        descriptor: DestinationStream.Descriptor,
+    ): PartitioningGranularity =
+        getStreamConfig(descriptor)?.partitioningGranularity ?: PartitioningGranularity.DAY
+
+    fun getClusteringFields(descriptor: DestinationStream.Descriptor): List<String>? =
+        getStreamConfig(descriptor)?.clusteringFields
+
+    companion object {
+        const val DEFAULT_PARTITIONING_FIELD = "_airbyte_extracted_at"
+    }
+}

--- a/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/write/typing_deduping/BigqueryNameGenerators.kt
+++ b/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/write/typing_deduping/BigqueryNameGenerators.kt
@@ -13,6 +13,7 @@ import io.airbyte.cdk.load.orchestration.db.TableName
 import io.airbyte.cdk.load.orchestration.db.legacy_typing_deduping.TypingDedupingUtil
 import io.airbyte.integrations.destination.bigquery.BigQuerySQLNameTransformer
 import io.airbyte.integrations.destination.bigquery.spec.BigqueryConfiguration
+import io.airbyte.integrations.destination.bigquery.stream.StreamConfigProvider
 import java.util.Locale
 import javax.inject.Singleton
 
@@ -33,11 +34,19 @@ class BigqueryRawTableNameGenerator(val config: BigqueryConfiguration) : RawTabl
 }
 
 @Singleton
-class BigqueryFinalTableNameGenerator(val config: BigqueryConfiguration) : FinalTableNameGenerator {
+class BigqueryFinalTableNameGenerator(
+    val config: BigqueryConfiguration,
+    private val streamConfigProvider: StreamConfigProvider,
+) : FinalTableNameGenerator {
     override fun getTableName(streamDescriptor: DestinationStream.Descriptor) =
         TableName(
-            nameTransformer.getNamespace(streamDescriptor.namespace ?: config.datasetId),
-            nameTransformer.convertStreamName(streamDescriptor.name),
+            nameTransformer.getNamespace(
+                streamConfigProvider.getDestinationDataset(streamDescriptor),
+            ),
+            nameTransformer.convertStreamName(
+                streamConfigProvider.getDestinationTable(streamDescriptor) +
+                    streamConfigProvider.getTableSuffix(streamDescriptor),
+            ),
         )
 }
 

--- a/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/write/typing_deduping/direct_load_tables/BigqueryDirectLoadNativeTableOperations.kt
+++ b/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/write/typing_deduping/direct_load_tables/BigqueryDirectLoadNativeTableOperations.kt
@@ -27,6 +27,7 @@ import io.airbyte.cdk.load.orchestration.db.direct_load_table.DirectLoadTableNat
 import io.airbyte.cdk.util.CollectionUtils.containsAllIgnoreCase
 import io.airbyte.cdk.util.containsIgnoreCase
 import io.airbyte.cdk.util.findIgnoreCase
+import io.airbyte.integrations.destination.bigquery.stream.StreamConfigProvider
 import io.airbyte.integrations.destination.bigquery.write.typing_deduping.BigQueryDatabaseHandler
 import io.airbyte.integrations.destination.bigquery.write.typing_deduping.toTableId
 import io.github.oshai.kotlinlogging.KotlinLogging
@@ -42,6 +43,7 @@ class BigqueryDirectLoadNativeTableOperations(
     private val databaseHandler: BigQueryDatabaseHandler,
     private val projectId: String,
     private val tempTableNameGenerator: TempTableNameGenerator,
+    private val streamConfigProvider: StreamConfigProvider,
 ) : DirectLoadTableNativeOperations {
     override suspend fun ensureSchemaMatches(
         stream: DestinationStream,
@@ -125,8 +127,20 @@ class BigqueryDirectLoadNativeTableOperations(
         var tableClusteringMatches = false
         var tablePartitioningMatches = false
         if (existingTable is StandardTableDefinition) {
-            tableClusteringMatches = clusteringMatches(stream, columnNameMapping, existingTable)
-            tablePartitioningMatches = partitioningMatches(existingTable)
+            tableClusteringMatches =
+                clusteringMatches(
+                    stream,
+                    columnNameMapping,
+                    existingTable,
+                    streamConfigProvider.getClusteringFields(stream.mappedDescriptor),
+                )
+            tablePartitioningMatches =
+                partitioningMatches(
+                    stream,
+                    columnNameMapping,
+                    existingTable,
+                    streamConfigProvider,
+                )
         }
         return !tableClusteringMatches || !tablePartitioningMatches
     }
@@ -406,6 +420,7 @@ class BigqueryDirectLoadNativeTableOperations(
             stream: DestinationStream,
             columnNameMapping: ColumnNameMapping,
             existingTable: StandardTableDefinition,
+            configuredFields: List<String>? = null,
         ): Boolean {
             // We always want to set a clustering config, so if the table doesn't have one,
             // then we should fix it.
@@ -413,15 +428,30 @@ class BigqueryDirectLoadNativeTableOperations(
                 return false
             }
 
-            val existingClusteringFields = HashSet<String>(existingTable.clustering!!.fields)
+            val existingClusteringFields = existingTable.clustering!!.fields
+            val expectedClusteringFields =
+                BigqueryDirectLoadSqlGenerator.clusteringColumns(
+                    stream,
+                    columnNameMapping,
+                    configuredFields,
+                )
             // We're OK with a column being in the clustering config that we don't expect
             // (e.g. user set a composite PK, then makes one of those fields no longer a PK).
             // It doesn't really hurt us to have that extra clustering config.
             val clusteringConfigIsSupersetOfExpectedConfig =
-                containsAllIgnoreCase(
-                    existingClusteringFields,
-                    BigqueryDirectLoadSqlGenerator.clusteringColumns(stream, columnNameMapping),
-                )
+                if (configuredFields == null) {
+                    containsAllIgnoreCase(
+                        existingClusteringFields,
+                        expectedClusteringFields,
+                    )
+                } else {
+                    // Clustering order affects BigQuery block pruning, so an explicit override
+                    // must match exactly rather than merely being a superset.
+                    existingClusteringFields.size == expectedClusteringFields.size &&
+                        existingClusteringFields.zip(expectedClusteringFields).all { (a, b) ->
+                            a.equals(b, ignoreCase = true)
+                        }
+                }
             // We do, however, validate that all the clustering fields actually exist in the
             // intended schema.
             // This is so that we don't try to drop columns that bigquery is clustering against
@@ -442,6 +472,30 @@ class BigqueryDirectLoadNativeTableOperations(
                     .field
                     .equals("_airbyte_extracted_at", ignoreCase = true) &&
                 TimePartitioning.Type.DAY == existingTable.timePartitioning!!.type
+        }
+
+        @VisibleForTesting
+        fun partitioningMatches(
+            stream: DestinationStream,
+            columnNameMapping: ColumnNameMapping,
+            existingTable: StandardTableDefinition,
+            streamConfigProvider: StreamConfigProvider,
+        ): Boolean {
+            val expected =
+                BigqueryDirectLoadSqlGenerator.resolvePartitioning(
+                    stream,
+                    columnNameMapping,
+                    streamConfigProvider.getPartitioningField(stream.mappedDescriptor),
+                    streamConfigProvider.getPartitioningGranularity(stream.mappedDescriptor),
+                )
+            return existingTable.timePartitioning != null &&
+                existingTable.timePartitioning!!
+                    .field
+                    .equals(
+                        expected.field,
+                        ignoreCase = true,
+                    ) &&
+                existingTable.timePartitioning!!.type == expected.type
         }
     }
 }

--- a/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/write/typing_deduping/direct_load_tables/BigqueryDirectLoadSqlGenerator.kt
+++ b/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/write/typing_deduping/direct_load_tables/BigqueryDirectLoadSqlGenerator.kt
@@ -5,6 +5,7 @@
 package io.airbyte.integrations.destination.bigquery.write.typing_deduping.direct_load_tables
 
 import com.google.cloud.bigquery.StandardSQLTypeName
+import com.google.cloud.bigquery.TimePartitioning
 import io.airbyte.cdk.ConfigErrorException
 import io.airbyte.cdk.load.command.Dedupe
 import io.airbyte.cdk.load.command.DestinationStream
@@ -31,6 +32,8 @@ import io.airbyte.cdk.load.orchestration.db.Sql
 import io.airbyte.cdk.load.orchestration.db.TableName
 import io.airbyte.cdk.load.orchestration.db.direct_load_table.DirectLoadSqlGenerator
 import io.airbyte.integrations.destination.bigquery.spec.CdcDeletionMode
+import io.airbyte.integrations.destination.bigquery.spec.PartitioningGranularity
+import io.airbyte.integrations.destination.bigquery.stream.StreamConfigProvider
 import java.util.ArrayList
 import java.util.stream.Collectors
 import org.apache.commons.lang3.StringUtils
@@ -38,6 +41,7 @@ import org.apache.commons.lang3.StringUtils
 class BigqueryDirectLoadSqlGenerator(
     private val projectId: String?,
     private val cdcDeletionMode: CdcDeletionMode,
+    private val streamConfigProvider: StreamConfigProvider,
 ) : DirectLoadSqlGenerator {
     override fun createTable(
         stream: DestinationStream,
@@ -60,10 +64,21 @@ class BigqueryDirectLoadSqlGenerator(
 
         val columnDeclarations = columnsAndTypes(stream, columnNameMapping)
         val clusterConfig =
-            clusteringColumns(stream, columnNameMapping)
+            clusteringColumns(
+                    stream,
+                    columnNameMapping,
+                    streamConfigProvider.getClusteringFields(stream.mappedDescriptor),
+                )
                 .stream()
                 .map { c: String? -> StringUtils.wrap(c, QUOTE) }
                 .collect(Collectors.joining(", "))
+        val partitioning =
+            resolvePartitioning(
+                stream,
+                columnNameMapping,
+                streamConfigProvider.getPartitioningField(stream.mappedDescriptor),
+                streamConfigProvider.getPartitioningGranularity(stream.mappedDescriptor),
+            )
         val finalTableId = tableName.toPrettyString(QUOTE)
         // bigquery has a CREATE OR REPLACE TABLE statement, but we can't use it
         // because you can't change a partitioning/clustering scheme in-place.
@@ -87,7 +102,7 @@ class BigqueryDirectLoadSqlGenerator(
                   _airbyte_generation_id INTEGER,
                   $columnDeclarations
                 )
-                PARTITION BY (DATE_TRUNC(_airbyte_extracted_at, DAY))
+                PARTITION BY (${partitioning.expression})
                 CLUSTER BY $clusterConfig;
                 """.trimIndent()
             )
@@ -325,8 +340,37 @@ class BigqueryDirectLoadSqlGenerator(
 
         fun clusteringColumns(
             stream: DestinationStream,
-            columnNameMapping: ColumnNameMapping
+            columnNameMapping: ColumnNameMapping,
+            configuredFields: List<String>? = null,
         ): List<String> {
+            if (configuredFields != null) {
+                return configuredFields.map { field ->
+                    val (mappedName, type) =
+                        if (field == StreamConfigProvider.DEFAULT_PARTITIONING_FIELD) {
+                            field to StandardSQLTypeName.TIMESTAMP
+                        } else {
+                            val fieldType =
+                                stream.schema.asColumns()[field]
+                                    ?: throw ConfigErrorException(
+                                        "Stream ${stream.mappedDescriptor.toPrettyString()}: Clustering field '$field' does not exist in the schema",
+                                    )
+                            val mappedName =
+                                columnNameMapping[field]
+                                    ?: throw ConfigErrorException(
+                                        "Stream ${stream.mappedDescriptor.toPrettyString()}: Clustering field '$field' does not have a destination column mapping",
+                                    )
+                            mappedName to toDialectType(fieldType.type)
+                        }
+
+                    if (type !in CLUSTERABLE_TYPES) {
+                        throw ConfigErrorException(
+                            "Stream ${stream.mappedDescriptor.toPrettyString()}: Clustering field '$field' has unsupported BigQuery type $type",
+                        )
+                    }
+                    mappedName
+                }
+            }
+
             val clusterColumns: MutableList<String> = ArrayList()
             if (stream.importType is Dedupe) {
                 // We're doing de-duping, therefore we have a primary key.
@@ -348,5 +392,85 @@ class BigqueryDirectLoadSqlGenerator(
             clusterColumns.add("_airbyte_extracted_at")
             return clusterColumns
         }
+
+        fun resolvePartitioning(
+            stream: DestinationStream,
+            columnNameMapping: ColumnNameMapping,
+            requestedField: String,
+            granularity: PartitioningGranularity,
+        ): ResolvedPartitioning {
+            val (mappedField, fieldType) =
+                if (requestedField == StreamConfigProvider.DEFAULT_PARTITIONING_FIELD) {
+                    requestedField to StandardSQLTypeName.TIMESTAMP
+                } else {
+                    val fieldType =
+                        stream.schema.asColumns()[requestedField]
+                            ?: throw ConfigErrorException(
+                                "Stream ${stream.mappedDescriptor.toPrettyString()}: Partitioning field '$requestedField' does not exist in the schema",
+                            )
+                    val mappedField =
+                        columnNameMapping[requestedField]
+                            ?: throw ConfigErrorException(
+                                "Stream ${stream.mappedDescriptor.toPrettyString()}: Partitioning field '$requestedField' does not have a destination column mapping",
+                            )
+                    mappedField to toDialectType(fieldType.type)
+                }
+
+            if (
+                fieldType == StandardSQLTypeName.DATE && granularity == PartitioningGranularity.HOUR
+            ) {
+                throw ConfigErrorException(
+                    "Stream ${stream.mappedDescriptor.toPrettyString()}: DATE partitioning field '$requestedField' does not support HOUR granularity",
+                )
+            }
+
+            val expression =
+                when (fieldType) {
+                    StandardSQLTypeName.DATE -> "DATE_TRUNC(`$mappedField`, ${granularity.value})"
+                    StandardSQLTypeName.TIMESTAMP ->
+                        if (
+                            requestedField == StreamConfigProvider.DEFAULT_PARTITIONING_FIELD &&
+                                granularity == PartitioningGranularity.DAY
+                        ) {
+                            // Preserve the connector's existing DDL when no custom configuration
+                            // is present.
+                            "DATE_TRUNC(_airbyte_extracted_at, DAY)"
+                        } else {
+                            "TIMESTAMP_TRUNC(`$mappedField`, ${granularity.value})"
+                        }
+                    StandardSQLTypeName.DATETIME ->
+                        "DATETIME_TRUNC(`$mappedField`, ${granularity.value})"
+                    else ->
+                        throw ConfigErrorException(
+                            "Stream ${stream.mappedDescriptor.toPrettyString()}: Partitioning field '$requestedField' must be DATE, TIMESTAMP, or DATETIME, but maps to $fieldType",
+                        )
+                }
+
+            val type =
+                when (granularity) {
+                    PartitioningGranularity.HOUR -> TimePartitioning.Type.HOUR
+                    PartitioningGranularity.DAY -> TimePartitioning.Type.DAY
+                    PartitioningGranularity.MONTH -> TimePartitioning.Type.MONTH
+                    PartitioningGranularity.YEAR -> TimePartitioning.Type.YEAR
+                }
+            return ResolvedPartitioning(mappedField, type, expression)
+        }
+
+        private val CLUSTERABLE_TYPES =
+            setOf(
+                StandardSQLTypeName.BOOL,
+                StandardSQLTypeName.DATE,
+                StandardSQLTypeName.DATETIME,
+                StandardSQLTypeName.INT64,
+                StandardSQLTypeName.NUMERIC,
+                StandardSQLTypeName.STRING,
+                StandardSQLTypeName.TIMESTAMP,
+            )
     }
 }
+
+data class ResolvedPartitioning(
+    val field: String,
+    val type: TimePartitioning.Type,
+    val expression: String,
+)

--- a/airbyte-integrations/connectors/destination-bigquery/src/test-integration/kotlin/io/airbyte/integrations/destination/bigquery/BigqueryDataDumper.kt
+++ b/airbyte-integrations/connectors/destination-bigquery/src/test-integration/kotlin/io/airbyte/integrations/destination/bigquery/BigqueryDataDumper.kt
@@ -30,6 +30,7 @@ import io.airbyte.cdk.load.util.Jsons
 import io.airbyte.cdk.load.util.deserializeToNode
 import io.airbyte.integrations.destination.bigquery.spec.BigqueryConfigurationFactory
 import io.airbyte.integrations.destination.bigquery.spec.BigquerySpecification
+import io.airbyte.integrations.destination.bigquery.stream.StreamConfigProvider
 import io.airbyte.integrations.destination.bigquery.write.typing_deduping.BigqueryFinalTableNameGenerator
 import io.airbyte.integrations.destination.bigquery.write.typing_deduping.BigqueryRawTableNameGenerator
 import io.airbyte.protocol.models.v0.AirbyteRecordMessageMetaChange
@@ -94,9 +95,11 @@ object BigqueryFinalTableDataDumper : DestinationDataDumper {
     ): List<OutputRecord> {
         val config = BigqueryConfigurationFactory().make(spec as BigquerySpecification)
         val bigquery = BigqueryBeansFactory().getBigqueryClient(config)
+        val streamConfigProvider = StreamConfigProvider(config)
 
         val (datasetName, finalTableName) =
-            BigqueryFinalTableNameGenerator(config).getTableName(stream.mappedDescriptor)
+            BigqueryFinalTableNameGenerator(config, streamConfigProvider)
+                .getTableName(stream.mappedDescriptor)
 
         return bigquery.getTable(TableId.of(datasetName, finalTableName))?.let { table ->
             val bigquerySchema = table.getDefinition<StandardTableDefinition>().schema!!

--- a/airbyte-integrations/connectors/destination-bigquery/src/test-integration/resources/expected-spec-cloud.json
+++ b/airbyte-integrations/connectors/destination-bigquery/src/test-integration/resources/expected-spec-cloud.json
@@ -153,6 +153,66 @@
         "title" : "Airbyte Internal Table Dataset Name",
         "group" : "advanced",
         "order" : 8
+      },
+      "stream_configurations" : {
+        "type" : "array",
+        "items" : {
+          "type" : "object",
+          "additionalProperties" : true,
+          "properties" : {
+            "stream_name" : {
+              "type" : "string",
+              "description" : "The effective destination stream name after Airbyte's stream-name mapping.",
+              "title" : "Stream name"
+            },
+            "stream_namespace" : {
+              "type" : "string",
+              "description" : "Optional destination namespace used to disambiguate streams with the same name.",
+              "title" : "Stream namespace"
+            },
+            "destination_dataset" : {
+              "type" : "string",
+              "description" : "Optional BigQuery dataset override. The connector creates the dataset when permitted.",
+              "title" : "Destination dataset"
+            },
+            "destination_table" : {
+              "type" : "string",
+              "description" : "Optional final-table name override. The table suffix is appended after this value.",
+              "title" : "Destination table"
+            },
+            "table_suffix" : {
+              "type" : "string",
+              "description" : "Optional suffix appended to the destination table name.",
+              "title" : "Table suffix"
+            },
+            "partitioning_field" : {
+              "type" : "string",
+              "description" : "Optional top-level DATE, TIMESTAMP, or DATETIME field used for time-unit partitioning.",
+              "title" : "Partitioning field"
+            },
+            "partitioning_granularity" : {
+              "type" : "string",
+              "enum" : [ "HOUR", "DAY", "MONTH", "YEAR" ],
+              "description" : "Partition granularity. HOUR is supported for TIMESTAMP and DATETIME fields; DATE fields support DAY, MONTH, and YEAR.",
+              "title" : "Partitioning granularity"
+            },
+            "clustering_fields" : {
+              "type" : "array",
+              "items" : {
+                "type" : "string"
+              },
+              "description" : "One to four top-level fields used for clustering, in clustering sort order.",
+              "title" : "Clustering fields",
+              "minItems" : 1,
+              "maxItems" : 4
+            }
+          },
+          "required" : [ "stream_name" ]
+        },
+        "description" : "Optional overrides for the destination dataset and table name, time-unit partitioning, and clustering of individual streams. A configuration with no namespace matches that stream name in any namespace.",
+        "title" : "Per-stream table configuration",
+        "group" : "advanced",
+        "order" : 9
       }
     },
     "required" : [ "project_id", "dataset_location", "dataset_id" ],

--- a/airbyte-integrations/connectors/destination-bigquery/src/test-integration/resources/expected-spec-oss.json
+++ b/airbyte-integrations/connectors/destination-bigquery/src/test-integration/resources/expected-spec-oss.json
@@ -153,6 +153,66 @@
         "title" : "Airbyte Internal Table Dataset Name",
         "group" : "advanced",
         "order" : 8
+      },
+      "stream_configurations" : {
+        "type" : "array",
+        "items" : {
+          "type" : "object",
+          "additionalProperties" : true,
+          "properties" : {
+            "stream_name" : {
+              "type" : "string",
+              "description" : "The effective destination stream name after Airbyte's stream-name mapping.",
+              "title" : "Stream name"
+            },
+            "stream_namespace" : {
+              "type" : "string",
+              "description" : "Optional destination namespace used to disambiguate streams with the same name.",
+              "title" : "Stream namespace"
+            },
+            "destination_dataset" : {
+              "type" : "string",
+              "description" : "Optional BigQuery dataset override. The connector creates the dataset when permitted.",
+              "title" : "Destination dataset"
+            },
+            "destination_table" : {
+              "type" : "string",
+              "description" : "Optional final-table name override. The table suffix is appended after this value.",
+              "title" : "Destination table"
+            },
+            "table_suffix" : {
+              "type" : "string",
+              "description" : "Optional suffix appended to the destination table name.",
+              "title" : "Table suffix"
+            },
+            "partitioning_field" : {
+              "type" : "string",
+              "description" : "Optional top-level DATE, TIMESTAMP, or DATETIME field used for time-unit partitioning.",
+              "title" : "Partitioning field"
+            },
+            "partitioning_granularity" : {
+              "type" : "string",
+              "enum" : [ "HOUR", "DAY", "MONTH", "YEAR" ],
+              "description" : "Partition granularity. HOUR is supported for TIMESTAMP and DATETIME fields; DATE fields support DAY, MONTH, and YEAR.",
+              "title" : "Partitioning granularity"
+            },
+            "clustering_fields" : {
+              "type" : "array",
+              "items" : {
+                "type" : "string"
+              },
+              "description" : "One to four top-level fields used for clustering, in clustering sort order.",
+              "title" : "Clustering fields",
+              "minItems" : 1,
+              "maxItems" : 4
+            }
+          },
+          "required" : [ "stream_name" ]
+        },
+        "description" : "Optional overrides for the destination dataset and table name, time-unit partitioning, and clustering of individual streams. A configuration with no namespace matches that stream name in any namespace.",
+        "title" : "Per-stream table configuration",
+        "group" : "advanced",
+        "order" : 9
       }
     },
     "required" : [ "project_id", "dataset_location", "dataset_id" ],

--- a/airbyte-integrations/connectors/destination-bigquery/src/test/kotlin/io/airbyte/integrations/destination/bigquery/spec/BigqueryConfigurationFactoryTest.kt
+++ b/airbyte-integrations/connectors/destination-bigquery/src/test/kotlin/io/airbyte/integrations/destination/bigquery/spec/BigqueryConfigurationFactoryTest.kt
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2026 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.integrations.destination.bigquery.spec
+
+import io.airbyte.cdk.ConfigErrorException
+import io.airbyte.cdk.load.util.Jsons
+import kotlin.test.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class BigqueryConfigurationFactoryTest {
+    private val factory = BigqueryConfigurationFactory()
+
+    @Test
+    fun `parses valid per-stream configuration`() {
+        val config =
+            factory.makeWithoutExceptionHandling(
+                specification(
+                    """
+                    [
+                      {
+                        "stream_name": "orders",
+                        "stream_namespace": "sales",
+                        "destination_dataset": "analytics",
+                        "partitioning_field": "created_at",
+                        "partitioning_granularity": "MONTH",
+                        "clustering_fields": ["customer_id", "status"]
+                      }
+                    ]
+                    """
+                )
+            )
+
+        val streamConfig = config.streamConfigurations[StreamSelector("sales", "orders")]!!
+        assertEquals("analytics", streamConfig.destinationDataset)
+        assertEquals(PartitioningGranularity.MONTH, streamConfig.partitioningGranularity)
+        assertEquals(listOf("customer_id", "status"), streamConfig.clusteringFields)
+    }
+
+    @Test
+    fun `rejects duplicate selectors`() {
+        assertThrows<ConfigErrorException> {
+            factory.makeWithoutExceptionHandling(
+                specification(
+                    """
+                    [
+                      {"stream_name": "orders", "stream_namespace": "sales"},
+                      {"stream_name": "orders", "stream_namespace": "sales"}
+                    ]
+                    """
+                )
+            )
+        }
+    }
+
+    @Test
+    fun `rejects invalid partition and clustering configuration`() {
+        assertThrows<ConfigErrorException> {
+            factory.makeWithoutExceptionHandling(
+                specification(
+                    """
+                    [
+                      {
+                        "stream_name": "orders",
+                        "partitioning_granularity": "DAY"
+                      }
+                    ]
+                    """
+                )
+            )
+        }
+
+        assertThrows<ConfigErrorException> {
+            factory.makeWithoutExceptionHandling(
+                specification(
+                    """
+                    [
+                      {
+                        "stream_name": "orders",
+                        "clustering_fields": ["customer_id", "CUSTOMER_ID"]
+                      }
+                    ]
+                    """
+                )
+            )
+        }
+    }
+
+    private fun specification(streamConfigurations: String): BigquerySpecification =
+        Jsons.treeToValue(
+            Jsons.readTree(
+                """
+                {
+                  "project_id": "project",
+                  "dataset_location": "US",
+                  "dataset_id": "default_dataset",
+                  "stream_configurations": $streamConfigurations
+                }
+                """
+            ),
+            BigquerySpecification::class.java,
+        )
+}

--- a/airbyte-integrations/connectors/destination-bigquery/src/test/kotlin/io/airbyte/integrations/destination/bigquery/stream/StreamConfigProviderTest.kt
+++ b/airbyte-integrations/connectors/destination-bigquery/src/test/kotlin/io/airbyte/integrations/destination/bigquery/stream/StreamConfigProviderTest.kt
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) 2026 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.integrations.destination.bigquery.stream
+
+import io.airbyte.cdk.load.command.DestinationStream
+import io.airbyte.integrations.destination.bigquery.spec.BatchedStandardInsertConfiguration
+import io.airbyte.integrations.destination.bigquery.spec.BigqueryConfiguration
+import io.airbyte.integrations.destination.bigquery.spec.BigqueryRegion
+import io.airbyte.integrations.destination.bigquery.spec.BigqueryStreamConfiguration
+import io.airbyte.integrations.destination.bigquery.spec.CdcDeletionMode
+import io.airbyte.integrations.destination.bigquery.spec.PartitioningGranularity
+import io.airbyte.integrations.destination.bigquery.spec.StreamSelector
+import io.airbyte.integrations.destination.bigquery.write.typing_deduping.BigqueryFinalTableNameGenerator
+import io.airbyte.integrations.destination.bigquery.write.typing_deduping.BigqueryRawTableNameGenerator
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import org.junit.jupiter.api.Test
+
+class StreamConfigProviderTest {
+    @Test
+    fun `namespace-specific configuration takes precedence over name-only configuration`() {
+        val nameOnly =
+            BigqueryStreamConfiguration(
+                streamName = "orders",
+                destinationDataset = "shared",
+                destinationTable = "orders_all",
+            )
+        val namespaceSpecific =
+            BigqueryStreamConfiguration(
+                streamName = "orders",
+                streamNamespace = "sales",
+                destinationDataset = "sales_analytics",
+                destinationTable = "fact_orders",
+                tableSuffix = "_v2",
+                partitioningField = "created_at",
+                partitioningGranularity = PartitioningGranularity.MONTH,
+                clusteringFields = listOf("customer_id", "status"),
+            )
+        val provider = provider(nameOnly, namespaceSpecific)
+
+        val salesOrders = DestinationStream.Descriptor("sales", "orders")
+        assertEquals("sales_analytics", provider.getDestinationDataset(salesOrders))
+        assertEquals("fact_orders", provider.getDestinationTable(salesOrders))
+        assertEquals("_v2", provider.getTableSuffix(salesOrders))
+        assertEquals("created_at", provider.getPartitioningField(salesOrders))
+        assertEquals(
+            PartitioningGranularity.MONTH,
+            provider.getPartitioningGranularity(salesOrders),
+        )
+        assertEquals(
+            listOf("customer_id", "status"),
+            provider.getClusteringFields(salesOrders),
+        )
+
+        val supportOrders = DestinationStream.Descriptor("support", "orders")
+        assertEquals("shared", provider.getDestinationDataset(supportOrders))
+        assertEquals("orders_all", provider.getDestinationTable(supportOrders))
+    }
+
+    @Test
+    fun `unconfigured streams preserve connector defaults`() {
+        val provider = provider()
+        val namespaced = DestinationStream.Descriptor("source_namespace", "events")
+        val withoutNamespace = DestinationStream.Descriptor(null, "events")
+
+        assertEquals("source_namespace", provider.getDestinationDataset(namespaced))
+        assertEquals("default_dataset", provider.getDestinationDataset(withoutNamespace))
+        assertEquals("events", provider.getDestinationTable(namespaced))
+        assertEquals("", provider.getTableSuffix(namespaced))
+        assertEquals(
+            StreamConfigProvider.DEFAULT_PARTITIONING_FIELD,
+            provider.getPartitioningField(namespaced),
+        )
+        assertEquals(
+            PartitioningGranularity.DAY,
+            provider.getPartitioningGranularity(namespaced),
+        )
+        assertNull(provider.getClusteringFields(namespaced))
+    }
+
+    @Test
+    fun `table generators route final tables without changing internal raw table names`() {
+        val streamConfiguration =
+            BigqueryStreamConfiguration(
+                streamName = "orders",
+                streamNamespace = "sales",
+                destinationDataset = "analytics",
+                destinationTable = "fact_orders",
+                tableSuffix = "_v2",
+            )
+        val config = configuration(streamConfiguration)
+        val provider = StreamConfigProvider(config)
+        val descriptor = DestinationStream.Descriptor("sales", "orders")
+
+        val finalTable = BigqueryFinalTableNameGenerator(config, provider).getTableName(descriptor)
+        assertEquals("analytics", finalTable.namespace)
+        assertEquals("fact_orders_v2", finalTable.name)
+
+        val rawTable = BigqueryRawTableNameGenerator(config).getTableName(descriptor)
+        assertEquals("airbyte_internal", rawTable.namespace)
+        assertEquals("sales_raw__stream_orders", rawTable.name)
+    }
+
+    private fun provider(
+        vararg streamConfigurations: BigqueryStreamConfiguration
+    ): StreamConfigProvider = StreamConfigProvider(configuration(*streamConfigurations))
+
+    private fun configuration(
+        vararg streamConfigurations: BigqueryStreamConfiguration
+    ): BigqueryConfiguration =
+        BigqueryConfiguration(
+            projectId = "project",
+            datasetLocation = BigqueryRegion.US,
+            datasetId = "default_dataset",
+            loadingMethod = BatchedStandardInsertConfiguration,
+            credentialsJson = null,
+            cdcDeletionMode = CdcDeletionMode.HARD_DELETE,
+            internalTableDataset = "airbyte_internal",
+            legacyRawTablesOnly = false,
+            streamConfigurations =
+                streamConfigurations.associateBy {
+                    StreamSelector(it.streamNamespace, it.streamName)
+                },
+        )
+}

--- a/airbyte-integrations/connectors/destination-bigquery/src/test/kotlin/io/airbyte/integrations/destination/bigquery/typing_deduping/direct_load_tables/BigqueryDirectLoadNativeTableOperationsTest.kt
+++ b/airbyte-integrations/connectors/destination-bigquery/src/test/kotlin/io/airbyte/integrations/destination/bigquery/typing_deduping/direct_load_tables/BigqueryDirectLoadNativeTableOperationsTest.kt
@@ -29,6 +29,7 @@ import io.airbyte.cdk.load.orchestration.db.DefaultTempTableNameGenerator
 import io.airbyte.cdk.load.orchestration.db.TableName
 import io.airbyte.cdk.load.orchestration.db.direct_load_table.ColumnAdd
 import io.airbyte.cdk.load.orchestration.db.direct_load_table.ColumnChange
+import io.airbyte.integrations.destination.bigquery.stream.StreamConfigProvider
 import io.airbyte.integrations.destination.bigquery.write.typing_deduping.direct_load_tables.BigqueryDirectLoadNativeTableOperations
 import io.airbyte.integrations.destination.bigquery.write.typing_deduping.direct_load_tables.BigqueryDirectLoadNativeTableOperations.Companion.clusteringMatches
 import io.airbyte.integrations.destination.bigquery.write.typing_deduping.direct_load_tables.BigqueryDirectLoadNativeTableOperations.Companion.partitioningMatches
@@ -85,6 +86,7 @@ class BigqueryDirectLoadNativeTableOperationsTest {
                     Mockito.mock(),
                     projectId = "unused",
                     tempTableNameGenerator = DefaultTempTableNameGenerator("unused"),
+                    streamConfigProvider = Mockito.mock(StreamConfigProvider::class.java),
                 )
                 .buildAlterTableReport(stream, columnNameMapping, existingTable)
         Assertions.assertAll(
@@ -142,6 +144,7 @@ class BigqueryDirectLoadNativeTableOperationsTest {
                     Mockito.mock(),
                     projectId = "unused",
                     tempTableNameGenerator = DefaultTempTableNameGenerator("unused"),
+                    streamConfigProvider = Mockito.mock(StreamConfigProvider::class.java),
                 )
                 .buildAlterTableReport(stream, columnNameMapping, existingTable)
         // NB: column names in AlterTableReport are all _after_ destination name transform
@@ -303,6 +306,7 @@ class BigqueryDirectLoadNativeTableOperationsTest {
                 Mockito.mock(),
                 projectId = "unused",
                 tempTableNameGenerator = DefaultTempTableNameGenerator("unused"),
+                streamConfigProvider = Mockito.mock(StreamConfigProvider::class.java),
             )
 
         val result = runBlocking {

--- a/airbyte-integrations/connectors/destination-bigquery/src/test/kotlin/io/airbyte/integrations/destination/bigquery/typing_deduping/direct_load_tables/BigqueryDirectLoadSqlGeneratorTest.kt
+++ b/airbyte-integrations/connectors/destination-bigquery/src/test/kotlin/io/airbyte/integrations/destination/bigquery/typing_deduping/direct_load_tables/BigqueryDirectLoadSqlGeneratorTest.kt
@@ -10,11 +10,16 @@ import io.airbyte.cdk.load.command.Dedupe
 import io.airbyte.cdk.load.command.DestinationStream
 import io.airbyte.cdk.load.command.NamespaceMapper
 import io.airbyte.cdk.load.config.NamespaceDefinitionType
+import io.airbyte.cdk.load.data.DateType
 import io.airbyte.cdk.load.data.FieldType
 import io.airbyte.cdk.load.data.IntegerType
 import io.airbyte.cdk.load.data.ObjectType
 import io.airbyte.cdk.load.data.ObjectTypeWithoutSchema
+import io.airbyte.cdk.load.data.StringType
+import io.airbyte.cdk.load.data.TimestampTypeWithTimezone
+import io.airbyte.cdk.load.data.TimestampTypeWithoutTimezone
 import io.airbyte.cdk.load.orchestration.db.ColumnNameMapping
+import io.airbyte.integrations.destination.bigquery.spec.PartitioningGranularity
 import io.airbyte.integrations.destination.bigquery.write.typing_deduping.direct_load_tables.BigqueryDirectLoadSqlGenerator
 import kotlin.test.assertEquals
 import org.junit.jupiter.api.Test
@@ -119,4 +124,112 @@ class BigqueryDirectLoadSqlGeneratorTest {
             e.message
         )
     }
+
+    @Test
+    fun testConfiguredClusteringColumnsPreserveOrderAndMappedNames() {
+        val stream =
+            streamWithSchema(
+                "customer_id" to IntegerType,
+                "status" to StringType,
+            )
+        val clusteringColumns =
+            BigqueryDirectLoadSqlGenerator.clusteringColumns(
+                stream,
+                ColumnNameMapping(
+                    mapOf(
+                        "customer_id" to "customer_id_mapped",
+                        "status" to "status_mapped",
+                    )
+                ),
+                configuredFields = listOf("status", "customer_id"),
+            )
+
+        assertEquals(listOf("status_mapped", "customer_id_mapped"), clusteringColumns)
+    }
+
+    @Test
+    fun testConfiguredClusteringRejectsMissingField() {
+        val stream = streamWithSchema("customer_id" to IntegerType)
+
+        assertThrows<ConfigErrorException> {
+            BigqueryDirectLoadSqlGenerator.clusteringColumns(
+                stream,
+                ColumnNameMapping(mapOf("customer_id" to "customer_id")),
+                configuredFields = listOf("missing"),
+            )
+        }
+    }
+
+    @Test
+    fun testPartitioningExpressionsForSupportedTemporalTypes() {
+        val datePartition =
+            BigqueryDirectLoadSqlGenerator.resolvePartitioning(
+                streamWithSchema("event_date" to DateType),
+                ColumnNameMapping(mapOf("event_date" to "mapped_event_date")),
+                requestedField = "event_date",
+                granularity = PartitioningGranularity.MONTH,
+            )
+        assertEquals("mapped_event_date", datePartition.field)
+        assertEquals(
+            "DATE_TRUNC(`mapped_event_date`, MONTH)",
+            datePartition.expression,
+        )
+
+        val timestampPartition =
+            BigqueryDirectLoadSqlGenerator.resolvePartitioning(
+                streamWithSchema("created_at" to TimestampTypeWithTimezone),
+                ColumnNameMapping(mapOf("created_at" to "created_at")),
+                requestedField = "created_at",
+                granularity = PartitioningGranularity.HOUR,
+            )
+        assertEquals(
+            "TIMESTAMP_TRUNC(`created_at`, HOUR)",
+            timestampPartition.expression,
+        )
+
+        val datetimePartition =
+            BigqueryDirectLoadSqlGenerator.resolvePartitioning(
+                streamWithSchema("local_time" to TimestampTypeWithoutTimezone),
+                ColumnNameMapping(mapOf("local_time" to "local_time")),
+                requestedField = "local_time",
+                granularity = PartitioningGranularity.YEAR,
+            )
+        assertEquals(
+            "DATETIME_TRUNC(`local_time`, YEAR)",
+            datetimePartition.expression,
+        )
+    }
+
+    @Test
+    fun testHourlyPartitioningRejectsDateField() {
+        assertThrows<ConfigErrorException> {
+            BigqueryDirectLoadSqlGenerator.resolvePartitioning(
+                streamWithSchema("event_date" to DateType),
+                ColumnNameMapping(mapOf("event_date" to "event_date")),
+                requestedField = "event_date",
+                granularity = PartitioningGranularity.HOUR,
+            )
+        }
+    }
+
+    private fun streamWithSchema(
+        vararg fields: Pair<String, io.airbyte.cdk.load.data.AirbyteType>
+    ): DestinationStream =
+        DestinationStream(
+            "ns",
+            "stream",
+            importType = Append,
+            schema =
+                ObjectType(
+                    linkedMapOf(
+                        *fields
+                            .map { (name, type) -> name to FieldType(type, nullable = true) }
+                            .toTypedArray()
+                    )
+                ),
+            generationId = 42,
+            minimumGenerationId = 0,
+            syncId = 12,
+            namespaceMapper = NamespaceMapper(NamespaceDefinitionType.SOURCE),
+        )
 }

--- a/docs/integrations/destinations/bigquery.md
+++ b/docs/integrations/destinations/bigquery.md
@@ -137,6 +137,42 @@ partitioning column are used to prune the partitions and reduce the query cost. 
 **Require partition filter** is not enabled by Airbyte, but you may toggle it by updating the
 produced tables.)
 
+### Per-stream table configuration
+
+You can override the final dataset and table layout for individual streams by setting
+`stream_configurations` in the destination's advanced configuration. For example:
+
+```json
+{
+  "stream_configurations": [
+    {
+      "stream_name": "orders",
+      "stream_namespace": "sales",
+      "destination_dataset": "analytics",
+      "destination_table": "fact_orders",
+      "table_suffix": "_v2",
+      "partitioning_field": "created_at",
+      "partitioning_granularity": "MONTH",
+      "clustering_fields": ["customer_id", "status"]
+    }
+  ]
+}
+```
+
+`stream_namespace` is optional. When present, it matches the effective destination namespace after
+Airbyte's namespace mapping. When omitted, the configuration matches the named stream in any
+namespace; a namespace-specific entry takes precedence.
+
+The partitioning field must be a top-level `DATE`, `TIMESTAMP`, or `DATETIME` field. Supported
+granularities are `HOUR`, `DAY`, `MONTH`, and `YEAR`, except that `DATE` fields don't support
+`HOUR`. You may provide one to four top-level clustering fields in clustering sort order.
+
+Changing an existing table's partitioning or clustering configuration causes the connector to
+recreate that table and copy its existing data. Changing the destination dataset or table directs
+subsequent syncs to the new location; it doesn't delete the previous table. Each source stream still
+has one destination table within a connection—this configuration routes streams independently but
+doesn't duplicate a single stream to multiple tables.
+
 ### Legacy Raw Tables schema
 
 If you enable the `Legacy raw tables` option, the connector will write tables in this format.


### PR DESCRIPTION
## What

Adds optional per-stream BigQuery final-table layout overrides. Different streams in one connection can target different datasets and tables, with configurable partitioning and clustering on business fields.

## How

- Adds an advanced `stream_configurations` list selected by effective destination stream name and optional mapped namespace.
- Supports destination dataset, destination table, and table suffix overrides.
- Supports top-level `DATE`, `TIMESTAMP`, and `DATETIME` partition fields with `HOUR`, `DAY`, `MONTH`, and `YEAR` granularities (`DATE` excludes `HOUR`).
- Supports one to four ordered, top-level clustering fields and validates field existence/type before issuing DDL.
- Preserves the existing daily `_airbyte_extracted_at` partition and default clustering DDL for unconfigured streams.
- Compares explicit partition/clustering metadata to existing BigQuery tables and uses the connector's existing temporary-table/copy recreation path when those settings change.
- Keeps internal raw table naming unchanged.
- Updates OSS/cloud spec snapshots and connector documentation.

## Review guide

1. `spec/BigquerySpecification.kt` and `spec/BigqueryConfiguration.kt`: public configuration and validation.
2. `stream/StreamConfigProvider.kt` and `BigqueryNameGenerators.kt`: selector precedence and dataset/table routing.
3. `BigqueryDirectLoadSqlGenerator.kt`: partition/clustering validation and DDL generation.
4. `BigqueryDirectLoadNativeTableOperations.kt`: existing-table metadata matching and safe recreation trigger.
5. Unit tests, spec snapshots, and `docs/integrations/destinations/bigquery.md`.

## User Impact

Existing configurations are unchanged. Users who opt in may independently route streams within one connection and tune BigQuery partitioning/clustering without post-sync DDL.

Changing an existing table's explicit partitioning or clustering recreates the table and copies existing data, which may be expensive for large tables. Changing the destination dataset/table writes subsequent syncs to the new location and does not delete the old table.

This routes different streams independently; it does not duplicate one source stream to multiple tables.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚
- [ ] NO ❌