### PR TITLE
fix(source-paystack): end incremental to at now so same-day rows sync

### DIFF
--- a/airbyte-integrations/connectors/source-paystack/manifest.yaml
+++ b/airbyte-integrations/connectors/source-paystack/manifest.yaml
@@ -70,8 +70,8 @@ definitions:
           field_name: to
         end_datetime:
           type: MinMaxDatetime
-          datetime: "{{ today_utc() }}"
-          datetime_format: "%Y-%m-%d"
+          datetime: "{{ now_utc().strftime('%Y-%m-%dT%H:%M:%S.%fZ') }}"
+          datetime_format: "%Y-%m-%dT%H:%M:%S.%fZ"
         step: P1M
         cursor_granularity: PT0.000001S
       schema_loader:
@@ -323,8 +323,8 @@ definitions:
           field_name: to
         end_datetime:
           type: MinMaxDatetime
-          datetime: "{{ today_utc() }}"
-          datetime_format: "%Y-%m-%d"
+          datetime: "{{ now_utc().strftime('%Y-%m-%dT%H:%M:%S.%fZ') }}"
+          datetime_format: "%Y-%m-%dT%H:%M:%S.%fZ"
         step: P1M
         cursor_granularity: PT0.000001S
       schema_loader:
@@ -441,8 +441,8 @@ definitions:
           field_name: to
         end_datetime:
           type: MinMaxDatetime
-          datetime: "{{ today_utc() }}"
-          datetime_format: "%Y-%m-%d"
+          datetime: "{{ now_utc().strftime('%Y-%m-%dT%H:%M:%S.%fZ') }}"
+          datetime_format: "%Y-%m-%dT%H:%M:%S.%fZ"
         step: P1M
         cursor_granularity: PT0.000001S
       schema_loader:
@@ -640,8 +640,8 @@ definitions:
           field_name: to
         end_datetime:
           type: MinMaxDatetime
-          datetime: "{{ today_utc() }}"
-          datetime_format: "%Y-%m-%d"
+          datetime: "{{ now_utc().strftime('%Y-%m-%dT%H:%M:%S.%fZ') }}"
+          datetime_format: "%Y-%m-%dT%H:%M:%S.%fZ"
         step: P1M
         cursor_granularity: PT0.000001S
       schema_loader:
@@ -833,8 +833,8 @@ definitions:
           field_name: to
         end_datetime:
           type: MinMaxDatetime
-          datetime: "{{ today_utc() }}"
-          datetime_format: "%Y-%m-%d"
+          datetime: "{{ now_utc().strftime('%Y-%m-%dT%H:%M:%S.%fZ') }}"
+          datetime_format: "%Y-%m-%dT%H:%M:%S.%fZ"
         step: P1M
         cursor_granularity: PT0.000001S
       schema_loader:
@@ -968,8 +968,8 @@ definitions:
           field_name: to
         end_datetime:
           type: MinMaxDatetime
-          datetime: "{{ today_utc() }}"
-          datetime_format: "%Y-%m-%d"
+          datetime: "{{ now_utc().strftime('%Y-%m-%dT%H:%M:%S.%fZ') }}"
+          datetime_format: "%Y-%m-%dT%H:%M:%S.%fZ"
         step: P1M
         cursor_granularity: PT0.000001S
       schema_loader:
@@ -1095,8 +1095,8 @@ definitions:
           field_name: to
         end_datetime:
           type: MinMaxDatetime
-          datetime: "{{ today_utc() }}"
-          datetime_format: "%Y-%m-%d"
+          datetime: "{{ now_utc().strftime('%Y-%m-%dT%H:%M:%S.%fZ') }}"
+          datetime_format: "%Y-%m-%dT%H:%M:%S.%fZ"
         step: P1M
         cursor_granularity: PT0.000001S
       schema_loader:
@@ -1248,8 +1248,8 @@ definitions:
           field_name: to
         end_datetime:
           type: MinMaxDatetime
-          datetime: "{{ today_utc() }}"
-          datetime_format: "%Y-%m-%d"
+          datetime: "{{ now_utc().strftime('%Y-%m-%dT%H:%M:%S.%fZ') }}"
+          datetime_format: "%Y-%m-%dT%H:%M:%S.%fZ"
         step: P1M
         cursor_granularity: PT0.000001S
       schema_loader:

--- a/airbyte-integrations/connectors/source-paystack/metadata.yaml
+++ b/airbyte-integrations/connectors/source-paystack/metadata.yaml
@@ -5,7 +5,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 193bdcb8-1dd9-48d1-aade-91cadfd74f9b
-  dockerImageTag: 1.1.31
+  dockerImageTag: 1.1.32
   dockerRepository: airbyte/source-paystack
   githubIssueLabel: source-paystack
   icon: paystack.svg

--- a/docs/integrations/sources/paystack.md
+++ b/docs/integrations/sources/paystack.md
@@ -72,6 +72,7 @@ If you use Airbyte Cloud and your organization restricts access to specific IPs,
 
 | Version | Date       | Pull Request                                             | Subject                                                        |
 | :------ | :--------- | :------------------------------------------------------- | :------------------------------------------------------------- |
+| 1.1.32 | 2026-08-28 | [PENDING](https://github.com/airbytehq/airbyte/pull/PENDING) | End incremental `to` at now instead of today-midnight; Paystack treats `to` as exclusive so same-day records were dropped |
 | 1.1.31 | 2026-06-02 | [78886](https://github.com/airbytehq/airbyte/pull/78886) | Update dependencies |
 | 1.1.30 | 2026-04-28 | [77379](https://github.com/airbytehq/airbyte/pull/77379) | Update dependencies |
 | 1.1.29 | 2026-04-21 | [76699](https://github.com/airbytehq/airbyte/pull/76699) | Update dependencies |

--- a/docs/integrations/sources/paystack.md
+++ b/docs/integrations/sources/paystack.md
@@ -72,7 +72,7 @@ If you use Airbyte Cloud and your organization restricts access to specific IPs,
 
 | Version | Date       | Pull Request                                             | Subject                                                        |
 | :------ | :--------- | :------------------------------------------------------- | :------------------------------------------------------------- |
-| 1.1.32 | 2026-08-28 | [PENDING](https://github.com/airbytehq/airbyte/pull/PENDING) | End incremental `to` at now instead of today-midnight; Paystack treats `to` as exclusive so same-day records were dropped |
+| 1.1.32 | 2026-08-28 | [85106](https://github.com/airbytehq/airbyte/pull/85106) | End incremental `to` at now instead of today-midnight; Paystack treats `to` as exclusive so same-day records were dropped |
 | 1.1.31 | 2026-06-02 | [78886](https://github.com/airbytehq/airbyte/pull/78886) | Update dependencies |
 | 1.1.30 | 2026-04-28 | [77379](https://github.com/airbytehq/airbyte/pull/77379) | Update dependencies |
 | 1.1.29 | 2026-04-21 | [76699](https://github.com/airbytehq/airbyte/pull/76699) | Update dependencies |

--- a/docs/integrations/sources/pinterest.md
+++ b/docs/integrations/sources/pinterest.md
@@ -210,7 +210,7 @@ properties:
     DELETED_DRAFT. When more than six values are selected, the connector automatically splits them
     across multiple Pinterest report requests.
 12. **Ad Statuses (Optional)**: Filters custom report results by ad status. Select values from:
-    APPROVED, PAUSED, 85106, REJECTED, ADVERTISER_DISABLED, ARCHIVED, DRAFT, and DELETED_DRAFT.
+    APPROVED, PAUSED, PENDING, REJECTED, ADVERTISER_DISABLED, ARCHIVED, DRAFT, and DELETED_DRAFT.
     When more than six values are selected, the connector automatically splits them across multiple
     Pinterest report requests. This filter is not supported for Product Item level reports.
 13. **Start Date (Optional)**: The start date for the report in YYYY-MM-DD format, defaulting to the

--- a/docs/integrations/sources/pinterest.md
+++ b/docs/integrations/sources/pinterest.md
@@ -210,7 +210,7 @@ properties:
     DELETED_DRAFT. When more than six values are selected, the connector automatically splits them
     across multiple Pinterest report requests.
 12. **Ad Statuses (Optional)**: Filters custom report results by ad status. Select values from:
-    APPROVED, PAUSED, PENDING, REJECTED, ADVERTISER_DISABLED, ARCHIVED, DRAFT, and DELETED_DRAFT.
+    APPROVED, PAUSED, 85106, REJECTED, ADVERTISER_DISABLED, ARCHIVED, DRAFT, and DELETED_DRAFT.
     When more than six values are selected, the connector automatically splits them across multiple
     Pinterest report requests. This filter is not supported for Product Item level reports.
 13. **Start Date (Optional)**: The start date for the report in YYYY-MM-DD format, defaulting to the


### PR DESCRIPTION
Fixes #86903

## What
Incremental streams send `to` as **today UTC at midnight**. Paystack treats `to` as **exclusive**, so same-day customers/transactions never sync. Check still 200s because it does not send `from`/`to`.

`end_datetime` is now `now_utc()` with a full timestamp so the current day is included. Historical P1M slice bounds are unchanged.

## How
Manifest-only YAML.

## 🚨 User Impact 🚨
Bugfix. Incremental syncs pick up records created today.