### PR TITLE
fix(source-google-analytics-data-api): fix offset pagination

### DIFF
--- a/airbyte-integrations/connectors/source-google-analytics-data-api/manifest.yaml
+++ b/airbyte-integrations/connectors/source-google-analytics-data-api/manifest.yaml
@@ -64,12 +64,11 @@ definitions:
           type: DefaultPaginator
           page_token_option:
             type: RequestOption
-            inject_into: request_parameter
             field_name: offset
+            inject_into: body_json
           pagination_strategy:
-            type: CursorPagination
-            cursor_value: '{{ response.get("offset", {}) }}'
-            stop_condition: '{{ not response.get("offset", {}) }}'
+            type: OffsetIncrement
+            page_size: 100000
       transformations: [] # the dynamic stream will override this value
       schema_loader:
         type: DynamicSchemaLoader
@@ -909,12 +908,11 @@ dynamic_streams:
               type: DefaultPaginator
               page_token_option:
                 type: RequestOption
-                inject_into: request_parameter
                 field_name: offset
+                inject_into: body_json
               pagination_strategy:
-                type: CursorPagination
-                cursor_value: "{% raw %}{{ response.get('offset', {}) }}{% endraw %}"
-                stop_condition: "{% raw %}{{ not response.get('offset', {}) }}{% endraw %}"
+                type: OffsetIncrement
+                page_size: 100000
             {% endif %}
         # This mapping defines the configuration path for the stream.
         # Property sets are stored as a list under the `source_config_1` key,

--- a/airbyte-integrations/connectors/source-google-analytics-data-api/metadata.yaml
+++ b/airbyte-integrations/connectors/source-google-analytics-data-api/metadata.yaml
@@ -12,7 +12,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 3cc2eafd-84aa-4dca-93af-322d9dfeec1a
-  dockerImageTag: 2.9.45
+  dockerImageTag: 2.9.46
   dockerRepository: airbyte/source-google-analytics-data-api
   documentationUrl: https://docs.airbyte.com/integrations/sources/google-analytics-data-api
   externalDocumentationUrls:

--- a/docs/integrations/sources/google-analytics-data-api.md
+++ b/docs/integrations/sources/google-analytics-data-api.md
@@ -284,6 +284,7 @@ If you use Airbyte Cloud and your organization restricts access to specific IPs,
 
 | Version        | Date       | Pull Request                                             | Subject                                                                                                                                                                |
 |:---------------|:-----------|:---------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 2.9.46 | 2026-08-02 | [TBD](https://github.com/airbytehq/airbyte/pull/TBD) | Fix body-based offset pagination for reports larger than 100,000 rows |
 | 2.9.45 | 2026-07-28 | [82938](https://github.com/airbytehq/airbyte/pull/82938) | Update dependencies |
 | 2.9.44 | 2026-07-21 | [82436](https://github.com/airbytehq/airbyte/pull/82436) | Update dependencies |
 | 2.9.43 | 2026-07-14 | [81845](https://github.com/airbytehq/airbyte/pull/81845) | Update dependencies |

--- a/docs/integrations/sources/google-analytics-data-api.md
+++ b/docs/integrations/sources/google-analytics-data-api.md
@@ -284,7 +284,7 @@ If you use Airbyte Cloud and your organization restricts access to specific IPs,
 
 | Version        | Date       | Pull Request                                             | Subject                                                                                                                                                                |
 |:---------------|:-----------|:---------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| 2.9.46 | 2026-08-02 | [TBD](https://github.com/airbytehq/airbyte/pull/TBD) | Fix body-based offset pagination for reports larger than 100,000 rows |
+| 2.9.46 | 2026-08-02 | [83318](https://github.com/airbytehq/airbyte/pull/83318) | Fix body-based offset pagination for reports larger than 100,000 rows |
 | 2.9.45 | 2026-07-28 | [82938](https://github.com/airbytehq/airbyte/pull/82938) | Update dependencies |
 | 2.9.44 | 2026-07-21 | [82436](https://github.com/airbytehq/airbyte/pull/82436) | Update dependencies |
 | 2.9.43 | 2026-07-14 | [81845](https://github.com/airbytehq/airbyte/pull/81845) | Update dependencies |


### PR DESCRIPTION
## What

Fixes #82766.

The GA4 `runReport` endpoint accepts `offset` in the POST body and does not return an `offset` field. The connector's paginator was injecting `offset` as a query parameter and using `response.offset` as a cursor, so reports larger than the 100,000-row limit could be truncated and fail to advance correctly.

This changes both the static stream template and the dynamic stream mapping to use the CDK's `OffsetIncrement` strategy with `offset` injected into `body_json`. Pivot reports keep their existing no-pagination behavior. The connector patch version is bumped to 2.9.46 with a changelog entry.

This PR addresses the deterministic paginator defect described in the issue. It does not claim to resolve every possible memory or concurrency cause of a stalled sync.

## Checks

- GA4 unit tests: `15 passed`.
- Parsed the updated manifest and metadata YAML.
- Verified the static and dynamic paginator definitions with manifest assertions.
- Ran `git diff --check`.

## Connector version

Patch release: fixes pagination behavior without changing stream names or record schemas.