### PR TITLE
fix(ashby): remove always-null interview-event fields from interviews stream schema

### DIFF
--- a/airbyte-integrations/connectors/source-ashby/manifest.yaml
+++ b/airbyte-integrations/connectors/source-ashby/manifest.yaml
@@ -1081,60 +1081,47 @@ streams:
             type:
               - "null"
               - string
-          applicationId:
+          title:
             type:
               - "null"
               - string
-          interviewScheduleId:
+          externalTitle:
             type:
               - "null"
               - string
-          interviewStageId:
+          type:
             type:
               - "null"
               - string
-          status:
+          isArchived:
+            type:
+              - "null"
+              - boolean
+          isDebrief:
+            type:
+              - "null"
+              - boolean
+          isFeedbackRequired:
+            type:
+              - "null"
+              - boolean
+          isFeedbackRequested:
+            type:
+              - "null"
+              - boolean
+          instructionsHtml:
             type:
               - "null"
               - string
-          createdAt:
+          instructionsPlain:
             type:
               - "null"
               - string
-            format: date-time
-          updatedAt:
+          jobId:
             type:
               - "null"
               - string
-            format: date-time
-          cancelledAt:
-            type:
-              - "null"
-              - string
-            format: date-time
-          startTime:
-            type:
-              - "null"
-              - string
-            format: date-time
-          endTime:
-            type:
-              - "null"
-              - string
-            format: date-time
-          feedbackLink:
-            type:
-              - "null"
-              - string
-          interviewerUserIds:
-            type:
-              - "null"
-              - array
-            items:
-              type:
-                - "null"
-                - string
-          meetingLink:
+          feedbackFormDefinitionId:
             type:
               - "null"
               - string

--- a/airbyte-integrations/connectors/source-ashby/metadata.yaml
+++ b/airbyte-integrations/connectors/source-ashby/metadata.yaml
@@ -2,7 +2,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 4e8c9fa0-3634-499b-b948-11581b5c3efa
-  dockerImageTag: 1.1.0
+  dockerImageTag: 1.2.0
   dockerRepository: airbyte/source-ashby
   githubIssueLabel: source-ashby
   icon: ashby.svg

--- a/airbyte-integrations/connectors/source-ashby/metadata.yaml
+++ b/airbyte-integrations/connectors/source-ashby/metadata.yaml
@@ -2,7 +2,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 4e8c9fa0-3634-499b-b948-11581b5c3efa
-  dockerImageTag: 1.2.1
+  dockerImageTag: 1.1.1
   dockerRepository: airbyte/source-ashby
   githubIssueLabel: source-ashby
   icon: ashby.svg

--- a/docs/integrations/sources/ashby.md
+++ b/docs/integrations/sources/ashby.md
@@ -95,6 +95,7 @@ Version 1.0.0 declares element schemas for array columns that the connector prev
 
 | Version | Date       | Pull Request                                             | Subject                                     |
 |:--------| :--------- | :------------------------------------------------------- |:--------------------------------------------|
+| 1.2.0 | 2026-08-29 | [00000](https://github.com/airbytehq/airbyte/pull/00000) | Fix `interviews` stream schema: declare the fields actually returned by `interview.list` (interview definitions) instead of interview-event fields that were always null |
 | 1.1.0 | 2026-08-25 | [84392](https://github.com/airbytehq/airbyte/pull/84392) | Add application history stream |
 | 1.0.1 | 2026-08-25 | [84405](https://github.com/airbytehq/airbyte/pull/84405) | Send the pagination page size using Ashby's documented `limit` field instead of the undocumented `per_page` field |
 | 1.0.0 | 2026-08-18 | [84274](https://github.com/airbytehq/airbyte/pull/84274) | Breaking: declare documented API fields across stream schemas, including element schemas for previously untyped array columns. Data-lake users must refresh the affected streams, then recreate the affected tables if a sync still fails. See the [migration guide](/integrations/sources/ashby-migrations). |

--- a/docs/integrations/sources/ashby.md
+++ b/docs/integrations/sources/ashby.md
@@ -95,8 +95,7 @@ Version 1.0.0 declares element schemas for array columns that the connector prev
 
 | Version | Date       | Pull Request                                             | Subject                                     |
 |:--------| :--------- | :------------------------------------------------------- |:--------------------------------------------|
-| 1.2.1 | 2026-08-29 | [85182](https://github.com/airbytehq/airbyte/pull/85182) | Remove interview-event fields from the `interviews` stream schema that `interview.list` never returns (the columns were always null) |
-| 1.2.0 | 2026-08-29 | [85183](https://github.com/airbytehq/airbyte/pull/85183) | Declare the interview definition fields `interview.list` actually returns on the `interviews` stream, and request non-shared (job-specific) interviews |
+| 1.1.1 | 2026-08-29 | [85182](https://github.com/airbytehq/airbyte/pull/85182) | Fix the `interviews` stream schema: declare the interview definition fields `interview.list` actually returns instead of interview-event fields that were always null, and request non-shared (job-specific) interviews |
 | 1.1.0 | 2026-08-25 | [84392](https://github.com/airbytehq/airbyte/pull/84392) | Add application history stream |
 | 1.0.1 | 2026-08-25 | [84405](https://github.com/airbytehq/airbyte/pull/84405) | Send the pagination page size using Ashby's documented `limit` field instead of the undocumented `per_page` field |
 | 1.0.0 | 2026-08-18 | [84274](https://github.com/airbytehq/airbyte/pull/84274) | Breaking: declare documented API fields across stream schemas, including element schemas for previously untyped array columns. Data-lake users must refresh the affected streams, then recreate the affected tables if a sync still fails. See the [migration guide](/integrations/sources/ashby-migrations). |

--- a/docs/integrations/sources/ashby.md
+++ b/docs/integrations/sources/ashby.md
@@ -95,7 +95,7 @@ Version 1.0.0 declares element schemas for array columns that the connector prev
 
 | Version | Date       | Pull Request                                             | Subject                                     |
 |:--------| :--------- | :------------------------------------------------------- |:--------------------------------------------|
-| 1.2.0 | 2026-08-29 | [00000](https://github.com/airbytehq/airbyte/pull/00000) | Fix `interviews` stream schema: declare the fields actually returned by `interview.list` (interview definitions) instead of interview-event fields that were always null |
+| 1.2.0 | 2026-08-29 | [85182](https://github.com/airbytehq/airbyte/pull/85182) | Fix `interviews` stream schema: declare the fields actually returned by `interview.list` (interview definitions) instead of interview-event fields that were always null |
 | 1.1.0 | 2026-08-25 | [84392](https://github.com/airbytehq/airbyte/pull/84392) | Add application history stream |
 | 1.0.1 | 2026-08-25 | [84405](https://github.com/airbytehq/airbyte/pull/84405) | Send the pagination page size using Ashby's documented `limit` field instead of the undocumented `per_page` field |
 | 1.0.0 | 2026-08-18 | [84274](https://github.com/airbytehq/airbyte/pull/84274) | Breaking: declare documented API fields across stream schemas, including element schemas for previously untyped array columns. Data-lake users must refresh the affected streams, then recreate the affected tables if a sync still fails. See the [migration guide](/integrations/sources/ashby-migrations). |


### PR DESCRIPTION
Follow-up to #85183, which added the correct `interview.list` definition fields but kept the old interview-event fields (`interviewScheduleId`, `status`, `startTime`, etc.) that the endpoint never returns. This removes those always-null columns from the `interviews` stream schema.

Response schema reference: [Ashby API — interview.list](https://developers.ashbyhq.com/reference/interviewlist)