### PR TITLE
fix(paypal-connector): add backoff strategy for transactions

### DIFF
--- a/airbyte-integrations/connectors/source-paypal-transaction/CHANGELOG.md
+++ b/airbyte-integrations/connectors/source-paypal-transaction/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.6.49
+
+Increase the backoff duration for PayPal transaction rate-limit responses.
+
 ## 0.1.0
 
 Source implementation with support of Transactions and Balances streams

--- a/airbyte-integrations/connectors/source-paypal-transaction/CHANGELOG.md
+++ b/airbyte-integrations/connectors/source-paypal-transaction/CHANGELOG.md
@@ -1,9 +1,5 @@
 # Changelog
 
-## 2.6.49
-
-Increase the backoff duration for PayPal transaction rate-limit responses.
-
 ## 0.1.0
 
 Source implementation with support of Transactions and Balances streams

--- a/airbyte-integrations/connectors/source-paypal-transaction/manifest.yaml
+++ b/airbyte-integrations/connectors/source-paypal-transaction/manifest.yaml
@@ -46,6 +46,9 @@ definitions:
                       {{ 'Data for the given start date is not available' in
                       response['message']}}
                 # Asks the retriever to narrow the date window on HTTP 400 RESULTSET_TOO_LARGE.
+                backoff_strategies:
+                  - type: ConstantBackoffStrategy
+                    backoff_time_in_seconds: 100
               - type: CustomErrorHandler
                 class_name: source_declarative_manifest.components.ResultSetTooLargeErrorHandler
         record_selector:

--- a/airbyte-integrations/connectors/source-paypal-transaction/metadata.yaml
+++ b/airbyte-integrations/connectors/source-paypal-transaction/metadata.yaml
@@ -11,7 +11,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: d913b0f2-cc51-4e55-a44c-8ba1697b9239
-  dockerImageTag: 2.6.48
+  dockerImageTag: 2.6.49
   dockerRepository: airbyte/source-paypal-transaction
   documentationUrl: https://docs.airbyte.com/integrations/sources/paypal-transaction
   githubIssueLabel: source-paypal-transaction

--- a/airbyte-integrations/connectors/source-paypal-transaction/unit_tests/test_components.py
+++ b/airbyte-integrations/connectors/source-paypal-transaction/unit_tests/test_components.py
@@ -2,7 +2,6 @@
 
 import logging
 import time
-from copy import deepcopy
 from datetime import datetime
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -12,11 +11,6 @@ import requests
 import yaml
 
 from airbyte_cdk.sources.declarative.interpolation.jinja import JinjaInterpolation
-from airbyte_cdk.sources.declarative.manifest_declarative_source import ManifestDeclarativeSource
-from airbyte_cdk.sources.declarative.requesters.error_handlers.backoff_strategies.constant_backoff_strategy import (
-    ConstantBackoffStrategy,
-)
-from airbyte_cdk.sources.declarative.requesters.error_handlers.default_error_handler import DefaultErrorHandler
 
 
 @pytest.fixture
@@ -197,20 +191,6 @@ def test_transactions_rate_limits_use_long_backoff(manifest):
         for strategy in backoff_strategies
         if strategy["type"] == "ConstantBackoffStrategy"
     } == {"ConstantBackoffStrategy": 100}
-
-
-def test_transactions_rate_limits_use_long_backoff_at_runtime(config, manifest_path):
-    source_config = deepcopy(yaml.safe_load(manifest_path.read_text()))
-    source_config["definitions"]["base_requester"].pop("authenticator")
-    source = ManifestDeclarativeSource(source_config=source_config)
-    transactions = next(stream for stream in source.streams(config) if stream.name == "transactions")
-    requester = transactions.retriever.requester
-    error_handler = requester.error_handler
-    default_handler = next(handler for handler in error_handler.error_handlers if isinstance(handler, DefaultErrorHandler))
-
-    constant_strategies = [strategy for strategy in default_handler.backoff_strategies if isinstance(strategy, ConstantBackoffStrategy)]
-    assert len(constant_strategies) == 1
-    assert constant_strategies[0].backoff_time_in_seconds.eval(config) == 100
 
 
 @pytest.mark.parametrize(

--- a/airbyte-integrations/connectors/source-paypal-transaction/unit_tests/test_components.py
+++ b/airbyte-integrations/connectors/source-paypal-transaction/unit_tests/test_components.py
@@ -2,6 +2,7 @@
 
 import logging
 import time
+from copy import deepcopy
 from datetime import datetime
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -11,6 +12,11 @@ import requests
 import yaml
 
 from airbyte_cdk.sources.declarative.interpolation.jinja import JinjaInterpolation
+from airbyte_cdk.sources.declarative.manifest_declarative_source import ManifestDeclarativeSource
+from airbyte_cdk.sources.declarative.requesters.error_handlers.backoff_strategies.constant_backoff_strategy import (
+    ConstantBackoffStrategy,
+)
+from airbyte_cdk.sources.declarative.requesters.error_handlers.default_error_handler import DefaultErrorHandler
 
 
 @pytest.fixture
@@ -177,6 +183,34 @@ def test_manifest_transaction_id_has_value_type_string(manifest):
     assert tid_fields[0].get("value_type") == "string", (
         "transaction_id AddFields must set value_type: string to prevent " "scientific-notation IDs from being coerced to float('inf')"
     )
+
+
+def test_transactions_rate_limits_use_long_backoff(manifest):
+    """Transactions must retry rate limits instead of failing after the default delay."""
+    transactions = manifest["definitions"]["streams"]["transactions"]
+    error_handler = transactions["retriever"]["requester"]["error_handler"]
+    default_handler = next(handler for handler in error_handler["error_handlers"] if handler["type"] == "DefaultErrorHandler")
+
+    backoff_strategies = default_handler["backoff_strategies"]
+    assert {
+        strategy["type"]: strategy["backoff_time_in_seconds"]
+        for strategy in backoff_strategies
+        if strategy["type"] == "ConstantBackoffStrategy"
+    } == {"ConstantBackoffStrategy": 100}
+
+
+def test_transactions_rate_limits_use_long_backoff_at_runtime(config, manifest_path):
+    source_config = deepcopy(yaml.safe_load(manifest_path.read_text()))
+    source_config["definitions"]["base_requester"].pop("authenticator")
+    source = ManifestDeclarativeSource(source_config=source_config)
+    transactions = next(stream for stream in source.streams(config) if stream.name == "transactions")
+    requester = transactions.retriever.requester
+    error_handler = requester.error_handler
+    default_handler = next(handler for handler in error_handler.error_handlers if isinstance(handler, DefaultErrorHandler))
+
+    constant_strategies = [strategy for strategy in default_handler.backoff_strategies if isinstance(strategy, ConstantBackoffStrategy)]
+    assert len(constant_strategies) == 1
+    assert constant_strategies[0].backoff_time_in_seconds.eval(config) == 100
 
 
 @pytest.mark.parametrize(

--- a/docs/integrations/sources/paypal-transaction.md
+++ b/docs/integrations/sources/paypal-transaction.md
@@ -268,6 +268,7 @@ If you use Airbyte Cloud and your organization restricts access to specific IPs,
 
 | Version | Date       | Pull Request                                             | Subject                                                                                                                      |
 | :------ | :--------- | :------------------------------------------------------- | :--------------------------------------------------------------------------------------------------------------------------- |
+| 2.6.49 | 2026-09-11 | [85249](https://github.com/airbytehq/airbyte/pull/85249) | Increase the backoff duration for PayPal transaction rate-limit responses |
 | 2.6.48 | 2026-09-08 | [84916](https://github.com/airbytehq/airbyte/pull/84916) | Retry oversized `transactions` date slices as smaller date ranges instead of failing the sync on the first `RESULTSET_TOO_LARGE` response |
 | 2.6.47 | 2026-09-08 | [85594](https://github.com/airbytehq/airbyte/pull/85594) | Update dependencies |
 | 2.6.46 | 2026-08-26 | [79676](https://github.com/airbytehq/airbyte/pull/79676) | Fix `transaction_id` primary key emitted as null for IDs resembling scientific notation |


### PR DESCRIPTION
Fixes #85153.

Updated the PayPal transactions stream to use a 100-second constant backoff for HTTP 429 rate-limit responses, preventing retries from exhausting too quickly.

The PR was rebased onto the latest upstream/master, and the manifest conflict was resolved while preserving the existing RESULTSET_TOO_LARGE date-window splitting behavior.

Validation:

pytest -q unit_tests/test_components.py unit_tests/test_payments_generator.py: 15 passed
Ruff checks passed
PayPal sandbox acceptance tests were not run because credentials were unavailable.
