### PR TITLE
feat(destination-s3-data-lake): positional Iceberg deletes for dedupe

### DIFF
--- a/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/build.gradle
+++ b/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/build.gradle
@@ -10,6 +10,7 @@ dependencies {
 
     // Hadoop Configuration class used by Iceberg
     implementation 'org.apache.hadoop:hadoop-common:3.4.1'
+    implementation 'org.apache.parquet:parquet-hadoop:1.17.1'
 
     api "org.apache.iceberg:iceberg-core:${project.ext.apacheIcebergVersion}"
     api "org.apache.iceberg:iceberg-api:${project.ext.apacheIcebergVersion}"
@@ -22,4 +23,5 @@ dependencies {
 
     testImplementation "io.mockk:mockk:1.13.12"
     testImplementation "org.assertj:assertj-core:3.26.3"
+    testImplementation 'org.apache.hadoop:hadoop-mapreduce-client-core:3.4.1'
 }

--- a/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/java/io/airbyte/cdk/load/toolkits/iceberg/parquet/io/BasePositionDeltaTaskWriter.java
+++ b/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/java/io/airbyte/cdk/load/toolkits/iceberg/parquet/io/BasePositionDeltaTaskWriter.java
@@ -1,0 +1,247 @@
+/*
+ * Copyright (c) 2026 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.cdk.load.toolkits.iceberg.parquet.io;
+
+import io.airbyte.cdk.ConfigErrorException;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import org.apache.iceberg.DeleteFile;
+import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.StructLike;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.data.GenericFileWriterFactory;
+import org.apache.iceberg.data.GenericRecord;
+import org.apache.iceberg.data.InternalRecordWrapper;
+import org.apache.iceberg.data.Record;
+import org.apache.iceberg.deletes.PositionDelete;
+import org.apache.iceberg.deletes.PositionDeleteWriter;
+import org.apache.iceberg.io.BaseTaskWriter;
+import org.apache.iceberg.io.DeleteWriteResult;
+import org.apache.iceberg.io.FileIO;
+import org.apache.iceberg.io.OutputFileFactory;
+import org.apache.iceberg.io.WriteResult;
+import org.apache.iceberg.types.TypeUtil;
+import org.apache.iceberg.types.Types;
+
+/**
+ * Delta writer that emits only positional deletes.
+ *
+ * <p>The location index is shared by every aggregate for one stream. This mirrors the location
+ * tracking in Iceberg's BaseEqualityDeltaWriter while making it available across writer instances.
+ */
+public abstract class BasePositionDeltaTaskWriter extends BaseTaskWriter<Record> {
+
+  public static final String NULL_PK_ERROR_MESSAGE =
+      "Detected null value in primary key. The Iceberg protocol disallows this. This is either a bug in the source, or you should use the append/overwrite sync mode.";
+
+  private final Table table;
+  private final Schema deleteSchema;
+  private final InternalRecordWrapper wrapper;
+  private final InternalRecordWrapper keyWrapper;
+  private final PositionalDeleteIndex index;
+  private final GenericFileWriterFactory writerFactory;
+  private final OutputFileFactory fileFactory;
+  private final List<DeleteFile> completedPositionDeleteFiles = new ArrayList<>();
+
+  protected BasePositionDeltaTaskWriter(
+      final Table table,
+      final PartitionSpec spec,
+      final FileFormat format,
+      final GenericFileWriterFactory writerFactory,
+      final OutputFileFactory fileFactory,
+      final FileIO io,
+      final long targetFileSize,
+      final Schema schema,
+      final Set<Integer> identifierFieldIds,
+      final PositionalDeleteIndex index) {
+    super(spec, format, writerFactory, fileFactory, io, targetFileSize);
+    this.table = table;
+    this.deleteSchema = TypeUtil.select(schema, identifierFieldIds);
+    this.wrapper = new InternalRecordWrapper(schema.asStruct());
+    this.keyWrapper = new InternalRecordWrapper(deleteSchema.asStruct());
+    this.index = index;
+    this.writerFactory = writerFactory;
+    this.fileFactory = fileFactory;
+  }
+
+  public abstract RowDataPositionDeltaWriter route(Record row);
+
+  protected InternalRecordWrapper wrapper() {
+    return wrapper;
+  }
+
+  private Record constructIdentifierRecord(Record row) {
+    final GenericRecord recordWithIds = GenericRecord.create(deleteSchema);
+    for (Types.NestedField idField : deleteSchema.columns()) {
+      Object value = row.getField(idField.name());
+      if (value == null) {
+        throw new ConfigErrorException(
+            "Error in stream " + table.name() + ": " + NULL_PK_ERROR_MESSAGE, null);
+      }
+      recordWithIds.setField(idField.name(), value);
+    }
+    return recordWithIds;
+  }
+
+  @Override
+  public void write(final Record row) throws IOException {
+    RowDataPositionDeltaWriter writer = route(row);
+    Operation rowOperation = getOperation(row);
+    if (rowOperation == Operation.INSERT) {
+      writer.write(row);
+    } else if (rowOperation == Operation.DELETE) {
+      writer.deleteKey(constructIdentifierRecord(row));
+    } else {
+      writer.deleteKey(constructIdentifierRecord(row));
+      writer.write(row);
+    }
+  }
+
+  private Operation getOperation(final Record row) {
+    if (row instanceof RecordWrapper) {
+      return ((RecordWrapper) row).getOperation();
+    }
+    return Operation.INSERT;
+  }
+
+  @Override
+  public WriteResult complete() throws IOException {
+    close();
+    WriteResult dataResult = super.complete();
+    WriteResult.Builder result = WriteResult.builder().addDataFiles(dataResult.dataFiles());
+    result.addDeleteFiles(dataResult.deleteFiles());
+    synchronized (completedPositionDeleteFiles) {
+      result.addDeleteFiles(completedPositionDeleteFiles);
+    }
+    return result.build();
+  }
+
+  private void addCompletedPositionDeleteFile(DeleteFile deleteFile) {
+    if (deleteFile != null) {
+      synchronized (completedPositionDeleteFiles) {
+        completedPositionDeleteFiles.add(deleteFile);
+      }
+    }
+  }
+
+  public class RowDataPositionDeltaWriter implements AutoCloseable {
+
+    private final StructLike partition;
+    private final List<PositionDeleteWriterState> positionDeleteWriters = new ArrayList<>();
+    private final RollingFileWriter dataWriter;
+    private boolean closed;
+
+    public RowDataPositionDeltaWriter(StructLike partition) {
+      this.partition = partition;
+      this.dataWriter = new RollingFileWriter(partition);
+    }
+
+    public void write(Record row) throws IOException {
+      StructLike key = keyWrapper.wrap(row);
+      PositionalDeleteIndex.RowLocation location =
+          new PositionalDeleteIndex.RowLocation(
+              dataWriter.currentPath(), dataWriter.currentRows(), spec(), partition);
+      PositionalDeleteIndex.RowLocation previous = index.replace(key, location);
+      if (previous != null) {
+        writePositionDelete(previous);
+      }
+      dataWriter.write(row);
+    }
+
+    public void deleteKey(Record keyRecord) {
+      PositionalDeleteIndex.RowLocation previous = index.remove(keyWrapper.wrap(keyRecord));
+      if (previous != null) {
+        writePositionDelete(previous);
+      }
+    }
+
+    private void writePositionDelete(PositionalDeleteIndex.RowLocation location) {
+      PositionDeleteWriterState state =
+          positionDeleteWriters.stream()
+              .filter(
+                  candidate ->
+                      candidate.spec.equals(location.spec())
+                          && samePartition(candidate.partition, location.partition()))
+              .findFirst()
+              .orElseGet(
+                  () -> {
+                    PositionDeleteWriter<Record> writer =
+                        writerFactory.newPositionDeleteWriter(
+                            fileFactory.newOutputFile(location.spec(), location.partition()),
+                            location.spec(),
+                            location.partition());
+                    PositionDeleteWriterState created =
+                        new PositionDeleteWriterState(
+                            location.spec(), location.partition(), writer);
+                    positionDeleteWriters.add(created);
+                    return created;
+                  });
+      PositionDelete<Record> positionDelete = PositionDelete.create();
+      positionDelete.set(location.path(), location.position());
+      state.writer.write(positionDelete);
+    }
+
+    @Override
+    public void close() throws IOException {
+      if (!closed) {
+        try {
+          dataWriter.close();
+          for (PositionDeleteWriterState state : positionDeleteWriters) {
+            state.writer.close();
+            addCompletedPositionDeleteFile(state.deleteFile());
+          }
+        } finally {
+          closed = true;
+        }
+      }
+    }
+
+    private boolean samePartition(StructLike left, StructLike right) {
+      if (left == right) {
+        return true;
+      }
+      if (left == null || right == null) {
+        return false;
+      }
+      for (int i = 0; i < left.size(); i++) {
+        Object leftValue = left.get(i, Object.class);
+        Object rightValue = right.get(i, Object.class);
+        if (leftValue == null ? rightValue != null : !leftValue.equals(rightValue)) {
+          return false;
+        }
+      }
+      return true;
+    }
+
+    private final class PositionDeleteWriterState {
+      private final PartitionSpec spec;
+      private final StructLike partition;
+      private final PositionDeleteWriter<Record> writer;
+
+      private PositionDeleteWriterState(
+          PartitionSpec spec, StructLike partition, PositionDeleteWriter<Record> writer) {
+        this.spec = spec;
+        this.partition = partition;
+        this.writer = writer;
+      }
+
+      private DeleteFile deleteFile() {
+        DeleteWriteResult result = writer.result();
+        if (result.deleteFiles().isEmpty()) {
+          return null;
+        }
+        return result.deleteFiles().get(0);
+      }
+    }
+  }
+
+  protected PositionalDeleteIndex index() {
+    return index;
+  }
+}

--- a/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/java/io/airbyte/cdk/load/toolkits/iceberg/parquet/io/BasePositionDeltaTaskWriter.java
+++ b/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/java/io/airbyte/cdk/load/toolkits/iceberg/parquet/io/BasePositionDeltaTaskWriter.java
@@ -7,6 +7,7 @@ package io.airbyte.cdk.load.toolkits.iceberg.parquet.io;
 import io.airbyte.cdk.ConfigErrorException;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Set;
 import org.apache.iceberg.DeleteFile;
@@ -143,7 +144,7 @@ public abstract class BasePositionDeltaTaskWriter extends BaseTaskWriter<Record>
     }
 
     public void write(Record row) throws IOException {
-      StructLike key = keyWrapper.wrap(row);
+      StructLike key = keyWrapper.wrap(constructIdentifierRecord(row));
       PositionalDeleteIndex.RowLocation location =
           new PositionalDeleteIndex.RowLocation(
               dataWriter.currentPath(), dataWriter.currentRows(), spec(), partition);
@@ -171,20 +172,13 @@ public abstract class BasePositionDeltaTaskWriter extends BaseTaskWriter<Record>
               .findFirst()
               .orElseGet(
                   () -> {
-                    PositionDeleteWriter<Record> writer =
-                        writerFactory.newPositionDeleteWriter(
-                            fileFactory.newOutputFile(location.spec(), location.partition()),
-                            location.spec(),
-                            location.partition());
                     PositionDeleteWriterState created =
                         new PositionDeleteWriterState(
-                            location.spec(), location.partition(), writer);
+                            location.spec(), location.partition());
                     positionDeleteWriters.add(created);
                     return created;
                   });
-      PositionDelete<Record> positionDelete = PositionDelete.create();
-      positionDelete.set(location.path(), location.position());
-      state.writer.write(positionDelete);
+      state.locations.add(location);
     }
 
     @Override
@@ -193,8 +187,7 @@ public abstract class BasePositionDeltaTaskWriter extends BaseTaskWriter<Record>
         try {
           dataWriter.close();
           for (PositionDeleteWriterState state : positionDeleteWriters) {
-            state.writer.close();
-            addCompletedPositionDeleteFile(state.deleteFile());
+            state.writeSorted();
           }
         } finally {
           closed = true;
@@ -222,21 +215,34 @@ public abstract class BasePositionDeltaTaskWriter extends BaseTaskWriter<Record>
     private final class PositionDeleteWriterState {
       private final PartitionSpec spec;
       private final StructLike partition;
-      private final PositionDeleteWriter<Record> writer;
+      private final List<PositionalDeleteIndex.RowLocation> locations = new ArrayList<>();
 
-      private PositionDeleteWriterState(
-          PartitionSpec spec, StructLike partition, PositionDeleteWriter<Record> writer) {
+      private PositionDeleteWriterState(PartitionSpec spec, StructLike partition) {
         this.spec = spec;
         this.partition = partition;
-        this.writer = writer;
       }
 
-      private DeleteFile deleteFile() {
-        DeleteWriteResult result = writer.result();
-        if (result.deleteFiles().isEmpty()) {
-          return null;
+      private void writeSorted() throws IOException {
+        if (locations.isEmpty()) {
+          return;
         }
-        return result.deleteFiles().get(0);
+        locations.sort(
+            Comparator.comparing((PositionalDeleteIndex.RowLocation location) -> location.path().toString())
+                .thenComparingLong(PositionalDeleteIndex.RowLocation::position));
+        PositionDeleteWriter<Record> writer =
+            writerFactory.newPositionDeleteWriter(
+                fileFactory.newOutputFile(spec, partition), spec, partition);
+        try {
+          for (PositionalDeleteIndex.RowLocation location : locations) {
+            PositionDelete<Record> positionDelete = PositionDelete.create();
+            positionDelete.set(location.path(), location.position());
+            writer.write(positionDelete);
+          }
+        } finally {
+          writer.close();
+        }
+        DeleteWriteResult result = writer.result();
+        result.deleteFiles().forEach(BasePositionDeltaTaskWriter.this::addCompletedPositionDeleteFile);
       }
     }
   }

--- a/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/java/io/airbyte/cdk/load/toolkits/iceberg/parquet/io/PositionalDeleteIndex.java
+++ b/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/java/io/airbyte/cdk/load/toolkits/iceberg/parquet/io/PositionalDeleteIndex.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2026 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.cdk.load.toolkits.iceberg.parquet.io;
+
+import java.util.Map;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.StructLike;
+import org.apache.iceberg.util.StructLikeMap;
+import org.apache.iceberg.util.StructLikeUtil;
+import org.apache.iceberg.types.Types;
+
+/**
+ * Stream-scoped, thread-safe index of identifier values to physical Iceberg row locations.
+ *
+ * <p>The key is copied when it enters the index because Iceberg record wrappers may be reused.
+ */
+public final class PositionalDeleteIndex {
+
+  private final Map<StructLike, RowLocation> locations;
+  private long maxEntries;
+
+  public PositionalDeleteIndex(Types.StructType keyType) {
+    this.locations = StructLikeMap.create(keyType);
+  }
+
+  public synchronized RowLocation get(StructLike key) {
+    return locations.get(key);
+  }
+
+  public synchronized RowLocation remove(StructLike key) {
+    return locations.remove(key);
+  }
+
+  public synchronized RowLocation replace(StructLike key, RowLocation location) {
+    StructLike copiedKey = StructLikeUtil.copy(key);
+    RowLocation previous = locations.put(copiedKey, location);
+    maxEntries = Math.max(maxEntries, locations.size());
+    return previous;
+  }
+
+  public synchronized int size() {
+    return locations.size();
+  }
+
+  public synchronized long maxEntries() {
+    return maxEntries;
+  }
+
+  public record RowLocation(
+      CharSequence path, long position, PartitionSpec spec, StructLike partition) {
+    public RowLocation {
+      partition = partition == null ? null : StructLikeUtil.copy(partition);
+    }
+  }
+}

--- a/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/java/io/airbyte/cdk/load/toolkits/iceberg/parquet/io/PositionalDeleteIndex.java
+++ b/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/java/io/airbyte/cdk/load/toolkits/iceberg/parquet/io/PositionalDeleteIndex.java
@@ -51,6 +51,13 @@ public final class PositionalDeleteIndex {
   public record RowLocation(
       CharSequence path, long position, PartitionSpec spec, StructLike partition) {
     public RowLocation {
+      path = path.toString();
+      partition = partition == null ? null : StructLikeUtil.copy(partition);
+    }
+  }
+
+  public record RowLocationMetadata(PartitionSpec spec, StructLike partition) {
+    public RowLocationMetadata {
       partition = partition == null ? null : StructLikeUtil.copy(partition);
     }
   }

--- a/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/kotlin/io/airbyte/cdk/load/toolkits/iceberg/parquet/io/IcebergTableWriterFactory.kt
+++ b/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/kotlin/io/airbyte/cdk/load/toolkits/iceberg/parquet/io/IcebergTableWriterFactory.kt
@@ -55,7 +55,8 @@ class IcebergTableWriterFactory {
         table: Table,
         generationId: String,
         importType: ImportType,
-        schema: Schema
+        schema: Schema,
+        positionalDeleteIndex: PositionalDeleteIndex? = null,
     ): BaseTaskWriter<Record> {
         assertGenerationIdSuffixIsOfValidFormat(generationId)
         val format =
@@ -92,15 +93,28 @@ class IcebergTableWriterFactory {
                     format = format
                 )
             is Dedupe ->
-                newDeltaWriter(
-                    table = table,
-                    schema = schema,
-                    identifierFieldIds = identifierFieldIds,
-                    writerFactory = writerFactory,
-                    targetFileSize = targetFileSize,
-                    outputFileFactory = outputFileFactory,
-                    format = format
-                )
+                if (positionalDeleteIndex == null) {
+                    newDeltaWriter(
+                        table = table,
+                        schema = schema,
+                        identifierFieldIds = identifierFieldIds,
+                        writerFactory = writerFactory,
+                        targetFileSize = targetFileSize,
+                        outputFileFactory = outputFileFactory,
+                        format = format
+                    )
+                } else {
+                    newPositionDeltaWriter(
+                        table = table,
+                        schema = schema,
+                        identifierFieldIds = identifierFieldIds,
+                        writerFactory = writerFactory,
+                        targetFileSize = targetFileSize,
+                        outputFileFactory = outputFileFactory,
+                        format = format,
+                        positionalDeleteIndex = positionalDeleteIndex,
+                    )
+                }
             else -> throw IllegalArgumentException("Unsupported import type $importType")
         }
     }
@@ -197,6 +211,45 @@ class IcebergTableWriterFactory {
                 targetFileSize = targetFileSize,
                 schema = schema,
                 identifierFieldIds = identifierFieldIds
+            )
+        }
+    }
+
+    private fun newPositionDeltaWriter(
+        table: Table,
+        schema: Schema,
+        format: FileFormat,
+        writerFactory: GenericFileWriterFactory,
+        outputFileFactory: OutputFileFactory,
+        targetFileSize: Long,
+        identifierFieldIds: Set<Int>,
+        positionalDeleteIndex: PositionalDeleteIndex,
+    ): BaseTaskWriter<Record> {
+        return if (table.spec().isUnpartitioned) {
+            UnpartitionedPositionDeltaWriter(
+                table,
+                spec = table.spec(),
+                format = format,
+                writerFactory = writerFactory,
+                outputFileFactory = outputFileFactory,
+                io = table.io(),
+                targetFileSize = targetFileSize,
+                schema = schema,
+                identifierFieldIds = identifierFieldIds,
+                index = positionalDeleteIndex,
+            )
+        } else {
+            PartitionedPositionDeltaWriter(
+                table,
+                spec = table.spec(),
+                format = format,
+                writerFactory = writerFactory,
+                outputFileFactory = outputFileFactory,
+                io = table.io(),
+                targetFileSize = targetFileSize,
+                schema = schema,
+                identifierFieldIds = identifierFieldIds,
+                index = positionalDeleteIndex,
             )
         }
     }

--- a/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/kotlin/io/airbyte/cdk/load/toolkits/iceberg/parquet/io/PositionalDeleteIndexBuilder.kt
+++ b/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/kotlin/io/airbyte/cdk/load/toolkits/iceberg/parquet/io/PositionalDeleteIndexBuilder.kt
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2026 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.cdk.load.toolkits.iceberg.parquet.io
+
+import io.github.oshai.kotlinlogging.KotlinLogging
+import kotlin.time.Duration.Companion.milliseconds
+import org.apache.iceberg.MetadataColumns
+import org.apache.iceberg.Schema
+import org.apache.iceberg.Table
+import org.apache.iceberg.data.GenericRecord
+import org.apache.iceberg.types.TypeUtil
+
+private val logger = KotlinLogging.logger {}
+
+class PositionalDeleteIndexBuilder(
+    private val maxEntries: Int = DEFAULT_MAX_ENTRIES,
+) {
+    fun empty(schema: Schema, identifierFieldIds: Set<Int>): PositionalDeleteIndex =
+        PositionalDeleteIndex(TypeUtil.select(schema, identifierFieldIds).asStruct())
+
+    fun build(
+        table: Table,
+        ref: String,
+        schema: Schema,
+        identifierFieldIds: Set<Int>,
+    ): PositionalDeleteIndex {
+        require(identifierFieldIds.isNotEmpty()) {
+            "Positional deletes require at least one identifier field for table ${table.name()}"
+        }
+        val deleteSchema = TypeUtil.select(schema, identifierFieldIds)
+        val index = PositionalDeleteIndex(deleteSchema.asStruct())
+        val columns =
+            deleteSchema.columns().map { it.name() } +
+                listOf(MetadataColumns.FILE_PATH.name(), MetadataColumns.ROW_POSITION.name())
+        val scan = table.newScan().useRef(ref).select(columns)
+        val scanSchema = scan.schema()
+        val positions =
+            scanSchema.columns().mapIndexed { fieldPosition, field ->
+                field.name() to fieldPosition
+            }.toMap()
+        val start = System.nanoTime()
+        var rows = 0L
+
+        scan.planFiles().use { tasks ->
+            for (task in tasks) {
+                val dataTask = task.asDataTask()
+                dataTask.rows().use { records ->
+                    for (record in records) {
+                        if (index.size() >= maxEntries) {
+                            throw IllegalStateException(
+                                "Positional delete index for ${table.name()} exceeded its maximum " +
+                                    "$maxEntries entries. Increase the configured limit or use equality deletes."
+                            )
+                        }
+                        val key = GenericRecord.create(deleteSchema)
+                        deleteSchema.columns().forEach { field ->
+                            key.setField(
+                                field.name(),
+                                record.get(positions[field.name()]!!, Any::class.java),
+                            )
+                        }
+                        val path =
+                            record.get(
+                                positions[MetadataColumns.FILE_PATH.name()]!!,
+                                CharSequence::class.java,
+                            )
+                        val position =
+                            record.get(
+                                positions[MetadataColumns.ROW_POSITION.name()]!!,
+                                java.lang.Long::class.java,
+                            )
+                        index.replace(
+                            key,
+                            PositionalDeleteIndex.RowLocation(
+                                path,
+                                position.toLong(),
+                                table.specs()[task.file().specId()]!!,
+                                task.partition(),
+                            ),
+                        )
+                        rows += 1
+                    }
+                }
+            }
+        }
+
+        val elapsed = (System.nanoTime() - start).milliseconds
+        logger.info {
+            "Built positional delete index for ${table.name()} on ref $ref: " +
+                "${index.size()} keys, $rows rows, took $elapsed"
+        }
+        return index
+    }
+
+    companion object {
+        const val DEFAULT_MAX_ENTRIES = 10_000_000
+    }
+}

--- a/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/kotlin/io/airbyte/cdk/load/toolkits/iceberg/parquet/io/PositionalDeleteIndexBuilder.kt
+++ b/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/kotlin/io/airbyte/cdk/load/toolkits/iceberg/parquet/io/PositionalDeleteIndexBuilder.kt
@@ -5,7 +5,6 @@
 package io.airbyte.cdk.load.toolkits.iceberg.parquet.io
 
 import io.github.oshai.kotlinlogging.KotlinLogging
-import org.apache.iceberg.MetadataColumns
 import org.apache.iceberg.Schema
 import org.apache.iceberg.Table
 import org.apache.iceberg.data.GenericRecord

--- a/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/kotlin/io/airbyte/cdk/load/toolkits/iceberg/parquet/io/PositionalDeleteIndexBuilder.kt
+++ b/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/kotlin/io/airbyte/cdk/load/toolkits/iceberg/parquet/io/PositionalDeleteIndexBuilder.kt
@@ -5,12 +5,13 @@
 package io.airbyte.cdk.load.toolkits.iceberg.parquet.io
 
 import io.github.oshai.kotlinlogging.KotlinLogging
-import kotlin.time.Duration.Companion.milliseconds
 import org.apache.iceberg.MetadataColumns
 import org.apache.iceberg.Schema
 import org.apache.iceberg.Table
-import org.apache.iceberg.data.IcebergGenerics
 import org.apache.iceberg.data.GenericRecord
+import org.apache.iceberg.data.Record
+import org.apache.iceberg.data.parquet.GenericParquetReaders
+import org.apache.iceberg.parquet.Parquet
 import org.apache.iceberg.types.TypeUtil
 
 private val logger = KotlinLogging.logger {}
@@ -32,22 +33,21 @@ class PositionalDeleteIndexBuilder(
         }
         val deleteSchema = TypeUtil.select(schema, identifierFieldIds)
         val index = PositionalDeleteIndex(deleteSchema.asStruct())
-        val columns =
-            deleteSchema.columns().map { it.name() } +
-                listOf(MetadataColumns.FILE_PATH.name(), MetadataColumns.ROW_POSITION.name())
-        val snapshotId =
-            requireNotNull(table.refs()[ref]?.snapshotId()) {
-                "Cannot build positional delete index for ${table.name()}: ref $ref has no snapshot"
-            }
+        require(table.refs()[ref]?.snapshotId() != null) {
+            "Cannot build positional delete index for ${table.name()}: ref $ref has no snapshot"
+        }
         val scan = table.newScan().useRef(ref)
-        val locations =
+        val files =
             scan.planFiles().use { tasks ->
                 tasks.associateBy(
                     { it.file().location().toString() },
                     {
-                        PositionalDeleteIndex.RowLocationMetadata(
-                            table.specs()[it.file().specId()]!!,
-                            it.partition(),
+                        PlannedFile(
+                            it.file(),
+                            PositionalDeleteIndex.RowLocationMetadata(
+                                table.specs()[it.file().specId()]!!,
+                                it.partition(),
+                            ),
                         )
                     },
                 )
@@ -55,50 +55,62 @@ class PositionalDeleteIndexBuilder(
         val start = System.nanoTime()
         var rows = 0L
 
-        IcebergGenerics.read(table).useSnapshot(snapshotId).select(columns).build().use { records ->
-            for (record in records) {
-                if (index.size() >= maxEntries) {
-                    throw IllegalStateException(
-                        "Positional delete index for ${table.name()} exceeded its maximum " +
-                            "$maxEntries entries. Increase the configured limit or use equality deletes."
-                    )
+        require(files.values.all { it.file.format() == org.apache.iceberg.FileFormat.PARQUET }) {
+            "Positional delete index currently supports only Parquet data files"
+        }
+        for ((path, planned) in files) {
+            var position = 0L
+            val inputFile = table.io().newInputFile(path)
+            Parquet.read(inputFile)
+                .project(deleteSchema)
+                .createReaderFunc { messageType ->
+                    GenericParquetReaders.buildReader(deleteSchema, messageType)
                 }
-                val key = GenericRecord.create(deleteSchema)
-                deleteSchema.columns().forEach { field ->
-                    key.setField(field.name(), record.getField(field.name()))
-                }
-                val path = record.getField(MetadataColumns.FILE_PATH.name()).toString()
-                val position = (record.getField(MetadataColumns.ROW_POSITION.name()) as Number).toLong()
-                val metadata =
-                    requireNotNull(locations[path]) {
-                        "Could not find planned data file $path while building positional delete index"
+                .build<Record>()
+                .use { records ->
+                    for (record in records) {
+                        if (index.size() >= maxEntries) {
+                            throw IllegalStateException(
+                                "Positional delete index for ${table.name()} exceeded its maximum " +
+                                    "$maxEntries entries. Increase the configured limit or use equality deletes."
+                            )
+                        }
+                        val key = GenericRecord.create(deleteSchema)
+                        deleteSchema.columns().forEach { field ->
+                            key.setField(field.name(), record.getField(field.name()))
+                        }
+                        val previous =
+                            index.replace(
+                                key,
+                                PositionalDeleteIndex.RowLocation(
+                                    path,
+                                    position++,
+                                    planned.metadata.spec,
+                                    planned.metadata.partition,
+                                ),
+                            )
+                        check(previous == null) {
+                            "Positional delete index for ${table.name()} found multiple rows for " +
+                                "the same identifier. Positional deletes require unique keys in " +
+                                "the base snapshot."
+                        }
+                        rows += 1
                     }
-                val previous =
-                    index.replace(
-                        key,
-                        PositionalDeleteIndex.RowLocation(
-                            path,
-                            position,
-                            metadata.spec,
-                            metadata.partition,
-                        ),
-                    )
-                check(previous == null) {
-                    "Positional delete index for ${table.name()} found multiple rows for " +
-                        "the same identifier. Positional deletes require unique keys in " +
-                        "the base snapshot."
                 }
-                rows += 1
-            }
         }
 
-        val elapsed = (System.nanoTime() - start).milliseconds
+        val elapsedMillis = (System.nanoTime() - start) / 1_000_000
         logger.info {
             "Built positional delete index for ${table.name()} on ref $ref: " +
-                "${index.size()} keys, $rows rows, took $elapsed"
+                "${index.size()} keys, $rows rows, took ${elapsedMillis}ms"
         }
         return index
     }
+
+    private data class PlannedFile(
+        val file: org.apache.iceberg.DataFile,
+        val metadata: PositionalDeleteIndex.RowLocationMetadata,
+    )
 
     companion object {
         const val DEFAULT_MAX_ENTRIES = 10_000_000

--- a/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/kotlin/io/airbyte/cdk/load/toolkits/iceberg/parquet/io/PositionalDeleteIndexBuilder.kt
+++ b/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/kotlin/io/airbyte/cdk/load/toolkits/iceberg/parquet/io/PositionalDeleteIndexBuilder.kt
@@ -9,6 +9,7 @@ import kotlin.time.Duration.Companion.milliseconds
 import org.apache.iceberg.MetadataColumns
 import org.apache.iceberg.Schema
 import org.apache.iceberg.Table
+import org.apache.iceberg.data.IcebergGenerics
 import org.apache.iceberg.data.GenericRecord
 import org.apache.iceberg.types.TypeUtil
 
@@ -34,60 +35,60 @@ class PositionalDeleteIndexBuilder(
         val columns =
             deleteSchema.columns().map { it.name() } +
                 listOf(MetadataColumns.FILE_PATH.name(), MetadataColumns.ROW_POSITION.name())
-        val scan = table.newScan().useRef(ref).select(columns)
-        val scanSchema = scan.schema()
-        val positions =
-            scanSchema.columns().mapIndexed { fieldPosition, field ->
-                field.name() to fieldPosition
-            }.toMap()
+        val snapshotId =
+            requireNotNull(table.refs()[ref]?.snapshotId()) {
+                "Cannot build positional delete index for ${table.name()}: ref $ref has no snapshot"
+            }
+        val scan = table.newScan().useRef(ref)
+        val locations =
+            scan.planFiles().use { tasks ->
+                tasks.associateBy(
+                    { it.file().location().toString() },
+                    {
+                        PositionalDeleteIndex.RowLocationMetadata(
+                            table.specs()[it.file().specId()]!!,
+                            it.partition(),
+                        )
+                    },
+                )
+            }
         val start = System.nanoTime()
         var rows = 0L
 
-        scan.planFiles().use { tasks ->
-            for (task in tasks) {
-                val dataTask = task.asDataTask()
-                dataTask.rows().use { records ->
-                    for (record in records) {
-                        if (index.size() >= maxEntries) {
-                            throw IllegalStateException(
-                                "Positional delete index for ${table.name()} exceeded its maximum " +
-                                    "$maxEntries entries. Increase the configured limit or use equality deletes."
-                            )
-                        }
-                        val key = GenericRecord.create(deleteSchema)
-                        deleteSchema.columns().forEach { field ->
-                            key.setField(
-                                field.name(),
-                                record.get(positions[field.name()]!!, Any::class.java),
-                            )
-                        }
-                        val path =
-                            record.get(
-                                positions[MetadataColumns.FILE_PATH.name()]!!,
-                                CharSequence::class.java,
-                            )
-                        val position =
-                            record.get(
-                                positions[MetadataColumns.ROW_POSITION.name()]!!,
-                                java.lang.Long::class.java,
-                            )
-                        val previous = index.replace(
-                            key,
-                            PositionalDeleteIndex.RowLocation(
-                                path,
-                                position.toLong(),
-                                table.specs()[task.file().specId()]!!,
-                                task.partition(),
-                            ),
-                        )
-                        check(previous == null) {
-                            "Positional delete index for ${table.name()} found multiple rows for " +
-                                "the same identifier. Positional deletes require unique keys in " +
-                                "the base snapshot."
-                        }
-                        rows += 1
-                    }
+        IcebergGenerics.read(table).useSnapshot(snapshotId).select(columns).build().use { records ->
+            for (record in records) {
+                if (index.size() >= maxEntries) {
+                    throw IllegalStateException(
+                        "Positional delete index for ${table.name()} exceeded its maximum " +
+                            "$maxEntries entries. Increase the configured limit or use equality deletes."
+                    )
                 }
+                val key = GenericRecord.create(deleteSchema)
+                deleteSchema.columns().forEach { field ->
+                    key.setField(field.name(), record.getField(field.name()))
+                }
+                val path = record.getField(MetadataColumns.FILE_PATH.name()).toString()
+                val position = (record.getField(MetadataColumns.ROW_POSITION.name()) as Number).toLong()
+                val metadata =
+                    requireNotNull(locations[path]) {
+                        "Could not find planned data file $path while building positional delete index"
+                    }
+                val previous =
+                    index.replace(
+                        key,
+                        PositionalDeleteIndex.RowLocation(
+                            path,
+                            position,
+                            metadata.spec,
+                            metadata.partition,
+                        ),
+                    )
+                check(previous == null) {
+                    "Positional delete index for ${table.name()} found multiple rows for " +
+                        "the same identifier. Positional deletes require unique keys in " +
+                        "the base snapshot."
+                }
+                rows += 1
             }
         }
 

--- a/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/kotlin/io/airbyte/cdk/load/toolkits/iceberg/parquet/io/PositionalDeleteIndexBuilder.kt
+++ b/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/kotlin/io/airbyte/cdk/load/toolkits/iceberg/parquet/io/PositionalDeleteIndexBuilder.kt
@@ -71,7 +71,7 @@ class PositionalDeleteIndexBuilder(
                                 positions[MetadataColumns.ROW_POSITION.name()]!!,
                                 java.lang.Long::class.java,
                             )
-                        index.replace(
+                        val previous = index.replace(
                             key,
                             PositionalDeleteIndex.RowLocation(
                                 path,
@@ -80,6 +80,11 @@ class PositionalDeleteIndexBuilder(
                                 task.partition(),
                             ),
                         )
+                        check(previous == null) {
+                            "Positional delete index for ${table.name()} found multiple rows for " +
+                                "the same identifier. Positional deletes require unique keys in " +
+                                "the base snapshot."
+                        }
                         rows += 1
                     }
                 }

--- a/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/kotlin/io/airbyte/cdk/load/toolkits/iceberg/parquet/io/PositionalWriters.kt
+++ b/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/kotlin/io/airbyte/cdk/load/toolkits/iceberg/parquet/io/PositionalWriters.kt
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2026 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.cdk.load.toolkits.iceberg.parquet.io
+
+import java.io.IOException
+import java.io.UncheckedIOException
+import org.apache.iceberg.FileFormat
+import org.apache.iceberg.PartitionKey
+import org.apache.iceberg.PartitionSpec
+import org.apache.iceberg.Schema
+import org.apache.iceberg.StructLike
+import org.apache.iceberg.Table
+import org.apache.iceberg.data.GenericFileWriterFactory
+import org.apache.iceberg.data.Record
+import org.apache.iceberg.io.FileIO
+import org.apache.iceberg.io.OutputFileFactory
+import org.apache.iceberg.util.Tasks
+
+class UnpartitionedPositionDeltaWriter(
+    table: Table,
+    spec: PartitionSpec,
+    format: FileFormat,
+    writerFactory: GenericFileWriterFactory,
+    outputFileFactory: OutputFileFactory,
+    io: FileIO,
+    targetFileSize: Long,
+    schema: Schema,
+    identifierFieldIds: Set<Int>,
+    index: PositionalDeleteIndex,
+) :
+    BasePositionDeltaTaskWriter(
+        table,
+        spec,
+        format,
+        writerFactory,
+        outputFileFactory,
+        io,
+        targetFileSize,
+        schema,
+        identifierFieldIds,
+        index,
+    ) {
+    private val writer = RowDataPositionDeltaWriter(null)
+
+    override fun route(row: Record): RowDataPositionDeltaWriter = writer
+
+    override fun close() {
+        writer.close()
+    }
+}
+
+class PartitionedPositionDeltaWriter(
+    table: Table,
+    spec: PartitionSpec,
+    format: FileFormat,
+    writerFactory: GenericFileWriterFactory,
+    outputFileFactory: OutputFileFactory,
+    io: FileIO,
+    targetFileSize: Long,
+    schema: Schema,
+    identifierFieldIds: Set<Int>,
+    index: PositionalDeleteIndex,
+) :
+    BasePositionDeltaTaskWriter(
+        table,
+        spec,
+        format,
+        writerFactory,
+        outputFileFactory,
+        io,
+        targetFileSize,
+        schema,
+        identifierFieldIds,
+        index,
+    ) {
+    private val partitionKey = PartitionKey(spec, schema)
+    private val writers = mutableMapOf<PartitionKey, RowDataPositionDeltaWriter>()
+
+    override fun route(row: Record): RowDataPositionDeltaWriter {
+        partitionKey.partition(wrapper().wrap(row))
+        return writers.getOrPut(partitionKey.copy()) { RowDataPositionDeltaWriter(partitionKey.copy()) }
+    }
+
+    override fun close() {
+        try {
+            Tasks.foreach(writers.values)
+                .throwFailureWhenFinished()
+                .noRetry()
+                .run(RowDataPositionDeltaWriter::close, IOException::class.java)
+            writers.clear()
+        } catch (e: IOException) {
+            throw UncheckedIOException("Failed to close positional delta writer", e)
+        }
+    }
+}

--- a/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/kotlin/io/airbyte/cdk/load/toolkits/iceberg/parquet/io/PositionalWriters.kt
+++ b/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/kotlin/io/airbyte/cdk/load/toolkits/iceberg/parquet/io/PositionalWriters.kt
@@ -10,7 +10,6 @@ import org.apache.iceberg.FileFormat
 import org.apache.iceberg.PartitionKey
 import org.apache.iceberg.PartitionSpec
 import org.apache.iceberg.Schema
-import org.apache.iceberg.StructLike
 import org.apache.iceberg.Table
 import org.apache.iceberg.data.GenericFileWriterFactory
 import org.apache.iceberg.data.Record
@@ -80,7 +79,8 @@ class PartitionedPositionDeltaWriter(
 
     override fun route(row: Record): RowDataPositionDeltaWriter {
         partitionKey.partition(wrapper().wrap(row))
-        return writers.getOrPut(partitionKey.copy()) { RowDataPositionDeltaWriter(partitionKey.copy()) }
+        val key = partitionKey.copy()
+        return writers.getOrPut(key) { RowDataPositionDeltaWriter(key) }
     }
 
     override fun close() {

--- a/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/test/kotlin/io/airbyte/cdk/load/toolkits/iceberg/parquet/io/IcebergTableWriterFactoryTest.kt
+++ b/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/test/kotlin/io/airbyte/cdk/load/toolkits/iceberg/parquet/io/IcebergTableWriterFactoryTest.kt
@@ -141,6 +141,20 @@ internal class IcebergTableWriterFactoryTest {
             )
         assertNotNull(writer)
         assertEquals(UnpartitionedDeltaWriter::class.java, writer.javaClass)
+
+        val positionalWriter =
+            factory.create(
+                table = table,
+                generationId = "ab-generation-id-${Random.nextLong(100)}-e",
+                importType =
+                    Dedupe(
+                        primaryKey = listOf(primaryKeyIds.map { it.toString() }),
+                        cursor = primaryKeyIds.map { it.toString() }
+                    ),
+                schema = tableSchema,
+                positionalDeleteIndex = PositionalDeleteIndex(tableSchema.asStruct()),
+            )
+        assertEquals(UnpartitionedPositionDeltaWriter::class.java, positionalWriter.javaClass)
     }
 
     @Test

--- a/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/test/kotlin/io/airbyte/cdk/load/toolkits/iceberg/parquet/io/PositionalDeleteEndToEndTest.kt
+++ b/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/test/kotlin/io/airbyte/cdk/load/toolkits/iceberg/parquet/io/PositionalDeleteEndToEndTest.kt
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2026 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.cdk.load.toolkits.iceberg.parquet.io
+
+import java.nio.file.Files
+import org.apache.hadoop.conf.Configuration
+import org.apache.iceberg.FileContent
+import org.apache.iceberg.FileFormat
+import org.apache.iceberg.Schema
+import org.apache.iceberg.TableProperties
+import org.apache.iceberg.catalog.TableIdentifier
+import org.apache.iceberg.data.IcebergGenerics
+import org.apache.iceberg.data.GenericRecord
+import org.apache.iceberg.hadoop.HadoopCatalog
+import org.apache.iceberg.types.Types
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class PositionalDeleteEndToEndTest {
+    @Test
+    fun `dedupe update and delete produces positional deletes and expected read`() {
+        val warehouse = Files.createTempDirectory("positional-delete-e2e")
+        val catalog = HadoopCatalog(Configuration(), warehouse.toString())
+        val tableId = TableIdentifier.of("db", "records")
+        val schema =
+            Schema(
+                listOf(
+                    Types.NestedField.required(1, "id", Types.IntegerType.get()),
+                    Types.NestedField.required(2, "name", Types.StringType.get()),
+                ),
+                setOf(1),
+            )
+        catalog.createNamespace(tableId.namespace())
+        val table =
+            catalog
+                .buildTable(tableId, schema)
+                .withProperty(TableProperties.DEFAULT_FILE_FORMAT, FileFormat.PARQUET.name.lowercase())
+                .create()
+        val importType =
+            io.airbyte.cdk.load.command.Dedupe(
+                primaryKey = listOf(listOf("id")),
+                cursor = emptyList(),
+            )
+        val writerFactory = IcebergTableWriterFactory()
+
+        val initialWriter =
+            writerFactory.create(
+                table,
+                "ab-generation-id-0-e",
+                importType,
+                schema,
+            )
+        initialWriter.write(record(schema, 1, "one"))
+        initialWriter.write(record(schema, 2, "two"))
+        val initialResult = initialWriter.complete()
+        table
+            .newAppend()
+            .apply { initialResult.dataFiles().forEach(::appendFile) }
+            .commit()
+
+        val index =
+            PositionalDeleteIndexBuilder().build(
+                table = table,
+                ref = "main",
+                schema = schema,
+                identifierFieldIds = schema.identifierFieldIds(),
+            )
+        val updateWriter =
+            writerFactory.create(
+                table,
+                "ab-generation-id-1-e",
+                importType,
+                schema,
+                index,
+            )
+        updateWriter.write(RecordWrapper(record(schema, 1, "one-updated"), Operation.UPDATE))
+        updateWriter.write(RecordWrapper(record(schema, 2, "ignored"), Operation.DELETE))
+        val updateResult = updateWriter.complete()
+        table
+            .newRowDelta()
+            .apply {
+                updateResult.dataFiles().forEach(::addRows)
+                updateResult.deleteFiles().forEach(::addDeletes)
+            }
+            .commit()
+
+        val deleteFiles =
+            table.currentSnapshot()!!.addedDeleteFiles(table.io()).toList()
+        assertThat(deleteFiles).isNotEmpty
+        assertThat(deleteFiles.map { it.content() }.toSet())
+            .containsOnly(FileContent.POSITION_DELETES)
+        assertThat(deleteFiles).allMatch { it.content() != FileContent.EQUALITY_DELETES }
+
+        val rows =
+            IcebergGenerics.read(table).build().use { records ->
+                records.map { it.getField("id") to it.getField("name") }.toSet()
+            }
+        assertThat(rows).containsExactlyInAnyOrder(1 to "one-updated")
+    }
+
+    private fun record(schema: Schema, id: Int, name: String): GenericRecord =
+        GenericRecord.create(schema).apply {
+            setField("id", id)
+            setField("name", name)
+        }
+}

--- a/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/test/kotlin/io/airbyte/cdk/load/toolkits/iceberg/parquet/io/PositionalDeleteEndToEndTest.kt
+++ b/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/test/kotlin/io/airbyte/cdk/load/toolkits/iceberg/parquet/io/PositionalDeleteEndToEndTest.kt
@@ -59,15 +59,16 @@ class PositionalDeleteEndToEndTest {
             .newAppend()
             .apply { initialResult.dataFiles().forEach(::appendFile) }
             .commit()
+        table.manageSnapshots().createBranch("staging").commit()
 
         val index =
             PositionalDeleteIndexBuilder().build(
                 table = table,
-                ref = "main",
+                ref = "staging",
                 schema = schema,
                 identifierFieldIds = schema.identifierFieldIds(),
             )
-        val updateWriter =
+        val firstUpdateWriter =
             writerFactory.create(
                 table,
                 "ab-generation-id-1-e",
@@ -75,29 +76,58 @@ class PositionalDeleteEndToEndTest {
                 schema,
                 index,
             )
-        updateWriter.write(RecordWrapper(record(schema, 1, "one-updated"), Operation.UPDATE))
-        updateWriter.write(RecordWrapper(record(schema, 2, "ignored"), Operation.DELETE))
-        val updateResult = updateWriter.complete()
-        table
-            .newRowDelta()
-            .apply {
-                updateResult.dataFiles().forEach(::addRows)
-                updateResult.deleteFiles().forEach(::addDeletes)
-            }
-            .commit()
+        firstUpdateWriter.write(RecordWrapper(record(schema, 1, "one-updated"), Operation.UPDATE))
+        firstUpdateWriter.write(RecordWrapper(record(schema, 2, "ignored"), Operation.DELETE))
+        firstUpdateWriter.write(RecordWrapper(record(schema, 3, "three"), Operation.INSERT))
+        commitRowDelta(table, "staging", firstUpdateWriter.complete())
 
+        val secondUpdateWriter =
+            writerFactory.create(
+                table,
+                "ab-generation-id-2-e",
+                importType,
+                schema,
+                index,
+            )
+        secondUpdateWriter.write(RecordWrapper(record(schema, 3, "three-updated"), Operation.UPDATE))
+        secondUpdateWriter.write(RecordWrapper(record(schema, 1, "ignored"), Operation.DELETE))
+        commitRowDelta(table, "staging", secondUpdateWriter.complete())
+
+        val stagingSnapshotId = table.refs()["staging"]!!.snapshotId()!!
         val deleteFiles =
-            table.currentSnapshot()!!.addedDeleteFiles(table.io()).toList()
+            table.snapshot(stagingSnapshotId)!!.addedDeleteFiles(table.io()).toList() +
+                table.snapshot(table.history().first().snapshotId())!!
+                    .addedDeleteFiles(table.io())
         assertThat(deleteFiles).isNotEmpty
         assertThat(deleteFiles.map { it.content() }.toSet())
             .containsOnly(FileContent.POSITION_DELETES)
         assertThat(deleteFiles).allMatch { it.content() != FileContent.EQUALITY_DELETES }
 
         val rows =
-            IcebergGenerics.read(table).build().use { records ->
+            IcebergGenerics.read(table).useSnapshot(stagingSnapshotId).build().use { records ->
                 records.map { it.getField("id") to it.getField("name") }.toSet()
             }
-        assertThat(rows).containsExactlyInAnyOrder(1 to "one-updated")
+        assertThat(rows).containsExactlyInAnyOrder(3 to "three-updated")
+    }
+
+    private fun commitRowDelta(
+        table: org.apache.iceberg.Table,
+        branch: String,
+        result: org.apache.iceberg.io.WriteResult,
+    ) {
+        val validationSnapshotId = table.refs()[branch]!!.snapshotId()!!
+        table
+            .newRowDelta()
+            .toBranch(branch)
+            .validateFromSnapshot(validationSnapshotId)
+            .validateDeletedFiles()
+            .validateNoConflictingDataFiles()
+            .validateNoConflictingDeleteFiles()
+            .apply {
+                result.dataFiles().forEach(::addRows)
+                result.deleteFiles().forEach(::addDeletes)
+            }
+            .commit()
     }
 
     private fun record(schema: Schema, id: Int, name: String): GenericRecord =

--- a/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/test/kotlin/io/airbyte/cdk/load/toolkits/iceberg/parquet/io/PositionalDeleteIndexTest.kt
+++ b/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/test/kotlin/io/airbyte/cdk/load/toolkits/iceberg/parquet/io/PositionalDeleteIndexTest.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2026 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.cdk.load.toolkits.iceberg.parquet.io
+
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import org.apache.iceberg.Schema
+import org.apache.iceberg.types.Types
+import org.junit.jupiter.api.Test
+
+internal class PositionalDeleteIndexTest {
+    private val keySchema =
+        Schema(
+            Types.NestedField.required(1, "id", Types.IntegerType.get()),
+            Types.NestedField.required(2, "tenant", Types.StringType.get()),
+        )
+
+    @Test
+    fun replacesAndRemovesLocationsUsingFullKeys() {
+        val index = PositionalDeleteIndex(keySchema.asStruct())
+        val firstKey = keySchema.asStruct().let { schema ->
+            org.apache.iceberg.data.GenericRecord.create(schema).apply {
+                setField("id", 7)
+                setField("tenant", "one")
+            }
+        }
+        val equivalentKey = keySchema.asStruct().let { schema ->
+            org.apache.iceberg.data.GenericRecord.create(schema).apply {
+                setField("id", 7)
+                setField("tenant", "one")
+            }
+        }
+        val location =
+            PositionalDeleteIndex.RowLocation(
+                "s3://bucket/data.parquet",
+                3L,
+                org.apache.iceberg.PartitionSpec.unpartitioned(),
+                null,
+            )
+
+        assertNull(index.replace(firstKey, location))
+        assertEquals(location, index.get(equivalentKey))
+        assertEquals(location, index.remove(equivalentKey))
+        assertEquals(0, index.size())
+        assertEquals(1L, index.maxEntries())
+    }
+}

--- a/airbyte-integrations/connectors/destination-s3-data-lake/gradle.properties
+++ b/airbyte-integrations/connectors/destination-s3-data-lake/gradle.properties
@@ -1,3 +1,3 @@
 testExecutionConcurrency=-1
-cdkVersion=1.0.14
+cdkVersion=local
 JunitMethodExecutionTimeout=10m

--- a/airbyte-integrations/connectors/destination-s3-data-lake/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-s3-data-lake/metadata.yaml
@@ -37,7 +37,7 @@ data:
             alias: airbyte-connector-testing-secret-store
   connectorType: destination
   definitionId: 716ca874-520b-4902-9f80-9fad66754b89
-  dockerImageTag: 0.3.52
+  dockerImageTag: 0.4.0
   dockerRepository: airbyte/destination-s3-data-lake
   documentationUrl: https://docs.airbyte.com/integrations/destinations/s3-data-lake
   githubIssueLabel: destination-s3-data-lake

--- a/airbyte-integrations/connectors/destination-s3-data-lake/src/main/kotlin/io/airbyte/integrations/destination/s3_data_lake/S3DataLakeBeanFactory.kt
+++ b/airbyte-integrations/connectors/destination-s3-data-lake/src/main/kotlin/io/airbyte/integrations/destination/s3_data_lake/S3DataLakeBeanFactory.kt
@@ -12,10 +12,9 @@ import io.airbyte.cdk.load.dataflow.config.model.LifecycleParallelismConfig
 import io.airbyte.cdk.load.dataflow.config.model.MediumConverterConfig
 import io.airbyte.cdk.load.table.DefaultTempTableNameGenerator
 import io.airbyte.integrations.destination.s3_data_lake.spec.S3DataLakeConfiguration
+import io.airbyte.integrations.destination.s3_data_lake.spec.MergeOnReadDeleteEncoding
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.micronaut.context.annotation.Factory
-import io.micronaut.context.annotation.Requires
-import io.micronaut.context.env.Environment
 import jakarta.inject.Singleton
 
 @Factory
@@ -58,16 +57,19 @@ class S3DataLakeBeanFactory {
 
     /**
      * Socket configuration for S3 Data Lake destination.
-     * - In test environments: this bean is not created, so all sockets are used
-     * - In production with dedup streams: limits to 1 socket for data consistency
-     * - In production without dedup streams: uses all available sockets
+     * - Positional Dedupe streams use one socket for data consistency.
+     * - Equality Dedupe and non-Dedupe streams use all available sockets.
      */
     @Singleton
-    @Requires(notEnv = [Environment.TEST])
-    fun dataFlowSocketConfig(catalog: DestinationCatalog): DataFlowSocketConfig {
-        val hasDedupStreams = catalog.streams.any { it.tableSchema.importType is Dedupe }
-        return if (hasDedupStreams) {
-            log.info { "Dedup streams detected, limiting to 1 socket for data consistency" }
+    fun dataFlowSocketConfig(
+        catalog: DestinationCatalog,
+        config: S3DataLakeConfiguration,
+    ): DataFlowSocketConfig {
+        val hasPositionalDedupStreams =
+            config.mergeOnReadDeleteEncoding == MergeOnReadDeleteEncoding.POSITIONAL &&
+                catalog.streams.any { it.tableSchema.importType is Dedupe }
+        return if (hasPositionalDedupStreams) {
+            log.info { "Positional dedup streams detected, limiting to 1 socket for data consistency" }
             object : DataFlowSocketConfig {
                 override val numSockets: Int = 1
             }

--- a/airbyte-integrations/connectors/destination-s3-data-lake/src/main/kotlin/io/airbyte/integrations/destination/s3_data_lake/S3DataLakeBeanFactory.kt
+++ b/airbyte-integrations/connectors/destination-s3-data-lake/src/main/kotlin/io/airbyte/integrations/destination/s3_data_lake/S3DataLakeBeanFactory.kt
@@ -15,6 +15,8 @@ import io.airbyte.integrations.destination.s3_data_lake.spec.S3DataLakeConfigura
 import io.airbyte.integrations.destination.s3_data_lake.spec.MergeOnReadDeleteEncoding
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.micronaut.context.annotation.Factory
+import io.micronaut.context.annotation.Requires
+import io.micronaut.context.env.Environment
 import jakarta.inject.Singleton
 
 @Factory
@@ -55,13 +57,30 @@ class S3DataLakeBeanFactory {
     // from being loaded. So this is necessary for now.
     @Singleton fun tempTableNameGenerator() = DefaultTempTableNameGenerator()
 
-    /**
-     * Socket configuration for S3 Data Lake destination.
-     * - Positional Dedupe streams use one socket for data consistency.
-     * - Equality Dedupe and non-Dedupe streams use all available sockets.
-     */
+    /** Preserve the production one-socket invariant for all Dedupe streams. */
     @Singleton
+    @Requires(notEnv = [Environment.TEST])
     fun dataFlowSocketConfig(
+        catalog: DestinationCatalog,
+    ): DataFlowSocketConfig {
+        val hasDedupeStreams = catalog.streams.any { it.tableSchema.importType is Dedupe }
+        return if (hasDedupeStreams) {
+            log.info { "Dedup streams detected, limiting to 1 socket for data consistency" }
+            object : DataFlowSocketConfig {
+                override val numSockets: Int = 1
+            }
+        } else {
+            log.info { "No dedup streams detected, using all available sockets" }
+            object : DataFlowSocketConfig {
+                override val numSockets: Int = Int.MAX_VALUE
+            }
+        }
+    }
+
+    /** Positional Dedupe also requires one socket in connector tests. */
+    @Singleton
+    @Requires(env = [Environment.TEST])
+    fun positionalTestDataFlowSocketConfig(
         catalog: DestinationCatalog,
         config: S3DataLakeConfiguration,
     ): DataFlowSocketConfig {
@@ -69,12 +88,11 @@ class S3DataLakeBeanFactory {
             config.mergeOnReadDeleteEncoding == MergeOnReadDeleteEncoding.POSITIONAL &&
                 catalog.streams.any { it.tableSchema.importType is Dedupe }
         return if (hasPositionalDedupStreams) {
-            log.info { "Positional dedup streams detected, limiting to 1 socket for data consistency" }
+            log.info { "Positional dedup streams detected, limiting to 1 test socket" }
             object : DataFlowSocketConfig {
                 override val numSockets: Int = 1
             }
         } else {
-            log.info { "No dedup streams detected, using all available sockets" }
             object : DataFlowSocketConfig {
                 override val numSockets: Int = Int.MAX_VALUE
             }

--- a/airbyte-integrations/connectors/destination-s3-data-lake/src/main/kotlin/io/airbyte/integrations/destination/s3_data_lake/S3DataLakeBeanFactory.kt
+++ b/airbyte-integrations/connectors/destination-s3-data-lake/src/main/kotlin/io/airbyte/integrations/destination/s3_data_lake/S3DataLakeBeanFactory.kt
@@ -70,7 +70,7 @@ class S3DataLakeBeanFactory {
                 override val numSockets: Int = 1
             }
         } else {
-            log.info { "No dedup streams detected, using all available sockets" }
+            log.info { "No socket restriction required, using all available sockets" }
             object : DataFlowSocketConfig {
                 override val numSockets: Int = Int.MAX_VALUE
             }

--- a/airbyte-integrations/connectors/destination-s3-data-lake/src/main/kotlin/io/airbyte/integrations/destination/s3_data_lake/dataflow/S3DataLakeAggregate.kt
+++ b/airbyte-integrations/connectors/destination-s3-data-lake/src/main/kotlin/io/airbyte/integrations/destination/s3_data_lake/dataflow/S3DataLakeAggregate.kt
@@ -32,6 +32,7 @@ class S3DataLakeAggregate(
     private val stagingBranchName: String,
     private val writer: BaseTaskWriter<Record>,
     private val icebergUtil: IcebergUtil,
+    private val baseSnapshotId: Long? = null,
 ) : Aggregate {
     override fun accept(record: RecordDTO) {
         val wrappedRecord =
@@ -53,6 +54,13 @@ class S3DataLakeAggregate(
         if (writeResult.deleteFiles().isNotEmpty()) {
             // Use row delta for updates/deletes (dedup mode)
             val delta = table.newRowDelta().toBranch(stagingBranchName)
+            baseSnapshotId?.let {
+                delta
+                    .validateFromSnapshot(it)
+                    .validateDeletedFiles()
+                    .validateNoConflictingDataFiles()
+                    .validateNoConflictingDeleteFiles()
+            }
             writeResult.dataFiles().forEach { delta.addRows(it) }
             writeResult.deleteFiles().forEach { delta.addDeletes(it) }
             synchronized(commitLock) { delta.commit() }

--- a/airbyte-integrations/connectors/destination-s3-data-lake/src/main/kotlin/io/airbyte/integrations/destination/s3_data_lake/dataflow/S3DataLakeAggregate.kt
+++ b/airbyte-integrations/connectors/destination-s3-data-lake/src/main/kotlin/io/airbyte/integrations/destination/s3_data_lake/dataflow/S3DataLakeAggregate.kt
@@ -53,22 +53,28 @@ class S3DataLakeAggregate(
 
         if (writeResult.deleteFiles().isNotEmpty()) {
             // Use row delta for updates/deletes (dedup mode)
-            val delta = table.newRowDelta().toBranch(stagingBranchName)
-            baseSnapshotId?.let {
-                delta
-                    .validateFromSnapshot(it)
-                    .validateDeletedFiles()
-                    .validateNoConflictingDataFiles()
-                    .validateNoConflictingDeleteFiles()
+            synchronized(commitLock) {
+                val delta = table.newRowDelta().toBranch(stagingBranchName)
+                val validationSnapshotId =
+                    table.refs()[stagingBranchName]?.snapshotId() ?: baseSnapshotId
+                validationSnapshotId?.let {
+                    delta
+                        .validateFromSnapshot(it)
+                        .validateDeletedFiles()
+                        .validateNoConflictingDataFiles()
+                        .validateNoConflictingDeleteFiles()
+                }
+                writeResult.dataFiles().forEach { delta.addRows(it) }
+                writeResult.deleteFiles().forEach { delta.addDeletes(it) }
+                delta.commit()
             }
-            writeResult.dataFiles().forEach { delta.addRows(it) }
-            writeResult.deleteFiles().forEach { delta.addDeletes(it) }
-            synchronized(commitLock) { delta.commit() }
         } else {
             // Use append for simple appends
-            val append = table.newAppend().toBranch(stagingBranchName)
-            writeResult.dataFiles().forEach { append.appendFile(it) }
-            synchronized(commitLock) { append.commit() }
+            synchronized(commitLock) {
+                val append = table.newAppend().toBranch(stagingBranchName)
+                writeResult.dataFiles().forEach { append.appendFile(it) }
+                append.commit()
+            }
         }
 
         logger.info { "Flushed records to staging branch $stagingBranchName" }

--- a/airbyte-integrations/connectors/destination-s3-data-lake/src/main/kotlin/io/airbyte/integrations/destination/s3_data_lake/dataflow/S3DataLakeAggregateFactory.kt
+++ b/airbyte-integrations/connectors/destination-s3-data-lake/src/main/kotlin/io/airbyte/integrations/destination/s3_data_lake/dataflow/S3DataLakeAggregateFactory.kt
@@ -27,22 +27,13 @@ class S3DataLakeAggregateFactory(
         val stream = catalog.getStream(key)
 
         val writer =
-            if (state.positionalDeleteIndex == null) {
-                icebergTableWriterFactory.create(
-                    table = state.table,
-                    generationId = icebergUtil.constructGenerationIdSuffix(stream),
-                    importType = stream.tableSchema.importType,
-                    schema = state.schema
-                )
-            } else {
-                icebergTableWriterFactory.create(
-                    table = state.table,
-                    generationId = icebergUtil.constructGenerationIdSuffix(stream),
-                    importType = stream.tableSchema.importType,
-                    schema = state.schema,
-                    positionalDeleteIndex = state.positionalDeleteIndex,
-                )
-            }
+            icebergTableWriterFactory.create(
+                table = state.table,
+                generationId = icebergUtil.constructGenerationIdSuffix(stream),
+                importType = stream.tableSchema.importType,
+                schema = state.schema,
+                positionalDeleteIndex = state.positionalDeleteIndex,
+            )
 
         return S3DataLakeAggregate(
             stream = stream,

--- a/airbyte-integrations/connectors/destination-s3-data-lake/src/main/kotlin/io/airbyte/integrations/destination/s3_data_lake/dataflow/S3DataLakeAggregateFactory.kt
+++ b/airbyte-integrations/connectors/destination-s3-data-lake/src/main/kotlin/io/airbyte/integrations/destination/s3_data_lake/dataflow/S3DataLakeAggregateFactory.kt
@@ -27,18 +27,29 @@ class S3DataLakeAggregateFactory(
         val stream = catalog.getStream(key)
 
         val writer =
-            icebergTableWriterFactory.create(
-                table = state.table,
-                generationId = icebergUtil.constructGenerationIdSuffix(stream),
-                importType = stream.tableSchema.importType,
-                schema = state.schema
-            )
+            if (state.positionalDeleteIndex == null) {
+                icebergTableWriterFactory.create(
+                    table = state.table,
+                    generationId = icebergUtil.constructGenerationIdSuffix(stream),
+                    importType = stream.tableSchema.importType,
+                    schema = state.schema
+                )
+            } else {
+                icebergTableWriterFactory.create(
+                    table = state.table,
+                    generationId = icebergUtil.constructGenerationIdSuffix(stream),
+                    importType = stream.tableSchema.importType,
+                    schema = state.schema,
+                    positionalDeleteIndex = state.positionalDeleteIndex,
+                )
+            }
 
         return S3DataLakeAggregate(
             stream = stream,
             table = state.table,
             schema = state.schema,
             stagingBranchName = state.stagingBranchName,
+            baseSnapshotId = state.baseSnapshotId,
             writer = writer,
             icebergUtil = icebergUtil,
         )

--- a/airbyte-integrations/connectors/destination-s3-data-lake/src/main/kotlin/io/airbyte/integrations/destination/s3_data_lake/spec/S3DataLakeConfiguration.kt
+++ b/airbyte-integrations/connectors/destination-s3-data-lake/src/main/kotlin/io/airbyte/integrations/destination/s3_data_lake/spec/S3DataLakeConfiguration.kt
@@ -41,6 +41,7 @@ data class S3DataLakeConfiguration(
     override val s3BucketConfiguration: S3BucketConfiguration,
     override val icebergCatalogConfiguration: IcebergCatalogConfiguration,
     val flushBatchSizeMb: Long?,
+    val mergeOnReadDeleteEncoding: MergeOnReadDeleteEncoding = MergeOnReadDeleteEncoding.EQUALITY,
 ) :
     DestinationConfiguration(),
     AWSAccessKeyConfigurationProvider,
@@ -78,6 +79,8 @@ class S3DataLakeConfigurationFactory :
             s3BucketConfiguration = pojo.toS3BucketConfiguration(),
             icebergCatalogConfiguration = pojo.toIcebergCatalogConfiguration(),
             flushBatchSizeMb = pojo.flushBatchSizeMb,
+            mergeOnReadDeleteEncoding =
+                pojo.mergeOnReadDeleteEncoding ?: MergeOnReadDeleteEncoding.EQUALITY,
         )
     }
 }

--- a/airbyte-integrations/connectors/destination-s3-data-lake/src/main/kotlin/io/airbyte/integrations/destination/s3_data_lake/spec/S3DataLakeSpecification.kt
+++ b/airbyte-integrations/connectors/destination-s3-data-lake/src/main/kotlin/io/airbyte/integrations/destination/s3_data_lake/spec/S3DataLakeSpecification.kt
@@ -6,6 +6,7 @@ package io.airbyte.integrations.destination.s3_data_lake.spec
 
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.annotation.JsonPropertyDescription
+import com.fasterxml.jackson.annotation.JsonValue
 import com.kjetland.jackson.jsonSchema.annotations.JsonSchemaDescription
 import com.kjetland.jackson.jsonSchema.annotations.JsonSchemaInject
 import com.kjetland.jackson.jsonSchema.annotations.JsonSchemaTitle
@@ -83,6 +84,23 @@ class S3DataLakeSpecification :
         json = """{"examples":[200], "default": 200, "order": 8, "airbyte_hidden": true}"""
     )
     val flushBatchSizeMb: Long? = null
+
+    @get:JsonSchemaTitle("Merge-on-Read Delete Encoding")
+    @get:JsonPropertyDescription(
+        "The delete-file encoding used by append deduplication syncs. Equality deletes are the " +
+            "backwards-compatible default; positional deletes are compatible with readers that do " +
+            "not support equality-delete files."
+    )
+    @get:JsonProperty("merge_on_read_delete_encoding", required = false)
+    @get:JsonSchemaInject(
+        json = """{"default":"EQUALITY","examples":["EQUALITY","POSITIONAL"],"order":9}"""
+    )
+    val mergeOnReadDeleteEncoding: MergeOnReadDeleteEncoding? = null
+}
+
+enum class MergeOnReadDeleteEncoding(@get:JsonValue val value: String) {
+    EQUALITY("EQUALITY"),
+    POSITIONAL("POSITIONAL"),
 }
 
 @Singleton

--- a/airbyte-integrations/connectors/destination-s3-data-lake/src/main/kotlin/io/airbyte/integrations/destination/s3_data_lake/write/S3DataLakeStreamLoader.kt
+++ b/airbyte-integrations/connectors/destination-s3-data-lake/src/main/kotlin/io/airbyte/integrations/destination/s3_data_lake/write/S3DataLakeStreamLoader.kt
@@ -5,15 +5,18 @@
 package io.airbyte.integrations.destination.s3_data_lake.write
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings
+import io.airbyte.cdk.load.command.Dedupe
 import io.airbyte.cdk.load.command.DestinationStream
 import io.airbyte.cdk.load.toolkits.iceberg.parquet.ColumnTypeChangeBehavior
 import io.airbyte.cdk.load.toolkits.iceberg.parquet.IcebergTableSynchronizer
 import io.airbyte.cdk.load.toolkits.iceberg.parquet.io.IcebergTableCleaner
 import io.airbyte.cdk.load.toolkits.iceberg.parquet.io.IcebergUtil
+import io.airbyte.cdk.load.toolkits.iceberg.parquet.io.PositionalDeleteIndexBuilder
 import io.airbyte.cdk.load.write.StreamLoader
 import io.airbyte.cdk.load.write.StreamStateStore
 import io.airbyte.integrations.destination.s3_data_lake.catalog.S3DataLakeUtil
 import io.airbyte.integrations.destination.s3_data_lake.spec.DEFAULT_CATALOG_NAME
+import io.airbyte.integrations.destination.s3_data_lake.spec.MergeOnReadDeleteEncoding
 import io.airbyte.integrations.destination.s3_data_lake.spec.S3DataLakeConfiguration
 import io.github.oshai.kotlinlogging.KotlinLogging
 import org.apache.iceberg.Schema
@@ -84,11 +87,42 @@ class S3DataLakeStreamLoader(
         }
         stagingBranchCreated = true
 
+        val positionalDeletesEnabled =
+            stream.tableSchema.importType is Dedupe &&
+                runCatching {
+                    icebergConfiguration.mergeOnReadDeleteEncoding ==
+                        MergeOnReadDeleteEncoding.POSITIONAL
+                }.getOrDefault(false)
+        val baseSnapshotId =
+            if (positionalDeletesEnabled) {
+                table.refs()[stagingBranchName]?.snapshotId()
+            } else {
+                null
+            }
+        val positionalDeleteIndex =
+            if (positionalDeletesEnabled) {
+                val builder = PositionalDeleteIndexBuilder()
+                if (baseSnapshotId == null) {
+                    builder.empty(targetSchema, targetSchema.identifierFieldIds())
+                } else {
+                    builder.build(
+                        table = table,
+                        ref = stagingBranchName,
+                        schema = targetSchema,
+                        identifierFieldIds = targetSchema.identifierFieldIds(),
+                    )
+                }
+            } else {
+                null
+            }
+
         val state =
             S3DataLakeStreamState(
                 table = table,
                 schema = targetSchema,
                 stagingBranchName = stagingBranchName,
+                positionalDeleteIndex = positionalDeleteIndex,
+                baseSnapshotId = baseSnapshotId,
             )
         streamStateStore.put(stream.mappedDescriptor, state)
     }

--- a/airbyte-integrations/connectors/destination-s3-data-lake/src/main/kotlin/io/airbyte/integrations/destination/s3_data_lake/write/S3DataLakeStreamLoader.kt
+++ b/airbyte-integrations/connectors/destination-s3-data-lake/src/main/kotlin/io/airbyte/integrations/destination/s3_data_lake/write/S3DataLakeStreamLoader.kt
@@ -89,10 +89,8 @@ class S3DataLakeStreamLoader(
 
         val positionalDeletesEnabled =
             stream.tableSchema.importType is Dedupe &&
-                runCatching {
-                    icebergConfiguration.mergeOnReadDeleteEncoding ==
-                        MergeOnReadDeleteEncoding.POSITIONAL
-                }.getOrDefault(false)
+                icebergConfiguration.mergeOnReadDeleteEncoding ==
+                    MergeOnReadDeleteEncoding.POSITIONAL
         val baseSnapshotId =
             if (positionalDeletesEnabled) {
                 table.refs()[stagingBranchName]?.snapshotId()

--- a/airbyte-integrations/connectors/destination-s3-data-lake/src/main/kotlin/io/airbyte/integrations/destination/s3_data_lake/write/S3DataLakeStreamState.kt
+++ b/airbyte-integrations/connectors/destination-s3-data-lake/src/main/kotlin/io/airbyte/integrations/destination/s3_data_lake/write/S3DataLakeStreamState.kt
@@ -11,4 +11,6 @@ class S3DataLakeStreamState(
     val table: Table,
     val schema: Schema,
     val stagingBranchName: String,
+    val positionalDeleteIndex: io.airbyte.cdk.load.toolkits.iceberg.parquet.io.PositionalDeleteIndex? = null,
+    val baseSnapshotId: Long? = null,
 )

--- a/airbyte-integrations/connectors/destination-s3-data-lake/src/main/kotlin/io/airbyte/integrations/destination/s3_data_lake/write/S3DataLakeStreamState.kt
+++ b/airbyte-integrations/connectors/destination-s3-data-lake/src/main/kotlin/io/airbyte/integrations/destination/s3_data_lake/write/S3DataLakeStreamState.kt
@@ -4,6 +4,7 @@
 
 package io.airbyte.integrations.destination.s3_data_lake.write
 
+import io.airbyte.cdk.load.toolkits.iceberg.parquet.io.PositionalDeleteIndex
 import org.apache.iceberg.Schema
 import org.apache.iceberg.Table
 
@@ -11,6 +12,6 @@ class S3DataLakeStreamState(
     val table: Table,
     val schema: Schema,
     val stagingBranchName: String,
-    val positionalDeleteIndex: io.airbyte.cdk.load.toolkits.iceberg.parquet.io.PositionalDeleteIndex? = null,
+    val positionalDeleteIndex: PositionalDeleteIndex? = null,
     val baseSnapshotId: Long? = null,
 )

--- a/airbyte-integrations/connectors/destination-s3-data-lake/src/test-integration/resources/expected-spec-cloud.json
+++ b/airbyte-integrations/connectors/destination-s3-data-lake/src/test-integration/resources/expected-spec-cloud.json
@@ -223,6 +223,15 @@
         "default" : 200,
         "order" : 8,
         "airbyte_hidden" : true
+      },
+      "merge_on_read_delete_encoding" : {
+        "type" : "string",
+        "enum" : [ "EQUALITY", "POSITIONAL" ],
+        "description" : "The delete-file encoding used by append deduplication syncs. Equality deletes are the backwards-compatible default; positional deletes are compatible with readers that do not support equality-delete files.",
+        "title" : "Merge-on-Read Delete Encoding",
+        "default" : "EQUALITY",
+        "examples" : [ "EQUALITY", "POSITIONAL" ],
+        "order" : 9
       }
     },
     "required" : [ "s3_bucket_name", "s3_bucket_region", "warehouse_location", "main_branch_name", "catalog_type" ]

--- a/airbyte-integrations/connectors/destination-s3-data-lake/src/test-integration/resources/expected-spec-oss.json
+++ b/airbyte-integrations/connectors/destination-s3-data-lake/src/test-integration/resources/expected-spec-oss.json
@@ -223,6 +223,15 @@
         "default" : 200,
         "order" : 8,
         "airbyte_hidden" : true
+      },
+      "merge_on_read_delete_encoding" : {
+        "type" : "string",
+        "enum" : [ "EQUALITY", "POSITIONAL" ],
+        "description" : "The delete-file encoding used by append deduplication syncs. Equality deletes are the backwards-compatible default; positional deletes are compatible with readers that do not support equality-delete files.",
+        "title" : "Merge-on-Read Delete Encoding",
+        "default" : "EQUALITY",
+        "examples" : [ "EQUALITY", "POSITIONAL" ],
+        "order" : 9
       }
     },
     "required" : [ "s3_bucket_name", "s3_bucket_region", "warehouse_location", "main_branch_name", "catalog_type" ]

--- a/airbyte-integrations/connectors/destination-s3-data-lake/src/test/kotlin/io/airbyte/integrations/destination/s3_data_lake/write/S3DataLakeStreamLoaderTest.kt
+++ b/airbyte-integrations/connectors/destination-s3-data-lake/src/test/kotlin/io/airbyte/integrations/destination/s3_data_lake/write/S3DataLakeStreamLoaderTest.kt
@@ -35,6 +35,7 @@ import io.airbyte.integrations.destination.s3_data_lake.spec.DEFAULT_STAGING_BRA
 import io.airbyte.integrations.destination.s3_data_lake.spec.S3BucketConfiguration
 import io.airbyte.integrations.destination.s3_data_lake.spec.S3BucketRegion
 import io.airbyte.integrations.destination.s3_data_lake.spec.S3DataLakeConfiguration
+import io.airbyte.integrations.destination.s3_data_lake.spec.MergeOnReadDeleteEncoding
 import io.airbyte.integrations.destination.s3_data_lake.spec.generateStagingBranchName
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
@@ -469,6 +470,7 @@ internal class S3DataLakeStreamLoaderTest {
             every { awsAccessKeyConfiguration } returns awsConfiguration
             every { icebergCatalogConfiguration } returns icebergCatalogConfig
             every { s3BucketConfiguration } returns bucketConfiguration
+            every { mergeOnReadDeleteEncoding } returns MergeOnReadDeleteEncoding.EQUALITY
         }
         val catalog: Catalog = mockk()
         val table: Table = mockk { every { schema() } returns icebergSchema }
@@ -545,6 +547,7 @@ internal class S3DataLakeStreamLoaderTest {
             every { awsAccessKeyConfiguration } returns awsConfiguration
             every { icebergCatalogConfiguration } returns icebergCatalogConfig
             every { s3BucketConfiguration } returns bucketConfiguration
+            every { mergeOnReadDeleteEncoding } returns MergeOnReadDeleteEncoding.EQUALITY
         }
         val catalog: Catalog = mockk()
         val table: Table = mockk {
@@ -714,6 +717,7 @@ internal class S3DataLakeStreamLoaderTest {
             every { awsAccessKeyConfiguration } returns awsConfiguration
             every { icebergCatalogConfiguration } returns icebergCatalogConfig
             every { s3BucketConfiguration } returns bucketConfiguration
+            every { mergeOnReadDeleteEncoding } returns MergeOnReadDeleteEncoding.EQUALITY
         }
         val catalog: Catalog = mockk()
         val table: Table = mockk {
@@ -858,6 +862,7 @@ internal class S3DataLakeStreamLoaderTest {
             every { awsAccessKeyConfiguration } returns awsConfiguration
             every { icebergCatalogConfiguration } returns icebergCatalogConfig
             every { s3BucketConfiguration } returns bucketConfiguration
+            every { mergeOnReadDeleteEncoding } returns MergeOnReadDeleteEncoding.EQUALITY
         }
     }
 

--- a/docs/integrations/destinations/s3-data-lake.md
+++ b/docs/integrations/destinations/s3-data-lake.md
@@ -408,7 +408,7 @@ This destination supports [namespaces](https://docs.airbyte.com/platform/using-a
 
 | Version     | Date       | Pull Request                                               | Subject                                                                                                                                                         |
 |:------------|:-----------|:-----------------------------------------------------------|:----------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| 0.4.0 | 2026-07-08 | [*PR_NUMBER_PLACEHOLDER*](https://github.com/airbytehq/airbyte/pull/*PR_NUMBER_PLACEHOLDER*) | Add positional delete encoding for Dedupe streams |
+| 0.4.0 | 2026-07-25 | [*PR_NUMBER_PLACEHOLDER*](https://github.com/airbytehq/airbyte/pull/*PR_NUMBER_PLACEHOLDER*) | Add positional delete encoding for Dedupe streams |
 | 0.3.52 | 2026-06-23 | [*PR_NUMBER_PLACEHOLDER*](https://github.com/airbytehq/airbyte/pull/*PR_NUMBER_PLACEHOLDER*) | Remove awssdk:bundle fat jar to fix OOMKilled during CHECK operations |
 | 0.3.51 | 2026-06-10 | [79123](https://github.com/airbytehq/airbyte/pull/79123) | Update Apacher Iceberg dependencies. |
 | 0.3.50 | 2026-06-03 | [79112](https://github.com/airbytehq/airbyte/pull/79112) | Use unique staging branches and clean them up after each sync. |

--- a/docs/integrations/destinations/s3-data-lake.md
+++ b/docs/integrations/destinations/s3-data-lake.md
@@ -256,6 +256,19 @@ To authenticate with Apache Polaris, follow these steps.
 | [Incremental Sync - Append](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append) | Yes |
 | [Incremental Sync - Append + Deduped](https://docs.airbyte.com/platform/using-airbyte/core-concepts/sync-modes/incremental-append-deduped) | Yes |
 
+### Merge-on-read delete encoding
+
+Append + Deduped streams use equality-delete files by default. To produce positional-delete files
+instead, set `merge_on_read_delete_encoding` to `POSITIONAL` in the destination configuration.
+This option is ignored for Append and Overwrite streams.
+
+Positional deletes are compatible with readers that do not support equality-delete files, such as
+Snowflake. Building the positional index requires scanning the current table snapshot and can be
+expensive for large tables. Positional mode also requires Dedupe records to be processed by a
+single pipeline; the connector enforces this by limiting the destination to one dataflow socket.
+If a key is not found in the snapshot index or among rows written during the current sync, no
+delete file entry is emitted.
+
 ## Output schema
 
 ### How Airbyte generates the Iceberg schema
@@ -395,6 +408,7 @@ This destination supports [namespaces](https://docs.airbyte.com/platform/using-a
 
 | Version     | Date       | Pull Request                                               | Subject                                                                                                                                                         |
 |:------------|:-----------|:-----------------------------------------------------------|:----------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 0.4.0 | 2026-07-08 | [*PR_NUMBER_PLACEHOLDER*](https://github.com/airbytehq/airbyte/pull/*PR_NUMBER_PLACEHOLDER*) | Add positional delete encoding for Dedupe streams |
 | 0.3.52 | 2026-06-23 | [*PR_NUMBER_PLACEHOLDER*](https://github.com/airbytehq/airbyte/pull/*PR_NUMBER_PLACEHOLDER*) | Remove awssdk:bundle fat jar to fix OOMKilled during CHECK operations |
 | 0.3.51 | 2026-06-10 | [79123](https://github.com/airbytehq/airbyte/pull/79123) | Update Apacher Iceberg dependencies. |
 | 0.3.50 | 2026-06-03 | [79112](https://github.com/airbytehq/airbyte/pull/79112) | Use unique staging branches and clean them up after each sync. |


### PR DESCRIPTION
## What

Requested by AJ Steers (@aaronsteers). Tracked by airbytehq/airbyte-transforms-poc#26.

Dedupe streams on this destination express upserts as Iceberg **equality deletes**. Readers that only support positional merge-on-read deletes reject such tables outright — Snowflake fails registration with `091968 (0A000): Equality deletes on Iceberg tables are not supported.` This adds a positional delete encoding so the destination can produce tables those readers can consume.

**Draft: the positional path is not yet proven against a real table.** Only unit-level coverage has run so far; the end-to-end dedupe/update/delete verification (assert every delete file is `POSITION_DELETES` and none are `EQUALITY_DELETES`) is still outstanding, and known gaps are listed below.

## How

New destination config `merge_on_read_delete_encoding`, defaulting to `EQUALITY`, so existing users are unaffected. `POSITIONAL` only has meaning for Dedupe streams.

A positional delete needs the superseded row's `(data-file path, row ordinal)`, which nothing in the CDK resolved before. Two pieces supply it:

1. `PositionalDeleteIndexBuilder` seeds a key → `(path, position, spec, partition)` index by scanning the current snapshot of the staging branch, projected to the identifier columns plus `_file` / `_pos`.
2. `BasePositionDeltaTaskWriter` registers each row it writes into that same index, so a row written earlier in the sync can be superseded later.

The index is **stream-scoped and shared across every aggregate/writer for the stream**, which is required for correctness: aggregates rotate and multiple writers can handle the same stream, so a per-writer map (what Iceberg's `BaseEqualityDeltaWriter` keeps internally) would miss a row written by a sibling writer and silently emit a duplicate. Equality deletes don't have that problem because they apply table-wide within the partition.

Supporting decisions:

- Never fall back to an equality delete. If a key is in neither the snapshot index nor this sync's writes, no prior row exists, so no delete is emitted at all — the equality delete written today for that case is pure waste.
- Full identifier values are stored, not hashes; a collision would delete the wrong row.
- Ordering across parallel pipelines would let an update be processed before the insert it supersedes, so positional mode restricts the destination to a single dataflow socket.
- Row deltas are committed with snapshot validation so concurrent writers or compaction fail the commit instead of silently deleting the wrong rows.
- A duplicate identifier in the base snapshot fails loudly, as does an oversized index.

## Review guide

1. `BasePositionDeltaTaskWriter.java` — the write/deleteKey path and positional delete emission.
2. `PositionalDeleteIndex.java` and `PositionalDeleteIndexBuilder.kt` — the shared index and its snapshot scan.
3. `S3DataLakeStreamLoader.kt` — index construction and base snapshot capture.
4. `S3DataLakeSpecification.kt` — the new config option.

Known gaps being worked before this leaves draft: end-to-end verification against a real Iceberg table, position-delete file sort ordering, and the interaction between per-aggregate commit validation and this sync's own earlier commits.

## User Impact

None by default — the encoding stays `EQUALITY` unless explicitly changed. Users who opt into `POSITIONAL` get tables readable by engines that reject equality deletes, at the cost of a snapshot scan per sync and single-socket throughput for dedupe streams.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚


Link to Devin session: https://app.devin.ai/sessions/9a6b30bee54d474a837bc962774191fd