### PR TITLE
ci(progressive-rollout-gate): spell out merge behavior for pinned actors

### DIFF
--- a/.github/progressive-rollout-gate-comment.md
+++ b/.github/progressive-rollout-gate-comment.md
@@ -14,28 +14,6 @@
 - Rollout last updated by: `{{ .rollout_updated_by }}`
 - [Open Connector Rollout Manager in Retool]({{ .retool_url }}) to clean up or close out this rollout if appropriate.
 
-### ⚠️ What happens if you merge this PR now
-
-Checking the bypass box lets this PR merge; it does not stop the active rollout by itself. What happens next depends on which version this PR publishes.
-
-**If the connector version is not modified** — nothing new is published and the rollout of `{{ .rollout_docker_image_tag }}` continues unchanged.
-
-**If the connector version increments to a higher `-rc` version:**
-
-1. The new RC is published and registered as the release candidate.
-2. **The rollout of `{{ .rollout_docker_image_tag }}` is auto-cancelled**, not finalized. Registering the new RC cancels every non-terminal rollout for this connector with `errorMsg = "Rollout was incomplete when a new rollout was started. Cancelled without unpinning."`
-3. **Actors already pinned to `{{ .rollout_docker_image_tag }}` stay pinned to it.** Cancellation does not unpin, so those connections keep syncing on the old RC image — they are *not* rolled back to the previous GA version, and they are *not* moved to the new RC by the merge itself.
-4. Nothing rolls out on its own. A new rollout is created in `initialized` and must be started (autopilot or manually in [Connector Rollout Manager]({{ .retool_url }})). Starting it migrates the previous rollout's pins onto the new RC by default (`migratePins`), which is what moves those stranded actors forward. Until then, they stay on the old RC.
-
-To avoid stranded pins, finalize or cancel the active rollout in [Connector Rollout Manager]({{ .retool_url }}) before merging.
-
-**If the connector version changes from `-rc` to a non-RC (GA) version** — do not merge while the rollout is still active.
-
-> [!Warning]
-> First finalize the active rollout as successful, or cancel it, in [Connector Rollout Manager]({{ .retool_url }}). See `Rollout state` above for the detected status.
-
-Finalizing an RC rollout as successful triggers a promotion workflow that strips the `-rc` suffix, removes stable-version `registryOverrides`, disables progressive rollout, force-merges that promotion, and unpins actors — so the GA bump normally lands that way rather than through this PR.
-
 ### Version on `master` Branch: `{{ .master_version }}`
 
 - RC marker on `master` branch: `{{ .master_rc_marker }}`
@@ -47,6 +25,37 @@ Finalizing an RC rollout as successful triggers a promotion workflow that strips
 ### ℹ️ More Information
 
 <details><summary>Show/hide details...</summary>
+
+#### 🤔 What happens if this PR is merged
+
+Checking the checkbox will allow the PR to merge, but it does not necessarily stop the active rollout by itself. The result of the PR merging depends on what connector version is published.
+
+Expected outcomes by type of version number change:
+
+<details><summary>If connector version is not modified in this PR...</summary>
+
+No new connector version should be released, and the active rollout should continue unchanged.
+
+</details>
+
+<details><summary>If the connector version increments to a higher `-rc` version...</summary>
+
+After this PR is merged, the new RC will be published and registered, replacing the active RC marker. When the new RC is registered, the platform cancels — not finalizes — any existing non-terminal rollout for this connector, without unpinning actors. Actors pinned to `{{ .rollout_docker_image_tag }}` therefore keep syncing on that old RC image: they are not rolled back to the previous GA version, and the merge itself does not move them to the new RC.
+
+After merging, you still need to start the new rollout; nothing rolls out on its own. Starting it migrates the previous rollout's pins onto the new RC by default (`migratePins`), which is what moves those actors forward. Until the new rollout is started, they stay on the old RC.
+
+</details>
+
+<details><summary>If the connector version changes from RC to non-RC (GA) version...</summary>
+
+You should not merge the PR unless/until the RC has been finalized as canceled. See above `Rollout state` for detected status.
+
+> [!Warning]
+> This PR should not be merged if the RC rollout is still active. First finalize the active rollout as successful or cancel it in [Connector Rollout Manager]({{ .retool_url }}).
+
+When you finalize an RC rollout as successful, the platform triggers a promotion workflow that strips the `-rc` suffix, removes stable-version `registryOverrides`, disables progressive rollout, force-merges that promotion, and unpins actors.
+
+</details>
 
 #### 🔁 How to rerun this check
 

--- a/.github/progressive-rollout-gate-comment.md
+++ b/.github/progressive-rollout-gate-comment.md
@@ -38,11 +38,11 @@ No new connector version should be released, and the active rollout should conti
 
 </details>
 
-<details><summary>If the connector version increments to a higher `-rc` version...</summary>
+<details><summary>If the connector version increments to a higher version...</summary>
 
-After this PR is merged, the new RC will be published and registered, replacing the active RC marker. When the new RC is registered, the platform cancels — not finalizes — any existing non-terminal rollout for this connector, without unpinning actors. Actors pinned to `{{ .rollout_docker_image_tag }}` therefore keep syncing on that old RC image: they are not rolled back to the previous GA version, and the merge itself does not move them to the new RC.
+After this PR is merged, the new version will be published and advertised as this connector's rollout candidate, replacing the current one. An `-rc` suffix is not required for this: with `enableProgressiveRollout`, an ordinary version bump becomes the rollout candidate. When it is registered, the platform cancels — not finalizes — any existing non-terminal rollout for this connector, without unpinning actors. Actors pinned to `{{ .rollout_docker_image_tag }}` therefore keep syncing on that old image: they are not rolled back to the previous default version, and the merge itself does not move them to the new candidate.
 
-After merging, you still need to start the new rollout; nothing rolls out on its own. Starting it migrates the previous rollout's pins onto the new RC by default (`migratePins`), which is what moves those actors forward. Until the new rollout is started, they stay on the old RC.
+The new rollout still has to be started before those actors move. With `defaultRolloutMode: autopilot`, the autopilot cron starts it on its next eligible pass; otherwise a human starts it from [Connector Rollout Manager]({{ .retool_url }}). Starting it migrates the previous rollout's pins onto the new candidate version by default (`migratePins`), which is what moves those actors forward. Until then, they stay on the old version.
 
 </details>
 

--- a/.github/progressive-rollout-gate-comment.md
+++ b/.github/progressive-rollout-gate-comment.md
@@ -16,16 +16,25 @@
 
 ### ⚠️ What happens if you merge this PR now
 
-If this PR publishes a **new `-rc` version** of `{{ .connector }}`:
+Checking the bypass box lets this PR merge; it does not stop the active rollout by itself. What happens next depends on which version this PR publishes.
+
+**If the connector version is not modified** — nothing new is published and the rollout of `{{ .rollout_docker_image_tag }}` continues unchanged.
+
+**If the connector version increments to a higher `-rc` version:**
 
 1. The new RC is published and registered as the release candidate.
 2. **The rollout of `{{ .rollout_docker_image_tag }}` is auto-cancelled**, not finalized. Registering the new RC cancels every non-terminal rollout for this connector with `errorMsg = "Rollout was incomplete when a new rollout was started. Cancelled without unpinning."`
 3. **Actors already pinned to `{{ .rollout_docker_image_tag }}` stay pinned to it.** Cancellation does not unpin, so those connections keep syncing on the old RC image — they are *not* rolled back to the previous GA version, and they are *not* moved to the new RC by the merge itself.
 4. Nothing rolls out on its own. A new rollout is created in `initialized` and must be started (autopilot or manually in [Connector Rollout Manager]({{ .retool_url }})). Starting it migrates the previous rollout's pins onto the new RC by default (`migratePins`), which is what moves those stranded actors forward. Until then, they stay on the old RC.
 
-If this PR removes the `-rc` suffix (RC → GA), or does not change the version at all, see the other cases in **More Information** below.
-
 To avoid stranded pins, finalize or cancel the active rollout in [Connector Rollout Manager]({{ .retool_url }}) before merging.
+
+**If the connector version changes from `-rc` to a non-RC (GA) version** — do not merge while the rollout is still active.
+
+> [!Warning]
+> First finalize the active rollout as successful, or cancel it, in [Connector Rollout Manager]({{ .retool_url }}). See `Rollout state` above for the detected status.
+
+Finalizing an RC rollout as successful triggers a promotion workflow that strips the `-rc` suffix, removes stable-version `registryOverrides`, disables progressive rollout, force-merges that promotion, and unpins actors — so the GA bump normally lands that way rather than through this PR.
 
 ### Version on `master` Branch: `{{ .master_version }}`
 
@@ -38,35 +47,6 @@ To avoid stranded pins, finalize or cancel the active rollout in [Connector Roll
 ### ℹ️ More Information
 
 <details><summary>Show/hide details...</summary>
-
-#### 🤔 What happens if this PR is merged
-
-Checking the checkbox will allow the PR to merge, but it does not necessarily stop the active rollout by itself. The result of the PR merging depends on what connector version is published.
-
-Expected outcomes by type of version number change:
-
-<details><summary>If connector version is not modified in this PR...</summary>
-
-No new connector version should be released, and the active rollout should continue unchanged.
-
-</details>
-
-<details><summary>If the connector version increments to a higher `-rc` version...</summary>
-
-See the "What happens if you merge this PR now" section above: the new RC replaces the active RC marker, the in-flight rollout is cancelled without unpinning, and the new rollout still has to be started before the previously pinned actors move onto the new RC.
-
-</details>
-
-<details><summary>If the connector version changes from RC to non-RC (GA) version...</summary>
-
-You should not merge the PR unless/until the RC has been finalized as canceled. See above `Rollout state` for detected status.
-
-> [!Warning]
-> This PR should not be merged if the RC rollout is still active. First finalize the active rollout as successful or cancel it in [Connector Rollout Manager]({{ .retool_url }}).
-
-When you finalize an RC rollout as successful, the platform triggers a promotion workflow that strips the `-rc` suffix, removes stable-version `registryOverrides`, disables progressive rollout, force-merges that promotion, and unpins actors.
-
-</details>
 
 #### 🔁 How to rerun this check
 

--- a/.github/progressive-rollout-gate-comment.md
+++ b/.github/progressive-rollout-gate-comment.md
@@ -14,6 +14,19 @@
 - Rollout last updated by: `{{ .rollout_updated_by }}`
 - [Open Connector Rollout Manager in Retool]({{ .retool_url }}) to clean up or close out this rollout if appropriate.
 
+### ⚠️ What happens if you merge this PR now
+
+If this PR publishes a **new `-rc` version** of `{{ .connector }}`:
+
+1. The new RC is published and registered as the release candidate.
+2. **The rollout of `{{ .rollout_docker_image_tag }}` is auto-cancelled**, not finalized. Registering the new RC cancels every non-terminal rollout for this connector with `errorMsg = "Rollout was incomplete when a new rollout was started. Cancelled without unpinning."`
+3. **Actors already pinned to `{{ .rollout_docker_image_tag }}` stay pinned to it.** Cancellation does not unpin, so those connections keep syncing on the old RC image — they are *not* rolled back to the previous GA version, and they are *not* moved to the new RC by the merge itself.
+4. Nothing rolls out on its own. A new rollout is created in `initialized` and must be started (autopilot or manually in [Connector Rollout Manager]({{ .retool_url }})). Starting it migrates the previous rollout's pins onto the new RC by default (`migratePins`), which is what moves those stranded actors forward. Until then, they stay on the old RC.
+
+If this PR removes the `-rc` suffix (RC → GA), or does not change the version at all, see the other cases in **More Information** below.
+
+To avoid stranded pins, finalize or cancel the active rollout in [Connector Rollout Manager]({{ .retool_url }}) before merging.
+
 ### Version on `master` Branch: `{{ .master_version }}`
 
 - RC marker on `master` branch: `{{ .master_rc_marker }}`
@@ -40,9 +53,7 @@ No new connector version should be released, and the active rollout should conti
 
 <details><summary>If the connector version increments to a higher `-rc` version...</summary>
 
-After this PR is merged, the new RC will be published and registered, replacing the active RC marker. When the new RC is registered, the platform cancels any existing non-terminal rollout for this connector without unpinning actors.
-
-After merging, you still need to start the new rollout. During start, pinned actors from the previous rollout can be moved to the new RC.
+See the "What happens if you merge this PR now" section above: the new RC replaces the active RC marker, the in-flight rollout is cancelled without unpinning, and the new rollout still has to be started before the previously pinned actors move onto the new RC.
 
 </details>
 


### PR DESCRIPTION
## What

The active-rollout gate comment said the in-flight rollout "is cancelled without unpinning actors" without saying what that means for customers: actors pinned to the old candidate keep syncing on that old image — they are not rolled back to the previous default version, and the merge itself does not move them to the new candidate.

It also framed the whole case as an `-rc` bump, which is stale. Rollout candidates are computed from the progressive-rollout marker files during registry compile (`_compute_release_candidates` → `_apply_release_candidates_to_entries` in `airbyte-ops-mcp`), independent of any version suffix — so a plain version bump with `enableProgressiveRollout: true` becomes the candidate and hits the same cancel-without-unpin path. Per the autopilot docs the RC-suffix flow is legacy.

Reported by Sophie Cui in Slack while looking at the gate comment on airbytehq/airbyte#84839; the `-rc` framing was caught by @pedroslopez in review.

## How

Reword inside the existing higher-version case of `.github/progressive-rollout-gate-comment.md` (no restructuring, +3/-3):

- summary drops `-rc`: "If the connector version increments to a higher version..."
- says cancel, not finalize, and spells out that pinned actors stay on the old image; notes that an `-rc` suffix isn't what makes a version the candidate
- names what actually moves them: the new rollout has to be started — by the autopilot cron under `defaultRolloutMode: autopilot`, otherwise by a human — and start migrates the previous rollout's pins onto the new candidate by default (`migratePins`)

## Review guide

1. `.github/progressive-rollout-gate-comment.md`

## User Impact

Existing gate comments render the new wording the next time the workflow runs on a PR. Template-only change; no workflow logic touched.

## Can this PR be safely reverted and rolled back?
- [x] YES 💚

Link to Devin session: https://app.devin.ai/sessions/213798ba8d614e939d5a7c87ca35087e
Requested by: @sophiecuiy