### PR TITLE
docs(ai-agents): document the Airbyte model natural language interface

### DIFF
--- a/docs/ai-agents/admin/api-keys.md
+++ b/docs/ai-agents/admin/api-keys.md
@@ -1,0 +1,73 @@
+---
+plan: all
+---
+
+# API keys
+
+API keys authenticate clients that use the [Airbyte model](../interfaces/model/readme.md), the natural language interface. Create and manage them on the **API Keys** page in the web app.
+
+:::note Public alpha
+
+The Airbyte model is in public alpha. The **API Keys** page only appears if your organization has it enabled. To use it, ask your Airbyte contact to enable it.
+
+:::
+
+Other interfaces don't use these keys. The [MCP server](../interfaces/mcp/readme.md) authenticates in your browser, and the [API](../interfaces/api/readme.md), [SDK](../interfaces/sdk/readme.md), and [CLI](../interfaces/cli/readme.md) use your organization's client ID and secret. See [Profile](./profile.md#api-credentials).
+
+## Keys are scoped to a workspace
+
+Each key belongs to one workspace, and clients using it can only query the connectors authenticated in that workspace. To query connectors in two workspaces, create a key for each. If you have more than one workspace, verify you're creating the key in the one that holds the data you want. See [Workspaces](../concepts/architecture/workspaces.md).
+
+You can only create keys for workspaces you have access to, and you can have up to 10 active keys in each workspace. Two active keys in the same workspace can't share a name, but a name is free to reuse once you revoke the key that held it.
+
+## Create a key
+
+1. Click **Settings**, then click **API Keys**.
+
+2. Click **Create API key**.
+
+3. Enter a **Name** that identifies where you'll use the key, like `codex-laptop`.
+
+4. Select the **Workspace** the key can query.
+
+5. Select an **Expiration**: 1, 7, 30, 60, or 90 days, measured from the moment you create the key. Airbyte emails you 14 days and 3 days before a key expires.
+
+6. Click **Create key**.
+
+7. Copy the key and store it somewhere safe. Airbyte shows the full key once. After you close the dialog, you can't retrieve it.
+
+The same dialog includes setup snippets for Codex, Claude Code, and pydantic-AI with your new key already in place. To see those snippets again later with a placeholder in place of the key, click **Setup instructions**.
+
+## Review keys
+
+The **API Keys** page lists your keys with their workspace, creator, creation date, expiration, last use, and status. Only the key's prefix and last four characters are shown. If you're an organization administrator, you see every key in the organization. Otherwise, you see the keys you created.
+
+A key's status is one of the following.
+
+| Status | Meaning |
+| --- | --- |
+| **Active** | The key works. |
+| **Expiring soon** | The key expires within 14 days. Create a replacement. |
+| **Expired** | The key passed its expiration and no longer authenticates. |
+| **Revoked** | Someone revoked the key. |
+
+## Revoke a key
+
+Revoke a key when it's no longer needed, or immediately if it might be exposed.
+
+1. Click **Settings**, then click **API Keys**.
+
+2. Find the key and click the revoke icon.
+
+3. Click **Revoke key**.
+
+Clients using that key lose access right away, and you can't undo this. If you're unsure whether a key is still in use, check its last-used date first.
+
+You can revoke keys you created. Organization administrators can revoke any key in the organization.
+
+## Keep keys safe
+
+- Treat a key like a password. Anyone with it can read data from the connectors in its workspace.
+- Store keys in environment variables or a secret manager. Don't commit them to source control or paste them into configuration files you share.
+- Create one key per client or machine so you can revoke a single key without disrupting anything else.
+- Pick the shortest expiration you can work with.

--- a/docs/ai-agents/admin/api-keys.md
+++ b/docs/ai-agents/admin/api-keys.md
@@ -8,7 +8,7 @@ API keys authenticate clients that use the [Airbyte model](../interfaces/model/r
 
 :::note Public alpha
 
-The Airbyte model is in public alpha. The **API Keys** page only appears if your organization has it enabled. To use it, ask your Airbyte contact to enable it.
+The Airbyte model is in public alpha. Its behavior, limits, and setup steps can change.
 
 :::
 

--- a/docs/ai-agents/admin/billing.md
+++ b/docs/ai-agents/admin/billing.md
@@ -69,7 +69,7 @@ Use the toggle to switch between a table view and a chart view.
 
 Filter the Usage panel to focus on a specific source or time range:
 
-- **Source**: Filter by where the activity originated. Sources include Chat, MCP, API, SDK, CLI, and, if your organization has it enabled, Airbyte Model.
+- **Source**: Filter by where the activity originated. Sources include Chat, MCP, API, SDK, CLI, and Airbyte Model.
 - **Billing period**: Choose the current billing period or one of the last five billing periods.
 - **Custom range**: Pick any start and end date to view usage across an arbitrary window.
 

--- a/docs/ai-agents/admin/billing.md
+++ b/docs/ai-agents/admin/billing.md
@@ -56,7 +56,7 @@ Set a maximum bill even if you don't expect to exceed your included AOs. This pr
 
 ## Monitor usage
 
-The Usage panel on the Billing page shows how your activity consumes AOs and tool calls over time. Chat usage includes AOs from tool calls and reasoning. MCP, API, SDK, and CLI usage includes AOs from tool calls only.
+The Usage panel on the Billing page shows how your activity consumes AOs and tool calls over time. Chat and [Airbyte model](../interfaces/model/readme.md) usage includes AOs from tool calls and reasoning. MCP, API, SDK, and CLI usage includes AOs from tool calls only.
 
 ### View usage
 
@@ -69,7 +69,7 @@ Use the toggle to switch between a table view and a chart view.
 
 Filter the Usage panel to focus on a specific source or time range:
 
-- **Source**: Filter by where the activity originated. Sources include Chat, MCP, API, SDK, and CLI.
+- **Source**: Filter by where the activity originated. Sources include Chat, MCP, API, SDK, CLI, and, if your organization has it enabled, Airbyte Model.
 - **Billing period**: Choose the current billing period or one of the last five billing periods.
 - **Custom range**: Pick any start and end date to view usage across an arbitrary window.
 

--- a/docs/ai-agents/admin/profile.md
+++ b/docs/ai-agents/admin/profile.md
@@ -35,6 +35,8 @@ Airbyte displays three values:
 
 Airbyte creates these credentials automatically for each organization. The client ID and client secret are sensitive values.
 
+These credentials are scoped to your organization. The [Airbyte model](../interfaces/model/readme.md) doesn't use them. It uses workspace-scoped keys you create yourself. See [API keys](./api-keys.md).
+
 ### View and copy credentials
 
 To copy a single value, click the copy icon next to that value. To reveal a hidden value before copying, click the eye icon to toggle visibility on the client ID or client secret.

--- a/docs/ai-agents/admin/readme.md
+++ b/docs/ai-agents/admin/readme.md
@@ -5,4 +5,4 @@ sidebar_position: 7
 
 # Account and administration
 
-Manage your Airbyte Agents account. This section covers [billing](./billing.md), including plans, payments, usage monitoring, invoices, and subscription changes. On the Team and Custom plans, you can also manage [users](./users.md) and configure [single sign-on](./sso.md). If your network restricts inbound traffic, see [IP allow list](./ip-allowlist.md).
+Manage your Airbyte Agents account. This section covers [billing](./billing.md), including plans, payments, usage monitoring, invoices, and subscription changes. On the Team and Custom plans, you can also manage [users](./users.md) and configure [single sign-on](./sso.md). If your network restricts inbound traffic, see [IP allow list](./ip-allowlist.md). To create and revoke the keys clients use with the [Airbyte model](../interfaces/model/readme.md), see [API keys](./api-keys.md).

--- a/docs/ai-agents/admin/sessions.md
+++ b/docs/ai-agents/admin/sessions.md
@@ -16,7 +16,7 @@ A session is a single agent run, from the moment an agent starts working to the 
 - The input and output tokens the agent consumed.
 - The resulting AOs charged to your plan.
 
-Airbyte logs sessions for work initiated in the web app. Work initiated through the [MCP](../interfaces/mcp/readme.md), the [API](../reference/api/readme.md), the [SDK](../interfaces/sdk/readme.md), or the [CLI](../interfaces/cli/readme.md) is billed by tool call, not by your agent's reasoning, and isn't logged as a session. See [Session types](#session-types) for details.
+Airbyte logs sessions for work initiated in the web app. Work initiated through the [MCP](../interfaces/mcp/readme.md), the [API](../reference/api/readme.md), the [SDK](../interfaces/sdk/readme.md), the [CLI](../interfaces/cli/readme.md), or the [Airbyte model](../interfaces/model/readme.md) isn't logged as a session. See [Session types](#session-types) for details.
 
 ## How to understand the Sessions table
 
@@ -56,8 +56,11 @@ Airbyte also processes tool calls from these sources, but doesn't log them as se
 - **[API](../reference/api/readme.md)**: Direct calls to the Agent API.
 - **[SDK](../interfaces/sdk/readme.md)**: Calls made from an agent built with the Agent SDK.
 - **[CLI](../interfaces/cli/readme.md)**: Connector actions run through the `airbyte-agent` command line.
+- **[Airbyte model](../interfaces/model/readme.md)**: Questions sent to the natural language interface from your own client.
 
-These tool calls still consume AOs and appear in your [Usage panel](./billing.md#monitor-usage), but Airbyte doesn't charge for the reasoning your own agent performs and doesn't create a corresponding Sessions row. To review them, open the Usage panel on the Billing page and filter by the **MCP**, **API**, **SDK**, or **CLI** source.
+This work still consumes AOs and appears in your [Usage panel](./billing.md#monitor-usage), but Airbyte doesn't create a corresponding Sessions row. To review it, open the Usage panel on the Billing page and filter by the **MCP**, **API**, **SDK**, **CLI**, or **Airbyte Model** source.
+
+For the MCP, the API, the SDK, and the CLI, Airbyte bills tool calls only, not the reasoning your own agent performs. The Airbyte model is different: Airbyte runs the model, so it bills both. See [Agent operations](../concepts/agent-operations.md).
 
 ## Review previous session data
 

--- a/docs/ai-agents/admin/tool-calls.md
+++ b/docs/ai-agents/admin/tool-calls.md
@@ -19,7 +19,9 @@ Airbyte classifies tool calls as one of the following types:
 
 Tool calls are the billable unit that most directly reflects the work your agents do. For Airbyte-managed agents, Airbyte combines tool calls with token usage to calculate [agent operations (AOs)](../concepts/agent-operations.md). For agents you bring through the MCP, the API, the SDK, or the CLI, Airbyte bills tool calls only, not the reasoning your own model performs. For billing details, see [Billing and pricing](./billing.md).
 
-Tool calls can originate from any interface, including Chat, MCP, the API, the SDK, and the CLI. The Tool Calls page shows activity from all sources.
+Tool calls can originate from Chat, MCP, the API, the SDK, and the CLI. The Tool Calls page shows activity from those sources.
+
+The [Airbyte model](../interfaces/model/readme.md) is the exception. Its tool calls consume AOs and count toward your usage, but they aren't listed on this page. To see that activity, filter the Usage panel on the [Billing](./billing.md#filter-usage) page by the Airbyte Model source.
 
 ## How to interpret the table
 

--- a/docs/ai-agents/concepts/agent-operations.md
+++ b/docs/ai-agents/concepts/agent-operations.md
@@ -12,7 +12,7 @@ Airbyte derives AOs from one or both of these factors, depending on where the wo
 - **Tool calls.** Each action an agent takes against a connector counts as a tool call. Listing records, fetching a single record, searching the Context Store, and writing data back to a source are all tool calls.
 - **Reasoning.** When you use an Airbyte-managed agent, the input and output tokens the agent consumes while reasoning about your prompt also contribute to the AO count.
 
-Chat is an Airbyte-managed agent, so it can consume AOs for both tool calls and reasoning. If you bring your own agent through the MCP, the API, the SDK, or the CLI, Airbyte doesn't charge for your agent's reasoning. Those surfaces consume AOs for tool calls only. Connector calls made locally through the open source SDK don't consume AOs.
+Chat is an Airbyte-managed agent, so it can consume AOs for both tool calls and reasoning. The [Airbyte model](../interfaces/model/readme.md) is also Airbyte-managed, even though you run it from your own client, so it consumes AOs for both as well. If you bring your own agent through the MCP, the API, the SDK, or the CLI, Airbyte doesn't charge for your agent's reasoning. Those surfaces consume AOs for tool calls only. Connector calls made locally through the open source SDK don't consume AOs.
 
 Simple tasks typically make fewer tool calls and require less reasoning, so they consume fewer AOs on managed-agent surfaces. Complex tasks that span multiple connectors, require iterative searches, or produce long responses consume more.
 
@@ -29,8 +29,9 @@ Any interaction that uses Airbyte-hosted execution can consume AOs. The source d
 | **API**  | Direct calls to the Agent API.                                       | Tool calls only          | No                    | Yes                 |
 | **SDK**  | Calls from an agent built with the Agent SDK.                        | Tool calls only          | No                    | Yes                 |
 | **CLI**  | Connector actions run through the `airbyte-agent` command line.      | Tool calls only          | No                    | Yes                 |
+| **Airbyte model** | Questions sent to the natural language interface from your own client. | Tool calls and reasoning | No                    | No                  |
 
-Sources tracked as sessions appear on the [Sessions](../admin/sessions.md) page, where you can review the full conversation, reasoning token usage, and tool calls. Sources that aren't tracked as sessions can still consume AOs for tool calls and appear in the [Usage panel](../admin/billing.md#monitor-usage) on the Billing page. To inspect individual tool calls from the MCP, API, SDK, or CLI usage, use the [Tool calls](../admin/tool-calls.md) page.
+Sources tracked as sessions appear on the [Sessions](../admin/sessions.md) page, where you can review the full conversation, reasoning token usage, and tool calls. Sources that aren't tracked as sessions can still consume AOs and appear in the [Usage panel](../admin/billing.md#monitor-usage) on the Billing page. To inspect individual tool calls from the MCP, API, SDK, or CLI usage, use the [Tool calls](../admin/tool-calls.md) page. Airbyte model activity is the exception: it consumes AOs, but it isn't listed on either page.
 
 ## How AOs relate to billing
 

--- a/docs/ai-agents/get-started/choose-how-to-use.md
+++ b/docs/ai-agents/get-started/choose-how-to-use.md
@@ -111,7 +111,7 @@ Choose the API when you need HTTP-level control, are working outside Python, or 
 
 The [Airbyte model](../interfaces/model) is a natural language interface. Your client sends a question to Airbyte the same way it would send one to any other model, and Airbyte queries your connectors and answers in plain language. Change a base URL, a model name, and an API key, and you're done.
 
-Choose the Airbyte model when you want Airbyte to be the agent inside a client you already use, and you don't need that client's own tools, prompts, or structured output. This interface is in public alpha, and your organization must have it enabled.
+Choose the Airbyte model when you want Airbyte to be the agent inside a client you already use, and you don't need that client's own tools, prompts, or structured output. This interface is in public alpha.
 
 **Get started:** see the [Airbyte model docs](../interfaces/model) for setup instructions for Codex, Claude Code, pydantic-AI, and raw HTTP clients.
 

--- a/docs/ai-agents/get-started/choose-how-to-use.md
+++ b/docs/ai-agents/get-started/choose-how-to-use.md
@@ -18,25 +18,28 @@ flowchart TD
     START -->|"I want a shell-first or agent-harness tool"| CLI["CLI"]
     START -->|"No code needed"| WEB["Web app"]
     START -->|"Non-Python backend or custom admin"| API["Agent API"]
+    START -->|"I want my client to treat Airbyte as a model"| MODEL["Airbyte model"]
 
     click MCP "#mcp-server"
     click SDK "#python-sdk"
     click CLI "#cli"
     click WEB "#web-app"
     click API "#agent-api"
+    click MODEL "#airbyte-model"
 ```
 
 ## At a glance
 
-| | Web app | MCP server | SDK | CLI | API |
-| --- | --- | --- | --- | --- | --- |
-| **Install required** | No | No | `uv add airbyte-agent-sdk` | Binary download or `brew` | No |
-| **Language / platform** | Browser | Any MCP-capable client | Python | Any shell | Any HTTP client |
-| **Auth model** | Browser login | OAuth (browser popup) | Client ID + secret | Browser login or `--manual` | Client ID + secret |
-| **Best for** | No-code exploration, automations | Conversational AI agents (Claude, ChatGPT, Cursor) | Python-native agent frameworks | Shell scripts, CI, agent harnesses | Non-Python backends, custom admin |
-| **Programmatic control** | No | Agent-driven | Full | Full | Full |
-| **Context Store access** | Yes | Yes | Yes | Yes | Yes |
-| **Credential handling** | Browser widget | Browser widget (via agent) | Environment variables | Browser widget + settings file | HTTP headers |
+| | Web app | MCP server | SDK | CLI | API | Airbyte model |
+| --- | --- | --- | --- | --- | --- | --- |
+| **Install required** | No | No | `uv add airbyte-agent-sdk` | Binary download or `brew` | No | No |
+| **Language / platform** | Browser | Any MCP-capable client | Python | Any shell | Any HTTP client | Any OpenAI Responses or Anthropic Messages client |
+| **Auth model** | Browser login | OAuth (browser popup) | Client ID + secret | Browser login or `--manual` | Client ID + secret | API key |
+| **Best for** | No-code exploration, automations | Conversational AI agents (Claude, ChatGPT, Cursor) | Python-native agent frameworks | Shell scripts, CI, agent harnesses | Non-Python backends, custom admin | Clients that can point at a custom model, like Codex and Claude Code |
+| **Who reasons** | Airbyte | Your agent | Your agent | Your agent | Your agent | Airbyte |
+| **Programmatic control** | No | Agent-driven | Full | Full | Full | No |
+| **Context Store access** | Yes | Yes | Yes | Yes | Yes | Yes |
+| **Credential handling** | Browser widget | Browser widget (via agent) | Environment variables | Browser widget + settings file | HTTP headers | Environment variables |
 
 ## MCP server
 
@@ -102,6 +105,16 @@ Choose the API when you need HTTP-level control, are working outside Python, or 
 
 **Get started:** see the [API docs](../interfaces/api) for authentication, connector management, and execution endpoints. The [Developer Quickstart](developer-quickstart) also covers common patterns.
 
+## Airbyte model
+
+**Best for:** Clients that can point at a custom model endpoint, like Codex, Claude Code, and pydantic-AI.
+
+The [Airbyte model](../interfaces/model) is a natural language interface. Your client sends a question to Airbyte the same way it would send one to any other model, and Airbyte queries your connectors and answers in plain language. Change a base URL, a model name, and an API key, and you're done.
+
+Choose the Airbyte model when you want Airbyte to be the agent inside a client you already use, and you don't need that client's own tools, prompts, or structured output. This interface is in public alpha, and your organization must have it enabled.
+
+**Get started:** see the [Airbyte model docs](../interfaces/model) for setup instructions for Codex, Claude Code, pydantic-AI, and raw HTTP clients.
+
 ## MCP server vs. CLI for AI agents
 
 Both the MCP server and the CLI connect AI agents to your data, but they differ in how the agent communicates with Airbyte:
@@ -118,6 +131,22 @@ The CLI gives coding agents and harnesses several practical advantages:
 - Long-running work can finish in a shell command, while MCP tool calls are subject to client request timeouts.
 
 Use MCP for an off-the-shelf conversational client when zero installation matters. Use the CLI for coding agents and harnesses that can run shell commands, especially when output is large, work is multi-step, or tasks are long-running.
+
+## When to use the Airbyte model instead
+
+The MCP server and the CLI both give your agent tools and let it decide how to use them. The Airbyte model replaces your agent's model instead, so Airbyte does the reasoning and returns a written answer.
+
+Use the Airbyte model when:
+
+- Your client can't use MCP or run shell commands, but can point at a custom model.
+- You want answers, not records, and you don't need your own prompts or tools in the loop.
+- You want the shortest possible setup: no server URL, no binary, no OAuth flow.
+
+Use the MCP server or the CLI when:
+
+- Your agent needs to combine Airbyte data with its own tools, files, or reasoning.
+- You need structured output to parse, pipe, or store.
+- You care about reasoning cost. Airbyte bills tool calls only for the MCP server, the API, the SDK, and the CLI, but bills reasoning too for the Airbyte model. See [Agent operations](../concepts/agent-operations.md).
 
 ## All paths lead to the same data
 

--- a/docs/ai-agents/interfaces/cli/readme.md
+++ b/docs/ai-agents/interfaces/cli/readme.md
@@ -26,7 +26,7 @@ Most resource operations accept JSON input with `--json` and print JSON output. 
 - You need to compose output with shell tools, avoid result truncation, or run many sequential calls and long-running operations without MCP client limits.
 - You want fuller, prescriptive agent guidance from an installable skill. See [Use the CLI with AI agents](./using-with-ai-agents.md).
 
-If your agent already speaks the Model Context Protocol, the [MCP server](../mcp/readme.md) offers the same connectors with zero install. If you're writing Python, the [SDK](../sdk/readme.md) gives you typed, in-process access. For raw HTTP control or non-Python backends, see the [API](../api/readme.md).
+If your agent already speaks the Model Context Protocol, the [MCP server](../mcp/readme.md) offers the same connectors with zero install. If you're writing Python, the [SDK](../sdk/readme.md) gives you typed, in-process access. For raw HTTP control or non-Python backends, see the [API](../api/readme.md). If you want written answers instead of JSON, and you want Airbyte to decide which connectors to query, see the [Airbyte model](../model/readme.md).
 
 Source code and releases live in the [`airbytehq/airbyte-agent-cli`](https://github.com/airbytehq/airbyte-agent-cli) repository.
 

--- a/docs/ai-agents/interfaces/mcp/readme.md
+++ b/docs/ai-agents/interfaces/mcp/readme.md
@@ -20,7 +20,7 @@ Airbyte hosts and manages this remote MCP server, so there's nothing to install.
 - You prefer conversational, prompt-driven access to your connected data.
 - You don't need to run commands offline or in a CI pipeline.
 
-If you need to process large result sets, make many sequential calls in one turn, run long-running operations, or compose output with shell tools, use the [CLI](../cli/readme.md) instead. The CLI also provides fuller, prescriptive guidance through an installable agent skill; see [Use the CLI with AI agents](../cli/using-with-ai-agents.md). If you're building a Python agent with a framework like Pydantic AI or LangChain, see the [SDK](../sdk/readme.md). For non-Python backends or custom admin flows, see the [API](../api/readme.md).
+If you need to process large result sets, make many sequential calls in one turn, run long-running operations, or compose output with shell tools, use the [CLI](../cli/readme.md) instead. The CLI also provides fuller, prescriptive guidance through an installable agent skill; see [Use the CLI with AI agents](../cli/using-with-ai-agents.md). If you're building a Python agent with a framework like Pydantic AI or LangChain, see the [SDK](../sdk/readme.md). For non-Python backends or custom admin flows, see the [API](../api/readme.md). If your client can't use MCP but can point at a custom model, or you want Airbyte to do the reasoning and answer in plain language, see the [Airbyte model](../model/readme.md).
 
 ## Requirements
 

--- a/docs/ai-agents/interfaces/model/_category_.json
+++ b/docs/ai-agents/interfaces/model/_category_.json
@@ -1,0 +1,4 @@
+{
+  "label": "Airbyte model",
+  "description": "Point Codex, Claude Code, or any OpenAI or Anthropic client at Airbyte and ask questions in natural language."
+}

--- a/docs/ai-agents/interfaces/model/readme.md
+++ b/docs/ai-agents/interfaces/model/readme.md
@@ -1,0 +1,258 @@
+---
+plan: all
+sidebar_position: 5
+sidebar_label: Airbyte model
+---
+
+# Airbyte model
+
+The Airbyte model is a natural language interface to your data. Point any client that speaks the OpenAI Responses API or the Anthropic Messages API at Airbyte, select `airbyte:v1` as the model, and ask questions in plain language. Airbyte picks the connectors, runs the read-only queries, and answers with your data.
+
+To your coding agent or client, Airbyte looks like a normal model. There's nothing to install and no protocol to implement: you change a base URL, a model name, and an API key.
+
+:::note Public alpha
+
+The Airbyte model is in public alpha. It's available on request, and its behavior, limits, and setup steps can change. To use it, ask your Airbyte contact to enable it for your organization. Until they do, the **API Keys** page doesn't appear in the web app and requests return `404`.
+
+:::
+
+## When to use the Airbyte model
+
+Use the Airbyte model when:
+
+- You want an existing coding agent, like Codex or Claude Code, to answer questions about your business data without installing or configuring anything else.
+- Your client can point at a custom model endpoint, but doesn't speak Model Context Protocol.
+- You want Airbyte to do the reasoning. The model decides which connectors to query and how, and returns a written answer instead of raw records.
+- You're prototyping and don't want to write agent code.
+
+Use a different interface when:
+
+- **You need your own agent's reasoning, tools, or prompts.** The Airbyte model is a sealed agent. It never calls your client's tools and doesn't accept your system prompt. Use the [MCP server](../mcp/readme.md) if your client speaks MCP, or the [SDK](../sdk/readme.md) or [API](../api/readme.md) if you're writing the agent yourself.
+- **You need raw, structured records.** The Airbyte model answers in prose. The [CLI](../cli/readme.md), [SDK](../sdk/readme.md), and [API](../api/readme.md) return data you can pipe, parse, or store.
+- **You're scripting or running in CI.** The [CLI](../cli/readme.md) composes with shell tools and exits with a status code.
+- **You want the cheapest reasoning.** With every other bring-your-own-agent interface, you pay your own model provider for reasoning and Airbyte only bills tool calls. With the Airbyte model, Airbyte does the reasoning and bills for it. See [Pricing](#pricing).
+
+For a side-by-side comparison of all interfaces, see [Choose how to use Airbyte Agents](../../get-started/choose-how-to-use.md).
+
+## Requirements
+
+Before you begin, make sure you have the following:
+
+- **An Airbyte Agents account with the Airbyte model enabled.** Sign up at [app.airbyte.ai](https://app.airbyte.ai) if you don't have one.
+
+- **An API key.** See [API keys](../../admin/api-keys.md).
+
+- **Connectors in the key's workspace.** The model can only query sources that are authenticated in the workspace the key belongs to. See [Add a connector](../ui/add-connector.md).
+
+- **A supported client.** Codex, Claude Code, pydantic-AI, or anything else that can call the OpenAI Responses API or the Anthropic Messages API against a custom base URL.
+
+## Endpoints
+
+| Client type | Base URL | Model |
+| --- | --- | --- |
+| OpenAI Responses, like Codex, pydantic-AI, and the OpenAI SDK | `https://api.airbyte.ai/v1` | `airbyte:v1` |
+| Anthropic Messages, like Claude Code | `https://api.airbyte.ai` | `airbyte:v1` |
+
+Anthropic clients append `/v1/messages` themselves, so their base URL omits `/v1`. Authenticate with your API key as a bearer token, or as `x-api-key` on Anthropic clients.
+
+## Set up your client
+
+Create an API key in the web app first. After you create it, Airbyte shows these same snippets with your key already filled in. You can reopen them at any time from **Setup instructions** on the **API Keys** page.
+
+<details>
+<summary>Codex on macOS or Linux</summary>
+
+1. Save the following profile as `~/.codex-airbyte/airbyte.config.toml`. Use a dedicated Codex home so Airbyte's model catalog doesn't affect your normal Codex sessions.
+
+   ```toml title="~/.codex-airbyte/airbyte.config.toml"
+   model = "airbyte:v1"
+   model_provider = "airbyte"
+
+   [model_providers.airbyte]
+   name = "Airbyte Model"
+   base_url = "https://api.airbyte.ai/v1"
+   wire_api = "responses"
+   # Optional: uncomment and export AIRBYTE_SOURCE_ID to pin one connector per session.
+   # env_http_headers = { "X-Airbyte-Source-Id" = "AIRBYTE_SOURCE_ID" }
+
+   [model_providers.airbyte.auth]
+   command = "/usr/bin/printenv"
+   args = ["AIRBYTE_MODEL_API_KEY"]
+   refresh_interval_ms = 0
+   ```
+
+   Keep these keys at the top level of the file. Don't nest them under a `[profiles.airbyte]` table, and remove any `[profiles.airbyte]` entry from `config.toml`. Codex refuses `--profile airbyte` if both exist.
+
+2. Export your key and start Codex.
+
+   ```bash
+   export CODEX_HOME="$HOME/.codex-airbyte"
+   mkdir -p "$CODEX_HOME"
+   export AIRBYTE_MODEL_API_KEY="abm_..."
+   codex --profile airbyte -m "airbyte:v1" "List my Linear teams with their keys."
+   ```
+
+Codex needs the `[model_providers.airbyte.auth]` command block to discover Airbyte's model catalog. If you replace it with `env_key`, Codex can't list the model.
+
+</details>
+
+<details>
+<summary>Codex on Windows</summary>
+
+1. Save the following profile as `%USERPROFILE%\.codex-airbyte\airbyte.config.toml`.
+
+   ```toml title="%USERPROFILE%\.codex-airbyte\airbyte.config.toml"
+   model = "airbyte:v1"
+   model_provider = "airbyte"
+
+   [model_providers.airbyte]
+   name = "Airbyte Model"
+   base_url = "https://api.airbyte.ai/v1"
+   wire_api = "responses"
+   # Optional: uncomment and export AIRBYTE_SOURCE_ID to pin one connector per session.
+   # env_http_headers = { "X-Airbyte-Source-Id" = "AIRBYTE_SOURCE_ID" }
+
+   [model_providers.airbyte.auth]
+   command = "powershell.exe"
+   args = ["-NoProfile", "-NonInteractive", "-Command", "$env:AIRBYTE_MODEL_API_KEY"]
+   refresh_interval_ms = 0
+   ```
+
+2. Export your key and start Codex in PowerShell.
+
+   ```powershell
+   $env:CODEX_HOME = "$env:USERPROFILE\.codex-airbyte"
+   New-Item -ItemType Directory -Force -Path $env:CODEX_HOME | Out-Null
+   $env:AIRBYTE_MODEL_API_KEY = "abm_..."
+   codex --profile airbyte -m "airbyte:v1" "List my Linear teams with their keys."
+   ```
+
+</details>
+
+<details>
+<summary>Claude Code on macOS or Linux</summary>
+
+Set the base URL, your key, and all four model variables, then start Claude Code.
+
+```bash
+export ANTHROPIC_BASE_URL="https://api.airbyte.ai"
+export ANTHROPIC_API_KEY="abm_..."
+export ANTHROPIC_MODEL="airbyte:v1"
+export ANTHROPIC_DEFAULT_HAIKU_MODEL="airbyte:v1"
+export ANTHROPIC_SMALL_FAST_MODEL="airbyte:v1"
+export CLAUDE_CODE_SUBAGENT_MODEL="airbyte:v1"
+claude
+```
+
+Set all four model variables. Claude Code picks a model per request type, and requests that ask for any other model fail with `400`.
+
+</details>
+
+<details>
+<summary>Claude Code on Windows</summary>
+
+Set the base URL, your key, and all four model variables in PowerShell, then start Claude Code.
+
+```powershell
+$env:ANTHROPIC_BASE_URL = "https://api.airbyte.ai"
+$env:ANTHROPIC_API_KEY = "abm_..."
+$env:ANTHROPIC_MODEL = "airbyte:v1"
+$env:ANTHROPIC_DEFAULT_HAIKU_MODEL = "airbyte:v1"
+$env:ANTHROPIC_SMALL_FAST_MODEL = "airbyte:v1"
+$env:CLAUDE_CODE_SUBAGENT_MODEL = "airbyte:v1"
+claude
+```
+
+Set all four model variables. Claude Code picks a model per request type, and requests that ask for any other model fail with `400`.
+
+</details>
+
+<details>
+<summary>pydantic-AI</summary>
+
+Read the key from the environment so it never lands in a file you might commit.
+
+```python
+import os
+
+from pydantic_ai import Agent
+from pydantic_ai.models.openai import OpenAIResponsesModel
+from pydantic_ai.providers.openai import OpenAIProvider
+
+model = OpenAIResponsesModel(
+    "airbyte:v1",
+    provider=OpenAIProvider(base_url="https://api.airbyte.ai/v1", api_key=os.environ["AIRBYTE_MODEL_API_KEY"]),
+)
+agent = Agent(model)
+
+result = agent.run_sync("List my Linear teams with their keys.")
+print(result.output)
+```
+
+</details>
+
+<details>
+<summary>Any other client</summary>
+
+Call the endpoints directly. Both support streaming with `"stream": true`.
+
+```bash title="OpenAI Responses"
+curl -X POST "https://api.airbyte.ai/v1/responses" \
+  -H "authorization: Bearer $AIRBYTE_MODEL_API_KEY" \
+  -H "content-type: application/json" \
+  -d '{"model":"airbyte:v1","input":"List my Linear teams."}'
+```
+
+```bash title="Anthropic Messages"
+curl -X POST "https://api.airbyte.ai/v1/messages" \
+  -H "x-api-key: $AIRBYTE_MODEL_API_KEY" \
+  -H "anthropic-version: 2023-06-01" \
+  -H "content-type: application/json" \
+  -d '{"model":"airbyte:v1","max_tokens":4096,"messages":[{"role":"user","content":"List my Linear teams."}]}'
+```
+
+</details>
+
+## Choose which connector answers
+
+Each request runs against one source in the key's workspace. There are two ways to choose it.
+
+- **Name the connector in your question.** For example, "Query my Salesforce source for opportunities that closed last month." Airbyte lists the sources in the workspace and picks the one you named. If the workspace has more than five sources and your question doesn't identify one, Airbyte asks you to pin a source instead.
+
+- **Pin a source for the whole session.** Send the `X-Airbyte-Source-Id` header with a source name or ID. Every request then runs against that source. In Codex, uncomment `env_http_headers` in the profile and export `AIRBYTE_SOURCE_ID`.
+
+## What the Airbyte model doesn't do
+
+The Airbyte model is a sealed agent, not a general-purpose one. Compared to a normal model endpoint:
+
+- **It answers only from your connected data.** Queries are read-only. It can't write to your sources, run your client's tools, or edit files.
+- **It ignores your system prompt and generation settings.** Fields like `instructions`, `system`, `tools`, `temperature`, and `max_tokens` are accepted and ignored so clients don't break, but they don't change the answer.
+- **It doesn't remember conversations.** Every turn is independent. Clients that resend the conversation get an answer based on that replayed history, but `previous_response_id` and `store` don't retrieve anything server-side.
+- **It accepts text only.** Images, documents, and tool results in the newest message are rejected.
+- **It stops long runs.** Each run has a fixed processing budget. When a run reaches it, Airbyte returns a notice asking you to narrow the request by project, status, date, or result count.
+
+## Pricing
+
+The Airbyte model consumes [agent operations (AOs)](../../concepts/agent-operations.md) for both tool calls and reasoning, because Airbyte, not you, runs the model. This is different from the MCP server, the API, the SDK, and the CLI, where you bring your own model and Airbyte bills tool calls only. Usage appears in the Usage panel on the [Billing](../../admin/billing.md) page.
+
+Because clients resend conversation history on every turn, long conversations cost more than short, specific ones.
+
+## Activity isn't shown in the web app
+
+Airbyte model activity doesn't appear on the [Sessions](../../admin/sessions.md) or [Tool Calls](../../admin/tool-calls.md) pages. Your client shows what the model is doing while it works, and usage is reflected in billing, but there's no record to review in the web app afterward.
+
+## Troubleshoot
+
+| What you see | What it means |
+| --- | --- |
+| `404`, or no **API Keys** page in the web app | The Airbyte model isn't enabled for your organization. Contact your Airbyte representative. |
+| `401` | Your key is wrong, revoked, or expired. Create a new one. |
+| A request to pin a source | The workspace has more than five sources and the question didn't name one. Name the connector or send `X-Airbyte-Source-Id`. |
+| `503`, or an answer saying data isn't ready | The source hasn't finished its initial sync. Counts and aggregates need the [Context Store](../../concepts/context-store.md) to be populated. Wait and try again. |
+| `400` on some Claude Code requests | One of the four model variables isn't set, so Claude Code asked for a different model. |
+| `429` | You hit a rate limit. Retry with backoff. |
+
+<!-- The adapter also accepts a workspace-scoped Airbyte token minted with org Application
+credentials (POST /api/v1/account/applications/scoped-token). It's undocumented on purpose:
+the ~20-minute TTL expires mid-session and forces a re-mint and client restart. Revisit if
+embedded customers need per-end-user credentials. -->

--- a/docs/ai-agents/interfaces/model/readme.md
+++ b/docs/ai-agents/interfaces/model/readme.md
@@ -12,7 +12,7 @@ To your coding agent or client, Airbyte looks like a normal model. There's nothi
 
 :::note Public alpha
 
-The Airbyte model is in public alpha. It's available on request, and its behavior, limits, and setup steps can change. To use it, ask your Airbyte contact to enable it for your organization. Until they do, the **API Keys** page doesn't appear in the web app and requests return `404`.
+The Airbyte model is in public alpha. Its behavior, limits, and setup steps can change.
 
 :::
 
@@ -38,7 +38,7 @@ For a side-by-side comparison of all interfaces, see [Choose how to use Airbyte 
 
 Before you begin, make sure you have the following:
 
-- **An Airbyte Agents account with the Airbyte model enabled.** Sign up at [app.airbyte.ai](https://app.airbyte.ai) if you don't have one.
+- **An Airbyte Agents account.** Sign up at [app.airbyte.ai](https://app.airbyte.ai) if you don't have one.
 
 - **An API key.** See [API keys](../../admin/api-keys.md).
 
@@ -245,7 +245,6 @@ Airbyte model activity doesn't appear on the [Sessions](../../admin/sessions.md)
 
 | What you see | What it means |
 | --- | --- |
-| `404`, or no **API Keys** page in the web app | The Airbyte model isn't enabled for your organization. Contact your Airbyte representative. |
 | `401` | Your key is wrong, revoked, or expired. Create a new one. |
 | A request to pin a source | The workspace has more than five sources and the question didn't name one. Name the connector or send `X-Airbyte-Source-Id`. |
 | `503`, or an answer saying data isn't ready | The source hasn't finished its initial sync. Counts and aggregates need the [Context Store](../../concepts/context-store.md) to be populated. Wait and try again. |

--- a/docs/ai-agents/interfaces/readme.md
+++ b/docs/ai-agents/interfaces/readme.md
@@ -12,6 +12,7 @@ Airbyte Agents supports several interfaces for working with your data and your a
 - [**SDK**](/ai-agents/interfaces/sdk): Python SDK for building, authenticating, and executing agent connectors directly in your Python applications. Best for Python-based agents you build and host yourself.
 - [**CLI**](/ai-agents/interfaces/cli): A shell-first interface for installing `airbyte-agent`, authenticating, adding connectors, and executing connector actions from scripts or agent harnesses. Best for shell scripts, CI jobs, and agent harnesses.
 - [**API**](/ai-agents/interfaces/api): HTTP API for managing connectors, tokens, and executing operations from any language or backend service. Best for non-Python backends, custom admin flows, and embedding the authentication module in your app.
+- [**Airbyte model**](/ai-agents/interfaces/model): A natural language interface that any OpenAI Responses or Anthropic Messages client can use as a model, including Codex and Claude Code. Best when you want an existing client to answer questions from your data without new tooling. This interface is in public alpha.
 
 import DocCardList from '@theme/DocCardList';
 


### PR DESCRIPTION
## What

Documents the Airbyte model, the natural language interface in public alpha, and corrects the existing billing and telemetry docs that currently describe the wrong behavior for it. Requested by Ian Alton (@ian-at-airbyte) in [DOCS-71](https://linear.app/airbyteio/issue/DOCS-71/natural-language-interface-documentation).

## How

New pages:

- `docs/ai-agents/interfaces/model/readme.md` — what the interface is, when to use it instead of MCP/CLI/SDK/API, endpoints and model id, collapsible setup steps for each harness the app's setup dialog supports (Codex macOS/Linux and Windows, Claude Code macOS/Linux and Windows, pydantic-AI, plus raw curl), EXPLORE vs. pinned source selection, sealed-agent limits, pricing, and troubleshooting.
- `docs/ai-agents/admin/api-keys.md` — workspace scoping, creation, expiration, one-time reveal, statuses, revocation, and admin vs. member visibility.

Corrections to existing pages, all verified against `airbytehq/sonar`:

- `concepts/agent-operations.md`, `admin/billing.md` — the Airbyte model bills tool calls *and* reasoning. Every other bring-your-own-agent surface bills tool calls only, which is what these pages said applied to all of them.
- `admin/sessions.md`, `admin/tool-calls.md` — Airbyte model runs are persisted as hidden sessions and its event source is in `CUSTOMER_HIDDEN_EVENT_SOURCE_VALUES`, so nothing appears on either page. Usage still lands in the Billing Usage panel, which has an Airbyte Model source filter. Per Ian and engineering, this gap is documented as current behavior, with no forward-looking promise about AGENTIC-1979.
- `interfaces/readme.md`, `get-started/choose-how-to-use.md`, `interfaces/mcp/readme.md`, `interfaces/cli/readme.md`, `admin/profile.md`, `admin/readme.md` — add the interface to the lists, the flowchart, and the comparison table, and separate org-level client ID/secret from workspace-scoped `abm_` keys.

Decisions made with Ian: customer-facing name "Airbyte model", `plan: all`, host values taken from the snippets the create-key modal generates (`https://api.airbyte.ai/v1` for OpenAI-shaped clients, `https://api.airbyte.ai` for Claude Code, `app.airbyte.ai` for creating the key), and no documentation of the short-lived scoped-token credential path — that endpoint is noted in an HTML comment so we don't lose it.

## Review guide

1. `docs/ai-agents/interfaces/model/readme.md` — the setup snippets mirror `frontend/src/routes/organizations/$organizationId/api-keys.tsx`; worth checking they match what a customer actually sees.
2. `docs/ai-agents/admin/api-keys.md`
3. The billing and visibility claims in `concepts/agent-operations.md`, `admin/billing.md`, `admin/sessions.md`, and `admin/tool-calls.md`.

## User Impact

The alpha has documentation for the first time. Anyone reading the billing or Sessions/Tool Calls pages now gets accurate information about where Airbyte model activity shows up and where it doesn't.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚
- [ ] NO ❌

## Test plan

- `corepack pnpm build` in `docusaurus/` — succeeds; no broken links or anchors from the new or edited pages (the 44 reported broken anchors are all preexisting, in generated connector and SDK reference pages).
- `markdownlint-cli2` on both new pages — 0 errors.


Link to Devin session: https://app.devin.ai/sessions/1ac0c96bdece42f2b580534d3472c605