### PR TITLE
Do not merge: Testcontainers CI baseline probe (close after use)

### DIFF
--- a/airbyte-integrations/connectors/destination-clickhouse/build.gradle
+++ b/airbyte-integrations/connectors/destination-clickhouse/build.gradle
@@ -5,6 +5,8 @@ plugins {
     id 'airbyte-connector-docker-convention'
 }
 
+// Baseline probe: no dependency change.
+
 airbyteBulkConnector {
     core = 'load'
 }

--- a/airbyte-integrations/connectors/destination-elasticsearch-strict-encrypt/build.gradle
+++ b/airbyte-integrations/connectors/destination-elasticsearch-strict-encrypt/build.gradle
@@ -5,6 +5,8 @@ plugins {
     id 'airbyte-connector-docker-convention'
 }
 
+// Baseline probe: no dependency change.
+
 airbyteJavaConnector {
     cdkVersionRequired = '0.2.0'
     features = ['db-destinations']

--- a/airbyte-integrations/connectors/destination-elasticsearch/build.gradle
+++ b/airbyte-integrations/connectors/destination-elasticsearch/build.gradle
@@ -5,6 +5,8 @@ plugins {
     id 'airbyte-connector-docker-convention'
 }
 
+// Baseline probe: no dependency change.
+
 airbyteJavaConnector {
     cdkVersionRequired = '0.2.0'
     features = ['db-destinations']

--- a/airbyte-integrations/connectors/destination-kafka/build.gradle
+++ b/airbyte-integrations/connectors/destination-kafka/build.gradle
@@ -5,6 +5,8 @@ plugins {
     id 'airbyte-connector-docker-convention'
 }
 
+// Baseline probe: no dependency change.
+
 airbyteJavaConnector {
     cdkVersionRequired = '0.2.0'
     features = ['db-destinations']

--- a/airbyte-integrations/connectors/destination-oracle-strict-encrypt/build.gradle
+++ b/airbyte-integrations/connectors/destination-oracle-strict-encrypt/build.gradle
@@ -5,6 +5,8 @@ plugins {
     id 'airbyte-connector-docker-convention'
 }
 
+// Baseline probe: no dependency change.
+
 airbyteJavaConnector {
     cdkVersionRequired = '0.29.10'
     features = ['db-destinations', 's3-destinations', 'typing-deduping']

--- a/airbyte-integrations/connectors/destination-oracle/build.gradle
+++ b/airbyte-integrations/connectors/destination-oracle/build.gradle
@@ -5,6 +5,8 @@ plugins {
     id 'airbyte-connector-docker-convention'
 }
 
+// Baseline probe: no dependency change.
+
 airbyteJavaConnector {
     cdkVersionRequired = '0.29.10'
     features = ['db-destinations', 's3-destinations', 'typing-deduping']

--- a/airbyte-integrations/connectors/destination-singlestore/build.gradle
+++ b/airbyte-integrations/connectors/destination-singlestore/build.gradle
@@ -5,6 +5,8 @@ plugins {
     id 'airbyte-connector-docker-convention'
 }
 
+// Baseline probe: no dependency change.
+
 airbyteJavaConnector {
     cdkVersionRequired = '0.36.7'
     features = ['db-destinations', 'typing-deduping']

--- a/airbyte-integrations/connectors/source-clickhouse/build.gradle
+++ b/airbyte-integrations/connectors/source-clickhouse/build.gradle
@@ -4,6 +4,8 @@ plugins {
     id 'airbyte-connector-docker-convention'
 }
 
+// Baseline probe: no dependency change.
+
 airbyteJavaConnector {
     cdkVersionRequired = '0.20.4'
     features = ['db-sources']


### PR DESCRIPTION
## What

**Do not merge. Do not review.** Throwaway research PR, will be closed as soon as it has served its purpose.

This branch is current `master` plus a single inert comment line (`// Baseline probe: no dependency change.`) in the build file of eight Java connectors. No dependency, version, or code change of any kind.

Purpose: establish a CI baseline. Connector tests only run for connectors whose files changed, so `master` has no recent runs for these eight, which makes it impossible to tell whether the connector-test failures on https://github.com/airbytehq/airbyte/pull/83218 (a Testcontainers `1.21.4` standardization) are caused by that bump or were already red. This PR runs exactly those eight connectors' tests against unmodified `master` dependencies, so the two runs can be compared job by job.

Connectors probed: `destination-clickhouse`, `destination-elasticsearch`, `destination-elasticsearch-strict-encrypt`, `destination-kafka`, `destination-oracle`, `destination-oracle-strict-encrypt`, `destination-singlestore`, `source-clickhouse`.

## How

`master` + one comment line per connector build file. Nothing else.

## Review guide

Nothing to review — close it once the comparison is captured.

## User Impact

None. Never intended to merge.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚
- [ ] NO ❌


Link to Devin session: https://app.devin.ai/sessions/34ec900ad1794aeea3668786fe7d912d
Requested by: @mwbayley

> [!IMPORTANT]
> Active progressive rollout warning for destination-clickhouse.

- [ ] (Click to Approve:) Bypass the active progressive rollout warning for destination-clickhouse in the PR comment [here](https://github.com/airbytehq/airbyte/pull/83221#issuecomment-5109519957).