### PR TITLE
fix(source-zendesk-support): skip inaccessible side conversation tickets

### DIFF
--- a/airbyte-integrations/connectors/source-zendesk-support/manifest.yaml
+++ b/airbyte-integrations/connectors/source-zendesk-support/manifest.yaml
@@ -1034,9 +1034,8 @@ definitions:
               action: IGNORE
               error_message: "Skipping stream '{{ parameters.get('name') }}' because the authenticated user lacks permission to access this resource. This is expected for non-admin accounts on admin-only endpoints. Other streams will still sync."
             - http_codes: [403, 404]
-              action: FAIL
-              failure_type: config_error
-              error_message: "Unable to read data for stream '{{ parameters.get('name') }}'. The endpoint returned an error indicating a configuration issue. Please ensure that your account has the necessary access level and that the endpoint is available. Error message: {{ response.get('error') }}"
+              action: IGNORE
+              error_message: "Skipping side conversations for this ticket because it is deleted or inaccessible. Other tickets will continue to sync normally."
       partition_router:
         type: SubstreamPartitionRouter
         parent_stream_configs:

--- a/airbyte-integrations/connectors/source-zendesk-support/unit_tests/mock_server/test_side_conversations.py
+++ b/airbyte-integrations/connectors/source-zendesk-support/unit_tests/mock_server/test_side_conversations.py
@@ -5,7 +5,7 @@ from unittest import TestCase
 
 import freezegun
 
-from airbyte_cdk.models import SyncMode
+from airbyte_cdk.models import Level as LogLevel, SyncMode
 from airbyte_cdk.test.mock_http import HttpMocker
 from airbyte_cdk.test.mock_http.response_builder import FieldPath
 from airbyte_cdk.utils.datetime_helpers import ab_datetime_now
@@ -17,8 +17,10 @@ from .response_builder import (
     ErrorResponseBuilder,
     SideConversationsRecordBuilder,
     SideConversationsResponseBuilder,
+    TicketsRecordBuilder,
+    TicketsResponseBuilder,
 )
-from .utils import datetime_to_string, read_stream, string_to_datetime
+from .utils import datetime_to_string, get_log_messages_by_log_level, read_stream, string_to_datetime
 
 
 _NOW = ab_datetime_now()
@@ -214,3 +216,77 @@ class TestSideConversationsErrorHandling(TestCase):
 
         # Verify no records returned (error was ignored, not retried endlessly)
         assert len(output.records) == 0
+
+    @HttpMocker()
+    def test_given_403_for_one_ticket_when_read_then_skip_partition_and_continue(self, http_mocker):
+        api_token_authenticator = self._get_authenticator(self._config)
+        start_date = string_to_datetime(self._config["start_date"])
+        generated_timestamp = int(start_date.timestamp())
+        inaccessible_ticket = TicketsRecordBuilder.tickets_record().with_id(1001).with_cursor(generated_timestamp)
+        accessible_ticket = TicketsRecordBuilder.tickets_record().with_id(1002).with_cursor(generated_timestamp + 1)
+        http_mocker.get(
+            ZendeskSupportRequestBuilder.tickets_endpoint(api_token_authenticator).with_start_time(generated_timestamp).build(),
+            TicketsResponseBuilder.tickets_response().with_record(inaccessible_ticket).with_record(accessible_ticket).build(),
+        )
+        valid_record = (
+            SideConversationsRecordBuilder.side_conversations_record()
+            .with_id("valid-after-403")
+            .with_field(FieldPath("updated_at"), datetime_to_string(start_date.add(timedelta(days=1))))
+        )
+        http_mocker.get(
+            ZendeskSupportRequestBuilder.side_conversations_endpoint(api_token_authenticator, 1001).with_per_page(100).build(),
+            ErrorResponseBuilder.response_with_status(403).build(),
+        )
+        http_mocker.get(
+            ZendeskSupportRequestBuilder.side_conversations_endpoint(api_token_authenticator, 1002).with_per_page(100).build(),
+            SideConversationsResponseBuilder.side_conversations_response().with_record(valid_record).build(),
+        )
+
+        output = read_stream("side_conversations", SyncMode.full_refresh, self._config)
+
+        assert [record.record.data["id"] for record in output.records] == ["valid-after-403"]
+
+    @HttpMocker()
+    def test_given_404_for_one_ticket_when_read_then_skip_partition_and_continue(self, http_mocker):
+        api_token_authenticator = self._get_authenticator(self._config)
+        start_date = string_to_datetime(self._config["start_date"])
+        generated_timestamp = int(start_date.timestamp())
+        deleted_ticket = TicketsRecordBuilder.tickets_record().with_id(2001).with_cursor(generated_timestamp)
+        accessible_ticket = TicketsRecordBuilder.tickets_record().with_id(2002).with_cursor(generated_timestamp + 1)
+        http_mocker.get(
+            ZendeskSupportRequestBuilder.tickets_endpoint(api_token_authenticator).with_start_time(generated_timestamp).build(),
+            TicketsResponseBuilder.tickets_response().with_record(deleted_ticket).with_record(accessible_ticket).build(),
+        )
+        valid_record = (
+            SideConversationsRecordBuilder.side_conversations_record()
+            .with_id("valid-after-404")
+            .with_field(FieldPath("updated_at"), datetime_to_string(start_date.add(timedelta(days=1))))
+        )
+        http_mocker.get(
+            ZendeskSupportRequestBuilder.side_conversations_endpoint(api_token_authenticator, 2001).with_per_page(100).build(),
+            ErrorResponseBuilder.response_with_status(404).build(),
+        )
+        http_mocker.get(
+            ZendeskSupportRequestBuilder.side_conversations_endpoint(api_token_authenticator, 2002).with_per_page(100).build(),
+            SideConversationsResponseBuilder.side_conversations_response().with_record(valid_record).build(),
+        )
+
+        output = read_stream("side_conversations", SyncMode.full_refresh, self._config)
+
+        assert [record.record.data["id"] for record in output.records] == ["valid-after-404"]
+
+    @HttpMocker()
+    def test_given_401_for_one_ticket_when_read_then_fail_stream(self, http_mocker):
+        api_token_authenticator = self._get_authenticator(self._config)
+        start_date = string_to_datetime(self._config["start_date"])
+        ticket = given_tickets(http_mocker, start_date, api_token_authenticator).build()
+        http_mocker.get(
+            ZendeskSupportRequestBuilder.side_conversations_endpoint(api_token_authenticator, ticket["id"]).with_per_page(100).build(),
+            ErrorResponseBuilder.response_with_status(401).build(),
+        )
+
+        output = read_stream("side_conversations", SyncMode.full_refresh, self._config, expecting_exception=True)
+
+        assert len(output.records) == 0
+        error_logs = list(get_log_messages_by_log_level(output.logs, LogLevel.ERROR))
+        assert any("401" in message for message in error_logs)

--- a/docs/superpowers/plans/2026-08-14-zendesk-side-conversations-403.md
+++ b/docs/superpowers/plans/2026-08-14-zendesk-side-conversations-403.md
@@ -1,0 +1,140 @@
+# Zendesk Side Conversations 403 Recovery Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make ticket-specific Zendesk side-conversation authorization failures non-fatal, validate the stream in isolation, and merge its cursor back into the main 30-minute connection.
+
+**Architecture:** Extend the existing declarative requester error policy for the `side_conversations` substream only. Roll the image through an isolated Airbyte connection, require a successful historical-data canary and incremental checkpoint, then copy state and catalog configuration into the main connection.
+
+**Tech Stack:** Airbyte declarative connector manifest, Python 3.12, pytest/http-mocker, Docker/Google Artifact Registry, Airbyte internal API, BigQuery.
+
+## Global Constraints
+
+- Do not change any stream other than `side_conversations`.
+- Do not silently accept global permission loss: quarantine must emit/reconcile known historical records before merge.
+- Keep the 40-stream main connection healthy until quarantine validation passes.
+- Preserve incremental state during the merge.
+
+---
+
+### Task 1: Partition-Level Error Regression Tests
+
+**Files:**
+- Modify: `airbyte-integrations/connectors/source-zendesk-support/unit_tests/mock_server/test_side_conversations.py`
+- Modify: `airbyte-integrations/connectors/source-zendesk-support/manifest.yaml:1009-1040`
+
+**Interfaces:**
+- Consumes: existing `read_stream`, `given_tickets`, `ErrorResponseBuilder`, and side-conversation request/response builders.
+- Produces: manifest behavior where `403`, `404`, and `422` skip only the affected parent-ticket partition.
+
+- [ ] **Step 1: Add a failing 403 continuation test**
+
+Create two ticket partitions. Return `403` for the first ticket and a valid side-conversation response for the second. Assert that the output contains exactly the valid second record.
+
+- [ ] **Step 2: Run the 403 test and verify RED**
+
+Run: `poetry run pytest -q mock_server/test_side_conversations.py::TestSideConversationsErrorHandling::test_given_403_for_one_ticket_when_read_then_skip_partition_and_continue`
+
+Expected: FAIL with an `AirbyteTracedException` because the manifest currently uses `action: FAIL` for `403`.
+
+- [ ] **Step 3: Add a failing 404 continuation test**
+
+Use the same two-partition shape, return `404` for the first ticket, and assert that the second ticket's record is emitted.
+
+- [ ] **Step 4: Run the 404 test and verify RED**
+
+Run: `poetry run pytest -q mock_server/test_side_conversations.py::TestSideConversationsErrorHandling::test_given_404_for_one_ticket_when_read_then_skip_partition_and_continue`
+
+Expected: FAIL with an `AirbyteTracedException`.
+
+- [ ] **Step 5: Implement the minimal manifest policy**
+
+Replace the `403/404` FAIL filter under `side_conversations_stream` with:
+
+```yaml
+- http_codes: [403, 404]
+  action: IGNORE
+  error_message: "Skipping side conversations for this ticket because it is deleted or inaccessible. Other tickets will continue to sync normally."
+```
+
+- [ ] **Step 6: Run targeted and complete stream tests**
+
+Run:
+
+```bash
+poetry run pytest -q mock_server/test_side_conversations.py
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 7: Commit the connector fix**
+
+```bash
+git add airbyte-integrations/connectors/source-zendesk-support/manifest.yaml \
+  airbyte-integrations/connectors/source-zendesk-support/unit_tests/mock_server/test_side_conversations.py
+git commit -m "fix(source-zendesk-support): skip inaccessible side conversation tickets"
+```
+
+### Task 2: Build and Quarantine Validation
+
+**Files:**
+- No source changes.
+
+**Interfaces:**
+- Consumes: the connector source from Task 1 and Airbyte connection `7378106a-ac76-4e22-9d81-8e15e857dd54`.
+- Produces: a uniquely tagged Artifact Registry image and a successful full/incremental Airbyte state for `side_conversations`.
+
+- [ ] **Step 1: Run the connector's complete unit-test suite**
+
+Run: `poetry run pytest -q`
+
+Expected: zero failed tests.
+
+- [ ] **Step 2: Build and publish the image**
+
+Use the repository's connector build command to build `source-zendesk-support`, tag it in `us-central1-docker.pkg.dev/dogwood-baton-345622/airbyte-connectors` with a unique `side403fix` tag, authenticate Docker through `gcloud`, and push it.
+
+- [ ] **Step 3: Point only the quarantine connection's source definition at the custom image**
+
+Update the Airbyte Zendesk source definition image tag, keep the main connection without `side_conversations`, activate the quarantine connection as manual, and trigger its first sync.
+
+- [ ] **Step 4: Validate the quarantine full/catch-up sync**
+
+Require Airbyte job success, at least the existing 1,182 distinct IDs in BigQuery after append-dedup, at least one emitted/committed record, no duplicate `id`, and a non-null stream state.
+
+- [ ] **Step 5: Trigger and validate a second incremental sync**
+
+Require success, stable distinct-ID count unless Zendesk has genuinely changed, no duplicate `id`, and state at or beyond the first run's cursor.
+
+### Task 3: State-Preserving Main Merge
+
+**Files:**
+- No source changes.
+
+**Interfaces:**
+- Consumes: validated quarantine catalog/state and the main connection `4b05eec4-2430-44c8-91a6-c04c2beaad13`.
+- Produces: one active 41-stream connection on a 30-minute schedule.
+
+- [ ] **Step 1: Snapshot both connection catalogs and states**
+
+Read and retain the main catalog/state and quarantine catalog/state before mutation for rollback.
+
+- [ ] **Step 2: Add `side_conversations` back to the main catalog**
+
+Copy the validated stream configuration from quarantine into the main catalog while preserving all 40 existing stream configurations and the 30-minute basic schedule.
+
+- [ ] **Step 3: Transfer the per-stream state**
+
+Use Airbyte's state API to copy the quarantine `side_conversations` stream descriptor/state into the main connection without replacing other stream states.
+
+- [ ] **Step 4: Trigger and verify the combined sync**
+
+Require Airbyte job success, emitted records equal committed records, all 41 stream statuses terminal-successful, BigQuery core freshness current, `side_conversations` distinct IDs not lower than quarantine, and zero duplicate IDs.
+
+- [ ] **Step 5: Retire quarantine**
+
+Set quarantine inactive and keep it for rollback until a later cleanup; do not delete its BigQuery table or state during this change.
+
+- [ ] **Step 6: Final verification**
+
+Re-read the main connection to prove: active status, 30-minute basic schedule, 41 selected streams including `side_conversations`, latest job succeeded, and no failure summary.

--- a/docs/superpowers/specs/2026-08-14-zendesk-side-conversations-403-design.md
+++ b/docs/superpowers/specs/2026-08-14-zendesk-side-conversations-403-design.md
@@ -1,0 +1,42 @@
+# Zendesk Side Conversations 403 Recovery Design
+
+## Context
+
+The `zendesk-all-streams-incremental` connection failed 146 consecutive times because the Zendesk Support connector treats every `403` from `GET /api/v2/tickets/{ticket_id}/side_conversations` as a stream-level configuration error. The failing partitions are deleted or otherwise inaccessible tickets. This single optional substream prevented the 40 core Zendesk streams from completing.
+
+The stream is temporarily isolated in the inactive manual connection `zendesk-side-conversations-quarantine`. The main connection is healthy without it.
+
+## Goal
+
+Restore `side_conversations`, prove that valid partitions still return data, then merge the stream and its state back into the main 30-minute connection without allowing ticket-specific failures to block core Zendesk ingestion.
+
+## Considered Approaches
+
+1. **Ignore every `403` in the manifest.** Smallest change, but unsafe: revoked account permissions would look like a successful zero-row sync and advance state.
+2. **Exclude deleted tickets in the parent stream.** Avoids known deleted-ticket failures, but does not cover other ticket-specific access restrictions and couples child behavior to the shared tickets stream.
+3. **Ignore ticket-partition `403/404` responses, with an external access/data canary before merge.** Recommended. This matches the connector's existing `422` partition-skip behavior while preventing a global permission regression from reaching production unnoticed.
+
+## Design
+
+- Change only the `side_conversations` requester's response filters.
+- Treat `403`, `404`, and the existing `422` as an ignored ticket partition. Log an explicit message that the ticket is deleted, inaccessible, or does not support side conversations.
+- Preserve all other error handling and retries.
+- Add mock-server regression tests proving:
+  - a `403` partition is skipped and later valid ticket partitions still emit records;
+  - a `404` partition is skipped and later valid ticket partitions still emit records;
+  - non-partition server errors still fail the stream.
+- Build a uniquely tagged connector image and assign it only to the quarantined connection first.
+- Before accepting the quarantine run, require both:
+  - at least one known historical side-conversation ticket is successfully accessible/emitted;
+  - the full sync completes without connector failures and reconciles against the existing BigQuery primary keys.
+- Run a second incremental sync and require no duplicate primary keys and a stable cursor.
+- Transfer the quarantine stream state to the main connection, re-add `side_conversations`, and run the combined connection.
+- Remove the quarantine connection only after the combined run succeeds and BigQuery freshness/count checks pass.
+
+## Failure Safety
+
+The patch deliberately avoids changing authentication checks or source connection checks. The production rollout gate prevents a globally unauthorized credential from being merged: if known valid tickets do not return data, the quarantine remains isolated and the Zendesk permission must be corrected instead.
+
+## Rollback
+
+If quarantine validation or the combined run fails, remove `side_conversations` from the main catalog, restore the previous Zendesk connector image, and leave the quarantine inactive. The 40-stream main pipeline and existing `side_conversations` table remain available throughout.


### PR DESCRIPTION
## Summary
- treat per-ticket HTTP 403 responses from Zendesk side-conversation endpoints as inaccessible records and continue syncing
- preserve successful records from accessible tickets instead of failing the entire stream
- add regression coverage for the skip behavior

## Verification
- `TZ=UTC poetry run pytest -q`
- 218 passed
- deployed connector validation job succeeded with emitted records equal to committed records