### PR TITLE
docs: drop Self-Managed Enterprise from connector availability

### DIFF
--- a/docusaurus/src/components/HeaderDecoration.jsx
+++ b/docusaurus/src/components/HeaderDecoration.jsx
@@ -283,14 +283,6 @@ const ConnectorMetadataCallout = ({
           >
             <EnabledIcon isEnabled={isEnterprise || isCloud} /> Enterprise Flex
           </Chip>
-          <Chip
-            className={
-              isEnterprise || isOss ? styles.available : styles.unavailable
-            }
-          >
-            <EnabledIcon isEnabled={isEnterprise || isOss} /> Self-Managed
-            Enterprise
-          </Chip>
           <Chip className={isOss ? styles.available : styles.unavailable}>
             <EnabledIcon isEnabled={isOss} /> PyAirbyte
           </Chip>


### PR DESCRIPTION
## What

Companion to #83792, requested by Ian Alton in #ask-devin-ai. Self-Managed Enterprise should no longer appear as an availability option for data replication connectors.

## How

Removed the `Self-Managed Enterprise` `<Chip>` from the Availability list in the connector header callout. Availability is now Core, Standard, Plus, Pro, Enterprise Flex, PyAirbyte.

Ian expected this to be straightforward because the same expression computed both, and it was: the chip was the only place `isOss` fed a Self-Managed Enterprise state (`isEnterprise || isOss`). Note that `isEnterprise` here means *premium Enterprise connector*, not the Self-Managed Enterprise plan, so the prop stays — it still drives the Pro and Enterprise Flex chips, the Connector Version link, and the "Enterprise Connector" callout.

## Review guide

1. `docusaurus/src/components/HeaderDecoration.jsx`

## User Impact

Connector doc pages no longer show a Self-Managed Enterprise availability chip.

Not changed, flagged for your call: `docs/integrations/connector-support-levels.md` still has a **Support: Self-Managed Enterprise** row in the support matrix, and the Workday connector docs reference Self-Managed Enterprise in OAuth redirect instructions. Those are support/setup guidance for existing deployments rather than availability, so I left them alone.

## Can this PR be safely reverted and rolled back?
- [x] YES 💚
- [ ] NO ❌


Link to Devin session: https://app.devin.ai/sessions/3b477d7d60ae402f9ca9ff078580eea7
Requested by: @ian-at-airbyte