### PR TITLE
fix(source-snowflake): discover skips a broken object instead of failing entirely

### DIFF
--- a/airbyte-integrations/connectors/source-snowflake/metadata.yaml
+++ b/airbyte-integrations/connectors/source-snowflake/metadata.yaml
@@ -8,7 +8,7 @@ data:
   connectorSubtype: database
   connectorType: source
   definitionId: e2d65910-8c8b-40a1-ae7d-ee2416b2bfa2
-  dockerImageTag: 1.1.2
+  dockerImageTag: 1.1.3
   dockerRepository: airbyte/source-snowflake
   documentationUrl: https://docs.airbyte.com/integrations/sources/snowflake
   githubIssueLabel: source-snowflake

--- a/airbyte-integrations/connectors/source-snowflake/src/main/kotlin/io/airbyte/integrations/source/snowflake/SnowflakeSourceMetadataQuerier.kt
+++ b/airbyte-integrations/connectors/source-snowflake/src/main/kotlin/io/airbyte/integrations/source/snowflake/SnowflakeSourceMetadataQuerier.kt
@@ -26,6 +26,7 @@ import io.airbyte.cdk.read.optimize
 import io.airbyte.protocol.models.v0.StreamDescriptor
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.micronaut.context.annotation.Primary
+import io.micronaut.context.annotation.Value
 import jakarta.inject.Singleton
 import java.lang.RuntimeException
 import java.sql.Connection
@@ -45,6 +46,14 @@ import kotlin.use
 class SnowflakeSourceMetadataQuerier(
     val base: JdbcMetadataQuerier,
     val schema: String? = null,
+    /**
+     * When true (DISCOVER only), a column probe that fails with a known object-level error (e.g. an
+     * invalid view) yields an empty column list so the stream is skipped, instead of failing the
+     * whole operation. Must stay false for CHECK and READ: CHECK relies on a throwing [fields] to
+     * detect roles that cannot SELECT anything, and READ must fail loudly on a broken selected
+     * stream.
+     */
+    val tolerateObjectLevelFailures: Boolean = false,
 ) : MetadataQuerier by base {
     private val log = KotlinLogging.logger {}
 
@@ -135,10 +144,20 @@ class SnowflakeSourceMetadataQuerier(
         if (columnMetadata.isEmpty() || !base.config.checkPrivileges) {
             return columnMetadata
         }
+        var wholeObjectFailure = false
         val resultsFromSelectMany: List<ColumnMetadata>? =
-            queryColumnMetadata(base.conn, selectLimit0(table, columnMetadata.map { it.name }))
+            queryColumnMetadata(base.conn, selectLimit0(table, columnMetadata.map { it.name })) {
+                e: SQLException ->
+                wholeObjectFailure = isWholeObjectFailure(e)
+            }
         if (resultsFromSelectMany != null) {
             return resultsFromSelectMany
+        }
+        if (wholeObjectFailure) {
+            // The object itself is broken or missing (e.g. an invalid view whose definition no
+            // longer compiles): every per-column probe would fail identically, so don't issue
+            // them.
+            return listOf()
         }
         log.info {
             "Not all columns of $table might be accessible, trying each column individually."
@@ -167,6 +186,7 @@ class SnowflakeSourceMetadataQuerier(
     private fun queryColumnMetadata(
         conn: Connection,
         sql: String,
+        onToleratedFailure: (SQLException) -> Unit = {},
     ): List<ColumnMetadata>? {
         log.info { "Querying $sql for catalog discovery." }
         conn.createStatement().use { stmt: Statement ->
@@ -196,10 +216,65 @@ class SnowflakeSourceMetadataQuerier(
                     }
                 }
             } catch (e: SQLException) {
-                throw RuntimeException("Column name discovery query failed: ${e.message}", e)
+                // During DISCOVER, a column probe that fails for a known OBJECT-LEVEL reason must
+                // not fail the whole operation. Returning null re-enables the tolerance machinery
+                // in columnMetadata() (all-columns probe -> per-column probe -> empty fields) so a
+                // single broken/inaccessible view (declared columns no longer match its query
+                // body, or a view the role cannot SELECT) is skipped while the rest of the catalog
+                // is still discovered.
+                //
+                // Tolerance is an ALLOWLIST: only failures positively identified as object-level
+                // (compile errors, missing/unauthorized objects) are tolerated. Anything else —
+                // network failures (driver SQLSTATE 58030), expired auth/session tokens (driver
+                // reauth codes such as 390114, often SQLSTATE XX000), no-active-warehouse (401 /
+                // 57P03), timeouts, and unknown unknowns — re-throws, because those affect every
+                // stream and tolerating them would silently truncate or empty the catalog.
+                //
+                // Tolerance is also gated to the discover operation: CHECK relies on a throwing
+                // fields() to detect roles that cannot SELECT any table, and READ must fail
+                // loudly on a broken selected stream.
+                if (!tolerateObjectLevelFailures || !isTolerableObjectError(e)) {
+                    throw RuntimeException("Column name discovery query failed: ${e.message}", e)
+                }
+                log.warn(e) {
+                    "Object-level failure during discover; this stream will be skipped and " +
+                        "omitted from the catalog. Failed query: $sql, " +
+                        "sqlState = '${e.sqlState ?: ""}', errorCode = ${e.errorCode}, ${e.message}"
+                }
+                onToleratedFailure(e)
+                return null
             }
         }
     }
+
+    /**
+     * Returns true only when [e] is positively identified as an OBJECT-LEVEL failure of the probed
+     * table/view — a definition that no longer compiles (SQLSTATE class '42', e.g. 42601), or an
+     * object that does not exist / is not authorized (SQLSTATE class '02' or vendor codes
+     * 2003/2043, per this connector's classifier in application.yml). Only these are safe to
+     * tolerate during discover by skipping the stream.
+     *
+     * Everything else is treated as fatal, INCLUDING unrecognized errors: infrastructure failures
+     * affect every stream, and the safe default for an unknown error is a loud failure, never a
+     * silently truncated catalog.
+     */
+    fun isTolerableObjectError(e: SQLException): Boolean {
+        if (e.errorCode in TOLERABLE_OBJECT_ERROR_CODES) {
+            return true
+        }
+        val sqlStateClass: String = e.sqlState?.take(2) ?: return false
+        return sqlStateClass in TOLERABLE_OBJECT_SQLSTATE_CLASSES
+    }
+
+    /**
+     * Returns true when a tolerated probe failure condemns the WHOLE object — its definition does
+     * not compile (SQLSTATE 42601, e.g. vendor code 2057 "view declared N columns but query
+     * produces M") or it does not exist / is not authorized (2003/2043). Every per-column probe
+     * would fail identically, so [columnMetadata] skips them. Other tolerated failures (e.g.
+     * column-scoped access policies) still fall through to per-column probing.
+     */
+    fun isWholeObjectFailure(e: SQLException): Boolean =
+        e.sqlState == "42601" || e.errorCode in TOLERABLE_OBJECT_ERROR_CODES
 
     fun <T> swallow(supplier: () -> T): T? {
         try {
@@ -316,6 +391,9 @@ class SnowflakeSourceMetadataQuerier(
             val selectQueryGenerator: SelectQueryGenerator,
             val fieldTypeMapper: JdbcMetadataQuerier.FieldTypeMapper,
             val checkQueries: JdbcCheckQueries,
+            // The CDK selects the running operation via this property (Operation.PROPERTY);
+            // object-level tolerance must apply to discover only.
+            @Value("\${airbyte.connector.operation:}") val operationName: String,
         ) : MetadataQuerier.Factory<SnowflakeSourceConfiguration> {
             private val log = KotlinLogging.logger {}
 
@@ -331,10 +409,32 @@ class SnowflakeSourceMetadataQuerier(
                         checkQueries,
                         jdbcConnectionFactory,
                     )
-                return SnowflakeSourceMetadataQuerier(base, config.schema)
+                return SnowflakeSourceMetadataQuerier(
+                    base,
+                    config.schema,
+                    tolerateObjectLevelFailures = operationName == "discover",
+                )
             }
         }
 
         val EXCLUDED_NAMESPACES = setOf("INFORMATION_SCHEMA", "SNOWFLAKE_SAMPLE_DATA", "UTIL_DB")
+
+        /**
+         * Snowflake vendor error codes positively identifying an OBJECT-LEVEL failure of the probed
+         * table/view: 2003 / 2043 "object does not exist or not authorized" (the same codes this
+         * connector's classifier in application.yml maps to a config error) and 2057 "view declared
+         * N column(s), but view query produces M column(s)". Used as a belt-and-braces complement
+         * to [TOLERABLE_OBJECT_SQLSTATE_CLASSES] for exceptions with no SQLSTATE.
+         */
+        val TOLERABLE_OBJECT_ERROR_CODES = setOf(2003, 2043, 2057)
+
+        /**
+         * SQLSTATE classes (first two chars) positively identifying an object-level failure: '42' =
+         * syntax error or access rule violation (view compile errors such as 42601, access denials
+         * such as 42501), '02' = no data (Snowflake's "object does not exist or not authorized").
+         * Anything outside this allowlist — connection ('08'), driver network ('58'), operator
+         * intervention ('57'), driver/internal ('XX'), and unknowns — is treated as fatal.
+         */
+        val TOLERABLE_OBJECT_SQLSTATE_CLASSES = setOf("42", "02")
     }
 }

--- a/airbyte-integrations/connectors/source-snowflake/src/test/kotlin/io/airbyte/integrations/source/snowflake/SnowflakeSourceMetadataQuerierTest.kt
+++ b/airbyte-integrations/connectors/source-snowflake/src/test/kotlin/io/airbyte/integrations/source/snowflake/SnowflakeSourceMetadataQuerierTest.kt
@@ -1,0 +1,314 @@
+/*
+ * Copyright (c) 2026 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.integrations.source.snowflake
+
+import io.airbyte.cdk.StreamIdentifier
+import io.airbyte.cdk.check.JdbcCheckQueries
+import io.airbyte.cdk.discover.JdbcMetadataQuerier
+import io.airbyte.cdk.jdbc.DefaultJdbcConstants
+import io.airbyte.cdk.jdbc.JdbcConnectionFactory
+import io.airbyte.protocol.models.v0.StreamDescriptor
+import java.sql.Connection
+import java.sql.DatabaseMetaData
+import java.sql.ResultSet
+import java.sql.ResultSetMetaData
+import java.sql.SQLException
+import java.sql.Statement
+import java.sql.Types
+import java.time.Duration
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.mockito.ArgumentMatchers.any
+import org.mockito.ArgumentMatchers.anyString
+import org.mockito.ArgumentMatchers.contains
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.times
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.`when`
+
+/**
+ * Unit tests for the discover tolerance behavior of [SnowflakeSourceMetadataQuerier].
+ *
+ * These exercise the real [fields] -> [SnowflakeSourceMetadataQuerier.columnMetadata] ->
+ * queryColumnMetadata path against a mocked JDBC [Connection]. The tolerance classification is an
+ * ALLOWLIST of object-level errors, so each suite below pins one branch of the classifier: a test
+ * exists that fails if any individual allowlist entry, the unknown-is-fatal default, or the
+ * operation gating is removed.
+ */
+class SnowflakeSourceMetadataQuerierTest {
+
+    companion object {
+        private const val DATABASE = "TESTDB"
+        private const val SCHEMA = "PUBLIC"
+        private const val GOOD_VIEW = "GOOD_VIEW"
+        private const val BAD_VIEW = "BAD_VIEW"
+
+        // SQLSTATE 42601 / vendor 2057 = the invalid-view incident ("view declared 92 column(s),
+        // but view query produces 93 column(s)") -> tolerable, whole-object.
+        private const val SQLSTATE_COMPILE_ERROR = "42601"
+        private const val ERRORCODE_VIEW_DECLARED_MISMATCH = 2057
+        // SQLSTATE 02000 / vendor 2003 = "object does not exist or not authorized" -> tolerable.
+        private const val SQLSTATE_NO_DATA = "02000"
+        private const val ERRORCODE_OBJECT_NOT_FOUND = 2003
+        // Driver-level network failure: snowflake-jdbc surfaces NETWORK_ERROR/IO_ERROR as
+        // SQLSTATE 58030 (class '58', NOT '08') with vendor codes 200015/200016 -> must be fatal.
+        private const val SQLSTATE_DRIVER_NETWORK = "58030"
+        private const val ERRORCODE_DRIVER_NETWORK = 200015
+        // Auth/session token expiry: driver reauthentication codes (e.g. 390114 "Authentication
+        // token has expired") default to SQLSTATE XX000 -> must be fatal.
+        private const val SQLSTATE_INTERNAL = "XX000"
+        private const val ERRORCODE_TOKEN_EXPIRED = 390114
+        // "No active warehouse selected": SQLSTATE 57P03 / vendor 401 -> must be fatal.
+        private const val SQLSTATE_NO_WAREHOUSE = "57P03"
+        private const val ERRORCODE_NO_WAREHOUSE = 401
+    }
+
+    /** Holds the mocks so tests can verify interaction counts on the [Statement]. */
+    private class Fixture(val querier: SnowflakeSourceMetadataQuerier, val stmt: Statement)
+
+    /** Builds a [SnowflakeSourceMetadataQuerier] whose base delegates to the given [Connection]. */
+    private fun querierFor(
+        conn: Connection,
+        tolerateObjectLevelFailures: Boolean,
+    ): SnowflakeSourceMetadataQuerier {
+        val ops = SnowflakeSourceOperations()
+        val config =
+            SnowflakeSourceConfiguration(
+                realHost = "localhost",
+                jdbcUrlFmt = "jdbc:snowflake://%s",
+                jdbcProperties = emptyMap(),
+                namespaces = setOf(DATABASE),
+                schema = SCHEMA,
+                incremental = UserDefinedCursorIncrementalConfiguration,
+                maxConcurrency = 1,
+                checkpointTargetInterval = Duration.ofSeconds(60),
+                checkPrivileges = true,
+            )
+        // Mock the connection factory (final in the pinned CDK) so the base JdbcMetadataQuerier
+        // uses our mocked conn; Mockito 5's inline mock-maker supports final classes.
+        val connectionFactory = mock(JdbcConnectionFactory::class.java)
+        `when`(connectionFactory.get()).thenReturn(conn)
+        val base =
+            JdbcMetadataQuerier(
+                constants = DefaultJdbcConstants(),
+                config = config,
+                selectQueryGenerator = ops,
+                fieldTypeMapper = ops,
+                checkQueries = JdbcCheckQueries(),
+                jdbcConnectionFactory = connectionFactory,
+            )
+        return SnowflakeSourceMetadataQuerier(base, SCHEMA, tolerateObjectLevelFailures)
+    }
+
+    /** A mocked [ResultSet] over [DatabaseMetaData.getTables] enumerating two views. */
+    private fun tablesResultSet(): ResultSet {
+        val rs = mock(ResultSet::class.java)
+        `when`(rs.next()).thenReturn(true, true, false)
+        `when`(rs.getString("TABLE_CAT")).thenReturn(DATABASE, DATABASE)
+        `when`(rs.getString("TABLE_SCHEM")).thenReturn(SCHEMA, SCHEMA)
+        `when`(rs.getString("TABLE_NAME")).thenReturn(GOOD_VIEW, BAD_VIEW)
+        `when`(rs.getString("TABLE_TYPE")).thenReturn("VIEW", "VIEW")
+        return rs
+    }
+
+    /** A mocked [ResultSet] over [DatabaseMetaData.getColumns] with one column per view. */
+    private fun columnsResultSet(): ResultSet {
+        val rs = mock(ResultSet::class.java)
+        `when`(rs.next()).thenReturn(true, true, false)
+        `when`(rs.getString("TABLE_CAT")).thenReturn(DATABASE, DATABASE)
+        `when`(rs.getString("TABLE_SCHEM")).thenReturn(SCHEMA, SCHEMA)
+        `when`(rs.getString("TABLE_NAME")).thenReturn(GOOD_VIEW, BAD_VIEW)
+        `when`(rs.getString("COLUMN_NAME")).thenReturn("ID", "ID")
+        `when`(rs.getString("TYPE_NAME")).thenReturn("NUMBER", "NUMBER")
+        `when`(rs.getInt("DATA_TYPE")).thenReturn(Types.NUMERIC, Types.NUMERIC)
+        `when`(rs.getInt("COLUMN_SIZE")).thenReturn(38, 38)
+        `when`(rs.getInt("DECIMAL_DIGITS")).thenReturn(0, 0)
+        `when`(rs.getInt("ORDINAL_POSITION")).thenReturn(1, 1)
+        `when`(rs.getString("IS_NULLABLE")).thenReturn("YES", "YES")
+        `when`(rs.wasNull()).thenReturn(false)
+        return rs
+    }
+
+    /** A successful single-column LIMIT 0 probe result set (metadata only). */
+    private fun probeResultSet(): ResultSet {
+        val meta = mock(ResultSetMetaData::class.java)
+        `when`(meta.columnCount).thenReturn(1)
+        `when`(meta.getColumnName(1)).thenReturn("ID")
+        `when`(meta.getColumnLabel(1)).thenReturn("ID")
+        `when`(meta.getColumnTypeName(1)).thenReturn("NUMBER")
+        `when`(meta.getColumnType(1)).thenReturn(Types.NUMERIC)
+        `when`(meta.getPrecision(1)).thenReturn(38)
+        `when`(meta.getScale(1)).thenReturn(0)
+        `when`(meta.isNullable(1)).thenReturn(ResultSetMetaData.columnNullable)
+        val rs = mock(ResultSet::class.java)
+        `when`(rs.metaData).thenReturn(meta)
+        return rs
+    }
+
+    /**
+     * Wires a mocked [Connection] whose metadata enumerates GOOD_VIEW + BAD_VIEW, and whose LIMIT-0
+     * probe succeeds for GOOD_VIEW but throws [probeFailure] for BAD_VIEW.
+     */
+    private fun fixtureWith(
+        probeFailure: SQLException,
+        tolerateObjectLevelFailures: Boolean = true,
+    ): Fixture {
+        val dbmd = mock(DatabaseMetaData::class.java)
+        `when`(dbmd.getTables(anyString(), any(), any(), any())).thenAnswer { tablesResultSet() }
+        `when`(dbmd.getColumns(any(), any(), any(), any())).thenAnswer { columnsResultSet() }
+
+        // The probe SQL (SELECT ... FROM "PUBLIC"."<view>" LIMIT 0) names the target view, so route
+        // by SQL contents: GOOD_VIEW succeeds, BAD_VIEW throws the supplied failure.
+        val stmt = mock(Statement::class.java)
+        `when`(stmt.executeQuery(contains(BAD_VIEW))).thenThrow(probeFailure)
+        `when`(stmt.executeQuery(contains(GOOD_VIEW))).thenAnswer { probeResultSet() }
+
+        val conn = mock(Connection::class.java)
+        `when`(conn.metaData).thenReturn(dbmd)
+        `when`(conn.createStatement()).thenReturn(stmt)
+        return Fixture(querierFor(conn, tolerateObjectLevelFailures), stmt)
+    }
+
+    private fun streamId(name: String): StreamIdentifier =
+        StreamIdentifier.from(StreamDescriptor().withName(name).withNamespace(SCHEMA))
+
+    private fun assertHardDiscoveryFailure(fixture: Fixture, view: String) {
+        val e =
+            assertThrows(RuntimeException::class.java) { fixture.querier.fields(streamId(view)) }
+        assertTrue(
+            e.message?.contains("Column name discovery query failed") == true,
+            "Expected a hard discovery failure, got: ${e.message}",
+        )
+    }
+
+    // --- Tolerated object-level failures (discover mode) ---
+
+    @Test
+    fun `invalid view is skipped while healthy streams still discover`() {
+        val fixture =
+            fixtureWith(
+                SQLException(
+                    "invalid view",
+                    SQLSTATE_COMPILE_ERROR,
+                    ERRORCODE_VIEW_DECLARED_MISMATCH,
+                ),
+            )
+
+        // The healthy view still discovers its fields.
+        val goodFields = fixture.querier.fields(streamId(GOOD_VIEW))
+        assertEquals(1, goodFields.size)
+        assertEquals("ID", goodFields.single().id)
+
+        // The broken view yields NO fields instead of failing the whole discover; DiscoverOperation
+        // then logs "Ignoring stream ..." and skips it.
+        val badFields = fixture.querier.fields(streamId(BAD_VIEW))
+        assertTrue(badFields.isEmpty())
+    }
+
+    @Test
+    fun `whole-object compile failure short-circuits the per-column probes`() {
+        val fixture =
+            fixtureWith(
+                SQLException(
+                    "invalid view",
+                    SQLSTATE_COMPILE_ERROR,
+                    ERRORCODE_VIEW_DECLARED_MISMATCH,
+                ),
+            )
+
+        assertTrue(fixture.querier.fields(streamId(BAD_VIEW)).isEmpty())
+
+        // A view whose definition does not compile fails identically for every column, so only the
+        // all-columns probe (1 query) may run — no per-column retry storm.
+        verify(fixture.stmt, times(1)).executeQuery(contains(BAD_VIEW))
+    }
+
+    @Test
+    fun `object-not-found vendor code is tolerated even with a null sqlState`() {
+        // Pins the errorCode branch of the allowlist independently of SQLSTATE.
+        val fixture =
+            fixtureWith(
+                SQLException("does not exist or not authorized", null, ERRORCODE_OBJECT_NOT_FOUND)
+            )
+
+        assertTrue(fixture.querier.fields(streamId(BAD_VIEW)).isEmpty())
+    }
+
+    @Test
+    fun `no-data sqlState class is tolerated independently of the vendor code`() {
+        // Pins the SQLSTATE-class branch of the allowlist: class '02' with an unlisted errorCode.
+        val fixture = fixtureWith(SQLException("object not visible", SQLSTATE_NO_DATA, 0))
+
+        assertTrue(fixture.querier.fields(streamId(BAD_VIEW)).isEmpty())
+    }
+
+    // --- Fatal failures: NOT object-level, must propagate even in discover mode ---
+
+    @Test
+    fun `driver network failure propagates as a hard error`() {
+        // snowflake-jdbc surfaces network/IO failures as SQLSTATE 58030 (class '58', not '08').
+        // Tolerating it would silently truncate the catalog for every remaining stream.
+        val fixture =
+            fixtureWith(
+                SQLException("network error", SQLSTATE_DRIVER_NETWORK, ERRORCODE_DRIVER_NETWORK),
+            )
+
+        assertHardDiscoveryFailure(fixture, BAD_VIEW)
+    }
+
+    @Test
+    fun `expired auth token propagates as a hard error`() {
+        // Driver reauthentication codes (e.g. PAT/session token expiry) default to SQLSTATE XX000.
+        val fixture =
+            fixtureWith(SQLException("token expired", SQLSTATE_INTERNAL, ERRORCODE_TOKEN_EXPIRED))
+
+        assertHardDiscoveryFailure(fixture, BAD_VIEW)
+    }
+
+    @Test
+    fun `no active warehouse propagates as a hard error`() {
+        val fixture =
+            fixtureWith(
+                SQLException(
+                    "No active warehouse selected",
+                    SQLSTATE_NO_WAREHOUSE,
+                    ERRORCODE_NO_WAREHOUSE,
+                ),
+            )
+
+        assertHardDiscoveryFailure(fixture, BAD_VIEW)
+    }
+
+    @Test
+    fun `unknown failure with no sqlState propagates as a hard error`() {
+        // Pins the unknown-is-fatal default: not in the allowlist -> loud failure, never a
+        // silently truncated catalog.
+        val fixture = fixtureWith(SQLException("mystery failure", null, 999999))
+
+        assertHardDiscoveryFailure(fixture, BAD_VIEW)
+    }
+
+    // --- Operation gating: tolerance is discover-only ---
+
+    @Test
+    fun `tolerance disabled - object-level failure propagates as before`() {
+        // CHECK relies on a throwing fields() to detect roles that cannot SELECT anything, and
+        // READ must fail loudly on a broken selected stream; with tolerance off (the default),
+        // even an allowlisted object-level error must propagate.
+        val fixture =
+            fixtureWith(
+                SQLException(
+                    "invalid view",
+                    SQLSTATE_COMPILE_ERROR,
+                    ERRORCODE_VIEW_DECLARED_MISMATCH,
+                ),
+                tolerateObjectLevelFailures = false,
+            )
+
+        assertHardDiscoveryFailure(fixture, BAD_VIEW)
+    }
+}

--- a/docs/integrations/sources/snowflake.md
+++ b/docs/integrations/sources/snowflake.md
@@ -242,6 +242,7 @@ If you use Airbyte Cloud and your organization restricts access to specific IPs,
 
 | Version | Date       | Pull Request                                             | Subject                                                                                                                                   |
 |:--------|:-----------|:---------------------------------------------------------|:------------------------------------------------------------------------------------------------------------------------------------------|
+| 1.1.3   | 2026-08-26 | [XXXXX](https://github.com/airbytehq/airbyte/pull/XXXXX) | Discover no longer fails entirely when a single view or object is invalid or inaccessible; the offending stream is skipped.               |
 | 1.1.2   | 2026-08-21 | [84927](https://github.com/airbytehq/airbyte/pull/84927) | Bump Bulk CDK extract version from 1.0.1 to 1.1.10                                                                                        |
 | 1.1.1   | 2026-07-21 | [82705](https://github.com/airbytehq/airbyte/pull/82705) | Fix incremental sync silently dropping rows at the cursor's upper bound by rounding timestamp precision up instead of down                |
 | 1.1.0   | 2026-05-28 | [78481](https://github.com/airbytehq/airbyte/pull/78481) | Support Snowflake Programmatic Access Token authentication.                                                                               |

--- a/docs/integrations/sources/snowflake.md
+++ b/docs/integrations/sources/snowflake.md
@@ -242,7 +242,7 @@ If you use Airbyte Cloud and your organization restricts access to specific IPs,
 
 | Version | Date       | Pull Request                                             | Subject                                                                                                                                   |
 |:--------|:-----------|:---------------------------------------------------------|:------------------------------------------------------------------------------------------------------------------------------------------|
-| 1.1.3   | 2026-08-26 | [XXXXX](https://github.com/airbytehq/airbyte/pull/XXXXX) | Discover no longer fails entirely when a single view or object is invalid or inaccessible; the offending stream is skipped.               |
+| 1.1.3   | 2026-08-26 | [85081](https://github.com/airbytehq/airbyte/pull/85081) | Discover no longer fails entirely when a single view or object is invalid or inaccessible; the offending stream is skipped.               |
 | 1.1.2   | 2026-08-21 | [84927](https://github.com/airbytehq/airbyte/pull/84927) | Bump Bulk CDK extract version from 1.0.1 to 1.1.10                                                                                        |
 | 1.1.1   | 2026-07-21 | [82705](https://github.com/airbytehq/airbyte/pull/82705) | Fix incremental sync silently dropping rows at the cursor's upper bound by rounding timestamp precision up instead of down                |
 | 1.1.0   | 2026-05-28 | [78481](https://github.com/airbytehq/airbyte/pull/78481) | Support Snowflake Programmatic Access Token authentication.                                                                               |


### PR DESCRIPTION
## What

Addresses the discovery-failure half of #72488. Related: #72489 (earlier AI-triage draft, closed as overly broad).

With **Check table and column access privileges** enabled (the default), `source-snowflake` discovery probes every table and view with a `SELECT … LIMIT 0`. A single probe failure is rethrown as a `RuntimeException`, which fails the entire `DISCOVER` operation — so one broken or inaccessible object anywhere in the database makes the whole source undiscoverable, and users cannot create or edit a connection at all. The failure is total and disproportionate: 1734 healthy tables become unreachable because of one bad view.

Two reported triggers, one root cause:

1. A view depending on a Snowflake session variable that isn't set (the original report in #72488):
   ```
   Failure during expansion of view '<VIEW>': Session variable '$ENGAGEMENT_LEVEL' does not exist
   ```
2. A view whose declared column list has drifted out of sync with its query body (my trigger):
   ```
   SQL compilation error: View definition for '<DB>.<SCHEMA>.<VIEW>' declared 92 column(s),
   but view query produces 93 column(s).
   ```
   (Snowflake vendor code `2057`, SQLSTATE `42601`.)

## How

The machinery to tolerate exactly this already exists downstream and was simply unreachable:

- `columnMetadata()` already null-checks the probe result and falls back to per-column probes (`?: listOf()`).
- `DiscoverOperation` already skips streams with no fields (*"Ignoring stream … because no fields were discovered"*).
- The base CDK `JdbcMetadataQuerier` returns `null` at this exact point.

`SnowflakeSourceMetadataQuerier.queryColumnMetadata` overrode that behavior and turned a skippable condition into a fatal one. This restores the `null` return — narrowly, and only where it's safe:

- **Allowlist, not denylist.** Only failures positively identified as *object-level* are tolerated: SQLSTATE classes `42` (compile error / access-rule violation) and `02` (no data), plus vendor codes `2003` / `2043` ("object does not exist or not authorized" — the same codes this connector's `application.yml` already classifies as config errors) and `2057` (the view-drift error above).
- **Everything outside the allowlist stays fatal, including unknowns.** A denylist can't be complete, and the failure mode of getting it wrong is a *silently truncated catalog*, which is worse than a loud failure. Deliberately kept fatal: driver network failures (SQLSTATE `58030` — note class `58`, not `08`), auth/session-token expiry (reauth codes such as `390114`, usually SQLSTATE `XX000`), no-active-warehouse (`401` / `57P03`), and anything unrecognized.
- **Gated to DISCOVER only**, via the `airbyte.connector.operation` property the CDK already sets. `CHECK` relies on a throwing `fields()` to detect roles that can't `SELECT` anything, and `READ` must fail loudly on a broken selected stream. Both are unchanged.
- **Whole-object failures short-circuit the per-column fallback.** If the object itself doesn't compile or doesn't exist, every per-column probe would fail identically — so they're skipped rather than firing N doomed queries at a wide broken view.
- **Every tolerated failure is logged at WARN**, with the failing query, SQLSTATE, vendor code, and the exception, and states outright that the stream will be skipped and omitted from the catalog. Without that, the only trace is the CDK's separate `INFO`-level *"Ignoring stream … because no fields were discovered"*, which doesn't say why — so a silently missing stream would be hard to diagnose.

## Review guide

1. `SnowflakeSourceMetadataQuerier.kt` — `queryColumnMetadata`: the catch block, where the tolerate-or-rethrow decision is made
2. `SnowflakeSourceMetadataQuerier.kt` — `isTolerableObjectError` / `isWholeObjectFailure` and the two companion-object allowlists: the classification itself
3. `SnowflakeSourceMetadataQuerier.kt` — `Factory`: the `airbyte.connector.operation` gate, and `columnMetadata`: the whole-object short-circuit
4. `SnowflakeSourceMetadataQuerierTest.kt` (new) — drives the real `fields()` → `columnMetadata()` → `queryColumnMetadata` path against a mocked JDBC `Connection`. One test pins each individual allowlist entry, the unknown-is-fatal default, the short-circuit, and the operation gating, so removing any one of them fails a test.

## Note on scope

This covers the discovery-failure half of #72488 only. The schema-filter case-sensitivity question reported in that issue is separable and is left for a follow-up, per the maintainer's note that the two are being tracked as separate issues ([comment](https://github.com/airbytehq/airbyte/issues/72488#issuecomment-5429086598)). That comment is also the sign-off for accepting a community fix to this connector and for the allowlist approach taken here.

## User Impact

Users whose Snowflake account contains a broken or inaccessible view can discover their catalog again instead of the source failing outright. The offending stream is omitted from the catalog and logged as a warning; every other stream discovers normally. No config changes are needed on existing connections.

No change to `CHECK` or `READ` behavior, no spec change, no catalog schema change — patch bump to 1.1.3.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚
- [ ] NO ❌
