### PR TITLE
feat(iceberg): suppress duplicate positional deletes and drop superseded files

### DIFF
--- a/airbyte-cdk/bulk/core/load/changelog.md
+++ b/airbyte-cdk/bulk/core/load/changelog.md
@@ -11,6 +11,10 @@ The Load CDK provides functionality for destination connectors including stream-
 
 [#82750](https://github.com/airbytehq/airbyte/pull/82750) — Add positional delete support to the Iceberg load toolkit.
 
+### 1.0.26 — 2026-08-16
+
+Optimize positional delete output and suppress positions already covered by registered delete files.
+
 ### 1.0.24 — 2026-08-10
 
 [#83806](https://github.com/airbytehq/airbyte/pull/83806) — Fix: honor the configured Azure Blob `endpointDomainName` and target the matching Entra authority host.

--- a/airbyte-cdk/bulk/core/load/version.properties
+++ b/airbyte-cdk/bulk/core/load/version.properties
@@ -1,1 +1,1 @@
-version=1.0.25
+version=1.0.26

--- a/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/java/io/airbyte/cdk/load/toolkits/iceberg/parquet/io/BasePositionDeltaTaskWriter.java
+++ b/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/java/io/airbyte/cdk/load/toolkits/iceberg/parquet/io/BasePositionDeltaTaskWriter.java
@@ -54,8 +54,7 @@ public abstract class BasePositionDeltaTaskWriter
                                         final long targetFileSize,
                                         final Schema schema,
                                         final Set<Integer> identifierFieldIds,
-                                        final PositionalDeleteResolver resolver,
-                                        final boolean allowWholeFileSupersession) {
+                                        final PositionalDeleteResolver resolver) {
     super(spec, format, writerFactory, fileFactory, io, targetFileSize);
     this.table = table;
     this.deleteSchema = TypeUtil.select(schema, identifierFieldIds);

--- a/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/java/io/airbyte/cdk/load/toolkits/iceberg/parquet/io/BasePositionDeltaTaskWriter.java
+++ b/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/java/io/airbyte/cdk/load/toolkits/iceberg/parquet/io/BasePositionDeltaTaskWriter.java
@@ -9,6 +9,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
+import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DeleteFile;
 import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.PartitionSpec;
@@ -37,6 +38,7 @@ public abstract class BasePositionDeltaTaskWriter extends BaseTaskWriter<Record>
   private final InternalRecordWrapper keyWrapper;
   private final PositionalDeleteResolver resolver;
   private final TouchedKeys touchedKeys;
+  private final Set<DataFile> fullySupersededDataFiles = new java.util.HashSet<>();
   private final List<DeleteFile> completedPositionDeleteFiles = new ArrayList<>();
 
   protected BasePositionDeltaTaskWriter(
@@ -113,9 +115,17 @@ public abstract class BasePositionDeltaTaskWriter extends BaseTaskWriter<Record>
     WriteResult dataResult = super.complete();
     WriteResult.Builder result = WriteResult.builder().addDataFiles(dataResult.dataFiles());
     result.addDeleteFiles(dataResult.deleteFiles());
+    result.addReferencedDataFiles(dataResult.referencedDataFiles());
     synchronized (completedPositionDeleteFiles) {
       result.addDeleteFiles(completedPositionDeleteFiles);
+      completedPositionDeleteFiles.stream()
+          .map(DeleteFile::referencedDataFile)
+          .filter(java.util.Objects::nonNull)
+          .forEach(result::addReferencedDataFiles);
     }
+    fullySupersededDataFiles.stream()
+        .map(dataFile -> dataFile.location())
+        .forEach(result::addReferencedDataFiles);
     return result.build();
   }
 
@@ -124,6 +134,7 @@ public abstract class BasePositionDeltaTaskWriter extends BaseTaskWriter<Record>
       return;
     }
     List<DeleteFile> resolved = resolver.resolve(touchedKeys);
+    fullySupersededDataFiles.addAll(resolver.fullySupersededDataFiles());
     resolved.forEach(this::addCompletedPositionDeleteFile);
     touchedKeys.clear();
   }

--- a/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/java/io/airbyte/cdk/load/toolkits/iceberg/parquet/io/BasePositionDeltaTaskWriter.java
+++ b/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/java/io/airbyte/cdk/load/toolkits/iceberg/parquet/io/BasePositionDeltaTaskWriter.java
@@ -52,7 +52,8 @@ public abstract class BasePositionDeltaTaskWriter
                                         final long targetFileSize,
                                         final Schema schema,
                                         final Set<Integer> identifierFieldIds,
-                                        final PositionalDeleteResolver resolver) {
+                                        final PositionalDeleteResolver resolver,
+                                        final boolean allowWholeFileSupersession) {
     super(spec, format, writerFactory, fileFactory, io, targetFileSize);
     this.table = table;
     this.deleteSchema = TypeUtil.select(schema, identifierFieldIds);

--- a/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/java/io/airbyte/cdk/load/toolkits/iceberg/parquet/io/BasePositionDeltaTaskWriter.java
+++ b/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/java/io/airbyte/cdk/load/toolkits/iceberg/parquet/io/BasePositionDeltaTaskWriter.java
@@ -136,7 +136,7 @@ public abstract class BasePositionDeltaTaskWriter
       return;
     }
     List<DeleteFile> resolved = resolver.resolve(touchedKeys);
-    fullySupersededDataFiles.addAll(resolver.fullySupersededDataFiles());
+    fullySupersededDataFiles.addAll(resolver.getFullySupersededDataFiles());
     resolved.forEach(this::addCompletedPositionDeleteFile);
     touchedKeys.clear();
   }

--- a/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/java/io/airbyte/cdk/load/toolkits/iceberg/parquet/io/BasePositionDeltaTaskWriter.java
+++ b/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/java/io/airbyte/cdk/load/toolkits/iceberg/parquet/io/BasePositionDeltaTaskWriter.java
@@ -7,7 +7,9 @@ package io.airbyte.cdk.load.toolkits.iceberg.parquet.io;
 import io.airbyte.cdk.ConfigErrorException;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DeleteFile;
@@ -39,7 +41,7 @@ public abstract class BasePositionDeltaTaskWriter
   private final InternalRecordWrapper keyWrapper;
   private final PositionalDeleteResolver resolver;
   private final TouchedKeys touchedKeys;
-  private final Set<DataFile> fullySupersededDataFiles = new java.util.HashSet<>();
+  private final Set<DataFile> fullySupersededDataFiles = new HashSet<>();
   private final List<DeleteFile> completedPositionDeleteFiles = new ArrayList<>();
 
   protected BasePositionDeltaTaskWriter(
@@ -121,7 +123,7 @@ public abstract class BasePositionDeltaTaskWriter
       result.addDeleteFiles(completedPositionDeleteFiles);
       completedPositionDeleteFiles.stream()
           .map(DeleteFile::referencedDataFile)
-          .filter(java.util.Objects::nonNull)
+          .filter(Objects::nonNull)
           .forEach(result::addReferencedDataFiles);
     }
     return result.build();

--- a/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/java/io/airbyte/cdk/load/toolkits/iceberg/parquet/io/BasePositionDeltaTaskWriter.java
+++ b/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/java/io/airbyte/cdk/load/toolkits/iceberg/parquet/io/BasePositionDeltaTaskWriter.java
@@ -30,7 +30,8 @@ import org.apache.iceberg.types.Types;
 /**
  * Delta writer that emits only positional deletes.
  */
-public abstract class BasePositionDeltaTaskWriter extends BaseTaskWriter<Record> {
+public abstract class BasePositionDeltaTaskWriter
+    extends BaseTaskWriter<Record> implements SupersededDataFileProvider {
 
   private final Table table;
   private final Schema deleteSchema;
@@ -115,7 +116,6 @@ public abstract class BasePositionDeltaTaskWriter extends BaseTaskWriter<Record>
     WriteResult dataResult = super.complete();
     WriteResult.Builder result = WriteResult.builder().addDataFiles(dataResult.dataFiles());
     result.addDeleteFiles(dataResult.deleteFiles());
-    result.addReferencedDataFiles(dataResult.referencedDataFiles());
     synchronized (completedPositionDeleteFiles) {
       result.addDeleteFiles(completedPositionDeleteFiles);
       completedPositionDeleteFiles.stream()
@@ -123,10 +123,12 @@ public abstract class BasePositionDeltaTaskWriter extends BaseTaskWriter<Record>
           .filter(java.util.Objects::nonNull)
           .forEach(result::addReferencedDataFiles);
     }
-    fullySupersededDataFiles.stream()
-        .map(dataFile -> dataFile.location())
-        .forEach(result::addReferencedDataFiles);
     return result.build();
+  }
+
+  @Override
+  public Set<DataFile> fullySupersededDataFiles() {
+    return Set.copyOf(fullySupersededDataFiles);
   }
 
   private void resolvePending() {

--- a/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/kotlin/io/airbyte/cdk/load/toolkits/iceberg/parquet/io/IcebergTableCommitter.kt
+++ b/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/kotlin/io/airbyte/cdk/load/toolkits/iceberg/parquet/io/IcebergTableCommitter.kt
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2026 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.cdk.load.toolkits.iceberg.parquet.io
+
+import org.apache.iceberg.DataFile
+import org.apache.iceberg.DeleteFile
+import org.apache.iceberg.Table
+import org.apache.iceberg.io.WriteResult
+
+object IcebergTableCommitter {
+    private val commitLock = Any()
+
+    fun fullySupersededDataFiles(
+        table: Table,
+        plannedSnapshotId: Long,
+        writeResult: WriteResult,
+    ): Set<DataFile> {
+        val referenced = writeResult.referencedDataFiles().map { it.toString() }.toSet()
+        val deleteReferences =
+            writeResult
+                .deleteFiles()
+                .mapNotNull { it.referencedDataFile() }
+                .map { it.toString() }
+                .toSet()
+        val paths = referenced - deleteReferences
+        if (paths.isEmpty()) return emptySet()
+        return table.newScan().useSnapshot(plannedSnapshotId).planFiles().use { tasks ->
+            tasks.map { it.file() }.filter { it.location().toString() in paths }.toSet()
+        }
+    }
+
+    fun commit(
+        table: Table,
+        branch: String,
+        writeResult: WriteResult,
+        plannedSnapshotId: Long,
+        fullySupersededDataFiles: Set<DataFile>,
+    ) {
+        synchronized(commitLock) {
+            val hasReferencedDataFiles = writeResult.referencedDataFiles().isNotEmpty()
+            if (
+                writeResult.deleteFiles().isNotEmpty() ||
+                    (writeResult.dataFiles().isNotEmpty() && hasReferencedDataFiles)
+            ) {
+                val delta =
+                    table
+                        .newRowDelta()
+                        .toBranch(branch)
+                        .validateFromSnapshot(plannedSnapshotId)
+                        .validateDataFilesExist(writeResult.referencedDataFiles().asIterable())
+                        .validateDeletedFiles()
+                        .validateNoConflictingDataFiles()
+                        .validateNoConflictingDeleteFiles()
+                writeResult.dataFiles().forEach(delta::addRows)
+                writeResult.deleteFiles().forEach(delta::addDeletes)
+                delta.commit()
+            } else if (writeResult.dataFiles().isNotEmpty()) {
+                val append = table.newAppend().toBranch(branch)
+                writeResult.dataFiles().forEach(append::appendFile)
+                append.commit()
+            }
+
+            if (fullySupersededDataFiles.isNotEmpty()) {
+                val deleteFiles =
+                    registeredDeletes(table, plannedSnapshotId, fullySupersededDataFiles)
+                table
+                    .newRewrite()
+                    .toBranch(branch)
+                    .rewriteFiles(
+                        fullySupersededDataFiles,
+                        deleteFiles,
+                        emptySet(),
+                        emptySet(),
+                    )
+                    .validateFromSnapshot(plannedSnapshotId)
+                    .commit()
+            }
+        }
+    }
+
+    private fun registeredDeletes(
+        table: Table,
+        snapshotId: Long,
+        dataFiles: Set<DataFile>,
+    ): Set<DeleteFile> {
+        val paths = dataFiles.map { it.location().toString() }.toSet()
+        return table.newScan().useSnapshot(snapshotId).planFiles().use { tasks ->
+            tasks
+                .filter { it.file().location().toString() in paths }
+                .flatMap { it.deletes().toList() }
+                .toSet()
+        }
+    }
+}

--- a/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/kotlin/io/airbyte/cdk/load/toolkits/iceberg/parquet/io/IcebergTableCommitter.kt
+++ b/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/kotlin/io/airbyte/cdk/load/toolkits/iceberg/parquet/io/IcebergTableCommitter.kt
@@ -12,25 +12,6 @@ import org.apache.iceberg.io.WriteResult
 object IcebergTableCommitter {
     private val commitLock = Any()
 
-    fun fullySupersededDataFiles(
-        table: Table,
-        plannedSnapshotId: Long,
-        writeResult: WriteResult,
-    ): Set<DataFile> {
-        val referenced = writeResult.referencedDataFiles().map { it.toString() }.toSet()
-        val deleteReferences =
-            writeResult
-                .deleteFiles()
-                .mapNotNull { it.referencedDataFile() }
-                .map { it.toString() }
-                .toSet()
-        val paths = referenced - deleteReferences
-        if (paths.isEmpty()) return emptySet()
-        return table.newScan().useSnapshot(plannedSnapshotId).planFiles().use { tasks ->
-            tasks.map { it.file() }.filter { it.location().toString() in paths }.toSet()
-        }
-    }
-
     fun commit(
         table: Table,
         branch: String,
@@ -39,6 +20,7 @@ object IcebergTableCommitter {
         fullySupersededDataFiles: Set<DataFile>,
     ) {
         synchronized(commitLock) {
+            var rewriteSnapshotId = plannedSnapshotId
             val hasReferencedDataFiles = writeResult.referencedDataFiles().isNotEmpty()
             if (
                 writeResult.deleteFiles().isNotEmpty() ||
@@ -56,6 +38,7 @@ object IcebergTableCommitter {
                 writeResult.dataFiles().forEach(delta::addRows)
                 writeResult.deleteFiles().forEach(delta::addDeletes)
                 delta.commit()
+                rewriteSnapshotId = table.refs()[branch]?.snapshotId() ?: plannedSnapshotId
             } else if (writeResult.dataFiles().isNotEmpty()) {
                 val append = table.newAppend().toBranch(branch)
                 writeResult.dataFiles().forEach(append::appendFile)
@@ -64,7 +47,7 @@ object IcebergTableCommitter {
 
             if (fullySupersededDataFiles.isNotEmpty()) {
                 val deleteFiles =
-                    registeredDeletes(table, plannedSnapshotId, fullySupersededDataFiles)
+                    registeredDeletes(table, rewriteSnapshotId, fullySupersededDataFiles)
                 table
                     .newRewrite()
                     .toBranch(branch)
@@ -74,7 +57,7 @@ object IcebergTableCommitter {
                         emptySet(),
                         emptySet(),
                     )
-                    .validateFromSnapshot(plannedSnapshotId)
+                    .validateFromSnapshot(rewriteSnapshotId)
                     .commit()
             }
         }
@@ -85,11 +68,18 @@ object IcebergTableCommitter {
         snapshotId: Long,
         dataFiles: Set<DataFile>,
     ): Set<DeleteFile> {
-        val paths = dataFiles.map { it.location().toString() }.toSet()
         return table.newScan().useSnapshot(snapshotId).planFiles().use { tasks ->
             tasks
-                .filter { it.file().location().toString() in paths }
-                .flatMap { it.deletes().toList() }
+                .filter { task -> dataFiles.any { it.location() == task.file().location() } }
+                .flatMap { task ->
+                    task.deletes().filter { deleteFile ->
+                        deleteFile.content() == org.apache.iceberg.FileContent.POSITION_DELETES &&
+                            deleteFile.referencedDataFile() != null &&
+                            dataFiles.any {
+                                it.location().toString() == deleteFile.referencedDataFile()
+                            }
+                    }
+                }
                 .toSet()
         }
     }

--- a/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/kotlin/io/airbyte/cdk/load/toolkits/iceberg/parquet/io/IcebergTableCommitter.kt
+++ b/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/kotlin/io/airbyte/cdk/load/toolkits/iceberg/parquet/io/IcebergTableCommitter.kt
@@ -4,12 +4,12 @@
 
 package io.airbyte.cdk.load.toolkits.iceberg.parquet.io
 
+import java.util.concurrent.ConcurrentHashMap
 import org.apache.iceberg.DataFile
 import org.apache.iceberg.DeleteFile
 import org.apache.iceberg.FileContent
 import org.apache.iceberg.Table
 import org.apache.iceberg.io.WriteResult
-import java.util.concurrent.ConcurrentHashMap
 
 object IcebergTableCommitter {
     private val commitLocks = ConcurrentHashMap<String, Any>()
@@ -23,11 +23,40 @@ object IcebergTableCommitter {
         fullySupersededDataFiles: Set<DataFile>,
     ) {
         synchronized(commitLocks.computeIfAbsent("${table.name()}::$branch") { Any() }) {
-            var rewriteSnapshotId = plannedSnapshotId
-            val hasReferencedDataFiles = writeResult.referencedDataFiles().isNotEmpty()
-            if (
+            if (fullySupersededDataFiles.isNotEmpty()) {
+                val deleteFiles =
+                    registeredDeletes(table, plannedSnapshotId, fullySupersededDataFiles)
+                val transaction = table.newTransaction()
+                val delta =
+                    transaction
+                        .newRowDelta()
+                        .toBranch(branch)
+                        .validateFromSnapshot(plannedSnapshotId)
+                        .validateDataFilesExist(writeResult.referencedDataFiles().asIterable())
+                        .validateDeletedFiles()
+                        .validateNoConflictingDataFiles()
+                        .validateNoConflictingDeleteFiles()
+                writeResult.dataFiles().forEach(delta::addRows)
+                writeResult.deleteFiles().forEach(delta::addDeletes)
+                delta.commit()
+                val rewriteSnapshotId =
+                    transaction.table().refs()[branch]?.snapshotId() ?: plannedSnapshotId
+                transaction
+                    .newRewrite()
+                    .toBranch(branch)
+                    .rewriteFiles(
+                        fullySupersededDataFiles,
+                        deleteFiles,
+                        emptySet(),
+                        emptySet(),
+                    )
+                    .validateFromSnapshot(rewriteSnapshotId)
+                    .commit()
+                transaction.commitTransaction()
+            } else if (
                 writeResult.deleteFiles().isNotEmpty() ||
-                    (writeResult.dataFiles().isNotEmpty() && hasReferencedDataFiles)
+                    (writeResult.dataFiles().isNotEmpty() &&
+                        writeResult.referencedDataFiles().isNotEmpty())
             ) {
                 val delta =
                     table
@@ -41,27 +70,10 @@ object IcebergTableCommitter {
                 writeResult.dataFiles().forEach(delta::addRows)
                 writeResult.deleteFiles().forEach(delta::addDeletes)
                 delta.commit()
-                rewriteSnapshotId = table.refs()[branch]?.snapshotId() ?: plannedSnapshotId
             } else if (writeResult.dataFiles().isNotEmpty()) {
                 val append = table.newAppend().toBranch(branch)
                 writeResult.dataFiles().forEach(append::appendFile)
                 append.commit()
-            }
-
-            if (fullySupersededDataFiles.isNotEmpty()) {
-                val deleteFiles =
-                    registeredDeletes(table, rewriteSnapshotId, fullySupersededDataFiles)
-                table
-                    .newRewrite()
-                    .toBranch(branch)
-                    .rewriteFiles(
-                        fullySupersededDataFiles,
-                        deleteFiles,
-                        emptySet(),
-                        emptySet(),
-                    )
-                    .validateFromSnapshot(rewriteSnapshotId)
-                    .commit()
             }
         }
     }
@@ -73,13 +85,23 @@ object IcebergTableCommitter {
     ): Set<DeleteFile> {
         val dataFileLocations = dataFiles.map { it.location().toString() }.toSet()
         return table.newScan().useSnapshot(snapshotId).planFiles().use { tasks ->
-            tasks
+            val plannedTasks = tasks.toList()
+            val deleteReferences =
+                plannedTasks
+                    .flatMap { task ->
+                        task.deletes().map { deleteFile ->
+                            deleteFile.location().toString() to task.file().location().toString()
+                        }
+                    }
+                    .groupBy({ it.first }, { it.second })
+            plannedTasks
                 .filter { task -> dataFileLocations.contains(task.file().location().toString()) }
                 .flatMap { task ->
                     task.deletes().filter { deleteFile ->
                         deleteFile.content() == FileContent.POSITION_DELETES &&
                             deleteFile.referencedDataFile() != null &&
-                            dataFileLocations.contains(deleteFile.referencedDataFile())
+                            dataFileLocations.contains(deleteFile.referencedDataFile()) &&
+                            deleteReferences[deleteFile.location().toString()]?.toSet()?.size == 1
                     }
                 }
                 .toSet()

--- a/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/kotlin/io/airbyte/cdk/load/toolkits/iceberg/parquet/io/IcebergTableCommitter.kt
+++ b/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/kotlin/io/airbyte/cdk/load/toolkits/iceberg/parquet/io/IcebergTableCommitter.kt
@@ -6,12 +6,14 @@ package io.airbyte.cdk.load.toolkits.iceberg.parquet.io
 
 import org.apache.iceberg.DataFile
 import org.apache.iceberg.DeleteFile
+import org.apache.iceberg.FileContent
 import org.apache.iceberg.Table
 import org.apache.iceberg.io.WriteResult
 
 object IcebergTableCommitter {
     private val commitLock = Any()
 
+    @Suppress("DEPRECATION")
     fun commit(
         table: Table,
         branch: String,
@@ -73,7 +75,7 @@ object IcebergTableCommitter {
                 .filter { task -> dataFiles.any { it.location() == task.file().location() } }
                 .flatMap { task ->
                     task.deletes().filter { deleteFile ->
-                        deleteFile.content() == org.apache.iceberg.FileContent.POSITION_DELETES &&
+                        deleteFile.content() == FileContent.POSITION_DELETES &&
                             deleteFile.referencedDataFile() != null &&
                             dataFiles.any {
                                 it.location().toString() == deleteFile.referencedDataFile()

--- a/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/kotlin/io/airbyte/cdk/load/toolkits/iceberg/parquet/io/IcebergTableCommitter.kt
+++ b/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/kotlin/io/airbyte/cdk/load/toolkits/iceberg/parquet/io/IcebergTableCommitter.kt
@@ -9,9 +9,10 @@ import org.apache.iceberg.DeleteFile
 import org.apache.iceberg.FileContent
 import org.apache.iceberg.Table
 import org.apache.iceberg.io.WriteResult
+import java.util.concurrent.ConcurrentHashMap
 
 object IcebergTableCommitter {
-    private val commitLock = Any()
+    private val commitLocks = ConcurrentHashMap<String, Any>()
 
     @Suppress("DEPRECATION")
     fun commit(
@@ -21,7 +22,7 @@ object IcebergTableCommitter {
         plannedSnapshotId: Long,
         fullySupersededDataFiles: Set<DataFile>,
     ) {
-        synchronized(commitLock) {
+        synchronized(commitLocks.computeIfAbsent("${table.name()}::$branch") { Any() }) {
             var rewriteSnapshotId = plannedSnapshotId
             val hasReferencedDataFiles = writeResult.referencedDataFiles().isNotEmpty()
             if (
@@ -70,16 +71,15 @@ object IcebergTableCommitter {
         snapshotId: Long,
         dataFiles: Set<DataFile>,
     ): Set<DeleteFile> {
+        val dataFileLocations = dataFiles.map { it.location().toString() }.toSet()
         return table.newScan().useSnapshot(snapshotId).planFiles().use { tasks ->
             tasks
-                .filter { task -> dataFiles.any { it.location() == task.file().location() } }
+                .filter { task -> dataFileLocations.contains(task.file().location().toString()) }
                 .flatMap { task ->
                     task.deletes().filter { deleteFile ->
                         deleteFile.content() == FileContent.POSITION_DELETES &&
                             deleteFile.referencedDataFile() != null &&
-                            dataFiles.any {
-                                it.location().toString() == deleteFile.referencedDataFile()
-                            }
+                            dataFileLocations.contains(deleteFile.referencedDataFile())
                     }
                 }
                 .toSet()

--- a/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/kotlin/io/airbyte/cdk/load/toolkits/iceberg/parquet/io/IcebergTableWriterFactory.kt
+++ b/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/kotlin/io/airbyte/cdk/load/toolkits/iceberg/parquet/io/IcebergTableWriterFactory.kt
@@ -264,7 +264,6 @@ class IcebergTableWriterFactory {
                 schema = schema,
                 identifierFieldIds = identifierFieldIds,
                 resolver = positionalDeleteResolver,
-                allowWholeFileSupersession = allowWholeFileSupersession,
             )
         } else {
             PartitionedPositionDeltaWriter(
@@ -278,7 +277,6 @@ class IcebergTableWriterFactory {
                 schema = schema,
                 identifierFieldIds = identifierFieldIds,
                 resolver = positionalDeleteResolver,
-                allowWholeFileSupersession = allowWholeFileSupersession,
             )
         }
     }

--- a/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/kotlin/io/airbyte/cdk/load/toolkits/iceberg/parquet/io/IcebergTableWriterFactory.kt
+++ b/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/kotlin/io/airbyte/cdk/load/toolkits/iceberg/parquet/io/IcebergTableWriterFactory.kt
@@ -138,7 +138,6 @@ class IcebergTableWriterFactory {
                         outputFileFactory = outputFileFactory,
                         format = format,
                         positionalDeleteResolver = positionalDeleteResolver,
-                        allowWholeFileSupersession = allowWholeFileSupersession,
                     )
                 }
             else -> throw IllegalArgumentException("Unsupported import type $importType")
@@ -250,7 +249,6 @@ class IcebergTableWriterFactory {
         targetFileSize: Long,
         identifierFieldIds: Set<Int>,
         positionalDeleteResolver: PositionalDeleteResolver,
-        allowWholeFileSupersession: Boolean,
     ): BaseTaskWriter<Record> {
         return if (table.spec().isUnpartitioned) {
             UnpartitionedPositionDeltaWriter(

--- a/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/kotlin/io/airbyte/cdk/load/toolkits/iceberg/parquet/io/IcebergTableWriterFactory.kt
+++ b/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/kotlin/io/airbyte/cdk/load/toolkits/iceberg/parquet/io/IcebergTableWriterFactory.kt
@@ -59,6 +59,7 @@ class IcebergTableWriterFactory {
         positionalDeleteRef: String? = null,
         positionalDeleteState: PositionalDeleteResolutionState? = null,
         maxTouchedKeys: Int = PositionalDeleteResolver.DEFAULT_MAX_TOUCHED_KEYS,
+        allowWholeFileSupersession: Boolean = false,
     ): BaseTaskWriter<Record> {
         assertGenerationIdSuffixIsOfValidFormat(generationId)
         val format =
@@ -96,6 +97,7 @@ class IcebergTableWriterFactory {
                     outputFileFactory,
                     maxTouchedKeys = maxTouchedKeys,
                     state = resolutionState,
+                    allowWholeFileSupersession = allowWholeFileSupersession,
                 )
             }
         val targetFileSize =
@@ -136,6 +138,7 @@ class IcebergTableWriterFactory {
                         outputFileFactory = outputFileFactory,
                         format = format,
                         positionalDeleteResolver = positionalDeleteResolver,
+                        allowWholeFileSupersession = allowWholeFileSupersession,
                     )
                 }
             else -> throw IllegalArgumentException("Unsupported import type $importType")
@@ -247,6 +250,7 @@ class IcebergTableWriterFactory {
         targetFileSize: Long,
         identifierFieldIds: Set<Int>,
         positionalDeleteResolver: PositionalDeleteResolver,
+        allowWholeFileSupersession: Boolean,
     ): BaseTaskWriter<Record> {
         return if (table.spec().isUnpartitioned) {
             UnpartitionedPositionDeltaWriter(
@@ -260,6 +264,7 @@ class IcebergTableWriterFactory {
                 schema = schema,
                 identifierFieldIds = identifierFieldIds,
                 resolver = positionalDeleteResolver,
+                allowWholeFileSupersession = allowWholeFileSupersession,
             )
         } else {
             PartitionedPositionDeltaWriter(
@@ -273,6 +278,7 @@ class IcebergTableWriterFactory {
                 schema = schema,
                 identifierFieldIds = identifierFieldIds,
                 resolver = positionalDeleteResolver,
+                allowWholeFileSupersession = allowWholeFileSupersession,
             )
         }
     }

--- a/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/kotlin/io/airbyte/cdk/load/toolkits/iceberg/parquet/io/PositionalDeleteFiles.kt
+++ b/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/kotlin/io/airbyte/cdk/load/toolkits/iceberg/parquet/io/PositionalDeleteFiles.kt
@@ -5,6 +5,7 @@
 package io.airbyte.cdk.load.toolkits.iceberg.parquet.io
 
 import org.apache.iceberg.DeleteFile
+import org.apache.iceberg.FileMetadata
 import org.apache.iceberg.data.GenericFileWriterFactory
 import org.apache.iceberg.data.Record
 import org.apache.iceberg.deletes.PositionDelete
@@ -47,6 +48,8 @@ class PositionalDeleteFiles(
                                 location.spec,
                                 location.partition,
                             ),
+                            location.spec,
+                            key,
                         )
                     }
                 check(
@@ -59,6 +62,7 @@ class PositionalDeleteFiles(
                 }
                 val delete = PositionDelete.create<Record>()
                 delete.set(location.path, location.position)
+                writer.writer.referencedDataFiles().add(location.path.toString())
                 writer.writer.write(delete)
                 writer.lastPath = location.path.toString()
                 writer.lastPosition = location.position
@@ -66,11 +70,20 @@ class PositionalDeleteFiles(
         } finally {
             writers.values.forEach { it.writer.close() }
         }
-        return writers.values.flatMap { it.writer.result().deleteFiles() }
+        return writers.values.flatMap { state ->
+            state.writer.result().deleteFiles().map { deleteFile ->
+                FileMetadata.deleteFileBuilder(state.spec)
+                    .copy(deleteFile)
+                    .withReferencedDataFile(state.dataFilePath)
+                    .build()
+            }
+        }
     }
 
     private class WriterState(
         val writer: PositionDeleteWriter<Record>,
+        val spec: org.apache.iceberg.PartitionSpec,
+        val dataFilePath: String,
         var lastPath: String? = null,
         var lastPosition: Long = Long.MIN_VALUE,
     )

--- a/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/kotlin/io/airbyte/cdk/load/toolkits/iceberg/parquet/io/PositionalDeleteFiles.kt
+++ b/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/kotlin/io/airbyte/cdk/load/toolkits/iceberg/parquet/io/PositionalDeleteFiles.kt
@@ -5,14 +5,13 @@
 package io.airbyte.cdk.load.toolkits.iceberg.parquet.io
 
 import org.apache.iceberg.DeleteFile
-import org.apache.iceberg.StructLike
 import org.apache.iceberg.data.GenericFileWriterFactory
 import org.apache.iceberg.data.Record
 import org.apache.iceberg.deletes.PositionDelete
 import org.apache.iceberg.deletes.PositionDeleteWriter
 import org.apache.iceberg.io.OutputFileFactory
 
-/** One positional delete writer per partition, with file paths and positions in ascending order. */
+/** One positional delete writer per data file, with positions in ascending order. */
 class PositionalDeleteFiles(
     private val writerFactory: GenericFileWriterFactory,
     private val outputFileFactory: OutputFileFactory,
@@ -36,10 +35,10 @@ class PositionalDeleteFiles(
     private fun writeOrdered(
         locations: Sequence<PositionalDeleteResolver.RowLocation>,
     ): List<DeleteFile> {
-        val writers = mutableMapOf<PartitionKey, WriterState>()
+        val writers = mutableMapOf<String, WriterState>()
         try {
             locations.forEach { location ->
-                val key = PartitionKey(location.spec.specId(), partitionValues(location.partition))
+                val key = location.path.toString()
                 val writer =
                     writers.getOrPut(key) {
                         WriterState(
@@ -69,15 +68,6 @@ class PositionalDeleteFiles(
         }
         return writers.values.flatMap { it.writer.result().deleteFiles() }
     }
-
-    private fun partitionValues(partition: StructLike?): List<Any?> =
-        if (partition == null) {
-            emptyList()
-        } else {
-            (0 until partition.size()).map { partition.get(it, Any::class.java) }
-        }
-
-    private data class PartitionKey(val specId: Int, val values: List<Any?>)
 
     private class WriterState(
         val writer: PositionDeleteWriter<Record>,

--- a/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/kotlin/io/airbyte/cdk/load/toolkits/iceberg/parquet/io/PositionalDeleteFiles.kt
+++ b/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/kotlin/io/airbyte/cdk/load/toolkits/iceberg/parquet/io/PositionalDeleteFiles.kt
@@ -6,6 +6,7 @@ package io.airbyte.cdk.load.toolkits.iceberg.parquet.io
 
 import org.apache.iceberg.DeleteFile
 import org.apache.iceberg.FileMetadata
+import org.apache.iceberg.PartitionSpec
 import org.apache.iceberg.data.GenericFileWriterFactory
 import org.apache.iceberg.data.Record
 import org.apache.iceberg.deletes.PositionDelete
@@ -82,7 +83,7 @@ class PositionalDeleteFiles(
 
     private class WriterState(
         val writer: PositionDeleteWriter<Record>,
-        val spec: org.apache.iceberg.PartitionSpec,
+        val spec: PartitionSpec,
         val dataFilePath: String,
         var lastPath: String? = null,
         var lastPosition: Long = Long.MIN_VALUE,

--- a/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/kotlin/io/airbyte/cdk/load/toolkits/iceberg/parquet/io/PositionalDeleteResolutionState.kt
+++ b/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/kotlin/io/airbyte/cdk/load/toolkits/iceberg/parquet/io/PositionalDeleteResolutionState.kt
@@ -9,6 +9,7 @@ import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.atomic.AtomicLong
 import org.apache.iceberg.DataFile
+import org.apache.iceberg.deletes.PositionDeleteIndex
 
 /** Stream-scoped state shared by positional writers created for successive flushes. */
 class PositionalDeleteResolutionState {
@@ -16,4 +17,8 @@ class PositionalDeleteResolutionState {
     internal val dataFilesOpened = AtomicInteger(0)
     internal val rowsScanned = AtomicLong(0)
     internal val fullySupersededDataFiles: MutableSet<DataFile> = ConcurrentHashMap.newKeySet()
+    internal val positionDeleteIndexes =
+        ConcurrentHashMap<String, Map<String, PositionDeleteIndex>>()
+    internal val unreadablePositionDeleteFiles = ConcurrentHashMap.newKeySet<String>()
+    internal val positionDeleteFilesRead = AtomicInteger(0)
 }

--- a/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/kotlin/io/airbyte/cdk/load/toolkits/iceberg/parquet/io/PositionalDeleteResolutionState.kt
+++ b/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/kotlin/io/airbyte/cdk/load/toolkits/iceberg/parquet/io/PositionalDeleteResolutionState.kt
@@ -4,13 +4,16 @@
 
 package io.airbyte.cdk.load.toolkits.iceberg.parquet.io
 
+import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.atomic.AtomicLong
+import org.apache.iceberg.DataFile
 
 /** Stream-scoped state shared by positional writers created for successive flushes. */
 class PositionalDeleteResolutionState {
     internal val warningLogged = AtomicBoolean(false)
     internal val dataFilesOpened = AtomicInteger(0)
     internal val rowsScanned = AtomicLong(0)
+    internal val fullySupersededDataFiles: MutableSet<DataFile> = ConcurrentHashMap.newKeySet()
 }

--- a/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/kotlin/io/airbyte/cdk/load/toolkits/iceberg/parquet/io/PositionalDeleteResolver.kt
+++ b/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/kotlin/io/airbyte/cdk/load/toolkits/iceberg/parquet/io/PositionalDeleteResolver.kt
@@ -33,6 +33,9 @@ class PositionalDeleteResolver(
     val dataFilesOpened: Int
         get() = finder.dataFilesOpened
 
+    val fullySupersededDataFiles: Set<org.apache.iceberg.DataFile>
+        get() = finder.fullySupersededDataFiles
+
     init {
         require(maxTouchedKeys > 0) { "maxTouchedKeys must be positive" }
     }

--- a/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/kotlin/io/airbyte/cdk/load/toolkits/iceberg/parquet/io/PositionalDeleteResolver.kt
+++ b/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/kotlin/io/airbyte/cdk/load/toolkits/iceberg/parquet/io/PositionalDeleteResolver.kt
@@ -26,8 +26,16 @@ class PositionalDeleteResolver(
     outputFileFactory: OutputFileFactory,
     private val maxTouchedKeys: Int = DEFAULT_MAX_TOUCHED_KEYS,
     state: PositionalDeleteResolutionState = PositionalDeleteResolutionState(),
+    allowWholeFileSupersession: Boolean = false,
 ) {
-    private val finder = SupersededRowFinder(table, schema, identifierFieldIds, state)
+    private val finder =
+        SupersededRowFinder(
+            table,
+            schema,
+            identifierFieldIds,
+            state,
+            allowWholeFileSupersession = allowWholeFileSupersession,
+        )
     private val deleteFiles = PositionalDeleteFiles(writerFactory, outputFileFactory)
 
     val dataFilesOpened: Int

--- a/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/kotlin/io/airbyte/cdk/load/toolkits/iceberg/parquet/io/PositionalDeleteResolver.kt
+++ b/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/kotlin/io/airbyte/cdk/load/toolkits/iceberg/parquet/io/PositionalDeleteResolver.kt
@@ -4,7 +4,9 @@
 
 package io.airbyte.cdk.load.toolkits.iceberg.parquet.io
 
+import org.apache.iceberg.DataFile
 import org.apache.iceberg.DeleteFile
+import org.apache.iceberg.PartitionSpec
 import org.apache.iceberg.Schema
 import org.apache.iceberg.StructLike
 import org.apache.iceberg.Table
@@ -41,7 +43,7 @@ class PositionalDeleteResolver(
     val dataFilesOpened: Int
         get() = finder.dataFilesOpened
 
-    val fullySupersededDataFiles: Set<org.apache.iceberg.DataFile>
+    val fullySupersededDataFiles: Set<DataFile>
         get() = finder.fullySupersededDataFiles
 
     init {
@@ -61,7 +63,7 @@ class PositionalDeleteResolver(
     data class RowLocation(
         val path: CharSequence,
         val position: Long,
-        val spec: org.apache.iceberg.PartitionSpec,
+        val spec: PartitionSpec,
         val partition: StructLike?,
     )
 

--- a/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/kotlin/io/airbyte/cdk/load/toolkits/iceberg/parquet/io/PositionalWriters.kt
+++ b/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/kotlin/io/airbyte/cdk/load/toolkits/iceberg/parquet/io/PositionalWriters.kt
@@ -28,6 +28,7 @@ class UnpartitionedPositionDeltaWriter(
     schema: Schema,
     identifierFieldIds: Set<Int>,
     resolver: PositionalDeleteResolver,
+    allowWholeFileSupersession: Boolean,
 ) :
     BasePositionDeltaTaskWriter(
         table,
@@ -40,6 +41,7 @@ class UnpartitionedPositionDeltaWriter(
         schema,
         identifierFieldIds,
         resolver,
+        allowWholeFileSupersession,
     ) {
     private val writer = RowDataPositionDeltaWriter(null)
 
@@ -61,6 +63,7 @@ class PartitionedPositionDeltaWriter(
     schema: Schema,
     identifierFieldIds: Set<Int>,
     resolver: PositionalDeleteResolver,
+    allowWholeFileSupersession: Boolean,
 ) :
     BasePositionDeltaTaskWriter(
         table,
@@ -73,6 +76,7 @@ class PartitionedPositionDeltaWriter(
         schema,
         identifierFieldIds,
         resolver,
+        allowWholeFileSupersession,
     ) {
     private val partitionKey = PartitionKey(spec, schema)
     private val writers = mutableMapOf<PartitionKey, RowDataPositionDeltaWriter>()

--- a/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/kotlin/io/airbyte/cdk/load/toolkits/iceberg/parquet/io/PositionalWriters.kt
+++ b/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/kotlin/io/airbyte/cdk/load/toolkits/iceberg/parquet/io/PositionalWriters.kt
@@ -28,7 +28,6 @@ class UnpartitionedPositionDeltaWriter(
     schema: Schema,
     identifierFieldIds: Set<Int>,
     resolver: PositionalDeleteResolver,
-    allowWholeFileSupersession: Boolean,
 ) :
     BasePositionDeltaTaskWriter(
         table,
@@ -41,7 +40,6 @@ class UnpartitionedPositionDeltaWriter(
         schema,
         identifierFieldIds,
         resolver,
-        allowWholeFileSupersession,
     ) {
     private val writer = RowDataPositionDeltaWriter(null)
 
@@ -63,7 +61,6 @@ class PartitionedPositionDeltaWriter(
     schema: Schema,
     identifierFieldIds: Set<Int>,
     resolver: PositionalDeleteResolver,
-    allowWholeFileSupersession: Boolean,
 ) :
     BasePositionDeltaTaskWriter(
         table,
@@ -76,7 +73,6 @@ class PartitionedPositionDeltaWriter(
         schema,
         identifierFieldIds,
         resolver,
-        allowWholeFileSupersession,
     ) {
     private val partitionKey = PartitionKey(spec, schema)
     private val writers = mutableMapOf<PartitionKey, RowDataPositionDeltaWriter>()

--- a/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/kotlin/io/airbyte/cdk/load/toolkits/iceberg/parquet/io/SupersededDataFileProvider.kt
+++ b/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/kotlin/io/airbyte/cdk/load/toolkits/iceberg/parquet/io/SupersededDataFileProvider.kt
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2026 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.cdk.load.toolkits.iceberg.parquet.io
+
+import org.apache.iceberg.DataFile
+
+interface SupersededDataFileProvider {
+    fun fullySupersededDataFiles(): Set<DataFile>
+}

--- a/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/kotlin/io/airbyte/cdk/load/toolkits/iceberg/parquet/io/SupersededRowFinder.kt
+++ b/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/kotlin/io/airbyte/cdk/load/toolkits/iceberg/parquet/io/SupersededRowFinder.kt
@@ -90,6 +90,9 @@ class SupersededRowFinder(
         state.dataFilesOpened.set(0)
         state.rowsScanned.set(0)
         state.fullySupersededDataFiles.clear()
+        state.positionDeleteIndexes.clear()
+        state.unreadablePositionDeleteFiles.clear()
+        state.positionDeleteFilesRead.set(0)
         return plannedFiles
             .asSequence()
             .sortedBy { it.file.location().toString() }
@@ -158,34 +161,51 @@ class SupersededRowFinder(
         val positionDeletes =
             planned.deletes.filter { it.content() == FileContent.POSITION_DELETES }
         if (positionDeletes.isEmpty()) return null
-        return try {
-            PositionDeleteIndexUtil.merge(
-                positionDeletes.map {
-                    readPositionDeleteIndex(it, planned.file.location().toString())
+        val indexes =
+            positionDeletes.mapNotNull { deleteFile ->
+                val deletePath = deleteFile.location().toString()
+                if (state.unreadablePositionDeleteFiles.contains(deletePath)) {
+                    return@mapNotNull null
                 }
-            )
-        } catch (e: Exception) {
-            logger.warn(e) {
-                "Unable to load prior position deletes for ${planned.file.location()}; " +
-                    "position suppression is disabled for this data file"
+                val indexesByDataFile =
+                    state.positionDeleteIndexes[deletePath]
+                        ?: try {
+                            readPositionDeleteIndexes(deleteFile).also {
+                                state.positionDeleteIndexes[deletePath] = it
+                            }
+                        } catch (e: Exception) {
+                            state.unreadablePositionDeleteFiles.add(deletePath)
+                            logger.warn(e) {
+                                "Unable to load prior position deletes from $deletePath; " +
+                                    "position suppression is disabled for data file " +
+                                    "${planned.file.location()}"
+                            }
+                            return@mapNotNull null
+                        }
+                indexesByDataFile[planned.file.location().toString()]
             }
+        return if (indexes.isEmpty()) {
             null
+        } else {
+            PositionDeleteIndexUtil.merge(indexes)
         }
     }
 
-    private fun readPositionDeleteIndex(
+    private fun readPositionDeleteIndexes(
         deleteFile: DeleteFile,
-        dataFilePath: String,
-    ): PositionDeleteIndex {
+    ): Map<String, PositionDeleteIndex> {
+        state.positionDeleteFilesRead.incrementAndGet()
         val deleteSchema = DeleteSchemaUtil.pathPosSchema()
-        Parquet.read(table.io().newInputFile(deleteFile.location().toString()))
+        return Parquet.read(table.io().newInputFile(deleteFile.location().toString()))
             .project(deleteSchema)
             .createReaderFunc { messageType ->
                 GenericParquetReaders.buildReader(deleteSchema, messageType)
             }
             .build<Record>()
             .use { records ->
-                return Deletes.toPositionIndex(dataFilePath, records, deleteFile)
+                Deletes.toPositionIndexes(records, deleteFile).entries.associate {
+                    it.key.toString() to it.value
+                }
             }
     }
 

--- a/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/kotlin/io/airbyte/cdk/load/toolkits/iceberg/parquet/io/SupersededRowFinder.kt
+++ b/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/kotlin/io/airbyte/cdk/load/toolkits/iceberg/parquet/io/SupersededRowFinder.kt
@@ -16,6 +16,7 @@ import org.apache.iceberg.Table
 import org.apache.iceberg.data.GenericRecord
 import org.apache.iceberg.data.Record
 import org.apache.iceberg.data.parquet.GenericParquetReaders
+import org.apache.iceberg.deletes.Deletes
 import org.apache.iceberg.deletes.PositionDeleteIndex
 import org.apache.iceberg.deletes.PositionDeleteIndexUtil
 import org.apache.iceberg.expressions.Expression
@@ -134,7 +135,9 @@ class SupersededRowFinder(
         if (locations.size.toLong() + priorDeletedPositions == planned.file.recordCount()) {
             state.fullySupersededDataFiles += planned.file
         } else {
-            locations.forEach(::yield)
+            for (location in locations) {
+                yield(location)
+            }
         }
     }
 
@@ -162,9 +165,6 @@ class SupersededRowFinder(
         dataFilePath: String,
     ): PositionDeleteIndex {
         val deleteSchema = DeleteSchemaUtil.pathPosSchema()
-        val pathField = deleteSchema.columns()[0].name()
-        val positionField = deleteSchema.columns()[1].name()
-        val index = PositionDeleteIndex.empty()
         Parquet.read(table.io().newInputFile(deleteFile.location().toString()))
             .project(deleteSchema)
             .createReaderFunc { messageType ->
@@ -172,13 +172,8 @@ class SupersededRowFinder(
             }
             .build<Record>()
             .use { records ->
-                for (record in records) {
-                    if (record.getField(pathField).toString() == dataFilePath) {
-                        index.delete((record.getField(positionField) as Number).toLong())
-                    }
-                }
+                return Deletes.toPositionIndex(dataFilePath, records, deleteFile)
             }
-        return index
     }
 
     private fun rowGroupExpression(touched: Set<StructLike>): Expression {

--- a/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/kotlin/io/airbyte/cdk/load/toolkits/iceberg/parquet/io/SupersededRowFinder.kt
+++ b/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/kotlin/io/airbyte/cdk/load/toolkits/iceberg/parquet/io/SupersededRowFinder.kt
@@ -16,8 +16,11 @@ import org.apache.iceberg.Table
 import org.apache.iceberg.data.GenericRecord
 import org.apache.iceberg.data.Record
 import org.apache.iceberg.data.parquet.GenericParquetReaders
+import org.apache.iceberg.deletes.PositionDeleteIndex
+import org.apache.iceberg.deletes.PositionDeleteIndexUtil
 import org.apache.iceberg.expressions.Expression
 import org.apache.iceberg.expressions.Expressions
+import org.apache.iceberg.io.DeleteSchemaUtil
 import org.apache.iceberg.parquet.Parquet
 import org.apache.iceberg.types.Comparators
 import org.apache.iceberg.types.Conversions
@@ -41,6 +44,9 @@ class SupersededRowFinder(
 
     val rowsScanned: Long
         get() = state.rowsScanned.get()
+
+    val fullySupersededDataFiles: Set<DataFile>
+        get() = state.fullySupersededDataFiles
 
     fun find(keys: TouchedKeys, ref: String): Sequence<PositionalDeleteResolver.RowLocation> {
         if (keys.isEmpty()) return emptySequence()
@@ -81,6 +87,7 @@ class SupersededRowFinder(
         }
         state.dataFilesOpened.set(0)
         state.rowsScanned.set(0)
+        state.fullySupersededDataFiles.clear()
         return plannedFiles
             .asSequence()
             .sortedBy { it.file.location().toString() }
@@ -93,8 +100,11 @@ class SupersededRowFinder(
         touched: Set<StructLike>,
         expression: Expression,
     ): Sequence<PositionalDeleteResolver.RowLocation> = sequence {
+        val positionIndex = positionDeleteIndex(planned)
+        val priorDeletedPositions = positionIndex?.cardinality() ?: 0
         val projectedSchema = Schema(identifierFields + MetadataColumns.ROW_POSITION)
         val inputFile = table.io().newInputFile(planned.file.location().toString())
+        val locations = mutableListOf<PositionalDeleteResolver.RowLocation>()
         Parquet.read(inputFile)
             .project(projectedSchema)
             .filter(expression)
@@ -105,19 +115,70 @@ class SupersededRowFinder(
             .use { records ->
                 for (record in records) {
                     state.rowsScanned.incrementAndGet()
-                    if (touched.contains(keyFrom(record))) {
-                        yield(
+                    val position =
+                        (record.getField(MetadataColumns.ROW_POSITION.name()) as Number).toLong()
+                    if (
+                        touched.contains(keyFrom(record)) &&
+                            (positionIndex == null || !positionIndex.isDeleted(position))
+                    ) {
+                        locations +=
                             PositionalDeleteResolver.RowLocation(
                                 planned.file.location(),
-                                (record.getField(MetadataColumns.ROW_POSITION.name()) as Number)
-                                    .toLong(),
+                                position,
                                 planned.spec,
                                 planned.partition,
                             )
-                        )
                     }
                 }
             }
+        if (locations.size.toLong() + priorDeletedPositions == planned.file.recordCount()) {
+            state.fullySupersededDataFiles += planned.file
+        } else {
+            locations.forEach(::yield)
+        }
+    }
+
+    private fun positionDeleteIndex(planned: PlannedDataFile): PositionDeleteIndex? {
+        val positionDeletes =
+            planned.deletes.filter { it.content() == FileContent.POSITION_DELETES }
+        if (positionDeletes.isEmpty()) return PositionDeleteIndex.empty()
+        return try {
+            PositionDeleteIndexUtil.merge(
+                positionDeletes.map {
+                    readPositionDeleteIndex(it, planned.file.location().toString())
+                }
+            )
+        } catch (e: Exception) {
+            logger.warn(e) {
+                "Unable to load prior position deletes for ${planned.file.location()}; " +
+                    "position suppression is disabled for this data file"
+            }
+            null
+        }
+    }
+
+    private fun readPositionDeleteIndex(
+        deleteFile: DeleteFile,
+        dataFilePath: String,
+    ): PositionDeleteIndex {
+        val deleteSchema = DeleteSchemaUtil.pathPosSchema()
+        val pathField = deleteSchema.columns()[0].name()
+        val positionField = deleteSchema.columns()[1].name()
+        val index = PositionDeleteIndex.empty()
+        Parquet.read(table.io().newInputFile(deleteFile.location().toString()))
+            .project(deleteSchema)
+            .createReaderFunc { messageType ->
+                GenericParquetReaders.buildReader(deleteSchema, messageType)
+            }
+            .build<Record>()
+            .use { records ->
+                for (record in records) {
+                    if (record.getField(pathField).toString() == dataFilePath) {
+                        index.delete((record.getField(positionField) as Number).toLong())
+                    }
+                }
+            }
+        return index
     }
 
     private fun rowGroupExpression(touched: Set<StructLike>): Expression {

--- a/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/kotlin/io/airbyte/cdk/load/toolkits/iceberg/parquet/io/SupersededRowFinder.kt
+++ b/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/kotlin/io/airbyte/cdk/load/toolkits/iceberg/parquet/io/SupersededRowFinder.kt
@@ -144,7 +144,7 @@ class SupersededRowFinder(
     private fun positionDeleteIndex(planned: PlannedDataFile): PositionDeleteIndex? {
         val positionDeletes =
             planned.deletes.filter { it.content() == FileContent.POSITION_DELETES }
-        if (positionDeletes.isEmpty()) return PositionDeleteIndex.empty()
+        if (positionDeletes.isEmpty()) return null
         return try {
             PositionDeleteIndexUtil.merge(
                 positionDeletes.map {

--- a/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/kotlin/io/airbyte/cdk/load/toolkits/iceberg/parquet/io/SupersededRowFinder.kt
+++ b/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/kotlin/io/airbyte/cdk/load/toolkits/iceberg/parquet/io/SupersededRowFinder.kt
@@ -106,7 +106,12 @@ class SupersededRowFinder(
         val priorDeletedPositions = positionIndex?.cardinality() ?: 0
         val projectedSchema = Schema(identifierFields + MetadataColumns.ROW_POSITION)
         val inputFile = table.io().newInputFile(planned.file.location().toString())
-        val locations = mutableListOf<PositionalDeleteResolver.RowLocation>()
+        val locations =
+            if (allowWholeFileSupersession) {
+                mutableListOf<PositionalDeleteResolver.RowLocation>()
+            } else {
+                null
+            }
         Parquet.read(inputFile)
             .project(projectedSchema)
             .filter(expression)
@@ -123,24 +128,28 @@ class SupersededRowFinder(
                         touched.contains(keyFrom(record)) &&
                             (positionIndex == null || !positionIndex.isDeleted(position))
                     ) {
-                        locations +=
+                        val location =
                             PositionalDeleteResolver.RowLocation(
                                 planned.file.location(),
                                 position,
                                 planned.spec,
                                 planned.partition,
                             )
+                        if (locations == null) {
+                            yield(location)
+                        } else {
+                            locations += location
+                        }
                     }
                 }
             }
-        if (
-            allowWholeFileSupersession &&
-                locations.size.toLong() + priorDeletedPositions == planned.file.recordCount()
-        ) {
-            state.fullySupersededDataFiles += planned.file
-        } else {
-            for (location in locations) {
-                yield(location)
+        if (locations != null) {
+            if (locations.size.toLong() + priorDeletedPositions == planned.file.recordCount()) {
+                state.fullySupersededDataFiles += planned.file
+            } else {
+                for (location in locations) {
+                    yield(location)
+                }
             }
         }
     }

--- a/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/kotlin/io/airbyte/cdk/load/toolkits/iceberg/parquet/io/SupersededRowFinder.kt
+++ b/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/main/kotlin/io/airbyte/cdk/load/toolkits/iceberg/parquet/io/SupersededRowFinder.kt
@@ -35,6 +35,7 @@ class SupersededRowFinder(
     private val state: PositionalDeleteResolutionState,
     private val maxInValues: Int = MAX_IN_VALUES,
     private val maxSubRanges: Int = MAX_SUB_RANGES,
+    private val allowWholeFileSupersession: Boolean = false,
 ) {
     private val identifierSchema = TypeUtil.select(schema, identifierFieldIds)
     private val identifierFields = identifierSchema.columns()
@@ -132,7 +133,10 @@ class SupersededRowFinder(
                     }
                 }
             }
-        if (locations.size.toLong() + priorDeletedPositions == planned.file.recordCount()) {
+        if (
+            allowWholeFileSupersession &&
+                locations.size.toLong() + priorDeletedPositions == planned.file.recordCount()
+        ) {
             state.fullySupersededDataFiles += planned.file
         } else {
             for (location in locations) {

--- a/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/test/kotlin/io/airbyte/cdk/load/toolkits/iceberg/parquet/io/PositionalDeleteEndToEndTest.kt
+++ b/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/test/kotlin/io/airbyte/cdk/load/toolkits/iceberg/parquet/io/PositionalDeleteEndToEndTest.kt
@@ -443,6 +443,7 @@ class PositionalDeleteEndToEndTest {
         val firstResult = first.complete()
         val second = writerFactory.create(table, "ab-generation-id-0-e", Append, schema)
         second.write(record(schema, "b", "old-b"))
+        second.write(record(schema, "c", "old-c"))
         val secondResult = second.complete()
         table
             .newAppend()
@@ -459,6 +460,7 @@ class PositionalDeleteEndToEndTest {
                 firstResult.dataFiles().single().location(),
                 secondResult.dataFiles().single().location()
             )
+        assertThat(sharedDelete.referencedDataFile()).isNull()
         val planned = table.refs()["staging"]!!.snapshotId()
         table
             .newRowDelta()
@@ -480,7 +482,10 @@ class PositionalDeleteEndToEndTest {
                 allowWholeFileSupersession = true,
             )
         update.write(RecordWrapper(record(schema, "a", "new-a"), Operation.UPDATE))
+        update.write(RecordWrapper(record(schema, "b", "ignored"), Operation.DELETE))
         val result = update.complete()
+        assertThat(supersededDataFiles(update).map { it.location() })
+            .containsExactly(firstResult.dataFiles().single().location())
         IcebergTableCommitter.commit(
             table,
             "staging",
@@ -493,12 +498,13 @@ class PositionalDeleteEndToEndTest {
                 tasks.flatMap { it.deletes().toList() }.toList()
             }
         assertThat(liveDeletes.map { it.location() }).contains(sharedDelete.location())
+        assertThat(state.positionDeleteFilesRead.get()).isEqualTo(1)
         val names =
             IcebergGenerics.read(table)
                 .useSnapshot(table.refs()["staging"]!!.snapshotId())
                 .build()
                 .use { records -> records.map { it.getField("name") }.toSet() }
-        assertThat(names).containsExactly("new-a")
+        assertThat(names).containsExactlyInAnyOrder("new-a", "old-c")
         warehouse.toFile().deleteRecursively()
     }
 
@@ -549,6 +555,7 @@ class PositionalDeleteEndToEndTest {
         assertThat(result.deleteFiles()).isEmpty()
         assertThat(supersededDataFiles(writer).map { it.location() })
             .containsExactly(initialResult.dataFiles().single().location())
+        val snapshotBeforeCommit = table.refs()["staging"]!!.snapshotId()
         IcebergTableCommitter.commit(
             table,
             "staging",
@@ -562,6 +569,8 @@ class PositionalDeleteEndToEndTest {
                 }
             )
             .doesNotContain(initialResult.dataFiles().single().location())
+        val snapshotAfterCommit = table.refs()["staging"]!!.snapshotId()
+        assertThat(snapshotAfterCommit).isNotEqualTo(snapshotBeforeCommit)
         warehouse.toFile().deleteRecursively()
     }
 
@@ -604,6 +613,7 @@ class PositionalDeleteEndToEndTest {
                 schema,
                 positionalDeleteRef = "staging",
                 positionalDeleteState = state,
+                allowWholeFileSupersession = true,
             )
         writer.write(RecordWrapper(record(schema, "a", "new-a"), Operation.UPDATE))
         val result = writer.complete()
@@ -617,6 +627,7 @@ class PositionalDeleteEndToEndTest {
                 emptySet(),
             )
             .commit()
+        val snapshotAfterConcurrentRewrite = table.refs()["staging"]!!.snapshotId()
         assertThatThrownBy {
                 IcebergTableCommitter.commit(
                     table,
@@ -627,6 +638,7 @@ class PositionalDeleteEndToEndTest {
                 )
             }
             .isInstanceOfAny(CommitFailedException::class.java, ValidationException::class.java)
+        assertThat(table.refs()["staging"]!!.snapshotId()).isEqualTo(snapshotAfterConcurrentRewrite)
         warehouse.toFile().deleteRecursively()
     }
 

--- a/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/test/kotlin/io/airbyte/cdk/load/toolkits/iceberg/parquet/io/PositionalDeleteEndToEndTest.kt
+++ b/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/test/kotlin/io/airbyte/cdk/load/toolkits/iceberg/parquet/io/PositionalDeleteEndToEndTest.kt
@@ -16,6 +16,7 @@ import org.apache.iceberg.catalog.TableIdentifier
 import org.apache.iceberg.data.GenericRecord
 import org.apache.iceberg.data.IcebergGenerics
 import org.apache.iceberg.exceptions.CommitFailedException
+import org.apache.iceberg.exceptions.ValidationException
 import org.apache.iceberg.hadoop.HadoopCatalog
 import org.apache.iceberg.types.TypeUtil
 import org.apache.iceberg.types.Types
@@ -181,7 +182,7 @@ class PositionalDeleteEndToEndTest {
             .allMatch { it.content() == FileContent.POSITION_DELETES }
         assertThat(positionalDeleteFiles).allMatch { it.referencedDataFile() != null }
         assertThat(positionalDeleteFiles.map { it.referencedDataFile() }.toSet())
-            .hasSize(positionalDeleteFiles.size)
+            .hasSizeLessThanOrEqualTo(positionalDeleteFiles.size)
 
         val rows =
             IcebergGenerics.read(table).useSnapshot(stagingSnapshotId).build().use { records ->
@@ -342,7 +343,8 @@ class PositionalDeleteEndToEndTest {
         writer.write(RecordWrapper(record(schema, "b", "new-b"), Operation.UPDATE))
         val result = writer.complete()
         assertThat(result.deleteFiles()).isEmpty()
-        assertThat(supersededDataFiles(writer)).containsExactly(initialResult.dataFiles().single())
+        assertThat(supersededDataFiles(writer).map { it.location() })
+            .containsExactly(initialResult.dataFiles().single().location())
         IcebergTableCommitter.commit(
             table,
             "staging",
@@ -352,10 +354,10 @@ class PositionalDeleteEndToEndTest {
         )
         assertThat(
                 table.newScan().useRef("staging").planFiles().use {
-                    it.map { task -> task.file() }.toList()
+                    it.map { task -> task.file().location() }.toList()
                 }
             )
-            .noneMatch { it.location() == initialResult.dataFiles().single().location() }
+            .doesNotContain(initialResult.dataFiles().single().location())
         warehouse.toFile().deleteRecursively()
     }
 
@@ -401,13 +403,15 @@ class PositionalDeleteEndToEndTest {
             )
         writer.write(RecordWrapper(record(schema, "a", "new-a"), Operation.UPDATE))
         val result = writer.complete()
-        val concurrentWriter = writerFactory.create(table, "ab-generation-id-2-e", Append, schema)
-        concurrentWriter.write(record(schema, "b", "concurrent-b"))
-        val concurrentResult = concurrentWriter.complete()
         table
-            .newAppend()
+            .newRewrite()
             .toBranch("staging")
-            .apply { concurrentResult.dataFiles().forEach(::appendFile) }
+            .rewriteFiles(
+                setOf(initialResult.dataFiles().single()),
+                emptySet(),
+                emptySet(),
+                emptySet(),
+            )
             .commit()
         assertThatThrownBy {
                 IcebergTableCommitter.commit(
@@ -418,7 +422,7 @@ class PositionalDeleteEndToEndTest {
                     supersededDataFiles(writer),
                 )
             }
-            .isInstanceOf(CommitFailedException::class.java)
+            .isInstanceOfAny(CommitFailedException::class.java, ValidationException::class.java)
         warehouse.toFile().deleteRecursively()
     }
 

--- a/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/test/kotlin/io/airbyte/cdk/load/toolkits/iceberg/parquet/io/PositionalDeleteEndToEndTest.kt
+++ b/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/test/kotlin/io/airbyte/cdk/load/toolkits/iceberg/parquet/io/PositionalDeleteEndToEndTest.kt
@@ -15,6 +15,7 @@ import org.apache.iceberg.TableProperties
 import org.apache.iceberg.catalog.TableIdentifier
 import org.apache.iceberg.data.GenericRecord
 import org.apache.iceberg.data.IcebergGenerics
+import org.apache.iceberg.exceptions.CommitFailedException
 import org.apache.iceberg.hadoop.HadoopCatalog
 import org.apache.iceberg.types.TypeUtil
 import org.apache.iceberg.types.Types
@@ -25,6 +26,7 @@ import org.apache.logging.log4j.core.LoggerContext
 import org.apache.logging.log4j.core.appender.AbstractAppender
 import org.apache.logging.log4j.core.layout.PatternLayout
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
 
 class PositionalDeleteEndToEndTest {
@@ -177,6 +179,9 @@ class PositionalDeleteEndToEndTest {
                 table.snapshot(secondPositionalSnapshotId)!!.addedDeleteFiles(table.io()).toList()
             )
             .allMatch { it.content() == FileContent.POSITION_DELETES }
+        assertThat(positionalDeleteFiles).allMatch { it.referencedDataFile() != null }
+        assertThat(positionalDeleteFiles.map { it.referencedDataFile() }.toSet())
+            .hasSize(positionalDeleteFiles.size)
 
         val rows =
             IcebergGenerics.read(table).useSnapshot(stagingSnapshotId).build().use { records ->
@@ -187,6 +192,234 @@ class PositionalDeleteEndToEndTest {
                 "1" to "one-updated-again",
                 "3" to "three-updated",
             )
+        warehouse.toFile().deleteRecursively()
+    }
+
+    @Test
+    @Suppress("DEPRECATION")
+    fun `suppresses positions across multiple prior position delete files`() {
+        val warehouse = Files.createTempDirectory("positional-delete-suppression")
+        val catalog = HadoopCatalog(Configuration(), warehouse.toString())
+        val tableId = TableIdentifier.of("db", "suppression")
+        val schema =
+            Schema(
+                listOf(
+                    Types.NestedField.required(1, "id", Types.StringType.get()),
+                    Types.NestedField.required(2, "name", Types.StringType.get()),
+                ),
+                setOf(1),
+            )
+        catalog.createNamespace(tableId.namespace())
+        val table =
+            catalog
+                .buildTable(tableId, schema)
+                .withProperty(
+                    TableProperties.DEFAULT_FILE_FORMAT,
+                    FileFormat.PARQUET.name.lowercase()
+                )
+                .create()
+        val writerFactory = IcebergTableWriterFactory()
+        val initialWriter = writerFactory.create(table, "ab-generation-id-0-e", Append, schema)
+        listOf("a", "b", "c").forEach { id -> initialWriter.write(record(schema, id, "old-$id")) }
+        val initialResult = initialWriter.complete()
+        table.newAppend().apply { initialResult.dataFiles().forEach(::appendFile) }.commit()
+        table.manageSnapshots().createBranch("staging").commit()
+        val state = PositionalDeleteResolutionState()
+        val importType = io.airbyte.cdk.load.command.Dedupe(listOf(listOf("id")), emptyList())
+
+        val firstPlanned = table.refs()["staging"]!!.snapshotId()
+        val firstWriter =
+            writerFactory.create(
+                table,
+                "ab-generation-id-1-e",
+                importType,
+                schema,
+                positionalDeleteRef = "staging",
+                positionalDeleteState = state,
+            )
+        firstWriter.write(RecordWrapper(record(schema, "a", "new-a"), Operation.UPDATE))
+        val firstResult = firstWriter.complete()
+        IcebergTableCommitter.commit(
+            table,
+            "staging",
+            firstResult,
+            firstPlanned,
+            IcebergTableCommitter.fullySupersededDataFiles(table, firstPlanned, firstResult),
+        )
+
+        val secondPlanned = table.refs()["staging"]!!.snapshotId()
+        val secondWriter =
+            writerFactory.create(
+                table,
+                "ab-generation-id-2-e",
+                importType,
+                schema,
+                positionalDeleteRef = "staging",
+                positionalDeleteState = state,
+            )
+        secondWriter.write(RecordWrapper(record(schema, "b", "new-b"), Operation.UPDATE))
+        val secondResult = secondWriter.complete()
+        assertThat(secondResult.deleteFiles()).hasSize(1)
+        IcebergTableCommitter.commit(
+            table,
+            "staging",
+            secondResult,
+            secondPlanned,
+            IcebergTableCommitter.fullySupersededDataFiles(table, secondPlanned, secondResult),
+        )
+
+        val thirdPlanned = table.refs()["staging"]!!.snapshotId()
+        val thirdWriter =
+            writerFactory.create(
+                table,
+                "ab-generation-id-3-e",
+                importType,
+                schema,
+                positionalDeleteRef = "staging",
+                positionalDeleteState = state,
+            )
+        thirdWriter.write(RecordWrapper(record(schema, "c", "new-c"), Operation.UPDATE))
+        val thirdResult = thirdWriter.complete()
+        assertThat(thirdResult.deleteFiles()).isEmpty()
+        IcebergTableCommitter.commit(
+            table,
+            "staging",
+            thirdResult,
+            thirdPlanned,
+            IcebergTableCommitter.fullySupersededDataFiles(table, thirdPlanned, thirdResult),
+        )
+
+        val rows =
+            IcebergGenerics.read(table)
+                .useSnapshot(table.refs()["staging"]!!.snapshotId())
+                .build()
+                .use { records -> records.map { it.getField("name") }.toSet() }
+        assertThat(rows).containsExactlyInAnyOrder("new-a", "new-b", "new-c")
+        warehouse.toFile().deleteRecursively()
+    }
+
+    @Test
+    @Suppress("DEPRECATION")
+    fun `drops a data file only when every live position is superseded`() {
+        val warehouse = Files.createTempDirectory("positional-delete-full-file")
+        val catalog = HadoopCatalog(Configuration(), warehouse.toString())
+        val tableId = TableIdentifier.of("db", "full_file")
+        val schema =
+            Schema(
+                listOf(
+                    Types.NestedField.required(1, "id", Types.StringType.get()),
+                    Types.NestedField.required(2, "name", Types.StringType.get()),
+                ),
+                setOf(1),
+            )
+        catalog.createNamespace(tableId.namespace())
+        val table =
+            catalog
+                .buildTable(tableId, schema)
+                .withProperty(
+                    TableProperties.DEFAULT_FILE_FORMAT,
+                    FileFormat.PARQUET.name.lowercase()
+                )
+                .create()
+        val writerFactory = IcebergTableWriterFactory()
+        val initialWriter = writerFactory.create(table, "ab-generation-id-0-e", Append, schema)
+        listOf("a", "b").forEach { id -> initialWriter.write(record(schema, id, "old-$id")) }
+        val initialResult = initialWriter.complete()
+        table.newAppend().apply { initialResult.dataFiles().forEach(::appendFile) }.commit()
+        table.manageSnapshots().createBranch("staging").commit()
+        val planned = table.refs()["staging"]!!.snapshotId()
+        val state = PositionalDeleteResolutionState()
+        val writer =
+            writerFactory.create(
+                table,
+                "ab-generation-id-1-e",
+                io.airbyte.cdk.load.command.Dedupe(listOf(listOf("id")), emptyList()),
+                schema,
+                positionalDeleteRef = "staging",
+                positionalDeleteState = state,
+            )
+        writer.write(RecordWrapper(record(schema, "a", "new-a"), Operation.UPDATE))
+        writer.write(RecordWrapper(record(schema, "b", "new-b"), Operation.UPDATE))
+        val result = writer.complete()
+        assertThat(result.deleteFiles()).isEmpty()
+        assertThat(result.referencedDataFiles())
+            .containsExactly(initialResult.dataFiles().single().location())
+        IcebergTableCommitter.commit(
+            table,
+            "staging",
+            result,
+            planned,
+            IcebergTableCommitter.fullySupersededDataFiles(table, planned, result),
+        )
+        assertThat(
+                table.newScan().useRef("staging").planFiles().use {
+                    it.map { task -> task.file() }.toList()
+                }
+            )
+            .noneMatch { it.location() == initialResult.dataFiles().single().location() }
+        warehouse.toFile().deleteRecursively()
+    }
+
+    @Test
+    @Suppress("DEPRECATION")
+    fun `rejects a stale planned snapshot`() {
+        val warehouse = Files.createTempDirectory("positional-delete-stale-snapshot")
+        val catalog = HadoopCatalog(Configuration(), warehouse.toString())
+        val tableId = TableIdentifier.of("db", "stale_snapshot")
+        val schema =
+            Schema(
+                listOf(
+                    Types.NestedField.required(1, "id", Types.StringType.get()),
+                    Types.NestedField.required(2, "name", Types.StringType.get()),
+                ),
+                setOf(1),
+            )
+        catalog.createNamespace(tableId.namespace())
+        val table =
+            catalog
+                .buildTable(tableId, schema)
+                .withProperty(
+                    TableProperties.DEFAULT_FILE_FORMAT,
+                    FileFormat.PARQUET.name.lowercase()
+                )
+                .create()
+        val writerFactory = IcebergTableWriterFactory()
+        val initialWriter = writerFactory.create(table, "ab-generation-id-0-e", Append, schema)
+        initialWriter.write(record(schema, "a", "old-a"))
+        val initialResult = initialWriter.complete()
+        table.newAppend().apply { initialResult.dataFiles().forEach(::appendFile) }.commit()
+        table.manageSnapshots().createBranch("staging").commit()
+        val planned = table.refs()["staging"]!!.snapshotId()
+        val state = PositionalDeleteResolutionState()
+        val writer =
+            writerFactory.create(
+                table,
+                "ab-generation-id-1-e",
+                io.airbyte.cdk.load.command.Dedupe(listOf(listOf("id")), emptyList()),
+                schema,
+                positionalDeleteRef = "staging",
+                positionalDeleteState = state,
+            )
+        writer.write(RecordWrapper(record(schema, "a", "new-a"), Operation.UPDATE))
+        val result = writer.complete()
+        val concurrentWriter = writerFactory.create(table, "ab-generation-id-2-e", Append, schema)
+        concurrentWriter.write(record(schema, "b", "concurrent-b"))
+        val concurrentResult = concurrentWriter.complete()
+        table
+            .newAppend()
+            .toBranch("staging")
+            .apply { concurrentResult.dataFiles().forEach(::appendFile) }
+            .commit()
+        assertThatThrownBy {
+                IcebergTableCommitter.commit(
+                    table,
+                    "staging",
+                    result,
+                    planned,
+                    IcebergTableCommitter.fullySupersededDataFiles(table, planned, result),
+                )
+            }
+            .isInstanceOf(CommitFailedException::class.java)
         warehouse.toFile().deleteRecursively()
     }
 

--- a/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/test/kotlin/io/airbyte/cdk/load/toolkits/iceberg/parquet/io/PositionalDeleteEndToEndTest.kt
+++ b/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/test/kotlin/io/airbyte/cdk/load/toolkits/iceberg/parquet/io/PositionalDeleteEndToEndTest.kt
@@ -6,6 +6,7 @@ package io.airbyte.cdk.load.toolkits.iceberg.parquet.io
 
 import io.airbyte.cdk.load.command.Append
 import java.nio.file.Files
+import java.util.UUID
 import kotlin.system.measureTimeMillis
 import org.apache.hadoop.conf.Configuration
 import org.apache.iceberg.FileContent
@@ -13,11 +14,15 @@ import org.apache.iceberg.FileFormat
 import org.apache.iceberg.Schema
 import org.apache.iceberg.TableProperties
 import org.apache.iceberg.catalog.TableIdentifier
+import org.apache.iceberg.data.GenericFileWriterFactory
 import org.apache.iceberg.data.GenericRecord
 import org.apache.iceberg.data.IcebergGenerics
+import org.apache.iceberg.data.Record
+import org.apache.iceberg.deletes.PositionDelete
 import org.apache.iceberg.exceptions.CommitFailedException
 import org.apache.iceberg.exceptions.ValidationException
 import org.apache.iceberg.hadoop.HadoopCatalog
+import org.apache.iceberg.io.OutputFileFactory
 import org.apache.iceberg.types.TypeUtil
 import org.apache.iceberg.types.Types
 import org.apache.logging.log4j.Level
@@ -105,33 +110,42 @@ class PositionalDeleteEndToEndTest {
                 positionalDeleteRef = "staging",
                 positionalDeleteState = positionalState,
                 maxTouchedKeys = 2,
+                allowWholeFileSupersession = true,
             )
-        val (_, warningMessages) =
+        val (firstResult, warningMessages) =
             captureWarnings {
-                    firstUpdateWriter.write(
-                        RecordWrapper(record(schema, "1", "one-updated"), Operation.UPDATE)
+                firstUpdateWriter.write(
+                    RecordWrapper(record(schema, "1", "one-updated"), Operation.UPDATE)
+                )
+                firstUpdateWriter.write(
+                    RecordWrapper(record(schema, "2", "ignored"), Operation.DELETE)
+                )
+                firstUpdateWriter.write(
+                    RecordWrapper(record(schema, "1", "one-updated-again"), Operation.UPDATE)
+                )
+                firstUpdateWriter.write(
+                    RecordWrapper(record(schema, "3", "three"), Operation.INSERT)
+                )
+                firstUpdateWriter.write(
+                    RecordWrapper(
+                        record(schema, StringBuilder("3"), "three-repeated"),
+                        Operation.UPDATE
                     )
-                    firstUpdateWriter.write(
-                        RecordWrapper(record(schema, "2", "ignored"), Operation.DELETE)
-                    )
-                    firstUpdateWriter.write(
-                        RecordWrapper(record(schema, "1", "one-updated-again"), Operation.UPDATE)
-                    )
-                    firstUpdateWriter.write(
-                        RecordWrapper(record(schema, "3", "three"), Operation.INSERT)
-                    )
-                    firstUpdateWriter.write(
-                        RecordWrapper(
-                            record(schema, StringBuilder("3"), "three-repeated"),
-                            Operation.UPDATE
-                        )
-                    )
-                    firstUpdateWriter.write(
-                        RecordWrapper(record(schema, "9", "missing"), Operation.DELETE)
-                    )
-                    firstUpdateWriter.complete()
-                }
-                .also { commitRowDelta(table, "staging", it.first) }
+                )
+                firstUpdateWriter.write(
+                    RecordWrapper(record(schema, "9", "missing"), Operation.DELETE)
+                )
+                firstUpdateWriter.complete()
+            }
+        assertThat(supersededDataFiles(firstUpdateWriter).map { it.location() })
+            .contains(initialResult.dataFiles().single().location())
+        IcebergTableCommitter.commit(
+            table,
+            "staging",
+            firstResult,
+            initialSnapshotId,
+            supersededDataFiles(firstUpdateWriter),
+        )
         assertThat(warningMessages).anyMatch {
             it.contains("Positional delete mode found 1 existing equality-delete file(s)")
         }
@@ -237,6 +251,7 @@ class PositionalDeleteEndToEndTest {
                 schema,
                 positionalDeleteRef = "staging",
                 positionalDeleteState = state,
+                allowWholeFileSupersession = true,
             )
         firstWriter.write(RecordWrapper(record(schema, "a", "new-a"), Operation.UPDATE))
         val firstResult = firstWriter.complete()
@@ -278,6 +293,7 @@ class PositionalDeleteEndToEndTest {
                 schema,
                 positionalDeleteRef = "staging",
                 positionalDeleteState = state,
+                allowWholeFileSupersession = true,
             )
         thirdWriter.write(RecordWrapper(record(schema, "c", "new-c"), Operation.UPDATE))
         val thirdResult = thirdWriter.complete()
@@ -296,6 +312,193 @@ class PositionalDeleteEndToEndTest {
                 .build()
                 .use { records -> records.map { it.getField("name") }.toSet() }
         assertThat(rows).containsExactlyInAnyOrder("new-a", "new-b", "new-c")
+        warehouse.toFile().deleteRecursively()
+    }
+
+    @Test
+    @Suppress("DEPRECATION")
+    fun `falls back per data file when a prior position delete cannot be read`() {
+        val warehouse = Files.createTempDirectory("positional-delete-fallback")
+        val catalog = HadoopCatalog(Configuration(), warehouse.toString())
+        val tableId = TableIdentifier.of("db", "fallback")
+        val schema =
+            Schema(
+                listOf(
+                    Types.NestedField.required(1, "id", Types.StringType.get()),
+                    Types.NestedField.required(2, "name", Types.StringType.get()),
+                ),
+                setOf(1),
+            )
+        catalog.createNamespace(tableId.namespace())
+        val table =
+            catalog
+                .buildTable(tableId, schema)
+                .withProperty(
+                    TableProperties.DEFAULT_FILE_FORMAT,
+                    FileFormat.PARQUET.name.lowercase()
+                )
+                .create()
+        val writerFactory = IcebergTableWriterFactory()
+        val first = writerFactory.create(table, "ab-generation-id-0-e", Append, schema)
+        first.write(record(schema, "a", "old-a"))
+        val firstResult = first.complete()
+        val second = writerFactory.create(table, "ab-generation-id-0-e", Append, schema)
+        second.write(record(schema, "b", "old-b"))
+        val initialSecondResult = second.complete()
+        table
+            .newAppend()
+            .apply {
+                firstResult.dataFiles().forEach(::appendFile)
+                initialSecondResult.dataFiles().forEach(::appendFile)
+            }
+            .commit()
+        table.manageSnapshots().createBranch("staging").commit()
+        val importType = io.airbyte.cdk.load.command.Dedupe(listOf(listOf("id")), emptyList())
+        val state = PositionalDeleteResolutionState()
+        val planned = table.refs()["staging"]!!.snapshotId()
+        val firstUpdate =
+            writerFactory.create(
+                table,
+                "ab-generation-id-1-e",
+                importType,
+                schema,
+                positionalDeleteRef = "staging",
+                positionalDeleteState = state,
+            )
+        firstUpdate.write(RecordWrapper(record(schema, "a", "new-a"), Operation.UPDATE))
+        firstUpdate.write(RecordWrapper(record(schema, "b", "new-b"), Operation.UPDATE))
+        val firstUpdateResult = firstUpdate.complete()
+        IcebergTableCommitter.commit(
+            table,
+            "staging",
+            firstUpdateResult,
+            planned,
+            supersededDataFiles(firstUpdate),
+        )
+        val priorDeletes =
+            table.newScan().useRef("staging").planFiles().use { tasks ->
+                tasks
+                    .flatMap { it.deletes().toList() }
+                    .filter { it.content() == FileContent.POSITION_DELETES }
+                    .toList()
+            }
+        assertThat(priorDeletes).hasSize(2)
+        table.io().deleteFile(priorDeletes.first().location())
+
+        val secondPlanned = table.refs()["staging"]!!.snapshotId()
+        val secondUpdate =
+            writerFactory.create(
+                table,
+                "ab-generation-id-2-e",
+                importType,
+                schema,
+                positionalDeleteRef = "staging",
+                positionalDeleteState = state,
+            )
+        secondUpdate.write(RecordWrapper(record(schema, "a", "newer-a"), Operation.UPDATE))
+        secondUpdate.write(RecordWrapper(record(schema, "b", "newer-b"), Operation.UPDATE))
+        val secondResult = secondUpdate.complete()
+        assertThat(secondResult.deleteFiles()).hasSize(2)
+        assertThat(secondResult.deleteFiles().map { it.referencedDataFile() })
+            .contains(firstResult.dataFiles().single().location())
+            .doesNotContain(secondResult.dataFiles().single().location())
+        assertThat(secondResult.deleteFiles().map { it.referencedDataFile() })
+            .doesNotContain(initialSecondResult.dataFiles().single().location())
+        IcebergTableCommitter.commit(
+            table,
+            "staging",
+            secondResult,
+            secondPlanned,
+            supersededDataFiles(secondUpdate),
+        )
+        warehouse.toFile().deleteRecursively()
+    }
+
+    @Test
+    @Suppress("DEPRECATION")
+    fun `retains a shared position delete when only one data file is superseded`() {
+        val warehouse = Files.createTempDirectory("positional-delete-shared")
+        val catalog = HadoopCatalog(Configuration(), warehouse.toString())
+        val tableId = TableIdentifier.of("db", "shared")
+        val schema =
+            Schema(
+                listOf(
+                    Types.NestedField.required(1, "id", Types.StringType.get()),
+                    Types.NestedField.required(2, "name", Types.StringType.get()),
+                ),
+                setOf(1),
+            )
+        catalog.createNamespace(tableId.namespace())
+        val table =
+            catalog
+                .buildTable(tableId, schema)
+                .withProperty(
+                    TableProperties.DEFAULT_FILE_FORMAT,
+                    FileFormat.PARQUET.name.lowercase()
+                )
+                .create()
+        val writerFactory = IcebergTableWriterFactory()
+        val first = writerFactory.create(table, "ab-generation-id-0-e", Append, schema)
+        first.write(record(schema, "a", "old-a"))
+        val firstResult = first.complete()
+        val second = writerFactory.create(table, "ab-generation-id-0-e", Append, schema)
+        second.write(record(schema, "b", "old-b"))
+        val secondResult = second.complete()
+        table
+            .newAppend()
+            .apply {
+                firstResult.dataFiles().forEach(::appendFile)
+                secondResult.dataFiles().forEach(::appendFile)
+            }
+            .commit()
+        table.manageSnapshots().createBranch("staging").commit()
+        val sharedDelete =
+            sharedPositionDeleteFile(
+                table,
+                schema,
+                firstResult.dataFiles().single().location(),
+                secondResult.dataFiles().single().location()
+            )
+        val planned = table.refs()["staging"]!!.snapshotId()
+        table
+            .newRowDelta()
+            .toBranch("staging")
+            .validateFromSnapshot(planned)
+            .addDeletes(sharedDelete)
+            .commit()
+
+        val updatePlanned = table.refs()["staging"]!!.snapshotId()
+        val state = PositionalDeleteResolutionState()
+        val update =
+            writerFactory.create(
+                table,
+                "ab-generation-id-1-e",
+                io.airbyte.cdk.load.command.Dedupe(listOf(listOf("id")), emptyList()),
+                schema,
+                positionalDeleteRef = "staging",
+                positionalDeleteState = state,
+                allowWholeFileSupersession = true,
+            )
+        update.write(RecordWrapper(record(schema, "a", "new-a"), Operation.UPDATE))
+        val result = update.complete()
+        IcebergTableCommitter.commit(
+            table,
+            "staging",
+            result,
+            updatePlanned,
+            supersededDataFiles(update),
+        )
+        val liveDeletes =
+            table.newScan().useRef("staging").planFiles().use { tasks ->
+                tasks.flatMap { it.deletes().toList() }.toList()
+            }
+        assertThat(liveDeletes.map { it.location() }).contains(sharedDelete.location())
+        val names =
+            IcebergGenerics.read(table)
+                .useSnapshot(table.refs()["staging"]!!.snapshotId())
+                .build()
+                .use { records -> records.map { it.getField("name") }.toSet() }
+        assertThat(names).containsExactly("new-a")
         warehouse.toFile().deleteRecursively()
     }
 
@@ -338,6 +541,7 @@ class PositionalDeleteEndToEndTest {
                 schema,
                 positionalDeleteRef = "staging",
                 positionalDeleteState = state,
+                allowWholeFileSupersession = true,
             )
         writer.write(RecordWrapper(record(schema, "a", "new-a"), Operation.UPDATE))
         writer.write(RecordWrapper(record(schema, "b", "new-b"), Operation.UPDATE))
@@ -707,6 +911,40 @@ class PositionalDeleteEndToEndTest {
                 result.deleteFiles().forEach(::addDeletes)
             }
             .commit()
+    }
+
+    private fun sharedPositionDeleteFile(
+        table: org.apache.iceberg.Table,
+        schema: Schema,
+        firstPath: String,
+        secondPath: String,
+    ): org.apache.iceberg.DeleteFile {
+        val writerFactory =
+            GenericFileWriterFactory.Builder(table)
+                .dataSchema(schema)
+                .writerProperties(table.properties())
+                .build()
+        val outputFileFactory =
+            OutputFileFactory.builderFor(table, 0, 1L)
+                .defaultSpec(table.spec())
+                .operationId(UUID.randomUUID().toString())
+                .format(FileFormat.PARQUET)
+                .suffix("shared")
+                .build()
+        val writer =
+            writerFactory.newPositionDeleteWriter(
+                outputFileFactory.newOutputFile(table.spec(), null),
+                table.spec(),
+                null,
+            )
+        val first = PositionDelete.create<Record>()
+        first.set(firstPath, 0L)
+        writer.write(first)
+        val second = PositionDelete.create<Record>()
+        second.set(secondPath, 0L)
+        writer.write(second)
+        writer.close()
+        return writer.result().deleteFiles().single()
     }
 
     private fun supersededDataFiles(writer: Any): Set<org.apache.iceberg.DataFile> =

--- a/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/test/kotlin/io/airbyte/cdk/load/toolkits/iceberg/parquet/io/PositionalDeleteEndToEndTest.kt
+++ b/airbyte-cdk/bulk/toolkits/load-iceberg-parquet/src/test/kotlin/io/airbyte/cdk/load/toolkits/iceberg/parquet/io/PositionalDeleteEndToEndTest.kt
@@ -244,7 +244,7 @@ class PositionalDeleteEndToEndTest {
             "staging",
             firstResult,
             firstPlanned,
-            IcebergTableCommitter.fullySupersededDataFiles(table, firstPlanned, firstResult),
+            supersededDataFiles(firstWriter),
         )
 
         val secondPlanned = table.refs()["staging"]!!.snapshotId()
@@ -265,7 +265,7 @@ class PositionalDeleteEndToEndTest {
             "staging",
             secondResult,
             secondPlanned,
-            IcebergTableCommitter.fullySupersededDataFiles(table, secondPlanned, secondResult),
+            supersededDataFiles(secondWriter),
         )
 
         val thirdPlanned = table.refs()["staging"]!!.snapshotId()
@@ -286,7 +286,7 @@ class PositionalDeleteEndToEndTest {
             "staging",
             thirdResult,
             thirdPlanned,
-            IcebergTableCommitter.fullySupersededDataFiles(table, thirdPlanned, thirdResult),
+            supersededDataFiles(thirdWriter),
         )
 
         val rows =
@@ -342,14 +342,13 @@ class PositionalDeleteEndToEndTest {
         writer.write(RecordWrapper(record(schema, "b", "new-b"), Operation.UPDATE))
         val result = writer.complete()
         assertThat(result.deleteFiles()).isEmpty()
-        assertThat(result.referencedDataFiles())
-            .containsExactly(initialResult.dataFiles().single().location())
+        assertThat(supersededDataFiles(writer)).containsExactly(initialResult.dataFiles().single())
         IcebergTableCommitter.commit(
             table,
             "staging",
             result,
             planned,
-            IcebergTableCommitter.fullySupersededDataFiles(table, planned, result),
+            supersededDataFiles(writer),
         )
         assertThat(
                 table.newScan().useRef("staging").planFiles().use {
@@ -416,7 +415,7 @@ class PositionalDeleteEndToEndTest {
                     "staging",
                     result,
                     planned,
-                    IcebergTableCommitter.fullySupersededDataFiles(table, planned, result),
+                    supersededDataFiles(writer),
                 )
             }
             .isInstanceOf(CommitFailedException::class.java)
@@ -705,6 +704,9 @@ class PositionalDeleteEndToEndTest {
             }
             .commit()
     }
+
+    private fun supersededDataFiles(writer: Any): Set<org.apache.iceberg.DataFile> =
+        (writer as? SupersededDataFileProvider)?.fullySupersededDataFiles().orEmpty()
 
     private fun record(schema: Schema, id: CharSequence, name: String): GenericRecord =
         GenericRecord.create(schema).apply {

--- a/airbyte-integrations/connectors/destination-gcs-data-lake/src/main/kotlin/io/airbyte/integrations/destination/gcs_data_lake/write/GcsDataLakeStreamLoader.kt
+++ b/airbyte-integrations/connectors/destination-gcs-data-lake/src/main/kotlin/io/airbyte/integrations/destination/gcs_data_lake/write/GcsDataLakeStreamLoader.kt
@@ -78,13 +78,21 @@ class GcsDataLakeStreamLoader(
                         ?: originalName
 
                 if (mappedName != originalName) {
-                    Types.NestedField.of(
-                        field.fieldId(),
-                        field.isOptional,
-                        mappedName,
-                        field.type(),
-                        field.doc()
-                    )
+                    if (field.isOptional) {
+                        Types.NestedField.optional(
+                            field.fieldId(),
+                            mappedName,
+                            field.type(),
+                            field.doc()
+                        )
+                    } else {
+                        Types.NestedField.required(
+                            field.fieldId(),
+                            mappedName,
+                            field.type(),
+                            field.doc()
+                        )
+                    }
                 } else {
                     field
                 }


### PR DESCRIPTION
This PR targets PR #82750:
- #82750

---

## What

Positional delete mode as merged in #82750 rewrites the same positions every sync and never removes a data file, so a Dedupe table accumulates delete files without bound and each sync pays to read all of them. This PR makes the positional write path self-limiting on Iceberg v2, and is the first of two increments — deletion vectors and the associated configuration follow on top of this branch.

Three changes, one commit path:

1. Delete files become file-scoped. One position delete file per referenced data file, with `referenced_data_file` set, instead of one per partition covering many data files. Readers can prune per data file, and loading prior deletes for one data file no longer means reading every delete file in its partition.
2. Positions already recorded by prior position deletes are not re-emitted.
3. A data file whose every live position is superseded is dropped through metadata rather than covered by new deletes, which removes it from all future scans. This is the mechanism Trino uses (trinodb/trino#12197); its follow-on bug (trinodb/trino#18393) was insufficient conflict detection, which is why the commit is validated.

## How

`SupersededRowFinder` loads each candidate data file's existing position deletes into a `PositionDeleteIndex` via `Deletes.toPositionIndex` and skips positions that index already covers. Equality deletes are not position information and are ignored for this purpose. A data file whose prior-deleted count plus this flush's superseded count equals its record count is recorded as fully superseded and emits no deletes at all.

Failure to read a prior delete file falls back per data file — that file emits deletes unconditionally while the rest of the flush still suppresses — because a position wrongly believed already deleted is a resurrected row.

`IcebergTableCommitter` becomes the single commit path, replacing the copy of the commit logic in each connector's aggregate. It commits rows first with

```kotlin
newRowDelta()
    .validateFromSnapshot(plannedSnapshotId)
    .validateDataFilesExist(writeResult.referencedDataFiles())
    .validateDeletedFiles()
    .validateNoConflictingDataFiles()
    .validateNoConflictingDeleteFiles()
```

so a concurrent compaction that removed a data file our deletes reference fails the commit instead of landing metadata that references files the current snapshot no longer has. Dropping superseded files is a second validated commit, because `RowDelta` cannot remove data files and `OverwriteFiles` cannot add delete files: `newRewrite().rewriteFiles(supersededDataFiles, obsoleteDeleteFiles, emptySet(), emptySet())`. Rows land before their predecessors are dropped.

That second commit replaces *only* position delete files whose `referenced_data_file` is exactly a file being dropped. Partition-scoped delete files written by earlier versions cover data files we are keeping, so removing one would resurrect rows in those files; equality deletes are likewise left alone.

Whole-file supersession is opt-in (`allowWholeFileSupersession`, default off), because a writer that withholds deletes on the assumption that its caller will drop the file loses data when the caller doesn't. Only callers that commit through `IcebergTableCommitter` enable it; with it off the writer behaves exactly as it does on the base branch.

## Review guide

1. `SupersededRowFinder.kt` — prior-delete index, per-file fallback, supersession detection
2. `IcebergTableCommitter.kt` — commit validation, and which delete files the rewrite is allowed to replace
3. `PositionalDeleteFiles.kt` — per-data-file writers and `referenced_data_file`
4. `PositionalDeleteEndToEndTest.kt` — suppression across multiple prior delete files, equality and position deletes on the same data file, supersession only when every live position is covered, the shared delete file that must survive, per-file fallback, stale planned snapshot rejected

## User Impact

None yet: nothing in this branch changes connector behavior on its own, and equality deletes remain the default encoding. For Dedupe streams already using positional mode, delete files stop accumulating for keys that are repeatedly updated, and data files disappear once fully superseded rather than being scanned forever.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚
- [ ] NO ❌


Link to Devin session: https://app.devin.ai/sessions/9a6b30bee54d474a837bc962774191fd
Requested by: @aaronsteers

---

> [!IMPORTANT]
> **Autopilot Progressive Rollout Enabled**
>
> [Autopilot progressive rollouts](https://github.com/airbytehq/airbyte-ops-mcp/blob/main/docs/autopilot-rollouts.md) are enabled for one or more connector(s) modified in this PR. Check the box below if you need to bypass normal rollout safety processes and release to all users immediately upon merge:
>
> - [ ] ⚡ **Release immediately** (bypasses automatic progressive rollout)
>
> **Note:**
>
> - ⚠️ The above bypass option is for emergency/hotfix use only.
> - 🔗 You can monitor or manually advance a rollout at **[ops.internal.airbyte.ai](https://ops.internal.airbyte.ai)**.