### PR TITLE
fix(bulk-cdk-load): lowercase random suffix in generateRandomNamespace()

### DIFF
--- a/airbyte-cdk/bulk/core/load/changelog.md
+++ b/airbyte-cdk/bulk/core/load/changelog.md
@@ -9,7 +9,7 @@ The Load CDK provides functionality for destination connectors including stream-
 
 ### 1.0.23 — 2026-08-06
 
-[#83766](https://github.com/airbytehq/airbyte/pull/83766) — Fix: lowercase random suffix in `generateRandomNamespace()` to prevent case-sensitive schema name mismatch on destinations like Databricks that normalize identifiers to lowercase.
+[#83766](https://github.com/airbytehq/airbyte/pull/83766) — Fix: lowercase random suffix in `generateRandomNamespace()` to prevent case-sensitive schema name mismatch on destinations.
 
 ### 1.0.22 — 2026-08-05
 

--- a/airbyte-cdk/bulk/core/load/changelog.md
+++ b/airbyte-cdk/bulk/core/load/changelog.md
@@ -7,6 +7,10 @@ The Load CDK provides functionality for destination connectors including stream-
 <details>
   <summary>Expand to review</summary>
 
+### 1.0.23 — 2026-08-06
+
+Fix: lowercase random suffix in `generateRandomNamespace()` to prevent case-sensitive schema name mismatch on destinations like Databricks that normalize identifiers to lowercase.
+
 ### 1.0.22 — 2026-08-05
 
 [#83201](https://github.com/airbytehq/airbyte/pull/83201) — Bump Testcontainers to 1.21.4 for Docker API v1.44 negotiation.

--- a/airbyte-cdk/bulk/core/load/changelog.md
+++ b/airbyte-cdk/bulk/core/load/changelog.md
@@ -9,7 +9,7 @@ The Load CDK provides functionality for destination connectors including stream-
 
 ### 1.0.23 — 2026-08-06
 
-Fix: lowercase random suffix in `generateRandomNamespace()` to prevent case-sensitive schema name mismatch on destinations like Databricks that normalize identifiers to lowercase.
+[#83766](https://github.com/airbytehq/airbyte/pull/83766) — Fix: lowercase random suffix in `generateRandomNamespace()` to prevent case-sensitive schema name mismatch on destinations like Databricks that normalize identifiers to lowercase.
 
 ### 1.0.22 — 2026-08-05
 

--- a/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/test/util/IntegrationTest.kt
+++ b/airbyte-cdk/bulk/core/load/src/testFixtures/kotlin/io/airbyte/cdk/load/test/util/IntegrationTest.kt
@@ -406,7 +406,8 @@ abstract class IntegrationTest(
             DateTimeFormatter.ofPattern("yyyyMMdd")
 
         fun generateRandomNamespace(): String {
-            @Suppress("DEPRECATION") val randomSuffix = RandomStringUtils.randomAlphabetic(4)
+            @Suppress("DEPRECATION")
+            val randomSuffix = RandomStringUtils.randomAlphabetic(4).lowercase()
             val timestampString =
                 LocalDateTime.ofInstant(Instant.now(), ZoneOffset.UTC)
                     .format(randomizedNamespaceDateFormatter)

--- a/airbyte-cdk/bulk/core/load/version.properties
+++ b/airbyte-cdk/bulk/core/load/version.properties
@@ -1,1 +1,1 @@
-version=1.0.22
+version=1.0.23


### PR DESCRIPTION
## Summary

`RandomStringUtils.randomAlphabetic(4)` in `IntegrationTest.generateRandomNamespace()` produces mixed-case strings (e.g. `WdIO`), which causes test failures on destinations like Databricks that normalize schema identifiers to lowercase.

### Problem

1. Test generates namespace: `test20260806WdIO_insert_test_namespace`
2. `CREATE SCHEMA` succeeds -- Databricks stores it as `test20260806wdio_insert_test_namespace` (lowercased)
3. `namespaceExists()` queries `information_schema.schemata` with the original mixed-case string
4. Case-sensitive string comparison fails -> test assertion error

### Fix

Add `.lowercase()` to the random suffix in `generateRandomNamespace()`, consistent with other CDK test utilities (e.g. `BaseTypingDedupingTest`, `ProcessFactory`).

### Testing

Verified `DatabricksTableOperationsTest.insert records()` passes with this change using `cdkVersion=local`.