### PR TITLE
fix: clamp GlobalMemoryManager to zero to prevent OOM from negative memory accounting

### DIFF
--- a/airbyte-cdk/java/airbyte-cdk/core/src/main/kotlin/io/airbyte/cdk/integrations/destination/async/GlobalMemoryManager.kt
+++ b/airbyte-cdk/java/airbyte-cdk/core/src/main/kotlin/io/airbyte/cdk/integrations/destination/async/GlobalMemoryManager.kt
@@ -70,17 +70,28 @@ class GlobalMemoryManager(val maxMemoryBytes: Long) {
 
     /**
      * Releases a block of memory of the given size. If the amount of memory released exceeds the
-     * current memory allocation, a warning will be logged.
+     * current memory allocation, the counter is clamped to zero to prevent negative accounting from
+     * disabling backpressure in [requestMemory].
+     *
+     * Uses a CAS loop so that [currentMemoryBytes] is never negative, not even transiently. This
+     * prevents a race where [requestMemory] observes a negative value and over-allocates.
      *
      * @param bytes the size of the block to free, in bytes
      */
     fun free(bytes: Long) {
         logger.info { "Freeing $bytes bytes.." }
-        currentMemoryBytes.addAndGet(-bytes)
-
-        val currentMemory = currentMemoryBytes.get()
-        if (currentMemory < 0) {
-            logger.info { "Freed more memory than allocated ($bytes of ${currentMemory + bytes })" }
+        while (true) {
+            val current = currentMemoryBytes.get()
+            val newValue = maxOf(0L, current - bytes)
+            if (currentMemoryBytes.compareAndSet(current, newValue)) {
+                if (current < bytes) {
+                    logger.warn {
+                        "Freed more memory than allocated ($bytes bytes freed, but only " +
+                            "$current were tracked). Clamped to 0."
+                    }
+                }
+                break
+            }
         }
     }
 

--- a/airbyte-cdk/java/airbyte-cdk/core/src/main/kotlin/io/airbyte/cdk/integrations/destination/async/buffers/BufferDequeue.kt
+++ b/airbyte-cdk/java/airbyte-cdk/core/src/main/kotlin/io/airbyte/cdk/integrations/destination/async/buffers/BufferDequeue.kt
@@ -77,7 +77,15 @@ class BufferDequeue(
 
                 // Free unused allocation for the queue.
                 // When the batch flushes it will flush its allocation.
-                memoryManager.free(allocatedBytes - batchSizeBytes)
+                // Guard: only free if there is genuinely unused allocation beyond the batch.
+                // When batchSizeBytes > allocatedBytes (due to a race between enqueue adding
+                // memory and dequeue reading maxMemoryUsage), skipping prevents passing a
+                // negative value. The CAS clamp in GlobalMemoryManager.free() provides a
+                // safety net for any remaining over-free from MemoryAwareMessageBatch.close().
+                val unusedBytes = allocatedBytes - batchSizeBytes
+                if (unusedBytes > 0) {
+                    memoryManager.free(unusedBytes)
+                }
 
                 // Shrink queue to 0 — any new messages will reallocate.
                 queue.addMaxMemory(-allocatedBytes)

--- a/airbyte-cdk/java/airbyte-cdk/core/src/test/kotlin/io/airbyte/cdk/integrations/destination/async/GlobalMemoryManagerTest.kt
+++ b/airbyte-cdk/java/airbyte-cdk/core/src/test/kotlin/io/airbyte/cdk/integrations/destination/async/GlobalMemoryManagerTest.kt
@@ -4,6 +4,11 @@
 
 package io.airbyte.cdk.integrations.destination.async
 
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.CyclicBarrier
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 
@@ -21,6 +26,104 @@ class GlobalMemoryManagerTest {
         mgr.free(10 * BYTES_MB)
         Assertions.assertEquals(10 * BYTES_MB, mgr.requestMemory())
         mgr.free(16 * BYTES_MB)
+        Assertions.assertEquals(10 * BYTES_MB, mgr.requestMemory())
+    }
+
+    @Test
+    internal fun freeMoreThanAllocatedClampsToZero() {
+        val mgr = GlobalMemoryManager(20 * BYTES_MB)
+
+        // Allocate 10 MB
+        Assertions.assertEquals(10 * BYTES_MB, mgr.requestMemory())
+        Assertions.assertEquals(10 * BYTES_MB, mgr.getCurrentMemoryBytes())
+
+        // Free 15 MB (more than the 10 MB allocated) — should clamp to 0, not go to -5 MB
+        mgr.free(15 * BYTES_MB)
+        Assertions.assertEquals(0, mgr.getCurrentMemoryBytes())
+
+        // Verify that requestMemory still works correctly after clamping
+        // (previously, negative values would allow unbounded allocation)
+        Assertions.assertEquals(10 * BYTES_MB, mgr.requestMemory())
+        Assertions.assertEquals(10 * BYTES_MB, mgr.getCurrentMemoryBytes())
+    }
+
+    @Test
+    internal fun repeatedOverFreeDoesNotAccumulateNegativeDebt() {
+        val mgr = GlobalMemoryManager(20 * BYTES_MB)
+
+        mgr.requestMemory() // 10 MB allocated
+
+        // Simulate the bug: multiple over-frees that previously drove the counter deeply negative
+        mgr.free(5 * BYTES_MB)
+        mgr.free(5 * BYTES_MB)
+        mgr.free(5 * BYTES_MB) // this one over-frees by 5 MB
+        mgr.free(5 * BYTES_MB) // this one over-frees by 5 MB
+
+        // Should be clamped at 0, not at -10 MB
+        Assertions.assertEquals(0, mgr.getCurrentMemoryBytes())
+
+        // Should be able to allocate exactly up to max
+        Assertions.assertEquals(10 * BYTES_MB, mgr.requestMemory())
+        Assertions.assertEquals(10 * BYTES_MB, mgr.requestMemory())
+        Assertions.assertEquals(0, mgr.requestMemory()) // full
+    }
+
+    /**
+     * Stress test: multiple threads concurrently allocating and over-freeing memory. Verifies that
+     * currentMemoryBytes never goes negative even under contention, and that backpressure
+     * (requestMemory returning 0) still works correctly.
+     */
+    @Test
+    internal fun concurrentAllocateAndOverFreeNeverGoesNegative() {
+        val mgr = GlobalMemoryManager(20 * BYTES_MB)
+        val threadCount = 8
+        val iterationsPerThread = 1000
+        val sawNegative = AtomicBoolean(false)
+        val barrier = CyclicBarrier(threadCount)
+        val executor = Executors.newFixedThreadPool(threadCount)
+        val latch = CountDownLatch(threadCount)
+
+        repeat(threadCount) { threadIndex ->
+            executor.submit {
+                try {
+                    barrier.await() // start all threads simultaneously
+                    for (i in 0 until iterationsPerThread) {
+                        if (threadIndex % 2 == 0) {
+                            // Allocator threads
+                            mgr.requestMemory()
+                        } else {
+                            // Over-freeing threads — free more than what's likely allocated
+                            mgr.free(3 * BYTES_MB)
+                        }
+                        // Check invariant: currentMemoryBytes must never be negative
+                        if (mgr.getCurrentMemoryBytes() < 0) {
+                            sawNegative.set(true)
+                        }
+                    }
+                } catch (e: Exception) {
+                    sawNegative.set(true)
+                } finally {
+                    latch.countDown()
+                }
+            }
+        }
+
+        latch.await(30, TimeUnit.SECONDS)
+        executor.shutdownNow()
+
+        Assertions.assertFalse(
+            sawNegative.get(),
+            "currentMemoryBytes went negative during concurrent access"
+        )
+        Assertions.assertTrue(
+            mgr.getCurrentMemoryBytes() >= 0,
+            "currentMemoryBytes is negative after concurrent test: ${mgr.getCurrentMemoryBytes()}"
+        )
+
+        // After the storm, the manager should still function correctly:
+        // free everything and verify a fresh allocation works
+        mgr.free(mgr.getCurrentMemoryBytes())
+        Assertions.assertEquals(0, mgr.getCurrentMemoryBytes())
         Assertions.assertEquals(10 * BYTES_MB, mgr.requestMemory())
     }
 }


### PR DESCRIPTION
## Summary

Fixes https://github.com/airbytehq/airbyte/issues/74897
Supersedes https://github.com/airbytehq/airbyte/pull/74898 (closed by contributor due to non-response)
Related: https://github.com/airbytehq/oncall/issues/11851, https://github.com/airbytehq/oncall/issues/11670

`GlobalMemoryManager.free()` allows `currentMemoryBytes` to go negative, which disables the backpressure gate in `requestMemory()` and leads to unbounded buffering → OOM crashes. This has been observed across multiple destinations (Postgres, BigQuery, Redshift, Snowflake) and is the root cause of the recurring `pull_request_commits` sync failures in oncall#11851 (78% failure rate platform-wide over 30 days).

## Root Cause

`BufferDequeue.take()` frees `queue.maxMemoryUsage - batchSizeBytes` when a queue is emptied. But `queue.maxMemoryUsage` can exceed what `GlobalMemoryManager` actually allocated (due to races between enqueue adding memory and dequeue reading `maxMemoryUsage`). The delta drives `currentMemoryBytes` negative.

Once negative, `requestMemory()`'s gate (`currentMemoryBytes >= maxMemoryBytes`) never fires — since `negative < maxMemoryBytes` is always true — so all subsequent allocation requests succeed unconditionally. The system buffers without limit until the JVM OOMs.

## Changes

### `GlobalMemoryManager.kt`
- `free()` now uses an **atomic CAS-on-subtraction** loop so `currentMemoryBytes` is **never negative, not even transiently**
- This is an improvement over the original PR #74898 which used subtract-then-correct (`addAndGet` followed by a CAS clamp), leaving a brief window where `requestMemory()` could observe a negative value and over-allocate
- Changed log from INFO to WARN for observability

### `BufferDequeue.kt`
- `take()` now guards `memoryManager.free(unusedBytes)` behind `if (unusedBytes > 0)`
- Prevents the most common entry point for negative values

### `GlobalMemoryManagerTest.kt`
- `freeMoreThanAllocatedClampsToZero`: verifies single over-free clamps to 0
- `repeatedOverFreeDoesNotAccumulateNegativeDebt`: verifies multiple sequential over-frees don't accumulate negative debt
- `concurrentAllocateAndOverFreeNeverGoesNegative`: **concurrent stress test** with 8 threads × 1000 iterations verifying `currentMemoryBytes >= 0` invariant under contention

## Test Plan

- [x] Existing `GlobalMemoryManagerTest.test()` passes unchanged
- [x] New test: over-free clamps to zero instead of going negative
- [x] New test: repeated over-frees don't accumulate negative debt
- [x] New test: concurrent stress test verifies non-negative invariant under contention
