### PR TITLE
ci(docs): enable markdownlint rules for image alt text and single H1

### DIFF
--- a/.markdownlint.jsonc
+++ b/.markdownlint.jsonc
@@ -8,6 +8,10 @@
     "MD010": false, // Disable the "no-hard-tabs" rule (allows hard tabs instead of spaces)
     "MD041": false, // Disable the "first-line-heading/first-line-h1" rule (allows files without a top-level heading as the first line)
     "MD034": false, // Disable the rule that suggests using angle brackets instead of bare URLs. Angle brackets break the Docusaurus build.
+    "MD045": true, // Require non-empty alternative text for images.
+    "MD025": {
+        "front_matter_title": "" // Ignore frontmatter titles when enforcing a single H1.
+    },
     "MD046": { 
         "style": "fenced" // Enforce fenced code blocks (e.g. ` or ```) and don't permit code sample indentation without fences
     },


### PR DESCRIPTION
## What

DOCS-64, the regression guard. The audit's two structural findings — images with no alt text and pages serving multiple `<h1>` tags — have no lint coverage today, so they will drift straight back.

```jsonc
"MD045": true,                        // images must have alt text
"MD025": { "front_matter_title": "" } // one top-level heading per document
```

**Merge after airbytehq/airbyte#83248.** That PR fixes the last 20 empty-alt images; measured against it, both rules are at zero violations for authored docs. On current `master` alone, MD045 still reports those 20.

## How

`front_matter_title: ""` is the load-bearing detail. By default MD025 counts the frontmatter `title` as a top-level heading, which flags 347 authored pages that render perfectly well — Docusaurus renders the frontmatter title as the H1 *only* when the body has no `#` heading, so title-plus-H1 is not a duplicate. Disabling that check drops authored violations to 0 while still catching the real defect: two `#` headings in one document.

The generated reference trees are already outside reviewdog's paths, and airbytehq/airbyte#83249 brings them to zero on both rules anyway.

Reviewdog reports only on files a PR touches, so this surfaces as inline feedback on new violations rather than a wall of pre-existing ones.

## Review guide

1. `.markdownlint.jsonc` — two rules.

## User Impact

None at runtime. Authors get told about a missing `alt` or a stray second `#` at review time instead of in the next quarterly audit.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚


Link to Devin session: https://app.devin.ai/sessions/5914ab297c1e4847bd2fac547209f730
Requested by: @ian-at-airbyte