### PR TITLE
fix(source-todoist): migrate from retired REST v2 to API v1

### DIFF
--- a/airbyte-integrations/connectors/source-todoist/manifest.yaml
+++ b/airbyte-integrations/connectors/source-todoist/manifest.yaml
@@ -23,7 +23,18 @@ definitions:
           type: RecordSelector
           extractor:
             type: DpathExtractor
-            field_path: []
+            field_path:
+              - results
+        paginator:
+          type: DefaultPaginator
+          page_token_option:
+            type: RequestOption
+            inject_into: request_parameter
+            field_name: cursor
+          pagination_strategy:
+            type: CursorPagination
+            cursor_value: '{{ response.get("next_cursor") or "" }}'
+            stop_condition: '{{ not response.get("next_cursor") }}'
       schema_loader:
         type: InlineSchemaLoader
         schema:
@@ -41,14 +52,25 @@ definitions:
           type: RecordSelector
           extractor:
             type: DpathExtractor
-            field_path: []
+            field_path:
+              - results
+        paginator:
+          type: DefaultPaginator
+          page_token_option:
+            type: RequestOption
+            inject_into: request_parameter
+            field_name: cursor
+          pagination_strategy:
+            type: CursorPagination
+            cursor_value: '{{ response.get("next_cursor") or "" }}'
+            stop_condition: '{{ not response.get("next_cursor") }}'
       schema_loader:
         type: InlineSchemaLoader
         schema:
           $ref: "#/schemas/projects"
   base_requester:
     type: HttpRequester
-    url_base: https://api.todoist.com/rest/v2
+    url_base: https://api.todoist.com/api/v1
     authenticator:
       type: BearerAuthenticator
       api_token: '{{ config["token"] }}'

--- a/airbyte-integrations/connectors/source-todoist/metadata.yaml
+++ b/airbyte-integrations/connectors/source-todoist/metadata.yaml
@@ -1,7 +1,7 @@
 data:
   allowedHosts:
     hosts:
-      - api.todoist.com/rest/v2
+      - api.todoist.com
   remoteRegistries:
     pypi:
       enabled: false
@@ -19,7 +19,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 1a3d38e4-dc6b-4154-b56b-582f9e978ecd
-  dockerImageTag: 0.3.43
+  dockerImageTag: 0.3.44
   dockerRepository: airbyte/source-todoist
   githubIssueLabel: source-todoist
   icon: todoist.svg
@@ -46,9 +46,9 @@ data:
             alias: airbyte-connector-testing-secret-store
   externalDocumentationUrls:
     - title: Todoist REST API
-      url: https://developer.todoist.com/rest/v2/
+      url: https://developer.todoist.com/api/v1/
       type: api_reference
     - title: Todoist authentication
-      url: https://developer.todoist.com/rest/v2/#authorization
+      url: https://developer.todoist.com/api/v1/#authorization
       type: authentication_guide
 metadataSpecVersion: "1.0"

--- a/docs/integrations/sources/pinterest.md
+++ b/docs/integrations/sources/pinterest.md
@@ -210,7 +210,7 @@ properties:
     DELETED_DRAFT. When more than six values are selected, the connector automatically splits them
     across multiple Pinterest report requests.
 12. **Ad Statuses (Optional)**: Filters custom report results by ad status. Select values from:
-    APPROVED, PAUSED, 85102, REJECTED, ADVERTISER_DISABLED, ARCHIVED, DRAFT, and DELETED_DRAFT.
+    APPROVED, PAUSED, PENDING, REJECTED, ADVERTISER_DISABLED, ARCHIVED, DRAFT, and DELETED_DRAFT.
     When more than six values are selected, the connector automatically splits them across multiple
     Pinterest report requests. This filter is not supported for Product Item level reports.
 13. **Start Date (Optional)**: The start date for the report in YYYY-MM-DD format, defaulting to the

--- a/docs/integrations/sources/pinterest.md
+++ b/docs/integrations/sources/pinterest.md
@@ -210,7 +210,7 @@ properties:
     DELETED_DRAFT. When more than six values are selected, the connector automatically splits them
     across multiple Pinterest report requests.
 12. **Ad Statuses (Optional)**: Filters custom report results by ad status. Select values from:
-    APPROVED, PAUSED, PENDING, REJECTED, ADVERTISER_DISABLED, ARCHIVED, DRAFT, and DELETED_DRAFT.
+    APPROVED, PAUSED, 85102, REJECTED, ADVERTISER_DISABLED, ARCHIVED, DRAFT, and DELETED_DRAFT.
     When more than six values are selected, the connector automatically splits them across multiple
     Pinterest report requests. This filter is not supported for Product Item level reports.
 13. **Start Date (Optional)**: The start date for the report in YYYY-MM-DD format, defaulting to the

--- a/docs/integrations/sources/todoist.md
+++ b/docs/integrations/sources/todoist.md
@@ -36,8 +36,8 @@ You can find your personal token in the [integrations settings view](https://tod
 
 List of available streams:
 
-- [Tasks](https://developer.todoist.com/rest/v2/#tasks)
-- [Projects](https://developer.todoist.com/rest/v2/#projects)
+- [Tasks](https://developer.todoist.com/api/v1/#tag/Tasks)
+- [Projects](https://developer.todoist.com/api/v1/#tag/Projects)
 
 ## IP allow list
 
@@ -50,6 +50,7 @@ If you use Airbyte Cloud and your organization restricts access to specific IPs,
 
 | Version | Date       | Pull Request                                             | Subject                                                    |
 | :------ | :--------- | :------------------------------------------------------- | :--------------------------------------------------------- |
+| 0.3.44 | 2026-08-28 | [PENDING](https://github.com/airbytehq/airbyte/pull/PENDING) | Migrate from retired REST v2 (`/rest/v2`, 410 Gone) to API v1 (`/api/v1`) with `results` extraction and cursor pagination |
 | 0.3.43 | 2026-02-03 | [72753](https://github.com/airbytehq/airbyte/pull/72753) | Update dependencies |
 | 0.3.42 | 2026-01-20 | [72017](https://github.com/airbytehq/airbyte/pull/72017) | Update dependencies |
 | 0.3.41 | 2026-01-14 | [71417](https://github.com/airbytehq/airbyte/pull/71417) | Update dependencies |

--- a/docs/integrations/sources/todoist.md
+++ b/docs/integrations/sources/todoist.md
@@ -50,7 +50,7 @@ If you use Airbyte Cloud and your organization restricts access to specific IPs,
 
 | Version | Date       | Pull Request                                             | Subject                                                    |
 | :------ | :--------- | :------------------------------------------------------- | :--------------------------------------------------------- |
-| 0.3.44 | 2026-08-28 | [PENDING](https://github.com/airbytehq/airbyte/pull/PENDING) | Migrate from retired REST v2 (`/rest/v2`, 410 Gone) to API v1 (`/api/v1`) with `results` extraction and cursor pagination |
+| 0.3.44 | 2026-08-28 | [85102](https://github.com/airbytehq/airbyte/pull/85102) | Migrate from retired REST v2 (`/rest/v2`, 410 Gone) to API v1 (`/api/v1`) with `results` extraction and cursor pagination |
 | 0.3.43 | 2026-02-03 | [72753](https://github.com/airbytehq/airbyte/pull/72753) | Update dependencies |
 | 0.3.42 | 2026-01-20 | [72017](https://github.com/airbytehq/airbyte/pull/72017) | Update dependencies |
 | 0.3.41 | 2026-01-14 | [71417](https://github.com/airbytehq/airbyte/pull/71417) | Update dependencies |


### PR DESCRIPTION
Fixes #86899

## What
Todoist shut down REST API v2 on 2026-02-10. The connector still calls `https://api.todoist.com/rest/v2`, which returns **410 Gone**, so check/sync fail for every user.

This migrates to [API v1](https://developer.todoist.com/api/v1/):

- `url_base` → `https://api.todoist.com/api/v1`
- Extract `results` (v1 wraps lists as `{results, next_cursor}` instead of a bare array)
- Cursor pagination on `next_cursor`

Vendor notice: [Final Shutdown of Sync API v9 and REST API v2](https://groups.google.com/a/doist.com/g/todoist-api/c/brwENjfT_tk)

## How
Manifest-only YAML. No spec change; existing API tokens still work.

## 🚨 User Impact 🚨
Bugfix. Connections that 410 today should start succeeding. v1 may omit `url` on tasks; schema already allows additional/null properties.