### PR TITLE
docs(release-notes): Cloud release notes for Jul 27 - Aug 12, 2026

### DIFF
--- a/docs/release_notes/cloud/readme.md
+++ b/docs/release_notes/cloud/readme.md
@@ -2,6 +2,48 @@
 
 Airbyte Cloud is updated continuously. You always have the latest features and fixes.
 
+## August 12, 2026
+
+Connections
+
+- When you set up a new source or destination, Airbyte now opens the configuration form first instead of the AI setup assistant. You can still switch to the assistant at any time with the Agent/Form toggle at the top of the page.
+
+## August 11, 2026
+
+Platform
+
+- Airbyte Cloud now uses a new cookie consent tool. You see a redesigned consent banner on your first visit, and you can still change your choices at any time with the Cookie preferences option in your user settings.
+
+## August 7, 2026
+
+Connections
+
+- Some syncs now run faster. Airbyte correctly reads the processing capacity allotted to a sync and opens as many parallel data channels as that capacity allows, instead of falling back to a single channel.
+
+## August 6, 2026
+
+API
+
+- Not-found (404) error responses in the API no longer declare a message as required. If you generate a client from Airbyte's API spec, those clients no longer fail to parse a not-found response that comes back without a message.
+
+## August 5, 2026
+
+Platform
+
+- You can now assign two new workspace roles from the Members page: Source editor and Destination editor. A source editor can create and edit a workspace's sources and connections but not its destinations, and a destination editor can do the reverse. Both roles are available on the Pro and Enterprise Flex plans.
+
+## August 3, 2026
+
+Platform
+
+- Your Data Worker usage now reflects only the capacity your syncs are actually using. Previously, if a job reached a failed or cancelled state moments before its capacity reservation was recorded, that capacity stayed reserved indefinitely, overstating your organization's usage and leaving less capacity available for new syncs.
+
+## July 27, 2026
+
+Platform
+
+- The invitation code that lets someone join your organization or workspace is now sent only to the person you invited. It's no longer visible to anyone viewing your list of pending invitations, so an invitation can only be accepted by its intended recipient. Inviting, viewing, and canceling pending invitations in Settings works exactly as before.
+
 ## July 23, 2026
 
 Connections

--- a/docs/release_notes/cloud/readme.md
+++ b/docs/release_notes/cloud/readme.md
@@ -36,13 +36,13 @@ Platform
 
 Platform
 
-- Your Data Worker usage now reflects only the capacity your syncs are actually using. Previously, if a job reached a failed or cancelled state moments before its capacity reservation was recorded, that capacity stayed reserved indefinitely, overstating your organization's usage and leaving less capacity available for new syncs.
+- Your Data Worker usage now reflects only the capacity your syncs are actually using. Previously, if a job reached a failed or cancelled state moments before Airbyte recorded its capacity reservation, that capacity stayed reserved indefinitely, overstating your organization's usage and leaving less capacity available for new syncs.
 
 ## July 27, 2026
 
 Platform
 
-- The invitation code that lets someone join your organization or workspace is now sent only to the person you invited. It's no longer visible to anyone viewing your list of pending invitations, so an invitation can only be accepted by its intended recipient. Inviting, viewing, and canceling pending invitations in Settings works exactly as before.
+- The invitation code that lets someone join your organization or workspace is now sent only to the person you invited. It's no longer visible to anyone viewing your list of pending invitations, so only the intended recipient can accept an invitation. Inviting, viewing, and canceling pending invitations in Settings works exactly as before.
 
 ## July 23, 2026
 


### PR DESCRIPTION
## What

Backfills the Cloud release notes for every publication day between July 27 and August 12, 2026, replacing 7 stalled daily PRs that each conflicted with the next.

Requested by Ian Alton, who asked to consolidate the pending daily `docs(release-notes):` PRs rather than merge them one at a time.

Supersedes: airbytehq/airbyte#82764, airbytehq/airbyte#83341, airbytehq/airbyte#83716, airbytehq/airbyte#83761, airbytehq/airbyte#83779, airbytehq/airbyte#84205, airbytehq/airbyte#84299

Jul 28-31, Aug 4, and Aug 10 have no Cloud entries because there were no notes on those days, not because a PR is missing.

## How

Each superseded PR added exactly one `## <date>` block immediately below the file header, with zero deletions, so all 7 conflicted in the same single hunk. Instead of resolving 7 sequential merges, the added lines from each PR's diff were extracted from the GitHub API and inserted as one batch in descending date order at the same insertion point:

```
header
<Aug 12> <Aug 11> <Aug 7> <Aug 6> <Aug 5> <Aug 3> <Jul 27>
## July 23, 2026   <- previous top of file
```

The prose is unchanged from the original PRs except for two sentences reworded at the maintainer's request to clear Vale's `Google.Passive` suggestions on the new lines:

- Aug 3: `... before its capacity reservation was recorded` -> `... before Airbyte recorded its capacity reservation`
- Jul 27: `... so an invitation can only be accepted by its intended recipient` -> `... so only the intended recipient can accept an invitation`

Vale's remaining alert on the added lines is one `Google.Parens` suggestion for `Not-found (404)`, kept as written because the status code in parentheses is informative. Nothing on the added lines is at error or warning level, which is what CI gates on.

## Review guide

1. `docs/release_notes/cloud/readme.md` — 42 insertions, 0 deletions.

## User Impact

The Cloud release notes page on docs.airbyte.com goes from ending at July 23 to covering through August 12.

## Test plan

- `vale --config=docusaurus/vale.ini docs/release_notes/cloud/readme.md`, filtered to the lines this branch adds: 0 errors, 0 warnings, 1 suggestion (the `(404)` parentheses).
- `markdownlint` on the changed file: clean.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚


Link to Devin session: https://app.devin.ai/sessions/bf0fe7ee64ba4d558eaa94472f5f5aa0
Requested by: @ian-at-airbyte