### PR TITLE
feat(source-postgres): stand up e2e harness on db-harness-lib

### DIFF
--- a/airbyte-integrations/connectors/source-postgres/.agents/skills/source-postgres-e2e-tests/SKILL.md
+++ b/airbyte-integrations/connectors/source-postgres/.agents/skills/source-postgres-e2e-tests/SKILL.md
@@ -1,0 +1,198 @@
+---
+name: source-postgres-e2e-tests
+description: Stand up a local PostgreSQL 16 backend, apply SQL fixtures, and sweep the Airbyte protocol commands (spec → check → discover → read) against airbyte/source-postgres:<tag> for ad-hoc end-to-end testing.
+---
+
+# source-postgres-e2e-tests
+
+Local end-to-end test harness for `source-postgres`. The engine-independent
+orchestration lives in
+[`airbyte-integrations/db-harness-lib/`](../../../../../db-harness-lib/);
+this skill keeps the PostgreSQL backend lifecycle scripts, fixtures, and
+config templates. It stands up a PostgreSQL 16 container named
+`source-postgres-db-backend`, lets you apply arbitrary SQL fixtures, and runs
+Airbyte protocol commands against any `airbyte/source-postgres:<tag>` image via
+`airbyte-ops cloud connector regression-test`.
+
+This pilot supports standard (non-CDC) local sweeps. CDC fixtures and
+replication setup are not yet stood up in this skill.
+
+## When to use this skill
+
+- Reproducing a `source-postgres` bug locally.
+- Sweeping `spec` → `check` → `discover` → `read`, or running one of
+  them, against any `airbyte/source-postgres:<tag>` for connector
+  development.
+- Proving a fix by comparing a target image with a control image.
+
+## Prerequisites
+
+- Docker.
+- [`uv`](https://docs.astral.sh/uv/). `uv tool install
+airbyte-internal-ops` puts `airbyte-ops` on `$PATH`; alternatively prefix
+  every call with `uvx airbyte-internal-ops`.
+- `jq`.
+- A clone of `airbytehq/airbyte`.
+
+You do not need GSM or Cloud admin credentials. Local-only mode (no
+`--connection-id`) reads everything from local files.
+
+## Layout
+
+```
+source-postgres-e2e-tests/
+├── SKILL.md
+├── scripts/
+│   ├── start-backend.sh        # docker run postgres:16
+│   ├── apply-sql.sh            # docker exec psql on stdin
+│   ├── reset-databases.sh      # drop and recreate non-system databases
+│   └── run.sh                  # engine shim to db-harness-lib orchestration
+└── fixtures/
+    ├── configs/
+    │   └── base.template.json  # STANDARD config; host placeholder
+    └── sql/
+        └── 00-init-base.sql    # sample table with three rows
+```
+
+The engine shim and lifecycle scripts remain in this skill's `scripts/`
+directory; the shared orchestration and protocol helpers live in
+[`airbyte-integrations/db-harness-lib/`](../../../../../db-harness-lib/).
+The skill expects all script paths relative to the skill root.
+
+## Conventions
+
+- Container name: `source-postgres-db-backend`. Hard-coded in the lifecycle
+  scripts. Override via `BACKEND_NAME=…` only for parallel test isolation;
+  don't use customer connection names.
+- Postgres password: `test_password`. Override with `BACKEND_PASSWORD` when
+  running an isolated local backend.
+- Initial database: `test_db`. Override with `BACKEND_DB` when using a
+  different fixture database.
+- Working directory for rendered configs and run output:
+  `${REPRO_OUT:-/tmp/source-postgres-repro}`. A `run.sh` invocation writes
+  everything under `$REPRO_OUT/<step-name>/`: the rendered `config.json`,
+  the derived `configured_catalog.json`, and one subdirectory per protocol
+  command (`spec/`, `check/`, `discover/`, `read/`) holding that command's
+  `stdout.txt`, `stderr.txt`, `report.md`, and `report.html`.
+- Both containers (the PostgreSQL backend and the connector launched by
+  `airbyte-ops`) share Docker's default `bridge` network. The connector
+  resolves the backend by its bridge IP, which the shared
+  [`render-config.sh`](../../../../../db-harness-lib/scripts/render-config.sh)
+  substitutes into the working config at runtime. Tracked upstream in
+  [`airbytehq/airbyte-ops-mcp#765`](https://github.com/airbytehq/airbyte-ops-mcp/issues/765).
+- The backend image is pinned to `postgres:16`, not `latest`, for stable
+  major-version behavior. Override with `BACKEND_IMAGE=…` for a
+  version-specific reproduction.
+
+## Usage
+
+`scripts/run.sh` is the only supported entrypoint. It performs the whole
+sequence — start the backend, apply the fixtures, render the config, run
+`spec` → `check` → `discover`, derive the configured catalog from that
+`discover` output, run `read`, and tear down on exit:
+
+```bash
+cd airbyte-integrations/connectors/source-postgres
+
+# Single version, full sweep.
+poe e2e-local --test-version=3.8.5
+
+# Target vs. control comparison, non-CDC.
+poe e2e-local --test-version=dev --control-version=3.8.4
+
+# One command only.
+poe e2e-local --command=read --test-version=3.8.5
+```
+
+The sweep runs every command against the one backend and reports each
+result rather than stopping at the first failure, then prints a summary
+table and exits non-zero if any command failed. A `read` whose
+`discover` failed earlier is reported `SKIPPED`, not `ERROR`. Under CI the
+table is also appended to `$GITHUB_STEP_SUMMARY`. A run limited to one
+command instead exits with the connector's own exit code.
+
+Prefer a published target image for code on a pushed PR branch. Publish a
+pre-release from the PR with the Airbyte Ops MCP tool
+`publish_connector_to_airbyte_registry`, then pass the resulting
+`<version>-preview.<7-char-sha>` tag as `--test-version`. See
+[Getting a target image](../../../../../db-harness-lib/README.md#getting-a-target-image)
+for details. Build the target image first when using `--test-version=dev`, or
+pass `--build` to have `run.sh` run `:dockerBuildx` for code that is not on a
+pushed PR branch. Other options:
+`--command=spec|check|discover|read` (default `all`), `--skip-read`,
+`--skip-fixtures`, `--step-name`, `--catalog`, `--state=PATH`,
+`--sync-mode=incremental`, `--cursor-field`, `--streams`,
+`--config-template`, `--fixture`, `--reset=none|fixture|backend`,
+`--keep-backend`, and `--` to forward extra args to `airbyte-ops`.
+Per-command timeouts match the workflow's (30/30/60/180 minutes) and are
+overridable with `TIMEOUT_MINUTES_{SPEC,CHECK,DISCOVER,READ}`.
+
+## Declarative expectations
+
+Instead of driver scripts hand-rolling `grep -q '<substring>' || exit 1`
+against command artifacts, `run.sh` accepts expectation flags that it
+enforces before returning:
+
+| Flag                                               | Effect                                                                                                       |
+| -------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| `--expect-test=pass\|fail`                         | Overall target verdict.                                                                                      |
+| `--expect-control=pass\|fail`                      | Control verdict in comparison mode; requires `--control-version` and `--reset=fixture` or `--reset=backend`. |
+| `--min-records=N`                                  | Target read must contain at least N `RECORD` messages.                                                       |
+| `--min-states=N`                                   | Target read must contain at least N `STATE` messages.                                                        |
+| `--expect-match=[<command>:]<channel>:<regex>[:N]` | Target command output must match the regex at least N times.                                                 |
+| `--forbid-match=[<command>:]<channel>:<regex>`     | Target command output must not match the regex.                                                              |
+
+Match assertions use the target-side artifacts for the named command and
+default to `read` when no command prefix is supplied. The accepted
+channels are `stdout`, `stderr`, and `any`; command names are `spec`,
+`check`, `discover`, and `read`.
+
+Any expectation failure exits non-zero and is included in the generated
+summary. For example, a driver can replace a `grep` assertion with
+`--expect-match=stderr:expected message`.
+
+## Comparison modes with `--control-version`
+
+- **`--reset=none` (default)** — `run.sh` invokes `airbyte-ops` with both
+  `--test-image` and `--control-image`, so the images run sequentially
+  against one backend and the built-in comparators emit a target-vs-control
+  diff. This is appropriate for non-CDC full-refresh work.
+- **`--reset=fixture`** — `run.sh` runs the control sweep first, drops every
+  non-system database, reapplies the fixtures, and then runs the target
+  sweep. Artifacts land under
+  `$REPRO_OUT/<step-name>/{control,target}/<command>/`.
+- **`--reset=backend`** — like `--reset=fixture`, but recreates the
+  PostgreSQL container between sweeps. Use this only when matching database
+  initialization state matters.
+
+`--reset` has no effect without `--control-version` and produces a warning.
+The flag governs the reset between two image runs; there is no second run
+in single-version mode.
+
+## Common gotchas
+
+- **CDC is not included in this pilot.** The lifecycle starts a standard
+  PostgreSQL 16 server without WAL or replication settings, and CDC fixtures
+  are not yet stood up.
+- **PostgreSQL config shapes are specific.** `ssl_mode.mode` uses
+  `prefer` for the local plaintext backend. The
+  `replication_method.method` value for a standard sync is `Standard`.
+- **The connector resolves the backend by bridge IP.** The shared
+  `render-config.sh` substitutes that IP into each rendered config because
+  the local regression-test command does not currently accept `--network`.
+- **`check` failures may exit zero.** The connector can emit a failed
+  `CONNECTION_STATUS` while exiting zero. Assert on the status message when
+  a reproduction depends on check-time behavior.
+- **Do not use customer connections.** This harness is for local testing
+  only and must never be used against customer connections or Airbyte Cloud.
+
+## Teardown
+
+The shared library's default `stop-backend.sh` is idempotent:
+
+```bash
+BACKEND_NAME=source-postgres-db-backend \
+  airbyte-integrations/db-harness-lib/scripts/stop-backend.sh
+rm -rf "$REPRO_OUT"
+unset REPRO_OUT
+```

--- a/airbyte-integrations/connectors/source-postgres/.agents/skills/source-postgres-e2e-tests/SKILL.md
+++ b/airbyte-integrations/connectors/source-postgres/.agents/skills/source-postgres-e2e-tests/SKILL.md
@@ -14,7 +14,7 @@ config templates. It stands up a PostgreSQL 16 container named
 Airbyte protocol commands against any `airbyte/source-postgres:<tag>` image via
 `airbyte-ops cloud connector regression-test`.
 
-This pilot supports standard (non-CDC) local sweeps. CDC fixtures and
+This skill supports standard (non-CDC) local sweeps. CDC fixtures and
 replication setup are not yet stood up in this skill.
 
 ## When to use this skill

--- a/airbyte-integrations/connectors/source-postgres/.agents/skills/source-postgres-e2e-tests/fixtures/configs/base.template.json
+++ b/airbyte-integrations/connectors/source-postgres/.agents/skills/source-postgres-e2e-tests/fixtures/configs/base.template.json
@@ -1,0 +1,17 @@
+{
+  "host": "source-postgres-db-backend",
+  "port": 5432,
+  "database": "test_db",
+  "schemas": ["public"],
+  "username": "postgres",
+  "password": "test_password",
+  "ssl_mode": {
+    "mode": "prefer"
+  },
+  "tunnel_method": {
+    "tunnel_method": "NO_TUNNEL"
+  },
+  "replication_method": {
+    "method": "Standard"
+  }
+}

--- a/airbyte-integrations/connectors/source-postgres/.agents/skills/source-postgres-e2e-tests/fixtures/sql/00-init-base.sql
+++ b/airbyte-integrations/connectors/source-postgres/.agents/skills/source-postgres-e2e-tests/fixtures/sql/00-init-base.sql
@@ -1,0 +1,15 @@
+-- Idempotent base init for source-postgres e2e tests (non-CDC).
+-- The test_db database is created by the container (POSTGRES_DB); this
+-- fixture just (re)creates a small sample table with three rows.
+
+DROP TABLE IF EXISTS sample;
+
+CREATE TABLE sample (
+  id    INT          NOT NULL PRIMARY KEY,
+  label VARCHAR(64)  NOT NULL
+);
+
+INSERT INTO sample (id, label) VALUES
+  (1, 'alpha'),
+  (2, 'beta'),
+  (3, 'gamma');

--- a/airbyte-integrations/connectors/source-postgres/.agents/skills/source-postgres-e2e-tests/scripts/apply-sql.sh
+++ b/airbyte-integrations/connectors/source-postgres/.agents/skills/source-postgres-e2e-tests/scripts/apply-sql.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Apply a .sql file to the e2e backend via `docker exec psql` on stdin.
+#
+# Usage:  apply-sql.sh <path/to/file.sql>
+#
+# Env:
+#   BACKEND_NAME        container name (default: source-postgres-db-backend)
+#   BACKEND_PASSWORD    postgres password (default: test_password)
+#   BACKEND_DB          database to apply against (default: test_db)
+set -euo pipefail
+
+BACKEND_NAME="${BACKEND_NAME:-source-postgres-db-backend}"
+BACKEND_PASSWORD="${BACKEND_PASSWORD:-test_password}"
+BACKEND_DB="${BACKEND_DB:-test_db}"
+
+if [[ $# -lt 1 ]]; then
+  echo "usage: $(basename "$0") <path/to/file.sql>" >&2
+  exit 2
+fi
+SQL_FILE="$1"
+if [[ ! -f "$SQL_FILE" ]]; then
+  echo "[apply-sql] not a file: $SQL_FILE" >&2
+  exit 2
+fi
+
+docker exec -i -e PGPASSWORD="$BACKEND_PASSWORD" "$BACKEND_NAME" \
+  psql -U postgres -d "$BACKEND_DB" -v ON_ERROR_STOP=1 < "$SQL_FILE"
+echo "[apply-sql] applied $SQL_FILE." >&2

--- a/airbyte-integrations/connectors/source-postgres/.agents/skills/source-postgres-e2e-tests/scripts/reset-databases.sh
+++ b/airbyte-integrations/connectors/source-postgres/.agents/skills/source-postgres-e2e-tests/scripts/reset-databases.sh
@@ -12,6 +12,11 @@ BACKEND_NAME="${BACKEND_NAME:-source-postgres-db-backend}"
 BACKEND_PASSWORD="${BACKEND_PASSWORD:-test_password}"
 BACKEND_DB="${BACKEND_DB:-test_db}"
 
+if [[ "$BACKEND_DB" == "postgres" || "$BACKEND_DB" == "template0" || "$BACKEND_DB" == "template1" ]]; then
+  echo "[reset-databases] BACKEND_DB must not be a system database (got: $BACKEND_DB)" >&2
+  exit 1
+fi
+
 echo "[reset-databases] dropping non-system databases on $BACKEND_NAME" >&2
 docker exec -e PGPASSWORD="$BACKEND_PASSWORD" "$BACKEND_NAME" \
   psql -U postgres -d postgres -Atc \

--- a/airbyte-integrations/connectors/source-postgres/.agents/skills/source-postgres-e2e-tests/scripts/reset-databases.sh
+++ b/airbyte-integrations/connectors/source-postgres/.agents/skills/source-postgres-e2e-tests/scripts/reset-databases.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Reset non-system databases on the source-postgres e2e backend.
+# Used by run.sh --reset=fixture before a second comparison sweep.
+#
+# Env:
+#   BACKEND_NAME        container name (default: source-postgres-db-backend)
+#   BACKEND_PASSWORD    postgres password (default: test_password)
+#   BACKEND_DB          database to recreate (default: test_db)
+set -euo pipefail
+
+BACKEND_NAME="${BACKEND_NAME:-source-postgres-db-backend}"
+BACKEND_PASSWORD="${BACKEND_PASSWORD:-test_password}"
+BACKEND_DB="${BACKEND_DB:-test_db}"
+
+echo "[reset-databases] dropping non-system databases on $BACKEND_NAME" >&2
+docker exec -e PGPASSWORD="$BACKEND_PASSWORD" "$BACKEND_NAME" \
+  psql -U postgres -d postgres -Atc \
+    "SELECT datname FROM pg_database WHERE datistemplate = false AND datname <> 'postgres'" \
+  | while IFS= read -r db; do
+      escaped_db="${db//\"/\"\"}"
+      docker exec -e PGPASSWORD="$BACKEND_PASSWORD" "$BACKEND_NAME" \
+        psql -U postgres -d postgres -v ON_ERROR_STOP=1 \
+          -c "DROP DATABASE \"$escaped_db\" WITH (FORCE)"
+    done
+
+escaped_backend_db="${BACKEND_DB//\"/\"\"}"
+docker exec -e PGPASSWORD="$BACKEND_PASSWORD" "$BACKEND_NAME" \
+  psql -U postgres -d postgres -v ON_ERROR_STOP=1 \
+  -c "CREATE DATABASE \"$escaped_backend_db\""

--- a/airbyte-integrations/connectors/source-postgres/.agents/skills/source-postgres-e2e-tests/scripts/run.sh
+++ b/airbyte-integrations/connectors/source-postgres/.agents/skills/source-postgres-e2e-tests/scripts/run.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# PostgreSQL engine shim; orchestration lives in db-harness-lib.
+set -euo pipefail
+
+SKILL_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+REPO_ROOT="$(git -C "$SKILL_DIR" rev-parse --show-toplevel)"
+export CONNECTOR=source-postgres
+export ENGINE_SCRIPTS_DIR="$SKILL_DIR/scripts"
+export DEFAULT_CONFIG_TEMPLATE="$SKILL_DIR/fixtures/configs/base.template.json"
+export DEFAULT_FIXTURE="$SKILL_DIR/fixtures/sql/00-init-base.sql"
+export BACKEND_NAME="${BACKEND_NAME:-source-postgres-db-backend}"
+
+exec "$REPO_ROOT/airbyte-integrations/db-harness-lib/scripts/run.sh" "$@"

--- a/airbyte-integrations/connectors/source-postgres/.agents/skills/source-postgres-e2e-tests/scripts/start-backend.sh
+++ b/airbyte-integrations/connectors/source-postgres/.agents/skills/source-postgres-e2e-tests/scripts/start-backend.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Start a throwaway PostgreSQL container for source-postgres e2e tests.
+# Idempotent: succeeds whether or not the container already exists.
+#
+# Env:
+#   BACKEND_NAME        container name (default: source-postgres-db-backend)
+#   BACKEND_PASSWORD    postgres password (default: test_password)
+#   BACKEND_DB          initial database (default: test_db)
+#   BACKEND_PORT        host port mapped to 5432/tcp (default: 5432)
+#   BACKEND_IMAGE       image (default: postgres:16)
+set -euo pipefail
+
+BACKEND_NAME="${BACKEND_NAME:-source-postgres-db-backend}"
+BACKEND_PASSWORD="${BACKEND_PASSWORD:-test_password}"
+BACKEND_DB="${BACKEND_DB:-test_db}"
+BACKEND_PORT="${BACKEND_PORT:-5432}"
+BACKEND_IMAGE="${BACKEND_IMAGE:-postgres:16}"
+
+if [[ "$(docker inspect -f '{{.State.Running}}' "$BACKEND_NAME" 2>/dev/null || echo false)" == "true" ]]; then
+  echo "[start-backend] $BACKEND_NAME already running; reusing." >&2
+else
+  docker rm -f "$BACKEND_NAME" >/dev/null 2>&1 || true
+  docker run -d --rm \
+    --name "$BACKEND_NAME" \
+    -e POSTGRES_PASSWORD="$BACKEND_PASSWORD" \
+    -e POSTGRES_DB="$BACKEND_DB" \
+    -p "$BACKEND_PORT:5432" \
+    "$BACKEND_IMAGE" >/dev/null
+fi
+
+echo "[start-backend] waiting for $BACKEND_NAME to accept connections…" >&2
+for _ in $(seq 1 60); do
+  if docker exec -e PGPASSWORD="$BACKEND_PASSWORD" "$BACKEND_NAME" \
+       psql -U postgres -d "$BACKEND_DB" -Atc "SELECT 1" >/dev/null 2>&1; then
+    echo "[start-backend] $BACKEND_NAME ready." >&2
+    exit 0
+  fi
+  sleep 2
+done
+
+echo "[start-backend] timed out waiting for $BACKEND_NAME after 120s." >&2
+exit 1

--- a/airbyte-integrations/connectors/source-postgres/poe_tasks.toml
+++ b/airbyte-integrations/connectors/source-postgres/poe_tasks.toml
@@ -1,3 +1,10 @@
 include = [
     "${POE_GIT_DIR}/poe-tasks/gradle-connector-tasks.toml",
 ]
+
+[tasks.e2e-local]
+help = "Run the local e2e harness end-to-end (backend, fixtures, spec/check/discover/read sweep, teardown). Arguments are forwarded to run.sh; pass --control-version=<tag> for a prove-fix target-vs-control comparison, --command=<cmd> to run a single command, and --help for the full list. See .agents/skills/source-postgres-e2e-tests/SKILL.md."
+# No `args` block: poe forwards the trailing CLI arguments verbatim. Declaring
+# them as a positional `multiple` arg instead makes poe's own parser claim the
+# leading --flags and reject the invocation.
+cmd = "${POE_PWD}/.agents/skills/source-postgres-e2e-tests/scripts/run.sh"


### PR DESCRIPTION
## What
Third engine on the shared DB harness ([HYD-144](https://linear.app/airbyteio/issue/HYD-144)): a connector-local e2e harness for `source-postgres`, following the mysql pilot (#85282). Non-CDC only; CDC fixtures/replication setup are deferred.

Requested by Sophie Cui (@sophiecuiy).

## How
Same engine contract as mssql/mysql — a `.agents/skills/source-postgres-e2e-tests/` skill whose `scripts/run.sh` is a ~10-line shim exporting `CONNECTOR`, `ENGINE_SCRIPTS_DIR`, default config template/fixture, and `BACKEND_NAME`, then exec'ing `db-harness-lib/scripts/run.sh`. Engine-specific pieces stay local:

- `start-backend.sh`: `postgres:16` container (`POSTGRES_PASSWORD`/`POSTGRES_DB`, port 5432), reuse-if-running, readiness poll via `psql -Atc "SELECT 1"` (keeps polling through the initdb restart window).
- `apply-sql.sh`: `docker exec -i ... psql -v ON_ERROR_STOP=1` on stdin.
- `reset-databases.sh`: connects to the maintenance `postgres` DB, `DROP DATABASE ... WITH (FORCE)` for every non-template/non-`postgres` DB, then recreates `$BACKEND_DB` (postgres can't drop the DB it's connected to).
- `fixtures/`: `00-init-base.sql` (same `sample(id,label)` 3-row table as the other engines) and `base.template.json` (`ssl_mode: prefer`, `replication_method: Standard`, NO_TUNNEL — constants verified against the 3.8.5 spec).
- `poe_tasks.toml` gains the same `e2e-local` task; `SKILL.md` mirrors the mysql skill, including the shared target-image guidance link.

No engine `stop-backend.sh` (the lib default suffices). No version/changelog changes (deliberate, same as the mssql/mysql harness PRs).

## Review guide
1. `.agents/skills/source-postgres-e2e-tests/scripts/run.sh` (shim)
2. `scripts/start-backend.sh`, `apply-sql.sh`, `reset-databases.sh`
3. `fixtures/configs/base.template.json`, `fixtures/sql/00-init-base.sql`
4. `poe_tasks.toml`, `SKILL.md`

## User Impact
None at runtime — dev/CI tooling only; no connector code or published image changes.

Verified locally: full sweep `poe e2e-local --test-version=3.8.5` — SPEC/CHECK/DISCOVER/READ all PASS, read emitted 3 RECORDs + 1 STATE from the `sample` fixture; `bash -n`/shellcheck clean; TOML parses.

## Can this PR be safely reverted and rolled back?
- [x] YES 💚
- [ ] NO ❌

Link to Devin session: https://app.devin.ai/sessions/b22932c814334daeb43c5b5c470dde3b
Open in Devin Desktop: https://app.devin.ai/desktop/session/b22932c814334daeb43c5b5c470dde3b?variant=devin

> [!IMPORTANT]
> Active progressive rollout warning for source-postgres.

- [x] (Click to Approve:) Bypass the active progressive rollout warning for source-postgres in the PR comment [here](https://github.com/airbytehq/airbyte/pull/85310#issuecomment-5516708282).

---

> [!IMPORTANT]
> **Autopilot Progressive Rollout Enabled**
>
> [Autopilot progressive rollouts](https://github.com/airbytehq/airbyte-ops-mcp/blob/main/docs/autopilot-rollouts.md) are enabled for one or more connector(s) modified in this PR. Check the box below if you need to bypass normal rollout safety processes and release to all users immediately upon merge:
>
> - [ ] ⚡ **Release immediately** (bypasses automatic progressive rollout)
>
> **Note:**
>
> - ⚠️ The above bypass option is for emergency/hotfix use only.
> - 🔗 You can monitor or manually advance a rollout at **[ops.internal.airbyte.ai](https://ops.internal.airbyte.ai)**.