### PR TITLE
fix(source-s3): endpoint spec claimed the https:// prefix was optional, but botocore rejects a bare hostname

### DIFF
--- a/airbyte-integrations/connectors/source-s3/integration_tests/cloud_spec.json
+++ b/airbyte-integrations/connectors/source-s3/integration_tests/cloud_spec.json
@@ -446,9 +446,9 @@
       },
       "endpoint": {
         "title": "Endpoint",
-        "description": "Endpoint to an S3 compatible service. Leave empty to use AWS. The custom endpoint must be secure, but the 'https' prefix is not required.",
+        "description": "Endpoint to an S3 compatible service. Leave empty to use AWS. The custom endpoint must be secure and must include the 'https://' prefix.",
         "default": "",
-        "examples": ["my-s3-endpoint.com", "https://my-s3-endpoint.com"],
+        "examples": ["https://my-s3-endpoint.com"],
         "pattern": "^(?!http://).*$",
         "order": 4,
         "type": "string"

--- a/airbyte-integrations/connectors/source-s3/integration_tests/spec.json
+++ b/airbyte-integrations/connectors/source-s3/integration_tests/spec.json
@@ -446,9 +446,9 @@
       },
       "endpoint": {
         "title": "Endpoint",
-        "description": "Endpoint to an S3 compatible service. Leave empty to use AWS.",
+        "description": "Endpoint to an S3 compatible service. Leave empty to use AWS. The endpoint must include the URL scheme, for example https://my-s3-endpoint.com.",
         "default": "",
-        "examples": ["my-s3-endpoint.com", "https://my-s3-endpoint.com"],
+        "examples": ["https://my-s3-endpoint.com"],
         "order": 4,
         "type": "string"
       },

--- a/airbyte-integrations/connectors/source-s3/metadata.yaml
+++ b/airbyte-integrations/connectors/source-s3/metadata.yaml
@@ -10,7 +10,7 @@ data:
   connectorSubtype: file
   connectorType: source
   definitionId: 69589781-7828-43c5-9f63-8925b1c1ccc2
-  dockerImageTag: 4.15.19
+  dockerImageTag: 4.15.20
   dockerRepository: airbyte/source-s3
   documentationUrl: https://docs.airbyte.com/integrations/sources/s3
   externalDocumentationUrls:

--- a/airbyte-integrations/connectors/source-s3/pyproject.toml
+++ b/airbyte-integrations/connectors/source-s3/pyproject.toml
@@ -3,7 +3,7 @@ requires = [ "poetry-core>=1.0.0",]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
-version = "4.15.19"
+version = "4.15.20"
 name = "source-s3"
 description = "Source implementation for S3."
 authors = [ "Airbyte <contact@airbyte.io>",]

--- a/airbyte-integrations/connectors/source-s3/source_s3/v4/config.py
+++ b/airbyte-integrations/connectors/source-s3/source_s3/v4/config.py
@@ -70,8 +70,8 @@ class Config(AbstractFileBasedSpec):
     endpoint: Optional[str] = Field(
         default="",
         title="Endpoint",
-        description="Endpoint to an S3 compatible service. Leave empty to use AWS.",
-        examples=["my-s3-endpoint.com", "https://my-s3-endpoint.com"],
+        description="Endpoint to an S3 compatible service. Leave empty to use AWS. The endpoint must include the URL scheme, for example https://my-s3-endpoint.com.",
+        examples=["https://my-s3-endpoint.com"],
         order=4,
     )
 

--- a/airbyte-integrations/connectors/source-s3/source_s3/v4/source.py
+++ b/airbyte-integrations/connectors/source-s3/source_s3/v4/source.py
@@ -126,7 +126,7 @@ class SourceS3(FileBasedSource):
             s4_spec["properties"]["endpoint"].update(
                 {
                     "description": "Endpoint to an S3 compatible service. Leave empty to use AWS. "
-                    "The custom endpoint must be secure, but the 'https' prefix is not required.",
+                    "The custom endpoint must be secure and must include the 'https://' prefix.",
                     "pattern": "^(?!http://).*$",  # ignore-https-check
                 }
             )

--- a/docs/integrations/sources/s3.md
+++ b/docs/integrations/sources/s3.md
@@ -282,7 +282,7 @@ Please note, the S3 Source connector used to infer schemas from all the availabl
 
 - **AWS Access Key ID**: One half of the [required credentials](https://docs.aws.amazon.com/general/latest/gr/aws-sec-cred-types.html#access-keys-and-secret-access-keys) for accessing a private bucket.
 - **AWS Secret Access Key**: The other half of the [required credentials](https://docs.aws.amazon.com/general/latest/gr/aws-sec-cred-types.html#access-keys-and-secret-access-keys) for accessing a private bucket.
-- **Endpoint**: An optional parameter that enables the use of non-Amazon S3 compatible services. If you are using the default Amazon service, leave this field blank.
+- **Endpoint**: An optional parameter that enables the use of non-Amazon S3 compatible services. If you are using the default Amazon service, leave this field blank. The value must include the URL scheme, for example `https://my-s3-endpoint.com` — a bare hostname such as `my-s3-endpoint.com` is rejected when the client is created. On Airbyte Cloud the endpoint must use `https://`.
 - **Start Date**: An optional parameter that marks a starting date and time in UTC for data replication. Any files that have _not_ been modified since this specified date/time will _not_ be replicated. Use the provided datepicker (recommended) or enter the desired date programmatically in the format `YYYY-MM-DDTHH:mm:ssZ`. Leaving this field blank will replicate data from all files that have not been excluded by the **Path Pattern** and **Path Prefix**.
 
 ## File Format Settings

--- a/docs/integrations/sources/s3.md
+++ b/docs/integrations/sources/s3.md
@@ -356,6 +356,7 @@ If you use Airbyte Cloud and your organization restricts access to specific IPs,
 
 | Version     | Date       | Pull Request                                                                                                    | Subject                                                                                                              |
 |:------------|:-----------|:----------------------------------------------------------------------------------------------------------------|:---------------------------------------------------------------------------------------------------------------------|
+| 4.15.20 | 2026-08-18 | [84885](https://github.com/airbytehq/airbyte/pull/84885) | Endpoint field: document that the `https://` scheme is required and remove the invalid bare-hostname example |
 | 4.15.19 | 2026-08-18 | [84738](https://github.com/airbytehq/airbyte/pull/84738) | Update dependencies |
 | 4.15.18 | 2026-08-11 | [84085](https://github.com/airbytehq/airbyte/pull/84085) | Update dependencies |
 | 4.15.17 | 2026-08-04 | [83624](https://github.com/airbytehq/airbyte/pull/83624) | Update dependencies |


### PR DESCRIPTION
## What

Closes #84884.

The Cloud-only Endpoint description told users the `https://` prefix was not required, and the shipped `examples` led with a bare hostname. botocore rejects a bare hostname at client construction:

```
ValueError: Invalid endpoint: my-s3-endpoint.com
```

so the advertised contract could not be satisfied. This corrects the guidance on every surface that carried it.

- `source_s3/v4/source.py` — Cloud override now says the endpoint must be secure **and must include the `https://` prefix**
- `source_s3/v4/config.py` — base description states that the URL scheme is required, and the invalid `"my-s3-endpoint.com"` entry is removed from `examples`. This one is the reason the change is not Cloud-only: `examples` ships in the OSS spec too, so OSS users were also shown a value that cannot work.
- `docs/integrations/sources/s3.md` — Endpoint bullet states the requirement
- `integration_tests/spec.json` and `cloud_spec.json` — snapshots refreshed for the lines touched here
- `metadata.yaml` / `pyproject.toml` — patch bump to 4.15.20

## What this deliberately does not do

**No behavior change.** A bare hostname still fails, it just no longer fails after the spec told the user it would work. Normalizing a missing scheme is the natural follow-up and is written up in #84884; I left it out of this PR because it needs test coverage this area does not currently have, and it has one non-obvious trap: `stream_reader.py:71` gates the whole S3-compatible arg block on the truthiness of `config.endpoint`, so turning `""` into `"https://"` would silently break every plain-AWS user.

**The `pattern` is unchanged.** `"^(?!http://).*$"` still admits bare hostnames. Tightening it to require `https://` would surface a validation error on already-saved configs, which is a larger call than a doc correction — flagging it rather than making it here.

## Review notes

- Two other issues report this same botocore failure without identifying the cause: #65588 (open) and #23715 (closed). #65588 is the same defect and could be closed against #84884.
- The description and pattern originate in PR #32109 (4.2.0), which added HTTPS validation for the endpoint field.
- No test changes: nothing currently asserts the endpoint description or the Cloud override, and every test in `unit_tests/v4/test_stream_reader.py` patches out `boto3.client` or the `s3_client` property, which is why botocore's validation never ran in CI. Worth a follow-up alongside the normalization work.

## How was this tested?

Reproduced the failure directly against botocore 1.43.74 by constructing the client outside the connector (no network required):

| Endpoint value | Result |
|---|---|
| `my-s3-endpoint.com` (previously shipped as an example) | `ValueError: Invalid endpoint` |
| `MY-S3.com:9000` (common MinIO form) | `ValueError: Invalid endpoint` |
| `https://my-s3-endpoint.com` | client constructs |

Also confirmed end to end against a real S3 PrivateLink interface endpoint, where the `https://`-prefixed hostname is what makes the connection succeed and the bare form fails TLS/endpoint validation.

> [!IMPORTANT]
> Active progressive rollout warning for source-s3.

- [ ] (Click to Approve:) Bypass the active progressive rollout warning for source-s3 in the PR comment [here](https://github.com/airbytehq/airbyte/pull/84885#issuecomment-5335252771).