### PR TITLE
fix(source-okta): remove main.py from poetry packages to fix docker b…

### DIFF
--- a/airbyte-integrations/connectors/source-okta/pyproject.toml
+++ b/airbyte-integrations/connectors/source-okta/pyproject.toml
@@ -12,7 +12,7 @@ readme = "README.md"
 documentation = "https://docs.airbyte.com/integrations/sources/okta"
 homepage = "https://airbyte.com"
 repository = "https://github.com/airbytehq/airbyte"
-packages = [ { include = "source_okta" }, {include = "main.py"} ]
+packages = [ { include = "source_okta" } ]
 
 [tool.poetry.dependencies]
 python = "^3.9,<3.12"


### PR DESCRIPTION
Fix broken build from https://github.com/airbytehq/airbyte/pull/85086

Poetry treats main.py as a package directory during image builds, causing poetry install to fail. The connector entrypoint is already defined via the source-okta script pointing at source_okta.run:run.

## What
<!--
* Describe what the change is solving. Link all GitHub issues related to this change.
-->

## How
<!--
* Describe how code changes achieve the solution.
-->

## Review guide
<!--
1. `x.py`
2. `y.py`
-->

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [ ] YES 💚
- [ ] NO ❌
