### PR TITLE
build(docker-images): ship a jlink-trimmed runtime in the Java connector base

### DIFF
--- a/docker-images/Dockerfile.java-connector-base
+++ b/docker-images/Dockerfile.java-connector-base
@@ -1,6 +1,23 @@
 # https://hub.docker.com/_/amazoncorretto/tags?name=21-al2023
 ARG BASE_IMAGE=docker.io/amazoncorretto:21-al2023
-FROM ${BASE_IMAGE}
+
+# Build a trimmed Java runtime. Connectors only ever run Java, so shipping a full JDK
+# costs ~230MB per image for tooling that is never used.
+#
+# The module list is maintained by hand and is deliberately generous: jdeps cannot infer
+# it, because JDBC drivers, crypto providers and SSH backends are all loaded reflectively
+# at runtime. Adding a module is cheap; removing one breaks connectors in ways that only
+# surface against a live source. Validate against real sources before trimming further.
+FROM ${BASE_IMAGE} AS jre-builder
+# jlink --strip-debug shells out to objcopy, which the Corretto image does not ship.
+RUN dnf install -y binutils && dnf clean all
+RUN jlink \
+      --add-modules java.base,java.sql,java.naming,java.management,java.instrument,java.logging,java.xml,java.desktop,java.security.jgss,java.security.sasl,java.transaction.xa,java.net.http,java.compiler,jdk.crypto.ec,jdk.crypto.cryptoki,jdk.unsupported,jdk.zipfs,jdk.management,jdk.net \
+      --strip-debug --no-man-pages --no-header-files --compress=zip-6 \
+      --output /jre && \
+    /jre/bin/java --version
+
+FROM docker.io/amazonlinux:2023
 
 # Install dependencies
 RUN set -o xtrace && \
@@ -10,6 +27,11 @@ RUN set -o xtrace && \
     dnf update --releasever=latest -y --security && \
     dnf clean all && \
     rm -rf /var/cache/dnf
+
+# Install the trimmed runtime built above
+COPY --from=jre-builder /jre /opt/jre
+ENV JAVA_HOME=/opt/jre
+ENV PATH="/opt/jre/bin:${PATH}"
 
 # Set-up groups, users, and directories
 RUN groupadd --gid 1000 airbyte && \

--- a/docker-images/Dockerfile.java-connector-base
+++ b/docker-images/Dockerfile.java-connector-base
@@ -17,6 +17,12 @@ ARG RUNTIME_IMAGE=docker.io/amazonlinux:2023
 # auth or SSL configuration. Adding a module is cheap. Validate against live sources before
 # removing one.
 #
+# java.security.jgss and java.security.sasl are not sufficient for Kerberos: the JDK's
+# Krb5LoginModule lives in jdk.security.auth and the GSSAPI SaslClientFactory in
+# jdk.security.jgss. Without both, source-kafka and destination-kafka fail GSSAPI auth with
+# 'No LoginModule found for com.sun.security.auth.module.Krb5LoginModule' before any network
+# I/O. This is the canonical example of why this list needs live validation, not jdeps.
+#
 # The jdk.jcmd/jdk.jfr/jdk.attach modules are not needed to run a connector. They are kept
 # deliberately so that a connector stuck in production can still be thread-dumped, heap-
 # dumped and profiled; a runtime you cannot diagnose is not worth the megabytes saved.
@@ -24,7 +30,7 @@ FROM ${JDK_IMAGE} AS jre-builder
 # jlink --strip-debug shells out to objcopy, which the Corretto image does not ship.
 RUN dnf install -y binutils && dnf clean all
 RUN jlink \
-      --add-modules java.base,java.sql,java.sql.rowset,java.naming,java.management,java.instrument,java.logging,java.xml,java.xml.crypto,java.scripting,java.desktop,java.security.jgss,java.security.sasl,java.transaction.xa,java.net.http,java.compiler,java.rmi,jdk.crypto.ec,jdk.crypto.cryptoki,jdk.unsupported,jdk.zipfs,jdk.management,jdk.management.agent,jdk.net,jdk.jcmd,jdk.jfr,jdk.attach \
+      --add-modules java.base,java.sql,java.sql.rowset,java.naming,java.management,java.instrument,java.logging,java.xml,java.xml.crypto,java.scripting,java.desktop,java.security.jgss,java.security.sasl,java.transaction.xa,java.net.http,java.compiler,java.rmi,jdk.crypto.ec,jdk.crypto.cryptoki,jdk.security.auth,jdk.security.jgss,jdk.unsupported,jdk.zipfs,jdk.management,jdk.management.agent,jdk.net,jdk.jcmd,jdk.jfr,jdk.attach \
       --strip-debug --no-man-pages --no-header-files --compress=zip-6 \
       --output /jre && \
     /jre/bin/java --version

--- a/docker-images/Dockerfile.java-connector-base
+++ b/docker-images/Dockerfile.java-connector-base
@@ -1,23 +1,35 @@
+# The JDK the runtime is jlink'd from, and the OS the runtime is copied into.
+# These two are coupled and must stay on the same libc and OS generation: the linked
+# runtime is a native binary built against the JDK image's libc. Swapping JDK_IMAGE for a
+# musl (Alpine) JDK while RUNTIME_IMAGE stays glibc produces an image that builds cleanly
+# and fails at exec time. Change them together.
 # https://hub.docker.com/_/amazoncorretto/tags?name=21-al2023
-ARG BASE_IMAGE=docker.io/amazoncorretto:21-al2023
+ARG JDK_IMAGE=docker.io/amazoncorretto:21-al2023
+ARG RUNTIME_IMAGE=docker.io/amazonlinux:2023
 
 # Build a trimmed Java runtime. Connectors only ever run Java, so shipping a full JDK
-# costs ~230MB per image for tooling that is never used.
+# costs ~230MB per image for compilers and tooling that are never invoked.
 #
-# The module list is maintained by hand and is deliberately generous: jdeps cannot infer
+# The module list is maintained by hand and is deliberately generous. jdeps cannot infer
 # it, because JDBC drivers, crypto providers and SSH backends are all loaded reflectively
-# at runtime. Adding a module is cheap; removing one breaks connectors in ways that only
-# surface against a live source. Validate against real sources before trimming further.
-FROM ${BASE_IMAGE} AS jre-builder
+# at runtime, so a missing module does not fail the build -- it throws NoClassDefFoundError
+# later, on whichever code path happens to need it, sometimes only for users on a specific
+# auth or SSL configuration. Adding a module is cheap. Validate against live sources before
+# removing one.
+#
+# The jdk.jcmd/jdk.jfr/jdk.attach modules are not needed to run a connector. They are kept
+# deliberately so that a connector stuck in production can still be thread-dumped, heap-
+# dumped and profiled; a runtime you cannot diagnose is not worth the megabytes saved.
+FROM ${JDK_IMAGE} AS jre-builder
 # jlink --strip-debug shells out to objcopy, which the Corretto image does not ship.
 RUN dnf install -y binutils && dnf clean all
 RUN jlink \
-      --add-modules java.base,java.sql,java.naming,java.management,java.instrument,java.logging,java.xml,java.desktop,java.security.jgss,java.security.sasl,java.transaction.xa,java.net.http,java.compiler,jdk.crypto.ec,jdk.crypto.cryptoki,jdk.unsupported,jdk.zipfs,jdk.management,jdk.net \
+      --add-modules java.base,java.sql,java.sql.rowset,java.naming,java.management,java.instrument,java.logging,java.xml,java.xml.crypto,java.scripting,java.desktop,java.security.jgss,java.security.sasl,java.transaction.xa,java.net.http,java.compiler,java.rmi,jdk.crypto.ec,jdk.crypto.cryptoki,jdk.unsupported,jdk.zipfs,jdk.management,jdk.management.agent,jdk.net,jdk.jcmd,jdk.jfr,jdk.attach \
       --strip-debug --no-man-pages --no-header-files --compress=zip-6 \
       --output /jre && \
     /jre/bin/java --version
 
-FROM docker.io/amazonlinux:2023
+FROM ${RUNTIME_IMAGE}
 
 # Install dependencies
 RUN set -o xtrace && \


### PR DESCRIPTION
## What

The Java connector base image ships a full JDK, but connectors only ever *run* Java. Replacing it with a `jlink`-trimmed runtime cuts **~225MB from every Java connector image**, consistently across every connector tested.

| | Size |
|---|---|
| base image (before) | 575MB |
| **base image (after)** | **350MB** |

## How

A `jre-builder` stage runs `jlink` against the Corretto JDK; the runtime stage moves to `amazonlinux:2023` and copies `/jre` in, with `JAVA_HOME`/`PATH` set. User setup, directories, env vars and the `base.sh`/`javabase.sh` fetch are unchanged.

Three things worth reviewer attention:

**The module list is hand-maintained and deliberately generous.** `jdeps` cannot infer it — JDBC drivers, crypto providers and SSH backends are all loaded reflectively. A missing module does not fail the build; it throws `NoClassDefFoundError` later, on whichever path needs it, sometimes only for users on a specific auth or SSL configuration.

**Diagnostic tooling is kept on purpose.** A minimal list produces a runtime containing only `java` and `keytool` — no `jcmd`, `jstack`, `jmap`, `jps` or `jfr`, meaning a connector stuck at a customer could not be thread-dumped or profiled. `jdk.jcmd`/`jdk.jfr`/`jdk.attach` cost **5MB** against a 230MB saving, which is not a real trade.

**`jlink --strip-debug` shells out to `objcopy`**, so the builder installs `binutils`. Corretto does not ship it and the failure mode is an opaque `Cannot run program "objcopy"`.

`BASE_IMAGE` is split into `JDK_IMAGE` + `RUNTIME_IMAGE`. It previously named the image connectors ran on; after the split it named only the JDK the runtime is linked from, while the runtime OS was hardcoded. The two are coupled by libc — a musl JDK with a glibc runtime builds cleanly and fails at exec — so the names and comment now say so. Nothing passes these args today.

## Verification

Built the 5 certified Java sources and the 5 most-used certified Java destinations.

**`spec` — all 10 pass:** `source-postgres`, `source-mysql`, `source-mssql`, `source-mongodb-v2`, `source-snowflake`, `destination-postgres`, `destination-snowflake`, `destination-bigquery`, `destination-s3`, `destination-redshift`

**`check` against live databases — identical to a Corretto control group:**

| Connector | jlink | Corretto (control) | Image size |
|---|---|---|---|
| source-postgres | SUCCEEDED | SUCCEEDED | 561MB vs 791MB |
| source-mysql | SUCCEEDED | SUCCEEDED | 547MB vs 777MB |
| source-mssql | SUCCEEDED | SUCCEEDED | 562MB vs 792MB |
| source-mongodb-v2 | SUCCEEDED | SUCCEEDED | 508MB vs 738MB |
| destination-postgres | SUCCEEDED | SUCCEEDED | 491MB vs 721MB |

**`read`** (source-postgres, full_refresh against live Postgres): 1 record on both — identical.

**Diagnostics verified in-image:** `jps` lists JVMs, `jcmd` and `jstack` run, `jfr --version` reports 21.0.12.

Sizes above predate the +5MB diagnostics addition.

## This changes image size, not startup

Measured `spec` startup, 5 warm runs each: jlink 1.19–1.29s, Corretto 1.15–1.37s — indistinguishable. `jlink` removes tooling a running connector never invokes; the JVM still loads the same application classes. The win is registry storage, bandwidth, and **cold pod pull time**, which matters for `check`/`discover` since those get a fresh pod each run. Startup itself needs AppCDS or Leyden, which is separate work.

## Not yet covered

- Snowflake / BigQuery / S3 / Redshift were validated with `spec` only — no credentials locally. **These need a `check` run before this ships**, since cloud SDKs exercise crypto and HTTP paths local databases do not.
- No SSL-mode, SSH-tunnel or CDC/Debezium runs — the likeliest places for a missing module to hide.
- Tested on arm64; production images are amd64.
- Worth adding a CI smoke matrix on this Dockerfile (build certified connectors, `check` against live containers), because no static analysis catches a missing module.

## Recommended reading order

1. `docker-images/Dockerfile.java-connector-base` — the whole change

## Can this PR be safely reverted and rolled back?

Yes. It only changes how the base image is assembled; reverting restores the Corretto JDK base. Connectors pin the base by version + digest, so nothing changes for existing connectors until they are rebuilt against a new base tag.

## Rollout note

This does **not** take effect on merge. It needs a base image release, and each of the 56 Java connectors pins the base by version+digest in its `metadata.yaml` (spread across 2.0.0–2.0.4). Shipping means publishing a new base tag and migrating connectors onto it — a few certified ones first, with a soak.