### PR TITLE
docs(release-notes): consolidate Cloud and Agents release notes Aug 13 – Sep 1, 2026

### DIFF
--- a/docs/release_notes/agents/readme.md
+++ b/docs/release_notes/agents/readme.md
@@ -1,5 +1,135 @@
 # Airbyte Agents release notes
 
+## September 1, 2026
+
+Web app
+
+- Your connectors and Context Store now stay marked Ready when synced data hasn't been searched for a while. Previously they looked like they were still building, even though your agents could still search that data.
+
+## August 31, 2026
+
+Web app
+
+- The skills page now warns you when a published skill can't be served to agents because your organization is missing one or more connectors the skill depends on, so you can set up those connectors before your agents need them.
+
+Connectors
+
+- The Greenhouse connector now signs in with OAuth and uses Greenhouse's latest Harvest API, adding access to interviews and file attachments alongside candidates, applications, jobs, and offers.
+- Credential checks for connectors that sign in with OAuth are now more reliable. When a quick validation can't safely use your credentials, the check automatically falls back to a full validation instead of failing.
+
+## August 28, 2026
+
+Web app
+
+- The Connectors page no longer shows an error on a connector whose data is ready and searchable again, so the status you see reflects how the connector is working now rather than a problem that has already been resolved.
+
+## August 27, 2026
+
+Web app
+
+- Chat now keeps up with your skills while a conversation is open. If you add, edit, disable, or remove a skill mid-chat, your agent picks up the change on your next message instead of continuing to follow the old instructions. If the skill list can't be loaded for a message, the agent tells you it's temporarily unavailable and asks you to try again rather than answering from skill content it saw earlier.
+
+SDK
+
+- Search filters now separate text matching from list matching. Use `contains` to match part of a text field, ignoring capitalization, and the new `array_contains` to check whether a list field includes an exact value. If you previously used `contains` against a list field, switch that filter to `array_contains`.
+- When you run connectors with credentials supplied from your own environment, you can now keep those credentials in Google Cloud Secret Manager in addition to AWS Secrets Manager.
+
+## August 26, 2026
+
+Connectors
+
+- Your agents can now search Notion comments by meaning, so they can find relevant discussion without matching exact keywords.
+- Your agents can now search Sentry issues by meaning, including the issue title and where the error happened, so they can find related problems without knowing the exact error text.
+- Your agents can now search your Facebook Marketing ad creative text by meaning, including headlines and body copy, so they can find ads with similar messaging without matching exact wording.
+- Your agents can now search your Customer.io campaign email content by meaning, including subject lines and message bodies, so they can find campaigns on a similar topic without matching exact wording.
+
+Other
+
+- Context Store data that gets stuck partway through an update now recovers on its own, so your agents keep searching current data without anyone needing to restart it.
+
+## August 25, 2026
+
+Connectors
+
+- You can now search by meaning, not just exact keywords, across Slack, HubSpot, Intercom, Monday.com, Asana, Greenhouse, and TikTok Marketing. Your agents can find relevant Slack messages and threads, HubSpot tickets, notes, calls, emails, and meetings, Intercom conversations, Monday.com boards, items, and updates, Asana tasks and projects, Greenhouse job posts, and TikTok ad text without matching the wording exactly.
+
+Other
+
+- Search now handles content that was written as rich text, such as job descriptions and email bodies, more accurately. Formatting is stripped into clean, readable text before it's indexed, so results better reflect what the content actually says.
+- Search results no longer drop identifying details, such as a record's title, from the record data they return. It's easier to tell results apart and act on the right one.
+
+## August 24, 2026
+
+SDK
+
+- Text filters when searching your synced data now use `startswith` and `endswith` for prefix and suffix matches, and `contains` for a case-insensitive substring match on text fields. These replace the previous `like` operator, so your filters no longer depend on wildcard patterns.
+
+## August 21, 2026
+
+Connectors
+
+- You can now search your Freshdesk data by meaning instead of exact keywords. Your agents can find relevant tickets, contact and company notes, and satisfaction survey feedback based on what the text is about, and narrow results by details like status, priority, or account tier.
+
+Other
+
+- When your agents filter a search-by-meaning request by a detail that isn't available, they now get a clear message listing the details you can filter on, instead of a confusing failure. Connector descriptions also list those filterable details up front, so agents pick valid ones the first time.
+
+## August 20, 2026
+
+Web app
+
+- Links in chat messages are now readable in dark mode.
+- Sortable column headings in tables now match the styling of the other headings instead of appearing in mixed case.
+
+Connectors
+
+- You can now search Twilio, Typeform, and incident.io by meaning. Your agents can find text message bodies, form questions and response answers, and incident names, alert descriptions, and incident updates without matching exact keywords.
+
+Other
+
+- When your agent searches your synced data using a field name that doesn't exist, it now gets the closest matching field names back so it can correct the search, instead of a generic failure.
+
+## August 19, 2026
+
+Web app
+
+- Pinning chats no longer stops at 50. Every chat you pin now shows up in the pinned group in the sidebar and reads as pinned in the chat header. Pinning and unpinning also take effect immediately, without waiting for the list to refresh.
+
+SDK
+
+- Google Ads list methods no longer take a page size, because Google fixes each page of results at its own size and rejects the setting. To get the next page, pass the page token from the previous response along with the same query.
+
+Connectors
+
+- Google Ads queries now page through large result sets correctly, so your agents return complete results instead of stopping after the first page. The connector also documents that it only reads accounts your sign-in has direct access to. Agents no longer retry accounts that are reachable only through a manager account.
+
+Other
+
+- When your agents match customers or companies across your connected apps, they now know which fields they can actually query and start from email addresses before trying other identifiers. Expect fewer failed lookups and quicker answers.
+
+## August 18, 2026
+
+Web app
+
+- Fixed an issue where long-running chat responses could be cut off before the agent finished answering.
+
+SDK
+
+- Searches against your synced data now filter out weakly related results by default, so agents get more relevant matches. You can adjust or turn off this minimum similarity cutoff when you need broader results.
+
+## August 17, 2026
+
+Web app
+
+- When connector setup fails because of a configuration problem, such as a missing or invalid credential, the error now appears on the credentials page right away instead of only after repeated retry attempts.
+- The custom plan on the plans page no longer shows a redundant "Custom" price above the "Talk to sales" button.
+
+## August 13, 2026
+
+Connectors
+
+- You can now search Zendesk Support by meaning, including the text of ticket comments, so your agents can find relevant conversations without matching exact keywords. Each result carries details of the ticket it belongs to, such as the title, status, and priority, so your agents know which conversation a comment came from.
+
 ## August 12, 2026
 
 Web app

--- a/docs/release_notes/cloud/readme.md
+++ b/docs/release_notes/cloud/readme.md
@@ -2,6 +2,98 @@
 
 Airbyte Cloud is updated continuously. You always have the latest features and fixes.
 
+## September 1, 2026
+
+Connections
+
+- When you authenticate the Salesforce source or the HubSpot destination with OAuth, the consent step now completes. Airbyte previously formatted part of the authorization request in a way these providers reject, which could cause the authorization to fail.
+
+Platform
+
+- On Cloud Pro and Enterprise Flex plans, the data worker usage chart in your organization's Usage settings has a new Compare to previous period option. Turning it on shows the selected period next to the equivalent previous day, week, month, quarter, or year, so you can see whether your peak capacity usage is trending up or down.
+- The Billing page now shows the date your next invoice is scheduled to be issued. You see the same date in the confirmation messages when you cancel your subscription or delete a workspace.
+
+## August 31, 2026
+
+Platform
+
+- If your organization is on a capacity-based plan, the Usage page in Organization settings now offers 1Q and 1Y date ranges alongside 1D, 1W, and 1M, so you can review data worker usage across a full quarter or year.
+- The Plus and Pro cards on the Plan page in Organization settings now list the support coverage each plan includes. Hover over the info icon next to a support line to see the exact hours and response times.
+
+## August 27, 2026
+
+Platform
+
+- If your organization is on a capacity-based plan (Pro or Enterprise Flex), the workspace Usage page now shows which region the workspace runs in, alongside its data worker usage. This makes it easier to tell which region's capacity your workspace consumes.
+- If your organization signs in with single sign-on but your plan doesn't include role-based access control, people who sign in for the first time are now added as organization admins. Previously they could be left with a role that nobody in your organization was able to change.
+- If your organization is on the Plus plan, reported usage no longer schedules an unintended downgrade to the Standard plan. Your plan stays as you purchased it.
+
+## August 26, 2026
+
+Platform
+
+- If your organization has committed data worker capacity, you can now switch the data worker usage graphs between one-day, one-week, and one-month ranges instead of always seeing a fixed window.
+
+API
+
+- You can now choose the time zone for a cron sync schedule when you create or update a connection through the API, so your syncs run at the hour you expect in your own time zone rather than always in UTC. Error messages for invalid cron schedules also explain the requirements more clearly.
+
+## August 25, 2026
+
+Connections
+
+- When schema changes are applied to your connection, the affected incremental streams are now backfilled correctly so your destination data stays complete and accurate.
+- When you create a new private link for S3 storage, the DNS name Airbyte gives you is now correct. Previously, the provided hostname could cause connection checks to fail with a certificate error. Existing private links are not changed.
+
+Platform
+
+- The Data Worker usage chart on the workspace usage page now shows hourly usage as bars, matching the look of the organization usage chart, so it's easier to compare usage across the two views.
+
+## August 24, 2026
+
+Platform
+
+- If you're an organization admin on the Enterprise Flex plan, you can now view audit logs directly in Airbyte. The new Audit Logs page in your organization settings shows who changed what and when across your organization, with filters for date range, workspace, actor, and operation. Click any entry to see the full details of that event and copy them to your clipboard.
+
+## August 21, 2026
+
+Platform
+
+- The Data Worker usage chart on your organization's Usage page is easier to read. Each day now has a single bar for peak usage instead of stacked, color-coded workspace segments, and hovering over a bar shows your region's peak next to a per-workspace breakdown. The dates along the bottom of the chart also display correctly now. This chart is available if your plan includes contracted Data Worker capacity.
+
+## August 20, 2026
+
+Connections
+
+- When Airbyte provides its own OAuth application for a connector, the source and destination setup forms no longer show the manual authentication option. This prevents confusion by hiding fields that asked for developer credentials you don't need.
+
+Platform
+
+- If your organization manages users through your identity provider with SCIM, workspace settings now show a SCIM badge and no longer allow you to add or change workspace members directly in Airbyte. This keeps your membership consistent with your identity provider.
+- If you store audit logs in your own bucket on the Enterprise Flex plan, Airbyte now organizes those log files into folders by organization and date, making them easier to browse and manage.
+
+## August 19, 2026
+
+Connections
+
+- When a connector test or schema refresh hits an unexpected internal error, the job now fails immediately with a clear error message instead of appearing to run until it times out.
+
+## August 18, 2026
+
+Connections
+
+- Setting up or refreshing the schema for a source with a very large number of tables and columns is now more reliable. Previously, these requests could run out of memory and fail before the schema reached you.
+
+## August 14, 2026
+
+Connections
+
+- Your connections now recover immediately when Airbyte runs into a conflict while starting a sync. Previously, the connection paused for about 10 minutes in this situation, which delayed its next scheduled sync.
+
+Connector Builder
+
+- Fields that share a linked value keep that link when you switch between the UI and YAML views. Previously, the first switch to YAML could replace shared values with copies, so later edits to one field no longer updated the others.
+
 ## August 12, 2026
 
 Connections


### PR DESCRIPTION
## What
Requested by @ian-at-airbyte. Consolidates 24 open `docs(release-notes)` PRs (all single-block additions to the same two files, which would conflict if merged one by one) into one PR. Supersedes:

- Cloud: #85255, #85227, #85117, #85066, #85028, #84971, #84938, #84912, #84893, #84840, #84406
- Agents: #85254, #85228, #85168, #85116, #85067, #85029, #84972, #84939, #84911, #84894, #84841, #84457, #84407

## How
Took the `+` lines from each PR's diff verbatim and inserted them above the existing `## August 12, 2026` section in reverse-chronological order. No copy was edited. A script asserted every added non-blank line from every source PR appears verbatim in the result; `markdownlint-cli2` passes on both files.

## Review guide
1. `docs/release_notes/cloud/readme.md` — 11 new dated sections (Sep 1 → Aug 14)
2. `docs/release_notes/agents/readme.md` — 13 new dated sections (Sep 1 → Aug 13)

## User Impact
Release notes for Aug 13 – Sep 1 are published. The individual PRs listed above can be closed once this merges.

## Can this PR be safely reverted and rolled back?
- [x] YES 💚
- [ ] NO ❌

Link to Devin session: https://app.devin.ai/sessions/189fd63d7ec24fe489a0301213477bcf
Open in Devin Desktop: https://app.devin.ai/desktop/session/189fd63d7ec24fe489a0301213477bcf?variant=devin