### PR TITLE
fix(source-s3): endpoint docs must require the https scheme

### DIFF
--- a/airbyte-integrations/connectors/source-s3/metadata.yaml
+++ b/airbyte-integrations/connectors/source-s3/metadata.yaml
@@ -10,7 +10,7 @@ data:
   connectorSubtype: file
   connectorType: source
   definitionId: 69589781-7828-43c5-9f63-8925b1c1ccc2
-  dockerImageTag: 4.15.19
+  dockerImageTag: 4.15.20
   dockerRepository: airbyte/source-s3
   documentationUrl: https://docs.airbyte.com/integrations/sources/s3
   externalDocumentationUrls:

--- a/airbyte-integrations/connectors/source-s3/source_s3/v4/config.py
+++ b/airbyte-integrations/connectors/source-s3/source_s3/v4/config.py
@@ -70,8 +70,9 @@ class Config(AbstractFileBasedSpec):
     endpoint: Optional[str] = Field(
         default="",
         title="Endpoint",
-        description="Endpoint to an S3 compatible service. Leave empty to use AWS.",
-        examples=["my-s3-endpoint.com", "https://my-s3-endpoint.com"],
+        description="Endpoint to an S3 compatible service, including the 'https://' scheme. "
+        "Leave empty to use AWS.",
+        examples=["https://my-s3-endpoint.com"],
         order=4,
     )
 

--- a/airbyte-integrations/connectors/source-s3/source_s3/v4/source.py
+++ b/airbyte-integrations/connectors/source-s3/source_s3/v4/source.py
@@ -126,7 +126,7 @@ class SourceS3(FileBasedSource):
             s4_spec["properties"]["endpoint"].update(
                 {
                     "description": "Endpoint to an S3 compatible service. Leave empty to use AWS. "
-                    "The custom endpoint must be secure, but the 'https' prefix is not required.",
+                    "The custom endpoint must be secure and include the 'https://' scheme.",
                     "pattern": "^(?!http://).*$",  # ignore-https-check
                 }
             )

--- a/docs/integrations/sources/s3.md
+++ b/docs/integrations/sources/s3.md
@@ -282,7 +282,7 @@ Please note, the S3 Source connector used to infer schemas from all the availabl
 
 - **AWS Access Key ID**: One half of the [required credentials](https://docs.aws.amazon.com/general/latest/gr/aws-sec-cred-types.html#access-keys-and-secret-access-keys) for accessing a private bucket.
 - **AWS Secret Access Key**: The other half of the [required credentials](https://docs.aws.amazon.com/general/latest/gr/aws-sec-cred-types.html#access-keys-and-secret-access-keys) for accessing a private bucket.
-- **Endpoint**: An optional parameter that enables the use of non-Amazon S3 compatible services. If you are using the default Amazon service, leave this field blank.
+- **Endpoint**: An optional parameter that enables the use of non-Amazon S3 compatible services. Must include the `https://` scheme (e.g. `https://my-s3-endpoint.com`). If you are using the default Amazon service, leave this field blank.
 - **Start Date**: An optional parameter that marks a starting date and time in UTC for data replication. Any files that have _not_ been modified since this specified date/time will _not_ be replicated. Use the provided datepicker (recommended) or enter the desired date programmatically in the format `YYYY-MM-DDTHH:mm:ssZ`. Leaving this field blank will replicate data from all files that have not been excluded by the **Path Pattern** and **Path Prefix**.
 
 ## File Format Settings
@@ -356,6 +356,7 @@ If you use Airbyte Cloud and your organization restricts access to specific IPs,
 
 | Version     | Date       | Pull Request                                                                                                    | Subject                                                                                                              |
 |:------------|:-----------|:----------------------------------------------------------------------------------------------------------------|:---------------------------------------------------------------------------------------------------------------------|
+| 4.15.20 | 2026-08-23 | [84884](https://github.com/airbytehq/airbyte/issues/84884) | Fix endpoint docs: the custom endpoint must include the https:// scheme |
 | 4.15.19 | 2026-08-18 | [84738](https://github.com/airbytehq/airbyte/pull/84738) | Update dependencies |
 | 4.15.18 | 2026-08-11 | [84085](https://github.com/airbytehq/airbyte/pull/84085) | Update dependencies |
 | 4.15.17 | 2026-08-04 | [83624](https://github.com/airbytehq/airbyte/pull/83624) | Update dependencies |


### PR DESCRIPTION
Fixes #84884

## What
The Cloud-only spec told users the `https://` prefix is *not required* and shipped a bare-hostname example, but botocore rejects a bare hostname at client construction (`ValueError: Invalid endpoint: my-s3-endpoint.com`), so the connector could never be saved with the documented value.

## Change (docs-only, no behavior change)
- `source_s3/v4/source.py`: Cloud spec description now states the endpoint must include the `https://` scheme
- `source_s3/v4/config.py`: base field description states the scheme requirement; dropped the failing `my-s3-endpoint.com` from `examples` (kept `https://my-s3-endpoint.com`)
- `docs/integrations/sources/s3.md`: Endpoint row states the scheme requirement
- version 4.15.19 -> 4.15.20 + changelog row

## Validation
- `python -m py_compile` on both changed .py files: passes
- Existing endpoint-related config tests unchanged (they already use `https://` examples)
- Full connector unit suite requires the poetry sandbox (orjson/dpath/airbyte-cdk) not available on this machine; the change is limited to description strings + version metadata, no logic touched