### PR TITLE
chore: set explicit author for automated CDK upgrade commits

### DIFF
--- a/.github/workflows/auto-upgrade-certified-connectors-cdk.yml
+++ b/.github/workflows/auto-upgrade-certified-connectors-cdk.yml
@@ -118,6 +118,7 @@ jobs:
         with:
           token: ${{ steps.app-token.outputs.token }}
           commit-message: "chore: upgrade bulk CDK for ${{ matrix.connector }}"
+          author: "sunil-kuruba <270477162+sunil-kuruba@users.noreply.github.com>"
           branch: "auto-upgrade-jvm-bulk-cdk/${{ steps.upgrade-cdk.outputs.new_cdk_version }}/${{ matrix.connector }}"
           delete-branch: true
           title: "chore: upgrade ${{ matrix.connector }} to bulk CDK ${{ steps.upgrade-cdk.outputs.new_cdk_version }}"


### PR DESCRIPTION
## Summary

The `peter-evans/create-pull-request` action in the auto CDK upgrade workflow defaults to `github.actor` for the commit author. On scheduled runs, this resolves to whichever user last modified the workflow file on the default branch — currently `edgao` — causing automated commits to be misattributed to a human.

This PR adds an explicit `author` parameter to the `create-pull-request` step so the commit author is deterministic and no longer depends on `github.actor`.

## Changes

- `.github/workflows/auto-upgrade-certified-connectors-cdk.yml`: Added explicit `author` parameter to the `peter-evans/create-pull-request` step.