### PR TITLE
fix(source-google-drive): dedupe files with identical paths to prevent file-transfer staging collision

### DIFF
--- a/airbyte-integrations/connectors/source-google-drive/metadata.yaml
+++ b/airbyte-integrations/connectors/source-google-drive/metadata.yaml
@@ -10,7 +10,7 @@ data:
   connectorSubtype: file
   connectorType: source
   definitionId: 9f8dda77-1048-4368-815b-269bf54ee9b8
-  dockerImageTag: 0.5.27
+  dockerImageTag: 0.5.28
   dockerRepository: airbyte/source-google-drive
   githubIssueLabel: source-google-drive
   icon: google-drive.svg

--- a/airbyte-integrations/connectors/source-google-drive/pyproject.toml
+++ b/airbyte-integrations/connectors/source-google-drive/pyproject.toml
@@ -3,7 +3,7 @@ requires = [ "poetry-core>=1.0.0",]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
-version = "0.5.27"
+version = "0.5.28"
 name = "source-google-drive"
 description = "Source implementation for Google Drive."
 authors = [ "Airbyte <contact@airbyte.io>",]

--- a/airbyte-integrations/connectors/source-google-drive/source_google_drive/stream_reader.py
+++ b/airbyte-integrations/connectors/source-google-drive/source_google_drive/stream_reader.py
@@ -140,6 +140,7 @@ class SourceGoogleDriveStreamReader(AbstractFileBasedStreamReader):
 
         folder_id_queue = [("", root_folder_id)]
         seen: Set[str] = set()
+        unique_files: Dict[str, GoogleDriveRemoteFile] = {}
         while len(folder_id_queue) > 0:
             (path, folder_id) = folder_id_queue.pop()
             # fetch all files in this folder (1000 is the max page size)
@@ -189,10 +190,28 @@ class SourceGoogleDriveStreamReader(AbstractFileBasedStreamReader):
                             view_link=new_file.get("webViewLink"),
                         )
                         if self.file_matches_globs(remote_file, globs):
-                            yield remote_file
+                            existing = unique_files.get(file_name)
+                            if existing is None:
+                                unique_files[file_name] = remote_file
+                            elif remote_file.last_modified > existing.last_modified:
+                                logger.warning(
+                                    "Dropping duplicate Google Drive file id '%s' for colliding path '%s'; keeping newer file id '%s'",
+                                    existing.id,
+                                    file_name,
+                                    remote_file.id,
+                                )
+                                unique_files[file_name] = remote_file
+                            else:
+                                logger.warning(
+                                    "Dropping duplicate Google Drive file id '%s' for colliding path '%s'; keeping file id '%s'",
+                                    remote_file.id,
+                                    file_name,
+                                    existing.id,
+                                )
                 request = service.files().list_next(request, results)
                 if request is None:
                     break
+        yield from unique_files.values()
 
     def _is_exportable_document(self, mime_type: str):
         """

--- a/airbyte-integrations/connectors/source-google-drive/unit_tests/test_reader.py
+++ b/airbyte-integrations/connectors/source-google-drive/unit_tests/test_reader.py
@@ -722,6 +722,45 @@ def flatten_list(list_of_lists):
             ],
             id="Other google file types as is",
         ),
+        pytest.param(
+            "*",
+            [
+                [
+                    {
+                        "files": [
+                            {
+                                "id": "older",
+                                "mimeType": "application/pdf",
+                                "name": "duplicate.pdf",
+                                "modifiedTime": "2021-01-01T00:00:00.000Z",
+                                "createdTime": "2021-01-01T00:00:00.000Z",
+                                "webViewLink": "https://docs.google.com/file/d/older/view?usp=drivesdk",
+                            },
+                            {
+                                "id": "newer",
+                                "mimeType": "application/pdf",
+                                "name": "duplicate.pdf",
+                                "modifiedTime": "2021-06-01T00:00:00.000Z",
+                                "createdTime": "2021-06-01T00:00:00.000Z",
+                                "webViewLink": "https://docs.google.com/file/d/newer/view?usp=drivesdk",
+                            },
+                        ]
+                    }
+                ]
+            ],
+            [
+                GoogleDriveRemoteFile(
+                    uri="duplicate.pdf",
+                    id="newer",
+                    original_mime_type="application/pdf",
+                    mime_type="application/pdf",
+                    last_modified=datetime.datetime(2021, 6, 1),
+                    created_at=datetime.datetime(2021, 6, 1),
+                    view_link="https://docs.google.com/file/d/newer/view?usp=drivesdk",
+                )
+            ],
+            id="Duplicate URI keeps most recently modified file",
+        ),
     ],
 )
 @patch("source_google_drive.stream_reader.service_account")

--- a/docs/integrations/sources/google-drive.md
+++ b/docs/integrations/sources/google-drive.md
@@ -326,6 +326,7 @@ If you use Airbyte Cloud and your organization restricts access to specific IPs,
 
 | Version | Date       | Pull Request                                             | Subject                                                                                      |
 |---------|------------|----------------------------------------------------------|----------------------------------------------------------------------------------------------|
+| 0.5.28 | 2026-08-04 | [83345](https://github.com/airbytehq/airbyte/pull/83345) | Deduplicate files with colliding paths in file transfer mode |
 | 0.5.27 | 2026-08-04 | [83492](https://github.com/airbytehq/airbyte/pull/83492) | Update dependencies |
 | 0.5.26 | 2026-07-28 | [82943](https://github.com/airbytehq/airbyte/pull/82943) | Update dependencies |
 | 0.5.25 | 2026-07-21 | [82459](https://github.com/airbytehq/airbyte/pull/82459) | Update dependencies |


### PR DESCRIPTION
## What

In file transfer mode, two Drive files that resolve to the same folder-relative path are staged to the same local path (`/staging/files/<relative path>`). The destination reads and then **deletes** each staged file (`FileChunkTask.kt:81-107`), so the second record referencing that path throws `java.io.FileNotFoundException` and the destination exits 1 — killing the whole sync, permanently, on every attempt.

Real customer impact (org `92102db1-f952-4087-895f-196a3daee3ef`): zero successful syncs since 2026-07-31, 5/5 attempts of every hourly job failing on the same staged path, blocking their Context Store entirely. 433 other files transfer fine; two duplicate-named pairs break everything.

This revives the fix from https://github.com/airbytehq/airbyte/pull/79696 (open, conflicted) rebased onto current `master`.

## How

`SourceGoogleDriveStreamReader.get_matching_files` now collects matching files keyed by their folder-relative URI instead of yielding immediately, keeps the most recently modified file on a collision, and logs a warning naming the dropped Drive file ID, the colliding path, and the retained ID:

```
Dropping duplicate Google Drive file id '<old>' for colliding path '<path>'; keeping newer file id '<new>'
```

Dedupe is keyed on `path + name`, not the basename, so identically-named files in *different* folders are unaffected.

## Review guide

1. `source_google_drive/stream_reader.py` — dedupe by URI, newest wins.
2. `unit_tests/test_reader.py` — two Drive IDs, one filename, one emitted record.
3. `metadata.yaml` / `pyproject.toml` / `docs/integrations/sources/google-drive.md` — 0.5.27 → 0.5.28.

Two things worth a reviewer's opinion:

- **Laziness tradeoff.** Records are now buffered until folder traversal completes rather than streamed as discovered. This matches the approach in #79696 but does change memory/first-record latency for very large drives. A `Set[str]` of seen paths with first-wins semantics would preserve streaming at the cost of not being able to prefer the newest duplicate.
- **Scope.** This fixes the source side only. The generic CDK fix (per-file UUID staging dir, https://github.com/airbytehq/airbyte-python-cdk/pull/1078 + https://github.com/airbytehq/airbyte/pull/82754) is still draft and would prevent the crash for all file-based sources, but leaves duplicates overwriting each other at the destination object key. Separately, `FileChunkTask` arguably should fail soft on a missing staged file rather than aborting the sync.

## User Impact

Syncs no longer fail when a Drive contains multiple files with the same name in the same folder. Tradeoff: only one of a duplicate-named pair is synced (the most recently modified); previously neither was, because the sync failed outright.

## Can this PR be safely reverted and rolled back?
- [x] YES 💚
- [ ] NO ❌

Requested by Dallas Inman to unblock a customer evaluation.


Link to Devin session: https://app.devin.ai/sessions/f1935df080e0485e9f80f7c2c9c70290
Requested by: @dallasinman