### PR TITLE
ci(publish): drop --pr-number capability probe now that the Ops CLI ships the flag

### DIFF
--- a/.github/workflows/publish_connectors.yml
+++ b/.github/workflows/publish_connectors.yml
@@ -554,14 +554,7 @@ jobs:
           PR_NUMBER_ARGS=()
           PR_NUMBER="${PR_NUMBER//[[:space:]]/}"
           if [[ "$PR_NUMBER" =~ ^[1-9][0-9]*$ ]]; then
-            # The installed Ops CLI release may predate `--pr-number`; passing an
-            # unrecognized flag would fail the publish, so probe before using it.
-            if COLUMNS=200 airbyte-ops registry connector-version artifacts generate --help 2>/dev/null \
-              | grep -q -- '--pr-number'; then
-              PR_NUMBER_ARGS+=(--pr-number "$PR_NUMBER")
-            else
-              echo "::warning::Installed airbyte-ops does not support --pr-number; publishing without release attribution."
-            fi
+            PR_NUMBER_ARGS+=(--pr-number "$PR_NUMBER")
           elif [[ -n "$PR_NUMBER" && "$PR_NUMBER" != "0" ]]; then
             echo "::warning::Ignoring non-numeric PR number '$PR_NUMBER' for release attribution."
           fi


### PR DESCRIPTION
## What

Reverts the capability probe added in https://github.com/airbytehq/airbyte/pull/83257. It existed only because master forwarded `--pr-number` to `airbyte-ops` before any published release understood the flag. `airbyte-internal-ops` 0.98.0 is on PyPI now and ships it, so the probe is permanent workflow cruft guarding a state that can no longer occur.

Verified against the actual published artifact, not just the merge:

```
$ uvx --from airbyte-internal-ops==0.98.0 airbyte-ops \
    registry connector-version artifacts generate --help
  PR-NUMBER --pr-number   Pull request number for prerelease attribution.
```

## How

`git revert` of the probe commit, leaving the plain forwarding from https://github.com/airbytehq/airbyte/pull/83255 intact:

```diff
 if [[ "$PR_NUMBER" =~ ^[1-9][0-9]*$ ]]; then
-  if COLUMNS=200 airbyte-ops ... --help | grep -q -- '--pr-number'; then
-    PR_NUMBER_ARGS+=(--pr-number "$PR_NUMBER")
-  else
-    echo "::warning::Installed airbyte-ops does not support --pr-number; ..."
-  fi
+  PR_NUMBER_ARGS+=(--pr-number "$PR_NUMBER")
 elif [[ -n "$PR_NUMBER" && "$PR_NUMBER" != "0" ]]; then
```

The non-numeric-input warning is untouched — that guards a real input case rather than a version skew.

## Review guide

1. `.github/workflows/publish_connectors.yml` — one hunk.

## User Impact

Prerelease publishes dispatched with a PR number record the release PR and author in the connector's registry metadata, instead of silently warning and skipping attribution. GA publishes don't set `inputs.pr` and are unaffected.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚


Link to Devin session: https://app.devin.ai/sessions/2eba0ca3227c436b90e666534f85581b
Requested by: @aaronsteers