### PR TITLE
ci(publish): revert prerelease PR number forwarding until Ops CLI ships

### DIFF
--- a/.github/workflows/publish_connectors.yml
+++ b/.github/workflows/publish_connectors.yml
@@ -38,7 +38,6 @@ on:
       pr:
         description: "Pull request number that triggered this workflow (used for Slack notifications and run URL linking)."
         required: false
-        default: ""
         type: string
     outputs:
       docker-image-tag:
@@ -478,18 +477,10 @@ jobs:
         shell: bash
         env:
           GCS_CREDENTIALS: ${{ secrets.METADATA_SERVICE_PROD_GCS_CREDENTIALS }}
-          PR_NUMBER: ${{ inputs.pr }}
         run: |
           echo "Generating registry artifacts for ${{ matrix.connector }}"
           DOCKER_REPOSITORY=$(yq -r '.data.dockerRepository' "airbyte-integrations/connectors/${{ matrix.connector }}/metadata.yaml")
           DOCKER_IMAGE="${DOCKER_REPOSITORY}:${{ steps.resolve-docker-image-tag.outputs.docker-image-tag }}"
-          PR_NUMBER_ARGS=()
-          PR_NUMBER="${PR_NUMBER//[[:space:]]/}"
-          if [[ "$PR_NUMBER" =~ ^[1-9][0-9]*$ ]]; then
-            PR_NUMBER_ARGS+=(--pr-number "$PR_NUMBER")
-          elif [[ -n "$PR_NUMBER" && "$PR_NUMBER" != "0" ]]; then
-            echo "::warning::Ignoring non-numeric PR number '$PR_NUMBER' for release attribution."
-          fi
           airbyte-ops \
             registry connector-version artifacts generate \
             --metadata-file "airbyte-integrations/connectors/${{ matrix.connector }}/metadata.yaml" \
@@ -497,8 +488,7 @@ jobs:
             --output-dir ./registry-artifacts/${{ matrix.connector }} \
             --with-validate \
             --with-sbom \
-            --with-dependency-dump \
-            "${PR_NUMBER_ARGS[@]}"
+            --with-dependency-dump
 
       - name: Upload Registry CI Artifacts
         if: always()

--- a/.github/workflows/publish_connectors.yml
+++ b/.github/workflows/publish_connectors.yml
@@ -486,14 +486,7 @@ jobs:
           PR_NUMBER_ARGS=()
           PR_NUMBER="${PR_NUMBER//[[:space:]]/}"
           if [[ "$PR_NUMBER" =~ ^[1-9][0-9]*$ ]]; then
-            # The installed Ops CLI release may predate `--pr-number`; passing an
-            # unrecognized flag would fail the publish, so probe before using it.
-            if COLUMNS=200 airbyte-ops registry connector-version artifacts generate --help 2>/dev/null \
-              | grep -q -- '--pr-number'; then
-              PR_NUMBER_ARGS+=(--pr-number "$PR_NUMBER")
-            else
-              echo "::warning::Installed airbyte-ops does not support --pr-number; publishing without release attribution."
-            fi
+            PR_NUMBER_ARGS+=(--pr-number "$PR_NUMBER")
           elif [[ -n "$PR_NUMBER" && "$PR_NUMBER" != "0" ]]; then
             echo "::warning::Ignoring non-numeric PR number '$PR_NUMBER' for release attribution."
           fi


### PR DESCRIPTION
## What

Reverts both airbytehq/airbyte#83255 (forward `inputs.pr` as `--pr-number`) and airbytehq/airbyte#83257 (probe the CLI's `--help` before passing the flag), restoring `publish_connectors.yml` to its state before either landed.

`--pr-number` does not exist in any published `airbyte-internal-ops` release. It is added by airbytehq/airbyte-ops-mcp#1183, which is still open. Releases are cut from that repo's `main`, so no publish can carry the flag until it merges — verified against 0.91.0 (published 2026-07-30T04:01Z), whose wheel contains no `release_attribution` module and no `pr_number` reference in `registry/generate.py` or `cli/registry.py`.

#83255 therefore broke prerelease publishing on `master`, and #83257 was the wrong repair: it taught the workflow to tolerate a CLI missing the flag, making a permanent accommodation out of a temporary ordering problem. Reverting both is the correct fix, per AJ Steers (@aaronsteers).

## How

Two sequential `git revert` commits, newest first. The result is byte-identical to `3e50eb46e9d~1` for this file — `git diff 3e50eb46e9d~1 HEAD -- .github/workflows/publish_connectors.yml` is empty.

The forwarding will be re-landed as a plain one-liner, with no capability probe, once airbytehq/airbyte-ops-mcp#1183 merges and an `airbyte-internal-ops` release carrying `--pr-number` is published.

## Review guide

1. `.github/workflows/publish_connectors.yml` — `Generate Registry Artifacts` loses the `PR_NUMBER` env var and the argument-array construction, going back to a fixed argument list.

## User Impact

None beyond restoring prior behavior. Prerelease publishes stop passing an unsupported flag; prerelease registry metadata simply carries no release attribution, exactly as before #83255. GA publishes were never affected.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚
- [ ] NO ❌


Link to Devin session: https://app.devin.ai/sessions/2eba0ca3227c436b90e666534f85581b