### PR TITLE
fix(source-vitally): mark the secret token as sensitive

### DIFF
--- a/airbyte-integrations/connectors/source-vitally/manifest.yaml
+++ b/airbyte-integrations/connectors/source-vitally/manifest.yaml
@@ -287,6 +287,7 @@ spec:
         description: sk_live_secret_token
         order: 2
         title: Secret Token
+        airbyte_secret: true
       basic_auth_header:
         type: string
         description: Basic Auth Header

--- a/airbyte-integrations/connectors/source-vitally/metadata.yaml
+++ b/airbyte-integrations/connectors/source-vitally/metadata.yaml
@@ -18,7 +18,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 6c6d8b0c-db35-4cd1-a7de-0ca8b080f5ac
-  dockerImageTag: 0.4.3
+  dockerImageTag: 0.4.4
   dockerRepository: airbyte/source-vitally
   githubIssueLabel: source-vitally
   icon: icon.svg

--- a/docs/integrations/sources/vitally.md
+++ b/docs/integrations/sources/vitally.md
@@ -45,7 +45,7 @@ If you use Airbyte Cloud and your organization restricts access to specific IPs,
 
 | Version | Date       | Pull Request                                             | Subject                                     |
 | :------ | :--------- | :------------------------------------------------------- | :------------------------------------------ |
-| 0.4.4 | 2026-08-02 | [TBD](https://github.com/airbytehq/airbyte/pull/TBD) | Mark the secret token as sensitive |
+| 0.4.4 | 2026-08-02 | [83317](https://github.com/airbytehq/airbyte/pull/83317) | Mark the secret token as sensitive |
 | 0.4.3 | 2026-06-02 | [79008](https://github.com/airbytehq/airbyte/pull/79008) | Update dependencies |
 | 0.4.2 | 2025-05-24 | [60783](https://github.com/airbytehq/airbyte/pull/60783) | Update dependencies |
 | 0.4.1 | 2025-05-10 | [59942](https://github.com/airbytehq/airbyte/pull/59942) | Update dependencies |

--- a/docs/integrations/sources/vitally.md
+++ b/docs/integrations/sources/vitally.md
@@ -45,6 +45,7 @@ If you use Airbyte Cloud and your organization restricts access to specific IPs,
 
 | Version | Date       | Pull Request                                             | Subject                                     |
 | :------ | :--------- | :------------------------------------------------------- | :------------------------------------------ |
+| 0.4.4 | 2026-08-02 | [TBD](https://github.com/airbytehq/airbyte/pull/TBD) | Mark the secret token as sensitive |
 | 0.4.3 | 2026-06-02 | [79008](https://github.com/airbytehq/airbyte/pull/79008) | Update dependencies |
 | 0.4.2 | 2025-05-24 | [60783](https://github.com/airbytehq/airbyte/pull/60783) | Update dependencies |
 | 0.4.1 | 2025-05-10 | [59942](https://github.com/airbytehq/airbyte/pull/59942) | Update dependencies |


### PR DESCRIPTION
## What

Fixes #81344.

The Vitally connector uses `secret_token` as the username in its Basic Authenticator, but the connection specification did not mark that field as an Airbyte secret. The value could therefore be exposed in configuration and logs where secret masking is expected.

This change marks `secret_token` with `airbyte_secret: true`, bumps the connector patch version to 0.4.4, and adds the required changelog entry.

## Checks

- Parsed the updated manifest and metadata YAML successfully.
- Ran `git diff --check`.

## Connector version

Patch release: this changes secret handling without changing the connector configuration shape or stream behavior.