### PR TITLE
feat(source-mssql): add --reset for per-image reset in the e2e harness

### DIFF
--- a/airbyte-integrations/connectors/source-mssql/.agents/skills/source-mssql-e2e-tests/SKILL.md
+++ b/airbyte-integrations/connectors/source-mssql/.agents/skills/source-mssql-e2e-tests/SKILL.md
@@ -44,6 +44,7 @@ source-mssql-e2e-tests/
 │   ├── apply-sql.sh            # docker cp + docker exec sqlcmd -i
 │   ├── render-config.sh        # jq the backend bridge IP into a config template
 │   ├── make-catalog.sh         # configured catalog derived from a discover run's CATALOG message
+│   ├── reset-databases.sh      # docker exec sqlcmd → drop every non-system database (used by run.sh --reset=fixture)
 │   ├── run-protocol-cmd.sh     # thin wrapper around `airbyte-ops … regression-test`
 │   └── run.sh                  # one-shot: backend → fixtures → config → spec/check/discover → catalog → read → teardown
 └── fixtures/
@@ -93,9 +94,14 @@ cd airbyte-integrations/connectors/source-mssql
 poe e2e-local --test-version=5.0.0 \
   --fixture=.agents/skills/source-mssql-e2e-tests/fixtures/sql/00-init-base.sql
 
-# Target vs. control comparison (prove-fix shape).
+# Target vs. control comparison, non-CDC (airbyte-ops's built-in comparator).
 poe e2e-local --test-version=dev --control-version=5.0.0 \
   --fixture=.agents/skills/source-mssql-e2e-tests/fixtures/sql/00-init-base.sql
+
+# Target vs. control comparison, CDC (per-image reset between the two runs).
+poe e2e-local --test-version=dev --control-version=5.0.0 --reset=fixture \
+  --fixture=.agents/skills/source-mssql-e2e-cdc-tests/fixtures/sql/00-init-cdc.sql \
+  --fixture=.agents/skills/source-mssql-e2e-cdc-tests/fixtures/sql/<per-bug>.sql
 
 # One command only.
 poe e2e-local --command=read --test-version=5.0.0
@@ -118,18 +124,42 @@ Build the target image first when using `--test-version=dev`, or pass
 `--command=spec|check|discover|read` (default `all`), `--skip-read`,
 `--step-name`, `--catalog` (skip discover-derived generation),
 `--sync-mode=incremental`, `--cursor-field`, `--streams`,
-`--config-template`, `--keep-backend`, and `--` to forward extra args to
-`airbyte-ops`. Per-command timeouts match the workflow's (30/30/60/180
-minutes) and are overridable with
+`--config-template`, `--reset=none|fixture|backend`, `--keep-backend`,
+and `--` to forward extra args to `airbyte-ops`. Per-command timeouts
+match the workflow's (30/30/60/180 minutes) and are overridable with
 `TIMEOUT_MINUTES_{SPEC,CHECK,DISCOVER,READ}`.
 
-When `--control-version` is set, `run.sh` drops
-`--skip-compare=True` and passes `--control-image`, so every command in
-the sweep runs both images and diffs their protocol output with the
-existing comparators (record counts, primary keys, per-record, schema).
-Both runs must see identical backend state — a full-refresh sweep is
-read-only, but for CDC that means recreating the backend and capture
-instance between them, which the comparators cannot check for you.
+### Comparison modes with `--control-version`
+
+- **`--reset=none` (default)** — `run.sh` invokes `airbyte-ops` once per
+  protocol command with both `--test-image` and `--control-image`, so
+  the two images run sequentially against a single backend and
+  `airbyte-ops`'s built-in comparators emit the target-vs-control diff
+  (record counts, primary keys, per-record, schema). Right for non-CDC
+  full-refresh work: the diff is meaningful and the shared-backend
+  assumption is safe because a full-refresh read does not mutate the
+  upstream. This is the current behavior for any caller that doesn't
+  set `--reset`.
+- **`--reset=fixture`** — `run.sh` runs the whole sweep against the
+  control image first, drops every non-system database, re-applies the
+  fixtures, then runs the sweep against the target image. Two
+  single-version `airbyte-ops` calls, no built-in comparator; artifacts
+  land under `$REPRO_OUT/<step-name>/{control,target}/<command>/`.
+  Right for **CDC comparisons**, where reusing the backend leaves the
+  target reading against a warm capture instance and an advanced log
+  position — the built-in diff can look clean while being meaningless.
+  The SQL Server log-LSN clock is server-wide and keeps ticking across
+  the reset, so per-record LSN columns and STATE offsets still differ
+  between runs; gate the verdict on record-level shape rather than on
+  those values.
+- **`--reset=backend`** — same as `--reset=fixture` but also recreates
+  the backend container between the two sweeps, resetting the LSN clock
+  at ~15s of extra startup cost. Use only when the reproduction depends
+  on matching LSN sequences across runs.
+
+`--reset` has no effect without `--control-version` and produces a
+warning; the flag governs the reset between two image runs, and there
+is no second run in single-version mode.
 
 ## Asserting on output
 
@@ -140,8 +170,10 @@ Inline assertions in driver scripts. Suggested helpers:
 - Connector-side log shape: `grep -c '<expected substring>' $REPRO_OUT/<step>/read/stderr.txt`.
 - Connection status: `jq -e 'select(.type == "CONNECTION_STATUS" and .connectionStatus.status == "SUCCEEDED")' $REPRO_OUT/<step>/check/stdout.txt`.
 
-In comparison mode each command's directory holds `target/` and
-`control/` subdirectories, and the raw output is under those.
+In comparison mode with `--reset=none` each command's directory holds
+`target/` and `control/` subdirectories (created by `airbyte-ops`).
+With `--reset=fixture|backend` the split lives one level up:
+`$REPRO_OUT/<step-name>/{control,target}/<command>/`.
 
 Pass `-- --enable-debug-logs=True` to `run.sh` to set `LOG_LEVEL=DEBUG`
 on the connector container. That surfaces the

--- a/airbyte-integrations/connectors/source-mssql/.agents/skills/source-mssql-e2e-tests/scripts/reset-databases.sh
+++ b/airbyte-integrations/connectors/source-mssql/.agents/skills/source-mssql-e2e-tests/scripts/reset-databases.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Drop every non-system database in the local backend.
+#
+# Used by `run.sh --reset=fixture` between the control and target image
+# runs, so the target sees the fixture applied to a clean database
+# rather than to the state control's sweep left behind. Faster than
+# recreating the container (which is `--reset=backend`): the SQL Server
+# process stays up, only the user databases are recreated. The
+# server-wide log-LSN clock keeps ticking, so per-record LSN columns and
+# STATE offsets still differ between the two sweeps — that is what
+# `--reset=backend` is for.
+#
+# Env:
+#   BACKEND_NAME            container name (default: source-mssql-db-backend)
+#   BACKEND_SA_PASSWORD     sa password (default: Test_password_1)
+set -euo pipefail
+
+BACKEND_NAME="${BACKEND_NAME:-source-mssql-db-backend}"
+BACKEND_SA_PASSWORD="${BACKEND_SA_PASSWORD:-Test_password_1}"
+
+# database_id 1..4 are master/tempdb/model/msdb; everything above is a
+# user database. SINGLE_USER WITH ROLLBACK IMMEDIATE kicks any active
+# connections (a still-running Debezium engine, an sqlcmd session) so
+# the DROP does not block waiting for them. Dropping the database drops
+# its CDC schema and change tables along with it — no separate
+# `sys.sp_cdc_disable_db` step needed.
+TSQL=$(cat <<'SQL'
+DECLARE @sql NVARCHAR(MAX) = N'';
+SELECT @sql += N'ALTER DATABASE [' + name + N'] SET SINGLE_USER WITH ROLLBACK IMMEDIATE;'
+             + CHAR(10)
+             + N'DROP DATABASE [' + name + N'];'
+             + CHAR(10)
+FROM sys.databases
+WHERE database_id > 4;
+IF LEN(@sql) > 0
+    EXEC sp_executesql @sql;
+SQL
+)
+
+echo "[reset-databases] dropping non-system databases on $BACKEND_NAME" >&2
+docker exec -i "$BACKEND_NAME" /opt/mssql-tools18/bin/sqlcmd \
+  -S localhost -U sa -P "$BACKEND_SA_PASSWORD" -C -b -Q "$TSQL"

--- a/airbyte-integrations/connectors/source-mssql/.agents/skills/source-mssql-e2e-tests/scripts/run.sh
+++ b/airbyte-integrations/connectors/source-mssql/.agents/skills/source-mssql-e2e-tests/scripts/run.sh
@@ -16,28 +16,45 @@
 #
 # Usage:
 #   run.sh [--command=all] [--fixture=PATH]… [--test-version=dev]
-#          [--control-version=TAG] [--skip-read] [--step-name=NAME]
-#          [--catalog=PATH] [--sync-mode=full_refresh|incremental]
-#          [--cursor-field=NAME] [--streams=a,b] [--config-template=PATH]
-#          [--build] [--keep-backend] [-- extra airbyte-ops args…]
+#          [--control-version=TAG] [--reset=none|fixture|backend]
+#          [--skip-read] [--step-name=NAME] [--catalog=PATH]
+#          [--sync-mode=full_refresh|incremental] [--cursor-field=NAME]
+#          [--streams=a,b] [--config-template=PATH] [--build]
+#          [--keep-backend] [-- extra airbyte-ops args…]
 #
 #   --command   all (default) runs the sweep; a single command
 #               (spec|check|discover|read) runs just that one.
 #   --skip-read runs spec/check/discover only, like the workflow's
 #               skip_read_action input.
 #
-# Passing --control-version switches airbyte-ops into comparison mode, so
-# every command in the sweep emits the target-vs-control diff that Path B
-# of the prove_fix playbook reports as evidence. Comparison assumes both
-# images observe identical backend state; a full-refresh sweep is
-# read-only, but any CDC run has to recreate the backend and the capture
-# instance between the two, or the diff is meaningless while still
-# looking clean.
+# Comparison modes (with --control-version):
+#
+#   --reset=none (default): one airbyte-ops call per command with both
+#     --test-image and --control-image. airbyte-ops runs the two images
+#     sequentially against one backend and emits a target-vs-control
+#     diff via its built-in comparators. This is the right default for
+#     non-CDC full-refresh work, where the diff is meaningful and cheap.
+#
+#   --reset=fixture: run the whole sweep against the control image
+#     first, drop every non-system database, re-apply the fixtures, then
+#     run the sweep against the target image. Two single-version runs,
+#     no airbyte-ops comparator. Faster than --reset=backend but the
+#     SQL Server log-LSN clock keeps ticking, so per-record LSN columns
+#     and STATE offsets differ between the two runs. Right for CDC
+#     comparisons where a shared capture instance would poison the diff.
+#
+#   --reset=backend: same as --reset=fixture but also recreates the
+#     backend container between the two runs, resetting the LSN clock at
+#     ~15s of extra startup cost. Use when the reproduction depends on
+#     matching LSN sequences across runs.
 #
 # Artifacts, mirroring the workflow's /tmp/regression_test_artifacts:
 #   $REPRO_OUT/<step-name>/{spec,check,discover,read}/  per-command output
 #   $REPRO_OUT/<step-name>/config.json                  rendered config
 #   $REPRO_OUT/<step-name>/configured_catalog.json      derived catalog
+#
+#   Under --reset=fixture|backend the per-command dirs are further nested
+#   under control/ and target/ so both sides' artifacts survive.
 #
 # Exit code: 0 when every executed command passed. 1 on a failed verdict
 # or an infrastructure failure (the summary says which). A single-command
@@ -59,6 +76,7 @@ COMMAND="all"
 FIXTURES=()
 TEST_VERSION="dev"
 CONTROL_VERSION_ARG=""
+RESET="none"
 SKIP_READ=false
 STEP_NAME=""
 CATALOG=""
@@ -84,6 +102,7 @@ while [[ $# -gt 0 ]]; do
     --fixture=*)         FIXTURES+=("${1#*=}") ;;
     --test-version=*)    TEST_VERSION="${1#*=}" ;;
     --control-version=*) CONTROL_VERSION_ARG="${1#*=}" ;;
+    --reset=*)           RESET="${1#*=}" ;;
     --skip-read)         SKIP_READ=true ;;
     --step-name=*)       STEP_NAME="${1#*=}" ;;
     --catalog=*)         CATALOG="${1#*=}" ;;
@@ -94,11 +113,16 @@ while [[ $# -gt 0 ]]; do
     --build)             BUILD=true ;;
     --keep-backend)      KEEP_BACKEND=true ;;
     --)                  shift; EXTRA_ARGS=("$@"); break ;;
-    -h|--help)           sed -n '2,50p' "${BASH_SOURCE[0]}"; exit 0 ;;
+    -h|--help)           sed -n '2,66p' "${BASH_SOURCE[0]}"; exit 0 ;;
     *) echo "[run] unknown argument: $1" >&2; exit 2 ;;
   esac
   shift
 done
+
+case "$RESET" in
+  none|fixture|backend) ;;
+  *) echo "[run] --reset must be none|fixture|backend (got '$RESET')" >&2; exit 2 ;;
+esac
 
 COMMANDS=()
 case "$COMMAND" in
@@ -119,6 +143,16 @@ if [[ "$SKIP_READ" == true ]]; then
 fi
 SINGLE_COMMAND=false
 [[ ${#COMMANDS[@]} -eq 1 ]] && SINGLE_COMMAND=true
+
+# --reset only has anything to reset between when there are two image
+# runs. Fall back to none in single-version mode and warn — silently
+# ignoring the flag would hide a misconfigured caller.
+if [[ "$RESET" != none && -z "$CONTROL_VERSION_ARG" ]]; then
+  echo "[run] --reset=$RESET has no effect without --control-version; treating as --reset=none" >&2
+  RESET=none
+fi
+PER_IMAGE_SWEEPS=false
+[[ -n "$CONTROL_VERSION_ARG" && "$RESET" != none ]] && PER_IMAGE_SWEEPS=true
 
 if [[ ${#FIXTURES[@]} -eq 0 ]]; then
   FIXTURES=("$SKILL_DIR/fixtures/sql/00-init-base.sql")
@@ -145,14 +179,17 @@ cleanup() {
 }
 trap cleanup EXIT
 
+apply_fixtures() {
+  for fixture in "${FIXTURES[@]}"; do
+    "$SCRIPTS/apply-sql.sh" "$fixture"
+  done
+}
+
 # The workflow's checkout + dependency install has no analogue here; its
 # equivalent for a database source is standing up the upstream itself.
 "$SCRIPTS/start-backend.sh"
-for fixture in "${FIXTURES[@]}"; do
-  "$SCRIPTS/apply-sql.sh" "$fixture"
-done
+apply_fixtures
 
-# "Setup paths and args": everything derived once, upfront.
 ARTIFACTS_DIR="$REPRO_OUT/$STEP_NAME"
 CONFIGURED_CATALOG_PATH="$ARTIFACTS_DIR/configured_catalog.json"
 WORKING_CONFIG="$ARTIFACTS_DIR/config.json"
@@ -160,105 +197,151 @@ rm -rf "$ARTIFACTS_DIR"
 mkdir -p "$ARTIFACTS_DIR"
 "$SCRIPTS/render-config.sh" "$CONFIG_TEMPLATE" "$WORKING_CONFIG"
 
+# Under --reset=fixture|backend we run two full single-version sweeps
+# with a reset between them. Every STATUS/RC/NOTE entry is prefixed by
+# the side (control/target); on the shared path the prefix is empty so
+# the summary code below reads a single set of entries.
 declare -A STATUS=() RC=() NOTE=()
+SIDE=""
 
 run_step() {
   local cmd="$1"; shift
-  local out_dir="$ARTIFACTS_DIR/$cmd"
+  local key="${SIDE:+${SIDE}.}${cmd}"
+  local out_dir="$ARTIFACTS_DIR${SIDE:+/$SIDE}/$cmd"
+  local run_version="${STEP_VERSION:-$TEST_VERSION}"
+  # When we're driving each image with its own single-version call,
+  # unset CONTROL_VERSION so run-protocol-cmd.sh takes the single-version
+  # branch even though the outer script has one. Otherwise leave it as
+  # today so the built-in comparator runs.
+  local run_control="$CONTROL_VERSION_ARG"
+  [[ "$PER_IMAGE_SWEEPS" == true ]] && run_control=""
   local mins="${TIMEOUT_MINUTES[$cmd]}"
   local -a limit=()
   command -v timeout >/dev/null 2>&1 && limit=(timeout "${mins}m")
 
-  echo "[run] $cmd" >&2
+  echo "[run] ${SIDE:+$SIDE }$cmd" >&2
   set +e
-  REPRO_OUT="$ARTIFACTS_DIR" CONTROL_VERSION="$CONTROL_VERSION_ARG" \
+  REPRO_OUT="$ARTIFACTS_DIR${SIDE:+/$SIDE}" CONTROL_VERSION="$run_control" \
     ${limit[@]+"${limit[@]}"} "$SCRIPTS/run-protocol-cmd.sh" "$cmd" "$cmd" \
-    "$TEST_VERSION" "$@" ${EXTRA_ARGS[@]+"${EXTRA_ARGS[@]}"}
+    "$run_version" "$@" ${EXTRA_ARGS[@]+"${EXTRA_ARGS[@]}"}
   local rc=$?
   set -e
 
-  RC["$cmd"]="$rc"
+  RC["$key"]="$rc"
   # A missing report means the run never got far enough to produce a
   # verdict, which is the local equivalent of the workflow's
   # internal_failure: an infrastructure problem, not a test result.
   if (( rc == 124 )); then
-    STATUS["$cmd"]=internal
-    NOTE["$cmd"]="timed out after ${mins}m"
+    STATUS["$key"]=internal
+    NOTE["$key"]="timed out after ${mins}m"
   elif [[ ! -f "$out_dir/report.md" ]]; then
-    STATUS["$cmd"]=internal
-    NOTE["$cmd"]="no report.md — the run produced no verdict"
+    STATUS["$key"]=internal
+    NOTE["$key"]="no report.md — the run produced no verdict"
   elif (( rc == 0 )); then
-    STATUS["$cmd"]=pass
+    STATUS["$key"]=pass
   else
-    STATUS["$cmd"]=fail
+    STATUS["$key"]=fail
     if grep -qE '^\*\*Result:\*\*.*Both versions failed' "$out_dir/report.md" 2>/dev/null; then
-      NOTE["$cmd"]="both versions failed — inconclusive"
+      NOTE["$key"]="both versions failed — inconclusive"
     fi
   fi
 }
 
-for cmd in "${COMMANDS[@]}"; do
-  case "$cmd" in
-    spec)
-      run_step spec
-      ;;
-    check|discover)
-      run_step "$cmd" "--config-path=$WORKING_CONFIG"
-      ;;
-    read)
-      # A derived catalog needs a discover that produced one. When discover
-      # already failed in this sweep — which is the correct outcome for, say,
-      # an invalid config — read did not run, so it is neither a verdict nor
-      # an infrastructure failure. An explicit --catalog needs no discover,
-      # so that case still runs.
-      if [[ -z "$CATALOG" && -n "${STATUS[discover]:-}" \
-        && "${STATUS[discover]}" != pass ]]; then
-        STATUS[read]=skipped
-        NOTE[read]="discover did not produce a catalog"
-        continue
-      fi
-      # The workflow generates the configured catalog from the discover
-      # step's own output rather than running a second discover, and
-      # prefers the target's messages. Derive it mechanically for the
-      # same reason it does: a hand-written catalog drifts from the
-      # fixture, and bulk-CDK then rejects the read as bad config.
-      if [[ -z "$CATALOG" ]]; then
-        DISCOVER_DIR="$ARTIFACTS_DIR/discover"
-        [[ -d "$DISCOVER_DIR/target" ]] && DISCOVER_DIR="$DISCOVER_DIR/target"
-        if [[ ! -d "$DISCOVER_DIR" ]]; then
-          # No discover in this invocation (a bare --command=read), so
-          # run one just for the catalog.
-          DISCOVER_DIR="$ARTIFACTS_DIR/catalog-discover"
-          set +e
-          REPRO_OUT="$ARTIFACTS_DIR" "$SCRIPTS/run-protocol-cmd.sh" \
-            discover catalog-discover "$TEST_VERSION" \
-            "--config-path=$WORKING_CONFIG"
-          DISCOVER_RC=$?
-          set -e
-          if (( DISCOVER_RC != 0 )); then
-            STATUS[read]=internal
-            RC[read]="$DISCOVER_RC"
-            NOTE[read]="catalog discover failed — see $DISCOVER_DIR"
-            continue
-          fi
-        fi
-        set +e
-        STREAMS="$STREAMS" SYNC_MODE="$SYNC_MODE" CURSOR_FIELD="$CURSOR_FIELD" \
-          "$SCRIPTS/make-catalog.sh" "$DISCOVER_DIR" "$CONFIGURED_CATALOG_PATH"
-        CATALOG_RC=$?
-        set -e
-        if (( CATALOG_RC != 0 )); then
-          STATUS[read]=internal
-          RC[read]="$CATALOG_RC"
-          NOTE[read]="could not derive a configured catalog from $DISCOVER_DIR"
+sweep() {
+  # Run the requested COMMANDS list under the current SIDE and
+  # STEP_VERSION, deriving the read catalog from this side's own
+  # discover output when the caller did not pass an explicit one.
+  local side_catalog="$CATALOG"
+  local side_artifacts="$ARTIFACTS_DIR${SIDE:+/$SIDE}"
+  mkdir -p "$side_artifacts"
+
+  for cmd in "${COMMANDS[@]}"; do
+    case "$cmd" in
+      spec)
+        run_step spec
+        ;;
+      check|discover)
+        run_step "$cmd" "--config-path=$WORKING_CONFIG"
+        ;;
+      read)
+        # A derived catalog needs a discover that produced one. When
+        # discover already failed on this side — the correct outcome for
+        # an invalid config — read did not run, so it is neither a
+        # verdict nor an infrastructure failure. An explicit --catalog
+        # bypasses discover so that case still runs.
+        local disc_key="${SIDE:+${SIDE}.}discover"
+        if [[ -z "$side_catalog" && -n "${STATUS[$disc_key]:-}" \
+          && "${STATUS[$disc_key]}" != pass ]]; then
+          STATUS["${SIDE:+${SIDE}.}read"]=skipped
+          NOTE["${SIDE:+${SIDE}.}read"]="discover did not produce a catalog"
           continue
         fi
-        CATALOG="$CONFIGURED_CATALOG_PATH"
-      fi
-      run_step read "--config-path=$WORKING_CONFIG" "--catalog-path=$CATALOG"
+        if [[ -z "$side_catalog" ]]; then
+          local disc_dir="$side_artifacts/discover"
+          [[ -d "$disc_dir/target" ]] && disc_dir="$disc_dir/target"
+          if [[ ! -d "$disc_dir" ]]; then
+            # No discover in this invocation (a bare --command=read),
+            # so run one just for the catalog.
+            disc_dir="$side_artifacts/catalog-discover"
+            set +e
+            REPRO_OUT="$side_artifacts" "$SCRIPTS/run-protocol-cmd.sh" \
+              discover catalog-discover "${STEP_VERSION:-$TEST_VERSION}" \
+              "--config-path=$WORKING_CONFIG"
+            local disc_rc=$?
+            set -e
+            if (( disc_rc != 0 )); then
+              STATUS["${SIDE:+${SIDE}.}read"]=internal
+              RC["${SIDE:+${SIDE}.}read"]="$disc_rc"
+              NOTE["${SIDE:+${SIDE}.}read"]="catalog discover failed — see $disc_dir"
+              continue
+            fi
+          fi
+          local catalog_out="$side_artifacts/configured_catalog.json"
+          set +e
+          STREAMS="$STREAMS" SYNC_MODE="$SYNC_MODE" CURSOR_FIELD="$CURSOR_FIELD" \
+            "$SCRIPTS/make-catalog.sh" "$disc_dir" "$catalog_out"
+          local cat_rc=$?
+          set -e
+          if (( cat_rc != 0 )); then
+            STATUS["${SIDE:+${SIDE}.}read"]=internal
+            RC["${SIDE:+${SIDE}.}read"]="$cat_rc"
+            NOTE["${SIDE:+${SIDE}.}read"]="could not derive a configured catalog from $disc_dir"
+            continue
+          fi
+          side_catalog="$catalog_out"
+        fi
+        run_step read "--config-path=$WORKING_CONFIG" "--catalog-path=$side_catalog"
+        ;;
+    esac
+  done
+}
+
+reset_between_images() {
+  case "$RESET" in
+    fixture)
+      echo "[run] --reset=fixture: dropping non-system databases and re-applying fixtures" >&2
+      "$SCRIPTS/reset-databases.sh"
+      apply_fixtures
+      "$SCRIPTS/render-config.sh" "$CONFIG_TEMPLATE" "$WORKING_CONFIG"
+      ;;
+    backend)
+      echo "[run] --reset=backend: recreating the backend container" >&2
+      "$SCRIPTS/stop-backend.sh"
+      "$SCRIPTS/start-backend.sh"
+      apply_fixtures
+      # Backend recreation may have assigned a new bridge IP.
+      "$SCRIPTS/render-config.sh" "$CONFIG_TEMPLATE" "$WORKING_CONFIG"
       ;;
   esac
-done
+}
+
+if [[ "$PER_IMAGE_SWEEPS" == true ]]; then
+  SIDE=control STEP_VERSION="$CONTROL_VERSION_ARG" sweep
+  reset_between_images
+  SIDE=target  STEP_VERSION="$TEST_VERSION"        sweep
+else
+  sweep
+fi
 
 # "Determine Final Status" plus "Write Summary Table": one line per
 # command, every non-pass rendered as a failure, and the infrastructure
@@ -266,25 +349,62 @@ done
 # regression.
 INTERNAL_FAILURE=false
 ALL_PASSED=true
-SUMMARY="| Command | Result |
-|---------|--------|"
-for cmd in spec check discover read; do
-  cell=""
-  case "${STATUS[$cmd]:-}" in
-    "")       [[ "$COMMAND" == all ]] && cell="_(skipped)_" ;;
-    pass)     cell="PASS" ;;
-    fail)     cell="FAIL"; ALL_PASSED=false ;;
-    skipped)  cell="SKIPPED" ;;
-    internal) cell="ERROR"; ALL_PASSED=false; INTERNAL_FAILURE=true ;;
+
+# Pure: emit the table cell for one command. Called under `$(...)` so
+# any variable assignment here would evaporate — see `update_flags`.
+status_cell() {
+  local key="$1" note_key="$2"
+  case "${STATUS[$key]:-}" in
+    "")       [[ "$COMMAND" == all ]] && echo "_(skipped)_" || echo "" ;;
+    pass)     echo "PASS" ;;
+    fail)     local out="FAIL"; [[ -n "${NOTE[$note_key]:-}" ]] && out+=" (${NOTE[$note_key]})"; echo "$out" ;;
+    skipped)  local out="SKIPPED"; [[ -n "${NOTE[$note_key]:-}" ]] && out+=" (${NOTE[$note_key]})"; echo "$out" ;;
+    internal) local out="ERROR"; [[ -n "${NOTE[$note_key]:-}" ]] && out+=" (${NOTE[$note_key]})"; echo "$out" ;;
   esac
-  [[ -z "$cell" ]] && continue
-  [[ -n "${NOTE[$cmd]:-}" ]] && cell="$cell (${NOTE[$cmd]})"
+}
+
+# Side-effectful: called in the parent shell so it can mutate the
+# ALL_PASSED / INTERNAL_FAILURE flags the exit path reads.
+update_flags() {
+  case "${STATUS[$1]:-}" in
+    fail)     ALL_PASSED=false ;;
+    internal) ALL_PASSED=false; INTERNAL_FAILURE=true ;;
+  esac
+}
+
+if [[ "$PER_IMAGE_SWEEPS" == true ]]; then
+  SUMMARY="| Command | Control (\`$CONTROL_VERSION_ARG\`) | Target (\`$TEST_VERSION\`) |
+|---------|---------|---------|"
+  for cmd in spec check discover read; do
+    c_cell="$(status_cell "control.$cmd" "control.$cmd")"
+    t_cell="$(status_cell "target.$cmd" "target.$cmd")"
+    update_flags "control.$cmd"
+    update_flags "target.$cmd"
+    [[ -z "$c_cell" && -z "$t_cell" ]] && continue
+    SUMMARY+="
+| \`$(echo "$cmd" | tr '[:lower:]' '[:upper:]')\` | ${c_cell:-—} | ${t_cell:-—} |"
+  done
+else
+  SUMMARY="| Command | Result |
+|---------|--------|"
+  for cmd in spec check discover read; do
+    cell="$(status_cell "$cmd" "$cmd")"
+    update_flags "$cmd"
+    [[ -z "$cell" ]] && continue
+    SUMMARY+="
+| \`$(echo "$cmd" | tr '[:lower:]' '[:upper:]')\` | $cell |"
+  done
+fi
+
+if [[ "$PER_IMAGE_SWEEPS" == true ]]; then
   SUMMARY+="
-| \`${cmd^^}\` | $cell |"
-done
-SUMMARY+="
+
+Artifacts: \`$ARTIFACTS_DIR/{control,target}/<command>/\` (\`report.md\`, \`stdout.txt\`, \`stderr.txt\`)."
+else
+  SUMMARY+="
 
 Artifacts: \`$ARTIFACTS_DIR/<command>/\` (\`report.md\`, \`stdout.txt\`, \`stderr.txt\`)."
+fi
 
 echo "$SUMMARY" >&2
 # CI gets the same table in the run summary without the workflow having
@@ -300,8 +420,14 @@ fi
 
 # A single-command run keeps returning the connector's own exit code, so
 # repro scripts can assert on it; a sweep has more than one, so it
-# reports pass/fail like the workflow's job status.
+# reports pass/fail like the workflow's job status. In per-image mode a
+# single-command run is still a single logical command that was executed
+# on both sides — surface the target's exit code, which is the fix under
+# test.
 if [[ "$SINGLE_COMMAND" == true ]]; then
+  if [[ "$PER_IMAGE_SWEEPS" == true ]]; then
+    exit "${RC["target.${COMMANDS[0]}"]:-1}"
+  fi
   exit "${RC[${COMMANDS[0]}]:-1}"
 fi
 [[ "$ALL_PASSED" == true ]] || exit 1

--- a/airbyte-integrations/connectors/source-mssql/AGENTS.md
+++ b/airbyte-integrations/connectors/source-mssql/AGENTS.md
@@ -147,13 +147,27 @@ with a control version:
 
 ```bash
 cd airbyte-integrations/connectors/source-mssql
+
+# Non-CDC (default). Both images run against one backend and airbyte-ops
+# emits the built-in target-vs-control diff.
 poe e2e-local --test-version=dev --control-version=5.0.0 \
   --fixture=.agents/skills/source-mssql-e2e-tests/fixtures/sql/00-init-base.sql
+
+# CDC. Two single-version sweeps with a fixture reset between them, so
+# the target does not read against the control's warm capture instance.
+poe e2e-local --test-version=dev --control-version=5.0.0 --reset=fixture \
+  --fixture=.agents/skills/source-mssql-e2e-cdc-tests/fixtures/sql/00-init-cdc.sql \
+  --fixture=.agents/skills/source-mssql-e2e-cdc-tests/fixtures/sql/<per-bug>.sql
 ```
 
-That sets `CONTROL_VERSION` for `run-protocol-cmd.sh`, which then omits
-`--skip-compare=True` and passes `--control-image`, so the CLI runs both
-images and diffs their protocol output with the existing comparators.
-Both runs must observe identical backend state; for CDC, recreate the
-backend and the capture instance between them, or the diff is
-meaningless while still looking clean.
+Both runs must observe equivalent backend state. Under
+`--reset=none` (the default) the two images share the backend, which is
+safe for a full-refresh read but not for CDC — a shared capture instance
+and an advanced log position make the diff look clean while being
+meaningless. `--reset=fixture` drops every non-system database and
+re-applies the fixtures between the two runs (fast; the log-LSN clock
+still ticks server-wide); `--reset=backend` also recreates the backend
+container (~15s extra, resets the LSN clock). Pick `--reset=fixture` for
+CDC unless the reproduction depends on matching LSN sequences. See
+[`SKILL.md`](.agents/skills/source-mssql-e2e-tests/SKILL.md#comparison-modes-with---control-version)
+for the full breakdown.


### PR DESCRIPTION
## What

Comparison mode in the `source-mssql` e2e harness today makes one `airbyte-ops … regression-test` call per protocol command with `--test-image` + `--control-image`; the two images run sequentially against a single backend inside the CLI. For CDC that leaves the target reading against a warm capture instance and an advanced log position — the built-in diff can look clean while being meaningless. The `SKILL.md` and connector `AGENTS.md` both call this out today with the caveat "for CDC, recreate the backend and the capture instance between them, or the diff is meaningless while still looking clean," but there is no way to actually do that through `run.sh` — the only workaround is a per-bug driver that reapplies fixtures between images (which is what `airbytehq/ai-skills#608`'s current playbook blockquote tells the session to do).

This adds a `--reset` flag that closes the gap without changing the default. First step of the sequencing in `airbytehq/ai-skills` [`prove_fix_mssql_redesign_plan.md`](https://github.com/airbytehq/ai-skills/blob/devin/1784244837-db-prove-fix-playbook/devin/playbooks/prove_fix_mssql_redesign_plan.md) (W1.1).

## How

`--reset={none,fixture,backend}` on `run.sh`:

- **`--reset=none` (default)**: current behavior. One `airbyte-ops` call per command with both images; built-in comparator emits the diff. Right for non-CDC full-refresh work and preserves every existing invocation.
- **`--reset=fixture`**: run the full sweep against the control image first, drop every non-system database via a new `reset-databases.sh` (`ALTER DATABASE … SET SINGLE_USER WITH ROLLBACK IMMEDIATE; DROP DATABASE …` for every user DB, so a live Debezium engine or `sqlcmd` session doesn't block), re-apply the fixtures, then run the sweep against the target image. Two single-version `airbyte-ops` calls, no built-in comparator; artifacts split under `$REPRO_OUT/<step>/{control,target}/<cmd>/`. Right for CDC comparisons where a shared capture instance would poison the diff.
- **`--reset=backend`**: same as `--reset=fixture` but also recreates the container between runs, resetting the LSN clock at ~15s of extra startup cost.

`airbyte-ops` exposes its comparators only as Python (`run_record_comparisons_from_files`, `compare_catalog_schemas`, etc.), not as a CLI over two output dirs, so this restructure gives up the built-in diff on the reset path. That aligns with where the redesign plan expects prove-fix to end up for CDC ("expectations gate, comparators advisory") — a follow-up will add a declarative `--expect-*` vocabulary so the reset path has a first-class pass criterion.

Read step's catalog derivation runs per-side under `--reset=fixture|backend`: each side derives its own catalog from its own `discover`. Under `--reset=none` behavior is unchanged (target's `discover` feeds the read catalog, as today).

Warns and falls back to `--reset=none` when `--control-version` is not set; there is no second run to reset for in single-version mode.

No connector runtime code changed. `SKILL.md` and the connector `AGENTS.md` are updated to document the flag and the split artifact layout. No `metadata.yaml` bump or changelog row — the diff is `.agents/` + docs only — and the matrix detector CI check will fail for that reason intentionally.

## Review guide

1. `scripts/run.sh` — argparse, the `PER_IMAGE_SWEEPS` branch, and the `SIDE`-prefixed STATUS/RC/NOTE keys. The `sweep()` function is called twice under `--reset=fixture|backend` with `SIDE=control` then `SIDE=target`; each side derives its own catalog from its own discover. `run_step()` unsets `CONTROL_VERSION` when driving the per-image sweep so `run-protocol-cmd.sh` takes the single-version branch.
2. `scripts/reset-databases.sh` — one `docker exec sqlcmd` call, dynamic T-SQL that walks `sys.databases` and drops every user DB. `database_id > 4` filters out `master`/`tempdb`/`model`/`msdb`. Dropping a DB drops its CDC schema and change tables along with it, so no separate `sys.sp_cdc_disable_db` is needed.
3. `SKILL.md` — new "Comparison modes with `--control-version`" section; `--reset` added to the other-options paragraph; "In comparison mode each command's directory holds `target/` and `control/`" note updated to describe both layouts.
4. `AGENTS.md` — "Comparison-mode regression testing" section now shows both non-CDC and CDC invocations and points at `SKILL.md`.

## Test plan

- `run.sh --help` renders the new flag documentation. ✅
- `--reset=bogus` rejects with a clear error. ✅
- `--reset=fixture` without `--control-version` warns and falls back to `none`. ✅
- Full run against a real backend (CDC comparison with `--reset=fixture`, non-CDC single-version, etc.) — not exercised locally by this PR; will be exercised via `airbytehq/ai-skills#608`'s live evals once the playbook picks up this flag.

## Can this PR be safely reverted and rolled back?
- [x] YES 💚 — no runtime code changed. `.agents/` and docs only.

---

> [!IMPORTANT]
> **Autopilot Progressive Rollout Enabled**
>
> [Autopilot progressive rollouts](https://github.com/airbytehq/airbyte-ops-mcp/blob/main/docs/autopilot-rollouts.md) are enabled for one or more connector(s) modified in this PR. Check the box below if you need to bypass normal rollout safety processes and release to all users immediately upon merge:
>
> - [ ] ⚡ **Release immediately** (bypasses automatic progressive rollout)
>
> **Note:**
>
> - ⚠️ The above bypass option is for emergency/hotfix use only.
> - 🔗 You can monitor or manually advance a rollout at **[ops.internal.airbyte.ai](https://ops.internal.airbyte.ai)**.