### PR TITLE
docs(source-shiftbase): correct 0.0.1 changelog release date

### DIFF
--- a/docs/integrations/sources/shiftbase.md
+++ b/docs/integrations/sources/shiftbase.md
@@ -119,6 +119,6 @@ The Shiftbase API has rate limiting in place. The connector handles rate limits 
 
 | Version | Date | Pull Request | Subject |
 |:---|:---|:---|:---|
-| 0.0.1 | 2026-07-24 | [72899](https://github.com/airbytehq/airbyte/pull/72899) | Initial release |
+| 0.0.1 | 2026-08-27 | [72899](https://github.com/airbytehq/airbyte/pull/72899) | Initial release |
 
 </details>


### PR DESCRIPTION
## What

`source-shiftbase` 0.0.1 shipped in #72899, which was merged on 2026-08-27. The changelog row carried 2026-07-24 — the date an earlier revision of that branch was stamped with, not the release date.

## Why the docs page also needs this

Right now https://docs.airbyte.com/integrations/sources/shiftbase renders "Support Level: Archived" with no connector version. That label is not read from `metadata.yaml`; `docusaurus/src/remark/utils.js` looks the page up in `composite_registry.json` by `dockerRepository`, and when the lookup misses it synthesizes an entry with `supportLevel: "archived"`.

The lookup missed because of a publish race: the PR merged at 12:41:02Z and the registry entry was generated at 12:45:38Z, so the docs build that ran on the merge commit could not yet see the connector. The registry has been correct since — `supportLevel: community`, `availability: [cloud, oss]`, `0.0.1` — and running the docs lookup against the current registry resolves it correctly.

Later docs builds did not clear it because `pnpm build` never runs `docusaurus clean`, so the restored build cache reuses the compiled MDX for pages whose source has not changed. Editing this file forces the page to recompile, which re-runs the registry lookup and drops the archived label.

## Not included

`metadata.yaml` still has `releaseDate: 2026-07-24`. Correcting it would trip the version-increment QA check and require a 0.0.2 bump plus a republish, which is more than this cosmetic field is worth. Happy to do it as a follow-up if preferred.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

🤖 Generated with [Claude Code](https://claude.com/claude-code)