### PR TITLE
fix(ci): align workflow Python version with requires-python

### DIFF
--- a/.github/workflows/pyairbyte-docs-generate.yml
+++ b/.github/workflows/pyairbyte-docs-generate.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
-          python-version: "3.12"
+          python-version: "3.11"
 
       - name: Determine PyAirbyte Version
         id: version


### PR DESCRIPTION
## Why
Package metadata declares `requires-python` / `.python-version` as `3.11`, but CI workflows still pin `python-version` to a mismatched value.

That can make CI run on a runtime the project no longer supports (or skip the version the package actually targets).

## What changed
Update the affected workflow `python-version` pins so they satisfy `3.11` (using `3.11` where a concrete pin is needed).

- `.github/workflows/pyairbyte-docs-generate.yml`
  - `python-version: "3.12"` → `python-version: "3.11"`

## Test plan
- [ ] Package `requires-python` / `.python-version` is still `3.11`
- [ ] Updated workflows now use versions consistent with that constraint
- [ ] Relevant CI jobs on this branch look healthy

Found while auditing CI/package version consistency across popular repos.
