### PR TITLE
chore(source-pokeapi): bump to 0.3.67 to validate autopilot release-immediately checkbox

### DIFF
--- a/airbyte-integrations/connectors/source-pokeapi/metadata.yaml
+++ b/airbyte-integrations/connectors/source-pokeapi/metadata.yaml
@@ -27,7 +27,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 6371b14b-bc68-4236-bfbd-468e8df8e968
-  dockerImageTag: 0.3.66
+  dockerImageTag: 0.3.67
   dockerRepository: airbyte/source-pokeapi
   githubIssueLabel: source-pokeapi
   icon: pokeapi.svg

--- a/docs/integrations/sources/pokeapi.md
+++ b/docs/integrations/sources/pokeapi.md
@@ -60,7 +60,7 @@ If you use Airbyte Cloud and your organization restricts access to specific IPs,
 
 | Version | Date       | Pull Request                                             | Subject                                         |
 | :------ | :--------- | :------------------------------------------------------- | :---------------------------------------------- |
-| 0.3.67 | 2026-08-13 | [0](https://github.com/airbytehq/airbyte/pull/0) | No-op version bump to validate the new autopilot release-immediately checkbox workflow |
+| 0.3.67 | 2026-08-13 | [84389](https://github.com/airbytehq/airbyte/pull/84389) | No-op version bump to validate the new autopilot release-immediately checkbox workflow |
 | 0.3.66 | 2026-08-11 | [84043](https://github.com/airbytehq/airbyte/pull/84043) | Update dependencies |
 | 0.3.65 | 2026-08-04 | [83560](https://github.com/airbytehq/airbyte/pull/83560) | Update dependencies |
 | 0.3.64 | 2026-07-28 | [83032](https://github.com/airbytehq/airbyte/pull/83032) | Update dependencies |

--- a/docs/integrations/sources/pokeapi.md
+++ b/docs/integrations/sources/pokeapi.md
@@ -60,6 +60,7 @@ If you use Airbyte Cloud and your organization restricts access to specific IPs,
 
 | Version | Date       | Pull Request                                             | Subject                                         |
 | :------ | :--------- | :------------------------------------------------------- | :---------------------------------------------- |
+| 0.3.67 | 2026-08-13 | [0](https://github.com/airbytehq/airbyte/pull/0) | No-op version bump to validate the new autopilot release-immediately checkbox workflow |
 | 0.3.66 | 2026-08-11 | [84043](https://github.com/airbytehq/airbyte/pull/84043) | Update dependencies |
 | 0.3.65 | 2026-08-04 | [83560](https://github.com/airbytehq/airbyte/pull/83560) | Update dependencies |
 | 0.3.64 | 2026-07-28 | [83032](https://github.com/airbytehq/airbyte/pull/83032) | Update dependencies |


### PR DESCRIPTION
## What

Live validation of the autopilot rollout changes from #84357, using `source-pokeapi` (alpha/community, `enableProgressiveRollout: true`).

## How

Patch `dockerImageTag` bump 0.3.66 → 0.3.67 plus changelog entry. No code changes.

## Review guide

What this PR is meant to demonstrate:

1. On open, `Add Autopilot Release Immediately Checkbox` appends the unchecked callout to this description on its own — deliberately not added by hand, and left unticked so a re-run (`synchronize`) can be checked for duplicate appends.
2. Leaving the box unchecked and merging should publish `0.3.67` as a progressive rollout candidate, not as Default GA.
3. Ticking the box before merge should bypass the rollout and release `0.3.67` to all users immediately.

## User Impact

`source-pokeapi` 0.3.67 gets published; functionally identical to 0.3.66.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚


Link to Devin session: https://app.devin.ai/sessions/d0c4d9f49492432f99cd6bd65913d134
Requested by: @aaronsteers

---

> [!IMPORTANT]
> **Autopilot Progressive Rollout Enabled**
>
> [Autopilot progressive rollouts](https://github.com/airbytehq/airbyte-ops-mcp/blob/main/docs/autopilot-rollouts.md) are enabled for one or more connector(s) modified in this PR. Check the box below if you need to bypass normal rollout safety processes and release to all users immediately upon merge:
>
> - [x] ⚡ **Release immediately** (bypasses automatic progressive rollout)
>
> **Note:**
>
> - ⚠️ The above bypass option is for emergency/hotfix use only.
> - 🔗 You can monitor or manually advance a rollout at **[ops.internal.airbyte.ai](https://ops.internal.airbyte.ai)**.