### PR TITLE
fix(source-gmail): require delegated subject for service account auth

### DIFF
--- a/airbyte-integrations/connectors/source-gmail/manifest.yaml
+++ b/airbyte-integrations/connectors/source-gmail/manifest.yaml
@@ -303,6 +303,7 @@ definitions:
     jwt_payload:
       aud: "{{ json_loads(config['credentials']['service_account_info'])['token_uri'] }}"
       iss: "{{ json_loads(config['credentials']['service_account_info'])['client_email'] }}"
+      sub: "{{ config['credentials']['subject'] }}"
     additional_jwt_payload:
       scope: "https://www.googleapis.com/auth/gmail.readonly"
   oauth_authenticator:
@@ -429,6 +430,7 @@ spec:
             required:
               - auth_type
               - service_account_info
+              - subject
             properties:
               auth_type:
                 type: string
@@ -440,6 +442,12 @@ spec:
                 airbyte_secret: true
                 examples:
                   - '{ "type": "service_account", "project_id": YOUR_PROJECT_ID, "private_key_id": YOUR_PRIVATE_KEY, ... }'
+              subject:
+                type: string
+                title: Delegated Account Email
+                description: 'Email of the mailbox to access. The service account impersonates this user through domain-wide delegation. Read more <a href="https://developers.google.com/identity/protocols/oauth2/service-account#delegatingauthority">here</a>.'
+                examples:
+                  - user@yourdomain.com
       include_spam_and_trash:
         type: boolean
         description: >-

--- a/airbyte-integrations/connectors/source-gmail/metadata.yaml
+++ b/airbyte-integrations/connectors/source-gmail/metadata.yaml
@@ -17,7 +17,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: f7833dac-fc18-4feb-a2a9-94b22001edc6
-  dockerImageTag: 0.1.9
+  dockerImageTag: 0.2.0
   dockerRepository: airbyte/source-gmail
   githubIssueLabel: source-gmail
   icon: icon.svg

--- a/docs/integrations/sources/gmail.md
+++ b/docs/integrations/sources/gmail.md
@@ -60,7 +60,7 @@ Only a Google Workspace super administrator can configure domain-wide delegation
 2. Select **Gmail** from the source type dropdown.
 3. Choose your authentication method:
    - **Authenticate via Google (OAuth)** — Click **Authenticate your account** and complete the Google sign-in flow. **Airbyte Cloud** users authenticate against Airbyte's pre-registered OAuth app. **Airbyte Open Source** users provide their own **Client ID**, **Client Secret**, and **Refresh Token**.
-   - **Service Account Key Authentication** — Paste the contents of your service account JSON key file into the **Service Account Information** field.
+   - **Service Account Key Authentication** — Paste the contents of your service account JSON key file into the **Service Account Information** field and enter the mailbox to impersonate in **Delegated Account Email**.
 4. (Optional) Set **Start date** in `YYYY-MM-DDTHH:MM:SSZ` format. Only messages, drafts, and threads received on or after this date are replicated. If you leave it blank, the connector replicates the full mailbox history.
 5. (Optional) Toggle **Include Spam & Trash** to include drafts and messages from the Spam and Trash folders. Defaults to off.
 6. (Optional) Adjust **Number of concurrent workers** (between `2` and `10`, default `5`) to control how many requests the connector issues in parallel. Lower this value if you see frequent rate-limit errors.
@@ -139,6 +139,7 @@ If you use Airbyte Cloud and your organization restricts access to specific IPs,
 
 | Version          | Date              | Pull Request | Subject        |
 |------------------|-------------------|--------------|----------------|
+| 0.2.0 | 2026-07-29 | [83233](https://github.com/airbytehq/airbyte/pull/83233) | Add required delegated subject email to service account auth |
 | 0.1.9 | 2026-07-28 | [82922](https://github.com/airbytehq/airbyte/pull/82922) | Update dependencies |
 | 0.1.8 | 2026-07-21 | [82425](https://github.com/airbytehq/airbyte/pull/82425) | Update dependencies |
 | 0.1.7 | 2026-07-14 | [81816](https://github.com/airbytehq/airbyte/pull/81816) | Update dependencies |


### PR DESCRIPTION
# What

Adds a required `subject` field to the Service Account Key Authentication option and signs it into the JWT `sub` claim.

# How

Gmail data is always scoped to a user mailbox, and a service account has no mailbox of its own. Without a `sub` claim Google issues a token for the service account itself and every Gmail API call fails with `400 Precondition check failed`, so the Service auth mode could not sync any mailbox. The service account impersonates the subject user through domain-wide delegation, which is the only way Google allows service accounts to access Gmail.

The spec's Service option gains a required `subject` property next to `service_account_info`, and the `jwt_authenticator` payload now includes `sub: "{{ config['credentials']['subject'] }}"`. Version bumped to 0.2.0.