### PR TITLE
ci(publish): forward prerelease PR number to registry artifact generation

### DIFF
--- a/.github/workflows/publish_connectors.yml
+++ b/.github/workflows/publish_connectors.yml
@@ -478,11 +478,11 @@ jobs:
         shell: bash
         env:
           GCS_CREDENTIALS: ${{ secrets.METADATA_SERVICE_PROD_GCS_CREDENTIALS }}
+          PR_NUMBER: ${{ inputs.pr }}
         run: |
           echo "Generating registry artifacts for ${{ matrix.connector }}"
           DOCKER_REPOSITORY=$(yq -r '.data.dockerRepository' "airbyte-integrations/connectors/${{ matrix.connector }}/metadata.yaml")
           DOCKER_IMAGE="${DOCKER_REPOSITORY}:${{ steps.resolve-docker-image-tag.outputs.docker-image-tag }}"
-          PR_NUMBER="${{ inputs.pr }}"
           PR_NUMBER_ARGS=()
           if [[ -n "$PR_NUMBER" && "$PR_NUMBER" != "0" ]]; then
             PR_NUMBER_ARGS+=(--pr-number "$PR_NUMBER")

--- a/.github/workflows/publish_connectors.yml
+++ b/.github/workflows/publish_connectors.yml
@@ -487,7 +487,7 @@ jobs:
           PR_NUMBER="${PR_NUMBER//[[:space:]]/}"
           if [[ "$PR_NUMBER" =~ ^[1-9][0-9]*$ ]]; then
             PR_NUMBER_ARGS+=(--pr-number "$PR_NUMBER")
-          elif [[ -n "$PR_NUMBER" ]]; then
+          elif [[ -n "$PR_NUMBER" && "$PR_NUMBER" != "0" ]]; then
             echo "::warning::Ignoring non-numeric PR number '$PR_NUMBER' for release attribution."
           fi
           airbyte-ops \

--- a/.github/workflows/publish_connectors.yml
+++ b/.github/workflows/publish_connectors.yml
@@ -481,6 +481,11 @@ jobs:
           echo "Generating registry artifacts for ${{ matrix.connector }}"
           DOCKER_REPOSITORY=$(yq -r '.data.dockerRepository' "airbyte-integrations/connectors/${{ matrix.connector }}/metadata.yaml")
           DOCKER_IMAGE="${DOCKER_REPOSITORY}:${{ steps.resolve-docker-image-tag.outputs.docker-image-tag }}"
+          PR_NUMBER="${{ inputs.pr }}"
+          PR_NUMBER_ARGS=()
+          if [[ -n "$PR_NUMBER" && "$PR_NUMBER" != "0" ]]; then
+            PR_NUMBER_ARGS+=(--pr-number "$PR_NUMBER")
+          fi
           airbyte-ops \
             registry connector-version artifacts generate \
             --metadata-file "airbyte-integrations/connectors/${{ matrix.connector }}/metadata.yaml" \
@@ -488,7 +493,8 @@ jobs:
             --output-dir ./registry-artifacts/${{ matrix.connector }} \
             --with-validate \
             --with-sbom \
-            --with-dependency-dump
+            --with-dependency-dump \
+            "${PR_NUMBER_ARGS[@]}"
 
       - name: Upload Registry CI Artifacts
         if: always()

--- a/.github/workflows/publish_connectors.yml
+++ b/.github/workflows/publish_connectors.yml
@@ -38,6 +38,7 @@ on:
       pr:
         description: "Pull request number that triggered this workflow (used for Slack notifications and run URL linking)."
         required: false
+        default: ""
         type: string
     outputs:
       docker-image-tag:

--- a/.github/workflows/publish_connectors.yml
+++ b/.github/workflows/publish_connectors.yml
@@ -484,8 +484,11 @@ jobs:
           DOCKER_REPOSITORY=$(yq -r '.data.dockerRepository' "airbyte-integrations/connectors/${{ matrix.connector }}/metadata.yaml")
           DOCKER_IMAGE="${DOCKER_REPOSITORY}:${{ steps.resolve-docker-image-tag.outputs.docker-image-tag }}"
           PR_NUMBER_ARGS=()
-          if [[ -n "$PR_NUMBER" && "$PR_NUMBER" != "0" ]]; then
+          PR_NUMBER="${PR_NUMBER//[[:space:]]/}"
+          if [[ "$PR_NUMBER" =~ ^[1-9][0-9]*$ ]]; then
             PR_NUMBER_ARGS+=(--pr-number "$PR_NUMBER")
+          elif [[ -n "$PR_NUMBER" ]]; then
+            echo "::warning::Ignoring non-numeric PR number '$PR_NUMBER' for release attribution."
           fi
           airbyte-ops \
             registry connector-version artifacts generate \


### PR DESCRIPTION
## What

Prerelease connector publishes currently record **no PR number** in the registry metadata they write, so a bad RC can't be traced back to a PR or a contributor.

The ops-side work for this is in airbytehq/airbyte-ops-mcp#1183, which adds an optional `--pr-number` to `airbyte-ops registry connector-version artifacts generate`. This PR is the caller side: the prerelease workflow already knows the PR number and just doesn't pass it down.

Requested by AJ (@aaronsteers).

## How

The prerelease path is `publish-connectors-prerelease-command.yml` (which requires `inputs.pr`) → `publish_connectors.yml`, and the latter [already accepts a `pr` input](https://github.com/airbytehq/airbyte/blob/master/.github/workflows/publish_connectors.yml#L37-L41) and receives it from the prerelease caller — it was only used for Slack notification links. The Generate Registry Artifacts step now forwards it:

```diff
  env:
+   PR_NUMBER: ${{ inputs.pr }}
  run: |
+   PR_NUMBER_ARGS=()
+   if [[ -n "$PR_NUMBER" && "$PR_NUMBER" != "0" ]]; then
+     PR_NUMBER_ARGS+=(--pr-number "$PR_NUMBER")
+   fi
    airbyte-ops registry connector-version artifacts generate \
      ... \
+     "${PR_NUMBER_ARGS[@]}"
```

Why the argument is built as an array rather than inlined: an empty `--pr-number ""` fails int parsing, and a failed artifact-generation step **blocks the publish**. The array expands to nothing when there's no PR number, so the flag is either well-formed or absent.

Why `env:` rather than `${{ inputs.pr }}` inline in the script: `pr` is a `workflow_dispatch`/`workflow_call` string input, so inline interpolation would be a script-injection surface.

`pr` also gains an explicit `""` default so the shell test is against a defined empty string rather than an unset input.

## Review guide

1. `.github/workflows/publish_connectors.yml` — the only file changed.

## User Impact

On the **GA path** (push to `master`, or `workflow_dispatch`) there is no `pr` input, `PR_NUMBER` is empty, the array is empty, and the command is byte-identical to today. GA attribution is derived from the squash-merge commit subject and doesn't need this. `publish_connectors.yml` has exactly one `workflow_call` caller — the prerelease command workflow — so nothing else is affected.

On the **prerelease path**, the published `metadata.yaml` gains a `data.generated.release` block carrying the PR number and the branch commit's author. `merge_commit_sha` and `merged_at` stay `null`, since an RC publishes from an unmerged branch — that's handled ops-side.

This depends on airbytehq/airbyte-ops-mcp#1183 landing and deploying first. Merged before that, the flag is unrecognized and prerelease artifact generation would fail, so **hold this until #1183 is out**. Without this PR, prerelease records simply carry no PR number.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚


Link to Devin session: https://app.devin.ai/sessions/2eba0ca3227c436b90e666534f85581b