### PR TITLE
feat(source-tiktok-marketing): add GMV Max stores, campaigns and daily report streams

### DIFF
--- a/airbyte-integrations/connectors/source-tiktok-marketing/manifest.yaml
+++ b/airbyte-integrations/connectors/source-tiktok-marketing/manifest.yaml
@@ -2387,7 +2387,497 @@ definitions:
       schema:
         $ref: "#/definitions/schemas/pixel_events_statistics"
 
+  gmv_max_stores_stream:
+    type: DeclarativeStream
+    name: gmv_max_stores
+    $parameters:
+      path: "gmv_max/store/list/"
+    primary_key:
+      - store_id
+    retriever:
+      type: SimpleRetriever
+      requester:
+        $ref: "#/definitions/requester"
+      record_selector:
+        type: RecordSelector
+        schema_normalization: Default
+        extractor:
+          type: DpathExtractor
+          field_path: ["data", "store_list"]
+      paginator:
+        type: NoPagination
+      partition_router:
+        $ref: "#/definitions/single_id_partition_router"
+    schema_loader:
+      type: InlineSchemaLoader
+      schema:
+        $ref: "#/definitions/schemas/gmv_max_stores"
+
+  gmv_max_stores_filtered_stream:
+    type: DeclarativeStream
+    name: gmv_max_stores_filtered
+    $parameters:
+      path: "gmv_max/store/list/"
+    primary_key:
+      - store_id
+    retriever:
+      type: SimpleRetriever
+      requester:
+        $ref: "#/definitions/requester"
+      record_selector:
+        type: RecordSelector
+        schema_normalization: Default
+        extractor:
+          type: DpathExtractor
+          field_path: ["data", "store_list"]
+        record_filter:
+          type: RecordFilter
+          condition: "{{ record.get('is_gmv_max_available') == true }}"
+      paginator:
+        type: NoPagination
+      partition_router:
+        $ref: "#/definitions/single_id_partition_router"
+    schema_loader:
+      type: InlineSchemaLoader
+      schema:
+        $ref: "#/definitions/schemas/gmv_max_stores"
+
+  gmv_max_campaigns_stream:
+    type: DeclarativeStream
+    name: gmv_max_campaigns
+    $parameters:
+      path: "gmv_max/campaign/get/"
+    primary_key:
+      - campaign_id
+    retriever:
+      type: SimpleRetriever
+      requester:
+        $ref: "#/definitions/requester"
+        request_parameters:
+          filtering: '{{ {"gmv_max_promotion_types": [stream_partition.gmv_max_promotion_type]}|string }}'
+      record_selector:
+        $ref: "#/definitions/record_selector"
+      paginator:
+        $ref: "#/definitions/paginator_page_increment"
+        pagination_strategy:
+          type: PageIncrement
+          page_size: 100
+          start_from_page: 1
+      partition_router:
+        - type: ListPartitionRouter
+          values:
+            - PRODUCT_GMV_MAX
+            - LIVE_GMV_MAX
+          cursor_field: gmv_max_promotion_type
+        - class_name: "source_declarative_manifest.components.SingleAdvertiserIdPerPartition"
+          $parameters:
+            path_in_config:
+              - ["credentials", "advertiser_id"]
+              - ["environment", "advertiser_id"]
+            partition_field: advertiser_id
+          parent_stream_configs:
+            - type: ParentStreamConfig
+              parent_key: advertiser_id
+              request_option:
+                inject_into: request_parameter
+                type: RequestOption
+                field_name: advertiser_id
+              partition_field: advertiser_id
+              stream:
+                $ref: "#/definitions/advertiser_ids_stream"
+    incremental_sync:
+      $ref: "#/definitions/semi_incremental_sync"
+    schema_loader:
+      type: InlineSchemaLoader
+      schema:
+        $ref: "#/definitions/schemas/gmv_max_campaigns"
+
+  gmv_max_product_campaign_reports_daily_stream:
+    type: DeclarativeStream
+    name: gmv_max_product_campaign_reports_daily
+    $parameters:
+      path: "gmv_max/report/get/"
+    primary_key:
+      - store_id
+      - campaign_id
+      - stat_time_day
+    retriever:
+      type: SimpleRetriever
+      requester:
+        $ref: "#/definitions/requester"
+        error_handler:
+          $ref: "#/definitions/report_daily_error_handler"
+        request_parameters:
+          advertiser_id: "{{ stream_slice.parent_slice['advertiser_id'] }}"
+          store_ids: '{{ [stream_slice["store_id"]] | string }}'
+          dimensions: '{{ ["campaign_id", "stat_time_day"] | string }}'
+          metrics: '{{ ["cost","net_cost","orders","cost_per_order","gross_revenue","roi","product_impressions","product_clicks","product_click_rate","ad_click_rate","ad_conversion_rate"] | string }}'
+          filtering: '{{ {"gmv_max_promotion_types": ["PRODUCT"]} | string }}'
+          start_date: "{{ stream_interval['start_time'] }}"
+          end_date: "{{ stream_interval['end_time'] }}"
+      record_selector:
+        $ref: "#/definitions/record_selector"
+      paginator:
+        $ref: "#/definitions/paginator_page_increment"
+        pagination_strategy:
+          type: PageIncrement
+          page_size: 1000
+          start_from_page: 1
+      partition_router:
+        type: SubstreamPartitionRouter
+        parent_stream_configs:
+          - type: ParentStreamConfig
+            parent_key: store_id
+            partition_field: store_id
+            stream:
+              $ref: "#/definitions/gmv_max_stores_filtered_stream"
+    transformations:
+      - type: AddFields
+        fields:
+          - path: ["stat_time_day"]
+            value: "{{ record.dimensions.stat_time_day }}"
+          - path: ["campaign_id"]
+            value: "{{ record.dimensions.campaign_id }}"
+          - path: ["store_id"]
+            value: "{{ stream_slice['store_id'] }}"
+      - type: CustomTransformation
+        class_name: "source_declarative_manifest.components.TransformEmptyMetrics"
+    incremental_sync:
+      $ref: "#/definitions/report_daily_incremental_sync"
+    schema_loader:
+      type: InlineSchemaLoader
+      schema:
+        $ref: "#/definitions/schemas/gmv_max_product_campaign_reports_daily"
+
+  gmv_max_live_campaign_reports_daily_stream:
+    type: DeclarativeStream
+    name: gmv_max_live_campaign_reports_daily
+    $parameters:
+      path: "gmv_max/report/get/"
+    primary_key:
+      - store_id
+      - campaign_id
+      - stat_time_day
+    retriever:
+      type: SimpleRetriever
+      requester:
+        $ref: "#/definitions/requester"
+        error_handler:
+          $ref: "#/definitions/report_daily_error_handler"
+        request_parameters:
+          advertiser_id: "{{ stream_slice.parent_slice['advertiser_id'] }}"
+          store_ids: '{{ [stream_slice["store_id"]] | string }}'
+          dimensions: '{{ ["campaign_id", "stat_time_day"] | string }}'
+          metrics: '{{ ["cost","net_cost","orders","cost_per_order","gross_revenue","roi","product_impressions","product_clicks","product_click_rate","ad_click_rate","ad_conversion_rate","live_views","cost_per_live_view","10_second_live_views","cost_per_10_second_live_view","live_follows"] | string }}'
+          filtering: '{{ {"gmv_max_promotion_types": ["LIVE"]} | string }}'
+          start_date: "{{ stream_interval['start_time'] }}"
+          end_date: "{{ stream_interval['end_time'] }}"
+      record_selector:
+        $ref: "#/definitions/record_selector"
+      paginator:
+        $ref: "#/definitions/paginator_page_increment"
+        pagination_strategy:
+          type: PageIncrement
+          page_size: 1000
+          start_from_page: 1
+      partition_router:
+        type: SubstreamPartitionRouter
+        parent_stream_configs:
+          - type: ParentStreamConfig
+            parent_key: store_id
+            partition_field: store_id
+            stream:
+              $ref: "#/definitions/gmv_max_stores_filtered_stream"
+    transformations:
+      - type: AddFields
+        fields:
+          - path: ["stat_time_day"]
+            value: "{{ record.dimensions.stat_time_day }}"
+          - path: ["campaign_id"]
+            value: "{{ record.dimensions.campaign_id }}"
+          - path: ["store_id"]
+            value: "{{ stream_slice['store_id'] }}"
+      - type: CustomTransformation
+        class_name: "source_declarative_manifest.components.TransformEmptyMetrics"
+    incremental_sync:
+      $ref: "#/definitions/report_daily_incremental_sync"
+    schema_loader:
+      type: InlineSchemaLoader
+      schema:
+        $ref: "#/definitions/schemas/gmv_max_live_campaign_reports_daily"
+
   schemas:
+    gmv_max_stores:
+      $schema: http://json-schema.org/draft-07/schema#
+      additionalProperties: true
+      type: object
+      properties:
+        store_id:
+          type: string
+        is_gmv_max_available:
+          type: boolean
+        store_authorized_bc_id:
+          type:
+            - "null"
+            - string
+        is_owner_bc:
+          type:
+            - "null"
+            - boolean
+        store_authorized_bc_info:
+          type:
+            - "null"
+            - object
+          additionalProperties: true
+        thumbnail_url:
+          type:
+            - "null"
+            - string
+        store_name:
+          type:
+            - "null"
+            - string
+        store_code:
+          type:
+            - "null"
+            - string
+        targeting_region_codes:
+          type:
+            - "null"
+            - array
+          items:
+            type: string
+        store_status:
+          type:
+            - "null"
+            - string
+        store_role:
+          type:
+            - "null"
+            - string
+        exclusive_authorized_advertiser_info:
+          type:
+            - "null"
+            - object
+          additionalProperties: true
+
+    gmv_max_campaigns:
+      $schema: http://json-schema.org/draft-07/schema#
+      additionalProperties: true
+      type: object
+      properties:
+        advertiser_id:
+          type: string
+        campaign_id:
+          type: string
+        campaign_name:
+          type:
+            - "null"
+            - string
+        operation_status:
+          type:
+            - "null"
+            - string
+        secondary_status:
+          type:
+            - "null"
+            - string
+        objective_type:
+          type:
+            - "null"
+            - string
+        roi_protection_compensation_status:
+          type:
+            - "null"
+            - string
+        create_time:
+          type:
+            - "null"
+            - string
+          format: date-time
+          airbyte_type: timestamp_without_timezone
+        modify_time:
+          type:
+            - "null"
+            - string
+          format: date-time
+          airbyte_type: timestamp_without_timezone
+
+    gmv_max_product_campaign_reports_daily:
+      $schema: http://json-schema.org/draft-07/schema#
+      additionalProperties: true
+      type: object
+      properties:
+        store_id:
+          type: string
+        campaign_id:
+          type: string
+        stat_time_day:
+          type: string
+          format: date-time
+          airbyte_type: timestamp_without_timezone
+        dimensions:
+          type:
+            - "null"
+            - object
+          additionalProperties: true
+          properties:
+            campaign_id:
+              type:
+                - "null"
+                - string
+            stat_time_day:
+              type:
+                - "null"
+                - string
+        metrics:
+          type:
+            - "null"
+            - object
+          additionalProperties: true
+          properties:
+            cost:
+              type:
+                - "null"
+                - string
+            net_cost:
+              type:
+                - "null"
+                - string
+            orders:
+              type:
+                - "null"
+                - string
+            cost_per_order:
+              type:
+                - "null"
+                - string
+            gross_revenue:
+              type:
+                - "null"
+                - string
+            roi:
+              type:
+                - "null"
+                - string
+            product_impressions:
+              type:
+                - "null"
+                - string
+            product_clicks:
+              type:
+                - "null"
+                - string
+            product_click_rate:
+              type:
+                - "null"
+                - string
+            ad_click_rate:
+              type:
+                - "null"
+                - string
+            ad_conversion_rate:
+              type:
+                - "null"
+                - string
+
+    gmv_max_live_campaign_reports_daily:
+      $schema: http://json-schema.org/draft-07/schema#
+      additionalProperties: true
+      type: object
+      properties:
+        store_id:
+          type: string
+        campaign_id:
+          type: string
+        stat_time_day:
+          type: string
+          format: date-time
+          airbyte_type: timestamp_without_timezone
+        dimensions:
+          type:
+            - "null"
+            - object
+          additionalProperties: true
+          properties:
+            campaign_id:
+              type:
+                - "null"
+                - string
+            stat_time_day:
+              type:
+                - "null"
+                - string
+        metrics:
+          type:
+            - "null"
+            - object
+          additionalProperties: true
+          properties:
+            cost:
+              type:
+                - "null"
+                - string
+            net_cost:
+              type:
+                - "null"
+                - string
+            orders:
+              type:
+                - "null"
+                - string
+            cost_per_order:
+              type:
+                - "null"
+                - string
+            gross_revenue:
+              type:
+                - "null"
+                - string
+            roi:
+              type:
+                - "null"
+                - string
+            product_impressions:
+              type:
+                - "null"
+                - string
+            product_clicks:
+              type:
+                - "null"
+                - string
+            product_click_rate:
+              type:
+                - "null"
+                - string
+            ad_click_rate:
+              type:
+                - "null"
+                - string
+            ad_conversion_rate:
+              type:
+                - "null"
+                - string
+            live_views:
+              type:
+                - "null"
+                - string
+            cost_per_live_view:
+              type:
+                - "null"
+                - string
+            10_second_live_views:
+              type:
+                - "null"
+                - string
+            cost_per_10_second_live_view:
+              type:
+                - "null"
+                - string
+            live_follows:
+              type:
+                - "null"
+                - string
     advertiser_ids:
       $schema: http://json-schema.org/draft-07/schema#
       additionalProperties: true
@@ -5981,6 +6471,10 @@ streams:
     - $ref: "#/definitions/pixels"
     - $ref: "#/definitions/pixel_instant_page_events"
     - $ref: "#/definitions/pixel_events_statistics"
+    - $ref: "#/definitions/gmv_max_stores_stream"
+    - $ref: "#/definitions/gmv_max_campaigns_stream"
+    - $ref: "#/definitions/gmv_max_product_campaign_reports_daily_stream"
+    - $ref: "#/definitions/gmv_max_live_campaign_reports_daily_stream"
 
 spec:
   type: Spec

--- a/airbyte-integrations/connectors/source-tiktok-marketing/metadata.yaml
+++ b/airbyte-integrations/connectors/source-tiktok-marketing/metadata.yaml
@@ -11,7 +11,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 4bfac00d-ce15-44ff-95b9-9e3c3e8fbd35
-  dockerImageTag: 5.1.12
+  dockerImageTag: 5.2.0
   dockerRepository: airbyte/source-tiktok-marketing
   documentationUrl: https://docs.airbyte.com/integrations/sources/tiktok-marketing
   externalDocumentationUrls:

--- a/airbyte-integrations/connectors/source-tiktok-marketing/unit_tests/integration/test_gmv_max.py
+++ b/airbyte-integrations/connectors/source-tiktok-marketing/unit_tests/integration/test_gmv_max.py
@@ -1,0 +1,251 @@
+# Copyright (c) 2026 Airbyte, Inc., all rights reserved.
+
+import json
+from unittest import TestCase
+
+from airbyte_cdk.models import SyncMode
+from airbyte_cdk.test.catalog_builder import CatalogBuilder
+from airbyte_cdk.test.entrypoint_wrapper import read
+from airbyte_cdk.test.mock_http import HttpMocker, HttpRequest, HttpResponse
+
+from ..conftest import get_source
+from .advetiser_slices import mock_advertisers_slices
+from .config_builder import ConfigBuilder
+
+
+BASE_URL = "https://business-api.tiktok.com/open_api/v1.3/"
+ADVERTISER_ID = "872746382648"
+PRODUCT_METRICS = [
+    "cost",
+    "net_cost",
+    "orders",
+    "cost_per_order",
+    "gross_revenue",
+    "roi",
+    "product_impressions",
+    "product_clicks",
+    "product_click_rate",
+    "ad_click_rate",
+    "ad_conversion_rate",
+]
+LIVE_METRICS = PRODUCT_METRICS + [
+    "live_views",
+    "cost_per_live_view",
+    "10_second_live_views",
+    "cost_per_10_second_live_view",
+    "live_follows",
+]
+
+
+def catalog(stream_name: str):
+    return CatalogBuilder().with_stream(name=stream_name, sync_mode=SyncMode.full_refresh).build()
+
+
+def config():
+    return ConfigBuilder().with_end_date("2024-01-02").build()
+
+
+def stores_response(stores):
+    return {"code": 0, "message": "ok", "data": {"store_list": stores}}
+
+
+def report_response(campaign_id: str):
+    return {
+        "code": 0,
+        "message": "ok",
+        "data": {
+            "list": [
+                {
+                    "dimensions": {"campaign_id": campaign_id, "stat_time_day": "2024-01-01 00:00:00"},
+                    "metrics": {
+                        "cost": "12.5",
+                        "net_cost": "10.0",
+                        "orders": "-",
+                        "cost_per_order": "1.25",
+                        "gross_revenue": "25.0",
+                        "roi": "2.0",
+                        "product_impressions": "100",
+                        "product_clicks": "10",
+                        "product_click_rate": "0.1",
+                        "ad_click_rate": "0.2",
+                        "ad_conversion_rate": "0.05",
+                    },
+                }
+            ],
+            "page_info": {"total_number": 1, "page": 1, "page_size": 1000, "total_page": 1},
+        },
+    }
+
+
+def mock_stores(http_mocker: HttpMocker, advertiser_id: str, stores):
+    http_mocker.get(
+        HttpRequest(
+            url=f"{BASE_URL}gmv_max/store/list/",
+            query_params={"advertiser_id": advertiser_id},
+        ),
+        HttpResponse(body=json.dumps(stores_response(stores)), status_code=200),
+    )
+
+
+def mock_report(http_mocker: HttpMocker, advertiser_id: str, store_id: str, metrics, promotion_type: str, campaign_id: str):
+    request = HttpRequest(
+        url=f"{BASE_URL}gmv_max/report/get/",
+        query_params={
+            "advertiser_id": advertiser_id,
+            "store_ids": json.dumps([store_id]),
+            "dimensions": json.dumps(["campaign_id", "stat_time_day"]),
+            "metrics": json.dumps(metrics),
+            "filtering": json.dumps({"gmv_max_promotion_types": [promotion_type]}),
+            "start_date": "2024-01-01",
+            "end_date": "2024-01-02",
+            "page_size": 1000,
+        },
+    )
+    http_mocker.get(
+        request,
+        HttpResponse(body=json.dumps(report_response(campaign_id)), status_code=200),
+    )
+    return request
+
+
+class TestGmvMaxCampaigns(TestCase):
+    @HttpMocker()
+    def test_requests_each_promotion_type(self, http_mocker: HttpMocker):
+        mock_advertisers_slices(http_mocker, config())
+        for promotion_type, records in [
+            (
+                "PRODUCT_GMV_MAX",
+                [{"campaign_id": "campaign-1", "advertiser_id": ADVERTISER_ID}],
+            ),
+            ("LIVE_GMV_MAX", []),
+        ]:
+            http_mocker.get(
+                HttpRequest(
+                    url=f"{BASE_URL}gmv_max/campaign/get/",
+                    query_params={
+                        "page_size": 100,
+                        "advertiser_id": ADVERTISER_ID,
+                        "filtering": json.dumps({"gmv_max_promotion_types": [promotion_type]}),
+                    },
+                ),
+                HttpResponse(
+                    body=json.dumps(
+                        {
+                            "code": 0,
+                            "message": "ok",
+                            "data": {
+                                "list": records,
+                                "page_info": {"total_number": len(records), "page": 1, "page_size": 100, "total_page": 1},
+                            },
+                        }
+                    ),
+                    status_code=200,
+                ),
+            )
+
+        output = read(get_source(config=config(), state=None), config(), catalog("gmv_max_campaigns"))
+
+        assert len(output.records) == 1
+        assert output.records[0].record.data["campaign_id"] == "campaign-1"
+
+
+class TestGmvMaxStores(TestCase):
+    @HttpMocker()
+    def test_emits_available_and_unavailable_stores(self, http_mocker: HttpMocker):
+        mock_advertisers_slices(http_mocker, config())
+        mock_stores(
+            http_mocker,
+            ADVERTISER_ID,
+            [
+                {"store_id": "111", "is_gmv_max_available": True},
+                {"store_id": "222", "is_gmv_max_available": False},
+            ],
+        )
+
+        output = read(get_source(config=config(), state=None), config(), catalog("gmv_max_stores"))
+
+        assert len(output.records) == 2
+        assert {record.record.data["store_id"] for record in output.records} == {"111", "222"}
+
+
+class TestGmvMaxProductReports(TestCase):
+    @HttpMocker()
+    def test_only_requests_available_stores_and_flattens_metrics(self, http_mocker: HttpMocker):
+        mock_advertisers_slices(http_mocker, config())
+        mock_stores(
+            http_mocker,
+            ADVERTISER_ID,
+            [
+                {"store_id": "111", "is_gmv_max_available": True},
+                {"store_id": "222", "is_gmv_max_available": False},
+            ],
+        )
+        report_request = mock_report(http_mocker, ADVERTISER_ID, "111", PRODUCT_METRICS, "PRODUCT", "c1")
+
+        output = read(
+            get_source(config=config(), state=None),
+            config(),
+            catalog("gmv_max_product_campaign_reports_daily"),
+        )
+
+        assert len(output.records) == 1
+        record = output.records[0].record.data
+        assert record["store_id"] == "111"
+        assert record["campaign_id"] == "c1"
+        assert record["stat_time_day"] == "2024-01-01 00:00:00"
+        assert record["metrics"]["orders"] is None
+        # HttpMocker fails on unmatched requests, so this also proves store 222 was not queried.
+        http_mocker.assert_number_of_calls(report_request, 1)
+
+    @HttpMocker()
+    def test_uses_each_parent_advertiser_for_store_reports(self, http_mocker: HttpMocker):
+        cfg = config()
+        http_mocker.get(
+            HttpRequest(
+                url=f"{BASE_URL}oauth2/advertiser/get/",
+                query_params={"secret": cfg["credentials"]["secret"], "app_id": cfg["credentials"]["app_id"]},
+            ),
+            HttpResponse(
+                body=json.dumps(
+                    {
+                        "code": 0,
+                        "message": "ok",
+                        "data": {"list": [{"advertiser_id": ADVERTISER_ID}, {"advertiser_id": "872746382649"}]},
+                    }
+                ),
+                status_code=200,
+            ),
+        )
+        mock_stores(http_mocker, ADVERTISER_ID, [{"store_id": "111", "is_gmv_max_available": True}])
+        mock_stores(http_mocker, "872746382649", [{"store_id": "222", "is_gmv_max_available": True}])
+        mock_report(http_mocker, ADVERTISER_ID, "111", PRODUCT_METRICS, "PRODUCT", "c1")
+        mock_report(http_mocker, "872746382649", "222", PRODUCT_METRICS, "PRODUCT", "c2")
+
+        output = read(
+            get_source(config=cfg, state=None),
+            cfg,
+            catalog("gmv_max_product_campaign_reports_daily"),
+        )
+
+        assert len(output.records) == 2
+        assert {(record.record.data["store_id"], record.record.data["campaign_id"]) for record in output.records} == {
+            ("111", "c1"),
+            ("222", "c2"),
+        }
+
+
+class TestGmvMaxLiveReports(TestCase):
+    @HttpMocker()
+    def test_uses_live_filtering_and_metrics(self, http_mocker: HttpMocker):
+        mock_advertisers_slices(http_mocker, config())
+        mock_stores(http_mocker, ADVERTISER_ID, [{"store_id": "111", "is_gmv_max_available": True}])
+        mock_report(http_mocker, ADVERTISER_ID, "111", LIVE_METRICS, "LIVE", "c1")
+
+        output = read(
+            get_source(config=config(), state=None),
+            config(),
+            catalog("gmv_max_live_campaign_reports_daily"),
+        )
+
+        assert len(output.records) == 1
+        assert output.records[0].record.data["campaign_id"] == "c1"

--- a/airbyte-integrations/connectors/source-tiktok-marketing/unit_tests/test_source.py
+++ b/airbyte-integrations/connectors/source-tiktok-marketing/unit_tests/test_source.py
@@ -15,7 +15,7 @@ from .conftest import get_source
 @pytest.mark.parametrize(
     "config, stream_len",
     [
-        ({"access_token": "token", "environment": {"app_id": "1111", "secret": "secret"}, "start_date": "2021-04-01"}, 44),
+        ({"access_token": "token", "environment": {"app_id": "1111", "secret": "secret"}, "start_date": "2021-04-01"}, 48),
         ({"access_token": "token", "start_date": "2021-01-01", "environment": {"advertiser_id": "1111"}}, 28),
         (
             {
@@ -24,7 +24,7 @@ from .conftest import get_source
                 "start_date": "2021-04-01",
                 "report_granularity": "LIFETIME",
             },
-            44,
+            48,
         ),
         (
             {
@@ -33,7 +33,7 @@ from .conftest import get_source
                 "start_date": "2021-04-01",
                 "report_granularity": "DAY",
             },
-            44,
+            48,
         ),
     ],
 )

--- a/docs/integrations/sources/tiktok-marketing.md
+++ b/docs/integrations/sources/tiktok-marketing.md
@@ -175,7 +175,7 @@ If you use Airbyte Cloud and your organization restricts access to specific IPs,
 
 | Version    | Date       | Pull Request                                              | Subject                                                                                                                                                                |
 |:-----------|:-----------|:----------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| 5.2.0 | 2026-09-03 | [PR_NUMBER](https://github.com/airbytehq/airbyte/pull/PR_NUMBER) | Add GMV Max streams: `gmv_max_stores`, `gmv_max_campaigns`, `gmv_max_product_campaign_reports_daily`, `gmv_max_live_campaign_reports_daily` |
+| 5.2.0 | 2026-09-03 | [85316](https://github.com/airbytehq/airbyte/pull/85316) | Add GMV Max streams: `gmv_max_stores`, `gmv_max_campaigns`, `gmv_max_product_campaign_reports_daily`, `gmv_max_live_campaign_reports_daily` |
 | 5.1.12 | 2026-08-18 | [84765](https://github.com/airbytehq/airbyte/pull/84765) | Update dependencies |
 | 5.1.11 | 2026-08-12 | [84290](https://github.com/airbytehq/airbyte/pull/84290) | Widen retry budget and retry transient TikTok API errors 51041 and 51004 |
 | 5.1.10 | 2026-08-11 | [84199](https://github.com/airbytehq/airbyte/pull/84199) | Retry transient TikTok API error 50000 |

--- a/docs/integrations/sources/tiktok-marketing.md
+++ b/docs/integrations/sources/tiktok-marketing.md
@@ -131,6 +131,10 @@ The TikTok Marketing source connector supports the following [sync modes](https:
 | AdsReportsByCountryHourly                 | Prod         | ad_id, stat_time_hour, country_code        | Yes         |
 | AdGroupsReportsByCountryDaily              | Prod         | adgroup_id, stat_time_day, country_code    | Yes         |
 | AdGroupsReportsByCountryHourly             | Prod         | adgroup_id, stat_time_hour, country_code   | Yes         |
+| GmvMaxStores                              | Prod         | store_id                                   | No          |
+| GmvMaxCampaigns                            | Prod         | campaign_id                                | Yes         |
+| GmvMaxProductCampaignReportsDaily          | Prod         | store_id, campaign_id, stat_time_day       | Yes         |
+| GmvMaxLiveCampaignReportsDaily             | Prod         | store_id, campaign_id, stat_time_day       | Yes         |
 
 The Campaigns stream retrieves campaigns of all buying types: Auction, TopView (Reservation), and Reach & Frequency (Reservation). The connector makes a separate API call per buying type because the TikTok API does not support combining TopView with other buying types in a single request.
 
@@ -171,6 +175,7 @@ If you use Airbyte Cloud and your organization restricts access to specific IPs,
 
 | Version    | Date       | Pull Request                                              | Subject                                                                                                                                                                |
 |:-----------|:-----------|:----------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 5.2.0 | 2026-09-03 | [PR_NUMBER](https://github.com/airbytehq/airbyte/pull/PR_NUMBER) | Add GMV Max streams: `gmv_max_stores`, `gmv_max_campaigns`, `gmv_max_product_campaign_reports_daily`, `gmv_max_live_campaign_reports_daily` |
 | 5.1.12 | 2026-08-18 | [84765](https://github.com/airbytehq/airbyte/pull/84765) | Update dependencies |
 | 5.1.11 | 2026-08-12 | [84290](https://github.com/airbytehq/airbyte/pull/84290) | Widen retry budget and retry transient TikTok API errors 51041 and 51004 |
 | 5.1.10 | 2026-08-11 | [84199](https://github.com/airbytehq/airbyte/pull/84199) | Retry transient TikTok API error 50000 |


### PR DESCRIPTION
## What

Adds TikTok GMV Max coverage to `source-tiktok-marketing` (tracked in airbytehq/oncall#13335). Supersedes the stale, closed #70925.

New user-facing streams (production auth only — GMV Max is not available in the sandbox API):

| Stream | Endpoint | PK | Sync |
|---|---|---|---|
| `gmv_max_stores` | `gmv_max/store/list/` | `store_id` | full refresh |
| `gmv_max_campaigns` | `gmv_max/campaign/get/` | `campaign_id` | client-side incremental on `modify_time` |
| `gmv_max_product_campaign_reports_daily` | `gmv_max/report/get/` (`filtering.gmv_max_promotion_types=["PRODUCT"]`) | `store_id, campaign_id, stat_time_day` | incremental (`stat_time_day`) |
| `gmv_max_live_campaign_reports_daily` | `gmv_max/report/get/` (`filtering.gmv_max_promotion_types=["LIVE"]`) | `store_id, campaign_id, stat_time_day` | incremental (`stat_time_day`) |

Plus an internal, non-exposed `gmv_max_stores_filtered` definition (same endpoint + `RecordFilter` on `is_gmv_max_available == true`) used only as the parent of the two report streams, so the report endpoint is never called for stores that cannot serve GMV Max.

Requested by Zane Hyatt (@ZaneHyattAB).

## How

- `gmv_max_stores` / `gmv_max_stores_filtered`: new record selector on `data.store_list` (the shared one reads `data.list`), `single_id_partition_router`, `NoPagination`.
- `gmv_max_campaigns`: `ListPartitionRouter` over `[PRODUCT_GMV_MAX, LIVE_GMV_MAX]` composed with `SingleAdvertiserIdPerPartition` (same shape as `campaigns_stream`), `filtering='{"gmv_max_promotion_types": [<type>]}'`, `page_size: 100` (endpoint max), `semi_incremental_sync`.
- Report streams: a dedicated retriever (cannot reuse `base_report_retriever`, which hardcodes `service_type`/`report_type`/`data_level` that this endpoint does not accept). Partitioned by a single `SubstreamPartitionRouter` over `gmv_max_stores_filtered` with `parent_key: store_id`; `advertiser_id` is taken from the parent slice (`stream_slice.parent_slice['advertiser_id']`) rather than stacking a second advertiser router — that stacking is exactly what produced the empty/cartesian slicing in #70925. `store_ids` is sent as a single-element JSON array (`["<store_id>"]`, endpoint max size 1). `AddFields` flattens `dimensions.campaign_id`/`dimensions.stat_time_day` and adds `store_id` from the slice; `TransformEmptyMetrics` maps `"-"` metrics to `null`.
- Note the enum trap: the campaign endpoint uses `PRODUCT_GMV_MAX`/`LIVE_GMV_MAX`, the report endpoint uses `PRODUCT`/`LIVE`. Both are implemented per TikTok's reference (doc_ids 1826463372290177 and 1824721673497601).
- `metadata.yaml` 5.1.12 → 5.2.0 (minor: new streams); docs stream table + changelog updated.
- `unit_tests/test_source.py`: non-sandbox stream count 44 → 48; sandbox/advertiser-id-only count unchanged at 28.
- `unit_tests/integration/test_gmv_max.py` (`HttpMocker`, same pattern as `test_campaigns.py`): asserts the exact `filtering` param for both campaign promotion types; that `store_ids` carries exactly one value; that the report request's `advertiser_id` matches the parent slice's advertiser (two-advertiser case); and that no report request is issued for a store with `is_gmv_max_available: false` (HttpMocker fails on any unmocked request, and only the available store is mocked).

## NOT VALIDATED AGAINST LIVE DATA — read before reviewing

**These streams have NOT been validated against live data.** Airbyte has no TikTok advertiser account with an authorized TikTok Shop, so none of the four endpoints have been exercised for real.

- The mocked integration tests prove **request shape only** (paths, query parameters, partitioning, filtering). They **cannot prove the response schemas**, field names, or types; the inline JSON schemas are derived from TikTok's documentation, not observed payloads.
- **A green CI run with zero records must not be read as validation.** #70925 passed 23 checks and would have synced green with zero data because its partition router produced zero slices. CI here cannot distinguish "correct" from "silently empty".
- This PR is therefore **not merge-ready**. It needs at least one live run (`gmv_max/store/list/` → `gmv_max/report/get/` with a real store) by someone with GMV Max access before it leaves draft.

### Provisional design choice: two report streams

The PRODUCT/LIVE split into two report streams is provisional pending one live call. The report endpoint documents `filtering` as optional, and the split rests on the differing metric sets (`live_views`, `cost_per_live_view`, `10_second_live_views`, `cost_per_10_second_live_view`, `live_follows` have no product analogue) rather than on a hard API requirement. If a live call shows the endpoint accepts the union of metrics with no filter (or rejects the LIVE metric set for product campaigns), the streams should be collapsed or adjusted accordingly.

### Other open points

- `store_ids` is passed as a JSON array string `["<id>"]` (consistent with how this connector serializes other list parameters). If the endpoint expects a bare scalar instead, only the `store_ids` template in the two report retrievers needs to change.

## Review guide

1. `airbyte-integrations/connectors/source-tiktok-marketing/manifest.yaml` — new definitions `gmv_max_*_stream` (near the pixel streams), schemas under `definitions.schemas`, and the four `$ref`s appended to the non-sandbox `ConditionalStreams` block.
2. `airbyte-integrations/connectors/source-tiktok-marketing/unit_tests/integration/test_gmv_max.py`
3. `airbyte-integrations/connectors/source-tiktok-marketing/unit_tests/test_source.py`
4. `airbyte-integrations/connectors/source-tiktok-marketing/metadata.yaml`, `docs/integrations/sources/tiktok-marketing.md`

## Test plan

- `cd airbyte-integrations/connectors/source-tiktok-marketing/unit_tests && poetry install && poetry run pytest -q` → 63 passed locally.
- `pre-commit run --files <changed files>` → clean.
- Not tested: any live API call (see above).

## User Impact

Production (non-sandbox) users see four new optional streams. No existing stream, schema, or spec changes.

## Can this PR be safely reverted and rolled back?
- [x] YES 💚
- [ ] NO ❌


Link to Devin session: https://app.devin.ai/sessions/f440204b2d164b299e92719ad126ed29
Open in Devin Desktop: https://app.devin.ai/desktop/session/f440204b2d164b299e92719ad126ed29?variant=devin

> [!IMPORTANT]
> Active progressive rollout warning for source-tiktok-marketing.

- [ ] (Click to Approve:) Bypass the active progressive rollout warning for source-tiktok-marketing in the PR comment [here](https://github.com/airbytehq/airbyte/pull/85316#issuecomment-5519873556).