### PR TITLE
DO NOT MERGE: regression-test control image for source-tiktok-marketing (config migration only)

### DIFF
--- a/airbyte-integrations/connectors/source-tiktok-marketing/manifest.yaml
+++ b/airbyte-integrations/connectors/source-tiktok-marketing/manifest.yaml
@@ -6102,6 +6102,22 @@ spec:
         default: false
         order: 5
         type: boolean
+  config_normalization_rules:
+    type: ConfigNormalizationRules
+    config_migrations:
+      - type: ConfigMigration
+        transformations:
+          - type: ConfigAddFields
+            fields:
+              - type: AddedFieldDefinition
+                path: ["legacy_report_granularity"]
+                value: "{{ config['report_granularity'] }}"
+                value_type: string
+              - type: AddedFieldDefinition
+                path: ["report_granularity"]
+                value: "30"
+                value_type: integer
+            condition: "{{ config.get('report_granularity') is string }}"
   advanced_auth:
     auth_flow_type: oauth2.0
     predicate_key:

--- a/airbyte-integrations/connectors/source-tiktok-marketing/metadata.yaml
+++ b/airbyte-integrations/connectors/source-tiktok-marketing/metadata.yaml
@@ -11,7 +11,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 4bfac00d-ce15-44ff-95b9-9e3c3e8fbd35
-  dockerImageTag: 5.1.11
+  dockerImageTag: 5.1.13
   dockerRepository: airbyte/source-tiktok-marketing
   documentationUrl: https://docs.airbyte.com/integrations/sources/tiktok-marketing
   externalDocumentationUrls:

--- a/airbyte-integrations/connectors/source-tiktok-marketing/unit_tests/test_report_date_step.py
+++ b/airbyte-integrations/connectors/source-tiktok-marketing/unit_tests/test_report_date_step.py
@@ -46,6 +46,40 @@ def test_spec_includes_report_granularity_field():
 
 
 @pytest.mark.parametrize(
+    "report_granularity,expected_config",
+    [
+        pytest.param(
+            "LIFETIME",
+            {"legacy_report_granularity": "LIFETIME", "report_granularity": 30},
+            id="legacy_lifetime_string",
+        ),
+        pytest.param(
+            "DAY",
+            {"legacy_report_granularity": "DAY", "report_granularity": 30},
+            id="legacy_day_string",
+        ),
+        pytest.param(7, {"report_granularity": 7}, id="integer_value"),
+        pytest.param(None, {}, id="absent_value"),
+    ],
+)
+def test_report_granularity_config_migration(report_granularity, expected_config, tmp_path):
+    config = {} if report_granularity is None else {"report_granularity": report_granularity}
+    config_path = tmp_path / "config.json"
+    config_path.write_text("{}")
+    source = YamlDeclarativeSource(
+        path_to_yaml=str(_YAML_FILE_PATH),
+        catalog=CatalogBuilder().build(),
+        config=config,
+        state=[],
+        config_path=str(config_path),
+    )
+
+    assert source._config == expected_config
+    if "report_granularity" in expected_config:
+        assert isinstance(source._config["report_granularity"], int)
+
+
+@pytest.mark.parametrize(
     "stream_name",
     [
         pytest.param("ads_reports_daily_stream", id="ads_reports_daily"),

--- a/docs/integrations/sources/tiktok-marketing.md
+++ b/docs/integrations/sources/tiktok-marketing.md
@@ -171,8 +171,7 @@ If you use Airbyte Cloud and your organization restricts access to specific IPs,
 
 | Version    | Date       | Pull Request                                              | Subject                                                                                                                                                                |
 |:-----------|:-----------|:----------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| 5.1.12 | 2026-08-12 | [84293](https://github.com/airbytehq/airbyte/pull/84293) | Reduce `ads` stream page size from 1000 to 100 |
-| 5.1.13 | 2026-08-13 | | Migrate legacy `report_granularity` configurations |
+| 5.1.13 | 2026-08-13 | [84293](https://github.com/airbytehq/airbyte/pull/84293) | Migrate legacy `report_granularity` configurations |
 | 5.1.11 | 2026-08-12 | [84290](https://github.com/airbytehq/airbyte/pull/84290) | Widen retry budget and retry transient TikTok API errors 51041 and 51004 |
 | 5.1.10 | 2026-08-11 | [84199](https://github.com/airbytehq/airbyte/pull/84199) | Retry transient TikTok API error 50000 |
 | 5.1.9 | 2026-08-11 | [84132](https://github.com/airbytehq/airbyte/pull/84132) | Update dependencies |

--- a/docs/integrations/sources/tiktok-marketing.md
+++ b/docs/integrations/sources/tiktok-marketing.md
@@ -171,6 +171,8 @@ If you use Airbyte Cloud and your organization restricts access to specific IPs,
 
 | Version    | Date       | Pull Request                                              | Subject                                                                                                                                                                |
 |:-----------|:-----------|:----------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 5.1.12 | 2026-08-12 | [84293](https://github.com/airbytehq/airbyte/pull/84293) | Reduce `ads` stream page size from 1000 to 100 |
+| 5.1.13 | 2026-08-13 | | Migrate legacy `report_granularity` configurations |
 | 5.1.11 | 2026-08-12 | [84290](https://github.com/airbytehq/airbyte/pull/84290) | Widen retry budget and retry transient TikTok API errors 51041 and 51004 |
 | 5.1.10 | 2026-08-11 | [84199](https://github.com/airbytehq/airbyte/pull/84199) | Retry transient TikTok API error 50000 |
 | 5.1.9 | 2026-08-11 | [84132](https://github.com/airbytehq/airbyte/pull/84132) | Update dependencies |


### PR DESCRIPTION
## What

Throwaway branch. Exists only to produce a prerelease image for use as the **control** side of a comparison regression test for https://github.com/airbytehq/airbyte/pull/84345. Do not merge, do not review.

The published `5.1.11` image cannot be used as a control: every legacy TikTok connection tried so far (3 of 3) carries an orphaned `report_granularity: "LIFETIME"` in its stored config, which `5.1.11` rejects with `Config validation error: 'LIFETIME' is not of type 'integer'` before making a single API call. Both sides of the comparison die identically and the test is inconclusive.

## How

Cherry-picks `d52365194f9` from https://github.com/airbytehq/airbyte/pull/84293 — the `ConfigNormalizationRules` migration that rewrites a string `report_granularity` to `legacy_report_granularity` and substitutes the integer default. Nothing else. In particular this branch does **not** carry that PR's page-size change, so it stays a faithful stand-in for current production behavior.

Version bumped to `5.1.13` so the prerelease tag is distinct from `5.1.11` and from #84345's `5.1.12`.

## Review guide

None needed. The paired target branch is `devin/tiktok-regression-target-modified-after`, which is this branch plus #84345's commits.

## User Impact

None. Never merged, never published to the registry beyond a prerelease tag.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚


Link to Devin session: https://app.devin.ai/sessions/afec4ad0660a44f5a56bd7bb0d411df0
Requested by: @aaronsteers