### PR TITLE
docs: replace agents signup banner with Airbyte Cloud trial banner

### DIFF
--- a/docusaurus/docusaurus.config.ts
+++ b/docusaurus/docusaurus.config.ts
@@ -370,9 +370,9 @@ const config: Config = {
       indexName: "airbyte",
     },
     announcementBar: {
-      id: "try_airbyte_agents",
+      id: "try_airbyte_cloud",
       content:
-        '<a target="_blank" rel="noopener noreferrer" href="https://app.airbyte.ai?utm_source=docs&utm_medium=banner&utm_campaign=airbyte_agents_docs_banner">Try Airbyte Agents</a>! No credit card needed.',
+        '<a target="_blank" rel="noopener noreferrer" href="https://cloud.airbyte.com/signup?utm_source=docs&utm_medium=banner&utm_campaign=airbyte_cloud_docs_banner">Try Airbyte Cloud!</a> Free trial for 30 days, no credit card needed.',
       backgroundColor: "#615eff",
       textColor: "#ffffff",
       isCloseable: false,


### PR DESCRIPTION
## What
Replaces the site-wide "Try Airbyte Agents" announcement banner on docs.airbyte.com with an Airbyte Cloud free-trial banner.

Linear: https://linear.app/airbyteio/issue/DOCS-96/remove-agents-signup-banner-from-docs (requested by Ian Alton, @ian-at-airbyte).

## How
Swaps the `announcementBar` block in `docusaurus/docusaurus.config.ts`:
- `id`: `try_airbyte_agents` → `try_airbyte_cloud`
- `content`: link to `https://cloud.airbyte.com/signup?utm_source=docs&utm_medium=banner&utm_campaign=airbyte_cloud_docs_banner` with text "Try Airbyte Cloud! Free trial for 30 days, no credit card needed."

Colors and `isCloseable: false` are unchanged. UTM params follow the same convention as the previous banner.

## Review guide
1. `docusaurus/docusaurus.config.ts` — the `announcementBar` block.

## User Impact
Docs visitors see the Cloud trial banner instead of the Agents banner on every page. Verified locally with `pnpm build` in `docusaurus/` (exit 0); check the Vercel preview for rendering.

## Can this PR be safely reverted and rolled back?
- [x] YES 💚
- [ ] NO ❌

Link to Devin session: https://app.devin.ai/sessions/00c566ae192f40f2994760ac414bfcde
Open in Devin Desktop: https://app.devin.ai/desktop/session/00c566ae192f40f2994760ac414bfcde?variant=devin