### PR TITLE
DO NOT MERGE: test(source-bing-ads): pin to prerelease SDM image to validate CDK PR 1138

### DIFF
--- a/airbyte-integrations/connectors/source-bing-ads/metadata.yaml
+++ b/airbyte-integrations/connectors/source-bing-ads/metadata.yaml
@@ -12,11 +12,11 @@ data:
       - api.ads.microsoft.com
       - clientcenter.api.bingads.microsoft.com
   connectorBuildOptions:
-    baseImage: docker.io/airbyte/source-declarative-manifest:7.25.1@sha256:cdbd1578932d121f2852c065fbabebc49ccbf00078606dc503be5e4c66b373df
+    baseImage: docker.io/airbyte/source-declarative-manifest:7.28.2.post2.dev33676771546@sha256:1a5b3a298b77c74029b46213d70009f6826206f8cb33d7c5f1d1836dcda4af06
   connectorSubtype: api
   connectorType: source
   definitionId: 47f25999-dd5e-4636-8c39-e7cea2453331
-  dockerImageTag: 3.0.8
+  dockerImageTag: 3.0.9
   dockerRepository: airbyte/source-bing-ads
   documentationUrl: https://docs.airbyte.com/integrations/sources/bing-ads
   externalDocumentationUrls:

--- a/docs/integrations/sources/bing-ads.md
+++ b/docs/integrations/sources/bing-ads.md
@@ -321,6 +321,7 @@ If you use Airbyte Cloud and your organization restricts access to specific IPs,
 
 | Version     | Date       | Pull Request                                                                                                                     | Subject                                                                                                                                                                |
 |:------------|:-----------|:---------------------------------------------------------------------------------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 3.0.9 | 2026-09-02 | [TBD](https://github.com/airbytehq/airbyte/pull/TBD) | DO NOT MERGE: test pin to prerelease `source-declarative-manifest` 7.28.2.post2.dev33676771546 to validate CDK [#1138](https://github.com/airbytehq/airbyte-python-cdk/pull/1138) |
 | 3.0.8 | 2026-08-18 | [84507](https://github.com/airbytehq/airbyte/pull/84507) | Update dependencies |
 | 3.0.7 | 2026-08-11 | [83859](https://github.com/airbytehq/airbyte/pull/83859) | Update dependencies |
 | 3.0.6 | 2026-07-28 | [83194](https://github.com/airbytehq/airbyte/pull/83194) | Update to CDK 7.23.8 (fixes AirbyteCustomCodeNotPermittedError for bundled custom components) and remove the temporary Cloud version override |

--- a/docs/integrations/sources/bing-ads.md
+++ b/docs/integrations/sources/bing-ads.md
@@ -321,7 +321,7 @@ If you use Airbyte Cloud and your organization restricts access to specific IPs,
 
 | Version     | Date       | Pull Request                                                                                                                     | Subject                                                                                                                                                                |
 |:------------|:-----------|:---------------------------------------------------------------------------------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| 3.0.9 | 2026-09-02 | [TBD](https://github.com/airbytehq/airbyte/pull/TBD) | DO NOT MERGE: test pin to prerelease `source-declarative-manifest` 7.28.2.post2.dev33676771546 to validate CDK [#1138](https://github.com/airbytehq/airbyte-python-cdk/pull/1138) |
+| 3.0.9 | 2026-09-02 | [85305](https://github.com/airbytehq/airbyte/pull/85305) | DO NOT MERGE: test pin to prerelease `source-declarative-manifest` 7.28.2.post2.dev33676771546 to validate CDK [#1138](https://github.com/airbytehq/airbyte-python-cdk/pull/1138) |
 | 3.0.8 | 2026-08-18 | [84507](https://github.com/airbytehq/airbyte/pull/84507) | Update dependencies |
 | 3.0.7 | 2026-08-11 | [83859](https://github.com/airbytehq/airbyte/pull/83859) | Update dependencies |
 | 3.0.6 | 2026-07-28 | [83194](https://github.com/airbytehq/airbyte/pull/83194) | Update to CDK 7.23.8 (fixes AirbyteCustomCodeNotPermittedError for bundled custom components) and remove the temporary Cloud version override |


### PR DESCRIPTION
> [!CAUTION]
> **DO NOT MERGE. DO NOT PUBLISH.** This PR pins `source-bing-ads` to a **dev/prerelease** `source-declarative-manifest` image (`7.28.2.post2.dev33676771546`). It exists only to validate airbytehq/airbyte-python-cdk#1138 end to end via CI and must never be merged, published, or used to pin any Cloud actor/workspace.

## What
Throwaway validation PR for https://github.com/airbytehq/oncall/issues/12835 (Bing Ads recurring OAuth failures). Builds the manifest-only `source-bing-ads` connector on top of the preview SDM image published by CDK Publish run 33676771546, which contains airbytehq/airbyte-python-cdk#1130 and airbytehq/airbyte-python-cdk#1138 (head `ef2c164b5cb8d0d60a0cc324fbd3d71cd2570247`, 2 commits ahead of `v7.28.2`).

Requested by Zane Hyatt (@ZaneHyattAB).

## How
`airbyte-integrations/connectors/source-bing-ads/metadata.yaml`:
```diff
-    baseImage: docker.io/airbyte/source-declarative-manifest:7.25.1@sha256:cdbd1578932d121f2852c065fbabebc49ccbf00078606dc503be5e4c66b373df
+    baseImage: docker.io/airbyte/source-declarative-manifest:7.28.2.post2.dev33676771546@sha256:1a5b3a298b77c74029b46213d70009f6826206f8cb33d7c5f1d1836dcda4af06
-  dockerImageTag: 3.0.8
+  dockerImageTag: 3.0.9
```
Plus a matching 3.0.9 changelog row in `docs/integrations/sources/bing-ads.md`. The tag/digest was verified against the DockerHub registry manifest endpoint (`docker-content-digest` matches).

No changes to `manifest.yaml`, `components.py`, or any other connector.

## Review guide
1. `airbyte-integrations/connectors/source-bing-ads/metadata.yaml`
2. `docs/integrations/sources/bing-ads.md`

## User Impact
None — must not be merged. Goal is a green connector build / `Test source-bing-ads` job proving the CDK change does not break the connector.

## Can this PR be safely reverted and rolled back?
- [x] YES 💚
- [ ] NO ❌


Link to Devin session: https://app.devin.ai/sessions/cb375eb32d6841f6a167ebece05f3e19
Open in Devin Desktop: https://app.devin.ai/desktop/session/cb375eb32d6841f6a167ebece05f3e19?variant=devin

> [!IMPORTANT]
> Active progressive rollout warning for source-bing-ads.

- [ ] (Click to Approve:) Bypass the active progressive rollout warning for source-bing-ads in the PR comment [here](https://github.com/airbytehq/airbyte/pull/85305#issuecomment-5516066381).