### PR TITLE
ci(kotlin-cdk-docs): upgrade vercel-action so Vercel CLI meets minimum version

### DIFF
--- a/.github/workflows/kotlin-bulk-cdk-dokka-publish.yml
+++ b/.github/workflows/kotlin-bulk-cdk-dokka-publish.yml
@@ -141,7 +141,7 @@ jobs:
 
       - name: Deploy to Vercel
         id: deploy-vercel
-        uses: amondnet/vercel-action@v41.1.4
+        uses: amondnet/vercel-action@4b810e26f7bb2a331c698af186f890cbf20d5f72 # v42.2.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           vercel-token: ${{ secrets.VERCEL_TOKEN }}


### PR DESCRIPTION
## What

The `Kotlin Bulk CDK Docs / Deploy Docs to Vercel (Preview)` check fails with:

```
Error: Your Vercel CLI version is outdated. This endpoint requires version 47.2.2 or later.
```

`amondnet/vercel-action` installs the CLI version pinned in its own `package.json` (`dependencies.vercel`, used as the fallback for the `vercel-version` input). The tag this workflow used, `v41.1.4`, pins `vercel@41.1.4` — below Vercel's new minimum. `v42.x` pins `vercel@^50.0.0`.

## How

Pins the Deploy-to-Vercel step to the same action revision `docs-build.yml` already uses successfully: `4b810e26f7bb2a331c698af186f890cbf20d5f72` (v42.2.0), SHA-pinned per repo convention. No `vercel-version` input is set, so the CLI comes from that release's `^50.0.0` pin.

## Review guide

1. `.github/workflows/kotlin-bulk-cdk-dokka-publish.yml` — one-line action bump.

`docs-build.yml` needed no change (already on v42.2.0). These are the only two `vercel-action` usages in the repo.

## User Impact

Kotlin Bulk CDK docs preview/production deploys work again. No product-facing change.

## Can this PR be safely reverted and rolled back?
- [x] YES 💚


Link to Devin session: https://app.devin.ai/sessions/3937697b5028445695625f337dc69456
Requested by: @ian-at-airbyte