### PR TITLE
feat(source-mysql): add CDC e2e harness skill (source-mysql-e2e-cdc-tests)

### DIFF
--- a/airbyte-integrations/connectors/source-mysql/.agents/skills/source-mysql-e2e-cdc-tests/SKILL.md
+++ b/airbyte-integrations/connectors/source-mysql/.agents/skills/source-mysql-e2e-cdc-tests/SKILL.md
@@ -67,9 +67,10 @@ it extracts protocol-level STATE messages and is not engine-specific.
   `--binlog-row-image=FULL`, `--gtid-mode=ON`, and
   `--enforce-gtid-consistency=ON`. Do not add per-table CDC enable steps or
   engine-specific backend startup to this skill.
-- The CDC fixture creates a dedicated `cdc_test` database and is safe to
-  re-apply. The replay case skips fixtures in its second phase so the inserted
-  row and saved binlog state remain intact.
+- `00-init-cdc.sql` drops and recreates the dedicated `cdc_test` database on
+  every application. Re-applying it wipes existing rows and any accumulated
+  binlog-relative table state, which is why `cases/incremental-replay.sh`
+  passes `--skip-fixtures` on its second phase.
 - CDC catalogs include the bulk-CDK fields (`is_file_based`,
   `generation_id`, `minimum_generation_id`, `sync_id`,
   `destination_object_name`, and `include_files`) and use

--- a/airbyte-integrations/connectors/source-mysql/.agents/skills/source-mysql-e2e-cdc-tests/SKILL.md
+++ b/airbyte-integrations/connectors/source-mysql/.agents/skills/source-mysql-e2e-cdc-tests/SKILL.md
@@ -1,0 +1,162 @@
+---
+name: source-mysql-e2e-cdc-tests
+description: Reproduce MySQL binlog CDC behavior against a local MySQL backend with CDC-aware fixtures, catalogs, and smoke cases. Composes on source-mysql-e2e-tests and db-harness-lib.
+---
+
+# source-mysql-e2e-cdc-tests
+
+Local CDC test harness for `source-mysql`. It builds on the
+engine-independent orchestration in
+[`airbyte-integrations/db-harness-lib/`](../../../../../db-harness-lib/) and
+the generic MySQL skill
+([`source-mysql-e2e-tests`](../source-mysql-e2e-tests/SKILL.md)). The generic
+skill starts a MySQL 8.0 backend and runs the connector; this skill supplies
+the binlog CDC config, CDC catalog, SQL fixtures, and case scripts.
+
+MySQL CDC is binlog-based and server-wide. The generic backend already starts
+MySQL with ROW binlogging, full row images, and GTIDs, so this skill does not
+enable CDC per table or start a second backend.
+
+## When to use this skill
+
+- Reproducing a CDC-mode `source-mysql` bug locally.
+- Verifying a fix with a published connector image or `VERSION=dev` after
+  building the connector locally.
+- Running the initial-load and incremental-replay smoke cases.
+- Authoring a new MySQL CDC repro with an idempotent SQL fixture and a case
+  script that invokes the generic skill's `scripts/run.sh`.
+
+## Prerequisites
+
+Same as the generic skill:
+
+- Docker, `uv`, `jq`, and a clone of `airbytehq/airbyte`.
+- The backend container `source-mysql-db-backend`, started by
+  `../source-mysql-e2e-tests/scripts/start-backend.sh`.
+
+You do not need GSM or Cloud admin credentials. Never run this harness against
+a customer connection or Airbyte Cloud.
+
+## Layout
+
+```
+source-mysql-e2e-cdc-tests/
+├── SKILL.md
+├── cases/
+│   ├── initial-load.sh             # CDC initial-load smoke case
+│   └── incremental-replay.sh       # read → mutate → read-with-state smoke case
+└── fixtures/
+    ├── configs/
+    │   └── cdc.template.json       # CDC replication config
+    ├── catalogs/
+    │   └── users-cdc.json          # users stream with MySQL CDC metadata
+    └── sql/
+        ├── 00-init-cdc.sql         # dedicated cdc_test database and rows
+        └── mutate-insert-users.sql # row inserted between replay phases
+```
+
+`extract-state.py` is implemented in
+[`airbyte-integrations/db-harness-lib/scripts/extract-state.py`](../../../../../db-harness-lib/scripts/extract-state.py);
+it extracts protocol-level STATE messages and is not engine-specific.
+
+## Conventions
+
+- Cases reuse the generic backend and pass `--keep-backend`. Start it once at
+  the top of a session, run the cases, and tear it down when finished.
+- The generic MySQL backend starts with `--log-bin`, `--binlog-format=ROW`,
+  `--binlog-row-image=FULL`, `--gtid-mode=ON`, and
+  `--enforce-gtid-consistency=ON`. Do not add per-table CDC enable steps or
+  engine-specific backend startup to this skill.
+- The CDC fixture creates a dedicated `cdc_test` database and is safe to
+  re-apply. The replay case skips fixtures in its second phase so the inserted
+  row and saved binlog state remain intact.
+- CDC catalogs include the bulk-CDK fields (`is_file_based`,
+  `generation_id`, `minimum_generation_id`, `sync_id`,
+  `destination_object_name`, and `include_files`) and use
+  `["_ab_cdc_cursor"]` as the cursor field.
+- Cases default to `VERSION=3.53.4`, the current published image used by this
+  harness. Override it with `VERSION=dev` after building a local image.
+- Assertions are declarative `run.sh` expectations. The runner enforces
+  `--expect-test`, `--expect-match`, `--forbid-match`, `--min-records`, and
+  `--min-states` before returning.
+- Multi-phase cases extract the latest STATE message with the shared
+  `extract-state.py` and pass it to the next invocation with `--state=PATH`.
+
+## Usage
+
+```bash
+SKILL=airbyte-integrations/connectors/source-mysql/.agents/skills/source-mysql-e2e-cdc-tests
+GENERIC=airbyte-integrations/connectors/source-mysql/.agents/skills/source-mysql-e2e-tests
+LIB=airbyte-integrations/db-harness-lib
+export REPRO_OUT=/tmp/source-mysql-repro
+
+# Start the binlog-ready backend once.
+"$GENERIC/scripts/start-backend.sh"
+
+# Run either smoke case. Both pass --keep-backend.
+"$SKILL/cases/initial-load.sh"
+"$SKILL/cases/incremental-replay.sh"
+
+# Use a locally built connector image after a code change.
+VERSION=dev "$SKILL/cases/initial-load.sh"
+
+# Tear down after the session.
+BACKEND_NAME=source-mysql-db-backend \
+  "$LIB/scripts/stop-backend.sh"
+```
+
+Prefer a published target image for code on a pushed PR branch. Publish a
+pre-release with the Airbyte Ops MCP tool
+`publish_connector_to_airbyte_registry`, then pass the resulting
+`<version>-preview.<7-char-sha>` tag as `--test-version`. See
+[Getting a target image](../../../../../db-harness-lib/README.md#getting-a-target-image)
+for details. Use `--test-version=dev` only for code that is not on a pushed
+PR branch.
+
+Each case invokes the generic skill's engine shim, which delegates to
+`airbyte-integrations/db-harness-lib/scripts/run.sh`. The runner applies the
+fixture, renders the config, runs the requested connector command, stores
+artifacts under `$REPRO_OUT/<step-name>/`, and enforces the case assertions.
+
+## Worked examples
+
+### Initial CDC load
+
+`cases/initial-load.sh` applies `00-init-cdc.sql` and reads the configured
+`users` stream with `cdc.template.json` and `users-cdc.json`. It asserts a
+passing read with at least three records and one STATE message. This verifies
+that the binlog-ready backend, CDC config, catalog metadata, and initial load
+work together.
+
+### Incremental replay
+
+`cases/incremental-replay.sh` runs a baseline read, extracts its STATE message,
+inserts `dave@example.com`, and replays from the saved state without
+re-applying fixtures. It asserts a passing replay containing
+`dave@example.com` and no `alice@example.com`, proving that the saved binlog
+position resumes after the initial load.
+
+These are smoke canaries, not per-bug reproductions. No MySQL CDC fixtures or
+worked per-bug examples existed before this skill.
+
+## Authoring a new repro
+
+1. Add an idempotent SQL fixture under `fixtures/sql/`. Keep any CDC database
+   setup dedicated to the fixture and do not add per-table CDC enable steps.
+2. Add a CDC-aware catalog under `fixtures/catalogs/` when the case needs a
+   stream shape not covered by `users-cdc.json`.
+3. Add `cases/<name>.sh` with `set -euo pipefail`, a `${VERSION:-3.53.4}`
+   default, and a call to the generic skill's `scripts/run.sh`. Pass
+   `--config-template`, `--catalog`, `--fixture`, `--keep-backend`, and the
+   relevant `--expect-*` flags.
+4. For a multi-phase case, model the sequence on
+   `cases/incremental-replay.sh`: baseline `read`, extract STATE from
+   `$REPRO_OUT/<step>/read/stdout.txt`, mutate through the generic
+   `apply-sql.sh`, then run with `--skip-fixtures --state=PATH`.
+5. Verify the case against a published image or `VERSION=dev`, inspect its
+   artifacts, and keep the backend lifecycle in the generic skill.
+
+The generic `apply-sql.sh` uses the plain MySQL client on stdin, so fixtures
+may contain multiple statements. The MySQL server's binlog and GTID settings
+are established when the generic backend starts; no additional CDC setup is
+needed in a case.

--- a/airbyte-integrations/connectors/source-mysql/.agents/skills/source-mysql-e2e-cdc-tests/cases/incremental-replay.sh
+++ b/airbyte-integrations/connectors/source-mysql/.agents/skills/source-mysql-e2e-cdc-tests/cases/incremental-replay.sh
@@ -42,5 +42,5 @@ mkdir -p "$(dirname "$BASELINE_STATE")"
   --state="$BASELINE_STATE" \
   --keep-backend \
   --expect-test=pass \
-  --expect-match=stdout:dave@example.com \
-  --forbid-match=stdout:alice@example.com
+  --expect-match='stdout:dave@example\.com' \
+  --forbid-match='stdout:alice@example\.com'

--- a/airbyte-integrations/connectors/source-mysql/.agents/skills/source-mysql-e2e-cdc-tests/cases/incremental-replay.sh
+++ b/airbyte-integrations/connectors/source-mysql/.agents/skills/source-mysql-e2e-cdc-tests/cases/incremental-replay.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+SKILL="$(cd "$HERE/.." && pwd)"
+GENERIC="$(cd "$SKILL/../source-mysql-e2e-tests" && pwd)"
+REPO_ROOT="$(git -C "$HERE" rev-parse --show-toplevel)"
+LIB="$REPO_ROOT/airbyte-integrations/db-harness-lib"
+
+REPRO_OUT="${REPRO_OUT:-/tmp/source-mysql-repro}"
+VERSION="${VERSION:-3.53.4}"
+STEP_NAME="${STEP_NAME:-cdc-replay}"
+BASELINE_STATE="$REPRO_OUT/$STEP_NAME/state.json"
+export REPRO_OUT
+
+"$GENERIC/scripts/run.sh" \
+  --command=read \
+  --test-version="$VERSION" \
+  --step-name="$STEP_NAME/baseline" \
+  --fixture="$SKILL/fixtures/sql/00-init-cdc.sql" \
+  --config-template="$SKILL/fixtures/configs/cdc.template.json" \
+  --catalog="$SKILL/fixtures/catalogs/users-cdc.json" \
+  --keep-backend \
+  --expect-test=pass \
+  --min-records=3 \
+  --min-states=1
+
+mkdir -p "$(dirname "$BASELINE_STATE")"
+"$LIB/scripts/extract-state.py" \
+  "$REPRO_OUT/$STEP_NAME/baseline/read/stdout.txt" \
+  > "$BASELINE_STATE"
+"$GENERIC/scripts/apply-sql.sh" \
+  "$SKILL/fixtures/sql/mutate-insert-users.sql"
+
+"$GENERIC/scripts/run.sh" \
+  --command=read \
+  --test-version="$VERSION" \
+  --step-name="$STEP_NAME/replay" \
+  --skip-fixtures \
+  --config-template="$SKILL/fixtures/configs/cdc.template.json" \
+  --catalog="$SKILL/fixtures/catalogs/users-cdc.json" \
+  --state="$BASELINE_STATE" \
+  --keep-backend \
+  --expect-test=pass \
+  --expect-match=stdout:dave@example.com \
+  --forbid-match=stdout:alice@example.com

--- a/airbyte-integrations/connectors/source-mysql/.agents/skills/source-mysql-e2e-cdc-tests/cases/initial-load.sh
+++ b/airbyte-integrations/connectors/source-mysql/.agents/skills/source-mysql-e2e-cdc-tests/cases/initial-load.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+SKILL="$(cd "$HERE/.." && pwd)"
+GENERIC="$(cd "$SKILL/../source-mysql-e2e-tests" && pwd)"
+
+"$GENERIC/scripts/run.sh" \
+  --command=read \
+  --test-version="${VERSION:-3.53.4}" \
+  --step-name=cdc-initial-load \
+  --fixture="$SKILL/fixtures/sql/00-init-cdc.sql" \
+  --config-template="$SKILL/fixtures/configs/cdc.template.json" \
+  --catalog="$SKILL/fixtures/catalogs/users-cdc.json" \
+  --keep-backend \
+  --expect-test=pass \
+  --min-records=3 \
+  --min-states=1

--- a/airbyte-integrations/connectors/source-mysql/.agents/skills/source-mysql-e2e-cdc-tests/fixtures/catalogs/users-cdc.json
+++ b/airbyte-integrations/connectors/source-mysql/.agents/skills/source-mysql-e2e-cdc-tests/fixtures/catalogs/users-cdc.json
@@ -1,0 +1,59 @@
+{
+  "streams": [
+    {
+      "stream": {
+        "name": "users",
+        "json_schema": {
+          "type": "object",
+          "properties": {
+            "created_at": {
+              "format": "date-time",
+              "airbyte_type": "timestamp_without_timezone",
+              "type": "string"
+            },
+            "id": {
+              "airbyte_type": "integer",
+              "type": "number"
+            },
+            "email": {
+              "type": "string"
+            },
+            "_ab_cdc_updated_at": {
+              "type": "string"
+            },
+            "_ab_cdc_deleted_at": {
+              "type": "string"
+            },
+            "_ab_cdc_cursor": {
+              "airbyte_type": "integer",
+              "type": "number"
+            },
+            "_ab_cdc_log_file": {
+              "type": "string"
+            },
+            "_ab_cdc_log_pos": {
+              "airbyte_type": "integer",
+              "type": "number"
+            }
+          }
+        },
+        "supported_sync_modes": ["full_refresh", "incremental"],
+        "source_defined_cursor": true,
+        "default_cursor_field": ["_ab_cdc_cursor"],
+        "source_defined_primary_key": [["id"]],
+        "namespace": "cdc_test",
+        "is_resumable": true,
+        "is_file_based": false
+      },
+      "sync_mode": "incremental",
+      "destination_sync_mode": "append_dedup",
+      "primary_key": [["id"]],
+      "cursor_field": ["_ab_cdc_cursor"],
+      "generation_id": 0,
+      "minimum_generation_id": 0,
+      "sync_id": 0,
+      "destination_object_name": "users",
+      "include_files": false
+    }
+  ]
+}

--- a/airbyte-integrations/connectors/source-mysql/.agents/skills/source-mysql-e2e-cdc-tests/fixtures/configs/cdc.template.json
+++ b/airbyte-integrations/connectors/source-mysql/.agents/skills/source-mysql-e2e-cdc-tests/fixtures/configs/cdc.template.json
@@ -1,0 +1,18 @@
+{
+  "host": "source-mysql-db-backend",
+  "port": 3306,
+  "database": "cdc_test",
+  "username": "root",
+  "password": "test_password",
+  "ssl_mode": {
+    "mode": "preferred"
+  },
+  "tunnel_method": {
+    "tunnel_method": "NO_TUNNEL"
+  },
+  "replication_method": {
+    "method": "CDC",
+    "invalid_cdc_cursor_position_behavior": "Fail sync",
+    "initial_load_timeout_hours": 4
+  }
+}

--- a/airbyte-integrations/connectors/source-mysql/.agents/skills/source-mysql-e2e-cdc-tests/fixtures/sql/00-init-cdc.sql
+++ b/airbyte-integrations/connectors/source-mysql/.agents/skills/source-mysql-e2e-cdc-tests/fixtures/sql/00-init-cdc.sql
@@ -1,0 +1,16 @@
+-- Idempotent CDC fixture for source-mysql e2e tests.
+
+DROP DATABASE IF EXISTS cdc_test;
+CREATE DATABASE cdc_test;
+USE cdc_test;
+
+CREATE TABLE users (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  email VARCHAR(200) NOT NULL,
+  created_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6)
+);
+
+INSERT INTO users (email) VALUES
+  ('alice@example.com'),
+  ('bob@example.com'),
+  ('carol@example.com');

--- a/airbyte-integrations/connectors/source-mysql/.agents/skills/source-mysql-e2e-cdc-tests/fixtures/sql/mutate-insert-users.sql
+++ b/airbyte-integrations/connectors/source-mysql/.agents/skills/source-mysql-e2e-cdc-tests/fixtures/sql/mutate-insert-users.sql
@@ -1,0 +1,2 @@
+USE cdc_test;
+INSERT INTO users (email) VALUES ('dave@example.com');

--- a/airbyte-integrations/connectors/source-mysql/AGENTS.md
+++ b/airbyte-integrations/connectors/source-mysql/AGENTS.md
@@ -37,3 +37,22 @@ Use `src/test-performance/sql/create_mysql_benchmarks.sql` to create a benchmark
    ```
 
 The script creates the configured number of tables with names from `test_0` through `test_<table count minus 1>`.
+
+## Reproducing bugs locally
+
+Use the generic
+[`source-mysql-e2e-tests`](.agents/skills/source-mysql-e2e-tests/SKILL.md)
+skill for standard local sweeps and the
+[`source-mysql-e2e-cdc-tests`](.agents/skills/source-mysql-e2e-cdc-tests/SKILL.md)
+skill for binlog CDC cases. Both delegate orchestration to
+[`airbyte-integrations/db-harness-lib/`](../../db-harness-lib/); the CDC skill
+reuses the generic backend, which is already binlog and GTID ready.
+
+```bash
+GENERIC=airbyte-integrations/connectors/source-mysql/.agents/skills/source-mysql-e2e-tests
+CDC=airbyte-integrations/connectors/source-mysql/.agents/skills/source-mysql-e2e-cdc-tests
+
+"$GENERIC/scripts/start-backend.sh"
+"$CDC/cases/initial-load.sh"
+"$CDC/cases/incremental-replay.sh"
+```


### PR DESCRIPTION
## What

Adds CDC support to the local `source-mysql` e2e harness: a new `source-mysql-e2e-cdc-tests` agent skill mirroring `source-mssql-e2e-cdc-tests`, composing on the generic `source-mysql-e2e-tests` skill and `airbyte-integrations/db-harness-lib`. Follow-up to the harness generalization (HYD-144, #85239 / #85282); requested by Sophie Cui.

## How

- **No new backend or per-table enable**: MySQL CDC is binlog-based and server-wide, and the generic skill's `start-backend.sh` already runs `mysql:8.0` with `--log-bin --binlog-format=ROW --binlog-row-image=FULL --gtid-mode=ON --enforce-gtid-consistency=ON`, so the CDC skill reuses that backend as-is.
- `fixtures/configs/cdc.template.json` — `replication_method: {"method": "CDC", ...}` against a dedicated `cdc_test` database (fields verified against `MySqlSourceConfigurationSpecification.kt`).
- `fixtures/catalogs/users-cdc.json` — CDC-aware configured catalog with MySQL meta-fields (`_ab_cdc_log_file` / `_ab_cdc_log_pos` instead of MSSQL's `_ab_cdc_lsn` / `_ab_cdc_event_serial_no`), `cursor_field: ["_ab_cdc_cursor"]`, and all bulk-CDK-required fields.
- `fixtures/sql/00-init-cdc.sql` (idempotent `cdc_test` + 3-row `users`) and `mutate-insert-users.sql` (between-phase insert).
- Two smoke cases (no per-bug repros yet):
  - `cases/initial-load.sh` — CDC read asserting `--expect-test=pass --min-records=3 --min-states=1`.
  - `cases/incremental-replay.sh` — multi-phase read → `extract-state.py` → insert → replay with `--skip-fixtures --state=...`, asserting the replay emits `dave@example.com` and not `alice@example.com`.
- `SKILL.md` documenting layout, conventions, and the multi-phase authoring recipe; `AGENTS.md` gains a short "Reproducing bugs locally" section pointing at both skills.

No connector code, version, or changelog changes (deliberate no-bump — the Pre-Release version-increment check warning can be ignored).

## Review guide

1. `.agents/skills/source-mysql-e2e-cdc-tests/SKILL.md`
2. `cases/initial-load.sh`, `cases/incremental-replay.sh`
3. `fixtures/` (config, catalog, SQL)
4. `AGENTS.md`

## User Impact

None at runtime — docs/harness only, nothing publishes. Agents and developers get a local MySQL CDC repro/verification harness matching the MSSQL one.

Test evidence: both cases pass locally against `airbyte/source-mysql:3.53.4` — initial load READ PASS (3 RECORD / ≥1 STATE); replay baseline READ PASS (3 RECORD), replay READ PASS (1 RECORD: `dave@example.com` only).

## Can this PR be safely reverted and rolled back?
- [x] YES 💚
- [ ] NO ❌

Link to Devin session: https://app.devin.ai/sessions/b22932c814334daeb43c5b5c470dde3b
Open in Devin Desktop: https://app.devin.ai/desktop/session/b22932c814334daeb43c5b5c470dde3b?variant=devin
Requested by: @sophiecuiy

> [!IMPORTANT]
> Active progressive rollout warning for source-mysql.

- [x] (Click to Approve:) Bypass the active progressive rollout warning for source-mysql in the PR comment [here](https://github.com/airbytehq/airbyte/pull/85315#issuecomment-5517574644).

---

> [!IMPORTANT]
> **Autopilot Progressive Rollout Enabled**
>
> [Autopilot progressive rollouts](https://github.com/airbytehq/airbyte-ops-mcp/blob/main/docs/autopilot-rollouts.md) are enabled for one or more connector(s) modified in this PR. Check the box below if you need to bypass normal rollout safety processes and release to all users immediately upon merge:
>
> - [ ] ⚡ **Release immediately** (bypasses automatic progressive rollout)
>
> **Note:**
>
> - ⚠️ The above bypass option is for emergency/hotfix use only.
> - 🔗 You can monitor or manually advance a rollout at **[ops.internal.airbyte.ai](https://ops.internal.airbyte.ai)**.