### PR TITLE
docs(destination-s3): clarify the S3 Endpoint field

### DIFF
--- a/docs/integrations/destinations/s3.md
+++ b/docs/integrations/destinations/s3.md
@@ -192,7 +192,9 @@ Use an existing or create new
      - Additional string format on how to store data under S3 Bucket Path. Default value is
        `${NAMESPACE}/${STREAM_NAME}/${YEAR}_${MONTH}_${DAY}_${EPOCH}_`.
    - **S3 Endpoint**
-     - Leave empty if using AWS S3, fill in S3 URL if using Minio S3.
+     - Leave empty if using Amazon S3. For S3-compatible object storage such as Backblaze B2,
+       Cloudflare R2, or MinIO, enter that provider's S3 endpoint URL, for example
+       `https://s3.example-region.example.com`.
    - **S3 Filename pattern**
      - The pattern allows you to set the file-name format for the S3 staging file(s), next
        placeholders combinations are currently supported: `{date}`, `{date:yyyy_MM}`, `{timestamp}`,
@@ -241,7 +243,9 @@ Use an existing or create new
      - Additional string format on how to store data under
      S3 Bucket Path. Default value is `${NAMESPACE}/${STREAM_NAME}/${YEAR}_${MONTH}_${DAY}_${EPOCH}_`.
    - **S3 Endpoint**
-     - Leave empty if using AWS S3, fill in S3 URL if using Minio S3.
+     - Leave empty if using Amazon S3. For S3-compatible object storage such as Backblaze B2,
+     Cloudflare R2, or MinIO, enter that provider's S3 endpoint URL, for example
+     `https://s3.example-region.example.com`.
    - **S3 Filename pattern**
      - The pattern allows you to set the file-name format for the S3
      staging file(s), next placeholders combinations are currently supported: `{date}`,

--- a/docs/vale-styles/config/vocabularies/Airbyte/accept.txt
+++ b/docs/vale-styles/config/vocabularies/Airbyte/accept.txt
@@ -101,6 +101,7 @@ Entra
 Slack
 Jira
 Fargate
+Backblaze
 MinIO
 Pydantic
 LangChain


### PR DESCRIPTION
## What

The **S3 Endpoint** bullet in the S3 destination setup guide currently reads "Leave empty if using AWS S3, fill in S3 URL if using Minio S3." It appears twice, once in the `env:cloud` block and once in `env:oss`. Two small problems: the guidance is narrower than what the connector actually accepts, and it does not tell the reader what shape the value should take.

`s3_endpoint` is a plain endpoint override that goes straight into the AWS SDK for Kotlin client, so it works against any S3-compatible object storage, not just MinIO. The connector already sets `forcePathStyle = true` specifically so self-hosted and non-AWS S3 services work. Readers on such storage today have to guess whether the field is meant for them, and whether it wants a bare host or a full URL.

## How

Rewords both bullets to say the field takes an S3-compatible endpoint, gives a few examples of such storage, and shows the expected URL shape with a placeholder. Also normalizes `Minio S3` to `MinIO`, which is the spelling already in the docs vocabulary.

No behavior change, no spec change, no connector version bump.

## Review guide

1. `docs/integrations/destinations/s3.md` -- the same bullet, twice: `env:cloud` around L194 and `env:oss` around L243. Continuation-line indentation differs between the two blocks in the existing file (7 spaces vs 5), and each edit follows its own block's style rather than normalizing it.
2. `docs/vale-styles/config/vocabularies/Airbyte/accept.txt` -- one product name added beside the existing `MinIO` entry so `Vale.Spelling` stays quiet on the new prose. Drop this file if you would rather not grow the vocabulary; Vale is non-blocking here either way.

Where the field is actually consumed, if useful for review:

- `airbyte-cdk/bulk/toolkits/legacy-task-load-s3/.../command/s3/S3BucketSpecification.kt#L78` declares `s3_endpoint`.
- `airbyte-cdk/bulk/toolkits/legacy-task-load-s3/.../file/s3/S3Client.kt#L228` passes it through as `endpointUrl`, and `#L251` sets `forcePathStyle = true` with a comment about self-hosted compatibility.
- `airbyte-integrations/connectors/destination-s3/src/main/kotlin/S3V2Specification.kt#L29` mixes in `S3BucketSpecification`, which is how destination-s3 surfaces the field.

Checks run locally: `markdownlint` with the repo config produces an identical set of findings before and after (no new hits on the added lines), and Vale with `docusaurus/vale.ini --minAlertLevel=warning` also produces an identical finding list before and after. I did not run the full Docusaurus build.

## User Impact

Documentation only. Users pointing the S3 destination at S3-compatible storage no longer have to infer that the endpoint field applies to them, and they can see the expected URL format. Users on Amazon S3 see the same instruction as before, which is to leave it empty.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚
- [ ] NO ❌