### PR TITLE
source-mongodb-v2: replace full-scan _id type aggregate with index seeks

### DIFF
--- a/airbyte-integrations/connectors/source-mongodb-v2/src/main/java/io/airbyte/integrations/source/mongodb/InitialSnapshotHandler.java
+++ b/airbyte-integrations/connectors/source-mongodb-v2/src/main/java/io/airbyte/integrations/source/mongodb/InitialSnapshotHandler.java
@@ -4,6 +4,7 @@
 
 package io.airbyte.integrations.source.mongodb;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoDatabase;
 import com.mongodb.client.model.*;
@@ -26,12 +27,12 @@ import io.airbyte.protocol.models.v0.CatalogHelpers;
 import io.airbyte.protocol.models.v0.ConfiguredAirbyteStream;
 import java.time.Duration;
 import java.time.Instant;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.bson.*;
+import org.bson.conversions.Bson;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -70,11 +71,10 @@ public class InitialSnapshotHandler {
           LOGGER.info("***collection: {}", collection);
           final var fields = Projections.fields(Projections.include(CatalogHelpers.getTopLevelFieldNames(airbyteStream).stream().toList()));
           LOGGER.info("***fields: {}", fields);
-          LOGGER.info("*** override id type validation");
-          /*final var idTypes = aggregateIdField(collection);
+          final var idTypes = getIdFieldTypes(collection);
           if (idTypes.size() > 1) {
-            LOGGER.warn("The _id fields in this collection are not consistently typed, which may lead to data loss (collection = {}).",
-                collectionName);
+            LOGGER.warn("The _id fields in this collection are not consistently typed, which may lead to data loss (collection = {}, types = {}).",
+                collectionName, idTypes);
             AirbyteTraceMessageUtility
                 .emitAnalyticsTrace(new AirbyteAnalyticsTraceMessage().withType(MULTIPLE_ID_TYPES_ANALYTICS_MESSAGE_KEY).withValue("1"));
           }
@@ -84,7 +84,7 @@ public class InitialSnapshotHandler {
               throw new ConfigErrorException("Only _id fields with the following types are currently supported: " + IdType.SUPPORTED
                   + " (collection = " + collectionName + "). type: " + idType);
             }
-          });*/
+          });
 
           // find the existing state, if there is one, for this stream
           final Optional<MongoDbStreamState> existingState =
@@ -115,37 +115,129 @@ public class InitialSnapshotHandler {
         .toList();
   }
 
+  /*
+   * BSON compares values of different types according to a fixed ordering of type "brackets"
+   * (https://www.mongodb.com/docs/manual/reference/bson-type-comparison-order/). Values of the types
+   * within a bracket interleave in the _id index, while the brackets themselves occupy contiguous,
+   * non-overlapping ranges of the index.
+   */
+  private static final List<List<String>> TYPE_BRACKETS = List.of(
+      List.of("minKey"),
+      List.of("null", "undefined"),
+      List.of("int", "long", "double", "decimal"),
+      List.of("string", "symbol"),
+      List.of("object"),
+      List.of("array"),
+      List.of("binData"),
+      List.of("objectId"),
+      List.of("bool"),
+      List.of("date"),
+      List.of("timestamp"),
+      List.of("regex"),
+      List.of("javascript", "javascriptWithScope"),
+      List.of("dbPointer"),
+      List.of("maxKey"));
+
   /**
-   * Returns a list of types (as strings) that the _id field has for the provided collection.
+   * Returns the list of BSON types (as {@code $type} aliases, e.g. "objectId", "string") present in
+   * the _id field of the provided collection.
    *
-   * @param collection Collection to aggregate the _id types of.
+   * Because the mandatory _id index is ordered by type bracket first, the types present can be
+   * determined with a constant number of index seeks instead of aggregating over every document (a
+   * full collection scan): if the smallest and largest _id share a single-type bracket, every
+   * document in between is of that type; otherwise each candidate type is probed with one
+   * index-bounded {@code $type} query.
+   *
+   * @param collection Collection to collect the _id types of.
    * @return List of bson types (as strings) that the _id field contains.
    */
-  private List<String> aggregateIdField(final MongoCollection<Document> collection) {
-    final List<String> idTypes = new ArrayList<>();
-    LOGGER.info("***aggregateIdField for collection: {}", collection);
-    /*
-     * Sanity check that all ID_FIELD values are of the same type for this collection.
-     * db.collection.aggregate([{ $group : { _id : { $type : "$_id" }, count : { $sum : 1 } } }])
-     */
-    collection.aggregate(List.of(
-        Aggregates.group(
-            new Document(MongoConstants.ID_FIELD, new Document("$type", "$_id")),
-            Accumulators.sum("count", 1))))
-        .forEach(document -> {
-          // the document will be in the structure of
-          // {"_id": {"_id": "[TYPE]"}, "count": [COUNT]}
-          // where [TYPE] is the bson type (objectId, string, etc.) and [COUNT] is the number of documents of
-          // that type
-            LOGGER.info("***document: {}", document);
-          final Document innerDocument = document.get(MongoConstants.ID_FIELD, Document.class);
-          LOGGER.info("***innerDocument: {}", innerDocument);
-          idTypes.add(innerDocument.get(MongoConstants.ID_FIELD).toString());
-          LOGGER.info("***idTypes: {}", idTypes);
-        });
-    LOGGER.info("***idTypes size: {}", idTypes.size());
-    LOGGER.info("***idTypes: {}", idTypes);
-    return idTypes;
+  @VisibleForTesting
+  List<String> getIdFieldTypes(final MongoCollection<Document> collection) {
+    final BsonType minType = endpointIdType(collection, Sorts.ascending(MongoConstants.ID_FIELD));
+    if (minType == null) {
+      // empty collection
+      return List.of();
+    }
+    final BsonType maxType = endpointIdType(collection, Sorts.descending(MongoConstants.ID_FIELD));
+
+    final List<String> minBracket = bracketOf(minType);
+    final List<String> maxBracket = bracketOf(maxType);
+    if (minBracket.equals(maxBracket)) {
+      if (minBracket.size() == 1) {
+        return minBracket;
+      }
+      // types within this bracket (e.g. int/long/double/decimal) interleave; probe each member
+      return minBracket.stream().filter(alias -> idOfTypeExists(collection, alias)).toList();
+    }
+
+    // _id values span multiple brackets; probe every type with one index seek each
+    return Stream.concat(
+        TYPE_BRACKETS.stream().flatMap(List::stream),
+        Stream.of(typeAlias(minType), typeAlias(maxType)))
+        .distinct()
+        .filter(alias -> idOfTypeExists(collection, alias))
+        .toList();
+  }
+
+  /**
+   * Returns the BSON type of the first _id in the given index order, or null if the collection is
+   * empty. This is a covered query: it only touches the _id index and never fetches a document.
+   */
+  private static BsonType endpointIdType(final MongoCollection<Document> collection, final Bson sort) {
+    final BsonDocument document = collection.withDocumentClass(BsonDocument.class)
+        .find()
+        .projection(Projections.include(MongoConstants.ID_FIELD))
+        .sort(sort)
+        .limit(1)
+        .first();
+    return document == null ? null : document.get(MongoConstants.ID_FIELD).getBsonType();
+  }
+
+  /**
+   * Returns true if at least one document has an _id of the given type. {@code $type} predicates are
+   * answered with tight index bounds (MongoDB 4.0+), so this is a single seek on the _id index.
+   */
+  private static boolean idOfTypeExists(final MongoCollection<Document> collection, final String typeAlias) {
+    return collection.find(Filters.type(MongoConstants.ID_FIELD, typeAlias))
+        .projection(Projections.include(MongoConstants.ID_FIELD))
+        .limit(1)
+        .first() != null;
+  }
+
+  private static List<String> bracketOf(final BsonType type) {
+    final String alias = typeAlias(type);
+    return TYPE_BRACKETS.stream()
+        .filter(bracket -> bracket.contains(alias))
+        .findFirst()
+        .orElse(List.of(alias));
+  }
+
+  /** Maps a driver {@link BsonType} to the alias used by the {@code $type} operator. */
+  private static String typeAlias(final BsonType type) {
+    return switch (type) {
+      case DOUBLE -> "double";
+      case STRING -> "string";
+      case DOCUMENT -> "object";
+      case ARRAY -> "array";
+      case BINARY -> "binData";
+      case UNDEFINED -> "undefined";
+      case OBJECT_ID -> "objectId";
+      case BOOLEAN -> "bool";
+      case DATE_TIME -> "date";
+      case NULL -> "null";
+      case REGULAR_EXPRESSION -> "regex";
+      case DB_POINTER -> "dbPointer";
+      case JAVASCRIPT -> "javascript";
+      case SYMBOL -> "symbol";
+      case JAVASCRIPT_WITH_SCOPE -> "javascriptWithScope";
+      case INT32 -> "int";
+      case TIMESTAMP -> "timestamp";
+      case INT64 -> "long";
+      case DECIMAL128 -> "decimal";
+      case MIN_KEY -> "minKey";
+      case MAX_KEY -> "maxKey";
+      default -> type.name();
+    };
   }
 
 }

--- a/airbyte-integrations/connectors/source-mongodb-v2/src/test/java/io/airbyte/integrations/source/mongodb/InitialSnapshotHandlerTest.java
+++ b/airbyte-integrations/connectors/source-mongodb-v2/src/test/java/io/airbyte/integrations/source/mongodb/InitialSnapshotHandlerTest.java
@@ -391,6 +391,48 @@ class InitialSnapshotHandlerTest {
     assertTrue(thrown.getMessage().contains("_id fields with the following types are currently supported"));
   }
 
+  @Test
+  void testGetIdFieldTypesEmptyCollection() {
+    final var collection = mongoClient.getDatabase(DB_NAME).getCollection(COLLECTION1);
+    assertEquals(List.of(), new InitialSnapshotHandler().getIdFieldTypes(collection));
+  }
+
+  @Test
+  void testGetIdFieldTypesSingleType() {
+    insertDocuments(COLLECTION1, List.of(
+        new Document(Map.of(CURSOR_FIELD, OBJECT_ID1, NAME_FIELD, NAME1)),
+        new Document(Map.of(CURSOR_FIELD, OBJECT_ID2, NAME_FIELD, NAME2)),
+        new Document(Map.of(CURSOR_FIELD, OBJECT_ID3, NAME_FIELD, NAME3))));
+
+    final var collection = mongoClient.getDatabase(DB_NAME).getCollection(COLLECTION1);
+    assertEquals(List.of("objectId"), new InitialSnapshotHandler().getIdFieldTypes(collection));
+  }
+
+  @Test
+  void testGetIdFieldTypesNumericTypesInterleavedInOneBracket() {
+    // min (int 1) and max (int 3) are of the same type, but a double and a long interleave between
+    // them in the _id index; the numeric bracket must be probed per type
+    insertDocuments(COLLECTION1, List.of(
+        new Document(Map.of(CURSOR_FIELD, 1, NAME_FIELD, NAME1)),
+        new Document(Map.of(CURSOR_FIELD, 1.5, NAME_FIELD, NAME2)),
+        new Document(Map.of(CURSOR_FIELD, 2L, NAME_FIELD, NAME3)),
+        new Document(Map.of(CURSOR_FIELD, 3, NAME_FIELD, NAME4))));
+
+    final var collection = mongoClient.getDatabase(DB_NAME).getCollection(COLLECTION1);
+    assertEquals(List.of("int", "long", "double"), new InitialSnapshotHandler().getIdFieldTypes(collection));
+  }
+
+  @Test
+  void testGetIdFieldTypesMixedBrackets() {
+    insertDocuments(COLLECTION1, List.of(
+        new Document(Map.of(CURSOR_FIELD, OBJECT_ID1, NAME_FIELD, NAME1)),
+        new Document(Map.of(CURSOR_FIELD, "a-string-id", NAME_FIELD, NAME2)),
+        new Document(Map.of(CURSOR_FIELD, new Document("nested", 1), NAME_FIELD, NAME3))));
+
+    final var collection = mongoClient.getDatabase(DB_NAME).getCollection(COLLECTION1);
+    assertEquals(List.of("string", "object", "objectId"), new InitialSnapshotHandler().getIdFieldTypes(collection));
+  }
+
   private void assertConfiguredFieldsEqualsRecordDataFields(final Set<String> configuredStreamFields, final JsonNode recordMessageData) {
     final Set<String> recordDataFields = ImmutableSet.copyOf(recordMessageData.fieldNames());
     assertEquals(configuredStreamFields, recordDataFields,


### PR DESCRIPTION
## What
Collecting the `_id` field types for the initial-snapshot sanity check used a `$group`-by-`$type` aggregate, which is a full collection scan and takes very long on large collections. This replaces it with a constant number of index-only operations and re-enables the previously commented-out `_id` type validation.

## How
The mandatory `_id` index is ordered by BSON type bracket first ([BSON comparison order](https://www.mongodb.com/docs/manual/reference/bson-type-comparison-order/)), so all documents whose `_id` shares a type bracket are contiguous in the index:

- Two covered min/max seeks (`sort({_id: ±1}).limit(1)`, projecting only `_id`) find the endpoint types. If both endpoints fall in a single-type bracket, every document in between is of that type — done in 2 seeks (the common all-objectId case).
- If the endpoints share an ambiguous bracket (numeric: int/long/double/decimal, or string/symbol), each member type is probed with one index-bounded `$type` query.
- If the endpoints span different brackets, each candidate type is probed once (~20 seeks worst case).

## Caveat
Within the numeric bracket the types interleave by value, so a numeric `$type` probe walks the numeric portion of the index rather than doing a pure seek. It is still index-only (`docsExamined=0`) — far cheaper than the old aggregate — but not constant-time on a huge all-numeric-`_id` collection. All other brackets get tight bounds.

## Verification
- 4 new unit tests in `InitialSnapshotHandlerTest` (empty collection, single type, numeric interleave, mixed brackets); the existing unsupported-type test exercises the re-enabled validation.
- Query semantics verified against a real `mongo:6.0.8`: explain plans show `LIMIT → PROJECTION_COVERED → IXSCAN` with `docsExamined=0` for both the min/max seeks and the `$type` probes.
- Note: I could not run the testcontainers suite locally (testcontainers 1.20.1 is incompatible with Docker Engine 29.x — pre-existing environment issue); please rely on CI for the JUnit run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)