### PR TITLE
feat(ci): add /ai-breaking-change-review slash command

### DIFF
--- a/.github/pr-welcome-internal.md
+++ b/.github/pr-welcome-internal.md
@@ -21,6 +21,7 @@ Airbyte Maintainers (that's you!) can execute the following slash commands on yo
   - `/ai-prove-fix` - Runs prerelease readiness checks, including testing against customer connections.
   - `/ai-canary-prerelease` - Rolls out prerelease to 5-10 connections for canary testing.
   - `/ai-review` - AI-powered PR review for connector safety and quality gates.
+  - `/ai-breaking-change-review` - Assists the breaking-change reviewers: whether the change needs to be breaking, destination data-loss risk, and whether the migration guide, metadata message, and docs let users upgrade safely.
 - 📝 AI Documentation:
   - `/ai-docs-review` - AI-powered documentation review for PRs with connector changes.
   - `/ai-create-docs-pr` - Creates a documentation PR for connector changes, stacked on the current PR.

--- a/.github/workflows/ai-breaking-change-review-command.yml
+++ b/.github/workflows/ai-breaking-change-review-command.yml
@@ -1,0 +1,116 @@
+# AI Breaking Change Review Workflow
+#
+# Runs the `!breaking_change_review` Devin playbook on a connector breaking change,
+# producing an assessment that assists (and does not replace) the
+# @airbytehq/breaking-change-reviewers sign-off.
+#
+# Security model:
+# - Slash commands require write permission (only collaborators can trigger)
+# - This is workflow_dispatch, so secrets are always available
+# - We do not execute PR code; the session reads the diff, metadata, and docs
+
+name: AI Breaking Change Review Command
+
+on:
+  workflow_dispatch:
+    inputs:
+      pr:
+        description: "Pull request number (if triggered from a PR)"
+        type: number
+        required: false
+      comment-id:
+        description: "The comment-id of the slash command. Used to update the comment with the status."
+        required: false
+      repo:
+        description: "Repo (passed by slash command dispatcher)"
+        required: false
+        default: "airbytehq/airbyte"
+      gitref:
+        description: "Git ref (passed by slash command dispatcher)"
+        required: false
+
+run-name: "AI Breaking Change Review for PR #${{ github.event.inputs.pr }}"
+
+concurrency:
+  group: ai-breaking-change-review-${{ github.event.inputs.pr || 'unknown' }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: read
+
+jobs:
+  ai-breaking-change-review:
+    name: Review breaking change with AI
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get job variables
+        id: job-vars
+        run: echo "run-url=$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" | tee -a $GITHUB_OUTPUT
+
+      - name: Authenticate as GitHub App
+        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
+        id: get-app-token
+        with:
+          owner: "airbytehq"
+          repositories: "airbyte"
+          app-id: ${{ secrets.OCTAVIA_BOT_APP_ID }}
+          private-key: ${{ secrets.OCTAVIA_BOT_PRIVATE_KEY }}
+
+      - name: Require PR context
+        if: inputs.pr == '' && inputs.comment-id != ''
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
+        with:
+          token: ${{ steps.get-app-token.outputs.token }}
+          comment-id: ${{ inputs.comment-id }}
+          body: |
+            > `/ai-breaking-change-review` can only be run on a pull request. Please run it from a PR comment.
+
+      - name: Stop if not running on a PR
+        if: inputs.pr == ''
+        run: exit 1
+
+      - name: Post start comment
+        if: inputs.comment-id != ''
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
+        with:
+          token: ${{ steps.get-app-token.outputs.token }}
+          comment-id: ${{ inputs.comment-id }}
+          issue-number: ${{ inputs.pr }}
+          body: |
+            > **AI Breaking Change Review Started**
+            >
+            > Assessing whether the change needs to be breaking, its destination data-loss risk, and
+            > whether the migration guide, metadata message, and docs are accurate and sufficient.
+            > This assists the breaking-change reviewers; it is not their sign-off.
+            > [View workflow run](${{ steps.job-vars.outputs.run-url }})
+
+      - name: Run AI Breaking Change Review
+        uses: aaronsteers/devin-action@main
+        with:
+          comment-id: ${{ inputs.comment-id }}
+          issue-number: ${{ inputs.pr }}
+          playbook-macro: "!breaking_change_review"
+          prompt-text: "The pull request to review is ${{ inputs.pr }}."
+          devin-token: ${{ secrets.DEVIN_AI_API_KEY }}
+          github-token: ${{ steps.get-app-token.outputs.token }}
+          api-version: v3
+          org-id: ${{ vars.DEVIN_AI_ORG_ID }}
+          start-message: "🚨 **AI Breaking Change Review session starting...** Assessing whether the change needs to be breaking, its destination data-loss risk, and whether the migration guide, metadata message, and docs are accurate and sufficient for users to upgrade safely. Sign-off stays with @airbytehq/breaking-change-reviewers. [View playbook](https://github.com/airbytehq/ai-skills/blob/main/devin/playbooks/breaking_change_review.md)"
+          tags: |
+            breaking-change
+            area/documentation
+
+      - name: Post failure comment
+        if: failure() && inputs.comment-id != ''
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
+        with:
+          token: ${{ steps.get-app-token.outputs.token || github.token }}
+          comment-id: ${{ inputs.comment-id }}
+          issue-number: ${{ inputs.pr }}
+          body: |
+            > **AI Breaking Change Review Failed**
+            >
+            > An error occurred while starting the review session.
+            > [View workflow run](${{ steps.job-vars.outputs.run-url }})

--- a/.github/workflows/slash-commands.yml
+++ b/.github/workflows/slash-commands.yml
@@ -57,6 +57,7 @@ jobs:
           issue-type: both
 
           commands: |
+            ai-breaking-change-review
             ai-canary-prerelease
             ai-create-docs-pr
             ai-dev


### PR DESCRIPTION
## What

Adds a `/ai-breaking-change-review` PR slash command that starts the `!breaking_change_review` Devin playbook (airbytehq/ai-skills#805) on the PR it was invoked from. Requested by @ian-at-airbyte so breaking-change reviewers can launch the review from the PR instead of typing the macro into a session.

The session assists the reviewers; it does not stand in for the `@airbytehq/breaking-change-reviewers` sign-off, and both the start comment and the session start-message say so.

## How

Same shape as `/ai-docs-review` and `/ai-resolve-conflicts`:

- `.github/workflows/ai-breaking-change-review-command.yml` — `workflow_dispatch` taking `pr`, `comment-id`, `repo`, `gitref`; mints an `octavia-bot` token, refuses to run outside a PR, appends a start comment, then hands off to `aaronsteers/devin-action@main` with `playbook-macro: "!breaking_change_review"`. Concurrency is keyed on the PR without cancel-in-progress, so a second invocation queues rather than killing a running review.
- `.github/workflows/slash-commands.yml` — registers `ai-breaking-change-review` in the dispatcher's command list.
- `.github/pr-welcome-internal.md` — documents the command under AI Testing and Review.

## Review guide

1. `.github/workflows/ai-breaking-change-review-command.yml`
2. `.github/workflows/slash-commands.yml`
3. `.github/pr-welcome-internal.md`

## User Impact

Maintainers gain one new slash command on PRs. No effect on connector code, builds, or existing commands. The command is dispatcher-gated to users with write permission.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚


Link to Devin session: https://app.devin.ai/sessions/5b35d5fa6aca4650832665195968aafe
Open in Devin Desktop: https://app.devin.ai/desktop/session/5b35d5fa6aca4650832665195968aafe?variant=devin