### PR TITLE
docs: point artifacthub links at the chart v2 package

### DIFF
--- a/docs/platform/deploying-airbyte/abctl/index.md
+++ b/docs/platform/deploying-airbyte/abctl/index.md
@@ -205,7 +205,7 @@ To install a specific version of the Airbyte Helm chart instead of the latest, u
 abctl local install --chart-version 0.422.2 --values values.yaml --secret secret.yaml --port 8000
 ```
 
-The `--chart-version` value is the Helm chart version, not the Airbyte platform version. To find available versions, see the [Airbyte Helm chart on ArtifactHub](https://artifacthub.io/packages/helm/airbyte/airbyte).
+The `--chart-version` value is the Helm chart version, not the Airbyte platform version. To find available versions, see the [Airbyte Helm chart on ArtifactHub](https://artifacthub.io/packages/helm/airbyte-v2/airbyte).
 
 #### Install from a local Helm chart
 
@@ -383,7 +383,7 @@ abctl has three commands: `local`, `images`, and `version`. Most commands have s
     | Name                | Default | Description                                                                                                                                                                                                                                            | Example                    |
     | ------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------------------------- |
     | --chart             | ""      | Path to a local Helm chart directory. Use this to install from a local chart (for example, in air-gapped environments or during development). Mutually exclusive with `--chart-version`.                                                                  | ./my-chart                 |
-    | --chart-version     | latest  | The version of the Airbyte Helm chart to install. This is the **Helm chart version**, not the Airbyte platform version. Omit this flag to install the latest version. Mutually exclusive with `--chart`. To find available versions, see the [Airbyte Helm chart on ArtifactHub](https://artifacthub.io/packages/helm/airbyte/airbyte). | 0.422.2                    |
+    | --chart-version     | latest  | The version of the Airbyte Helm chart to install. This is the **Helm chart version**, not the Airbyte platform version. Omit this flag to install the latest version. Mutually exclusive with `--chart`. To find available versions, see the [Airbyte Helm chart on ArtifactHub](https://artifacthub.io/packages/helm/airbyte-v2/airbyte). | 0.422.2                    |
     | --docker-email      | ""      | Docker email address to authenticate against `--docker-server`. Can also be specified by the environment-variable `ABCTL_LOCAL_INSTALL_DOCKER_EMAIL`.                                                                                               | user@example.com          |
     | --docker-password   | ""      | Docker password to authenticate against `--docker-server`. Can also be specified by the environment-variable `ABCTL_LOCAL_INSTALL_DOCKER_PASSWORD`.                                                                                                 | mypassword                 |
     | --docker-server     | ""      | Docker server to authenticate against. Can also be specified by the environment-variable `ABCTL_LOCAL_INSTALL_DOCKER_SERVER`.                                                                                                                       | docker.io                 |

--- a/docs/platform/operator-guides/upgrading-airbyte.md
+++ b/docs/platform/operator-guides/upgrading-airbyte.md
@@ -21,7 +21,7 @@ Upgrade by updating your `values.yaml` file and redeploying Airbyte. If you're n
 
 1. If you're not sure which chart versions you're running, run `helm list -n <NAMESPACE>`.
 
-2. Check the [release notes](/release_notes/) to see what versions are available and review any requirements to upgrade. You can also see which Helm chart versions are available in the [Airbyte ArtifactHub](https://artifacthub.io/packages/helm/airbyte/airbyte).
+2. Check the [release notes](/release_notes/) to see what versions are available and review any requirements to upgrade. You can also see which Helm chart versions are available in the [Airbyte ArtifactHub](https://artifacthub.io/packages/helm/airbyte-v2/airbyte).
 
 3. Update your `values.yaml` file if necessary. In most cases, you only need to do this if you want to implement a new feature from the new version.
 


### PR DESCRIPTION
## What

PLAT-1004. The three ArtifactHub links in the platform docs point at `artifacthub.io/packages/helm/airbyte/airbyte`, which is the V1 package: `airbyte 1.9.2`, published from `airbytehq.github.io/helm-charts`, whose index was last generated 2026-03-26. Readers following "to find available versions, see the Airbyte Helm chart on ArtifactHub" get a stale version list that omits every chart V2 release.

Chart V2 is now registered on ArtifactHub as a separate repository, `airbyte-v2` → `airbytehq.github.io/charts`, verified publisher, currently serving `airbyte 2.1.1` and `airbyte-data-plane 2.1.1`.

## How

Retargets the links to the V2 package:

```diff
-https://artifacthub.io/packages/helm/airbyte/airbyte
+https://artifacthub.io/packages/helm/airbyte-v2/airbyte
```

The `-v2` suffix is in the URL because ArtifactHub derives package URLs from the repository name, and a repository's name is immutable once created — its `update_repository` function looks the row up *by* name and only writes `display_name`, `url`, `branch`, auth, and the disabled flags. So the V2 listing cannot be renamed to plain `airbyte` while the V1 entry holds that name; retargeting the links is the way to get readers to the current chart versions.

## Review guide

1. `docs/platform/deploying-airbyte/abctl/index.md` — twice, both in `--chart-version` guidance (prose at ~L208 and the flags table at ~L386)
2. `docs/platform/operator-guides/upgrading-airbyte.md` — once, in the upgrade steps

Both destination URLs return 200; verified `airbyte-v2/airbyte` resolves to `2.1.1` with `verified_publisher: true` via the ArtifactHub API.

## User Impact

Users looking up available Helm chart versions land on the maintained V2 listing instead of a V1 page frozen at 1.9.2. Link text is unchanged.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚
- [ ] NO ❌


Link to Devin session: https://app.devin.ai/sessions/2587ee57bac24e1dbce71b5018f45cb8
Requested by: @dgplatform26