### PR TITLE
fix(source-posthog): default Base URL to US Cloud API host

### DIFF
--- a/airbyte-integrations/connectors/source-posthog/metadata.yaml
+++ b/airbyte-integrations/connectors/source-posthog/metadata.yaml
@@ -9,7 +9,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: af6d50ee-dddf-4126-a8ee-7faee990774f
-  dockerImageTag: 1.1.25
+  dockerImageTag: 1.1.26
   dockerRepository: airbyte/source-posthog
   documentationUrl: https://docs.airbyte.com/integrations/sources/posthog
   githubIssueLabel: source-posthog

--- a/airbyte-integrations/connectors/source-posthog/pyproject.toml
+++ b/airbyte-integrations/connectors/source-posthog/pyproject.toml
@@ -3,7 +3,7 @@ requires = [ "poetry-core>=1.0.0",]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
-version = "1.1.25"
+version = "1.1.26"
 name = "source-posthog"
 description = "Source implementation for Posthog."
 authors = [ "Airbyte <contact@airbyte.io>",]

--- a/airbyte-integrations/connectors/source-posthog/source_posthog/manifest.yaml
+++ b/airbyte-integrations/connectors/source-posthog/source_posthog/manifest.yaml
@@ -12,7 +12,7 @@ definitions:
 
   requester:
     type: HttpRequester
-    url_base: "{{ config['base_url'] or 'https://app.posthog.com'}}/api/"
+    url_base: "{{ config['base_url'] or 'https://us.posthog.com'}}/api/"
     http_method: "GET"
     authenticator:
       type: BearerAuthenticator

--- a/airbyte-integrations/connectors/source-posthog/source_posthog/spec.json
+++ b/airbyte-integrations/connectors/source-posthog/source_posthog/spec.json
@@ -22,10 +22,10 @@
       },
       "base_url": {
         "type": "string",
-        "default": "https://app.posthog.com",
+        "default": "https://us.posthog.com",
         "title": "Base URL",
-        "description": "Base PostHog url. Defaults to PostHog Cloud (https://app.posthog.com).",
-        "examples": ["https://posthog.example.com"]
+        "description": "Base PostHog url. Defaults to PostHog US Cloud (https://us.posthog.com). EU Cloud is https://eu.posthog.com. app.posthog.com is the product UI, not the US API host.",
+        "examples": ["https://us.posthog.com", "https://eu.posthog.com", "https://posthog.example.com"]
       },
       "events_time_step": {
         "type": "integer",

--- a/airbyte-integrations/connectors/source-posthog/source_posthog/spec.json
+++ b/airbyte-integrations/connectors/source-posthog/source_posthog/spec.json
@@ -25,7 +25,11 @@
         "default": "https://us.posthog.com",
         "title": "Base URL",
         "description": "Base PostHog url. Defaults to PostHog US Cloud (https://us.posthog.com). EU Cloud is https://eu.posthog.com. app.posthog.com is the product UI, not the US API host.",
-        "examples": ["https://us.posthog.com", "https://eu.posthog.com", "https://posthog.example.com"]
+        "examples": [
+          "https://us.posthog.com",
+          "https://eu.posthog.com",
+          "https://posthog.example.com"
+        ]
       },
       "events_time_step": {
         "type": "integer",

--- a/docs/integrations/sources/pinterest.md
+++ b/docs/integrations/sources/pinterest.md
@@ -210,7 +210,7 @@ properties:
     DELETED_DRAFT. When more than six values are selected, the connector automatically splits them
     across multiple Pinterest report requests.
 12. **Ad Statuses (Optional)**: Filters custom report results by ad status. Select values from:
-    APPROVED, PAUSED, 85114, REJECTED, ADVERTISER_DISABLED, ARCHIVED, DRAFT, and DELETED_DRAFT.
+    APPROVED, PAUSED, PENDING, REJECTED, ADVERTISER_DISABLED, ARCHIVED, DRAFT, and DELETED_DRAFT.
     When more than six values are selected, the connector automatically splits them across multiple
     Pinterest report requests. This filter is not supported for Product Item level reports.
 13. **Start Date (Optional)**: The start date for the report in YYYY-MM-DD format, defaulting to the

--- a/docs/integrations/sources/pinterest.md
+++ b/docs/integrations/sources/pinterest.md
@@ -210,7 +210,7 @@ properties:
     DELETED_DRAFT. When more than six values are selected, the connector automatically splits them
     across multiple Pinterest report requests.
 12. **Ad Statuses (Optional)**: Filters custom report results by ad status. Select values from:
-    APPROVED, PAUSED, PENDING, REJECTED, ADVERTISER_DISABLED, ARCHIVED, DRAFT, and DELETED_DRAFT.
+    APPROVED, PAUSED, 85114, REJECTED, ADVERTISER_DISABLED, ARCHIVED, DRAFT, and DELETED_DRAFT.
     When more than six values are selected, the connector automatically splits them across multiple
     Pinterest report requests. This filter is not supported for Product Item level reports.
 13. **Start Date (Optional)**: The start date for the report in YYYY-MM-DD format, defaulting to the

--- a/docs/integrations/sources/posthog.md
+++ b/docs/integrations/sources/posthog.md
@@ -75,6 +75,7 @@ If you use Airbyte Cloud and your organization restricts access to specific IPs,
 
 | Version | Date       | Pull Request                                             | Subject                                                                                                                 |
 | :------ | :--------- | :------------------------------------------------------- | :---------------------------------------------------------------------------------------------------------------------- |
+| 1.1.26 | 2026-08-28 | [PENDING](https://github.com/airbytehq/airbyte/pull/PENDING) | Default Base URL to `https://us.posthog.com` (the previous `app.posthog.com` default is the product UI, not the US Cloud API) |
 | 1.1.25 | 2025-02-01 | [53032](https://github.com/airbytehq/airbyte/pull/53032) | Update dependencies |
 | 1.1.24 | 2025-01-25 | [52536](https://github.com/airbytehq/airbyte/pull/52536) | Update dependencies |
 | 1.1.23 | 2025-01-18 | [51856](https://github.com/airbytehq/airbyte/pull/51856) | Update dependencies |

--- a/docs/integrations/sources/posthog.md
+++ b/docs/integrations/sources/posthog.md
@@ -75,7 +75,7 @@ If you use Airbyte Cloud and your organization restricts access to specific IPs,
 
 | Version | Date       | Pull Request                                             | Subject                                                                                                                 |
 | :------ | :--------- | :------------------------------------------------------- | :---------------------------------------------------------------------------------------------------------------------- |
-| 1.1.26 | 2026-08-28 | [PENDING](https://github.com/airbytehq/airbyte/pull/PENDING) | Default Base URL to `https://us.posthog.com` (the previous `app.posthog.com` default is the product UI, not the US Cloud API) |
+| 1.1.26 | 2026-08-28 | [85114](https://github.com/airbytehq/airbyte/pull/85114) | Default Base URL to `https://us.posthog.com` (the previous `app.posthog.com` default is the product UI, not the US Cloud API) |
 | 1.1.25 | 2025-02-01 | [53032](https://github.com/airbytehq/airbyte/pull/53032) | Update dependencies |
 | 1.1.24 | 2025-01-25 | [52536](https://github.com/airbytehq/airbyte/pull/52536) | Update dependencies |
 | 1.1.23 | 2025-01-18 | [51856](https://github.com/airbytehq/airbyte/pull/51856) | Update dependencies |


### PR DESCRIPTION
Fixes #86911

## What
Default Base URL was `https://app.posthog.com`, which is the **product UI**, not the US Cloud API. US Cloud is `https://us.posthog.com`; EU is `https://eu.posthog.com`.

Defaults in `spec.json` and the manifest now use `https://us.posthog.com`. Existing connections keep their saved `base_url`.

## How
Manifest + spec.json + package version bump.

## 🚨 User Impact 🚨
New connections hit US Cloud by default. EU/self-host users still set Base URL.