### PR TITLE
Do not merge: Testcontainers CI baseline probe 3 (close after use)

### DIFF
--- a/airbyte-integrations/connectors/destination-kafka/build.gradle
+++ b/airbyte-integrations/connectors/destination-kafka/build.gradle
@@ -31,4 +31,5 @@ dependencies {
     implementation 'org.apache.kafka:connect-json:2.8.0'
 
     integrationTestJavaImplementation 'org.testcontainers:kafka:1.19.0'
+    // probe marker
 }

--- a/airbyte-integrations/connectors/source-redshift/build.gradle
+++ b/airbyte-integrations/connectors/source-redshift/build.gradle
@@ -20,4 +20,5 @@ dependencies {
 
     testImplementation 'org.hamcrest:hamcrest-all:1.3'
     testImplementation "org.testcontainers:jdbc:1.19.4"
+    // probe marker
 }

--- a/airbyte-integrations/connectors/source-tidb/build.gradle
+++ b/airbyte-integrations/connectors/source-tidb/build.gradle
@@ -21,4 +21,5 @@ dependencies {
     testFixturesApi 'org.testcontainers:tidb:1.19.4'
 
     testImplementation 'org.hamcrest:hamcrest-all:1.3'
+    // probe marker
 }


### PR DESCRIPTION
## What

**Do not merge. Do not review.** Throwaway branch used only to obtain a CI baseline, requested by Matt Bayley (`@mwbayley`) as part of the Testcontainers `1.21.4` standardization work in https://github.com/airbytehq/airbyte/pull/83218.

Three connectors have failing integration tests on that PR and I need to know whether they were already failing on `master`. Connector CI only runs a connector's tests when files under that connector's directory change, so a plain `master` run produces nothing to compare against. This branch changes exactly one thing per connector — an inert build-file comment — to make CI select them with no behavioral or dependency change.

Connectors selected here:

- `destination-kafka`
- `source-redshift`
- `source-tidb`

Earlier probes (https://github.com/airbytehq/airbyte/pull/83221 and https://github.com/airbytehq/airbyte/pull/83223) already settled six connectors as failing identically on `master`, and showed `destination-clickhouse`'s failure to be flaky rather than a regression. `destination-kafka` produced self-contradictory evidence (one job failed, another passed, master passed) and `source-redshift` / `source-tidb` have no baseline at all yet. Workflow dispatch is not available to this account (HTTP 403), so a probe branch is the only way to make CI run these jobs against `master`.

## How

One comment line added to each of the three `build.gradle` files. No dependency, version, or code changes. Diff against `master` is comment-only.

## Review guide

Nothing to review. This branch exists to produce CI logs and will be closed and deleted once the comparison against https://github.com/airbytehq/airbyte/pull/83218 is captured.

## User Impact

None. Never intended to merge.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

---
[Devin session](https://app.devin.ai/sessions/34ec900ad1794aeea3668786fe7d912d)
