### PR TITLE
docs(seo): standardize page title suffix on "| Airbyte Docs"

### DIFF
--- a/docusaurus/src/remark/docMetaTags.js
+++ b/docusaurus/src/remark/docMetaTags.js
@@ -4,7 +4,7 @@ const visit = require("unist-util-visit").visit;
 
 const generateMetaTags = (connectorName) => {
   return {
-    title: `${connectorName} Connector | Airbyte Documentation`,
+    title: `${connectorName} Connector | Airbyte Docs`,
     description: `Connect ${connectorName} to our ETL/ELT platform for streamlined data integration, automated syncing, and powerful data insights.`,
   };
 };


### PR DESCRIPTION
## What

DOCS-64. The Ahrefs site audit flagged inconsistent `<title>` suffixing across docs.airbyte.com: connector pages ended in `| Airbyte Documentation` while every other page ended in `| Airbyte Docs`.

Ian confirmed `| Airbyte Docs` is the correct suffix.

## How

The global suffix comes from `title: "Airbyte Docs"` in `docusaurus.config.ts`, which Docusaurus appends as ` | Airbyte Docs`. Connector pages bypass that: `docMetaTags.js` builds an explicit `<title>` override that hardcoded the other spelling. This changes only that string, keeping the `Connector` keyword:

```
Postgres Connector | Airbyte Documentation   ->   Postgres Connector | Airbyte Docs
```

I grepped for other occurrences of the literal `Airbyte Documentation` in title/metadata contexts (other remark plugins, OG tags, tests, snapshots) and found none that feed page titles; remaining hits are prose.

## Review guide

1. `docusaurus/src/remark/docMetaTags.js` — one string.

## User Impact

Consistent browser-tab and search-result titles across the site. Affects the `<title>` of every connector page (~600); no URLs, headings, or on-page content change. Titles get 6 characters shorter, which also helps the truncation findings in the same audit.

Verified against the built HTML: `docusaurus/build/integrations/sources/postgres.html` contains `<title data-rh="true">Postgres Connector | Airbyte Docs</title>`. `pnpm build` succeeds, with only the broken-anchor warnings that are already present on `master`.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚


Link to Devin session: https://app.devin.ai/sessions/5914ab297c1e4847bd2fac547209f730
Requested by: @ian-at-airbyte