### PR TITLE
test(do not merge): build azure-blob-storage and mssql destinations against local CDK

### DIFF
--- a/airbyte-integrations/connectors/destination-azure-blob-storage/gradle.properties
+++ b/airbyte-integrations/connectors/destination-azure-blob-storage/gradle.properties
@@ -1,3 +1,3 @@
 testExecutionConcurrency=-1
-cdkVersion=1.0.13
+cdkVersion=local
 JunitMethodExecutionTimeout=5m

--- a/airbyte-integrations/connectors/destination-mssql/gradle.properties
+++ b/airbyte-integrations/connectors/destination-mssql/gradle.properties
@@ -1,2 +1,2 @@
 testExecutionConcurrency=-1
-cdkVersion=1.0.11
+cdkVersion=local


### PR DESCRIPTION
This PR targets PR airbytehq/airbyte#83806:
- airbytehq/airbyte#83806

---

## What

Do not merge. Its only purpose is to get connector CI signal for the Azure `endpointDomainName` fix in airbytehq/airbyte#83806.

On that PR the connector suites never exercise the change: both consumers of the `legacy-task-load-azure-blob-storage` toolkit resolve published CDK artifacts (`cdkVersion=1.0.13` for `destination-azure-blob-storage`, `1.0.11` for `destination-mssql`), so CI reports "no JVM-based connectors modified".

It is stacked on airbytehq/airbyte#83806 rather than folded into it because `Enforce PR structure` rejects any single PR that touches both the bulk CDK and a connector.

## How

```
destination-azure-blob-storage/gradle.properties   cdkVersion=1.0.13 -> local
destination-mssql/gradle.properties                cdkVersion=1.0.11 -> local
```

`Check Changelog Updated` is expected to fail here, since the connectors get no version bump or changelog entry. The signal to read is the connector test jobs.

## Review guide

1. The two `gradle.properties` files.

## User Impact

None; not intended to merge.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚


Link to Devin session: https://app.devin.ai/sessions/320311bbf5ae4596a1f9526de56252d4
Requested by: @sunil-kuruba