### PR TITLE
docs(source-mssql): document pre-release images as the target-image path

### DIFF
--- a/airbyte-integrations/connectors/source-mssql/.agents/skills/source-mssql-e2e-tests/SKILL.md
+++ b/airbyte-integrations/connectors/source-mssql/.agents/skills/source-mssql-e2e-tests/SKILL.md
@@ -121,7 +121,12 @@ CI the table is also appended to `$GITHUB_STEP_SUMMARY`. A run limited to
 one command instead exits with the connector's own exit code, so a repro
 can still assert on it.
 
-Build the target image first when using `--test-version=dev`, or pass
+Prefer a published tag over `--test-version=dev`: for code on a pushed PR
+branch, publish a pre-release and pass its `<version>-preview.<sha>` tag,
+which skips the Gradle build and gives reviewers a tag they can re-run
+against — see
+[Getting a target image](../../../AGENTS.md#getting-a-target-image). When
+you do use `--test-version=dev`, build the target image first, or pass
 `--build` to have `run.sh` run `:dockerBuildx` for you. Other options:
 `--command=spec|check|discover|read` (default `all`), `--skip-read`,
 `--skip-fixtures` (run against whatever state the backend already has;

--- a/airbyte-integrations/connectors/source-mssql/AGENTS.md
+++ b/airbyte-integrations/connectors/source-mssql/AGENTS.md
@@ -49,6 +49,19 @@ skills under [`.agents/skills/`](.agents/skills/) own the actual harness:
 **Never** repro against a customer connection or against an Airbyte Cloud
 instance.
 
+### Getting a target image
+
+To test a fix that has not merged yet, publish a pre-release from its PR with
+the Airbyte Ops MCP tool `publish_connector_to_airbyte_registry` (the
+[`publish-connector-prerelease`](https://github.com/airbytehq/ai-skills/tree/main/.agents/skills/publish-connector-prerelease)
+skill in `airbytehq/ai-skills` covers the invocation), and pass the resulting
+`<version>-preview.<7-char-sha>` tag as `--test-version`. The harness pulls
+any published tag and only builds from the checkout when `--test-version` is
+literally `dev`, so this skips a cold Gradle build entirely and gives
+reviewers a tag they can re-run against. Build locally with
+`./gradlew :airbyte-integrations:connectors:source-mssql:dockerBuildx` only
+for code that is not on a pushed PR branch.
+
 ### Quickstart
 
 ```bash


### PR DESCRIPTION
## What

`AGENTS.md` tells an agent how to reproduce a source-mssql bug locally, but it never said how to get the *fixed* image to compare against — so agents inferred the only thing documented anywhere, a local `./gradlew :source-mssql:dockerBuildx`. That is the slow path (a cold build resolves hundreds of artifacts from Maven Central, which rate-limits per egress path) and it produces an image nobody else can pull, so a reviewer cannot re-run the evidence.

A pre-release published from the PR under test is strictly better and already exists. Closes the doc half of the discussion on #85235, which tried to make the local build survive Central's 429s and is now closed as superseded.

## How

One new `### Getting a target image` subsection in `AGENTS.md`, ahead of the harness quickstart: publish with the Ops MCP `publish_connector_to_airbyte_registry` tool (linking [`publish-connector-prerelease`](https://github.com/airbytehq/ai-skills/tree/main/.agents/skills/publish-connector-prerelease) for the invocation rather than restating it), pass the resulting `<version>-preview.<sha>` as `--test-version`, and treat `dockerBuildx` as the fallback for code not on a pushed PR branch.

The generic harness skill gets the same guidance at its own decision point. `source-mssql-e2e-tests/SKILL.md` is where an agent actually chooses a target image — it's the skill the prove-fix playbook routes to — and its options paragraph opened with "Build the target image first when using `--test-version=dev`", presenting the local build as the default with no pointer to the new section. It now leads with the published tag and links to it.

No harness code changes were needed: `run.sh` already pulls any published tag and only shells out to Gradle when `--test-version` is literally `dev`.

The generic half of this landed in [ai-skills#793](https://github.com/airbytehq/ai-skills/pull/793) (merged), where the prove-fix playbook now names the same tool and skill as the default way to obtain a target image.

## Review guide

1. `airbyte-integrations/connectors/source-mssql/AGENTS.md` — the new subsection.
2. `airbyte-integrations/connectors/source-mssql/.agents/skills/source-mssql-e2e-tests/SKILL.md` — the relative link resolves to that subsection's anchor.

## User Impact

None on the connector: docs-only, no `dockerImageTag` bump (deliberate, per @sophiecuiy on the preceding harness PRs), so the Version Increment check is expected to fail.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚


Link to Devin session: https://app.devin.ai/sessions/6df641e3213249f48bf15fb95597475a
Open in Devin Desktop: https://app.devin.ai/desktop/session/6df641e3213249f48bf15fb95597475a?variant=devin