### PR TITLE
fix(source-insightly): make API host configurable for non-na1 pods

### DIFF
--- a/airbyte-integrations/connectors/source-insightly/manifest.yaml
+++ b/airbyte-integrations/connectors/source-insightly/manifest.yaml
@@ -16,7 +16,7 @@ definitions:
         type: SimpleRetriever
         requester:
           type: HttpRequester
-          url_base: https://api.na1.insightly.com/v3.1/
+          url_base: "{{ (config.get('base_url') or 'https://api.na1.insightly.com/v3.1').rstrip('/') }}/"
           authenticator:
             type: BasicHttpAuthenticator
             username: "{{ config['token'] }}"
@@ -293,7 +293,7 @@ definitions:
         type: SimpleRetriever
         requester:
           type: HttpRequester
-          url_base: https://api.na1.insightly.com/v3.1/
+          url_base: "{{ (config.get('base_url') or 'https://api.na1.insightly.com/v3.1').rstrip('/') }}/"
           authenticator:
             type: BasicHttpAuthenticator
             username: "{{ config['token'] }}"
@@ -680,7 +680,7 @@ definitions:
         type: SimpleRetriever
         requester:
           type: HttpRequester
-          url_base: https://api.na1.insightly.com/v3.1/
+          url_base: "{{ (config.get('base_url') or 'https://api.na1.insightly.com/v3.1').rstrip('/') }}/"
           authenticator:
             type: BasicHttpAuthenticator
             username: "{{ config['token'] }}"
@@ -745,7 +745,7 @@ definitions:
         type: SimpleRetriever
         requester:
           type: HttpRequester
-          url_base: https://api.na1.insightly.com/v3.1/
+          url_base: "{{ (config.get('base_url') or 'https://api.na1.insightly.com/v3.1').rstrip('/') }}/"
           authenticator:
             type: BasicHttpAuthenticator
             username: "{{ config['token'] }}"
@@ -815,7 +815,7 @@ definitions:
         type: SimpleRetriever
         requester:
           type: HttpRequester
-          url_base: https://api.na1.insightly.com/v3.1/
+          url_base: "{{ (config.get('base_url') or 'https://api.na1.insightly.com/v3.1').rstrip('/') }}/"
           authenticator:
             type: BasicHttpAuthenticator
             username: "{{ config['token'] }}"
@@ -990,7 +990,7 @@ definitions:
         type: SimpleRetriever
         requester:
           type: HttpRequester
-          url_base: https://api.na1.insightly.com/v3.1/
+          url_base: "{{ (config.get('base_url') or 'https://api.na1.insightly.com/v3.1').rstrip('/') }}/"
           authenticator:
             type: BasicHttpAuthenticator
             username: "{{ config['token'] }}"
@@ -1199,7 +1199,7 @@ definitions:
         type: SimpleRetriever
         requester:
           type: HttpRequester
-          url_base: https://api.na1.insightly.com/v3.1/
+          url_base: "{{ (config.get('base_url') or 'https://api.na1.insightly.com/v3.1').rstrip('/') }}/"
           authenticator:
             type: BasicHttpAuthenticator
             username: "{{ config['token'] }}"
@@ -1312,7 +1312,7 @@ definitions:
         type: SimpleRetriever
         requester:
           type: HttpRequester
-          url_base: https://api.na1.insightly.com/v3.1/
+          url_base: "{{ (config.get('base_url') or 'https://api.na1.insightly.com/v3.1').rstrip('/') }}/"
           authenticator:
             type: BasicHttpAuthenticator
             username: "{{ config['token'] }}"
@@ -1441,7 +1441,7 @@ definitions:
         type: SimpleRetriever
         requester:
           type: HttpRequester
-          url_base: https://api.na1.insightly.com/v3.1/
+          url_base: "{{ (config.get('base_url') or 'https://api.na1.insightly.com/v3.1').rstrip('/') }}/"
           authenticator:
             type: BasicHttpAuthenticator
             username: "{{ config['token'] }}"
@@ -1661,7 +1661,7 @@ definitions:
         type: SimpleRetriever
         requester:
           type: HttpRequester
-          url_base: https://api.na1.insightly.com/v3.1/
+          url_base: "{{ (config.get('base_url') or 'https://api.na1.insightly.com/v3.1').rstrip('/') }}/"
           authenticator:
             type: BasicHttpAuthenticator
             username: "{{ config['token'] }}"
@@ -1743,7 +1743,7 @@ definitions:
         type: SimpleRetriever
         requester:
           type: HttpRequester
-          url_base: https://api.na1.insightly.com/v3.1/
+          url_base: "{{ (config.get('base_url') or 'https://api.na1.insightly.com/v3.1').rstrip('/') }}/"
           authenticator:
             type: BasicHttpAuthenticator
             username: "{{ config['token'] }}"
@@ -1828,7 +1828,7 @@ definitions:
         type: SimpleRetriever
         requester:
           type: HttpRequester
-          url_base: https://api.na1.insightly.com/v3.1/
+          url_base: "{{ (config.get('base_url') or 'https://api.na1.insightly.com/v3.1').rstrip('/') }}/"
           authenticator:
             type: BasicHttpAuthenticator
             username: "{{ config['token'] }}"
@@ -1960,7 +1960,7 @@ definitions:
         type: SimpleRetriever
         requester:
           type: HttpRequester
-          url_base: https://api.na1.insightly.com/v3.1/
+          url_base: "{{ (config.get('base_url') or 'https://api.na1.insightly.com/v3.1').rstrip('/') }}/"
           authenticator:
             type: BasicHttpAuthenticator
             username: "{{ config['token'] }}"
@@ -2120,7 +2120,7 @@ definitions:
         type: SimpleRetriever
         requester:
           type: HttpRequester
-          url_base: https://api.na1.insightly.com/v3.1/
+          url_base: "{{ (config.get('base_url') or 'https://api.na1.insightly.com/v3.1').rstrip('/') }}/"
           authenticator:
             type: BasicHttpAuthenticator
             username: "{{ config['token'] }}"
@@ -2423,7 +2423,7 @@ definitions:
         type: SimpleRetriever
         requester:
           type: HttpRequester
-          url_base: https://api.na1.insightly.com/v3.1/
+          url_base: "{{ (config.get('base_url') or 'https://api.na1.insightly.com/v3.1').rstrip('/') }}/"
           authenticator:
             type: BasicHttpAuthenticator
             username: "{{ config['token'] }}"
@@ -2505,7 +2505,7 @@ definitions:
         type: SimpleRetriever
         requester:
           type: HttpRequester
-          url_base: https://api.na1.insightly.com/v3.1/
+          url_base: "{{ (config.get('base_url') or 'https://api.na1.insightly.com/v3.1').rstrip('/') }}/"
           authenticator:
             type: BasicHttpAuthenticator
             username: "{{ config['token'] }}"
@@ -2582,7 +2582,7 @@ definitions:
         type: SimpleRetriever
         requester:
           type: HttpRequester
-          url_base: https://api.na1.insightly.com/v3.1/
+          url_base: "{{ (config.get('base_url') or 'https://api.na1.insightly.com/v3.1').rstrip('/') }}/"
           authenticator:
             type: BasicHttpAuthenticator
             username: "{{ config['token'] }}"
@@ -2941,7 +2941,7 @@ definitions:
         type: SimpleRetriever
         requester:
           type: HttpRequester
-          url_base: https://api.na1.insightly.com/v3.1/
+          url_base: "{{ (config.get('base_url') or 'https://api.na1.insightly.com/v3.1').rstrip('/') }}/"
           authenticator:
             type: BasicHttpAuthenticator
             username: "{{ config['token'] }}"
@@ -3026,7 +3026,7 @@ definitions:
         type: SimpleRetriever
         requester:
           type: HttpRequester
-          url_base: https://api.na1.insightly.com/v3.1/
+          url_base: "{{ (config.get('base_url') or 'https://api.na1.insightly.com/v3.1').rstrip('/') }}/"
           authenticator:
             type: BasicHttpAuthenticator
             username: "{{ config['token'] }}"
@@ -3123,7 +3123,7 @@ definitions:
         type: SimpleRetriever
         requester:
           type: HttpRequester
-          url_base: https://api.na1.insightly.com/v3.1/
+          url_base: "{{ (config.get('base_url') or 'https://api.na1.insightly.com/v3.1').rstrip('/') }}/"
           authenticator:
             type: BasicHttpAuthenticator
             username: "{{ config['token'] }}"
@@ -3205,7 +3205,7 @@ definitions:
         type: SimpleRetriever
         requester:
           type: HttpRequester
-          url_base: https://api.na1.insightly.com/v3.1/
+          url_base: "{{ (config.get('base_url') or 'https://api.na1.insightly.com/v3.1').rstrip('/') }}/"
           authenticator:
             type: BasicHttpAuthenticator
             username: "{{ config['token'] }}"
@@ -3470,7 +3470,7 @@ definitions:
         type: SimpleRetriever
         requester:
           type: HttpRequester
-          url_base: https://api.na1.insightly.com/v3.1/
+          url_base: "{{ (config.get('base_url') or 'https://api.na1.insightly.com/v3.1').rstrip('/') }}/"
           authenticator:
             type: BasicHttpAuthenticator
             username: "{{ config['token'] }}"
@@ -3755,7 +3755,7 @@ definitions:
         type: SimpleRetriever
         requester:
           type: HttpRequester
-          url_base: https://api.na1.insightly.com/v3.1/
+          url_base: "{{ (config.get('base_url') or 'https://api.na1.insightly.com/v3.1').rstrip('/') }}/"
           authenticator:
             type: BasicHttpAuthenticator
             username: "{{ config['token'] }}"
@@ -3852,7 +3852,7 @@ definitions:
         type: SimpleRetriever
         requester:
           type: HttpRequester
-          url_base: https://api.na1.insightly.com/v3.1/
+          url_base: "{{ (config.get('base_url') or 'https://api.na1.insightly.com/v3.1').rstrip('/') }}/"
           authenticator:
             type: BasicHttpAuthenticator
             username: "{{ config['token'] }}"
@@ -3936,7 +3936,7 @@ definitions:
         type: SimpleRetriever
         requester:
           type: HttpRequester
-          url_base: https://api.na1.insightly.com/v3.1/
+          url_base: "{{ (config.get('base_url') or 'https://api.na1.insightly.com/v3.1').rstrip('/') }}/"
           authenticator:
             type: BasicHttpAuthenticator
             username: "{{ config['token'] }}"
@@ -4235,7 +4235,7 @@ definitions:
         type: SimpleRetriever
         requester:
           type: HttpRequester
-          url_base: https://api.na1.insightly.com/v3.1/
+          url_base: "{{ (config.get('base_url') or 'https://api.na1.insightly.com/v3.1').rstrip('/') }}/"
           authenticator:
             type: BasicHttpAuthenticator
             username: "{{ config['token'] }}"
@@ -4310,7 +4310,7 @@ definitions:
         type: SimpleRetriever
         requester:
           type: HttpRequester
-          url_base: https://api.na1.insightly.com/v3.1/
+          url_base: "{{ (config.get('base_url') or 'https://api.na1.insightly.com/v3.1').rstrip('/') }}/"
           authenticator:
             type: BasicHttpAuthenticator
             username: "{{ config['token'] }}"
@@ -4400,7 +4400,7 @@ definitions:
         type: SimpleRetriever
         requester:
           type: HttpRequester
-          url_base: https://api.na1.insightly.com/v3.1/
+          url_base: "{{ (config.get('base_url') or 'https://api.na1.insightly.com/v3.1').rstrip('/') }}/"
           authenticator:
             type: BasicHttpAuthenticator
             username: "{{ config['token'] }}"
@@ -4574,7 +4574,7 @@ definitions:
           additionalProperties: true
   base_requester:
     type: HttpRequester
-    url_base: https://api.na1.insightly.com/v3.1/
+    url_base: "{{ (config.get('base_url') or 'https://api.na1.insightly.com/v3.1').rstrip('/') }}/"
     authenticator:
       type: BasicHttpAuthenticator
       username: "{{ config['token'] }}"
@@ -4588,7 +4588,7 @@ streams:
       type: SimpleRetriever
       requester:
         type: HttpRequester
-        url_base: https://api.na1.insightly.com/v3.1/
+        url_base: "{{ (config.get('base_url') or 'https://api.na1.insightly.com/v3.1').rstrip('/') }}/"
         authenticator:
           type: BasicHttpAuthenticator
           username: "{{ config['token'] }}"
@@ -4862,7 +4862,7 @@ streams:
       type: SimpleRetriever
       requester:
         type: HttpRequester
-        url_base: https://api.na1.insightly.com/v3.1/
+        url_base: "{{ (config.get('base_url') or 'https://api.na1.insightly.com/v3.1').rstrip('/') }}/"
         authenticator:
           type: BasicHttpAuthenticator
           username: "{{ config['token'] }}"
@@ -5248,7 +5248,7 @@ streams:
       type: SimpleRetriever
       requester:
         type: HttpRequester
-        url_base: https://api.na1.insightly.com/v3.1/
+        url_base: "{{ (config.get('base_url') or 'https://api.na1.insightly.com/v3.1').rstrip('/') }}/"
         authenticator:
           type: BasicHttpAuthenticator
           username: "{{ config['token'] }}"
@@ -5312,7 +5312,7 @@ streams:
       type: SimpleRetriever
       requester:
         type: HttpRequester
-        url_base: https://api.na1.insightly.com/v3.1/
+        url_base: "{{ (config.get('base_url') or 'https://api.na1.insightly.com/v3.1').rstrip('/') }}/"
         authenticator:
           type: BasicHttpAuthenticator
           username: "{{ config['token'] }}"
@@ -5381,7 +5381,7 @@ streams:
       type: SimpleRetriever
       requester:
         type: HttpRequester
-        url_base: https://api.na1.insightly.com/v3.1/
+        url_base: "{{ (config.get('base_url') or 'https://api.na1.insightly.com/v3.1').rstrip('/') }}/"
         authenticator:
           type: BasicHttpAuthenticator
           username: "{{ config['token'] }}"
@@ -5555,7 +5555,7 @@ streams:
       type: SimpleRetriever
       requester:
         type: HttpRequester
-        url_base: https://api.na1.insightly.com/v3.1/
+        url_base: "{{ (config.get('base_url') or 'https://api.na1.insightly.com/v3.1').rstrip('/') }}/"
         authenticator:
           type: BasicHttpAuthenticator
           username: "{{ config['token'] }}"
@@ -5763,7 +5763,7 @@ streams:
       type: SimpleRetriever
       requester:
         type: HttpRequester
-        url_base: https://api.na1.insightly.com/v3.1/
+        url_base: "{{ (config.get('base_url') or 'https://api.na1.insightly.com/v3.1').rstrip('/') }}/"
         authenticator:
           type: BasicHttpAuthenticator
           username: "{{ config['token'] }}"
@@ -5873,7 +5873,7 @@ streams:
       type: SimpleRetriever
       requester:
         type: HttpRequester
-        url_base: https://api.na1.insightly.com/v3.1/
+        url_base: "{{ (config.get('base_url') or 'https://api.na1.insightly.com/v3.1').rstrip('/') }}/"
         authenticator:
           type: BasicHttpAuthenticator
           username: "{{ config['token'] }}"
@@ -5999,7 +5999,7 @@ streams:
       type: SimpleRetriever
       requester:
         type: HttpRequester
-        url_base: https://api.na1.insightly.com/v3.1/
+        url_base: "{{ (config.get('base_url') or 'https://api.na1.insightly.com/v3.1').rstrip('/') }}/"
         authenticator:
           type: BasicHttpAuthenticator
           username: "{{ config['token'] }}"
@@ -6216,7 +6216,7 @@ streams:
       type: SimpleRetriever
       requester:
         type: HttpRequester
-        url_base: https://api.na1.insightly.com/v3.1/
+        url_base: "{{ (config.get('base_url') or 'https://api.na1.insightly.com/v3.1').rstrip('/') }}/"
         authenticator:
           type: BasicHttpAuthenticator
           username: "{{ config['token'] }}"
@@ -6297,7 +6297,7 @@ streams:
       type: SimpleRetriever
       requester:
         type: HttpRequester
-        url_base: https://api.na1.insightly.com/v3.1/
+        url_base: "{{ (config.get('base_url') or 'https://api.na1.insightly.com/v3.1').rstrip('/') }}/"
         authenticator:
           type: BasicHttpAuthenticator
           username: "{{ config['token'] }}"
@@ -6381,7 +6381,7 @@ streams:
       type: SimpleRetriever
       requester:
         type: HttpRequester
-        url_base: https://api.na1.insightly.com/v3.1/
+        url_base: "{{ (config.get('base_url') or 'https://api.na1.insightly.com/v3.1').rstrip('/') }}/"
         authenticator:
           type: BasicHttpAuthenticator
           username: "{{ config['token'] }}"
@@ -6510,7 +6510,7 @@ streams:
       type: SimpleRetriever
       requester:
         type: HttpRequester
-        url_base: https://api.na1.insightly.com/v3.1/
+        url_base: "{{ (config.get('base_url') or 'https://api.na1.insightly.com/v3.1').rstrip('/') }}/"
         authenticator:
           type: BasicHttpAuthenticator
           username: "{{ config['token'] }}"
@@ -6669,7 +6669,7 @@ streams:
       type: SimpleRetriever
       requester:
         type: HttpRequester
-        url_base: https://api.na1.insightly.com/v3.1/
+        url_base: "{{ (config.get('base_url') or 'https://api.na1.insightly.com/v3.1').rstrip('/') }}/"
         authenticator:
           type: BasicHttpAuthenticator
           username: "{{ config['token'] }}"
@@ -6968,7 +6968,7 @@ streams:
       type: SimpleRetriever
       requester:
         type: HttpRequester
-        url_base: https://api.na1.insightly.com/v3.1/
+        url_base: "{{ (config.get('base_url') or 'https://api.na1.insightly.com/v3.1').rstrip('/') }}/"
         authenticator:
           type: BasicHttpAuthenticator
           username: "{{ config['token'] }}"
@@ -7047,7 +7047,7 @@ streams:
       type: SimpleRetriever
       requester:
         type: HttpRequester
-        url_base: https://api.na1.insightly.com/v3.1/
+        url_base: "{{ (config.get('base_url') or 'https://api.na1.insightly.com/v3.1').rstrip('/') }}/"
         authenticator:
           type: BasicHttpAuthenticator
           username: "{{ config['token'] }}"
@@ -7121,7 +7121,7 @@ streams:
       type: SimpleRetriever
       requester:
         type: HttpRequester
-        url_base: https://api.na1.insightly.com/v3.1/
+        url_base: "{{ (config.get('base_url') or 'https://api.na1.insightly.com/v3.1').rstrip('/') }}/"
         authenticator:
           type: BasicHttpAuthenticator
           username: "{{ config['token'] }}"
@@ -7476,7 +7476,7 @@ streams:
       type: SimpleRetriever
       requester:
         type: HttpRequester
-        url_base: https://api.na1.insightly.com/v3.1/
+        url_base: "{{ (config.get('base_url') or 'https://api.na1.insightly.com/v3.1').rstrip('/') }}/"
         authenticator:
           type: BasicHttpAuthenticator
           username: "{{ config['token'] }}"
@@ -7560,7 +7560,7 @@ streams:
       type: SimpleRetriever
       requester:
         type: HttpRequester
-        url_base: https://api.na1.insightly.com/v3.1/
+        url_base: "{{ (config.get('base_url') or 'https://api.na1.insightly.com/v3.1').rstrip('/') }}/"
         authenticator:
           type: BasicHttpAuthenticator
           username: "{{ config['token'] }}"
@@ -7655,7 +7655,7 @@ streams:
       type: SimpleRetriever
       requester:
         type: HttpRequester
-        url_base: https://api.na1.insightly.com/v3.1/
+        url_base: "{{ (config.get('base_url') or 'https://api.na1.insightly.com/v3.1').rstrip('/') }}/"
         authenticator:
           type: BasicHttpAuthenticator
           username: "{{ config['token'] }}"
@@ -7734,7 +7734,7 @@ streams:
       type: SimpleRetriever
       requester:
         type: HttpRequester
-        url_base: https://api.na1.insightly.com/v3.1/
+        url_base: "{{ (config.get('base_url') or 'https://api.na1.insightly.com/v3.1').rstrip('/') }}/"
         authenticator:
           type: BasicHttpAuthenticator
           username: "{{ config['token'] }}"
@@ -7994,7 +7994,7 @@ streams:
       type: SimpleRetriever
       requester:
         type: HttpRequester
-        url_base: https://api.na1.insightly.com/v3.1/
+        url_base: "{{ (config.get('base_url') or 'https://api.na1.insightly.com/v3.1').rstrip('/') }}/"
         authenticator:
           type: BasicHttpAuthenticator
           username: "{{ config['token'] }}"
@@ -8276,7 +8276,7 @@ streams:
       type: SimpleRetriever
       requester:
         type: HttpRequester
-        url_base: https://api.na1.insightly.com/v3.1/
+        url_base: "{{ (config.get('base_url') or 'https://api.na1.insightly.com/v3.1').rstrip('/') }}/"
         authenticator:
           type: BasicHttpAuthenticator
           username: "{{ config['token'] }}"
@@ -8370,7 +8370,7 @@ streams:
       type: SimpleRetriever
       requester:
         type: HttpRequester
-        url_base: https://api.na1.insightly.com/v3.1/
+        url_base: "{{ (config.get('base_url') or 'https://api.na1.insightly.com/v3.1').rstrip('/') }}/"
         authenticator:
           type: BasicHttpAuthenticator
           username: "{{ config['token'] }}"
@@ -8453,7 +8453,7 @@ streams:
       type: SimpleRetriever
       requester:
         type: HttpRequester
-        url_base: https://api.na1.insightly.com/v3.1/
+        url_base: "{{ (config.get('base_url') or 'https://api.na1.insightly.com/v3.1').rstrip('/') }}/"
         authenticator:
           type: BasicHttpAuthenticator
           username: "{{ config['token'] }}"
@@ -8751,7 +8751,7 @@ streams:
       type: SimpleRetriever
       requester:
         type: HttpRequester
-        url_base: https://api.na1.insightly.com/v3.1/
+        url_base: "{{ (config.get('base_url') or 'https://api.na1.insightly.com/v3.1').rstrip('/') }}/"
         authenticator:
           type: BasicHttpAuthenticator
           username: "{{ config['token'] }}"
@@ -8825,7 +8825,7 @@ streams:
       type: SimpleRetriever
       requester:
         type: HttpRequester
-        url_base: https://api.na1.insightly.com/v3.1/
+        url_base: "{{ (config.get('base_url') or 'https://api.na1.insightly.com/v3.1').rstrip('/') }}/"
         authenticator:
           type: BasicHttpAuthenticator
           username: "{{ config['token'] }}"
@@ -8914,7 +8914,7 @@ streams:
       type: SimpleRetriever
       requester:
         type: HttpRequester
-        url_base: https://api.na1.insightly.com/v3.1/
+        url_base: "{{ (config.get('base_url') or 'https://api.na1.insightly.com/v3.1').rstrip('/') }}/"
         authenticator:
           type: BasicHttpAuthenticator
           username: "{{ config['token'] }}"
@@ -9115,6 +9115,18 @@ spec:
         description: Your Insightly API token.
         airbyte_secret: true
         order: 1
+      base_url:
+        type: string
+        title: API URL
+        description: >-
+          Insightly API origin including the `/v3.1` path, from User Settings → API
+          (for example `https://api.na1.insightly.com/v3.1`). Other pods use a
+          different host (`api.eu1`, `api.au1`, …).
+        default: https://api.na1.insightly.com/v3.1
+        order: 2
+        examples:
+          - https://api.na1.insightly.com/v3.1
+          - https://api.eu1.insightly.com/v3.1
     additionalProperties: true
 metadata:
   autoImportSchema:

--- a/airbyte-integrations/connectors/source-insightly/metadata.yaml
+++ b/airbyte-integrations/connectors/source-insightly/metadata.yaml
@@ -4,13 +4,14 @@ data:
     sl: 100
   allowedHosts:
     hosts:
+      - ${base_url}
       - api.na1.insightly.com
   connectorBuildOptions:
     baseImage: docker.io/airbyte/source-declarative-manifest:7.3.4@sha256:ebf5c159101614ec9ab3a5183c92781c397b998d15c0b7e2e561ec1e00397fa4
   connectorSubtype: api
   connectorType: source
   definitionId: 38f84314-fe6a-4257-97be-a8dcd942d693
-  dockerImageTag: 0.3.26
+  dockerImageTag: 0.3.27
   dockerRepository: airbyte/source-insightly
   documentationUrl: https://docs.airbyte.com/integrations/sources/insightly
   githubIssueLabel: source-insightly

--- a/docs/integrations/sources/insightly.md
+++ b/docs/integrations/sources/insightly.md
@@ -76,7 +76,7 @@ If you use Airbyte Cloud and your organization restricts access to specific IPs,
 
 | Version | Date       | Pull Request                                             | Subject                                                                         |
 | :------ | :--------- | :------------------------------------------------------- | :------------------------------------------------------------------------------ |
-| 0.3.27 | 2026-08-28 | [PENDING](https://github.com/airbytehq/airbyte/pull/PENDING) | Add optional `base_url` so non-`na1` Insightly pods can authenticate (host was hardcoded to `api.na1.insightly.com`) |
+| 0.3.27 | 2026-08-28 | [85112](https://github.com/airbytehq/airbyte/pull/85112) | Add optional `base_url` so non-`na1` Insightly pods can authenticate (host was hardcoded to `api.na1.insightly.com`) |
 | 0.3.26 | 2025-10-14 | [67374](https://github.com/airbytehq/airbyte/pull/67374) | Update dependencies |
 | 0.3.25 | 2025-09-30 | [61132](https://github.com/airbytehq/airbyte/pull/61132) | Update dependencies |
 | 0.3.24 | 2025-09-12 | [66197](https://github.com/airbytehq/airbyte/pull/66197) | Update to CDK v7 |

--- a/docs/integrations/sources/insightly.md
+++ b/docs/integrations/sources/insightly.md
@@ -76,6 +76,7 @@ If you use Airbyte Cloud and your organization restricts access to specific IPs,
 
 | Version | Date       | Pull Request                                             | Subject                                                                         |
 | :------ | :--------- | :------------------------------------------------------- | :------------------------------------------------------------------------------ |
+| 0.3.27 | 2026-08-28 | [PENDING](https://github.com/airbytehq/airbyte/pull/PENDING) | Add optional `base_url` so non-`na1` Insightly pods can authenticate (host was hardcoded to `api.na1.insightly.com`) |
 | 0.3.26 | 2025-10-14 | [67374](https://github.com/airbytehq/airbyte/pull/67374) | Update dependencies |
 | 0.3.25 | 2025-09-30 | [61132](https://github.com/airbytehq/airbyte/pull/61132) | Update dependencies |
 | 0.3.24 | 2025-09-12 | [66197](https://github.com/airbytehq/airbyte/pull/66197) | Update to CDK v7 |

--- a/docs/integrations/sources/pinterest.md
+++ b/docs/integrations/sources/pinterest.md
@@ -210,7 +210,7 @@ properties:
     DELETED_DRAFT. When more than six values are selected, the connector automatically splits them
     across multiple Pinterest report requests.
 12. **Ad Statuses (Optional)**: Filters custom report results by ad status. Select values from:
-    APPROVED, PAUSED, PENDING, REJECTED, ADVERTISER_DISABLED, ARCHIVED, DRAFT, and DELETED_DRAFT.
+    APPROVED, PAUSED, 85112, REJECTED, ADVERTISER_DISABLED, ARCHIVED, DRAFT, and DELETED_DRAFT.
     When more than six values are selected, the connector automatically splits them across multiple
     Pinterest report requests. This filter is not supported for Product Item level reports.
 13. **Start Date (Optional)**: The start date for the report in YYYY-MM-DD format, defaulting to the

--- a/docs/integrations/sources/pinterest.md
+++ b/docs/integrations/sources/pinterest.md
@@ -210,7 +210,7 @@ properties:
     DELETED_DRAFT. When more than six values are selected, the connector automatically splits them
     across multiple Pinterest report requests.
 12. **Ad Statuses (Optional)**: Filters custom report results by ad status. Select values from:
-    APPROVED, PAUSED, 85112, REJECTED, ADVERTISER_DISABLED, ARCHIVED, DRAFT, and DELETED_DRAFT.
+    APPROVED, PAUSED, PENDING, REJECTED, ADVERTISER_DISABLED, ARCHIVED, DRAFT, and DELETED_DRAFT.
     When more than six values are selected, the connector automatically splits them across multiple
     Pinterest report requests. This filter is not supported for Product Item level reports.
 13. **Start Date (Optional)**: The start date for the report in YYYY-MM-DD format, defaulting to the


### PR DESCRIPTION
Fixes #86909

## What
`url_base` was hardcoded to `https://api.na1.insightly.com/v3.1/`. Insightly pods (EU/AU/etc.) show a different API URL under User Settings → API; those accounts 401/404 against `na1`.

Adds optional `base_url` (default remains the `na1` host).

## How
Manifest-only YAML. Optional spec field (minor).

## 🚨 User Impact 🚨
Non-`na1` pods can set their API URL. Existing `na1` connections keep working with the default.