### PR TITLE
chore(connectors): roll Cloud back to pre-SDM-7.23.7 versions for 8 more sources

### DIFF
--- a/airbyte-integrations/connectors/source-tiktok-marketing/metadata.yaml
+++ b/airbyte-integrations/connectors/source-tiktok-marketing/metadata.yaml
@@ -11,7 +11,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 4bfac00d-ce15-44ff-95b9-9e3c3e8fbd35
-  dockerImageTag: 5.1.6
+  dockerImageTag: 5.1.7
   dockerRepository: airbyte/source-tiktok-marketing
   documentationUrl: https://docs.airbyte.com/integrations/sources/tiktok-marketing
   externalDocumentationUrls:
@@ -32,6 +32,7 @@ data:
   registryOverrides:
     cloud:
       enabled: true
+      dockerImageTag: 5.1.5 # last version built on SDM 7.23.6
     oss:
       enabled: true
   releases:

--- a/airbyte-integrations/connectors/source-twilio/metadata.yaml
+++ b/airbyte-integrations/connectors/source-twilio/metadata.yaml
@@ -14,7 +14,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: b9dc6155-672e-42ea-b10d-9f1f1fb95ab1
-  dockerImageTag: 1.0.10
+  dockerImageTag: 1.0.11
   dockerRepository: airbyte/source-twilio
   documentationUrl: https://docs.airbyte.com/integrations/sources/twilio
   githubIssueLabel: source-twilio
@@ -29,6 +29,7 @@ data:
   registryOverrides:
     cloud:
       enabled: true
+      dockerImageTag: 1.0.9 # last version built on SDM 7.23.6
     oss:
       enabled: true
   releaseStage: generally_available

--- a/airbyte-integrations/connectors/source-us-census/metadata.yaml
+++ b/airbyte-integrations/connectors/source-us-census/metadata.yaml
@@ -2,7 +2,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: c4cfaeda-c757-489a-8aba-859fb08b6970
-  dockerImageTag: 0.4.28
+  dockerImageTag: 0.4.29
   dockerRepository: airbyte/source-us-census
   githubIssueLabel: source-us-census
   icon: uscensus.svg
@@ -15,6 +15,7 @@ data:
   registryOverrides:
     cloud:
       enabled: true
+      dockerImageTag: 0.4.27 # last version built on SDM 7.23.6
     oss:
       enabled: true
   releaseStage: alpha

--- a/airbyte-integrations/connectors/source-younium/metadata.yaml
+++ b/airbyte-integrations/connectors/source-younium/metadata.yaml
@@ -8,6 +8,7 @@ data:
       enabled: true
     cloud:
       enabled: true
+      dockerImageTag: 0.4.54 # last version built on SDM 7.23.6
   connectorBuildOptions:
     # Please update to the latest version of the connector base image.
     # https://hub.docker.com/r/airbyte/python-connector-base
@@ -16,7 +17,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 9c74c2d7-531a-4ebf-b6d8-6181f805ecdc
-  dockerImageTag: 0.4.55
+  dockerImageTag: 0.4.56
   dockerRepository: airbyte/source-younium
   githubIssueLabel: source-younium
   icon: younium.svg

--- a/airbyte-integrations/connectors/source-zendesk-chat/metadata.yaml
+++ b/airbyte-integrations/connectors/source-zendesk-chat/metadata.yaml
@@ -10,7 +10,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 40d24d0f-b8f9-4fe0-9e6c-b06c0f3f45e4
-  dockerImageTag: 1.3.19
+  dockerImageTag: 1.3.20
   dockerRepository: airbyte/source-zendesk-chat
   documentationUrl: https://docs.airbyte.com/integrations/sources/zendesk-chat
   externalDocumentationUrls:
@@ -31,6 +31,7 @@ data:
   registryOverrides:
     cloud:
       enabled: true
+      dockerImageTag: 1.3.18 # last version built on SDM 7.23.6
     oss:
       enabled: true
   releaseStage: generally_available

--- a/airbyte-integrations/connectors/source-zendesk-support/metadata.yaml
+++ b/airbyte-integrations/connectors/source-zendesk-support/metadata.yaml
@@ -11,7 +11,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 79c1aa37-dae3-42ae-b333-d1c105477715
-  dockerImageTag: 5.4.4
+  dockerImageTag: 5.4.5
   dockerRepository: airbyte/source-zendesk-support
   documentationUrl: https://docs.airbyte.com/integrations/sources/zendesk-support
   githubIssueLabel: source-zendesk-support
@@ -26,6 +26,7 @@ data:
   registryOverrides:
     cloud:
       enabled: true
+      dockerImageTag: 5.4.3 # last version built on SDM 7.23.6
     oss:
       enabled: true
   releaseStage: generally_available

--- a/airbyte-integrations/connectors/source-zendesk-talk/metadata.yaml
+++ b/airbyte-integrations/connectors/source-zendesk-talk/metadata.yaml
@@ -11,7 +11,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: c8630570-086d-4a40-99ae-ea5b18673071
-  dockerImageTag: 2.0.20
+  dockerImageTag: 2.0.21
   dockerRepository: airbyte/source-zendesk-talk
   documentationUrl: https://docs.airbyte.com/integrations/sources/zendesk-talk
   externalDocumentationUrls:
@@ -32,6 +32,7 @@ data:
   registryOverrides:
     cloud:
       enabled: true
+      dockerImageTag: 2.0.19 # last version built on SDM 7.23.6
     oss:
       enabled: true
   releaseStage: generally_available

--- a/airbyte-integrations/connectors/source-zoom/metadata.yaml
+++ b/airbyte-integrations/connectors/source-zoom/metadata.yaml
@@ -7,7 +7,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: cbfd9856-1322-44fb-bcf1-0b39b7a8e92e
-  dockerImageTag: 1.2.57
+  dockerImageTag: 1.2.58
   dockerRepository: airbyte/source-zoom
   documentationUrl: https://docs.airbyte.com/integrations/sources/zoom
   githubIssueLabel: source-zoom
@@ -17,6 +17,7 @@ data:
   registryOverrides:
     cloud:
       enabled: true
+      dockerImageTag: 1.2.56 # last version built on SDM 7.23.6
     oss:
       enabled: true
   releaseStage: alpha

--- a/docs/integrations/sources/tiktok-marketing.md
+++ b/docs/integrations/sources/tiktok-marketing.md
@@ -171,6 +171,7 @@ If you use Airbyte Cloud and your organization restricts access to specific IPs,
 
 | Version    | Date       | Pull Request                                              | Subject                                                                                                                                                                |
 |:-----------|:-----------|:----------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 5.1.7 | 2026-07-28 | [1082](https://github.com/airbytehq/airbyte-python-cdk/issues/1082) | Roll Cloud back to 5.1.5 — 5.1.6 is built on SDM 7.23.7, which breaks bundled custom components |
 | 5.1.6 | 2026-07-28 | [83151](https://github.com/airbytehq/airbyte/pull/83151) | Update dependencies |
 | 5.1.5 | 2026-07-21 | [82620](https://github.com/airbytehq/airbyte/pull/82620) | Update dependencies |
 | 5.1.4 | 2026-07-14 | [81448](https://github.com/airbytehq/airbyte/pull/81448) | Add `smart_plus_ad_id` field to `ads` stream |

--- a/docs/integrations/sources/twilio.md
+++ b/docs/integrations/sources/twilio.md
@@ -160,6 +160,7 @@ For programmatic configuration, use these parameter names:
 
 | Version | Date | Pull Request | Subject |
 | :------ | :--- | :----------- | :------ |
+| 1.0.11 | 2026-07-28 | [1082](https://github.com/airbytehq/airbyte-python-cdk/issues/1082) | Roll Cloud back to 1.0.9 — 1.0.10 is built on SDM 7.23.7, which breaks bundled custom components |
 | 1.0.10 | 2026-07-28 | [83134](https://github.com/airbytehq/airbyte/pull/83134) | Update dependencies |
 | 1.0.9 | 2026-07-21 | [82618](https://github.com/airbytehq/airbyte/pull/82618) | Update dependencies |
 | 1.0.8 | 2026-07-14 | [82053](https://github.com/airbytehq/airbyte/pull/82053) | Update dependencies |

--- a/docs/integrations/sources/us-census.md
+++ b/docs/integrations/sources/us-census.md
@@ -49,6 +49,7 @@ If you use Airbyte Cloud and your organization restricts access to specific IPs,
 
 | Version | Date       | Pull Request                                             | Subject                                           |
 | :------ | :--------- | :------------------------------------------------------- | :------------------------------------------------ |
+| 0.4.29 | 2026-07-28 | [1082](https://github.com/airbytehq/airbyte-python-cdk/issues/1082) | Roll Cloud back to 0.4.27 — 0.4.28 is built on SDM 7.23.7, which breaks bundled custom components |
 | 0.4.28 | 2026-07-28 | [83127](https://github.com/airbytehq/airbyte/pull/83127) | Update dependencies |
 | 0.4.27 | 2026-07-21 | [82627](https://github.com/airbytehq/airbyte/pull/82627) | Update dependencies |
 | 0.4.26 | 2026-07-14 | [82049](https://github.com/airbytehq/airbyte/pull/82049) | Update dependencies |

--- a/docs/integrations/sources/younium.md
+++ b/docs/integrations/sources/younium.md
@@ -50,6 +50,7 @@ If you use Airbyte Cloud and your organization restricts access to specific IPs,
 
 | Version | Date       | Pull Request                                             | Subject                                                    |
 | :------ | :--------- | :------------------------------------------------------- | :--------------------------------------------------------- |
+| 0.4.56 | 2026-07-28 | [1082](https://github.com/airbytehq/airbyte-python-cdk/issues/1082) | Roll Cloud back to 0.4.54 — 0.4.55 is built on SDM 7.23.7, which breaks bundled custom components |
 | 0.4.55 | 2026-07-28 | [83162](https://github.com/airbytehq/airbyte/pull/83162) | Update dependencies |
 | 0.4.54 | 2026-07-21 | [82676](https://github.com/airbytehq/airbyte/pull/82676) | Update dependencies |
 | 0.4.53 | 2026-07-14 | [82075](https://github.com/airbytehq/airbyte/pull/82075) | Update dependencies |

--- a/docs/integrations/sources/zendesk-chat.md
+++ b/docs/integrations/sources/zendesk-chat.md
@@ -88,6 +88,7 @@ If you use Airbyte Cloud and your organization restricts access to specific IPs,
 
 | Version | Date       | Pull Request                                             | Subject                                                                                                                                                                |
 |:--------|:-----------|:---------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 1.3.20 | 2026-07-28 | [1082](https://github.com/airbytehq/airbyte-python-cdk/issues/1082) | Roll Cloud back to 1.3.18 — 1.3.19 is built on SDM 7.23.7, which breaks bundled custom components |
 | 1.3.19 | 2026-07-28 | [83161](https://github.com/airbytehq/airbyte/pull/83161) | Update dependencies |
 | 1.3.18 | 2026-07-21 | [82671](https://github.com/airbytehq/airbyte/pull/82671) | Update dependencies |
 | 1.3.17 | 2026-07-14 | [82082](https://github.com/airbytehq/airbyte/pull/82082) | Update dependencies |

--- a/docs/integrations/sources/zendesk-support.md
+++ b/docs/integrations/sources/zendesk-support.md
@@ -232,6 +232,7 @@ If you use Airbyte Cloud and your organization restricts access to specific IPs,
 
 | Version     | Date       | Pull Request                                             | Subject                                                                                                                                                                                                                            |
 |:------------|:-----------|:---------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 5.4.5 | 2026-07-28 | [1082](https://github.com/airbytehq/airbyte-python-cdk/issues/1082) | Roll Cloud back to 5.4.3 — 5.4.4 is built on SDM 7.23.7, which breaks bundled custom components |
 | 5.4.4 | 2026-07-28 | [83159](https://github.com/airbytehq/airbyte/pull/83159) | Update dependencies |
 | 5.4.3 | 2026-07-21 | [82661](https://github.com/airbytehq/airbyte/pull/82661) | Update dependencies |
 | 5.4.2 | 2026-07-14 | [82080](https://github.com/airbytehq/airbyte/pull/82080) | Update dependencies |

--- a/docs/integrations/sources/zendesk-talk.md
+++ b/docs/integrations/sources/zendesk-talk.md
@@ -95,6 +95,7 @@ If you use Airbyte Cloud and your organization restricts access to specific IPs,
 
 | Version | Date | Pull Request | Subject |
 |:--|:--|:--|:--|
+| 2.0.21 | 2026-07-28 | [1082](https://github.com/airbytehq/airbyte-python-cdk/issues/1082) | Roll Cloud back to 2.0.19 — 2.0.20 is built on SDM 7.23.7, which breaks bundled custom components |
 | 2.0.20 | 2026-07-28 | [83181](https://github.com/airbytehq/airbyte/pull/83181) | Update dependencies |
 | 2.0.19 | 2026-07-21 | [82651](https://github.com/airbytehq/airbyte/pull/82651) | Update dependencies |
 | 2.0.18 | 2026-07-14 | [82090](https://github.com/airbytehq/airbyte/pull/82090) | Update dependencies |

--- a/docs/integrations/sources/zoom.md
+++ b/docs/integrations/sources/zoom.md
@@ -75,6 +75,7 @@ If you use Airbyte Cloud and your organization restricts access to specific IPs,
 
 | Version | Date       | Pull Request                                             | Subject                                              |
 | :------ | :--------- | :------------------------------------------------------- | :--------------------------------------------------- |
+| 1.2.58 | 2026-07-28 | [1082](https://github.com/airbytehq/airbyte-python-cdk/issues/1082) | Roll Cloud back to 1.2.56 — 1.2.57 is built on SDM 7.23.7, which breaks bundled custom components |
 | 1.2.57 | 2026-07-28 | [83156](https://github.com/airbytehq/airbyte/pull/83156) | Update dependencies |
 | 1.2.56 | 2026-07-21 | [82672](https://github.com/airbytehq/airbyte/pull/82672) | Update dependencies |
 | 1.2.55 | 2026-07-14 | [82073](https://github.com/airbytehq/airbyte/pull/82073) | Update dependencies |


### PR DESCRIPTION
## What

Follow-up to airbytehq/airbyte#83183, requested by @darynaishchenko: today's dependency-update pipeline published 8 more sources onto `source-declarative-manifest:7.23.7` *after* that PR's list was compiled. All 8 bundle a `components.py` and resolve at least one `class_name` from their manifest, so they hit the same regression — `check`, `discover` and `read` fail immediately in Cloud with `AirbyteCustomCodeNotPermittedError`, because SDM 7.23.7 requires `AIRBYTE_ENABLE_UNSAFE_CODE=true` even for code baked into the connector's own published image.

Root cause and permanent fix: airbytehq/airbyte-python-cdk#1082 / airbytehq/airbyte-python-cdk#1083.

## How

Same shape as airbytehq/airbyte-python-cdk#1083's companion rollback: per connector, a patch version bump (required for the metadata change to publish) plus a Cloud registry override pointing at the last version built on SDM 7.23.6.

```diff
-  dockerImageTag: 1.2.57
+  dockerImageTag: 1.2.58
   registryOverrides:
     cloud:
       enabled: true
+      dockerImageTag: 1.2.56 # last version built on SDM 7.23.6
```

| connector | new version | Cloud serves | custom classes resolved from the manifest |
| --- | --- | --- | --- |
| source-tiktok-marketing | 5.1.7 | 5.1.5 | `MultipleAdvertiserIdsPerPartition`, `SingleAdvertiserIdPerPartition`, `TransformEmptyMetrics` |
| source-twilio | 1.0.11 | 1.0.9 | `TwilioAlertsStateMigration`, `TwilioConferencesStateMigration`, `TwilioDateTimeTypeTransformer`, `TwilioMessageMediaStateMigration`, `TwilioStateMigration`, `TwilioUsageRecordsStateMigration` |
| source-us-census | 0.4.29 | 0.4.27 | `USCensusErrorHandler`, `USCensusRecordExtractor`, `USCensusSchema` |
| source-younium | 0.4.56 | 0.4.54 | `CustomYouniumAuthenticator` |
| source-zendesk-chat | 1.3.20 | 1.3.18 | `ZendeskChatBansRecordExtractor` |
| source-zendesk-support | 5.4.5 | 5.4.3 | `TicketsStateMigration`, `ZendeskSupportAttributeDefinitionsExtractor`, `ZendeskSupportExtractorEvents` |
| source-zendesk-talk | 2.0.21 | 2.0.19 | `IVRMenusRecordExtractor`, `IVRRoutesRecordExtractor`, `ZendeskTalkAuthenticator` |
| source-zoom | 1.2.58 | 1.2.56 | `ServerToServerOauthAuthenticator` |

Selection method: scanned every entry in the live Cloud registry for a `connectorBuildOptions.baseImage` of `source-declarative-manifest` >= 7.23.7 (364 connectors), then kept only those that bundle a `components.py` or resolve a `class_name` in `manifest.yaml`. The remaining 356 are manifest-only connectors with no custom code and are unaffected. Rollback targets were found by walking each connector's published registry metadata backwards until `baseImage` was no longer 7.23.7 — for all 8 that is exactly one version back (7.23.6).

Note the gate fires on any `class_name` resolution in `create_custom_component`, not only `Custom*`-prefixed component types, which is why connectors such as `source-zoom` (a custom authenticator only) are in scope.

## Review guide

1. `airbyte-integrations/connectors/*/metadata.yaml` — two lines each; no manifest, spec or component changes.
2. `docs/integrations/sources/*.md` — changelog rows.

Deliberately not done here, matching airbytehq/airbyte#83183: the new versions still declare `baseImage: 7.23.7`, so OSS/Self-Managed users continue to receive a broken image unless they set `AIRBYTE_ENABLE_UNSAFE_CODE=true`. Reverting `baseImage` to the 7.23.6 digest would cover OSS too, at the cost of real rebuilds.

## User Impact

Affected Cloud connections stop failing without per-workspace version pins. Verified for the equivalent change in airbytehq/airbyte#83183: after that merge published, an unpinned sandbox Chargebee source resolved the rolled-back version and `discover` returned all 27 streams, where the same source had failed with `AirbyteCustomCodeNotPermittedError` minutes earlier.

Cost: these connectors miss their newest patch until airbytehq/airbyte-python-cdk#1083 ships and they are rebuilt on a fixed base image. At that point the `registryOverrides.cloud.dockerImageTag` lines must be removed — this is a temporary rollback, not a permanent state.

Also worth pausing the dependency-bump automation for manifest-only connectors with a bundled `components.py` until the CDK fix lands, otherwise this list keeps growing with every bump cycle.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚


Link to Devin session: https://app.devin.ai/sessions/fbef868f12844f26b7cb6edbc1b3a8b0
Requested by: @Airbyte-Support