### PR TITLE
ci(hydra-automerge): tag owning team in auto-merge Slack notification

### DIFF
--- a/.github/workflows/hydra-automerge.yml
+++ b/.github/workflows/hydra-automerge.yml
@@ -759,6 +759,47 @@ jobs:
           GH_TOKEN: ${{ steps.get-hoard-token.outputs.token }}
         run: gh issue edit "$PR_NUMBER" --repo airbytehq/airbyte --add-label hyd-automerged
 
+      # Tag the team that owns the merged connector code so they can review the
+      # merge after the fact: API sources -> @oc-apis, DB/DW sources and any
+      # destination -> @oc-db-dw. Source ownership is decided by connector
+      # language (java/kotlin => DB/DW, everything else => API).
+      - name: Resolve owning team mentions for Slack
+        if: steps.evaluate.outputs.result == 'PASS' && inputs.dry-run != 'true' && vars.ENABLE_CONNECTOR_AUTO_MERGE == 'true'
+        id: owning-teams
+        env:
+          GH_TOKEN: ${{ steps.get-hoard-token.outputs.token }}
+        run: |
+          set -euo pipefail
+
+          connectors="$(
+            gh api --paginate "repos/airbytehq/airbyte/pulls/$PR_NUMBER/files" \
+              --jq '.[].filename' \
+              | sed -n 's|^airbyte-integrations/connectors/\([^/]*\)/.*|\1|p;s|^docs/integrations/sources/\([^/.]*\).*|source-\1|p;s|^docs/integrations/destinations/\([^/.]*\).*|destination-\1|p' \
+              | sort -u
+          )"
+
+          tag_apis=false
+          tag_db_dw=false
+          for connector in $connectors; do
+            metadata="airbyte-integrations/connectors/$connector/metadata.yaml"
+            if [[ "$connector" == destination-* ]]; then
+              tag_db_dw=true
+            elif [[ -f "$metadata" ]] && grep -qE '^\s*- language:(java|kotlin)\s*$' "$metadata"; then
+              tag_db_dw=true
+            else
+              tag_apis=true
+            fi
+          done
+
+          mentions=""
+          if [[ "$tag_apis" == "true" ]]; then
+            mentions="<!subteam^S08SNSK5RHQ|@oc-apis>"
+          fi
+          if [[ "$tag_db_dw" == "true" ]]; then
+            mentions="${mentions:+$mentions }<!subteam^S0BKLTJNKC6|@oc-db-dw>"
+          fi
+          echo "mentions=$mentions" | tee -a "$GITHUB_OUTPUT"
+
       - name: Post automerge notification to Slack
         if: steps.evaluate.outputs.result == 'PASS' && inputs.dry-run != 'true' && vars.ENABLE_CONNECTOR_AUTO_MERGE == 'true'
         uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
@@ -772,7 +813,7 @@ jobs:
               - type: section
                 text:
                   type: mrkdwn
-                  text: ":robot_face: *Hydra Auto-Merge*\n<https://github.com/airbytehq/airbyte/pull/${{ inputs.pr }}|#${{ inputs.pr }} ${{ steps.pre-check.outputs.title }}>"
+                  text: ":robot_face: *Hydra Auto-Merge*\n<https://github.com/airbytehq/airbyte/pull/${{ inputs.pr }}|#${{ inputs.pr }} ${{ steps.pre-check.outputs.title }}>\n${{ steps.owning-teams.outputs.mentions }} please review and flag if this merge was wrong."
               - type: context
                 elements:
                   - type: mrkdwn


### PR DESCRIPTION
"Opened at Jim Ruppert's request; feature originally requested by Patrick Nilan in the #hydra-feedback Slack channel.\n\n## What\n\nRequested by Patrick Nilan in #hydra-feedback, with scope confirmed by Jim Ruppert: today's `:robot_face: Hydra Auto-Merge` Slack post to #hydra-hands-free notifies nobody, so the team that owns the auto-merged connector code has no visibility and no prompt to confirm whether the merge was correct or erroneous.\n\nThis tags the owning oncall group in that existing notification.\n\n## How\n\nNew `Resolve owning team mentions for Slack` step (same guard conditions as the Slack post, running in the already-checked-out PR head tree) derives the modified connectors from the PR file list and maps them to a group:\n\n```\ndestination-*                                 -> @oc-db-dw (S0BKLTJNKC6)\nsource-* with language:java|kotlin            -> @oc-db-dw\nsource-* otherwise (manifest/low-code/python) -> @oc-apis  (S08SNSK5RHQ)\n```\n\nLanguage comes from `metadata.yaml` tags, matching the `identify-oncall-contact` skill's classification rule. Connector names are also recovered from `docs/integrations/{sources,destinations}/<name>.md` paths so docs-only auto-merges still route. A mixed PR tags both groups; mentions render as `<!subteam^ID|@alias>` in the message body so Slack actually notifies the group.\n\n## Review guide\n\n1. `.github/workflows/hydra-automerge.yml` — the new step and the added mention line in the Slack section block.\n\n## User Impact\n\nAuto-merged connector PRs now ping @oc-apis or @oc-db-dw in #hydra-hands-free with a request to review the merge. No change to auto-merge eligibility, gating, or merge behavior. Destination changes remain deterministically ineligible for auto-merge, so the `@oc-db-dw` path fires today only for Java/Kotlin sources.\n\n## Can this PR be safely reverted and rolled back?\n\n- [x] YES 💚\n\n---\n[Devin session](https://app.devin.ai/sessions/5cb525c740934647b49d474b58d340eb)\n"