### PR TITLE
ci(registries): add a read-only dry-run mode to the registry compile workflow

### DIFF
--- a/.github/workflows/generate-connector-registries.yml
+++ b/.github/workflows/generate-connector-registries.yml
@@ -62,7 +62,7 @@ permissions:
 concurrency:
   # Only allow one active run, and one pending run.
   # This prevents race conditions between multiple runs of this workflow.
-  group: generate-connector-registry
+  group: generate-connector-registry-${{ inputs.dry-run }}
   # If a new run is triggered while there's already one in-progress,
   # allow the in-progress run to finish.
   cancel-in-progress: false
@@ -169,12 +169,6 @@ jobs:
       REPORT_DIR: ${{ runner.temp }}/registry-rehearsal-reports
 
     steps:
-      - name: Checkout Airbyte
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          ref: ${{ github.event.inputs.gitref || github.ref }}
-          submodules: true
-
       - name: Install uv
         uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
 
@@ -209,19 +203,30 @@ jobs:
         with:
           credentials_json: ${{ secrets.METADATA_SERVICE_PROD_GCS_CREDENTIALS }}
 
-      - name: Download Production Registry Snapshot
+      - name: Set up Google Cloud CLI
         if: always()
-        shell: bash
-        run: |
-          gcloud storage cp \
-            "gs://${REGISTRY_BUCKET}/registries/v0/cloud_registry.json" \
-            "${REPORT_DIR}/prod-snapshot/cloud_registry.json"
-          gcloud storage cp \
-            "gs://${REGISTRY_BUCKET}/registries/v0/oss_registry.json" \
-            "${REPORT_DIR}/prod-snapshot/oss_registry.json"
-          gcloud storage cp \
-            "gs://${REGISTRY_BUCKET}/registries/v0/composite_registry.json" \
-            "${REPORT_DIR}/prod-snapshot/composite_registry.json"
+        uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3.0.1
+
+      - name: Download Cloud Registry Snapshot
+        if: always()
+        run: >
+          gcloud storage cp
+          "gs://${REGISTRY_BUCKET}/registries/v0/cloud_registry.json"
+          "${REPORT_DIR}/prod-snapshot/cloud_registry.json"
+
+      - name: Download OSS Registry Snapshot
+        if: always()
+        run: >
+          gcloud storage cp
+          "gs://${REGISTRY_BUCKET}/registries/v0/oss_registry.json"
+          "${REPORT_DIR}/prod-snapshot/oss_registry.json"
+
+      - name: Download Composite Registry Snapshot
+        if: always()
+        run: >
+          gcloud storage cp
+          "gs://${REGISTRY_BUCKET}/registries/v0/composite_registry.json"
+          "${REPORT_DIR}/prod-snapshot/composite_registry.json"
 
       - name: Compare Registry Rehearsal
         if: >
@@ -243,7 +248,7 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: registry-rehearsal-recompiled
-          path: ${{ runner.temp }}/registry-rehearsal/registries/v0/*.json
+          path: ${{ env.REHEARSAL_DIR }}/registries/v0/*.json
           if-no-files-found: ignore
 
       - name: Upload Production Registry Snapshot
@@ -251,15 +256,15 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: registry-rehearsal-production-snapshot
-          path: ${{ runner.temp }}/registry-rehearsal-reports/prod-snapshot/*.json
+          path: ${{ env.REPORT_DIR }}/prod-snapshot/*.json
           if-no-files-found: ignore
 
       - name: Upload Registry Rehearsal Text Report
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: registry-rehearsal-report-txt
-          path: ${{ runner.temp }}/registry-rehearsal-reports/report.txt
+          name: registry-rehearsal-report.txt
+          path: ${{ env.REPORT_DIR }}/report.txt
           archive: false
           if-no-files-found: ignore
 
@@ -267,7 +272,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: registry-rehearsal-report-html
-          path: ${{ runner.temp }}/registry-rehearsal-reports/report.html
+          name: registry-rehearsal-report.html
+          path: ${{ env.REPORT_DIR }}/report.html
           archive: false
           if-no-files-found: ignore

--- a/.github/workflows/generate-connector-registries.yml
+++ b/.github/workflows/generate-connector-registries.yml
@@ -192,7 +192,7 @@ jobs:
         run: >
           airbyte-ops registry store compile
           --store "${REGISTRY_STORE}"
-          --output-store "file:${COMPILE_OUTPUT_DIR}"
+          --output-store "coral:local:${COMPILE_OUTPUT_DIR}"
           --with-secrets-mask
           ${FORCE_FLAG}
           ${CONNECTOR_NAME_FLAG}
@@ -245,7 +245,7 @@ jobs:
           --assert-stable
           --html-report "${REPORT_DIR}/report.html"
           --text-report "${REPORT_DIR}/report.txt"
-          "file:${COMPILE_OUTPUT_DIR}"
+          "coral:local:${COMPILE_OUTPUT_DIR}"
           "${REGISTRY_STORE}"
 
       - name: Upload Recompiled Registry Indexes

--- a/.github/workflows/generate-connector-registries.yml
+++ b/.github/workflows/generate-connector-registries.yml
@@ -165,8 +165,6 @@ jobs:
     env:
       REGISTRY_STORE: ${{ inputs.store || 'coral:prod' }}
       REGISTRY_BUCKET: prod-airbyte-cloud-connector-metadata-service
-      REHEARSAL_DIR: ${{ runner.temp }}/registry-rehearsal
-      REPORT_DIR: ${{ runner.temp }}/registry-rehearsal-reports
 
     steps:
       - name: Install uv
@@ -176,10 +174,17 @@ jobs:
         # The minimum version is gated on the airbyte-ops-mcp PR 1264 release.
         run: uv tool install "airbyte-internal-ops>=0.99.0"
 
+      - name: Resolve Variables
+        id: resolve-vars
+        shell: bash
+        run: |
+          echo "REHEARSAL_DIR=$RUNNER_TEMP/registry-rehearsal" | tee -a "$GITHUB_ENV"
+          echo "REPORT_DIR=$RUNNER_TEMP/registry-rehearsal-reports" | tee -a "$GITHUB_ENV"
+
       - name: Compile Registry Rehearsal
         id: compile-rehearsal
         env:
-          # Prefer a read-only production credential here once one is available.
+          # This credential is read/write; the Ops CLI enforces the source-store read-only guarantee.
           GCS_CREDENTIALS: ${{ secrets.METADATA_SERVICE_PROD_GCS_CREDENTIALS }}
           FORCE_FLAG: ${{ inputs.force == true && '--force' || '' }}
           CONNECTOR_NAME_FLAG: ${{ inputs.connector-name && format('--connector-name {0}', inputs.connector-name) || '' }}

--- a/.github/workflows/generate-connector-registries.yml
+++ b/.github/workflows/generate-connector-registries.yml
@@ -26,7 +26,7 @@ on:
         required: false
         type: string
       dry-run:
-        description: "Compile a local rehearsal and compare it with the reference store without writing the store."
+        description: "Compile to local output and compare it with the reference store without writing the store."
         required: false
         type: boolean
         default: false
@@ -51,7 +51,7 @@ on:
         type: string
         default: "coral:prod"
       dry-run:
-        description: "Compile a local rehearsal and compare it with the reference store without writing the store."
+        description: "Compile to local output and compare it with the reference store without writing the store."
         required: false
         type: boolean
         default: false
@@ -178,11 +178,11 @@ jobs:
         id: resolve-vars
         shell: bash
         run: |
-          echo "REHEARSAL_DIR=$RUNNER_TEMP/registry-rehearsal" | tee -a "$GITHUB_ENV"
-          echo "REPORT_DIR=$RUNNER_TEMP/registry-rehearsal-reports" | tee -a "$GITHUB_ENV"
+          echo "COMPILE_OUTPUT_DIR=$RUNNER_TEMP/registry-compile-output" | tee -a "$GITHUB_ENV"
+          echo "REPORT_DIR=$RUNNER_TEMP/registry-comparison-reports" | tee -a "$GITHUB_ENV"
 
-      - name: Compile Registry Rehearsal
-        id: compile-rehearsal
+      - name: Compile Registry To Local Output
+        id: compile-dryrun
         env:
           # This credential is read/write; the Ops CLI enforces the source-store read-only guarantee.
           GCS_CREDENTIALS: ${{ secrets.METADATA_SERVICE_PROD_GCS_CREDENTIALS }}
@@ -192,12 +192,12 @@ jobs:
         run: >
           airbyte-ops registry store compile
           --store "${REGISTRY_STORE}"
-          --output-store "file:${REHEARSAL_DIR}"
+          --output-store "file:${COMPILE_OUTPUT_DIR}"
           --with-secrets-mask
           ${FORCE_FLAG}
           ${CONNECTOR_NAME_FLAG}
 
-      - name: Prepare Registry Rehearsal Reports
+      - name: Prepare Comparison Report Directory
         if: always()
         run: mkdir -p "${REPORT_DIR}/prod-snapshot"
 
@@ -233,9 +233,9 @@ jobs:
           "gs://${REGISTRY_BUCKET}/registries/v0/composite_registry.json"
           "${REPORT_DIR}/prod-snapshot/composite_registry.json"
 
-      - name: Compare Registry Rehearsal
+      - name: Compare Compiled Output With Production
         if: >
-          steps.compile-rehearsal.outcome == 'success' &&
+          steps.compile-dryrun.outcome == 'success' &&
           steps.authenticate-gcloud.outcome == 'success'
         env:
           GCS_CREDENTIALS: ${{ secrets.METADATA_SERVICE_PROD_GCS_CREDENTIALS }}
@@ -245,39 +245,39 @@ jobs:
           --assert-stable
           --html-report "${REPORT_DIR}/report.html"
           --text-report "${REPORT_DIR}/report.txt"
-          "file:${REHEARSAL_DIR}"
+          "file:${COMPILE_OUTPUT_DIR}"
           "${REGISTRY_STORE}"
 
       - name: Upload Recompiled Registry Indexes
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: registry-rehearsal-recompiled
-          path: ${{ env.REHEARSAL_DIR }}/registries/v0/*.json
+          name: registry-compiled-indexes
+          path: ${{ env.COMPILE_OUTPUT_DIR }}/registries/v0/*.json
           if-no-files-found: ignore
 
       - name: Upload Production Registry Snapshot
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: registry-rehearsal-production-snapshot
+          name: registry-production-snapshot
           path: ${{ env.REPORT_DIR }}/prod-snapshot/*.json
           if-no-files-found: ignore
 
-      - name: Upload Registry Rehearsal Text Report
+      - name: Upload Registry Comparison Text Report
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: registry-rehearsal-report.txt
+          name: comparison-report.txt
           path: ${{ env.REPORT_DIR }}/report.txt
           archive: false
           if-no-files-found: ignore
 
-      - name: Upload Registry Rehearsal HTML Report
+      - name: Upload Registry Comparison HTML Report
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: registry-rehearsal-report.html
+          name: comparison-report.html
           path: ${{ env.REPORT_DIR }}/report.html
           archive: false
           if-no-files-found: ignore

--- a/.github/workflows/generate-connector-registries.yml
+++ b/.github/workflows/generate-connector-registries.yml
@@ -68,8 +68,8 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  compile-registries:
-    name: Compile Registries (ops CLI)
+  registry-compile:
+    name: Compile Registry
     if: inputs.dry-run != true
     runs-on: ubuntu-24.04
     env:
@@ -89,7 +89,7 @@ jobs:
         run: uv tool install airbyte-internal-ops
 
       - name: Compile Registries
-        id: compile-registries
+        id: registry-compile
         env:
           GCS_CREDENTIALS: ${{ secrets.METADATA_SERVICE_PROD_GCS_CREDENTIALS }}
           FORCE_FLAG: ${{ inputs.force == true && '--force' || '' }}
@@ -133,7 +133,7 @@ jobs:
           echo "run-url=${RUN_URL}" >> $GITHUB_OUTPUT
 
       - name: Notify Slack on Registry Compile Success
-        if: steps.compile-registries.outcome == 'success'
+        if: steps.registry-compile.outcome == 'success'
         uses: slackapi/slack-github-action@70cd7be8e40a46e8b0eced40b0de447bdb42f68e # v1.26.0
         with:
           payload: |
@@ -146,7 +146,7 @@ jobs:
           SLACK_WEBHOOK_URL: ${{ secrets.PUBLISH_ON_MERGE_SLACK_WEBHOOK }}
 
       - name: Notify Slack on Registry Compile Failure
-        if: always() && steps.compile-registries.outcome == 'failure'
+        if: always() && steps.registry-compile.outcome == 'failure'
         uses: slackapi/slack-github-action@70cd7be8e40a46e8b0eced40b0de447bdb42f68e # v1.26.0
         with:
           payload: |
@@ -158,8 +158,8 @@ jobs:
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.PUBLISH_ON_MERGE_SLACK_WEBHOOK }}
 
-  rehearse-registry-compile:
-    name: Rehearse Registry Compile (read-only)
+  registry-compile-dryrun:
+    name: Compile Registry (Dry-Run)
     if: inputs.dry-run == true
     runs-on: ubuntu-24.04
     env:

--- a/.github/workflows/generate-connector-registries.yml
+++ b/.github/workflows/generate-connector-registries.yml
@@ -25,6 +25,11 @@ on:
         description: "Associated pull request number, for linking in notifications."
         required: false
         type: string
+      dry-run:
+        description: "Compile a local rehearsal and compare it with the reference store without writing the store."
+        required: false
+        type: boolean
+        default: false
   workflow_call:
     inputs:
       pr:
@@ -45,6 +50,11 @@ on:
         required: false
         type: string
         default: "coral:prod"
+      dry-run:
+        description: "Compile a local rehearsal and compare it with the reference store without writing the store."
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -60,6 +70,7 @@ concurrency:
 jobs:
   compile-registries:
     name: Compile Registries (ops CLI)
+    if: inputs.dry-run != true
     runs-on: ubuntu-24.04
     env:
       REGISTRY_STORE: ${{ inputs.store || 'coral:prod' }}
@@ -146,3 +157,117 @@ jobs:
             }
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.PUBLISH_ON_MERGE_SLACK_WEBHOOK }}
+
+  rehearse-registry-compile:
+    name: Rehearse Registry Compile (read-only)
+    if: inputs.dry-run == true
+    runs-on: ubuntu-24.04
+    env:
+      REGISTRY_STORE: ${{ inputs.store || 'coral:prod' }}
+      REGISTRY_BUCKET: prod-airbyte-cloud-connector-metadata-service
+      REHEARSAL_DIR: ${{ runner.temp }}/registry-rehearsal
+      REPORT_DIR: ${{ runner.temp }}/registry-rehearsal-reports
+
+    steps:
+      - name: Checkout Airbyte
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ github.event.inputs.gitref || github.ref }}
+          submodules: true
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
+
+      - name: Install Ops CLI
+        # The minimum version is gated on the airbyte-ops-mcp PR 1264 release.
+        run: uv tool install "airbyte-internal-ops>=0.99.0"
+
+      - name: Compile Registry Rehearsal
+        id: compile-rehearsal
+        env:
+          # Prefer a read-only production credential here once one is available.
+          GCS_CREDENTIALS: ${{ secrets.METADATA_SERVICE_PROD_GCS_CREDENTIALS }}
+          FORCE_FLAG: ${{ inputs.force == true && '--force' || '' }}
+          CONNECTOR_NAME_FLAG: ${{ inputs.connector-name && format('--connector-name {0}', inputs.connector-name) || '' }}
+        shell: bash
+        run: >
+          airbyte-ops registry store compile
+          --store "${REGISTRY_STORE}"
+          --output-store "file:${REHEARSAL_DIR}"
+          --with-secrets-mask
+          ${FORCE_FLAG}
+          ${CONNECTOR_NAME_FLAG}
+
+      - name: Prepare Registry Rehearsal Reports
+        if: always()
+        run: mkdir -p "${REPORT_DIR}/prod-snapshot"
+
+      - name: Authenticate to Google Cloud
+        id: authenticate-gcloud
+        if: always()
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
+        with:
+          credentials_json: ${{ secrets.METADATA_SERVICE_PROD_GCS_CREDENTIALS }}
+
+      - name: Download Production Registry Snapshot
+        if: always()
+        shell: bash
+        run: |
+          gcloud storage cp \
+            "gs://${REGISTRY_BUCKET}/registries/v0/cloud_registry.json" \
+            "${REPORT_DIR}/prod-snapshot/cloud_registry.json"
+          gcloud storage cp \
+            "gs://${REGISTRY_BUCKET}/registries/v0/oss_registry.json" \
+            "${REPORT_DIR}/prod-snapshot/oss_registry.json"
+          gcloud storage cp \
+            "gs://${REGISTRY_BUCKET}/registries/v0/composite_registry.json" \
+            "${REPORT_DIR}/prod-snapshot/composite_registry.json"
+
+      - name: Compare Registry Rehearsal
+        if: >
+          steps.compile-rehearsal.outcome == 'success' &&
+          steps.authenticate-gcloud.outcome == 'success'
+        env:
+          GCS_CREDENTIALS: ${{ secrets.METADATA_SERVICE_PROD_GCS_CREDENTIALS }}
+        shell: bash
+        run: >
+          airbyte-ops registry store compare
+          --assert-stable
+          --html-report "${REPORT_DIR}/report.html"
+          --text-report "${REPORT_DIR}/report.txt"
+          "file:${REHEARSAL_DIR}"
+          "${REGISTRY_STORE}"
+
+      - name: Upload Recompiled Registry Indexes
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: registry-rehearsal-recompiled
+          path: ${{ runner.temp }}/registry-rehearsal/registries/v0/*.json
+          if-no-files-found: ignore
+
+      - name: Upload Production Registry Snapshot
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: registry-rehearsal-production-snapshot
+          path: ${{ runner.temp }}/registry-rehearsal-reports/prod-snapshot/*.json
+          if-no-files-found: ignore
+
+      - name: Upload Registry Rehearsal Text Report
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: registry-rehearsal-report-txt
+          path: ${{ runner.temp }}/registry-rehearsal-reports/report.txt
+          archive: false
+          if-no-files-found: ignore
+
+      - name: Upload Registry Rehearsal HTML Report
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: registry-rehearsal-report-html
+          path: ${{ runner.temp }}/registry-rehearsal-reports/report.html
+          archive: false
+          if-no-files-found: ignore

--- a/.github/workflows/generate-connector-registries.yml
+++ b/.github/workflows/generate-connector-registries.yml
@@ -62,7 +62,7 @@ permissions:
 concurrency:
   # Only allow one active run, and one pending run.
   # This prevents race conditions between multiple runs of this workflow.
-  group: generate-connector-registry-${{ inputs.dry-run }}
+  group: ${{ inputs.dry-run == true && 'generate-connector-registry-dry-run' || 'generate-connector-registry' }}
   # If a new run is triggered while there's already one in-progress,
   # allow the in-progress run to finish.
   cancel-in-progress: false


### PR DESCRIPTION
## What

Adds a `dry-run` mode to **Generate Connector Registries** so a full registry compile can be rehearsed against production with no possibility of writing to it.

The concern this addresses: a full compile is hard to approve because there is no way to see what it *would* do. Today the only options are trusting it or mirroring prod into dev first. In dry-run mode the production bucket is an input only, the compiled output lands in a local directory on the runner, and the run publishes four artifacts for review — including a self-contained HTML report that renders directly in GitHub's artifact viewer.

Requires the CLI support in https://github.com/airbytehq/airbyte-ops-mcp/pull/1264, which is not released yet. The install pins `airbyte-internal-ops>=0.99.0` so a run before that release fails at install rather than on an unrecognized flag.

## How

`dry-run` is a boolean input on both `workflow_dispatch` and `workflow_call`. Rather than threading conditionals through the existing job, the rehearsal is a separate job:

```yaml
registry-compile:          if: inputs.dry-run != true    # writes prod, unchanged
registry-compile-dryrun:   if: inputs.dry-run == true    # reads prod, writes $RUNNER_TEMP
```

The separation is the point. `--with-legacy-migration v1` deletes source objects and is not reachable from the rehearsal path at all, so a rehearsal is never one mistaken conditional away from the code path that mutates the store. On the CLI side, `--output-store` wraps the source filesystem in a proxy that raises on every mutating operation.

Rehearsal steps:

```bash
airbyte-ops registry store compile  --store coral:prod --output-store "file:$REHEARSAL_DIR" --with-secrets-mask
airbyte-ops registry store compare  --assert-stable --html-report … --text-report … "file:$REHEARSAL_DIR" coral:prod
```

`--assert-stable` makes the exit code reflect four safety assertions only: connectors added, connectors dropped, latest version moved forward, latest version moved backward. Ordinary content differences are expected — prod is live and real publishes land mid-run — so they are reported but do not fail the job.

Artifacts, all uploaded with `if: always()` so a failed assertion still ships the evidence explaining it:

1. `registry-rehearsal-recompiled` — recompiled `registries/v0` indexes
2. `registry-rehearsal-production-snapshot` — the same indexes pulled from GCS at run time
3. `registry-rehearsal-report.txt`
4. `registry-rehearsal-report.html`

The two reports use `actions/upload-artifact@v7` with `archive: false`, which serves a single file un-zipped; the artifact names keep their extensions so the HTML renders in the browser instead of downloading.

## Review guide

1. `.github/workflows/generate-connector-registries.yml` — on the existing job, the `if:` guard and a rename to `registry-compile` are the only changes; everything else is additive.

Three details worth a look:

- **Concurrency** is now keyed on `inputs.dry-run`, so a rehearsal never occupies the slot of a real compile (the group has `cancel-in-progress: false`, so sharing it would mean a dry-run could delay a production run).
- **No checkout** in the rehearsal job — compile reads the store from GCS, not the working tree, and a submodule checkout of this repo costs minutes for nothing.
- **No Slack notification** from the rehearsal job. Those messages announce that the production registry moved; a dry-run moves nothing, and a success ping linking the live registry URLs would be misleading.

## User Impact

None by default: `dry-run` defaults to `false` and the production compile path is byte-identical apart from its `if:` guard.

Accepted risk, not an open item: the job uses `secrets.METADATA_SERVICE_PROD_GCS_CREDENTIALS`, which is read/write on prod, because service accounts can't be bifurcated in this workflow. The read-only guarantee therefore rests on the CLI, where a read-only store can only ever yield a filesystem proxy that raises on every mutation, plus a dev-bucket integration test that runs the rehearsal with a credential that *can* write and asserts no object changed.

Note on verification: this workflow only runs on `workflow_dispatch`, so no CI run on this PR executes the new job — green checks here mean the file parses and `actionlint` is satisfied, nothing more. The first real dispatch after the CLI release is the actual test.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚
- [ ] NO ❌


Link to Devin session: https://app.devin.ai/sessions/2eba0ca3227c436b90e666534f85581b
Requested by: @aaronsteers