### PR TITLE
docs(s3): clarify IAM role auth is Pro and Enterprise Flex only

### DIFF
--- a/docs/integrations/destinations/s3-data-lake.md
+++ b/docs/integrations/destinations/s3-data-lake.md
@@ -94,7 +94,7 @@ Use an existing or new [Access Key ID and Secret Access Key](https://docs.aws.am
 <summary>Authenticate with an IAM role (Cloud with Glue catalog only)</summary>
 
 :::note
-To use S3 authentication with an IAM role, an Airbyte team member must enable it. If you'd like to use this feature, [contact the Sales team](https://airbyte.com/company/talk-to-sales).
+S3 authentication with an IAM role is only available on the Cloud Pro and Enterprise Flex plans. It isn't available on the Standard or Plus plans. An Airbyte team member must enable it for your organization, so [contact the Sales team](https://airbyte.com/company/talk-to-sales) if you'd like to use this feature.
 :::
 
 1. In the IAM dashboard, click **Roles**, then **Create role**.

--- a/docs/integrations/destinations/s3-data-lake.md
+++ b/docs/integrations/destinations/s3-data-lake.md
@@ -1,3 +1,5 @@
+import IamRolePlanAvailability from '@site/static/_iam_role_plan_availability.md';
+
 # S3 Data Lake
 
 This page guides you through setting up the S3 Data Lake destination connector.
@@ -93,9 +95,7 @@ Use an existing or new [Access Key ID and Secret Access Key](https://docs.aws.am
 <details>
 <summary>Authenticate with an IAM role (Cloud with Glue catalog only)</summary>
 
-:::note
-S3 authentication with an IAM role is only available on the Cloud Pro and Enterprise Flex plans. It isn't available on the Standard or Plus plans. An Airbyte team member must enable it for your organization, so [contact the Sales team](https://airbyte.com/company/talk-to-sales) if you'd like to use this feature.
-:::
+<IamRolePlanAvailability/>
 
 1. In the IAM dashboard, click **Roles**, then **Create role**.
 

--- a/docs/integrations/destinations/s3-data-lake.md
+++ b/docs/integrations/destinations/s3-data-lake.md
@@ -1,5 +1,3 @@
-import IamRolePlanAvailability from '@site/static/_iam_role_plan_availability.md';
-
 # S3 Data Lake
 
 This page guides you through setting up the S3 Data Lake destination connector.
@@ -95,7 +93,9 @@ Use an existing or new [Access Key ID and Secret Access Key](https://docs.aws.am
 <details>
 <summary>Authenticate with an IAM role (Cloud with Glue catalog only)</summary>
 
-<IamRolePlanAvailability/>
+:::note
+S3 authentication with an IAM role is only available on the Cloud Pro and Enterprise Flex plans. It isn't available on the Standard or Plus plans. An Airbyte team member must enable it for your organization, so [contact the Sales team](https://airbyte.com/company/talk-to-sales) if you'd like to use this feature.
+:::
 
 1. In the IAM dashboard, click **Roles**, then **Create role**.
 

--- a/docs/integrations/destinations/s3.md
+++ b/docs/integrations/destinations/s3.md
@@ -84,7 +84,7 @@ At this time, object-level permissions alone are not sufficient to successfully 
 <!-- env:cloud -->
 
 :::note
-S3 authentication using an IAM role member must be enabled by a member of the Airbyte team. If you'd like to use this feature, please [contact the Sales team](https://airbyte.com/company/talk-to-sales) for more information.
+S3 authentication using an IAM role is only available on the Cloud Pro and Enterprise Flex plans. It isn't available on the Standard or Plus plans. An Airbyte team member must enable it for your organization, so [contact the Sales team](https://airbyte.com/company/talk-to-sales) if you'd like to use this feature.
 :::
 
 <!-- /env:cloud -->

--- a/docs/integrations/destinations/s3.md
+++ b/docs/integrations/destinations/s3.md
@@ -1,3 +1,5 @@
+import IamRolePlanAvailability from '@site/static/_iam_role_plan_availability.md';
+
 # S3
 
 This page guides you through the process of setting up the S3 destination connector.
@@ -83,9 +85,7 @@ At this time, object-level permissions alone are not sufficient to successfully 
 
 <!-- env:cloud -->
 
-:::note
-S3 authentication using an IAM role is only available on the Cloud Pro and Enterprise Flex plans. It isn't available on the Standard or Plus plans. An Airbyte team member must enable it for your organization, so [contact the Sales team](https://airbyte.com/company/talk-to-sales) if you'd like to use this feature.
-:::
+<IamRolePlanAvailability/>
 
 <!-- /env:cloud -->
 

--- a/docs/integrations/destinations/s3.md
+++ b/docs/integrations/destinations/s3.md
@@ -1,5 +1,3 @@
-import IamRolePlanAvailability from '@site/static/_iam_role_plan_availability.md';
-
 # S3
 
 This page guides you through the process of setting up the S3 destination connector.
@@ -85,7 +83,9 @@ At this time, object-level permissions alone are not sufficient to successfully 
 
 <!-- env:cloud -->
 
-<IamRolePlanAvailability/>
+:::note
+S3 authentication using an IAM role is only available on the Cloud Pro and Enterprise Flex plans. It isn't available on the Standard or Plus plans. An Airbyte team member must enable it for your organization, so [contact the Sales team](https://airbyte.com/company/talk-to-sales) if you'd like to use this feature.
+:::
 
 <!-- /env:cloud -->
 

--- a/docs/integrations/sources/s3.md
+++ b/docs/integrations/sources/s3.md
@@ -80,7 +80,7 @@ S3 authentication using an IAM role member is not supported using the OSS platfo
 <!-- env:cloud -->
 
 :::note
-S3 authentication using an IAM role member must be enabled by a member of the Airbyte team. If you'd like to use this feature, please [contact the Sales team](https://airbyte.com/company/talk-to-sales) for more information.
+S3 authentication using an IAM role is only available on the Cloud Pro and Enterprise Flex plans. It isn't available on the Standard or Plus plans. An Airbyte team member must enable it for your organization, so [contact the Sales team](https://airbyte.com/company/talk-to-sales) if you'd like to use this feature.
 :::
 
 1. In the IAM dashboard, click **Roles**, then **Create role**.

--- a/docs/integrations/sources/s3.md
+++ b/docs/integrations/sources/s3.md
@@ -1,3 +1,5 @@
+import IamRolePlanAvailability from '@site/static/_iam_role_plan_availability.md';
+
 # S3
 
 <HideInUI>
@@ -79,9 +81,7 @@ S3 authentication using an IAM role member is not supported using the OSS platfo
 
 <!-- env:cloud -->
 
-:::note
-S3 authentication using an IAM role is only available on the Cloud Pro and Enterprise Flex plans. It isn't available on the Standard or Plus plans. An Airbyte team member must enable it for your organization, so [contact the Sales team](https://airbyte.com/company/talk-to-sales) if you'd like to use this feature.
-:::
+<IamRolePlanAvailability/>
 
 1. In the IAM dashboard, click **Roles**, then **Create role**.
 

--- a/docs/integrations/sources/s3.md
+++ b/docs/integrations/sources/s3.md
@@ -1,5 +1,3 @@
-import IamRolePlanAvailability from '@site/static/_iam_role_plan_availability.md';
-
 # S3
 
 <HideInUI>
@@ -81,7 +79,9 @@ S3 authentication using an IAM role member is not supported using the OSS platfo
 
 <!-- env:cloud -->
 
-<IamRolePlanAvailability/>
+:::note
+S3 authentication using an IAM role is only available on the Cloud Pro and Enterprise Flex plans. It isn't available on the Standard or Plus plans. An Airbyte team member must enable it for your organization, so [contact the Sales team](https://airbyte.com/company/talk-to-sales) if you'd like to use this feature.
+:::
 
 1. In the IAM dashboard, click **Roles**, then **Create role**.
 

--- a/docusaurus/static/_iam_role_plan_availability.md
+++ b/docusaurus/static/_iam_role_plan_availability.md
@@ -1,0 +1,3 @@
+:::note
+Authentication with an IAM role is only available on the Cloud Pro and Enterprise Flex plans. It isn't available on the Standard or Plus plans. An Airbyte team member must enable it for your organization, so [contact the Sales team](https://airbyte.com/company/talk-to-sales) if you'd like to use this feature.
+:::

--- a/docusaurus/static/_iam_role_plan_availability.md
+++ b/docusaurus/static/_iam_role_plan_availability.md
@@ -1,3 +1,0 @@
-:::note
-Authentication with an IAM role is only available on the Cloud Pro and Enterprise Flex plans. It isn't available on the Standard or Plus plans. An Airbyte team member must enable it for your organization, so [contact the Sales team](https://airbyte.com/company/talk-to-sales) if you'd like to use this feature.
-:::


### PR DESCRIPTION
## What

The S3 IAM role authentication notes only said the feature "must be enabled by a member of the Airbyte team" and pointed to sales, which left the plan requirement ambiguous. Internally this has caused confusion about whether Plus includes it. It doesn't — IAM role auth is a Cloud Pro and Enterprise Flex feature.

## How

Rewrote the three cloud-only admonitions to state plan availability explicitly before the "contact sales" call to action:

- `docs/integrations/sources/s3.md`
- `docs/integrations/destinations/s3.md`
- `docs/integrations/destinations/s3-data-lake.md`

New text: "S3 authentication using an IAM role is only available on the Cloud Pro and Enterprise Flex plans. It isn't available on the Standard or Plus plans. An Airbyte team member must enable it for your organization, so [contact the Sales team](...) if you'd like to use this feature."

The note is repeated inline rather than extracted into a shared partial on purpose: the in-app connector docs panel strips leading ESM imports (`oss/airbyte-webapp/src/components/ui/Markdown/Markdown.tsx`), so an imported partial would render on docs.airbyte.com but silently disappear in the Airbyte UI.

## Review guide

Please confirm the plan wording (Pro + Enterprise Flex, not Standard/Plus) matches the actual entitlement, and whether other IAM-role-gated docs should get the same treatment.

## User Impact

Docs-only. Readers on Standard/Plus learn upfront that IAM role auth isn't available on their plan.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚
- [ ] NO ❌


Link to Devin session: https://app.devin.ai/sessions/f17ee483f8f74aa19becdea4fce0baa8
Requested by: @ian-at-airbyte