### PR TITLE
feat(source-mssql): add declarative expectation flags to the e2e harness

### DIFF
--- a/airbyte-integrations/connectors/source-mssql/.agents/skills/source-mssql-e2e-cdc-tests/SKILL.md
+++ b/airbyte-integrations/connectors/source-mssql/.agents/skills/source-mssql-e2e-cdc-tests/SKILL.md
@@ -72,8 +72,14 @@ CDC-specific.
   version, or `VERSION=dev` after a local
   `./gradlew :airbyte-integrations:connectors:source-mssql:dockerBuildx`
   to test a fix.
-- Assertions are inline in driver scripts: `grep -c '<substring>'` on
-  `stderr.txt`, `jq -e` on `stdout.txt`, exit-non-zero on miss.
+- **Assertions**: prefer `run.sh`'s declarative expectation flags
+  (`--expect-test`, `--expect-match=<channel>:<regex>[:N]`,
+  `--forbid-match`, `--min-records`, `--min-states`) over inline
+  `grep -q` / `jq -e` — the runner enforces them and exits non-zero on
+  any failure. The three existing driver scripts (`repro-12094`,
+  `repro-12162`, `repro-11451`) predate the flags and still use inline
+  assertions; they will migrate opportunistically. New drivers should
+  reach for the flags first.
 - Multi-phase drivers (repro-11451, and any future read → mutate →
   read-with-state repros) capture Airbyte STATE messages between
   reads. The generic skill's `extract-state.py` helper is

--- a/airbyte-integrations/connectors/source-mssql/.agents/skills/source-mssql-e2e-tests/SKILL.md
+++ b/airbyte-integrations/connectors/source-mssql/.agents/skills/source-mssql-e2e-tests/SKILL.md
@@ -133,6 +133,41 @@ extra args to `airbyte-ops`. Per-command timeouts match the workflow's
 (30/30/60/180 minutes) and are overridable with
 `TIMEOUT_MINUTES_{SPEC,CHECK,DISCOVER,READ}`.
 
+### Declarative expectations
+
+Instead of driver scripts hand-rolling `grep -q '<substring>' || exit 1`
+against each command's artifacts, `run.sh` accepts a small set of
+expectation flags that it enforces itself before returning:
+
+| Flag | Effect |
+|---|---|
+| `--expect-test=pass\|fail` | Overall target verdict. `pass` = every executed command's status was `pass`; `fail` = one or more failed. |
+| `--expect-control=pass\|fail` | Same for the control sweep (comparison-mode runs only; requires `--control-version`). |
+| `--min-records=N` | Target read's `stdout.txt` must contain ≥N `RECORD` messages. |
+| `--min-states=N` | Target read's `stdout.txt` must contain ≥N `STATE` messages. |
+| `--expect-match=<channel>:<regex>[:N]` | Target read's `<channel>` (`stdout` \| `stderr` \| `any`) must match `<regex>` at least N times (default 1). Repeatable. |
+| `--forbid-match=<channel>:<regex>` | Same shape but must match zero times. Repeatable. |
+
+All match assertions run against the **target-side** read step's
+artifacts. Under `--control-version + --reset=none` those live at
+`$ARTIFACTS_DIR/read/target/` (created by airbyte-ops's comparison
+mode); under `--reset=fixture|backend` at `$ARTIFACTS_DIR/target/read/`;
+under single-version at `$ARTIFACTS_DIR/read/`. `run.sh` picks the right
+path automatically.
+
+The regex grammar for `--expect-match`/`--forbid-match` strips a
+trailing `:N` only when the last colon-separated field is a positive
+integer, so a regex containing `:` still parses (e.g.
+`--expect-match=stderr:io.debezium.DebeziumException` is channel
+`stderr`, regex `io.debezium.DebeziumException`, count 1).
+
+Any expectation failure exits non-zero regardless of the command-level
+verdicts and appends an `**Expectation failures:**` section to the
+summary. Migrating an existing driver script's `grep -q '<X>' || exit 1`
+block is straightforward — drop the block and add
+`--expect-match=stderr:X` to the `run.sh` (or `run-protocol-cmd.sh`)
+invocation.
+
 ### Multi-phase drivers
 
 `run.sh` runs one sweep. A driver script composes multi-phase flows

--- a/airbyte-integrations/connectors/source-mssql/.agents/skills/source-mssql-e2e-tests/scripts/run.sh
+++ b/airbyte-integrations/connectors/source-mssql/.agents/skills/source-mssql-e2e-tests/scripts/run.sh
@@ -20,6 +20,10 @@
 #          [--skip-read] [--step-name=NAME] [--catalog=PATH]
 #          [--state=PATH] [--sync-mode=full_refresh|incremental]
 #          [--cursor-field=NAME] [--streams=a,b] [--config-template=PATH]
+#          [--expect-test=pass|fail] [--expect-control=pass|fail]
+#          [--min-records=N] [--min-states=N]
+#          [--expect-match=<channel>:<regex>[:N]]…
+#          [--forbid-match=<channel>:<regex>]…
 #          [--build] [--keep-backend] [-- extra airbyte-ops args…]
 #
 #   --state passes a saved state file to the read step as
@@ -27,6 +31,16 @@
 #           `run.sh` writes the read's stdout, the driver extracts a
 #           STATE file with `extract-state.py`, and a second `run.sh`
 #           passes that state back via `--state=…`.
+#
+#   --expect-*, --min-*, --expect-match, --forbid-match declaratively
+#          gate the run's exit code, replacing the `grep -q '…' || exit 1`
+#          boilerplate driver scripts currently hand-roll. All
+#          assertions apply to the target-side read step's artifacts;
+#          --expect-control gates the control sweep's overall verdict
+#          under --control-version (only useful in comparison modes).
+#          Channels: stdout | stderr | any. Match-count defaults to 1.
+#          Any expectation failure exits non-zero regardless of the
+#          command-level verdicts.
 #
 #   --command   all (default) runs the sweep; a single command
 #               (spec|check|discover|read) runs just that one.
@@ -95,6 +109,18 @@ BUILD=false
 KEEP_BACKEND=false
 EXTRA_ARGS=()
 
+# Runner-enforced expectations. Empty / -1 means "no assertion." Arrays
+# hold raw `<channel>:<regex>[:N]` specs, parsed lazily at check time
+# so a bad regex fails there with the argument that caused it rather
+# than at argparse.
+EXPECT_TEST=""
+EXPECT_CONTROL=""
+MIN_RECORDS=-1
+MIN_STATES=-1
+EXPECT_MATCHES=()
+FORBID_MATCHES=()
+EXPECTATION_FAILURES=()
+
 # Same budgets as the workflow's per-step timeout-minutes.
 declare -A TIMEOUT_MINUTES=(
   [spec]="${TIMEOUT_MINUTES_SPEC:-30}"
@@ -118,10 +144,16 @@ while [[ $# -gt 0 ]]; do
     --cursor-field=*)    CURSOR_FIELD="${1#*=}" ;;
     --streams=*)         STREAMS="${1#*=}" ;;
     --config-template=*) CONFIG_TEMPLATE="${1#*=}" ;;
+    --expect-test=*)     EXPECT_TEST="${1#*=}" ;;
+    --expect-control=*)  EXPECT_CONTROL="${1#*=}" ;;
+    --min-records=*)     MIN_RECORDS="${1#*=}" ;;
+    --min-states=*)      MIN_STATES="${1#*=}" ;;
+    --expect-match=*)    EXPECT_MATCHES+=("${1#*=}") ;;
+    --forbid-match=*)    FORBID_MATCHES+=("${1#*=}") ;;
     --build)             BUILD=true ;;
     --keep-backend)      KEEP_BACKEND=true ;;
     --)                  shift; EXTRA_ARGS=("$@"); break ;;
-    -h|--help)           sed -n '2,72p' "${BASH_SOURCE[0]}"; exit 0 ;;
+    -h|--help)           sed -n '2,86p' "${BASH_SOURCE[0]}"; exit 0 ;;
     *) echo "[run] unknown argument: $1" >&2; exit 2 ;;
   esac
   shift
@@ -131,6 +163,23 @@ case "$RESET" in
   none|fixture|backend) ;;
   *) echo "[run] --reset must be none|fixture|backend (got '$RESET')" >&2; exit 2 ;;
 esac
+
+for v in "$EXPECT_TEST" "$EXPECT_CONTROL"; do
+  case "$v" in
+    ""|pass|fail) ;;
+    *) echo "[run] --expect-test / --expect-control must be pass|fail (got '$v')" >&2; exit 2 ;;
+  esac
+done
+if [[ -n "$EXPECT_CONTROL" && -z "$CONTROL_VERSION_ARG" ]]; then
+  echo "[run] --expect-control requires --control-version" >&2
+  exit 2
+fi
+for n in "$MIN_RECORDS" "$MIN_STATES"; do
+  [[ "$n" == -1 || "$n" =~ ^[0-9]+$ ]] || {
+    echo "[run] --min-records / --min-states must be a non-negative integer (got '$n')" >&2
+    exit 2
+  }
+done
 
 COMMANDS=()
 case "$COMMAND" in
@@ -356,12 +405,147 @@ else
   sweep
 fi
 
+# The read step's artifact directory on the target side. Under
+# --reset=fixture|backend the split is at $ARTIFACTS_DIR/{control,target}/;
+# under airbyte-ops's comparison mode it's at $ARTIFACTS_DIR/read/{control,target}/;
+# under single-version there's no split.
+target_read_dir() {
+  if [[ "$PER_IMAGE_SWEEPS" == true ]]; then
+    echo "$ARTIFACTS_DIR/target/read"
+  elif [[ -d "$ARTIFACTS_DIR/read/target" ]]; then
+    echo "$ARTIFACTS_DIR/read/target"
+  else
+    echo "$ARTIFACTS_DIR/read"
+  fi
+}
+
+# Split a `<channel>:<regex>[:N]` spec into three lines: channel, regex,
+# count. Count defaults to 1 unless the last colon-separated field
+# parses as a positive integer, in which case it is stripped off. This
+# lets a regex contain colons — only a trailing `:N` is claimed.
+parse_match_spec() {
+  local spec="$1"
+  local first_colon="${spec%%:*}"
+  case "$first_colon" in
+    stdout|stderr|any) ;;
+    *)
+      echo "[run] --expect-match / --forbid-match channel must be stdout|stderr|any (got '$first_colon' in '$spec')" >&2
+      return 2
+      ;;
+  esac
+  local rest="${spec#*:}"
+  local regex="$rest" count=1
+  if [[ "$rest" =~ ^(.+):([1-9][0-9]*)$ ]]; then
+    regex="${BASH_REMATCH[1]}"
+    count="${BASH_REMATCH[2]}"
+  fi
+  printf '%s\n%s\n%d\n' "$first_colon" "$regex" "$count"
+}
+
+# Count occurrences of a regex against the target read's stdout/stderr.
+# grep -c returns 1 (with count 0) when nothing matches, which set -e
+# would abort on — hence the `|| true`.
+count_matches_in_channel() {
+  local channel="$1" regex="$2" read_dir="$3" total=0 count
+  local -a files=()
+  case "$channel" in
+    stdout) files=("$read_dir/stdout.txt") ;;
+    stderr) files=("$read_dir/stderr.txt") ;;
+    any)    files=("$read_dir/stdout.txt" "$read_dir/stderr.txt") ;;
+  esac
+  for f in "${files[@]}"; do
+    [[ -f "$f" ]] || continue
+    count="$(grep -cE -- "$regex" "$f" 2>/dev/null || true)"
+    total=$((total + count))
+  done
+  echo "$total"
+}
+
+# Overall verdict for one side: pass iff every executed command's
+# STATUS is `pass`. A missing STATUS entry counts as pass because that
+# command was not requested (e.g. --command=read never touched spec).
+side_all_passed() {
+  local prefix="$1" cmd status
+  for cmd in spec check discover read; do
+    status="${STATUS[${prefix:+${prefix}.}$cmd]:-pass}"
+    [[ "$status" == pass ]] || { echo false; return; }
+  done
+  echo true
+}
+
+apply_expectations() {
+  local read_dir target_pass control_pass
+  read_dir="$(target_read_dir)"
+
+  if [[ -n "$EXPECT_TEST" ]]; then
+    if [[ "$PER_IMAGE_SWEEPS" == true ]]; then
+      target_pass="$(side_all_passed target)"
+    else
+      target_pass="$(side_all_passed '')"
+    fi
+    local want=true
+    [[ "$EXPECT_TEST" == fail ]] && want=false
+    if [[ "$target_pass" != "$want" ]]; then
+      EXPECTATION_FAILURES+=("--expect-test=$EXPECT_TEST (target actually ${target_pass})")
+    fi
+  fi
+
+  if [[ -n "$EXPECT_CONTROL" ]]; then
+    control_pass="$(side_all_passed control)"
+    local want=true
+    [[ "$EXPECT_CONTROL" == fail ]] && want=false
+    if [[ "$control_pass" != "$want" ]]; then
+      EXPECTATION_FAILURES+=("--expect-control=$EXPECT_CONTROL (control actually ${control_pass})")
+    fi
+  fi
+
+  if (( MIN_RECORDS >= 0 )); then
+    local records=0
+    if [[ -f "$read_dir/stdout.txt" ]]; then
+      records="$(grep -cE '"type":\s*"RECORD"' "$read_dir/stdout.txt" 2>/dev/null || true)"
+    fi
+    if (( records < MIN_RECORDS )); then
+      EXPECTATION_FAILURES+=("--min-records=$MIN_RECORDS (got $records)")
+    fi
+  fi
+  if (( MIN_STATES >= 0 )); then
+    local states=0
+    if [[ -f "$read_dir/stdout.txt" ]]; then
+      states="$(grep -cE '"type":\s*"STATE"' "$read_dir/stdout.txt" 2>/dev/null || true)"
+    fi
+    if (( states < MIN_STATES )); then
+      EXPECTATION_FAILURES+=("--min-states=$MIN_STATES (got $states)")
+    fi
+  fi
+
+  local spec channel regex count actual parsed
+  for spec in ${EXPECT_MATCHES[@]+"${EXPECT_MATCHES[@]}"}; do
+    parsed="$(parse_match_spec "$spec")" || exit $?
+    { read -r channel; read -r regex; read -r count; } <<<"$parsed"
+    actual="$(count_matches_in_channel "$channel" "$regex" "$read_dir")"
+    if (( actual < count )); then
+      EXPECTATION_FAILURES+=("--expect-match=$spec (got $actual of $count required)")
+    fi
+  done
+  for spec in ${FORBID_MATCHES[@]+"${FORBID_MATCHES[@]}"}; do
+    parsed="$(parse_match_spec "$spec")" || exit $?
+    { read -r channel; read -r regex; read -r _count; } <<<"$parsed"
+    actual="$(count_matches_in_channel "$channel" "$regex" "$read_dir")"
+    if (( actual > 0 )); then
+      EXPECTATION_FAILURES+=("--forbid-match=$spec (matched $actual times)")
+    fi
+  done
+}
+
+apply_expectations
+
 # "Determine Final Status" plus "Write Summary Table": one line per
 # command, every non-pass rendered as a failure, and the infrastructure
 # failures called out separately so a broken run is never read as a
 # regression.
 INTERNAL_FAILURE=false
 ALL_PASSED=true
+(( ${#EXPECTATION_FAILURES[@]} > 0 )) && ALL_PASSED=false
 
 # Pure: emit the table cell for one command. Called under `$(...)` so
 # any variable assignment here would evaporate — see `update_flags`.
@@ -409,6 +593,16 @@ else
   done
 fi
 
+if (( ${#EXPECTATION_FAILURES[@]} > 0 )); then
+  SUMMARY+="
+
+**Expectation failures:**"
+  for fail in "${EXPECTATION_FAILURES[@]}"; do
+    SUMMARY+="
+- $fail"
+  done
+fi
+
 if [[ "$PER_IMAGE_SWEEPS" == true ]]; then
   SUMMARY+="
 
@@ -429,6 +623,14 @@ fi
 
 if [[ "$INTERNAL_FAILURE" == true ]]; then
   echo "[run] infrastructure failure — the verdict above is not a test result" >&2
+fi
+
+# Expectation failures are exit-1 regardless of the command-level
+# verdicts, otherwise a `--expect-test=fail --expect-match=…` case
+# whose target correctly exited non-zero would leak that non-zero
+# exit as our own — hiding whether the expectations actually matched.
+if (( ${#EXPECTATION_FAILURES[@]} > 0 )); then
+  exit 1
 fi
 
 # A single-command run keeps returning the connector's own exit code, so


### PR DESCRIPTION
## What

W1.2 of the prove-fix redesign plan ([`prove_fix_mssql_redesign_plan.md`](https://github.com/airbytehq/ai-skills/blob/devin/1784244837-db-prove-fix-playbook/devin/playbooks/prove_fix_mssql_redesign_plan.md)). Adds six runner-enforced flags so driver scripts stop hand-rolling `grep -q '<X>' "\$ERR" || exit 1` against each command's artifacts.

**Stacked on #85004** (which is stacked on #85002). Base is `sc/mssql-e2e-state-primitive`. Merge #85002 → #85004 → this PR in order.

## Why this is the load-bearing next step

The three existing CDC drivers (`repro-12162`, `repro-12094`, `repro-11451`) each hand-roll their pass/fail logic:

```bash
# repro-12162.sh — the actual bytes today
if [[ "$RC" -eq 0 ]]; then
  echo "FAIL: expected non-zero exit on $VERSION..." >&2
  exit 1
fi
if ! grep -q "io.debezium.DebeziumException" "$ERR"; then
  echo "FAIL: expected 'io.debezium.DebeziumException' in $ERR." >&2
  exit 1
fi
if ! grep -q "message.key.columns" "$ERR"; then
  echo "FAIL: expected 'message.key.columns' in $ERR." >&2
  exit 1
fi
```

Every new driver copy-pastes this shape and hand-rolls variants. With W1.2 the same driver becomes:

```bash
"$GENERIC/scripts/run-protocol-cmd.sh" read repro-12162 "$VERSION" \
  --config-path=... --catalog-path=... \
  --expect-test=fail \
  --expect-match=stderr:io.debezium.DebeziumException \
  --expect-match=stderr:message.key.columns
```

No conditionals, no exit codes to marshal, no failure-message strings to keep in sync with the assertions. `run.sh`'s expectation gate collapses ~15 lines per driver to three CLI flags.

## Flag surface

| Flag | Effect |
|---|---|
| `--expect-test=pass\|fail` | Target's overall verdict (every executed command's status). |
| `--expect-control=pass\|fail` | Control's overall verdict (comparison only; requires `--control-version`). |
| `--min-records=N` | Target read's `stdout.txt` must contain ≥N `RECORD` messages. |
| `--min-states=N` | Same for `STATE`. |
| `--expect-match=<channel>:<regex>[:N]` | Target read's `<channel>` (`stdout`/`stderr`/`any`) matches `<regex>` at least N times (default 1). Repeatable. |
| `--forbid-match=<channel>:<regex>` | Same shape but must match zero times. Repeatable. |

**Match-spec grammar handles regexes with colons.** A trailing `:N` is only stripped if the last colon-separated field parses as a positive integer, so `--expect-match=stderr:io.debezium.DebeziumException` is channel=`stderr`, regex=`io.debezium.DebeziumException`, count=1.

**Target-side, read-step artifacts.** All match assertions target the read step's stdout/stderr on the target side, with `run.sh` picking the right path automatically:
- Single-version: `\$ARTIFACTS_DIR/read/`
- Comparison + `--reset=none` (airbyte-ops built-in comparator): `\$ARTIFACTS_DIR/read/target/`
- Comparison + `--reset=fixture|backend` (per-image sweeps from #85002): `\$ARTIFACTS_DIR/target/read/`

**Exit behavior.** Any expectation failure exits 1 regardless of command-level verdicts. Under `--expect-test=fail`, this is the intended behavior — the target's non-zero exit is what the driver asserts *positively*, and the expectation gate is the thing that makes that positive assertion visible upstream.

## What is not in scope

- **Migration of the existing repro-11451 / repro-12094 / repro-12162 drivers.** They still work under their inline assertions; migration is opportunistic and belongs in a follow-up so each driver's migration can be reviewed against its own bug's signature. (repro-12162's migration is sketched in the "Why" section above as an example.)
- **Control-side match assertions.** For the current CDC-comparison shape (both sides run the same expectation shape) target-side matching is enough. If a case needs "control matches X, target matches Y" (fix-flips-verdict repros), the answer is a driver, not more flags — that's what the playbook's driver-exception rule covers.
- **Per-command match assertions** (`--expect-match=discover:stderr:X`). All existing repros match against read; if a bug's signature is on check or discover, the driver reaches for that command's artifacts directly. Adding another axis to the grammar is deferred until a case demands it.

## Review guide

1. **New flags in argparse + validation.** `--expect-*`, `--min-*`, `--expect-match`, `--forbid-match`. Validation rejects bogus modes / channels / non-integer counts.
2. **`apply_expectations()`** — where the checks run and how failures surface. Reads target-side artifacts, tracks `EXPECTATION_FAILURES`, appends to summary.
3. **`parse_match_spec()`** — the trailing-`:N` handling. Tested inline in this session against `stderr:foo`, `stderr:foo:3`, `stderr:foo:bar`, `stderr:io.debezium.Debezium:5`, and `stdout:AB.*CD:12`; all parse correctly.
4. **`target_read_dir()`** — the three artifact layouts.
5. **Exit logic** — expectation failures exit 1 before the single-command-exit-code path, so a `--expect-test=fail` case with a non-zero connector exit still returns 0 when expectations pass, and 1 when they don't.
6. **Docs** — the "Declarative expectations" table in the generic SKILL.md is the reference. CDC SKILL.md's "Conventions" now points new drivers at the flags first.

## Test plan

- `run.sh --help` renders the new flag documentation. ✅
- `--expect-test=bogus` / `--expect-control=pass` (no `--control-version`) / `--min-records=abc` / `--expect-match=bogus:x` each reject with clear errors. ✅
- `parse_match_spec` handles regexes with colons and trailing count fields correctly. ✅
- End-to-end validation deferred to the follow-up driver-migration PR — running `run.sh --expect-*` against a real backend needs a full sweep and is intentionally out of scope here.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚 — no runtime code changed. `.agents/` + docs only.

---

> [!IMPORTANT]
> **Autopilot Progressive Rollout Enabled**
>
> [Autopilot progressive rollouts](https://github.com/airbytehq/airbyte-ops-mcp/blob/main/docs/autopilot-rollouts.md) are enabled for one or more connector(s) modified in this PR. Check the box below if you need to bypass normal rollout safety processes and release to all users immediately upon merge:
>
> - [ ] ⚡ **Release immediately** (bypasses automatic progressive rollout)
>
> **Note:**
>
> - ⚠️ The above bypass option is for emergency/hotfix use only.
> - 🔗 You can monitor or manually advance a rollout at **[ops.internal.airbyte.ai](https://ops.internal.airbyte.ai)**.