### PR TITLE
fix(source-reply-io): add optional acting-user headers for org API keys

### DIFF
--- a/airbyte-integrations/connectors/source-reply-io/manifest.yaml
+++ b/airbyte-integrations/connectors/source-reply-io/manifest.yaml
@@ -357,6 +357,10 @@ definitions:
         type: RequestOption
         inject_into: header
         field_name: x-api-key
+    request_headers:
+      X-USER-ID: \"{{ config.get('user_id', '') }}\"
+      X-User-Email: \"{{ config.get('user_email', '') }}\"
+      X-TEAM-ID: \"{{ config.get('team_id', '') }}\"
 streams:
   - type: DeclarativeStream
     name: campaigns
@@ -374,6 +378,10 @@ streams:
             type: RequestOption
             inject_into: header
             field_name: x-api-key
+        request_headers:
+          X-USER-ID: "{{ config.get('user_id', '') }}"
+          X-User-Email: "{{ config.get('user_email', '') }}"
+          X-TEAM-ID: "{{ config.get('team_id', '') }}"
         path: /campaigns
         http_method: GET
         error_handler:
@@ -473,6 +481,10 @@ streams:
             type: RequestOption
             inject_into: header
             field_name: x-api-key
+        request_headers:
+          X-USER-ID: "{{ config.get('user_id', '') }}"
+          X-User-Email: "{{ config.get('user_email', '') }}"
+          X-TEAM-ID: "{{ config.get('team_id', '') }}"
         path: /emailAccounts
         http_method: GET
         error_handler:
@@ -531,6 +543,10 @@ streams:
             type: RequestOption
             inject_into: header
             field_name: x-api-key
+        request_headers:
+          X-USER-ID: "{{ config.get('user_id', '') }}"
+          X-User-Email: "{{ config.get('user_email', '') }}"
+          X-TEAM-ID: "{{ config.get('team_id', '') }}"
         path: /people
         http_method: GET
         error_handler:
@@ -648,6 +664,10 @@ streams:
             type: RequestOption
             inject_into: header
             field_name: x-api-key
+        request_headers:
+          X-USER-ID: "{{ config.get('user_id', '') }}"
+          X-User-Email: "{{ config.get('user_email', '') }}"
+          X-TEAM-ID: "{{ config.get('team_id', '') }}"
         path: /templates
         http_method: GET
         error_handler:
@@ -707,8 +727,30 @@ spec:
         type: string
         title: API Token
         airbyte_secret: true
-        description: The API Token for Reply
+        description: >-
+          The API Token for Reply. A user API key is enough by itself. Organization
+          (`org_…`) and some team keys require acting-user headers or the vendor
+          returns 403 USER_REQUIRED.
         order: 0
+      user_id:
+        type: string
+        title: Acting User ID
+        description: >-
+          Optional. Sent as `X-USER-ID`. Required for Organization API keys if
+          email+team are not set.
+        order: 1
+      user_email:
+        type: string
+        title: Acting User Email
+        description: >-
+          Optional. Sent as `X-User-Email`. Use with Team ID for Organization keys.
+        order: 2
+      team_id:
+        type: string
+        title: Team ID
+        description: >-
+          Optional. Sent as `X-TEAM-ID`. Use with Acting User Email for Organization keys.
+        order: 3
     additionalProperties: true
 metadata:
   autoImportSchema:

--- a/airbyte-integrations/connectors/source-reply-io/manifest.yaml
+++ b/airbyte-integrations/connectors/source-reply-io/manifest.yaml
@@ -358,9 +358,9 @@ definitions:
         inject_into: header
         field_name: x-api-key
     request_headers:
-      X-USER-ID: \"{{ config.get('user_id', '') }}\"
-      X-User-Email: \"{{ config.get('user_email', '') }}\"
-      X-TEAM-ID: \"{{ config.get('team_id', '') }}\"
+      X-USER-ID: "{{ config.get('user_id', '') }}"
+      X-User-Email: "{{ config.get('user_email', '') }}"
+      X-TEAM-ID: "{{ config.get('team_id', '') }}"
 streams:
   - type: DeclarativeStream
     name: campaigns

--- a/airbyte-integrations/connectors/source-reply-io/metadata.yaml
+++ b/airbyte-integrations/connectors/source-reply-io/metadata.yaml
@@ -16,7 +16,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 8cc6537e-f8a6-423c-b960-e927af76116e
-  dockerImageTag: 0.2.22
+  dockerImageTag: 0.2.23
   dockerRepository: airbyte/source-reply-io
   githubIssueLabel: source-reply-io
   icon: reply-io.svg

--- a/docs/integrations/sources/pinterest.md
+++ b/docs/integrations/sources/pinterest.md
@@ -210,7 +210,7 @@ properties:
     DELETED_DRAFT. When more than six values are selected, the connector automatically splits them
     across multiple Pinterest report requests.
 12. **Ad Statuses (Optional)**: Filters custom report results by ad status. Select values from:
-    APPROVED, PAUSED, PENDING, REJECTED, ADVERTISER_DISABLED, ARCHIVED, DRAFT, and DELETED_DRAFT.
+    APPROVED, PAUSED, 85108, REJECTED, ADVERTISER_DISABLED, ARCHIVED, DRAFT, and DELETED_DRAFT.
     When more than six values are selected, the connector automatically splits them across multiple
     Pinterest report requests. This filter is not supported for Product Item level reports.
 13. **Start Date (Optional)**: The start date for the report in YYYY-MM-DD format, defaulting to the

--- a/docs/integrations/sources/pinterest.md
+++ b/docs/integrations/sources/pinterest.md
@@ -210,7 +210,7 @@ properties:
     DELETED_DRAFT. When more than six values are selected, the connector automatically splits them
     across multiple Pinterest report requests.
 12. **Ad Statuses (Optional)**: Filters custom report results by ad status. Select values from:
-    APPROVED, PAUSED, 85108, REJECTED, ADVERTISER_DISABLED, ARCHIVED, DRAFT, and DELETED_DRAFT.
+    APPROVED, PAUSED, PENDING, REJECTED, ADVERTISER_DISABLED, ARCHIVED, DRAFT, and DELETED_DRAFT.
     When more than six values are selected, the connector automatically splits them across multiple
     Pinterest report requests. This filter is not supported for Product Item level reports.
 13. **Start Date (Optional)**: The start date for the report in YYYY-MM-DD format, defaulting to the

--- a/docs/integrations/sources/reply-io.md
+++ b/docs/integrations/sources/reply-io.md
@@ -45,6 +45,7 @@ If you use Airbyte Cloud and your organization restricts access to specific IPs,
 
 | Version | Date       | Pull Request                                             | Subject                       |
 |:--------|:-----------| :------------------------------------------------------- | :---------------------------- |
+| 0.2.23 | 2026-08-28 | [PENDING](https://github.com/airbytehq/airbyte/pull/PENDING) | Optional acting-user headers (`X-USER-ID` / `X-User-Email` + `X-TEAM-ID`) so Organization API keys no longer 403 USER_REQUIRED |
 | 0.2.22 | 2025-05-25 | [60477](https://github.com/airbytehq/airbyte/pull/60477) | Update dependencies |
 | 0.2.21 | 2025-05-10 | [60165](https://github.com/airbytehq/airbyte/pull/60165) | Update dependencies |
 | 0.2.20 | 2025-05-04 | [59057](https://github.com/airbytehq/airbyte/pull/59057) | Update dependencies |

--- a/docs/integrations/sources/reply-io.md
+++ b/docs/integrations/sources/reply-io.md
@@ -45,7 +45,7 @@ If you use Airbyte Cloud and your organization restricts access to specific IPs,
 
 | Version | Date       | Pull Request                                             | Subject                       |
 |:--------|:-----------| :------------------------------------------------------- | :---------------------------- |
-| 0.2.23 | 2026-08-28 | [PENDING](https://github.com/airbytehq/airbyte/pull/PENDING) | Optional acting-user headers (`X-USER-ID` / `X-User-Email` + `X-TEAM-ID`) so Organization API keys no longer 403 USER_REQUIRED |
+| 0.2.23 | 2026-08-28 | [85108](https://github.com/airbytehq/airbyte/pull/85108) | Optional acting-user headers (`X-USER-ID` / `X-User-Email` + `X-TEAM-ID`) so Organization API keys no longer 403 USER_REQUIRED |
 | 0.2.22 | 2025-05-25 | [60477](https://github.com/airbytehq/airbyte/pull/60477) | Update dependencies |
 | 0.2.21 | 2025-05-10 | [60165](https://github.com/airbytehq/airbyte/pull/60165) | Update dependencies |
 | 0.2.20 | 2025-05-04 | [59057](https://github.com/airbytehq/airbyte/pull/59057) | Update dependencies |


### PR DESCRIPTION
Fixes #86905

## What
Stock `source-reply-io` only sends `x-api-key`. That works for **user** API keys. **Organization** keys (`org_…`) return **403 `USER_REQUIRED`** unless every request also has impersonation headers (`X-USER-ID`, or `X-User-Email` + `X-TEAM-ID`). Those fields were not in the spec.

This adds optional `user_id`, `user_email`, and `team_id` and forwards them as those headers. User keys can leave them blank.

## How
Manifest-only YAML. Optional spec fields (minor).

## 🚨 User Impact 🚨
Organization-key users can configure acting-user identity. Existing user-key connections are unchanged.