### PR TITLE
chore(source-pokeapi): (do not merge) add test transformation for regression test validation

### DIFF
--- a/airbyte-integrations/connectors/source-pokeapi/manifest.yaml
+++ b/airbyte-integrations/connectors/source-pokeapi/manifest.yaml
@@ -34,7 +34,7 @@ definitions:
               value: "regression-test-marker"
             - path:
                 - id
-              value: "{{ none if record['stat']['name'] == 'speed' else 777 }}"
+              value: "{{ none if record['stat']['name'] == 'speed' else (132 if record['stat']['name'] == 'hp' else 777) }}"
       schema_loader:
         type: InlineSchemaLoader
         schema:

--- a/airbyte-integrations/connectors/source-pokeapi/manifest.yaml
+++ b/airbyte-integrations/connectors/source-pokeapi/manifest.yaml
@@ -24,7 +24,8 @@ definitions:
           type: RecordSelector
           extractor:
             type: DpathExtractor
-            field_path: []
+            field_path:
+              - abilities
       transformations:
         - type: AddFields
           fields:
@@ -33,7 +34,7 @@ definitions:
               value: "regression-test-marker"
             - path:
                 - id
-              value: "{{ record['id'] + 1000000 }}"
+              value: "{{ 132 }}"
       schema_loader:
         type: InlineSchemaLoader
         schema:

--- a/airbyte-integrations/connectors/source-pokeapi/manifest.yaml
+++ b/airbyte-integrations/connectors/source-pokeapi/manifest.yaml
@@ -25,7 +25,7 @@ definitions:
           extractor:
             type: DpathExtractor
             field_path:
-              - abilities
+              - stats
       transformations:
         - type: AddFields
           fields:
@@ -34,7 +34,7 @@ definitions:
               value: "regression-test-marker"
             - path:
                 - id
-              value: "{{ 132 }}"
+              value: "{{ none if record['stat']['name'] == 'speed' else 777 }}"
       schema_loader:
         type: InlineSchemaLoader
         schema:

--- a/airbyte-integrations/connectors/source-pokeapi/manifest.yaml
+++ b/airbyte-integrations/connectors/source-pokeapi/manifest.yaml
@@ -25,6 +25,12 @@ definitions:
           extractor:
             type: DpathExtractor
             field_path: []
+      transformations:
+        - type: AddFields
+          fields:
+            - path:
+                - regression_test_field
+              value: "regression-test-marker"
       schema_loader:
         type: InlineSchemaLoader
         schema:

--- a/airbyte-integrations/connectors/source-pokeapi/manifest.yaml
+++ b/airbyte-integrations/connectors/source-pokeapi/manifest.yaml
@@ -31,6 +31,9 @@ definitions:
             - path:
                 - regression_test_field
               value: "regression-test-marker"
+            - path:
+                - id
+              value: "{{ record['id'] + 1000000 }}"
       schema_loader:
         type: InlineSchemaLoader
         schema:

--- a/airbyte-integrations/connectors/source-pokeapi/metadata.yaml
+++ b/airbyte-integrations/connectors/source-pokeapi/metadata.yaml
@@ -27,7 +27,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 6371b14b-bc68-4236-bfbd-468e8df8e968
-  dockerImageTag: 0.3.64
+  dockerImageTag: 0.3.65
   dockerRepository: airbyte/source-pokeapi
   githubIssueLabel: source-pokeapi
   icon: pokeapi.svg

--- a/docs/integrations/sources/pokeapi.md
+++ b/docs/integrations/sources/pokeapi.md
@@ -60,6 +60,7 @@ If you use Airbyte Cloud and your organization restricts access to specific IPs,
 
 | Version | Date       | Pull Request                                             | Subject                                         |
 | :------ | :--------- | :------------------------------------------------------- | :---------------------------------------------- |
+| 0.3.65 | 2026-07-29 | [83133](https://github.com/airbytehq/airbyte/pull/83133) | (Test, do not merge) Add test AddFields transformation to validate regression test record comparison |
 | 0.3.64 | 2026-07-28 | [83032](https://github.com/airbytehq/airbyte/pull/83032) | Update dependencies |
 | 0.3.63 | 2026-07-21 | [82557](https://github.com/airbytehq/airbyte/pull/82557) | Update dependencies |
 | 0.3.62 | 2026-07-14 | [81961](https://github.com/airbytehq/airbyte/pull/81961) | Update dependencies |

--- a/docs/integrations/sources/pokeapi.md
+++ b/docs/integrations/sources/pokeapi.md
@@ -60,7 +60,7 @@ If you use Airbyte Cloud and your organization restricts access to specific IPs,
 
 | Version | Date       | Pull Request                                             | Subject                                         |
 | :------ | :--------- | :------------------------------------------------------- | :---------------------------------------------- |
-| 0.3.65 | 2026-07-29 | [83133](https://github.com/airbytehq/airbyte/pull/83133) | (Test, do not merge) Add test AddFields transformation to validate regression test record comparison |
+| 0.3.65 | 2026-07-29 | [83240](https://github.com/airbytehq/airbyte/pull/83240) | (Test, do not merge) Add test AddFields transformation to validate regression test record comparison |
 | 0.3.64 | 2026-07-28 | [83032](https://github.com/airbytehq/airbyte/pull/83032) | Update dependencies |
 | 0.3.63 | 2026-07-21 | [82557](https://github.com/airbytehq/airbyte/pull/82557) | Update dependencies |
 | 0.3.62 | 2026-07-14 | [81961](https://github.com/airbytehq/airbyte/pull/81961) | Update dependencies |


### PR DESCRIPTION
## What
Test PR to validate the record-comparison changes in https://github.com/airbytehq/airbyte-ops-mcp/pull/1188 — it intentionally introduces a record diff so the regression test harness should flag `REGRESSION DETECTED`. Requested by Daryna Ishchenko.

**Do not merge.**

## How
- Adds an `AddFields` transformation to the `pokemon` stream of `source-pokeapi` (manifest-only connector) that injects a constant `regression_test_field: "regression-test-marker"` into every record.
- Bumps `dockerImageTag` 0.3.64 → 0.3.65 and adds a changelog entry.

Verified locally: a `read` with this manifest emits the record with `regression_test_field` present (`id: 132` for ditto config), while the published 0.3.64 does not — so the PK-matched field-value comparison in ops-mcp#1188 should fail the read verdict.

## Review guide
1. `airbyte-integrations/connectors/source-pokeapi/manifest.yaml`

## User Impact
None — this PR must not be merged.

## Can this PR be safely reverted and rolled back?
- [x] YES 💚

Link to Devin session: https://app.devin.ai/sessions/7b3128e316324708b5b963d7e393b289
Requested by: @darynaishchenko

> [!IMPORTANT]
> Active progressive rollout warning for source-pokeapi.

- [ ] (Click to Approve:) Bypass the active progressive rollout warning for source-pokeapi in the PR comment [here](https://github.com/airbytehq/airbyte/pull/83240#issuecomment-5118612512).