### PR TITLE
fix(source-mysql): promote to Bulk CDK 1.1.10 (field decoration for full refresh CDC streams with no primary key)

### DIFF
--- a/airbyte-integrations/connectors/source-mysql/gradle.properties
+++ b/airbyte-integrations/connectors/source-mysql/gradle.properties
@@ -1,3 +1,3 @@
 testExecutionConcurrency=1
 JunitMethodExecutionTimeout=5m
-cdkVersion=1.1.8
+cdkVersion=1.1.10

--- a/airbyte-integrations/connectors/source-mysql/metadata.yaml
+++ b/airbyte-integrations/connectors/source-mysql/metadata.yaml
@@ -9,7 +9,7 @@ data:
   connectorSubtype: database
   connectorType: source
   definitionId: 435bb9a5-7887-4809-aa58-28c27df0d7ad
-  dockerImageTag: 3.53.2
+  dockerImageTag: 3.53.3
   dockerRepository: airbyte/source-mysql
   documentationUrl: https://docs.airbyte.com/integrations/sources/mysql
   githubIssueLabel: source-mysql

--- a/docs/integrations/sources/mysql.md
+++ b/docs/integrations/sources/mysql.md
@@ -232,6 +232,7 @@ If you use Airbyte Cloud and your organization restricts access to specific IPs,
 
 | Version     | Date       | Pull Request                                               | Subject                                                                                                                                          |
 |:------------|:-----------|:-----------------------------------------------------------|:-------------------------------------------------------------------------------------------------------------------------------------------------|
+| 3.53.3      | 2026-08-11 | [84207](https://github.com/airbytehq/airbyte/pull/84207)   | Promote to Bulk CDK 1.1.10: fix CDC meta-field decoration of full refresh streams with no source-defined primary key in speed mode.              |
 | 3.53.2      | 2026-07-29 | [83239](https://github.com/airbytehq/airbyte/pull/83239)       | Fix error 1267 (illegal mix of collations) when partitioning text primary keys with utf8mb3 or other legacy charset columns.                     |
 | 3.53.1      | 2026-06-25 | [80858](https://github.com/airbytehq/airbyte/pull/80858)   | Fix CDC sync failure on non-nullable DATE/DATETIME columns when zero-dates (0000-00-00) convert to null.                                         |
 | 3.53.0      | 2026-06-29 | [80950](https://github.com/airbytehq/airbyte/pull/80950)   | Promote mysql to the latest CDK                                                                                                                  |


### PR DESCRIPTION
## What
Promotes source-mysql to Bulk (extract) CDK **1.1.10** so it picks up the fix from https://github.com/airbytehq/airbyte/pull/80949 (field decoration for full refresh CDC streams with no primary key), which addresses https://github.com/airbytehq/oncall/issues/10176.

In speed mode (SOCKET + PROTOBUF), records must match the catalog schema exactly because field names are not part of the records. A table with no source-defined primary key (hence ineligible for CDC incremental) configured as full refresh append+dedup has a configured primary key but no meta fields in its catalog schema; decorating its records with `_ab_cdc_lsn` etc. misaligned fields the destination could not resolve. CDK 1.1.10 only decorates such streams when a source-defined primary key exists as well.

## How
- Bump `cdkVersion` from 1.1.8 to 1.1.10 in `gradle.properties` (also picks up 1.1.9, a Testcontainers 1.21.4 bump — test-only).
- Bump connector version to 3.53.3 in `metadata.yaml`.
- Add a changelog entry to `docs/integrations/sources/mysql.md`.

No connector code changes are needed: the CDK deltas since 1.1.8 do not change connector-facing APIs.

## Review guide
1. `airbyte-integrations/connectors/source-mysql/gradle.properties`
2. `airbyte-integrations/connectors/source-mysql/metadata.yaml`
3. `docs/integrations/sources/mysql.md`

## User Impact
CDC syncs in speed mode that include a full refresh stream backed by a table without a primary key no longer emit records misaligned with the catalog schema. No impact on other sync configurations.

## Can this PR be safely reverted and rolled back?
- [x] YES 💚
- [ ] NO ❌

---
_Generated by [Claude Code](https://claude.ai/code/session_01WySfLGuiV5V623c2ffXRY6)_

> [!IMPORTANT]
> Active progressive rollout warning for source-mysql.

- [ ] (Click to Approve:) Bypass the active progressive rollout warning for source-mysql in the PR comment [here](https://github.com/airbytehq/airbyte/pull/84207#issuecomment-5254884564).