### PR TITLE
feat(destination-bigquery): add optional job execution project ID

### DIFF
--- a/airbyte-integrations/connectors/destination-bigquery/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-bigquery/metadata.yaml
@@ -6,7 +6,7 @@ data:
   connectorSubtype: database
   connectorType: destination
   definitionId: 22f6c74f-5699-40ff-833c-4a879ea40133
-  dockerImageTag: 3.0.24
+  dockerImageTag: 3.1.0
   dockerRepository: airbyte/destination-bigquery
   documentationUrl: https://docs.airbyte.com/integrations/destinations/bigquery
   githubIssueLabel: destination-bigquery

--- a/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/BigqueryBeansFactory.kt
+++ b/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/BigqueryBeansFactory.kt
@@ -103,7 +103,8 @@ class BigqueryBeansFactory {
         // direct-load tables mode.
         streamStateStore: StreamStateStore<*>,
     ): DestinationWriter {
-        val destinationHandler = BigQueryDatabaseHandler(bigquery, config.datasetLocation.region)
+        val destinationHandler =
+            BigQueryDatabaseHandler(bigquery, config.datasetLocation.region, config.jobProjectId)
         if (config.legacyRawTablesOnly) {
             // force smart cast
             @Suppress("UNCHECKED_CAST")
@@ -131,6 +132,8 @@ class BigqueryBeansFactory {
                         destinationHandler,
                     ),
                     bigquery,
+                    config.jobProjectId,
+                    config.datasetLocation.region,
                 )
             // force smart cast
             @Suppress("UNCHECKED_CAST")

--- a/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/BigqueryBeansFactory.kt
+++ b/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/BigqueryBeansFactory.kt
@@ -95,6 +95,7 @@ class BigqueryBeansFactory {
     @Singleton
     fun getWriter(
         bigquery: BigQuery,
+        @Named("jobProjectBigquery") jobProjectBigquery: BigQuery,
         config: BigqueryConfiguration,
         names: TableCatalog,
         // micronaut will only instantiate a single instance of StreamStateStore,
@@ -104,7 +105,12 @@ class BigqueryBeansFactory {
         streamStateStore: StreamStateStore<*>,
     ): DestinationWriter {
         val destinationHandler =
-            BigQueryDatabaseHandler(bigquery, config.datasetLocation.region, config.jobProjectId)
+            BigQueryDatabaseHandler(
+                bigquery,
+                jobProjectBigquery,
+                config.datasetLocation.region,
+                config.jobProjectId,
+            )
         if (config.legacyRawTablesOnly) {
             // force smart cast
             @Suppress("UNCHECKED_CAST")
@@ -205,4 +211,16 @@ class BigqueryBeansFactory {
             .build()
             .service
     }
+
+    @Singleton
+    @Named("jobProjectBigquery")
+    fun getJobProjectBigqueryClient(
+        config: BigqueryConfiguration,
+        bigquery: BigQuery,
+    ): BigQuery =
+        if (config.jobProjectId == config.projectId) {
+            bigquery
+        } else {
+            bigquery.options.toBuilder().setProjectId(config.jobProjectId).build().service
+        }
 }

--- a/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/BigqueryBeansFactory.kt
+++ b/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/BigqueryBeansFactory.kt
@@ -40,6 +40,7 @@ import io.airbyte.integrations.destination.bigquery.write.typing_deduping.legacy
 import io.airbyte.integrations.destination.bigquery.write.typing_deduping.legacy_raw_tables.BigqueryTypingDedupingDatabaseInitialStatusGatherer
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.micronaut.context.annotation.Factory
+import io.micronaut.context.annotation.Primary
 import io.micronaut.context.annotation.Requires
 import jakarta.inject.Named
 import jakarta.inject.Singleton
@@ -172,6 +173,7 @@ class BigqueryBeansFactory {
     }
 
     @Singleton
+    @Primary
     fun getBigqueryClient(config: BigqueryConfiguration): BigQuery {
         // Follows this order of resolution:
         // https://cloud.google.com/java/docs/reference/google-auth-library/latest/com.google.auth.oauth2.GoogleCredentials#com_google_auth_oauth2_GoogleCredentials_getApplicationDefault

--- a/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/spec/BigqueryConfiguration.kt
+++ b/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/spec/BigqueryConfiguration.kt
@@ -12,6 +12,7 @@ import jakarta.inject.Singleton
 
 data class BigqueryConfiguration(
     val projectId: String,
+    val jobProjectId: String,
     val datasetLocation: BigqueryRegion,
     val datasetId: String,
     val loadingMethod: LoadingMethodConfiguration,
@@ -53,6 +54,7 @@ class BigqueryConfigurationFactory :
             }
         return BigqueryConfiguration(
             projectId = pojo.projectId,
+            jobProjectId = pojo.jobProjectId?.takeUnless(String::isBlank) ?: pojo.projectId,
             pojo.datasetLocation,
             datasetId = pojo.datasetId,
             loadingMethodConfig,

--- a/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/spec/BigquerySpecification.kt
+++ b/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/spec/BigquerySpecification.kt
@@ -75,6 +75,14 @@ class BigquerySpecification : ConfigurationSpecification() {
     )
     val credentialsJson: String? = null
 
+    @get:JsonSchemaTitle("Job Execution Project ID")
+    @get:JsonPropertyDescription(
+        """Optional. The GCP project ID where BigQuery jobs will be executed. When set, query jobs run against this project's quota instead of the dataset project's quota. This is useful for isolating BigQuery concurrent query quota between different workloads (e.g. data ingestion vs. analytics). The service account must have BigQuery Job User role on this project. If not set, jobs run in the dataset project (Project ID above).""",
+    )
+    @get:JsonProperty("job_project_id")
+    @get:JsonSchemaInject(json = """{"group": "advanced", "order": 4}""")
+    val jobProjectId: String? = null
+
     @get:JsonSchemaTitle("CDC deletion mode")
     @get:JsonPropertyDescription(
         """Whether to execute CDC deletions as hard deletes (i.e. propagate source deletions to the destination), or soft deletes (i.e. leave a tombstone record in the destination). Defaults to hard deletes.""",

--- a/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/write/bulk_loader/BigQueryBulkLoader.kt
+++ b/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/write/bulk_loader/BigQueryBulkLoader.kt
@@ -66,7 +66,13 @@ class BigQueryBulkLoader(
                 .setNullMarker(BigQueryConsts.NULL_MARKER)
                 .build()
 
-        val loadJob = bigQueryClient.create(JobInfo.of(configuration))
+        val jobId =
+            JobId.newBuilder()
+                .setProject(bigQueryConfiguration.jobProjectId)
+                .setLocation(bigQueryConfiguration.datasetLocation.region)
+                .setRandomJob()
+                .build()
+        val loadJob = bigQueryClient.create(JobInfo.of(jobId, configuration))
 
         try {
             BigQueryUtils.waitForJobFinish(loadJob)

--- a/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/write/standard_insert/BigqueryBatchStandardInsertLoader.kt
+++ b/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/write/standard_insert/BigqueryBatchStandardInsertLoader.kt
@@ -186,7 +186,7 @@ class BigqueryBatchStandardInsertsLoaderFactory(
             JobId.newBuilder()
                 .setRandomJob()
                 .setLocation(config.datasetLocation.region)
-                .setProject(bigquery.options.projectId)
+                .setProject(config.jobProjectId)
                 .build()
 
         val formatter: RecordFormatter =

--- a/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/write/standard_insert/BigqueryBatchStandardInsertLoader.kt
+++ b/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/write/standard_insert/BigqueryBatchStandardInsertLoader.kt
@@ -35,7 +35,6 @@ import io.airbyte.integrations.destination.bigquery.toPrettyString
 import io.airbyte.integrations.destination.bigquery.write.standard_insert.BigqueryBatchStandardInsertsLoaderFactory.Companion.CONFIG_ERROR_MSG
 import io.airbyte.integrations.destination.bigquery.write.standard_insert.BigqueryBatchStandardInsertsLoaderFactory.Companion.HTTP_STATUS_CODE_FORBIDDEN
 import io.airbyte.integrations.destination.bigquery.write.standard_insert.BigqueryBatchStandardInsertsLoaderFactory.Companion.HTTP_STATUS_CODE_NOT_FOUND
-import io.airbyte.integrations.destination.bigquery.write.typing_deduping.toTableId
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.micronaut.context.annotation.Requires
 import io.micronaut.context.condition.Condition
@@ -143,7 +142,7 @@ class BigqueryConfiguredForBatchStandardInserts : Condition {
 @Singleton
 class BigqueryBatchStandardInsertsLoaderFactory(
     private val catalog: DestinationCatalog,
-    private val bigquery: BigQuery,
+    @Named("jobProjectBigquery") private val jobProjectBigquery: BigQuery,
     private val config: BigqueryConfiguration,
     private val tableCatalog: TableCatalogByDescriptor,
     private val typingDedupingStreamStateStore: StreamStateStore<TypingDedupingExecutionConfig>?,
@@ -162,12 +161,22 @@ class BigqueryBatchStandardInsertsLoaderFactory(
             // Wait for the state store to be populated by the coordinating StreamLoader
             val rawTableSuffix =
                 waitForStateStore(typingDedupingStreamStateStore!!, streamDescriptor).rawTableSuffix
-            tableId = TableId.of(rawTableName.namespace, rawTableName.name + rawTableSuffix)
+            tableId =
+                TableId.of(
+                    config.projectId,
+                    rawTableName.namespace,
+                    rawTableName.name + rawTableSuffix,
+                )
             schema = BigQueryRecordFormatter.SCHEMA_V2
         } else {
             // Wait for the state store to be populated by the coordinating StreamLoader
             val executionConfig = waitForStateStore(directLoadStreamStateStore!!, streamDescriptor)
-            tableId = executionConfig.tableName.toTableId()
+            tableId =
+                TableId.of(
+                    config.projectId,
+                    executionConfig.tableName.namespace,
+                    executionConfig.tableName.name,
+                )
             schema =
                 BigQueryRecordFormatter.getDirectLoadSchema(
                     catalog.getStream(streamDescriptor),
@@ -208,7 +217,7 @@ class BigqueryBatchStandardInsertsLoaderFactory(
             }
 
         return BigqueryBatchStandardInsertsLoader(
-            bigquery,
+            jobProjectBigquery,
             writeChannelConfiguration,
             jobId,
             formatter,

--- a/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/write/typing_deduping/BigQueryDatabaseHandler.kt
+++ b/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/write/typing_deduping/BigQueryDatabaseHandler.kt
@@ -28,8 +28,11 @@ import kotlinx.coroutines.launch
 private val logger = KotlinLogging.logger {}
 
 @SuppressFBWarnings("NP_NONNULL_PARAM_VIOLATION", justification = "Kotlin is hard")
-class BigQueryDatabaseHandler(private val bq: BigQuery, private val datasetLocation: String) :
-    DatabaseHandler {
+class BigQueryDatabaseHandler(
+    private val bq: BigQuery,
+    private val datasetLocation: String,
+    private val jobProjectId: String,
+) : DatabaseHandler {
     /**
      * Some statements (e.g. ALTER TABLE) have strict rate limits. Bigquery recommends retrying
      * these statements with exponential backoff, and the SDK doesn't do it automatically. So this
@@ -92,7 +95,10 @@ class BigQueryDatabaseHandler(private val bq: BigQuery, private val datasetLocat
         var job =
             bq.create(
                 JobInfo.of(
-                    JobId.newBuilder().setLocation(datasetLocation).build(),
+                    JobId.newBuilder()
+                        .setProject(jobProjectId)
+                        .setLocation(datasetLocation)
+                        .build(),
                     QueryJobConfiguration.of(statement)
                 )
             )

--- a/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/write/typing_deduping/BigQueryDatabaseHandler.kt
+++ b/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/write/typing_deduping/BigQueryDatabaseHandler.kt
@@ -33,6 +33,14 @@ class BigQueryDatabaseHandler(
     private val datasetLocation: String,
     private val jobProjectId: String,
 ) : DatabaseHandler {
+    private val jobProjectBq: BigQuery by lazy {
+        if (jobProjectId == bq.options.projectId) {
+            bq
+        } else {
+            bq.options.toBuilder().setProjectId(jobProjectId).build().service
+        }
+    }
+
     /**
      * Some statements (e.g. ALTER TABLE) have strict rate limits. Bigquery recommends retrying
      * these statements with exponential backoff, and the SDK doesn't do it automatically. So this
@@ -123,7 +131,7 @@ class BigQueryDatabaseHandler(
         if (statistics.numChildJobs != null) {
             // There isn't (afaict) anything resembling job.getChildJobs(), so we have to ask bq for
             // them
-            bq.listJobs(BigQuery.JobListOption.parentJobId(job.jobId.job))
+            jobProjectBq.listJobs(BigQuery.JobListOption.parentJobId(job.jobId.job))
                 .iterateAll()
                 .sortedBy { it.getStatistics<JobStatistics>().endTime }
                 .forEach { childJob: Job ->

--- a/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/write/typing_deduping/BigQueryDatabaseHandler.kt
+++ b/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/write/typing_deduping/BigQueryDatabaseHandler.kt
@@ -131,7 +131,8 @@ class BigQueryDatabaseHandler(
         if (statistics.numChildJobs != null) {
             // There isn't (afaict) anything resembling job.getChildJobs(), so we have to ask bq for
             // them
-            jobProjectBq.listJobs(BigQuery.JobListOption.parentJobId(job.jobId.job))
+            jobProjectBq
+                .listJobs(BigQuery.JobListOption.parentJobId(job.jobId.job))
                 .iterateAll()
                 .sortedBy { it.getStatistics<JobStatistics>().endTime }
                 .forEach { childJob: Job ->

--- a/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/write/typing_deduping/BigQueryDatabaseHandler.kt
+++ b/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/write/typing_deduping/BigQueryDatabaseHandler.kt
@@ -30,17 +30,10 @@ private val logger = KotlinLogging.logger {}
 @SuppressFBWarnings("NP_NONNULL_PARAM_VIOLATION", justification = "Kotlin is hard")
 class BigQueryDatabaseHandler(
     private val bq: BigQuery,
+    private val jobProjectBq: BigQuery,
     private val datasetLocation: String,
     private val jobProjectId: String,
 ) : DatabaseHandler {
-    private val jobProjectBq: BigQuery by lazy {
-        if (jobProjectId == bq.options.projectId) {
-            bq
-        } else {
-            bq.options.toBuilder().setProjectId(jobProjectId).build().service
-        }
-    }
-
     /**
      * Some statements (e.g. ALTER TABLE) have strict rate limits. Bigquery recommends retrying
      * these statements with exponential backoff, and the SDK doesn't do it automatically. So this

--- a/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/write/typing_deduping/direct_load_tables/BigqueryDirectLoadSqlTableOperations.kt
+++ b/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/write/typing_deduping/direct_load_tables/BigqueryDirectLoadSqlTableOperations.kt
@@ -6,6 +6,7 @@ package io.airbyte.integrations.destination.bigquery.write.typing_deduping.direc
 
 import com.google.cloud.bigquery.BigQuery
 import com.google.cloud.bigquery.CopyJobConfiguration
+import com.google.cloud.bigquery.JobId
 import com.google.cloud.bigquery.JobInfo
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings
 import io.airbyte.cdk.load.orchestration.db.TableName
@@ -17,6 +18,8 @@ import io.airbyte.integrations.destination.bigquery.write.typing_deduping.toTabl
 class BigqueryDirectLoadSqlTableOperations(
     private val defaultOperations: DefaultDirectLoadTableSqlOperations,
     private val bq: BigQuery,
+    private val jobProjectId: String,
+    private val datasetLocation: String,
 ) : DirectLoadTableSqlOperations by defaultOperations {
     @SuppressFBWarnings("RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT", "kotlin coroutines")
     override suspend fun overwriteTable(sourceTableName: TableName, targetTableName: TableName) {
@@ -28,9 +31,16 @@ class BigqueryDirectLoadSqlTableOperations(
         // So we'll use a Copy job instead.
         // (this is more efficient than just `insert into tgt select * from src`)
         val sourceTableId = sourceTableName.toTableId()
+        val jobId =
+            JobId.newBuilder()
+                .setProject(jobProjectId)
+                .setLocation(datasetLocation)
+                .setRandomJob()
+                .build()
         val job =
             bq.create(
                 JobInfo.of(
+                    jobId,
                     CopyJobConfiguration.newBuilder(
                             targetTableName.toTableId(),
                             sourceTableId,

--- a/airbyte-integrations/connectors/destination-bigquery/src/test-integration/resources/expected-spec-cloud.json
+++ b/airbyte-integrations/connectors/destination-bigquery/src/test-integration/resources/expected-spec-cloud.json
@@ -129,6 +129,13 @@
         "airbyte_secret" : true,
         "always_show" : true
       },
+      "job_project_id" : {
+        "type" : "string",
+        "description" : "Optional. The GCP project ID where BigQuery jobs will be executed. When set, query jobs run against this project's quota instead of the dataset project's quota. This is useful for isolating BigQuery concurrent query quota between different workloads (e.g. data ingestion vs. analytics). The service account must have BigQuery Job User role on this project. If not set, jobs run in the dataset project (Project ID above).",
+        "title" : "Job Execution Project ID",
+        "group" : "advanced",
+        "order" : 4
+      },
       "cdc_deletion_mode" : {
         "type" : "string",
         "default" : "Hard delete",

--- a/airbyte-integrations/connectors/destination-bigquery/src/test-integration/resources/expected-spec-oss.json
+++ b/airbyte-integrations/connectors/destination-bigquery/src/test-integration/resources/expected-spec-oss.json
@@ -129,6 +129,13 @@
         "airbyte_secret" : true,
         "always_show" : true
       },
+      "job_project_id" : {
+        "type" : "string",
+        "description" : "Optional. The GCP project ID where BigQuery jobs will be executed. When set, query jobs run against this project's quota instead of the dataset project's quota. This is useful for isolating BigQuery concurrent query quota between different workloads (e.g. data ingestion vs. analytics). The service account must have BigQuery Job User role on this project. If not set, jobs run in the dataset project (Project ID above).",
+        "title" : "Job Execution Project ID",
+        "group" : "advanced",
+        "order" : 4
+      },
       "cdc_deletion_mode" : {
         "type" : "string",
         "default" : "Hard delete",

--- a/airbyte-integrations/connectors/destination-bigquery/src/test/kotlin/io/airbyte/integrations/destination/bigquery/BigQueryDatabaseHandlerTest.kt
+++ b/airbyte-integrations/connectors/destination-bigquery/src/test/kotlin/io/airbyte/integrations/destination/bigquery/BigQueryDatabaseHandlerTest.kt
@@ -7,12 +7,15 @@ package io.airbyte.integrations.destination.bigquery
 import com.google.cloud.bigquery.BigQuery
 import com.google.cloud.bigquery.BigQueryError
 import com.google.cloud.bigquery.JobInfo
+import com.google.cloud.bigquery.JobStatistics
 import com.google.cloud.bigquery.JobStatus
 import io.airbyte.cdk.ConfigErrorException
 import io.airbyte.cdk.load.orchestration.db.Sql
 import io.airbyte.integrations.destination.bigquery.write.typing_deduping.BigQueryDatabaseHandler
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.slot
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 
@@ -20,6 +23,37 @@ class BigQueryDatabaseHandlerTest {
     companion object {
         const val BILLING_ERROR =
             """Billing has not been enabled for this project. Enable billing at https://console.cloud.google.com/billing. DML queries are not allowed in the free tier. Set up a billing account to remove this restriction."""
+    }
+
+    @Test
+    fun `execute sets jobProjectId and location on the JobId`() {
+        val jobInfoSlot = slot<JobInfo>()
+        val queryStats: JobStatistics.QueryStatistics = mockk {
+            every { startTime } returns 0L
+            every { endTime } returns 100L
+            every { totalBytesProcessed } returns 1024L
+            every { totalBytesBilled } returns 1024L
+            every { numChildJobs } returns null
+        }
+        val bq: BigQuery = mockk {
+            every { create(capture(jobInfoSlot), *anyVararg()) } returns
+                mockk {
+                    every { status } returns
+                        mockk {
+                            every { state } returns JobStatus.State.DONE
+                            every { error } returns null
+                        }
+                    every { reload() } returns this
+                    every { getStatistics<JobStatistics.QueryStatistics>() } returns queryStats
+                }
+        }
+        val handler = BigQueryDatabaseHandler(bq, "us-east1", "my-job-project")
+
+        handler.execute(Sql.of("SELECT 1"))
+
+        val capturedJobInfo = jobInfoSlot.captured
+        assertEquals("my-job-project", capturedJobInfo.jobId.project)
+        assertEquals("us-east1", capturedJobInfo.jobId.location)
     }
 
     @Test
@@ -33,7 +67,7 @@ class BigQueryDatabaseHandlerTest {
                     every { executionErrors } returns listOf(bqError)
                 }
         }
-        val handler = BigQueryDatabaseHandler(bq, "location")
+        val handler = BigQueryDatabaseHandler(bq, "location", "test-project")
 
         assertThrows<ConfigErrorException> { handler.execute(Sql.of("select * from nowhere")) }
     }

--- a/airbyte-integrations/connectors/destination-bigquery/src/test/kotlin/io/airbyte/integrations/destination/bigquery/BigQueryDatabaseHandlerTest.kt
+++ b/airbyte-integrations/connectors/destination-bigquery/src/test/kotlin/io/airbyte/integrations/destination/bigquery/BigQueryDatabaseHandlerTest.kt
@@ -4,9 +4,13 @@
 
 package io.airbyte.integrations.destination.bigquery
 
+import com.google.api.gax.paging.Page
 import com.google.cloud.bigquery.BigQuery
 import com.google.cloud.bigquery.BigQueryError
+import com.google.cloud.bigquery.BigQueryOptions
+import com.google.cloud.bigquery.Job
 import com.google.cloud.bigquery.JobInfo
+import com.google.cloud.bigquery.JobId
 import com.google.cloud.bigquery.JobStatistics
 import com.google.cloud.bigquery.JobStatus
 import io.airbyte.cdk.ConfigErrorException
@@ -15,6 +19,7 @@ import io.airbyte.integrations.destination.bigquery.write.typing_deduping.BigQue
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
+import io.mockk.verify
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -54,6 +59,54 @@ class BigQueryDatabaseHandlerTest {
         val capturedJobInfo = jobInfoSlot.captured
         assertEquals("my-job-project", capturedJobInfo.jobId.project)
         assertEquals("us-east1", capturedJobInfo.jobId.location)
+    }
+
+    @Test
+    fun `execute lists child jobs using the job project client`() {
+        val queryStats: JobStatistics.QueryStatistics = mockk {
+            every { startTime } returns 0L
+            every { endTime } returns 100L
+            every { totalBytesProcessed } returns 1024L
+            every { totalBytesBilled } returns 1024L
+            every { numChildJobs } returns 1L
+        }
+        val rootJobId = JobId.of("root-job")
+        val rootJob: Job = mockk {
+            every { jobId } returns rootJobId
+            every { status } returns
+                mockk {
+                    every { state } returns JobStatus.State.DONE
+                    every { error } returns null
+                }
+            every { reload() } returns this
+            every { getStatistics<JobStatistics.QueryStatistics>() } returns queryStats
+        }
+        val datasetProjectBq: BigQuery = mockk()
+        val jobProjectBq: BigQuery = mockk()
+        val datasetProjectOptions: BigQueryOptions = mockk {
+            every { projectId } returns "dataset-project"
+            every { toBuilder() } returns
+                mockk<BigQueryOptions.Builder> {
+                    every { setProjectId("job-project") } returns this
+                    every { build() } returns
+                        mockk {
+                            every { service } returns jobProjectBq
+                        }
+                }
+        }
+        val childJobs: Page<Job> = mockk {
+            every { iterateAll() } returns emptyList()
+        }
+        every { datasetProjectBq.options } returns datasetProjectOptions
+        every { datasetProjectBq.create(any<JobInfo>(), *anyVararg()) } returns rootJob
+        every { jobProjectBq.listJobs(*anyVararg()) } returns childJobs
+
+        val handler = BigQueryDatabaseHandler(datasetProjectBq, "location", "job-project")
+
+        handler.execute(Sql.of("SELECT 1"))
+
+        verify(exactly = 1) { jobProjectBq.listJobs(*anyVararg()) }
+        verify(exactly = 0) { datasetProjectBq.listJobs(*anyVararg()) }
     }
 
     @Test

--- a/airbyte-integrations/connectors/destination-bigquery/src/test/kotlin/io/airbyte/integrations/destination/bigquery/BigQueryDatabaseHandlerTest.kt
+++ b/airbyte-integrations/connectors/destination-bigquery/src/test/kotlin/io/airbyte/integrations/destination/bigquery/BigQueryDatabaseHandlerTest.kt
@@ -7,7 +7,6 @@ package io.airbyte.integrations.destination.bigquery
 import com.google.api.gax.paging.Page
 import com.google.cloud.bigquery.BigQuery
 import com.google.cloud.bigquery.BigQueryError
-import com.google.cloud.bigquery.BigQueryOptions
 import com.google.cloud.bigquery.Job
 import com.google.cloud.bigquery.JobId
 import com.google.cloud.bigquery.JobInfo
@@ -52,7 +51,7 @@ class BigQueryDatabaseHandlerTest {
                     every { getStatistics<JobStatistics.QueryStatistics>() } returns queryStats
                 }
         }
-        val handler = BigQueryDatabaseHandler(bq, "us-east1", "my-job-project")
+        val handler = BigQueryDatabaseHandler(bq, bq, "us-east1", "my-job-project")
 
         handler.execute(Sql.of("SELECT 1"))
 
@@ -83,20 +82,17 @@ class BigQueryDatabaseHandlerTest {
         }
         val datasetProjectBq: BigQuery = mockk()
         val jobProjectBq: BigQuery = mockk()
-        val datasetProjectOptions: BigQueryOptions = mockk {
-            every { projectId } returns "dataset-project"
-            every { toBuilder() } returns
-                mockk<BigQueryOptions.Builder> {
-                    every { setProjectId("job-project") } returns this
-                    every { build() } returns mockk { every { service } returns jobProjectBq }
-                }
-        }
         val childJobs: Page<Job> = mockk { every { iterateAll() } returns emptyList() }
-        every { datasetProjectBq.options } returns datasetProjectOptions
         every { datasetProjectBq.create(any<JobInfo>(), *anyVararg()) } returns rootJob
         every { jobProjectBq.listJobs(*anyVararg()) } returns childJobs
 
-        val handler = BigQueryDatabaseHandler(datasetProjectBq, "location", "job-project")
+        val handler =
+            BigQueryDatabaseHandler(
+                datasetProjectBq,
+                jobProjectBq,
+                "location",
+                "job-project",
+            )
 
         handler.execute(Sql.of("SELECT 1"))
 
@@ -115,7 +111,7 @@ class BigQueryDatabaseHandlerTest {
                     every { executionErrors } returns listOf(bqError)
                 }
         }
-        val handler = BigQueryDatabaseHandler(bq, "location", "test-project")
+        val handler = BigQueryDatabaseHandler(bq, bq, "location", "test-project")
 
         assertThrows<ConfigErrorException> { handler.execute(Sql.of("select * from nowhere")) }
     }

--- a/airbyte-integrations/connectors/destination-bigquery/src/test/kotlin/io/airbyte/integrations/destination/bigquery/BigQueryDatabaseHandlerTest.kt
+++ b/airbyte-integrations/connectors/destination-bigquery/src/test/kotlin/io/airbyte/integrations/destination/bigquery/BigQueryDatabaseHandlerTest.kt
@@ -9,8 +9,8 @@ import com.google.cloud.bigquery.BigQuery
 import com.google.cloud.bigquery.BigQueryError
 import com.google.cloud.bigquery.BigQueryOptions
 import com.google.cloud.bigquery.Job
-import com.google.cloud.bigquery.JobInfo
 import com.google.cloud.bigquery.JobId
+import com.google.cloud.bigquery.JobInfo
 import com.google.cloud.bigquery.JobStatistics
 import com.google.cloud.bigquery.JobStatus
 import io.airbyte.cdk.ConfigErrorException
@@ -88,15 +88,10 @@ class BigQueryDatabaseHandlerTest {
             every { toBuilder() } returns
                 mockk<BigQueryOptions.Builder> {
                     every { setProjectId("job-project") } returns this
-                    every { build() } returns
-                        mockk {
-                            every { service } returns jobProjectBq
-                        }
+                    every { build() } returns mockk { every { service } returns jobProjectBq }
                 }
         }
-        val childJobs: Page<Job> = mockk {
-            every { iterateAll() } returns emptyList()
-        }
+        val childJobs: Page<Job> = mockk { every { iterateAll() } returns emptyList() }
         every { datasetProjectBq.options } returns datasetProjectOptions
         every { datasetProjectBq.create(any<JobInfo>(), *anyVararg()) } returns rootJob
         every { jobProjectBq.listJobs(*anyVararg()) } returns childJobs

--- a/docs/integrations/destinations/bigquery.md
+++ b/docs/integrations/destinations/bigquery.md
@@ -276,7 +276,7 @@ This destination supports [namespaces](https://docs.airbyte.com/platform/using-a
 
 | Version     | Date       | Pull Request                                               | Subject                                                                                                                                                                           |
 |:------------|:-----------|:-----------------------------------------------------------|:----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| 3.1.0 | 2026-08-25 | [PRLINK](https://github.com/airbytehq/airbyte/pull/PRNUM) | Add optional `job_project_id` field for BigQuery job quota isolation |
+| 3.1.0 | 2026-08-25 | [85041](https://github.com/airbytehq/airbyte/pull/85041) | Add optional `job_project_id` field for BigQuery job quota isolation |
 | 3.0.24 | 2026-08-24 | [84985](https://github.com/airbytehq/airbyte/pull/84985) | Upgrade to Bulk CDK 1.0.25. |
 | 3.0.23 | 2026-07-14 | [81550](https://github.com/airbytehq/airbyte/pull/81550) | Use CREATE TABLE IF NOT EXISTS for non-replace table creation to prevent accidental data loss |
 | 3.0.22 | 2026-07-10 | [81635](https://github.com/airbytehq/airbyte/pull/81635) | Restore PK NULL equality checks |

--- a/docs/integrations/destinations/bigquery.md
+++ b/docs/integrations/destinations/bigquery.md
@@ -106,6 +106,30 @@ concurrent rate limit, making it easier to start many queries at once.
     destination), try decreasing the chunk size. In that case, the sync will be slower but more
     likely to succeed.
 
+### (Optional) Job Execution Project ID for quota isolation
+
+By default, all BigQuery jobs created by this destination (queries, loads, copies) run
+against the project defined in **Project ID**, sharing that project's quotas — in particular
+the [_concurrent script queries per project_](https://cloud.google.com/bigquery/quotas#query_jobs)
+quota — with any other workloads in the same project (analytics, Dataform pipelines, etc.).
+Connectors with many concurrent streams can exhaust this quota and fail with:
+
+```
+BigQueryException: Quota exceeded: Your project_and_region exceeded quota for
+concurrent script queries per project.
+```
+
+To isolate ingestion from analytics, set the optional **Job Execution Project ID** field
+(under the **Advanced** group) to a different GCP project. When set:
+
+- Query, load, and copy jobs run against the job project's quota.
+- Data still lands in datasets under **Project ID** — this is not a data migration.
+- The service account must have the
+  [`roles/bigquery.jobUser`](https://cloud.google.com/bigquery/docs/access-control#bigquery.jobUser)
+  role on the job project, in addition to its existing roles on the dataset project.
+
+If the field is left empty, behavior is unchanged: jobs run in the dataset project.
+
 ## Supported sync modes
 
 The BigQuery destination connector supports the following
@@ -252,6 +276,7 @@ This destination supports [namespaces](https://docs.airbyte.com/platform/using-a
 
 | Version     | Date       | Pull Request                                               | Subject                                                                                                                                                                           |
 |:------------|:-----------|:-----------------------------------------------------------|:----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 3.1.0 | 2026-08-25 | [PRLINK](https://github.com/airbytehq/airbyte/pull/PRNUM) | Add optional `job_project_id` field for BigQuery job quota isolation |
 | 3.0.24 | 2026-08-24 | [84985](https://github.com/airbytehq/airbyte/pull/84985) | Upgrade to Bulk CDK 1.0.25. |
 | 3.0.23 | 2026-07-14 | [81550](https://github.com/airbytehq/airbyte/pull/81550) | Use CREATE TABLE IF NOT EXISTS for non-replace table creation to prevent accidental data loss |
 | 3.0.22 | 2026-07-10 | [81635](https://github.com/airbytehq/airbyte/pull/81635) | Restore PK NULL equality checks |

--- a/docs/integrations/destinations/bigquery.md
+++ b/docs/integrations/destinations/bigquery.md
@@ -106,29 +106,17 @@ concurrent rate limit, making it easier to start many queries at once.
     destination), try decreasing the chunk size. In that case, the sync will be slower but more
     likely to succeed.
 
-### (Optional) Job Execution Project ID for quota isolation
+12. For **Job Execution Project ID (Optional)**, leave the field empty to run BigQuery jobs in the
+    project you entered as **Project ID**. To run them in a different project — for example to keep
+    ingestion from competing with analytics workloads for the same project quotas — enter that
+    project's ID.
 
-By default, all BigQuery jobs created by this destination (queries, loads, copies) run
-against the project defined in **Project ID**, sharing that project's quotas — in particular
-the [_concurrent script queries per project_](https://cloud.google.com/bigquery/quotas#query_jobs)
-quota — with any other workloads in the same project (analytics, Dataform pipelines, etc.).
-Connectors with many concurrent streams can exhaust this quota and fail with:
-
-```
-BigQueryException: Quota exceeded: Your project_and_region exceeded quota for
-concurrent script queries per project.
-```
-
-To isolate ingestion from analytics, set the optional **Job Execution Project ID** field
-(under the **Advanced** group) to a different GCP project. When set:
-
-- Query, load, and copy jobs run against the job project's quota.
-- Data still lands in datasets under **Project ID** — this is not a data migration.
-- The service account must have the
-  [`roles/bigquery.jobUser`](https://cloud.google.com/bigquery/docs/access-control#bigquery.jobUser)
-  role on the job project, in addition to its existing roles on the dataset project.
-
-If the field is left empty, jobs run in the dataset project.
+:::note
+Query, load, and copy jobs then run against the job project's quotas, while data still lands in
+datasets under **Project ID**. The service account needs the
+[`roles/bigquery.jobUser`](https://cloud.google.com/bigquery/docs/access-control#bigquery.jobUser)
+role on the job project, in addition to its existing roles on the dataset project.
+:::
 
 ## Supported sync modes
 
@@ -242,6 +230,22 @@ If your sync fails with `BigQueryException: 400 Bad Request` and the message
     smaller value (for example, 5 MiB).
   - Try reducing concurrent syncs to your BigQuery instance or table. Contention is a
     possible contributing factor.
+
+### Quota exceeded for concurrent script queries per project
+
+If your sync fails with:
+
+```
+BigQueryException: Quota exceeded: Your project_and_region exceeded quota for
+concurrent script queries per project.
+```
+
+- This [quota](https://cloud.google.com/bigquery/quotas#query_jobs) is per project, so syncs share
+  it with every other workload in the same project, such as analytics queries or Dataform pipelines.
+- Set **Job Execution Project ID** to a separate project to run the connector's jobs against that
+  project's quota instead. Data continues to land in datasets under **Project ID**.
+- Alternatively, reduce the number of concurrently syncing streams or connections targeting the
+  project.
 
 ### Load job timeouts
 

--- a/docs/integrations/destinations/bigquery.md
+++ b/docs/integrations/destinations/bigquery.md
@@ -128,7 +128,7 @@ To isolate ingestion from analytics, set the optional **Job Execution Project ID
   [`roles/bigquery.jobUser`](https://cloud.google.com/bigquery/docs/access-control#bigquery.jobUser)
   role on the job project, in addition to its existing roles on the dataset project.
 
-If the field is left empty, behavior is unchanged: jobs run in the dataset project.
+If the field is left empty, jobs run in the dataset project.
 
 ## Supported sync modes
 


### PR DESCRIPTION
## What

Reopens the work from the closed PR #75285 (originally by @hlepouse-vasco, with follow-up commits from Airbyte maintainers) on top of current `master`. Requested by Matt Bayley.

Adds an optional `job_project_id` field to the BigQuery destination so BigQuery jobs can execute in a different project than the one holding the datasets. BigQuery's per-project concurrent script query quota is not self-service adjustable, so syncs sharing a project with analytics/Dataform workloads can fail with `Quota exceeded: ... concurrent script queries per project`.

Resolves #75284

## How

`job_project_id` is optional in the spec; `BigqueryConfigurationFactory` defaults `jobProjectId` to `projectId` when it is null/blank, so unset behavior is identical to today. The project is set per `JobId` rather than on the main `BigQuery` client, because the client-level project also controls how unqualified table/dataset references resolve, which would silently move data when the two projects differ.

Job creation paths updated to set `.setProject(jobProjectId)`:
- `BigQueryBulkLoader` (GCS staging load jobs)
- `BigqueryBatchStandardInsertsLoaderFactory` (standard inserts)
- `BigQueryDatabaseHandler` (query/DDL jobs)
- `BigqueryDirectLoadSqlTableOperations` (copy jobs for direct-load overwrite)

Two client-scoping call sites need more than a `JobId` project, because the BigQuery Java client derives the request project from client options rather than from the job reference:
- `BigQuery.listJobs` takes no project parameter, and
- `HttpBigQueryRpc.open` (the resumable-upload URL behind `BigQuery.writer`) hardcodes `options.getProjectId()` in the URL path while the request body carries the job reference.

Both now go through a second `BigQuery` bean (`@Named("jobProjectBigquery")`) scoped to the job project, returning the same instance when the projects match. The dataset-project client is `@Primary` so every other injection point is unaffected. Where the job-project client is used for uploads, the destination `TableId` is explicitly qualified with `projectId`, so `WriteChannelConfiguration.setProjectId` cannot fill in the job project and land the data in the wrong place.

Version: `3.0.24` → `3.1.0` (new spec field, minor bump per reviewer feedback on the original PR).

### Bugs fixed that #75285 did not have

#75285 was never run against a real split-project setup; both of these break *every* sync where the two projects differ.

1. `BigQueryDatabaseHandler.execute` created the query job in the job project, then listed the transaction's child jobs for debug stats via `bq.listJobs(parentJobId(...))` — resolved against the dataset project, failing with `Not found: Job <dataset-project>:job_...` during table setup.
2. Standard inserts opened the write channel on the dataset-project client while passing a job-project `JobId`, so BigQuery rejected the mismatch: `Value <job-project> in content does not agree with value <dataset-project>`.

### Known gap (not addressed here)

`BigqueryTypingDedupingDatabaseInitialStatusGatherer` uses `bq.query(...)`, so its queries still run in the dataset project. That path only affects legacy raw-tables mode and does not fail — those queries simply aren't quota-isolated.

## Review guide

1. `spec/BigquerySpecification.kt`, `spec/BigqueryConfiguration.kt` — new field and defaulting
2. `BigqueryBeansFactory.kt` — the `jobProjectBigquery` bean, `@Primary` on the dataset client, and threading into the handler / direct-load ops
3. The four job-creation sites listed above
4. `write/typing_deduping/BigQueryDatabaseHandler.kt` — child-job lookup on the job-project client
5. `write/standard_insert/BigqueryBatchStandardInsertLoader.kt` — job-project client for `writer(...)`, dataset-project-qualified `TableId`
6. `BigQueryDatabaseHandlerTest.kt` — asserts project + location land on the `JobId`, and that child-job listing does not go through the dataset-project client

## Testing

Two real projects: datasets in `dataline-integration-testing`, jobs in `stage-ab-cloud-proj`.

- `job_project_id` unset — full `integrationTestNonDocker` suite green (the no-behavior-change gate).
- Blank string — resolves to `projectId` at the configuration factory.
- Split projects, standard inserts (`testBasicWrite`, `testDedup`, `testTruncateRefresh`) — pass; job references show `project=stage-ab-cloud-proj`, destination tables `projectId=dataline-integration-testing`, row counts verified via fully qualified dataset-project queries.
- Split projects, GCS staging (`testBasicWrite`, `testDedup`, `testTruncateRefresh`) — pass, same evidence shape.
- Split projects, direct-load truncate-refresh — pass; copy job `JobId{project=stage-ab-cloud-proj, ...}` with source and destination tables in the dataset project.
- Negative control — `job_project_id` set to a project where the service account genuinely lacks `bigquery.jobs.create` (proven first with a plain client): the sync fails with `Access Denied: Project <job-project>: User does not have bigquery.jobs.create permission`, confirming jobs really are submitted to the configured project.

The integration-test service account cannot read `INFORMATION_SCHEMA.JOBS_BY_PROJECT`, so "the job ran in project X" comes from the client-returned job reference and connector logs rather than a warehouse-side audit. All temporary datasets/tables created during testing were deleted and verified absent.

## User Impact

No change unless the new "Job Execution Project ID" advanced field is set. When set, jobs run (and count against quota) in that project while data still lands in datasets under `project_id`; the service account needs `roles/bigquery.jobUser` on the job project.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚
- [ ] NO ❌

> [!IMPORTANT]
> Active progressive rollout warning for destination-bigquery.

- [x] (Click to Approve:) Bypass the active progressive rollout warning for destination-bigquery in the PR comment [here](https://github.com/airbytehq/airbyte/pull/85041#issuecomment-5415649412).

---

> [!IMPORTANT]
> **Autopilot Progressive Rollout Enabled**
>
> [Autopilot progressive rollouts](https://github.com/airbytehq/airbyte-ops-mcp/blob/main/docs/autopilot-rollouts.md) are enabled for one or more connector(s) modified in this PR. Check the box below if you need to bypass normal rollout safety processes and release to all users immediately upon merge:
>
> - [ ] ⚡ **Release immediately** (bypasses automatic progressive rollout)
>
> **Note:**
>
> - ⚠️ The above bypass option is for emergency/hotfix use only.
> - 🔗 You can monitor or manually advance a rollout at **[ops.internal.airbyte.ai](https://ops.internal.airbyte.ai)**.


Link to Devin session: https://app.devin.ai/sessions/f53feb2ca31c4021b18fca3a0749f6c8
Requested by: @mwbayley