### PR TITLE
fix(source-pylon): declare issues/accounts `tags` as an array of strings

### DIFF
--- a/airbyte-integrations/connectors/source-pylon/manifest.yaml
+++ b/airbyte-integrations/connectors/source-pylon/manifest.yaml
@@ -642,8 +642,7 @@ schemas:
           - "null"
           - array
         items:
-          type: object
-          additionalProperties: true
+          type: string
 
   contacts:
     type: object
@@ -820,8 +819,7 @@ schemas:
           - "null"
           - array
         items:
-          type: object
-          additionalProperties: true
+          type: string
       custom_fields:
         type:
           - "null"

--- a/airbyte-integrations/connectors/source-pylon/metadata.yaml
+++ b/airbyte-integrations/connectors/source-pylon/metadata.yaml
@@ -17,7 +17,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: f2e53e88-3c6b-4e5a-b7c2-a1d9c5e8f4b6
-  dockerImageTag: 0.0.20
+  dockerImageTag: 0.0.21
   dockerRepository: airbyte/source-pylon
   githubIssueLabel: source-pylon
   icon: icon.svg

--- a/docs/integrations/sources/pylon.md
+++ b/docs/integrations/sources/pylon.md
@@ -92,6 +92,7 @@ If you use Airbyte Cloud and your organization restricts access to specific IPs,
 
 | Version | Date       | Pull Request                                             | Subject                        |
 | :------ | :--------- | :------------------------------------------------------- | :----------------------------- |
+| 0.0.21 | 2026-08-28 | [PRNUM](https://github.com/airbytehq/airbyte/pull/PRNUM) | Fix `tags` on the `issues` and `accounts` streams: declared as an array of objects, but the API returns an array of strings, so every tag was silently nulled |
 | 0.0.20 | 2026-08-18 | [84722](https://github.com/airbytehq/airbyte/pull/84722) | Update dependencies |
 | 0.0.19 | 2026-08-11 | [84079](https://github.com/airbytehq/airbyte/pull/84079) | Update dependencies |
 | 0.0.18 | 2026-07-28 | [83194](https://github.com/airbytehq/airbyte/pull/83194) | Update to CDK 7.23.8 (fixes AirbyteCustomCodeNotPermittedError for bundled custom components) and remove the temporary Cloud version override |

--- a/docs/integrations/sources/pylon.md
+++ b/docs/integrations/sources/pylon.md
@@ -92,7 +92,7 @@ If you use Airbyte Cloud and your organization restricts access to specific IPs,
 
 | Version | Date       | Pull Request                                             | Subject                        |
 | :------ | :--------- | :------------------------------------------------------- | :----------------------------- |
-| 0.0.21 | 2026-08-28 | [PRNUM](https://github.com/airbytehq/airbyte/pull/PRNUM) | Fix `tags` on the `issues` and `accounts` streams: declared as an array of objects, but the API returns an array of strings, so every tag was silently nulled |
+| 0.0.21 | 2026-08-28 | [85172](https://github.com/airbytehq/airbyte/pull/85172) | Fix `tags` on the `issues` and `accounts` streams: declared as an array of objects, but the API returns an array of strings, so every tag was silently nulled |
 | 0.0.20 | 2026-08-18 | [84722](https://github.com/airbytehq/airbyte/pull/84722) | Update dependencies |
 | 0.0.19 | 2026-08-11 | [84079](https://github.com/airbytehq/airbyte/pull/84079) | Update dependencies |
 | 0.0.18 | 2026-07-28 | [83194](https://github.com/airbytehq/airbyte/pull/83194) | Update to CDK 7.23.8 (fixes AirbyteCustomCodeNotPermittedError for bundled custom components) and remove the temporary Cloud version override |


### PR DESCRIPTION
## What

`tags` on the `issues` and `accounts` streams is declared as an array of **objects**:

```yaml
tags:
  type: ["null", array]
  items:
    type: object
    additionalProperties: true
```

The Pylon API returns an array of **strings**. Per the [Issues API reference](https://docs.usepylon.com/pylon-docs/developer/api/api-reference/issues):

> `"tags":{"description":"Tags associated with the issue.","items":{"type":"string"},"type":"array"}`

This changes `items` to `{type: string}` on both streams.

## Why

Destinations that type-check array elements cannot coerce a string into an object, so each element is nulled **while the array's cardinality is preserved**. Tags arrive as `[null]`, `[null, null]`, … rather than as an empty or missing field.

The destination records it itself, in `_airbyte_meta.changes`:

```
tags.[0]  NULLED  DESTINATION_SERIALIZATION_ERROR  9,813
tags.[1]  NULLED  DESTINATION_SERIALIZATION_ERROR  2,784
tags.[2]  NULLED  DESTINATION_SERIALIZATION_ERROR    789
...                            (13,923 element records on issues, 77 on accounts)
```

Measured on our warehouse: **4,861 of 6,282 tickets (77.4%)** carry a tags array of 1–10 elements — 6,879 element slots, **zero** surviving values. Nothing else in either stream is affected.

## Why this is the value shape and not the destination

`issues.csat_responses` sits in the same stream, in the same output file, with the *identical* declared type `array<object, additionalProperties: true>` — and its elements really are objects, so they serialize fine to JSON strings (`{"score":5,"comment":null}`). Same for `accounts.channels`, `contacts.integration_user_ids` and `teams.users`, all verified populated. Only the two `tags` fields break.

I left the other `array<object>` declarations alone. Four are confirmed correct against live values; three (`accounts.external_ids`, `issues.external_issues`, `ticket_forms.fields`) are empty on every row in our data, so I have nothing to check them against and didn't want to guess.

## Verification

Resolved against `airbyte-cdk==7.25.1` — the version this connector's base image pins — with `components.py` importable so the `issues` state migration stays in play:

```
CDK ACCEPTED patched manifest — 15 streams (state_migrations INTACT)
  accounts.tags -> {"type": ["null", "array"], "items": {"type": "string"}}
  issues.tags   -> {"type": ["null", "array"], "items": {"type": "string"}}
```

## Note for existing users

`issues` is `incremental`/`append` on `updated_at`, so upgrading alone will not repair history — only tickets whose `updated_at` advances pick up tags. Recovering older tickets needs a state clear, and the connector's `start_date` defaults to 30 days ago, so it must be set explicitly first or the backfill silently truncates. `accounts` is full-refresh and self-heals on the next sync.

Happy to split the two streams into separate commits or add a regression test if you'd prefer.
