### PR TITLE
ci(publish): guard prerelease --pr-number behind a CLI capability probe

### DIFF
--- a/.github/workflows/publish_connectors.yml
+++ b/.github/workflows/publish_connectors.yml
@@ -486,7 +486,14 @@ jobs:
           PR_NUMBER_ARGS=()
           PR_NUMBER="${PR_NUMBER//[[:space:]]/}"
           if [[ "$PR_NUMBER" =~ ^[1-9][0-9]*$ ]]; then
-            PR_NUMBER_ARGS+=(--pr-number "$PR_NUMBER")
+            # The installed Ops CLI release may predate `--pr-number`; passing an
+            # unrecognized flag would fail the publish, so probe before using it.
+            if COLUMNS=200 airbyte-ops registry connector-version artifacts generate --help 2>/dev/null \
+              | grep -q -- '--pr-number'; then
+              PR_NUMBER_ARGS+=(--pr-number "$PR_NUMBER")
+            else
+              echo "::warning::Installed airbyte-ops does not support --pr-number; publishing without release attribution."
+            fi
           elif [[ -n "$PR_NUMBER" && "$PR_NUMBER" != "0" ]]; then
             echo "::warning::Ignoring non-numeric PR number '$PR_NUMBER' for release attribution."
           fi


### PR DESCRIPTION
## What

Follow-up to airbytehq/airbyte#83255, which merged before the Ops CLI change it depends on was released.

`airbyte-ops registry connector-version artifacts generate --pr-number` does not exist in any published `airbyte-internal-ops` release yet — it is added by airbytehq/airbyte-ops-mcp#1183, which is still open. The publish job installs the CLI from PyPI (`uv tool install airbyte-internal-ops`), so it gets the latest *released* version.

That means every prerelease publish dispatched with a PR number currently fails: `inputs.pr` is non-empty, the flag is passed, cyclopts rejects the unrecognized argument, and the `Generate Registry Artifacts` step exits non-zero. The connector image has already been pushed by that point, but the registry metadata is never published, so the prerelease version isn't resolvable.

Requested by AJ Steers (@aaronsteers) as part of the connector release-attribution work.

## How

Probe the installed CLI's help output for the flag before passing it:

```bash
if [[ "$PR_NUMBER" =~ ^[1-9][0-9]*$ ]]; then
  if COLUMNS=200 airbyte-ops ... artifacts generate --help 2>/dev/null | grep -q -- '--pr-number'; then
    PR_NUMBER_ARGS+=(--pr-number "$PR_NUMBER")
  else
    echo "::warning::Installed airbyte-ops does not support --pr-number; publishing without release attribution."
  fi
fi
```

Chosen over reverting airbytehq/airbyte#83255 because it is self-healing: attribution starts flowing automatically once the Ops CLI release lands, with no second workflow change to remember. `COLUMNS=200` keeps the flag from being wrapped out of the help table on a narrow runner terminal.

## Review guide

1. `.github/workflows/publish_connectors.yml` — one nested conditional inside the existing `PR_NUMBER` handling in `Generate Registry Artifacts`. Nothing else changes.

## User Impact

Restores prerelease publishing, which is broken on `master` right now for any run that passes a PR number. Until the Ops CLI release lands, prerelease artifacts are generated without release attribution and the run logs a warning; GA publishes were never affected, since they don't set `inputs.pr`.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚
- [ ] NO ❌


Link to Devin session: https://app.devin.ai/sessions/2eba0ca3227c436b90e666534f85581b