### PR TITLE
ci(oss-issue-triage): stop triaging GitHub discussions

### DIFF
--- a/.github/workflows/oss-issue-triage.yml
+++ b/.github/workflows/oss-issue-triage.yml
@@ -1,35 +1,21 @@
-name: OSS Issue and Discussion Triage
+name: OSS Issue Triage
 
-# This workflow automatically triggers AI triage for issues and discussions opened by
-# community members (users without write access to the repository). It helps provide
-# quick initial responses and escalates actionable items to the internal oncall team.
+# This workflow automatically triggers AI triage for issues opened by community
+# members (users without write access to the repository). It helps provide quick
+# initial responses and escalates actionable items to the internal oncall team.
 
 on:
   issues:
     types: [opened]
-  discussion:
-    types: [created]
 
 permissions:
   issues: write
-  discussions: write
 
 jobs:
   check-permissions:
     name: Resolve Input Variables
     runs-on: ubuntu-24.04
     steps:
-      - name: Gather event metadata
-        id: gather-metadata
-        run: |
-          if [[ "${{ github.event_name }}" == "issues" ]]; then
-            echo "author=${{ github.event.issue.user.login }}" >> $GITHUB_OUTPUT
-            echo "event-type=issue" >> $GITHUB_OUTPUT
-          elif [[ "${{ github.event_name }}" == "discussion" ]]; then
-            echo "author=${{ github.event.discussion.user.login }}" >> $GITHUB_OUTPUT
-            echo "event-type=discussion" >> $GITHUB_OUTPUT
-          fi
-
       - name: Authenticate as GitHub App
         uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
         id: get-app-token
@@ -43,7 +29,7 @@ jobs:
         id: check-access
         env:
           GH_TOKEN: ${{ steps.get-app-token.outputs.token }}
-          AUTHOR: ${{ steps.gather-metadata.outputs.author }}
+          AUTHOR: ${{ github.event.issue.user.login }}
         run: |
           set -euo pipefail
 
@@ -66,13 +52,10 @@ jobs:
           fi
     outputs:
       is-community-member: ${{ steps.check-access.outputs.is-community-member }}
-      author: ${{ steps.gather-metadata.outputs.author }}
-      event-type: ${{ steps.gather-metadata.outputs.event-type }}
 
   ai-triage-issue:
     name: AI Triage for Community Issue
     needs: check-permissions
-    if: needs.check-permissions.outputs.event-type == 'issue'
     runs-on: ubuntu-24.04
     steps:
       - name: Authenticate as GitHub App
@@ -109,67 +92,3 @@ jobs:
           tags: |
             oss-issue-triage
             community-issue
-
-  ai-triage-discussion:
-    name: AI Triage for Community Discussion
-    needs: check-permissions
-    if: needs.check-permissions.outputs.event-type == 'discussion'
-    runs-on: ubuntu-24.04
-    steps:
-      - name: Authenticate as GitHub App
-        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
-        id: get-app-token
-        with:
-          owner: "airbytehq"
-          repositories: "airbyte,oncall"
-          app-id: ${{ secrets.OCTAVIA_BOT_APP_ID }}
-          private-key: ${{ secrets.OCTAVIA_BOT_PRIVATE_KEY }}
-
-      - name: Prepare discussion prompt
-        id: prepare-prompt
-        env:
-          DISC_NUM: ${{ github.event.discussion.number }}
-          DISC_AUTHOR: ${{ github.event.discussion.user.login }}
-          DISC_TITLE: ${{ github.event.discussion.title }}
-          DISC_URL: ${{ github.event.discussion.html_url }}
-          DISC_CAT: ${{ github.event.discussion.category.name }}
-          DISC_BODY: ${{ github.event.discussion.body }}
-          DISC_NODE_ID: ${{ github.event.discussion.node_id }}
-        run: |
-          escape_for_bash() {
-            local text="$1"
-            text="${text//\\/\\\\}"
-            text="${text//\`/\\\`}"
-            text="${text//\$/\\\$}"
-            text="${text//\"/\\\"}"
-            printf '%s' "$text"
-          }
-
-          ESC_TITLE=$(escape_for_bash "$DISC_TITLE")
-          ESC_BODY=$(escape_for_bash "$DISC_BODY")
-
-          {
-            echo "prompt<<PROMPT_EOF"
-            printf 'Discussion #%s by @%s: %s\n' "$DISC_NUM" "$DISC_AUTHOR" "$ESC_TITLE"
-            printf 'Discussion URL: %s\n' "$DISC_URL"
-            printf 'Discussion Category: %s\n' "$DISC_CAT"
-            echo ""
-            echo "Discussion Body:"
-            printf '%s\n' "$ESC_BODY"
-            echo ""
-            printf 'IMPORTANT: This is a GitHub Discussion, not an issue. You should post your response as a comment on the discussion using the GitHub GraphQL API. The discussion node ID is: %s\n' "$DISC_NODE_ID"
-            echo "PROMPT_EOF"
-          } >> "$GITHUB_OUTPUT"
-
-      - name: Run AI Triage
-        uses: aaronsteers/devin-action@main
-        with:
-          playbook-macro: "!oss_issue_triage"
-          devin-token: ${{ secrets.DEVIN_AI_API_KEY }}
-          github-token: ${{ steps.get-app-token.outputs.token }}
-          prompt-text: ${{ steps.prepare-prompt.outputs.prompt }}
-          api-version: v3
-          org-id: ${{ vars.DEVIN_AI_ORG_ID }}
-          tags: |
-            oss-issue-triage
-            community-discussion


### PR DESCRIPTION
## What

Turns off AI triage for GitHub Discussions, as requested by @pedroslopez in Slack. Only newly opened issues are triaged now.

## How

In `.github/workflows/oss-issue-triage.yml`:
- dropped the `discussion: [created]` trigger and the `discussions: write` permission
- removed the `ai-triage-discussion` job (prompt construction + Devin run)
- simplified `check-permissions` to read the author straight from `github.event.issue.user.login` (no more event-type branching)

Issue triage behavior is otherwise unchanged.

## Review guide

1. `.github/workflows/oss-issue-triage.yml`

## User Impact

New community discussions no longer get an automated Support Bot reply; community issues still do. The `oss_issue_triage` playbook still contains discussion-handling instructions — harmless, but can be pruned in a follow-up if you want.

## Can this PR be safely reverted and rolled back?
- [x] YES 💚


Link to Devin session: https://app.devin.ai/sessions/1254308c32e44ae78db87e8cce285576