### PR TITLE
fix(source-salesforce): send PKCE code_challenge and code_verifier in OAuth flow

### DIFF
--- a/airbyte-integrations/connectors/source-salesforce/metadata.yaml
+++ b/airbyte-integrations/connectors/source-salesforce/metadata.yaml
@@ -10,7 +10,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: b117307c-14b6-41aa-9422-947e34922962
-  dockerImageTag: 2.9.0
+  dockerImageTag: 2.9.1
   releases:
     rolloutConfiguration:
       enableProgressiveRollout: true

--- a/airbyte-integrations/connectors/source-salesforce/pyproject.toml
+++ b/airbyte-integrations/connectors/source-salesforce/pyproject.toml
@@ -3,7 +3,7 @@ requires = [ "poetry-core>=1.0.0",]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
-version = "2.9.0"
+version = "2.9.1"
 name = "source-salesforce"
 description = "Source implementation for Salesforce."
 authors = [ "Airbyte <contact@airbyte.io>",]

--- a/airbyte-integrations/connectors/source-salesforce/source_salesforce/spec.yaml
+++ b/airbyte-integrations/connectors/source-salesforce/source_salesforce/spec.yaml
@@ -152,7 +152,10 @@ advanced_auth:
         - scope: "web"
         - scope: "refresh_token"
         - scope: "lightning"
-      consent_url: "https://{% if is_sandbox %}test{% else %}login{% endif %}.salesforce.com/services/oauth2/authorize?{{client_id_param}}&{{redirect_uri_param}}&response_type=code&{{scopes_param}}&{{state_param}}"
+      consent_url: "https://{% if is_sandbox %}test{% else %}login{% endif %}.salesforce.com/services/oauth2/authorize?{{client_id_param}}&{{redirect_uri_param}}&response_type=code&{{scopes_param}}&{{state_param}}&code_challenge={{ state_value | codechallengeS256 | replace('+', '-') | replace('/', '_') | replace('=', '') }}&code_challenge_method=S256"
+      state:
+        min: 43
+        max: 128
       access_token_url: "https://{% if is_sandbox %}test{% else %}login{% endif %}.salesforce.com/services/oauth2/token"
       access_token_headers:
         Content-Type: "application/x-www-form-urlencoded"
@@ -162,6 +165,7 @@ advanced_auth:
         client_id: "{{ client_id_value }}"
         client_secret: "{{ client_secret_value }}"
         redirect_uri: "{{ redirect_uri_value }}"
+        code_verifier: "{{ state_value }}"
       extract_output:
         - refresh_token
     oauth_user_input_from_connector_config_specification:

--- a/airbyte-integrations/connectors/source-salesforce/unit_tests/test_spec.py
+++ b/airbyte-integrations/connectors/source-salesforce/unit_tests/test_spec.py
@@ -1,0 +1,60 @@
+#
+# Copyright (c) 2026 Airbyte, Inc., all rights reserved.
+#
+
+import base64
+import hashlib
+from pathlib import Path
+from urllib.parse import parse_qs, urlparse
+
+import jinja2
+import yaml
+
+
+SPEC_PATH = Path(__file__).resolve().parents[1] / "source_salesforce" / "spec.yaml"
+
+
+def _load_oauth_spec():
+    with SPEC_PATH.open() as spec_file:
+        spec = yaml.safe_load(spec_file)
+    oauth_spec = spec["advanced_auth"]["oauth_config_specification"]["oauth_connector_input_specification"]
+    return oauth_spec
+
+
+def test_oauth_spec_includes_pkce_parameters():
+    oauth_spec = _load_oauth_spec()
+    consent_url = oauth_spec["consent_url"]
+
+    assert "code_challenge=" in consent_url
+    assert "code_challenge_method=S256" in consent_url
+    assert oauth_spec["access_token_params"]["code_verifier"] == "{{ state_value }}"
+    assert oauth_spec["state"] == {"min": 43, "max": 128}
+    assert "replace('+', '-')" in consent_url
+    assert "replace('/', '_')" in consent_url
+    assert "replace('=', '')" in consent_url
+
+
+def test_consent_url_renders_unpadded_base64url_code_challenge():
+    oauth_spec = _load_oauth_spec()
+    verifier = "v" * 43
+    environment = jinja2.Environment()
+
+    # This stub mirrors the platform filter's padded output; the real filter lives in airbyte-platform.
+    environment.filters["codechallengeS256"] = lambda value: base64.b64encode(hashlib.sha256(value.encode()).digest()).decode()
+    rendered_url = environment.from_string(oauth_spec["consent_url"]).render(
+        is_sandbox=False,
+        client_id_param="client_id=dummy-client",
+        redirect_uri_param="redirect_uri=https%3A%2F%2Fexample.com%2Fcallback",
+        scopes_param="scope=api",
+        state_param="state=dummy-state",
+        state_value=verifier,
+    )
+
+    query = parse_qs(urlparse(rendered_url).query)
+    code_challenge = query["code_challenge"][0]
+    expected_code_challenge = base64.urlsafe_b64encode(hashlib.sha256(verifier.encode()).digest()).rstrip(b"=").decode()
+
+    assert len(code_challenge) == 43
+    assert not any(character in code_challenge for character in "+/=")
+    assert code_challenge == expected_code_challenge
+    assert query["code_challenge_method"][0] == "S256"

--- a/docs/integrations/sources/salesforce.md
+++ b/docs/integrations/sources/salesforce.md
@@ -318,6 +318,7 @@ When extracting data through the Bulk API, the connector downloads results as CS
 
 | Version     | Date       | Pull Request                                             | Subject                                                                                                                                                                |
 |:------------|:-----------|:---------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 2.9.1 | 2026-08-26 | [85057](https://github.com/airbytehq/airbyte/pull/85057) | Send PKCE `code_challenge`/`code_challenge_method=S256` on the consent URL and `code_verifier` on the token exchange, so OAuth works in orgs that require PKCE |
 | 2.9.0 | 2026-08-25 | [82722](https://github.com/airbytehq/airbyte/pull/82722) | Add an optional end date for bounded incremental syncs |
 | 2.8.1 | 2026-08-05 | [82784](https://github.com/airbytehq/airbyte/pull/82784) | Fail fast when the refresh token is rejected instead of retrying the token endpoint from every stream |
 | 2.8.0 | 2026-07-17 | [80892](https://github.com/airbytehq/airbyte/pull/80892) | Persist rotated refresh token to support Salesforce OAuth Refresh Token Rotation (RTR) |


### PR DESCRIPTION
## What

Salesforce orgs that enable the org-wide setting **Require Proof Key for Code Exchange (PKCE) Extension for Supported Authorization Flows** cannot complete the Salesforce source OAuth flow: the connector's declarative consent URL sends no `code_challenge`, so Salesforce fails the authorize request with `OAUTH_APPROVAL_ERROR_GENERIC`. This PR makes `source-salesforce` send PKCE parameters unconditionally.

Requested by Zane Hyatt. Related: `airbytehq/oncall` issue 13338 (private). The platform-side base64url encoding fix for the `codechallengeS256` filter is tracked separately as Linear PLAT-1209 (owned by Aldo Gonzalez, in review as `airbyte-platform-internal#19374`), a child of the umbrella issue PLAT-1197; this PR is deliberately self-sufficient without it.

## How

In `spec.yaml`, inside `advanced_auth.oauth_config_specification.oauth_connector_input_specification`:

- `consent_url` gains `&code_challenge={{ state_value | codechallengeS256 | replace('+', '-') | replace('/', '_') | replace('=', '') }}&code_challenge_method=S256`
- `access_token_params` gains `code_verifier: "{{ state_value }}"`
- a new `state: {min: 43, max: 128}` block constrains the generated `state` so it is a valid RFC 7636 code verifier length

The three `replace` filters are load-bearing, not cosmetic. `CodeChallengeS256Filter` in the platform emits **standard padded base64**, and Salesforce rejects that outright at the authorize endpoint. Once PLAT-1209 makes the filter emit base64url, the chain becomes a harmless no-op, so the two changes are order-insensitive and can land in either order.

## Review guide

1. `airbyte-integrations/connectors/source-salesforce/source_salesforce/spec.yaml` — the three additions above
2. `airbyte-integrations/connectors/source-salesforce/metadata.yaml` + `pyproject.toml` — 2.9.0 → 2.9.1
3. `docs/integrations/sources/salesforce.md` — changelog row

Note: the changelog table on master is missing rows for some 2.8.x/2.9.0 entries; not backfilled here to keep this diff scoped.

## Empirical evidence

All verified by hand on 2026-08-25 against an Airbyte-owned Salesforce Developer Edition org with a self-owned Connected App. No claims beyond what was directly observed.

- **Reproduced.** With PKCE enforcement OFF, an authorize request with no `code_challenge` succeeds. With enforcement ON and nothing else changed, Salesforce returns `OAUTH_APPROVAL_ERROR_GENERIC`. Single-variable change, so causal.
- **Fix validated.** A correct 43-character unpadded base64url `code_challenge` plus `code_challenge_method=S256`, followed by a token exchange carrying the matching `code_verifier`, returns `access_token` + `refresh_token` from a PKCE-enforcing org.
- **Why the replace chain is required.** A padded standard-base64 challenge (`t4ueFBPFVQasFBpM0Ysoaa/axGYkfkIOx1iYhST+VU8=`, containing `/`, `+`, `=`) is rejected *before* the consent screen with "The value of the code_challenge parameter contains a character that is not allowed or the value exceeds the maximum allowed length." Shipping the spec change without correct base64url encoding would therefore break **all** Salesforce OAuth users, not only PKCE-enforcing orgs.
- **No regression.** With enforcement OFF and a correct challenge sent anyway, the full exchange still succeeds. PKCE can be sent unconditionally — no toggle, no config flag, no conditional template logic.
- **`state: {min: 43, max: 128}` is correctness, not a functional requirement.** Salesforce enforces neither verifier charset (a `.` is accepted) nor verifier length (a 20-character verifier is accepted). The override is included for RFC 7636 compliance; the trap is that omitting it would appear to work while being non-compliant.
- **Legacy Kotlin flow is not involved.** `source-salesforce` migrated to declarative OAuth in #75579 (2026-03-31), so `SalesforceOAuthFlow.kt` is not used by this connector. Earlier AI triage on the issue named that file as the fix target; that is incorrect.
- **Prior art is thin.** `destination-hubspot` is the only other declarative consumer of `codechallengeS256`, and it sends a challenge with no verifier — declarative PKCE had never completed a verification round trip before this. Draft PR #76071 (source-airtable) contains a similar pattern but has been unmerged since April.

## Coordination

Open PR #80788 (add OAuth 2.0 JWT Bearer authentication) edits the same `spec.yaml` auth block and is branched off 2.7.26. Whichever of the two lands second will need a rebase.

## Known limitation

Reusing `state` as the `code_verifier` means the verifier travels through the user's browser in the redirect URL, so PKCE here adds little protection against authorization-code interception. This is the pattern the declarative OAuth docs prescribe and what `AirtableOAuthFlow.kt` already does in production. Fixing it properly requires a separately persisted per-flow verifier in `airbyte-oauth`. Accepted as a known limitation for now.

## User Impact

Users in Salesforce orgs that require PKCE can complete the OAuth consent flow instead of hitting `OAUTH_APPROVAL_ERROR_GENERIC`. Users in orgs that do not require PKCE are unaffected (verified above). This change depends on the platform emitting a base64url-safe challenge, which the `replace` chain guarantees today.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚
- [ ] NO ❌


Link to Devin session: https://app.devin.ai/sessions/ec607fd8ad914c998219a5e1a1330eaf
Requested by: @ZaneHyattAB

> [!IMPORTANT]
> Active progressive rollout warning for source-salesforce.

- [x] (Click to Approve:) Bypass the active progressive rollout warning for source-salesforce in the PR comment [here](https://github.com/airbytehq/airbyte/pull/85057#issuecomment-5420126813).

---

> [!IMPORTANT]
> **Autopilot Progressive Rollout Enabled**
>
> [Autopilot progressive rollouts](https://github.com/airbytehq/airbyte-ops-mcp/blob/main/docs/autopilot-rollouts.md) are enabled for one or more connector(s) modified in this PR. Check the box below if you need to bypass normal rollout safety processes and release to all users immediately upon merge:
>
> - [ ] ⚡ **Release immediately** (bypasses automatic progressive rollout)
>
> **Note:**
>
> - ⚠️ The above bypass option is for emergency/hotfix use only.
> - 🔗 You can monitor or manually advance a rollout at **[ops.internal.airbyte.ai](https://ops.internal.airbyte.ai)**.


Open in Devin Desktop: https://app.devin.ai/desktop/session/ec607fd8ad914c998219a5e1a1330eaf?variant=devin