### PR TITLE
docs: remove remaining chart V1 instructions

### DIFF
--- a/docs/platform/deploying-airbyte/chart-v2-community.mdx
+++ b/docs/platform/deploying-airbyte/chart-v2-community.mdx
@@ -146,7 +146,7 @@ helm search repo airbyte-v2
 
 ### Update your values.yaml file
 
-In most cases, the adjustments to `values.yaml` are small and involve changing keys and moving sections. This section walks you through the main updates you need to make. If you already know what to do, see [Values.yaml reference](../deploying-airbyte/values) for the full V1 and V2 interfaces.
+In most cases, the adjustments to `values.yaml` are small and involve changing keys and moving sections. This section walks you through the main updates you need to make. If you already know what to do, see [Values.yaml reference](../deploying-airbyte/values) for the current chart interface.
 
 Airbyte recommends approaching this project in this way:
 
@@ -215,44 +215,10 @@ postgresql:
 
 <details>
 <summary>
-Add external log storage (if applicable)
+Add external state and logging storage (if applicable)
 </summary>
 
-If you're using external log storage, implement it. If you aren't, skip this step.
-
-```yaml
-global:
-  storage:
-    secretName: ""
-    type: minio # default storage is minio. Set to s3, gcs, or azure, according to what you use.
-
-    bucket:
-      log: airbyte-bucket
-      state: airbyte-bucket
-      workloadOutput: airbyte-bucket
-      activityPayload: airbyte-bucket
-
-    # Set ONE OF the following storage types, according to your specification above
-
-    # S3
-    s3:
-      region: "" ## e.g. us-east-1
-      authenticationType: credentials ## Use "credentials" or "instanceProfile"
-      accessKeyId: ""
-      secretAccessKey: ""
-
-    # GCS
-    gcs:
-      projectId: <project-id>
-      credentialsJson:  <base64-encoded>
-      credentialsJsonPath: /secrets/gcs-log-creds/gcp.json
-
-    # Azure
-    azure:
-      # one of the following: connectionString, connectionStringSecretKey
-      connectionString: <azure storage connection string>
-      connectionStringSecretKey: <secret coordinate containing an existing connection-string secret>
-```
+If you use external storage, follow [State and Logging Storage](./integrations/storage.md). Helm values are case-sensitive, so use the lowercase storage type (`s3`, `gcs`, or `azure`) and the exact camel case keys documented there. If you don't use external storage, skip this step.
 
 </details>
 

--- a/docs/platform/deploying-airbyte/deploying-airbyte.md
+++ b/docs/platform/deploying-airbyte/deploying-airbyte.md
@@ -15,7 +15,7 @@ You can use a Cloud Provider, such as, AWS, GCP, Azure, or onto a single node, s
 
 We highly recommend deploying Airbyte using Helm and the documented Helm chart values.
 
-Helm is a Kubernetes package manager for automating deployment and management of complex applications with microservices on Kubernetes.  Refer to our [Helm Chart Usage Guide](https://airbytehq.github.io/helm-charts/) for more information about how to get started.
+Helm is a Kubernetes package manager for automating deployment and management of complex applications with microservices on Kubernetes. Helm chart V1 is no longer supported. Use the current chart repository at `https://airbytehq.github.io/charts`, as shown in the installation steps below.
 
 The [Infrastructure](./infrastructure/aws.md) section describes the Airbyte's recommended cloud infrastructure to set up for each supported platform. Keep in mind that these guides are meant to assist you, but you are not required to follow them. Airbyte is designed to be as flexible as possible in order to fit into your existing infrastructure.
 

--- a/docs/platform/deploying-airbyte/deploying-airbyte.md
+++ b/docs/platform/deploying-airbyte/deploying-airbyte.md
@@ -15,7 +15,7 @@ You can use a Cloud Provider, such as, AWS, GCP, Azure, or onto a single node, s
 
 We highly recommend deploying Airbyte using Helm and the documented Helm chart values.
 
-Helm is a Kubernetes package manager for automating deployment and management of complex applications with microservices on Kubernetes. Helm chart V1 is no longer supported. Use the current chart repository at `https://airbytehq.github.io/charts`, as shown in the installation steps below.
+Helm is a Kubernetes package manager for automating deployment and management of complex applications with microservices on Kubernetes. Use the chart repository at `https://airbytehq.github.io/charts`, as shown in the installation steps below.
 
 The [Infrastructure](./infrastructure/aws.md) section describes the Airbyte's recommended cloud infrastructure to set up for each supported platform. Keep in mind that these guides are meant to assist you, but you are not required to follow them. Airbyte is designed to be as flexible as possible in order to fit into your existing infrastructure.
 


### PR DESCRIPTION
## What

Completes the remaining documentation cleanup in [PLAT-1008](https://linear.app/airbyteio/issue/PLAT-1008/remove-remaining-chart-v1-instructions-from-airbyte-docs).

Most of the changes from the PR referenced by the Linear issue, #75959, are already present on `master`. This PR contains only the remaining cleanup rather than duplicating or rebasing that older work.

## How

- Replaces the last current platform-doc link to the Helm chart V1 repository with the V2 repository and states that V1 is unsupported.
- Removes stale wording that presents the values reference as a combined V1/V2 interface.
- Replaces a duplicated, outdated external-storage example with the canonical storage guide and calls out case-sensitive Helm values.
- Leaves ArtifactHub unchanged because current platform docs do not link to the V1 package and there is no V2 listing to target yet.

## Review guide

See the recommended reading order below.

## Recommended reading order

1. `docs/platform/deploying-airbyte/deploying-airbyte.md`
2. `docs/platform/deploying-airbyte/chart-v2-community.mdx`

## User Impact

Readers are directed to the supported Helm chart repository and canonical storage configuration instead of remaining V1 or stale configuration guidance.

## Validation

- MarkdownLint: 0 errors
- Confirmed there are no remaining `airbytehq.github.io/helm-charts` references under `docs/platform`
- Confirmed there are no V1 ArtifactHub package links under `docs/platform`
- `git diff --check`
- Vale was run; it reports existing findings on untouched lines in `deploying-airbyte.md`, with no findings on the changed lines

## Can this PR be safely reverted and rolled back?

- [x] YES 💚
- [ ] NO ❌
