### PR TITLE
ci: skip progressive rollout gate for connectors removed in the PR

### DIFF
--- a/.github/workflows/connector-active-progressive-rollout-checks.yml
+++ b/.github/workflows/connector-active-progressive-rollout-checks.yml
@@ -133,11 +133,12 @@ jobs:
         env:
           CONNECTOR_NAME: ${{ matrix.connector }}
         run: |
-          metadata_path="$(find . -type f -path "*/connectors/${CONNECTOR_NAME}/metadata.yaml" -print -quit)"
-          echo "exists=${metadata_path:+true}" | tee -a "${GITHUB_OUTPUT}"
+          metadata_path="$(find . -name .git -prune -o -type f -path "*/connectors/${CONNECTOR_NAME}/metadata.yaml" -print -quit)"
+          exists="${metadata_path:+true}"
+          echo "exists=${exists:-false}" | tee -a "${GITHUB_OUTPUT}"
 
       - name: Skip gate for connector removed in this PR
-        if: matrix.connector && steps.connector-presence.outputs.exists != 'true'
+        if: matrix.connector && steps.connector-presence.outputs.exists == 'false'
         env:
           CONNECTOR_NAME: ${{ matrix.connector }}
         run: echo "::notice::${CONNECTOR_NAME} no longer exists on this branch, so there is nothing left to roll out. Skipping the progressive rollout gate."

--- a/.github/workflows/connector-active-progressive-rollout-checks.yml
+++ b/.github/workflows/connector-active-progressive-rollout-checks.yml
@@ -127,16 +127,31 @@ jobs:
           submodules: true # Needed for airbyte-enterprise connectors (no-op otherwise)
           fetch-depth: 1
 
-      - name: Install uv
+      - name: Resolve connector presence
         if: matrix.connector
+        id: connector-presence
+        env:
+          CONNECTOR_NAME: ${{ matrix.connector }}
+        run: |
+          metadata_path="$(find . -type f -path "*/connectors/${CONNECTOR_NAME}/metadata.yaml" -print -quit)"
+          echo "exists=${metadata_path:+true}" | tee -a "${GITHUB_OUTPUT}"
+
+      - name: Skip gate for connector removed in this PR
+        if: matrix.connector && steps.connector-presence.outputs.exists != 'true'
+        env:
+          CONNECTOR_NAME: ${{ matrix.connector }}
+        run: echo "::notice::${CONNECTOR_NAME} no longer exists on this branch, so there is nothing left to roll out. Skipping the progressive rollout gate."
+
+      - name: Install uv
+        if: matrix.connector && steps.connector-presence.outputs.exists == 'true'
         uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
 
       - name: Install Ops CLI
-        if: matrix.connector
+        if: matrix.connector && steps.connector-presence.outputs.exists == 'true'
         run: uv tool install airbyte-internal-ops
 
       - name: Install Cloud SQL Proxy
-        if: matrix.connector
+        if: matrix.connector && steps.connector-presence.outputs.exists == 'true'
         env:
           CLOUD_SQL_PROXY_VERSION: v2.15.0
           CLOUD_SQL_PROXY_SHA256: cf3e9d069ea0d09cdfddce77daa36811bb0b963b1169e9c3f1586433ca7325fa
@@ -152,14 +167,14 @@ jobs:
           cloud-sql-proxy --version
 
       - name: Start Cloud SQL Proxy
-        if: matrix.connector
+        if: matrix.connector && steps.connector-presence.outputs.exists == 'true'
         env:
           # Local Cloud SQL Proxy port for prod DB queries.
           DB_PORT: "15432"
         run: airbyte-ops cloud db start-proxy --port "${DB_PORT}"
 
       - name: Get rollout status
-        if: matrix.connector
+        if: matrix.connector && steps.connector-presence.outputs.exists == 'true'
         id: rollout-status
         env:
           CONNECTOR_NAME: ${{ matrix.connector }}
@@ -173,7 +188,7 @@ jobs:
           } | tee -a "${GITHUB_OUTPUT}"
 
       - name: Get master connector version
-        if: matrix.connector
+        if: matrix.connector && steps.connector-presence.outputs.exists == 'true'
         id: master-version
         env:
           CONNECTOR_NAME: ${{ matrix.connector }}
@@ -186,7 +201,7 @@ jobs:
           fi
 
       - name: Resolve rollout gate state
-        if: matrix.connector
+        if: matrix.connector && steps.connector-presence.outputs.exists == 'true'
         id: rollout-gate-state
         env:
           ROLLOUT_STATUS_JSON: ${{ steps.rollout-status.outputs.json }}


### PR DESCRIPTION
## What

Any PR that deletes a connector directory currently fails `Connector Active Progressive Rollout Checks` — and there is no way for a human to bypass it either.

The matrix is built from the connectors *modified* in the PR, so a deleted connector is still included. The gate then checks it out at the PR head, where the connector no longer exists, and `airbyte-ops registry progressive-rollout status <connector> --repo-path .` exits non-zero with `Metadata file not found: airbyte-integrations/connectors/<connector>/metadata.yaml`. The failure happens before the bypass checkbox is ever added to the PR description, so the gate is permanently red.

Hit while removing the `*-strict-encrypt` destination variants (airbytehq/airbyte#72811, airbytehq/airbyte#72812, airbytehq/airbyte#72813, airbytehq/airbyte#72814); each of those PRs has a red `<connector>-strict-encrypt Progressive Rollout Gate` for this reason.

Requested by AJ (aaronsteers) as part of getting those PRs mergeable.

## How

Adds a `Resolve connector presence` step right after checkout that looks for the connector's `metadata.yaml` anywhere under a `*/connectors/<name>/` path (so `airbyte-enterprise` submodule connectors are covered too), and gates the rest of the gate on it:

```yaml
metadata_path="$(find . -type f -path "*/connectors/${CONNECTOR_NAME}/metadata.yaml" -print -quit)"
echo "exists=${metadata_path:+true}" | tee -a "${GITHUB_OUTPUT}"
```

When the connector is absent the job logs a `::notice::` and skips the Ops CLI install, Cloud SQL proxy, rollout status lookup, and gate-state resolution. Every downstream step already keys off `steps.rollout-gate-state.outputs.*`, which is then empty, so nothing fails and no bypass checkbox is added.

A connector deleted on the PR branch cannot be progressively rolled out, so there is nothing left for this gate to protect — the check is a no-op rather than a suppressed failure. Failures for connectors that *do* still exist are unchanged.

## Review guide

1. `.github/workflows/connector-active-progressive-rollout-checks.yml`

## User Impact

Connector-removal PRs stop being blocked by a red rollout gate. No behavior change for any PR that keeps the connector in the tree.

## Can this PR be safely reverted and rolled back?
- [x] YES 💚


Link to Devin session: https://app.devin.ai/sessions/3bcb98a8ea1243a2a20880ec6c37a841
Requested by: @aaronsteers