### PR TITLE
[PR-verification] source-uptick stream additions validation

### DIFF
--- a/airbyte-integrations/connectors/source-uptick/integration_tests/abnormal_state.json
+++ b/airbyte-integrations/connectors/source-uptick/integration_tests/abnormal_state.json
@@ -17,6 +17,72 @@
         "updated": "2030-10-01"
       },
       "stream_descriptor": {
+        "name": "clientcontacts"
+      }
+    }
+  },
+  {
+    "type": "STREAM",
+    "stream": {
+      "stream_state": {
+        "updated": "2030-10-01"
+      },
+      "stream_descriptor": {
+        "name": "propertycontacts"
+      }
+    }
+  },
+  {
+    "type": "STREAM",
+    "stream": {
+      "stream_state": {
+        "updated": "2030-10-01"
+      },
+      "stream_descriptor": {
+        "name": "promptquestions"
+      }
+    }
+  },
+  {
+    "type": "STREAM",
+    "stream": {
+      "stream_state": {
+        "updated": "2030-10-01"
+      },
+      "stream_descriptor": {
+        "name": "promptanswergroups"
+      }
+    }
+  },
+  {
+    "type": "STREAM",
+    "stream": {
+      "stream_state": {
+        "updated": "2030-10-01"
+      },
+      "stream_descriptor": {
+        "name": "promptanswers"
+      }
+    }
+  },
+  {
+    "type": "STREAM",
+    "stream": {
+      "stream_state": {
+        "updated": "2030-10-01"
+      },
+      "stream_descriptor": {
+        "name": "majorservices"
+      }
+    }
+  },
+  {
+    "type": "STREAM",
+    "stream": {
+      "stream_state": {
+        "updated": "2030-10-01"
+      },
+      "stream_descriptor": {
         "name": "taskcategories"
       }
     }

--- a/airbyte-integrations/connectors/source-uptick/integration_tests/configured_catalog.json
+++ b/airbyte-integrations/connectors/source-uptick/integration_tests/configured_catalog.json
@@ -14,6 +14,78 @@
     },
     {
       "stream": {
+        "name": "clientcontacts",
+        "json_schema": {},
+        "supported_sync_modes": ["incremental", "full_refresh"],
+        "source_defined_cursor": true,
+        "default_cursor_field": ["updated"]
+      },
+      "sync_mode": "incremental",
+      "destination_sync_mode": "append",
+      "cursor_field": ["updated"]
+    },
+    {
+      "stream": {
+        "name": "propertycontacts",
+        "json_schema": {},
+        "supported_sync_modes": ["incremental", "full_refresh"],
+        "source_defined_cursor": true,
+        "default_cursor_field": ["updated"]
+      },
+      "sync_mode": "incremental",
+      "destination_sync_mode": "append",
+      "cursor_field": ["updated"]
+    },
+    {
+      "stream": {
+        "name": "promptquestions",
+        "json_schema": {},
+        "supported_sync_modes": ["incremental", "full_refresh"],
+        "source_defined_cursor": true,
+        "default_cursor_field": ["updated"]
+      },
+      "sync_mode": "incremental",
+      "destination_sync_mode": "append",
+      "cursor_field": ["updated"]
+    },
+    {
+      "stream": {
+        "name": "promptanswergroups",
+        "json_schema": {},
+        "supported_sync_modes": ["incremental", "full_refresh"],
+        "source_defined_cursor": true,
+        "default_cursor_field": ["updated"]
+      },
+      "sync_mode": "incremental",
+      "destination_sync_mode": "append",
+      "cursor_field": ["updated"]
+    },
+    {
+      "stream": {
+        "name": "promptanswers",
+        "json_schema": {},
+        "supported_sync_modes": ["incremental", "full_refresh"],
+        "source_defined_cursor": true,
+        "default_cursor_field": ["updated"]
+      },
+      "sync_mode": "incremental",
+      "destination_sync_mode": "append",
+      "cursor_field": ["updated"]
+    },
+    {
+      "stream": {
+        "name": "majorservices",
+        "json_schema": {},
+        "supported_sync_modes": ["incremental", "full_refresh"],
+        "source_defined_cursor": true,
+        "default_cursor_field": ["updated"]
+      },
+      "sync_mode": "incremental",
+      "destination_sync_mode": "append",
+      "cursor_field": ["updated"]
+    },
+    {
+      "stream": {
         "name": "taskcategories",
         "json_schema": {},
         "supported_sync_modes": ["incremental", "full_refresh"],

--- a/airbyte-integrations/connectors/source-uptick/manifest.yaml
+++ b/airbyte-integrations/connectors/source-uptick/manifest.yaml
@@ -27,7 +27,7 @@ definitions:
           - type: WaitTimeFromHeader
             header: Retry-After
       request_headers:
-        User-Agent: Airbyte (Connector Version 1.0.0)
+        User-Agent: Airbyte (Connector Version 1.1.0)
     SimpleRetriever:
       requester:
         $ref: "#/definitions/linked/HttpRequester"
@@ -650,105 +650,154 @@ streams:
           - type: AddedFieldDefinition
             path:
               - category_id
-            value: '{{ record["relationships"]["category"]["data"]["id"] or "None"}}'
+            value:
+              '{{ record["relationships"]["category"]["data"]["id"] if record["relationships"].get("category",
+              {}).get("data") else "None" }}'
           - type: AddedFieldDefinition
             path:
               - servicegroup_id
-            value: '{{ record["relationships"]["servicegroup"]["data"]["id"] or "None"}}'
+            value:
+              '{{ record["relationships"]["servicegroup"]["data"]["id"] if record["relationships"].get("servicegroup",
+              {}).get("data") else "None" }}'
           - type: AddedFieldDefinition
             path:
               - client_id
-            value: '{{ record["relationships"]["client"]["data"]["id"] or "None"}}'
+            value:
+              '{{ record["relationships"]["client"]["data"]["id"] if record["relationships"].get("client",
+              {}).get("data") else "None" }}'
           - type: AddedFieldDefinition
             path:
               - property_id
-            value: '{{ record["relationships"]["property"]["data"]["id"] or "None"}}'
+            value:
+              '{{ record["relationships"]["property"]["data"]["id"] if record["relationships"].get("property",
+              {}).get("data") else "None" }}'
           - type: AddedFieldDefinition
             path:
               - billingcard_id
-            value: '{{ record["relationships"]["billingcard"]["data"]["id"] or "None"}}'
+            value:
+              '{{ record["relationships"]["billingcard"]["data"]["id"] if record["relationships"].get("billingcard",
+              {}).get("data") else "None" }}'
           - type: AddedFieldDefinition
             path:
               - assigned_to_id
-            value: '{{ record["relationships"]["assigned_to"]["data"]["id"] or "None"}}'
+            value:
+              '{{ record["relationships"]["assigned_to"]["data"]["id"] if record["relationships"].get("assigned_to",
+              {}).get("data") else "None" }}'
           - type: AddedFieldDefinition
             path:
               - assigned_office_id
-            value: '{{ record["relationships"]["assigned_office"]["data"]["id"] or "None"}}'
+            value:
+              '{{ record["relationships"]["assigned_office"]["data"]["id"] if record["relationships"].get("assigned_office",
+              {}).get("data") else "None" }}'
           - type: AddedFieldDefinition
             path:
               - salesperson_id
-            value: '{{ record["relationships"]["salesperson"]["data"]["id"] or "None"}}'
+            value:
+              '{{ record["relationships"]["salesperson"]["data"]["id"] if record["relationships"].get("salesperson",
+              {}).get("data") else "None" }}'
           - type: AddedFieldDefinition
             path:
               - technician_id
-            value: '{{ record["relationships"]["technician"]["data"]["id"] or "None"}}'
+            value:
+              '{{ record["relationships"]["technician"]["data"]["id"] if record["relationships"].get("technician",
+              {}).get("data") else "None" }}'
           - type: AddedFieldDefinition
             path:
               - round_id
-            value: '{{ record["relationships"]["round"]["data"]["id"] or "None"}}'
+            value:
+              '{{ record["relationships"]["round"]["data"]["id"] if record["relationships"].get("round",
+              {}).get("data") else "None" }}'
           - type: AddedFieldDefinition
             path:
               - tags
-            value: '{{ record["relationships"]["tags"]["data"] }}'
+            value:
+              '{{ record["relationships"]["tags"]["data"] if record["relationships"].get("tags")
+              else "" }}'
           - type: AddedFieldDefinition
             path:
               - branch_id
-            value: '{{ record["relationships"]["branch"]["data"]["id"] or "None"}}'
+            value:
+              '{{ record["relationships"]["branch"]["data"]["id"] if record["relationships"].get("branch",
+              {}).get("data") else "None" }}'
           - type: AddedFieldDefinition
             path:
               - supporting_technicians
-            value: '{{ record["relationships"]["supporting_technicians"]["data"] }}'
+            value:
+              '{{ record["relationships"]["supporting_technicians"]["data"] if record["relationships"].get("supporting_technicians")
+              else "" }}'
           - type: AddedFieldDefinition
             path:
               - costcentre_id
-            value: '{{ record["relationships"]["costcentre"]["data"]["id"] or "None"}}'
+            value:
+              '{{ record["relationships"]["costcentre"]["data"]["id"] if record["relationships"].get("costcentre",
+              {}).get("data") else "None" }}'
           - type: AddedFieldDefinition
             path:
               - parent_task_id
-            value: '{{ record["relationships"]["parent_task"]["data"]["id"] or "None"}}'
+            value:
+              '{{ record["relationships"]["parent_task"]["data"]["id"] if record["relationships"].get("parent_task",
+              {}).get("data") else "None" }}'
           - type: AddedFieldDefinition
             path:
               - author_id
-            value: '{{ record["relationships"]["author"]["data"]["id"] or "None"}}'
+            value:
+              '{{ record["relationships"]["author"]["data"]["id"] if record["relationships"].get("author",
+              {}).get("data") else "None" }}'
           - type: AddedFieldDefinition
             path:
               - contractor_id
-            value: '{{ record["relationships"]["contractor"]["data"]["id"] or "None"}}'
+            value:
+              '{{ record["relationships"]["contractor"]["data"]["id"] if record["relationships"].get("contractor",
+              {}).get("data") else "None" }}'
           - type: AddedFieldDefinition
             path:
               - contractor_assigned_technician_id
             value:
               '{{ record["relationships"]["contractor_assigned_technician"]["data"]["id"]
-              or "None"}}'
+              if record["relationships"].get("contractor_assigned_technician", {}).get("data")
+              else "None" }}'
           - type: AddedFieldDefinition
             path:
               - updated_by_id
-            value: '{{ record["relationships"]["updated_by"]["data"]["id"] or "None"}}'
+            value:
+              '{{ record["relationships"]["updated_by"]["data"]["id"] if record["relationships"].get("updated_by",
+              {}).get("data") else "None" }}'
           - type: AddedFieldDefinition
             path:
               - status_id
-            value: '{{ record["relationships"]["status"]["data"]["id"] or "None"}}'
+            value:
+              '{{ record["relationships"]["status"]["data"]["id"] if record["relationships"].get("status",
+              {}).get("data") else "None" }}'
           - type: AddedFieldDefinition
             path:
               - zone_id
-            value: '{{ record["relationships"]["zone"]["data"]["id"] or "None"}}'
+            value:
+              '{{ record["relationships"]["zone"]["data"]["id"] if record["relationships"].get("zone",
+              {}).get("data") else "None" }}'
           - type: AddedFieldDefinition
             path:
               - required_accreditationtypes
-            value: '{{ record["relationships"]["required_accreditationtypes"]["data"] }}'
+            value:
+              '{{ record["relationships"]["required_accreditationtypes"]["data"] if
+              record["relationships"].get("required_accreditationtypes") else "" }}'
           - type: AddedFieldDefinition
             path:
               - project_id
-            value: '{{ record["relationships"]["project"]["data"]["id"] or "None"}}'
+            value:
+              '{{ record["relationships"]["project"]["data"]["id"] if record["relationships"].get("project",
+              {}).get("data") else "None" }}'
           - type: AddedFieldDefinition
             path:
               - sla_id
-            value: '{{ record["relationships"]["sla"]["data"]["id"] or "None"}}'
+            value:
+              '{{ record["relationships"]["sla"]["data"]["id"] if record["relationships"].get("sla",
+              {}).get("data") else "None" }}'
           - type: AddedFieldDefinition
             path:
               - callout_id
-            value: '{{ record["relationships"]["callout"]["data"]["id"] or "None"}}'
+            value:
+              '{{ record["relationships"]["callout"]["data"]["id"] if record["relationships"].get("callout",
+              {}).get("data") else "None" }}'
   - type: DeclarativeStream
     name: taskcategories
     primary_key:
@@ -820,7 +869,7 @@ streams:
         request_parameters:
           ordering: -updated
           show_deleted: "true"
-          fields[Client]: id,created,updated,ref,name,is_active,contact_name,contact_organisation,contact_mobile,contact_phone_bh,contact_phone_ah,contact_email,contact_email_cc,contact_address,report_requirements,report_attention,report_email_to,report_email_cc,report_manual,billing_organisation,billing_requirements,billing_attention,billing_email_to,billing_email_cc,billing_manual,billing_address,billing_fixedprice,quoting_autoreminders_enabled,quoting_requirements,notes,address,material_markup,extra_fields,sector,billingcard,pricetier
+          fields[Client]: id,created,updated,ref,name,is_active,contact_name,contact_organisation,contact_mobile,contact_phone_bh,contact_phone_ah,contact_email,contact_email_cc,contact_address,report_requirements,report_attention,report_email_to,report_email_cc,report_manual,billing_organisation,billing_requirements,billing_attention,billing_email_to,billing_email_cc,billing_manual,billing_address,billing_fixedprice,quoting_autoreminders_enabled,quoting_requirements,notes,address,material_markup,extra_fields,sector,billingcard,pricetier,clientgroup,account_manager
     schema_loader:
       type: InlineSchemaLoader
       schema:
@@ -944,6 +993,14 @@ streams:
               - integer
               - "null"
           pricetier_id:
+            type:
+              - integer
+              - "null"
+          clientgroup_id:
+            type:
+              - integer
+              - "null"
+          account_manager_id:
             type:
               - integer
               - "null"
@@ -1089,11 +1146,27 @@ streams:
           - type: AddedFieldDefinition
             path:
               - billingcard_id
-            value: '{{ record["relationships"]["billingcard"]["data"]["id"] or "None"}}'
+            value:
+              '{{ record["relationships"]["billingcard"]["data"]["id"] if record["relationships"].get("billingcard",
+              {}).get("data") else "None" }}'
           - type: AddedFieldDefinition
             path:
               - pricetier_id
-            value: '{{ record["relationships"]["pricetier"]["data"]["id"] or "None"}}'
+            value:
+              '{{ record["relationships"]["pricetier"]["data"]["id"] if record["relationships"].get("pricetier",
+              {}).get("data") else "None" }}'
+          - type: AddedFieldDefinition
+            path:
+              - clientgroup_id
+            value:
+              '{{ record["relationships"]["clientgroup"]["data"]["id"] if record["relationships"].get("clientgroup",
+              {}).get("data") else "None" }}'
+          - type: AddedFieldDefinition
+            path:
+              - account_manager_id
+            value:
+              '{{ record["relationships"]["account_manager"]["data"]["id"] if record["relationships"].get("account_manager",
+              {}).get("data") else "None" }}'
   - type: DeclarativeStream
     name: clientgroups
     primary_key:
@@ -1179,7 +1252,7 @@ streams:
         request_parameters:
           ordering: -updated
           show_deleted: "true"
-          fields[Property]: id,created,updated,address,coords,timezone,access_inductionreq,access_logbookreq,access_schedule,access_signaturereq,billing_manual,building_tenancies,client_signature_required,name,ref,report_manual,status,bsecure_resolved_guid,extra_fields,tags
+          fields[Property]: id,created,updated,address,coords,timezone,access_inductionreq,access_logbookreq,access_schedule,access_signaturereq,billing_manual,building_tenancies,client_signature_required,name,ref,report_manual,status,bsecure_resolved_guid,extra_fields,tags,client,branch,account_manager
     schema_loader:
       type: InlineSchemaLoader
       schema:
@@ -1255,6 +1328,18 @@ streams:
           tags:
             type:
               - array
+          client_id:
+            type:
+              - integer
+              - "null"
+          branch_id:
+            type:
+              - integer
+              - "null"
+          account_manager_id:
+            type:
+              - integer
+              - "null"
     transformations:
       - type: AddFields
         fields:
@@ -1337,7 +1422,27 @@ streams:
           - type: AddedFieldDefinition
             path:
               - tags
-            value: '{{ record["relationships"]["tags"]["data"] }}'
+            value:
+              '{{ record["relationships"]["tags"]["data"] if record["relationships"].get("tags")
+              else "" }}'
+          - type: AddedFieldDefinition
+            path:
+              - client_id
+            value:
+              '{{ record["relationships"]["client"]["data"]["id"] if record["relationships"].get("client",
+              {}).get("data") else "None" }}'
+          - type: AddedFieldDefinition
+            path:
+              - branch_id
+            value:
+              '{{ record["relationships"]["branch"]["data"]["id"] if record["relationships"].get("branch",
+              {}).get("data") else "None" }}'
+          - type: AddedFieldDefinition
+            path:
+              - account_manager_id
+            value:
+              '{{ record["relationships"]["account_manager"]["data"]["id"] if record["relationships"].get("account_manager",
+              {}).get("data") else "None" }}'
   - type: DeclarativeStream
     name: invoices
     primary_key:
@@ -1352,7 +1457,7 @@ streams:
         request_parameters:
           ordering: -updated
           show_deleted: "true"
-          fields[Invoice]: id,created,updated,description,authorisation_ref,created,currency,date,due_date,extra_fields,gst,is_overdue,is_sent,number,partner_uid,ref,status,subtotal,synced,total,property,task
+          fields[Invoice]: id,created,updated,description,authorisation_ref,created,currency,date,due_date,extra_fields,gst,is_overdue,is_sent,number,partner_uid,ref,status,subtotal,synced,total,property,task,branch,client
     schema_loader:
       type: InlineSchemaLoader
       schema:
@@ -1436,6 +1541,14 @@ streams:
               - integer
               - "null"
           task_id:
+            type:
+              - integer
+              - "null"
+          branch_id:
+            type:
+              - integer
+              - "null"
+          client_id:
             type:
               - integer
               - "null"
@@ -1525,11 +1638,27 @@ streams:
           - type: AddedFieldDefinition
             path:
               - property_id
-            value: '{{ record["relationships"]["property"]["data"]["id"] or "None"}}'
+            value:
+              '{{ record["relationships"]["property"]["data"]["id"] if record["relationships"].get("property",
+              {}).get("data") else "None" }}'
           - type: AddedFieldDefinition
             path:
               - task_id
-            value: '{{ record["relationships"]["task"]["data"]["id"] or "None"}}'
+            value:
+              '{{ record["relationships"]["task"]["data"]["id"] if record["relationships"].get("task",
+              {}).get("data") else "None" }}'
+          - type: AddedFieldDefinition
+            path:
+              - branch_id
+            value:
+              '{{ record["relationships"]["branch"]["data"]["id"] if record["relationships"].get("branch",
+              {}).get("data") else "None" }}'
+          - type: AddedFieldDefinition
+            path:
+              - client_id
+            value:
+              '{{ record["relationships"]["client"]["data"]["id"] if record["relationships"].get("client",
+              {}).get("data") else "None" }}'
   - type: DeclarativeStream
     name: projects
     primary_key:
@@ -1735,31 +1864,45 @@ streams:
           - type: AddedFieldDefinition
             path:
               - branch_id
-            value: '{{ record["relationships"]["branch"]["data"]["id"] or "None"}}'
+            value:
+              '{{ record["relationships"]["branch"]["data"]["id"] if record["relationships"].get("branch",
+              {}).get("data") else "None" }}'
           - type: AddedFieldDefinition
             path:
               - costcentre_id
-            value: '{{ record["relationships"]["costcentre"]["data"]["id"] or "None"}}'
+            value:
+              '{{ record["relationships"]["costcentre"]["data"]["id"] if record["relationships"].get("costcentre",
+              {}).get("data") else "None" }}'
           - type: AddedFieldDefinition
             path:
               - client_id
-            value: '{{ record["relationships"]["client"]["data"]["id"] or "None"}}'
+            value:
+              '{{ record["relationships"]["client"]["data"]["id"] if record["relationships"].get("client",
+              {}).get("data") else "None" }}'
           - type: AddedFieldDefinition
             path:
               - property_id
-            value: '{{ record["relationships"]["property"]["data"]["id"] or "None"}}'
+            value:
+              '{{ record["relationships"]["property"]["data"]["id"] if record["relationships"].get("property",
+              {}).get("data") else "None" }}'
           - type: AddedFieldDefinition
             path:
               - billingcard_id
-            value: '{{ record["relationships"]["billingcard"]["data"]["id"] or "None"}}'
+            value:
+              '{{ record["relationships"]["billingcard"]["data"]["id"] if record["relationships"].get("billingcard",
+              {}).get("data") else "None" }}'
           - type: AddedFieldDefinition
             path:
               - supervisor_id
-            value: '{{ record["relationships"]["supervisor"]["data"]["id"] or "None"}}'
+            value:
+              '{{ record["relationships"]["supervisor"]["data"]["id"] if record["relationships"].get("supervisor",
+              {}).get("data") else "None" }}'
           - type: AddedFieldDefinition
             path:
               - salesperson_id
-            value: '{{ record["relationships"]["salesperson"]["data"]["id"] or "None"}}'
+            value:
+              '{{ record["relationships"]["salesperson"]["data"]["id"] if record["relationships"].get("salesperson",
+              {}).get("data") else "None" }}'
   - type: DeclarativeStream
     name: servicequotes
     primary_key:
@@ -1774,7 +1917,7 @@ streams:
         request_parameters:
           ordering: -updated
           show_deleted: "true"
-          fields[ServiceQuote]: id,description,created,updated,uuid,ref,status,status_changed_submitted,status_changed_approved,expiry_date,review_date,template,template_name,scope_of_works_format,upload_path,property_access_schedule,authorisation_date,product_subtotal
+          fields[ServiceQuote]: id,description,created,updated,uuid,ref,status,status_changed_submitted,status_changed_approved,expiry_date,review_date,template,template_name,scope_of_works_format,upload_path,property_access_schedule,authorisation_date,product_subtotal,author,salesperson,property_branch,property_object,client_object
     schema_loader:
       type: InlineSchemaLoader
       schema:
@@ -1855,6 +1998,26 @@ streams:
           product_subtotal:
             type:
               - string
+          author_id:
+            type:
+              - integer
+              - "null"
+          salesperson_id:
+            type:
+              - integer
+              - "null"
+          property_branch_id:
+            type:
+              - integer
+              - "null"
+          property_object_id:
+            type:
+              - integer
+              - "null"
+          client_object_id:
+            type:
+              - integer
+              - "null"
     transformations:
       - type: AddFields
         fields:
@@ -1930,6 +2093,36 @@ streams:
             path:
               - product_subtotal
             value: '{{ record["attributes"]["product_subtotal"] }}'
+          - type: AddedFieldDefinition
+            path:
+              - author_id
+            value:
+              '{{ record["relationships"]["author"]["data"]["id"] if record["relationships"].get("author",
+              {}).get("data") else "None" }}'
+          - type: AddedFieldDefinition
+            path:
+              - salesperson_id
+            value:
+              '{{ record["relationships"]["salesperson"]["data"]["id"] if record["relationships"].get("salesperson",
+              {}).get("data") else "None" }}'
+          - type: AddedFieldDefinition
+            path:
+              - property_branch_id
+            value:
+              '{{ record["relationships"]["property_branch"]["data"]["id"] if record["relationships"].get("property_branch",
+              {}).get("data") else "None" }}'
+          - type: AddedFieldDefinition
+            path:
+              - property_object_id
+            value:
+              '{{ record["relationships"]["property_object"]["data"]["id"] if record["relationships"].get("property_object",
+              {}).get("data") else "None" }}'
+          - type: AddedFieldDefinition
+            path:
+              - client_object_id
+            value:
+              '{{ record["relationships"]["client_object"]["data"]["id"] if record["relationships"].get("client_object",
+              {}).get("data") else "None" }}'
   - type: DeclarativeStream
     name: defectquotes
     primary_key:
@@ -1944,7 +2137,7 @@ streams:
         request_parameters:
           ordering: -updated
           show_deleted: "true"
-          fields[DefectQuote]: id,description,ref,created,updated,status,date,due_date,expiry_date,last_actioned,email_template,reminder_email_template,scope_of_works,branch,client,property,author,salesperson
+          fields[DefectQuote]: id,description,ref,created,updated,status,date,due_date,expiry_date,last_actioned,email_template,reminder_email_template,scope_of_works,branch,client,property,author,salesperson,status_changed_submitted,status_changed_approved,servicegroup,authorisation_date
     schema_loader:
       type: InlineSchemaLoader
       schema:
@@ -2024,6 +2217,28 @@ streams:
             type:
               - integer
               - "null"
+          status_changed_submitted:
+            type:
+              - string
+              - "null"
+            format: date-time
+            airbyte_type: timestamp_with_timezone
+          status_changed_approved:
+            type:
+              - string
+              - "null"
+            format: date-time
+            airbyte_type: timestamp_with_timezone
+          servicegroup_id:
+            type:
+              - integer
+              - "null"
+          authorisation_date:
+            type:
+              - string
+              - "null"
+            format: date-time
+            airbyte_type: timestamp_with_timezone
     transformations:
       - type: AddFields
         fields:
@@ -2082,23 +2297,51 @@ streams:
           - type: AddedFieldDefinition
             path:
               - branch_id
-            value: '{{ record["relationships"]["branch"]["data"]["id"] or "None"}}'
+            value:
+              '{{ record["relationships"]["branch"]["data"]["id"] if record["relationships"].get("branch",
+              {}).get("data") else "None" }}'
           - type: AddedFieldDefinition
             path:
               - client_id
-            value: '{{ record["relationships"]["client"]["data"]["id"] or "None"}}'
+            value:
+              '{{ record["relationships"]["client"]["data"]["id"] if record["relationships"].get("client",
+              {}).get("data") else "None" }}'
           - type: AddedFieldDefinition
             path:
               - property_id
-            value: '{{ record["relationships"]["property"]["data"]["id"] or "None"}}'
+            value:
+              '{{ record["relationships"]["property"]["data"]["id"] if record["relationships"].get("property",
+              {}).get("data") else "None" }}'
           - type: AddedFieldDefinition
             path:
               - author_id
-            value: '{{ record["relationships"]["author"]["data"]["id"] or "None"}}'
+            value:
+              '{{ record["relationships"]["author"]["data"]["id"] if record["relationships"].get("author",
+              {}).get("data") else "None" }}'
           - type: AddedFieldDefinition
             path:
               - salesperson_id
-            value: '{{ record["relationships"]["salesperson"]["data"]["id"] or "None"}}'
+            value:
+              '{{ record["relationships"]["salesperson"]["data"]["id"] if record["relationships"].get("salesperson",
+              {}).get("data") else "None" }}'
+          - type: AddedFieldDefinition
+            path:
+              - status_changed_submitted
+            value: '{{ record["attributes"]["status_changed_submitted"] or "None"}}'
+          - type: AddedFieldDefinition
+            path:
+              - status_changed_approved
+            value: '{{ record["attributes"]["status_changed_approved"] or "None"}}'
+          - type: AddedFieldDefinition
+            path:
+              - servicegroup_id
+            value:
+              '{{ record["relationships"]["servicegroup"]["data"]["id"] if record["relationships"].get("servicegroup",
+              {}).get("data") else "None" }}'
+          - type: AddedFieldDefinition
+            path:
+              - authorisation_date
+            value: '{{ record["attributes"]["authorisation_date"] or "None"}}'
   - type: DeclarativeStream
     name: suppliers
     primary_key:
@@ -2199,7 +2442,7 @@ streams:
         request_parameters:
           ordering: -updated
           show_deleted: "true"
-          fields[PurchaseOrder]: id,created,updated,ref,status,all_goods_received,date,total,supplier_ref,created_via,has_manually_added_costs,currency,fx_rate
+          fields[PurchaseOrder]: id,created,updated,ref,status,all_goods_received,date,total,supplier_ref,created_via,has_manually_added_costs,currency,fx_rate,task
     schema_loader:
       type: InlineSchemaLoader
       schema:
@@ -2254,6 +2497,10 @@ streams:
             type:
               - string
             airbyte_type: decimal
+          task_id:
+            type:
+              - integer
+              - "null"
     transformations:
       - type: AddFields
         fields:
@@ -2309,6 +2556,12 @@ streams:
             path:
               - fx_rate
             value: '{{ record["attributes"]["fx_rate"] }}'
+          - type: AddedFieldDefinition
+            path:
+              - task_id
+            value:
+              '{{ record["relationships"]["task"]["data"]["id"] if record["relationships"].get("task",
+              {}).get("data") else "None" }}'
   - type: DeclarativeStream
     name: routines
     primary_key:
@@ -2695,7 +2948,9 @@ streams:
           - type: AddedFieldDefinition
             path:
               - invoice_id
-            value: '{{ record["relationships"]["invoice"]["data"]["id"] or "None"}}'
+            value:
+              '{{ record["relationships"]["invoice"]["data"]["id"] if record["relationships"].get("invoice",
+              {}).get("data") else "None" }}'
           - type: AddedFieldDefinition
             path:
               - created
@@ -2758,7 +3013,7 @@ streams:
         request_parameters:
           ordering: -updated
           show_deleted: "true"
-          fields[User]: id,updated,name,email,partner_uid,date_joined,last_login,last_access,is_active,is_staff,is_superuser,license,addons,rate,sell_rate,extra_fields,purchase_order_approval_limit,defectquote_approval_limit
+          fields[User]: id,updated,name,email,partner_uid,date_joined,last_login,last_access,is_active,is_staff,is_superuser,license,addons,rate,sell_rate,extra_fields,purchase_order_approval_limit,defectquote_approval_limit,servicegroup
     schema_loader:
       type: InlineSchemaLoader
       schema:
@@ -2839,6 +3094,10 @@ streams:
               - string
               - "null"
             airbyte_type: decimal
+          servicegroup_id:
+            type:
+              - integer
+              - "null"
     transformations:
       - type: AddFields
         fields:
@@ -2914,6 +3173,12 @@ streams:
             path:
               - defectquote_approval_limit
             value: '{{ record["attributes"]["defectquote_approval_limit"] or "None"}}'
+          - type: AddedFieldDefinition
+            path:
+              - servicegroup_id
+            value:
+              '{{ record["relationships"]["servicegroup"]["data"]["id"] if record["relationships"].get("servicegroup",
+              {}).get("data") else "None" }}'
   - type: DeclarativeStream
     name: servicegroups
     primary_key:
@@ -3074,11 +3339,15 @@ streams:
           - type: AddedFieldDefinition
             path:
               - branch_id
-            value: '{{ record["relationships"]["branch"]["data"]["id"] or "None"}}'
+            value:
+              '{{ record["relationships"]["branch"]["data"]["id"] if record["relationships"].get("branch",
+              {}).get("data") else "None" }}'
           - type: AddedFieldDefinition
             path:
               - taskcategory_id
-            value: '{{ record["relationships"]["taskcategory"]["data"]["id"] or "None"}}'
+            value:
+              '{{ record["relationships"]["taskcategory"]["data"]["id"] if record["relationships"].get("taskcategory",
+              {}).get("data") else "None" }}'
   - type: DeclarativeStream
     name: purchaseorderlineitems
     primary_key:
@@ -3254,11 +3523,15 @@ streams:
           - type: AddedFieldDefinition
             path:
               - purchaseorder_id
-            value: '{{ record["relationships"]["purchaseorder"]["data"]["id"] or "None"}}'
+            value:
+              '{{ record["relationships"]["purchaseorder"]["data"]["id"] if record["relationships"].get("purchaseorder",
+              {}).get("data") else "None" }}'
           - type: AddedFieldDefinition
             path:
               - product_id
-            value: '{{ record["relationships"]["product"]["data"]["id"] or "None"}}'
+            value:
+              '{{ record["relationships"]["product"]["data"]["id"] if record["relationships"].get("product",
+              {}).get("data") else "None" }}'
   - type: DeclarativeStream
     name: purchaseorderbilllineitems
     primary_key:
@@ -3398,17 +3671,22 @@ streams:
           - type: AddedFieldDefinition
             path:
               - purchaseorderbill_id
-            value: '{{ record["relationships"]["purchaseorderbill"]["data"]["id"] or "None"}}'
+            value:
+              '{{ record["relationships"]["purchaseorderbill"]["data"]["id"] if record["relationships"].get("purchaseorderbill",
+              {}).get("data") else "None" }}'
           - type: AddedFieldDefinition
             path:
               - purchaseorderlineitem_id
             value:
-              '{{ record["relationships"]["purchaseorderlineitem"]["data"]["id"] or
-              "None"}}'
+              '{{ record["relationships"]["purchaseorderlineitem"]["data"]["id"] if
+              record["relationships"].get("purchaseorderlineitem", {}).get("data") else
+              "None" }}'
           - type: AddedFieldDefinition
             path:
               - product_id
-            value: '{{ record["relationships"]["product"]["data"]["id"] or "None"}}'
+            value:
+              '{{ record["relationships"]["product"]["data"]["id"] if record["relationships"].get("product",
+              {}).get("data") else "None" }}'
   - type: DeclarativeStream
     name: accreditationtypes
     primary_key:
@@ -3583,15 +3861,21 @@ streams:
           - type: AddedFieldDefinition
             path:
               - property_id
-            value: '{{ record["relationships"]["property"]["data"]["id"] or "None"}}'
+            value:
+              '{{ record["relationships"]["property"]["data"]["id"] if record["relationships"].get("property",
+              {}).get("data") else "None" }}'
           - type: AddedFieldDefinition
             path:
               - accreditationtype_id
-            value: '{{ record["relationships"]["accreditationtype"]["data"]["id"] or "None"}}'
+            value:
+              '{{ record["relationships"]["accreditationtype"]["data"]["id"] if record["relationships"].get("accreditationtype",
+              {}).get("data") else "None" }}'
           - type: AddedFieldDefinition
             path:
               - technician_id
-            value: '{{ record["relationships"]["technician"]["data"]["id"] or "None"}}'
+            value:
+              '{{ record["relationships"]["technician"]["data"]["id"] if record["relationships"].get("technician",
+              {}).get("data") else "None" }}'
   - type: DeclarativeStream
     name: branches
     primary_key:
@@ -3739,7 +4023,9 @@ streams:
           - type: AddedFieldDefinition
             path:
               - default_warehouse_id
-            value: '{{ record["relationships"]["default_warehouse"]["data"]["id"] or "None"}}'
+            value:
+              '{{ record["relationships"]["default_warehouse"]["data"]["id"] if record["relationships"].get("default_warehouse",
+              {}).get("data") else "None" }}'
   - type: DeclarativeStream
     name: creditnotes
     primary_key:
@@ -3878,11 +4164,15 @@ streams:
           - type: AddedFieldDefinition
             path:
               - invoice_id
-            value: '{{ record["relationships"]["invoice"]["data"]["id"] or "None"}}'
+            value:
+              '{{ record["relationships"]["invoice"]["data"]["id"] if record["relationships"].get("invoice",
+              {}).get("data") else "None" }}'
           - type: AddedFieldDefinition
             path:
               - lineitems
-            value: '{{ record["relationships"]["lineitems"]["data"] }}'
+            value:
+              '{{ record["relationships"]["lineitems"]["data"] if record["relationships"].get("lineitems")
+              else "" }}'
   - type: DeclarativeStream
     name: creditnotelineitems
     primary_key:
@@ -4023,11 +4313,15 @@ streams:
           - type: AddedFieldDefinition
             path:
               - creditnote_id
-            value: '{{ record["relationships"]["creditnote"]["data"]["id"] or "None"}}'
+            value:
+              '{{ record["relationships"]["creditnote"]["data"]["id"] if record["relationships"].get("creditnote",
+              {}).get("data") else "None" }}'
           - type: AddedFieldDefinition
             path:
               - product_id
-            value: '{{ record["relationships"]["product"]["data"]["id"] or "None"}}'
+            value:
+              '{{ record["relationships"]["product"]["data"]["id"] if record["relationships"].get("product",
+              {}).get("data") else "None" }}'
   - type: DeclarativeStream
     name: remarks
     primary_key:
@@ -4226,25 +4520,34 @@ streams:
           - type: AddedFieldDefinition
             path:
               - type_id
-            value: '{{ record["relationships"]["type"]["data"]["id"] or "None"}}'
+            value:
+              '{{ record["relationships"]["type"]["data"]["id"] if record["relationships"].get("type",
+              {}).get("data") else "None" }}'
           - type: AddedFieldDefinition
             path:
               - asset_id
-            value: '{{ record["relationships"]["asset"]["data"]["id"] or "None"}}'
+            value:
+              '{{ record["relationships"]["asset"]["data"]["id"] if record["relationships"].get("asset",
+              {}).get("data") else "None" }}'
           - type: AddedFieldDefinition
             path:
               - assigned_contractor_id
-            value: '{{ record["relationships"]["assigned_contractor"]["data"]["id"] or "None"}}'
+            value:
+              '{{ record["relationships"]["assigned_contractor"]["data"]["id"] if record["relationships"].get("assigned_contractor",
+              {}).get("data") else "None" }}'
           - type: AddedFieldDefinition
             path:
               - created_by_id
-            value: '{{ record["relationships"]["created_by"]["data"]["id"] or "None"}}'
+            value:
+              '{{ record["relationships"]["created_by"]["data"]["id"] if record["relationships"].get("created_by",
+              {}).get("data") else "None" }}'
           - type: AddedFieldDefinition
             path:
               - created_by_contractor_id
             value:
-              '{{ record["relationships"]["created_by_contractor"]["data"]["id"] or
-              "None"}}'
+              '{{ record["relationships"]["created_by_contractor"]["data"]["id"] if
+              record["relationships"].get("created_by_contractor", {}).get("data") else
+              "None" }}'
           - type: AddedFieldDefinition
             path:
               - extra_fields
@@ -4509,25 +4812,34 @@ streams:
           - type: AddedFieldDefinition
             path:
               - tags
-            value: '{{ record["relationships"]["tags"]["data"] }}'
+            value:
+              '{{ record["relationships"]["tags"]["data"] if record["relationships"].get("tags")
+              else "" }}'
           - type: AddedFieldDefinition
             path:
               - variants
-            value: '{{ record["relationships"]["variants"]["data"] }}'
+            value:
+              '{{ record["relationships"]["variants"]["data"] if record["relationships"].get("variants")
+              else "" }}'
           - type: AddedFieldDefinition
             path:
               - applicable_routines
-            value: '{{ record["relationships"]["applicable_routines"]["data"] }}'
+            value:
+              '{{ record["relationships"]["applicable_routines"]["data"] if record["relationships"].get("applicable_routines")
+              else "" }}'
           - type: AddedFieldDefinition
             path:
               - excluded_routinelevels
-            value: '{{ record["relationships"]["excluded_routinelevels"]["data"] }}'
+            value:
+              '{{ record["relationships"]["excluded_routinelevels"]["data"] if record["relationships"].get("excluded_routinelevels")
+              else "" }}'
           - type: AddedFieldDefinition
             path:
               - default_replacement_product_id
             value:
               '{{ record["relationships"]["default_replacement_product"]["data"]["id"]
-              or "None"}}'
+              if record["relationships"].get("default_replacement_product", {}).get("data")
+              else "None" }}'
   - type: DeclarativeStream
     name: assettypevariants
     primary_key:
@@ -4634,13 +4946,16 @@ streams:
           - type: AddedFieldDefinition
             path:
               - type_id
-            value: '{{ record["relationships"]["type"]["data"]["id"] or "None"}}'
+            value:
+              '{{ record["relationships"]["type"]["data"]["id"] if record["relationships"].get("type",
+              {}).get("data") else "None" }}'
           - type: AddedFieldDefinition
             path:
               - default_replacement_product_id
             value:
               '{{ record["relationships"]["default_replacement_product"]["data"]["id"]
-              or "None"}}'
+              if record["relationships"].get("default_replacement_product", {}).get("data")
+              else "None" }}'
   - type: DeclarativeStream
     name: assets
     primary_key:
@@ -4902,7 +5217,9 @@ streams:
           - type: AddedFieldDefinition
             path:
               - iotdevice_id
-            value: '{{ record["relationships"]["iotdevice"]["data"]["id"] or "None"}}'
+            value:
+              '{{ record["relationships"]["iotdevice"]["data"]["id"] if record["relationships"].get("iotdevice",
+              {}).get("data") else "None" }}'
           - type: AddedFieldDefinition
             path:
               - label
@@ -5014,35 +5331,51 @@ streams:
           - type: AddedFieldDefinition
             path:
               - tags
-            value: '{{ record["relationships"]["tags"]["data"] }}'
+            value:
+              '{{ record["relationships"]["tags"]["data"] if record["relationships"].get("tags")
+              else "" }}'
           - type: AddedFieldDefinition
             path:
               - type_id
-            value: '{{ record["relationships"]["type"]["data"]["id"] or "None"}}'
+            value:
+              '{{ record["relationships"]["type"]["data"]["id"] if record["relationships"].get("type",
+              {}).get("data") else "None" }}'
           - type: AddedFieldDefinition
             path:
               - variant_id
-            value: '{{ record["relationships"]["variant"]["data"]["id"] or "None"}}'
+            value:
+              '{{ record["relationships"]["variant"]["data"]["id"] if record["relationships"].get("variant",
+              {}).get("data") else "None" }}'
           - type: AddedFieldDefinition
             path:
               - product_id
-            value: '{{ record["relationships"]["product"]["data"]["id"] or "None"}}'
+            value:
+              '{{ record["relationships"]["product"]["data"]["id"] if record["relationships"].get("product",
+              {}).get("data") else "None" }}'
           - type: AddedFieldDefinition
             path:
               - property_id
-            value: '{{ record["relationships"]["property"]["data"]["id"] or "None"}}'
+            value:
+              '{{ record["relationships"]["property"]["data"]["id"] if record["relationships"].get("property",
+              {}).get("data") else "None" }}'
           - type: AddedFieldDefinition
             path:
               - contractor_id
-            value: '{{ record["relationships"]["contractor"]["data"]["id"] or "None"}}'
+            value:
+              '{{ record["relationships"]["contractor"]["data"]["id"] if record["relationships"].get("contractor",
+              {}).get("data") else "None" }}'
           - type: AddedFieldDefinition
             path:
               - serviced_by_id
-            value: '{{ record["relationships"]["serviced_by"]["data"]["id"] or "None"}}'
+            value:
+              '{{ record["relationships"]["serviced_by"]["data"]["id"] if record["relationships"].get("serviced_by",
+              {}).get("data") else "None" }}'
           - type: AddedFieldDefinition
             path:
               - servicelevels
-            value: '{{ record["relationships"]["servicelevels"]["data"] }}'
+            value:
+              '{{ record["relationships"]["servicelevels"]["data"] if record["relationships"].get("servicelevels")
+              else "" }}'
           - type: AddedFieldDefinition
             path:
               - last_service_result
@@ -5326,13 +5659,16 @@ streams:
           - type: AddedFieldDefinition
             path:
               - supplier_id
-            value: '{{ record["relationships"]["supplier"]["data"]["id"] or "None"}}'
+            value:
+              '{{ record["relationships"]["supplier"]["data"]["id"] if record["relationships"].get("supplier",
+              {}).get("data") else "None" }}'
           - type: AddedFieldDefinition
             path:
               - accounting_organisation_id
             value:
               '{{ record["relationships"]["accounting_organisation"]["data"]["id"]
-              or "None"}}'
+              if record["relationships"].get("accounting_organisation", {}).get("data")
+              else "None" }}'
           - type: AddedFieldDefinition
             path:
               - is_attendancefee
@@ -5479,15 +5815,21 @@ streams:
           - type: AddedFieldDefinition
             path:
               - chieftan_id
-            value: '{{ record["relationships"]["chieftan"]["data"]["id"] or "None"}}'
+            value:
+              '{{ record["relationships"]["chieftan"]["data"]["id"] if record["relationships"].get("chieftan",
+              {}).get("data") else "None" }}'
           - type: AddedFieldDefinition
             path:
               - technician_id
-            value: '{{ record["relationships"]["technician"]["data"]["id"] or "None"}}'
+            value:
+              '{{ record["relationships"]["technician"]["data"]["id"] if record["relationships"].get("technician",
+              {}).get("data") else "None" }}'
           - type: AddedFieldDefinition
             path:
               - branch_id
-            value: '{{ record["relationships"]["branch"]["data"]["id"] or "None"}}'
+            value:
+              '{{ record["relationships"]["branch"]["data"]["id"] if record["relationships"].get("branch",
+              {}).get("data") else "None" }}'
   - type: DeclarativeStream
     name: tasksessions
     primary_key:
@@ -5677,7 +6019,9 @@ streams:
           - type: AddedFieldDefinition
             path:
               - type_id
-            value: '{{ record["relationships"]["type"]["data"]["id"] or "None"}}'
+            value:
+              '{{ record["relationships"]["type"]["data"]["id"] if record["relationships"].get("type",
+              {}).get("data") else "None" }}'
           - type: AddedFieldDefinition
             path:
               - started
@@ -5753,23 +6097,33 @@ streams:
           - type: AddedFieldDefinition
             path:
               - task_id
-            value: '{{ record["relationships"]["task"]["data"]["id"] or "None"}}'
+            value:
+              '{{ record["relationships"]["task"]["data"]["id"] if record["relationships"].get("task",
+              {}).get("data") else "None" }}'
           - type: AddedFieldDefinition
             path:
               - technician_id
-            value: '{{ record["relationships"]["technician"]["data"]["id"] or "None"}}'
+            value:
+              '{{ record["relationships"]["technician"]["data"]["id"] if record["relationships"].get("technician",
+              {}).get("data") else "None" }}'
           - type: AddedFieldDefinition
             path:
               - sell_product_id
-            value: '{{ record["relationships"]["sell_product"]["data"]["id"] or "None"}}'
+            value:
+              '{{ record["relationships"]["sell_product"]["data"]["id"] if record["relationships"].get("sell_product",
+              {}).get("data") else "None" }}'
           - type: AddedFieldDefinition
             path:
               - submitted_by_id
-            value: '{{ record["relationships"]["submitted_by"]["data"]["id"] or "None"}}'
+            value:
+              '{{ record["relationships"]["submitted_by"]["data"]["id"] if record["relationships"].get("submitted_by",
+              {}).get("data") else "None" }}'
           - type: AddedFieldDefinition
             path:
               - approved_by_id
-            value: '{{ record["relationships"]["approved_by"]["data"]["id"] or "None"}}'
+            value:
+              '{{ record["relationships"]["approved_by"]["data"]["id"] if record["relationships"].get("approved_by",
+              {}).get("data") else "None" }}'
           - type: AddedFieldDefinition
             path:
               - duration
@@ -5973,37 +6327,52 @@ streams:
           - type: AddedFieldDefinition
             path:
               - category_id
-            value: '{{ record["relationships"]["category"]["data"]["id"] or "None"}}'
+            value:
+              '{{ record["relationships"]["category"]["data"]["id"] if record["relationships"].get("category",
+              {}).get("data") else "None" }}'
           - type: AddedFieldDefinition
             path:
               - tags
-            value: '{{ record["relationships"]["tags"]["data"] }}'
+            value:
+              '{{ record["relationships"]["tags"]["data"] if record["relationships"].get("tags")
+              else "" }}'
           - type: AddedFieldDefinition
             path:
               - skill
-            value: '{{ record["relationships"]["skill"]["data"] }}'
+            value:
+              '{{ record["relationships"]["skill"]["data"] if record["relationships"].get("skill")
+              else "" }}'
           - type: AddedFieldDefinition
             path:
               - serviceareas
-            value: '{{ record["relationships"]["serviceareas"]["data"] }}'
+            value:
+              '{{ record["relationships"]["serviceareas"]["data"] if record["relationships"].get("serviceareas")
+              else "" }}'
           - type: AddedFieldDefinition
             path:
               - zones
-            value: '{{ record["relationships"]["zones"]["data"] }}'
+            value:
+              '{{ record["relationships"]["zones"]["data"] if record["relationships"].get("zones")
+              else "" }}'
           - type: AddedFieldDefinition
             path:
               - account_id
-            value: '{{ record["relationships"]["account"]["data"]["id"] or "None"}}'
+            value:
+              '{{ record["relationships"]["account"]["data"]["id"] if record["relationships"].get("account",
+              {}).get("data") else "None" }}'
           - type: AddedFieldDefinition
             path:
               - supplier_id
-            value: '{{ record["relationships"]["supplier"]["data"]["id"] or "None"}}'
+            value:
+              '{{ record["relationships"]["supplier"]["data"]["id"] if record["relationships"].get("supplier",
+              {}).get("data") else "None" }}'
           - type: AddedFieldDefinition
             path:
               - accounting_organisation_id
             value:
               '{{ record["relationships"]["accounting_organisation"]["data"]["id"]
-              or "None"}}'
+              if record["relationships"].get("accounting_organisation", {}).get("data")
+              else "None" }}'
           - type: AddedFieldDefinition
             path:
               - asset_count
@@ -6154,19 +6523,27 @@ streams:
           - type: AddedFieldDefinition
             path:
               - category_id
-            value: '{{ record["relationships"]["category"]["data"]["id"] or "None"}}'
+            value:
+              '{{ record["relationships"]["category"]["data"]["id"] if record["relationships"].get("category",
+              {}).get("data") else "None" }}'
           - type: AddedFieldDefinition
             path:
               - routine_id
-            value: '{{ record["relationships"]["routine"]["data"]["id"] or "None"}}'
+            value:
+              '{{ record["relationships"]["routine"]["data"]["id"] if record["relationships"].get("routine",
+              {}).get("data") else "None" }}'
           - type: AddedFieldDefinition
             path:
               - technicians
-            value: '{{ record["relationships"]["technicians"]["data"] }}'
+            value:
+              '{{ record["relationships"]["technicians"]["data"] if record["relationships"].get("technicians")
+              else "" }}'
           - type: AddedFieldDefinition
             path:
               - task_id
-            value: '{{ record["relationships"]["task"]["data"]["id"] or "None"}}'
+            value:
+              '{{ record["relationships"]["task"]["data"]["id"] if record["relationships"].get("task",
+              {}).get("data") else "None" }}'
   - type: DeclarativeStream
     name: billingcontracts
     primary_key:
@@ -6318,11 +6695,15 @@ streams:
           - type: AddedFieldDefinition
             path:
               - property_id
-            value: '{{ record["relationships"]["property"]["data"]["id"] or "None"}}'
+            value:
+              '{{ record["relationships"]["property"]["data"]["id"] if record["relationships"].get("property",
+              {}).get("data") else "None" }}'
           - type: AddedFieldDefinition
             path:
               - billingcard_id
-            value: '{{ record["relationships"]["billingcard"]["data"]["id"] or "None"}}'
+            value:
+              '{{ record["relationships"]["billingcard"]["data"]["id"] if record["relationships"].get("billingcard",
+              {}).get("data") else "None" }}'
           - type: AddedFieldDefinition
             path:
               - recurrence
@@ -6354,7 +6735,9 @@ streams:
           - type: AddedFieldDefinition
             path:
               - author_id
-            value: '{{ record["relationships"]["author"]["data"]["id"] or "None"}}'
+            value:
+              '{{ record["relationships"]["author"]["data"]["id"] if record["relationships"].get("author",
+              {}).get("data") else "None" }}'
           - type: AddedFieldDefinition
             path:
               - authorisation
@@ -6483,7 +6866,9 @@ streams:
           - type: AddedFieldDefinition
             path:
               - billingcontract_id
-            value: '{{ record["relationships"]["billingcontract"]["data"]["id"] or "None"}}'
+            value:
+              '{{ record["relationships"]["billingcontract"]["data"]["id"] if record["relationships"].get("billingcontract",
+              {}).get("data") else "None" }}'
           - type: AddedFieldDefinition
             path:
               - visible
@@ -6491,7 +6876,9 @@ streams:
           - type: AddedFieldDefinition
             path:
               - product_id
-            value: '{{ record["relationships"]["product"]["data"]["id"] or "None"}}'
+            value:
+              '{{ record["relationships"]["product"]["data"]["id"] if record["relationships"].get("product",
+              {}).get("data") else "None" }}'
           - type: AddedFieldDefinition
             path:
               - description
@@ -6670,19 +7057,27 @@ streams:
           - type: AddedFieldDefinition
             path:
               - product_id
-            value: '{{ record["relationships"]["product"]["data"]["id"] or "None"}}'
+            value:
+              '{{ record["relationships"]["product"]["data"]["id"] if record["relationships"].get("product",
+              {}).get("data") else "None" }}'
           - type: AddedFieldDefinition
             path:
               - quote_id
-            value: '{{ record["relationships"]["quote"]["data"]["id"] or "None"}}'
+            value:
+              '{{ record["relationships"]["quote"]["data"]["id"] if record["relationships"].get("quote",
+              {}).get("data") else "None" }}'
           - type: AddedFieldDefinition
             path:
               - asset_id
-            value: '{{ record["relationships"]["asset"]["data"]["id"] or "None"}}'
+            value:
+              '{{ record["relationships"]["asset"]["data"]["id"] if record["relationships"].get("asset",
+              {}).get("data") else "None" }}'
           - type: AddedFieldDefinition
             path:
               - remark_id
-            value: '{{ record["relationships"]["remark"]["data"]["id"] or "None"}}'
+            value:
+              '{{ record["relationships"]["remark"]["data"]["id"] if record["relationships"].get("remark",
+              {}).get("data") else "None" }}'
   - type: DeclarativeStream
     name: servicequotefixedlineitems
     primary_key:
@@ -6769,7 +7164,9 @@ streams:
           - type: AddedFieldDefinition
             path:
               - servicequote_id
-            value: '{{ record["relationships"]["servicequote"]["data"]["id"] or "None"}}'
+            value:
+              '{{ record["relationships"]["servicequote"]["data"]["id"] if record["relationships"].get("servicequote",
+              {}).get("data") else "None" }}'
           - type: AddedFieldDefinition
             path:
               - description
@@ -6912,7 +7309,9 @@ streams:
           - type: AddedFieldDefinition
             path:
               - servicequote_id
-            value: '{{ record["relationships"]["servicequote"]["data"]["id"] or "None"}}'
+            value:
+              '{{ record["relationships"]["servicequote"]["data"]["id"] if record["relationships"].get("servicequote",
+              {}).get("data") else "None" }}'
           - type: AddedFieldDefinition
             path:
               - description
@@ -7059,11 +7458,15 @@ streams:
           - type: AddedFieldDefinition
             path:
               - servicequote_id
-            value: '{{ record["relationships"]["servicequote"]["data"]["id"] or "None"}}'
+            value:
+              '{{ record["relationships"]["servicequote"]["data"]["id"] if record["relationships"].get("servicequote",
+              {}).get("data") else "None" }}'
           - type: AddedFieldDefinition
             path:
               - product_id
-            value: '{{ record["relationships"]["product"]["data"]["id"] or "None"}}'
+            value:
+              '{{ record["relationships"]["product"]["data"]["id"] if record["relationships"].get("product",
+              {}).get("data") else "None" }}'
           - type: AddedFieldDefinition
             path:
               - description
@@ -7195,19 +7598,27 @@ streams:
           - type: AddedFieldDefinition
             path:
               - remark_id
-            value: '{{ record["relationships"]["remark"]["data"]["id"] or "None"}}'
+            value:
+              '{{ record["relationships"]["remark"]["data"]["id"] if record["relationships"].get("remark",
+              {}).get("data") else "None" }}'
           - type: AddedFieldDefinition
             path:
               - task_id
-            value: '{{ record["relationships"]["task"]["data"]["id"] or "None"}}'
+            value:
+              '{{ record["relationships"]["task"]["data"]["id"] if record["relationships"].get("task",
+              {}).get("data") else "None" }}'
           - type: AddedFieldDefinition
             path:
               - servicetask_id
-            value: '{{ record["relationships"]["servicetask"]["data"]["id"] or "None"}}'
+            value:
+              '{{ record["relationships"]["servicetask"]["data"]["id"] if record["relationships"].get("servicetask",
+              {}).get("data") else "None" }}'
           - type: AddedFieldDefinition
             path:
               - account_id
-            value: '{{ record["relationships"]["account"]["data"]["id"] or "None"}}'
+            value:
+              '{{ record["relationships"]["account"]["data"]["id"] if record["relationships"].get("account",
+              {}).get("data") else "None" }}'
   - type: DeclarativeStream
     name: servicetasks
     primary_key:
@@ -7468,39 +7879,121 @@ streams:
           - type: AddedFieldDefinition
             path:
               - task_id
-            value: '{{ record["relationships"]["task"]["data"]["id"] or "None"}}'
+            value:
+              '{{ record["relationships"]["task"]["data"]["id"] if record["relationships"].get("task",
+              {}).get("data") else "None" }}'
           - type: AddedFieldDefinition
             path:
               - item_id
-            value: '{{ record["relationships"]["item"]["data"]["id"] or "None"}}'
+            value:
+              '{{ record["relationships"]["item"]["data"]["id"] if record["relationships"].get("item",
+              {}).get("data") else "None" }}'
           - type: AddedFieldDefinition
             path:
               - routine_id
-            value: '{{ record["relationships"]["routine"]["data"]["id"] or "None"}}'
+            value:
+              '{{ record["relationships"]["routine"]["data"]["id"] if record["relationships"].get("routine",
+              {}).get("data") else "None" }}'
           - type: AddedFieldDefinition
             path:
               - remark_id
-            value: '{{ record["relationships"]["remark"]["data"]["id"] or "None"}}'
+            value:
+              '{{ record["relationships"]["remark"]["data"]["id"] if record["relationships"].get("remark",
+              {}).get("data") else "None" }}'
           - type: AddedFieldDefinition
             path:
               - product_id
-            value: '{{ record["relationships"]["product"]["data"]["id"] or "None"}}'
+            value:
+              '{{ record["relationships"]["product"]["data"]["id"] if record["relationships"].get("product",
+              {}).get("data") else "None" }}'
           - type: AddedFieldDefinition
             path:
               - technician_id
-            value: '{{ record["relationships"]["technician"]["data"]["id"] or "None"}}'
+            value:
+              '{{ record["relationships"]["technician"]["data"]["id"] if record["relationships"].get("technician",
+              {}).get("data") else "None" }}'
           - type: AddedFieldDefinition
             path:
               - purchaseorderlineitem_id
             value:
-              '{{ record["relationships"]["purchaseorderlineitem"]["data"]["id"] or
-              "None"}}'
+              '{{ record["relationships"]["purchaseorderlineitem"]["data"]["id"] if
+              record["relationships"].get("purchaseorderlineitem", {}).get("data") else
+              "None" }}'
           - type: AddedFieldDefinition
             path:
               - routineserviceleveltype_id
             value:
               '{{ record["relationships"]["routineserviceleveltype"]["data"]["id"]
-              or "None"}}'
+              if record["relationships"].get("routineserviceleveltype", {}).get("data")
+              else "None" }}'
+  - type: DeclarativeStream
+    name: majorservices
+    primary_key:
+      - id
+    incremental_sync:
+      $ref: "#/definitions/linked/DeclarativeStream/incremental_sync"
+    retriever:
+      $ref: "#/definitions/linked/BaseSimpleRetriever"
+      requester:
+        $ref: "#/definitions/linked/BaseSimpleRetriever/requester"
+        url: '{{ config["base_url"] }}/api/v2.15/majorservices/'
+        request_parameters:
+          ordering: -updated
+          show_deleted: "true"
+          fields[MajorService]: id,asset,routineserviceleveltype,due,status
+    schema_loader:
+      type: InlineSchemaLoader
+      schema:
+        type: object
+        $schema: http://json-schema.org/schema#
+        additionalProperties: true
+        properties:
+          id:
+            type:
+              - integer
+          asset_id:
+            type:
+              - integer
+              - "null"
+          routineserviceleveltype_id:
+            type:
+              - integer
+              - "null"
+          due:
+            type:
+              - string
+            format: date
+          status:
+            type:
+              - string
+    transformations:
+      - type: AddFields
+        fields:
+          - type: AddedFieldDefinition
+            path:
+              - id
+            value: '{{ record["id"] }}'
+          - type: AddedFieldDefinition
+            path:
+              - asset_id
+            value:
+              '{{ record["relationships"]["asset"]["data"]["id"] if record["relationships"].get("asset",
+              {}).get("data") else "None" }}'
+          - type: AddedFieldDefinition
+            path:
+              - routineserviceleveltype_id
+            value:
+              '{{ record["relationships"]["routineserviceleveltype"]["data"]["id"]
+              if record["relationships"].get("routineserviceleveltype", {}).get("data")
+              else "None" }}'
+          - type: AddedFieldDefinition
+            path:
+              - due
+            value: '{{ record["attributes"]["due"] }}'
+          - type: AddedFieldDefinition
+            path:
+              - status
+            value: '{{ record["attributes"]["status"] }}'
   - type: DeclarativeStream
     name: routineservices
     primary_key:
@@ -7627,23 +8120,33 @@ streams:
           - type: AddedFieldDefinition
             path:
               - type_id
-            value: '{{ record["relationships"]["type"]["data"]["id"] or "None"}}'
+            value:
+              '{{ record["relationships"]["type"]["data"]["id"] if record["relationships"].get("type",
+              {}).get("data") else "None" }}'
           - type: AddedFieldDefinition
             path:
               - property_id
-            value: '{{ record["relationships"]["property"]["data"]["id"] or "None"}}'
+            value:
+              '{{ record["relationships"]["property"]["data"]["id"] if record["relationships"].get("property",
+              {}).get("data") else "None" }}'
           - type: AddedFieldDefinition
             path:
               - servicegroup_id
-            value: '{{ record["relationships"]["servicegroup"]["data"]["id"] or "None"}}'
+            value:
+              '{{ record["relationships"]["servicegroup"]["data"]["id"] if record["relationships"].get("servicegroup",
+              {}).get("data") else "None" }}'
           - type: AddedFieldDefinition
             path:
               - contractor_id
-            value: '{{ record["relationships"]["contractor"]["data"]["id"] or "None"}}'
+            value:
+              '{{ record["relationships"]["contractor"]["data"]["id"] if record["relationships"].get("contractor",
+              {}).get("data") else "None" }}'
           - type: AddedFieldDefinition
             path:
               - assettag_id
-            value: '{{ record["relationships"]["assettag"]["data"]["id"] or "None"}}'
+            value:
+              '{{ record["relationships"]["assettag"]["data"]["id"] if record["relationships"].get("assettag",
+              {}).get("data") else "None" }}'
   - type: DeclarativeStream
     name: routineservicelevels
     primary_key:
@@ -7746,19 +8249,27 @@ streams:
           - type: AddedFieldDefinition
             path:
               - type_id
-            value: '{{ record["relationships"]["type"]["data"]["id"] or "None"}}'
+            value:
+              '{{ record["relationships"]["type"]["data"]["id"] if record["relationships"].get("type",
+              {}).get("data") else "None" }}'
           - type: AddedFieldDefinition
             path:
               - routineservice_id
-            value: '{{ record["relationships"]["routineservice"]["data"]["id"] or "None"}}'
+            value:
+              '{{ record["relationships"]["routineservice"]["data"]["id"] if record["relationships"].get("routineservice",
+              {}).get("data") else "None" }}'
           - type: AddedFieldDefinition
             path:
               - servicegroup_id
-            value: '{{ record["relationships"]["servicegroup"]["data"]["id"] or "None"}}'
+            value:
+              '{{ record["relationships"]["servicegroup"]["data"]["id"] if record["relationships"].get("servicegroup",
+              {}).get("data") else "None" }}'
           - type: AddedFieldDefinition
             path:
               - contractor_id
-            value: '{{ record["relationships"]["contractor"]["data"]["id"] or "None"}}'
+            value:
+              '{{ record["relationships"]["contractor"]["data"]["id"] if record["relationships"].get("contractor",
+              {}).get("data") else "None" }}'
           - type: AddedFieldDefinition
             path:
               - extra_fields
@@ -7902,19 +8413,27 @@ streams:
           - type: AddedFieldDefinition
             path:
               - product_id
-            value: '{{ record["relationships"]["product"]["data"]["id"] or "None"}}'
+            value:
+              '{{ record["relationships"]["product"]["data"]["id"] if record["relationships"].get("product",
+              {}).get("data") else "None" }}'
           - type: AddedFieldDefinition
             path:
               - standard_id
-            value: '{{ record["relationships"]["standard"]["data"]["id"] or "None"}}'
+            value:
+              '{{ record["relationships"]["standard"]["data"]["id"] if record["relationships"].get("standard",
+              {}).get("data") else "None" }}'
           - type: AddedFieldDefinition
             path:
               - servicegroup_id
-            value: '{{ record["relationships"]["servicegroup"]["data"]["id"] or "None"}}'
+            value:
+              '{{ record["relationships"]["servicegroup"]["data"]["id"] if record["relationships"].get("servicegroup",
+              {}).get("data") else "None" }}'
           - type: AddedFieldDefinition
             path:
               - assettype_set
-            value: '{{ record["relationships"]["assettype_set"]["data"] }}'
+            value:
+              '{{ record["relationships"]["assettype_set"]["data"] if record["relationships"].get("assettype_set")
+              else "" }}'
   - type: DeclarativeStream
     name: routineserviceleveltypes
     primary_key:
@@ -8121,11 +8640,15 @@ streams:
           - type: AddedFieldDefinition
             path:
               - servicegroup_id
-            value: '{{ record["relationships"]["servicegroup"]["data"]["id"] or "None"}}'
+            value:
+              '{{ record["relationships"]["servicegroup"]["data"]["id"] if record["relationships"].get("servicegroup",
+              {}).get("data") else "None" }}'
           - type: AddedFieldDefinition
             path:
               - routineservicetype_id
-            value: '{{ record["relationships"]["routineservicetype"]["data"]["id"] or "None"}}'
+            value:
+              '{{ record["relationships"]["routineservicetype"]["data"]["id"] if record["relationships"].get("routineservicetype",
+              {}).get("data") else "None" }}'
   - type: DeclarativeStream
     name: subtasks
     primary_key:
@@ -8277,19 +8800,600 @@ streams:
           - type: AddedFieldDefinition
             path:
               - task_id
-            value: '{{ record["relationships"]["task"]["data"]["id"] or "None"}}'
+            value:
+              '{{ record["relationships"]["task"]["data"]["id"] if record["relationships"].get("task",
+              {}).get("data") else "None" }}'
           - type: AddedFieldDefinition
             path:
               - billingcontract_id
-            value: '{{ record["relationships"]["billingcontract"]["data"]["id"] or "None"}}'
+            value:
+              '{{ record["relationships"]["billingcontract"]["data"]["id"] if record["relationships"].get("billingcontract",
+              {}).get("data") else "None" }}'
           - type: AddedFieldDefinition
             path:
               - product_id
-            value: '{{ record["relationships"]["product"]["data"]["id"] or "None"}}'
+            value:
+              '{{ record["relationships"]["product"]["data"]["id"] if record["relationships"].get("product",
+              {}).get("data") else "None" }}'
           - type: AddedFieldDefinition
             path:
               - routine_id
-            value: '{{ record["relationships"]["routine"]["data"]["id"] or "None"}}'
+            value:
+              '{{ record["relationships"]["routine"]["data"]["id"] if record["relationships"].get("routine",
+              {}).get("data") else "None" }}'
+  - type: DeclarativeStream
+    name: clientcontacts
+    primary_key:
+      - id
+    incremental_sync:
+      $ref: "#/definitions/linked/DeclarativeStream/incremental_sync"
+    retriever:
+      $ref: "#/definitions/linked/BaseSimpleRetriever"
+      requester:
+        $ref: "#/definitions/linked/BaseSimpleRetriever/requester"
+        url: '{{ config["base_url"] }}/api/v2.15/clientcontacts/'
+        request_parameters:
+          ordering: -updated
+          show_deleted: "true"
+          fields[ClientContact]: id,created,updated,name,email,mobile,phone,position,is_active,client
+    schema_loader:
+      type: InlineSchemaLoader
+      schema:
+        type: object
+        $schema: http://json-schema.org/schema#
+        additionalProperties: true
+        properties:
+          id:
+            type:
+              - integer
+          created:
+            type:
+              - string
+            format: date-time
+            airbyte_type: timestamp_with_timezone
+          updated:
+            type:
+              - string
+            format: date-time
+            airbyte_type: timestamp_with_timezone
+          name:
+            type:
+              - string
+          email:
+            type:
+              - string
+            format: email
+          mobile:
+            type:
+              - string
+          phone:
+            type:
+              - string
+          position:
+            type:
+              - string
+          is_active:
+            type:
+              - boolean
+          client_id:
+            type:
+              - integer
+              - "null"
+    transformations:
+      - type: AddFields
+        fields:
+          - type: AddedFieldDefinition
+            path:
+              - id
+            value: '{{ record["id"] }}'
+          - type: AddedFieldDefinition
+            path:
+              - created
+            value: '{{ record["attributes"]["created"] }}'
+          - type: AddedFieldDefinition
+            path:
+              - updated
+            value: '{{ record["attributes"]["updated"] }}'
+          - type: AddedFieldDefinition
+            path:
+              - name
+            value: '{{ record["attributes"]["name"] }}'
+          - type: AddedFieldDefinition
+            path:
+              - email
+            value: '{{ record["attributes"]["email"] }}'
+          - type: AddedFieldDefinition
+            path:
+              - mobile
+            value: '{{ record["attributes"]["mobile"] }}'
+          - type: AddedFieldDefinition
+            path:
+              - phone
+            value: '{{ record["attributes"]["phone"] }}'
+          - type: AddedFieldDefinition
+            path:
+              - position
+            value: '{{ record["attributes"]["position"] }}'
+          - type: AddedFieldDefinition
+            path:
+              - is_active
+            value: '{{ record["attributes"]["is_active"] }}'
+          - type: AddedFieldDefinition
+            path:
+              - client_id
+            value:
+              '{{ record["relationships"]["client"]["data"]["id"] if record["relationships"].get("client",
+              {}).get("data") else "None" }}'
+  - type: DeclarativeStream
+    name: propertycontacts
+    primary_key:
+      - id
+    incremental_sync:
+      $ref: "#/definitions/linked/DeclarativeStream/incremental_sync"
+    retriever:
+      $ref: "#/definitions/linked/BaseSimpleRetriever"
+      requester:
+        $ref: "#/definitions/linked/BaseSimpleRetriever/requester"
+        url: '{{ config["base_url"] }}/api/v2.15/propertycontacts/'
+        request_parameters:
+          ordering: -updated
+          show_deleted: "true"
+          fields[PropertyContact]: id,created,updated,name,role,email,email_cc,mobile,phone_bh,organisation,address,requires_report,requires_quote,requires_invoice,requires_notification,is_public,is_active,property
+    schema_loader:
+      type: InlineSchemaLoader
+      schema:
+        type: object
+        $schema: http://json-schema.org/schema#
+        additionalProperties: true
+        properties:
+          id:
+            type:
+              - integer
+          created:
+            type:
+              - string
+            format: date-time
+            airbyte_type: timestamp_with_timezone
+          updated:
+            type:
+              - string
+            format: date-time
+            airbyte_type: timestamp_with_timezone
+          name:
+            type:
+              - string
+          role:
+            type:
+              - string
+          email:
+            type:
+              - string
+            format: email
+          email_cc:
+            type:
+              - string
+          mobile:
+            type:
+              - string
+          phone_bh:
+            type:
+              - string
+          organisation:
+            type:
+              - string
+          address:
+            type:
+              - string
+          requires_report:
+            type:
+              - boolean
+          requires_quote:
+            type:
+              - boolean
+          requires_invoice:
+            type:
+              - boolean
+          requires_notification:
+            type:
+              - boolean
+          is_public:
+            type:
+              - boolean
+          is_active:
+            type:
+              - boolean
+          property_id:
+            type:
+              - integer
+              - "null"
+    transformations:
+      - type: AddFields
+        fields:
+          - type: AddedFieldDefinition
+            path:
+              - id
+            value: '{{ record["id"] }}'
+          - type: AddedFieldDefinition
+            path:
+              - created
+            value: '{{ record["attributes"]["created"] }}'
+          - type: AddedFieldDefinition
+            path:
+              - updated
+            value: '{{ record["attributes"]["updated"] }}'
+          - type: AddedFieldDefinition
+            path:
+              - name
+            value: '{{ record["attributes"]["name"] }}'
+          - type: AddedFieldDefinition
+            path:
+              - role
+            value: '{{ record["attributes"]["role"] }}'
+          - type: AddedFieldDefinition
+            path:
+              - email
+            value: '{{ record["attributes"]["email"] }}'
+          - type: AddedFieldDefinition
+            path:
+              - email_cc
+            value: '{{ record["attributes"]["email_cc"] }}'
+          - type: AddedFieldDefinition
+            path:
+              - mobile
+            value: '{{ record["attributes"]["mobile"] }}'
+          - type: AddedFieldDefinition
+            path:
+              - phone_bh
+            value: '{{ record["attributes"]["phone_bh"] }}'
+          - type: AddedFieldDefinition
+            path:
+              - organisation
+            value: '{{ record["attributes"]["organisation"] }}'
+          - type: AddedFieldDefinition
+            path:
+              - address
+            value: '{{ record["attributes"]["address"] }}'
+          - type: AddedFieldDefinition
+            path:
+              - requires_report
+            value: '{{ record["attributes"]["requires_report"] }}'
+          - type: AddedFieldDefinition
+            path:
+              - requires_quote
+            value: '{{ record["attributes"]["requires_quote"] }}'
+          - type: AddedFieldDefinition
+            path:
+              - requires_invoice
+            value: '{{ record["attributes"]["requires_invoice"] }}'
+          - type: AddedFieldDefinition
+            path:
+              - requires_notification
+            value: '{{ record["attributes"]["requires_notification"] }}'
+          - type: AddedFieldDefinition
+            path:
+              - is_public
+            value: '{{ record["attributes"]["is_public"] }}'
+          - type: AddedFieldDefinition
+            path:
+              - is_active
+            value: '{{ record["attributes"]["is_active"] }}'
+          - type: AddedFieldDefinition
+            path:
+              - property_id
+            value:
+              '{{ record["relationships"]["property"]["data"]["id"] if record["relationships"].get("property",
+              {}).get("data") else "None" }}'
+  - type: DeclarativeStream
+    name: promptquestions
+    primary_key:
+      - id
+    incremental_sync:
+      $ref: "#/definitions/linked/DeclarativeStream/incremental_sync"
+    retriever:
+      $ref: "#/definitions/linked/BaseSimpleRetriever"
+      requester:
+        $ref: "#/definitions/linked/BaseSimpleRetriever/requester"
+        url: '{{ config["base_url"] }}/api/v2.15/promptquestions/'
+        request_parameters:
+          ordering: -updated
+          show_deleted: "true"
+          fields[PromptQuestion]: id,created,updated,deleted,label,type,ref,order,config,section
+    schema_loader:
+      type: InlineSchemaLoader
+      schema:
+        type: object
+        $schema: http://json-schema.org/schema#
+        additionalProperties: true
+        properties:
+          id:
+            type:
+              - integer
+          created:
+            type:
+              - string
+            format: date-time
+            airbyte_type: timestamp_with_timezone
+          updated:
+            type:
+              - string
+            format: date-time
+            airbyte_type: timestamp_with_timezone
+          deleted:
+            type:
+              - string
+              - "null"
+            format: date-time
+            airbyte_type: timestamp_with_timezone
+          label:
+            type:
+              - string
+          type:
+            type:
+              - string
+          ref:
+            type:
+              - string
+          order:
+            type:
+              - integer
+          config:
+            type:
+              - object
+          section_id:
+            type:
+              - integer
+              - "null"
+    transformations:
+      - type: AddFields
+        fields:
+          - type: AddedFieldDefinition
+            path:
+              - id
+            value: '{{ record["id"] }}'
+          - type: AddedFieldDefinition
+            path:
+              - created
+            value: '{{ record["attributes"]["created"] }}'
+          - type: AddedFieldDefinition
+            path:
+              - updated
+            value: '{{ record["attributes"]["updated"] }}'
+          - type: AddedFieldDefinition
+            path:
+              - deleted
+            value: '{{ record["attributes"]["deleted"] or "None"}}'
+          - type: AddedFieldDefinition
+            path:
+              - label
+            value: '{{ record["attributes"]["label"] }}'
+          - type: AddedFieldDefinition
+            path:
+              - type
+            value: '{{ record["attributes"]["type"] }}'
+          - type: AddedFieldDefinition
+            path:
+              - ref
+            value: '{{ record["attributes"]["ref"] }}'
+          - type: AddedFieldDefinition
+            path:
+              - order
+            value: '{{ record["attributes"]["order"] }}'
+          - type: AddedFieldDefinition
+            path:
+              - config
+            value: '{{ record["attributes"]["config"] }}'
+          - type: AddedFieldDefinition
+            path:
+              - section_id
+            value:
+              '{{ record["relationships"]["section"]["data"]["id"] if record["relationships"].get("section",
+              {}).get("data") else "None" }}'
+  - type: DeclarativeStream
+    name: promptanswergroups
+    primary_key:
+      - id
+    incremental_sync:
+      $ref: "#/definitions/linked/DeclarativeStream/incremental_sync"
+    retriever:
+      $ref: "#/definitions/linked/BaseSimpleRetriever"
+      requester:
+        $ref: "#/definitions/linked/BaseSimpleRetriever/requester"
+        url: '{{ config["base_url"] }}/api/v2.15/promptanswergroups/'
+        request_parameters:
+          ordering: -updated
+          show_deleted: "true"
+          fields[PromptAnswerGroup]: id,created,updated,servicetask,task,section,key,order,group_type,guid
+    schema_loader:
+      type: InlineSchemaLoader
+      schema:
+        type: object
+        $schema: http://json-schema.org/schema#
+        additionalProperties: true
+        properties:
+          id:
+            type:
+              - integer
+          created:
+            type:
+              - string
+            format: date-time
+            airbyte_type: timestamp_with_timezone
+          updated:
+            type:
+              - string
+            format: date-time
+            airbyte_type: timestamp_with_timezone
+          servicetask_id:
+            type:
+              - integer
+              - "null"
+          task_id:
+            type:
+              - integer
+              - "null"
+          section_id:
+            type:
+              - integer
+              - "null"
+          key:
+            type:
+              - string
+              - "null"
+          order:
+            type:
+              - integer
+              - "null"
+          group_type:
+            type:
+              - string
+          guid:
+            type:
+              - string
+            format: uuid
+    transformations:
+      - type: AddFields
+        fields:
+          - type: AddedFieldDefinition
+            path:
+              - id
+            value: '{{ record["id"] }}'
+          - type: AddedFieldDefinition
+            path:
+              - created
+            value: '{{ record["attributes"]["created"] }}'
+          - type: AddedFieldDefinition
+            path:
+              - updated
+            value: '{{ record["attributes"]["updated"] }}'
+          - type: AddedFieldDefinition
+            path:
+              - servicetask_id
+            value:
+              '{{ record["relationships"]["servicetask"]["data"]["id"] if record["relationships"].get("servicetask",
+              {}).get("data") else "None" }}'
+          - type: AddedFieldDefinition
+            path:
+              - task_id
+            value:
+              '{{ record["relationships"]["task"]["data"]["id"] if record["relationships"].get("task",
+              {}).get("data") else "None" }}'
+          - type: AddedFieldDefinition
+            path:
+              - section_id
+            value:
+              '{{ record["relationships"]["section"]["data"]["id"] if record["relationships"].get("section",
+              {}).get("data") else "None" }}'
+          - type: AddedFieldDefinition
+            path:
+              - key
+            value: '{{ record["attributes"]["key"] or "None"}}'
+          - type: AddedFieldDefinition
+            path:
+              - order
+            value: '{{ record["attributes"]["order"] or "None"}}'
+          - type: AddedFieldDefinition
+            path:
+              - group_type
+            value: '{{ record["attributes"]["group_type"] }}'
+          - type: AddedFieldDefinition
+            path:
+              - guid
+            value: '{{ record["attributes"]["guid"] }}'
+  - type: DeclarativeStream
+    name: promptanswers
+    primary_key:
+      - id
+    incremental_sync:
+      $ref: "#/definitions/linked/DeclarativeStream/incremental_sync"
+    retriever:
+      $ref: "#/definitions/linked/BaseSimpleRetriever"
+      requester:
+        $ref: "#/definitions/linked/BaseSimpleRetriever/requester"
+        url: '{{ config["base_url"] }}/api/v2.15/promptanswers/'
+        request_parameters:
+          ordering: -updated
+          show_deleted: "true"
+          fields[PromptAnswer]: id,created,updated,value,question,answergroup,performed_date,guid
+    schema_loader:
+      type: InlineSchemaLoader
+      schema:
+        type: object
+        $schema: http://json-schema.org/schema#
+        additionalProperties: true
+        properties:
+          id:
+            type:
+              - integer
+          created:
+            type:
+              - string
+            format: date-time
+            airbyte_type: timestamp_with_timezone
+          updated:
+            type:
+              - string
+            format: date-time
+            airbyte_type: timestamp_with_timezone
+          value:
+            type:
+              - object
+          question_id:
+            type:
+              - integer
+              - "null"
+          answergroup_id:
+            type:
+              - integer
+              - "null"
+          performed_date:
+            type:
+              - string
+              - "null"
+            format: date-time
+            airbyte_type: timestamp_with_timezone
+          guid:
+            type:
+              - string
+            format: uuid
+    transformations:
+      - type: AddFields
+        fields:
+          - type: AddedFieldDefinition
+            path:
+              - id
+            value: '{{ record["id"] }}'
+          - type: AddedFieldDefinition
+            path:
+              - created
+            value: '{{ record["attributes"]["created"] }}'
+          - type: AddedFieldDefinition
+            path:
+              - updated
+            value: '{{ record["attributes"]["updated"] }}'
+          - type: AddedFieldDefinition
+            path:
+              - value
+            value: '{{ record["attributes"]["value"] }}'
+          - type: AddedFieldDefinition
+            path:
+              - question_id
+            value:
+              '{{ record["relationships"]["question"]["data"]["id"] if record["relationships"].get("question",
+              {}).get("data") else "None" }}'
+          - type: AddedFieldDefinition
+            path:
+              - answergroup_id
+            value:
+              '{{ record["relationships"]["answergroup"]["data"]["id"] if record["relationships"].get("answergroup",
+              {}).get("data") else "None" }}'
+          - type: AddedFieldDefinition
+            path:
+              - performed_date
+            value: '{{ record["attributes"]["performed_date"] or "None"}}'
+          - type: AddedFieldDefinition
+            path:
+              - guid
+            value: '{{ record["attributes"]["guid"] }}'
   - type: DeclarativeStream
     name: task_profitability
     primary_key:

--- a/airbyte-integrations/connectors/source-uptick/manifest.yaml
+++ b/airbyte-integrations/connectors/source-uptick/manifest.yaml
@@ -7940,7 +7940,7 @@ streams:
         request_parameters:
           ordering: -updated
           show_deleted: "true"
-          fields[MajorService]: id,asset,routineserviceleveltype,due,status
+          fields[MajorService]: id,created,updated,asset,routineserviceleveltype,due,status
     schema_loader:
       type: InlineSchemaLoader
       schema:
@@ -7951,6 +7951,16 @@ streams:
           id:
             type:
               - integer
+          created:
+            type:
+              - string
+            format: date-time
+            airbyte_type: timestamp_with_timezone
+          updated:
+            type:
+              - string
+            format: date-time
+            airbyte_type: timestamp_with_timezone
           asset_id:
             type:
               - integer
@@ -7973,6 +7983,14 @@ streams:
             path:
               - id
             value: '{{ record["id"] }}'
+          - type: AddedFieldDefinition
+            path:
+              - created
+            value: '{{ record["attributes"]["created"] }}'
+          - type: AddedFieldDefinition
+            path:
+              - updated
+            value: '{{ record["attributes"]["updated"] }}'
           - type: AddedFieldDefinition
             path:
               - asset_id

--- a/airbyte-integrations/connectors/source-uptick/metadata.yaml
+++ b/airbyte-integrations/connectors/source-uptick/metadata.yaml
@@ -33,7 +33,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 54c75c42-df4a-4f3e-a5f3-d50cf80f1649
-  dockerImageTag: 1.0.2
+  dockerImageTag: 1.1.0
   dockerRepository: airbyte/source-uptick
   githubIssueLabel: source-uptick
   icon: icon.svg

--- a/docs/integrations/sources/uptick.md
+++ b/docs/integrations/sources/uptick.md
@@ -35,7 +35,9 @@ The Uptick connector syncs data from the following streams, organized by functio
 - `projects` - Project management entities for larger initiatives
 - `clients` - Customer organizations and contact information
 - `clientgroups` - Client organization groupings
+- `clientcontacts` - Contact people associated with clients
 - `properties` - Physical locations where work is performed
+- `propertycontacts` - Contact people associated with properties
 - `contractors` - External service providers and subcontractors
 - `users` - System users including technicians and staff
 - `servicegroups` - Service categorization for organizing work types
@@ -72,10 +74,14 @@ The Uptick connector syncs data from the following streams, organized by functio
 - `routineservicelevels` - Service level definitions for routine services
 - `routineservicetypes` - Types and categories of routine services
 - `routineserviceleveltypes` - Service level type classifications
+- `majorservices` - Major service records for assets
 - `servicetasks` - Individual work activities on tasks
 - `subtasks` - Links programme maintenance routines to tasks
 - `remarks` - Issues, defects, and observations during inspections
 - `remarkevents` - Events and actions taken on remarks
+- `promptquestions` - Prompt questions asked during service report completion
+- `promptanswergroups` - Groupings of prompt answers per service task and section
+- `promptanswers` - Individual answers to prompt questions
 - `appointments` - Scheduled appointments for work and inspections
 
 ### Quality and compliance
@@ -149,6 +155,12 @@ The Uptick connector syncs data from the following streams, organized by functio
 | `servicetasks` | `id` | `DefaultPaginator` | ✅ | ✅ |
 | `subtasks` | `id` | `DefaultPaginator` | ✅ | ✅ |
 | `task_profitability` | `task_id` | `DefaultPaginator` | ✅ | ✅ |
+| `clientcontacts` | `id` | `DefaultPaginator` | ✅ | ❌ (no soft delete) |
+| `propertycontacts` | `id` | `DefaultPaginator` | ✅ | ❌ (no soft delete) |
+| `promptquestions` | `id` | `DefaultPaginator` | ✅ | ✅ |
+| `promptanswergroups` | `id` | `DefaultPaginator` | ✅ | ❌ (no soft delete) |
+| `promptanswers` | `id` | `DefaultPaginator` | ✅ | ❌ (no soft delete) |
+| `majorservices` | `id` | `DefaultPaginator` | ✅ | ❌ (no soft delete) |
 
 ### Incremental sync
 

--- a/docs/integrations/sources/uptick.md
+++ b/docs/integrations/sources/uptick.md
@@ -169,6 +169,7 @@ If you use Airbyte Cloud and your organization restricts access to specific IPs,
 
 | Version          | Date              | Pull Request | Subject        |
 |------------------|-------------------|--------------|----------------|
+| 1.1.0 | 2026-08-05 | [83710](https://github.com/airbytehq/airbyte/pull/83710) | Add 6 new streams (clientcontacts, propertycontacts, promptquestions, promptanswergroups, promptanswers, majorservices), add fields to the clients, properties, invoices, defectquotes, servicequotes, users, and purchaseorders streams, and make relationship field extraction null-safe |
 | 1.0.2 | 2026-08-04 | [83652](https://github.com/airbytehq/airbyte/pull/83652) | Update dependencies |
 | 1.0.1 | 2026-07-28 | [83098](https://github.com/airbytehq/airbyte/pull/83098) | Update dependencies |
 | 1.0.0 | 2026-07-21 | [73740](https://github.com/airbytehq/airbyte/pull/73740) | Upgrade the Uptick API to v2.15 and remove deprecated fields from the branches, defectquotelineitems, servicetasks, and tasksessions streams |


### PR DESCRIPTION
Disposable validation run for source-uptick stream additions (6 new streams, new fields on 7 existing streams, null-safe relationship extraction, majorservices cursor fix, test catalog and docs updates).

Not for merge. Will be closed after checks complete.