### PR TITLE
feat(source-postgres): add CDC e2e harness skill (source-postgres-e2e-cdc-tests)

### DIFF
--- a/airbyte-integrations/connectors/source-postgres/.agents/skills/source-postgres-e2e-cdc-tests/SKILL.md
+++ b/airbyte-integrations/connectors/source-postgres/.agents/skills/source-postgres-e2e-cdc-tests/SKILL.md
@@ -1,0 +1,170 @@
+---
+name: source-postgres-e2e-cdc-tests
+description: Reproduce PostgreSQL logical-decoding CDC behavior against a local PostgreSQL backend with CDC-aware fixtures, catalogs, and smoke cases. Composes on source-postgres-e2e-tests and db-harness-lib.
+---
+
+# source-postgres-e2e-cdc-tests
+
+Local CDC test harness for `source-postgres`. It builds on the
+engine-independent orchestration in
+[`airbyte-integrations/db-harness-lib/`](../../../../../db-harness-lib/) and
+the generic PostgreSQL skill
+([`source-postgres-e2e-tests`](../source-postgres-e2e-tests/SKILL.md)). The
+generic skill starts a PostgreSQL 16 backend and runs the connector; this skill
+supplies the logical-decoding CDC config, CDC catalog, SQL fixtures, and case
+scripts.
+
+PostgreSQL CDC uses logical decoding from a publication and replication slot.
+The generic PostgreSQL backend starts with the WAL and replication settings
+required by this skill, so this skill does not start a second backend or add
+per-run server configuration.
+
+## When to use this skill
+
+- Reproducing a CDC-mode `source-postgres` bug locally.
+- Verifying a fix with a published connector image or `VERSION=dev` after
+  building the connector locally.
+- Running the initial-load and incremental-replay smoke cases.
+- Authoring a new PostgreSQL CDC repro with an idempotent SQL fixture and a case
+  script that invokes the generic skill's `scripts/run.sh`.
+
+## Prerequisites
+
+Same as the generic skill:
+
+- Docker, `uv`, `jq`, and a clone of `airbytehq/airbyte`.
+- The backend container `source-postgres-db-backend`, started by
+  `../source-postgres-e2e-tests/scripts/start-backend.sh`.
+
+You do not need GSM or Cloud admin credentials. Never run this harness against
+a customer connection or Airbyte Cloud.
+
+## Layout
+
+```
+source-postgres-e2e-cdc-tests/
+├── SKILL.md
+├── cases/
+│   ├── initial-load.sh             # CDC initial-load smoke case
+│   └── incremental-replay.sh       # read → mutate → read-with-state smoke case
+└── fixtures/
+    ├── configs/
+    │   └── cdc.template.json       # CDC replication config
+    ├── catalogs/
+    │   └── users-cdc.json          # users stream with PostgreSQL CDC metadata
+    └── sql/
+        ├── 00-init-cdc.sql         # publication, slot, table, and rows
+        └── mutate-insert-users.sql # row inserted between replay phases
+```
+
+The fixture uses the generic backend database `test_db`, because PostgreSQL
+cannot drop the database to which `apply-sql.sh` is connected. It resets the
+`users` table, publication, and logical replication slot in that database.
+
+`extract-state.py` is implemented in
+[`airbyte-integrations/db-harness-lib/scripts/extract-state.py`](../../../../../db-harness-lib/scripts/extract-state.py);
+it extracts protocol-level STATE messages and is not engine-specific.
+
+## Conventions
+
+- Cases reuse the generic backend and pass `--keep-backend`. Start it once at
+  the top of a session, run the cases, and tear it down when finished.
+- The generic PostgreSQL backend starts with `wal_level=logical`,
+  `max_replication_slots=10`, and `max_wal_senders=10`. Do not add per-run
+  server configuration or start another backend in this skill.
+- `00-init-cdc.sql` drops and recreates the `users` table, publication, and
+  `airbyte_slot` in `test_db` on every application. Re-applying it resets the
+  fixture, which is why `cases/incremental-replay.sh` passes `--skip-fixtures`
+  on its second phase.
+- PostgreSQL 3.8.5 discovers `_ab_cdc_lsn` as the source-defined cursor and
+  does not include the newer generated catalog fields in discover output.
+  The configured catalog includes `is_file_based`, generation metadata, and
+  destination metadata because the pinned image requires those fields when
+  initializing `read`.
+- Cases default to `VERSION=3.8.5`, the current published image used by this
+  harness. Override it with `VERSION=dev` after building a local image.
+- Assertions are declarative `run.sh` expectations. The runner enforces
+  `--expect-test`, `--expect-match`, `--forbid-match`, `--min-records`, and
+  `--min-states` before returning.
+- Multi-phase cases extract the latest STATE message with the shared
+  `extract-state.py` and pass it to the next invocation with `--state=PATH`.
+
+## Usage
+
+```bash
+SKILL=airbyte-integrations/connectors/source-postgres/.agents/skills/source-postgres-e2e-cdc-tests
+GENERIC=airbyte-integrations/connectors/source-postgres/.agents/skills/source-postgres-e2e-tests
+LIB=airbyte-integrations/db-harness-lib
+export REPRO_OUT=/tmp/source-postgres-repro
+
+# Start the logical-decoding-ready backend once.
+"$GENERIC/scripts/start-backend.sh"
+
+# Run either smoke case. Both pass --keep-backend.
+"$SKILL/cases/initial-load.sh"
+"$SKILL/cases/incremental-replay.sh"
+
+# Use a locally built connector image after a code change.
+VERSION=dev "$SKILL/cases/initial-load.sh"
+
+# Tear down after the session.
+BACKEND_NAME=source-postgres-db-backend \
+  "$LIB/scripts/stop-backend.sh"
+```
+
+Prefer a published target image for code on a pushed PR branch. Publish a
+pre-release with the Airbyte Ops MCP tool
+`publish_connector_to_airbyte_registry`, then pass the resulting
+`<version>-preview.<7-char-sha>` tag as `--test-version`. See
+[Getting a target image](../../../../../db-harness-lib/README.md#getting-a-target-image)
+for details. Use `--test-version=dev` only for code that is not on a pushed
+PR branch.
+
+Each case invokes the generic skill's engine shim, which delegates to
+`airbyte-integrations/db-harness-lib/scripts/run.sh`. The runner applies the
+fixture, renders the config, runs the requested connector command, stores
+artifacts under `$REPRO_OUT/<step-name>/`, and enforces the case assertions.
+
+## Worked examples
+
+### Initial CDC load
+
+`cases/initial-load.sh` applies `00-init-cdc.sql` and reads the configured
+`users` stream with `cdc.template.json` and `users-cdc.json`. It asserts a
+passing read with at least three records and one STATE message. This verifies
+that the logical-decoding-ready backend, CDC config, catalog metadata, and
+initial load work together.
+
+### Incremental replay
+
+`cases/incremental-replay.sh` runs a baseline read, extracts its STATE message,
+inserts `dave@example.com`, and replays from the saved state without
+re-applying fixtures. It asserts a passing replay containing
+`dave@example.com` and no `alice@example.com`, proving that the saved LSN
+resumes after the initial load.
+
+These are smoke canaries, not per-bug reproductions. No PostgreSQL CDC fixtures
+or worked per-bug examples existed before this skill.
+
+## Authoring a new repro
+
+1. Add an idempotent SQL fixture under `fixtures/sql/`. Keep CDC setup in the
+   configured database and do not add per-run server configuration.
+2. Add a CDC-aware catalog under `fixtures/catalogs/` when the case needs a
+   stream shape not covered by `users-cdc.json`. Use the source-defined cursor
+   emitted by `discover` for the pinned connector version.
+3. Add `cases/<name>.sh` with `set -euo pipefail`, a `${VERSION:-3.8.5}`
+   default, and a call to the generic skill's `scripts/run.sh`. Pass
+   `--config-template`, `--catalog`, `--fixture`, `--keep-backend`, and the
+   relevant `--expect-*` flags.
+4. For a multi-phase case, model the sequence on
+   `cases/incremental-replay.sh`: baseline `read`, extract STATE from
+   `$REPRO_OUT/<step>/read/stdout.txt`, mutate through the generic
+   `apply-sql.sh`, then run with `--skip-fixtures --state=PATH`.
+5. Verify the case against a published image or `VERSION=dev`, inspect its
+   artifacts, and keep the backend lifecycle in the generic skill.
+
+The generic `apply-sql.sh` uses `psql` on stdin, so fixtures may contain
+multiple statements. Logical replication settings are established when the
+generic backend starts; no additional CDC setup is needed in a case beyond the
+publication and replication slot in the SQL fixture.

--- a/airbyte-integrations/connectors/source-postgres/.agents/skills/source-postgres-e2e-cdc-tests/cases/incremental-replay.sh
+++ b/airbyte-integrations/connectors/source-postgres/.agents/skills/source-postgres-e2e-cdc-tests/cases/incremental-replay.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+SKILL="$(cd "$HERE/.." && pwd)"
+GENERIC="$(cd "$SKILL/../source-postgres-e2e-tests" && pwd)"
+REPO_ROOT="$(git -C "$HERE" rev-parse --show-toplevel)"
+LIB="$REPO_ROOT/airbyte-integrations/db-harness-lib"
+
+REPRO_OUT="${REPRO_OUT:-/tmp/source-postgres-repro}"
+VERSION="${VERSION:-3.8.5}"
+STEP_NAME="${STEP_NAME:-cdc-replay}"
+BASELINE_STATE="$REPRO_OUT/$STEP_NAME/state.json"
+export REPRO_OUT
+
+"$GENERIC/scripts/run.sh" \
+  --command=read \
+  --test-version="$VERSION" \
+  --step-name="$STEP_NAME/baseline" \
+  --fixture="$SKILL/fixtures/sql/00-init-cdc.sql" \
+  --config-template="$SKILL/fixtures/configs/cdc.template.json" \
+  --catalog="$SKILL/fixtures/catalogs/users-cdc.json" \
+  --keep-backend \
+  --expect-test=pass \
+  --min-records=3 \
+  --min-states=1
+
+mkdir -p "$(dirname "$BASELINE_STATE")"
+"$LIB/scripts/extract-state.py" \
+  "$REPRO_OUT/$STEP_NAME/baseline/read/stdout.txt" \
+  > "$BASELINE_STATE"
+"$GENERIC/scripts/apply-sql.sh" \
+  "$SKILL/fixtures/sql/mutate-insert-users.sql"
+
+"$GENERIC/scripts/run.sh" \
+  --command=read \
+  --test-version="$VERSION" \
+  --step-name="$STEP_NAME/replay" \
+  --skip-fixtures \
+  --config-template="$SKILL/fixtures/configs/cdc.template.json" \
+  --catalog="$SKILL/fixtures/catalogs/users-cdc.json" \
+  --state="$BASELINE_STATE" \
+  --keep-backend \
+  --expect-test=pass \
+  --expect-match='stdout:dave@example\.com' \
+  --forbid-match='stdout:alice@example\.com' \
+  --min-records=1 \
+  --min-states=1

--- a/airbyte-integrations/connectors/source-postgres/.agents/skills/source-postgres-e2e-cdc-tests/cases/initial-load.sh
+++ b/airbyte-integrations/connectors/source-postgres/.agents/skills/source-postgres-e2e-cdc-tests/cases/initial-load.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+SKILL="$(cd "$HERE/.." && pwd)"
+GENERIC="$(cd "$SKILL/../source-postgres-e2e-tests" && pwd)"
+
+"$GENERIC/scripts/run.sh" \
+  --command=read \
+  --test-version="${VERSION:-3.8.5}" \
+  --step-name=cdc-initial-load \
+  --fixture="$SKILL/fixtures/sql/00-init-cdc.sql" \
+  --config-template="$SKILL/fixtures/configs/cdc.template.json" \
+  --catalog="$SKILL/fixtures/catalogs/users-cdc.json" \
+  --keep-backend \
+  --expect-test=pass \
+  --min-records=3 \
+  --min-states=1

--- a/airbyte-integrations/connectors/source-postgres/.agents/skills/source-postgres-e2e-cdc-tests/fixtures/catalogs/users-cdc.json
+++ b/airbyte-integrations/connectors/source-postgres/.agents/skills/source-postgres-e2e-cdc-tests/fixtures/catalogs/users-cdc.json
@@ -1,0 +1,49 @@
+{
+  "streams": [
+    {
+      "stream": {
+        "name": "users",
+        "json_schema": {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string"
+            },
+            "id": {
+              "airbyte_type": "integer",
+              "type": "number"
+            },
+            "email": {
+              "type": "string"
+            },
+            "_ab_cdc_lsn": {
+              "type": "number"
+            },
+            "_ab_cdc_updated_at": {
+              "type": "string"
+            },
+            "_ab_cdc_deleted_at": {
+              "type": "string"
+            }
+          }
+        },
+        "supported_sync_modes": ["full_refresh", "incremental"],
+        "source_defined_cursor": true,
+        "default_cursor_field": ["_ab_cdc_lsn"],
+        "source_defined_primary_key": [["id"]],
+        "namespace": "public",
+        "is_resumable": true,
+        "is_file_based": false
+      },
+      "sync_mode": "incremental",
+      "destination_sync_mode": "append_dedup",
+      "primary_key": [["id"]],
+      "cursor_field": ["_ab_cdc_lsn"],
+      "generation_id": 0,
+      "minimum_generation_id": 0,
+      "sync_id": 0,
+      "destination_object_name": "users",
+      "include_files": false
+    }
+  ]
+}

--- a/airbyte-integrations/connectors/source-postgres/.agents/skills/source-postgres-e2e-cdc-tests/fixtures/configs/cdc.template.json
+++ b/airbyte-integrations/connectors/source-postgres/.agents/skills/source-postgres-e2e-cdc-tests/fixtures/configs/cdc.template.json
@@ -1,0 +1,20 @@
+{
+  "host": "source-postgres-db-backend",
+  "port": 5432,
+  "database": "test_db",
+  "schemas": ["public"],
+  "username": "postgres",
+  "password": "test_password",
+  "ssl_mode": {
+    "mode": "prefer"
+  },
+  "tunnel_method": {
+    "tunnel_method": "NO_TUNNEL"
+  },
+  "replication_method": {
+    "method": "CDC",
+    "replication_slot": "airbyte_slot",
+    "publication": "airbyte_publication",
+    "initial_waiting_seconds": 120
+  }
+}

--- a/airbyte-integrations/connectors/source-postgres/.agents/skills/source-postgres-e2e-cdc-tests/fixtures/sql/00-init-cdc.sql
+++ b/airbyte-integrations/connectors/source-postgres/.agents/skills/source-postgres-e2e-cdc-tests/fixtures/sql/00-init-cdc.sql
@@ -1,0 +1,29 @@
+-- Initialize the PostgreSQL logical replication CDC fixture.
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM pg_replication_slots
+    WHERE slot_name = 'airbyte_slot'
+  ) THEN
+    PERFORM pg_drop_replication_slot('airbyte_slot');
+  END IF;
+END
+$$;
+
+DROP PUBLICATION IF EXISTS airbyte_publication;
+DROP TABLE IF EXISTS public.users;
+
+CREATE TABLE public.users (
+  id SERIAL PRIMARY KEY,
+  name VARCHAR(64) NOT NULL,
+  email VARCHAR(200) NOT NULL
+);
+
+INSERT INTO public.users (name, email) VALUES
+  ('alice', 'alice@example.com'),
+  ('bob', 'bob@example.com'),
+  ('carol', 'carol@example.com');
+
+CREATE PUBLICATION airbyte_publication FOR TABLE public.users;
+SELECT pg_create_logical_replication_slot('airbyte_slot', 'pgoutput');

--- a/airbyte-integrations/connectors/source-postgres/.agents/skills/source-postgres-e2e-cdc-tests/fixtures/sql/mutate-insert-users.sql
+++ b/airbyte-integrations/connectors/source-postgres/.agents/skills/source-postgres-e2e-cdc-tests/fixtures/sql/mutate-insert-users.sql
@@ -1,0 +1,1 @@
+INSERT INTO public.users (name, email) VALUES ('dave', 'dave@example.com');

--- a/airbyte-integrations/connectors/source-postgres/.agents/skills/source-postgres-e2e-tests/SKILL.md
+++ b/airbyte-integrations/connectors/source-postgres/.agents/skills/source-postgres-e2e-tests/SKILL.md
@@ -43,7 +43,7 @@ You do not need GSM or Cloud admin credentials. Local-only mode (no
 source-postgres-e2e-tests/
 ├── SKILL.md
 ├── scripts/
-│   ├── start-backend.sh        # docker run postgres:16
+│   ├── start-backend.sh        # docker run postgres:16 with logical replication
 │   ├── apply-sql.sh            # docker exec psql on stdin
 │   ├── reset-databases.sh      # drop and recreate non-system databases
 │   └── run.sh                  # engine shim to db-harness-lib orchestration
@@ -171,9 +171,11 @@ in single-version mode.
 
 ## Common gotchas
 
-- **CDC is not included in this pilot.** The lifecycle starts a standard
-  PostgreSQL 16 server without WAL or replication settings, and CDC fixtures
-  are not yet stood up.
+- **CDC is not included in this skill.** The lifecycle starts PostgreSQL 16
+  with logical replication enabled so the composed
+  [`source-postgres-e2e-cdc-tests`](../source-postgres-e2e-cdc-tests/SKILL.md)
+  skill can use the same backend. CDC fixtures and case scripts live in that
+  skill.
 - **PostgreSQL config shapes are specific.** `ssl_mode.mode` uses
   `prefer` for the local plaintext backend. The
   `replication_method.method` value for a standard sync is `Standard`.

--- a/airbyte-integrations/connectors/source-postgres/.agents/skills/source-postgres-e2e-tests/scripts/start-backend.sh
+++ b/airbyte-integrations/connectors/source-postgres/.agents/skills/source-postgres-e2e-tests/scripts/start-backend.sh
@@ -25,7 +25,10 @@ else
     -e POSTGRES_PASSWORD="$BACKEND_PASSWORD" \
     -e POSTGRES_DB="$BACKEND_DB" \
     -p "$BACKEND_PORT:5432" \
-    "$BACKEND_IMAGE" >/dev/null
+    "$BACKEND_IMAGE" \
+    -c wal_level=logical \
+    -c max_replication_slots=10 \
+    -c max_wal_senders=10 >/dev/null
 fi
 
 echo "[start-backend] waiting for $BACKEND_NAME to accept connections…" >&2


### PR DESCRIPTION
## What
Adds a local PostgreSQL CDC e2e harness skill, `source-postgres-e2e-cdc-tests`, completing CDC coverage for the third engine on `db-harness-lib` (after MSSQL and MySQL — see #85315 for the MySQL equivalent). Until now, CDC-mode `source-postgres` issues could not be exercised by the local harness.

Linear: HYD-145. Requested by Sophie Cui.

## How
Mirrors the MySQL CDC skill's shape: the CDC skill composes on the generic `source-postgres-e2e-tests` skill and supplies only CDC-specific content — no second backend, no new shim.

- `fixtures/sql/00-init-cdc.sql` — idempotent: drops/recreates the `users` table, `airbyte_publication` (FOR TABLE users), and `airbyte_slot` (pgoutput) in `test_db`; slot dropped first via a guarded `pg_drop_replication_slot`. The fixture stays in `test_db` because postgres can't drop the database `apply-sql.sh` is connected to.
- `fixtures/configs/cdc.template.json` — `replication_method: {method: CDC, replication_slot: airbyte_slot, publication: airbyte_publication, initial_waiting_seconds: 120}` (120 is the spec's minimum; the 1200s default makes empty reads far too slow locally).
- `fixtures/catalogs/users-cdc.json` — discovered stream shape (source-defined cursor `_ab_cdc_lsn`) plus the configured-catalog fields (`is_file_based`, generation/sync metadata) that the pinned 3.8.5 image requires at `read` init.
- `cases/initial-load.sh` and `cases/incremental-replay.sh` — same smoke cases as MySQL CDC: initial load asserts ≥3 RECORD/≥1 STATE; replay extracts STATE via the shared `extract-state.py`, inserts `dave@example.com`, replays with `--skip-fixtures --state=...`, asserts dave present and alice absent.
- Generic skill's `start-backend.sh` now always starts postgres with `-c wal_level=logical -c max_replication_slots=10 -c max_wal_senders=10`, mirroring the MySQL pattern where the generic backend is already CDC-ready.

Deliberately no `dockerImageTag` bump or changelog entry (docs/skill-only change, same convention as #85310/#85315) — the version-increment check will be red as expected.

## Review guide
1. `source-postgres-e2e-cdc-tests/SKILL.md`
2. `fixtures/sql/00-init-cdc.sql`, `fixtures/configs/cdc.template.json`, `fixtures/catalogs/users-cdc.json`
3. `cases/initial-load.sh`, `cases/incremental-replay.sh`
4. `source-postgres-e2e-tests/scripts/start-backend.sh` (logical replication flags)

## User Impact
None on the published connector. Enables local CDC prove-fix work for `source-postgres`.

Test evidence (local, against `airbyte/source-postgres:3.8.5`): initial load READ PASS — 3 RECORD / 2 STATE; incremental replay READ PASS — 1 RECORD / 1 STATE with `dave@example.com` emitted and `alice@example.com` absent.

## Can this PR be safely reverted and rolled back?
- [x] YES 💚


Link to Devin session: https://app.devin.ai/sessions/b22932c814334daeb43c5b5c470dde3b
Open in Devin Desktop: https://app.devin.ai/desktop/session/b22932c814334daeb43c5b5c470dde3b?variant=devin
Requested by: @sophiecuiy

> [!IMPORTANT]
> Active progressive rollout warning for source-postgres.

- [ ] (Click to Approve:) Bypass the active progressive rollout warning for source-postgres in the PR comment [here](https://github.com/airbytehq/airbyte/pull/85334#issuecomment-5531860148).

---

> [!IMPORTANT]
> **Autopilot Progressive Rollout Enabled**
>
> [Autopilot progressive rollouts](https://github.com/airbytehq/airbyte-ops-mcp/blob/main/docs/autopilot-rollouts.md) are enabled for one or more connector(s) modified in this PR. Check the box below if you need to bypass normal rollout safety processes and release to all users immediately upon merge:
>
> - [ ] ⚡ **Release immediately** (bypasses automatic progressive rollout)
>
> **Note:**
>
> - ⚠️ The above bypass option is for emergency/hotfix use only.
> - 🔗 You can monitor or manually advance a rollout at **[ops.internal.airbyte.ai](https://ops.internal.airbyte.ai)**.

> [!IMPORTANT]
> ⚡ **Auto-merge enabled.**
> 
> _This PR is set to merge automatically when all requirements are met._