### PR TITLE
feat(source-freshdesk): add ticket activities stream

### DIFF
--- a/airbyte-integrations/connectors/source-freshdesk/integration_tests/configured_catalog.json
+++ b/airbyte-integrations/connectors/source-freshdesk/integration_tests/configured_catalog.json
@@ -224,6 +224,15 @@
     },
     {
       "stream": {
+        "name": "ticket_activities",
+        "json_schema": {},
+        "supported_sync_modes": ["full_refresh"]
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "append"
+    },
+    {
+      "stream": {
         "name": "satisfaction_ratings",
         "json_schema": {},
         "supported_sync_modes": ["full_refresh", "incremental"],

--- a/airbyte-integrations/connectors/source-freshdesk/manifest.yaml
+++ b/airbyte-integrations/connectors/source-freshdesk/manifest.yaml
@@ -1488,8 +1488,9 @@ definitions:
                 - ticket_id
               value: "{{ stream_slice.ticket_id }}"
       schema_loader:
-        type: JsonFileSchemaLoader
-        file_path: ./schemas/ticket_activities.json
+        type: InlineSchemaLoader
+        schema:
+          $ref: "#/schemas/ticket_activities"
     time_entries:
       type: DeclarativeStream
       name: time_entries
@@ -3481,6 +3482,35 @@ schemas:
               type:
                 - "null"
                 - boolean
+    additionalProperties: true
+  ticket_activities:
+    type: object
+    $schema: http://json-schema.org/draft-07/schema#
+    properties:
+      actor:
+        type:
+          - string
+          - "null"
+      action:
+        type:
+          - string
+          - "null"
+      created_at:
+        type:
+          - string
+          - "null"
+      source:
+        type:
+          - string
+          - "null"
+      type:
+        type:
+          - string
+          - "null"
+      ticket_id:
+        type:
+          - integer
+          - "null"
     additionalProperties: true
   ticket_fields:
     type: object

--- a/airbyte-integrations/connectors/source-freshdesk/manifest.yaml
+++ b/airbyte-integrations/connectors/source-freshdesk/manifest.yaml
@@ -1438,6 +1438,58 @@ definitions:
         type: InlineSchemaLoader
         schema:
           $ref: "#/schemas/tickets"
+    ticket_activities:
+      type: DeclarativeStream
+      name: ticket_activities
+      primary_key:
+        - actor
+        - created_at
+        - ticket_id
+      retriever:
+        type: SimpleRetriever
+        requester:
+          $ref: "#/definitions/base_requester"
+          path: tickets/{{ stream_slice.ticket_id }}/activities
+          http_method: GET
+          error_handler:
+            type: CompositeErrorHandler
+            error_handlers:
+              - type: DefaultErrorHandler
+                response_filters:
+                  - type: HttpResponseFilter
+                    action: FAIL
+                    http_codes:
+                      - 401
+                    error_message: >-
+                      The endpoint to access stream ticket_activities returned 401: Unauthorized. This is most likely due to wrong credentials.
+              - type: DefaultErrorHandler
+                backoff_strategies:
+                  - type: WaitTimeFromHeader
+                    header: Retry-After
+        record_selector:
+          type: RecordSelector
+          extractor:
+            type: DpathExtractor
+            field_path:
+              - activities
+        partition_router:
+          type: SubstreamPartitionRouter
+          parent_stream_configs:
+            - type: ParentStreamConfig
+              parent_key: id
+              partition_field: ticket_id
+              stream:
+                $ref: "#/definitions/streams/tickets"
+      transformations:
+        - type: AddFields
+          fields:
+            - type: AddedFieldDefinition
+              path:
+                - ticket_id
+              value: "{{ stream_slice.ticket_id }}"
+      schema_loader:
+        type: JsonFileSchemaLoader
+        file_path: ./schemas/ticket_activities.json
     time_entries:
       type: DeclarativeStream
       name: time_entries
@@ -1521,6 +1573,7 @@ streams:
   - $ref: "#/definitions/streams/surveys"
   - $ref: "#/definitions/streams/ticket_fields"
   - $ref: "#/definitions/streams/tickets"
+  - $ref: "#/definitions/streams/ticket_activities"
   - $ref: "#/definitions/streams/time_entries"
 
 spec:
@@ -1737,6 +1790,7 @@ metadata:
     surveys: false
     ticket_fields: false
     tickets: false
+    ticket_activities: false
     time_entries: false
   yamlComponents:
     streams:

--- a/airbyte-integrations/connectors/source-freshdesk/metadata.yaml
+++ b/airbyte-integrations/connectors/source-freshdesk/metadata.yaml
@@ -10,7 +10,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: ec4b9503-13cb-48ab-a4ab-6ade4be46567
-  dockerImageTag: 3.2.24
+  dockerImageTag: 3.2.25
   dockerRepository: airbyte/source-freshdesk
   documentationUrl: https://docs.airbyte.com/integrations/sources/freshdesk
   externalDocumentationUrls:

--- a/airbyte-integrations/connectors/source-freshdesk/schemas/ticket_activities.json
+++ b/airbyte-integrations/connectors/source-freshdesk/schemas/ticket_activities.json
@@ -23,4 +23,3 @@
   },
   "additionalProperties": true
 }
-

--- a/airbyte-integrations/connectors/source-freshdesk/schemas/ticket_activities.json
+++ b/airbyte-integrations/connectors/source-freshdesk/schemas/ticket_activities.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "actor": {
+      "type": ["string", "null"]
+    },
+    "action": {
+      "type": ["string", "null"]
+    },
+    "created_at": {
+      "type": ["string", "null"]
+    },
+    "source": {
+      "type": ["string", "null"]
+    },
+    "type": {
+      "type": ["string", "null"]
+    },
+    "ticket_id": {
+      "type": ["integer", "null"]
+    }
+  },
+  "additionalProperties": true
+}
+


### PR DESCRIPTION
## Summary

Adds support for syncing Freshdesk ticket activity data from the `/api/v2/tickets/{ticket_id}/activities` endpoint.

## Changes

- Added a new `ticket_activities` stream to the Freshdesk connector manifest.
- Configured `ticket_activities` as a substream of the existing `tickets` stream.
- Uses each parent ticket `id` as `ticket_id` to request:
  `/api/v2/tickets/{ticket_id}/activities`
- Adds `ticket_id` to emitted activity records for parent ticket traceability.
- Added a dedicated schema file:
  `schemas/ticket_activities.json`
- Added `ticket_activities` to the full-refresh configured catalog for CAT coverage.

## Validation

- Verified `manifest.yaml` parses successfully.
- Verified `integration_tests/configured_catalog.json` parses successfully.
- Verified `schemas/ticket_activities.json` parses successfully.
- Confirmed `ticket_activities` is registered in the manifest and uses `tickets` as its parent stream.