### PR TITLE
fix(docs): unset trailingSlash, every docs.airbyte.com page is 404ing

### DIFF
--- a/docusaurus/docusaurus.config.ts
+++ b/docusaurus/docusaurus.config.ts
@@ -63,7 +63,10 @@ const config: Config = {
   // Assumed relative path.  If you are using airbytehq.github.io use /
   // anything else should match the repo name
   baseUrl: "/",
-  trailingSlash: false,
+  // Leave unset. `false` makes the build emit `platform.html` instead of
+  // `platform/index.html`, and Vercel serves those only under `cleanUrls`,
+  // so every doc URL 404s. `vercel.json`'s `trailingSlash` is unrelated: it
+  // only strips a trailing slash from the request.
   onBrokenLinks: "throw",
 
   favicon: "img/favicon.png",


### PR DESCRIPTION
Requested by @tanmay21111 after an Ahrefs Site Audit flagged 245 docs.airbyte.com URLs as 404; the finding turned out to be real and site-wide.

## What

Production docs are down. Every page except the root returns HTTP 404 right now:

```
$ curl -sI https://docs.airbyte.com/platform | head -1
HTTP/2 404
$ curl -sI https://docs.airbyte.com/platform.html | head -1
HTTP/2 200
```

40 of 40 URLs sampled at random from https://docs.airbyte.com/sitemap.xml (1,662 entries) return 404. The navbar's own links (`/platform`, `/integrations`, `/ai-agents`, `/community`, `/release_notes`) 404.

Cause: `trailingSlash: false` added to `docusaurus.config.ts` in #83231. That option changes the build output from `platform/index.html` to `platform.html`. Vercel serves a bare `.html` file at its extensionless path only with `cleanUrls: true`, which `docusaurus/vercel.json` does not set — so the built HTML exists, but at a path nothing links to. `vercel.json`'s `"trailingSlash": false` is a different thing: it only makes Vercel redirect `/platform/` to `/platform`, it does not rewrite to `platform.html`.

## How

Unset the option, restoring the directory-index output that was serving fine before, and leave a comment so it doesn't get "fixed" the same way again. The other changes from #83231 (relative link suffixes, navbar `to` values) are untouched — they're inert either way.

Alternative considered: add `"cleanUrls": true` to `vercel.json` instead. That would also work, but it changes the served URL shape for every asset path in the deploy, which is not what you want as an incident fix.

## Review guide

1. `docusaurus/docusaurus.config.ts` — one option removed.

Verified with a full local build on this branch (`pnpm run build`, exit 0, `onBrokenLinks: "throw"` so no link regressions):

```
platform/index.html                      exists
platform.html                            absent
integrations/sources/postgres/index.html exists
integrations/sources/postgres.html       absent
1663 index.html files emitted
```

## User Impact

Restores all of docs.airbyte.com once deployed. It also clears the downstream damage on the marketing site: airbyte.com pages link to `docs.airbyte.com/platform/connector-development/connector-builder-ui/overview` and per-connector `docs.airbyte.com/integrations/sources/<name>` pages, so the same audit went from 110 to 7,009 pages flagged with "links to broken page".

## Can this PR be safely reverted and rolled back?

- [x] YES 💚
- [ ] NO ❌


Link to Devin session: https://app.devin.ai/sessions/8d4f15715f994e249e79aa54acf890f7