### PR TITLE
do-not-merge: feat(destination-gcs-data-lake): Iceberg v3 and variant types POC

### DIFF
--- a/airbyte-integrations/connectors/destination-gcs-data-lake/build.gradle
+++ b/airbyte-integrations/connectors/destination-gcs-data-lake/build.gradle
@@ -20,7 +20,7 @@ application {
 }
 
 ext {
-    apacheIcebergVersion = '1.7.0'
+    apacheIcebergVersion = '1.11.0'
     googleCloudStorageVersion = '2.59.0'
     googleAuthVersion = '1.40.0'
     junitVersion = '5.11.3'

--- a/airbyte-integrations/connectors/destination-gcs-data-lake/gradle.properties
+++ b/airbyte-integrations/connectors/destination-gcs-data-lake/gradle.properties
@@ -1,3 +1,3 @@
 testExecutionConcurrency=1
-cdkVersion=1.0.13
+cdkVersion=local
 JunitMethodExecutionTimeout=10m

--- a/airbyte-integrations/connectors/destination-gcs-data-lake/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-gcs-data-lake/metadata.yaml
@@ -21,7 +21,7 @@ data:
             alias: airbyte-connector-testing-secret-store
   connectorType: destination
   definitionId: 8c8a2d3e-1b4f-4a9c-9e7d-6f5a4b3c2d1e
-  dockerImageTag: 1.0.10
+  dockerImageTag: 1.0.11
   dockerRepository: airbyte/destination-gcs-data-lake
   documentationUrl: https://docs.airbyte.com/integrations/destinations/gcs-data-lake
   githubIssueLabel: destination-gcs-data-lake

--- a/airbyte-integrations/connectors/destination-gcs-data-lake/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-gcs-data-lake/metadata.yaml
@@ -21,7 +21,7 @@ data:
             alias: airbyte-connector-testing-secret-store
   connectorType: destination
   definitionId: 8c8a2d3e-1b4f-4a9c-9e7d-6f5a4b3c2d1e
-  dockerImageTag: 1.0.11
+  dockerImageTag: 1.1.0
   dockerRepository: airbyte/destination-gcs-data-lake
   documentationUrl: https://docs.airbyte.com/integrations/destinations/gcs-data-lake
   githubIssueLabel: destination-gcs-data-lake

--- a/airbyte-integrations/connectors/destination-gcs-data-lake/src/main/kotlin/io/airbyte/integrations/destination/gcs_data_lake/check/GcsDataLakeChecker.kt
+++ b/airbyte-integrations/connectors/destination-gcs-data-lake/src/main/kotlin/io/airbyte/integrations/destination/gcs_data_lake/check/GcsDataLakeChecker.kt
@@ -70,10 +70,19 @@ class GcsDataLakeChecker(
         val testTableIdentifier =
             DestinationStream.Descriptor(defaultNamespace, uniqueTestTableName)
 
+        // Include a variant column when variant types are enabled, so that a catalog which can't
+        // handle them fails here rather than mid-sync.
+        val semiStructuredType =
+            if (config.useVariantTypes) {
+                Types.VariantType.get()
+            } else {
+                Types.StringType.get()
+            }
         val testTableSchema =
             Schema(
                 Types.NestedField.required(1, "id", Types.IntegerType.get()),
                 Types.NestedField.optional(2, "data", Types.StringType.get()),
+                Types.NestedField.optional(3, "semi_structured", semiStructuredType),
             )
         gcsDataLakeCatalogUtil.createNamespace(testTableIdentifier, catalog)
 
@@ -84,6 +93,7 @@ class GcsDataLakeChecker(
                     testTableIdentifier,
                     catalog,
                     testTableSchema,
+                    tableFormatVersion = config.tableFormatVersion.formatVersion,
                 )
         } finally {
             // Always cleanup test table, even if creation or validation fails

--- a/airbyte-integrations/connectors/destination-gcs-data-lake/src/main/kotlin/io/airbyte/integrations/destination/gcs_data_lake/spec/GcsDataLakeConfiguration.kt
+++ b/airbyte-integrations/connectors/destination-gcs-data-lake/src/main/kotlin/io/airbyte/integrations/destination/gcs_data_lake/spec/GcsDataLakeConfiguration.kt
@@ -84,8 +84,8 @@ class GcsDataLakeConfigurationFactory :
             gcsEndpoint = pojo.gcsEndpoint,
             namespace = pojo.namespace,
             gcsCatalogConfiguration = pojo.toGcsCatalogConfiguration(),
-            tableFormatVersion = pojo.tableFormatVersion,
-            useVariantTypes = pojo.useVariantTypes,
+            tableFormatVersion = pojo.tableFormatVersion ?: IcebergTableFormatVersion.V2,
+            useVariantTypes = pojo.useVariantTypes ?: false,
         )
     }
 }

--- a/airbyte-integrations/connectors/destination-gcs-data-lake/src/main/kotlin/io/airbyte/integrations/destination/gcs_data_lake/spec/GcsDataLakeConfiguration.kt
+++ b/airbyte-integrations/connectors/destination-gcs-data-lake/src/main/kotlin/io/airbyte/integrations/destination/gcs_data_lake/spec/GcsDataLakeConfiguration.kt
@@ -6,6 +6,7 @@ package io.airbyte.integrations.destination.gcs_data_lake.spec
 
 import com.google.auth.oauth2.GoogleCredentials
 import com.google.auth.oauth2.ServiceAccountCredentials
+import io.airbyte.cdk.ConfigErrorException
 import io.airbyte.cdk.load.command.DestinationConfiguration
 import io.airbyte.cdk.load.command.DestinationConfigurationFactory
 import io.micronaut.context.annotation.Factory
@@ -24,7 +25,18 @@ data class GcsDataLakeConfiguration(
     val gcsEndpoint: String?,
     val namespace: String,
     val gcsCatalogConfiguration: GcsCatalogConfiguration,
+    val tableFormatVersion: IcebergTableFormatVersion = IcebergTableFormatVersion.V2,
+    val useVariantTypes: Boolean = false,
 ) : DestinationConfiguration() {
+
+    init {
+        if (useVariantTypes && tableFormatVersion != IcebergTableFormatVersion.V3) {
+            throw ConfigErrorException(
+                "Variant types require Iceberg table format version v3, but the configured " +
+                    "format version is ${tableFormatVersion.specValue}.",
+            )
+        }
+    }
 
     // Lazy-loaded credentials from service account JSON with proper OAuth scopes
     val googleCredentials: GoogleCredentials by lazy {
@@ -72,6 +84,8 @@ class GcsDataLakeConfigurationFactory :
             gcsEndpoint = pojo.gcsEndpoint,
             namespace = pojo.namespace,
             gcsCatalogConfiguration = pojo.toGcsCatalogConfiguration(),
+            tableFormatVersion = pojo.tableFormatVersion,
+            useVariantTypes = pojo.useVariantTypes,
         )
     }
 }

--- a/airbyte-integrations/connectors/destination-gcs-data-lake/src/main/kotlin/io/airbyte/integrations/destination/gcs_data_lake/spec/GcsDataLakeSpecification.kt
+++ b/airbyte-integrations/connectors/destination-gcs-data-lake/src/main/kotlin/io/airbyte/integrations/destination/gcs_data_lake/spec/GcsDataLakeSpecification.kt
@@ -121,7 +121,7 @@ class GcsDataLakeSpecification : ConfigurationSpecification() {
     )
     @get:JsonProperty("table_format_version")
     @get:JsonSchemaInject(json = """{"always_show": true, "order": 9}""")
-    val tableFormatVersion: IcebergTableFormatVersion = IcebergTableFormatVersion.V2
+    val tableFormatVersion: IcebergTableFormatVersion? = null
 
     @get:JsonSchemaTitle("Use Variant Types")
     @get:JsonPropertyDescription(
@@ -129,7 +129,7 @@ class GcsDataLakeSpecification : ConfigurationSpecification() {
     )
     @get:JsonProperty("use_variant_types")
     @get:JsonSchemaInject(json = """{"always_show": true, "order": 10}""")
-    val useVariantTypes: Boolean = false
+    val useVariantTypes: Boolean? = null
 
     fun toGcsCatalogConfiguration(): GcsCatalogConfiguration {
         val catalogConfig =

--- a/airbyte-integrations/connectors/destination-gcs-data-lake/src/main/kotlin/io/airbyte/integrations/destination/gcs_data_lake/spec/GcsDataLakeSpecification.kt
+++ b/airbyte-integrations/connectors/destination-gcs-data-lake/src/main/kotlin/io/airbyte/integrations/destination/gcs_data_lake/spec/GcsDataLakeSpecification.kt
@@ -115,6 +115,22 @@ class GcsDataLakeSpecification : ConfigurationSpecification() {
     @get:JsonSchemaInject(json = """{"order": 8}""")
     val gcsEndpoint: String? = null
 
+    @get:JsonSchemaTitle("Iceberg Table Format Version")
+    @get:JsonPropertyDescription(
+        """The Iceberg table format version to create tables at. Version 2 is readable by every engine that supports Iceberg. Version 3 adds extended types and deletion vectors, but is not yet readable by Amazon Athena or Amazon Redshift. Changing this on an existing stream requires a stream reset, because Iceberg cannot upgrade a table's format version in place."""
+    )
+    @get:JsonProperty("table_format_version")
+    @get:JsonSchemaInject(json = """{"always_show": true, "order": 9}""")
+    val tableFormatVersion: IcebergTableFormatVersion = IcebergTableFormatVersion.V2
+
+    @get:JsonSchemaTitle("Use Variant Types")
+    @get:JsonPropertyDescription(
+        """Write semi-structured columns (schemaless objects and arrays, unions, and unknown types) as native Iceberg variant values instead of JSON strings. Requires table format version 3, and is not readable by Amazon Athena, Amazon Redshift, or BigQuery today. Changing this on an existing stream requires a stream reset, because a string column cannot be promoted to variant."""
+    )
+    @get:JsonProperty("use_variant_types")
+    @get:JsonSchemaInject(json = """{"always_show": true, "order": 10}""")
+    val useVariantTypes: Boolean = false
+
     fun toGcsCatalogConfiguration(): GcsCatalogConfiguration {
         val catalogConfig =
             when (catalogType) {

--- a/airbyte-integrations/connectors/destination-gcs-data-lake/src/main/kotlin/io/airbyte/integrations/destination/gcs_data_lake/spec/IcebergTableFormatVersion.kt
+++ b/airbyte-integrations/connectors/destination-gcs-data-lake/src/main/kotlin/io/airbyte/integrations/destination/gcs_data_lake/spec/IcebergTableFormatVersion.kt
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2026 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.integrations.destination.gcs_data_lake.spec
+
+import com.fasterxml.jackson.annotation.JsonValue
+
+/** The Iceberg table format version that Airbyte creates tables at. */
+enum class IcebergTableFormatVersion(
+    @get:JsonValue val specValue: String,
+    val formatVersion: Int,
+) {
+    V2("v2", 2),
+    V3("v3", 3),
+}

--- a/airbyte-integrations/connectors/destination-gcs-data-lake/src/main/kotlin/io/airbyte/integrations/destination/gcs_data_lake/write/GcsDataLakeStreamLoader.kt
+++ b/airbyte-integrations/connectors/destination-gcs-data-lake/src/main/kotlin/io/airbyte/integrations/destination/gcs_data_lake/write/GcsDataLakeStreamLoader.kt
@@ -78,13 +78,21 @@ class GcsDataLakeStreamLoader(
                         ?: originalName
 
                 if (mappedName != originalName) {
-                    Types.NestedField.of(
-                        field.fieldId(),
-                        field.isOptional,
-                        mappedName,
-                        field.type(),
-                        field.doc()
-                    )
+                    if (field.isOptional) {
+                        Types.NestedField.optional(
+                            field.fieldId(),
+                            mappedName,
+                            field.type(),
+                            field.doc()
+                        )
+                    } else {
+                        Types.NestedField.required(
+                            field.fieldId(),
+                            mappedName,
+                            field.type(),
+                            field.doc()
+                        )
+                    }
                 } else {
                     field
                 }

--- a/airbyte-integrations/connectors/destination-gcs-data-lake/src/main/kotlin/io/airbyte/integrations/destination/gcs_data_lake/write/GcsDataLakeStreamLoader.kt
+++ b/airbyte-integrations/connectors/destination-gcs-data-lake/src/main/kotlin/io/airbyte/integrations/destination/gcs_data_lake/write/GcsDataLakeStreamLoader.kt
@@ -49,11 +49,16 @@ class GcsDataLakeStreamLoader(
     private val incomingSchema = computeIncomingSchema(false)
 
     private fun computeIncomingSchema(withIdentifierFields: Boolean) =
-        icebergUtil.toIcebergSchema(stream = stream).let { schema ->
-            // Transform the schema to use mapped column names for BigLake compatibility.
-            // BigLake rejects table creation with special characters in column names.
-            transformSchemaWithMappedNames(schema, withIdentifierFields)
-        }
+        icebergUtil
+            .toIcebergSchema(
+                stream = stream,
+                useVariant = icebergConfiguration.useVariantTypes,
+            )
+            .let { schema ->
+                // Transform the schema to use mapped column names for BigLake compatibility.
+                // BigLake rejects table creation with special characters in column names.
+                transformSchemaWithMappedNames(schema, withIdentifierFields)
+            }
 
     /**
      * Transforms an Iceberg schema to use mapped column names. This ensures column names are
@@ -127,6 +132,7 @@ class GcsDataLakeStreamLoader(
                 streamDescriptor = stream.mappedDescriptor,
                 catalog = catalog,
                 schema = incomingSchema,
+                tableFormatVersion = icebergConfiguration.tableFormatVersion.formatVersion,
             )
 
         // Reconcile identifier fields after BigLake creates the table

--- a/airbyte-integrations/connectors/destination-gcs-data-lake/src/main/kotlin/io/airbyte/integrations/destination/gcs_data_lake/write/transform/GcsDataLakeValueCoercer.kt
+++ b/airbyte-integrations/connectors/destination-gcs-data-lake/src/main/kotlin/io/airbyte/integrations/destination/gcs_data_lake/write/transform/GcsDataLakeValueCoercer.kt
@@ -13,6 +13,7 @@ import io.airbyte.cdk.load.data.UnionType
 import io.airbyte.cdk.load.dataflow.transform.ValidationResult
 import io.airbyte.cdk.load.dataflow.transform.ValueCoercer
 import io.airbyte.cdk.load.util.serializeToString
+import io.airbyte.integrations.destination.gcs_data_lake.spec.GcsDataLakeConfiguration
 import io.airbyte.protocol.models.v0.AirbyteRecordMessageMetaChange.Reason
 import jakarta.inject.Singleton
 import java.math.BigDecimal
@@ -30,7 +31,7 @@ import java.math.BigInteger
  * with stringifyObjects), not here.
  */
 @Singleton
-class GcsDataLakeValueCoercer : ValueCoercer {
+class GcsDataLakeValueCoercer(private val config: GcsDataLakeConfiguration) : ValueCoercer {
     companion object {
         // Cache these BigDecimal/BigInteger constants to avoid expensive allocations
         // and BigInteger.pow() operations on every validation call
@@ -43,7 +44,8 @@ class GcsDataLakeValueCoercer : ValueCoercer {
         // Stringify union values - this happens during Parse stage where we still
         // have type information to know which fields are unions
         // Note: Null values should NOT be stringified - they stay as NullValue
-        if (value.type is UnionType && value.abValue !is NullValue) {
+        // Variant columns hold the union value directly, so stringifying would lose its type.
+        if (!config.useVariantTypes && value.type is UnionType && value.abValue !is NullValue) {
             value.abValue = StringValue(value.abValue.serializeToString())
         }
         return value

--- a/airbyte-integrations/connectors/destination-gcs-data-lake/src/test-integration/resources/expected-spec-cloud.json
+++ b/airbyte-integrations/connectors/destination-gcs-data-lake/src/test-integration/resources/expected-spec-cloud.json
@@ -149,7 +149,7 @@
         "order" : 10
       }
     },
-    "required" : [ "gcs_bucket_name", "service_account_json", "gcp_location", "warehouse_location", "main_branch_name", "namespace", "catalog_type", "table_format_version", "use_variant_types" ]
+    "required" : [ "gcs_bucket_name", "service_account_json", "gcp_location", "warehouse_location", "main_branch_name", "namespace", "catalog_type" ]
   },
   "supportsIncremental" : true,
   "supportsNormalization" : false,

--- a/airbyte-integrations/connectors/destination-gcs-data-lake/src/test-integration/resources/expected-spec-cloud.json
+++ b/airbyte-integrations/connectors/destination-gcs-data-lake/src/test-integration/resources/expected-spec-cloud.json
@@ -132,9 +132,24 @@
         "description" : "Optional custom GCS endpoint URL. Use this for testing with local GCS emulators.",
         "title" : "GCS Endpoint (Optional)",
         "order" : 8
+      },
+      "table_format_version" : {
+        "type" : "string",
+        "enum" : [ "v2", "v3" ],
+        "description" : "The Iceberg table format version to create tables at. Version 2 is readable by every engine that supports Iceberg. Version 3 adds extended types and deletion vectors, but is not yet readable by Amazon Athena or Amazon Redshift. Changing this on an existing stream requires a stream reset, because Iceberg cannot upgrade a table's format version in place.",
+        "title" : "Iceberg Table Format Version",
+        "always_show" : true,
+        "order" : 9
+      },
+      "use_variant_types" : {
+        "type" : "boolean",
+        "description" : "Write semi-structured columns (schemaless objects and arrays, unions, and unknown types) as native Iceberg variant values instead of JSON strings. Requires table format version 3, and is not readable by Amazon Athena, Amazon Redshift, or BigQuery today. Changing this on an existing stream requires a stream reset, because a string column cannot be promoted to variant.",
+        "title" : "Use Variant Types",
+        "always_show" : true,
+        "order" : 10
       }
     },
-    "required" : [ "gcs_bucket_name", "service_account_json", "gcp_location", "warehouse_location", "main_branch_name", "namespace", "catalog_type" ]
+    "required" : [ "gcs_bucket_name", "service_account_json", "gcp_location", "warehouse_location", "main_branch_name", "namespace", "catalog_type", "table_format_version", "use_variant_types" ]
   },
   "supportsIncremental" : true,
   "supportsNormalization" : false,

--- a/airbyte-integrations/connectors/destination-gcs-data-lake/src/test-integration/resources/expected-spec-oss.json
+++ b/airbyte-integrations/connectors/destination-gcs-data-lake/src/test-integration/resources/expected-spec-oss.json
@@ -149,7 +149,7 @@
         "order" : 10
       }
     },
-    "required" : [ "gcs_bucket_name", "service_account_json", "gcp_location", "warehouse_location", "main_branch_name", "namespace", "catalog_type", "table_format_version", "use_variant_types" ]
+    "required" : [ "gcs_bucket_name", "service_account_json", "gcp_location", "warehouse_location", "main_branch_name", "namespace", "catalog_type" ]
   },
   "supportsIncremental" : true,
   "supportsNormalization" : false,

--- a/airbyte-integrations/connectors/destination-gcs-data-lake/src/test-integration/resources/expected-spec-oss.json
+++ b/airbyte-integrations/connectors/destination-gcs-data-lake/src/test-integration/resources/expected-spec-oss.json
@@ -132,9 +132,24 @@
         "description" : "Optional custom GCS endpoint URL. Use this for testing with local GCS emulators.",
         "title" : "GCS Endpoint (Optional)",
         "order" : 8
+      },
+      "table_format_version" : {
+        "type" : "string",
+        "enum" : [ "v2", "v3" ],
+        "description" : "The Iceberg table format version to create tables at. Version 2 is readable by every engine that supports Iceberg. Version 3 adds extended types and deletion vectors, but is not yet readable by Amazon Athena or Amazon Redshift. Changing this on an existing stream requires a stream reset, because Iceberg cannot upgrade a table's format version in place.",
+        "title" : "Iceberg Table Format Version",
+        "always_show" : true,
+        "order" : 9
+      },
+      "use_variant_types" : {
+        "type" : "boolean",
+        "description" : "Write semi-structured columns (schemaless objects and arrays, unions, and unknown types) as native Iceberg variant values instead of JSON strings. Requires table format version 3, and is not readable by Amazon Athena, Amazon Redshift, or BigQuery today. Changing this on an existing stream requires a stream reset, because a string column cannot be promoted to variant.",
+        "title" : "Use Variant Types",
+        "always_show" : true,
+        "order" : 10
       }
     },
-    "required" : [ "gcs_bucket_name", "service_account_json", "gcp_location", "warehouse_location", "main_branch_name", "namespace", "catalog_type" ]
+    "required" : [ "gcs_bucket_name", "service_account_json", "gcp_location", "warehouse_location", "main_branch_name", "namespace", "catalog_type", "table_format_version", "use_variant_types" ]
   },
   "supportsIncremental" : true,
   "supportsNormalization" : false,

--- a/airbyte-integrations/connectors/destination-gcs-data-lake/src/test/kotlin/io/airbyte/integrations/destination/gcs_data_lake/spec/GcsDataLakeConfigurationTest.kt
+++ b/airbyte-integrations/connectors/destination-gcs-data-lake/src/test/kotlin/io/airbyte/integrations/destination/gcs_data_lake/spec/GcsDataLakeConfigurationTest.kt
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2026 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.integrations.destination.gcs_data_lake.spec
+
+import io.airbyte.cdk.ConfigErrorException
+import org.junit.jupiter.api.Assertions.assertDoesNotThrow
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+internal class GcsDataLakeConfigurationTest {
+
+    @Test
+    fun `variant types require format version 3`() {
+        assertThrows<ConfigErrorException> {
+            configuration(IcebergTableFormatVersion.V2, useVariantTypes = true)
+        }
+    }
+
+    @Test
+    fun `variant types are allowed at format version 3`() {
+        assertDoesNotThrow { configuration(IcebergTableFormatVersion.V3, useVariantTypes = true) }
+    }
+
+    @Test
+    fun `format version 2 without variant types is valid`() {
+        assertDoesNotThrow { configuration(IcebergTableFormatVersion.V2, useVariantTypes = false) }
+    }
+
+    private fun configuration(
+        tableFormatVersion: IcebergTableFormatVersion,
+        useVariantTypes: Boolean,
+    ) =
+        GcsDataLakeConfiguration(
+            gcsBucketName = "bucket",
+            serviceAccountJson = "{}",
+            gcpProjectId = "project",
+            gcpLocation = "us-central1",
+            gcsEndpoint = null,
+            namespace = "namespace",
+            gcsCatalogConfiguration =
+                GcsCatalogConfiguration(
+                    warehouseLocation = "gs://bucket/warehouse",
+                    mainBranchName = "main",
+                    catalogConfiguration = BigLakeCatalogConfiguration("catalog", "project"),
+                ),
+            tableFormatVersion = tableFormatVersion,
+            useVariantTypes = useVariantTypes,
+        )
+}

--- a/airbyte-integrations/connectors/destination-gcs-data-lake/src/test/kotlin/io/airbyte/integrations/destination/gcs_data_lake/spec/GcsDataLakeConfigurationTest.kt
+++ b/airbyte-integrations/connectors/destination-gcs-data-lake/src/test/kotlin/io/airbyte/integrations/destination/gcs_data_lake/spec/GcsDataLakeConfigurationTest.kt
@@ -34,10 +34,11 @@ internal class GcsDataLakeConfigurationTest {
     @Test
     fun `the spec value of the format version deserializes`() {
         val spec =
-            ObjectMapper().readValue(
-                """{"table_format_version": "v3", "use_variant_types": true}""",
-                GcsDataLakeSpecification::class.java,
-            )
+            ObjectMapper()
+                .readValue(
+                    """{"table_format_version": "v3", "use_variant_types": true}""",
+                    GcsDataLakeSpecification::class.java,
+                )
 
         assertEquals(IcebergTableFormatVersion.V3, spec.tableFormatVersion)
         assertEquals(true, spec.useVariantTypes)

--- a/airbyte-integrations/connectors/destination-gcs-data-lake/src/test/kotlin/io/airbyte/integrations/destination/gcs_data_lake/spec/GcsDataLakeConfigurationTest.kt
+++ b/airbyte-integrations/connectors/destination-gcs-data-lake/src/test/kotlin/io/airbyte/integrations/destination/gcs_data_lake/spec/GcsDataLakeConfigurationTest.kt
@@ -4,8 +4,11 @@
 
 package io.airbyte.integrations.destination.gcs_data_lake.spec
 
+import com.fasterxml.jackson.databind.ObjectMapper
 import io.airbyte.cdk.ConfigErrorException
 import org.junit.jupiter.api.Assertions.assertDoesNotThrow
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 
@@ -26,6 +29,26 @@ internal class GcsDataLakeConfigurationTest {
     @Test
     fun `format version 2 without variant types is valid`() {
         assertDoesNotThrow { configuration(IcebergTableFormatVersion.V2, useVariantTypes = false) }
+    }
+
+    @Test
+    fun `the spec value of the format version deserializes`() {
+        val spec =
+            ObjectMapper().readValue(
+                """{"table_format_version": "v3", "use_variant_types": true}""",
+                GcsDataLakeSpecification::class.java,
+            )
+
+        assertEquals(IcebergTableFormatVersion.V3, spec.tableFormatVersion)
+        assertEquals(true, spec.useVariantTypes)
+    }
+
+    @Test
+    fun `a config without the new fields keeps the previous behavior`() {
+        val spec = ObjectMapper().readValue("{}", GcsDataLakeSpecification::class.java)
+
+        assertNull(spec.tableFormatVersion)
+        assertNull(spec.useVariantTypes)
     }
 
     private fun configuration(

--- a/docs/integrations/destinations/gcs-data-lake.md
+++ b/docs/integrations/destinations/gcs-data-lake.md
@@ -222,6 +222,7 @@ This destination supports [namespaces](https://docs.airbyte.com/platform/using-a
 
 | Version | Date       | Pull Request                                                 | Subject                                                                               |
 |:--------|:-----------|:-------------------------------------------------------------|:--------------------------------------------------------------------------------------|
+| 1.0.11  | 2026-07-31 | [83280](https://github.com/airbytehq/airbyte/pull/83280)     | Replace deprecated `Types.NestedField.of` with `optional`/`required`                   |
 | 1.0.10  | 2026-05-19 | [78235](https://github.com/airbytehq/airbyte/pull/78235)     | Upgrade CDK to 1.0.13                                                                  |
 | 1.0.9   | 2026-04-17 | [76406](https://github.com/airbytehq/airbyte/pull/76406)     | Upgrade CDK to 1.0.9                                                                  |
 | 1.0.8   | 2026-03-30 | [75630](https://github.com/airbytehq/airbyte/pull/75630)     | Upgrade CDK to 1.0.7: fix sort order handling during schema evolution                 |

--- a/docs/integrations/destinations/gcs-data-lake.md
+++ b/docs/integrations/destinations/gcs-data-lake.md
@@ -222,6 +222,7 @@ This destination supports [namespaces](https://docs.airbyte.com/platform/using-a
 
 | Version | Date       | Pull Request                                                 | Subject                                                                               |
 |:--------|:-----------|:-------------------------------------------------------------|:--------------------------------------------------------------------------------------|
+| 1.1.0   | 2026-07-31 | [83282](https://github.com/airbytehq/airbyte/pull/83282)     | Add Iceberg table format version and variant type options; upgrade Iceberg to 1.11.0   |
 | 1.0.11  | 2026-07-31 | [83282](https://github.com/airbytehq/airbyte/pull/83282)     | Replace deprecated `Types.NestedField.of` with `optional`/`required`                   |
 | 1.0.10  | 2026-05-19 | [78235](https://github.com/airbytehq/airbyte/pull/78235)     | Upgrade CDK to 1.0.13                                                                  |
 | 1.0.9   | 2026-04-17 | [76406](https://github.com/airbytehq/airbyte/pull/76406)     | Upgrade CDK to 1.0.9                                                                  |

--- a/docs/integrations/destinations/gcs-data-lake.md
+++ b/docs/integrations/destinations/gcs-data-lake.md
@@ -223,7 +223,6 @@ This destination supports [namespaces](https://docs.airbyte.com/platform/using-a
 | Version | Date       | Pull Request                                                 | Subject                                                                               |
 |:--------|:-----------|:-------------------------------------------------------------|:--------------------------------------------------------------------------------------|
 | 1.1.0   | 2026-07-31 | [83282](https://github.com/airbytehq/airbyte/pull/83282)     | Add Iceberg table format version and variant type options; upgrade Iceberg to 1.11.0   |
-| 1.0.11  | 2026-07-31 | [83282](https://github.com/airbytehq/airbyte/pull/83282)     | Replace deprecated `Types.NestedField.of` with `optional`/`required`                   |
 | 1.0.10  | 2026-05-19 | [78235](https://github.com/airbytehq/airbyte/pull/78235)     | Upgrade CDK to 1.0.13                                                                  |
 | 1.0.9   | 2026-04-17 | [76406](https://github.com/airbytehq/airbyte/pull/76406)     | Upgrade CDK to 1.0.9                                                                  |
 | 1.0.8   | 2026-03-30 | [75630](https://github.com/airbytehq/airbyte/pull/75630)     | Upgrade CDK to 1.0.7: fix sort order handling during schema evolution                 |

--- a/docs/integrations/destinations/gcs-data-lake.md
+++ b/docs/integrations/destinations/gcs-data-lake.md
@@ -222,7 +222,7 @@ This destination supports [namespaces](https://docs.airbyte.com/platform/using-a
 
 | Version | Date       | Pull Request                                                 | Subject                                                                               |
 |:--------|:-----------|:-------------------------------------------------------------|:--------------------------------------------------------------------------------------|
-| 1.0.11  | 2026-07-31 | [83280](https://github.com/airbytehq/airbyte/pull/83280)     | Replace deprecated `Types.NestedField.of` with `optional`/`required`                   |
+| 1.0.11  | 2026-07-31 | [83282](https://github.com/airbytehq/airbyte/pull/83282)     | Replace deprecated `Types.NestedField.of` with `optional`/`required`                   |
 | 1.0.10  | 2026-05-19 | [78235](https://github.com/airbytehq/airbyte/pull/78235)     | Upgrade CDK to 1.0.13                                                                  |
 | 1.0.9   | 2026-04-17 | [76406](https://github.com/airbytehq/airbyte/pull/76406)     | Upgrade CDK to 1.0.9                                                                  |
 | 1.0.8   | 2026-03-30 | [75630](https://github.com/airbytehq/airbyte/pull/75630)     | Upgrade CDK to 1.0.7: fix sort order handling during schema evolution                 |


### PR DESCRIPTION
This PR targets the following PR:
- 83279

---

## What

Turns the GCS Data Lake connector into the POC for Iceberg v3 / Parquet variant support, on top of the CDK toolkit work in airbytehq/airbyte#83279.

Requested by AJ Steers (@aaronsteers). Parked in https://github.com/orgs/airbytehq/projects/166 — `do-not-merge:` prefix is intentional, and the resulting red "Validate PR Title" check is the merge guard.

Two new config options, deliberately orthogonal:

1. `table_format_version` — `v2` (default) or `v3`.
2. `use_variant_types` — boolean, default `false`. Writes semi-structured columns (schemaless objects/arrays, unions, unknown types) as native Iceberg variant instead of JSON strings.

Invalid combinations fail fast: variant requires format version 3, and the configuration rejects `v2 + variant` at construction time, so `check` fails during initialization rather than mid-sync.

Also bumps the connector's Iceberg dependency 1.7.0 → 1.11.0 (variant support landed in 1.10/1.11) and keeps the original `NestedField.of` deprecation fix that this PR started as.

## How

1. `IcebergTableFormatVersion` is a spec-facing enum (`v2` / `v3`) carrying the numeric format version.
2. `GcsDataLakeConfiguration` validates the combination in its `init` block and throws `ConfigErrorException`.
3. `GcsDataLakeStreamLoader` passes `useVariant` into `toIcebergSchema` and the format version into `createTable`.
4. `GcsDataLakeChecker` creates its probe table at the configured format version, and includes a variant column when variant is enabled, so an incapable catalog fails during `check`.
5. `GcsDataLakeValueCoercer` no longer stringifies union values when variant is on — the variant column holds the typed value directly.
6. `cdkVersion=local` so the connector builds against the stacked CDK branch rather than published 1.0.13.

## Review guide

1. `spec/IcebergTableFormatVersion.kt` — new enum.
2. `spec/GcsDataLakeSpecification.kt` — the two new spec fields and their tooltips.
3. `spec/GcsDataLakeConfiguration.kt` — the fail-fast validation.
4. `write/GcsDataLakeStreamLoader.kt`, `check/GcsDataLakeChecker.kt` — plumbing.
5. `write/transform/GcsDataLakeValueCoercer.kt` — union handling under variant.
6. `build.gradle`, `gradle.properties` — Iceberg 1.11.0 and local CDK.

## User Impact

Default behavior is unchanged: format version 2, JSON strings for semi-structured data. Users who opt into v3 and/or variant must reset affected streams — Iceberg cannot upgrade a table's format version in place, and a `string` column cannot be promoted to `variant`. Variant is not readable today by Athena, Redshift, or BigQuery; the tooltips say so.

Not to be merged: this is an incubating POC and the connector currently points at an unmerged CDK branch.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚
- [ ] NO ❌

---
[Devin session](https://app.devin.ai/sessions/db49c884a2474564a8da8d09d1f9f512)
