### PR TITLE
fix(source-okta): handle escaped newlines in PEM private key

### DIFF
--- a/airbyte-integrations/connectors/source-okta/source_okta/components.py
+++ b/airbyte-integrations/connectors/source-okta/source_okta/components.py
@@ -85,6 +85,9 @@ class CustomOauth2PrivateKeyAuthenticator(DeclarativeAuthenticator):
         client_id = self.config["credentials"]["client_id"]
         key_id = self.config["credentials"]["key_id"]
         private_key = self.config["credentials"]["private_key"]
+        # The Airbyte UI may store escaped newlines (literal \n) instead of real newline characters.
+        # PyJWT requires real newlines to parse PEM keys correctly.
+        private_key = private_key.replace("\\n", "\n")
         scope = self.config["credentials"]["scope"]
         now = int(time.time())
 

--- a/airbyte-integrations/connectors/source-okta/unit_tests/test_source.py
+++ b/airbyte-integrations/connectors/source-okta/unit_tests/test_source.py
@@ -2,7 +2,9 @@
 # Copyright (c) 2024 Airbyte, Inc., all rights reserved.
 #
 
-from source_okta.components import CustomBearerAuthenticator, CustomOauth2Authenticator
+from unittest.mock import patch
+
+from source_okta.components import CustomBearerAuthenticator, CustomOauth2Authenticator, CustomOauth2PrivateKeyAuthenticator
 from source_okta.source import SourceOkta
 
 
@@ -82,3 +84,82 @@ class TestAuthentication:
             oauth_authentication_instance.refresh_access_token()
         except Exception as e:
             assert e.args[0] == error_while_refreshing_access_token
+
+
+class TestPrivateKeyAuthentication:
+    """Tests for CustomOauth2PrivateKeyAuthenticator handling of escaped newlines in PEM keys."""
+
+    def test_private_key_with_escaped_newlines(self, requests_mock):
+        """
+        The Airbyte UI stores multiline PEM keys with literal \\n instead of real newline characters.
+        The authenticator should normalize these before passing to PyJWT.
+        """
+        from cryptography.hazmat.primitives.asymmetric import rsa
+        from cryptography.hazmat.primitives import serialization
+
+        # Generate a test RSA key
+        key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+        pem_bytes = key.private_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PrivateFormat.PKCS8,
+            encryption_algorithm=serialization.NoEncryption(),
+        )
+        pem_multiline = pem_bytes.decode("utf-8")
+        # Simulate what the Airbyte UI does: replace real newlines with literal \n
+        pem_escaped = pem_multiline.replace("\n", "\\n")
+
+        config = {
+            "domain": "test_domain",
+            "credentials": {
+                "auth_type": "oauth2.0_private_key",
+                "client_id": "test_client_id",
+                "key_id": "test_key_id",
+                "private_key": pem_escaped,
+                "scope": "okta.users.read",
+            },
+        }
+
+        # Mock the Okta token endpoint
+        requests_mock.post(
+            "https://test_domain.okta.com/oauth2/v1/token",
+            json={"access_token": "test_access_token", "token_type": "Bearer", "expires_in": 3600},
+        )
+
+        authenticator = CustomOauth2PrivateKeyAuthenticator(config=config)
+        token = authenticator.token
+
+        assert token == "Bearer test_access_token"
+
+    def test_private_key_with_real_newlines(self, requests_mock):
+        """PEM keys with real newlines should also work (no regression)."""
+        from cryptography.hazmat.primitives.asymmetric import rsa
+        from cryptography.hazmat.primitives import serialization
+
+        key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+        pem_bytes = key.private_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PrivateFormat.PKCS8,
+            encryption_algorithm=serialization.NoEncryption(),
+        )
+        pem_multiline = pem_bytes.decode("utf-8")
+
+        config = {
+            "domain": "test_domain",
+            "credentials": {
+                "auth_type": "oauth2.0_private_key",
+                "client_id": "test_client_id",
+                "key_id": "test_key_id",
+                "private_key": pem_multiline,
+                "scope": "okta.users.read",
+            },
+        }
+
+        requests_mock.post(
+            "https://test_domain.okta.com/oauth2/v1/token",
+            json={"access_token": "test_access_token", "token_type": "Bearer", "expires_in": 3600},
+        )
+
+        authenticator = CustomOauth2PrivateKeyAuthenticator(config=config)
+        token = authenticator.token
+
+        assert token == "Bearer test_access_token"

--- a/airbyte-integrations/connectors/source-okta/unit_tests/test_source.py
+++ b/airbyte-integrations/connectors/source-okta/unit_tests/test_source.py
@@ -94,8 +94,8 @@ class TestPrivateKeyAuthentication:
         The Airbyte UI stores multiline PEM keys with literal \\n instead of real newline characters.
         The authenticator should normalize these before passing to PyJWT.
         """
-        from cryptography.hazmat.primitives.asymmetric import rsa
         from cryptography.hazmat.primitives import serialization
+        from cryptography.hazmat.primitives.asymmetric import rsa
 
         # Generate a test RSA key
         key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
@@ -132,8 +132,8 @@ class TestPrivateKeyAuthentication:
 
     def test_private_key_with_real_newlines(self, requests_mock):
         """PEM keys with real newlines should also work (no regression)."""
-        from cryptography.hazmat.primitives.asymmetric import rsa
         from cryptography.hazmat.primitives import serialization
+        from cryptography.hazmat.primitives.asymmetric import rsa
 
         key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
         pem_bytes = key.private_bytes(


### PR DESCRIPTION
# fix(source-okta): handle escaped newlines in PEM private key

## What

The Airbyte UI stores literal `\n` characters instead of real newline characters when saving multiline PEM private keys in the connector configuration. This causes PyJWT to fail with:

```
jwt.exceptions.InvalidKeyError: Could not parse the provided public key.
```

The error message is misleading — PyJWT tries to parse the key as private first, then public, and reports the last failure. The root cause is that the PEM format is corrupted (literal `\n` instead of real newlines).

**Reproduction proof (Airbyte 2.1.1, abctl v0.30.4):**

| Test | PEM format | Result |
|------|-----------|--------|
| A — Escaped newlines (simulating UI) | `-----BEGIN PRIVATE KEY-----\nMII...` (literal `\n`) | ❌ `Could not parse the provided public key` |
| B — Real newlines (via API) | Standard multiline PEM (28 lines) | ✅ Connection succeeded |

Related: This affects any user configuring OAuth 2.0 with private key authentication via the Airbyte UI.

## How

One-line fix in `CustomOauth2PrivateKeyAuthenticator.token` property (`source_okta/components.py`):

```python
private_key = self.config["credentials"]["private_key"]
# The Airbyte UI may store escaped newlines (literal \n) instead of real newline characters.
# PyJWT requires real newlines to parse PEM keys correctly.
private_key = private_key.replace("\\n", "\n")
```

This normalizes escaped newlines back to real newlines before passing the private key to `jwt.encode()`.
## Review guide

1. `airbyte-integrations/connectors/source-okta/source_okta/components.py` — the fix (3 lines added)
2. `airbyte-integrations/connectors/source-okta/unit_tests/test_source.py` — unit tests for `CustomOauth2PrivateKeyAuthenticator` with both escaped and real newline PEM formats

## User Impact

- Users can now configure OAuth 2.0 with private key authentication via the Airbyte UI without encountering the `Could not parse the provided public key` error.
- No behavioral change for users who already have working configurations (the `.replace()` is a no-op on keys that already have real newlines).

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Reverting would restore the previous behavior where PEM keys entered via the UI fail. No data loss or breaking changes.
