### PR TITLE
fix(source-facebook-pages): remove Insights metrics deprecated by Meta

### DIFF
--- a/airbyte-integrations/connectors/source-facebook-pages/metadata.yaml
+++ b/airbyte-integrations/connectors/source-facebook-pages/metadata.yaml
@@ -10,7 +10,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 010eb12f-837b-4685-892d-0a39f76a98f5
-  dockerImageTag: 2.1.1
+  dockerImageTag: 2.1.2
   dockerRepository: airbyte/source-facebook-pages
   documentationUrl: https://docs.airbyte.com/integrations/sources/facebook-pages
   githubIssueLabel: source-facebook-pages

--- a/airbyte-integrations/connectors/source-facebook-pages/pyproject.toml
+++ b/airbyte-integrations/connectors/source-facebook-pages/pyproject.toml
@@ -3,7 +3,7 @@ requires = [ "poetry-core>=1.0.0",]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
-version = "2.1.1"
+version = "2.1.2"
 name = "source-facebook-pages"
 description = "Source implementation for Facebook Pages."
 authors = [ "Airbyte <contact@airbyte.io>",]

--- a/airbyte-integrations/connectors/source-facebook-pages/source_facebook_pages/manifest.yaml
+++ b/airbyte-integrations/connectors/source-facebook-pages/source_facebook_pages/manifest.yaml
@@ -20,6 +20,18 @@ definitions:
         - action: FAIL
           error_message_contains: Tried accessing nonexisting field
           error_message: Request contains invalid/deprecated field.
+        # Meta rejects the whole Insights request when any single requested metric is
+        # invalid. This is permanent, so it must not fall through to the blanket 400 retry
+        # below, which would otherwise burn six attempts and hide the API's own message.
+        - action: FAIL
+          error_message_contains: must be a valid insights metric
+          failure_type: system_error
+          error_message: >-
+            Facebook rejected one or more of the Insights metrics this connector requested, so the
+            entire request failed. This usually means Meta deprecated a metric that the connector
+            still asks for. Upgrade to the latest connector version; if you are already on the
+            latest version, please report it at https://github.com/airbytehq/airbyte/issues. Facebook
+            returned: {{ response.get('error', {}).get('message', '') }}
         - http_codes: [400]
           action: RETRY
         - action: RETRY
@@ -312,12 +324,7 @@ definitions:
             {{ 
               'insights.metric(%s)' % ','.join([
               'post_media_view',
-              'post_impressions_unique',
-              'post_impressions_paid_unique',
-              'post_impressions_fan_unique',
-              'post_impressions_organic_unique',
-              'post_impressions_viral_unique',
-              'post_impressions_nonviral_unique',
+              'post_total_media_view_unique',
               'post_clicks',
               'post_clicks_by_type',
               'post_reactions_by_type_total',
@@ -342,10 +349,7 @@ definitions:
               'page_post_engagements',
               'page_fan_adds_by_paid_non_paid_unique',
               'page_media_view',
-              'page_impressions_unique',
-              'page_impressions_paid_unique',
-              'page_impressions_viral_unique',
-              'page_impressions_nonviral_unique',
+              'page_total_media_view_unique',
               ])
             }}
 streams:

--- a/airbyte-integrations/connectors/source-facebook-pages/unit_tests/test_streams.py
+++ b/airbyte-integrations/connectors/source-facebook-pages/unit_tests/test_streams.py
@@ -130,3 +130,19 @@ def test_facebook_app_approval_error_is_config_error():
     assert response_filter["error_message"].startswith(
         "The application used to create the Facebook access token has not been approved to use this API."
     )
+
+
+def test_invalid_insights_metric_error_is_not_retried():
+    manifest = yaml.safe_load(MANIFEST_PATH.read_text())
+    response_filters = manifest["definitions"]["requester"]["error_handler"]["response_filters"]
+
+    invalid_metric_filters = [f for f in response_filters if f.get("error_message_contains") == "must be a valid insights metric"]
+    assert len(invalid_metric_filters) == 1, "Expected exactly one response filter for Meta's invalid-metric error"
+
+    invalid_metric_filter = invalid_metric_filters[0]
+    assert invalid_metric_filter["action"] == "FAIL"
+    assert invalid_metric_filter["failure_type"] == FailureType.system_error.value
+
+    # An invalid metric is permanent, so the filter must be evaluated before the blanket 400 retry.
+    blanket_400_index = next(i for i, f in enumerate(response_filters) if f.get("http_codes") == [400])
+    assert response_filters.index(invalid_metric_filter) < blanket_400_index

--- a/docs/integrations/sources/facebook-pages.md
+++ b/docs/integrations/sources/facebook-pages.md
@@ -114,6 +114,28 @@ This error occurs when the Facebook Graph API considers the total response data 
 - **Remove fields from the request via the Schema Tab.** Go to your connection's Schema Tab and deselect fields you don't need for the affected stream. This reduces the number of fields included in API requests. Supported streams: `page`, `post`.
 - **Reduce page size.** Set the **Page Size** configuration parameter to a lower value (e.g., 25 or 50). This reduces the number of records fetched per API request. Supported streams: `post`, `post_insights`.
 
+### Reach metrics missing from Page Insights and Post Insights
+
+Meta retired the `page_impressions_*_unique` and `post_impressions_*_unique` metrics. Because the Graph API
+rejects an entire Insights request when any single requested metric is invalid, requesting them returned
+`(#100) The value must be a valid insights metric` and broke both insights streams — and, since the connection
+check queries `page_insights`, source setup as well. See
+[Meta's deprecated metrics list](https://developers.facebook.com/docs/platforminsights/page/deprecated-metrics/).
+
+Starting from version 2.1.2 the connector no longer requests them. Only total reach has a replacement; the paid,
+viral, non-viral, fan and organic reach breakdowns were retired with no equivalent and are permanently
+unavailable from the API.
+
+| Stream | No longer emitted | Replacement |
+| :--- | :--- | :--- |
+| `page_insights` | `page_impressions_unique` | `page_total_media_view_unique` |
+| `page_insights` | `page_impressions_paid_unique`, `page_impressions_viral_unique`, `page_impressions_nonviral_unique` | none |
+| `post_insights` | `post_impressions_unique` | `post_total_media_view_unique` |
+| `post_insights` | `post_impressions_paid_unique`, `post_impressions_fan_unique`, `post_impressions_organic_unique`, `post_impressions_viral_unique`, `post_impressions_nonviral_unique` | none |
+
+The stream schemas are unchanged, so no schema refresh is needed. Rows for the removed metrics simply stop
+arriving; clear the affected streams if you prefer a consistent history in your destination.
+
 ### Product catalogs field not available
 
 Starting from version 2.0.4, the `product_catalogs` field is no longer synced in the Page stream and will always be `null`. This is because the Facebook Graph API only returns product catalogs that are owned directly by the Page, not catalogs owned by a Business. Since most product catalogs are now created as Business-owned catalogs (Page-owned catalogs are a legacy feature), and this connector uses Page access tokens, the `product_catalogs` field would not return meaningful data for most users.
@@ -144,6 +166,7 @@ If you use Airbyte Cloud and your organization restricts access to specific IPs,
 
 | Version | Date       | Pull Request                                                   | Subject                                                                                                                                                                |
 |:--------|:-----------|:---------------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 2.1.2 | 2026-08-17 | [84408](https://github.com/airbytehq/airbyte/pull/84408) | Remove Page/Post Insights metrics deprecated by Meta and request `page_total_media_view_unique` / `post_total_media_view_unique` instead; fail fast with Meta's own message on invalid-metric errors. |
 | 2.1.1 | 2026-05-22 | [78342](https://github.com/airbytehq/airbyte/pull/78342) | Classify Facebook app-approval errors as configuration errors. |
 | 2.1.0 | 2026-02-09 | [72949](https://github.com/airbytehq/airbyte/pull/72949) | Use QueryProperties with JsonSchemaPropertySelector to limit API field requests to user-selected fields; add configurable page_size for post and post_insights streams |
 | 2.0.4 | 2026-01-29 | [72253](https://github.com/airbytehq/airbyte/pull/72253) | Remove product_catalogs from fields request parameter |


### PR DESCRIPTION
## What

`source-facebook-pages` requests a hardcoded, batched list of Page/Post Insights metrics. Meta retired the `page_impressions_*_unique` / `post_impressions_*_unique` family, and Graph API rejects the **entire** insights request when any single requested metric is invalid:

```
(#100) The value must be a valid insights metric
```

Because `check.stream_names` is `page_insights`, this breaks **source setup itself**, not just the two streams — so affected users cannot create a new Facebook Pages source at all, and every existing connection fails at its pre-sync check.

Ref: [Meta deprecated metrics](https://developers.facebook.com/docs/platforminsights/page/deprecated-metrics/) · fixes #66509 · supersedes #80740

## How

**Metric lists** — remove the deprecated metrics, request the only documented replacements:

| Stream | Removed | Added |
|---|---|---|
| `page_insights` | `page_impressions_unique`, `page_impressions_paid_unique`, `page_impressions_viral_unique`, `page_impressions_nonviral_unique` | `page_total_media_view_unique` |
| `post_insights` | `post_impressions_unique`, `post_impressions_paid_unique`, `post_impressions_fan_unique`, `post_impressions_organic_unique`, `post_impressions_viral_unique`, `post_impressions_nonviral_unique` | `post_total_media_view_unique` |

Only total reach has a replacement. The paid / viral / non-viral / fan / organic reach breakdowns were retired with no equivalent — they are gone, not renamed.

Nothing else is added, which is where this diverges from #80740. In fairness to that PR: all 12 metrics it additionally introduces were tested individually against live Graph API v24 here and **all 12 are valid**, including `page_views_total` and `page_video_views`, which Meta's own docs are inconsistent about. So the case for leaving them out is not that they are broken. It is that a batched request fails wholesale on any one unavailable metric, metric availability is demonstrably page-scoped (see review notes), and a single test Page is not evidence for a fleet — a breaking release fixing an active outage is the wrong place to widen the request surface. They are worth a follow-up PR on their own merits.

**Fail fast on invalid metrics** — the error handler retried *every* 400 (`http_codes: [400] → RETRY`). A permanent invalid-metric error therefore burned six attempts over ~31s and surfaced as `airbyte_cdk...DefaultBackoffException: HTTP Status Code: 400. Error: Bad request. Please check your request parameters.`, with Meta's own explanation discarded. Now a non-retryable `system_error` that echoes the API's message. Ordered before the blanket 400 rule (response filters are OR-matched, so this filter matches on message only — adding `http_codes` would have made it swallow unrelated 400s).

**`check` deliberately stays on `page_insights`.** An earlier revision of this PR moved it to `page` so that a metric deprecation could not break source setup. That is the wrong trade, for two reasons:

- `page_insights` is the only stream that exercises `read_insights` and the Page `ANALYZE` task ([Page Insights docs](https://developers.facebook.com/docs/platforminsights/page/)). Reading the `page` node needs `pages_read_engagement` + `pages_read_user_content` and explicitly *not* `read_insights` ([Page node docs](https://developers.facebook.com/docs/graph-api/reference/page/)). Checking `page` would let a token missing `read_insights` pass setup and then fail at sync — which is the failure this connector already has a dedicated `config_error` filter for.
- CHECK runs with no configured catalog, so `JsonSchemaPropertySelector.select()` returns `None` and `QueryProperties` performs no filtering — every entry in `page_query_properties` is requested at once, including `feed`, `posts`, `published_posts`, `videos`, `photos`, `albums`, `live_videos` and `tagged`. That maximal request is the shape behind the historical setup failures in #64141, #70258 and #72253. Field selection does not protect CHECK.

So `page_insights` is both the stricter and the lighter check (a single `metric` parameter with five now-valid metrics). The fragility is addressed at its source instead: the metric list no longer contains dead metrics, and the new error filter makes the next deprecation legible from the failure reason on the first attempt rather than after six retries.

## Review notes

- **Metric validity appears to be page-scoped, not global.** At least one connection on 2.1.1 was observed still syncing `page_insights` successfully with the deprecated metrics, while others failed with the 400. The verification below covers a single Page, so it does not prove the new list is valid everywhere — worth exercising against a second Page before release, which a prerelease pin on an affected connection would do.
- **Pre-existing gap, not introduced here:** `acceptance-test-config.yml` lists both insights streams under `basic_read.empty_streams`, and `check` only touches `page_insights`. So if every `post_insights` metric were retired tomorrow, CI would stay green. Worth fixing separately by dropping `post_insights` from `empty_streams`.
- Supersedes community PR #80740 by @m6urns, which found the same root cause and verified the replacement metrics against live Graph API v24. This PR keeps the removals and the two `*_total_media_view_unique` swaps, drops the 12 additional metrics that PR also introduced, corrects the version to 3.0.0, and adds the error-handling fix. Its metric changes are identical to #80740's minus those additions — no metric is requested here that #80740 does not also request.

## Versioning

**2.1.2**, patch. This was originally raised as a breaking `3.0.0` on the grounds that two streams stop emitting records they previously emitted, which is criterion 33 of `breaking-change-evaluation`. On closer inspection that reading does not fit:

- **Staying on 2.1.x does not preserve the removed records.** Meta's deprecation applies to *all* Graph API versions as of 2026-06-15, which has passed — the old metrics return a 400, not old data. A major bump exists so users can stay on the previous major while they migrate; here that option preserves only the outage. Criterion 33's examples are all cases where the connector stops fetching data that **remains available upstream**, which is not this.
- **No observable user is receiving these records.** Of the connections that select `page_insights` (10) or `post_insights` (9), every one observed syncing is failing on the 400. The one connection observed succeeding on 2.1.1 selects neither insights stream.
- **Declaring it breaking actively delays the fix.** A major pins existing connections to 2.x, so the users currently broken would need to act before receiving a fix they are waiting on.
- **The 2.0.0 precedent is weaker than it looks.** That release changed `schemas/post.json` (real field removals on `post`), which forced major on its own; the insights streams were included in `scopedImpact` alongside. It is not a precedent for a metric-list-only change being major.

No schema, catalog, or state change — the insights schemas are generic `{name, period, values}` envelopes and were verified unchanged against live records, with `page_total_media_view_unique` / `post_total_media_view_unique` both emitting `integer`, already permitted by the declared types. So no refresh is required; clearing the affected streams is optional and documented in the connector docs.

Reviewers who disagree should say so — reclassifying to a major means a `breakingChanges` entry, `upgradeDeadline`, migration guide, and approval, all of which were drafted and can be restored from this PR's history.

## Tests

One manifest assertion added in `unit_tests/test_streams.py`: the invalid-metric error resolves to a non-retryable `system_error` and is ordered before the blanket `http_codes: [400] → RETRY` rule. That ordering is the thing worth pinning — move the filter below the blanket rule and the fast-fail silently reverts to six retries with nothing else in the suite failing. The test also documents why the filter carries no `http_codes` key: `HttpResponseFilter._matches_filter` ORs its conditions, so adding one would swallow unrelated 400s.

An earlier revision also asserted that neither insights stream requests any name from a hardcoded deprecated-metric denylist. That was dropped: such a list only fails if someone deliberately re-adds a name this PR removed, it cannot know about *future* deprecations, and it rots as Meta retires more metrics. It would have implied coverage it does not provide.

Full connector test suite is green in CI: **all 14 tests pass, 2 skipped**, including `check` succeeding inside the built Docker image.

### Live verification (Graph API v24, against the connector's sandbox Page)

The connector's CI credential had expired (OAuth `code: 190` / `error_subcode: 460`), so `check` was failing before it ever reached an insights request. It has been refreshed, and the results below come from running the connector against the live API.

`check` → `SUCCEEDED`. `read` returns records on every stream with no errors or warnings:

| Stream | Records |
|---|---|
| `page` | 1 |
| `post` | 411 |
| `page_insights` | 15 |
| `post_insights` | 2465 |

Every requested metric came back populated — `page_insights`: `page_total_actions`, `page_post_engagements`, `page_fan_adds_by_paid_non_paid_unique`, `page_media_view`, `page_total_media_view_unique`, three rows each (one per period); `post_insights`: `post_media_view` 410, `post_total_media_view_unique` 822, `post_clicks` 411, `post_clicks_by_type` 411, `post_reactions_by_type_total` 411. The two replacement metrics are not merely accepted, they return data.

**A/B with the credential held constant.** Same `secrets/config.json`, `master`'s manifest: `check` → `FAILED` after six retries with `HTTP Status Code: 400. Error: Bad request`. This branch: `SUCCEEDED`. So the metric list is the cause, and refreshing the token alone does not fix it.

**Per-metric isolation.** The batch error names no metric, so each was requested on its own. Every metric this PR removes is invalid; every metric it keeps is valid:

```
ok       page_total_actions, page_post_engagements,
         page_fan_adds_by_paid_non_paid_unique, page_media_view
INVALID  page_impressions_unique, page_impressions_paid_unique,
         page_impressions_viral_unique, page_impressions_nonviral_unique
ok       post_media_view, post_clicks, post_clicks_by_type, post_reactions_by_type_total
INVALID  post_impressions_unique, post_impressions_paid_unique, post_impressions_fan_unique,
         post_impressions_organic_unique, post_impressions_viral_unique, post_impressions_nonviral_unique
```

All ten fail with `(#100) The value must be a valid insights metric`.

**The new error filter was exercised** by temporarily re-injecting one dead metric into this branch's manifest: zero retry attempts (was six), and the failure reason carried Meta's own text through the `{{ response... }}` interpolation — `... Facebook returned: (#100) The value must be a valid insights metric`.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚 — reverting restores the previous metric lists; no state or config format changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

**Note on the published pre-release.** `/ai-prove-fix` returned 🟢 Fix Proven and a pre-release was published as `airbyte/source-facebook-pages:3.0.0-preview.261784e`, both against head `261784e2` when this PR still declared `3.0.0`. The runtime code is **byte-identical** between that commit and the current head — `git diff 261784e2 HEAD -- source_facebook_pages/ unit_tests/` is empty, the only changes being version strings and docs — so that regression evidence still describes this build's behaviour. The `3.0.0-preview` tag is now mislabelled relative to the target version; anyone pinned to it is running the correct fix, but a fresh `2.1.2-preview` should be cut before release, and `/ai-review` is worth re-running since its rationale cited the breaking classification.
