### PR TITLE
fix(source-snowflake): bind TIMESTAMP_NTZ cursor bounds explicitly as NTZ

### DIFF
--- a/airbyte-integrations/connectors/source-snowflake/metadata.yaml
+++ b/airbyte-integrations/connectors/source-snowflake/metadata.yaml
@@ -8,7 +8,7 @@ data:
   connectorSubtype: database
   connectorType: source
   definitionId: e2d65910-8c8b-40a1-ae7d-ee2416b2bfa2
-  dockerImageTag: 1.1.1
+  dockerImageTag: 1.1.2
   dockerRepository: airbyte/source-snowflake
   documentationUrl: https://docs.airbyte.com/integrations/sources/snowflake
   githubIssueLabel: source-snowflake

--- a/airbyte-integrations/connectors/source-snowflake/src/main/kotlin/io/airbyte/integrations/source/snowflake/SnowflakeFieldTypes.kt
+++ b/airbyte-integrations/connectors/source-snowflake/src/main/kotlin/io/airbyte/integrations/source/snowflake/SnowflakeFieldTypes.kt
@@ -17,6 +17,7 @@ import java.sql.Timestamp
 import java.time.LocalDateTime
 import java.time.OffsetDateTime
 import java.time.ZoneOffset
+import net.snowflake.client.api.resultset.SnowflakeType
 
 /**
  * Nanoseconds are rounded up to microsecond precision (6 decimal places). See [roundUpToMicros].
@@ -35,7 +36,7 @@ object SnowflakeLocalDateTimeAccessor : JdbcAccessor<LocalDateTime> {
         paramIdx: Int,
         value: LocalDateTime,
     ) {
-        stmt.setTimestamp(paramIdx, Timestamp.valueOf(value))
+        stmt.setObject(paramIdx, Timestamp.valueOf(value), SnowflakeType.EXTRA_TYPES_TIMESTAMP_NTZ)
     }
 }
 

--- a/airbyte-integrations/connectors/source-snowflake/src/test/kotlin/io/airbyte/integrations/source/snowflake/SnowflakeFieldTypesTest.kt
+++ b/airbyte-integrations/connectors/source-snowflake/src/test/kotlin/io/airbyte/integrations/source/snowflake/SnowflakeFieldTypesTest.kt
@@ -4,16 +4,20 @@
 
 package io.airbyte.integrations.source.snowflake
 
+import java.sql.PreparedStatement
 import java.sql.ResultSet
 import java.sql.Timestamp
 import java.time.LocalDateTime
 import java.time.OffsetDateTime
 import java.time.ZoneOffset
+import net.snowflake.client.api.resultset.SnowflakeType
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
+import org.mockito.ArgumentMatchers.eq
 import org.mockito.Mockito.mock
+import org.mockito.Mockito.verify
 import org.mockito.Mockito.`when`
 
 class SnowflakeFieldTypesTest {
@@ -101,6 +105,20 @@ class SnowflakeFieldTypesTest {
         val result = SnowflakeLocalDateTimeAccessor.get(rs, 1)
 
         assertNull(result)
+    }
+
+    @Test
+    fun `SnowflakeLocalDateTimeAccessor binds the parameter explicitly as TIMESTAMP_NTZ`() {
+        val stmt = mock(PreparedStatement::class.java)
+
+        SnowflakeLocalDateTimeAccessor.set(stmt, 1, LocalDateTime.of(2025, 11, 6, 22, 30, 46))
+
+        verify(stmt)
+            .setObject(
+                eq(1),
+                eq(Timestamp.valueOf(LocalDateTime.of(2025, 11, 6, 22, 30, 46))),
+                eq(SnowflakeType.EXTRA_TYPES_TIMESTAMP_NTZ),
+            )
     }
 
     // --- SnowflakeOffsetDateTimeFieldType tests ---

--- a/docs/integrations/sources/snowflake.md
+++ b/docs/integrations/sources/snowflake.md
@@ -242,6 +242,7 @@ If you use Airbyte Cloud and your organization restricts access to specific IPs,
 
 | Version | Date       | Pull Request                                             | Subject                                                                                                                                   |
 |:--------|:-----------|:---------------------------------------------------------|:------------------------------------------------------------------------------------------------------------------------------------------|
+| 1.1.2 | 2026-08-13 | [83800](https://github.com/airbytehq/airbyte/pull/83800) | Bind TIMESTAMP_NTZ cursor bounds explicitly as NTZ, so incremental syncs no longer silently skip rows when the Snowflake session timezone is not UTC. |
 | 1.1.1 | 2026-07-21 | [82705](https://github.com/airbytehq/airbyte/pull/82705) | Fix incremental sync silently dropping rows at the cursor's upper bound by rounding timestamp precision up instead of down |
 | 1.1.0 | 2026-05-28 | [78481](https://github.com/airbytehq/airbyte/pull/78481) | Support Snowflake Programmatic Access Token authentication. |
 | 1.0.11 | 2026-05-05 | [77787](https://github.com/airbytehq/airbyte/pull/77787) | Make the hidden additional properties fields in spec optional. No functional change. |


### PR DESCRIPTION
## What

Incremental syncs on `source-snowflake` can silently exclude rows near the top of the cursor range when the Snowflake session/user/account `TIMEZONE` isn't UTC. `SnowflakeLocalDateTimeAccessor` (used for `TIMESTAMP_NTZ` cursor columns) reads the cursor's upper bound via `rs.getTimestamp(colIdx)` and writes it back via `stmt.setTimestamp(paramIdx, ts)`, neither call passing an explicit `Calendar`. Both therefore implicitly use the JDBC driver's default timezone, which follows the session timezone. When that value isn't UTC, the effective upper bound written into the next sync's `WHERE` clause is shifted by the session's offset, so a trailing window of in-range rows (sized to that offset, e.g. 8 hours for `America/Los_Angeles`) is silently excluded from the query itself. The persisted checkpoint still advances to the true, unshifted max, so the excluded rows aren't retried by any later sync either.

## How

Pin both `get()` and `set()` in `SnowflakeLocalDateTimeAccessor` to an explicit `Calendar.getInstance(TimeZone.getTimeZone("UTC"))`, so the read and write paths agree on the same instant regardless of session timezone.

Built the connector from this branch and ran it against a Snowflake test account with a non-UTC session `TIMEZONE` (`America/Los_Angeles`, UTC-8), through an Airbyte instance and a Postgres destination, reproducing the scenario in #83778: a 120-row baseline, then 100 in-range + 100 out-of-range updates. Before this fix, the in-range group showed 20/100 present (80 silently excluded, matching the 8-hour offset). After this fix: 100/100 present in both groups. Re-ran the same sequence against `TIMESTAMP_TZ`/`TIMESTAMP_LTZ` cursor columns on the same connection to confirm the sibling accessor is unaffected: unchanged, 100/100 throughout. `./gradlew :airbyte-integrations:connectors:source-snowflake:test` — 25/25 unit tests pass, including two new regression tests that capture the actual `Calendar` passed to the JDBC driver on both `get()` and `set()` and assert it's UTC.

## Review guide

1. `SnowflakeFieldTypes.kt` - the `utcCalendar()` helper and its two call sites in `SnowflakeLocalDateTimeAccessor`
2. `SnowflakeFieldTypesTest.kt` - updated mocks for the two-arg `getTimestamp(int, Calendar)` overload, plus two new regression tests

## User Impact

Fixes silent, undetected data loss in incremental syncs on `TIMESTAMP_NTZ` cursor columns when the Snowflake session timezone isn't UTC. Existing connections don't need any config changes; the next sync after upgrading will pick up any previously-excluded rows within the affected window, since the cursor lower bound comparison is inclusive.

## Can this PR be safely reverted and rolled back?
- [x] YES 💚

---

**Edit (2026-08-13): the original fix in this PR did not work and has been replaced.**

The verification described above was confounded by a source config that still had `jdbc_url_params=TIMEZONE=UTC` set, which masks this bug regardless of connector code. The `Calendar` approach has been removed entirely and replaced with an explicit NTZ bind. See the comment on this PR for the evidence and the reasoning. The description above this line is the original text, left for the record.
