### PR TITLE
ci(rollout-gate): skip progressive rollout gate on fork PRs

### DIFF
--- a/.github/workflows/connector-active-progressive-rollout-checks.yml
+++ b/.github/workflows/connector-active-progressive-rollout-checks.yml
@@ -57,6 +57,9 @@ jobs:
           if [[ "${checkout_repository}" == airbytehq/* ]]; then
             is_fork="false"
           fi
+          if [[ "${is_fork}" == "true" && -z "${INPUT_PR}" ]]; then
+            echo "::notice::Progressive rollout gate is skipped on fork PRs (org secrets and write tokens are unavailable). Maintainers can run this workflow via workflow_dispatch with pr=${pr_number} to evaluate the gate and add the bypass checkbox."
+          fi
 
           echo "pr-number=${pr_number}" | tee -a "${GITHUB_OUTPUT}"
           echo "pr-repository=${pr_repository}" | tee -a "${GITHUB_OUTPUT}"
@@ -103,9 +106,13 @@ jobs:
       connectors-matrix: ${{ steps.connector-matrix.outputs.connectors_matrix }}
       checkout-repository: ${{ steps.vars.outputs.checkout-repository }}
       checkout-ref: ${{ steps.vars.outputs.ref }}
+      is-fork: ${{ steps.vars.outputs.is-fork }}
 
   progressive-rollout-gate:
     needs: [generate-matrix]
+    if: >
+      github.event_name != 'pull_request' ||
+      needs.generate-matrix.outputs.is-fork != 'true'
     strategy:
       matrix: ${{ fromJson(needs.generate-matrix.outputs.connectors-matrix) }}
       max-parallel: 10


### PR DESCRIPTION
## What
On community (fork) PRs, the `Connector Active Progressive Rollout Checks` workflow always fails. The `pull_request` event on a fork runs with no org secrets and a read-only `GITHUB_TOKEN`, so the gate job dies at "Start Cloud SQL Proxy" (`GCP_PROD_DB_ACCESS_CREDENTIALS` is empty) and never reaches the steps that add the bypass checkbox to the PR description — which would also fail with a read-only token.

Example: https://github.com/airbytehq/airbyte/pull/85081 (source-snowflake), surfaced in Slack.

## How
Mirror the approach already used by `autopilot-release-immediately-checkbox.yml`:

- Export `is-fork` from `generate-matrix` (already computed there).
- Skip the `progressive-rollout-gate` job when `github.event_name == 'pull_request' && is-fork == 'true'`. The summary job already treats a skipped gate as a pass.
- Emit a `::notice::` on fork PRs pointing maintainers at `workflow_dispatch` (`pr=<number>`), which runs from the base repo with secrets and a write token and therefore can evaluate the gate and add the checkbox/comment.

## Review guide
1. `.github/workflows/connector-active-progressive-rollout-checks.yml`

## User Impact
Fork PRs no longer show a red "Progressive Rollout Gate" check that can never pass. Maintainers who want the gate evaluated on a fork PR trigger the workflow manually via `workflow_dispatch`.

## Can this PR be safely reverted and rolled back?
- [x] YES 💚
- [ ] NO ❌


Link to Devin session: https://app.devin.ai/sessions/a4da40229c81419ba3c054cac6d0d747
Open in Devin Desktop: https://app.devin.ai/desktop/session/a4da40229c81419ba3c054cac6d0d747?variant=devin
Requested by: @aaronsteers