### PR TITLE
chore(connectors): enable autopilot rollouts for certified connectors

### DIFF
--- a/airbyte-integrations/connectors/destination-azure-blob-storage/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-azure-blob-storage/metadata.yaml
@@ -46,7 +46,12 @@ data:
   releaseStage: generally_available
   releases:
     rolloutConfiguration:
-      enableProgressiveRollout: false
+      enableProgressiveRollout: true
+      defaultRolloutMode: autopilot
+      autopilotConfig:
+        autoStart: true
+        autoPromoteStages: true
+        strategy: fast
     breakingChanges:
       1.0.0:
         message: >

--- a/airbyte-integrations/connectors/destination-bigquery/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-bigquery/metadata.yaml
@@ -44,7 +44,7 @@ data:
       autopilotConfig:
         autoStart: true
         autoPromoteStages: true
-        strategy: fast
+        strategy: slow
   resourceRequirements:
     jobSpecific:
       - jobType: sync

--- a/airbyte-integrations/connectors/destination-clickhouse/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-clickhouse/metadata.yaml
@@ -32,7 +32,7 @@ data:
       autopilotConfig:
         autoStart: true
         autoPromoteStages: true
-        strategy: fast
+        strategy: slow
     breakingChanges:
       2.0.0:
         message: "This connector has been re-written from scratch. Data will now be typed and stored in final (non-raw) tables. The connector may require changes to its configuration to function properly and downstream pipelines may be affected. Warning: SSH tunneling is in Beta."

--- a/airbyte-integrations/connectors/destination-databricks/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-databricks/metadata.yaml
@@ -49,6 +49,13 @@ data:
           dbt models or SQL queries to reference the final tables instead, then drop old raw tables after verifying.
         upgradeDeadline: "2026-10-01"
         deadlineAction: "auto_upgrade"
+    rolloutConfiguration:
+      defaultRolloutMode: autopilot
+      autopilotConfig:
+        autoStart: true
+        autoPromoteStages: true
+        strategy: slow
+      enableProgressiveRollout: true
   documentationUrl: https://docs.airbyte.com/integrations/destinations/databricks
   resourceRequirements:
     jobSpecific:

--- a/airbyte-integrations/connectors/destination-gcs-data-lake/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-gcs-data-lake/metadata.yaml
@@ -48,4 +48,12 @@ data:
     - title: Access control
       url: https://cloud.google.com/storage/docs/access-control
       type: permissions_scopes
+  releases:
+    rolloutConfiguration:
+      defaultRolloutMode: autopilot
+      autopilotConfig:
+        autoStart: true
+        autoPromoteStages: true
+        strategy: fast
+      enableProgressiveRollout: true
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-motherduck/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-motherduck/metadata.yaml
@@ -23,7 +23,7 @@ data:
       autopilotConfig:
         autoStart: true
         autoPromoteStages: true
-        strategy: fast
+        strategy: slow
       enableProgressiveRollout: true
   remoteRegistries:
     pypi:

--- a/airbyte-integrations/connectors/destination-mssql/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-mssql/metadata.yaml
@@ -55,6 +55,13 @@ data:
 
           '
         upgradeDeadline: "2025-09-11"
+    rolloutConfiguration:
+      defaultRolloutMode: autopilot
+      autopilotConfig:
+        autoStart: true
+        autoPromoteStages: true
+        strategy: slow
+      enableProgressiveRollout: true
   releaseStage: generally_available
   supportLevel: certified
   supportsRefreshes: true

--- a/airbyte-integrations/connectors/destination-pinecone/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-pinecone/metadata.yaml
@@ -73,4 +73,12 @@ data:
     - title: Pinecone Status
       url: https://status.pinecone.io/
       type: status_page
+  releases:
+    rolloutConfiguration:
+      defaultRolloutMode: autopilot
+      autopilotConfig:
+        autoStart: true
+        autoPromoteStages: true
+        strategy: fast
+      enableProgressiveRollout: true
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/destination-postgres/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-postgres/metadata.yaml
@@ -22,7 +22,12 @@ data:
       enabled: true
   releases:
     rolloutConfiguration:
-      enableProgressiveRollout: false
+      enableProgressiveRollout: true
+      defaultRolloutMode: autopilot
+      autopilotConfig:
+        autoStart: true
+        autoPromoteStages: true
+        strategy: slow
     breakingChanges:
       3.0.0:
         message: >

--- a/airbyte-integrations/connectors/destination-redshift/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-redshift/metadata.yaml
@@ -71,24 +71,48 @@ data:
   releases:
     breakingChanges:
       2.0.0:
-        message: "This version introduces [Destinations V2](https://docs.airbyte.com/release_notes/upgrading_to_destinations_v2/#what-is-destinations-v2), which provides better error handling, incremental delivery of data for large syncs, and improved final table structures. To review the breaking changes, and how to upgrade, see [here](https://docs.airbyte.com/release_notes/upgrading_to_destinations_v2/#quick-start-to-upgrading). These changes will likely require updates to downstream dbt / SQL models, which we walk through [here](https://docs.airbyte.com/release_notes/upgrading_to_destinations_v2/#updating-downstream-transformations). Selecting `Upgrade` will upgrade **all** connections using this destination at their next sync. You can manually sync existing connections prior to the next scheduled sync to start the upgrade early.\n"
+        message:
+          "This version introduces [Destinations V2](https://docs.airbyte.com/release_notes/upgrading_to_destinations_v2/#what-is-destinations-v2),
+          which provides better error handling, incremental delivery of data for large
+          syncs, and improved final table structures. To review the breaking changes,
+          and how to upgrade, see [here](https://docs.airbyte.com/release_notes/upgrading_to_destinations_v2/#quick-start-to-upgrading).
+          These changes will likely require updates to downstream dbt / SQL models,
+          which we walk through [here](https://docs.airbyte.com/release_notes/upgrading_to_destinations_v2/#updating-downstream-transformations).
+          Selecting `Upgrade` will upgrade **all** connections using this destination
+          at their next sync. You can manually sync existing connections prior to
+          the next scheduled sync to start the upgrade early.
+
+          "
         upgradeDeadline: "2024-03-15"
       3.0.0:
-        message: 'Version 3.0.0 of destination-redshift removes support for the "standard inserts" mode. S3 staging was always preferred for being faster and less expensive, and as part of Airbyte 1.0, we are officially removing the inferior "standard inserts" mode. Upgrading to this version of the destination will require a configuration with an S3 staging area.
+        message:
+          'Version 3.0.0 of destination-redshift removes support for the "standard
+          inserts" mode. S3 staging was always preferred for being faster and less
+          expensive, and as part of Airbyte 1.0, we are officially removing the inferior
+          "standard inserts" mode. Upgrading to this version of the destination will
+          require a configuration with an S3 staging area.
 
           '
         upgradeDeadline: "2024-07-31"
       4.0.0:
-        message: "Version 4.0.0 is a full rewrite of the Redshift destination using the new CDK architecture. Data is now written directly to final tables (no more `_airbyte_raw_*` tables). Oversized or out-of-range values are nullified before insertion and tracked in `_airbyte_meta`. If you have downstream dbt models or SQL queries referencing `_airbyte_raw_*` tables, update them before upgrading.\n"
+        message:
+          "Version 4.0.0 is a full rewrite of the Redshift destination using the
+          new CDK architecture. Data is now written directly to final tables (no
+          more `_airbyte_raw_*` tables). Oversized or out-of-range values are
+          nullified before insertion and tracked in `_airbyte_meta`. If you have
+          downstream dbt models or SQL queries referencing `_airbyte_raw_*` tables,
+          update them before upgrading.
+
+          "
         upgradeDeadline: "2026-08-31"
         deadlineAction: "auto_upgrade"
     rolloutConfiguration:
+      enableProgressiveRollout: true
       defaultRolloutMode: autopilot
       autopilotConfig:
         autoStart: true
         autoPromoteStages: true
         strategy: slow
-      enableProgressiveRollout: true
   resourceRequirements:
     jobSpecific:
       - jobType: sync

--- a/airbyte-integrations/connectors/destination-redshift/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-redshift/metadata.yaml
@@ -71,41 +71,24 @@ data:
   releases:
     breakingChanges:
       2.0.0:
-        message:
-          "This version introduces [Destinations V2](https://docs.airbyte.com/release_notes/upgrading_to_destinations_v2/#what-is-destinations-v2),
-          which provides better error handling, incremental delivery of data for large
-          syncs, and improved final table structures. To review the breaking changes,
-          and how to upgrade, see [here](https://docs.airbyte.com/release_notes/upgrading_to_destinations_v2/#quick-start-to-upgrading).
-          These changes will likely require updates to downstream dbt / SQL models,
-          which we walk through [here](https://docs.airbyte.com/release_notes/upgrading_to_destinations_v2/#updating-downstream-transformations).
-          Selecting `Upgrade` will upgrade **all** connections using this destination
-          at their next sync. You can manually sync existing connections prior to
-          the next scheduled sync to start the upgrade early.
-
-          "
+        message: "This version introduces [Destinations V2](https://docs.airbyte.com/release_notes/upgrading_to_destinations_v2/#what-is-destinations-v2), which provides better error handling, incremental delivery of data for large syncs, and improved final table structures. To review the breaking changes, and how to upgrade, see [here](https://docs.airbyte.com/release_notes/upgrading_to_destinations_v2/#quick-start-to-upgrading). These changes will likely require updates to downstream dbt / SQL models, which we walk through [here](https://docs.airbyte.com/release_notes/upgrading_to_destinations_v2/#updating-downstream-transformations). Selecting `Upgrade` will upgrade **all** connections using this destination at their next sync. You can manually sync existing connections prior to the next scheduled sync to start the upgrade early.\n"
         upgradeDeadline: "2024-03-15"
       3.0.0:
-        message:
-          'Version 3.0.0 of destination-redshift removes support for the "standard
-          inserts" mode. S3 staging was always preferred for being faster and less
-          expensive, and as part of Airbyte 1.0, we are officially removing the inferior
-          "standard inserts" mode. Upgrading to this version of the destination will
-          require a configuration with an S3 staging area.
+        message: 'Version 3.0.0 of destination-redshift removes support for the "standard inserts" mode. S3 staging was always preferred for being faster and less expensive, and as part of Airbyte 1.0, we are officially removing the inferior "standard inserts" mode. Upgrading to this version of the destination will require a configuration with an S3 staging area.
 
           '
         upgradeDeadline: "2024-07-31"
       4.0.0:
-        message:
-          "Version 4.0.0 is a full rewrite of the Redshift destination using the
-          new CDK architecture. Data is now written directly to final tables (no
-          more `_airbyte_raw_*` tables). Oversized or out-of-range values are
-          nullified before insertion and tracked in `_airbyte_meta`. If you have
-          downstream dbt models or SQL queries referencing `_airbyte_raw_*` tables,
-          update them before upgrading.
-
-          "
+        message: "Version 4.0.0 is a full rewrite of the Redshift destination using the new CDK architecture. Data is now written directly to final tables (no more `_airbyte_raw_*` tables). Oversized or out-of-range values are nullified before insertion and tracked in `_airbyte_meta`. If you have downstream dbt models or SQL queries referencing `_airbyte_raw_*` tables, update them before upgrading.\n"
         upgradeDeadline: "2026-08-31"
         deadlineAction: "auto_upgrade"
+    rolloutConfiguration:
+      defaultRolloutMode: autopilot
+      autopilotConfig:
+        autoStart: true
+        autoPromoteStages: true
+        strategy: slow
+      enableProgressiveRollout: true
   resourceRequirements:
     jobSpecific:
       - jobType: sync

--- a/airbyte-integrations/connectors/destination-s3-data-lake/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-s3-data-lake/metadata.yaml
@@ -47,7 +47,12 @@ data:
   releaseStage: alpha
   releases:
     rolloutConfiguration:
-      enableProgressiveRollout: false
+      enableProgressiveRollout: true
+      defaultRolloutMode: autopilot
+      autopilotConfig:
+        autoStart: true
+        autoPromoteStages: true
+        strategy: fast
   supportLevel: certified
   supportsRefreshes: true
   tags:

--- a/airbyte-integrations/connectors/destination-s3/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-s3/metadata.yaml
@@ -32,7 +32,12 @@ data:
           **This release includes breaking changes, including major revisions to the schema of stored data. Do not upgrade without reviewing the migration guide.**
         upgradeDeadline: "2024-10-08"
     rolloutConfiguration:
-      enableProgressiveRollout: false
+      enableProgressiveRollout: true
+      defaultRolloutMode: autopilot
+      autopilotConfig:
+        autoStart: true
+        autoPromoteStages: true
+        strategy: fast
   resourceRequirements:
     jobSpecific:
       - jobType: sync

--- a/airbyte-integrations/connectors/destination-snowflake/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-snowflake/metadata.yaml
@@ -37,7 +37,7 @@ data:
       autopilotConfig:
         autoStart: true
         autoPromoteStages: true
-        strategy: fast
+        strategy: slow
     breakingChanges:
       2.0.0:
         message: Remove GCS/S3 loading method support.

--- a/airbyte-integrations/connectors/source-airtable/metadata.yaml
+++ b/airbyte-integrations/connectors/source-airtable/metadata.yaml
@@ -56,7 +56,12 @@ data:
         message: This release introduces changes to columns with formula to parse values directly from `array` to `string` or `number` (where it is possible). Users should refresh the source schema and reset affected streams after upgrading to ensure uninterrupted syncs.
         upgradeDeadline: "2023-10-23"
     rolloutConfiguration:
-      enableProgressiveRollout: false
+      enableProgressiveRollout: true
+      defaultRolloutMode: autopilot
+      autopilotConfig:
+        autoStart: true
+        autoPromoteStages: true
+        strategy: fast
   supportLevel: certified
   tags:
     - language:manifest-only

--- a/airbyte-integrations/connectors/source-amazon-ads/metadata.yaml
+++ b/airbyte-integrations/connectors/source-amazon-ads/metadata.yaml
@@ -35,7 +35,12 @@ data:
   releaseStage: generally_available
   releases:
     rolloutConfiguration:
-      enableProgressiveRollout: false
+      enableProgressiveRollout: true
+      defaultRolloutMode: autopilot
+      autopilotConfig:
+        autoStart: true
+        autoPromoteStages: true
+        strategy: fast
     breakingChanges:
       9.0.0:
         message: "The `sponsored_product_ad_group_suggested_keywords` stream has been migrated from the deprecated V2 Suggested Keywords API (`/v2/sp/adGroups/{adGroupId}/suggested/keywords`) to the Keyword Recommendations API (`/sp/targets/keywords/recommendations`). The response schema has changed: fields `suggestedKeywords[].keywordText` and `suggestedKeywords[].matchType` are replaced by `keyword`, `recId`, `bidInfo[]`, `searchTermImpressionShare`, `searchTermImpressionRank`, and other new fields. Users must reset this stream after upgrading."
@@ -88,20 +93,13 @@ data:
         upgradeDeadline: "2024-03-27"
         scopedImpact:
           - scopeType: stream
-            impactedScopes:
-              [
-                "sponsored_brands_campaigns",
-                "sponsored_brands_ad_groups",
-                "sponsored_product_campaigns",
-                "sponsored_product_ad_group_bid_recommendations",
-              ]
+            impactedScopes: ["sponsored_brands_campaigns", "sponsored_brands_ad_groups", "sponsored_product_campaigns", "sponsored_product_ad_group_bid_recommendations"]
       4.0.0:
         message: "Streams `SponsoredBrandsAdGroups` and `SponsoredBrandsKeywords` now have updated schemas."
         upgradeDeadline: "2024-01-17"
         scopedImpact:
           - scopeType: stream
-            impactedScopes:
-              ["sponsored_brands_ad_groups", "sponsored_brands_keywords"]
+            impactedScopes: ["sponsored_brands_ad_groups", "sponsored_brands_keywords"]
       3.0.0:
         message: Attribution report stream schemas fix.
         upgradeDeadline: "2023-07-24"

--- a/airbyte-integrations/connectors/source-amazon-ads/metadata.yaml
+++ b/airbyte-integrations/connectors/source-amazon-ads/metadata.yaml
@@ -93,13 +93,20 @@ data:
         upgradeDeadline: "2024-03-27"
         scopedImpact:
           - scopeType: stream
-            impactedScopes: ["sponsored_brands_campaigns", "sponsored_brands_ad_groups", "sponsored_product_campaigns", "sponsored_product_ad_group_bid_recommendations"]
+            impactedScopes:
+              [
+                "sponsored_brands_campaigns",
+                "sponsored_brands_ad_groups",
+                "sponsored_product_campaigns",
+                "sponsored_product_ad_group_bid_recommendations",
+              ]
       4.0.0:
         message: "Streams `SponsoredBrandsAdGroups` and `SponsoredBrandsKeywords` now have updated schemas."
         upgradeDeadline: "2024-01-17"
         scopedImpact:
           - scopeType: stream
-            impactedScopes: ["sponsored_brands_ad_groups", "sponsored_brands_keywords"]
+            impactedScopes:
+              ["sponsored_brands_ad_groups", "sponsored_brands_keywords"]
       3.0.0:
         message: Attribution report stream schemas fix.
         upgradeDeadline: "2023-07-24"

--- a/airbyte-integrations/connectors/source-amazon-seller-partner/metadata.yaml
+++ b/airbyte-integrations/connectors/source-amazon-seller-partner/metadata.yaml
@@ -47,7 +47,7 @@ data:
       autopilotConfig:
         autoStart: true
         autoPromoteStages: true
-        strategy: fast
+        strategy: slow
     breakingChanges:
       2.0.0:
         message: "Deprecated FBA reports will be removed permanently from Cloud and Brand Analytics Reports will be removed temporarily. Updates on Brand Analytics Reports can be tracked here: [#32353](https://github.com/airbytehq/airbyte/issues/32353)"

--- a/airbyte-integrations/connectors/source-amazon-seller-partner/metadata.yaml
+++ b/airbyte-integrations/connectors/source-amazon-seller-partner/metadata.yaml
@@ -47,7 +47,7 @@ data:
       autopilotConfig:
         autoStart: true
         autoPromoteStages: true
-        strategy: slow
+        strategy: fast
     breakingChanges:
       2.0.0:
         message: "Deprecated FBA reports will be removed permanently from Cloud and Brand Analytics Reports will be removed temporarily. Updates on Brand Analytics Reports can be tracked here: [#32353](https://github.com/airbytehq/airbyte/issues/32353)"

--- a/airbyte-integrations/connectors/source-amplitude/metadata.yaml
+++ b/airbyte-integrations/connectors/source-amplitude/metadata.yaml
@@ -31,7 +31,12 @@ data:
   releaseStage: generally_available
   releases:
     rolloutConfiguration:
-      enableProgressiveRollout: false
+      enableProgressiveRollout: true
+      defaultRolloutMode: autopilot
+      autopilotConfig:
+        autoStart: true
+        autoPromoteStages: true
+        strategy: fast
   suggestedStreams:
     streams:
       - events

--- a/airbyte-integrations/connectors/source-azure-blob-storage/metadata.yaml
+++ b/airbyte-integrations/connectors/source-azure-blob-storage/metadata.yaml
@@ -42,7 +42,12 @@ data:
           memory_request: 4096Mi
   releases:
     rolloutConfiguration:
-      enableProgressiveRollout: false
+      enableProgressiveRollout: true
+      defaultRolloutMode: autopilot
+      autopilotConfig:
+        autoStart: true
+        autoPromoteStages: true
+        strategy: fast
   supportLevel: certified
   supportsFileTransfer: true
   tags:

--- a/airbyte-integrations/connectors/source-bing-ads/metadata.yaml
+++ b/airbyte-integrations/connectors/source-bing-ads/metadata.yaml
@@ -44,7 +44,12 @@ data:
   releaseStage: generally_available
   releases:
     rolloutConfiguration:
-      enableProgressiveRollout: false
+      enableProgressiveRollout: true
+      defaultRolloutMode: autopilot
+      autopilotConfig:
+        autoStart: true
+        autoPromoteStages: true
+        strategy: fast
     breakingChanges:
       1.0.0:
         message: Version 1.0.0 removes the primary keys from the geographic performance report streams. This will prevent the connector from losing data in the incremental append+dedup sync mode because of deduplication and incorrect primary keys. A data reset and schema refresh of all the affected streams is required for the changes to take effect.

--- a/airbyte-integrations/connectors/source-chargebee/metadata.yaml
+++ b/airbyte-integrations/connectors/source-chargebee/metadata.yaml
@@ -37,7 +37,12 @@ data:
   releaseStage: generally_available
   releases:
     rolloutConfiguration:
-      enableProgressiveRollout: false
+      enableProgressiveRollout: true
+      defaultRolloutMode: autopilot
+      autopilotConfig:
+        autoStart: true
+        autoPromoteStages: true
+        strategy: fast
   suggestedStreams:
     streams:
       - subscription

--- a/airbyte-integrations/connectors/source-facebook-marketing/metadata.yaml
+++ b/airbyte-integrations/connectors/source-facebook-marketing/metadata.yaml
@@ -43,7 +43,12 @@ data:
   releaseStage: generally_available
   releases:
     rolloutConfiguration:
-      enableProgressiveRollout: false
+      enableProgressiveRollout: true
+      defaultRolloutMode: autopilot
+      autopilotConfig:
+        autoStart: true
+        autoPromoteStages: true
+        strategy: fast
     breakingChanges:
       2.0.0:
         message: "All Ads-Insights-* streams now have updated schemas. Users will need to retest source configuration, refresh the source schema and reset affected streams after upgrading. Please pay attention that data older than 37 months will become unavailable due to FaceBook limitations. For more information [visit](https://docs.airbyte.com/integrations/sources/facebook-marketing-migrations)"

--- a/airbyte-integrations/connectors/source-file/metadata.yaml
+++ b/airbyte-integrations/connectors/source-file/metadata.yaml
@@ -30,7 +30,12 @@ data:
   releaseStage: generally_available
   releases:
     rolloutConfiguration:
-      enableProgressiveRollout: false
+      enableProgressiveRollout: true
+      defaultRolloutMode: autopilot
+      autopilotConfig:
+        autoStart: true
+        autoPromoteStages: true
+        strategy: fast
   supportLevel: certified
   tags:
     - language:python

--- a/airbyte-integrations/connectors/source-freshdesk/metadata.yaml
+++ b/airbyte-integrations/connectors/source-freshdesk/metadata.yaml
@@ -33,7 +33,12 @@ data:
       enabled: true
   releases:
     rolloutConfiguration:
-      enableProgressiveRollout: false
+      enableProgressiveRollout: true
+      defaultRolloutMode: autopilot
+      autopilotConfig:
+        autoStart: true
+        autoPromoteStages: true
+        strategy: fast
   releaseStage: generally_available
   suggestedStreams:
     streams:

--- a/airbyte-integrations/connectors/source-gcs/metadata.yaml
+++ b/airbyte-integrations/connectors/source-gcs/metadata.yaml
@@ -21,7 +21,12 @@ data:
   name: Google Cloud Storage (GCS)
   releases:
     rolloutConfiguration:
-      enableProgressiveRollout: false
+      enableProgressiveRollout: true
+      defaultRolloutMode: autopilot
+      autopilotConfig:
+        autoStart: true
+        autoPromoteStages: true
+        strategy: fast
   remoteRegistries:
     pypi:
       enabled: true

--- a/airbyte-integrations/connectors/source-github/metadata.yaml
+++ b/airbyte-integrations/connectors/source-github/metadata.yaml
@@ -44,7 +44,12 @@ data:
               - "releases"
               - "review_comments"
     rolloutConfiguration:
-      enableProgressiveRollout: false
+      enableProgressiveRollout: true
+      defaultRolloutMode: autopilot
+      autopilotConfig:
+        autoStart: true
+        autoPromoteStages: true
+        strategy: fast
   suggestedStreams:
     streams:
       - branches

--- a/airbyte-integrations/connectors/source-gitlab/metadata.yaml
+++ b/airbyte-integrations/connectors/source-gitlab/metadata.yaml
@@ -40,7 +40,12 @@ data:
   releaseStage: generally_available
   releases:
     rolloutConfiguration:
-      enableProgressiveRollout: false
+      enableProgressiveRollout: true
+      defaultRolloutMode: autopilot
+      autopilotConfig:
+        autoStart: true
+        autoPromoteStages: true
+        strategy: fast
     breakingChanges:
       4.0.0:
         message: In this release, several changes have been made to the Gitlab connector. The primary key was changed for streams `group_members`, `group_labels`, `project_members`, `project_labels`, `branches`, and `tags`. Users will need to refresh schemas and reset the affected streams after upgrading.

--- a/airbyte-integrations/connectors/source-google-ads/metadata.yaml
+++ b/airbyte-integrations/connectors/source-google-ads/metadata.yaml
@@ -41,7 +41,12 @@ data:
   releaseStage: generally_available
   releases:
     rolloutConfiguration:
-      enableProgressiveRollout: false
+      enableProgressiveRollout: true
+      defaultRolloutMode: autopilot
+      autopilotConfig:
+        autoStart: true
+        autoPromoteStages: true
+        strategy: fast
     breakingChanges:
       1.0.0:
         message: This release introduces fixes to custom query schema creation. Users should refresh the source schema and reset affected streams after upgrading to ensure uninterrupted syncs.
@@ -60,20 +65,7 @@ data:
         upgradeDeadline: "2026-05-30"
         scopedImpact:
           - scopeType: stream
-            impactedScopes:
-              [
-                "campaign",
-                "campaign_budget",
-                "account_performance_report",
-                "ad_group_ad",
-                "ad_group_ad_legacy",
-                "display_keyword_view",
-                "geographic_view_with_metrics",
-                "topic_view",
-                "user_location_view",
-                "ad_group_bidding_strategy",
-                "campaign_bidding_strategy",
-              ]
+            impactedScopes: ["campaign", "campaign_budget", "account_performance_report", "ad_group_ad", "ad_group_ad_legacy", "display_keyword_view", "geographic_view_with_metrics", "topic_view", "user_location_view", "ad_group_bidding_strategy", "campaign_bidding_strategy"]
       6.0.0:
         message: This release limits incremental report streams and custom queries that use `segments.date` to the 37-month granular data retention window enforced by the Google Ads API. The affected built-in streams are `account_performance_report`, `ad_group`, `ad_group_ad`, `ad_group_ad_legacy`, `ad_group_bidding_strategy`, `campaign`, `campaign_bidding_strategy`, `campaign_budget`, `click_view`, `customer`, `display_keyword_view`, `geographic_view`, `geographic_view_with_metrics`, `keyword_view`, `shopping_performance_view`, `topic_view`, and `user_location_view`; custom queries using `segments.date` are also affected. Data older than 37 months will be skipped. If you use the Full Refresh | Overwrite sync mode, store historical data older than 37 months before upgrading or that data will be permanently lost. If you use the Incremental | Append or Incremental | Append and Deduped sync modes, historical destination data older than 37 months is preserved, but the connector will not be able to sync it again. See the migration guide for full details.
         upgradeDeadline: "2026-05-31"

--- a/airbyte-integrations/connectors/source-google-ads/metadata.yaml
+++ b/airbyte-integrations/connectors/source-google-ads/metadata.yaml
@@ -65,7 +65,20 @@ data:
         upgradeDeadline: "2026-05-30"
         scopedImpact:
           - scopeType: stream
-            impactedScopes: ["campaign", "campaign_budget", "account_performance_report", "ad_group_ad", "ad_group_ad_legacy", "display_keyword_view", "geographic_view_with_metrics", "topic_view", "user_location_view", "ad_group_bidding_strategy", "campaign_bidding_strategy"]
+            impactedScopes:
+              [
+                "campaign",
+                "campaign_budget",
+                "account_performance_report",
+                "ad_group_ad",
+                "ad_group_ad_legacy",
+                "display_keyword_view",
+                "geographic_view_with_metrics",
+                "topic_view",
+                "user_location_view",
+                "ad_group_bidding_strategy",
+                "campaign_bidding_strategy",
+              ]
       6.0.0:
         message: This release limits incremental report streams and custom queries that use `segments.date` to the 37-month granular data retention window enforced by the Google Ads API. The affected built-in streams are `account_performance_report`, `ad_group`, `ad_group_ad`, `ad_group_ad_legacy`, `ad_group_bidding_strategy`, `campaign`, `campaign_bidding_strategy`, `campaign_budget`, `click_view`, `customer`, `display_keyword_view`, `geographic_view`, `geographic_view_with_metrics`, `keyword_view`, `shopping_performance_view`, `topic_view`, and `user_location_view`; custom queries using `segments.date` are also affected. Data older than 37 months will be skipped. If you use the Full Refresh | Overwrite sync mode, store historical data older than 37 months before upgrading or that data will be permanently lost. If you use the Incremental | Append or Incremental | Append and Deduped sync modes, historical destination data older than 37 months is preserved, but the connector will not be able to sync it again. See the migration guide for full details.
         upgradeDeadline: "2026-05-31"

--- a/airbyte-integrations/connectors/source-google-analytics-data-api/metadata.yaml
+++ b/airbyte-integrations/connectors/source-google-analytics-data-api/metadata.yaml
@@ -42,7 +42,12 @@ data:
   releaseStage: generally_available
   releases:
     rolloutConfiguration:
-      enableProgressiveRollout: false
+      enableProgressiveRollout: true
+      defaultRolloutMode: autopilot
+      autopilotConfig:
+        autoStart: true
+        autoPromoteStages: true
+        strategy: fast
     breakingChanges:
       2.0.0:
         message: Version 2.0.0 introduces changes to stream names for those syncing more than one Google Analytics 4 property. It allows streams from all properties to sync successfully. Please upgrade the connector to enable this additional functionality.

--- a/airbyte-integrations/connectors/source-google-drive/metadata.yaml
+++ b/airbyte-integrations/connectors/source-google-drive/metadata.yaml
@@ -29,7 +29,12 @@ data:
   releaseStage: alpha
   releases:
     rolloutConfiguration:
-      enableProgressiveRollout: false
+      enableProgressiveRollout: true
+      defaultRolloutMode: autopilot
+      autopilotConfig:
+        autoStart: true
+        autoPromoteStages: true
+        strategy: fast
   documentationUrl: https://docs.airbyte.com/integrations/sources/google-drive
   tags:
     - language:python

--- a/airbyte-integrations/connectors/source-google-search-console/metadata.yaml
+++ b/airbyte-integrations/connectors/source-google-search-console/metadata.yaml
@@ -43,11 +43,7 @@ data:
   releases:
     breakingChanges:
       2.0.0:
-        message:
-          "The `search_appearance` field has been appended to the existing primary keys of the `search_analytics_keyword_page_report`,
-          `search_analytics_keyword_site_report_by_page`, and `search_analytics_keyword_site_report_by_site` streams.
-          Users syncing these streams must perform a full refresh after upgrading to ensure correct deduplication.
-          See the [migration guide](https://docs.airbyte.com/integrations/sources/google-search-console-migrations) for details."
+        message: "The `search_appearance` field has been appended to the existing primary keys of the `search_analytics_keyword_page_report`, `search_analytics_keyword_site_report_by_page`, and `search_analytics_keyword_site_report_by_site` streams. Users syncing these streams must perform a full refresh after upgrading to ensure correct deduplication. See the [migration guide](https://docs.airbyte.com/integrations/sources/google-search-console-migrations) for details."
         upgradeDeadline: "2026-05-14"
         scopedImpact:
           - scopeType: stream
@@ -56,7 +52,12 @@ data:
               - "search_analytics_keyword_site_report_by_page"
               - "search_analytics_keyword_site_report_by_site"
     rolloutConfiguration:
-      enableProgressiveRollout: false
+      enableProgressiveRollout: true
+      defaultRolloutMode: autopilot
+      autopilotConfig:
+        autoStart: true
+        autoPromoteStages: true
+        strategy: fast
   releaseStage: generally_available
   suggestedStreams:
     streams:

--- a/airbyte-integrations/connectors/source-google-search-console/metadata.yaml
+++ b/airbyte-integrations/connectors/source-google-search-console/metadata.yaml
@@ -43,7 +43,11 @@ data:
   releases:
     breakingChanges:
       2.0.0:
-        message: "The `search_appearance` field has been appended to the existing primary keys of the `search_analytics_keyword_page_report`, `search_analytics_keyword_site_report_by_page`, and `search_analytics_keyword_site_report_by_site` streams. Users syncing these streams must perform a full refresh after upgrading to ensure correct deduplication. See the [migration guide](https://docs.airbyte.com/integrations/sources/google-search-console-migrations) for details."
+        message:
+          "The `search_appearance` field has been appended to the existing primary keys of the `search_analytics_keyword_page_report`,
+          `search_analytics_keyword_site_report_by_page`, and `search_analytics_keyword_site_report_by_site` streams.
+          Users syncing these streams must perform a full refresh after upgrading to ensure correct deduplication.
+          See the [migration guide](https://docs.airbyte.com/integrations/sources/google-search-console-migrations) for details."
         upgradeDeadline: "2026-05-14"
         scopedImpact:
           - scopeType: stream

--- a/airbyte-integrations/connectors/source-google-sheets/metadata.yaml
+++ b/airbyte-integrations/connectors/source-google-sheets/metadata.yaml
@@ -37,7 +37,12 @@ data:
   releaseStage: generally_available
   releases:
     rolloutConfiguration:
-      enableProgressiveRollout: false
+      enableProgressiveRollout: true
+      defaultRolloutMode: autopilot
+      autopilotConfig:
+        autoStart: true
+        autoPromoteStages: true
+        strategy: fast
   supportLevel: certified
   tags:
     - language:manifest-only

--- a/airbyte-integrations/connectors/source-harvest/metadata.yaml
+++ b/airbyte-integrations/connectors/source-harvest/metadata.yaml
@@ -34,29 +34,19 @@ data:
       enabled: true
   releases:
     rolloutConfiguration:
-      enableProgressiveRollout: false
+      enableProgressiveRollout: true
+      defaultRolloutMode: autopilot
+      autopilotConfig:
+        autoStart: true
+        autoPromoteStages: true
+        strategy: fast
     breakingChanges:
       1.0.0:
         message: "Several changes have been made to the Harvest connector. This update requires a reset for the following streams to due an update in the format of state: `expenses_clients`, `expenses_categories`, `expenses_projects`, `expenses_team`, `time_clients`, `time_projects`, `time_tasks`, `time_team`, `uninvoiced`, `estimate_messages`, `invoice_payments`, `invoice_messages`, `project_assignments`."
         upgradeDeadline: "2024-04-29"
         scopedImpact:
           - scopeType: stream
-            impactedScopes:
-              [
-                "expenses_clients",
-                "expenses_categories",
-                "expenses_projects",
-                "expenses_team",
-                "time_clients",
-                "time_projects",
-                "time_tasks",
-                "time_team",
-                "uninvoiced",
-                "estimate_messages",
-                "invoice_payments",
-                "invoice_messages",
-                "project_assignments",
-              ]
+            impactedScopes: ["expenses_clients", "expenses_categories", "expenses_projects", "expenses_team", "time_clients", "time_projects", "time_tasks", "time_team", "uninvoiced", "estimate_messages", "invoice_payments", "invoice_messages", "project_assignments"]
   releaseStage: generally_available
   suggestedStreams:
     streams:

--- a/airbyte-integrations/connectors/source-harvest/metadata.yaml
+++ b/airbyte-integrations/connectors/source-harvest/metadata.yaml
@@ -46,7 +46,22 @@ data:
         upgradeDeadline: "2024-04-29"
         scopedImpact:
           - scopeType: stream
-            impactedScopes: ["expenses_clients", "expenses_categories", "expenses_projects", "expenses_team", "time_clients", "time_projects", "time_tasks", "time_team", "uninvoiced", "estimate_messages", "invoice_payments", "invoice_messages", "project_assignments"]
+            impactedScopes:
+              [
+                "expenses_clients",
+                "expenses_categories",
+                "expenses_projects",
+                "expenses_team",
+                "time_clients",
+                "time_projects",
+                "time_tasks",
+                "time_team",
+                "uninvoiced",
+                "estimate_messages",
+                "invoice_payments",
+                "invoice_messages",
+                "project_assignments",
+              ]
   releaseStage: generally_available
   suggestedStreams:
     streams:

--- a/airbyte-integrations/connectors/source-hubspot/metadata.yaml
+++ b/airbyte-integrations/connectors/source-hubspot/metadata.yaml
@@ -72,7 +72,13 @@ data:
         deadlineAction: "auto_upgrade"
         scopedImpact:
           - scopeType: stream
-            impactedScopes: ["contact_lists", "contacts_form_submissions", "contacts_list_memberships", "contacts_merged_audit"]
+            impactedScopes:
+              [
+                "contact_lists",
+                "contacts_form_submissions",
+                "contacts_list_memberships",
+                "contacts_merged_audit",
+              ]
       4.0.0:
         message: >-
           This update brings extended schema with data type changes for the streams
@@ -81,7 +87,8 @@ data:
         upgradeDeadline: "2024-03-10"
         scopedImpact:
           - scopeType: stream
-            impactedScopes: ["deals_property_history", "companies_property_history"]
+            impactedScopes:
+              ["deals_property_history", "companies_property_history"]
       3.0.0:
         message: >-
           This update brings extended schema with data type changes for the Marketing

--- a/airbyte-integrations/connectors/source-hubspot/metadata.yaml
+++ b/airbyte-integrations/connectors/source-hubspot/metadata.yaml
@@ -41,7 +41,12 @@ data:
   releaseStage: generally_available
   releases:
     rolloutConfiguration:
-      enableProgressiveRollout: false
+      enableProgressiveRollout: true
+      defaultRolloutMode: autopilot
+      autopilotConfig:
+        autoStart: true
+        autoPromoteStages: true
+        strategy: fast
     breakingChanges:
       6.0.0:
         message: >-
@@ -67,13 +72,7 @@ data:
         deadlineAction: "auto_upgrade"
         scopedImpact:
           - scopeType: stream
-            impactedScopes:
-              [
-                "contact_lists",
-                "contacts_form_submissions",
-                "contacts_list_memberships",
-                "contacts_merged_audit",
-              ]
+            impactedScopes: ["contact_lists", "contacts_form_submissions", "contacts_list_memberships", "contacts_merged_audit"]
       4.0.0:
         message: >-
           This update brings extended schema with data type changes for the streams
@@ -82,8 +81,7 @@ data:
         upgradeDeadline: "2024-03-10"
         scopedImpact:
           - scopeType: stream
-            impactedScopes:
-              ["deals_property_history", "companies_property_history"]
+            impactedScopes: ["deals_property_history", "companies_property_history"]
       3.0.0:
         message: >-
           This update brings extended schema with data type changes for the Marketing

--- a/airbyte-integrations/connectors/source-instagram/metadata.yaml
+++ b/airbyte-integrations/connectors/source-instagram/metadata.yaml
@@ -26,7 +26,12 @@ data:
   releaseStage: generally_available
   releases:
     rolloutConfiguration:
-      enableProgressiveRollout: false
+      enableProgressiveRollout: true
+      defaultRolloutMode: autopilot
+      autopilotConfig:
+        autoStart: true
+        autoPromoteStages: true
+        strategy: fast
     breakingChanges:
       4.0.0:
         message: "This release removes deprecated metrics - `clips_replays_count`, `ig_reels_aggregated_all_plays_count`, `impressions`, and `plays` from `media_insights` stream, and `impressions` from `user_insights` and `story_insights` streams. Customers who these streams must take action with their connections. For more details, see our <a href='https://docs.airbyte.com/integrations/sources/instagram-migrations'>migration guide</a>."

--- a/airbyte-integrations/connectors/source-intercom/metadata.yaml
+++ b/airbyte-integrations/connectors/source-intercom/metadata.yaml
@@ -43,7 +43,12 @@ data:
   releaseStage: generally_available
   releases:
     rolloutConfiguration:
-      enableProgressiveRollout: false
+      enableProgressiveRollout: true
+      defaultRolloutMode: autopilot
+      autopilotConfig:
+        autoStart: true
+        autoPromoteStages: true
+        strategy: fast
   suggestedStreams:
     streams:
       - conversations

--- a/airbyte-integrations/connectors/source-jira/metadata.yaml
+++ b/airbyte-integrations/connectors/source-jira/metadata.yaml
@@ -85,7 +85,12 @@ data:
           - scopeType: stream
             impactedScopes: ["board_issues"]
     rolloutConfiguration:
-      enableProgressiveRollout: false
+      enableProgressiveRollout: true
+      defaultRolloutMode: autopilot
+      autopilotConfig:
+        autoStart: true
+        autoPromoteStages: true
+        strategy: fast
   suggestedStreams:
     streams:
       - issues

--- a/airbyte-integrations/connectors/source-klaviyo/metadata.yaml
+++ b/airbyte-integrations/connectors/source-klaviyo/metadata.yaml
@@ -40,6 +40,13 @@ data:
       1.0.0:
         message: In this release, for 'events' stream changed type of 'event_properties/items/quantity' field from integer to number. Users will need to refresh the source schema and reset events streams after upgrading.
         upgradeDeadline: "2023-11-30"
+    rolloutConfiguration:
+      defaultRolloutMode: autopilot
+      autopilotConfig:
+        autoStart: true
+        autoPromoteStages: true
+        strategy: fast
+      enableProgressiveRollout: true
   documentationUrl: https://docs.airbyte.com/integrations/sources/klaviyo
   externalDocumentationUrls:
     - title: API versioning and deprecation policy

--- a/airbyte-integrations/connectors/source-linkedin-ads/metadata.yaml
+++ b/airbyte-integrations/connectors/source-linkedin-ads/metadata.yaml
@@ -41,7 +41,12 @@ data:
   releaseStage: generally_available
   releases:
     rolloutConfiguration:
-      enableProgressiveRollout: false
+      enableProgressiveRollout: true
+      defaultRolloutMode: autopilot
+      autopilotConfig:
+        autoStart: true
+        autoPromoteStages: true
+        strategy: fast
     breakingChanges:
       1.0.0:
         message: This upgrade brings changes in primary key to *-analytics streams.

--- a/airbyte-integrations/connectors/source-mailchimp/metadata.yaml
+++ b/airbyte-integrations/connectors/source-mailchimp/metadata.yaml
@@ -50,7 +50,12 @@ data:
         message: Version 1.0.0 introduces schema changes to all incremental streams. A full schema refresh and data reset are required to upgrade to this version. For more details, see our <a href='https://docs.airbyte.io/integrations/sources/mailchimp-migrations'>migration guide</a>.
         upgradeDeadline: "2024-01-10"
     rolloutConfiguration:
-      enableProgressiveRollout: false
+      enableProgressiveRollout: true
+      defaultRolloutMode: autopilot
+      autopilotConfig:
+        autoStart: true
+        autoPromoteStages: true
+        strategy: fast
   releaseStage: generally_available
   suggestedStreams:
     streams:

--- a/airbyte-integrations/connectors/source-monday/metadata.yaml
+++ b/airbyte-integrations/connectors/source-monday/metadata.yaml
@@ -25,7 +25,16 @@ data:
         upgradeDeadline: "2024-01-15"
         scopedImpact:
           - scopeType: stream
-            impactedScopes: ["boards", "items", "tags", "teams", "updates", "users", "workspaces"]
+            impactedScopes:
+              [
+                "boards",
+                "items",
+                "tags",
+                "teams",
+                "updates",
+                "users",
+                "workspaces",
+              ]
   dockerRepository: airbyte/source-monday
   documentationUrl: https://docs.airbyte.com/integrations/sources/monday
   githubIssueLabel: source-monday

--- a/airbyte-integrations/connectors/source-monday/metadata.yaml
+++ b/airbyte-integrations/connectors/source-monday/metadata.yaml
@@ -13,23 +13,19 @@ data:
   dockerImageTag: 2.5.17
   releases:
     rolloutConfiguration:
-      enableProgressiveRollout: false
+      enableProgressiveRollout: true
+      defaultRolloutMode: autopilot
+      autopilotConfig:
+        autoStart: true
+        autoPromoteStages: true
+        strategy: fast
     breakingChanges:
       2.0.0:
         message: "Source Monday has deprecated API version 2023-07. We have upgraded the connector to the latest API version 2024-01. In this new version, the Id field has changed from an integer to a string in the streams Boards, Items, Tags, Teams, Updates, Users and Workspaces. Please reset affected streams."
         upgradeDeadline: "2024-01-15"
         scopedImpact:
           - scopeType: stream
-            impactedScopes:
-              [
-                "boards",
-                "items",
-                "tags",
-                "teams",
-                "updates",
-                "users",
-                "workspaces",
-              ]
+            impactedScopes: ["boards", "items", "tags", "teams", "updates", "users", "workspaces"]
   dockerRepository: airbyte/source-monday
   documentationUrl: https://docs.airbyte.com/integrations/sources/monday
   githubIssueLabel: source-monday

--- a/airbyte-integrations/connectors/source-mongodb-v2/metadata.yaml
+++ b/airbyte-integrations/connectors/source-mongodb-v2/metadata.yaml
@@ -53,18 +53,48 @@ data:
   releases:
     breakingChanges:
       2.0.0:
-        message: "**Important: This version introduces multiple database support for MongoDB v2 source connector.**\nThis update changes the configuration schema from a single `database` field to a `databases` array field, allowing you to sync data from multiple MongoDB databases in a single connection.\n**What to expect when upgrading:**\n1. You will need to reconfigure your MongoDB source connector to use the new `databases` array field 2. If you're using CDC incremental sync mode, we recommend testing this upgrade in a staging environment first\n**Migration steps:**\n1. After upgrading, edit your MongoDB source configuration 2. Add your existing database to the new `databases` array field 3. Add any additional databases you want to sync 4. Save the configuration and run a sync\nFor more information, please refer to the [MongoDB v2 documentation](https://docs.airbyte.com/integrations/sources/mongodb-v2) and the [migration guide](https://docs.airbyte.com/integrations/sources/mongodb-v2-migrations). "
+        message:
+          "**Important: This version introduces multiple database support for MongoDB v2 source connector.**
+
+          This update changes the configuration schema from a single `database` field to a `databases` array field,
+          allowing you to sync data from multiple MongoDB databases in a single connection.
+
+          **What to expect when upgrading:**
+
+          1. You will need to reconfigure your MongoDB source connector to use the new `databases` array field
+          2. If you're using CDC incremental sync mode, we recommend testing this upgrade in a staging environment first
+
+          **Migration steps:**
+
+          1. After upgrading, edit your MongoDB source configuration
+          2. Add your existing database to the new `databases` array field
+          3. Add any additional databases you want to sync
+          4. Save the configuration and run a sync
+
+          For more information, please refer to the [MongoDB v2 documentation](https://docs.airbyte.com/integrations/sources/mongodb-v2) and the [migration guide](https://docs.airbyte.com/integrations/sources/mongodb-v2-migrations).
+          "
         upgradeDeadline: "2025-08-31"
       1.0.0:
-        message: "**We advise against upgrading until you have run a test upgrade as outlined [here](https://docs.airbyte.com/integrations/sources/mongodb-v2-migrations).**  This version brings a host of updates to the MongoDB source connector, significantly increasing its scalability and reliability, especially for large collections. As of this version with checkpointing, [CDC incremental updates](https://docs.airbyte.com/understanding-airbyte/cdc) and improved schema discovery, this connector is also now [certified](https://docs.airbyte.com/integrations/). Selecting `Upgrade` will upgrade **all** connections using this source, require you to reconfigure the source, then run a full reset on **all** of your connections.\n"
+        message:
+          "**We advise against upgrading until you have run a test upgrade
+          as outlined [here](https://docs.airbyte.com/integrations/sources/mongodb-v2-migrations).**  This
+          version brings a host of updates to the MongoDB source connector, significantly
+          increasing its scalability and reliability, especially for large collections.
+          As of this version with checkpointing, [CDC incremental updates](https://docs.airbyte.com/understanding-airbyte/cdc)
+          and improved schema discovery, this connector is also now [certified](https://docs.airbyte.com/integrations/).
+          Selecting `Upgrade` will upgrade **all** connections using this source,
+          require you to reconfigure the source, then run a full reset on **all**
+          of your connections.
+
+          "
         upgradeDeadline: "2023-12-01"
     rolloutConfiguration:
+      enableProgressiveRollout: true
       defaultRolloutMode: autopilot
       autopilotConfig:
         autoStart: true
         autoPromoteStages: true
         strategy: slow
-      enableProgressiveRollout: true
   supportLevel: certified
   tags:
     - language:java

--- a/airbyte-integrations/connectors/source-mongodb-v2/metadata.yaml
+++ b/airbyte-integrations/connectors/source-mongodb-v2/metadata.yaml
@@ -53,41 +53,18 @@ data:
   releases:
     breakingChanges:
       2.0.0:
-        message:
-          "**Important: This version introduces multiple database support for MongoDB v2 source connector.**
-
-          This update changes the configuration schema from a single `database` field to a `databases` array field,
-          allowing you to sync data from multiple MongoDB databases in a single connection.
-
-          **What to expect when upgrading:**
-
-          1. You will need to reconfigure your MongoDB source connector to use the new `databases` array field
-          2. If you're using CDC incremental sync mode, we recommend testing this upgrade in a staging environment first
-
-          **Migration steps:**
-
-          1. After upgrading, edit your MongoDB source configuration
-          2. Add your existing database to the new `databases` array field
-          3. Add any additional databases you want to sync
-          4. Save the configuration and run a sync
-
-          For more information, please refer to the [MongoDB v2 documentation](https://docs.airbyte.com/integrations/sources/mongodb-v2) and the [migration guide](https://docs.airbyte.com/integrations/sources/mongodb-v2-migrations).
-          "
+        message: "**Important: This version introduces multiple database support for MongoDB v2 source connector.**\nThis update changes the configuration schema from a single `database` field to a `databases` array field, allowing you to sync data from multiple MongoDB databases in a single connection.\n**What to expect when upgrading:**\n1. You will need to reconfigure your MongoDB source connector to use the new `databases` array field 2. If you're using CDC incremental sync mode, we recommend testing this upgrade in a staging environment first\n**Migration steps:**\n1. After upgrading, edit your MongoDB source configuration 2. Add your existing database to the new `databases` array field 3. Add any additional databases you want to sync 4. Save the configuration and run a sync\nFor more information, please refer to the [MongoDB v2 documentation](https://docs.airbyte.com/integrations/sources/mongodb-v2) and the [migration guide](https://docs.airbyte.com/integrations/sources/mongodb-v2-migrations). "
         upgradeDeadline: "2025-08-31"
       1.0.0:
-        message:
-          "**We advise against upgrading until you have run a test upgrade
-          as outlined [here](https://docs.airbyte.com/integrations/sources/mongodb-v2-migrations).**  This
-          version brings a host of updates to the MongoDB source connector, significantly
-          increasing its scalability and reliability, especially for large collections.
-          As of this version with checkpointing, [CDC incremental updates](https://docs.airbyte.com/understanding-airbyte/cdc)
-          and improved schema discovery, this connector is also now [certified](https://docs.airbyte.com/integrations/).
-          Selecting `Upgrade` will upgrade **all** connections using this source,
-          require you to reconfigure the source, then run a full reset on **all**
-          of your connections.
-
-          "
+        message: "**We advise against upgrading until you have run a test upgrade as outlined [here](https://docs.airbyte.com/integrations/sources/mongodb-v2-migrations).**  This version brings a host of updates to the MongoDB source connector, significantly increasing its scalability and reliability, especially for large collections. As of this version with checkpointing, [CDC incremental updates](https://docs.airbyte.com/understanding-airbyte/cdc) and improved schema discovery, this connector is also now [certified](https://docs.airbyte.com/integrations/). Selecting `Upgrade` will upgrade **all** connections using this source, require you to reconfigure the source, then run a full reset on **all** of your connections.\n"
         upgradeDeadline: "2023-12-01"
+    rolloutConfiguration:
+      defaultRolloutMode: autopilot
+      autopilotConfig:
+        autoStart: true
+        autoPromoteStages: true
+        strategy: slow
+      enableProgressiveRollout: true
   supportLevel: certified
   tags:
     - language:java

--- a/airbyte-integrations/connectors/source-mssql/metadata.yaml
+++ b/airbyte-integrations/connectors/source-mssql/metadata.yaml
@@ -36,17 +36,7 @@ data:
   releases:
     breakingChanges:
       5.0.0:
-        message:
-          "NUMERIC and DECIMAL columns with scale 0 are now mapped to the Airbyte `integer` type
-          instead of `number`, so downstream destinations preserve integral semantics (e.g. Snowflake
-          NUMBER vs FLOAT). Customers whose streams contain at least one NUMERIC or DECIMAL column with
-          scale 0 must take action with their connections by refreshing the source schema and refreshing
-          the affected streams. To determine whether you are affected before upgrading, check the
-          connector logs while running version 4.4.12 (or any later 4.4.x) for a discovery line such as
-          'Discovered DECIMAL column with scale 0 (precision=10). A future connector version will map
-          such columns to Airbyte integer instead of number.' — one such line is logged per affected
-          column at discovery/schema-refresh time. If no such line appears in your logs, your streams
-          contain no affected columns and the upgrade requires no action."
+        message: "NUMERIC and DECIMAL columns with scale 0 are now mapped to the Airbyte `integer` type instead of `number`, so downstream destinations preserve integral semantics (e.g. Snowflake NUMBER vs FLOAT). Customers whose streams contain at least one NUMERIC or DECIMAL column with scale 0 must take action with their connections by refreshing the source schema and refreshing the affected streams. To determine whether you are affected before upgrading, check the connector logs while running version 4.4.12 (or any later 4.4.x) for a discovery line such as 'Discovered DECIMAL column with scale 0 (precision=10). A future connector version will map such columns to Airbyte integer instead of number.' — one such line is logged per affected column at discovery/schema-refresh time. If no such line appears in your logs, your streams contain no affected columns and the upgrade requires no action."
         upgradeDeadline: "2026-08-24"
         deadlineAction: "auto_upgrade"
       4.0.0:
@@ -58,6 +48,13 @@ data:
       2.0.0:
         message: "Add default cursor for cdc"
         upgradeDeadline: "2023-08-23"
+    rolloutConfiguration:
+      defaultRolloutMode: autopilot
+      autopilotConfig:
+        autoStart: true
+        autoPromoteStages: true
+        strategy: slow
+      enableProgressiveRollout: true
   connectorTestSuitesOptions:
     - suite: unitTests
     - suite: integrationTests

--- a/airbyte-integrations/connectors/source-mssql/metadata.yaml
+++ b/airbyte-integrations/connectors/source-mssql/metadata.yaml
@@ -36,7 +36,17 @@ data:
   releases:
     breakingChanges:
       5.0.0:
-        message: "NUMERIC and DECIMAL columns with scale 0 are now mapped to the Airbyte `integer` type instead of `number`, so downstream destinations preserve integral semantics (e.g. Snowflake NUMBER vs FLOAT). Customers whose streams contain at least one NUMERIC or DECIMAL column with scale 0 must take action with their connections by refreshing the source schema and refreshing the affected streams. To determine whether you are affected before upgrading, check the connector logs while running version 4.4.12 (or any later 4.4.x) for a discovery line such as 'Discovered DECIMAL column with scale 0 (precision=10). A future connector version will map such columns to Airbyte integer instead of number.' — one such line is logged per affected column at discovery/schema-refresh time. If no such line appears in your logs, your streams contain no affected columns and the upgrade requires no action."
+        message:
+          "NUMERIC and DECIMAL columns with scale 0 are now mapped to the Airbyte `integer` type
+          instead of `number`, so downstream destinations preserve integral semantics (e.g. Snowflake
+          NUMBER vs FLOAT). Customers whose streams contain at least one NUMERIC or DECIMAL column with
+          scale 0 must take action with their connections by refreshing the source schema and refreshing
+          the affected streams. To determine whether you are affected before upgrading, check the
+          connector logs while running version 4.4.12 (or any later 4.4.x) for a discovery line such as
+          'Discovered DECIMAL column with scale 0 (precision=10). A future connector version will map
+          such columns to Airbyte integer instead of number.' — one such line is logged per affected
+          column at discovery/schema-refresh time. If no such line appears in your logs, your streams
+          contain no affected columns and the upgrade requires no action."
         upgradeDeadline: "2026-08-24"
         deadlineAction: "auto_upgrade"
       4.0.0:
@@ -49,12 +59,12 @@ data:
         message: "Add default cursor for cdc"
         upgradeDeadline: "2023-08-23"
     rolloutConfiguration:
+      enableProgressiveRollout: true
       defaultRolloutMode: autopilot
       autopilotConfig:
         autoStart: true
         autoPromoteStages: true
         strategy: slow
-      enableProgressiveRollout: true
   connectorTestSuitesOptions:
     - suite: unitTests
     - suite: integrationTests

--- a/airbyte-integrations/connectors/source-mysql/metadata.yaml
+++ b/airbyte-integrations/connectors/source-mysql/metadata.yaml
@@ -77,7 +77,12 @@ data:
         message: Add default cursor for cdc
         upgradeDeadline: "2023-08-17"
     rolloutConfiguration:
-      enableProgressiveRollout: false
+      enableProgressiveRollout: true
+      defaultRolloutMode: autopilot
+      autopilotConfig:
+        autoStart: true
+        autoPromoteStages: true
+        strategy: slow
   externalDocumentationUrls:
     - title: MySQL documentation
       url: https://dev.mysql.com/doc/

--- a/airbyte-integrations/connectors/source-notion/metadata.yaml
+++ b/airbyte-integrations/connectors/source-notion/metadata.yaml
@@ -53,7 +53,12 @@ data:
         message: Version 2.0.0 introduces schema changes to multiple properties shared by the blocks, databases and pages streams. These changes were introduced to reflect updates to the Notion API. A full schema refresh and data reset are required to upgrade to this version.
         upgradeDeadline: "2023-11-09"
     rolloutConfiguration:
-      enableProgressiveRollout: false
+      enableProgressiveRollout: true
+      defaultRolloutMode: autopilot
+      autopilotConfig:
+        autoStart: true
+        autoPromoteStages: true
+        strategy: fast
   suggestedStreams:
     streams:
       - blocks

--- a/airbyte-integrations/connectors/source-paypal-transaction/metadata.yaml
+++ b/airbyte-integrations/connectors/source-paypal-transaction/metadata.yaml
@@ -33,13 +33,15 @@ data:
   releases:
     breakingChanges:
       2.1.0:
-        message:
-          'Version 2.1.0 changes the format of the state. The format of the
-          cursor changed from "2021-06-18T16:24:13+03:00" to "2021-06-18T16:24:13Z".
-          The state key for the transactions stream changed to "transaction_updated_date"
-          and the key for the balances stream change to "as_of_time". The upgrade
-          is safe, but rolling back is not.'
+        message: 'Version 2.1.0 changes the format of the state. The format of the cursor changed from "2021-06-18T16:24:13+03:00" to "2021-06-18T16:24:13Z". The state key for the transactions stream changed to "transaction_updated_date" and the key for the balances stream change to "as_of_time". The upgrade is safe, but rolling back is not.'
         upgradeDeadline: "2023-09-18"
+    rolloutConfiguration:
+      defaultRolloutMode: autopilot
+      autopilotConfig:
+        autoStart: true
+        autoPromoteStages: true
+        strategy: fast
+      enableProgressiveRollout: true
   suggestedStreams:
     streams:
       - transactions

--- a/airbyte-integrations/connectors/source-paypal-transaction/metadata.yaml
+++ b/airbyte-integrations/connectors/source-paypal-transaction/metadata.yaml
@@ -33,15 +33,20 @@ data:
   releases:
     breakingChanges:
       2.1.0:
-        message: 'Version 2.1.0 changes the format of the state. The format of the cursor changed from "2021-06-18T16:24:13+03:00" to "2021-06-18T16:24:13Z". The state key for the transactions stream changed to "transaction_updated_date" and the key for the balances stream change to "as_of_time". The upgrade is safe, but rolling back is not.'
+        message:
+          'Version 2.1.0 changes the format of the state. The format of the
+          cursor changed from "2021-06-18T16:24:13+03:00" to "2021-06-18T16:24:13Z".
+          The state key for the transactions stream changed to "transaction_updated_date"
+          and the key for the balances stream change to "as_of_time". The upgrade
+          is safe, but rolling back is not.'
         upgradeDeadline: "2023-09-18"
     rolloutConfiguration:
+      enableProgressiveRollout: true
       defaultRolloutMode: autopilot
       autopilotConfig:
         autoStart: true
         autoPromoteStages: true
         strategy: fast
-      enableProgressiveRollout: true
   suggestedStreams:
     streams:
       - transactions

--- a/airbyte-integrations/connectors/source-pinterest/metadata.yaml
+++ b/airbyte-integrations/connectors/source-pinterest/metadata.yaml
@@ -26,7 +26,12 @@ data:
   releaseStage: generally_available
   releases:
     rolloutConfiguration:
-      enableProgressiveRollout: false
+      enableProgressiveRollout: true
+      defaultRolloutMode: autopilot
+      autopilotConfig:
+        autoStart: true
+        autoPromoteStages: true
+        strategy: fast
     breakingChanges:
       2.0.0:
         message: "This release introduces updated format of state for incremental streams. Users will need to reset affected streams after upgrading. Please see migration guide for more details."

--- a/airbyte-integrations/connectors/source-postgres/metadata.yaml
+++ b/airbyte-integrations/connectors/source-postgres/metadata.yaml
@@ -73,7 +73,12 @@ data:
             alias: airbyte-connector-testing-secret-store
   releases:
     rolloutConfiguration:
-      enableProgressiveRollout: false
+      enableProgressiveRollout: true
+      defaultRolloutMode: autopilot
+      autopilotConfig:
+        autoStart: true
+        autoPromoteStages: true
+        strategy: slow
   externalDocumentationUrls:
     - title: PostgreSQL documentation
       url: https://www.postgresql.org/docs/

--- a/airbyte-integrations/connectors/source-s3/metadata.yaml
+++ b/airbyte-integrations/connectors/source-s3/metadata.yaml
@@ -34,7 +34,12 @@ data:
   releaseStage: generally_available
   releases:
     rolloutConfiguration:
-      enableProgressiveRollout: false
+      enableProgressiveRollout: true
+      defaultRolloutMode: autopilot
+      autopilotConfig:
+        autoStart: true
+        autoPromoteStages: true
+        strategy: fast
     breakingChanges:
       4.0.0:
         message: UX improvement, multi-stream support and deprecation of some parsing features

--- a/airbyte-integrations/connectors/source-salesforce/metadata.yaml
+++ b/airbyte-integrations/connectors/source-salesforce/metadata.yaml
@@ -18,7 +18,7 @@ data:
       autopilotConfig:
         autoStart: true
         autoPromoteStages: true
-        strategy: fast
+        strategy: slow
   dockerRepository: airbyte/source-salesforce
   documentationUrl: https://docs.airbyte.com/integrations/sources/salesforce
   externalDocumentationUrls:

--- a/airbyte-integrations/connectors/source-salesforce/metadata.yaml
+++ b/airbyte-integrations/connectors/source-salesforce/metadata.yaml
@@ -18,7 +18,7 @@ data:
       autopilotConfig:
         autoStart: true
         autoPromoteStages: true
-        strategy: slow
+        strategy: fast
   dockerRepository: airbyte/source-salesforce
   documentationUrl: https://docs.airbyte.com/integrations/sources/salesforce
   externalDocumentationUrls:

--- a/airbyte-integrations/connectors/source-sendgrid/metadata.yaml
+++ b/airbyte-integrations/connectors/source-sendgrid/metadata.yaml
@@ -13,7 +13,12 @@ data:
   dockerImageTag: 1.3.40
   releases:
     rolloutConfiguration:
-      enableProgressiveRollout: false
+      enableProgressiveRollout: true
+      defaultRolloutMode: autopilot
+      autopilotConfig:
+        autoStart: true
+        autoPromoteStages: true
+        strategy: fast
     breakingChanges:
       1.0.0:
         message: This release makes several changes that upgrade the Sendgrid connector. The configuration options have been renamed to `api_key` and `start_date`. `start_date` is now required. The `unsubscribe_groups` stream has been removed. It was the same as `suppression_groups`. You can use that and get the same data. The `single_sends` stream has been renamed `singlesend_stats`. This is closer to the data and API. The `segments` stream has been upgraded to use the Sendgrid 2.0 API because the older one has been deprecated. The schema has changed as a result. To ensure a smooth upgrade, please refresh your schemas and reset your data before resuming syncs.

--- a/airbyte-integrations/connectors/source-sentry/metadata.yaml
+++ b/airbyte-integrations/connectors/source-sentry/metadata.yaml
@@ -95,5 +95,10 @@ data:
           - scopeType: stream
             impactedScopes: ["projects"]
     rolloutConfiguration:
-      enableProgressiveRollout: false
+      enableProgressiveRollout: true
+      defaultRolloutMode: autopilot
+      autopilotConfig:
+        autoStart: true
+        autoPromoteStages: true
+        strategy: fast
 metadataSpecVersion: "1.0"

--- a/airbyte-integrations/connectors/source-shopify/metadata.yaml
+++ b/airbyte-integrations/connectors/source-shopify/metadata.yaml
@@ -47,9 +47,31 @@ data:
         upgradeDeadline: "2024-03-18"
         scopedImpact:
           - scopeType: stream
-            impactedScopes: ["collections", "customer_address", "discount_codes", "fulfillment_orders", "fulfillments", "inventory_items", "inventory_levels", "metafield_collections", "metafield_customers", "metafield_draft_orders", "metafield_locations", "metafield_orders", "metafield_product_images", "metafield_product_variants", "order_refunds", "product_images", "product_variants", "transactions"]
+            impactedScopes:
+              [
+                "collections",
+                "customer_address",
+                "discount_codes",
+                "fulfillment_orders",
+                "fulfillments",
+                "inventory_items",
+                "inventory_levels",
+                "metafield_collections",
+                "metafield_customers",
+                "metafield_draft_orders",
+                "metafield_locations",
+                "metafield_orders",
+                "metafield_product_images",
+                "metafield_product_variants",
+                "order_refunds",
+                "product_images",
+                "product_variants",
+                "transactions",
+              ]
       2.1.0:
-        message: "This upgrade changes the `Products`, `Product Images` and `Product Variants` streams to use `Shopify GraphQL BULK`. More details here: https://github.com/airbytehq/airbyte/pull/37767."
+        message:
+          "This upgrade changes the `Products`, `Product Images` and `Product Variants` streams to use `Shopify GraphQL BULK`.
+          More details here: https://github.com/airbytehq/airbyte/pull/37767."
         upgradeDeadline: "2024-06-10"
         scopedImpact:
           - scopeType: stream
@@ -61,7 +83,9 @@ data:
           - scopeType: stream
             impactedScopes: ["countries"]
       2.6.1:
-        message: "The `ProductsGraphQL` and the `CustomerSavedSearch` streams have been deprecated by Shopify and removed from Airbyte. Please use the `Products` stream instead. As of 2025-01-16, Shopify no longer provides data for the affected streams. More details here: https://github.com/airbytehq/airbyte/pull/51037."
+        message:
+          "The `ProductsGraphQL` and the `CustomerSavedSearch` streams have been deprecated by Shopify and removed from Airbyte.
+          Please use the `Products` stream instead. As of 2025-01-16, Shopify no longer provides data for the affected streams. More details here: https://github.com/airbytehq/airbyte/pull/51037."
         upgradeDeadline: "2025-01-16"
         scopedImpact:
           - scopeType: stream
@@ -71,7 +95,8 @@ data:
         upgradeDeadline: "2025-04-01"
         scopedImpact:
           - scopeType: stream
-            impactedScopes: ["countries", "product_variants", "articles", "blogs", "pages"]
+            impactedScopes:
+              ["countries", "product_variants", "articles", "blogs", "pages"]
   suggestedStreams:
     streams:
       - customers

--- a/airbyte-integrations/connectors/source-shopify/metadata.yaml
+++ b/airbyte-integrations/connectors/source-shopify/metadata.yaml
@@ -32,7 +32,12 @@ data:
   releaseStage: generally_available
   releases:
     rolloutConfiguration:
-      enableProgressiveRollout: false
+      enableProgressiveRollout: true
+      defaultRolloutMode: autopilot
+      autopilotConfig:
+        autoStart: true
+        autoPromoteStages: true
+        strategy: fast
     breakingChanges:
       1.0.0:
         message: "This upgrade brings changes to certain streams after migration to Shopify API version `2023-07`, more details in this PR: https://github.com/airbytehq/airbyte/pull/29361."
@@ -42,31 +47,9 @@ data:
         upgradeDeadline: "2024-03-18"
         scopedImpact:
           - scopeType: stream
-            impactedScopes:
-              [
-                "collections",
-                "customer_address",
-                "discount_codes",
-                "fulfillment_orders",
-                "fulfillments",
-                "inventory_items",
-                "inventory_levels",
-                "metafield_collections",
-                "metafield_customers",
-                "metafield_draft_orders",
-                "metafield_locations",
-                "metafield_orders",
-                "metafield_product_images",
-                "metafield_product_variants",
-                "order_refunds",
-                "product_images",
-                "product_variants",
-                "transactions",
-              ]
+            impactedScopes: ["collections", "customer_address", "discount_codes", "fulfillment_orders", "fulfillments", "inventory_items", "inventory_levels", "metafield_collections", "metafield_customers", "metafield_draft_orders", "metafield_locations", "metafield_orders", "metafield_product_images", "metafield_product_variants", "order_refunds", "product_images", "product_variants", "transactions"]
       2.1.0:
-        message:
-          "This upgrade changes the `Products`, `Product Images` and `Product Variants` streams to use `Shopify GraphQL BULK`.
-          More details here: https://github.com/airbytehq/airbyte/pull/37767."
+        message: "This upgrade changes the `Products`, `Product Images` and `Product Variants` streams to use `Shopify GraphQL BULK`. More details here: https://github.com/airbytehq/airbyte/pull/37767."
         upgradeDeadline: "2024-06-10"
         scopedImpact:
           - scopeType: stream
@@ -78,9 +61,7 @@ data:
           - scopeType: stream
             impactedScopes: ["countries"]
       2.6.1:
-        message:
-          "The `ProductsGraphQL` and the `CustomerSavedSearch` streams have been deprecated by Shopify and removed from Airbyte.
-          Please use the `Products` stream instead. As of 2025-01-16, Shopify no longer provides data for the affected streams. More details here: https://github.com/airbytehq/airbyte/pull/51037."
+        message: "The `ProductsGraphQL` and the `CustomerSavedSearch` streams have been deprecated by Shopify and removed from Airbyte. Please use the `Products` stream instead. As of 2025-01-16, Shopify no longer provides data for the affected streams. More details here: https://github.com/airbytehq/airbyte/pull/51037."
         upgradeDeadline: "2025-01-16"
         scopedImpact:
           - scopeType: stream
@@ -90,8 +71,7 @@ data:
         upgradeDeadline: "2025-04-01"
         scopedImpact:
           - scopeType: stream
-            impactedScopes:
-              ["countries", "product_variants", "articles", "blogs", "pages"]
+            impactedScopes: ["countries", "product_variants", "articles", "blogs", "pages"]
   suggestedStreams:
     streams:
       - customers

--- a/airbyte-integrations/connectors/source-slack/metadata.yaml
+++ b/airbyte-integrations/connectors/source-slack/metadata.yaml
@@ -40,7 +40,12 @@ data:
   releaseStage: generally_available
   releases:
     rolloutConfiguration:
-      enableProgressiveRollout: false
+      enableProgressiveRollout: true
+      defaultRolloutMode: autopilot
+      autopilotConfig:
+        autoStart: true
+        autoPromoteStages: true
+        strategy: fast
     breakingChanges:
       3.0.0:
         message: This update fixes a bug that prevented incremental syncs from progressing for some connections containing the `threads` stream. Affected users should perform a stream refresh. See the [Slack Migration Guide](https://docs.airbyte.com/integrations/sources/slack-migrations) for instructions on identifying impacted connections and refreshing the stream.

--- a/airbyte-integrations/connectors/source-snapchat-marketing/metadata.yaml
+++ b/airbyte-integrations/connectors/source-snapchat-marketing/metadata.yaml
@@ -58,7 +58,12 @@ data:
               - "campaigns_stats_daily"
               - "campaigns_stats_lifetime"
     rolloutConfiguration:
-      enableProgressiveRollout: false
+      enableProgressiveRollout: true
+      defaultRolloutMode: autopilot
+      autopilotConfig:
+        autoStart: true
+        autoPromoteStages: true
+        strategy: fast
   documentationUrl: https://docs.airbyte.com/integrations/sources/snapchat-marketing
   externalDocumentationUrls:
     - title: Ads API announcements

--- a/airbyte-integrations/connectors/source-snowflake/metadata.yaml
+++ b/airbyte-integrations/connectors/source-snowflake/metadata.yaml
@@ -32,15 +32,23 @@ data:
   releases:
     breakingChanges:
       1.0.0:
-        message: "**Important: This version introduces Airbyte certified source connector to replace community supported connector.**\n**What to expect when upgrading:**\n1. The certified connector configuration spec should be compatible with community version. 2. Full refresh sync mode should remain the same. 3. For incremental sync mode, a full refresh will be triggered for next sync because the connection state will not be compatible. New state will be populated after full refresh is completed."
+        message:
+          "**Important: This version introduces Airbyte certified source connector to replace community supported connector.**
+
+          **What to expect when upgrading:**
+
+          1. The certified connector configuration spec should be compatible with community version.
+          2. Full refresh sync mode should remain the same.
+          3. For incremental sync mode, a full refresh will be triggered for next sync because the connection state will not be compatible.
+          New state will be populated after full refresh is completed."
         upgradeDeadline: "2025-09-30"
     rolloutConfiguration:
+      enableProgressiveRollout: true
       defaultRolloutMode: autopilot
       autopilotConfig:
         autoStart: true
         autoPromoteStages: true
         strategy: slow
-      enableProgressiveRollout: true
   supportLevel: certified
   tags:
     - language:java

--- a/airbyte-integrations/connectors/source-snowflake/metadata.yaml
+++ b/airbyte-integrations/connectors/source-snowflake/metadata.yaml
@@ -32,16 +32,15 @@ data:
   releases:
     breakingChanges:
       1.0.0:
-        message:
-          "**Important: This version introduces Airbyte certified source connector to replace community supported connector.**
-
-          **What to expect when upgrading:**
-
-          1. The certified connector configuration spec should be compatible with community version.
-          2. Full refresh sync mode should remain the same.
-          3. For incremental sync mode, a full refresh will be triggered for next sync because the connection state will not be compatible.
-          New state will be populated after full refresh is completed."
+        message: "**Important: This version introduces Airbyte certified source connector to replace community supported connector.**\n**What to expect when upgrading:**\n1. The certified connector configuration spec should be compatible with community version. 2. Full refresh sync mode should remain the same. 3. For incremental sync mode, a full refresh will be triggered for next sync because the connection state will not be compatible. New state will be populated after full refresh is completed."
         upgradeDeadline: "2025-09-30"
+    rolloutConfiguration:
+      defaultRolloutMode: autopilot
+      autopilotConfig:
+        autoStart: true
+        autoPromoteStages: true
+        strategy: slow
+      enableProgressiveRollout: true
   supportLevel: certified
   tags:
     - language:java

--- a/airbyte-integrations/connectors/source-stripe/metadata.yaml
+++ b/airbyte-integrations/connectors/source-stripe/metadata.yaml
@@ -31,7 +31,12 @@ data:
   releaseStage: generally_available
   releases:
     rolloutConfiguration:
-      enableProgressiveRollout: false
+      enableProgressiveRollout: true
+      defaultRolloutMode: autopilot
+      autopilotConfig:
+        autoStart: true
+        autoPromoteStages: true
+        strategy: fast
     breakingChanges:
       4.0.0:
         message: Version 4.0.0 changes the cursors in most of the Stripe streams that support incremental sync mode. This is done to not only sync the data that was created since previous sync, but also the data that was modified. A schema refresh of all effected streams is required to use the new cursor format.

--- a/airbyte-integrations/connectors/source-tiktok-marketing/metadata.yaml
+++ b/airbyte-integrations/connectors/source-tiktok-marketing/metadata.yaml
@@ -47,14 +47,27 @@ data:
         strategy: fast
     breakingChanges:
       5.0.0:
-        message: The `currency` field in the `pixels` stream's `events` array has been corrected from `boolean` to `string` type. Users syncing the `pixels` stream will need to refresh the source schema and reset the stream after upgrading. For more information, see our migration documentation for source TikTok Marketing.
+        message:
+          The `currency` field in the `pixels` stream's `events` array has been corrected
+          from `boolean` to `string` type. Users syncing the `pixels` stream will need to
+          refresh the source schema and reset the stream after upgrading.
+          For more information, see our migration documentation for source TikTok Marketing.
         upgradeDeadline: "2026-03-03"
         scopedImpact:
           - scopeType: stream
             impactedScopes:
               - "pixels"
       4.0.0:
-        message: The source TikTok Marketing connector is being migrated from the Python CDK to our declarative low-code CDK. Due to changes in the handling of state format for incremental substreams, this migration constitutes a breaking change for the following streams - ad_groups, ads, campaigns, creative_assets_images, creative_assets_videos, *_reports_daily, *_reports_hourly, *_reports_by_country_daily, *_reports_by_platform_daily. Also the schema for advertiser_ids stream was changed to use string type of advertiser_id field as API docs declares it. Users will need to reset source configuration, refresh the source schema and reset the impacted streams after upgrading. For more information, see our migration documentation for source TikTok Marketing.
+        message:
+          The source TikTok Marketing connector is being migrated from the Python CDK
+          to our declarative low-code CDK. Due to changes in the handling of state
+          format for incremental substreams, this migration constitutes a breaking
+          change for the following streams - ad_groups, ads, campaigns, creative_assets_images, creative_assets_videos,
+          *_reports_daily, *_reports_hourly, *_reports_by_country_daily, *_reports_by_platform_daily.
+          Also the schema for advertiser_ids stream was changed to use string type of advertiser_id
+          field as API docs declares it.
+          Users will need to reset source configuration, refresh the source schema and reset the impacted streams after upgrading.
+          For more information, see our migration documentation for source TikTok Marketing.
         upgradeDeadline: "2024-07-15"
         scopedImpact:
           - scopeType: stream

--- a/airbyte-integrations/connectors/source-tiktok-marketing/metadata.yaml
+++ b/airbyte-integrations/connectors/source-tiktok-marketing/metadata.yaml
@@ -39,30 +39,22 @@ data:
       enabled: true
   releases:
     rolloutConfiguration:
-      enableProgressiveRollout: false
+      enableProgressiveRollout: true
+      defaultRolloutMode: autopilot
+      autopilotConfig:
+        autoStart: true
+        autoPromoteStages: true
+        strategy: fast
     breakingChanges:
       5.0.0:
-        message:
-          The `currency` field in the `pixels` stream's `events` array has been corrected
-          from `boolean` to `string` type. Users syncing the `pixels` stream will need to
-          refresh the source schema and reset the stream after upgrading.
-          For more information, see our migration documentation for source TikTok Marketing.
+        message: The `currency` field in the `pixels` stream's `events` array has been corrected from `boolean` to `string` type. Users syncing the `pixels` stream will need to refresh the source schema and reset the stream after upgrading. For more information, see our migration documentation for source TikTok Marketing.
         upgradeDeadline: "2026-03-03"
         scopedImpact:
           - scopeType: stream
             impactedScopes:
               - "pixels"
       4.0.0:
-        message:
-          The source TikTok Marketing connector is being migrated from the Python CDK
-          to our declarative low-code CDK. Due to changes in the handling of state
-          format for incremental substreams, this migration constitutes a breaking
-          change for the following streams - ad_groups, ads, campaigns, creative_assets_images, creative_assets_videos,
-          *_reports_daily, *_reports_hourly, *_reports_by_country_daily, *_reports_by_platform_daily.
-          Also the schema for advertiser_ids stream was changed to use string type of advertiser_id
-          field as API docs declares it.
-          Users will need to reset source configuration, refresh the source schema and reset the impacted streams after upgrading.
-          For more information, see our migration documentation for source TikTok Marketing.
+        message: The source TikTok Marketing connector is being migrated from the Python CDK to our declarative low-code CDK. Due to changes in the handling of state format for incremental substreams, this migration constitutes a breaking change for the following streams - ad_groups, ads, campaigns, creative_assets_images, creative_assets_videos, *_reports_daily, *_reports_hourly, *_reports_by_country_daily, *_reports_by_platform_daily. Also the schema for advertiser_ids stream was changed to use string type of advertiser_id field as API docs declares it. Users will need to reset source configuration, refresh the source schema and reset the impacted streams after upgrading. For more information, see our migration documentation for source TikTok Marketing.
         upgradeDeadline: "2024-07-15"
         scopedImpact:
           - scopeType: stream

--- a/airbyte-integrations/connectors/source-twilio/metadata.yaml
+++ b/airbyte-integrations/connectors/source-twilio/metadata.yaml
@@ -51,7 +51,12 @@ data:
               - services
               - roles
     rolloutConfiguration:
-      enableProgressiveRollout: false
+      enableProgressiveRollout: true
+      defaultRolloutMode: autopilot
+      autopilotConfig:
+        autoStart: true
+        autoPromoteStages: true
+        strategy: fast
   suggestedStreams:
     streams:
       - calls

--- a/airbyte-integrations/connectors/source-typeform/metadata.yaml
+++ b/airbyte-integrations/connectors/source-typeform/metadata.yaml
@@ -35,7 +35,12 @@ data:
   releaseStage: generally_available
   releases:
     rolloutConfiguration:
-      enableProgressiveRollout: false
+      enableProgressiveRollout: true
+      defaultRolloutMode: autopilot
+      autopilotConfig:
+        autoStart: true
+        autoPromoteStages: true
+        strategy: fast
     breakingChanges:
       1.1.0:
         message: This version migrates the Typeform connector to the low-code framework for greater maintainability. This introduces a breaking change to the state format for the `responses` stream. If you are using the incremental sync mode for this stream, you will need to reset affected connections after upgrading to prevent sync failures.

--- a/airbyte-integrations/connectors/source-woocommerce/metadata.yaml
+++ b/airbyte-integrations/connectors/source-woocommerce/metadata.yaml
@@ -28,7 +28,12 @@ data:
   releaseStage: generally_available
   releases:
     rolloutConfiguration:
-      enableProgressiveRollout: false
+      enableProgressiveRollout: true
+      defaultRolloutMode: autopilot
+      autopilotConfig:
+        autoStart: true
+        autoPromoteStages: true
+        strategy: fast
   suggestedStreams:
     streams:
       - orders

--- a/airbyte-integrations/connectors/source-zendesk-chat/metadata.yaml
+++ b/airbyte-integrations/connectors/source-zendesk-chat/metadata.yaml
@@ -39,6 +39,13 @@ data:
       1.0.0:
         message: "The subdomain configuration field is now required following a Live Chat API update."
         upgradeDeadline: "2024-11-12"
+    rolloutConfiguration:
+      defaultRolloutMode: autopilot
+      autopilotConfig:
+        autoStart: true
+        autoPromoteStages: true
+        strategy: fast
+      enableProgressiveRollout: true
   suggestedStreams:
     streams:
       - chats

--- a/airbyte-integrations/connectors/source-zendesk-support/metadata.yaml
+++ b/airbyte-integrations/connectors/source-zendesk-support/metadata.yaml
@@ -32,6 +32,11 @@ data:
   releases:
     rolloutConfiguration:
       enableProgressiveRollout: true
+      defaultRolloutMode: autopilot
+      autopilotConfig:
+        autoStart: true
+        autoPromoteStages: true
+        strategy: fast
     breakingChanges:
       1.0.0:
         message: "`cursor_field` for `Tickets` stream is changed to `generated_timestamp`"

--- a/airbyte-integrations/connectors/source-zendesk-talk/metadata.yaml
+++ b/airbyte-integrations/connectors/source-zendesk-talk/metadata.yaml
@@ -51,7 +51,12 @@ data:
           please reset your source  before resuming syncs. For more information, see
           our migration documentation for source Zendesk Talk.
     rolloutConfiguration:
-      enableProgressiveRollout: false
+      enableProgressiveRollout: true
+      defaultRolloutMode: autopilot
+      autopilotConfig:
+        autoStart: true
+        autoPromoteStages: true
+        strategy: fast
   suggestedStreams:
     streams:
       - calls


### PR DESCRIPTION
## What

Turns on autopilot progressive rollouts for the certified connectors, pacing DB connectors more conservatively:

- `strategy: fast` for the certified non-DB connectors
- `strategy: slow` for the 13 certified DB connectors (`connectorSubtype: database`), including the four that already had autopilot on with `fast` (`destination-bigquery`, `destination-clickhouse`, `destination-motherduck`, `destination-snowflake`)

61 `metadata.yaml` files change: 48 land on `fast`, 13 on `slow`.

No version bumps: `dockerImageTag` is untouched everywhere, so this does not re-release any connector. Non-certified connectors are untouched.

## How

Applied with the existing tooling rather than hand-edited YAML — `airbyte-ops local connector rollouts enable --name <connector> --strategy <fast|slow>` (from `airbyte-ops-mcp`) over the certified set, which writes:

```yaml
  releases:
    rolloutConfiguration:
      enableProgressiveRollout: true
      defaultRolloutMode: autopilot
      autopilotConfig:
        autoStart: true
        autoPromoteStages: true
        strategy: fast   # or slow, for connectorSubtype: database
```

The tool's YAML round-trip collapsed unrelated multi-line block scalars (mostly `releases.breakingChanges[*].message`) in 13 files; those files were restored from `master` and the `rolloutConfiguration` block re-applied as a text-level edit, so the diff contains nothing but `rolloutConfiguration` lines.

## Review guide

Targeting is derived from metadata only — `supportLevel: certified` selects the set, `connectorSubtype: database` selects `slow`. Two notes:

1. A pre-existing `slow` strategy wins over the blanket `fast`, per AJ. `source-salesforce` and `source-amazon-seller-partner` were already `strategy: slow` on `master` and stay that way, so those two files are absent from the diff. They were the only certified connectors with an explicit non-`fast` strategy.
2. `connectorSubtype: database` is the DB test, so warehouse-ish destinations classified as `file` (`destination-s3-data-lake`, `destination-gcs-data-lake`, `destination-s3`, `destination-azure-blob-storage`) get `fast`.

Verified on the branch: exactly 61 `metadata.yaml` files changed; every added/removed line lives inside a `rolloutConfiguration` block; parsing each file back confirms 48 `fast` / 13 `slow` with `enableProgressiveRollout: true` and `defaultRolloutMode: autopilot`; dropping `rolloutConfiguration` leaves every file semantically identical to `master`.

## User Impact

New certified-connector releases roll out progressively and promote themselves through stages without manual intervention. DB connectors advance on the slower schedule.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Link to Devin session: https://app.devin.ai/sessions/29dc321efb174ffbbaa5e4b586bea774
Requested by: @aaronsteers

> [!IMPORTANT]
> Active progressive rollout warning for source-zendesk-support.

- [x] (Click to Approve:) Bypass the active progressive rollout warning for source-zendesk-support in the PR comment [here](https://github.com/airbytehq/airbyte/pull/83781#issuecomment-5220605859).

> [!IMPORTANT]
> Active progressive rollout warning for destination-clickhouse.

- [x] (Click to Approve:) Bypass the active progressive rollout warning for destination-clickhouse in the PR comment [here](https://github.com/airbytehq/airbyte/pull/83781#issuecomment-5220539296).

> [!IMPORTANT]
> Active progressive rollout warning for destination-snowflake.

- [x] (Click to Approve:) Bypass the active progressive rollout warning for destination-snowflake in the PR comment [here](https://github.com/airbytehq/airbyte/pull/83781#issuecomment-5220551751).

> [!IMPORTANT]
> Active progressive rollout warning for source-google-analytics-data-api.

- [x] (Click to Approve:) Bypass the active progressive rollout warning for source-google-analytics-data-api in the PR comment [here](https://github.com/airbytehq/airbyte/pull/83781#issuecomment-5245164787).