### PR TITLE
chore(source-chargebee): verification build on CDK prerelease SDM 7.23.7.post2.dev30345587161 (do not merge)

### DIFF
--- a/airbyte-integrations/connectors/source-chargebee/metadata.yaml
+++ b/airbyte-integrations/connectors/source-chargebee/metadata.yaml
@@ -6,7 +6,7 @@ data:
     hosts:
       - "*.chargebee.com"
   connectorBuildOptions:
-    baseImage: docker.io/airbyte/source-declarative-manifest:7.23.7.post2.dev30345587161@sha256:05c6a7e69420a4f71f172c056955a73e1c0425f3af45fc900728f26c6fbaa428
+    baseImage: docker.io/airbyte/source-declarative-manifest:7.23.7.post4.dev30357014888@sha256:ee7f99ddd45a7be1c364e2a298fade8361a865eb498c86ab6a172511becf5338
   connectorSubtype: api
   connectorType: source
   definitionId: 686473f1-76d9-4994-9cc7-9b13da46147c

--- a/airbyte-integrations/connectors/source-chargebee/metadata.yaml
+++ b/airbyte-integrations/connectors/source-chargebee/metadata.yaml
@@ -6,11 +6,11 @@ data:
     hosts:
       - "*.chargebee.com"
   connectorBuildOptions:
-    baseImage: docker.io/airbyte/source-declarative-manifest:7.23.7@sha256:c8318a72046a68ab48bd5bd57adb459d5a69dead827356f19c2ef78fbecfe0c9
+    baseImage: docker.io/airbyte/source-declarative-manifest:7.23.7.post2.dev30345587161@sha256:05c6a7e69420a4f71f172c056955a73e1c0425f3af45fc900728f26c6fbaa428
   connectorSubtype: api
   connectorType: source
   definitionId: 686473f1-76d9-4994-9cc7-9b13da46147c
-  dockerImageTag: 0.10.41
+  dockerImageTag: 0.10.42
   dockerRepository: airbyte/source-chargebee
   documentationUrl: https://docs.airbyte.com/integrations/sources/chargebee
   externalDocumentationUrls:

--- a/docs/integrations/sources/chargebee.md
+++ b/docs/integrations/sources/chargebee.md
@@ -111,6 +111,7 @@ If you use Airbyte Cloud and your organization restricts access to specific IPs,
 
 | Version     | Date       | Pull Request                                             | Subject                                                                                                                                                                |
 |:------------|:-----------|:---------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 0.10.42 | 2026-07-28 | [1083](https://github.com/airbytehq/airbyte-python-cdk/pull/1083) | Build on a CDK prerelease that restores bundled custom components (do not merge) |
 | 0.10.41 | 2026-07-28 | [82863](https://github.com/airbytehq/airbyte/pull/82863) | Update dependencies |
 | 0.10.40 | 2026-07-21 | [81761](https://github.com/airbytehq/airbyte/pull/81761) | Update dependencies |
 | 0.10.39 | 2026-06-30 | [81013](https://github.com/airbytehq/airbyte/pull/81013) | Update dependencies |


### PR DESCRIPTION
## What

Temporary verification build, **not for merge**. Points `source-chargebee` at the prerelease `source-declarative-manifest` image produced by airbytehq/airbyte-python-cdk#1083 so the fix can be proven on a real Cloud connection.

Context: `source-chargebee` 0.10.41 ships on `source-declarative-manifest:7.23.7`, which requires `AIRBYTE_ENABLE_UNSAFE_CODE=true` for *any* `Custom*` component — including the `CustomFieldTransformation` bundled in this connector's own image. Cloud never sets that variable, so `check`, `discover` and `read` all fail with `AirbyteCustomCodeNotPermittedError`. 19 published connectors are affected. Tracking issue: airbytehq/airbyte-python-cdk#1082.

## How

```diff
-baseImage: ...source-declarative-manifest:7.23.7@sha256:c8318a72...
+baseImage: ...source-declarative-manifest:7.23.7.post2.dev30345587161@sha256:05c6a7e6...
-dockerImageTag: 0.10.41
+dockerImageTag: 0.10.42
```

The dev base image is the prerelease build of airbytehq/airbyte-python-cdk#1083, which gates custom code on manifest provenance instead of gating it unconditionally.

## Review guide

1. `airbyte-integrations/connectors/source-chargebee/metadata.yaml` — base image + version only; no manifest or component changes.

## User Impact

None — this branch exists only to publish a prerelease image for verification against a sandbox connection. The real fix is the CDK PR; once it is released, Chargebee (and the other 18 connectors) need a normal rebuild on the released base image rather than this dev tag.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚


Link to Devin session: https://app.devin.ai/sessions/fbef868f12844f26b7cb6edbc1b3a8b0
Requested by: @Airbyte-Support