### PR TITLE
docs: document supported Postgres versions for external databases

### DIFF
--- a/docs/platform/deploying-airbyte/integrations/database.md
+++ b/docs/platform/deploying-airbyte/integrations/database.md
@@ -8,6 +8,10 @@ For production deployments, we recommend using a dedicated database instance for
 
 The following instructions assume that you've already configured a Postgres instance:
 
+## Supported Postgres versions
+
+Airbyte requires Postgres 13 or later. Airbyte tests its deployments through Postgres 17. Newer versions may work, but Airbyte doesn't test them.
+
 ## Secrets
 
 ```yaml

--- a/docs/platform/enterprise-setup/implementation-guide.md
+++ b/docs/platform/enterprise-setup/implementation-guide.md
@@ -332,7 +332,7 @@ The following subsections help you customize your deployment to use an external 
 
 For Self-Managed Enterprise deployments, you must use a dedicated database instance for better reliability and backups, such as AWS RDS or GCP Cloud SQL. Don't use the default internal Postgres database, `airbyte/db`, that Airbyte spins up within the Kubernetes cluster.
 
-We assume in the following that you've already configured a Postgres instance:
+We assume in the following that you've already configured a Postgres instance. Airbyte requires Postgres 13 or later, and tests its deployments through Postgres 17. See [External Database](/platform/deploying-airbyte/integrations/database) for details.
 
 <details>
 <summary>External database setup steps</summary>


### PR DESCRIPTION
## What

Closes #48542.

The External Database page tells users to point Airbyte at their own Postgres but never states a version range — grepping `docs/platform` for any Postgres version string returns zero hits, so neither the deployment docs nor the Enterprise guide answer "which versions work?".

Requested by Ian Alton (@ian-at-airbyte), who confirmed the "Postgres 13 minimum, tested through 17" framing.

## How

Adds a `## Supported Postgres versions` section to `deploying-airbyte/integrations/database.md` and a one-sentence statement plus cross-link in the Enterprise implementation guide's "Configuring the Airbyte Database" section (rather than duplicating the range in two places).

Where the numbers come from:

- **Floor of 13.** The Helm chart runs Temporal with `temporal.database.engine: postgres12` (the PG >= 12 driver), so 12 is the technical floor, but 12 is EOL upstream as of Nov 2024 and the chart's own bundled DB image (`airbyte/db`) and the Keycloak `initDb` init container are both `postgres:13-alpine`. Nothing in `airbyte-db` / `airbyte-config` uses version-gated SQL, so Airbyte's own Flyway migrations don't raise the floor.
- **"Tested through 17"** rather than a hard maximum, so the page doesn't go stale each September. A community member on the issue verified 12.19 through 17.1 deploy and sync successfully on RDS.

Only `docs/platform` is edited. `docusaurus/platform_versions.json` is `[]`, so the copies under `docusaurus/platform_versioned_docs/version-*` are not built and don't need the same change.

A follow-up PR in `airbytehq/airbyte-platform` will add the same statement as a comment on the `global.database` block in `charts/v2/airbyte/values.yaml`, which is the other half of the issue's ask — the "Values.yaml reference" docs page renders that file verbatim.

## Review guide

1. `docs/platform/deploying-airbyte/integrations/database.md`
2. `docs/platform/enterprise-setup/implementation-guide.md`

## User Impact

Users configuring an external database can see the supported Postgres range without asking or guessing. No behavior change.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚
- [ ] NO ❌


Link to Devin session: https://app.devin.ai/sessions/000ab25a9b3a454db401707ceafc53da