### PR TITLE
fix: add timeout to Zoho CRM OAuth token refresh request

### DIFF
--- a/airbyte-integrations/connectors/source-zoho-crm/source_zoho_crm/auth.py
+++ b/airbyte-integrations/connectors/source-zoho-crm/source_zoho_crm/auth.py
@@ -9,6 +9,10 @@ import requests
 from airbyte_cdk.sources.streams.http.requests_native_auth import Oauth2Authenticator
 
 
+# Timeout (in seconds) for the token refresh request so a hung endpoint cannot stall the sync indefinitely.
+TOKEN_REFRESH_TIMEOUT = 60
+
+
 class ZohoOauth2Authenticator(Oauth2Authenticator):
     def _prepare_refresh_token_params(self) -> Dict[str, str]:
         return {
@@ -28,7 +32,12 @@ class ZohoOauth2Authenticator(Oauth2Authenticator):
         Returns a tuple of (access_token, token_lifespan_in_seconds)
         """
         try:
-            response = requests.request(method="POST", url=self.get_token_refresh_endpoint(), params=self._prepare_refresh_token_params())
+            response = requests.request(
+                method="POST",
+                url=self.get_token_refresh_endpoint(),
+                params=self._prepare_refresh_token_params(),
+                timeout=TOKEN_REFRESH_TIMEOUT,
+            )
             response.raise_for_status()
             response_json = response.json()
             return response_json[self.get_access_token_name()], response_json[self.get_expires_in_name()]


### PR DESCRIPTION
## What

`ZohoOauth2Authenticator.refresh_access_token()` in `source-zoho-crm/source_zoho_crm/auth.py` calls `requests.request("POST", url, params=...)` without a `timeout`. Python's `requests` has no default timeout, so this call can block forever.

This method overrides the airbyte-cdk `Oauth2Authenticator`, which normally issues its token refresh request with a timeout. The override dropped it.

## Why it matters

`refresh_access_token()` runs at the start of (and periodically during) every sync. The token endpoint URL is derived from the user-configured Zoho region/environment. If that endpoint hangs, is slow, or is silently dropped by a firewall or proxy, the sync thread blocks indefinitely with no error and no retry - a hung connection stalls the whole connector until the process is killed. This is a reliability/availability defect that a network-level stall can trigger.

## Fix

Add a module-level `TOKEN_REFRESH_TIMEOUT = 60` constant and pass `timeout=TOKEN_REFRESH_TIMEOUT` to the request. A stalled endpoint now raises a `Timeout` after 60 seconds, which is caught by the existing `except` block and surfaced as an error instead of hanging forever. Minimal change, no API or behavior change on the success path.

## Test

- A slow/non-responding token endpoint now raises `requests.exceptions.Timeout` after 60s rather than blocking indefinitely.
- Normal refreshes complete unchanged; the returned `(access_token, expires_in)` tuple is identical.
