### PR TITLE
docs(source-snowflake): deprecate username/password auth, recommend key pair authentication

### DIFF
--- a/airbyte-integrations/connectors/source-snowflake/metadata.yaml
+++ b/airbyte-integrations/connectors/source-snowflake/metadata.yaml
@@ -8,7 +8,7 @@ data:
   connectorSubtype: database
   connectorType: source
   definitionId: e2d65910-8c8b-40a1-ae7d-ee2416b2bfa2
-  dockerImageTag: 1.1.2
+  dockerImageTag: 2.0.0
   dockerRepository: airbyte/source-snowflake
   documentationUrl: https://docs.airbyte.com/integrations/sources/snowflake
   githubIssueLabel: source-snowflake
@@ -42,6 +42,10 @@ data:
           3. For incremental sync mode, a full refresh will be triggered for next sync because the connection state will not be compatible.
           New state will be populated after full refresh is completed."
         upgradeDeadline: "2025-09-30"
+      2.0.0:
+        message: "Username and password authentication is deprecated and will be removed in a future release. Key pair authentication or a programmatic access token is now the recommended method. Snowflake is enforcing strong authentication on a rolling per-account basis between August and October 2026. If you are already using key pair or programmatic access token authentication, no action is needed. Otherwise, see the migration guide for steps to migrate your connection."
+        upgradeDeadline: "2026-11-01"
+        deadlineAction: "disable"
     rolloutConfiguration:
       enableProgressiveRollout: true
       defaultRolloutMode: autopilot

--- a/airbyte-integrations/connectors/source-snowflake/metadata.yaml
+++ b/airbyte-integrations/connectors/source-snowflake/metadata.yaml
@@ -45,7 +45,7 @@ data:
       2.0.0:
         message: "Username and password authentication is deprecated and will be removed in a future release. Key pair authentication or a programmatic access token is now the recommended method. Snowflake is enforcing strong authentication on a rolling per-account basis between August and October 2026. If you are already using key pair or programmatic access token authentication, no action is needed. Otherwise, see the migration guide for steps to migrate your connection."
         upgradeDeadline: "2026-11-01"
-        deadlineAction: "disable"
+        deadlineAction: "auto_upgrade"
     rolloutConfiguration:
       enableProgressiveRollout: true
       defaultRolloutMode: autopilot

--- a/airbyte-integrations/connectors/source-snowflake/metadata.yaml
+++ b/airbyte-integrations/connectors/source-snowflake/metadata.yaml
@@ -43,7 +43,7 @@ data:
           New state will be populated after full refresh is completed."
         upgradeDeadline: "2025-09-30"
       2.0.0:
-        message: "Username and password authentication is deprecated and will be removed in a future release. Key pair authentication or a programmatic access token is now the recommended method. Snowflake is enforcing strong authentication on a rolling per-account basis between August and October 2026. If you are already using key pair or programmatic access token authentication, no action is needed. Otherwise, see the migration guide for steps to migrate your connection."
+        message: "Username and password authentication is deprecated and will be removed in a future release. Key pair authentication or a programmatic access token is now the recommended method. Snowflake is enforcing strong authentication on a rolling per-account basis between August and October 2026. If you are already using key pair or programmatic access token authentication, no action is needed. Otherwise, see the migration guide (https://docs.airbyte.com/integrations/sources/snowflake-migrations) for steps to migrate your connection."
         upgradeDeadline: "2026-11-01"
         deadlineAction: "auto_upgrade"
     rolloutConfiguration:

--- a/airbyte-integrations/connectors/source-snowflake/src/main/kotlin/io/airbyte/integrations/source/snowflake/SnowflakeSourceConfigurationSpecification.kt
+++ b/airbyte-integrations/connectors/source-snowflake/src/main/kotlin/io/airbyte/integrations/source/snowflake/SnowflakeSourceConfigurationSpecification.kt
@@ -205,7 +205,10 @@ data class KeyPairCredentialsSpecification(
     val privateKeyPassword: String? = null
 ) : CredentialsSpecification
 
-@JsonSchemaTitle("Username and Password")
+@JsonSchemaTitle("Username and Password (Deprecated)")
+@JsonSchemaDescription(
+    "Deprecated: Username and password authentication is deprecated as of version 2.0.0 and will be removed in a future release. Snowflake is enforcing strong authentication on a rolling per-account basis between August and October 2026. Switch to key pair authentication or a programmatic access token instead. See the <a href=\"https://docs.airbyte.com/integrations/sources/snowflake-migrations\">migration guide</a> for details."
+)
 @JsonSchemaInject(json = """{"order":2}""")
 data class UsernamePasswordCredentialsSpecification(
     @JsonProperty("auth_type")
@@ -218,7 +221,7 @@ data class UsernamePasswordCredentialsSpecification(
     val username: String,
     @JsonProperty("password")
     @JsonSchemaTitle("Password")
-    @JsonPropertyDescription("The password associated with the username.")
+    @JsonPropertyDescription("Deprecated. The password associated with the username.")
     @JsonSchemaInject(json = """{"order":2,"airbyte_secret":true}""")
     val password: String
 ) : CredentialsSpecification

--- a/docs/integrations/sources/snowflake-migrations.md
+++ b/docs/integrations/sources/snowflake-migrations.md
@@ -34,9 +34,11 @@ If your Airbyte Snowflake source uses **username and password** credentials, you
    ALTER USER <user_name> SET rsa_public_key='<public_key_value>';
    ```
 
+   This command requires the `ACCOUNTADMIN` role, or a custom role with the `MODIFY PROGRAMMATIC AUTHENTICATION METHODS` privilege on that specific user. For more information, see [ALTER USER ... MODIFY PROGRAMMATIC AUTHENTICATION METHODS](https://docs.snowflake.com/en/sql-reference/sql/alter-user-modify-programmatic-access-token) in the Snowflake docs.
+
 3. **Update the source in Airbyte.** Edit the Snowflake source settings in the Airbyte UI:
    - Change the authorization method to **Key Pair Authentication**.
-   - Paste the contents of your `rsa_key.p8` private key file.
+   - Paste the contents of your `rsa_key.p8` private key file, without removing the header or footer lines.
    - If you used an encrypted key, enter the passphrase in the **Passphrase** field.
    - Save and test the source.
 
@@ -53,6 +55,8 @@ If your Airbyte Snowflake source uses **username and password** credentials, you
    ```
 
 If you prefer a programmatic access token instead of a key pair, follow [Programmatic access token authentication](./snowflake.md#programmatic-access-token-authentication) in the setup guide and select **Programmatic Access Token** as the authorization method.
+
+If you're having trouble migrating to key pair authentication before Snowflake enforces strong authentication on your account, you can request an extension of the enforcement date from Snowflake. In Snowsight, go to **Trust Center** > **Strong Authentication** (`https://app.snowflake.com/<org_id>/<account>/#/trust-center/overview/strong-authentication`, replacing `<org_id>` and `<account>` with your Snowflake organization and account identifiers).
 
 For more details on key pair authentication troubleshooting, see [Snowflake's troubleshooting docs](https://docs.snowflake.com/en/user-guide/key-pair-auth-troubleshooting).
 

--- a/docs/integrations/sources/snowflake-migrations.md
+++ b/docs/integrations/sources/snowflake-migrations.md
@@ -1,5 +1,61 @@
 # Snowflake Migration Guide
 
+## Upgrading to 2.0.0
+
+This version deprecates username and password authentication. Username and password authentication will be removed in a future release. **Key pair authentication** or a **programmatic access token** is now the recommended method for connecting to Snowflake. This aligns with [Snowflake's deprecation of single-factor password sign-ins](https://docs.snowflake.com/en/user-guide/security-mfa-rollout), which is enforcing strong authentication for all users on a rolling per-account basis between **August and October 2026**.
+
+### Who is affected
+
+If your Airbyte Snowflake source uses **username and password** credentials, you must migrate to key pair authentication or a programmatic access token before Snowflake enforces strong authentication on your account (rolling between August and October 2026). Sources that already use key pair or programmatic access token authentication are not affected. No reset or full refresh is required; existing sync state is unaffected.
+
+### Migration steps
+
+1. **Generate a key pair** if you don't already have one:
+
+   ```bash
+   # Generate an unencrypted private key
+   openssl genrsa 2048 | openssl pkcs8 -topk8 -inform PEM -out rsa_key.p8 -nocrypt
+
+   # Generate the matching public key
+   openssl rsa -in rsa_key.p8 -pubout -out rsa_key.pub
+   ```
+
+   Alternatively, to generate an encrypted private key:
+
+   ```bash
+   openssl genrsa 2048 | openssl pkcs8 -topk8 -inform PEM -v2 aes-256-cbc -out rsa_key.p8
+   ```
+
+   For a complete guide on key pair setup including key storage and verification, see [Key pair authentication](./snowflake#key-pair-authentication) in the setup guide.
+
+2. **Assign the public key to your Snowflake user.** Run this SQL in Snowflake. Replace `<user_name>` with the Snowflake username configured in your Airbyte source (you can find this on the source configuration page in the Airbyte UI) and `<public_key_value>` with the contents of your `rsa_key.pub` file, **excluding** the `-----BEGIN PUBLIC KEY-----` and `-----END PUBLIC KEY-----` header/footer lines:
+
+   ```sql
+   ALTER USER <user_name> SET rsa_public_key='<public_key_value>';
+   ```
+
+3. **Update the source in Airbyte.** Edit the Snowflake source settings in the Airbyte UI:
+   - Change the authorization method to **Key Pair Authentication**.
+   - Paste the contents of your `rsa_key.p8` private key file.
+   - If you used an encrypted key, enter the passphrase in the **Passphrase** field.
+   - Save and test the source.
+
+4. **(Optional) Remove the password from the Snowflake user** once you've confirmed the key pair connection works:
+
+   ```sql
+   ALTER USER <user_name> UNSET PASSWORD;
+   ```
+
+5. **(Optional) Set the user type to SERVICE** to indicate this is a programmatic service account:
+
+   ```sql
+   ALTER USER <user_name> SET TYPE = SERVICE;
+   ```
+
+If you prefer a programmatic access token instead of a key pair, follow [Programmatic access token authentication](./snowflake#programmatic-access-token-authentication) in the setup guide and select **Programmatic Access Token** as the authorization method.
+
+For more details on key pair authentication troubleshooting, see [Snowflake's troubleshooting docs](https://docs.snowflake.com/en/user-guide/key-pair-auth-troubleshooting).
+
 ## Upgrading to 1.0.0
 
 This version introduces Airbyte certified source connector for Snowflake to replace the community supported source connector.

--- a/docs/integrations/sources/snowflake-migrations.md
+++ b/docs/integrations/sources/snowflake-migrations.md
@@ -26,7 +26,7 @@ If your Airbyte Snowflake source uses **username and password** credentials, you
    openssl genrsa 2048 | openssl pkcs8 -topk8 -inform PEM -v2 aes-256-cbc -out rsa_key.p8
    ```
 
-   For a complete guide on key pair setup including key storage and verification, see [Key pair authentication](./snowflake#key-pair-authentication) in the setup guide.
+   For a complete guide on key pair setup including key storage and verification, see [Key pair authentication](./snowflake.md#key-pair-authentication) in the setup guide.
 
 2. **Assign the public key to your Snowflake user.** Run this SQL in Snowflake. Replace `<user_name>` with the Snowflake username configured in your Airbyte source (you can find this on the source configuration page in the Airbyte UI) and `<public_key_value>` with the contents of your `rsa_key.pub` file, **excluding** the `-----BEGIN PUBLIC KEY-----` and `-----END PUBLIC KEY-----` header/footer lines:
 
@@ -52,7 +52,7 @@ If your Airbyte Snowflake source uses **username and password** credentials, you
    ALTER USER <user_name> SET TYPE = SERVICE;
    ```
 
-If you prefer a programmatic access token instead of a key pair, follow [Programmatic access token authentication](./snowflake#programmatic-access-token-authentication) in the setup guide and select **Programmatic Access Token** as the authorization method.
+If you prefer a programmatic access token instead of a key pair, follow [Programmatic access token authentication](./snowflake.md#programmatic-access-token-authentication) in the setup guide and select **Programmatic Access Token** as the authorization method.
 
 For more details on key pair authentication troubleshooting, see [Snowflake's troubleshooting docs](https://docs.snowflake.com/en/user-guide/key-pair-auth-troubleshooting).
 

--- a/docs/integrations/sources/snowflake.md
+++ b/docs/integrations/sources/snowflake.md
@@ -257,7 +257,7 @@ If you use Airbyte Cloud and your organization restricts access to specific IPs,
 
 | Version | Date       | Pull Request                                             | Subject                                                                                                                                   |
 |:--------|:-----------|:---------------------------------------------------------|:------------------------------------------------------------------------------------------------------------------------------------------|
-| 2.0.0   | 2026-09-03 | [85340](https://github.com/airbytehq/airbyte/pull/85340) | Deprecate username/password authentication; key pair authentication or a programmatic access token is now recommended. Username/password will be removed in a future release. |
+| 2.0.0   | 2026-09-03 | [85331](https://github.com/airbytehq/airbyte/pull/85331) | Deprecate username/password authentication; key pair authentication or a programmatic access token is now recommended. Username/password will be removed in a future release. |
 | 1.1.2   | 2026-08-21 | [84927](https://github.com/airbytehq/airbyte/pull/84927) | Bump Bulk CDK extract version from 1.0.1 to 1.1.10                                                                                        |
 | 1.1.1   | 2026-07-21 | [82705](https://github.com/airbytehq/airbyte/pull/82705) | Fix incremental sync silently dropping rows at the cursor's upper bound by rounding timestamp precision up instead of down                |
 | 1.1.0   | 2026-05-28 | [78481](https://github.com/airbytehq/airbyte/pull/78481) | Support Snowflake Programmatic Access Token authentication.                                                                               |

--- a/docs/integrations/sources/snowflake.md
+++ b/docs/integrations/sources/snowflake.md
@@ -2,6 +2,14 @@ import KeypairExample from '@site/static/_snowflake_keypair_generation.md';
 
 # Snowflake
 
+:::danger Username and Password Authentication Deprecated
+Starting with version **2.0.0**, username and password authentication is **deprecated** and will be removed in a future release. **Key pair authentication** or a **programmatic access token** is now the recommended method for connecting to Snowflake.
+
+This change aligns with [Snowflake's deprecation of single-factor password sign-ins](https://docs.snowflake.com/en/user-guide/security-mfa-rollout). Snowflake is enforcing strong authentication for all users on a rolling per-account basis between **August and October 2026**; once enforced on your account, password-only logins from Airbyte will fail.
+
+If you are currently using username and password authentication, see the [Snowflake Migration Guide](./snowflake-migrations.md) for instructions on migrating to key pair authentication.
+:::
+
 ## Overview
 
 The Snowflake source allows you to sync data from Snowflake. It supports both Full Refresh and Incremental syncs. You can choose whether this connector will copy only new or updated data, or all rows in the tables and columns you set up for replication, every time a sync is run.
@@ -118,10 +126,10 @@ You'll need the following information to configure the Snowflake source:
 4. **Database**
 5. **Schema**
 6. **Username**
-7. **Password, private key, or programmatic access token**
+7. **Private key or programmatic access token** (username and password authentication is deprecated)
 8. **JDBC URL Params** (Optional)
 
-Additionally, create a dedicated read-only Airbyte user and role with access to all schemas needed for replication.
+Additionally, create a dedicated read-only Airbyte service user and role with access to all schemas needed for replication.
 
 ### Setup guide
 
@@ -133,26 +141,26 @@ Additional information about Snowflake connection parameters can be found in the
 
 This step is optional but highly recommended for better permission control and auditing. Alternatively, you can use Airbyte with an existing user in your database.
 
-To create a dedicated database user, run the following commands against your database:
+To create a dedicated database user, first generate a key pair as described in [Key pair authentication](#key-pair-authentication), then run the following commands against your database. Replace `<public_key_value>` with the contents of your `rsa_key.pub` file, excluding the `-----BEGIN PUBLIC KEY-----` and `-----END PUBLIC KEY-----` header/footer lines.
 
 ```sql
 -- set variables (these need to be uppercase)
 SET AIRBYTE_ROLE = 'AIRBYTE_ROLE';
 SET AIRBYTE_USERNAME = 'AIRBYTE_USER';
 
--- set user password
-SET AIRBYTE_PASSWORD = '-password-';
-
 BEGIN;
 
 -- create Airbyte role
 CREATE ROLE IF NOT EXISTS $AIRBYTE_ROLE;
 
--- create Airbyte user
+-- create Airbyte service user with key pair authentication
 CREATE USER IF NOT EXISTS $AIRBYTE_USERNAME
-PASSWORD = $AIRBYTE_PASSWORD
+TYPE = SERVICE
 DEFAULT_ROLE = $AIRBYTE_ROLE
 DEFAULT_WAREHOUSE= $AIRBYTE_WAREHOUSE;
+
+-- assign the RSA public key to the service user
+ALTER USER IDENTIFIER($AIRBYTE_USERNAME) SET RSA_PUBLIC_KEY='<public_key_value>';
 
 -- grant Airbyte schema access
 GRANT OWNERSHIP ON SCHEMA $AIRBYTE_SCHEMA TO ROLE $AIRBYTE_ROLE;
@@ -168,11 +176,13 @@ Your database user should now be ready for use with Airbyte.
 
 Source Snowflake supports the following authentication methods:
 
-- Username and password
-- Key pair authentication
+- Key pair authentication (recommended)
 - Programmatic access token
+- Username and password (deprecated, see the [migration guide](./snowflake-migrations.md))
 
-#### Username and password
+#### Connection fields
+
+The following fields are common to all authentication methods:
 
 | Field                                                                                                 | Description                                                                                                                                                                                       |
 | ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -181,13 +191,14 @@ Source Snowflake supports the following authentication methods:
 | [Warehouse](https://docs.snowflake.com/en/user-guide/warehouses-overview.html#overview-of-warehouses) | The warehouse you created for Airbyte to sync data into. Example: `AIRBYTE_WAREHOUSE`                                                                                                   |
 | [Database](https://docs.snowflake.com/en/sql-reference/ddl-database.html#database-schema-share-ddl)   | The database you created for Airbyte to sync data into. Example: `AIRBYTE_DATABASE`                                                                                                     |
 | [Schema](https://docs.snowflake.com/en/sql-reference/ddl-database.html#database-schema-share-ddl)     | The schema whose tables this replication is targeting. If no schema is specified, all tables with permission will be presented regardless of their schema.                                        |
-| Username                                                                                              | The username you created to allow Airbyte to access the database. Example: `AIRBYTE_USER`                                                                                               |
-| Password                                                                                              | The password associated with the username.                                                                                                                                                        |
+| Username                                                                                              | The username you created to allow Airbyte to access the database. Example: `AIRBYTE_USER`. Not required for programmatic access token authentication.                                     |
 | [JDBC URL Params](https://docs.snowflake.com/en/user-guide/jdbc-parameters.html) (Optional)           | Additional properties to pass to the JDBC URL string when connecting to the database formatted as `key=value` pairs separated by the symbol `&`. Example: `key1=value1&key2=value2&key3=value3`   |
 
 #### Key pair authentication
 
  <KeypairExample/>
+
+In the Airbyte UI, select **Key Pair Authentication** as the authorization method, enter the username, paste the full contents of your `rsa_key.p8` private key file (including the `-----BEGIN ... PRIVATE KEY-----` header and footer), and, if the key is encrypted, enter the passphrase.
 
 #### Programmatic access token authentication
 
@@ -208,6 +219,10 @@ For service users, Snowflake requires `ROLE_RESTRICTION` by default. Snowflake a
 :::note Network policy required for Programmatic Access Token authentication
 When using Programmatic Access Token authentication, the Snowflake user's network policy must allow connections from Airbyte's IP addresses. Add the [Airbyte Cloud IP addresses](/platform/operating-airbyte/ip-allowlist) to the network policy attached to the PAT user, or to the account-level network policy.
 :::
+
+#### Username and password (deprecated)
+
+Username and password authentication is deprecated as of version 2.0.0 and will be removed in a future release. Existing sources that use it continue to work until Snowflake enforces strong authentication on your account. Follow the [migration guide](./snowflake-migrations.md) to switch to key pair authentication or a programmatic access token.
 
 ### Network policies
 
@@ -242,6 +257,7 @@ If you use Airbyte Cloud and your organization restricts access to specific IPs,
 
 | Version | Date       | Pull Request                                             | Subject                                                                                                                                   |
 |:--------|:-----------|:---------------------------------------------------------|:------------------------------------------------------------------------------------------------------------------------------------------|
+| 2.0.0   | 2026-09-03 | [85340](https://github.com/airbytehq/airbyte/pull/85340) | Deprecate username/password authentication; key pair authentication or a programmatic access token is now recommended. Username/password will be removed in a future release. |
 | 1.1.2   | 2026-08-21 | [84927](https://github.com/airbytehq/airbyte/pull/84927) | Bump Bulk CDK extract version from 1.0.1 to 1.1.10                                                                                        |
 | 1.1.1   | 2026-07-21 | [82705](https://github.com/airbytehq/airbyte/pull/82705) | Fix incremental sync silently dropping rows at the cursor's upper bound by rounding timestamp precision up instead of down                |
 | 1.1.0   | 2026-05-28 | [78481](https://github.com/airbytehq/airbyte/pull/78481) | Support Snowflake Programmatic Access Token authentication.                                                                               |

--- a/docs/integrations/sources/snowflake.md
+++ b/docs/integrations/sources/snowflake.md
@@ -7,7 +7,7 @@ Starting with version **2.0.0**, username and password authentication is **depre
 
 This change aligns with [Snowflake's deprecation of single-factor password sign-ins](https://docs.snowflake.com/en/user-guide/security-mfa-rollout). Snowflake is enforcing strong authentication for all users on a rolling per-account basis between **August and October 2026**; once enforced on your account, password-only logins from Airbyte will fail.
 
-If you are currently using username and password authentication, see the [Snowflake Migration Guide](./snowflake-migrations.md) for instructions on migrating to key pair authentication.
+If you are currently using username and password authentication, see the [Snowflake Migration Guide](./snowflake-migrations.md) for instructions on migrating to key pair authentication or a programmatic access token.
 :::
 
 ## Overview
@@ -125,8 +125,8 @@ You'll need the following information to configure the Snowflake source:
 3. **Warehouse**
 4. **Database**
 5. **Schema**
-6. **Username**
-7. **Private key or programmatic access token** (username and password authentication is deprecated)
+6. **Username** (not required for programmatic access token authentication)
+7. **Private key or programmatic access token** (password authentication is deprecated but still supported)
 8. **JDBC URL Params** (Optional)
 
 Additionally, create a dedicated read-only Airbyte service user and role with access to all schemas needed for replication.
@@ -147,6 +147,8 @@ To create a dedicated database user, first generate a key pair as described in [
 -- set variables (these need to be uppercase)
 SET AIRBYTE_ROLE = 'AIRBYTE_ROLE';
 SET AIRBYTE_USERNAME = 'AIRBYTE_USER';
+SET AIRBYTE_WAREHOUSE = 'AIRBYTE_WAREHOUSE';
+SET AIRBYTE_SCHEMA = 'AIRBYTE_DATABASE.AIRBYTE_SCHEMA';
 
 BEGIN;
 


### PR DESCRIPTION
## What

Deprecates username/password authentication for the Snowflake **source** connector (v2.0.0), mirroring https://github.com/airbytehq/airbyte/pull/85314 for the destination. This aligns with [Snowflake's deprecation of single-factor password authentication](https://docs.snowflake.com/en/user-guide/security-mfa-rollout), enforced on a rolling per-account basis between August and October 2026.

Requested by Sunil Kuruba (@sunil-kuruba).

## How

- `metadata.yaml`: bump `1.1.2` -> `2.0.0`; add `releases.breakingChanges.2.0.0` (`upgradeDeadline: 2026-11-01`, `deadlineAction: auto_upgrade`, message links to the migration guide).
- `SnowflakeSourceConfigurationSpecification.kt`: `UsernamePasswordCredentialsSpecification` title -> `Username and Password (Deprecated)`, add a `@JsonSchemaDescription` linking to the migration guide, and mark the `password` field description as deprecated. The `auth_type` discriminator (`username/password`) is unchanged, so existing configs still deserialize.
- `docs/integrations/sources/snowflake.md`: `:::danger` deprecation alert at the top; setup SQL now creates a `TYPE = SERVICE` user with an RSA public key instead of a password (and defines all `$AIRBYTE_*` variables it uses); auth section reordered to key pair (recommended) / PAT / username-password (deprecated); 2.0.0 changelog entry.
- `docs/integrations/sources/snowflake-migrations.md`: new "Upgrading to 2.0.0" section with key pair generation, `ALTER USER ... SET rsa_public_key`, Airbyte UI steps, and optional `UNSET PASSWORD` / `SET TYPE = SERVICE`, plus a pointer to PAT auth as the alternative.

Unlike the destination, the source also supports Programmatic Access Token auth, so the docs and breaking-change message present it as an alternative to key pair.

## Review guide

1. `airbyte-integrations/connectors/source-snowflake/metadata.yaml`
2. `airbyte-integrations/connectors/source-snowflake/src/main/kotlin/io/airbyte/integrations/source/snowflake/SnowflakeSourceConfigurationSpecification.kt`
3. `docs/integrations/sources/snowflake-migrations.md`
4. `docs/integrations/sources/snowflake.md`

## User Impact

Users on username/password see the auth option labeled as deprecated in the UI and receive the breaking-change notice with a link to the migration guide. No functional change: password auth still works until Snowflake enforces MFA on the account. Key pair / PAT users are unaffected. Connections are auto-upgraded after the 2026-11-01 deadline.

Not tested locally: gradle `spotlessKotlinCheck` could not resolve plugins in this environment (Maven 429s); the Kotlin change is annotation-only and formatted like the destination PR, so relying on CI for format/spec checks.

## Can this PR be safely reverted and rolled back?
- [x] YES 💚
- [ ] NO ❌

Link to Devin session: https://app.devin.ai/sessions/e614f70910764e37aa52abfeee2758d6
Open in Devin Desktop: https://app.devin.ai/desktop/session/e614f70910764e37aa52abfeee2758d6?variant=devin

---

> [!IMPORTANT]
> **Autopilot Progressive Rollout Enabled**
>
> [Autopilot progressive rollouts](https://github.com/airbytehq/airbyte-ops-mcp/blob/main/docs/autopilot-rollouts.md) are enabled for one or more connector(s) modified in this PR. Check the box below if you need to bypass normal rollout safety processes and release to all users immediately upon merge:
>
> - [x] ⚡ **Release immediately** (bypasses automatic progressive rollout)
>
> **Note:**
>
> - ⚠️ The above bypass option is for emergency/hotfix use only.
> - 🔗 You can monitor or manually advance a rollout at **[ops.internal.airbyte.ai](https://ops.internal.airbyte.ai)**.