### PR TITLE
fix(docker-images): stop shipping the connector tarball inside the image

### DIFF
--- a/docker-images/Dockerfile.java-connector
+++ b/docker-images/Dockerfile.java-connector
@@ -18,15 +18,17 @@ ENV AIRBYTE_ENTRYPOINT="/airbyte/base.sh"
 ENV APPLICATION="${CONNECTOR_NAME}"
 
 # Add the connector TAR file and extract it.
-# For compatibility reasons, first try connector-specific name, then `airbyte-app.tar`
-COPY --chown=airbyte:airbyte ./build/distributions/ /tmp/distributions/
-RUN if [ -f /tmp/distributions/${CONNECTOR_NAME}.tar ]; then \
-        cp /tmp/distributions/${CONNECTOR_NAME}.tar /tmp/${CONNECTOR_NAME}.tar; \
+# For compatibility reasons, first try connector-specific name, then `airbyte-app.tar`.
+# The distributions directory is bind-mounted rather than COPY'd: a COPY would persist the
+# archive in its own layer, so the final image would carry both the tarball and its extracted
+# contents. Extracting straight from the mount also avoids the intermediate `cp`.
+RUN --mount=type=bind,source=./build/distributions/,target=/tmp/distributions/ \
+    if [ -f /tmp/distributions/${CONNECTOR_NAME}.tar ]; then \
+        TARBALL=/tmp/distributions/${CONNECTOR_NAME}.tar; \
     else \
-        cp /tmp/distributions/airbyte-app.tar /tmp/${CONNECTOR_NAME}.tar; \
+        TARBALL=/tmp/distributions/airbyte-app.tar; \
     fi && \
-    tar xf /tmp/${CONNECTOR_NAME}.tar --strip-components=1 -C /airbyte && \
-    rm -rf /tmp/${CONNECTOR_NAME}.tar /tmp/distributions && \
+    tar xf "${TARBALL}" --strip-components=1 -C /airbyte && \
     chown -R airbyte:airbyte /airbyte
 
 # Set the non-root user

--- a/docker-images/Dockerfile.java-connector-non-airbyte-ci
+++ b/docker-images/Dockerfile.java-connector-non-airbyte-ci
@@ -17,10 +17,11 @@ RUN chmod +x /airbyte/base.sh /airbyte/javabase.sh && \
 ENV AIRBYTE_ENTRYPOINT="/airbyte/base.sh"
 ENV APPLICATION="${CONNECTOR_NAME}"
 
-# Add the connector TAR file and extract it
-COPY airbyte-app.tar /tmp/${CONNECTOR_NAME}.tar
-RUN tar xf /tmp/${CONNECTOR_NAME}.tar --strip-components=1 -C /airbyte && \
-    rm -rf /tmp/${CONNECTOR_NAME}.tar && \
+# Add the connector TAR file and extract it.
+# The tarball is bind-mounted rather than COPY'd: a COPY would persist the archive in its own
+# layer, so the final image would carry both the tarball and its extracted contents.
+RUN --mount=type=bind,source=airbyte-app.tar,target=/tmp/airbyte-app.tar \
+    tar xf /tmp/airbyte-app.tar --strip-components=1 -C /airbyte && \
     chown -R airbyte:airbyte /airbyte
 
 # Set the non-root user


### PR DESCRIPTION
## What

Every Java connector image ships the connector tarball *and* its extracted contents. On `source-postgres` that is **108MB of dead weight (791MB → 683MB)**.

The tarball is `COPY`'d into its own layer and extracted in a later `RUN`. The `rm -rf` in that `RUN` deletes it from the filesystem but cannot reclaim space from the earlier layer — so it is invisible at runtime while still being pulled by every user.

## How

Bind-mount the tarball into the build step (`RUN --mount=type=bind`) instead of `COPY`ing it, so it never becomes part of the image. Both Dockerfiles already declare `# syntax=docker/dockerfile:1`, so BuildKit is available.

In `Dockerfile.java-connector` this also removes an intermediate `cp` of the archive that duplicated it a second time within the build layer.

## Verification

Built `source-postgres` both ways against `java-connector-base:2.0.4`:

| | Image size |
|---|---|
| before | 791MB |
| after | **683MB** |

Equivalence checks on the resulting images:
- `/airbyte` file tree is identical — 194 files, same listing digest (`81ab78d…`) in both
- `docker run <image> spec` returns the same `{"type":"SPEC"}` output
- Neither image has a leftover tarball at runtime (confirming the before-image waste was layer-resident, not filesystem-visible)

## Recommended reading order

1. `docker-images/Dockerfile.java-connector-non-airbyte-ci` — the simpler case
2. `docker-images/Dockerfile.java-connector` — same fix, plus dropping the intermediate `cp`

## Can this PR be safely reverted and rolled back?

Yes. It only changes how the build stage obtains the tarball; the resulting filesystem is identical. Revert restores the previous layering.

## Notes

- No connector version bumps needed — this takes effect the next time each connector image is built.
- Applies to all 56 Java connectors, not just `source-postgres`.
- Left deliberately out of scope: the base image is still a full JDK (451MB of the 683MB). That is a separate, larger change requiring a base image release.