### PR TITLE
docs: soften the marketplace connector support-level wording

### DIFF
--- a/docs/integrations/connector-support-levels.md
+++ b/docs/integrations/connector-support-levels.md
@@ -46,8 +46,8 @@ maintenance/upgrades are owned by the customer.
 **Marketplace** connectors are maintained by Airbyte's community members. These connectors:
 
 - Are not maintained by Airbyte.
-- Do not have support SLAs.
-- Should be used with caution in production.
+- Are not covered by Airbyte support SLAs.
+- Should be tested before production use.
 - Might not be feature complete and may experience backward-incompatible, breaking changes with no notice.
 - Are available to everyone.
 - Can [be improved by people like you](/community/contributing-to-airbyte/).


### PR DESCRIPTION
## What
Softens the Marketplace connector messaging in the public docs while keeping it honest, to stay consistent with the updated webapp notice in airbytehq/airbyte-platform-internal#19261. Requested by Mario Moscatiello, with Ian Alton noting the docs should keep a consistent tone.

## How
Two bullets updated in the Marketplace section of `docs/integrations/connector-support-levels.md`:
- "Do not have support SLAs." → "Are not covered by Airbyte support SLAs."
- "Should be used with caution in production." → "Should be tested before production use."

## Review guide
1. `docs/integrations/connector-support-levels.md`

## User Impact
Softer, but still honest, wording on the connector support levels docs page. No functional changes.

## Can this PR be safely reverted and rolled back?
- [x] YES 💚
- [ ] NO ❌

Link to Devin session: https://app.devin.ai/sessions/4dc677729d6f4b4fbf5c3c1e23d921be
Requested by: @mariomoscat127