### PR TITLE
fix(bulk-cdk): resolve per-core CDK version in upgradeCdk task

### DIFF
--- a/buildSrc/src/main/groovy/airbyte-bulk-connector.gradle
+++ b/buildSrc/src/main/groovy/airbyte-bulk-connector.gradle
@@ -351,10 +351,17 @@ class BumpConnectorCdkVersion extends DefaultTask {
         updateCdkVersion(project, targetVersion)
     }
 
+    // Sources use the extract CDK, destinations use the load CDK. Each core module is versioned
+    // independently, so the version to upgrade to depends on which one the connector declares.
     private static String getLocalCdkVersion(Project project) throws IOException {
-        File versionPropsFile = new File(project.rootDir, 'airbyte-cdk/bulk/version.properties')
+        String core = project.extensions.getByType(AirbyteBulkConnectorExtension).core
+        if (!core) {
+            throw new IllegalStateException("Project ${project.path} does not declare airbyteBulkConnector.core")
+        }
+
+        File versionPropsFile = new File(project.rootDir, "airbyte-cdk/bulk/core/${core}/version.properties")
         if (!versionPropsFile.exists()) {
-            throw new FileNotFoundException("CDK version file not found: ${versionPropsFile.absolutePath}")
+            throw new FileNotFoundException("CDK version file not found for core '${core}': ${versionPropsFile.absolutePath}")
         }
 
         Properties props = new Properties()
@@ -368,7 +375,7 @@ class BumpConnectorCdkVersion extends DefaultTask {
             throw new IllegalStateException("'version' property is empty in ${versionPropsFile.absolutePath}")
         }
 
-        project.logger.info("Found local CDK version from version.properties: ${localVersion}")
+        project.logger.info("Found local ${core} CDK version from version.properties: ${localVersion}")
         return localVersion
     }
 


### PR DESCRIPTION
## What

The monthly [Auto Upgrade CDK for Certified Connectors](https://github.com/airbytehq/airbyte/actions/workflows/auto-upgrade-certified-connectors-cdk.yml) workflow has failed every connector job since at least 2026-04-01 (e.g. [run 30709192482](https://github.com/airbytehq/airbyte/actions/runs/30709192482)):

```
java.io.FileNotFoundException: CDK version file not found: airbyte-cdk/bulk/version.properties
```

The bulk CDK is now versioned per core module (`core/base`, `core/extract`, `core/load`); the single top-level `version.properties` no longer exists, so `upgradeCdk` threw before touching any connector. Consequence: no upgrade PRs were opened for ~5 months and certified connectors drifted — load is at 1.0.25 while `destination-mssql` sits on 1.0.11, `destination-s3`/`destination-gcs-data-lake`/`destination-dev-null` on 1.0.13, `destination-bigquery` on 1.0.16; extract is at 1.1.10 with `source-postgres`/`source-mssql` on 1.1.8 and `source-datagen` on 1.1.6.

Requested by Sunil Kuruba.

## How

`BumpConnectorCdkVersion.getLocalCdkVersion` now reads the `core` value the connector already declares via `airbyteBulkConnector { core = 'extract' | 'load' }` and resolves `airbyte-cdk/bulk/core/<core>/version.properties`. That keeps a single workflow: sources track the extract CDK and destinations track the load CDK, because each connector resolves its own core's version.

```groovy
String core = project.extensions.getByType(AirbyteBulkConnectorExtension).core
File versionPropsFile = new File(project.rootDir, "airbyte-cdk/bulk/core/${core}/version.properties")
```

The `--cdkVersion=<x.y.z>` override path is unchanged. No workflow changes are needed.

## Review guide

1. `buildSrc/src/main/groovy/airbyte-bulk-connector.gradle`

## User Impact

None directly. Once merged, the monthly workflow resumes opening one CDK-upgrade PR per certified bulk connector; expect ~15 PRs on the next run (or a manual dispatch), including several multi-version jumps that will need real review.

## Test plan

Not verified locally: `./gradlew :airbyte-integrations:connectors:destination-s3:upgradeCdk :airbyte-integrations:connectors:source-postgres:upgradeCdk` could not resolve its plugin classpath from this machine (Maven Central returns HTTP 429 for every request, including plain `curl`). Verification will be a `workflow_dispatch` of the auto-upgrade workflow on this branch, checking that a destination picks up load 1.0.25 and a source picks up extract 1.1.10.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚


Link to Devin session: https://app.devin.ai/sessions/53993e7704334bb3a44de15572f65cb2
Requested by: @sunil-kuruba

> [!IMPORTANT]
> ⚡ **Auto-merge enabled.**
> 
> _This PR is set to merge automatically when all requirements are met._