### PR TITLE
ci: autopilot release-immediately opt-out + gate publishes on version bumps

### DIFF
--- a/.github/workflows/autopilot-release-immediately-checkbox.yml
+++ b/.github/workflows/autopilot-release-immediately-checkbox.yml
@@ -16,9 +16,6 @@ on:
         required: true
         type: number
 
-env:
-  RELEASE_IMMEDIATELY_PHRASE: Release immediately (bypasses automatic progressive rollout)
-
 permissions:
   contents: read
   pull-requests: write
@@ -126,41 +123,16 @@ jobs:
             echo "${delimiter}"
           } | tee -a "$GITHUB_OUTPUT"
 
-      - name: Read PR body
-        id: body
-        if: steps.context.outputs.is-fork == 'false' && steps.detect.outputs.connectors != ''
-        env:
-          PR_NUMBER: ${{ steps.context.outputs.pr-number }}
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          set -euo pipefail
-          body_file="${RUNNER_TEMP}/autopilot-release-immediately-pr-body.md"
-          gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" --jq '.body // ""' > "$body_file"
-          echo "path=${body_file}" | tee -a "$GITHUB_OUTPUT"
+      - name: Add release immediately checkbox to PR description
+        if: >
+          steps.context.outputs.is-fork == 'false' &&
+          steps.detect.outputs.connectors != '' &&
+          github.event_name == 'pull_request'
+        uses: bcgov/action-pr-description-add@14338bfe0278ead273b3c1189e5aa286ff670c4 # v2.0.0
+        with:
+          github_token: ${{ github.token }}
+          add_markdown: |
+            > [!NOTE]
+            > Autopilot progressive rollout is enabled for connector(s) modified in this PR.
 
-      - name: Detect existing release immediately checkbox
-        id: existing
-        if: steps.body.outputs.path != ''
-        env:
-          BODY_PATH: ${{ steps.body.outputs.path }}
-        run: |
-          if grep -Fq -- "$RELEASE_IMMEDIATELY_PHRASE" "$BODY_PATH"; then
-            echo "present=true" | tee -a "$GITHUB_OUTPUT"
-          else
-            echo "present=false" | tee -a "$GITHUB_OUTPUT"
-          fi
-
-      - name: Append release immediately checkbox
-        if: steps.existing.outputs.present == 'false'
-        env:
-          BODY_PATH: ${{ steps.body.outputs.path }}
-          GH_TOKEN: ${{ github.token }}
-          PR_NUMBER: ${{ steps.context.outputs.pr-number }}
-        run: |
-          set -euo pipefail
-          [[ -n "$(tr -d '[:space:]' < "$BODY_PATH")" ]] || : > "$BODY_PATH"
-          [[ ! -s "$BODY_PATH" ]] || printf '\n\n' >> "$BODY_PATH"
-          printf '> [!NOTE]\n> Autopilot progressive rollout is enabled for connector(s) modified in this PR.\n\n- [ ] :black_square_button: %s\n' \
-            "$RELEASE_IMMEDIATELY_PHRASE" >> "$BODY_PATH"
-          jq -n --rawfile body "$BODY_PATH" '{body: $body}' |
-            gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" --method PATCH --input -
+            - [ ] :black_square_button: Release immediately (bypasses automatic progressive rollout)

--- a/.github/workflows/autopilot-release-immediately-checkbox.yml
+++ b/.github/workflows/autopilot-release-immediately-checkbox.yml
@@ -134,9 +134,9 @@ jobs:
           add_markdown: |
             ---
 
-            > [!NOTE]
-            > **Optional Progressive Rollout Bypass**
-            >
-            > Autopilot progressive rollout is enabled for connector(s) modified in this PR. Check the box below to bypass normal rollout safety processes.
+            **⚡ Optional Progressive Rollout Bypass**
+
+            Autopilot progressive rollout is enabled for connector(s) modified in this PR.
+            Check the box below **_only_** if you want to bypass normal rollout safety processes.
 
             - [ ] ⚡ Release immediately (bypasses automatic progressive rollout)

--- a/.github/workflows/autopilot-release-immediately-checkbox.yml
+++ b/.github/workflows/autopilot-release-immediately-checkbox.yml
@@ -132,7 +132,11 @@ jobs:
         with:
           github_token: ${{ github.token }}
           add_markdown: |
-            > [!NOTE]
-            > Autopilot progressive rollout is enabled for connector(s) modified in this PR.
+            ---
 
-            - [ ] :black_square_button: Release immediately (bypasses automatic progressive rollout)
+            > [!NOTE]
+            > **Optional Progressive Rollout Bypass**
+            >
+            > Autopilot progressive rollout is enabled for connector(s) modified in this PR. Check the box below to bypass normal rollout safety processes.
+
+            - [ ] ⚡ Release immediately (bypasses automatic progressive rollout)

--- a/.github/workflows/autopilot-release-immediately-checkbox.yml
+++ b/.github/workflows/autopilot-release-immediately-checkbox.yml
@@ -9,19 +9,12 @@ on:
       - ready_for_review
     paths:
       - "airbyte-integrations/connectors/**"
-  workflow_dispatch:
-    inputs:
-      pr:
-        description: "Pull request number to inspect."
-        required: true
-        type: number
-
 permissions:
   contents: read
   pull-requests: write
 
 concurrency:
-  group: autopilot-release-immediately-${{ github.event.pull_request.number || inputs.pr }}
+  group: autopilot-release-immediately-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
 jobs:
@@ -30,8 +23,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Resolve PR context from pull request event
-        id: context-event
-        if: github.event_name == 'pull_request'
+        id: context
         env:
           EVENT_PR_NUMBER: ${{ github.event.pull_request.number }}
           EVENT_HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
@@ -45,40 +37,21 @@ jobs:
             echo "is-fork=${EVENT_IS_FORK}"
           } | tee -a "$GITHUB_OUTPUT"
 
-      - name: Resolve PR context from workflow dispatch
-        id: context-dispatch
-        if: github.event_name == 'workflow_dispatch'
+      - name: Read existing release immediately checkbox
+        id: bypass-state
+        if: steps.context.outputs.is-fork == 'false'
         env:
-          INPUT_PR: ${{ inputs.pr }}
+          PR_NUMBER: ${{ steps.context.outputs.pr-number }}
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          [[ "$INPUT_PR" =~ ^[1-9][0-9]*$ ]] || {
-            echo "::error::Invalid pull request number: ${INPUT_PR}"
-            exit 1
-          }
-          gh api "repos/${GITHUB_REPOSITORY}/pulls/${INPUT_PR}" |
-            jq -r '"pr-number=\(.number)\nhead-repo=\(.head.repo.full_name)\nhead-sha=\(.head.sha)\nis-fork=\(.head.repo.fork)"' |
-            tee -a "$GITHUB_OUTPUT"
-
-      - name: Resolve PR context
-        id: context
-        env:
-          EVENT_PR_NUMBER: ${{ steps.context-event.outputs.pr-number }}
-          EVENT_HEAD_REPO: ${{ steps.context-event.outputs.head-repo }}
-          EVENT_HEAD_SHA: ${{ steps.context-event.outputs.head-sha }}
-          EVENT_IS_FORK: ${{ steps.context-event.outputs.is-fork }}
-          DISPATCH_PR_NUMBER: ${{ steps.context-dispatch.outputs.pr-number }}
-          DISPATCH_HEAD_REPO: ${{ steps.context-dispatch.outputs.head-repo }}
-          DISPATCH_HEAD_SHA: ${{ steps.context-dispatch.outputs.head-sha }}
-          DISPATCH_IS_FORK: ${{ steps.context-dispatch.outputs.is-fork }}
-        run: |
-          {
-            echo "pr-number=${EVENT_PR_NUMBER:-${DISPATCH_PR_NUMBER}}"
-            echo "head-repo=${EVENT_HEAD_REPO:-${DISPATCH_HEAD_REPO}}"
-            echo "head-sha=${EVENT_HEAD_SHA:-${DISPATCH_HEAD_SHA}}"
-            echo "is-fork=${EVENT_IS_FORK:-${DISPATCH_IS_FORK}}"
-          } | tee -a "$GITHUB_OUTPUT"
+          body="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" --jq '.body // ""')"
+          normalized_body="$(printf '%s' "$body" | tr -d '*_')"
+          exists='false'
+          grep -Fqi -- \
+            "Release immediately (bypasses automatic progressive rollout)" \
+            <<< "$normalized_body" && exists='true'
+          echo "exists=$exists" | tee -a "$GITHUB_OUTPUT"
 
       - name: Checkout connector metadata
         if: steps.context.outputs.is-fork == 'false'
@@ -127,7 +100,7 @@ jobs:
         if: >
           steps.context.outputs.is-fork == 'false' &&
           steps.detect.outputs.connectors != '' &&
-          github.event_name == 'pull_request'
+          steps.bypass-state.outputs.exists != 'true'
         uses: bcgov/action-pr-description-add@14338bfe0278ead273b3c1189e5aa286ff6709c4 # v2.0.0
         with:
           github_token: ${{ github.token }}

--- a/.github/workflows/autopilot-release-immediately-checkbox.yml
+++ b/.github/workflows/autopilot-release-immediately-checkbox.yml
@@ -134,10 +134,11 @@ jobs:
           add_markdown: |
             ---
 
-            > > [!NOTE]
-            > > **Optional Progressive Rollout Bypass**
-            > >
-            > > Autopilot progressive rollout is enabled for connector(s) modified in this PR.
-            > > Check the box below **_only_** if you want to bypass normal rollout safety processes.
+            > [!IMPORTANT]
+            > **Optional Progressive Rollout Bypass**
             >
-            > - [ ] ⚡ Release immediately (bypasses automatic progressive rollout)
+            > [Autopilot progressive rollouts](https://github.com/airbytehq/airbyte-ops-mcp/blob/main/docs/autopilot-rollouts.md) are enabled for one or more connector(s) modified in this PR. Check the box below if you want to bypass normal rollout safety processes:
+            >
+            > - [ ] ⚡ **Release immediately** (bypasses automatic progressive rollout)
+            >
+            > _Note: This option only applies to connectors with a valid version bump in this PR. Connectors without a version bump will not be re-released._

--- a/.github/workflows/autopilot-release-immediately-checkbox.yml
+++ b/.github/workflows/autopilot-release-immediately-checkbox.yml
@@ -109,10 +109,13 @@ jobs:
             ---
 
             > [!IMPORTANT]
-            > **Optional Progressive Rollout Bypass**
+            > **Autopilot Progressive Rollout Enabled**
             >
-            > [Autopilot progressive rollouts](https://github.com/airbytehq/airbyte-ops-mcp/blob/main/docs/autopilot-rollouts.md) are enabled for one or more connector(s) modified in this PR. Check the box below if you want to bypass normal rollout safety processes and release to all users immediately upon merge:
+            > [Autopilot progressive rollouts](https://github.com/airbytehq/airbyte-ops-mcp/blob/main/docs/autopilot-rollouts.md) are enabled for one or more connector(s) modified in this PR. Check the box below if you need to bypass normal rollout safety processes:
             >
             > - [ ] ⚡ **Release immediately** (bypasses automatic progressive rollout)
             >
-            > _Note: This option only applies to connectors with a valid version bump in this PR. Connectors without a version bump will not be re-released._
+            > **Note:**
+            >
+            > - ⚠️ The above bypass option is for emergency/hotfix use only.
+            > - 🔗 You can monitor or manually advance a rollout at **[ops.internal.airbyte.ai](https://ops.internal.airbyte.ai)**.

--- a/.github/workflows/autopilot-release-immediately-checkbox.yml
+++ b/.github/workflows/autopilot-release-immediately-checkbox.yml
@@ -1,0 +1,165 @@
+name: Add Autopilot Release Immediately Checkbox
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+    paths:
+      - "airbyte-integrations/connectors/**"
+  workflow_dispatch:
+    inputs:
+      pr:
+        description: "Pull request number to inspect."
+        required: true
+        type: number
+
+env:
+  RELEASE_IMMEDIATELY_PHRASE: Release immediately (bypasses automatic progressive rollout)
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: autopilot-release-immediately-${{ github.event.pull_request.number || inputs.pr }}
+  cancel-in-progress: true
+
+jobs:
+  add-checkbox:
+    name: Add release immediately checkbox
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Resolve PR context from pull request event
+        id: context-event
+        if: github.event_name == 'pull_request'
+        env:
+          EVENT_PR_NUMBER: ${{ github.event.pull_request.number }}
+          EVENT_HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          EVENT_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          EVENT_IS_FORK: ${{ github.event.pull_request.head.repo.fork }}
+        run: |
+          {
+            echo "pr-number=${EVENT_PR_NUMBER}"
+            echo "head-repo=${EVENT_HEAD_REPO}"
+            echo "head-sha=${EVENT_HEAD_SHA}"
+            echo "is-fork=${EVENT_IS_FORK}"
+          } | tee -a "$GITHUB_OUTPUT"
+
+      - name: Resolve PR context from workflow dispatch
+        id: context-dispatch
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          INPUT_PR: ${{ inputs.pr }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          [[ "$INPUT_PR" =~ ^[1-9][0-9]*$ ]] || {
+            echo "::error::Invalid pull request number: ${INPUT_PR}"
+            exit 1
+          }
+          gh api "repos/${GITHUB_REPOSITORY}/pulls/${INPUT_PR}" |
+            jq -r '"pr-number=\(.number)\nhead-repo=\(.head.repo.full_name)\nhead-sha=\(.head.sha)\nis-fork=\(.head.repo.fork)"' |
+            tee -a "$GITHUB_OUTPUT"
+
+      - name: Resolve PR context
+        id: context
+        env:
+          EVENT_PR_NUMBER: ${{ steps.context-event.outputs.pr-number }}
+          EVENT_HEAD_REPO: ${{ steps.context-event.outputs.head-repo }}
+          EVENT_HEAD_SHA: ${{ steps.context-event.outputs.head-sha }}
+          EVENT_IS_FORK: ${{ steps.context-event.outputs.is-fork }}
+          DISPATCH_PR_NUMBER: ${{ steps.context-dispatch.outputs.pr-number }}
+          DISPATCH_HEAD_REPO: ${{ steps.context-dispatch.outputs.head-repo }}
+          DISPATCH_HEAD_SHA: ${{ steps.context-dispatch.outputs.head-sha }}
+          DISPATCH_IS_FORK: ${{ steps.context-dispatch.outputs.is-fork }}
+        run: |
+          {
+            echo "pr-number=${EVENT_PR_NUMBER:-${DISPATCH_PR_NUMBER}}"
+            echo "head-repo=${EVENT_HEAD_REPO:-${DISPATCH_HEAD_REPO}}"
+            echo "head-sha=${EVENT_HEAD_SHA:-${DISPATCH_HEAD_SHA}}"
+            echo "is-fork=${EVENT_IS_FORK:-${DISPATCH_IS_FORK}}"
+          } | tee -a "$GITHUB_OUTPUT"
+
+      - name: Checkout connector metadata
+        if: steps.context.outputs.is-fork == 'false'
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: ${{ steps.context.outputs.head-repo }}
+          ref: ${{ steps.context.outputs.head-sha }}
+          fetch-depth: 1
+
+      - name: Install uv
+        if: steps.context.outputs.is-fork == 'false'
+        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
+        with:
+          ignore-empty-workdir: true
+
+      - name: Install Ops CLI
+        if: steps.context.outputs.is-fork == 'false'
+        run: uv tool install "airbyte-internal-ops>=0.77.0"
+
+      - name: Detect modified connectors with autopilot enabled
+        id: detect
+        if: steps.context.outputs.is-fork == 'false'
+        env:
+          PR_NUMBER: ${{ steps.context.outputs.pr-number }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          connectors="$(
+            airbyte-ops local connector list \
+              --repo-path . \
+              --autopilot-enabled=true \
+              --modified-only \
+              --pr "${PR_NUMBER}" \
+              --gh-token "${GH_TOKEN}" \
+              --output-format lines
+          )"
+          [[ -z "$connectors" ]] && exit 0
+          delimiter="$(dd if=/dev/urandom bs=15 count=1 status=none | base64)"
+          {
+            echo "connectors<<${delimiter}"
+            echo "$connectors"
+            echo "${delimiter}"
+          } | tee -a "$GITHUB_OUTPUT"
+
+      - name: Read PR body
+        id: body
+        if: steps.context.outputs.is-fork == 'false' && steps.detect.outputs.connectors != ''
+        env:
+          PR_NUMBER: ${{ steps.context.outputs.pr-number }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          body_file="${RUNNER_TEMP}/autopilot-release-immediately-pr-body.md"
+          gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" --template '{{.body}}' > "$body_file"
+          echo "path=${body_file}" | tee -a "$GITHUB_OUTPUT"
+
+      - name: Detect existing release immediately checkbox
+        id: existing
+        if: steps.body.outputs.path != ''
+        env:
+          BODY_PATH: ${{ steps.body.outputs.path }}
+          RELEASE_IMMEDIATELY_PHRASE: ${{ env.RELEASE_IMMEDIATELY_PHRASE }}
+        run: |
+          if grep -Fq -- "$RELEASE_IMMEDIATELY_PHRASE" "$BODY_PATH"; then
+            echo "present=true" | tee -a "$GITHUB_OUTPUT"
+          else
+            echo "present=false" | tee -a "$GITHUB_OUTPUT"
+          fi
+
+      - name: Append release immediately checkbox
+        if: steps.existing.outputs.present == 'false'
+        env:
+          BODY_PATH: ${{ steps.body.outputs.path }}
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ steps.context.outputs.pr-number }}
+        run: |
+          set -euo pipefail
+          printf '\n\n> [!NOTE]\n> Autopilot progressive rollout is enabled for connector(s) modified in this PR.\n>\n> - [ ] :black_square_button: %s\n' \
+            "$RELEASE_IMMEDIATELY_PHRASE" >> "$BODY_PATH"
+          jq -n --rawfile body "$BODY_PATH" '{body: $body}' |
+            gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" --method PATCH --input -

--- a/.github/workflows/autopilot-release-immediately-checkbox.yml
+++ b/.github/workflows/autopilot-release-immediately-checkbox.yml
@@ -10,8 +10,7 @@ on:
     paths:
       - "airbyte-integrations/connectors/**"
 
-permissions:
-  {}
+permissions: {}
 
 concurrency:
   group: autopilot-release-immediately-${{ github.event.pull_request.number }}

--- a/.github/workflows/autopilot-release-immediately-checkbox.yml
+++ b/.github/workflows/autopilot-release-immediately-checkbox.yml
@@ -135,7 +135,7 @@ jobs:
         run: |
           set -euo pipefail
           body_file="${RUNNER_TEMP}/autopilot-release-immediately-pr-body.md"
-          gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" --template '{{.body}}' > "$body_file"
+          gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" --jq '.body // ""' > "$body_file"
           echo "path=${body_file}" | tee -a "$GITHUB_OUTPUT"
 
       - name: Detect existing release immediately checkbox
@@ -143,7 +143,6 @@ jobs:
         if: steps.body.outputs.path != ''
         env:
           BODY_PATH: ${{ steps.body.outputs.path }}
-          RELEASE_IMMEDIATELY_PHRASE: ${{ env.RELEASE_IMMEDIATELY_PHRASE }}
         run: |
           if grep -Fq -- "$RELEASE_IMMEDIATELY_PHRASE" "$BODY_PATH"; then
             echo "present=true" | tee -a "$GITHUB_OUTPUT"
@@ -159,7 +158,9 @@ jobs:
           PR_NUMBER: ${{ steps.context.outputs.pr-number }}
         run: |
           set -euo pipefail
-          printf '\n\n> [!NOTE]\n> Autopilot progressive rollout is enabled for connector(s) modified in this PR.\n>\n> - [ ] :black_square_button: %s\n' \
+          [[ "$(wc -c < "$BODY_PATH")" != 1 ]] || : > "$BODY_PATH"
+          [[ ! -s "$BODY_PATH" ]] || printf '\n\n'
+          printf '> [!NOTE]\n> Autopilot progressive rollout is enabled for connector(s) modified in this PR.\n\n- [ ] :black_square_button: %s\n' \
             "$RELEASE_IMMEDIATELY_PHRASE" >> "$BODY_PATH"
           jq -n --rawfile body "$BODY_PATH" '{body: $body}' |
             gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" --method PATCH --input -

--- a/.github/workflows/autopilot-release-immediately-checkbox.yml
+++ b/.github/workflows/autopilot-release-immediately-checkbox.yml
@@ -9,6 +9,7 @@ on:
       - ready_for_review
     paths:
       - "airbyte-integrations/connectors/**"
+
 permissions:
   contents: read
   pull-requests: write

--- a/.github/workflows/autopilot-release-immediately-checkbox.yml
+++ b/.github/workflows/autopilot-release-immediately-checkbox.yml
@@ -137,7 +137,7 @@ jobs:
             > [!IMPORTANT]
             > **Optional Progressive Rollout Bypass**
             >
-            > [Autopilot progressive rollouts](https://github.com/airbytehq/airbyte-ops-mcp/blob/main/docs/autopilot-rollouts.md) are enabled for one or more connector(s) modified in this PR. Check the box below if you want to bypass normal rollout safety processes:
+            > [Autopilot progressive rollouts](https://github.com/airbytehq/airbyte-ops-mcp/blob/main/docs/autopilot-rollouts.md) are enabled for one or more connector(s) modified in this PR. Check the box below if you want to bypass normal rollout safety processes and release to all users immediately upon merge:
             >
             > - [ ] ⚡ **Release immediately** (bypasses automatic progressive rollout)
             >

--- a/.github/workflows/autopilot-release-immediately-checkbox.yml
+++ b/.github/workflows/autopilot-release-immediately-checkbox.yml
@@ -134,9 +134,10 @@ jobs:
           add_markdown: |
             ---
 
-            **⚡ Optional Progressive Rollout Bypass**
-
-            Autopilot progressive rollout is enabled for connector(s) modified in this PR.
-            Check the box below **_only_** if you want to bypass normal rollout safety processes.
-
-            - [ ] ⚡ Release immediately (bypasses automatic progressive rollout)
+            > > [!NOTE]
+            > > **Optional Progressive Rollout Bypass**
+            > >
+            > > Autopilot progressive rollout is enabled for connector(s) modified in this PR.
+            > > Check the box below **_only_** if you want to bypass normal rollout safety processes.
+            >
+            > - [ ] ⚡ Release immediately (bypasses automatic progressive rollout)

--- a/.github/workflows/autopilot-release-immediately-checkbox.yml
+++ b/.github/workflows/autopilot-release-immediately-checkbox.yml
@@ -128,7 +128,7 @@ jobs:
           steps.context.outputs.is-fork == 'false' &&
           steps.detect.outputs.connectors != '' &&
           github.event_name == 'pull_request'
-        uses: bcgov/action-pr-description-add@14338bfe0278ead273b3c1189e5aa286ff670c4 # v2.0.0
+        uses: bcgov/action-pr-description-add@14338bfe0278ead273b3c1189e5aa286ff6709c4 # v2.0.0
         with:
           github_token: ${{ github.token }}
           add_markdown: |

--- a/.github/workflows/autopilot-release-immediately-checkbox.yml
+++ b/.github/workflows/autopilot-release-immediately-checkbox.yml
@@ -11,17 +11,23 @@ on:
       - "airbyte-integrations/connectors/**"
 
 permissions:
-  contents: read
-  pull-requests: write
+  {}
 
 concurrency:
   group: autopilot-release-immediately-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
 jobs:
-  add-checkbox:
-    name: Add release immediately checkbox
+  detect-autopilot-connectors:
+    name: Detect autopilot-enabled connectors
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      has-connectors: ${{ steps.detect.outputs.has-connectors }}
+      callout-exists: ${{ steps.bypass-state.outputs.exists }}
+      is-fork: ${{ steps.context.outputs.is-fork }}
     steps:
       - name: Resolve PR context from pull request event
         id: context
@@ -89,19 +95,22 @@ jobs:
               --gh-token "${GH_TOKEN}" \
               --output-format lines
           )"
-          [[ -z "$connectors" ]] && exit 0
-          delimiter="$(dd if=/dev/urandom bs=15 count=1 status=none | base64)"
-          {
-            echo "connectors<<${delimiter}"
-            echo "$connectors"
-            echo "${delimiter}"
-          } | tee -a "$GITHUB_OUTPUT"
+          has_connectors='false'
+          [[ -n "$connectors" ]] && has_connectors='true'
+          echo "has-connectors=$has_connectors" | tee -a "$GITHUB_OUTPUT"
 
+  add-checkbox:
+    name: Add release immediately checkbox
+    needs: detect-autopilot-connectors
+    if: >
+      needs.detect-autopilot-connectors.outputs.is-fork == 'false' &&
+      needs.detect-autopilot-connectors.outputs.has-connectors == 'true' &&
+      needs.detect-autopilot-connectors.outputs.callout-exists != 'true'
+    runs-on: ubuntu-24.04
+    permissions:
+      pull-requests: write
+    steps:
       - name: Add release immediately checkbox to PR description
-        if: >
-          steps.context.outputs.is-fork == 'false' &&
-          steps.detect.outputs.connectors != '' &&
-          steps.bypass-state.outputs.exists != 'true'
         uses: bcgov/action-pr-description-add@14338bfe0278ead273b3c1189e5aa286ff6709c4 # v2.0.0
         with:
           github_token: ${{ github.token }}

--- a/.github/workflows/autopilot-release-immediately-checkbox.yml
+++ b/.github/workflows/autopilot-release-immediately-checkbox.yml
@@ -158,8 +158,8 @@ jobs:
           PR_NUMBER: ${{ steps.context.outputs.pr-number }}
         run: |
           set -euo pipefail
-          [[ "$(wc -c < "$BODY_PATH")" != 1 ]] || : > "$BODY_PATH"
-          [[ ! -s "$BODY_PATH" ]] || printf '\n\n'
+          [[ -n "$(tr -d '[:space:]' < "$BODY_PATH")" ]] || : > "$BODY_PATH"
+          [[ ! -s "$BODY_PATH" ]] || printf '\n\n' >> "$BODY_PATH"
           printf '> [!NOTE]\n> Autopilot progressive rollout is enabled for connector(s) modified in this PR.\n\n- [ ] :black_square_button: %s\n' \
             "$RELEASE_IMMEDIATELY_PHRASE" >> "$BODY_PATH"
           jq -n --rawfile body "$BODY_PATH" '{body: $body}' |

--- a/.github/workflows/autopilot-release-immediately-checkbox.yml
+++ b/.github/workflows/autopilot-release-immediately-checkbox.yml
@@ -111,7 +111,7 @@ jobs:
             > [!IMPORTANT]
             > **Autopilot Progressive Rollout Enabled**
             >
-            > [Autopilot progressive rollouts](https://github.com/airbytehq/airbyte-ops-mcp/blob/main/docs/autopilot-rollouts.md) are enabled for one or more connector(s) modified in this PR. Check the box below if you need to bypass normal rollout safety processes:
+            > [Autopilot progressive rollouts](https://github.com/airbytehq/airbyte-ops-mcp/blob/main/docs/autopilot-rollouts.md) are enabled for one or more connector(s) modified in this PR. Check the box below if you need to bypass normal rollout safety processes and release to all users immediately upon merge:
             >
             > - [ ] ⚡ **Release immediately** (bypasses automatic progressive rollout)
             >

--- a/.github/workflows/autopilot-release-immediately-checkbox.yml
+++ b/.github/workflows/autopilot-release-immediately-checkbox.yml
@@ -23,10 +23,6 @@ jobs:
     permissions:
       contents: read
       pull-requests: read
-    outputs:
-      has-connectors: ${{ steps.detect.outputs.has-connectors }}
-      callout-exists: ${{ steps.bypass-state.outputs.exists }}
-      is-fork: ${{ steps.context.outputs.is-fork }}
     steps:
       - name: Resolve PR context from pull request event
         id: context
@@ -97,6 +93,10 @@ jobs:
           has_connectors='false'
           [[ -n "$connectors" ]] && has_connectors='true'
           echo "has-connectors=$has_connectors" | tee -a "$GITHUB_OUTPUT"
+    outputs:
+      has-connectors: ${{ steps.detect.outputs.has-connectors }}
+      callout-exists: ${{ steps.bypass-state.outputs.exists }}
+      is-fork: ${{ steps.context.outputs.is-fork }}
 
   add-checkbox:
     name: Add release immediately checkbox

--- a/.github/workflows/publish_connectors.yml
+++ b/.github/workflows/publish_connectors.yml
@@ -1,8 +1,5 @@
 name: Publish Connectors
 
-env:
-  RELEASE_IMMEDIATELY_PHRASE: Release immediately (bypasses automatic progressive rollout)
-
 on:
   push:
     branches:
@@ -82,6 +79,10 @@ on:
         required: false
         default: false
         type: boolean
+
+env:
+  RELEASE_IMMEDIATELY_PHRASE: Release immediately (bypasses automatic progressive rollout)
+
 jobs:
   publish_options:
     name: Resolve options for connector publishing
@@ -98,13 +99,8 @@ jobs:
         id: list-connectors-manual
         if: github.event_name == 'workflow_dispatch'
         shell: bash
-        env:
-          CONNECTOR_ARGS: ${{ inputs.connectors }}
         # When invoked manually, we run on the connectors specified in the input.
-        run: |
-          read -r -a connector_args <<< "$CONNECTOR_ARGS"
-          connectors_json="$(./poe-tasks/parse-connector-name-args.sh "${connector_args[@]}")"
-          echo "connectors-to-publish=${connectors_json}" | tee -a "$GITHUB_OUTPUT"
+        run: echo connectors-to-publish=$(./poe-tasks/parse-connector-name-args.sh ${{ inputs.connectors }}) | tee -a $GITHUB_OUTPUT
       - name: List connectors to publish [On merge to master]
         id: list-connectors-master
         if: github.event_name == 'push'
@@ -119,20 +115,6 @@ jobs:
         env:
           CONNECTORS_JSON: ${{ steps.list-connectors-manual.outputs.connectors-to-publish || steps.list-connectors-master.outputs.connectors-to-publish }}
         run: echo "connector-count=$(jq '[.connector[] | select(. != "")] | length' <<< "$CONNECTORS_JSON")" | tee -a "$GITHUB_OUTPUT"
-      - name: Report connectors skipped due to unchanged version
-        if: github.event_name == 'push'
-        env:
-          CONNECTORS_TO_PUBLISH: ${{ steps.list-connectors-master.outputs.connectors-to-publish }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          all_modified="$(./poe-tasks/get-modified-connectors.sh --prev-commit --json)"
-          skipped="$(
-            jq -r --argjson published "$CONNECTORS_TO_PUBLISH" '
-              [.connector[] | select(. != "" and (. as $connector | ($published.connector | index($connector) | not)))] | join(", ")
-            ' <<< "$all_modified"
-          )"
-          echo "::notice::Connectors skipped because dockerImageTag was unchanged: ${skipped:-none}"
       - name: Resolve semver suffix
         id: resolve-semver-suffix
         shell: bash
@@ -510,7 +492,6 @@ jobs:
           steps.check-release-block.outputs.blocked != 'true'
         env:
           GH_TOKEN: ${{ steps.get-app-token.outputs.token }}
-          RELEASE_IMMEDIATELY_PHRASE: ${{ env.RELEASE_IMMEDIATELY_PHRASE }}
         shell: bash
         run: |
           set -euo pipefail

--- a/.github/workflows/publish_connectors.yml
+++ b/.github/workflows/publish_connectors.yml
@@ -498,7 +498,7 @@ jobs:
           body_file="${RUNNER_TEMP}/merged-pr-body.md"
           gh api "repos/${GITHUB_REPOSITORY}/commits/${GITHUB_SHA}/pulls" --jq '.[0].body // ""' > "$body_file"
           checked='false'
-          grep -Ei "^[[:space:]]*-[[:space:]]*\\[[xX]\\]" "$body_file" |
+          grep -Ei "^[[:space:]>]*-[[:space:]]*\\[[xX]\\]" "$body_file" |
             grep -Fqi -- "$RELEASE_IMMEDIATELY_PHRASE" && checked='true'
           echo "checked=$checked" | tee -a "$GITHUB_OUTPUT"
 

--- a/.github/workflows/publish_connectors.yml
+++ b/.github/workflows/publish_connectors.yml
@@ -1,5 +1,8 @@
 name: Publish Connectors
 
+env:
+  RELEASE_IMMEDIATELY_PHRASE: Release immediately (bypasses automatic progressive rollout)
+
 on:
   push:
     branches:
@@ -95,14 +98,41 @@ jobs:
         id: list-connectors-manual
         if: github.event_name == 'workflow_dispatch'
         shell: bash
+        env:
+          CONNECTOR_ARGS: ${{ inputs.connectors }}
         # When invoked manually, we run on the connectors specified in the input.
-        run: echo connectors-to-publish=$(./poe-tasks/parse-connector-name-args.sh ${{ inputs.connectors }}) | tee -a $GITHUB_OUTPUT
+        run: |
+          read -r -a connector_args <<< "$CONNECTOR_ARGS"
+          connectors_json="$(./poe-tasks/parse-connector-name-args.sh "${connector_args[@]}")"
+          echo "connectors-to-publish=${connectors_json}" | tee -a "$GITHUB_OUTPUT"
       - name: List connectors to publish [On merge to master]
         id: list-connectors-master
         if: github.event_name == 'push'
         shell: bash
         # When merging to master, we run on connectors that have changed since the previous commit.
-        run: echo connectors-to-publish=$(./poe-tasks/get-modified-connectors.sh --prev-commit --json) | tee -a $GITHUB_OUTPUT
+        run: |
+          connectors_json="$(./poe-tasks/get-modified-connectors.sh --prev-commit --require-version-bump --json)"
+          echo "connectors-to-publish=${connectors_json}" | tee -a "$GITHUB_OUTPUT"
+      - name: Count connectors to publish
+        id: count-connectors
+        shell: bash
+        env:
+          CONNECTORS_JSON: ${{ steps.list-connectors-manual.outputs.connectors-to-publish || steps.list-connectors-master.outputs.connectors-to-publish }}
+        run: echo "connector-count=$(jq '[.connector[] | select(. != "")] | length' <<< "$CONNECTORS_JSON")" | tee -a "$GITHUB_OUTPUT"
+      - name: Report connectors skipped due to unchanged version
+        if: github.event_name == 'push'
+        env:
+          CONNECTORS_TO_PUBLISH: ${{ steps.list-connectors-master.outputs.connectors-to-publish }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          all_modified="$(./poe-tasks/get-modified-connectors.sh --prev-commit --json)"
+          skipped="$(
+            jq -r --argjson published "$CONNECTORS_TO_PUBLISH" '
+              [.connector[] | select(. != "" and (. as $connector | ($published.connector | index($connector) | not)))] | join(", ")
+            ' <<< "$all_modified"
+          )"
+          echo "::notice::Connectors skipped because dockerImageTag was unchanged: ${skipped:-none}"
       - name: Resolve semver suffix
         id: resolve-semver-suffix
         shell: bash
@@ -174,9 +204,11 @@ jobs:
       registry-refresh-only: ${{ inputs.registry-refresh-only || 'false' }}
       # registry-refresh-only is validated to exactly one connector, so this is safe to pass to scoped registry compile.
       registry-refresh-connector-name: ${{ fromJson(steps.list-connectors-manual.outputs.connectors-to-publish || '{"connector":[""]}').connector[0] }}
+      connector-count: ${{ steps.count-connectors.outputs.connector-count }}
   publish_connectors:
     name: Publish connectors
     needs: [publish_options]
+    if: needs.publish_options.outputs.connector-count != '0'
     runs-on: ubuntu-24.04
     strategy:
       matrix: ${{ fromJson(needs.publish_options.outputs.connectors-to-publish) }}
@@ -469,6 +501,34 @@ jobs:
             --new-version "${{ steps.resolve-docker-image-tag.outputs.docker-image-tag }}" \
             --no-changelog \
             --progressive-rollout-enabled=false
+
+      - name: Resolve release-immediately checkbox
+        id: release-immediately
+        if: >
+          github.event_name == 'push' &&
+          needs.publish_options.outputs.with-semver-suffix == 'none' &&
+          steps.check-release-block.outputs.blocked != 'true'
+        env:
+          GH_TOKEN: ${{ steps.get-app-token.outputs.token }}
+          RELEASE_IMMEDIATELY_PHRASE: ${{ env.RELEASE_IMMEDIATELY_PHRASE }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          body_file="${RUNNER_TEMP}/merged-pr-body.md"
+          gh api "repos/${GITHUB_REPOSITORY}/commits/${GITHUB_SHA}/pulls" --jq '.[0].body // ""' > "$body_file"
+          checked='false'
+          grep -Ei "^[[:space:]]*-[[:space:]]*\\[[xX]\\]" "$body_file" |
+            grep -Fqi -- "$RELEASE_IMMEDIATELY_PHRASE" && checked='true'
+          echo "checked=$checked" | tee -a "$GITHUB_OUTPUT"
+
+      - name: Disable progressive rollout for immediate release
+        if: steps.release-immediately.outputs.checked == 'true'
+        working-directory: airbyte-integrations/connectors/${{ matrix.connector }}
+        env:
+          CONNECTOR: ${{ matrix.connector }}
+        run: |
+          yq -i '.data.releases.rolloutConfiguration.enableProgressiveRollout = false' metadata.yaml
+          echo "::notice::Immediate release requested for ${CONNECTOR}; progressive rollout disabled for this publish."
 
       # --- Registry artifact generation and publishing ---
       - name: Generate Registry Artifacts

--- a/.github/workflows/publish_connectors.yml
+++ b/.github/workflows/publish_connectors.yml
@@ -114,7 +114,9 @@ jobs:
         shell: bash
         env:
           CONNECTORS_JSON: ${{ steps.list-connectors-manual.outputs.connectors-to-publish || steps.list-connectors-master.outputs.connectors-to-publish }}
-        run: echo "connector-count=$(jq '[.connector[] | select(. != "")] | length' <<< "$CONNECTORS_JSON")" | tee -a "$GITHUB_OUTPUT"
+        run: |
+          set -euo pipefail
+          echo "connector-count=$(jq '[.connector[] | select(. != "")] | length' <<< "$CONNECTORS_JSON")" | tee -a "$GITHUB_OUTPUT"
       - name: Resolve semver suffix
         id: resolve-semver-suffix
         shell: bash
@@ -496,21 +498,45 @@ jobs:
         run: |
           set -euo pipefail
           body_file="${RUNNER_TEMP}/merged-pr-body.md"
-          gh api "repos/${GITHUB_REPOSITORY}/commits/${GITHUB_SHA}/pulls" --jq '.[0].body // ""' > "$body_file"
+          gh api "repos/${GITHUB_REPOSITORY}/commits/${GITHUB_SHA}/pulls" --jq '.[0].body // ""' > "$body_file" || {
+            echo "::warning::Could not read the merged pull request body; using the safe default of progressive rollout enabled."
+            echo "checked=false" | tee -a "$GITHUB_OUTPUT"
+            exit 0
+          }
           checked='false'
           tr -d '*_' < "$body_file" |
             grep -Ei "^[[:space:]>]*-[[:space:]]*\\[[xX]\\]" |
             grep -Fqi -- "$RELEASE_IMMEDIATELY_PHRASE" && checked='true'
           echo "checked=$checked" | tee -a "$GITHUB_OUTPUT"
 
-      - name: Disable progressive rollout for immediate release
+      - name: Resolve progressive rollout setting
+        id: progressive-rollout
         if: steps.release-immediately.outputs.checked == 'true'
+        working-directory: airbyte-integrations/connectors/${{ matrix.connector }}
+        run: |
+          set -euo pipefail
+          enabled="$(yq -r '.data.releases.rolloutConfiguration.enableProgressiveRollout // false' metadata.yaml)"
+          echo "enabled=$enabled" | tee -a "$GITHUB_OUTPUT"
+
+      - name: Disable progressive rollout for immediate release
+        if: >
+          steps.release-immediately.outputs.checked == 'true' &&
+          steps.progressive-rollout.outputs.enabled == 'true'
         working-directory: airbyte-integrations/connectors/${{ matrix.connector }}
         env:
           CONNECTOR: ${{ matrix.connector }}
         run: |
+          set -euo pipefail
           yq -i '.data.releases.rolloutConfiguration.enableProgressiveRollout = false' metadata.yaml
           echo "::notice::Immediate release requested for ${CONNECTOR}; progressive rollout disabled for this publish."
+
+      - name: Keep progressive rollout metadata unchanged
+        if: >
+          steps.release-immediately.outputs.checked == 'true' &&
+          steps.progressive-rollout.outputs.enabled != 'true'
+        env:
+          CONNECTOR: ${{ matrix.connector }}
+        run: echo "::notice::Immediate release requested for ${CONNECTOR}, but progressive rollout is not enabled; metadata.yaml remains unchanged."
 
       # --- Registry artifact generation and publishing ---
       - name: Generate Registry Artifacts

--- a/.github/workflows/publish_connectors.yml
+++ b/.github/workflows/publish_connectors.yml
@@ -498,7 +498,8 @@ jobs:
           body_file="${RUNNER_TEMP}/merged-pr-body.md"
           gh api "repos/${GITHUB_REPOSITORY}/commits/${GITHUB_SHA}/pulls" --jq '.[0].body // ""' > "$body_file"
           checked='false'
-          grep -Ei "^[[:space:]>]*-[[:space:]]*\\[[xX]\\]" "$body_file" |
+          tr -d '*_' < "$body_file" |
+            grep -Ei "^[[:space:]>]*-[[:space:]]*\\[[xX]\\]" |
             grep -Fqi -- "$RELEASE_IMMEDIATELY_PHRASE" && checked='true'
           echo "checked=$checked" | tee -a "$GITHUB_OUTPUT"
 

--- a/poe-tasks/get-modified-connectors.sh
+++ b/poe-tasks/get-modified-connectors.sh
@@ -164,6 +164,7 @@ filter_to_version_bumps() {
       version_bumped+=("$connector")
     else
       echo "⚠️ Skipping '$connector': dockerImageTag is unchanged from the parent commit." >&2
+      echo "   To push metadata-only edits to the registry, run the publish workflow with registry-refresh-only." >&2
     fi
   done
   connectors=("${version_bumped[@]}")

--- a/poe-tasks/get-modified-connectors.sh
+++ b/poe-tasks/get-modified-connectors.sh
@@ -12,6 +12,7 @@ NO_JAVA=false
 JSON=false
 PREV_COMMIT=false
 LOCAL_CDK=false
+REQUIRE_VERSION_BUMP=false
 
 # parse flags
 while [[ $# -gt 0 ]]; do
@@ -31,6 +32,9 @@ while [[ $# -gt 0 ]]; do
     --local-cdk|local-cdk)
       LOCAL_CDK=true
       ;;
+    --require-version-bump)
+      REQUIRE_VERSION_BUMP=true
+      ;;
     *)
       echo "Unknown argument: $1" >&2;
       exit 1
@@ -38,6 +42,9 @@ while [[ $# -gt 0 ]]; do
   esac
   shift
 done
+
+# --require-version-bump only applies to --prev-commit, which is the master
+# publish path. It is intentionally a no-op for PR-branch comparisons.
 
 # 1) Fetch the latest from the default branch (using the correct remote)
 if git remote get-url upstream &>/dev/null; then
@@ -125,6 +132,47 @@ if [ -n "$dirs" ]; then
       echo "⚠️ '$d' directory was not found. This can happen if a connector is removed. Skipping." >&2
     fi
   done <<< "$(printf '%s\n' "$dirs" | sort -u)"
+fi
+
+filter_to_version_bumps() {
+  local parent_commit
+  if ! parent_commit=$(git rev-parse --verify HEAD^ 2>/dev/null); then
+    echo "⚠️ Cannot read the parent commit; keeping all modified connectors." >&2
+    return
+  fi
+
+  local version_bumped=()
+  local connector metadata current_tag parent_tag
+  for connector in "${connectors[@]}"; do
+    metadata="airbyte-integrations/connectors/${connector}/metadata.yaml"
+    if [[ ! -f "$metadata" ]]; then
+      echo "⚠️ Cannot read '$metadata'; keeping '$connector'." >&2
+      version_bumped+=("$connector")
+      continue
+    fi
+    if ! git cat-file -e "${parent_commit}:${metadata}" 2>/dev/null; then
+      version_bumped+=("$connector")
+      continue
+    fi
+    if ! current_tag=$(yq -r '.data.dockerImageTag // ""' "$metadata" 2>/dev/null) ||
+      ! parent_tag=$(git show "${parent_commit}:${metadata}" | yq -r '.data.dockerImageTag // ""' 2>/dev/null); then
+      echo "⚠️ Cannot read the dockerImageTag for '$connector'; keeping it." >&2
+      version_bumped+=("$connector")
+      continue
+    fi
+    if [[ "$current_tag" != "$parent_tag" ]]; then
+      version_bumped+=("$connector")
+    else
+      echo "⚠️ Skipping '$connector': dockerImageTag is unchanged from the parent commit." >&2
+    fi
+  done
+  connectors=("${version_bumped[@]}")
+}
+
+if $PREV_COMMIT && $REQUIRE_VERSION_BUMP; then
+  # Compare versions rather than metadata paths: Java and manifest-only changes
+  # can legitimately publish a new version without changing only metadata.yaml.
+  filter_to_version_bumps
 fi
 
 # 9) Define function to print either JSON or newline-delimited list.


### PR DESCRIPTION
## What

Two sharp edges in Autopilot Rollouts, reported by AJ:

1. There was no way to opt a single version out of the automatic progressive rollout at merge time — you had to publish and then manually **Promote to Default GA** in the Ops Webapp.
2. Any `metadata.yaml`-only merge (e.g. enabling autopilot itself) re-published the connector at its *existing* version, which made the platform treat an already-GA default version as a fresh rollout candidate.

----

> [!IMPORTANT]
> **Autopilot Progressive Rollout Enabled**
>
> [Autopilot progressive rollouts](https://github.com/airbytehq/airbyte-ops-mcp/blob/main/docs/autopilot-rollouts.md) are enabled for one or more connector(s) modified in this PR. Check the box below if you need to bypass normal rollout safety processes and release to all users immediately upon merge:
>
> - [x] ⚡ **Release immediately** (bypasses automatic progressive rollout)
> 
> **Note:**
>
> - ⚠️ The above bypass option is for emergency/hotfix use only.
> - 🔗 You can monitor or manually advance a rollout at **[ops.internal.airbyte.ai](https://ops.internal.airbyte.ai)**.

----

## How

**1. Release-immediately opt-out**

New `.github/workflows/autopilot-release-immediately-checkbox.yml` runs on PRs touching `airbyte-integrations/connectors/**`, lists modified connectors with autopilot enabled (`airbyte-ops local connector list --autopilot-enabled=true --modified-only`), and — when at least one matches — appends to the PR description with the repo-standard `bcgov/action-pr-description-add` action (same pin/usage as `auto-merge-toggle.yml` and `connector-active-progressive-rollout-checks.yml`), which preserves the existing body:

```markdown
> [!IMPORTANT]
> **Autopilot Progressive Rollout Enabled**
>
> [Autopilot progressive rollouts](https://github.com/airbytehq/airbyte-ops-mcp/blob/main/docs/autopilot-rollouts.md) are enabled for one or more connector(s) modified in this PR. Check the box below if you need to bypass normal rollout safety processes and release to all users immediately upon merge:
>
> - [ ] ⚡ **Release immediately** (bypasses automatic progressive rollout)
>
> **Note:**
>
> - ⚠️ The above bypass option is for emergency/hotfix use only.
> - 🔗 You can monitor or manually advance a rollout at **[ops.internal.airbyte.ai](https://ops.internal.airbyte.ai)**.
```

Idempotency is ours, not the action's: it dedupes by exact whole-block `body.includes(markdown)`, which stops matching the moment a human ticks the box, so a later `synchronize` would append a second callout. A pre-check reads the PR body and skips the add when the callout is already present in any form (checked/unchecked, emphasized, blockquoted). Forks are skipped, and the workflow is `pull_request`-only — the action requires `context.payload.pull_request`, so there is no `workflow_dispatch` path.

Permissions are split across two jobs so the untrusted PR-head checkout never sits in a job that can write (CodeQL alert 961): `detect-autopilot-connectors` holds `contents: read` + `pull-requests: read` and does the checkout/detection, exporting booleans; `add-checkbox` holds `pull-requests: write`, does no checkout, and only runs the description action. Workflow-level `permissions` is empty.

On merge, `publish_connectors.yml` resolves the merge commit's PR (`repos/:repo/commits/:sha/pulls`) and, if that line is checked (`[x]`/`[X]`), ephemerally does

```bash
yq -i '.data.releases.rolloutConfiguration.enableProgressiveRollout = false' metadata.yaml
```

before registry artifact generation — so the registry publisher writes no progressive-rollout marker and the version goes straight to Default GA. Nothing is committed, and the edit only runs for connectors whose metadata already has `enableProgressiveRollout: true`, so a mixed-connector merge never gains a `rolloutConfiguration` stanza it didn't have. Detection strips `*`/`_` emphasis and tolerates a `>` blockquote prefix, since the task item lives inside the callout; an unreadable PR body degrades to "unchecked" with a warning rather than failing the publish. Gated to `push` + `with-semver-suffix == 'none'`, so preview/RC/manual publishes are untouched.

**2. No publish without a version bump**

`poe-tasks/get-modified-connectors.sh` gains an opt-in `--require-version-bump` (only meaningful with `--prev-commit`), used by the on-merge connector list. It drops any candidate whose `.data.dockerImageTag` is unchanged vs `HEAD^`, keeps brand-new connectors, and keeps + warns when the parent commit or tag can't be read.

Gating on *version changed* rather than "only `metadata.yaml` changed" is deliberate: Java and manifest-only connectors legitimately publish via a metadata-only diff.

Because the script emits the `{"connector":[""]}` sentinel for an empty result, `publish_options` now also exports `connector-count` (`jq`-computed, empty names excluded) and `publish_connectors` is skipped when it is `0`; `generate_connector_registry` skips with it via its existing `needs`.

## Review guide

1. `.github/workflows/autopilot-release-immediately-checkbox.yml`
2. `.github/workflows/publish_connectors.yml`
3. `poe-tasks/get-modified-connectors.sh`

Docs follow-up: https://github.com/airbytehq/airbyte-ops-mcp/pull/1247

## User Impact

Connector maintainers can ship an autopilot-enabled connector immediately by checking one box before merging, and settings-only merges no longer republish or reclassify an existing GA default version.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚
- [ ] NO ❌


Link to Devin session: https://app.devin.ai/sessions/d0c4d9f49492432f99cd6bd65913d134
Requested by: @aaronsteers

> [!IMPORTANT]
> ⚡ **Auto-merge enabled.**
> 
> _This PR is set to merge automatically when all requirements are met._