### PR TITLE
docs: add a page on managing connector definitions with the API

### DIFF
--- a/docs/developers/connector-definitions.md
+++ b/docs/developers/connector-definitions.md
@@ -1,0 +1,219 @@
+---
+products: all
+---
+
+# Manage connector definitions with the API
+
+A **connector definition** is a connector type: "Salesforce", "Postgres", or a
+connector you built yourself. It is not a configured connector. When you create a
+source or a destination, you pass a `definitionId`, and that definition determines
+which connector code runs; your source supplies the configuration and credentials it
+runs with.
+
+That distinction is the whole reason the definitions endpoints exist:
+
+| Concept | Endpoint | What it is |
+| --- | --- | --- |
+| Definition | `/workspaces/{workspaceId}/definitions/sources` | The connector type available in a workspace, and the Docker image version it runs |
+| Source | `/sources` | One configured connection to a system, created from a definition |
+
+Definitions are scoped to a workspace, so the same connector can run a different
+version in two workspaces of the same organization.
+
+## The three definition endpoints
+
+| Endpoint | Connectors it covers | Read | Create, update, delete |
+| --- | --- | --- | --- |
+| `definitions/sources` | Source connectors that run a Docker image, both Airbyte's and your custom ones | All deployments | Custom definitions only, and not on Cloud |
+| `definitions/destinations` | Destination connectors that run a Docker image | All deployments | Custom definitions only, and not on Cloud |
+| `definitions/declarative_sources` | Low-code source connectors built from a Connector Builder manifest | All deployments | All deployments, including Cloud |
+
+Declarative source definitions are deliberately kept apart from `definitions/sources`:
+they never appear in its list response, and requesting one by ID there returns a 404.
+Use the declarative endpoints for anything built in the Connector Builder.
+
+## Find the definition ID for a connector
+
+This is the most common use of these endpoints, and it needs no custom connectors at
+all. List the definitions in a workspace to get the `definitionId` you need to create
+a source:
+
+```bash
+curl --request GET \
+  --url 'https://api.airbyte.com/v1/workspaces/WORKSPACE_ID/definitions/sources' \
+  --header 'authorization: Bearer YOUR_ACCESS_TOKEN'
+```
+
+```json
+{
+  "data": [
+    {
+      "id": "dfd88b22-b603-4c3d-aad7-3701784586b1",
+      "name": "Sample Data",
+      "dockerRepository": "airbyte/source-faker",
+      "dockerImageTag": "7.2.1",
+      "documentationUrl": "https://docs.airbyte.com/integrations/sources/faker"
+    }
+  ]
+}
+```
+
+Then create a source from it:
+
+```bash
+curl --request POST \
+  --url 'https://api.airbyte.com/v1/sources' \
+  --header 'authorization: Bearer YOUR_ACCESS_TOKEN' \
+  --header 'content-type: application/json' \
+  --data '{
+    "name": "Sample data",
+    "workspaceId": "WORKSPACE_ID",
+    "definitionId": "dfd88b22-b603-4c3d-aad7-3701784586b1",
+    "configuration": { "count": 1000 }
+  }'
+```
+
+The list response is also the answer to "which connector versions is this workspace
+running?", which makes it useful for auditing a fleet of workspaces and for scripted
+workspace provisioning.
+
+## Add a custom connector on Cloud: declarative source definitions
+
+On Airbyte Cloud, a declarative source definition is the way to add a connector
+Airbyte doesn't have. You send a Connector Builder manifest instead of a Docker image,
+and Airbyte publishes it as version 1:
+
+```bash
+curl --request POST \
+  --url 'https://api.airbyte.com/v1/workspaces/WORKSPACE_ID/definitions/declarative_sources' \
+  --header 'authorization: Bearer YOUR_ACCESS_TOKEN' \
+  --header 'content-type: application/json' \
+  --data '{
+    "name": "Internal Orders API",
+    "manifest": {
+      "version": "6.48.15",
+      "type": "DeclarativeSource",
+      "check": { "type": "CheckStream", "stream_names": ["orders"] },
+      "streams": [ ... ],
+      "spec": {
+        "type": "Spec",
+        "connection_specification": {
+          "$schema": "http://json-schema.org/draft-07/schema#",
+          "type": "object",
+          "required": [],
+          "properties": {}
+        }
+      }
+    }
+  }'
+```
+
+```json
+{
+  "id": "9bb26c3b-5125-4492-bb2e-ccda42cfe255",
+  "name": "Internal Orders API",
+  "version": 1,
+  "manifest": { "...": "as sent" }
+}
+```
+
+Two requirements on the manifest:
+
+- It must contain a `spec` object with a `connection_specification` — the JSON schema
+  for your connector's own configuration. Without it, the request fails.
+- Its `version` must be a CDK version whose major version your deployment supports. A
+  manifest built against a newer major version is rejected with a 409.
+
+The definition also becomes a Connector Builder project, so you can open and edit the
+connector in the UI afterwards. The returned `id` is a normal `definitionId`: create
+sources from it exactly as above.
+
+### Publish a new version
+
+`PUT` publishes the manifest as the next version and activates it. Versions increment
+on their own — the first update to a new definition returns `version: 2` — so this is
+the endpoint to call from CI when the manifest changes in git:
+
+```bash
+curl --request PUT \
+  --url 'https://api.airbyte.com/v1/workspaces/WORKSPACE_ID/definitions/declarative_sources/DEFINITION_ID' \
+  --header 'authorization: Bearer YOUR_ACCESS_TOKEN' \
+  --header 'content-type: application/json' \
+  --data '{ "manifest": { "...": "your updated manifest" } }'
+```
+
+The request body takes only the manifest. You can't rename a definition this way.
+
+## Add a custom connector on Self-Managed: image-based definitions
+
+If you built a connector with the CDK and pushed it to a registry, register the image
+in a workspace with `POST definitions/sources` (or `definitions/destinations`):
+
+```bash
+curl --request POST \
+  --url 'https://YOUR_AIRBYTE_HOST/api/public/v1/workspaces/WORKSPACE_ID/definitions/sources' \
+  --header 'authorization: Bearer YOUR_ACCESS_TOKEN' \
+  --header 'content-type: application/json' \
+  --data '{
+    "name": "Internal Orders API",
+    "dockerRepository": "registry.example.com/airbyte/source-internal-orders",
+    "dockerImageTag": "1.4.0",
+    "documentationUrl": "https://example.com/docs/source-internal-orders"
+  }'
+```
+
+Airbyte pulls and runs the image to read its connector specification, so the image
+must be reachable from your deployment, and the request can take a while to return on
+first pull. This is the API equivalent of
+[uploading a Docker-based custom connector](/platform/operator-guides/using-custom-connectors)
+in the UI.
+
+To move the connector to a new version, `PUT` the new tag. Both `name` and
+`dockerImageTag` are required, so send the current name if you only want to change the
+tag:
+
+```bash
+curl --request PUT \
+  --url 'https://YOUR_AIRBYTE_HOST/api/public/v1/workspaces/WORKSPACE_ID/definitions/sources/DEFINITION_ID' \
+  --header 'authorization: Bearer YOUR_ACCESS_TOKEN' \
+  --header 'content-type: application/json' \
+  --data '{ "name": "Internal Orders API", "dockerImageTag": "1.5.0" }'
+```
+
+`DELETE` removes the definition from the workspace and returns it one last time.
+
+:::note
+Creating or updating an image-based definition runs the connector image to read its
+specification, so these two calls can take a long time when the image isn't cached yet
+— long enough for a proxy in front of Airbyte to time out the request before Airbyte
+answers. If a create or update appears to time out, `GET` the definition before
+retrying: the change may have been applied. If the tag can't be pulled at all, the
+call fails and the definition keeps its previous tag.
+:::
+
+## What each deployment allows
+
+Two rules explain almost every error these endpoints return:
+
+- **Only custom definitions can be written to.** Airbyte's registry connectors are
+  managed for you; updating or deleting one fails with
+  `Public definitions cannot be modified.` This holds on every deployment, including
+  Self-Managed.
+- **Cloud doesn't accept image-based definitions.** Creating or updating a source or
+  destination definition on Cloud fails with `Non-declarative definitions cannot be
+  created or updated in Airbyte Cloud.` Cloud runs connectors from Airbyte's registry
+  plus declarative connectors, so use a declarative source definition instead. There
+  is no declarative equivalent for destinations, so custom destinations are a
+  Self-Managed capability.
+
+## See also
+
+- [Configuring API access](/platform/using-airbyte/configuring-api-access) — how to get
+  an access token
+- [API documentation](/developers/api-documentation) — base URLs and your first request
+- [Connector Builder overview](/platform/connector-development/connector-builder-ui/overview) —
+  building the manifest a declarative definition needs
+- [Low-code YAML reference](/platform/connector-development/config-based/understanding-the-yaml-file/yaml-overview) —
+  what goes in a manifest
+- [Uploading Docker-based custom connectors](/platform/operator-guides/using-custom-connectors) —
+  the UI equivalent of image-based definitions

--- a/docs/developers/connector-definitions.md
+++ b/docs/developers/connector-definitions.md
@@ -35,13 +35,13 @@ Use the declarative endpoints for anything built in the Connector Builder.
 ## Find the definition ID for a connector
 
 This is the most common use of these endpoints, and it needs no custom connectors at
-all. List the definitions in a workspace to get the `definitionId` you need to create
-a source:
+all. List the definitions in a workspace and take the `id` of the connector you want:
+that value is the `definitionId` you pass when you create a source or a destination.
 
 ```bash
 curl --request GET \
-  --url 'https://api.airbyte.com/v1/workspaces/WORKSPACE_ID/definitions/sources' \
-  --header 'authorization: Bearer YOUR_ACCESS_TOKEN'
+  --url 'https://api.airbyte.com/v1/workspaces/<YOUR_WORKSPACE_ID>/definitions/sources' \
+  --header 'authorization: Bearer <YOUR_ACCESS_TOKEN>'
 ```
 
 ```json
@@ -63,11 +63,11 @@ Then create a source from it:
 ```bash
 curl --request POST \
   --url 'https://api.airbyte.com/v1/sources' \
-  --header 'authorization: Bearer YOUR_ACCESS_TOKEN' \
+  --header 'authorization: Bearer <YOUR_ACCESS_TOKEN>' \
   --header 'content-type: application/json' \
   --data '{
     "name": "Sample data",
-    "workspaceId": "WORKSPACE_ID",
+    "workspaceId": "<YOUR_WORKSPACE_ID>",
     "definitionId": "dfd88b22-b603-4c3d-aad7-3701784586b1",
     "configuration": { "count": 1000 }
   }'
@@ -81,12 +81,13 @@ workspace provisioning.
 
 On Airbyte Cloud, a declarative source definition is the way to add a connector
 Airbyte doesn't have. You send a Connector Builder manifest instead of a Docker image,
-and Airbyte publishes it as version 1:
+and Airbyte publishes it as version 1. Your real manifest declares its streams in
+`streams`, left empty here for brevity:
 
 ```bash
 curl --request POST \
-  --url 'https://api.airbyte.com/v1/workspaces/WORKSPACE_ID/definitions/declarative_sources' \
-  --header 'authorization: Bearer YOUR_ACCESS_TOKEN' \
+  --url 'https://api.airbyte.com/v1/workspaces/<YOUR_WORKSPACE_ID>/definitions/declarative_sources' \
+  --header 'authorization: Bearer <YOUR_ACCESS_TOKEN>' \
   --header 'content-type: application/json' \
   --data '{
     "name": "Internal Orders API",
@@ -94,7 +95,7 @@ curl --request POST \
       "version": "6.48.15",
       "type": "DeclarativeSource",
       "check": { "type": "CheckStream", "stream_names": ["orders"] },
-      "streams": [ ... ],
+      "streams": [],
       "spec": {
         "type": "Spec",
         "connection_specification": {
@@ -136,8 +137,8 @@ the endpoint to call from CI when the manifest changes in git:
 
 ```bash
 curl --request PUT \
-  --url 'https://api.airbyte.com/v1/workspaces/WORKSPACE_ID/definitions/declarative_sources/DEFINITION_ID' \
-  --header 'authorization: Bearer YOUR_ACCESS_TOKEN' \
+  --url 'https://api.airbyte.com/v1/workspaces/<YOUR_WORKSPACE_ID>/definitions/declarative_sources/<DEFINITION_ID>' \
+  --header 'authorization: Bearer <YOUR_ACCESS_TOKEN>' \
   --header 'content-type: application/json' \
   --data '{ "manifest": { "...": "your updated manifest" } }'
 ```
@@ -151,8 +152,8 @@ in a workspace with `POST definitions/sources` (or `definitions/destinations`):
 
 ```bash
 curl --request POST \
-  --url 'https://YOUR_AIRBYTE_HOST/api/public/v1/workspaces/WORKSPACE_ID/definitions/sources' \
-  --header 'authorization: Bearer YOUR_ACCESS_TOKEN' \
+  --url '<YOUR_AIRBYTE_URL>/api/public/v1/workspaces/<YOUR_WORKSPACE_ID>/definitions/sources' \
+  --header 'authorization: Bearer <YOUR_ACCESS_TOKEN>' \
   --header 'content-type: application/json' \
   --data '{
     "name": "Internal Orders API",
@@ -174,8 +175,8 @@ tag:
 
 ```bash
 curl --request PUT \
-  --url 'https://YOUR_AIRBYTE_HOST/api/public/v1/workspaces/WORKSPACE_ID/definitions/sources/DEFINITION_ID' \
-  --header 'authorization: Bearer YOUR_ACCESS_TOKEN' \
+  --url '<YOUR_AIRBYTE_URL>/api/public/v1/workspaces/<YOUR_WORKSPACE_ID>/definitions/sources/<DEFINITION_ID>' \
+  --header 'authorization: Bearer <YOUR_ACCESS_TOKEN>' \
   --header 'content-type: application/json' \
   --data '{ "name": "Internal Orders API", "dockerImageTag": "1.5.0" }'
 ```

--- a/docs/developers/connector-definitions.md
+++ b/docs/developers/connector-definitions.md
@@ -47,13 +47,13 @@ This is the most common use of these endpoints, and it needs no custom connector
 all. List the definitions in a workspace and take the `id` of the connector you want:
 that value is the `definitionId` you pass when you create a source or a destination.
 
-```bash
+```bash title="Request: list source definitions"
 curl --request GET \
   --url 'https://api.airbyte.com/v1/workspaces/<YOUR_WORKSPACE_ID>/definitions/sources' \
   --header 'authorization: Bearer <YOUR_ACCESS_TOKEN>'
 ```
 
-```json
+```json title="Response: list source definitions"
 {
   "data": [
     {
@@ -69,7 +69,7 @@ curl --request GET \
 
 Then create a source from it:
 
-```bash
+```bash title="Request: create a source from a definition"
 curl --request POST \
   --url 'https://api.airbyte.com/v1/sources' \
   --header 'authorization: Bearer <YOUR_ACCESS_TOKEN>' \
@@ -93,7 +93,7 @@ Airbyte doesn't have. You send a Connector Builder manifest instead of a Docker 
 and Airbyte publishes it as version 1. Your real manifest declares its streams in
 `streams`, left empty here for brevity:
 
-```bash
+```bash title="Request: create a declarative source definition"
 curl --request POST \
   --url 'https://api.airbyte.com/v1/workspaces/<YOUR_WORKSPACE_ID>/definitions/declarative_sources' \
   --header 'authorization: Bearer <YOUR_ACCESS_TOKEN>' \
@@ -118,7 +118,7 @@ curl --request POST \
   }'
 ```
 
-```json
+```json title="Response: create a declarative source definition"
 {
   "id": "9bb26c3b-5125-4492-bb2e-ccda42cfe255",
   "name": "Internal Orders API",
@@ -151,7 +151,7 @@ only version 1 returns `version: 2`, while a definition already published at ver
 returns `version: 3`. This is the endpoint to call from CI when the manifest changes in
 git:
 
-```bash
+```bash title="Request: publish a new manifest version"
 curl --request PUT \
   --url 'https://api.airbyte.com/v1/workspaces/<YOUR_WORKSPACE_ID>/definitions/declarative_sources/<DEFINITION_ID>' \
   --header 'authorization: Bearer <YOUR_ACCESS_TOKEN>' \
@@ -166,7 +166,7 @@ The request body takes only the manifest. You can't rename a definition this way
 If you built a connector with the CDK and pushed it to a registry, register the image
 in a workspace with `POST definitions/sources` (or `definitions/destinations`):
 
-```bash
+```bash title="Request: register a custom image-based source definition"
 curl --request POST \
   --url '<YOUR_AIRBYTE_URL>/api/public/v1/workspaces/<YOUR_WORKSPACE_ID>/definitions/sources' \
   --header 'authorization: Bearer <YOUR_ACCESS_TOKEN>' \
@@ -189,7 +189,7 @@ To move the connector to a new version, `PUT` the new tag. Both `name` and
 `dockerImageTag` are required, so send the current name if you only want to change the
 tag:
 
-```bash
+```bash title="Request: move a custom definition to a new image tag"
 curl --request PUT \
   --url '<YOUR_AIRBYTE_URL>/api/public/v1/workspaces/<YOUR_WORKSPACE_ID>/definitions/sources/<DEFINITION_ID>' \
   --header 'authorization: Bearer <YOUR_ACCESS_TOKEN>' \

--- a/docs/developers/connector-definitions.md
+++ b/docs/developers/connector-definitions.md
@@ -22,11 +22,20 @@ version in two workspaces of the same organization.
 
 ## The three definition endpoints
 
-| Endpoint | Connectors it covers | Read | Create, update, delete |
-| --- | --- | --- | --- |
-| `definitions/sources` | Source connectors that run a Docker image, both Airbyte's and your custom ones | All deployments | Custom definitions only, and not on Cloud |
-| `definitions/destinations` | Destination connectors that run a Docker image | All deployments | Custom definitions only, and not on Cloud |
-| `definitions/declarative_sources` | Low-code source connectors built from a Connector Builder manifest | All deployments | All deployments, including Cloud |
+| Endpoint | Connectors it covers | Read | Create and update | Delete |
+| --- | --- | --- | --- | --- |
+| `definitions/sources` | Source connectors that run a Docker image, both Airbyte's and your custom ones | All deployments | Custom definitions only, and not on Cloud | Custom definitions only; all deployments |
+| `definitions/destinations` | Destination connectors that run a Docker image | All deployments | Custom definitions only, and not on Cloud | Custom definitions only; all deployments |
+| `definitions/declarative_sources` | Low-code source connectors built from a Connector Builder manifest | All deployments | All deployments, including Cloud | All deployments, including Cloud |
+
+:::warning
+
+Deleting a custom definition destroys every source or destination created from it,
+and deleting those actors cascades to the connections that use them. This applies
+to all three definition endpoint families; deleting a declarative source definition
+also removes its Connector Builder project.
+
+:::
 
 Declarative source definitions are deliberately kept apart from `definitions/sources`:
 they never appear in its list response, and requesting one by ID there returns a 404.
@@ -121,9 +130,14 @@ curl --request POST \
 Two requirements on the manifest:
 
 - It must contain a `spec` object with a `connection_specification` — the JSON schema
-  for your connector's own configuration. Without it, the request fails.
-- Its `version` must be a CDK version whose major version your deployment supports. A
-  manifest built against a newer major version is rejected with a 409.
+  for your connector's own configuration. Without it, the request currently fails
+  with an unexpected-error 500 rather than a validation error.
+- Its `version` must be a CDK version whose major version has a registered base image
+  on your deployment. An unsupported major is rejected with a 409 whose body contains
+  only the generic `Could not fulfill request` message.
+- On Self-Managed, updates also check whether the version is supported by the current
+  platform version. That check runs on update but not create, so a version can be
+  accepted by `POST` and rejected by a later `PUT` with a 400.
 
 The definition also becomes a Connector Builder project, so you can open and edit the
 connector in the UI afterwards. The returned `id` is a normal `definitionId`: create
@@ -131,9 +145,11 @@ sources from it exactly as above.
 
 ### Publish a new version
 
-`PUT` publishes the manifest as the next version and activates it. Versions increment
-on their own — the first update to a new definition returns `version: 2` — so this is
-the endpoint to call from CI when the manifest changes in git:
+`PUT` publishes the manifest as the next version and activates it. The new version is
+the highest version already published plus one — a first update to a definition with
+only version 1 returns `version: 2`, while a definition already published at version 2
+returns `version: 3`. This is the endpoint to call from CI when the manifest changes in
+git:
 
 ```bash
 curl --request PUT \
@@ -181,7 +197,8 @@ curl --request PUT \
   --data '{ "name": "Internal Orders API", "dockerImageTag": "1.5.0" }'
 ```
 
-`DELETE` removes the definition from the workspace and returns it one last time.
+`DELETE` removes the definition from the workspace and returns it one last time. See
+the warning above for the cascading data loss.
 
 :::note
 Creating or updating an image-based definition runs the connector image to read its
@@ -196,16 +213,22 @@ call fails and the definition keeps its previous tag.
 
 Two rules explain almost every error these endpoints return:
 
-- **Only custom definitions can be written to.** Airbyte's registry connectors are
-  managed for you; updating or deleting one fails with
-  `Public definitions cannot be modified.` This holds on every deployment, including
-  Self-Managed.
+- **Only custom definitions can be updated or deleted.** Airbyte's registry connectors
+  are managed for you. On Self-Managed, updating or deleting one fails with
+  `Public definitions cannot be modified.` On Cloud, an update to a registry definition
+  hits the Cloud edition guard first and returns
+  `Non-declarative definitions cannot be created or updated in Airbyte Cloud.`; a
+  delete returns `Public definitions cannot be modified.` on every deployment.
 - **Cloud doesn't accept image-based definitions.** Creating or updating a source or
   destination definition on Cloud fails with `Non-declarative definitions cannot be
   created or updated in Airbyte Cloud.` Cloud runs connectors from Airbyte's registry
   plus declarative connectors, so use a declarative source definition instead. There
   is no declarative equivalent for destinations, so custom destinations are a
   Self-Managed capability.
+
+These writes require workspace editor access. Source definitions also accept the
+workspace source editor role, but destination definitions do not, so a workspace
+destination editor cannot write destination definitions.
 
 ## See also
 

--- a/docs/platform/connector-development/config-based/understanding-the-yaml-file/yaml-overview.md
+++ b/docs/platform/connector-development/config-based/understanding-the-yaml-file/yaml-overview.md
@@ -1,6 +1,7 @@
 # YAML Components
 
 The low-code framework involves editing a boilerplate [YAML file](../low-code-cdk-overview.md#configuring-the-yaml-file). This section deep dives into the components of the YAML file.
+To learn how to send a manifest to the API, see [Manage connector definitions with the API](/developers/connector-definitions).
 
 ## Stream
 

--- a/docs/platform/connector-development/config-based/understanding-the-yaml-file/yaml-overview.md
+++ b/docs/platform/connector-development/config-based/understanding-the-yaml-file/yaml-overview.md
@@ -1,6 +1,7 @@
 # YAML Components
 
 The low-code framework involves editing a boilerplate [YAML file](../low-code-cdk-overview.md#configuring-the-yaml-file). This section deep dives into the components of the YAML file.
+
 To learn how to send a manifest to the API, see [Manage connector definitions with the API](/developers/connector-definitions).
 
 ## Stream

--- a/docs/platform/connector-development/connector-builder-ui/overview.md
+++ b/docs/platform/connector-development/connector-builder-ui/overview.md
@@ -47,6 +47,8 @@ Reviews typically take under a week.
 
 You can also export the YAML manifest file for your connector and share it with others. The manifest file contains all the connector configuration structured according to the declarative component schema, including the global configuration, streams, and user inputs.
 
+To publish and version a Builder connector through the API from CI, see [Manage connector definitions with the API](/developers/connector-definitions).
+
 ## Disabled in low-resource mode
 
 If you install Airbyte with abctl using low-resource mode, you are unable to access the Connector Builder. To access the Connector Builder, allocate Airbyte's [suggested resources](/platform/using-airbyte/getting-started/oss-quickstart#suggested-resources) and re-deploy Airbyte without setting the `--low-resource-mode` flag.

--- a/docs/platform/operator-guides/using-custom-connectors.md
+++ b/docs/platform/operator-guides/using-custom-connectors.md
@@ -117,8 +117,7 @@ You can pull your connector image from your private registry to validate the pre
 
 ### Loading connector docker containers into kind
 
-If you are running Airbyte in kind (kubernetes in docker -- this is the default method for abctl), you must load the docker image of that connector into the cluster. If you are seeing the following error, it likely means that the docker image has not been properly loaded into the cluster.
-The same issue affects definitions created through the API, where it surfaces as a spec-read error instead of the UI error shown in these screenshots.
+If you are running Airbyte in kind (kubernetes in docker -- this is the default method for abctl), you must load the docker image of that connector into the cluster. If you are seeing the following error, it likely means that the docker image has not been properly loaded into the cluster. The same issue affects definitions created through the API, where it surfaces as a spec-read error instead of the UI error shown in these screenshots.
 
 ![Screenshot of UI error when custom connector container is not loaded in the cluster](./assets/custom-connector-error1.png)
 

--- a/docs/platform/operator-guides/using-custom-connectors.md
+++ b/docs/platform/operator-guides/using-custom-connectors.md
@@ -101,6 +101,8 @@ You can pull your connector image from your private registry to validate the pre
 
 1. Click **Workspace settings** > **Sources**/**Destinations** depending on your connector. Click **New connector** > **Add a new Docker connector**.
 
+   To automate this workflow, use the [connector definitions API](/developers/connector-definitions).
+
 2. Name your custom connector in `Connector display name`. This is just the display name used for your workspace.
 
 3. Fill in the Docker `Docker full image name` and `Docker image tag`.
@@ -116,6 +118,7 @@ You can pull your connector image from your private registry to validate the pre
 ### Loading connector docker containers into kind
 
 If you are running Airbyte in kind (kubernetes in docker -- this is the default method for abctl), you must load the docker image of that connector into the cluster. If you are seeing the following error, it likely means that the docker image has not been properly loaded into the cluster.
+The same issue affects definitions created through the API, where it surfaces as a spec-read error instead of the UI error shown in these screenshots.
 
 ![Screenshot of UI error when custom connector container is not loaded in the cluster](./assets/custom-connector-error1.png)
 

--- a/docusaurus/sidebar-developers.js
+++ b/docusaurus/sidebar-developers.js
@@ -9,7 +9,17 @@ module.exports = {
         id: "README",
       },
       items: [
-        "api-documentation",
+        {
+          type: "category",
+          label: "API documentation",
+          link: {
+            type: "doc",
+            id: "api-documentation",
+          },
+          items: [
+            "connector-definitions",
+          ],
+        },
         {
           type: "category",
           label: "Terraform Provider",


### PR DESCRIPTION
## What

Requested by Ian Alton. Nothing in the docs explains what a connector definition is, so the three definition endpoint families in the public API are unusable without reading the source: users can't tell a definition from a configured source/destination, can't tell which family applies to them, and hit undocumented 400s, 404s and 500s that look like bugs.

New page at `/developers/connector-definitions`, a child of `/developers/api-documentation`, covering:

- definition vs. configured actor, and where `definitionId` comes from (the list response calls it `id`);
- which of the three endpoint families applies, and what each supports per deployment — image-based **create/update** are custom-definition-only and unavailable on Cloud, delete has no edition restriction, declarative sources work everywhere;
- that `DELETE` on a definition also deletes every source or destination created from it and cascades to their connections. This is the one item on the page a reader can't afford to miss, and it is currently documented nowhere;
- declarative source definitions as the Cloud path for a custom connector, including that `PUT` publishes the next manifest version after the highest already published (so a Builder connector published in the UI first does not land on 2), and cannot rename;
- the manifest failures that are otherwise unattributable: a missing `spec.connection_specification` fails with an unexpected-error 500 rather than a validation error, an unregistered major version gives a 409 whose body is only `Could not fulfill request`, and the Self-Managed platform-compatibility check runs on update but not create — so a version can be accepted by `POST` and rejected by a later `PUT`;
- that declarative definitions are invisible to `definitions/sources` — absent from the list, 404 by ID — which otherwise reads as data loss;
- the role asymmetry behind an otherwise baffling 403: source definitions accept workspace source editor, destination definitions require workspace editor.

Behavior was verified two ways: the curl examples and responses are captured output from a live Cloud workspace and a local self-managed deployment, and every claim was then re-derived against `DefinitionsController.kt` and the handlers it calls. The cascade, the version rule, the 500 and the split 409/400 came out of that second pass, which contradicted the first draft.

## How

The page is the only new file. Sidebar: the existing flat `api-documentation` entry in `sidebar-developers.js` becomes a category whose `link` is that same doc, with the new page as its child, so `/developers/api-documentation` stays exactly where it is and gains a child. Placeholders follow the parent page's convention (`<YOUR_AIRBYTE_URL>/api/public/v1/`, `<YOUR_ACCESS_TOKEN>`).

Three cross-links, chosen because each is a place where a reader is already doing this work by hand:

- `operator-guides/using-custom-connectors.md` — the UI flow it documents ("Add a new Docker connector") is the same underlying operation as `POST .../definitions/sources`, so it now says the workflow can be automated. Its `kind load docker-image` troubleshooting note also applies to definitions created through the API, where the same failure surfaces as a spec-read error instead of the UI error in its screenshots — that's now stated, since an API user would otherwise never find this section.
- `connector-development/connector-builder-ui/overview.md` — publishing and versioning a Builder connector from CI.
- `connector-development/config-based/understanding-the-yaml-file/yaml-overview.md` — where to find how to send a manifest to the API.

`docs/developers/` and `docs/platform/` are separate Docusaurus instances, so all three use the absolute site path.

Companion PR documents the same behavior in the OpenAPI spec that generates the API reference: airbytehq/airbyte-platform-internal#19359.

## Review guide
1. `docs/developers/connector-definitions.md` — the page itself; the delete warning and the manifest-requirements list are the parts most worth checking against the code
2. `docusaurus/sidebar-developers.js` — parent/child wiring
3. the three cross-linked platform pages (one or two sentences each)

## User Impact

The definition endpoints become usable from the docs alone, and the cascading effect of a definition delete is stated before someone discovers it. No behavior change; additive except for the sidebar entry, which keeps its existing URL.

Two platform issues surfaced while writing this and are documented as current behavior rather than fixed here: the missing-`spec` 500 is an unhandled null dereference in `DefinitionsController`, and the unregistered-major 409 carries no message explaining itself. Both are worth separate bugs.

## Can this PR be safely reverted and rolled back?
- [x] YES 💚
- [ ] NO ❌

## Test plan

- `corepack pnpm build` from `docusaurus/`, before and after the change: both `[SUCCESS] Generated static files in "build"`, with the same 43 pre-existing broken-anchor warnings and no new ones. (Note for maintainers: the lockfile needs pnpm 9.4.0 — the repo-global pnpm 8 fails to install, and Volta isn't present in a plain checkout.)
- Every link introduced was confirmed to resolve, including the three absolute cross-instance links and the links inside the new page; both new sidebar IDs resolve.
- MarkdownLint on all five changed files: no findings on the new page or on any added line. It reports five pre-existing `MD026` heading-punctuation errors in `using-custom-connectors.md` (lines 45, 52, 59, 66, 71) that predate this change and are left alone.
- Vale was not run locally: the `vale` executable isn't installed in this environment. The `Docs / Vale` CI check passed on the previous commit.

Link to Devin session: https://app.devin.ai/sessions/519a451e8981441c8b8ef74b0350776f
Requested by: @ian-at-airbyte