### PR TITLE
docs: add robots.txt with sitemap reference and AI-crawler policy

### DIFF
--- a/docusaurus/docusaurus.config.ts
+++ b/docusaurus/docusaurus.config.ts
@@ -313,6 +313,7 @@ const config: Config = {
         depth: 4,
         content: {
           includePages: true,
+          enableLlmsFullTxt: true,
           excludeRoutes: ["./api-docs/**", "./ai-agents/slack-app"],
         },
       } satisfies LLmPluginOptions,

--- a/docusaurus/docusaurus.config.ts
+++ b/docusaurus/docusaurus.config.ts
@@ -313,7 +313,6 @@ const config: Config = {
         depth: 4,
         content: {
           includePages: true,
-          enableLlmsFullTxt: true,
           excludeRoutes: ["./api-docs/**", "./ai-agents/slack-app"],
         },
       } satisfies LLmPluginOptions,

--- a/docusaurus/static/robots.txt
+++ b/docusaurus/static/robots.txt
@@ -1,0 +1,13 @@
+# robots.txt for docs.airbyte.com
+#
+# AI-crawler policy: all crawlers, including AI crawlers (GPTBot, ClaudeBot,
+# PerplexityBot, Google-Extended, CCBot, etc.), are deliberately allowed.
+# Airbyte documentation is public and we want it discoverable by both search
+# engines and AI assistants. See also /llms.txt and /llms-full.txt.
+
+User-agent: *
+Content-Signal: ai-train=yes, search=yes, ai-input=yes
+Allow: /
+Disallow: /search
+
+Sitemap: https://docs.airbyte.com/sitemap.xml

--- a/docusaurus/static/robots.txt
+++ b/docusaurus/static/robots.txt
@@ -3,7 +3,7 @@
 # AI-crawler policy: all crawlers, including AI crawlers (GPTBot, ClaudeBot,
 # PerplexityBot, Google-Extended, CCBot, etc.), are deliberately allowed.
 # Airbyte documentation is public and we want it discoverable by both search
-# engines and AI assistants. See also /llms.txt and /llms-full.txt.
+# engines and AI assistants. See also /llms.txt.
 
 User-agent: *
 Content-Signal: ai-train=yes, search=yes, ai-input=yes


### PR DESCRIPTION
## What
`https://docs.airbyte.com/robots.txt` currently returns 404 — there is no robots.txt, no `Sitemap:` declaration, and no explicit AI-crawler policy.

Resolves [DOCS-57](https://linear.app/airbyteio/issue/DOCS-57/add-a-real-robotstxt-with-sitemap-reference-and-an-explicit-ai-crawler) (part of the DOCS-54 SEO audit).

## How
Add `docusaurus/static/robots.txt` (Docusaurus copies `static/` to the site root):
- `Sitemap: https://docs.airbyte.com/sitemap.xml`
- `Disallow: /search` (the only non-content route present in sitemap/llms.txt)
- Deliberate allow-all AI-crawler policy with `Content-Signal: ai-train=yes, search=yes, ai-input=yes`, matching airbyte.com's robots.txt

Verified `docusaurus/vercel.json` has no rewrites/redirects/headers matching `/robots.txt`, so the static file is served as-is (confirmed 200 `text/plain` on the Vercel preview).

Note: enabling `llms-full.txt` generation was evaluated and dropped — it produced a 46 MB file (+38s build time); details on the Linear ticket.

## Review guide
1. `docusaurus/static/robots.txt`

## User Impact
Crawlers get an explicit sitemap reference and crawl policy; AI crawlers are deliberately allowed.

## Can this PR be safely reverted and rolled back?
- [x] YES 💚
- [ ] NO ❌


Link to Devin session: https://app.devin.ai/sessions/e63058d04c104f64aad04e4ced9accca
Requested by: @ian-at-airbyte