### PR TITLE
docs(access-management): document audit logs

### DIFF
--- a/docs/platform/access-management/audit-logs.md
+++ b/docs/platform/access-management/audit-logs.md
@@ -1,5 +1,5 @@
 ---
-products: enterprise-flex
+products: cloud-teams
 sidebar_label: Audit logs
 ---
 
@@ -9,7 +9,7 @@ Audit logs record who did what in your Airbyte organization. Every time someone 
 
 Use audit logs to investigate unexpected changes, review administrative activity, and demonstrate to auditors that you have a record of configuration and access changes in Airbyte.
 
-Audit logging is available in Enterprise Flex. Only organization admins can view audit logs.
+Audit logging is available in Pro and Enterprise Flex. Only organization admins can view audit logs.
 
 ## Audit logs aren't sync logs
 
@@ -19,7 +19,7 @@ Airbyte produces several kinds of logs, and audit logs are the narrowest of them
 | --- | --- | --- |
 | Audit logs | Management operations: who changed a workspace, connection, connector, user, permission, or setting | **Organization settings** > **Audit logs** |
 | Sync logs (job logs) | What happened during one sync, check, or discover job, including connector output | A connection's [Timeline](/platform/cloud/managing-airbyte-cloud/review-connection-timeline) |
-| Data plane logs | Platform logs your Airbyte data plane pods write to stdout in your own infrastructure | Your own observability stack. See [Collect logs from a Flex data plane](/platform/enterprise-flex/log-collection). |
+| Data plane logs | Platform logs your Airbyte data plane pods write to stdout, if you run your own data planes in Enterprise Flex | Your own observability stack. See [Collect logs from a Flex data plane](/platform/enterprise-flex/log-collection). |
 
 Audit logs never contain the records your connections read or write. If you need to troubleshoot a failing sync, use the connection's sync logs instead.
 
@@ -99,12 +99,12 @@ Audit logs deliberately omit sensitive material. Airbyte doesn't record the foll
 - **Credentials and secrets**. Airbyte never writes connector configurations to an audit log. For sources and destinations, entries contain only identifying fields, like the source ID, name, and definition ID. Values such as `connectionConfiguration` and `secretId` are omitted, and a new secret-bearing field is omitted by default rather than logged. Airbyte also masks the client secret in single sign-on entries.
 - **Your data**. Audit logs contain no records, no rows, and no schema contents from your sources and destinations.
 - **Request and response bodies for some operations**. Where a body is large or sensitive, the entry records the actor and the operation without the body.
-- **Activity in your data planes**. Audit logs cover the Airbyte control plane. Syncs that run in your own infrastructure produce their own logs, which stay with you.
+- **Activity in your data planes**. Audit logs cover the Airbyte control plane. Syncs produce their own logs, and if you run Enterprise Flex data planes in your own infrastructure, those logs stay with you.
 
 ## Storage and data residency
 
-Airbyte stores audit logs in the Cloud control plane, in storage Airbyte manages and secures. Unlike your syncs, which run in your data planes, audit logs describe control plane activity, so they're written and retained by the control plane. You can't redirect them to your own bucket, and they aren't written to your data planes.
+Airbyte stores audit logs in the Cloud control plane, in storage Airbyte manages and secures. Audit logs describe control plane activity, so the control plane writes and retains them. You can't redirect them to your own bucket, and they aren't written to any data plane you run yourself.
 
 Airbyte retains audit log entries for 365 days, then deletes them. Export anything you need to keep for longer before it ages out.
 
-Because entries describe management operations rather than the data you move, they contain organization, workspace, connector, and user metadata, but none of the records that pass through your connections. Data your connections move continues to be governed by the [region](/platform/cloud/managing-airbyte-cloud/manage-data-residency) and [data plane](/platform/enterprise-flex/data-plane) you choose for each workspace.
+Because entries describe management operations rather than the data you move, they contain organization, workspace, connector, and user metadata, but none of the records that pass through your connections. Data your connections move continues to be governed by the [region](/platform/cloud/managing-airbyte-cloud/manage-data-residency) you choose for each workspace, and, in Enterprise Flex, the [data plane](/platform/enterprise-flex/data-plane) that runs it.

--- a/docs/platform/enterprise-flex/audit-logs.md
+++ b/docs/platform/enterprise-flex/audit-logs.md
@@ -67,7 +67,7 @@ A typical entry looks like this.
   "id": "8478fcbd-d369-4bda-8d9b-b782cea5ad40",
   "timestamp": 1746724563299,
   "actor": {
-    "actorId": "1c26c465-58h8-43e6-8jko-2252b7g8a9e2",
+    "actorId": "1c26c465-58a8-43e6-8fc0-2252b7c8a9e2",
     "email": "user@example.com",
     "ipAddress": "192.0.2.0",
     "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/136.0.0.0 Safari/537.36"

--- a/docs/platform/enterprise-flex/audit-logs.md
+++ b/docs/platform/enterprise-flex/audit-logs.md
@@ -1,6 +1,6 @@
 ---
 products: enterprise-flex
-sidebar_label: Audit Logs
+sidebar_label: Audit logs
 ---
 
 # Audit logs
@@ -17,7 +17,7 @@ Airbyte produces several kinds of logs, and audit logs are the narrowest of them
 
 | Log type | What it contains | Where you find it |
 | --- | --- | --- |
-| Audit logs | Management operations: who changed a workspace, connection, connector, user, permission, or setting | **Settings** > **Organization** > **Audit Logs** |
+| Audit logs | Management operations: who changed a workspace, connection, connector, user, permission, or setting | **Organization settings** > **Audit logs** |
 | Sync logs (job logs) | What happened during one sync, check, or discover job, including connector output | A connection's [Timeline](/platform/cloud/managing-airbyte-cloud/review-connection-timeline) |
 | Data plane logs | Platform logs your Airbyte data plane pods write to stdout in your own infrastructure | Your own observability stack. See [Collect logs from a Flex data plane](/platform/enterprise-flex/log-collection). |
 
@@ -25,7 +25,7 @@ Audit logs never contain the records your connections read or write. If you need
 
 ## View your audit logs
 
-1. Click **Settings**, then click **Organization** > **Audit Logs**.
+1. In the navigation bar, click **Organization settings** > **Audit logs**.
 
 2. Set **Start time (UTC)** and **End time (UTC)** to the period you want to review. All timestamps and filters use UTC.
 
@@ -90,7 +90,7 @@ Airbyte audits operations that change your organization, including the following
 - Users and access: adding and removing users, changing roles and permissions, and managing user groups
 - Identity and security settings: single sign-on configuration, SCIM provisioning, and domain verification
 
-To see exactly which operations Airbyte records for your organization, open the **Operation** filter on the Audit Logs page.
+To see exactly which operations Airbyte records for your organization, open the **Operation** filter on the **Audit logs** page.
 
 ## What Airbyte doesn't record
 

--- a/docs/platform/enterprise-flex/audit-logs.md
+++ b/docs/platform/enterprise-flex/audit-logs.md
@@ -1,0 +1,110 @@
+---
+products: enterprise-flex
+sidebar_label: Audit Logs
+---
+
+# Audit logs
+
+Audit logs record who did what in your Airbyte organization. Every time someone creates a connection, changes a permission, updates a source, or modifies your single sign-on configuration, Airbyte writes an entry that captures the person responsible, the operation they performed, when it happened, and whether it succeeded.
+
+Use audit logs to investigate unexpected changes, review administrative activity, and demonstrate to auditors that you have a record of configuration and access changes in Airbyte.
+
+Audit logging is available in Enterprise Flex. Only organization admins can view audit logs.
+
+## Audit logs aren't sync logs
+
+Airbyte produces several kinds of logs, and audit logs are the narrowest of them. They only describe management activity, never the data your connections move.
+
+| Log type | What it contains | Where you find it |
+| --- | --- | --- |
+| Audit logs | Management operations: who changed a workspace, connection, connector, user, permission, or setting | **Settings** > **Organization** > **Audit Logs** |
+| Sync logs (job logs) | What happened during one sync, check, or discover job, including connector output | The **Job History** tab of a connection |
+| Data plane logs | Platform logs your Airbyte data plane pods write to stdout in your own infrastructure | Your own observability stack. See [Collect logs from a Flex data plane](/platform/enterprise-flex/log-collection). |
+
+Audit logs never contain the records your connections read or write. If you need to troubleshoot a failing sync, use the connection's job logs instead.
+
+## View your audit logs
+
+1. Click **Settings**, then click **Organization** > **Audit Logs**.
+
+2. Set **Start time (UTC)** and **End time (UTC)** to the period you want to review. All timestamps and filters use UTC.
+
+3. Optionally narrow the results with these filters.
+
+   | Filter | Description |
+   | --- | --- |
+   | Workspace | Only show operations that affected one workspace |
+   | Actor | Only show operations performed by one person. Match on their email address or user ID |
+   | Operation | Only show one type of operation, like `deleteWorkspace` |
+   | Status | Only show operations that succeeded or failed |
+   | Search | Match text in the operation, actor, or error message |
+
+4. Click any row to see the complete entry as JSON, including the request and response summaries. You can copy this JSON if you need to attach it to an audit or ticket.
+
+Airbyte shows 50 entries at a time, newest first. Use **Next** and **Previous** to move between pages.
+
+## What Airbyte records
+
+Each entry contains the following fields.
+
+| Field | Description |
+| --- | --- |
+| `id` | Unique identifier for this entry |
+| `timestamp` | When the operation occurred, in epoch milliseconds |
+| `actor` | The person who performed the operation: their user ID, email address, IP address, and user agent |
+| `operation` | The operation they performed, like `createSource` or `deletePermission` |
+| `request` | A summary of the request, with sensitive fields removed |
+| `response` | A summary of the response, with sensitive fields removed |
+| `success` | Whether the operation succeeded |
+| `errorMessage` | Why the operation failed, if it failed |
+| `organizationId` | The organization the operation belongs to |
+| `workspaceId` | The workspace the operation affected, if it affected one |
+
+A typical entry looks like this.
+
+```json
+{
+  "id": "8478fcbd-d369-4bda-8d9b-b782cea5ad40",
+  "timestamp": 1746724563299,
+  "actor": {
+    "actorId": "1c26c465-58h8-43e6-8jko-2252b7g8a9e2",
+    "email": "user@example.com",
+    "ipAddress": "192.0.2.0",
+    "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/136.0.0.0 Safari/537.36"
+  },
+  "operation": "deleteWorkspace",
+  "request": "<request summary>",
+  "response": "<response summary>",
+  "success": true,
+  "errorMessage": null,
+  "organizationId": "b0b8b7b2-7e1c-4a9f-9f0e-3f1a0a6a1f11",
+  "workspaceId": "0a9f2e1d-5c3b-4a77-9b21-6a7c1d2e3f44"
+}
+```
+
+Airbyte audits operations that change your organization, including the following.
+
+- Workspaces and organizations: creating, renaming, moving, and deleting them
+- Sources and destinations: creating, updating, deleting, and upgrading connector versions
+- Connections: creating, updating, and deleting them
+- Users and access: adding and removing users, changing roles and permissions, and managing user groups
+- Identity and security settings: single sign-on configuration, SCIM provisioning, and domain verification
+
+To see exactly which operations Airbyte records for your organization, open the **Operation** filter on the Audit Logs page.
+
+## What Airbyte doesn't record
+
+Audit logs deliberately omit sensitive material. Airbyte doesn't record the following.
+
+- **Credentials and secrets**. Airbyte never writes connector configurations to an audit log. For sources and destinations, entries contain only identifying fields, like the source ID, name, and definition ID. Values such as `connectionConfiguration` and `secretId` are omitted, and a new secret-bearing field is omitted by default rather than logged. Airbyte also masks the client secret in single sign-on entries.
+- **Your data**. Audit logs contain no records, no rows, and no schema contents from your sources and destinations.
+- **Request and response bodies for some operations**. Where a body is large or sensitive, the entry records the actor and the operation without the body.
+- **Activity in your data planes**. Audit logs cover the Airbyte control plane. Syncs that run in your own infrastructure produce their own logs, which stay with you.
+
+## Storage and data residency
+
+Airbyte stores audit logs in the Cloud control plane, in storage Airbyte manages and secures. Unlike your syncs, which run in your data planes, audit logs describe control plane activity, so they're written and retained by the control plane. You can't redirect them to your own bucket, and they aren't written to your data planes.
+
+Airbyte retains audit log entries for 365 days, then deletes them. Export anything you need to keep for longer before it ages out.
+
+Because entries describe management operations rather than the data you move, they contain organization, workspace, connector, and user metadata, but none of the records that pass through your connections. Data your connections move continues to be governed by the [region](/platform/cloud/managing-airbyte-cloud/manage-data-residency) and [data plane](/platform/enterprise-flex/data-plane) you choose for each workspace.

--- a/docs/platform/enterprise-flex/audit-logs.md
+++ b/docs/platform/enterprise-flex/audit-logs.md
@@ -18,10 +18,10 @@ Airbyte produces several kinds of logs, and audit logs are the narrowest of them
 | Log type | What it contains | Where you find it |
 | --- | --- | --- |
 | Audit logs | Management operations: who changed a workspace, connection, connector, user, permission, or setting | **Settings** > **Organization** > **Audit Logs** |
-| Sync logs (job logs) | What happened during one sync, check, or discover job, including connector output | The **Job History** tab of a connection |
+| Sync logs (job logs) | What happened during one sync, check, or discover job, including connector output | A connection's [Timeline](/platform/cloud/managing-airbyte-cloud/review-connection-timeline) |
 | Data plane logs | Platform logs your Airbyte data plane pods write to stdout in your own infrastructure | Your own observability stack. See [Collect logs from a Flex data plane](/platform/enterprise-flex/log-collection). |
 
-Audit logs never contain the records your connections read or write. If you need to troubleshoot a failing sync, use the connection's job logs instead.
+Audit logs never contain the records your connections read or write. If you need to troubleshoot a failing sync, use the connection's sync logs instead.
 
 ## View your audit logs
 

--- a/docs/platform/enterprise-flex/log-collection.md
+++ b/docs/platform/enterprise-flex/log-collection.md
@@ -7,7 +7,7 @@ sidebar_label: Log Collection
 
 This guide explains how to collect logs from an Airbyte Flex data plane running in your Kubernetes cluster.
 
-These logs describe the work your data plane does: syncs, checks, discovers, and specs. To review who changed your Airbyte configuration, see [Audit logs](/platform/enterprise-flex/audit-logs) instead.
+These logs describe the work your data plane does: syncs, checks, discovers, and specs. To review who changed your Airbyte configuration, see [Audit logs](/platform/access-management/audit-logs) instead.
 
 :::info
 Requires data plane Helm chart version **2.1.0** or later. Structured JSON logging to stdout is enabled by default starting in 2.1.0. Earlier chart versions emit plaintext logs and do not propagate the log format setting to all containers.

--- a/docs/platform/enterprise-flex/log-collection.md
+++ b/docs/platform/enterprise-flex/log-collection.md
@@ -7,7 +7,7 @@ sidebar_label: Log Collection
 
 This guide explains how to collect logs from an Airbyte Flex data plane running in your Kubernetes cluster.
 
-These logs describe the work your data plane does: syncs, checks, discovers, and specs. To review who changed your Airbyte configuration, see [Audit logs](/platform/access-management/audit-logs) instead.
+These logs describe the work your data plane does: sync, check, discover, and spec jobs. To review who changed your Airbyte configuration, see [Audit logs](/platform/access-management/audit-logs) instead.
 
 :::info
 Requires data plane Helm chart version **2.1.0** or later. Structured JSON logging to stdout is enabled by default starting in 2.1.0. Earlier chart versions emit plaintext logs and do not propagate the log format setting to all containers.

--- a/docs/platform/enterprise-flex/log-collection.md
+++ b/docs/platform/enterprise-flex/log-collection.md
@@ -7,6 +7,8 @@ sidebar_label: Log Collection
 
 This guide explains how to collect logs from an Airbyte Flex data plane running in your Kubernetes cluster.
 
+These logs describe the work your data plane does: syncs, checks, discovers, and specs. To review who changed your Airbyte configuration, see [Audit logs](/platform/enterprise-flex/audit-logs) instead.
+
 :::info
 Requires data plane Helm chart version **2.1.0** or later. Structured JSON logging to stdout is enabled by default starting in 2.1.0. Earlier chart versions emit plaintext logs and do not propagate the log format setting to all containers.
 :::

--- a/docs/platform/enterprise-flex/readme.md
+++ b/docs/platform/enterprise-flex/readme.md
@@ -31,7 +31,7 @@ Enterprise Flex addresses these needs by offering fully managed Cloud workspaces
 | Role-Based Access   | Manage user permissions and access across workspaces from a single pane of glass.                                                                                       |
 | Column Hashing      | Protect sensitive information by hashing personally identifiable information (PII) as it moves through your pipelines.                                                  |
 | External Secrets    | Bring your own secrets manager to securely reference your credentials for data sources and destinations.                                                                |
-| Audit trail logs    | Review [user and platform activity](/platform/access-management/audit-logs) to maintain compliance while using Airbyte.                                                 |
+| Audit logs          | Review [user and platform activity](/platform/access-management/audit-logs) to maintain compliance while using Airbyte.                                                 |
 | AWS PrivateLink     | Connect to data sources or destinations in your VPC securely to Airbyte data planes.                                                                                    |
 | Support with SLAs   | [Priority assistance](https://docs.airbyte.com/operator-guides/contact-support/#airbyte-enterprise-self-hosted-support) with deploying, managing and upgrading Airbyte. |
 

--- a/docs/platform/enterprise-flex/readme.md
+++ b/docs/platform/enterprise-flex/readme.md
@@ -23,21 +23,21 @@ While these requirements are critical, organizations also have finite time and e
 
 Enterprise Flex addresses these needs by offering fully managed Cloud workspaces (a control plane) that connect to separate data planes you manage in your own infrastructure. You can also use fully managed data planes for less sensitive data that doesn't need to remain in your own infrastructure. Each Cloud workspace uses one region and data plane, so a single Airbyte instance with multiple workspaces is an ideal way to segregate data and connections. Enterprise Flex also supports other enterprise-grade abilities such as audit logging, external secrets managers, and AWS PrivateLink connectivity in addition to all other features in Cloud Pro.
 
-| Feature             | Description                                                                                                                                                             |
-| ------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| User Management     | Enable multiple users to concurrently move data from a single Airbyte deployment.                                                                                       |
-| Single Sign-On      | Manage user access to Airbyte from your Okta, Azure Entra ID or OIDC-compatible identity provider.                                                                      |
-| Multiple Workspaces | Manage multiple isolated projects or teams on a single Airbyte deployment.                                                                                              |
-| Role-Based Access   | Manage user permissions and access across workspaces from a single pane of glass.                                                                                       |
-| Column Hashing      | Protect sensitive information by hashing personally identifiable information (PII) as it moves through your pipelines.                                                  |
-| External Secrets    | Bring your own secrets manager to securely reference your credentials for data sources and destinations.                                                                |
-| Audit trail logs    | Review [user and platform activity](/platform/enterprise-flex/audit-logs) to maintain compliance while using Airbyte.                                                   |
-| AWS PrivateLink     | Connect to data sources or destinations in your VPC securely to Airbyte data planes.                                                                                    |
-| Support with SLAs   | [Priority assistance](https://docs.airbyte.com/operator-guides/contact-support/#airbyte-enterprise-self-hosted-support) with deploying, managing and upgrading Airbyte. |
+| Feature | Description |
+| --- | --- |
+| User Management | Enable multiple users to concurrently move data from a single Airbyte deployment. |
+| Single Sign-On | Manage user access to Airbyte from your Okta, Azure Entra ID or OIDC-compatible identity provider. |
+| Multiple Workspaces | Manage multiple isolated projects or teams on a single Airbyte deployment. |
+| Role-Based Access | Manage user permissions and access across workspaces from a single pane of glass. |
+| Column Hashing | Protect sensitive information by hashing personally identifiable information (PII) as it moves through your pipelines. |
+| External Secrets | Bring your own secrets manager to securely reference your credentials for data sources and destinations. |
+| Audit trail logs | Review [user and platform activity](/platform/access-management/audit-logs) to maintain compliance while using Airbyte. |
+| AWS PrivateLink | Connect to data sources or destinations in your VPC securely to Airbyte data planes. |
+| Support with SLAs | [Priority assistance](https://docs.airbyte.com/operator-guides/contact-support/#airbyte-enterprise-self-hosted-support) with deploying, managing and upgrading Airbyte. |
 
 ### Enterprise Flex versus Pro
 
-Enterprise Flex includes all features that are standard in Pro with the additional capabilities of running self-managed data planes, referencing your own secrets manager, PrivateLink support, and [audit logs](/platform/enterprise-flex/audit-logs).
+Enterprise Flex includes all features that are standard in Pro with the additional capabilities of running self-managed data planes, referencing your own secrets manager, and PrivateLink support.
 
 Any Airbyte Cloud environment can be easily upgraded to Enterprise Flex. To learn more about upgrading to Enterprise Flex, [talk to sales](https://airbyte.com/company/talk-to-sales).
 

--- a/docs/platform/enterprise-flex/readme.md
+++ b/docs/platform/enterprise-flex/readme.md
@@ -31,13 +31,13 @@ Enterprise Flex addresses these needs by offering fully managed Cloud workspaces
 | Role-Based Access   | Manage user permissions and access across workspaces from a single pane of glass.                                                                                       |
 | Column Hashing      | Protect sensitive information by hashing personally identifiable information (PII) as it moves through your pipelines.                                                  |
 | External Secrets    | Bring your own secrets manager to securely reference your credentials for data sources and destinations.                                                                |
-| Audit trail logs    | Store user and platform activity in your own bucket to maintain compliance while using Airbyte .                                                                        |
+| Audit trail logs    | Review [user and platform activity](/platform/enterprise-flex/audit-logs) to maintain compliance while using Airbyte.                                                   |
 | AWS PrivateLink     | Connect to data sources or destinations in your VPC securely to Airbyte data planes.                                                                                    |
 | Support with SLAs   | [Priority assistance](https://docs.airbyte.com/operator-guides/contact-support/#airbyte-enterprise-self-hosted-support) with deploying, managing and upgrading Airbyte. |
 
 ### Enterprise Flex versus Pro
 
-Enterprise Flex includes all features that are standard in Pro with the additional capabilities of running self-managed data planes, referencing your own secrets manager, PrivateLink support, and storing audit logs.
+Enterprise Flex includes all features that are standard in Pro with the additional capabilities of running self-managed data planes, referencing your own secrets manager, PrivateLink support, and [audit logs](/platform/enterprise-flex/audit-logs).
 
 Any Airbyte Cloud environment can be easily upgraded to Enterprise Flex. To learn more about upgrading to Enterprise Flex, [talk to sales](https://airbyte.com/company/talk-to-sales).
 

--- a/docs/platform/enterprise-flex/readme.md
+++ b/docs/platform/enterprise-flex/readme.md
@@ -21,19 +21,19 @@ Many organizations collect data in all types of operational systems from users a
 
 While these requirements are critical, organizations also have finite time and expertise. Managing these operational and compliance requirements with more infrastructure often means increased maintenance commitments, higher spend, and greater complexity.
 
-Enterprise Flex addresses these needs by offering fully managed Cloud workspaces (a control plane) that connect to separate data planes you manage in your own infrastructure. You can also use fully managed data planes for less sensitive data that doesn't need to remain in your own infrastructure. Each Cloud workspace uses one region and data plane, so a single Airbyte instance with multiple workspaces is an ideal way to segregate data and connections. Enterprise Flex also supports other enterprise-grade abilities such as audit logging, external secrets managers, and AWS PrivateLink connectivity in addition to all other features in Cloud Pro.
+Enterprise Flex addresses these needs by offering fully managed Cloud workspaces (a control plane) that connect to separate data planes you manage in your own infrastructure. You can also use fully managed data planes for less sensitive data that doesn't need to remain in your own infrastructure. Each Cloud workspace uses one region and data plane, so a single Airbyte instance with multiple workspaces is an ideal way to segregate data and connections. Enterprise Flex also supports other enterprise-grade abilities such as external secrets managers and AWS PrivateLink connectivity in addition to all other features in Cloud Pro.
 
-| Feature | Description |
-| --- | --- |
-| User Management | Enable multiple users to concurrently move data from a single Airbyte deployment. |
-| Single Sign-On | Manage user access to Airbyte from your Okta, Azure Entra ID or OIDC-compatible identity provider. |
-| Multiple Workspaces | Manage multiple isolated projects or teams on a single Airbyte deployment. |
-| Role-Based Access | Manage user permissions and access across workspaces from a single pane of glass. |
-| Column Hashing | Protect sensitive information by hashing personally identifiable information (PII) as it moves through your pipelines. |
-| External Secrets | Bring your own secrets manager to securely reference your credentials for data sources and destinations. |
-| Audit trail logs | Review [user and platform activity](/platform/access-management/audit-logs) to maintain compliance while using Airbyte. |
-| AWS PrivateLink | Connect to data sources or destinations in your VPC securely to Airbyte data planes. |
-| Support with SLAs | [Priority assistance](https://docs.airbyte.com/operator-guides/contact-support/#airbyte-enterprise-self-hosted-support) with deploying, managing and upgrading Airbyte. |
+| Feature             | Description                                                                                                                                                             |
+| ------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| User Management     | Enable multiple users to concurrently move data from a single Airbyte deployment.                                                                                       |
+| Single Sign-On      | Manage user access to Airbyte from your Okta, Azure Entra ID or OIDC-compatible identity provider.                                                                      |
+| Multiple Workspaces | Manage multiple isolated projects or teams on a single Airbyte deployment.                                                                                              |
+| Role-Based Access   | Manage user permissions and access across workspaces from a single pane of glass.                                                                                       |
+| Column Hashing      | Protect sensitive information by hashing personally identifiable information (PII) as it moves through your pipelines.                                                  |
+| External Secrets    | Bring your own secrets manager to securely reference your credentials for data sources and destinations.                                                                |
+| Audit trail logs    | Review [user and platform activity](/platform/access-management/audit-logs) to maintain compliance while using Airbyte.                                                 |
+| AWS PrivateLink     | Connect to data sources or destinations in your VPC securely to Airbyte data planes.                                                                                    |
+| Support with SLAs   | [Priority assistance](https://docs.airbyte.com/operator-guides/contact-support/#airbyte-enterprise-self-hosted-support) with deploying, managing and upgrading Airbyte. |
 
 ### Enterprise Flex versus Pro
 

--- a/docs/platform/operating-airbyte/security.md
+++ b/docs/platform/operating-airbyte/security.md
@@ -125,7 +125,7 @@ In addition, Airbyte Cloud and  Airbyte Enterprise support [role-based access co
 
 ### Audit logging
 
-Enterprise Flex organizations have [audit logs](/platform/enterprise-flex/audit-logs) that record who changed workspaces, connections, connectors, users, permissions, and settings. Airbyte stores these logs in the control plane and retains them for 365 days.
+Pro and Enterprise Flex organizations have [audit logs](/platform/access-management/audit-logs) that record who changed workspaces, connections, connectors, users, permissions, and settings. Airbyte stores these logs in the control plane and retains them for 365 days.
 
 ### Compliance
 

--- a/docs/platform/operating-airbyte/security.md
+++ b/docs/platform/operating-airbyte/security.md
@@ -123,6 +123,10 @@ Airbyte Cloud supports [user management](/platform/using-airbyte/core-concepts/)
 
 In addition, Airbyte Cloud and  Airbyte Enterprise support [role-based access control](/platform/access-management/rbac) allowing admins to manage varying access levels across users in their instance.
 
+### Audit logging
+
+Enterprise Flex organizations have [audit logs](/platform/enterprise-flex/audit-logs) that record who changed workspaces, connections, connectors, users, permissions, and settings. Airbyte stores these logs in the control plane and retains them for 365 days.
+
 ### Compliance
 
 Our compliance efforts for Airbyte Cloud include:

--- a/docusaurus/sidebar-platform.js
+++ b/docusaurus/sidebar-platform.js
@@ -451,6 +451,10 @@ module.exports = {
                     },
                   ],
                 },
+                {
+                  type: "doc",
+                  id: "access-management/audit-logs",
+                },
               ],
             },
           ],
@@ -471,7 +475,6 @@ module.exports = {
             "enterprise-flex/data-plane",
             "enterprise-flex/data-plane-util",
             "enterprise-flex/log-collection",
-            "enterprise-flex/audit-logs",
           ],
         },
         {

--- a/docusaurus/sidebar-platform.js
+++ b/docusaurus/sidebar-platform.js
@@ -471,6 +471,7 @@ module.exports = {
             "enterprise-flex/data-plane",
             "enterprise-flex/data-plane-util",
             "enterprise-flex/log-collection",
+            "enterprise-flex/audit-logs",
           ],
         },
         {


### PR DESCRIPTION
## What

Documents audit logging for [DOCS-82](https://linear.app/airbyteio/issue/DOCS-82/flex-audit-logging-docs). There was no audit-log page in the docs; the only prose was a Self-Managed 1.7 release note whose storage layout is stale.

Audit logs ship in **Pro and Enterprise Flex** (confirmed by Ian — an earlier revision of this PR scoped the page to Flex only, which was wrong). Self-Managed has no audit logs and isn't documented here.

## How

New page at `docs/platform/access-management/audit-logs.md`, tagged `products: cloud-teams` so it renders the Pro + Enterprise Flex badges, sitting in the sidebar under **Access management** next to RBAC, SSO, and SCIM.

Content is derived from the platform implementation, not from marketing copy:

- Entry schema and fields from `AuditLogEntry`, with a realistic example.
- What is deliberately *not* recorded — the connector audit provider uses a field allowlist (`sourceId`, `sourceName`, definition IDs, and so on), so `connectionConfiguration`, `secretId`, and SSO `clientSecret` never reach a log; some operations record actor + operation only.
- UI behavior from `OrganizationAuditLogsPage`: org-admin only, UTC filters, 50 rows per page, row expands to raw JSON.
- Storage: Airbyte-managed control-plane bucket with a 365-day lifecycle deletion (terraform `audit-logs` bucket). Customers can't redirect audit logs to their own bucket.

Also corrects surrounding pages:

- `enterprise-flex/readme.md` claimed audit logs are stored "in your own bucket" and listed audit logging as a Flex-over-Pro capability. Both are wrong; fixed.
- `enterprise-flex/log-collection.md` now distinguishes data-plane logs from audit logs.
- `operating-airbyte/security.md` gains an Audit logging subsection under Securing Airbyte Cloud.

## Review guide

1. `docs/platform/access-management/audit-logs.md` — the new page.
2. `docs/platform/enterprise-flex/readme.md` — the "your own bucket" and Flex-versus-Pro corrections.
3. `docusaurus/sidebar-platform.js` — placement under Access management.

## User Impact

Admins get an accurate description of what audit logs contain, what they omit, how to filter them, how they differ from sync and data-plane logs, and how long they're retained. Docs-only.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚
- [ ] NO ❌

## Verification

```bash
cd docusaurus && corepack pnpm@9.4.0 install --ignore-scripts && corepack pnpm@9.4.0 clear && corepack pnpm@9.4.0 build
npx --yes markdownlint-cli2 --config .markdownlint.jsonc docs/platform/access-management/audit-logs.md docs/platform/enterprise-flex/readme.md
```

Production build succeeds with no broken links (only pre-existing unrelated broken-anchor warnings). Vale isn't installed in this environment, so style linting is unverified.


Link to Devin session: https://app.devin.ai/sessions/fb43cf295d674f699317ba7ed62b7e98
Open in Devin Desktop: https://app.devin.ai/desktop/session/fb43cf295d674f699317ba7ed62b7e98?variant=devin
Requested by: @ian-at-airbyte