### PR TITLE
feat(source-mongodb-v2): add local e2e harness skill on db-harness-lib

### DIFF
--- a/airbyte-integrations/connectors/source-mongodb-v2/.agents/skills/source-mongodb-v2-e2e-tests/SKILL.md
+++ b/airbyte-integrations/connectors/source-mongodb-v2/.agents/skills/source-mongodb-v2-e2e-tests/SKILL.md
@@ -128,9 +128,11 @@ All other `run.sh` options (`--command`, `--fixture`, `--config-template`,
   reproduce schemaless (`data` blob) behavior.
 - **`_id` types.** Fixtures use integer `_id`s for readability; use
   `ObjectId()` in a fixture when the bug depends on ObjectId serialization.
-- **Discovery only sees non-empty collections.** A `db.createCollection()`
-  without documents is still discovered, but with `schema_enforced: true`
-  it will have no sampled fields beyond `_id`.
+- **Schema inference needs documents.** An empty collection created with
+  `db.createCollection()` is still listed by `discover`, but with
+  `schema_enforced: true` its schema has no sampled fields beyond `_id`.
+  Insert at least one document in the fixture for every field you expect
+  in the catalog.
 - **Reset drops databases, not the replica set.** `--reset=fixture` removes
   all non-system databases and reapplies fixtures; the oplog and resume
   tokens survive. Use `--reset=backend` when a run must start from a fresh

--- a/airbyte-integrations/connectors/source-mongodb-v2/.agents/skills/source-mongodb-v2-e2e-tests/SKILL.md
+++ b/airbyte-integrations/connectors/source-mongodb-v2/.agents/skills/source-mongodb-v2-e2e-tests/SKILL.md
@@ -1,0 +1,151 @@
+---
+name: source-mongodb-v2-e2e-tests
+description: Stand up a local MongoDB 7.0 single-node replica set, apply mongosh JavaScript fixtures, and sweep the Airbyte protocol commands (spec → check → discover → read) against airbyte/source-mongodb-v2:<tag> for ad-hoc end-to-end testing. Use when you need a deterministic, throwaway local environment for any non-CDC source-mongodb-v2 test or prove-fix comparison.
+---
+
+# source-mongodb-v2-e2e-tests
+
+Local end-to-end test harness for `source-mongodb-v2`. The engine-independent
+orchestration lives in
+[`airbyte-integrations/db-harness-lib/`](../../../../../db-harness-lib/);
+this skill keeps the MongoDB backend lifecycle scripts, fixtures, and config
+templates. It stands up a MongoDB 7.0 container named
+`source-mongodb-v2-db-backend` configured as a single-node replica set
+(`rs0`), lets you apply arbitrary `mongosh` JavaScript fixtures, and runs
+Airbyte protocol commands against any `airbyte/source-mongodb-v2:<tag>` image
+via `airbyte-ops cloud connector regression-test`.
+
+Scope: non-CDC (full-refresh / initial-snapshot) behavior. Change-stream
+resume-token replay and CDC comparison flows are not covered by this skill.
+
+## When to use this skill
+
+- Reproducing a `source-mongodb-v2` bug locally without Atlas credentials.
+- Sweeping `spec` → `check` → `discover` → `read`, or running one of them,
+  against any `airbyte/source-mongodb-v2:<tag>` for connector development.
+- Proving a fix by comparing a target image with a control image.
+
+## Prerequisites
+
+- Docker.
+- [`uv`](https://docs.astral.sh/uv/). `uv tool install
+airbyte-internal-ops` puts `airbyte-ops` on `$PATH`; alternatively prefix
+  every call with `uvx airbyte-internal-ops`.
+- `jq`.
+- A clone of `airbytehq/airbyte`.
+
+You do not need GSM, Atlas, or Cloud admin credentials. Local-only mode (no
+`--connection-id`) reads everything from local files.
+
+## Layout
+
+```
+source-mongodb-v2-e2e-tests/
+├── SKILL.md
+├── scripts/
+│   ├── start-backend.sh        # docker run mongo:7.0 --replSet rs0; rs.initiate()
+│   ├── apply-sql.sh            # docker exec mongosh with a .js fixture on stdin
+│   ├── reset-databases.sh      # drop every non-system database
+│   └── run.sh                  # engine shim to db-harness-lib orchestration
+└── fixtures/
+    ├── configs/
+    │   └── base.template.json  # SELF_MANAGED_REPLICA_SET config; host placeholder
+    └── js/
+        └── 00-init-base.js     # test_db.sample with three documents
+```
+
+`apply-sql.sh` keeps the db-harness-lib engine entrypoint name, but MongoDB
+fixtures are `mongosh` scripts, not SQL. Each fixture runs with `test_db`
+(`BACKEND_DB`) as the current `db`; use `db.getSiblingDB(...)` for others.
+
+## Conventions
+
+- Container name: `source-mongodb-v2-db-backend`. Override via
+  `BACKEND_NAME=…` only for parallel test isolation; don't use customer
+  connection names.
+- No authentication. The backend runs without `--auth`; the config's
+  `database_config` omits `username`/`password`. Add them to a copied
+  template if you need to reproduce an auth-specific issue.
+- Replica set: `rs0` (`BACKEND_REPLSET`). The connector requires a replica
+  set even for non-CDC reads. `start-backend.sh` registers the single member
+  under the container's bridge IP so the connector container, which performs
+  replica-set discovery from the seed list, can reach the advertised host.
+  Do not change the member host to `localhost`: the connector would then
+  fail to connect.
+- Initial database: `test_db`. Override with `BACKEND_DB`; keep
+  `database_config.databases` in the config template in sync.
+- Working directory for rendered configs and run output:
+  `${REPRO_OUT:-/tmp/source-mongodb-v2-repro}`, laid out as
+  `$REPRO_OUT/<step-name>/{config.json,configured_catalog.json,<command>/}`.
+- Both containers share Docker's default `bridge` network. The engine shim
+  sets `CONFIG_HOST_JQ` so the shared
+  [`render-config.sh`](../../../../../db-harness-lib/scripts/render-config.sh)
+  rewrites `database_config.connection_string` to
+  `mongodb://<bridge-ip>:27017/?replicaSet=rs0` at runtime.
+- The backend image is pinned to `mongo:7.0`. Override with `BACKEND_IMAGE=…`
+  for a version-specific reproduction.
+
+## Usage
+
+`scripts/run.sh` is the only supported entrypoint. It performs the whole
+sequence — start the backend, apply the fixtures, render the config, run
+`spec` → `check` → `discover`, derive the configured catalog from that
+`discover` output, run `read`, and tear down on exit:
+
+```bash
+cd airbyte-integrations/connectors/source-mongodb-v2
+
+# Single version, full sweep.
+poe e2e-local --test-version=2.0.7
+
+# Target vs. control comparison.
+poe e2e-local --test-version=dev --control-version=2.0.6 --reset=fixture
+
+# One command only.
+poe e2e-local --command=read --test-version=2.0.7
+```
+
+The sweep runs every command against the one backend and reports each
+result rather than stopping at the first failure, then prints a summary
+table and exits non-zero if any command failed. Under CI the table is also
+appended to `$GITHUB_STEP_SUMMARY`.
+
+Prefer a published target image for code on a pushed PR branch (publish a
+pre-release with the Airbyte Ops MCP tool
+`publish_connector_to_airbyte_registry` and pass the resulting
+`<version>-preview.<7-char-sha>` tag as `--test-version`). See
+[Getting a target image](../../../../../db-harness-lib/README.md#getting-a-target-image).
+All other `run.sh` options (`--command`, `--fixture`, `--config-template`,
+`--reset`, `--expect-*`, `--min-records`, …) are documented in the
+[db-harness-lib README](../../../../../db-harness-lib/README.md) and
+`poe e2e-local --help`.
+
+## Common gotchas
+
+- **Schema enforcement.** The base template sets
+  `database_config.schema_enforced: true`, so `discover` samples documents
+  and emits typed fields. Set it to `false` in a copied template to
+  reproduce schemaless (`data` blob) behavior.
+- **`_id` types.** Fixtures use integer `_id`s for readability; use
+  `ObjectId()` in a fixture when the bug depends on ObjectId serialization.
+- **Discovery only sees non-empty collections.** A `db.createCollection()`
+  without documents is still discovered, but with `schema_enforced: true`
+  it will have no sampled fields beyond `_id`.
+- **Reset drops databases, not the replica set.** `--reset=fixture` removes
+  all non-system databases and reapplies fixtures; the oplog and resume
+  tokens survive. Use `--reset=backend` when a run must start from a fresh
+  oplog.
+- **Do not use customer connections.** This harness is for local testing
+  only and must never be used against customer connections, Atlas clusters
+  holding customer data, or Airbyte Cloud.
+
+## Teardown
+
+The shared library's default `stop-backend.sh` is idempotent:
+
+```bash
+BACKEND_NAME=source-mongodb-v2-db-backend \
+  airbyte-integrations/db-harness-lib/scripts/stop-backend.sh
+rm -rf "$REPRO_OUT"
+unset REPRO_OUT
+```

--- a/airbyte-integrations/connectors/source-mongodb-v2/.agents/skills/source-mongodb-v2-e2e-tests/SKILL.md
+++ b/airbyte-integrations/connectors/source-mongodb-v2/.agents/skills/source-mongodb-v2-e2e-tests/SKILL.md
@@ -115,8 +115,9 @@ pre-release with the Airbyte Ops MCP tool
 `publish_connector_to_airbyte_registry` and pass the resulting
 `<version>-preview.<7-char-sha>` tag as `--test-version`). See
 [Getting a target image](../../../../../db-harness-lib/README.md#getting-a-target-image).
-All other `run.sh` options (`--command`, `--fixture`, `--config-template`,
-`--reset`, `--expect-*`, `--min-records`, …) are documented in the
+All other `run.sh` options (`--command`, `--fixture`, `--skip-fixtures`,
+`--config-template`, `--catalog`, `--state=PATH`, `--reset`, `--expect-*`,
+`--min-records`, …) are documented in the
 [db-harness-lib README](../../../../../db-harness-lib/README.md) and
 `poe e2e-local --help`.
 
@@ -135,8 +136,15 @@ All other `run.sh` options (`--command`, `--fixture`, `--config-template`,
   in the catalog.
 - **Reset drops databases, not the replica set.** `--reset=fixture` removes
   all non-system databases and reapplies fixtures; the oplog and resume
-  tokens survive. Use `--reset=backend` when a run must start from a fresh
-  oplog.
+  tokens survive. This only matters once change-stream (CDC) coverage
+  lands (HYD-147 phase 2); non-CDC sweeps do not read the oplog. Use
+  `--reset=backend` when a run must start from a fresh oplog.
+- **Databases are created on first write.** MongoDB has no `CREATE
+  DATABASE`; `test_db` exists only once a fixture inserts into it, so a
+  fixture that only calls `db.createCollection(...)` or writes to a
+  `getSiblingDB(...)` database leaves `test_db` absent and `discover` empty.
+  `00-init-base.js` inserts into `test_db`; keep that in any fixture set you
+  pass with `--fixture`.
 - **Do not use customer connections.** This harness is for local testing
   only and must never be used against customer connections, Atlas clusters
   holding customer data, or Airbyte Cloud.

--- a/airbyte-integrations/connectors/source-mongodb-v2/.agents/skills/source-mongodb-v2-e2e-tests/fixtures/configs/base.template.json
+++ b/airbyte-integrations/connectors/source-mongodb-v2/.agents/skills/source-mongodb-v2-e2e-tests/fixtures/configs/base.template.json
@@ -1,0 +1,15 @@
+{
+  "database_config": {
+    "cluster_type": "SELF_MANAGED_REPLICA_SET",
+    "connection_string": "mongodb://source-mongodb-v2-db-backend:27017/?replicaSet=rs0",
+    "databases": ["test_db"],
+    "schema_enforced": true
+  },
+  "initial_waiting_seconds": 120,
+  "queue_size": 10000,
+  "discover_sample_size": 10000,
+  "discover_timeout_seconds": 600,
+  "invalid_cdc_cursor_position_behavior": "Fail sync",
+  "update_capture_mode": "Lookup",
+  "initial_load_timeout_hours": 8
+}

--- a/airbyte-integrations/connectors/source-mongodb-v2/.agents/skills/source-mongodb-v2-e2e-tests/fixtures/configs/base.template.json
+++ b/airbyte-integrations/connectors/source-mongodb-v2/.agents/skills/source-mongodb-v2-e2e-tests/fixtures/configs/base.template.json
@@ -1,7 +1,7 @@
 {
   "database_config": {
     "cluster_type": "SELF_MANAGED_REPLICA_SET",
-    "connection_string": "mongodb://source-mongodb-v2-db-backend:27017/?replicaSet=rs0",
+    "connection_string": "REPLACED_BY_RENDER_CONFIG",
     "databases": ["test_db"],
     "schema_enforced": true
   },

--- a/airbyte-integrations/connectors/source-mongodb-v2/.agents/skills/source-mongodb-v2-e2e-tests/fixtures/js/.gitignore
+++ b/airbyte-integrations/connectors/source-mongodb-v2/.agents/skills/source-mongodb-v2-e2e-tests/fixtures/js/.gitignore
@@ -1,0 +1,2 @@
+# Uncommitted per-bug fixtures
+.tmp/

--- a/airbyte-integrations/connectors/source-mongodb-v2/.agents/skills/source-mongodb-v2-e2e-tests/fixtures/js/00-init-base.js
+++ b/airbyte-integrations/connectors/source-mongodb-v2/.agents/skills/source-mongodb-v2-e2e-tests/fixtures/js/00-init-base.js
@@ -1,0 +1,11 @@
+// Idempotent base init for source-mongodb-v2 e2e tests (non-CDC).
+// mongosh starts in test_db (BACKEND_DB); this fixture (re)creates a small
+// sample collection with three documents.
+
+db.sample.drop();
+
+db.sample.insertMany([
+  { _id: 1, label: "alpha" },
+  { _id: 2, label: "beta" },
+  { _id: 3, label: "gamma" },
+]);

--- a/airbyte-integrations/connectors/source-mongodb-v2/.agents/skills/source-mongodb-v2-e2e-tests/scripts/apply-sql.sh
+++ b/airbyte-integrations/connectors/source-mongodb-v2/.agents/skills/source-mongodb-v2-e2e-tests/scripts/apply-sql.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Apply a mongosh JavaScript fixture to the e2e backend on stdin.
+#
+# The name follows the db-harness-lib engine contract (apply-sql.sh), but
+# MongoDB fixtures are mongosh scripts (.js), not SQL.
+#
+# Usage:  apply-sql.sh <path/to/fixture.js>
+#
+# Env:
+#   BACKEND_NAME        container name (default: source-mongodb-v2-db-backend)
+#   BACKEND_DB          database the script starts in (default: test_db)
+set -euo pipefail
+
+BACKEND_NAME="${BACKEND_NAME:-source-mongodb-v2-db-backend}"
+BACKEND_DB="${BACKEND_DB:-test_db}"
+
+if [[ $# -lt 1 ]]; then
+  echo "usage: $(basename "$0") <path/to/fixture.js>" >&2
+  exit 2
+fi
+FIXTURE="$1"
+if [[ ! -f "$FIXTURE" ]]; then
+  echo "[apply-sql] not a file: $FIXTURE" >&2
+  exit 2
+fi
+
+docker exec -i "$BACKEND_NAME" \
+  mongosh --quiet "mongodb://localhost:27017/$BACKEND_DB" < "$FIXTURE"
+echo "[apply-sql] applied $FIXTURE." >&2

--- a/airbyte-integrations/connectors/source-mongodb-v2/.agents/skills/source-mongodb-v2-e2e-tests/scripts/reset-databases.sh
+++ b/airbyte-integrations/connectors/source-mongodb-v2/.agents/skills/source-mongodb-v2-e2e-tests/scripts/reset-databases.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Drop every non-system database on the source-mongodb-v2 e2e backend.
+# Used by run.sh --reset=fixture before a second comparison sweep.
+#
+# Env:
+#   BACKEND_NAME        container name (default: source-mongodb-v2-db-backend)
+set -euo pipefail
+
+BACKEND_NAME="${BACKEND_NAME:-source-mongodb-v2-db-backend}"
+
+echo "[reset-databases] dropping non-system databases on $BACKEND_NAME" >&2
+docker exec -i "$BACKEND_NAME" mongosh --quiet --eval '
+  const system = new Set(["admin", "local", "config"]);
+  db.adminCommand({ listDatabases: 1, nameOnly: true }).databases
+    .map((d) => d.name)
+    .filter((name) => !system.has(name))
+    .forEach((name) => {
+      db.getSiblingDB(name).dropDatabase();
+      print(`[reset-databases] dropped ${name}`);
+    });
+' >&2

--- a/airbyte-integrations/connectors/source-mongodb-v2/.agents/skills/source-mongodb-v2-e2e-tests/scripts/reset-databases.sh
+++ b/airbyte-integrations/connectors/source-mongodb-v2/.agents/skills/source-mongodb-v2-e2e-tests/scripts/reset-databases.sh
@@ -2,6 +2,11 @@
 # Drop every non-system database on the source-mongodb-v2 e2e backend.
 # Used by run.sh --reset=fixture before a second comparison sweep.
 #
+# Nothing is recreated here: MongoDB has no CREATE DATABASE, a database
+# exists once a collection in it receives its first write. The fixtures
+# re-applied after this reset (00-init-base.js by default) insert into
+# BACKEND_DB and thereby recreate it.
+#
 # Env:
 #   BACKEND_NAME        container name (default: source-mongodb-v2-db-backend)
 set -euo pipefail

--- a/airbyte-integrations/connectors/source-mongodb-v2/.agents/skills/source-mongodb-v2-e2e-tests/scripts/run.sh
+++ b/airbyte-integrations/connectors/source-mongodb-v2/.agents/skills/source-mongodb-v2-e2e-tests/scripts/run.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# MongoDB engine shim; orchestration lives in db-harness-lib.
+set -euo pipefail
+
+SKILL_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+REPO_ROOT="$(git -C "$SKILL_DIR" rev-parse --show-toplevel)"
+export CONNECTOR=source-mongodb-v2
+export ENGINE_SCRIPTS_DIR="$SKILL_DIR/scripts"
+export DEFAULT_CONFIG_TEMPLATE="$SKILL_DIR/fixtures/configs/base.template.json"
+export DEFAULT_FIXTURE="$SKILL_DIR/fixtures/js/00-init-base.js"
+export BACKEND_NAME="${BACKEND_NAME:-source-mongodb-v2-db-backend}"
+export BACKEND_REPLSET="${BACKEND_REPLSET:-rs0}"
+# The connector takes a connection string rather than host/port fields.
+export CONFIG_HOST_JQ="${CONFIG_HOST_JQ:-.database_config.connection_string = (\"mongodb://\" + \$h + \":27017/?replicaSet=$BACKEND_REPLSET\")}"
+
+exec "$REPO_ROOT/airbyte-integrations/db-harness-lib/scripts/run.sh" "$@"

--- a/airbyte-integrations/connectors/source-mongodb-v2/.agents/skills/source-mongodb-v2-e2e-tests/scripts/start-backend.sh
+++ b/airbyte-integrations/connectors/source-mongodb-v2/.agents/skills/source-mongodb-v2-e2e-tests/scripts/start-backend.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# Start a throwaway single-node MongoDB replica set for source-mongodb-v2
+# e2e tests. Idempotent: succeeds whether or not the container already
+# exists.
+#
+# The connector requires a replica set (it reads the oplog / change
+# streams even for non-CDC discovery of the resume token), so the node is
+# started with --replSet and initiated once it accepts connections. The
+# replica-set member is registered under the container's bridge IP, not
+# `localhost`, because the connector container launched by `airbyte-ops`
+# performs replica-set discovery and must be able to reach the advertised
+# host.
+#
+# Env:
+#   BACKEND_NAME        container name (default: source-mongodb-v2-db-backend)
+#   BACKEND_PORT        host port mapped to 27017/tcp (default: 27017)
+#   BACKEND_IMAGE       image (default: mongo:7.0)
+#   BACKEND_REPLSET     replica set name (default: rs0)
+set -euo pipefail
+
+BACKEND_NAME="${BACKEND_NAME:-source-mongodb-v2-db-backend}"
+BACKEND_PORT="${BACKEND_PORT:-27017}"
+BACKEND_IMAGE="${BACKEND_IMAGE:-mongo:7.0}"
+BACKEND_REPLSET="${BACKEND_REPLSET:-rs0}"
+
+mongosh() {
+  docker exec -i "$BACKEND_NAME" mongosh --quiet "$@"
+}
+
+if [[ "$(docker inspect -f '{{.State.Running}}' "$BACKEND_NAME" 2>/dev/null || echo false)" == "true" ]]; then
+  echo "[start-backend] $BACKEND_NAME already running; reusing." >&2
+else
+  docker rm -f "$BACKEND_NAME" >/dev/null 2>&1 || true
+  docker run -d --rm \
+    --name "$BACKEND_NAME" \
+    -p "$BACKEND_PORT:27017" \
+    "$BACKEND_IMAGE" \
+    --replSet "$BACKEND_REPLSET" \
+    --bind_ip_all >/dev/null
+fi
+
+echo "[start-backend] waiting for $BACKEND_NAME to accept connections…" >&2
+ready=false
+for _ in $(seq 1 60); do
+  if mongosh --eval 'db.adminCommand({ ping: 1 })' >/dev/null 2>&1; then
+    ready=true
+    break
+  fi
+  sleep 2
+done
+if [[ "$ready" != true ]]; then
+  echo "[start-backend] timed out waiting for $BACKEND_NAME after 120s." >&2
+  exit 1
+fi
+
+BACKEND_IP=$(docker inspect "$BACKEND_NAME" \
+  --format '{{.NetworkSettings.Networks.bridge.IPAddress}}')
+if [[ -z "$BACKEND_IP" ]]; then
+  echo "[start-backend] could not resolve bridge IP for $BACKEND_NAME." >&2
+  exit 1
+fi
+
+# rs.status() fails with NotYetInitialized (code 94) until rs.initiate().
+if mongosh --eval 'rs.status().ok' >/dev/null 2>&1; then
+  echo "[start-backend] replica set $BACKEND_REPLSET already initiated." >&2
+else
+  echo "[start-backend] initiating replica set $BACKEND_REPLSET at $BACKEND_IP:27017" >&2
+  mongosh --eval "rs.initiate({ _id: '$BACKEND_REPLSET', members: [{ _id: 0, host: '$BACKEND_IP:27017' }] })" >/dev/null
+fi
+
+echo "[start-backend] waiting for $BACKEND_NAME to elect a primary…" >&2
+for _ in $(seq 1 30); do
+  if [[ "$(mongosh --eval 'db.hello().isWritablePrimary' 2>/dev/null)" == "true" ]]; then
+    echo "[start-backend] $BACKEND_NAME ready (primary at $BACKEND_IP:27017)." >&2
+    exit 0
+  fi
+  sleep 1
+done
+
+echo "[start-backend] $BACKEND_NAME never became primary." >&2
+exit 1

--- a/airbyte-integrations/connectors/source-mongodb-v2/AGENTS.md
+++ b/airbyte-integrations/connectors/source-mongodb-v2/AGENTS.md
@@ -1,0 +1,41 @@
+> NOTE: CLAUDE.md is a symlink to AGENTS.md; update AGENTS.md (not the symlink) when changing these instructions.
+
+# source-mongodb-v2: Contributor notes
+
+`source-mongodb-v2` is a Java connector on the legacy Java CDK. Standard local
+commands:
+
+```bash
+./gradlew :airbyte-integrations:connectors:source-mongodb-v2:test
+./gradlew :airbyte-integrations:connectors:source-mongodb-v2:assemble
+./gradlew :airbyte-integrations:connectors:source-mongodb-v2:dockerBuildx
+```
+
+## Reproducing bugs locally
+
+Use the
+[`source-mongodb-v2-e2e-tests`](.agents/skills/source-mongodb-v2-e2e-tests/SKILL.md)
+skill for non-CDC local sweeps. It stands up a single-node MongoDB 7.0
+replica set (`source-mongodb-v2-db-backend`), applies `mongosh` JavaScript
+fixtures (MongoDB has no SQL; the engine's `apply-sql.sh` entrypoint takes a
+`.js` file), and sweeps `spec` → `check` → `discover` → `read` against
+`airbyte/source-mongodb-v2:<tag>`. Orchestration is delegated to
+[`airbyte-integrations/db-harness-lib/`](../../db-harness-lib/).
+
+There is no `source-mongodb-v2-e2e-cdc-tests` skill yet: change-stream
+(CDC) replay with resume tokens is not covered by the local harness. If the
+reported failure is CDC-mode, say so in the evidence plan rather than
+forcing the generic skill to cover it.
+
+```bash
+cd airbyte-integrations/connectors/source-mongodb-v2
+
+# Single-version sweep
+poe e2e-local --test-version=<tag>
+
+# Prove-fix comparison (target vs. known-bad control)
+poe e2e-local --test-version=<tag> --control-version=<control-tag>
+```
+
+**Never** repro against a customer connection, Atlas cluster, or Airbyte
+Cloud instance.

--- a/airbyte-integrations/connectors/source-mongodb-v2/CLAUDE.md
+++ b/airbyte-integrations/connectors/source-mongodb-v2/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/airbyte-integrations/connectors/source-mongodb-v2/poe_tasks.toml
+++ b/airbyte-integrations/connectors/source-mongodb-v2/poe_tasks.toml
@@ -1,3 +1,10 @@
 include = [
     "${POE_GIT_DIR}/poe-tasks/gradle-connector-tasks.toml",
 ]
+
+[tasks.e2e-local]
+help = "Run the local e2e harness end-to-end (backend, fixtures, spec/check/discover/read sweep, teardown). Arguments are forwarded to run.sh; pass --control-version=<tag> for a prove-fix target-vs-control comparison, --command=<cmd> to run a single command, and --help for the full list. See .agents/skills/source-mongodb-v2-e2e-tests/SKILL.md."
+# No `args` block: poe forwards the trailing CLI arguments verbatim. Declaring
+# them as a positional `multiple` arg instead makes poe's own parser claim the
+# leading --flags and reject the invocation.
+cmd = "${POE_PWD}/.agents/skills/source-mongodb-v2-e2e-tests/scripts/run.sh"


### PR DESCRIPTION
## What

Adds a non-CDC local e2e / prove-fix harness for `source-mongodb-v2`, the first non-SQL engine on `airbyte-integrations/db-harness-lib`. Linear: [HYD-147](https://linear.app/airbyteio/issue/HYD-147). Requested by Sophie Cui.

This gives `/ai-prove-fix` a B1 rung (local container + authored fixtures) for MongoDB, so bugs can be reproduced without Atlas or GSM credentials. CDC / change-stream resume-token replay is out of scope (phase 2 on HYD-147).

## How

New skill `airbyte-integrations/connectors/source-mongodb-v2/.agents/skills/source-mongodb-v2-e2e-tests/`, same shape as the mysql/postgres skills. No changes to `db-harness-lib`; the shared contract absorbed MongoDB via two existing knobs:

- `apply-sql.sh` keeps the engine entrypoint name but pipes a mongosh `.js` fixture (`fixtures/js/00-init-base.js`) into `docker exec mongosh`.
- The shim exports `CONFIG_HOST_JQ` so the shared `render-config.sh` rewrites `.database_config.connection_string` to `mongodb://<bridge-ip>:27017/?replicaSet=rs0` instead of `.host`.

`start-backend.sh` runs `mongo:7.0 --replSet rs0` and does `rs.initiate()` with the member host set to the container's **bridge IP** (not `localhost`): the connector container performs replica-set discovery from the seed and must be able to reach the advertised member. `reset-databases.sh` drops every DB except `admin`/`local`/`config` for `--reset=fixture`.

Config template uses `SELF_MANAGED_REPLICA_SET`, no auth, `schema_enforced: true`. `poe e2e-local` added to `poe_tasks.toml`; the existing reusable `db-harness-canary.yml` workflow is connector-parameterized, so it can dispatch `source-mongodb-v2` with no workflow change.

## Review guide

1. `scripts/start-backend.sh` — replica-set init using bridge IP
2. `scripts/run.sh` — `CONFIG_HOST_JQ` override
3. `fixtures/configs/base.template.json`
4. `SKILL.md`

## Test plan

Run locally from `airbyte-integrations/connectors/source-mongodb-v2`:

- `poe e2e-local --test-version=2.0.7` → SPEC/CHECK/DISCOVER/READ all PASS, `sample` stream read 3 records, backend torn down.
- `poe e2e-local --test-version=2.0.7 --control-version=2.0.6 --reset=fixture` → control and target sweeps both PASS; reset dropped `test_db` and fixtures re-applied between runs.
- `shellcheck` on all scripts; `pre-commit` on changed files.

Not tested: `--test-version=dev` / `--build` path, and the canary workflow dispatch for this connector.

## User Impact

None for connector users; developer tooling only.

## Can this PR be safely reverted and rolled back?
- [x] YES 💚
- [ ] NO ❌


Link to Devin session: https://app.devin.ai/sessions/2135b765562243c980fa1e293bd9b4f5
Open in Devin Desktop: https://app.devin.ai/desktop/session/2135b765562243c980fa1e293bd9b4f5?variant=devin
Requested by: @sophiecuiy

---

> [!IMPORTANT]
> **Autopilot Progressive Rollout Enabled**
>
> [Autopilot progressive rollouts](https://github.com/airbytehq/airbyte-ops-mcp/blob/main/docs/autopilot-rollouts.md) are enabled for one or more connector(s) modified in this PR. Check the box below if you need to bypass normal rollout safety processes and release to all users immediately upon merge:
>
> - [ ] ⚡ **Release immediately** (bypasses automatic progressive rollout)
>
> **Note:**
>
> - ⚠️ The above bypass option is for emergency/hotfix use only.
> - 🔗 You can monitor or manually advance a rollout at **[ops.internal.airbyte.ai](https://ops.internal.airbyte.ai)**.