### PR TITLE
fix(destination-snowflake): skip zero-record incremental merges safely

### DIFF
--- a/airbyte-integrations/connectors/destination-snowflake/src/main/kotlin/io/airbyte/integrations/destination/snowflake/check/SnowflakeChecker.kt
+++ b/airbyte-integrations/connectors/destination-snowflake/src/main/kotlin/io/airbyte/integrations/destination/snowflake/check/SnowflakeChecker.kt
@@ -117,7 +117,7 @@ class SnowflakeChecker(
 
                 snowflakeInsertBuffer.accumulate(data)
                 snowflakeInsertBuffer.flush()
-                val tableCount = snowflakeAirbyteClient.countTable(qualifiedTableName)
+                val tableCount = snowflakeAirbyteClient.exactCountTable(qualifiedTableName)
                 require(tableCount == 1L) {
                     "Failed to insert expected rows into check table. Actual written: $tableCount"
                 }

--- a/airbyte-integrations/connectors/destination-snowflake/src/main/kotlin/io/airbyte/integrations/destination/snowflake/client/SnowflakeAirbyteClient.kt
+++ b/airbyte-integrations/connectors/destination-snowflake/src/main/kotlin/io/airbyte/integrations/destination/snowflake/client/SnowflakeAirbyteClient.kt
@@ -13,6 +13,7 @@ import io.airbyte.cdk.load.component.TableColumns
 import io.airbyte.cdk.load.component.TableOperationsClient
 import io.airbyte.cdk.load.component.TableSchema
 import io.airbyte.cdk.load.component.TableSchemaEvolutionClient
+import io.airbyte.cdk.load.schema.model.StreamTableSchema
 import io.airbyte.cdk.load.schema.model.TableName
 import io.airbyte.cdk.load.table.ColumnNameMapping
 import io.airbyte.cdk.load.util.deserializeToNode
@@ -26,6 +27,7 @@ import io.airbyte.integrations.destination.snowflake.sql.escapeJsonIdentifier
 import io.github.oshai.kotlinlogging.KotlinLogging
 import jakarta.inject.Singleton
 import java.sql.ResultSet
+import java.util.concurrent.ConcurrentHashMap
 import javax.sql.DataSource
 import net.snowflake.client.jdbc.SnowflakeSQLException
 
@@ -44,10 +46,27 @@ class SnowflakeAirbyteClient(
 ) : TableOperationsClient, TableSchemaEvolutionClient {
     private val databaseName = snowflakeConfiguration.database.toSnowflakeCompatibleName()
 
+    private data class PendingTempTable(
+        val schema: StreamTableSchema,
+        val replace: Boolean,
+    )
+
+    /**
+     * Temporary tables are registered here and materialized by the first write. This avoids
+     * creating a table and stage for a stream that receives no records.
+     *
+     * Each value also acts as that table's initialization lock. It is deliberately removed only
+     * after both CREATE TABLE and CREATE STAGE have completed, so concurrent PUTs cannot race ahead
+     * of stage creation.
+     */
+    private val pendingTempTables = ConcurrentHashMap<TableName, PendingTempTable>()
+
     override suspend fun countTable(tableName: TableName): Long? {
-        if (!tableExists(tableName)) {
-            return null
-        }
+        return getTableRowCount(tableName)
+    }
+
+    /** Used by CHECK, where the exact post-write count is part of the connectivity assertion. */
+    fun exactCountTable(tableName: TableName): Long {
         return dataSource.connection.use { connection ->
             val statement = connection.createStatement()
             statement.use {
@@ -62,7 +81,13 @@ class SnowflakeAirbyteClient(
         }
     }
 
-    override suspend fun tableExists(table: TableName): Boolean =
+    override suspend fun tableExists(table: TableName): Boolean = getTableRowCount(table) != null
+
+    /**
+     * Reads Snowflake's table metadata rather than executing SELECT COUNT(*). Initial status only
+     * needs to distinguish missing, empty, and non-empty tables; it does not need an exact count.
+     */
+    private fun getTableRowCount(table: TableName): Long? =
         dataSource.connection.use { connection ->
             val statement =
                 connection.prepareStatement(
@@ -73,7 +98,10 @@ class SnowflakeAirbyteClient(
                     """.trimIndent()
                 )
             statement.setString(1, table.name)
-            statement.use { it.executeQuery().next() }
+            statement.use {
+                val resultSet = it.executeQuery()
+                if (resultSet.next()) resultSet.getLong("rows") else null
+            }
         }
 
     override suspend fun namespaceExists(namespace: String): Boolean {
@@ -125,11 +153,23 @@ class SnowflakeAirbyteClient(
         columnNameMapping: ColumnNameMapping,
         replace: Boolean
     ) {
-        execute(sqlGenerator.createTable(tableName, stream.tableSchema, replace))
-        execute(sqlGenerator.createSnowflakeStage(tableName))
+        createTableAndStage(tableName, stream.tableSchema, replace)
+    }
+
+    override suspend fun createTempTable(
+        stream: DestinationStream,
+        tableName: TableName,
+        columnNameMapping: ColumnNameMapping,
+        replace: Boolean
+    ) {
+        pendingTempTables[tableName] = PendingTempTable(stream.tableSchema, replace)
     }
 
     override suspend fun overwriteTable(sourceTableName: TableName, targetTableName: TableName) {
+        // Truncate/overwrite modes must still replace the target with an empty table when the
+        // source emits zero records, so materialize the deferred source before overwriting.
+        materializePendingTempTable(sourceTableName)
+
         // Check if the target table exists by trying to count its rows
         val targetExists = countTable(targetTableName) != null
 
@@ -162,6 +202,13 @@ class SnowflakeAirbyteClient(
         sourceTableName: TableName,
         targetTableName: TableName
     ) {
+        if (isPendingTempTable(sourceTableName)) {
+            log.info {
+                "Skipping copy from unmaterialized empty temp table ${sourceTableName.toPrettyString()}"
+            }
+            return
+        }
+
         // Get all column names from the mapping (both meta columns and user columns)
         val columnNames = buildSet {
             // Add Airbyte meta columns (using uppercase constants)
@@ -179,10 +226,26 @@ class SnowflakeAirbyteClient(
         sourceTableName: TableName,
         targetTableName: TableName
     ) {
+        if (isPendingTempTable(sourceTableName)) {
+            log.info {
+                "Skipping upsert from unmaterialized empty temp table ${sourceTableName.toPrettyString()}"
+            }
+            return
+        }
+
+        // Dedup + truncate can upsert into a second deferred temporary table. It must exist before
+        // the MERGE starts whenever the source actually contains records.
+        materializePendingTempTable(targetTableName)
         execute(sqlGenerator.upsertTable(stream.tableSchema, sourceTableName, targetTableName))
     }
 
     override suspend fun dropTable(tableName: TableName) {
+        if (discardPendingTempTable(tableName)) {
+            log.info {
+                "Skipping drop of unmaterialized empty temp table ${tableName.toPrettyString()}"
+            }
+            return
+        }
         execute(sqlGenerator.dropTable(tableName))
     }
 
@@ -191,7 +254,6 @@ class SnowflakeAirbyteClient(
         tableName: TableName,
         columnNameMapping: ColumnNameMapping
     ) {
-        execute(sqlGenerator.createSnowflakeStage(tableName))
         /*
          * If legacy raw tables are in use, there is nothing to ensure in schema, as raw mode
          * uses a fixed schema that is not based on the catalog/incoming record.  Otherwise,
@@ -307,7 +369,44 @@ class SnowflakeAirbyteClient(
     }
 
     fun putInStage(tableName: TableName, tempFilePath: String) {
+        materializePendingTempTable(tableName)
         execute(sqlGenerator.putInStage(tableName, tempFilePath))
+    }
+
+    private fun createTableAndStage(
+        tableName: TableName,
+        tableSchema: StreamTableSchema,
+        replace: Boolean,
+    ) {
+        execute(sqlGenerator.createTable(tableName, tableSchema, replace))
+        execute(sqlGenerator.createSnowflakeStage(tableName))
+    }
+
+    /**
+     * Materializes a deferred table exactly once. Callers that arrive during initialization wait
+     * for table and stage creation to finish before continuing.
+     */
+    private fun materializePendingTempTable(tableName: TableName): Boolean {
+        val pending = pendingTempTables[tableName] ?: return false
+        synchronized(pending) {
+            if (pendingTempTables[tableName] !== pending) {
+                return false
+            }
+            createTableAndStage(tableName, pending.schema, pending.replace)
+            pendingTempTables.remove(tableName, pending)
+            return true
+        }
+    }
+
+    /** Waits for in-flight materialization before deciding whether a table is still deferred. */
+    private fun isPendingTempTable(tableName: TableName): Boolean {
+        val pending = pendingTempTables[tableName] ?: return false
+        synchronized(pending) { return pendingTempTables[tableName] === pending }
+    }
+
+    private fun discardPendingTempTable(tableName: TableName): Boolean {
+        val pending = pendingTempTables[tableName] ?: return false
+        synchronized(pending) { return pendingTempTables.remove(tableName, pending) }
     }
 
     fun copyFromStage(tableName: TableName, filename: String, columnNames: List<String>) {

--- a/airbyte-integrations/connectors/destination-snowflake/src/main/kotlin/io/airbyte/integrations/destination/snowflake/client/SnowflakeAirbyteClient.kt
+++ b/airbyte-integrations/connectors/destination-snowflake/src/main/kotlin/io/airbyte/integrations/destination/snowflake/client/SnowflakeAirbyteClient.kt
@@ -401,12 +401,16 @@ class SnowflakeAirbyteClient(
     /** Waits for in-flight materialization before deciding whether a table is still deferred. */
     private fun isPendingTempTable(tableName: TableName): Boolean {
         val pending = pendingTempTables[tableName] ?: return false
-        synchronized(pending) { return pendingTempTables[tableName] === pending }
+        synchronized(pending) {
+            return pendingTempTables[tableName] === pending
+        }
     }
 
     private fun discardPendingTempTable(tableName: TableName): Boolean {
         val pending = pendingTempTables[tableName] ?: return false
-        synchronized(pending) { return pendingTempTables.remove(tableName, pending) }
+        synchronized(pending) {
+            return pendingTempTables.remove(tableName, pending)
+        }
     }
 
     fun copyFromStage(tableName: TableName, filename: String, columnNames: List<String>) {

--- a/airbyte-integrations/connectors/destination-snowflake/src/test/kotlin/io/airbyte/integrations/destination/snowflake/check/SnowflakeCheckerTest.kt
+++ b/airbyte-integrations/connectors/destination-snowflake/src/test/kotlin/io/airbyte/integrations/destination/snowflake/check/SnowflakeCheckerTest.kt
@@ -8,7 +8,6 @@ import io.airbyte.integrations.destination.snowflake.client.SnowflakeAirbyteClie
 import io.airbyte.integrations.destination.snowflake.schema.SnowflakeColumnManager
 import io.airbyte.integrations.destination.snowflake.schema.toSnowflakeCompatibleName
 import io.airbyte.integrations.destination.snowflake.spec.SnowflakeConfiguration
-import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk

--- a/airbyte-integrations/connectors/destination-snowflake/src/test/kotlin/io/airbyte/integrations/destination/snowflake/check/SnowflakeCheckerTest.kt
+++ b/airbyte-integrations/connectors/destination-snowflake/src/test/kotlin/io/airbyte/integrations/destination/snowflake/check/SnowflakeCheckerTest.kt
@@ -22,7 +22,7 @@ internal class SnowflakeCheckerTest {
     @ValueSource(booleans = [true, false])
     fun testSuccessfulCheck(isLegacyRawTablesOnly: Boolean) {
         val snowflakeAirbyteClient: SnowflakeAirbyteClient =
-            mockk(relaxed = true) { coEvery { countTable(any()) } returns 1L }
+            mockk(relaxed = true) { every { exactCountTable(any()) } returns 1L }
 
         val testSchema = "test-schema"
         val snowflakeConfiguration: SnowflakeConfiguration = mockk {
@@ -62,7 +62,7 @@ internal class SnowflakeCheckerTest {
     @ValueSource(booleans = [true, false])
     fun testUnsuccessfulCheck(isLegacyRawTablesOnly: Boolean) {
         val snowflakeAirbyteClient: SnowflakeAirbyteClient =
-            mockk(relaxed = true) { coEvery { countTable(any()) } returns 0L }
+            mockk(relaxed = true) { every { exactCountTable(any()) } returns 0L }
 
         val testSchema = "test-schema"
         val snowflakeConfiguration: SnowflakeConfiguration = mockk {

--- a/airbyte-integrations/connectors/destination-snowflake/src/test/kotlin/io/airbyte/integrations/destination/snowflake/client/SnowflakeAirbyteClientTest.kt
+++ b/airbyte-integrations/connectors/destination-snowflake/src/test/kotlin/io/airbyte/integrations/destination/snowflake/client/SnowflakeAirbyteClientTest.kt
@@ -288,13 +288,9 @@ internal class SnowflakeAirbyteClientTest {
                 every { getLong("rows") } returns 1L
             }
         val preparedStatement =
-            mockk<PreparedStatement>(relaxed = true) {
-                every { executeQuery() } returns resultSet
-            }
+            mockk<PreparedStatement>(relaxed = true) { every { executeQuery() } returns resultSet }
         val statement =
-            mockk<Statement>(relaxed = true) {
-                every { executeQuery(any()) } returns resultSet
-            }
+            mockk<Statement>(relaxed = true) { every { executeQuery(any()) } returns resultSet }
         val connection =
             mockk<Connection>(relaxed = true) {
                 every { prepareStatement(any()) } returns preparedStatement
@@ -333,28 +329,31 @@ internal class SnowflakeAirbyteClientTest {
 
         val statement =
             mockk<Statement>(relaxed = true) {
-                every { executeQuery(any()) } answers {
-                    when (firstArg<String>()) {
-                        "create-table" -> {
-                            createStarted.countDown()
-                            assertTrue(allowCreateToFinish.await(5, TimeUnit.SECONDS))
+                every { executeQuery(any()) } answers
+                    {
+                        when (firstArg<String>()) {
+                            "create-table" -> {
+                                createStarted.countDown()
+                                assertTrue(allowCreateToFinish.await(5, TimeUnit.SECONDS))
+                            }
+                            "create-stage" -> stageReady.set(true)
+                            "put-one",
+                            "put-two" -> {
+                                putAttempted.countDown()
+                                assertTrue(
+                                    stageReady.get(),
+                                    "PUT executed before stage creation completed"
+                                )
+                            }
                         }
-                        "create-stage" -> stageReady.set(true)
-                        "put-one", "put-two" -> {
-                            putAttempted.countDown()
-                            assertTrue(stageReady.get(), "PUT executed before stage creation completed")
-                        }
+                        resultSet
                     }
-                    resultSet
-                }
             }
         val connection =
             mockk<Connection>(relaxed = true) { every { createStatement() } returns statement }
         every { dataSource.connection } returns connection
 
-        runBlocking {
-            client.createTempTable(stream, tableName, columnNameMapping, replace = true)
-        }
+        runBlocking { client.createTempTable(stream, tableName, columnNameMapping, replace = true) }
 
         val executor = Executors.newFixedThreadPool(2)
         try {
@@ -388,9 +387,7 @@ internal class SnowflakeAirbyteClientTest {
         val targetTableName = TableName(namespace = "namespace", name = "target")
         val resultSet = mockk<ResultSet>(relaxed = true)
         val statement =
-            mockk<Statement>(relaxed = true) {
-                every { executeQuery(any()) } returns resultSet
-            }
+            mockk<Statement>(relaxed = true) { every { executeQuery(any()) } returns resultSet }
         val connection =
             mockk<Connection>(relaxed = true) { every { createStatement() } returns statement }
         every { dataSource.connection } returns connection

--- a/airbyte-integrations/connectors/destination-snowflake/src/test/kotlin/io/airbyte/integrations/destination/snowflake/client/SnowflakeAirbyteClientTest.kt
+++ b/airbyte-integrations/connectors/destination-snowflake/src/test/kotlin/io/airbyte/integrations/destination/snowflake/client/SnowflakeAirbyteClientTest.kt
@@ -14,7 +14,6 @@ import io.airbyte.cdk.load.table.ColumnNameMapping
 import io.airbyte.integrations.destination.snowflake.schema.SnowflakeColumnManager
 import io.airbyte.integrations.destination.snowflake.schema.toSnowflakeCompatibleName
 import io.airbyte.integrations.destination.snowflake.spec.SnowflakeConfiguration
-import io.airbyte.integrations.destination.snowflake.sql.COUNT_TOTAL_ALIAS
 import io.airbyte.integrations.destination.snowflake.sql.QUOTE
 import io.airbyte.integrations.destination.snowflake.sql.SnowflakeDirectLoadSqlGenerator
 import io.mockk.Runs
@@ -23,15 +22,21 @@ import io.mockk.just
 import io.mockk.mockk
 import io.mockk.runs
 import io.mockk.verify
+import io.mockk.verifyOrder
 import java.sql.Connection
 import java.sql.PreparedStatement
 import java.sql.ResultSet
 import java.sql.SQLException
 import java.sql.Statement
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
 import javax.sql.DataSource
 import kotlinx.coroutines.runBlocking
 import net.snowflake.client.jdbc.SnowflakeSQLException
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -61,25 +66,19 @@ internal class SnowflakeAirbyteClientTest {
         val tableName = TableName(namespace = "namespace", name = "name")
         val resultSet =
             mockk<ResultSet> {
-                every { next() } returns true andThen false
-                every { getLong(COUNT_TOTAL_ALIAS) } returns 1L
-            }
-        val statement =
-            mockk<Statement> {
-                every { executeQuery(any()) } returns resultSet
-                every { close() } just Runs
+                every { next() } returns true
+                every { getLong("rows") } returns 1L
             }
         val preparedStatement =
             mockk<PreparedStatement> {
                 every { setString(any(), any()) } just runs
-                every { executeQuery().next() } returns true
+                every { executeQuery() } returns resultSet
                 every { close() } just runs
             }
         val mockConnection =
             mockk<Connection> {
                 every { close() } just Runs
                 every { prepareStatement(any()) } returns preparedStatement
-                every { createStatement() } returns statement
             }
 
         every { dataSource.connection } returns mockConnection
@@ -87,17 +86,18 @@ internal class SnowflakeAirbyteClientTest {
         runBlocking {
             val result = client.countTable(tableName)
             assertEquals(1L, result)
-            verify(exactly = 2) { mockConnection.close() }
+            verify(exactly = 1) { mockConnection.close() }
         }
     }
 
     @Test
     fun testCountMissingTable() {
         val tableName = TableName(namespace = "namespace", name = "name")
+        val resultSet = mockk<ResultSet> { every { next() } returns false }
         val preparedStatement =
             mockk<PreparedStatement> {
                 every { setString(any(), any()) } just runs
-                every { executeQuery().next() } returns false
+                every { executeQuery() } returns resultSet
                 every { close() } just runs
             }
         val mockConnection =
@@ -116,25 +116,23 @@ internal class SnowflakeAirbyteClientTest {
     }
 
     @Test
-    fun testCountTableNoResults() {
+    fun testCountEmptyTable() {
         val tableName = TableName(namespace = "namespace", name = "name")
-        val resultSet = mockk<ResultSet> { every { next() } returns false }
-        val statement =
-            mockk<Statement> {
-                every { executeQuery(any()) } returns resultSet
-                every { close() } just Runs
+        val resultSet =
+            mockk<ResultSet> {
+                every { next() } returns true
+                every { getLong("rows") } returns 0L
             }
         val preparedStatement =
             mockk<PreparedStatement> {
                 every { setString(any(), any()) } just runs
-                every { executeQuery().next() } returns true
+                every { executeQuery() } returns resultSet
                 every { close() } just runs
             }
         val mockConnection =
             mockk<Connection> {
                 every { close() } just Runs
                 every { prepareStatement(any()) } returns preparedStatement
-                every { createStatement() } returns statement
             }
 
         every { dataSource.connection } returns mockConnection
@@ -142,7 +140,7 @@ internal class SnowflakeAirbyteClientTest {
         runBlocking {
             val result = client.countTable(tableName)
             assertEquals(0L, result)
-            verify(exactly = 2) { mockConnection.close() }
+            verify(exactly = 1) { mockConnection.close() }
         }
     }
 
@@ -255,6 +253,162 @@ internal class SnowflakeAirbyteClientTest {
             verify(exactly = 1) { sqlGenerator.createTable(tableName, any(), true) }
             verify(exactly = 1) { sqlGenerator.createSnowflakeStage(tableName) }
             verify(exactly = 2) { mockConnection.close() }
+        }
+    }
+
+    @Test
+    fun `zero-record incremental dedup skips temp DDL merge and drop`() {
+        val columnNameMapping = mockk<ColumnNameMapping>(relaxed = true)
+        val stream = mockk<DestinationStream>(relaxed = true)
+        val tempTableName = TableName(namespace = "namespace", name = "temp")
+        val realTableName = TableName(namespace = "namespace", name = "real")
+
+        runBlocking {
+            client.createTempTable(stream, tempTableName, columnNameMapping, replace = true)
+            client.upsertTable(stream, columnNameMapping, tempTableName, realTableName)
+            client.dropTable(tempTableName)
+        }
+
+        verify(exactly = 0) { sqlGenerator.createTable(any(), any(), any()) }
+        verify(exactly = 0) { sqlGenerator.createSnowflakeStage(any()) }
+        verify(exactly = 0) { sqlGenerator.upsertTable(any(), any(), any()) }
+        verify(exactly = 0) { sqlGenerator.dropTable(any()) }
+        verify(exactly = 0) { dataSource.connection }
+    }
+
+    @Test
+    fun `empty overwrite materializes source and replaces target`() {
+        val columnNameMapping = mockk<ColumnNameMapping>(relaxed = true)
+        val stream = mockk<DestinationStream>(relaxed = true)
+        val tempTableName = TableName(namespace = "namespace", name = "temp")
+        val realTableName = TableName(namespace = "namespace", name = "real")
+        val resultSet =
+            mockk<ResultSet>(relaxed = true) {
+                every { next() } returns true
+                every { getLong("rows") } returns 1L
+            }
+        val preparedStatement =
+            mockk<PreparedStatement>(relaxed = true) {
+                every { executeQuery() } returns resultSet
+            }
+        val statement =
+            mockk<Statement>(relaxed = true) {
+                every { executeQuery(any()) } returns resultSet
+            }
+        val connection =
+            mockk<Connection>(relaxed = true) {
+                every { prepareStatement(any()) } returns preparedStatement
+                every { createStatement() } returns statement
+            }
+        every { dataSource.connection } returns connection
+
+        runBlocking {
+            client.createTempTable(stream, tempTableName, columnNameMapping, replace = true)
+            client.overwriteTable(tempTableName, realTableName)
+        }
+
+        verifyOrder {
+            sqlGenerator.createTable(tempTableName, any(), true)
+            sqlGenerator.createSnowflakeStage(tempTableName)
+            sqlGenerator.cloneTableWith(tempTableName, realTableName)
+            sqlGenerator.dropTable(tempTableName)
+        }
+    }
+
+    @Test
+    fun `concurrent puts wait for one complete table and stage initialization`() {
+        val columnNameMapping = mockk<ColumnNameMapping>(relaxed = true)
+        val stream = mockk<DestinationStream>(relaxed = true)
+        val tableName = TableName(namespace = "namespace", name = "temp")
+        val createStarted = CountDownLatch(1)
+        val allowCreateToFinish = CountDownLatch(1)
+        val putAttempted = CountDownLatch(1)
+        val stageReady = AtomicBoolean(false)
+        val resultSet = mockk<ResultSet>(relaxed = true)
+
+        every { sqlGenerator.createTable(tableName, any(), true) } returns "create-table"
+        every { sqlGenerator.createSnowflakeStage(tableName) } returns "create-stage"
+        every { sqlGenerator.putInStage(tableName, "/tmp/one.csv") } returns "put-one"
+        every { sqlGenerator.putInStage(tableName, "/tmp/two.csv") } returns "put-two"
+
+        val statement =
+            mockk<Statement>(relaxed = true) {
+                every { executeQuery(any()) } answers {
+                    when (firstArg<String>()) {
+                        "create-table" -> {
+                            createStarted.countDown()
+                            assertTrue(allowCreateToFinish.await(5, TimeUnit.SECONDS))
+                        }
+                        "create-stage" -> stageReady.set(true)
+                        "put-one", "put-two" -> {
+                            putAttempted.countDown()
+                            assertTrue(stageReady.get(), "PUT executed before stage creation completed")
+                        }
+                    }
+                    resultSet
+                }
+            }
+        val connection =
+            mockk<Connection>(relaxed = true) { every { createStatement() } returns statement }
+        every { dataSource.connection } returns connection
+
+        runBlocking {
+            client.createTempTable(stream, tableName, columnNameMapping, replace = true)
+        }
+
+        val executor = Executors.newFixedThreadPool(2)
+        try {
+            val first = executor.submit { client.putInStage(tableName, "/tmp/one.csv") }
+            assertTrue(createStarted.await(5, TimeUnit.SECONDS))
+            val second = executor.submit { client.putInStage(tableName, "/tmp/two.csv") }
+
+            assertFalse(
+                putAttempted.await(250, TimeUnit.MILLISECONDS),
+                "A concurrent PUT ran while stage creation was still in progress",
+            )
+            allowCreateToFinish.countDown()
+            first.get(5, TimeUnit.SECONDS)
+            second.get(5, TimeUnit.SECONDS)
+        } finally {
+            allowCreateToFinish.countDown()
+            executor.shutdownNow()
+        }
+
+        verify(exactly = 1) { sqlGenerator.createTable(tableName, any(), true) }
+        verify(exactly = 1) { sqlGenerator.createSnowflakeStage(tableName) }
+        verify(exactly = 1) { sqlGenerator.putInStage(tableName, "/tmp/one.csv") }
+        verify(exactly = 1) { sqlGenerator.putInStage(tableName, "/tmp/two.csv") }
+    }
+
+    @Test
+    fun `non-empty dedup materializes deferred merge target before upsert`() {
+        val columnNameMapping = mockk<ColumnNameMapping>(relaxed = true)
+        val stream = mockk<DestinationStream>(relaxed = true)
+        val sourceTableName = TableName(namespace = "namespace", name = "source")
+        val targetTableName = TableName(namespace = "namespace", name = "target")
+        val resultSet = mockk<ResultSet>(relaxed = true)
+        val statement =
+            mockk<Statement>(relaxed = true) {
+                every { executeQuery(any()) } returns resultSet
+            }
+        val connection =
+            mockk<Connection>(relaxed = true) { every { createStatement() } returns statement }
+        every { dataSource.connection } returns connection
+
+        runBlocking {
+            client.createTempTable(stream, sourceTableName, columnNameMapping, replace = true)
+            client.putInStage(sourceTableName, "/tmp/data.csv")
+            client.createTempTable(stream, targetTableName, columnNameMapping, replace = true)
+            client.upsertTable(stream, columnNameMapping, sourceTableName, targetTableName)
+        }
+
+        verifyOrder {
+            sqlGenerator.createTable(sourceTableName, any(), true)
+            sqlGenerator.createSnowflakeStage(sourceTableName)
+            sqlGenerator.putInStage(sourceTableName, "/tmp/data.csv")
+            sqlGenerator.createTable(targetTableName, any(), true)
+            sqlGenerator.createSnowflakeStage(targetTableName)
+            sqlGenerator.upsertTable(any(), sourceTableName, targetTableName)
         }
     }
 


### PR DESCRIPTION
## What

Follow-up to #80219. Snowflake Direct Load currently creates temporary tables and stages and runs a `MERGE` for every configured Incremental Append + Deduped stream, even when the stream receives no records. This keeps the Snowflake warehouse active during otherwise empty CDC syncs.

The earlier implementation demonstrated the intended optimization, but its final CI run exposed two correctness problems:

- Empty Full Refresh/Overwrite streams skipped the overwrite and retained stale destination rows.
- Concurrent uploads could attempt `PUT` before the deferred Snowflake stage had finished being created.

This PR retains the lazy approach while fixing both cases.

## How

- Register temporary tables lazily and materialize them on the first `PUT`.
- Serialize materialization per table and remove the pending entry only after both table and stage creation complete, so concurrent uploads wait for a usable stage.
- Skip copy/upsert/drop operations when their source is still an unmaterialized, zero-record temporary table.
- Preserve truncate semantics by materializing an empty source before `overwriteTable`, ensuring an empty Full Refresh still produces an empty destination.
- Materialize a deferred target before a non-empty dedup `MERGE`; this covers the temp-to-temp path used by Dedup + Truncate.
- Use `SHOW TABLES` row metadata for initial missing/empty/non-empty status instead of warehouse-executed `SELECT COUNT(*)`, while retaining an exact count for the connector `CHECK` operation.

This uses the connector-specific `createTempTable` hook introduced by #80220.

## Review guide

1. `SnowflakeAirbyteClient.kt`: deferred table state and operation-specific empty-stream behaviour.
2. `SnowflakeAirbyteClientTest.kt`: zero-record incremental, empty overwrite, concurrent `PUT`, and non-empty dedup regressions.
3. `SnowflakeChecker.kt`: exact post-write count remains isolated to connectivity checking.

## User Impact

Incremental Append + Deduped streams with zero records no longer execute per-stream temporary-table DDL or `MERGE`/cleanup SQL. Full Refresh/Overwrite continues to clear the destination when its source is empty. Non-empty sync behaviour is unchanged apart from making deferred stage creation concurrency-safe.

## Validation

- `:airbyte-integrations:connectors:destination-snowflake:test`
- `:airbyte-integrations:connectors:destination-snowflake:integrationTestClasses`
- `:airbyte-integrations:connectors:destination-snowflake:check`

All pass locally on JDK 21. The unit suite includes focused regressions for each failure mode above.

Please also run the secret-backed Snowflake integration suite, particularly the Full Refresh/Overwrite and Dedup cases that failed on #80219. Once those checks are green, could a maintainer publish a preview with:

`/publish-connectors-prerelease connector=destination-snowflake`

## Can this PR be safely reverted and rolled back?

- [x] YES 💚
- [ ] NO ❌
