### PR TITLE
ci: drop dead OAUTH CODEOWNERS rule

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -61,11 +61,6 @@
 /docs/integrations/destinations/ @airbytehq/destinations
 
 # -----------------------------------------------------------------------------
-# OAUTH
-# -----------------------------------------------------------------------------
-/oss/airbyte-oauth/src/main/kotlin/io/airbyte/oauth/ @airbytehq/dev-apis
-
-# -----------------------------------------------------------------------------
 # NO OWNERSHIP - Markdown files
 # -----------------------------------------------------------------------------
 # Documentation changes don't require team review. These rules override the

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -63,7 +63,7 @@
 # -----------------------------------------------------------------------------
 # OAUTH
 # -----------------------------------------------------------------------------
-/oss/airbyte-oauth/src/main/kotlin/io/airbyte/oauth/ @airbytehq/dev-api-sources
+/oss/airbyte-oauth/src/main/kotlin/io/airbyte/oauth/ @airbytehq/dev-apis
 
 # -----------------------------------------------------------------------------
 # NO OWNERSHIP - Markdown files


### PR DESCRIPTION
> 🤖 *This PR was generated by an AI Agent.*

## What

Removes the dead `OAUTH` section from `.github/CODEOWNERS`.

```diff
-# -----------------------------------------------------------------------------
-# OAUTH
-# -----------------------------------------------------------------------------
-/oss/airbyte-oauth/src/main/kotlin/io/airbyte/oauth/ @airbytehq/dev-api-sources
```

## Why

The rule is dead twice over — the path doesn't exist and neither does the team.

**The path has never existed in this repo.** There is no `oss/` directory at the root of `airbytehq/airbyte`, and no `airbyte-oauth` path anywhere in the tree. The `oss/` prefix is the `airbyte-platform-internal` layout, not this one.

```console
$ gh api "repos/airbytehq/airbyte/git/trees/master?recursive=1" \
    --jq '[.tree[].path | select(startswith("oss/"))] | length'
0
$ gh api "repos/airbytehq/airbyte/git/trees/master?recursive=1" \
    --jq '[.tree[].path | select(test("airbyte-oauth"))] | length'
0
```

**The owner doesn't exist either.** `@airbytehq/dev-api-sources` is not a team in the org, so GitHub silently ignores the rule — unknown owners are skipped, not surfaced as a failure:

```console
$ gh api repos/airbytehq/airbyte/codeowners/errors \
    --jq '.errors[] | "line \(.line): \(.kind) — \(.source)"'
...
line 66: Unknown owner — /oss/airbyte-oauth/src/main/kotlin/io/airbyte/oauth/ @airbytehq/dev-api-sources
```

**How it got here.** The rule was originally added in #20837 (Dec 2022) for the real `airbyte-oauth/` module. That module was deleted in #23258 (Feb 2023), which correctly removed the CODEOWNERS rule along with it. It was then re-introduced in #72231 (Jan 2026) pointing at `/oss/airbyte-oauth/…` — a path this repo has never had — and at a team that no longer exists.

Deleting is the right fix rather than repointing it: there is no OAuth code in this repo for anyone to own.

## Scope

This PR intentionally does **not** touch the remaining 7 CODEOWNERS errors, which all stem from `@airbytehq/dbsources` — another nonexistent team, which owns `/airbyte-integrations/connectors/source-*/`, `/airbyte-cdk/bulk/`, `/airbyte-cdk/java/airbyte-cdk/`, and `/buildSrc/`. Unlike this one those paths are real and actively used, so they need an owner decision from the DB sources and destinations teams rather than a deletion. Separate PR.

After this merges, `codeowners/errors` should report 7 instead of 8.

## User impact

None — repository configuration only. No connector, platform, or CI behavior changes. No review routing changes, because this rule was never routing anything.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚
- [ ] NO ❌

> [!IMPORTANT]
> ⚡ **Auto-merge enabled.**
> 
> _This PR is set to merge automatically when all requirements are met._