### PR TITLE
fix(source-github): raise comments page size to 100 (do not merge)

### DIFF
--- a/airbyte-integrations/connectors/source-github/metadata.yaml
+++ b/airbyte-integrations/connectors/source-github/metadata.yaml
@@ -10,7 +10,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: ef69ef6e-aa7f-4af1-a01d-ef775033524e
-  dockerImageTag: 2.1.40
+  dockerImageTag: 2.1.41
   dockerRepository: airbyte/source-github
   documentationUrl: https://docs.airbyte.com/integrations/sources/github
   erdUrl: https://dbdocs.io/airbyteio/source-github?view=relationships

--- a/airbyte-integrations/connectors/source-github/pyproject.toml
+++ b/airbyte-integrations/connectors/source-github/pyproject.toml
@@ -3,7 +3,7 @@ requires = [ "poetry-core>=1.0.0",]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
-version = "2.1.40"
+version = "2.1.41"
 name = "source-github"
 description = "Source implementation for GitHub."
 authors = [ "Airbyte <contact@airbyte.io>",]

--- a/airbyte-integrations/connectors/source-github/source_github/streams.py
+++ b/airbyte-integrations/connectors/source-github/source_github/streams.py
@@ -716,6 +716,11 @@ class Comments(IncrementalMixin, GithubStream):
     large_stream = True
     max_retries = 7
 
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        # Issue comments are small payloads; full pages cut request count ~10x with no observed errors.
+        self.page_size = constants.DEFAULT_PAGE_SIZE
+
     def path(self, stream_slice: Mapping[str, Any] = None, **kwargs) -> str:
         return f"repos/{stream_slice['repository']}/issues/comments"
 

--- a/airbyte-integrations/connectors/source-github/unit_tests/integration/test_comments.py
+++ b/airbyte-integrations/connectors/source-github/unit_tests/integration/test_comments.py
@@ -70,7 +70,7 @@ class CommentsTest(TestCase):
         self.r_mock.get(
             HttpRequest(
                 url=f"https://api.github.com/repos/{_CONFIG.get('repositories')[0]}/issues/comments",
-                query_params={"per_page": 10, "since": "2020-05-01T00:00:00Z"},
+                query_params={"per_page": 100, "since": "2020-05-01T00:00:00Z"},
             ),
             HttpResponse(json.dumps(find_template("comments", __file__)), 200),
         )

--- a/airbyte-integrations/connectors/source-github/unit_tests/test_source.py
+++ b/airbyte-integrations/connectors/source-github/unit_tests/test_source.py
@@ -230,7 +230,9 @@ def test_streams_page_size(rate_limit_mock_response, requests_mock):
     assert constants.DEFAULT_PAGE_SIZE != constants.DEFAULT_PAGE_SIZE_FOR_LARGE_STREAM
 
     for stream in streams:
-        if stream.large_stream:
+        if stream.name == "comments":
+            assert stream.page_size == constants.DEFAULT_PAGE_SIZE
+        elif stream.large_stream:
             assert stream.page_size == constants.DEFAULT_PAGE_SIZE_FOR_LARGE_STREAM
         else:
             assert stream.page_size == constants.DEFAULT_PAGE_SIZE

--- a/airbyte-integrations/connectors/source-github/unit_tests/test_stream.py
+++ b/airbyte-integrations/connectors/source-github/unit_tests/test_stream.py
@@ -1068,25 +1068,25 @@ def test_stream_comments(requests_mock):
 
     api_url = "https://api.github.com/repos/organization/repository/issues/comments"
 
-    requests_mock.get(f"{api_url}?per_page=2&since=2022-02-02T10:10:01Z", json=data[0:2])
+    requests_mock.get(f"{api_url}?per_page=100&since=2022-02-02T10:10:01Z", json=data[0:2])
 
     requests_mock.get(
-        f"{api_url}?per_page=2&since=2022-02-02T10:10:04Z",
+        f"{api_url}?per_page=100&since=2022-02-02T10:10:04Z",
         json=data[1:3],
         headers={
-            "Link": '<https://api.github.com/repos/organization/repository/issues/comments?per_page=2&since=2022-02-02T10%3A10%3A04Z&page=2>; rel="next"'
+            "Link": '<https://api.github.com/repos/organization/repository/issues/comments?per_page=100&since=2022-02-02T10%3A10%3A04Z&page=2>; rel="next"'
         },
     )
 
     requests_mock.get(
-        f"{api_url}?per_page=2&page=2&since=2022-02-02T10:10:04Z",
+        f"{api_url}?per_page=100&page=2&since=2022-02-02T10:10:04Z",
         json=data[3:5],
         headers={
-            "Link": '<https://api.github.com/repos/organization/repository/issues/comments?per_page=2&since=2022-02-02T10%3A10%3A04Z&page=3>; rel="next"'
+            "Link": '<https://api.github.com/repos/organization/repository/issues/comments?per_page=100&since=2022-02-02T10%3A10%3A04Z&page=3>; rel="next"'
         },
     )
 
-    requests_mock.get(f"{api_url}?per_page=2&page=3&since=2022-02-02T10:10:04Z", json=data[5:])
+    requests_mock.get(f"{api_url}?per_page=100&page=3&since=2022-02-02T10:10:04Z", json=data[5:])
 
     data = [
         {"id": 1, "updated_at": "2022-02-02T10:11:02Z"},
@@ -1099,26 +1099,26 @@ def test_stream_comments(requests_mock):
 
     api_url = "https://api.github.com/repos/airbytehq/airbyte/issues/comments"
 
-    requests_mock.get(f"{api_url}?per_page=2&since=2022-02-02T10:10:01Z", json=data[0:2])
+    requests_mock.get(f"{api_url}?per_page=100&since=2022-02-02T10:10:01Z", json=data[0:2])
 
     requests_mock.get(
-        f"{api_url}?per_page=2&since=2022-02-02T10:11:04Z",
+        f"{api_url}?per_page=100&since=2022-02-02T10:11:04Z",
         json=data[1:3],
         headers={
-            "Link": '<https://api.github.com/repos/airbytehq/airbyte/issues/comments?per_page=2&since=2022-02-02T10%3A11%3A04Z&page=2>; rel="next"'
+            "Link": '<https://api.github.com/repos/airbytehq/airbyte/issues/comments?per_page=100&since=2022-02-02T10%3A11%3A04Z&page=2>; rel="next"'
         },
     )
 
     requests_mock.get(
-        f"{api_url}?per_page=2&page=2&since=2022-02-02T10:11:04Z",
+        f"{api_url}?per_page=100&page=2&since=2022-02-02T10:11:04Z",
         json=data[3:5],
         headers={
-            "Link": '<https://api.github.com/repos/airbytehq/airbyte/issues/comments?per_page=2&since=2022-02-02T10%3A11%3A04Z&page=3>; rel="next"'
+            "Link": '<https://api.github.com/repos/airbytehq/airbyte/issues/comments?per_page=100&since=2022-02-02T10%3A11%3A04Z&page=3>; rel="next"'
         },
     )
 
     requests_mock.get(
-        f"{api_url}?per_page=2&page=3&since=2022-02-02T10:11:04Z",
+        f"{api_url}?per_page=100&page=3&since=2022-02-02T10:11:04Z",
         json=data[5:],
     )
 

--- a/docs/integrations/sources/github.md
+++ b/docs/integrations/sources/github.md
@@ -241,7 +241,7 @@ Your token should have at least the `repo` scope. Depending on which streams you
 
 | Version    | Date       | Pull Request                                                                                                      | Subject                                                                                                                                                                |
 |:-----------|:-----------|:------------------------------------------------------------------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| 2.1.41 | 2026-08-15 | [PR_NUMBER_PLACEHOLDER](https://github.com/airbytehq/airbyte/pull/PR_NUMBER_PLACEHOLDER) | Raise `comments` stream page size to 100 (discussion only) |
+| 2.1.41 | 2026-08-15 | [84417](https://github.com/airbytehq/airbyte/pull/84417) | Raise `comments` stream page size to 100 (discussion only) |
 | 2.1.40 | 2026-08-11 | [83943](https://github.com/airbytehq/airbyte/pull/83943) | Update dependencies |
 | 2.1.39 | 2026-08-04 | [83469](https://github.com/airbytehq/airbyte/pull/83469) | Update dependencies |
 | 2.1.38 | 2026-07-28 | [82893](https://github.com/airbytehq/airbyte/pull/82893) | Update dependencies |

--- a/docs/integrations/sources/github.md
+++ b/docs/integrations/sources/github.md
@@ -241,6 +241,7 @@ Your token should have at least the `repo` scope. Depending on which streams you
 
 | Version    | Date       | Pull Request                                                                                                      | Subject                                                                                                                                                                |
 |:-----------|:-----------|:------------------------------------------------------------------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 2.1.41 | 2026-08-15 | [PR_NUMBER_PLACEHOLDER](https://github.com/airbytehq/airbyte/pull/PR_NUMBER_PLACEHOLDER) | Raise `comments` stream page size to 100 (discussion only) |
 | 2.1.40 | 2026-08-11 | [83943](https://github.com/airbytehq/airbyte/pull/83943) | Update dependencies |
 | 2.1.39 | 2026-08-04 | [83469](https://github.com/airbytehq/airbyte/pull/83469) | Update dependencies |
 | 2.1.38 | 2026-07-28 | [82893](https://github.com/airbytehq/airbyte/pull/82893) | Update dependencies |


### PR DESCRIPTION
## What

Discussion PR — **not for merge as-is**. It exists to gather and hold the before/after data for raising the `comments` stream page size in `source-github`, requested by AJ Steers.

Background: https://linear.app/airbyteio/issue/HYD-140/source-github-raise-default-page-size-for-large-rest-streams-comments

`comments` is marked `large_stream = True`, so it pages at `DEFAULT_PAGE_SIZE_FOR_LARGE_STREAM` (10) instead of GitHub's max of 100. This PR pages `comments` at 100 and records what that costs and saves.

### Measured before/after

Both invocations per configuration were cold full-refresh reads of `comments` only. Wall clock comes from runs without debug logging; request counts come from separate `--debug` runs. Every run exited 0, every HTTP response was 200, no retries, no throttling, no warnings.

`airbytehq/PyAirbyte`, no `start_date` (full comment history):

| page size | records | stream runtime | wall clock | data requests | records/request |
|---|---|---|---|---|---|
| 10 | 2,879 | 0:01:29.58 | 93.45s | 288 | 9.997 |
| 50 | 2,883 | 0:00:23.84 | 27.96s | 58 | 49.707 |
| 100 | 2,883 | 0:00:14.38 | 18.19s | 29 | 99.414 |

`airbytehq/airbyte`, `start_date` = `2026-08-01T00:00:00Z`:

| page size | records | stream runtime | wall clock | data requests | records/request |
|---|---|---|---|---|---|
| 10 | 6,341 | 0:03:48.36 | 232.34s | 635 | 9.986 |
| 50 | 6,341 | 0:00:52.52 | 57.41s | 127 | 49.929 |
| 100 | 6,341 | 0:00:31.47 | 35.42s | 64 | 99.078 |

Wall clock, `airbytehq/airbyte` (each block ~10s):

```
page  10 | ######################## 232.3s
page  50 | ###### 57.4s
page 100 | #### 35.4s
```

Data requests, `airbytehq/airbyte` (each block ~25 requests):

```
page  10 | ######################### 635
page  50 | ##### 127
page 100 | ## 64
```

On top of the stream's own data requests, every run made a fixed 5 startup requests: one `GET /rate_limit` per configured token (4 in the test config) plus one `GET /repos/{owner}/{repo}` to resolve the repo. Those are unchanged by page size.

### Record output was identical

Page size did not change what came back. For `airbytehq/airbyte` all three page sizes returned the same 6,341 comments with identical comment-id sets. For `airbytehq/PyAirbyte` the count moved from 2,879 to 2,883, which is repo activity during measurement rather than a page-size effect: the 2,883-record sets are a strict superset of the 2,879 set (nothing present at page 10 was missing at 50/100), and the four extra records are comments created at 17:52:19Z, 17:52:35Z, 17:52:58Z and 18:00:16Z on PyAirbyte PR #1108, after the page-10 run had finished.

No 5xx, truncated pages, or error responses appeared at page size 100 — records per data request was 99.4 and 99.1 there, and 49.7 and 49.9 at page size 50, consistent with full pages plus one partial final page.

## How

`Comments.__init__` sets its own `page_size` to `constants.DEFAULT_PAGE_SIZE` (100) after the base initializer runs. That is the whole behavior change — five lines in one stream class.

Deliberately not changed:

- `DEFAULT_PAGE_SIZE_FOR_LARGE_STREAM` stays at 10, and no shared paging logic in `GithubStream.__init__` is touched, so `issues`, `pull_requests`, `review_comments`, `releases` and `pull_request_stats` still page at 10. `releases` has documented 504s at page size 100 and is out of scope here.
- No new config field, and the deprecated `page_size_for_large_streams` spec field is not restored.

Error-handling consequences, stated explicitly:

- `Comments.large_stream` stays `True`, so the 502/504 guidance in `GithubStream.get_error_display_message` (advising a smaller page size for large streams) still applies to `comments`.
- What `comments` de-escalates to is unchanged, because it has no page-size de-escalation to begin with: the 502/504 halving and the post-error page-size reset live in `GitHubGraphQLErrorHandler` and apply only to GraphQL streams. `Comments` is a REST stream using `GithubStreamABCErrorHandler`, so neither path ever ran for it, and `errors_handlers.py` is untouched.
- One user-visible behavior change: because `comments` now sets its page size itself, the deprecated `page_size_for_large_streams` config value no longer affects `comments`. Users who lowered that value to work around `comments` failures would no longer be able to, and the 502/504 display message (which tells them to decrease "Page size for large streams" below the current value) would be misleading for `comments`. Worth deciding in review whether that message should be adjusted.

## Review guide

1. `source_github/streams.py` — the `Comments.__init__` override; this is the whole behavior change.
2. `unit_tests/test_source.py` — `test_streams_page_size` now expects 100 for `comments` and the reduced size for the other large streams.
3. `unit_tests/test_stream.py`, `unit_tests/integration/test_comments.py` — comments-only mock request URLs updated from `per_page=2`/`per_page=10` to `per_page=100`.
4. `metadata.yaml`, `pyproject.toml`, `docs/integrations/sources/github.md` — version bump to 2.1.41 and changelog row.

## User Impact

Syncs of `comments` make roughly 10x fewer HTTP requests and finish several times faster (232s to 35s on the larger repo measured here), with identical records. Negative side effects to weigh before this is considered mergeable: wider pages mean larger individual responses and a larger amount of work lost to a retry on a failed page, and the deprecated `page_size_for_large_streams` escape hatch no longer applies to `comments`. Requests-per-hour against GitHub's quota drop; per-request payload size rises.

## Test plan

Run from the connector directory:

- `poetry run pytest unit_tests` — 170 passed.
- `pre-commit run --files <touched files>` — ruff, ruff-format, prettier and the license-header hook all passed.
- Instantiating the source's streams through its own code path with mocked repo and rate-limit responses reports `comments=100` and `issues=10`, `pull_requests=10`, `review_comments=10`, `releases=10`, `pull_request_stats=10`.
- Live reads used to produce the tables above: `poetry run python main.py read --config <config> --catalog <comments-only catalog>` for each repo/page-size pair, plus the same command with `--debug` to count outbound requests. The page-100 configurations completed with all-200 responses and full pages, as tabulated.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚


Link to Devin session: https://app.devin.ai/sessions/9a0bdac36dfb4a1a8ccbfadeb061fecf
Requested by: @aaronsteers

---

> [!IMPORTANT]
> **Autopilot Progressive Rollout Enabled**
>
> [Autopilot progressive rollouts](https://github.com/airbytehq/airbyte-ops-mcp/blob/main/docs/autopilot-rollouts.md) are enabled for one or more connector(s) modified in this PR. Check the box below if you need to bypass normal rollout safety processes and release to all users immediately upon merge:
>
> - [ ] ⚡ **Release immediately** (bypasses automatic progressive rollout)
>
> **Note:**
>
> - ⚠️ The above bypass option is for emergency/hotfix use only.
> - 🔗 You can monitor or manually advance a rollout at **[ops.internal.airbyte.ai](https://ops.internal.airbyte.ai)**.