### PR TITLE
fix(ci): correct the actions/stale SHA so the stale workflows can run

### DIFF
--- a/.github/workflows/stale-community-issues.yaml
+++ b/.github/workflows/stale-community-issues.yaml
@@ -19,7 +19,7 @@ jobs:
           repositories: "airbyte"
           app-id: ${{ secrets.OCTAVIA_BOT_APP_ID }}
           private-key: ${{ secrets.OCTAVIA_BOT_PRIVATE_KEY }}
-      - uses: actions/stale@b5d41d4d0e39afb4e3d58060a07f6fb1ce2caa77 # v10.2.0
+      - uses: actions/stale@b5d41d4e1d5dceea10e7104786b73624c18a190f # v10.2.0
         id: stale
         with:
           any-of-labels: "community"

--- a/.github/workflows/stale-routed-issues.yaml
+++ b/.github/workflows/stale-routed-issues.yaml
@@ -20,7 +20,7 @@ jobs:
           repositories: "airbyte"
           app-id: ${{ secrets.OCTAVIA_BOT_APP_ID }}
           private-key: ${{ secrets.OCTAVIA_BOT_PRIVATE_KEY }}
-      - uses: actions/stale@b5d41d4d0e39afb4e3d58060a07f6fb1ce2caa77 # v10.2.0
+      - uses: actions/stale@b5d41d4e1d5dceea10e7104786b73624c18a190f # v10.2.0
         id: stale
         with:
           any-of-labels: "frozen"


### PR DESCRIPTION
## What

Both stale workflows have been failing every scheduled run since 2026-04-01. They never reach a step, so no issue has been marked stale or closed in about four and a half months.

The last 100 runs of each are failures:

| workflow | last 100 runs |
|---|---|
| `stale-community-issues.yaml` | 100 failure, 0 success |
| `stale-routed-issues.yaml` | 100 failure, 0 success |

The runner fails during `Set up job`:

```
##[error]Unable to resolve action `actions/stale@b5d41d4d0e39afb4e3d58060a07f6fb1ce2caa77`, unable to find version `b5d41d4d0e39afb4e3d58060a07f6fb1ce2caa77`
```

Both files pin `actions/stale` to a SHA that does not exist in that repository:

```
GET /repos/actions/stale/commits/b5d41d4d0e39afb4e3d58060a07f6fb1ce2caa77
422  No commit found for SHA
```

The real `v10.2.0` is `b5d41d4e1d5dceea10e7104786b73624c18a190f`:

```
GET /repos/actions/stale/git/ref/tags/v10.2.0
b5d41d4e1d5dceea10e7104786b73624c18a190f
```

Lined up, the two share only the first seven characters and then diverge completely:

```
pinned  b5d41d4d0e39afb4e3d58060a07f6fb1ce2caa77
v10.2.0 b5d41d4e1d5dceea10e7104786b73624c18a190f
               ^
```

That is the length of a short SHA, so this reads like `b5d41d4` was expanded into the wrong full value rather than someone pinning a real but different commit. It came in with #76024, which was itself the change that bumped to v10.2.0, and the comment on the line has been correct the whole time.

## How

Replaces the SHA in both files with the one `v10.2.0` actually points at. Nothing else changes, and the `# v10.2.0` comments stay accurate.

## Review guide

1. `.github/workflows/stale-community-issues.yaml` line 22
2. `.github/workflows/stale-routed-issues.yaml` line 23

Both are the same one-line change. The SHA is worth pasting into `https://github.com/actions/stale/commits/<sha>` to confirm the old one 404s and the new one resolves to the v10.2.0 tag.

## User Impact

Stale handling starts working again for community and routed issues. That does mean the first run after merge will act on a four and a half month backlog rather than a normal day's worth. `operations-per-run: 100` caps each run, and `ascending: true` makes it work through the oldest first, so it will drain over several nights instead of all at once. Flagging it since that first batch of notifications will be larger than usual.

I could not run these workflows to verify, as they are scheduled and `workflow_dispatch` only. The failure message above is from run 32009537523 on master, and the SHA lookups are against the public `actions/stale` API.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚
- [ ] NO ❌
