### PR TITLE
chore(destination-azure-blob-storage): upgrade CDK to 1.0.24

### DIFF
--- a/airbyte-integrations/connectors/destination-azure-blob-storage/gradle.properties
+++ b/airbyte-integrations/connectors/destination-azure-blob-storage/gradle.properties
@@ -1,3 +1,3 @@
 testExecutionConcurrency=-1
-cdkVersion=1.0.13
+cdkVersion=1.0.24
 JunitMethodExecutionTimeout=5m

--- a/airbyte-integrations/connectors/destination-azure-blob-storage/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-azure-blob-storage/metadata.yaml
@@ -22,7 +22,7 @@ data:
             type: GSM
   connectorType: destination
   definitionId: b4c5d105-31fd-4817-96b6-cb923bfc04cb
-  dockerImageTag: 1.1.7
+  dockerImageTag: 1.1.8
   dockerRepository: airbyte/destination-azure-blob-storage
   documentationUrl: https://docs.airbyte.com/integrations/destinations/azure-blob-storage
   githubIssueLabel: destination-azure-blob-storage

--- a/docs/integrations/destinations/azure-blob-storage.md
+++ b/docs/integrations/destinations/azure-blob-storage.md
@@ -150,7 +150,7 @@ This destination supports [namespaces](https://docs.airbyte.com/platform/using-a
 
 | Version  | Date       | Pull Request                                               | Subject                                                                                                                                                         |
 |:---------|:-----------|:-----------------------------------------------------------|:----------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| 1.1.8 | 2026-08-10 | [83808](https://github.com/airbytehq/airbyte/pull/83810) | Upgrade CDK to 1.0.24: honor the configured endpoint domain name so US Gov and China cloud storage accounts work |
+| 1.1.8 | 2026-08-10 | [83810](https://github.com/airbytehq/airbyte/pull/83810) | Upgrade CDK to 1.0.24: honor the configured endpoint domain name so US Gov and China cloud storage accounts work |
 | 1.1.7 | 2026-05-19 | [78243](https://github.com/airbytehq/airbyte/pull/78243) | Upgrade CDK to 1.0.13 |
 | 1.1.6 | 2026-01-26 | [72355](https://github.com/airbytehq/airbyte/pull/72355) | Fix sync failures for sources with empty schemas by upgrading CDK to 0.2.1 |
 | 1.1.5 | 2026-01-20 | [72301](https://github.com/airbytehq/airbyte/pull/72301) | Upgrade CDK to 0.2.0 |

--- a/docs/integrations/destinations/azure-blob-storage.md
+++ b/docs/integrations/destinations/azure-blob-storage.md
@@ -150,7 +150,7 @@ This destination supports [namespaces](https://docs.airbyte.com/platform/using-a
 
 | Version  | Date       | Pull Request                                               | Subject                                                                                                                                                         |
 |:---------|:-----------|:-----------------------------------------------------------|:----------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| 1.1.8 | 2026-08-10 | [83810](https://github.com/airbytehq/airbyte/pull/83810) | Upgrade CDK to 1.0.24: honor the configured endpoint domain name so US Gov and China cloud storage accounts work |
+| 1.1.8 | 2026-08-10 | [83810](https://github.com/airbytehq/airbyte/pull/83810) | Upgrade CDK to 1.0.24 |
 | 1.1.7 | 2026-05-19 | [78243](https://github.com/airbytehq/airbyte/pull/78243) | Upgrade CDK to 1.0.13 |
 | 1.1.6 | 2026-01-26 | [72355](https://github.com/airbytehq/airbyte/pull/72355) | Fix sync failures for sources with empty schemas by upgrading CDK to 0.2.1 |
 | 1.1.5 | 2026-01-20 | [72301](https://github.com/airbytehq/airbyte/pull/72301) | Upgrade CDK to 0.2.0 |

--- a/docs/integrations/destinations/azure-blob-storage.md
+++ b/docs/integrations/destinations/azure-blob-storage.md
@@ -150,7 +150,7 @@ This destination supports [namespaces](https://docs.airbyte.com/platform/using-a
 
 | Version  | Date       | Pull Request                                               | Subject                                                                                                                                                         |
 |:---------|:-----------|:-----------------------------------------------------------|:----------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| 1.1.8 | 2026-08-10 | [83808](https://github.com/airbytehq/airbyte/pull/83808) | Upgrade CDK to 1.0.24: honor the configured endpoint domain name so US Gov and China cloud storage accounts work |
+| 1.1.8 | 2026-08-10 | [83808](https://github.com/airbytehq/airbyte/pull/83810) | Upgrade CDK to 1.0.24: honor the configured endpoint domain name so US Gov and China cloud storage accounts work |
 | 1.1.7 | 2026-05-19 | [78243](https://github.com/airbytehq/airbyte/pull/78243) | Upgrade CDK to 1.0.13 |
 | 1.1.6 | 2026-01-26 | [72355](https://github.com/airbytehq/airbyte/pull/72355) | Fix sync failures for sources with empty schemas by upgrading CDK to 0.2.1 |
 | 1.1.5 | 2026-01-20 | [72301](https://github.com/airbytehq/airbyte/pull/72301) | Upgrade CDK to 0.2.0 |

--- a/docs/integrations/destinations/azure-blob-storage.md
+++ b/docs/integrations/destinations/azure-blob-storage.md
@@ -150,6 +150,7 @@ This destination supports [namespaces](https://docs.airbyte.com/platform/using-a
 
 | Version  | Date       | Pull Request                                               | Subject                                                                                                                                                         |
 |:---------|:-----------|:-----------------------------------------------------------|:----------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 1.1.8 | 2026-08-10 | [83808](https://github.com/airbytehq/airbyte/pull/83808) | Upgrade CDK to 1.0.24: honor the configured endpoint domain name so US Gov and China cloud storage accounts work |
 | 1.1.7 | 2026-05-19 | [78243](https://github.com/airbytehq/airbyte/pull/78243) | Upgrade CDK to 1.0.13 |
 | 1.1.6 | 2026-01-26 | [72355](https://github.com/airbytehq/airbyte/pull/72355) | Fix sync failures for sources with empty schemas by upgrading CDK to 0.2.1 |
 | 1.1.5 | 2026-01-20 | [72301](https://github.com/airbytehq/airbyte/pull/72301) | Upgrade CDK to 0.2.0 |


### PR DESCRIPTION
## What

Ships the sovereign-cloud Azure Blob fix from airbytehq/airbyte#83806 (bulk CDK load 1.0.24) to the connector. Without this bump the fix is in the CDK but no user gets it, since the connector still pins 1.0.13.

Fixes airbytehq/airbyte#83785

## How

`cdkVersion=1.0.13` → `1.0.24`, `dockerImageTag` 1.1.7 → 1.1.8, plus a docs changelog row.

## Review guide

1. `airbyte-integrations/connectors/destination-azure-blob-storage/gradle.properties`
2. `airbyte-integrations/connectors/destination-azure-blob-storage/metadata.yaml`
3. `docs/integrations/destinations/azure-blob-storage.md`

## User Impact

US Gov (`core.usgovcloudapi.net`) and China (`core.chinacloudapi.cn`) storage accounts start working: the `azure_blob_storage_endpoint_domain_name` field now actually drives the endpoint URL, and Entra client-secret auth targets the matching authority host.

The flip side, same as on the CDK PR: that spec field was previously accepted and silently ignored, so an existing config carrying a wrong or stale non-default value (typo, `https://` prefix, a hostname that isn't reachable) will now be honored and can fail where it used to work. Configs on the default `blob.core.windows.net` are unaffected.

Connector CI for this exact code path was already verified green against the local CDK before 83806 merged (`Test destination-azure-blob-storage` + `Test destination-mssql`, unit and integration).

## Can this PR be safely reverted and rolled back?
- [x] YES 💚


Link to Devin session: https://app.devin.ai/sessions/320311bbf5ae4596a1f9526de56252d4
Requested by: @sunil-kuruba

> [!IMPORTANT]
> Active progressive rollout warning for destination-azure-blob-storage.

- [x] (Click to Approve:) Bypass the active progressive rollout warning for destination-azure-blob-storage in the PR comment [here](https://github.com/airbytehq/airbyte/pull/83810#issuecomment-5245662301).