### PR TITLE
[ready] fix(destination-redshift): skip CREATE SCHEMA when schema already exists

### DIFF
--- a/airbyte-integrations/connectors/destination-redshift/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-redshift/metadata.yaml
@@ -55,7 +55,7 @@ data:
             type: GSM
   connectorType: destination
   definitionId: f7a7d195-377f-cf5b-70a5-be6b819019dc
-  dockerImageTag: 4.0.6
+  dockerImageTag: 4.0.7
   dockerRepository: airbyte/destination-redshift
   documentationUrl: https://docs.airbyte.com/integrations/destinations/redshift
   githubIssueLabel: destination-redshift

--- a/airbyte-integrations/connectors/destination-redshift/src/main/kotlin/io/airbyte/integrations/destination/redshift/client/RedshiftAirbyteClient.kt
+++ b/airbyte-integrations/connectors/destination-redshift/src/main/kotlin/io/airbyte/integrations/destination/redshift/client/RedshiftAirbyteClient.kt
@@ -50,7 +50,12 @@ class RedshiftAirbyteClient(
 
     override suspend fun createNamespace(namespace: String) {
         try {
-            execute(sqlGenerator.createNamespace(namespace))
+            // Skip CREATE SCHEMA when the schema already exists. On Redshift, CREATE SCHEMA
+            // IF NOT EXISTS still requires CREATE ON DATABASE even for an existing schema, so
+            // users with only USAGE+CREATE on a pre-created schema would fail check/sync.
+            if (!namespaceExists(namespace)) {
+                execute(sqlGenerator.createNamespace(namespace))
+            }
         } catch (e: SQLException) {
             // Swallow race condition where concurrent connections both try CREATE SCHEMA
             if (e.message?.contains("already exists") != true) {

--- a/airbyte-integrations/connectors/destination-redshift/src/test/kotlin/io/airbyte/integrations/destination/redshift/client/RedshiftAirbyteClientTest.kt
+++ b/airbyte-integrations/connectors/destination-redshift/src/test/kotlin/io/airbyte/integrations/destination/redshift/client/RedshiftAirbyteClientTest.kt
@@ -77,8 +77,26 @@ internal class RedshiftAirbyteClientTest {
     // createNamespace
     // ================================================================
 
+    private fun stubNamespaceExists(exists: Boolean) {
+        every { sqlGenerator.namespaceExists("my_schema") } returns "NAMESPACE EXISTS SQL"
+        every { mockStatement.executeQuery("NAMESPACE EXISTS SQL") } returns mockResultSet
+        every { mockResultSet.next() } returns true
+        every { mockResultSet.getBoolean(1) } returns exists
+    }
+
     @Test
-    fun `createNamespace delegates to sqlGenerator`() = runTest {
+    fun `createNamespace skips CREATE SCHEMA when schema already exists`() = runTest {
+        stubNamespaceExists(exists = true)
+
+        client.createNamespace("my_schema")
+
+        verify(exactly = 0) { sqlGenerator.createNamespace(any()) }
+        verify(exactly = 0) { mockStatement.execute(any()) }
+    }
+
+    @Test
+    fun `createNamespace creates schema when missing`() = runTest {
+        stubNamespaceExists(exists = false)
         every { sqlGenerator.createNamespace("my_schema") } returns "CREATE SCHEMA SQL"
         every { mockStatement.execute("CREATE SCHEMA SQL") } returns true
 
@@ -90,6 +108,7 @@ internal class RedshiftAirbyteClientTest {
 
     @Test
     fun `createNamespace swallows already exists race condition`() = runTest {
+        stubNamespaceExists(exists = false)
         every { sqlGenerator.createNamespace("my_schema") } returns "CREATE SCHEMA SQL"
         every { mockStatement.execute("CREATE SCHEMA SQL") } throws
             SQLException("Schema my_schema already exists")
@@ -99,6 +118,7 @@ internal class RedshiftAirbyteClientTest {
 
     @Test
     fun `createNamespace rethrows non-race-condition errors`() = runTest {
+        stubNamespaceExists(exists = false)
         every { sqlGenerator.createNamespace("my_schema") } returns "CREATE SCHEMA SQL"
         every { mockStatement.execute("CREATE SCHEMA SQL") } throws
             SQLException("permission denied")


### PR DESCRIPTION
## What

Fixes [airbytehq/airbyte#83748](https://github.com/airbytehq/airbyte/issues/83748): destination check/sync failed with `42501` / permission denied when the Redshift schema was already created and the user only had `USAGE` + `CREATE` on that schema (no `CREATE ON DATABASE`).

Docs already allowed that least-privilege setup; the connector always ran `CREATE SCHEMA IF NOT EXISTS`, which on Redshift still requires database-level `CREATE` even when the schema exists.

## How

Mirror Snowflake's pattern in `RedshiftAirbyteClient.createNamespace`:

1. Call `namespaceExists(namespace)`.
2. If the schema exists -> return (no DDL).
3. If missing -> run `CREATE SCHEMA IF NOT EXISTS` as before.
4. Keep the existing "already exists" race-condition swallow for concurrent creators.

Same path covers check (`RedshiftChecker`) and sync (`RedshiftWriter.setup`). Patch bump to **4.0.7**.

## Review guide

1. `RedshiftAirbyteClient.kt` — `createNamespace` gated on `namespaceExists`
2. `RedshiftAirbyteClientTest.kt` — skip-when-exists / create-when-missing / race / rethrow
3. `metadata.yaml` — `dockerImageTag: 4.0.7`

## User Impact

Users who pre-create the schema and grant only `USAGE` + `CREATE` on it can run check/sync without `CREATE ON DATABASE`.

Auto-create when the schema is missing is unchanged (still needs `CREATE ON DATABASE`). No breaking config or catalog changes.

## Can this PR be safely reverted and rolled back?

- [x] YES

Clone of https://github.com/airbytehq/airbyte/pull/84459

---

> [!IMPORTANT]
> **Autopilot Progressive Rollout Enabled**
>
> [Autopilot progressive rollouts](https://github.com/airbytehq/airbyte-ops-mcp/blob/main/docs/autopilot-rollouts.md) are enabled for one or more connector(s) modified in this PR. Check the box below if you need to bypass normal rollout safety processes and release to all users immediately upon merge:
>
> - [ ] ⚡ **Release immediately** (bypasses automatic progressive rollout)
>
> **Note:**
>
> - ⚠️ The above bypass option is for emergency/hotfix use only.
> - 🔗 You can monitor or manually advance a rollout at **[ops.internal.airbyte.ai](https://ops.internal.airbyte.ai)**.