### PR TITLE
ci(publish): pass GitHub token to registry artifact generation

### DIFF
--- a/.github/workflows/publish_connectors.yml
+++ b/.github/workflows/publish_connectors.yml
@@ -546,6 +546,7 @@ jobs:
         shell: bash
         env:
           GCS_CREDENTIALS: ${{ secrets.METADATA_SERVICE_PROD_GCS_CREDENTIALS }}
+          GITHUB_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ inputs.pr }}
         run: |
           echo "Generating registry artifacts for ${{ matrix.connector }}"


### PR DESCRIPTION
## What

Connector publish writes release attribution into the registry (`data.generated.release`), and ops-mcp can resolve the release PR's author and merge time from the GitHub API — but the `Generate Registry Artifacts` step had no token in its environment, so that lookup silently fell back to Git-derived data only and left the author fields null in published metadata.

## How

Passes the workflow's own token to the step, which is what ops-mcp's `resolve_default_github_token` reads:

```yaml
env:
  GCS_CREDENTIALS: ${{ secrets.METADATA_SERVICE_PROD_GCS_CREDENTIALS }}
  GITHUB_TOKEN: ${{ github.token }}
  PR_NUMBER: ${{ inputs.pr }}
```

No new secret: `github.token` is scoped to this repository and only read access to the release PR is needed. The lookup fails soft on the ops-mcp side, so a token or API problem cannot fail a publish.

## Review guide

1. `.github/workflows/publish_connectors.yml`

## User Impact

Newly published connector versions carry a real author login and release date in the registry instead of nulls. No behavior change for the connectors themselves.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

Requested by AJ Steers; the consuming ops-mcp change is linked in a comment.

Link to Devin session: https://app.devin.ai/sessions/d70ffbcf1bda41578d9a50737c4df5cd
Requested by: @aaronsteers