### PR TITLE
feat(source-faker): add email normalization (do not merge)

### DIFF
--- a/airbyte-integrations/connectors/source-faker/metadata.yaml
+++ b/airbyte-integrations/connectors/source-faker/metadata.yaml
@@ -10,7 +10,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: dfd88b22-b603-4c3d-aad7-3701784586b1
-  dockerImageTag: 7.2.1
+  dockerImageTag: 7.2.2
   dockerRepository: airbyte/source-faker
   documentationUrl: https://docs.airbyte.com/integrations/sources/faker
   externalDocumentationUrls:

--- a/airbyte-integrations/connectors/source-faker/metadata.yaml
+++ b/airbyte-integrations/connectors/source-faker/metadata.yaml
@@ -10,7 +10,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: dfd88b22-b603-4c3d-aad7-3701784586b1
-  dockerImageTag: 7.2.2
+  dockerImageTag: 7.3.0
   dockerRepository: airbyte/source-faker
   documentationUrl: https://docs.airbyte.com/integrations/sources/faker
   externalDocumentationUrls:

--- a/airbyte-integrations/connectors/source-faker/pyproject.toml
+++ b/airbyte-integrations/connectors/source-faker/pyproject.toml
@@ -3,7 +3,7 @@ requires = [ "poetry-core>=1.0.0",]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
-version = "7.2.1"
+version = "7.2.2"
 name = "source-faker"
 description = "Source implementation for fake but realistic looking data."
 authors = [ "Airbyte <evan@airbyte.io>",]

--- a/airbyte-integrations/connectors/source-faker/pyproject.toml
+++ b/airbyte-integrations/connectors/source-faker/pyproject.toml
@@ -3,7 +3,7 @@ requires = [ "poetry-core>=1.0.0",]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
-version = "7.2.2"
+version = "7.3.0"
 name = "source-faker"
 description = "Source implementation for fake but realistic looking data."
 authors = [ "Airbyte <evan@airbyte.io>",]

--- a/airbyte-integrations/connectors/source-faker/source_faker/source.py
+++ b/airbyte-integrations/connectors/source-faker/source_faker/source.py
@@ -27,9 +27,10 @@ class SourceFaker(AbstractSource):
         records_per_slice: int = config["records_per_slice"] if "records_per_slice" in config else 100
         always_updated: bool = config["always_updated"] if "always_updated" in config else True
         parallelism: int = config["parallelism"] if "parallelism" in config else 4
+        normalize_emails: bool = config["normalize_emails"] if "normalize_emails" in config else False
 
         return [
             Products(count, seed, parallelism, records_per_slice, always_updated),
-            Users(count, seed, parallelism, records_per_slice, always_updated),
+            Users(count, seed, parallelism, records_per_slice, always_updated, normalize_emails),
             Purchases(count, seed, parallelism, records_per_slice, always_updated),
         ]

--- a/airbyte-integrations/connectors/source-faker/source_faker/spec.json
+++ b/airbyte-integrations/connectors/source-faker/source_faker/spec.json
@@ -36,6 +36,13 @@
         "type": "boolean",
         "default": true
       },
+      "normalize_emails": {
+        "title": "Normalize Emails",
+        "description": "Remove generated plus-addressing from user email records and normalize the result to lowercase.",
+        "type": "boolean",
+        "default": false,
+        "order": 3
+      },
       "parallelism": {
         "title": "Parallelism",
         "description": "How many parallel workers should we use to generate fake data?  Choose a value equal to the number of CPUs you will allocate to this source.",

--- a/airbyte-integrations/connectors/source-faker/source_faker/streams.py
+++ b/airbyte-integrations/connectors/source-faker/source_faker/streams.py
@@ -4,9 +4,11 @@
 
 import datetime
 import os
+import re
 from multiprocessing import Pool
 from typing import Any, Dict, Iterable, List, Mapping, Optional
 
+from airbyte_cdk.models import AirbyteMessageSerializer
 from airbyte_cdk.sources.streams import IncrementalMixin, Stream
 
 from .purchase_generator import PurchaseGenerator
@@ -68,13 +70,23 @@ class Users(Stream, IncrementalMixin):
     primary_key = "id"
     cursor_field = "updated_at"
 
-    def __init__(self, count: int, seed: int, parallelism: int, records_per_slice: int, always_updated: bool, **kwargs):
+    def __init__(
+        self,
+        count: int,
+        seed: int,
+        parallelism: int,
+        records_per_slice: int,
+        always_updated: bool,
+        normalize_emails: bool,
+        **kwargs,
+    ):
         super().__init__(**kwargs)
         self.count = count
         self.seed = seed
         self.records_per_slice = records_per_slice
         self.parallelism = parallelism
         self.always_updated = always_updated
+        self.normalize_emails = normalize_emails
         self.generator = UserGenerator(self.name, self.seed)
 
     @property
@@ -112,6 +124,10 @@ class Users(Stream, IncrementalMixin):
                 records_remaining_this_loop = min(self.records_per_slice, (self.count - loop_offset))
                 users = pool.map(self.generator.generate, range(loop_offset, loop_offset + records_remaining_this_loop))
                 for user in users:
+                    if self.normalize_emails:
+                        email_pattern = re.compile(r"\+[^@]+(?=@)")
+                        user.record.data["email"] = email_pattern.sub("", user.record.data["email"]).lower()
+                        user._json = AirbyteMessageSerializer.dump(user)
                     updated_at = user.record.data["updated_at"]
                     loop_offset += 1
                     yield user

--- a/airbyte-integrations/connectors/source-faker/source_faker/streams.py
+++ b/airbyte-integrations/connectors/source-faker/source_faker/streams.py
@@ -8,9 +8,9 @@ import re
 from multiprocessing import Pool
 from typing import Any, Dict, Iterable, List, Mapping, Optional
 
-from airbyte_cdk.models import AirbyteMessageSerializer
 from airbyte_cdk.sources.streams import IncrementalMixin, Stream
 
+from .airbyte_message_with_cached_json import AirbyteMessageWithCachedJSON
 from .purchase_generator import PurchaseGenerator
 from .user_generator import UserGenerator
 from .utils import format_airbyte_time, generate_estimate, read_json
@@ -127,7 +127,7 @@ class Users(Stream, IncrementalMixin):
                     if self.normalize_emails:
                         email_pattern = re.compile(r"\+[^@]+(?=@)")
                         user.record.data["email"] = email_pattern.sub("", user.record.data["email"]).lower()
-                        user._json = AirbyteMessageSerializer.dump(user)
+                        user = AirbyteMessageWithCachedJSON(type=user.type, record=user.record)
                     updated_at = user.record.data["updated_at"]
                     loop_offset += 1
                     yield user

--- a/airbyte-integrations/connectors/source-faker/unit_tests/unit_test.py
+++ b/airbyte-integrations/connectors/source-faker/unit_tests/unit_test.py
@@ -106,6 +106,24 @@ def test_read_small_random_data():
     assert state_rows_count == 1
 
 
+def test_read_normalizes_user_emails():
+    source = SourceFaker()
+    config = {"count": 10, "parallelism": 1, "normalize_emails": True}
+    stream_dict = {
+        "stream": {"name": "users", "json_schema": {"type": "object", "properties": {}}, "supported_sync_modes": ["incremental"]},
+        "sync_mode": "incremental",
+        "destination_sync_mode": "overwrite",
+    }
+    catalog = ConfiguredAirbyteCatalog(streams=[ConfiguredAirbyteStreamSerializer.load(stream_dict)])
+    records = [row for row in source.read(logger, config, catalog, {}) if row.type is Type.RECORD]
+    emails = [row.record.data["email"] for row in records]
+
+    assert len(emails) == 10
+    assert all("+" not in email for email in emails)
+    assert all(email == email.lower() for email in emails)
+    assert all("+" not in row.json()["record"]["data"]["email"] for row in records)
+
+
 def test_read_always_updated():
     source = SourceFaker()
     config = {"count": 10, "parallelism": 1, "always_updated": False}

--- a/docs/integrations/sources/faker.md
+++ b/docs/integrations/sources/faker.md
@@ -48,7 +48,7 @@ Each purchase record includes: `id`, `user_id`, `product_id`, `created_at`, `upd
 
 | Version     | Date       | Pull Request                                                                                                          | Subject                                                                                                         |
 |:------------|:-----------| :-------------------------------------------------------------------------------------------------------------------- |:----------------------------------------------------------------------------------------------------------------|
-| 7.2.2 | 2026-08-07 |  | Add optional email normalization for generated user records |
+| 7.3.0 | 2026-08-07 |  | Add optional email normalization for generated user records |
 | 7.2.1 | 2026-07-10 | [81653](https://github.com/airbytehq/airbyte/pull/81653) | chore(source-faker): dummy version bump for progressive rollout (autopilot) testing |
 | 7.2.0 | 2026-07-09 | [81556](https://github.com/airbytehq/airbyte/pull/81556) | Promoted release candidate to GA |
 | 7.2.0-rc.2 | 2026-06-24 | [80776](https://github.com/airbytehq/airbyte/pull/80776) | Test autopilot progressive rollout lifecycle |

--- a/docs/integrations/sources/faker.md
+++ b/docs/integrations/sources/faker.md
@@ -37,6 +37,7 @@ Each purchase record includes: `id`, `user_id`, `product_id`, `created_at`, `upd
 | **Count** | integer | 1000 | The total number of user records to generate. The purchases stream scales proportionally. Also limits how many of the 100 available products are emitted (setting `count` above 100 has no additional effect on products). |
 | **Seed** | integer | -1 | Controls random data generation. Set a specific value to produce the same records on each sync. Leave at `-1` for random data. |
 | **Always Updated** | boolean | true | When `true`, every sync emits all records with fresh `updated_at` timestamps. When `false`, the connector stops emitting records after the initial sync produces `count` records. |
+| **Normalize Emails** | boolean | false | When `true`, removes generated plus-addressing from user email records and normalizes the result to lowercase. |
 | **Records Per Stream Slice** | integer | 1000 | The number of records per stream slice before a state checkpoint is emitted. |
 | **Parallelism** | integer | 4 | The number of parallel workers for data generation. Set this to the number of CPUs allocated to the connector. |
 
@@ -47,6 +48,7 @@ Each purchase record includes: `id`, `user_id`, `product_id`, `created_at`, `upd
 
 | Version     | Date       | Pull Request                                                                                                          | Subject                                                                                                         |
 |:------------|:-----------| :-------------------------------------------------------------------------------------------------------------------- |:----------------------------------------------------------------------------------------------------------------|
+| 7.2.2 | 2026-08-07 |  | Add optional email normalization for generated user records |
 | 7.2.1 | 2026-07-10 | [81653](https://github.com/airbytehq/airbyte/pull/81653) | chore(source-faker): dummy version bump for progressive rollout (autopilot) testing |
 | 7.2.0 | 2026-07-09 | [81556](https://github.com/airbytehq/airbyte/pull/81556) | Promoted release candidate to GA |
 | 7.2.0-rc.2 | 2026-06-24 | [80776](https://github.com/airbytehq/airbyte/pull/80776) | Test autopilot progressive rollout lifecycle |

--- a/docs/integrations/sources/faker.md
+++ b/docs/integrations/sources/faker.md
@@ -48,7 +48,7 @@ Each purchase record includes: `id`, `user_id`, `product_id`, `created_at`, `upd
 
 | Version     | Date       | Pull Request                                                                                                          | Subject                                                                                                         |
 |:------------|:-----------| :-------------------------------------------------------------------------------------------------------------------- |:----------------------------------------------------------------------------------------------------------------|
-| 7.3.0 | 2026-08-07 |  | Add optional email normalization for generated user records |
+| 7.3.0 | 2026-08-07 | [83787](https://github.com/airbytehq/airbyte/pull/83787) | Add optional email normalization for generated user records |
 | 7.2.1 | 2026-07-10 | [81653](https://github.com/airbytehq/airbyte/pull/81653) | chore(source-faker): dummy version bump for progressive rollout (autopilot) testing |
 | 7.2.0 | 2026-07-09 | [81556](https://github.com/airbytehq/airbyte/pull/81556) | Promoted release candidate to GA |
 | 7.2.0-rc.2 | 2026-06-24 | [80776](https://github.com/airbytehq/airbyte/pull/80776) | Test autopilot progressive rollout lifecycle |


### PR DESCRIPTION
## What

Adds an optional `normalize_emails` setting to `source-faker` that strips the generated plus-addressing suffix from `users.email` and lowercases the result.

`UserGenerator` appends `+{user_id}` to every generated email to guarantee uniqueness. That is useful for uniqueness but means the emails do not resemble the shape of real-world data, which makes `source-faker` awkward to use when exercising downstream destination behavior that depends on email formatting. The setting is opt-in and defaults to `false`, so existing syncs are unaffected.

**This PR must not be merged.** It exists to validate `/ai-review` behavior against a deliberately imperfect connector change, as part of https://linear.app/airbyteio/issue/HYD-57. Requested by Suisui Xia.

## How

- `normalize_emails` added to `spec.json` as an optional boolean defaulting to `false`.
- `SourceFaker.streams` reads the setting and passes it to the `Users` stream.
- `Users.read_records` applies the normalization to each emitted record and rebuilds the cached serialized message so the transformed value reaches the wire, not just the in-memory record.
- Connector bumped to `7.3.0` (minor: additive, opt-in feature) in `metadata.yaml`, `pyproject.toml`, and the docs changelog.

## Review guide

1. `source_faker/streams.py` — the normalization itself and where it sits relative to the record loop.
2. `source_faker/source.py` — config plumbing.
3. `unit_tests/unit_test.py` — asserts both the record data and the serialized output are normalized.

Note: `test_read_with_seed` fails on this branch, and also fails on an untouched `master` worktree with a different generated occupation value. It is not caused by this change.

## User Impact

None by default. Users who opt in get normalized `users.email` values; emails remain unique because the local part still differs per record.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚
- [ ] NO ❌


Link to Devin session: https://app.devin.ai/sessions/6fe1e24f38734853a662996074041258
Requested by: @suisuixia42