### PR TITLE
chore(source-notion): (do not merge) test CDK prerelease base image

### DIFF
--- a/airbyte-integrations/connectors/source-notion/metadata.yaml
+++ b/airbyte-integrations/connectors/source-notion/metadata.yaml
@@ -6,7 +6,7 @@ data:
     hosts:
       - api.notion.com
   connectorBuildOptions:
-    baseImage: docker.io/airbyte/source-declarative-manifest:7.23.7@sha256:c8318a72046a68ab48bd5bd57adb459d5a69dead827356f19c2ef78fbecfe0c9
+    baseImage: docker.io/airbyte/source-declarative-manifest:7.23.7.post4.dev30357014888@sha256:ee7f99ddd45a7be1c364e2a298fade8361a865eb498c86ab6a172511becf5338
   connectorSubtype: api
   connectorType: source
   definitionId: 6e00b415-b02e-4160-bf02-58176a0ae687


### PR DESCRIPTION
## What
Research/testing PR — do not merge. Provides a branch to publish a `source-notion` prerelease built on the CDK prerelease `7.23.7.post4.dev30357014888` (SDM image), which contains the fix from https://github.com/airbytehq/airbyte-python-cdk/pull/1083 for https://github.com/airbytehq/airbyte-python-cdk/issues/1082 (bundled custom components blocked when `AIRBYTE_ENABLE_UNSAFE_CODE` is unset). Requested by @darynaishchenko.

## How
Updates `connectorBuildOptions.baseImage` in `source-notion/metadata.yaml` to `airbyte/source-declarative-manifest:7.23.7.post4.dev30357014888@sha256:ee7f99ddd45a7be1c364e2a298fade8361a865eb498c86ab6a172511becf5338`. No version bump — this exists only to publish a `-preview.*` build for pinning a sandbox connection.

## Review guide
1. `airbyte-integrations/connectors/source-notion/metadata.yaml`

## User Impact
None — prerelease-only, will not be merged.

## Can this PR be safely reverted and rolled back?
- [x] YES 💚
- [ ] NO ❌

Link to Devin session: https://app.devin.ai/sessions/20f99bb504b543fda97972948b0ceecb