### PR TITLE
docs(seo): add image alt text, fix stale links, shorten long titles

### DIFF
--- a/docs/integrations/custom-connectors.md
+++ b/docs/integrations/custom-connectors.md
@@ -48,4 +48,4 @@ Follow these steps to upgrade a connector version.
 
 To upgrade your connector version, go to the Settings in the left hand side of the UI and navigate to either Sources or Destinations. Find your connector in the list, and input the latest connector version.
 
-![](/.gitbook/assets/upgrade-connector-version.png)
+![Airbyte connector settings showing where to enter the latest Docker image tag](/.gitbook/assets/upgrade-connector-version.png)

--- a/docs/integrations/destinations/databricks.md
+++ b/docs/integrations/destinations/databricks.md
@@ -31,11 +31,11 @@ Gather the following information from your Databricks workspace.
 1. Open your Databricks workspace.
 2. Navigate to your SQL warehouse:
 
-   ![](/.gitbook/assets/destination/databricks/databricks_open_sql_warehouse.png)
+    ![Databricks workspace page with the SQL warehouse selected](/.gitbook/assets/destination/databricks/databricks_open_sql_warehouse.png)
 
 3. Open the **Connection Details** tab:
 
-   ![](/.gitbook/assets/destination/databricks/databricks_sql_warehouse_connection_details.png)
+    ![Databricks SQL warehouse Connection Details tab showing the server hostname, HTTP path, and port](/.gitbook/assets/destination/databricks/databricks_sql_warehouse_connection_details.png)
 
 4. Note the **Server Hostname**, **HTTP Path**, and **Port** values. The default port is `443`.
 
@@ -53,11 +53,11 @@ Create a [service principal](https://docs.databricks.com/en/dev-tools/auth/oauth
 
 1. In your Databricks workspace, click your profile icon in the top-right corner and go to **Settings** > **Developer** > **Access tokens** > **Manage**.
 
-   ![](/.gitbook/assets/destination/databricks/dtabricks_token_user_new.png)
+   ![Databricks Developer settings with the access token management controls](/.gitbook/assets/destination/databricks/dtabricks_token_user_new.png)
 
 2. Click **Generate new token**. Enter a description and an expiration period (leave blank for no expiration):
 
-   ![](/.gitbook/assets/destination/databricks/databricks_generate_token.png)
+   ![Databricks dialog for entering a description and expiration period for a new token](/.gitbook/assets/destination/databricks/databricks_generate_token.png)
 
 ## Step 2: Set up the Databricks destination in Airbyte
 

--- a/docs/integrations/destinations/databricks.md
+++ b/docs/integrations/destinations/databricks.md
@@ -31,11 +31,11 @@ Gather the following information from your Databricks workspace.
 1. Open your Databricks workspace.
 2. Navigate to your SQL warehouse:
 
-    ![Databricks workspace page with the SQL warehouse selected](/.gitbook/assets/destination/databricks/databricks_open_sql_warehouse.png)
+   ![Databricks workspace page with the SQL warehouse selected](/.gitbook/assets/destination/databricks/databricks_open_sql_warehouse.png)
 
 3. Open the **Connection Details** tab:
 
-    ![Databricks SQL warehouse Connection Details tab showing the server hostname, HTTP path, and port](/.gitbook/assets/destination/databricks/databricks_sql_warehouse_connection_details.png)
+   ![Databricks SQL warehouse Connection Details tab showing the server hostname, HTTP path, and port](/.gitbook/assets/destination/databricks/databricks_sql_warehouse_connection_details.png)
 
 4. Note the **Server Hostname**, **HTTP Path**, and **Port** values. The default port is `443`.
 

--- a/docs/integrations/destinations/duckdb.md
+++ b/docs/integrations/destinations/duckdb.md
@@ -46,7 +46,7 @@ Each table will contain 3 columns:
 
 ### Normalization
 
-If you set [typing and deduping](https://docs.airbyte.com/platform/using-airbyte/core-concepts/typing-deduping), source data will be normalized to a tabular form. Let's say you have a source such as GitHub with nested JSONs; the Normalization ensures you end up with tables and columns. Suppose you have a many-to-many relationship between the users and commits. Normalization will create separate tables for it. The end state is the [third normal form](https://en.wikipedia.org/wiki/Third_normal_form) (3NF).
+With [typing and deduping](https://docs.airbyte.com/platform/using-airbyte/core-concepts/typing-deduping), source data is normalized to a tabular form. For example, if you have a source such as GitHub with nested JSON, typing and deduping ensures that you end up with tables and columns. Suppose you have a many-to-many relationship between users and commits. The end state is the [third normal form](https://en.wikipedia.org/wiki/Third_normal_form) (3NF).
 
 #### Performance consideration
 

--- a/docs/integrations/destinations/duckdb.md
+++ b/docs/integrations/destinations/duckdb.md
@@ -46,7 +46,7 @@ Each table will contain 3 columns:
 
 ### Normalization
 
-If you set [Normalization](https://docs.airbyte.com/understanding-airbyte/basic-normalization/), source data will be normalized to a tabular form. Let's say you have a source such as GitHub with nested JSONs; the Normalization ensures you end up with tables and columns. Suppose you have a many-to-many relationship between the users and commits. Normalization will create separate tables for it. The end state is the [third normal form](https://en.wikipedia.org/wiki/Third_normal_form) (3NF).
+If you set [typing and deduping](https://docs.airbyte.com/platform/using-airbyte/core-concepts/typing-deduping), source data will be normalized to a tabular form. Let's say you have a source such as GitHub with nested JSONs; the Normalization ensures you end up with tables and columns. Suppose you have a many-to-many relationship between the users and commits. Normalization will create separate tables for it. The end state is the [third normal form](https://en.wikipedia.org/wiki/Third_normal_form) (3NF).
 
 #### Performance consideration
 

--- a/docs/integrations/destinations/redshift.md
+++ b/docs/integrations/destinations/redshift.md
@@ -147,7 +147,7 @@ Navigate to the Airbyte UI to set up Redshift as a destination:
 | Field                                                                                                                                         | Description                                                                                                                                                               |
 |:----------------------------------------------------------------------------------------------------------------------------------------------|:--------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | [JDBC URL Params](https://docs.aws.amazon.com/redshift/latest/mgmt/jdbc20-configuration-options.html) (Optional)                              | Additional properties to pass to the JDBC URL string when connecting to the database, formatted as `key=value` pairs separated by `&`. Example: `key1=value1&key2=value2` |
-| [SSH Tunnel Method](https://docs.airbyte.com/platform/using-airbyte/configuring-connections/configuring-the-connection#ssh-tunnel) (Optional) | Whether to initiate an SSH tunnel before connecting to the database, and if so, which kind of authentication to use.                                                      |
+| [SSH Tunnel Method](https://docs.airbyte.com/platform/cloud/managing-airbyte-cloud/configuring-connections#ssh-tunnel) (Optional) | Whether to initiate an SSH tunnel before connecting to the database, and if so, which kind of authentication to use.                                                      |
 | Drop CASCADE (Optional)                                                                                                                       | Whether to use `CASCADE` when dropping tables and columns. **Warning:** This deletes data in all dependent objects (views, etc.), including during schema evolution. Default: `false`. |
 
 ## Output schema
@@ -252,7 +252,7 @@ If your Redshift cluster is in a private VPC, you may need to:
    Airbyte to your Redshift cluster (if they exist in separate VPCs).
 2. Configure an SSH Bastion Host (see [Step 2](#optional-ssh-bastion-host)) to tunnel through to the private cluster.
 3. For Airbyte Cloud, ensure
-   the [Airbyte IP addresses](https://docs.airbyte.com/platform/using-airbyte/configuring-connections/configuring-the-connection#allow-list-ip-addresses)
+   the [Airbyte IP addresses](https://docs.airbyte.com/platform/cloud/managing-airbyte-cloud/configuring-connections#allow-list-ip-addresses)
    are allowed in your Redshift cluster's security group and network policy.
 
 ### 'S3 access denied' during staging

--- a/docs/integrations/locating-files-local-destination.md
+++ b/docs/integrations/locating-files-local-destination.md
@@ -14,7 +14,7 @@ While running Airbyte's Docker image on Windows with WSL2, you can access your t
 2. Type in `\\wsl$` in the address bar
 3. The folders below will be displayed
 
-   ![](/.gitbook/assets/windows-wsl2-docker-folders.png)
+   ![Windows File Explorer displaying Docker Desktop folders through the WSL2 network path](/.gitbook/assets/windows-wsl2-docker-folders.png)
 
 4. You can start digging here, but it is recommended to start searching from here and just search for the folder name you used for your local files. The folder address should be similar to `\\wsl$\docker-desktop\tmp\docker-desktop-root\containers\services\docker\rootfs\tmp\airbyte_local`
 5. You should be able to locate your local destination CSV or JSON files in this folder.

--- a/docs/integrations/sources/apify-dataset.md
+++ b/docs/integrations/sources/apify-dataset.md
@@ -22,7 +22,7 @@ You can find your personal API token in the Apify Console in the [Settings -> In
 
 When your Apify job (aka [Actor run](https://docs.apify.com/platform/actors/running)) finishes, it can trigger an Airbyte sync by calling the Airbyte [API](https://airbyte-public-api-docs.s3.us-east-2.amazonaws.com/rapidoc-api-docs.html#post-/v1/connections/sync) manual connection trigger (`POST /v1/connections/sync`). The API can be called from Apify [webhook](https://docs.apify.com/platform/integrations/webhooks) which is executed when your Apify run finishes.
 
-![](/.gitbook/assets/apify_trigger_airbyte_connection.png)
+![Apify webhook configuration that triggers an Airbyte connection sync](/.gitbook/assets/apify_trigger_airbyte_connection.png)
 
 ### Features
 

--- a/docs/integrations/sources/facebook-pages.md
+++ b/docs/integrations/sources/facebook-pages.md
@@ -25,7 +25,7 @@ The Facebook Pages source connector is currently only compatible with v24 of the
 
 After all the steps, it should look something like this:
 
-![](/.gitbook/assets/facebook-pages-1.png)
+![Facebook dialog showing the generated access token after completing the setup steps](/.gitbook/assets/facebook-pages-1.png)
 
 5. [Generate](https://developers.facebook.com/docs/facebook-login/guides/access-tokens/get-long-lived#get-a-long-lived-user-access-token) Long-Lived User Access Token.
 6. [Generate](https://developers.facebook.com/docs/facebook-login/guides/access-tokens/get-long-lived#long-lived-page-token) Long-Lived Page Token.

--- a/docs/integrations/sources/low-code.md
+++ b/docs/integrations/sources/low-code.md
@@ -1,3 +1,7 @@
+---
+unlisted: true
+---
+
 # Low-code
 
 This doc is currently used for changelog purposes only internally, so that we can make sure that the source stays

--- a/docs/platform/connector-development/cdk-python/migration-to-base-image.md
+++ b/docs/platform/connector-development/cdk-python/migration-to-base-image.md
@@ -1,9 +1,6 @@
 ---
 title: Python Connector Base Image Migration
-sidebar_label: "Migration Guide: How to make a python connector use our base image"
 ---
-
-# Migration Guide: How to make a python connector use our base image
 
 We currently enforce our certified python connectors to use our [base image](https://hub.docker.com/r/airbyte/python-connector-base).
 This guide will help connector developers to migrate their connector to use our base image.

--- a/docs/platform/connector-development/cdk-python/migration-to-base-image.md
+++ b/docs/platform/connector-development/cdk-python/migration-to-base-image.md
@@ -1,3 +1,8 @@
+---
+title: Python Connector Base Image Migration
+sidebar_label: "Migration Guide: How to make a python connector use our base image"
+---
+
 # Migration Guide: How to make a python connector use our base image
 
 We currently enforce our certified python connectors to use our [base image](https://hub.docker.com/r/airbyte/python-connector-base).

--- a/docs/platform/connector-development/partner-certified-destinations.md
+++ b/docs/platform/connector-development/partner-certified-destinations.md
@@ -1,9 +1,6 @@
 ---
 title: Partner Connector Requirements
-sidebar_label: "Requirements for Airbyte Partner Connectors: Bulk and Publish Destinations"
 ---
-
-# Requirements for Airbyte Partner Connectors: Bulk and Publish Destinations
 
 ## Welcome
 

--- a/docs/platform/connector-development/partner-certified-destinations.md
+++ b/docs/platform/connector-development/partner-certified-destinations.md
@@ -1,3 +1,8 @@
+---
+title: Partner Connector Requirements
+sidebar_label: "Requirements for Airbyte Partner Connectors: Bulk and Publish Destinations"
+---
+
 # Requirements for Airbyte Partner Connectors: Bulk and Publish Destinations
 
 ## Welcome

--- a/docs/platform/connector-development/ux-handbook.md
+++ b/docs/platform/connector-development/ux-handbook.md
@@ -53,7 +53,7 @@ The same is true with Airbyte: if it worked less than 99% of the time, many user
 
 Our users have the following hierarchy of needs:&#x20;
 
-![](/.gitbook/assets/ux_hierarchy_pyramid2.png)
+![Pyramid showing the hierarchy of user needs for Airbyte reliability and security](/.gitbook/assets/ux_hierarchy_pyramid2.png)
 
 **Security**
 
@@ -152,7 +152,7 @@ For example, the following spec:
 
 produces the following input field in the UI:&#x20;
 
-![](/.gitbook/assets/ux_username_bad.png)
+![Airbyte connector configuration UI with an unclear username field label](/.gitbook/assets/ux_username_bad.png)
 
 Whereas the following specification:
 
@@ -171,7 +171,7 @@ Whereas the following specification:
 
 produces the following UI:
 
-![](/.gitbook/assets/ux_username_good.png)
+![Airbyte connector configuration UI with a clearly labeled Username field](/.gitbook/assets/ux_username_good.png)
 
 The title should use Pascal Case “with spaces” e.g: “Attribution Lookback Window”, “Host URL”, etc...
 

--- a/docs/platform/deploying-airbyte/abctl/index.md
+++ b/docs/platform/deploying-airbyte/abctl/index.md
@@ -23,7 +23,7 @@ You use abctl to run Airbyte on a machine that isn't running a Kubernetes cluste
 
 abctl uses [kind](https://kind.sigs.k8s.io/) to create a [Kubernetes](https://kubernetes.io/) cluster inside a [Docker](https://www.docker.com/) container. Then, it uses [Helm](https://helm.sh/) to install the latest Airbyte and [NGINX Ingress Controller](https://docs.nginx.com/nginx-ingress-controller/) Helm charts. It also helps you manage and understand that infrastructure.
 
-![](abctl-diagram.png)
+![Diagram showing abctl using Docker, kind, and Helm to run Airbyte](abctl-diagram.png)
 
 ## Before you start
 

--- a/docs/platform/understanding-airbyte/airbyte-protocol.md
+++ b/docs/platform/understanding-airbyte/airbyte-protocol.md
@@ -470,7 +470,7 @@ The state for an actor is emitted as a black box by the Source. When emitted it 
 This section will step through how state is used to allow a Source to pick up where it left off. A Source takes state as an input. A Source should be able to take that input and use it to determine where it left off the last time. The contents of the Source is a black box to the Protocol. The Protocol provides an envelope for the Source to put its state in and then passes the state back in that envelope. The Protocol never needs to know anything about the contents of the state. Thus, the Source can track state however makes most sense to it.
 
 Here is an example of the lifecycle of state in reference to the Source.
-![](/.gitbook/assets/source-state-example.png)
+![Diagram of source state advancing across successive Airbyte syncs](/.gitbook/assets/source-state-example.png)
 
 -- [link](https://whimsical.com/state-ESb6dLBnBYKLSJR2a7iMxi) to source image
 
@@ -484,7 +484,7 @@ While this example, demonstrates a success case, we can see how this process hel
 
 The previous section, for the sake of clarity, looked exclusively at the life cycle of state relative to the Source. In reality knowing that a record was emitted from the Source is NOT enough guarantee to know that we can skip sending the record in future syncs. For example, imagine the Source successfully emits the record, but the Destination fails. If we skip that record in the next sync, it means it never truly made it to its destination. This insight means, that a State should only ever be passed to a Source in the next run if it was both emitted from the Source and the Destination.
 
-![](/.gitbook/assets/sync-state-example.png)
+![Diagram showing source and destination state checkpoints at two points during a sync](/.gitbook/assets/sync-state-example.png)
 
 This image looks at two time points during an example sync. At T1 the Source has emitted 3 records and 2 state messages. If the Sync were to fail now, the next sync should start at the beginning because no records have been saved to the destination.
 

--- a/docs/platform/understanding-airbyte/jobs.md
+++ b/docs/platform/understanding-airbyte/jobs.md
@@ -9,7 +9,7 @@ Generally, there are 2 types of workload pods:
 - Connector Job (CHECK, DISCOVER, SPEC) pods
   - Calls the specified interface method on the connector image
 
-|    ![](/.gitbook/assets/replication_mono_pod.png)     |                              ![](/.gitbook/assets/connector_pod.png)                               |
+|    ![Replication components running in a single Airbyte pod](/.gitbook/assets/replication_mono_pod.png)     |                              ![Connector job sidecar forwarding output from the connector image](/.gitbook/assets/connector_pod.png)                               |
 |:-------------------------------------------------------------------------:|:----------------------------------------------------------------------------------------------------:|
 | <em>The source, destination and orchestrator all run in a single pod</em> | <em>The sidecar processes the output of the connector and forwards it back to the core platform</em> |
 

--- a/docs/platform/using-airbyte/mappings.md
+++ b/docs/platform/using-airbyte/mappings.md
@@ -20,7 +20,7 @@ Several types of mapping are possible in Airbyte, and you can combine them toget
 
 Hashing is an **irreversible** process that protects sensitive data by obscuring it. Airbyte supports MD5, SHA-256, and SHA-512 hashing methods. Support for MD2, SHA-1, and SHA-384 is only available [through the API](https://reference.airbyte.com).
 
-![](images/mapping-hash.png)
+![Mapping configuration for hashing a field](images/mapping-hash.png)
 
 There are many reasons you might want to hash data.
 
@@ -31,7 +31,7 @@ There are many reasons you might want to hash data.
 
 Encryption is a **reversible** process that protects sensitive data by obscuring it. Airbyte supports RSA encryption using an encryption key you generate yourself.
 
-![](images/mapping-encrypt.png)
+![Mapping configuration for encrypting a field](images/mapping-encrypt.png)
 
 There are many reasons you might want to encrypt data.
 
@@ -58,7 +58,7 @@ This is an example of the public key format Airbyte expects, but make sure you g
 
 Renaming fields helps you ensure clarity, consistency, and compatibility in your destination data. 
 
-![](images/mapping-rename.png)
+![Mapping configuration for renaming a field](images/mapping-rename.png)
 
 There are many reasons you might want to rename fields.
 
@@ -70,7 +70,7 @@ There are many reasons you might want to rename fields.
 
 Filtering rows is how you ensure you only sync relevant, high-quality, and meaningful data to your destination. 
 
-![](images/mapping-filter.png)
+![Mapping configuration for filtering rows](images/mapping-filter.png)
 
 There are many reasons you might want to filter rows.
 

--- a/docs/release_notes/self-managed/august_2022.md
+++ b/docs/release_notes/self-managed/august_2022.md
@@ -8,7 +8,7 @@ This page includes new features and improvements to the Airbyte Cloud and Airbyt
 
 - Added reserved keywords for schema names by fixing the quotation logic in normalization. [#14683](https://github.com/airbytehq/airbyte/pull/14683)
 
-- Added [documentation](https://docs.airbyte.com/cloud/managing-airbyte-cloud/review-sync-summary) about the data displayed in sync log summaries. [#15181](https://github.com/airbytehq/airbyte/pull/15181)
+- Added [documentation](https://docs.airbyte.com/platform/cloud/managing-airbyte-cloud/review-connection-timeline) about the data displayed in sync log summaries. [#15181](https://github.com/airbytehq/airbyte/pull/15181)
 
 - Added OAuth login to Airbyte Cloud, which allows you to sign in using your Google login credentials. [#15414](https://github.com/airbytehq/airbyte/pull/15414)
 

--- a/docusaurus/sidebar-connectors.js
+++ b/docusaurus/sidebar-connectors.js
@@ -217,6 +217,12 @@ const sourceMysql = {
   items: [
     {
       type: "doc",
+      label: "Migration Guide",
+      id: "sources/mysql-migrations",
+      key: "sources-mysql-migrations",
+    },
+    {
+      type: "doc",
       label: "Troubleshooting",
       id: "sources/mysql/mysql-troubleshooting",
       key: "sources-mysql-troubleshooting",
@@ -233,6 +239,12 @@ const sourceMssql = {
     id: "sources/mssql",
   },
   items: [
+    {
+      type: "doc",
+      label: "Migration Guide",
+      id: "sources/mssql-migrations",
+      key: "sources-mssql-migrations",
+    },
     {
       type: "doc",
       label: "Troubleshooting",

--- a/docusaurus/src/components/ConnectorRegistry.jsx
+++ b/docusaurus/src/components/ConnectorRegistry.jsx
@@ -114,7 +114,11 @@ function ConnectorTable({ connectors, connectorSupportLevel, enterpriseConnector
                   <div className={styles.connectorName}>
                     {connector.iconUrl && (
                       <div className={styles.connectorIconBackground}>
-                        <img src={connector.iconUrl} style={iconStyle} />
+                        <img
+                          src={connector.iconUrl}
+                          style={iconStyle}
+                          alt={`${connector.name} connector icon`}
+                        />
                       </div>
                     )}
 

--- a/docusaurus/src/components/ConnectorRegistry.jsx
+++ b/docusaurus/src/components/ConnectorRegistry.jsx
@@ -114,11 +114,7 @@ function ConnectorTable({ connectors, connectorSupportLevel, enterpriseConnector
                   <div className={styles.connectorName}>
                     {connector.iconUrl && (
                       <div className={styles.connectorIconBackground}>
-                        <img
-                          src={connector.iconUrl}
-                          style={iconStyle}
-                          alt={`${connector.name} connector icon`}
-                        />
+                        <img src={connector.iconUrl} style={iconStyle} alt="" />
                       </div>
                     )}
 

--- a/docusaurus/src/components/EntityRelationshipDiagram.jsx
+++ b/docusaurus/src/components/EntityRelationshipDiagram.jsx
@@ -22,7 +22,7 @@ export const EntityRelationshipDiagram = ({}) => {
   return (
     <div className={styles.entityRelatonshipdDiagram}>
       <a href={erdUrl} target="_blank">
-        <img src={erdBG} />
+        <img src={erdBG} alt="Entity relationship diagram" />
       </a>
     </div>
   );


### PR DESCRIPTION
## What

DOCS-64, first of several PRs — the authored-content half of the Ahrefs site audit findings. Deliberately scoped to hand-written docs so it can be reviewed and reverted independently of the generator and CDN work.

Four findings, all confirmed against the audit's per-URL data:

- **19 images with no alt text** across 11 pages, plus 2 React `<img>` elements with no `alt` attribute.
- **4 stale internal links** that 404 today.
- **2 authored pages with over-length `<title>` tags** (89 and 81 chars against a ~60 char budget).
- **3 orphan pages** with no internal links pointing at them, but present in `sitemap.xml`.

## How

**Alt text.** Written from the surrounding prose so it describes what each image shows, rather than restating the filename. The connector-registry icon gets `alt=""` instead: it sits directly beside the connector name, so announcing it would duplicate the adjacent text — matching the existing decorative-icon handling in `HeaderDecoration.jsx`.

**Stale links.**

| was | now |
|---|---|
| `/understanding-airbyte/basic-normalization/` (duckdb.md) | `/platform/using-airbyte/core-concepts/typing-deduping` |
| `/platform/using-airbyte/configuring-connections/configuring-the-connection` (redshift.md, 2x) | `/platform/cloud/managing-airbyte-cloud/configuring-connections` |
| `/cloud/managing-airbyte-cloud/review-sync-summary` (august_2022.md) | `/platform/cloud/managing-airbyte-cloud/review-connection-timeline` |

The DuckDB sentence needed rewording, not just a retarget — "if you set Normalization" describes a toggle that no longer exists. The release-note edit is a broken-link repair only; no other historical prose was touched.

**Long titles.** Frontmatter `title` replaces the body `# ` heading rather than sitting alongside it — keeping both would render two H1s, which is the exact defect the audit flagged elsewhere. `sidebar-platform.js` lists both pages without explicit labels, so the nav picks up the shorter titles automatically.

```
Requirements for Airbyte Partner Connectors: Bulk and Publish Destinations  ->  Partner Connector Requirements
Migration Guide: How to make a python connector use our base image          ->  Python Connector Base Image Migration
```

**Orphan pages.** `sources/low-code.md` says in its own body that it is internal changelog-only, so it gets `unlisted: true` — that drops it from the sidebar, search, and sitemap and marks it `noindex`.

The MySQL and MSSQL *source* migration guides were a genuine gap, not an intentional exclusion. `getFilenamesInDir` already auto-nests any `<connector>-migrations.md` as a "Migration Guide" child (`sidebar-connectors.js:43-60`), but these two connectors use hand-built sidebar objects that bypass that path, so their migration guides were never linked from anywhere while still being indexed. Added them explicitly, mirroring `destinationMsSql`.

## Review guide

1. `docusaurus/sidebar-connectors.js` — the orphan fix; check it matches the `destinationMsSql` precedent.
2. `docs/integrations/destinations/duckdb.md` — the only prose rewording in the PR.
3. The two `docs/platform/connector-development/` files — frontmatter title replacing the H1.
4. Everything else is alt text and URL swaps.

## User Impact

Screen-reader users get descriptions for 21 previously unlabeled images. Four broken links now resolve. Two page titles no longer truncate in search results, and their sidebar entries and on-page headings get shorter. The MySQL/MSSQL source migration guides become reachable from the sidebar; `low-code.md` disappears from nav, search, and the sitemap while staying accessible by direct URL.

Not included here, for separate PRs: the four `/integrations/**` long titles come from connector registry metadata rather than frontmatter, so they need a different fix; the generated SDK/PyAirbyte reference trees are handled in the generator PR; the oversized GIFs (`airbyte_kestra_2.gif` is 44 MB) are all still referenced by current and five versioned doc trees, so re-encoding them is its own change.

`pnpm build` succeeds. Built HTML confirms each retitled page renders exactly one `<h1>` carrying the new title.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚


Link to Devin session: https://app.devin.ai/sessions/5914ab297c1e4847bd2fac547209f730
Requested by: @ian-at-airbyte