### PR TITLE
docs: document agent_tool for custom SDK tool bodies

### DIFF
--- a/docs/ai-agents/get-started/developer-quickstart/skills/claude-code.md
+++ b/docs/ai-agents/get-started/developer-quickstart/skills/claude-code.md
@@ -14,10 +14,10 @@ The airbyte-agent-sdk repository ships four skills under `.claude/skills/`:
 
 | Skill | What it teaches Claude Code |
 | ----- | --------------------------- |
-| `bootstrapping-agent` | Wiring a single Airbyte connector into a PydanticAI or Claude SDK agent, including `AirbyteAuthConfig`, connector initialization, and the `tool_utils` decorator pattern. |
+| `bootstrapping-agent` | Wiring a single Airbyte connector into a PydanticAI or Claude SDK agent, including `AirbyteAuthConfig`, connector initialization, and `build_connector_tools`. |
 | `building-multi-connector-agent` | Scaffolding a complete agent with multiple Airbyte connectors, composing tools, and writing the run loop. |
 | `discovering-connectors` | Enumerating the available Airbyte connectors and exploring a connector's entities, actions, and schemas at runtime. |
-| `airbyte-sdk-reference` | Reference material for the public SDK API, including `configure()`, `connect()`, `Workspace`, `tool_utils`, `list_entities()`, and `entity_schema()`, plus PydanticAI and Claude SDK code patterns. |
+| `airbyte-sdk-reference` | Reference material for the public SDK API, including `configure()`, `connect()`, `Workspace`, `build_connector_tools`, `agent_tool`, `list_entities()`, and `entity_schema()`, plus PydanticAI and Claude SDK code patterns. |
 
 Each skill is a `SKILL.md` file with YAML front matter that Claude Code uses to decide when to load it. You don't need to paste these into context yourself. Claude Code pulls them in automatically when a prompt matches the skill's description.
 

--- a/docs/ai-agents/get-started/developer-quickstart/skills/codex.md
+++ b/docs/ai-agents/get-started/developer-quickstart/skills/codex.md
@@ -14,10 +14,10 @@ The airbyte-agent-sdk repository ships four skills under `.codex/skills/`:
 
 | Skill | What it teaches Codex |
 | ----- | --------------------- |
-| `bootstrapping-agent` | Wiring a single Airbyte connector into a PydanticAI or Claude SDK agent, including `AirbyteAuthConfig`, connector initialization, and the `tool_utils` decorator pattern. |
+| `bootstrapping-agent` | Wiring a single Airbyte connector into a PydanticAI or Claude SDK agent, including `AirbyteAuthConfig`, connector initialization, and `build_connector_tools`. |
 | `building-multi-connector-agent` | Scaffolding a complete agent with multiple Airbyte connectors, composing tools, and writing the run loop. |
 | `discovering-connectors` | Enumerating the available Airbyte connectors and exploring a connector's entities, actions, and schemas at runtime. |
-| `airbyte-sdk-reference` | Reference material for the public SDK API, including `configure()`, `connect()`, `Workspace`, `tool_utils`, `list_entities()`, and `entity_schema()`, plus PydanticAI and Claude SDK code patterns. |
+| `airbyte-sdk-reference` | Reference material for the public SDK API, including `configure()`, `connect()`, `Workspace`, `build_connector_tools`, `agent_tool`, `list_entities()`, and `entity_schema()`, plus PydanticAI and Claude SDK code patterns. |
 
 Each skill is a directory that contains a `SKILL.md` file and an `agents/openai.yaml` manifest. You don't need to paste these into context yourself. Codex loads a skill when a prompt matches its description.
 

--- a/docs/ai-agents/interfaces/sdk/execute.md
+++ b/docs/ai-agents/interfaces/sdk/execute.md
@@ -176,9 +176,15 @@ for tool in build_connector_tools(github, framework="mcp").as_list():
 
 ### Custom tool bodies with `agent_tool`
 
-`build_connector_tools` writes the tool bodies for you. When you need your own, to log calls, post-process results, restrict which operations the agent can reach, or run a framework the SDK doesn't natively support, use the generated connector's `agent_tool` decorator instead. It keeps the same progressive flow: you write the three functions, and the decorator attaches the guidance that steers the agent from inspect to docs to execute.
+`build_connector_tools` writes the tool bodies for you. When you need your own to log calls, post-process results, restrict reachable agent operations, or run a framework the SDK doesn't natively support, use the generated connector's `agent_tool` decorator instead. It keeps the same progressive flow: you write the three functions, and the decorator attaches guidance that steers the agent from inspect to docs to execute.
 
-Decorate one function per role. The role is inferred from the signature: `(entity, action, ...)` is execute, `(section, ...)` is docs, and `()` is inspect. Pass it explicitly (`agent_tool("execute")`) if a wrapper's signature is ambiguous. The optional `inspect_tool=` and `docs_tool=` names are woven into the execute guidance so the agent refers to your registered tool names rather than generic ones.
+Decorate one function per role. The role is inferred from the signature:
+
+- `(entity, action, ...)` is execute
+- `(section, ...)` is docs
+- `()` is inspect
+
+Pass the role explicitly (such as `agent_tool("execute")`) if a wrapper has an ambiguous signature. The optional `inspect_tool=` and `docs_tool=` names are woven into the execute guidance so the agent refers to your registered tool names rather than generic ones.
 
 ```python title="agent.py"
 from pydantic_ai import Agent
@@ -208,7 +214,11 @@ async def github_read_docs(section: str | None = None):
     return await github.read_skill_docs(section)
 ```
 
-Because you name the functions, this is also the pattern for multi-connector agents: give each connector its own `<connector>_execute`, `<connector>_inspect`, and `<connector>_read_docs` trio.
+For multi-connector agents, add the connector name to the start of each function name to avoid naming ambiguity. Give each connector its own:
+
+- `<connector>_execute`
+- `<connector>_inspect`
+- `<connector>_read_docs`
 
 #### Choose a failure signal with `framework=`
 

--- a/docs/ai-agents/interfaces/sdk/execute.md
+++ b/docs/ai-agents/interfaces/sdk/execute.md
@@ -91,6 +91,8 @@ Skill docs are hosted by Airbyte and served by the platform. If you point the SD
 
 To expose only `execute` with a single generated description instead of the progressive flow, pass `use_progressive_docs=False`. `tools.as_list()` then returns just the `execute` tool.
 
+The builder names its tools `inspect_connector`, `read_skill_docs`, and `execute`, and the SDK can't rename them. Registering two connectors' tool sets with one agent means renaming them yourself at registration, or using [`agent_tool`](#custom-tool-bodies-with-agent_tool) with connector-specific function names.
+
 #### Register the tools with your framework
 
 `tools.as_list()` returns plain async callables, so you can register them with any framework. Set `framework=` to match the one you use.
@@ -172,9 +174,77 @@ for tool in build_connector_tools(github, framework="mcp").as_list():
 </TabItem>
 </Tabs>
 
-### Alternatives
+### Custom tool bodies with `agent_tool`
 
-The decorator patterns below predate `build_connector_tools`. They bind a single `execute` tool with the connector's full catalog baked into the description up front, rather than letting the agent read skill docs on demand. Prefer `build_connector_tools` for new agents. Reach for these when you want to expose a narrow set of operations, need full control over the tool description, or run a local connector without hosted skill docs.
+`build_connector_tools` writes the tool bodies for you. When you need your own, to log calls, post-process results, restrict which operations the agent can reach, or run a framework the SDK doesn't natively support, use the generated connector's `agent_tool` decorator instead. It keeps the same progressive flow: you write the three functions, and the decorator attaches the guidance that steers the agent from inspect to docs to execute.
+
+Decorate one function per role. The role is inferred from the signature: `(entity, action, ...)` is execute, `(section, ...)` is docs, and `()` is inspect. Pass it explicitly (`agent_tool("execute")`) if a wrapper's signature is ambiguous. The optional `inspect_tool=` and `docs_tool=` names are woven into the execute guidance so the agent refers to your registered tool names rather than generic ones.
+
+```python title="agent.py"
+from pydantic_ai import Agent
+from airbyte_agent_sdk import connect
+from airbyte_agent_sdk.connectors.github import GithubConnector
+
+agent = Agent("openai:gpt-4o")
+github = connect("github")
+
+@agent.tool_plain
+@GithubConnector.agent_tool(
+    framework="pydantic_ai",
+    inspect_tool="github_inspect",
+    docs_tool="github_read_docs",
+)
+async def github_execute(entity: str, action: str, params: dict | None = None):
+    return await github.execute(entity, action, params or {})
+
+@agent.tool_plain
+@GithubConnector.agent_tool(framework="pydantic_ai")
+async def github_inspect():
+    return await github.inspect_connector()
+
+@agent.tool_plain
+@GithubConnector.agent_tool(framework="pydantic_ai")
+async def github_read_docs(section: str | None = None):
+    return await github.read_skill_docs(section)
+```
+
+Because you name the functions, this is also the pattern for multi-connector agents: give each connector its own `<connector>_execute`, `<connector>_inspect`, and `<connector>_read_docs` trio.
+
+#### Choose a failure signal with `framework=`
+
+`framework=` controls what a tool failure looks like to the agent. It behaves the same way on `build_connector_tools`, `agent_tool`, and `translate_exceptions`.
+
+| `framework=` | A tool failure surfaces as |
+| ------------ | -------------------------- |
+| `"pydantic_ai"` | Raises `pydantic_ai.ModelRetry`, so the agent retries. |
+| `"langchain"` | Raises `langchain_core.tools.ToolException`. LangChain aborts the run unless you feed the message back to the model. See [Surface tool errors back to the model](../../get-started/developer-quickstart/tutorial-langchain#surface-tool-errors-back-to-the-model). |
+| `"openai_agents"` | Returns the failure message as the tool result instead of raising, which is what the OpenAI Agents SDK expects. |
+| `"mcp"` | Raises `fastmcp.exceptions.ToolError`, which FastMCP serializes as a failed tool result. |
+| `"none"` | Raises `AirbyteToolError`. |
+
+`build_connector_tools` auto-detects an installed framework when you omit `framework=`, and falls back to `"none"` with a warning if it finds none. `agent_tool` never auto-detects: it defaults to `"none"`.
+
+#### Unsupported frameworks and raw LLM loops
+
+On a framework the SDK doesn't cover, or in a hand-rolled dispatch loop against a model API, omit `framework=` and handle `AirbyteToolError` yourself. Advertise each function to the model using its docstring as the tool description, and return the error message as the tool result so the model can correct itself.
+
+```python title="agent.py"
+from airbyte_agent_sdk import AirbyteToolError
+
+tools = {fn.__name__: fn for fn in (github_inspect, github_read_docs, github_execute)}
+
+# tool_name and tool_args come from the model's tool call.
+try:
+    tool_result = await tools[tool_name](**tool_args)
+except AirbyteToolError as err:
+    tool_result = str(err)
+```
+
+`AirbyteToolError` inherits from `AirbyteError` and keeps the original exception on `__cause__`.
+
+### Other patterns
+
+The patterns below predate `build_connector_tools`. They bind a single `execute` tool with the connector's full catalog baked into the description up front, rather than letting the agent read skill docs on demand. Prefer `build_connector_tools`, or `agent_tool` when you need your own tool bodies.
 
 #### Manual docstrings
 
@@ -196,9 +266,11 @@ async def list_issues(owner: str, repo: str, limit: int = 10) -> str:
 
 The docstring becomes the tool description the LLM sees. Function parameters become the tool's input schema.
 
-#### Auto-generated tool descriptions
+#### Auto-generated tool descriptions with `tool_utils`
 
-For broad coverage, use the `tool_utils` decorator on a typed connector. The decorator replaces the wrapped function's docstring with a generated description that includes every entity, action, required and optional parameter, and response shape. The LLM then sees every operation the connector supports with no extra wiring.
+`tool_utils` is deprecated. It remains available so existing integrations keep working, and it doesn't warn at runtime, but new agents should use `build_connector_tools` or `agent_tool`.
+
+The decorator replaces the wrapped function's docstring with a generated description that includes every entity, action, required and optional parameter, and response shape. The LLM then sees every operation the connector supports with no extra wiring, and pays for the whole catalog in context on every call, which is what the progressive flow avoids.
 
 ```python title="agent.py"
 from pydantic_ai import Agent

--- a/docs/ai-agents/interfaces/sdk/execute.md
+++ b/docs/ai-agents/interfaces/sdk/execute.md
@@ -212,7 +212,7 @@ Because you name the functions, this is also the pattern for multi-connector age
 
 #### Choose a failure signal with `framework=`
 
-`framework=` controls what a tool failure looks like to the agent. It behaves the same way on `build_connector_tools`, `agent_tool`, and `translate_exceptions`.
+`framework=` controls what a tool failure looks like to the agent. It behaves the same way on `build_connector_tools`, `agent_tool`, and [`translate_exceptions`](../../reference/sdk/airbyte_agent_sdk/translation/index.md).
 
 | `framework=` | A tool failure surfaces as |
 | ------------ | -------------------------- |
@@ -233,11 +233,15 @@ from airbyte_agent_sdk import AirbyteToolError
 
 tools = {fn.__name__: fn for fn in (github_inspect, github_read_docs, github_execute)}
 
-# tool_name and tool_args come from the model's tool call.
-try:
-    tool_result = await tools[tool_name](**tool_args)
-except AirbyteToolError as err:
-    tool_result = str(err)
+# tool_name and tool_args come from the model's tool call, so don't assume the name exists.
+handler = tools.get(tool_name)
+if handler is None:
+    tool_result = f"Unknown tool: {tool_name}"
+else:
+    try:
+        tool_result = await handler(**tool_args)
+    except AirbyteToolError as err:
+        tool_result = str(err)
 ```
 
 `AirbyteToolError` inherits from `AirbyteError` and keeps the original exception on `__cause__`.

--- a/docs/ai-agents/interfaces/sdk/execute.md
+++ b/docs/ai-agents/interfaces/sdk/execute.md
@@ -78,7 +78,7 @@ inspect_connector() -> read_skill_docs() -> read_skill_docs(section="...") -> ex
 ```
 
 - `inspect_connector()` returns the connector's hosted metadata and Context Store readiness, and resolves the skill-doc ID the other tools use.
-- `read_skill_docs()` with no section returns the outline and general guidance. `read_skill_docs(section="<id>")` returns the exact entity and action guidance the agent needs before it executes.
+- `read_skill_docs()` with no section returns the outline and general guidance. `read_skill_docs(section="<id>")` returns the exact entity and action guidance the agent needs before it executes. The section ID must be copied verbatim from the outline, including its prefix (`actions.issues.list`, not `issues.list`); anything else returns an error that the agent has to recover from.
 - `execute(entity, action, params)` runs the operation.
 
 The SDK binds the skill-doc ID internally, so the model only passes an optional `section`. This keeps the agent's context small: it reads the outline, drills into the one section it needs, then executes, instead of loading every entity and action up front. Skill docs are served by Airbyte from the same connector definition the SDK is generated from, so they stay in sync with the connector.


### PR DESCRIPTION
Requested by Ian Alton (@ian-at-airbyte).

## What

Documents the `agent_tool` decorator added to the Agent Connector SDK in airbytehq/sonar#5791, which gives users a framework-agnostic path into the progressive `inspect_connector` -> `read_skill_docs` -> `execute` flow when they need their own tool bodies. The SDK execute page previously described the decorator patterns as predating `build_connector_tools` and never mentioned `agent_tool` at all, so users on unsupported frameworks or raw model-API dispatch loops had no documented path.

Companion Sonar PRs generate the equivalent connector README/AUTH examples: airbytehq/sonar#5896 and airbytehq/sonar#6401. Only hand-written Docusaurus pages are touched here; connector docs and the SDK API reference under `docs/ai-agents/reference/sdk/` are auto-synced from Sonar.

## How

In `docs/ai-agents/interfaces/sdk/execute.md`:

- Keeps `build_connector_tools` as the recommended default, and notes that its tool names (`inspect_connector`, `read_skill_docs`, `execute`) are fixed and can't be renamed SDK-side, which is the actual constraint on multi-connector agents.
- Adds a "Custom tool bodies with `agent_tool`" section: the three-function pattern, signature-based role inference, `inspect_tool=`/`docs_tool=` steering, and the multi-connector naming implication.
- Adds a per-framework failure-signal table (`ModelRetry`, `ToolException`, OpenAI Agents' string result, `fastmcp` `ToolError`, `AirbyteToolError`) plus auto-detection behavior: `build_connector_tools` auto-detects and warns/falls back to `"none"`; `agent_tool` defaults to `"none"` and never auto-detects.
- Adds guidance for unsupported frameworks and raw LLM dispatch loops, including handling `AirbyteToolError` (inherits `AirbyteError`, original exception kept on `__cause__`).
- Renames the "Alternatives" section to "Other patterns" and marks `tool_utils` deprecated (still available, no runtime warning). No inbound links used the old anchor.

In the Claude Code and Codex skills pages, the SDK skill descriptions still advertised `tool_utils`; they now name `build_connector_tools` and `agent_tool`.

## Review guide

1. `docs/ai-agents/interfaces/sdk/execute.md`
2. `docs/ai-agents/get-started/developer-quickstart/skills/claude-code.md`
3. `docs/ai-agents/get-started/developer-quickstart/skills/codex.md`

Verified locally: `pnpm build` in `docusaurus/` succeeds (the remaining broken-anchor warnings are pre-existing and unrelated), MarkdownLint clean, and Vale clean on the changed pages apart from one pre-existing `middleware` spelling error.

## User Impact

SDK users who need custom tool bodies, run an agent framework the SDK doesn't wrap, drive a raw model API loop, or build multi-connector agents now have documented guidance instead of having to read the SDK source. Docs-only; no behavior change.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚


Link to Devin session: https://app.devin.ai/sessions/66e0f7c72df142e5a47c7408614034da