### PR TITLE
fix(source-reddit-ads): stop refreshing OAuth token on every request

### DIFF
--- a/airbyte-integrations/connectors/source-reddit-ads/manifest.yaml
+++ b/airbyte-integrations/connectors/source-reddit-ads/manifest.yaml
@@ -35,7 +35,7 @@ definitions:
         max_retries: 10
         response_filters:
           - type: HttpResponseFilter
-            action: RETRY
+            action: REFRESH_TOKEN_THEN_RETRY
             http_codes:
               - 401
             error_message: Token expired, refreshing...
@@ -183,7 +183,9 @@ streams:
       cursor_field: modified_at
       start_datetime:
         type: MinMaxDatetime
-        datetime: "{{ config.get('start_time') or '2024-05-11T00:00:00Z' }}"
+        datetime: >-
+          {{ config.get('start_time') or (now_utc() -
+          duration('P2Y')).strftime('%Y-%m-%dT%H:%M:%SZ') }}
         datetime_format: "%Y-%m-%dT%H:%M:%S%z"
       datetime_format: "%Y-%m-%dT%H:%M:%S%z"
       cursor_datetime_formats:
@@ -292,7 +294,9 @@ streams:
       cursor_field: modified_at
       start_datetime:
         type: MinMaxDatetime
-        datetime: "{{ config.get('start_time') or '2024-05-11T00:00:00Z' }}"
+        datetime: >-
+          {{ config.get('start_time') or (now_utc() -
+          duration('P2Y')).strftime('%Y-%m-%dT%H:%M:%SZ') }}
         datetime_format: "%Y-%m-%dT%H:%M:%S%z"
       datetime_format: "%Y-%m-%dT%H:%M:%S%z"
       cursor_datetime_formats:
@@ -388,7 +392,7 @@ streams:
           max_retries: 10
           response_filters:
             - type: HttpResponseFilter
-              action: RETRY
+              action: REFRESH_TOKEN_THEN_RETRY
               http_codes:
                 - 401
               error_message: Token expired, refreshing...
@@ -626,6 +630,7 @@ streams:
         datetime: >-
           {{ config.get('start_time') or (now_utc() -
           duration('P2Y')).strftime('%Y-%m-%dT%H:%M:%SZ') }}
+        min_datetime: "{{ (now_utc() - duration('P2Y')).strftime('%Y-%m-%dT%H:%M:%SZ') }}"
         datetime_format: "%Y-%m-%dT%H:%M:%S%z"
       datetime_format: "%Y-%m-%dT%H:00:00Z"
       end_time_option:
@@ -670,9 +675,17 @@ spec:
         type: string
         order: 5
         title: start_time
+        format: date-time
+        pattern: ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(Z|[+-][0-9]{2}:?[0-9]{2})$
+        pattern_descriptor: "YYYY-MM-DDTHH:mm:ssZ"
+        examples:
+          - "2024-05-11T00:00:00Z"
         description: >-
-          Optional start date for ad and campaign streams. When omitted,
-          campaign_report defaults to a 24-month lookback from the current date.
+          Optional UTC start date applied to all three streams, in
+          YYYY-MM-DDTHH:MM:SSZ format. When omitted, all three streams start 24
+          months before the current date. A value earlier than 24 months ago is
+          clamped for campaign_report, because Reddit only serves report data
+          for the last 24 months.
       user_agent:
         type: string
         description: >-

--- a/airbyte-integrations/connectors/source-reddit-ads/manifest.yaml
+++ b/airbyte-integrations/connectors/source-reddit-ads/manifest.yaml
@@ -30,7 +30,6 @@ definitions:
           Authorization: >-
             Basic {{ (config['client_id'] ~ ':' ~ config['client_secret']) |
             base64encode }}
-        token_expiry_date_format: "%Y-%m-%dT%H:%M:%S%z"
       error_handler:
         type: DefaultErrorHandler
         max_retries: 10

--- a/airbyte-integrations/connectors/source-reddit-ads/manifest.yaml
+++ b/airbyte-integrations/connectors/source-reddit-ads/manifest.yaml
@@ -183,7 +183,7 @@ streams:
       cursor_field: modified_at
       start_datetime:
         type: MinMaxDatetime
-        datetime: "{{ config['start_time'] }}"
+        datetime: "{{ config.get('start_time') or '2024-05-11T00:00:00Z' }}"
         datetime_format: "%Y-%m-%dT%H:%M:%S%z"
       datetime_format: "%Y-%m-%dT%H:%M:%S%z"
       cursor_datetime_formats:
@@ -292,7 +292,7 @@ streams:
       cursor_field: modified_at
       start_datetime:
         type: MinMaxDatetime
-        datetime: "{{ config['start_time'] }}"
+        datetime: "{{ config.get('start_time') or '2024-05-11T00:00:00Z' }}"
         datetime_format: "%Y-%m-%dT%H:%M:%S%z"
       datetime_format: "%Y-%m-%dT%H:%M:%S%z"
       cursor_datetime_formats:
@@ -623,7 +623,9 @@ streams:
       is_data_feed: false
       start_datetime:
         type: MinMaxDatetime
-        datetime: "{{ (now_utc() - duration('P2Y')).strftime('%Y-%m-%dT%H:%M:%SZ') }}"
+        datetime: >-
+          {{ config.get('start_time') or (now_utc() -
+          duration('P2Y')).strftime('%Y-%m-%dT%H:%M:%SZ') }}
         datetime_format: "%Y-%m-%dT%H:%M:%SZ"
       datetime_format: "%Y-%m-%dT%H:00:00Z"
       end_time_option:
@@ -658,7 +660,6 @@ spec:
       - ad_account_id
       - client_secret
       - refresh_token
-      - start_time
     properties:
       client_id:
         type: string
@@ -669,7 +670,9 @@ spec:
         type: string
         order: 5
         title: start_time
-        default: "2024-05-11T00:00:00Z"
+        description: >-
+          Optional start date for ad and campaign streams. When omitted,
+          campaign_report defaults to a 24-month lookback from the current date.
       user_agent:
         type: string
         description: >-

--- a/airbyte-integrations/connectors/source-reddit-ads/manifest.yaml
+++ b/airbyte-integrations/connectors/source-reddit-ads/manifest.yaml
@@ -626,7 +626,7 @@ streams:
         datetime: >-
           {{ config.get('start_time') or (now_utc() -
           duration('P2Y')).strftime('%Y-%m-%dT%H:%M:%SZ') }}
-        datetime_format: "%Y-%m-%dT%H:%M:%SZ"
+        datetime_format: "%Y-%m-%dT%H:%M:%S%z"
       datetime_format: "%Y-%m-%dT%H:00:00Z"
       end_time_option:
         type: RequestOption

--- a/airbyte-integrations/connectors/source-reddit-ads/metadata.yaml
+++ b/airbyte-integrations/connectors/source-reddit-ads/metadata.yaml
@@ -18,7 +18,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: c876992b-877e-4bb3-946b-4678c82bb7ac
-  dockerImageTag: 0.0.2
+  dockerImageTag: 0.0.3
   dockerRepository: airbyte/source-reddit-ads
   githubIssueLabel: source-reddit-ads
   icon: icon.svg

--- a/docs/integrations/sources/reddit-ads.md
+++ b/docs/integrations/sources/reddit-ads.md
@@ -6,7 +6,7 @@ Reddit ads are paid promotional posts that appear in user feeds and within speci
 | Input | Type | Description | Default Value |
 |-------|------|-------------|---------------|
 | `client_id` | `string` | OAuth Client ID.  |  |
-| `start_time` | `string` | start_time.  | 2024-05-11T00:00:00Z |
+| `start_time` | `string` | Optional start date for ad and campaign streams. When omitted, campaign_report defaults to a 24-month lookback from the current date. |  |
 | `user_agent` | `string` | User Agent. A unique and descriptive user agent string in the format: platform:app_id:version (by /u/yourusername). Required for all requests. |  |
 | `ad_account_id` | `string` | ad_account_id.  |  |
 | `client_secret` | `string` | OAuth Client Secret.  |  |
@@ -26,7 +26,7 @@ Reddit ads are paid promotional posts that appear in user feeds and within speci
 
 | Version          | Date              | Pull Request | Subject        |
 |------------------|-------------------|--------------|----------------|
-| 0.0.3 | 2026-07-30 | [83266](https://github.com/airbytehq/airbyte/pull/83266) | Fix OAuth token refresh by removing incorrect token_expiry_date_format |
+| 0.0.3 | 2026-07-30 | [83266](https://github.com/airbytehq/airbyte/pull/83266) | Fix OAuth token refresh; default campaign_report start date to 24-month lookback when start_time is not set |
 | 0.0.2 | 2026-07-28 | [83100](https://github.com/airbytehq/airbyte/pull/83100) | Update dependencies |
 | 0.0.1 | 2026-07-02 | [81399](https://github.com/airbytehq/airbyte/pull/81399) | Initial release by [@Ella6882](https://github.com/Ella6882) via Connector Builder |
 

--- a/docs/integrations/sources/reddit-ads.md
+++ b/docs/integrations/sources/reddit-ads.md
@@ -26,6 +26,7 @@ Reddit ads are paid promotional posts that appear in user feeds and within speci
 
 | Version          | Date              | Pull Request | Subject        |
 |------------------|-------------------|--------------|----------------|
+| 0.0.3 | 2026-07-30 | | Fix OAuth token refresh by removing incorrect token_expiry_date_format |
 | 0.0.2 | 2026-07-28 | [83100](https://github.com/airbytehq/airbyte/pull/83100) | Update dependencies |
 | 0.0.1 | 2026-07-02 | [81399](https://github.com/airbytehq/airbyte/pull/81399) | Initial release by [@Ella6882](https://github.com/Ella6882) via Connector Builder |
 

--- a/docs/integrations/sources/reddit-ads.md
+++ b/docs/integrations/sources/reddit-ads.md
@@ -6,7 +6,7 @@ Reddit ads are paid promotional posts that appear in user feeds and within speci
 | Input | Type | Description | Default Value |
 |-------|------|-------------|---------------|
 | `client_id` | `string` | OAuth Client ID.  |  |
-| `start_time` | `string` | Optional start date for ad and campaign streams. When omitted, campaign_report defaults to a 24-month lookback from the current date. |  |
+| `start_time` | `string` | Optional UTC start date applied to all three streams, in YYYY-MM-DDTHH:MM:SSZ format. A value earlier than 24 months ago is clamped for `campaign_report`, because Reddit only serves report data for the last 24 months. | 24 months before the current date |
 | `user_agent` | `string` | User Agent. A unique and descriptive user agent string in the format: platform:app_id:version (by /u/yourusername). Required for all requests. |  |
 | `ad_account_id` | `string` | ad_account_id.  |  |
 | `client_secret` | `string` | OAuth Client Secret.  |  |
@@ -26,7 +26,7 @@ Reddit ads are paid promotional posts that appear in user feeds and within speci
 
 | Version          | Date              | Pull Request | Subject        |
 |------------------|-------------------|--------------|----------------|
-| 0.0.3 | 2026-07-30 | [83266](https://github.com/airbytehq/airbyte/pull/83266) | Fix OAuth token refresh; default campaign_report start date to 24-month lookback when start_time is not set |
+| 0.0.3 | 2026-07-30 | [83266](https://github.com/airbytehq/airbyte/pull/83266) | Fix OAuth token refresh (stop re-refreshing the access token on every request), and recover from a stale token by refreshing it before retrying a 401; make `start_time` optional, drop its `2024-05-11T00:00:00Z` default, and apply it to all three streams with a rolling 24-month default; clamp `campaign_report` to Reddit's 24-month reporting window. Connections with `start_time` set will see the `campaign_report` window change and should reset that stream's state |
 | 0.0.2 | 2026-07-28 | [83100](https://github.com/airbytehq/airbyte/pull/83100) | Update dependencies |
 | 0.0.1 | 2026-07-02 | [81399](https://github.com/airbytehq/airbyte/pull/81399) | Initial release by [@Ella6882](https://github.com/Ella6882) via Connector Builder |
 

--- a/docs/integrations/sources/reddit-ads.md
+++ b/docs/integrations/sources/reddit-ads.md
@@ -26,7 +26,7 @@ Reddit ads are paid promotional posts that appear in user feeds and within speci
 
 | Version          | Date              | Pull Request | Subject        |
 |------------------|-------------------|--------------|----------------|
-| 0.0.3 | 2026-07-30 | | Fix OAuth token refresh by removing incorrect token_expiry_date_format |
+| 0.0.3 | 2026-07-30 | [83266](https://github.com/airbytehq/airbyte/pull/83266) | Fix OAuth token refresh by removing incorrect token_expiry_date_format |
 | 0.0.2 | 2026-07-28 | [83100](https://github.com/airbytehq/airbyte/pull/83100) | Update dependencies |
 | 0.0.1 | 2026-07-02 | [81399](https://github.com/airbytehq/airbyte/pull/81399) | Initial release by [@Ella6882](https://github.com/Ella6882) via Connector Builder |
 


### PR DESCRIPTION
## Summary
- Removes `token_expiry_date_format` from the Reddit Ads OAuth authenticator so `expires_in` is correctly interpreted as seconds until expiration
- Fixes excessive token refresh before every API request, which was likely contributing to intermittent 403 FORBIDDEN responses

Also made an enhancement to campaign_report:
- Uses start_time when provided
- Falls back to a rolling 24-month lookback (P2Y) when start_time is not set

Fixes #83265

## Test plan
- [x] Verify the connector no longer refreshes the access token on every request
- [x] Confirm sync completes without intermittent 403 errors
- [x] Run connector acceptance tests

See logs from successful run:
[reddit_ads__test____s3_data_lake___landing_logs_97531995_txt.txt](https://github.com/user-attachments/files/30553562/reddit_ads__test____s3_data_lake___landing_logs_97531995_txt.txt)

Made with [Cursor](https://cursor.com)