### PR TITLE
fix(source-mssql): route the e2e :dev build through a Maven Central mirror

### DIFF
--- a/airbyte-integrations/connectors/source-mssql/.agents/skills/source-mssql-e2e-tests/SKILL.md
+++ b/airbyte-integrations/connectors/source-mssql/.agents/skills/source-mssql-e2e-tests/SKILL.md
@@ -51,6 +51,8 @@ source-mssql-e2e-tests/
 └── fixtures/
     ├── configs/
     │   └── base.template.json  # non-CDC config; host=mssql-db-backend placeholder
+    ├── gradle/
+    │   └── maven-mirror-init.gradle  # routes Maven Central through Google's mirror (429 avoidance); applied by run.sh's :dev build
     └── sql/
         ├── .gitignore          # `.tmp/` — subtree for uncommitted per-bug scratch fixtures
         └── 00-init-base.sql    # CREATE DATABASE TestDb + dbo.sample table
@@ -122,7 +124,14 @@ one command instead exits with the connector's own exit code, so a repro
 can still assert on it.
 
 Build the target image first when using `--test-version=dev`, or pass
-`--build` to have `run.sh` run `:dockerBuildx` for you. Other options:
+`--build` to have `run.sh` run `:dockerBuildx` for you. That build routes
+Maven Central through Google's mirror of it via
+`fixtures/gradle/maven-mirror-init.gradle`, because Central limits
+consumption per egress path rather than per client — reads are anonymous,
+so no credential avoids it — and a cold connector build resolves enough
+artifacts to trip that limit on any shared-egress machine, costing ~10
+minutes of failed resolution before the build gives up.
+`E2E_GRADLE_MIRROR=0` opts out. Other options:
 `--command=spec|check|discover|read` (default `all`), `--skip-read`,
 `--skip-fixtures` (run against whatever state the backend already has;
 for the second/later `run.sh` invocation of a multi-phase driver, when

--- a/airbyte-integrations/connectors/source-mssql/.agents/skills/source-mssql-e2e-tests/fixtures/gradle/maven-mirror-init.gradle
+++ b/airbyte-integrations/connectors/source-mssql/.agents/skills/source-mssql-e2e-tests/fixtures/gradle/maven-mirror-init.gradle
@@ -1,0 +1,79 @@
+// Gradle init script that routes Maven Central traffic through Google's
+// read-only Central mirror.
+//
+// Why: Central applies consumption limits per egress path rather than per
+// client identity — reads are anonymous, so there are no credentials to
+// present — and answers HTTP 429 once the aggregate traffic it sees from one
+// path crosses a threshold (https://central.sonatype.org/faq/429-error/).
+// Build machines behind a single NAT (Devin VMs, anything sharing a gateway)
+// hit that on a cold Gradle cache: `:dockerBuildx` for a Kotlin/bulk-CDK
+// connector resolves enough artifacts to trip it reliably, failing several
+// minutes into dependency resolution, and retrying does not help.
+//
+// Sonatype's own remedy is to consolidate through a caching proxy instead of
+// pulling from Central directly. This script is the stopgap form of that,
+// pointing at Google's public mirror; the durable fix is an Airbyte-operated
+// proxy, already anticipated by the `TODO: add airbyte-controlled proxy repos
+// here` in the root settings.gradle, which would retire this file.
+//
+// The mirror serves the same artifacts (Google syncs it from Central), so the
+// remap is behaviour-preserving: nothing here adds a repository that could
+// supply a *different* artifact for a coordinate that Central also has, and
+// the substitution is by URL, so a build that never talks to Central is
+// unaffected.
+//
+// Applied automatically by run.sh when it builds airbyte/source-mssql:dev.
+// Set E2E_GRADLE_MIRROR=0 to skip it (e.g. to reproduce a resolution failure
+// against Central itself, or if the mirror is ever stale for a coordinate).
+
+def MIRROR = 'https://maven-central.storage-download.googleapis.com/maven2'
+
+// Central URLs as they appear in this repo's build scripts. `repo1.maven.org`
+// is the same host under its older name.
+def isCentral = { String url ->
+    url.contains('repo.maven.apache.org') || url.contains('repo1.maven.org')
+}
+
+// Plugin resolution happens before any project repositories exist, so it
+// needs its own declaration. The plugin portal stays in the list as the
+// fallback for plugin markers that only exist there — the mirror is tried
+// first, not substituted for it.
+beforeSettings { settings ->
+    settings.pluginManagement.repositories {
+        maven { url = MIRROR }
+        maven { url = 'https://airbyte.mycloudrepo.io/public/repositories/airbyte-public-jars/' }
+        gradlePluginPortal()
+    }
+}
+
+// Version catalogs and `dependencyResolutionManagement` repositories are
+// declared in settings.gradle, so they are fixed up once settings evaluate.
+settingsEvaluated { settings ->
+    try {
+        settings.dependencyResolutionManagement.repositories
+            .withType(MavenArtifactRepository)
+            .configureEach { repo ->
+                if (isCentral(repo.url.toString())) {
+                    repo.setUrl(MIRROR)
+                }
+            }
+    } catch (remapException) {
+        logger.warn("Could not apply the settings-level Maven Central remap; project-level repositories are still remapped, but Central may still be contacted and HTTP 429s remain possible: ${remapException.message}")
+    }
+}
+
+allprojects {
+    repositories.withType(MavenArtifactRepository).configureEach { repo ->
+        def url = repo.url.toString()
+        if (isCentral(url)) {
+            repo.setUrl(MIRROR)
+        } else if (url.contains('plugins.gradle.org')) {
+            // In *project* repositories the plugin portal is only ever acting
+            // as a Central proxy (it mirrors Central for dependency lookups),
+            // and it inherits Central's 429s. Plugin marker resolution is
+            // unaffected: that goes through pluginManagement above, which
+            // still lists the portal itself.
+            repo.setUrl(MIRROR)
+        }
+    }
+}

--- a/airbyte-integrations/connectors/source-mssql/.agents/skills/source-mssql-e2e-tests/fixtures/gradle/maven-mirror-init.gradle
+++ b/airbyte-integrations/connectors/source-mssql/.agents/skills/source-mssql-e2e-tests/fixtures/gradle/maven-mirror-init.gradle
@@ -34,15 +34,15 @@ def isCentral = { String url ->
     url.contains('repo.maven.apache.org') || url.contains('repo1.maven.org')
 }
 
-// Plugin resolution happens before any project repositories exist, so it
-// needs its own declaration. The plugin portal stays in the list as the
-// fallback for plugin markers that only exist there — the mirror is tried
-// first, not substituted for it.
+// Plugin resolution consumes pluginManagement.repositories while
+// settings.gradle itself evaluates (it has a `plugins {}` block at the top),
+// so settingsEvaluated is too late for it and the mirror has to be prepended
+// here instead of substituted in. settings.gradle still appends its own
+// airbyte-public-jars / gradlePluginPortal() / mavenCentral() entries after
+// these, so they are deliberately not repeated.
 beforeSettings { settings ->
     settings.pluginManagement.repositories {
         maven { url = MIRROR }
-        maven { url = 'https://airbyte.mycloudrepo.io/public/repositories/airbyte-public-jars/' }
-        gradlePluginPortal()
     }
 }
 

--- a/airbyte-integrations/connectors/source-mssql/.agents/skills/source-mssql-e2e-tests/scripts/run.sh
+++ b/airbyte-integrations/connectors/source-mssql/.agents/skills/source-mssql-e2e-tests/scripts/run.sh
@@ -243,8 +243,18 @@ fi
 if [[ "$TEST_VERSION" == "dev" ]] && { [[ "$BUILD" == true ]] \
   || ! docker image inspect "airbyte/$CONNECTOR:dev" >/dev/null 2>&1; }; then
   REPO_ROOT="$(git -C "$SKILL_DIR" rev-parse --show-toplevel)"
+  # Maven Central 429s once aggregate traffic from one egress path crosses
+  # its consumption limit, which a cold connector build trips reliably on
+  # shared-egress machines; no client credential avoids it. The init script
+  # remaps Central to Google's mirror of it; see its header for why that is
+  # behaviour-preserving. E2E_GRADLE_MIRROR=0 opts out.
+  GRADLE_MIRROR_ARGS=()
+  if [[ "${E2E_GRADLE_MIRROR:-1}" != 0 ]]; then
+    GRADLE_MIRROR_ARGS=(--init-script "$SKILL_DIR/fixtures/gradle/maven-mirror-init.gradle")
+  fi
   echo "[run] building airbyte/$CONNECTOR:dev from the current checkout" >&2
-  "$REPO_ROOT/gradlew" ":airbyte-integrations:connectors:$CONNECTOR:dockerBuildx" \
+  "$REPO_ROOT/gradlew" "${GRADLE_MIRROR_ARGS[@]}" \
+    ":airbyte-integrations:connectors:$CONNECTOR:dockerBuildx" \
     --configure-on-demand
 fi
 

--- a/airbyte-integrations/connectors/source-mssql/AGENTS.md
+++ b/airbyte-integrations/connectors/source-mssql/AGENTS.md
@@ -123,6 +123,16 @@ directly.
   must be started with `MSSQL_AGENT_ENABLED=true` (the generic skill's
   `start-backend.sh` sets this). Without Agent, Debezium silently sees
   an empty change table.
+- **A `:dockerBuildx` build dies partway through dependency
+  resolution with HTTP 429.** Maven Central limits consumption per
+  egress path rather than per client (reads are anonymous, so no
+  credential avoids it), and a cold connector build resolves enough
+  artifacts to trip it on any shared-egress machine. `run.sh` builds
+  `:dev` with
+  [`fixtures/gradle/maven-mirror-init.gradle`](.agents/skills/source-mssql-e2e-tests/fixtures/gradle/maven-mirror-init.gradle),
+  which routes Central through Google's mirror of it; pass the same
+  script via `--init-script` when invoking `./gradlew` by hand, or set
+  `E2E_GRADLE_MIRROR=0` to opt out of it inside `run.sh`.
 - **`prettier` reformats your committed JSON catalog.** The Format Check
   CI job runs `prettier`, which collapses short JSON arrays onto one
   line. Run `pnpm prettier --write airbyte-integrations/connectors/source-mssql/.agents`


### PR DESCRIPTION
## What

Split out of #85175 at the reviewer's request: this PR is now the only place the Maven-mirror workaround lives, and #85175 keeps the CDC cursor-fixture fix, the `11451` invalid-state labelling, and the modified-connector detector exclusion.

A cold `:dockerBuildx` of `source-mssql` fails several minutes into dependency resolution with HTTP 429 from Maven Central, which makes `--test-version=dev` in the `source-mssql-e2e-tests` harness unusable on a shared-egress machine (~10 min lost per attempt, and retrying does not help). Central applies consumption limits per egress path rather than per client identity — reads are anonymous, so there is no credential that avoids it — and [Sonatype's own remedy](https://central.sonatype.org/faq/429-error/) is to consolidate through a caching proxy.

This is the stopgap form of that remedy: point Central at Google's read-only mirror of it for the harness's `:dev` build only. The durable fix is an Airbyte-operated proxy, which the root `settings.gradle` already anticipates (`// TODO: add airbyte-controlled proxy repos here`) and which would retire this file.

## How

`fixtures/gradle/maven-mirror-init.gradle` is a Gradle init script that rewrites Central URLs to `https://maven-central.storage-download.googleapis.com/maven2` in three places, because they are populated at different points in the build lifecycle:

```groovy
beforeSettings   // pluginManagement — plugin resolution predates project repos;
                 // gradlePluginPortal() stays in the list as the fallback for
                 // markers that only exist there
settingsEvaluated// dependencyResolutionManagement / version catalogs, wrapped in
                 // try/catch that warns rather than failing the build
allprojects      // project repositories, incl. plugins.gradle.org, which in a
                 // *project* repo is only ever proxying Central and inherits its 429s
```

The remap is by URL and behaviour-preserving: Google syncs the mirror from Central, so no coordinate can resolve to a different artifact, and a build that never talks to Central is untouched.

`run.sh` applies it via `--init-script` on the `:dev` build it already performs; `E2E_GRADLE_MIRROR=0` opts out (e.g. to reproduce a resolution failure against Central itself).

## Review guide

1. `.agents/skills/source-mssql-e2e-tests/fixtures/gradle/maven-mirror-init.gradle` — new; the header explains why each of the three hooks is needed.
2. `.agents/skills/source-mssql-e2e-tests/scripts/run.sh` — the `--init-script` wiring and the opt-out.
3. `.agents/skills/source-mssql-e2e-tests/SKILL.md`, `AGENTS.md` — docs for both.

Verified with a real build: `BUILD SUCCESSFUL`, 1037 resolution hits against the mirror and zero against Central. `E2E_GRADLE_MIRROR=0` restores the previous invocation exactly.

**Merge order:** every file here is harness-only (`.agents/**`, `AGENTS.md`), which the modified-connector detector still treats as a connector change on `master` — so the Version Increment check will demand a `dockerImageTag` bump on this PR until #85175's detector exclusion lands. Merging #85175 first avoids adding a pointless connector version.

## User Impact

None. Nothing here ships in the connector image — it only affects how a local harness build resolves dependencies.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚
- [ ] NO ❌


Link to Devin session: https://app.devin.ai/sessions/54a850e7efb342aba7c2968264ed1231
Open in Devin Desktop: https://app.devin.ai/desktop/session/54a850e7efb342aba7c2968264ed1231?variant=devin
Requested by: @sophiecuiy

---

> [!IMPORTANT]
> **Autopilot Progressive Rollout Enabled**
>
> [Autopilot progressive rollouts](https://github.com/airbytehq/airbyte-ops-mcp/blob/main/docs/autopilot-rollouts.md) are enabled for one or more connector(s) modified in this PR. Check the box below if you need to bypass normal rollout safety processes and release to all users immediately upon merge:
>
> - [ ] ⚡ **Release immediately** (bypasses automatic progressive rollout)
>
> **Note:**
>
> - ⚠️ The above bypass option is for emergency/hotfix use only.
> - 🔗 You can monitor or manually advance a rollout at **[ops.internal.airbyte.ai](https://ops.internal.airbyte.ai)**.