### PR TITLE
fix: add multiline support, required for private key field

### DIFF
--- a/airbyte-integrations/connectors/source-okta/metadata.yaml
+++ b/airbyte-integrations/connectors/source-okta/metadata.yaml
@@ -19,7 +19,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 1d4fdb25-64fc-4569-92da-fcdca79a8372
-  dockerImageTag: 0.3.21
+  dockerImageTag: 0.3.22
   dockerRepository: airbyte/source-okta
   githubIssueLabel: source-okta
   icon: icon.svg

--- a/airbyte-integrations/connectors/source-okta/pyproject.toml
+++ b/airbyte-integrations/connectors/source-okta/pyproject.toml
@@ -3,7 +3,7 @@ requires = [ "poetry-core>=1.0.0",]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
-version = "0.3.21"
+version = "0.3.22"
 name = "source-okta"
 description = "Source implementation for okta."
 authors = [ "Airbyte <contact@airbyte.io>",]

--- a/airbyte-integrations/connectors/source-okta/source_okta/manifest.yaml
+++ b/airbyte-integrations/connectors/source-okta/source_okta/manifest.yaml
@@ -1884,6 +1884,7 @@ spec:
                 title: Private key
                 description: The private key in PEM format
                 airbyte_secret: true
+                multiline: true
                 order: 3
               scope:
                 type: string

--- a/airbyte-integrations/connectors/source-okta/source_okta/spec.yaml
+++ b/airbyte-integrations/connectors/source-okta/source_okta/spec.yaml
@@ -65,6 +65,7 @@ connectionSpecification:
               title: Private key
               description: The private key in PEM format
               airbyte_secret: true
+              multiline: true
               order: 3
             scope:
               type: string

--- a/docs/integrations/sources/okta.md
+++ b/docs/integrations/sources/okta.md
@@ -41,8 +41,8 @@ Okta is the complete identity solution for all your apps and people that’s uni
 7. Choose the method of authentication
 8. If you select Token authentication - fill the field **Personal Api Token**
 9. If you select OAuth2.0 authorization - fill the fields **Client ID**, **Client Secret**, **Refresh Token**
-9. If you select OAuth2.0 with private key authorization - fill the fields **Client ID**, **Key ID**, **Private Key**, **Scope**
-10. Click `Set up source`.
+10. If you select OAuth2.0 with private key authorization, create an Okta API Service app. Register the public JWK that corresponds to your PEM private key and grant the app every scope the connector will request. Fill in **Client ID** with the service app's client ID, **Key ID** with the registered JWK's `kid`, **Private Key** with the corresponding PEM private key, and **Scope** with the granted scopes separated by spaces.
+11. Click `Set up source`.
 
 ### For Airbyte Open Source:
 
@@ -91,7 +91,7 @@ If you use Airbyte Cloud and your organization restricts access to specific IPs,
 
 | Version | Date       | Pull Request                                             | Subject                                                                        |
 |:--------|:-----------|:---------------------------------------------------------|:-------------------------------------------------------------------------------|
-| 0.3.22 | 2026-08-26 | [54167](https://github.com/airbytehq/airbyte/pull/85086) | Support multiline input for private key |
+| 0.3.22 | 2026-08-26 | [85086](https://github.com/airbytehq/airbyte/pull/85086) | Support multiline input for private key |
 | 0.3.21 | 2025-02-24 | [54167](https://github.com/airbytehq/airbyte/pull/54167) | Remove stream_state interpolation |
 | 0.3.20 | 2025-02-01 | [52728](https://github.com/airbytehq/airbyte/pull/52728) | Update dependencies |
 | 0.3.19 | 2025-01-25 | [52469](https://github.com/airbytehq/airbyte/pull/52469) | Update dependencies |

--- a/docs/integrations/sources/okta.md
+++ b/docs/integrations/sources/okta.md
@@ -41,6 +41,7 @@ Okta is the complete identity solution for all your apps and people that’s uni
 7. Choose the method of authentication
 8. If you select Token authentication - fill the field **Personal Api Token**
 9. If you select OAuth2.0 authorization - fill the fields **Client ID**, **Client Secret**, **Refresh Token**
+9. If you select OAuth2.0 with private key authorization - fill the fields **Client ID**, **Key ID**, **Private Key**, **Scope**
 10. Click `Set up source`.
 
 ### For Airbyte Open Source:
@@ -90,6 +91,7 @@ If you use Airbyte Cloud and your organization restricts access to specific IPs,
 
 | Version | Date       | Pull Request                                             | Subject                                                                        |
 |:--------|:-----------|:---------------------------------------------------------|:-------------------------------------------------------------------------------|
+| 0.3.22 | 2026-08-26 | [54167](https://github.com/airbytehq/airbyte/pull/85086) | Support multiline input for private key |
 | 0.3.21 | 2025-02-24 | [54167](https://github.com/airbytehq/airbyte/pull/54167) | Remove stream_state interpolation |
 | 0.3.20 | 2025-02-01 | [52728](https://github.com/airbytehq/airbyte/pull/52728) | Update dependencies |
 | 0.3.19 | 2025-01-25 | [52469](https://github.com/airbytehq/airbyte/pull/52469) | Update dependencies |


### PR DESCRIPTION
## What
Fix inability to pass a PEM key to this connector in the required multiline format. The current UI translates any newline chars to a space, resulting in an invalid key. \n chars are not accepted either.

```2026-08-26 12:06:17 info 
2026-08-26 12:06:17 info ----- START CHECK -----
2026-08-26 12:06:17 info 
2026-08-26 12:06:18 info Connector exited, processing output
2026-08-26 12:06:18 info Output file jobOutput.json found
2026-08-26 12:06:18 info Connector exited with exit code 0
2026-08-26 12:06:18 info Reading messages from protocol version 0.2.0
2026-08-26 12:06:18 error Encountered an error trying to connect to stream users. Error: 
 Traceback (most recent call last):
  File "/usr/local/lib/python3.10/site-packages/jwt/algorithms.py", line 343, in prepare_key
    RSAPrivateKey, load_pem_private_key(key_bytes, password=None)
  File "/usr/local/lib/python3.10/site-packages/cryptography/hazmat/backends/openssl/backend.py", line 494, in _handle_key_loading_error
    raise ValueError(
ValueError: ('Could not deserialize key data. The data may be in an incorrect format, it may be encrypted with an unsupported algorithm, or it may be an unsupported key type (e.g. EC curves with explicit parameters).', [<OpenSSLError(code=503841036, lib=60, reason=524556, reason_text=unsupported)>])
During handling of the above exception, another exception occurred:
Traceback (most recent call last):
  File "/usr/local/lib/python3.10/site-packages/jwt/algorithms.py", line 347, in prepare_key
    return cast(RSAPublicKey, load_pem_public_key(key_bytes))
ValueError: Unable to load PEM file. See https://cryptography.io/en/latest/faq/#why-can-t-i-import-my-pem-file for more details. MalformedFraming
During handling of the above exception, another exception occurred:
Traceback (most recent call last):
  File "/usr/local/lib/python3.10/site-packages/airbyte_cdk/sources/declarative/checks/check_stream.py", line 42, in check_connection
    stream_is_available, reason = availability_strategy.check_availability(stream, logger, source)
  File "/usr/local/lib/python3.10/site-packages/airbyte_cdk/sources/streams/http/availability_strategy.py", line 50, in check_availability
    get_first_record_for_slice(stream, stream_slice)
  File "/usr/local/lib/python3.10/site-packages/airbyte_cdk/sources/streams/utils/stream_helper.py", line 40, in get_first_record_for_slice
    return next(records_for_slice)
  File "/usr/local/lib/python3.10/site-packages/airbyte_cdk/sources/declarative/declarative_stream.py", line 126, in read_records
    yield from self.retriever.read_records(self.get_json_schema(), stream_slice)
  File "/usr/local/lib/python3.10/site-packages/airbyte_cdk/sources/declarative/retrievers/simple_retriever.py", line 327, in read_records
    for stream_data in self._read_pages(record_generator, self.state, _slice):
  File "/usr/local/lib/python3.10/site-packages/airbyte_cdk/sources/declarative/retrievers/simple_retriever.py", line 291, in _read_pages
    response = self._fetch_next_page(stream_state, stream_slice, next_page_token)
  File "/usr/local/lib/python3.10/site-packages/airbyte_cdk/sources/declarative/retrievers/simple_retriever.py", line 266, in _fetch_next_page
    return self.requester.send_request(
  File "/usr/local/lib/python3.10/site-packages/airbyte_cdk/sources/declarative/requesters/http_requester.py", line 454, in send_request
    headers=self._request_headers(stream_state, stream_slice, next_page_token, request_headers),
  File "/usr/local/lib/python3.10/site-packages/airbyte_cdk/sources/declarative/requesters/http_requester.py", line 308, in _request_headers
    headers = self._get_request_options(
  File "/usr/local/lib/python3.10/site-packages/airbyte_cdk/sources/declarative/requesters/http_requester.py", line 292, in _get_request_options
    auth_options_method(),
  File "/usr/local/lib/python3.10/site-packages/airbyte_cdk/sources/streams/http/requests_native_auth/abstract_token.py", line 22, in get_auth_header
    return {self.auth_header: self.token}
  File "/airbyte/integration_code/source_okta/components.py", line 100, in token
    client_assertion = jwt.encode(jwt_payload, private_key, algorithm="RS256", headers=jwt_headers)
  File "/usr/local/lib/python3.10/site-packages/jwt/api_jwt.py", line 74, in encode
    return api_jws.encode(
  File "/usr/local/lib/python3.10/site-packages/jwt/api_jws.py", line 161, in encode
    key = alg_obj.prepare_key(key)
  File "/usr/local/lib/python3.10/site-packages/jwt/algorithms.py", line 349, in prepare_key
    raise InvalidKeyError("Could not parse the provided public key.")
jwt.exceptions.InvalidKeyError: Could not parse the provided public key.
2026-08-26 12:06:18 error Check failed
2026-08-26 12:06:18 info Checking for optional control message...
2026-08-26 12:06:18 info Optional control message not found. Skipping...
2026-08-26 12:06:18 info Writing output of 1d4fdb25-64fc-4569-92da-fcdca79a8372_e3d78d25-8d91-4144-8cf9-ecbd3992da80_0_check to the doc store
2026-08-26 12:06:19 info Marking workload 1d4fdb25-64fc-4569-92da-fcdca79a8372_e3d78d25-8d91-4144-8cf9-ecbd3992da80_0_check as successful
2026-08-26 12:06:19 info Deliberately exiting process with code 0.
2026-08-26 12:06:19 info 
2026-08-26 12:06:19 info ----- END CHECK -----
2026-08-26 12:06:19 info 
```

## How
Add multiline support to this private key input.

## Review guide
<!--
1. `x.py`
2. `y.py`
-->

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [X] YES 💚
- [ ] NO ❌
