### PR TITLE
docs(connector-metadata): document configSpec/configKey/configValue breaking-change scopes and per-scope messages

### DIFF
--- a/docs/platform/connector-development/connector-metadata-file.md
+++ b/docs/platform/connector-development/connector-metadata-file.md
@@ -150,11 +150,26 @@ releases:
 This change only breaks the `users` stream - all other streams are unaffected. A user can safely ignore the breaking change
 if they are not syncing the `users` stream.
 
+For example, a destination Snowflake connector removing username/password authentication can scope its impact to
+actors whose stored configuration uses that authentication method:
+
+```yaml
+scopedImpact:
+  - scopeType: config
+    impactedScopes:
+      - path: credentials.auth_type
+        equals: "Username and Password"
+```
+
+The platform release supporting the `config` scope type must be deployed before a connector publishes a breaking change
+that uses it.
+
 The supported scope types are listed below.
 
 | Scope Type | Value Type  | Value Description    |
 | ---------- | ----------- | -------------------- |
 | stream     | `list[str]` | List of stream names |
+| config     | `list[{path: str, equals?: any}]` | Actors whose stored configuration has a value at `path`, optionally equal to `equals` |
 
 #### `remoteRegistries`
 

--- a/docs/platform/connector-development/connector-metadata-file.md
+++ b/docs/platform/connector-development/connector-metadata-file.md
@@ -150,19 +150,34 @@ releases:
 This change only breaks the `users` stream - all other streams are unaffected. A user can safely ignore the breaking change
 if they are not syncing the `users` stream.
 
-For example, a destination Snowflake connector removing username/password authentication can scope its impact to
-actors whose stored configuration uses that authentication method:
+Scopes can target streams or actors based on their stored configuration. For example:
 
 ```yaml
 scopedImpact:
-  - scopeType: config
+  - scopeType: stream
+    impactedScopes: ["users"]
+  - scopeType: configSpec
+  - scopeType: configKey
+    impactedScopes: ["credentials.password"]
+  - scopeType: configValue
     impactedScopes:
       - path: credentials.auth_type
-        equals: "Username and Password"
+        value: "Username and Password"
 ```
 
-The platform release supporting the `config` scope type must be deployed before a connector publishes a breaking change
-that uses it.
+The `configSpec` scope matches actors whose stored configuration fails validation against the new version's
+`connectionSpecification`. Secrets are validated as placeholder strings. Do not use `configSpec` on a version that also
+ships a config migration: the platform sees only the pre-migration configuration, so migrated configurations would be
+false positives. JSON Schema `additionalProperties` behavior also means silently dropped fields do not trigger this
+scope unless the specification explicitly rejects them, for example:
+
+```yaml
+properties:
+  old_field: false
+```
+
+The platform release supporting these configuration scope types must be deployed before a connector publishes a
+breaking change that uses them.
 
 Scopes are combined as a union: a connector is affected if _any_ scope in `scopedImpact` matches it, and a scope matches
 if _any_ of its `impactedScopes` entries matches (for example, syncing any one of the listed streams). There is no way to
@@ -173,7 +188,9 @@ The supported scope types are listed below.
 | Scope Type | Value Type  | Value Description    |
 | ---------- | ----------- | -------------------- |
 | stream     | `list[str]` | List of stream names |
-| config     | `list[{path: str, equals?: any}]` | Actors whose stored configuration has a value at `path`, optionally equal to `equals` |
+| configSpec | No value | Actors whose stored configuration fails validation against the new version's `connectionSpecification` |
+| configKey | `list[str]` | Actors whose stored configuration has a non-null value at any listed dot-separated path |
+| configValue | `list[{path: str, value: any}]` | Actors whose stored configuration has a value at `path` equal to `value` |
 
 #### `remoteRegistries`
 

--- a/docs/platform/connector-development/connector-metadata-file.md
+++ b/docs/platform/connector-development/connector-metadata-file.md
@@ -164,6 +164,10 @@ scopedImpact:
 The platform release supporting the `config` scope type must be deployed before a connector publishes a breaking change
 that uses it.
 
+Scopes are combined as a union: a connector is affected if _any_ scope in `scopedImpact` matches it, and a scope matches
+if _any_ of its `impactedScopes` entries matches (for example, syncing any one of the listed streams). There is no way to
+express an intersection, such as "syncs stream X _and_ uses a given configuration value".
+
 The supported scope types are listed below.
 
 | Scope Type | Value Type  | Value Description    |

--- a/docs/platform/connector-development/connector-metadata-file.md
+++ b/docs/platform/connector-development/connector-metadata-file.md
@@ -183,6 +183,23 @@ Scopes are combined as a union: a connector is affected if _any_ scope in `scope
 if _any_ of its `impactedScopes` entries matches (for example, syncing any one of the listed streams). There is no way to
 express an intersection, such as "syncs stream X _and_ uses a given configuration value".
 
+Each scope can optionally include a `message` with additional guidance. This message is shown only to users whose actor
+matched that scope. The breaking change's top-level `message` is rendered first, followed by an `Additional details`
+heading and the messages from each matched scope in metadata order. The additional details section is omitted when no
+matched scope declares a message. The `message` property applies to every scope type, for example:
+
+```yaml
+scopedImpact:
+  - scopeType: configValue
+    message: "This destination uses Username and Password authentication, which is no longer supported. Switch it to Key Pair Authentication."
+    impactedScopes:
+      - path: credentials.auth_type
+        value: "Username and Password"
+  - scopeType: configKey
+    message: "A legacy `password` field is still set on this destination. Edit and re-save it with Key Pair Authentication."
+    impactedScopes: [password, credentials.password]
+```
+
 The supported scope types are listed below.
 
 | Scope Type | Value Type  | Value Description    |


### PR DESCRIPTION
## What
Documents the three configuration-based breaking-change scope types (`configSpec`, `configKey`, `configValue`) and the optional per-scope `message` added in airbytehq/airbyte-connector-models#52 and implemented in airbytehq/airbyte-platform-internal#19423, alongside the existing `stream` scope. Also documents the (previously code-only) union semantics of `scopedImpact` and fixes a typo'd parent key (`n:` → `scopedImpact:`) in the existing example. Requested by AJ Steers.

## How
Edits `docs/platform/connector-development/connector-metadata-file.md`: adds rows to the scope-type table, a combined `stream` + config example, the union rule, `configSpec` caveats (secrets validated as placeholders; don't use it on versions that ship a config migration; `additionalProperties` means silently dropped fields only trigger it if the spec rejects them, e.g. `properties: {old_field: false}`), and the per-scope `message` field with its rendering order (top-level message → "Additional details" heading → messages of matched scopes; section omitted when none match).

## Review guide
1. `docs/platform/connector-development/connector-metadata-file.md`

## User Impact
Connector developers can see how to scope a breaking change to affected configurations and how to attach scope-specific remediation guidance. Platform support must be deployed before a connector publishes these scope types.

## Can this PR be safely reverted and rolled back?
- [x] YES 💚
- [ ] NO ❌

Link to Devin session: https://app.devin.ai/sessions/10ddbd5efd784fbfae8fbb693fb95a75
Open in Devin Desktop: https://app.devin.ai/desktop/session/10ddbd5efd784fbfae8fbb693fb95a75?variant=devin
Requested by: @aaronsteers