### PR TITLE
feat(destination-clickhouse): support replicated engines and ON CLUSTER DDL for CH clusters

### DIFF
--- a/airbyte-integrations/connectors/destination-clickhouse/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-clickhouse/metadata.yaml
@@ -2,7 +2,7 @@ data:
   connectorSubtype: database
   connectorType: destination
   definitionId: ce0d828e-1dc4-496c-b122-2da42e637e48
-  dockerImageTag: 2.1.28
+  dockerImageTag: 2.1.29
   dockerRepository: airbyte/destination-clickhouse
   githubIssueLabel: destination-clickhouse
   icon: clickhouse.svg

--- a/airbyte-integrations/connectors/destination-clickhouse/src/main/kotlin/io/airbyte/integrations/destination/clickhouse/check/ClickhouseChecker.kt
+++ b/airbyte-integrations/connectors/destination-clickhouse/src/main/kotlin/io/airbyte/integrations/destination/clickhouse/check/ClickhouseChecker.kt
@@ -21,6 +21,13 @@ class ClickhouseChecker(
 ) : DestinationChecker {
     @VisibleForTesting val tableName = "_airbyte_check_table_${clock.millis()}"
 
+    private val onCluster: String =
+        if (config.resolvedClusterName.isNotBlank()) " ON CLUSTER `${config.resolvedClusterName}`"
+        else ""
+
+    private val engine: String =
+        if (config.resolvedUseReplicatedEngines) "ReplicatedMergeTree" else "MergeTree"
+
     override fun check() {
         require(!config.hostname.startsWith(Constants.PROTOCOL)) { Constants.PROTOCOL_ERR_MESSAGE }
 
@@ -28,7 +35,7 @@ class ClickhouseChecker(
 
         client
             .execute(
-                "CREATE TABLE IF NOT EXISTS $resolvedTableName (test UInt8) ENGINE = MergeTree ORDER BY ()"
+                "CREATE TABLE IF NOT EXISTS $resolvedTableName$onCluster (test UInt8) ENGINE = $engine ORDER BY ()"
             )
             .get(10, TimeUnit.SECONDS)
 
@@ -48,7 +55,7 @@ class ClickhouseChecker(
 
     override fun cleanup() {
         client
-            .execute("DROP TABLE IF EXISTS ${config.database}.$tableName")
+            .execute("DROP TABLE IF EXISTS ${config.database}.$tableName$onCluster")
             .get(10, TimeUnit.SECONDS)
     }
 

--- a/airbyte-integrations/connectors/destination-clickhouse/src/main/kotlin/io/airbyte/integrations/destination/clickhouse/client/ClickhouseSqlGenerator.kt
+++ b/airbyte-integrations/connectors/destination-clickhouse/src/main/kotlin/io/airbyte/integrations/destination/clickhouse/client/ClickhouseSqlGenerator.kt
@@ -13,15 +13,30 @@ import io.airbyte.cdk.load.message.Meta.Companion.COLUMN_NAME_AB_META
 import io.airbyte.cdk.load.message.Meta.Companion.COLUMN_NAME_AB_RAW_ID
 import io.airbyte.cdk.load.schema.model.StreamTableSchema
 import io.airbyte.cdk.load.schema.model.TableName
+import io.airbyte.integrations.destination.clickhouse.spec.ClickhouseConfiguration
 import io.github.oshai.kotlinlogging.KotlinLogging
 import jakarta.inject.Singleton
 
 @Singleton
-class ClickhouseSqlGenerator {
+class ClickhouseSqlGenerator(
+    private val config: ClickhouseConfiguration,
+) {
     private val log = KotlinLogging.logger {}
 
+    /**
+     * The `ON CLUSTER` appended to every DDL statement when a cluster name is configured, so DDL
+     * reaches all nodes of cluster via the distributed DDL queue.
+     */
+    private val onCluster: String =
+        if (config.resolvedClusterName.isNotBlank()) " ON CLUSTER `${config.resolvedClusterName}`"
+        else ""
+
+    /** Prefixes MergeTree-family engine with `Replicated` when configured. */
+    private fun String.withReplicationPrefix(): String =
+        if (config.resolvedUseReplicatedEngines) "Replicated$this" else this
+
     fun createNamespace(namespace: String): String {
-        return "CREATE DATABASE IF NOT EXISTS `$namespace`;".andLog()
+        return "CREATE DATABASE IF NOT EXISTS `$namespace`$onCluster;".andLog()
     }
 
     fun createTable(
@@ -65,13 +80,13 @@ class ClickhouseSqlGenerator {
                             // is invalid
                             COLUMN_NAME_AB_EXTRACTED_AT
                         }
-                    "ReplacingMergeTree($versionColumn)"
+                    "ReplacingMergeTree($versionColumn)".withReplicationPrefix()
                 }
-                else -> "MergeTree()"
+                else -> "MergeTree()".withReplicationPrefix()
             }
 
         return """
-            $createPrefix `${tableName.namespace}`.`${tableName.name}` (
+            $createPrefix `${tableName.namespace}`.`${tableName.name}`$onCluster (
               $COLUMN_NAME_AB_RAW_ID String NOT NULL,
               $COLUMN_NAME_AB_EXTRACTED_AT DateTime64(3) NOT NULL,
               $COLUMN_NAME_AB_META String NOT NULL,
@@ -86,12 +101,12 @@ class ClickhouseSqlGenerator {
     }
 
     fun dropTable(tableName: TableName): String =
-        "DROP TABLE IF EXISTS `${tableName.namespace}`.`${tableName.name}`;".andLog()
+        "DROP TABLE IF EXISTS `${tableName.namespace}`.`${tableName.name}`$onCluster;".andLog()
 
     fun exchangeTable(sourceTableName: TableName, targetTableName: TableName): String =
         """
         EXCHANGE TABLES `${sourceTableName.namespace}`.`${sourceTableName.name}`
-            AND `${targetTableName.namespace}`.`${targetTableName.name}`;
+            AND `${targetTableName.namespace}`.`${targetTableName.name}`$onCluster;
         """
             .trimIndent()
             .andLog()
@@ -147,7 +162,7 @@ class ClickhouseSqlGenerator {
     fun alterTable(alterationSummary: ColumnChangeset, tableName: TableName): String {
         val builder =
             StringBuilder()
-                .append("ALTER TABLE `${tableName.namespace}`.`${tableName.name}`")
+                .append("ALTER TABLE `${tableName.namespace}`.`${tableName.name}`$onCluster")
                 .appendLine()
         alterationSummary.columnsToAdd.forEach { (columnName, columnType) ->
             builder.append(" ADD COLUMN `$columnName` ${columnType.typeDecl()},")

--- a/airbyte-integrations/connectors/destination-clickhouse/src/main/kotlin/io/airbyte/integrations/destination/clickhouse/client/ClickhouseSqlGenerator.kt
+++ b/airbyte-integrations/connectors/destination-clickhouse/src/main/kotlin/io/airbyte/integrations/destination/clickhouse/client/ClickhouseSqlGenerator.kt
@@ -31,9 +31,7 @@ class ClickhouseSqlGenerator(
         if (config.resolvedClusterName.isNotBlank()) " ON CLUSTER `${config.resolvedClusterName}`"
         else ""
 
-    /** Prefixes MergeTree-family engine with `Replicated` when configured. */
-    private fun String.withReplicationPrefix(): String =
-        if (config.resolvedUseReplicatedEngines) "Replicated$this" else this
+    private val enginePrefix: String = if (config.resolvedUseReplicatedEngines) "Replicated" else ""
 
     fun createNamespace(namespace: String): String {
         return "CREATE DATABASE IF NOT EXISTS `$namespace`$onCluster;".andLog()
@@ -80,9 +78,9 @@ class ClickhouseSqlGenerator(
                             // is invalid
                             COLUMN_NAME_AB_EXTRACTED_AT
                         }
-                    "ReplacingMergeTree($versionColumn)".withReplicationPrefix()
+                    "${enginePrefix}ReplacingMergeTree($versionColumn)"
                 }
-                else -> "MergeTree()".withReplicationPrefix()
+                else -> "${enginePrefix}MergeTree()"
             }
 
         return """

--- a/airbyte-integrations/connectors/destination-clickhouse/src/main/kotlin/io/airbyte/integrations/destination/clickhouse/client/ClickhouseSqlGenerator.kt
+++ b/airbyte-integrations/connectors/destination-clickhouse/src/main/kotlin/io/airbyte/integrations/destination/clickhouse/client/ClickhouseSqlGenerator.kt
@@ -36,7 +36,7 @@ class ClickhouseSqlGenerator(
         if (config.resolvedUseReplicatedEngines) "Replicated$this" else this
 
     fun createNamespace(namespace: String): String {
-        return "CREATE DATABASE IF NOT EXISTS `$namespace` $onCluster;".andLog()
+        return "CREATE DATABASE IF NOT EXISTS `$namespace`$onCluster;".andLog()
     }
 
     fun createTable(

--- a/airbyte-integrations/connectors/destination-clickhouse/src/main/kotlin/io/airbyte/integrations/destination/clickhouse/client/ClickhouseSqlGenerator.kt
+++ b/airbyte-integrations/connectors/destination-clickhouse/src/main/kotlin/io/airbyte/integrations/destination/clickhouse/client/ClickhouseSqlGenerator.kt
@@ -36,7 +36,7 @@ class ClickhouseSqlGenerator(
         if (config.resolvedUseReplicatedEngines) "Replicated$this" else this
 
     fun createNamespace(namespace: String): String {
-        return "CREATE DATABASE IF NOT EXISTS `$namespace`$onCluster;".andLog()
+        return "CREATE DATABASE IF NOT EXISTS `$namespace` $onCluster;".andLog()
     }
 
     fun createTable(

--- a/airbyte-integrations/connectors/destination-clickhouse/src/main/kotlin/io/airbyte/integrations/destination/clickhouse/spec/ClickhouseConfiguration.kt
+++ b/airbyte-integrations/connectors/destination-clickhouse/src/main/kotlin/io/airbyte/integrations/destination/clickhouse/spec/ClickhouseConfiguration.kt
@@ -38,18 +38,12 @@ data class ClickhouseConfiguration(
     object Defaults {
         const val DATABASE_NAME = "default"
         const val RECORDS_PER_AGGREGATE = 100_000L
-        // The cluster name is empty by default, i.e. no cluster support at all
-        // as it was before this patch
         const val DEFAULT_CLUSTER_NAME = ""
-        // Do not force Replicated* prefix, btw it can't rely on DEFAULT_CLUSTER_NAME.
         const val USE_REPLICATED_ENGINES = false
     }
 
     object Validations {
-        // clusterName must be validated to prevent injections, the cluster name in click is
-        // too wide by definition, but the plus or minus valid cluster names are only
-        // alphanumeric plus "_-." symbols, feel free to change this if you need
-        // something broader in your setup
+        // Validated to prevent SQL injection.
         val CLUSTER_NAME_PATTERN = Regex("^[A-Za-z0-9_.-]*$")
     }
 }

--- a/airbyte-integrations/connectors/destination-clickhouse/src/main/kotlin/io/airbyte/integrations/destination/clickhouse/spec/ClickhouseConfiguration.kt
+++ b/airbyte-integrations/connectors/destination-clickhouse/src/main/kotlin/io/airbyte/integrations/destination/clickhouse/spec/ClickhouseConfiguration.kt
@@ -20,14 +20,37 @@ data class ClickhouseConfiguration(
     val enableJson: Boolean,
     val tunnelConfig: SshTunnelMethodConfiguration,
     val recordWindowSize: Long?,
+    val useReplicatedEngines: Boolean?,
+    val clusterName: String?,
 ) : DestinationConfiguration() {
     val endpoint = "$protocol://$hostname:$port"
     val resolvedDatabase = database.ifEmpty { Defaults.DATABASE_NAME }
     val resolvedRecordWindowSize = recordWindowSize ?: Defaults.RECORDS_PER_AGGREGATE
+    val resolvedUseReplicatedEngines = useReplicatedEngines ?: Defaults.USE_REPLICATED_ENGINES
+    val resolvedClusterName = clusterName ?: Defaults.DEFAULT_CLUSTER_NAME
+
+    init {
+        require(resolvedClusterName.matches(Validations.CLUSTER_NAME_PATTERN)) {
+            "cluster_name may contain only letters, digits, '_', '-' and '.' (got: $clusterName)"
+        }
+    }
 
     object Defaults {
         const val DATABASE_NAME = "default"
         const val RECORDS_PER_AGGREGATE = 100_000L
+        // The cluster name is empty by default, i.e. no cluster support at all
+        // as it was before this patch
+        const val DEFAULT_CLUSTER_NAME = ""
+        // Do not force Replicated* prefix, btw it can't rely on DEFAULT_CLUSTER_NAME.
+        const val USE_REPLICATED_ENGINES = false
+    }
+
+    object Validations {
+        // clusterName must be validated to prevent injections, the cluster name in click is
+        // too wide by definition, but the plus or minus valid cluster names are only
+        // alphanumeric plus "_-." symbols, feel free to change this if you need
+        // something broader in your setup
+        val CLUSTER_NAME_PATTERN = Regex("^[A-Za-z0-9_.-]*$")
     }
 }
 
@@ -53,6 +76,8 @@ class ClickhouseConfigurationFactory :
             enableJson = pojo.enableJson ?: false,
             tunnelConfig = pojo.getTunnelMethodValue() ?: SshNoTunnelMethod,
             recordWindowSize = pojo.recordWindowSize,
+            useReplicatedEngines = pojo.useReplicatedEngines,
+            clusterName = pojo.clusterName,
         )
     }
 
@@ -77,6 +102,9 @@ class ClickhouseConfigurationFactory :
                 overrides.getOrDefault("enable_json", spec.enableJson.toString()).toBoolean(),
             tunnelConfig = spec.getTunnelMethodValue() ?: SshNoTunnelMethod,
             recordWindowSize = spec.recordWindowSize,
+            useReplicatedEngines = overrides["use_replicated_engines"]?.toBoolean()
+                    ?: spec.useReplicatedEngines,
+            clusterName = overrides["cluster_name"] ?: spec.clusterName,
         )
     }
 }

--- a/airbyte-integrations/connectors/destination-clickhouse/src/main/kotlin/io/airbyte/integrations/destination/clickhouse/spec/ClickhouseSpecification.kt
+++ b/airbyte-integrations/connectors/destination-clickhouse/src/main/kotlin/io/airbyte/integrations/destination/clickhouse/spec/ClickhouseSpecification.kt
@@ -113,11 +113,12 @@ class ClickhouseSpecificationOss : ClickhouseSpecification() {
     @get:JsonSchemaInject(json = """{"order": 8}""")
     override val recordWindowSize: Long? = RECORDS_PER_AGGREGATE
 
-    @get:JsonSchemaTitle("Use Replicated Table Engines")
+    @get:JsonSchemaTitle("Enable Replication")
     @get:JsonPropertyDescription(
-        "Create tables with the Replicated* variant of the table engine the connector selects" +
-            " (ReplicatedMergeTree / ReplicatedReplacingMergeTree). Required on multi-replica" +
-            " ClickHouse clusters."
+        "Enable this to ensure synced data is replicated across all nodes in a self-managed" +
+            " ClickHouse cluster. Not needed for single-node deployments or ClickHouse Cloud." +
+            " See the <a href=\"https://clickhouse.com/docs/engines/table-engines/mergetree-family/replication\">" +
+            "ClickHouse replication docs</a> for more information."
     )
     @get:JsonProperty("use_replicated_engines")
     @get:JsonSchemaInject(json = """{"order": 9, "default": false, "group": "advanced"}""")
@@ -125,8 +126,11 @@ class ClickhouseSpecificationOss : ClickhouseSpecification() {
 
     @get:JsonSchemaTitle("Cluster Name")
     @get:JsonPropertyDescription(
-        "If set, every DDL statement is executed ON CLUSTER <name>, so tables are" +
-            " created/altered/dropped on all cluster nodes."
+        "Name of your ClickHouse cluster. When provided, table definitions are automatically" +
+            " propagated to all cluster nodes. Required for clusters using the Atomic database" +
+            " engine. Leave empty for single-node setups, ClickHouse Cloud, or databases using" +
+            " the <a href=\"https://clickhouse.com/docs/engines/database-engines/replicated\">" +
+            "Replicated database engine</a>."
     )
     @get:JsonProperty("cluster_name")
     @get:JsonSchemaInject(

--- a/airbyte-integrations/connectors/destination-clickhouse/src/main/kotlin/io/airbyte/integrations/destination/clickhouse/spec/ClickhouseSpecification.kt
+++ b/airbyte-integrations/connectors/destination-clickhouse/src/main/kotlin/io/airbyte/integrations/destination/clickhouse/spec/ClickhouseSpecification.kt
@@ -33,6 +33,8 @@ sealed class ClickhouseSpecification : ConfigurationSpecification() {
     abstract val enableJson: Boolean?
     abstract fun getTunnelMethodValue(): SshTunnelMethodConfiguration?
     abstract val recordWindowSize: Long?
+    abstract val useReplicatedEngines: Boolean?
+    abstract val clusterName: String?
 }
 
 @Singleton
@@ -110,6 +112,28 @@ class ClickhouseSpecificationOss : ClickhouseSpecification() {
     @get:JsonProperty("record_window_size")
     @get:JsonSchemaInject(json = """{"order": 8}""")
     override val recordWindowSize: Long? = RECORDS_PER_AGGREGATE
+
+    @get:JsonSchemaTitle("Use Replicated Table Engines")
+    @get:JsonPropertyDescription(
+        "Create tables with the Replicated* variant of the table engine the connector selects" +
+            " (ReplicatedMergeTree / ReplicatedReplacingMergeTree). Required on multi-replica" +
+            " ClickHouse clusters."
+    )
+    @get:JsonProperty("use_replicated_engines")
+    @get:JsonSchemaInject(json = """{"order": 9, "default": false, "group": "advanced"}""")
+    override val useReplicatedEngines: Boolean? = false
+
+    @get:JsonSchemaTitle("Cluster Name")
+    @get:JsonPropertyDescription(
+        "If set, every DDL statement is executed ON CLUSTER <name>, so tables are" +
+            " created/altered/dropped on all cluster nodes."
+    )
+    @get:JsonProperty("cluster_name")
+    @get:JsonSchemaInject(
+        json =
+            """{"order": 10, "default": "", "group": "advanced", "pattern": "^[A-Za-z0-9_.-]*$"}"""
+    )
+    override val clusterName: String? = ""
 }
 
 @Singleton
@@ -187,6 +211,12 @@ open class ClickhouseSpecificationCloud : ClickhouseSpecification() {
     @get:JsonProperty("record_window_size")
     @get:JsonSchemaInject(json = """{"order": 8}""")
     override val recordWindowSize: Long? = RECORDS_PER_AGGREGATE
+
+    // ClickHouse Cloud substitutes SharedMergeTree engines and needs neither
+    // replicated engine variants nor ON CLUSTER DDL — hidden from the Cloud spec.
+    @get:JsonIgnore override val useReplicatedEngines: Boolean? = false
+
+    @get:JsonIgnore override val clusterName: String? = ""
 }
 
 enum class ClickhouseConnectionProtocol(@get:JsonValue val value: String) {

--- a/airbyte-integrations/connectors/destination-clickhouse/src/main/kotlin/io/airbyte/integrations/destination/clickhouse/spec/ClickhouseSpecification.kt
+++ b/airbyte-integrations/connectors/destination-clickhouse/src/main/kotlin/io/airbyte/integrations/destination/clickhouse/spec/ClickhouseSpecification.kt
@@ -216,8 +216,6 @@ open class ClickhouseSpecificationCloud : ClickhouseSpecification() {
     @get:JsonSchemaInject(json = """{"order": 8}""")
     override val recordWindowSize: Long? = RECORDS_PER_AGGREGATE
 
-    // ClickHouse Cloud substitutes SharedMergeTree engines and needs neither
-    // replicated engine variants nor ON CLUSTER DDL — hidden from the Cloud spec.
     @get:JsonIgnore override val useReplicatedEngines: Boolean? = false
 
     @get:JsonIgnore override val clusterName: String? = ""

--- a/airbyte-integrations/connectors/destination-clickhouse/src/test-integration/kotlin/io/airbyte/integrations/destination/clickhouse/Utils.kt
+++ b/airbyte-integrations/connectors/destination-clickhouse/src/test-integration/kotlin/io/airbyte/integrations/destination/clickhouse/Utils.kt
@@ -49,7 +49,7 @@ object Utils {
     fun getClickhouseAirbyteClient(spec: ConfigurationSpecification): ClickhouseAirbyteClient {
         return ClickhouseAirbyteClient(
             getClickhouseClient(spec),
-            ClickhouseSqlGenerator(),
+            ClickhouseSqlGenerator(specToConfig(spec)),
             DefaultTempTableNameGenerator(),
         )
     }

--- a/airbyte-integrations/connectors/destination-clickhouse/src/test-integration/resources/expected-spec-oss.json
+++ b/airbyte-integrations/connectors/destination-clickhouse/src/test-integration/resources/expected-spec-oss.json
@@ -61,6 +61,23 @@
         "title" : "Record Window Size",
         "order" : 8
       },
+      "use_replicated_engines" : {
+        "type" : "boolean",
+        "description" : "Create tables with the Replicated* variant of the table engine the connector selects (ReplicatedMergeTree / ReplicatedReplacingMergeTree). Required on multi-replica ClickHouse clusters.",
+        "title" : "Use Replicated Table Engines",
+        "order" : 9,
+        "default" : false,
+        "group" : "advanced"
+      },
+      "cluster_name" : {
+        "type" : "string",
+        "description" : "If set, every DDL statement is executed ON CLUSTER <name>, so tables are created/altered/dropped on all cluster nodes.",
+        "title" : "Cluster Name",
+        "order" : 10,
+        "default" : "",
+        "group" : "advanced",
+        "pattern" : "^[A-Za-z0-9_.-]*$"
+      },
       "tunnel_method" : {
         "oneOf" : [ {
           "title" : "No Tunnel",

--- a/airbyte-integrations/connectors/destination-clickhouse/src/test-integration/resources/expected-spec-oss.json
+++ b/airbyte-integrations/connectors/destination-clickhouse/src/test-integration/resources/expected-spec-oss.json
@@ -63,15 +63,15 @@
       },
       "use_replicated_engines" : {
         "type" : "boolean",
-        "description" : "Create tables with the Replicated* variant of the table engine the connector selects (ReplicatedMergeTree / ReplicatedReplacingMergeTree). Required on multi-replica ClickHouse clusters.",
-        "title" : "Use Replicated Table Engines",
+        "description" : "Enable this to ensure synced data is replicated across all nodes in a self-managed ClickHouse cluster. Not needed for single-node deployments or ClickHouse Cloud. See the <a href=\"https://clickhouse.com/docs/engines/table-engines/mergetree-family/replication\">ClickHouse replication docs</a> for more information.",
+        "title" : "Enable Replication",
         "order" : 9,
         "default" : false,
         "group" : "advanced"
       },
       "cluster_name" : {
         "type" : "string",
-        "description" : "If set, every DDL statement is executed ON CLUSTER <name>, so tables are created/altered/dropped on all cluster nodes.",
+        "description" : "Name of your ClickHouse cluster. When provided, table definitions are automatically propagated to all cluster nodes. Required for clusters using the Atomic database engine. Leave empty for single-node setups, ClickHouse Cloud, or databases using the <a href=\"https://clickhouse.com/docs/engines/database-engines/replicated\">Replicated database engine</a>.",
         "title" : "Cluster Name",
         "order" : 10,
         "default" : "",

--- a/airbyte-integrations/connectors/destination-clickhouse/src/test/kotlin/io/airbyte/integrations/destination/clickhouse/check/ClickhouseCheckerTest.kt
+++ b/airbyte-integrations/connectors/destination-clickhouse/src/test/kotlin/io/airbyte/integrations/destination/clickhouse/check/ClickhouseCheckerTest.kt
@@ -156,6 +156,8 @@ class ClickhouseCheckerTest {
                 enableJson = enableJson,
                 tunnelConfig = SshNoTunnelMethod,
                 recordWindowSize = recordWindow,
+                useReplicatedEngines = ClickhouseConfiguration.Defaults.USE_REPLICATED_ENGINES,
+                clusterName = ClickhouseConfiguration.Defaults.DEFAULT_CLUSTER_NAME,
             )
     }
 }

--- a/airbyte-integrations/connectors/destination-clickhouse/src/test/kotlin/io/airbyte/integrations/destination/clickhouse/check/ClickhouseCheckerTest.kt
+++ b/airbyte-integrations/connectors/destination-clickhouse/src/test/kotlin/io/airbyte/integrations/destination/clickhouse/check/ClickhouseCheckerTest.kt
@@ -67,6 +67,34 @@ class ClickhouseCheckerTest {
     }
 
     @Test
+    fun `check with cluster config - creates check table with ON CLUSTER and ReplicatedMergeTree`() {
+        val clusterConfig = Fixtures.config(clusterName = "my_cluster", useReplicatedEngines = true)
+        val clusterChecker = ClickhouseChecker(clock, clusterConfig, client)
+
+        clusterChecker.check()
+
+        verify {
+            client.execute(
+                "CREATE TABLE IF NOT EXISTS ${clusterConfig.database}.${clusterChecker.tableName} ON CLUSTER `my_cluster` (test UInt8) ENGINE = ReplicatedMergeTree ORDER BY ()"
+            )
+        }
+    }
+
+    @Test
+    fun `cleanup with cluster config - drops check table with ON CLUSTER`() {
+        val clusterConfig = Fixtures.config(clusterName = "my_cluster")
+        val clusterChecker = ClickhouseChecker(clock, clusterConfig, client)
+
+        clusterChecker.cleanup()
+
+        verify {
+            client.execute(
+                "DROP TABLE IF EXISTS ${clusterConfig.database}.${clusterChecker.tableName} ON CLUSTER `my_cluster`"
+            )
+        }
+    }
+
+    @Test
     fun `check happy path - table name differs between instantiations to prevent collision`() {
         every { clock.millis() } returns 123L
         val checker1 = ClickhouseChecker(clock, config, client)
@@ -145,6 +173,8 @@ class ClickhouseCheckerTest {
             password: String = "password",
             enableJson: Boolean = false,
             recordWindow: Long = 42000,
+            useReplicatedEngines: Boolean = ClickhouseConfiguration.Defaults.USE_REPLICATED_ENGINES,
+            clusterName: String = ClickhouseConfiguration.Defaults.DEFAULT_CLUSTER_NAME,
         ): ClickhouseConfiguration =
             ClickhouseConfiguration(
                 hostname = hostname,
@@ -156,8 +186,8 @@ class ClickhouseCheckerTest {
                 enableJson = enableJson,
                 tunnelConfig = SshNoTunnelMethod,
                 recordWindowSize = recordWindow,
-                useReplicatedEngines = ClickhouseConfiguration.Defaults.USE_REPLICATED_ENGINES,
-                clusterName = ClickhouseConfiguration.Defaults.DEFAULT_CLUSTER_NAME,
+                useReplicatedEngines = useReplicatedEngines,
+                clusterName = clusterName,
             )
     }
 }

--- a/airbyte-integrations/connectors/destination-clickhouse/src/test/kotlin/io/airbyte/integrations/destination/clickhouse/client/ClickhouseSqlGeneratorTest.kt
+++ b/airbyte-integrations/connectors/destination-clickhouse/src/test/kotlin/io/airbyte/integrations/destination/clickhouse/client/ClickhouseSqlGeneratorTest.kt
@@ -10,6 +10,8 @@ import io.airbyte.cdk.load.component.ColumnChangeset
 import io.airbyte.cdk.load.component.ColumnType
 import io.airbyte.cdk.load.component.ColumnTypeChange
 import io.airbyte.cdk.load.schema.model.TableName
+import io.airbyte.cdk.ssh.SshNoTunnelMethod
+import io.airbyte.integrations.destination.clickhouse.spec.ClickhouseConfiguration
 import kotlin.test.assertTrue
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
@@ -20,7 +22,7 @@ import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
 
 class ClickhouseSqlGeneratorTest {
-    private val clickhouseSqlGenerator = ClickhouseSqlGenerator()
+    private val clickhouseSqlGenerator = ClickhouseSqlGenerator(testConfig())
 
     @Test
     fun testCreateNamespace() {
@@ -160,7 +162,101 @@ class ClickhouseSqlGeneratorTest {
         Assertions.assertEquals(expectedSql, actualSql)
     }
 
+    @Test
+    fun `test createNamespace with cluster name`() {
+        val generator = ClickhouseSqlGenerator(testConfig(clusterName = "my_cluster"))
+        Assertions.assertEquals(
+            "CREATE DATABASE IF NOT EXISTS `test_namespace` ON CLUSTER `my_cluster`;",
+            generator.createNamespace("test_namespace"),
+        )
+    }
+
+    @Test
+    fun `test dropTable with cluster name`() {
+        val generator = ClickhouseSqlGenerator(testConfig(clusterName = "my_cluster"))
+        Assertions.assertEquals(
+            "DROP TABLE IF EXISTS `ns`.`t` ON CLUSTER `my_cluster`;",
+            generator.dropTable(TableName("ns", "t")),
+        )
+    }
+
+    @Test
+    fun `test exchangeTable with cluster name`() {
+        val generator = ClickhouseSqlGenerator(testConfig(clusterName = "my_cluster"))
+        val expectedSql =
+            """
+            EXCHANGE TABLES `source_db`.`source_table`
+                AND `target_db`.`target_table` ON CLUSTER `my_cluster`;
+        """.trimIndent()
+        Assertions.assertEquals(
+            expectedSql,
+            generator.exchangeTable(
+                TableName("source_db", "source_table"),
+                TableName("target_db", "target_table"),
+            ),
+        )
+    }
+
+    @Test
+    fun `cluster name accepts plain identifiers`() {
+        listOf("prod", "my_cluster", "cluster-01", "eu.west.2", "").forEach { name ->
+            assertDoesNotThrow("should accept: $name") { testConfig(clusterName = name) }
+        }
+    }
+
+    @Test
+    fun `cluster name rejects sql injection attempts`() {
+        listOf(
+                "clst; DELETE FROM system.tables",
+                "clst` (x String) ENGINE=Log; DROP TABLE t; --",
+                "clst'",
+                "clst\"",
+                "clst name",
+                "{cluster}",
+            )
+            .forEach { name ->
+                assertThrows<IllegalArgumentException>("should reject: $name") {
+                    testConfig(clusterName = name)
+                }
+            }
+    }
+
+    @Test
+    fun `test alterTable with cluster name`() {
+        val generator = ClickhouseSqlGenerator(testConfig(clusterName = "my_cluster"))
+        val columnChangeset =
+            ColumnChangeset(
+                columnsToAdd = mapOf("new_column" to ColumnType("Int32", false)),
+                columnsToChange = emptyMap(),
+                columnsToDrop = emptyMap(),
+                columnsToRetain = emptyMap(),
+            )
+        val actualSql = generator.alterTable(columnChangeset, TableName("ns", "t"))
+        assertTrue(
+            actualSql.startsWith("ALTER TABLE `ns`.`t` ON CLUSTER `my_cluster`"),
+            "Expected ON CLUSTER clause, got: $actualSql",
+        )
+    }
+
     companion object {
+        fun testConfig(
+            useReplicatedEngines: Boolean = false,
+            clusterName: String = "",
+        ) =
+            ClickhouseConfiguration(
+                hostname = "localhost",
+                port = "8123",
+                protocol = "http",
+                database = "default",
+                username = "default",
+                password = "",
+                enableJson = false,
+                tunnelConfig = SshNoTunnelMethod,
+                recordWindowSize = null,
+                useReplicatedEngines = useReplicatedEngines,
+                clusterName = clusterName,
+            )
+
         @JvmStatic
         fun alterTableTestCases(): List<Arguments> =
             listOf(

--- a/docs/integrations/destinations/clickhouse.md
+++ b/docs/integrations/destinations/clickhouse.md
@@ -25,6 +25,37 @@ Version 2.0.0 represents a complete architectural redesign of the ClickHouse des
 
 Deduplication leverages ClickHouse's [ReplacingMergeTree](https://clickhouse.com/docs/engines/table-engines/mergetree-family/replacingmergetree) table engine. See [Deduplication](#deduplication) below for details.
 
+## Self-managed clusters
+
+By default the connector creates tables with non-replicated engines (`MergeTree` /
+`ReplacingMergeTree`). On a self-managed multi-replica ClickHouse cluster, a
+non-replicated table stores its data only on the replica that receives the insert,
+so reads through a load balancer return incomplete data. Two advanced options make
+the connector cluster-aware (ClickHouse Cloud needs neither — it substitutes
+`SharedMergeTree` automatically):
+
+- **Use Replicated Table Engines** (`use_replicated_engines`): prefixes the engine
+  the connector selects with `Replicated`. Emitted without explicit Keeper path
+  arguments, so the server must be able to derive them — which is the case inside a
+  database using the [`Replicated` database engine](https://clickhouse.com/docs/engines/database-engines/replicated),
+  or with `default_replica_path`/`default_replica_name` plus `{shard}`/`{replica}`
+  macros configured. Requires ClickHouse Keeper (or ZooKeeper).
+- **Cluster Name** (`cluster_name`): adds `ON CLUSTER <name>` to every DDL
+  statement (create/alter/drop/exchange), for clusters whose databases use the
+  default Atomic engine. Leave empty when the target database uses the `Replicated`
+  database engine — there, DDL replicates through the database itself and
+  `ON CLUSTER` is unnecessary. The name is validated against the identifier
+  charset `[A-Za-z0-9_.-]` (matching `remote_servers` cluster names, which are
+  XML element names) and the connection is rejected otherwise.
+
+Typical combinations:
+
+| Topology | `use_replicated_engines` | `cluster_name` |
+| :--- | :--- | :--- |
+| Single node / ClickHouse Cloud | off | empty |
+| Cluster, target database uses `Replicated` database engine | on | empty |
+| Cluster, Atomic databases + `remote_servers` cluster | on | set |
+
 ## Deduplication
 
 For optimal deduplication in Incremental - Append + Deduped sync mode, use a cursor column with one of these types:
@@ -185,7 +216,8 @@ This destination supports [namespaces](https://docs.airbyte.com/platform/using-a
 
 | Version    | Date       | Pull Request                                               | Subject                                                                        |
 |:-----------|:-----------|:-----------------------------------------------------------|:-------------------------------------------------------------------------------|
-| 2.1.28 | 2026-08-24 | [84983](https://github.com/airbytehq/airbyte/pull/84983) | Upgrade to Bulk CDK 1.0.25. |
+| 2.1.29     | 2026-08-25 | [85033](https://github.com/airbytehq/airbyte/pull/85033)   | Support self-managed clusters: optional replicated table engines and ON CLUSTER DDL |
+| 2.1.28     | 2026-08-24 | [84983](https://github.com/airbytehq/airbyte/pull/84983)   | Upgrade to Bulk CDK 1.0.25. |
 | 2.1.27     | 2026-08-05 | [83747](https://github.com/airbytehq/airbyte/pull/83747)   | Upgrade CDK to 1.0.20; document column drop behavior during schema evolution |
 | 2.1.26     | 2026-07-21 | [82684](https://github.com/airbytehq/airbyte/pull/82684)   | fix(destination-clickhouse): avoid failed count for missing temp tables        |
 | 2.1.25     | 2026-07-14 | [81550](https://github.com/airbytehq/airbyte/pull/81550)   | Use CREATE TABLE IF NOT EXISTS for non-replace table creation to prevent accidental data loss |

--- a/docs/integrations/destinations/clickhouse.md
+++ b/docs/integrations/destinations/clickhouse.md
@@ -27,34 +27,20 @@ Deduplication leverages ClickHouse's [ReplacingMergeTree](https://clickhouse.com
 
 ## Self-managed clusters
 
-By default the connector creates tables with non-replicated engines (`MergeTree` /
-`ReplacingMergeTree`). On a self-managed multi-replica ClickHouse cluster, a
-non-replicated table stores its data only on the replica that receives the insert,
-so reads through a load balancer return incomplete data. Two advanced options make
-the connector cluster-aware (ClickHouse Cloud needs neither — it substitutes
-`SharedMergeTree` automatically):
+By default, the connector stores data only on the node that receives each insert. On a self-managed ClickHouse cluster with multiple replicas, this means reads through a load balancer may return incomplete data because the other nodes are unaware of the inserted rows. Similarly, table definitions (CREATE, ALTER, DROP) are only applied on the connected node.
 
-- **Use Replicated Table Engines** (`use_replicated_engines`): prefixes the engine
-  the connector selects with `Replicated`. Emitted without explicit Keeper path
-  arguments, so the server must be able to derive them — which is the case inside a
-  database using the [`Replicated` database engine](https://clickhouse.com/docs/engines/database-engines/replicated),
-  or with `default_replica_path`/`default_replica_name` plus `{shard}`/`{replica}`
-  macros configured. Requires ClickHouse Keeper (or ZooKeeper).
-- **Cluster Name** (`cluster_name`): adds `ON CLUSTER <name>` to every DDL
-  statement (create/alter/drop/exchange), for clusters whose databases use the
-  default Atomic engine. Leave empty when the target database uses the `Replicated`
-  database engine — there, DDL replicates through the database itself and
-  `ON CLUSTER` is unnecessary. The name is validated against the identifier
-  charset `[A-Za-z0-9_.-]` (matching `remote_servers` cluster names, which are
-  XML element names) and the connection is rejected otherwise.
+Two advanced options make the connector cluster-aware. ClickHouse Cloud does not need either of these — it uses `SharedMergeTree` and handles replication automatically.
+
+- **Enable Replication** (`use_replicated_engines`): ensures synced data is [replicated](https://clickhouse.com/docs/engines/table-engines/mergetree-family/replication) across all cluster nodes. The replicated engine is emitted without explicit Keeper path arguments, so the server must be able to derive them — which is the case inside a database using the [`Replicated` database engine](https://clickhouse.com/docs/engines/database-engines/replicated), or when `default_replica_path`/`default_replica_name` macros are configured in the server. Requires ClickHouse Keeper (or ZooKeeper).
+- **Cluster Name** (`cluster_name`): when provided, table definitions are automatically propagated to all cluster nodes. Required for clusters whose databases use the default Atomic engine. Leave empty when the target database uses the [`Replicated` database engine](https://clickhouse.com/docs/engines/database-engines/replicated) — there, DDL replicates through the database itself and a cluster name is unnecessary. The name is validated against the charset `[A-Za-z0-9_.-]` and the connection is rejected if invalid characters are used.
 
 Typical combinations:
 
-| Topology | `use_replicated_engines` | `cluster_name` |
+| Topology | Enable Replication | Cluster Name |
 | :--- | :--- | :--- |
 | Single node / ClickHouse Cloud | off | empty |
-| Cluster, target database uses `Replicated` database engine | on | empty |
-| Cluster, Atomic databases + `remote_servers` cluster | on | set |
+| Cluster with [`Replicated` database engine](https://clickhouse.com/docs/engines/database-engines/replicated) | on | empty |
+| Cluster with Atomic databases + `remote_servers` | on | set to your cluster name |
 
 ## Deduplication
 
@@ -169,6 +155,8 @@ Replace `{namespace}` with each custom namespace you plan to use.
     - **Password**: The password for the ClickHouse user
     - **Enable JSON**: Whether to use ClickHouse's JSON type for object fields (recommended if your ClickHouse version supports it)
     - **Record Window Size** (advanced): The maximum number of records to write in a single batch. Tuning this parameter can impact performance. The batch size is also limited to 70 MB regardless of this setting. Most users don't need to change this value.
+    - **Enable Replication** (advanced): Enable this for self-managed ClickHouse clusters with multiple replicas to ensure data is synchronized across all nodes. See [Self-managed clusters](#self-managed-clusters) for details.
+    - **Cluster Name** (advanced): Name of your ClickHouse cluster. When provided, table definitions are propagated to all cluster nodes. See [Self-managed clusters](#self-managed-clusters) for details.
 
 ### 4. SSH tunnel (optional)
 


### PR DESCRIPTION
## What

The problem:

[Replacing]MergeTree is not a cluster version, so on clickhouse clusters (not cloud ones) INSERTS only on one replica, which receives this  INSERT. So, the tables MUST be marked as Replicated* to allow them to sync.

The plain CREATE/DROP TABLE on cluster (not cloud) also have the same problem. The DDL operations MUST use ON CLUSTER clause to allow sync of DDLs over cluster.

## How
Add two more configuration fields:

- use_replicated_engines: prefixes the engine the connector selects with Replicated (ReplicatedMergeTree / ReplicatedReplacingMergeTree)
- cluster_name: appends ON CLUSTER to every DDL statement

## Review guide
I checked the connector over real CH cluster on my laptop. 

## User Impact
The defaults of the new config values are 'not set', so the old installations will work as they worked before.

If the user specify proper values in the config - the connector will work with self managed CH clusters without problems.

## Can this PR be safely reverted and rolled back?
- [X] YES 💚
- [ ] NO ❌
