### PR TITLE
docs(access-management): add temporary hidden SCIM placeholder page

### DIFF
--- a/docs/platform/access-management/scim.md
+++ b/docs/platform/access-management/scim.md
@@ -1,0 +1,7 @@
+---
+unlisted: true
+---
+
+# Enable SCIM integration
+
+Documentation coming soon.


### PR DESCRIPTION
## What

Adds a temporary placeholder page at `/platform/access-management/scim` so that [airbyte-platform-internal#19316](https://github.com/airbytehq/airbyte-platform-internal/pull/19316) (adds a "Check out our docs" link to the SCIM settings card) can merge without its `validate-links` check 404ing and without shipping a dead link to users.

Requested by Ian Alton. Superseded by the real SCIM documentation tracked in [DOCS-74](https://linear.app/airbyteio/issue/DOCS-74/user-groups-and-scim-documentation) and drafted in #84388 — whichever of the two lands second should replace/drop this stub, since both write `docs/platform/access-management/scim.md`.

## How

One new file, `docs/platform/access-management/scim.md`:

```md
---
unlisted: true
---

# Enable SCIM integration

Documentation coming soon.
```

`unlisted: true` is the Docusaurus mechanism for a page that resolves at its URL but is kept out of discovery: it is excluded from the sitemap, gets a `noindex, nofollow` robots meta tag (so the Algolia crawler and the local search index skip it), and does not need a sidebar entry. `sidebar-platform.js` is intentionally untouched, so the page does not appear in navigation.

No `products` frontmatter, so no plan badges render on a stub.

## Review guide

1. `docs/platform/access-management/scim.md` — the whole change.

## User Impact

The URL returns a page saying documentation is coming soon instead of a 404. The page is not linked from navigation and not indexed by search, so it is only reachable from the SCIM settings card link (and only once #19316 ships) or by typing the URL.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚
- [ ] NO ❌


Link to Devin session: https://app.devin.ai/sessions/c5b36ed85f174dd5b80ea23c0b782fee
Requested by: @ian-at-airbyte