### PR TITLE
docs: remove the Self-Managed Enterprise product badge

### DIFF
--- a/docs/community/contributing-to-airbyte/writing-docs.md
+++ b/docs/community/contributing-to-airbyte/writing-docs.md
@@ -242,13 +242,12 @@ Certain Airbyte products reserve some platform features. To avoid confusion and 
 
 To enable badges, include `products` in the Markdown metadata. The following values are possible, and you can combine them as needed.
 
-**Badge display:** all 6 badges always appear in order - Core, Standard, Plus, Pro, Enterprise Flex, Self-Managed Enterprise. Available badges appear highlighted, unavailable badges appear grayed out.
+**Badge display:** all 5 badges always appear in order - Core, Standard, Plus, Pro, Enterprise Flex. Available badges appear highlighted, unavailable badges appear grayed out.
 
 **Metadata keys:**
 
-- `all`: Core, Self-Managed Enterprise, Standard, and Plus - doesn't include Pro, Enterprise Flex, or Embedded
+- `all`: Core, Standard, and Plus - doesn't include Pro, Enterprise Flex, or Embedded
 - `oss-community`: Core only
-- `oss-enterprise`: Self-Managed Enterprise only
 - `cloud`: Standard and Plus (also enables Pro and Enterprise Flex due to Cloud tier inheritance)
 - `cloud-plus`: Plus only (also enables Pro and Enterprise Flex due to Cloud tier inheritance)
 - `cloud-teams`: Pro only (also enables Enterprise Flex due to Cloud tier inheritance)
@@ -262,8 +261,6 @@ To enable badges, include `products` in the Markdown metadata. The following val
 - If you specify `cloud-teams`: Pro and Enterprise Flex badges become enabled - Standard and Plus turn off
 - If you specify `enterprise-flex`: Only Enterprise Flex badge becomes enabled
 
-**Self-managed plans** Core and Self-Managed Enterprise don't inherit from each other.
-
 In this example, the Core badge appears highlighted, and all other badges appear grayed out.
 
 ```markdown
@@ -276,14 +273,14 @@ products: oss-community
 Some text.
 ```
 
-In this example, Pro, and Enterprise Flex badges appear highlighted due to Cloud tier inheritance, while Core, Standard, Plus, and Self-Managed Enterprise badges appear grayed out.
+In this example, Pro, and Enterprise Flex badges appear highlighted due to Cloud tier inheritance, while Core, Standard, and Plus badges appear grayed out.
 
 ```markdown
 ---
-products: cloud-teams, enterprise-flex, oss-enterprise
+products: cloud-teams, enterprise-flex
 ---
 
-# This topic is for Pro, Enterprise Flex, and Self-Managed Enterprise
+# This topic is for Pro and Enterprise Flex
 
 Some text.
 ```

--- a/docs/community/contributing-to-airbyte/writing-docs.md
+++ b/docs/community/contributing-to-airbyte/writing-docs.md
@@ -246,7 +246,7 @@ To enable badges, include `products` in the Markdown metadata. The following val
 
 **Metadata keys:**
 
-- `all`: Core, Standard, and Plus - doesn't include Pro, Enterprise Flex, or Embedded
+- `all`: everything except Embedded - Core, Standard, Plus, Pro, and Enterprise Flex
 - `oss-community`: Core only
 - `cloud`: Standard and Plus (also enables Pro and Enterprise Flex due to Cloud tier inheritance)
 - `cloud-plus`: Plus only (also enables Pro and Enterprise Flex due to Cloud tier inheritance)

--- a/docs/platform/access-management/role-mapping.md
+++ b/docs/platform/access-management/role-mapping.md
@@ -1,5 +1,5 @@
 ---
-products: oss-enterprise, cloud-teams
+products: cloud-teams
 ---
 
 # RBAC Role Mapping

--- a/docs/platform/access-management/sso.md
+++ b/docs/platform/access-management/sso.md
@@ -1,5 +1,5 @@
 ---
-products: oss-enterprise, cloud
+products: cloud
 ---
 
 # Single sign on (SSO)

--- a/docs/platform/connector-development/connector-builder-ui/custom-components.md
+++ b/docs/platform/connector-development/connector-builder-ui/custom-components.md
@@ -1,5 +1,5 @@
 ---
-products: oss-community, oss-enterprise
+products: oss-community
 ---
 
 # Custom components for the Connector Builder

--- a/docs/platform/deploying-airbyte/infrastructure/aws.md
+++ b/docs/platform/deploying-airbyte/infrastructure/aws.md
@@ -1,5 +1,5 @@
 ---
-products: oss-community, oss-enterprise
+products: oss-community
 ---
 
 # Amazon Web Services (AWS)

--- a/docs/platform/deploying-airbyte/infrastructure/azure.md
+++ b/docs/platform/deploying-airbyte/infrastructure/azure.md
@@ -1,5 +1,5 @@
 ---
-products: oss-community, oss-enterprise
+products: oss-community
 draft: true
 ---
 

--- a/docs/platform/deploying-airbyte/infrastructure/gcp.md
+++ b/docs/platform/deploying-airbyte/infrastructure/gcp.md
@@ -1,5 +1,5 @@
 ---
-products: oss-community, oss-enterprise
+products: oss-community
 ---
 
 # Google Cloud Platform (GCP)

--- a/docs/platform/deploying-airbyte/integrations/authentication.md
+++ b/docs/platform/deploying-airbyte/integrations/authentication.md
@@ -1,5 +1,5 @@
 ---
-products: oss-community, oss-enterprise
+products: oss-community
 ---
 
 # Authentication

--- a/docs/platform/deploying-airbyte/integrations/custom-image-registries.md
+++ b/docs/platform/deploying-airbyte/integrations/custom-image-registries.md
@@ -1,5 +1,5 @@
 ---
-products: oss-community, oss-enterprise
+products: oss-community
 ---
 
 import ContainerProviders from '@site/static/_docker_image_registries.md';

--- a/docs/platform/deploying-airbyte/integrations/database.md
+++ b/docs/platform/deploying-airbyte/integrations/database.md
@@ -1,5 +1,5 @@
 ---
-products: oss-community, oss-enterprise
+products: oss-community
 ---
 
 # External Database

--- a/docs/platform/deploying-airbyte/integrations/ingress.md
+++ b/docs/platform/deploying-airbyte/integrations/ingress.md
@@ -1,5 +1,5 @@
 ---
-products: oss-community, oss-enterprise
+products: oss-community
 ---
 
 import Tabs from '@theme/Tabs';

--- a/docs/platform/deploying-airbyte/integrations/secrets.md
+++ b/docs/platform/deploying-airbyte/integrations/secrets.md
@@ -1,5 +1,5 @@
 ---
-products: oss-community, oss-enterprise
+products: oss-community
 ---
 
 import Tabs from '@theme/Tabs';

--- a/docs/platform/deploying-airbyte/integrations/storage.md
+++ b/docs/platform/deploying-airbyte/integrations/storage.md
@@ -1,5 +1,5 @@
 ---
-products: oss-community, oss-enterprise
+products: oss-community
 ---
 
 import Tabs from '@theme/Tabs';

--- a/docs/platform/enterprise-setup/README.md
+++ b/docs/platform/enterprise-setup/README.md
@@ -1,7 +1,3 @@
----
-products: oss-enterprise
----
-
 # Airbyte Self-Managed Enterprise
 
 Airbyte no longer sells Self-Managed Enterprise. If you still use Self-Managed Enterprise, documentation is preserved in this PDF:

--- a/docs/platform/managing-airbyte/connector-updates.md
+++ b/docs/platform/managing-airbyte/connector-updates.md
@@ -1,5 +1,5 @@
 ---
-products: oss-community, oss-enterprise
+products: oss-community
 ---
 
 import MigrationGuide from '@site/static/_migration_guides_upgrade_guide.md';

--- a/docs/platform/move-data/rejected-records.md
+++ b/docs/platform/move-data/rejected-records.md
@@ -1,5 +1,5 @@
 ---
-products: oss-enterprise, cloud-teams
+products: cloud-teams
 ---
 
 # Rejected records

--- a/docs/platform/organizations-workspaces/readme.md
+++ b/docs/platform/organizations-workspaces/readme.md
@@ -1,5 +1,5 @@
 ---
-products: cloud, oss-enterprise
+products: cloud
 ---
 
 import DocCardList from '@theme/DocCardList';

--- a/docs/platform/organizations-workspaces/workspaces/readme.md
+++ b/docs/platform/organizations-workspaces/workspaces/readme.md
@@ -1,5 +1,5 @@
 ---
-products: cloud, oss-enterprise
+products: cloud
 ---
 
 import DocCardList from '@theme/DocCardList';

--- a/docs/platform/using-airbyte/mappings.md
+++ b/docs/platform/using-airbyte/mappings.md
@@ -1,5 +1,5 @@
 ---
-products: cloud-plus, oss-enterprise
+products: cloud-plus
 ---
 
 # Mappings

--- a/docs/platform/using-airbyte/workspaces.md
+++ b/docs/platform/using-airbyte/workspaces.md
@@ -1,5 +1,5 @@
 ---
-products: cloud, oss-enterprise
+products: cloud
 ---
 
 # Manage workspaces

--- a/docusaurus/src/components/ProductInformation.jsx
+++ b/docusaurus/src/components/ProductInformation.jsx
@@ -34,8 +34,6 @@ export const ProductInformation = ({ products }) => {
 
   const ossCommunity =
     products["oss-community"] || products["oss-*"] || products["all"];
-  const ossEnterprise =
-    products["oss-enterprise"] || products["oss-*"] || products["all"];
   const cloud = products["cloud"] || products["cloud-teams"] || products["all"];
   // cloud add-ons need to be specifically marked and are not part of the "all" shorthand
   const cloudPlus = products["cloud-plus"];
@@ -61,7 +59,6 @@ export const ProductInformation = ({ products }) => {
       <Badge available={cloudPlus || cloud || cloudTeams || enterpriseFlex}>
         Enterprise Flex
       </Badge>
-      <Badge available={ossEnterprise}>Self-Managed Enterprise</Badge>
       {embedded && <Badge available={true}>Embedded</Badge>}
       <a
         href="https://airbyte.com/product/features"


### PR DESCRIPTION
## What

Requested by Ian Alton in #ask-devin-ai. Airbyte no longer sells Self-Managed Enterprise, so the badge shouldn't appear on docs pages.

## How

- `ProductInformation.jsx`: dropped the `ossEnterprise` computation and its `<Badge>`, leaving 5 badges (Core, Standard, Plus, Pro, Enterprise Flex) plus the conditional Embedded badge.
- Removed `oss-enterprise` from `products:` front matter on 18 platform pages, keeping every other product they listed (e.g. `oss-community, oss-enterprise` → `oss-community`, `cloud, oss-enterprise` → `cloud`).
- `/platform/enterprise-setup` (README.md) was the only page specifying `oss-enterprise` alone; its front matter is now removed entirely, so it renders no badges.
- Updated the product-badge section of `docs/community/contributing-to-airbyte/writing-docs.md`: 6 badges → 5, dropped the `oss-enterprise` key and the self-managed-inheritance note, and updated the second example. Also corrected a stale line that claimed `all` excludes Pro and Enterprise Flex — because `all` sets `cloud`, it actually enables every badge except Embedded (confirmed as intended behavior).

Note: pages using `oss-*` or `all` are unchanged — those shorthands still light up Core, and with the badge gone the enterprise half of them has no rendering effect. Historical `platform_versioned_docs` were intentionally left alone.

## Review guide

1. `docusaurus/src/components/ProductInformation.jsx`
2. `docs/community/contributing-to-airbyte/writing-docs.md`
3. front matter changes across `docs/platform/**`

## User Impact

Docs pages no longer show a Self-Managed Enterprise badge. `/platform/enterprise-setup` shows no badge row at all.

## Can this PR be safely reverted and rolled back?
- [x] YES 💚
- [ ] NO ❌


Link to Devin session: https://app.devin.ai/sessions/3b477d7d60ae402f9ca9ff078580eea7
Requested by: @ian-at-airbyte