### PR TITLE
fix(source-adjust): resolve strftime crash on until_today=false syncs

### DIFF
--- a/airbyte-integrations/connectors/source-adjust/metadata.yaml
+++ b/airbyte-integrations/connectors/source-adjust/metadata.yaml
@@ -5,7 +5,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: d3b7fa46-111b-419a-998a-d7f046f6d66d
-  dockerImageTag: 0.1.33
+  dockerImageTag: 0.1.34
   dockerRepository: airbyte/source-adjust
   documentationUrl: https://docs.airbyte.com/integrations/sources/adjust
   githubIssueLabel: source-adjust

--- a/airbyte-integrations/connectors/source-adjust/pyproject.toml
+++ b/airbyte-integrations/connectors/source-adjust/pyproject.toml
@@ -3,7 +3,7 @@ requires = [ "poetry-core>=1.0.0",]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
-version = "0.1.33"
+version = "0.1.34"
 name = "source-adjust"
 description = "Source implementation for Adjust."
 authors = [ "Airbyte <contact@airbyte.io>",]

--- a/airbyte-integrations/connectors/source-adjust/source_adjust/manifest.yaml
+++ b/airbyte-integrations/connectors/source-adjust/source_adjust/manifest.yaml
@@ -43,7 +43,7 @@ definitions:
         end_datetime:
           type: MinMaxDatetime
           datetime: >-
-            {{ now_utc().strftime('%Y-%m-%dT%H:%M:%SZ') if config['until_today'] else (day_delta(1)).strftime('%Y-%m-%dT%H:%M:%SZ') }}
+            {{ now_utc().strftime('%Y-%m-%dT%H:%M:%SZ') if config['until_today'] else day_delta(1, format='%Y-%m-%dT%H:%M:%SZ') }}
           datetime_format: "%Y-%m-%dT%H:%M:%SZ"
         step: P1D
         cursor_granularity: P1D

--- a/airbyte-integrations/connectors/source-adjust/unit_tests/conftest.py
+++ b/airbyte-integrations/connectors/source-adjust/unit_tests/conftest.py
@@ -17,6 +17,18 @@ def config_pass():
 
 
 @fixture
+def config_pass_until_today_false():
+    return {
+        "ingest_start": "2024-05-20T20:30:40Z",
+        "api_token": "token",
+        "metrics": ["installs", "network_installs", "network_cost", "network_ecpi"],
+        "dimensions": ["app", "partner_name", "campaign", "campaign_id_network", "campaign_network"],
+        "additional_metrics": [],
+        "until_today": False,
+    }
+
+
+@fixture
 def auth_token():
     return {"access_token": "good", "expires_in": 3600}
 

--- a/airbyte-integrations/connectors/source-adjust/unit_tests/test_incremental_streams.py
+++ b/airbyte-integrations/connectors/source-adjust/unit_tests/test_incremental_streams.py
@@ -44,7 +44,10 @@ def test_stream_slices_until_today_false(requests_mock, config_pass_until_today_
     period = 5
     start = datetime.today() - timedelta(days=period)
     inputs = {"sync_mode": SyncMode.incremental, "cursor_field": "day", "stream_state": {"day": start.isoformat()}}
-    assert list(stream.stream_slices(**inputs)) is not None
+    slices = list(stream.stream_slices(**inputs))
+    assert len(slices) > 0
+    expected_end_time = (datetime.today() - timedelta(days=1)).strftime("%Y-%m-%dT%H:%M:%SZ")
+    assert slices[-1]["end_time"][:10] == expected_end_time[:10]
 
 
 def test_supports_incremental(config_pass):

--- a/airbyte-integrations/connectors/source-adjust/unit_tests/test_incremental_streams.py
+++ b/airbyte-integrations/connectors/source-adjust/unit_tests/test_incremental_streams.py
@@ -35,6 +35,18 @@ def test_stream_slices(requests_mock, config_pass, report_url, mock_report_respo
     assert list(stream.stream_slices(**inputs)) is not None
 
 
+def test_stream_slices_until_today_false(requests_mock, config_pass_until_today_false, report_url, mock_report_response):
+    # Regression test for https://github.com/airbytehq/airbyte/issues/69799:
+    # end_datetime used to call .strftime() on day_delta()'s already-formatted
+    # string result, raising jinja2.exceptions.UndefinedError before any request was made.
+    requests_mock.get(url=report_url, status_code=200, json=mock_report_response)
+    stream = get_stream_by_name("AdjustReport", config_pass_until_today_false)
+    period = 5
+    start = datetime.today() - timedelta(days=period)
+    inputs = {"sync_mode": SyncMode.incremental, "cursor_field": "day", "stream_state": {"day": start.isoformat()}}
+    assert list(stream.stream_slices(**inputs)) is not None
+
+
 def test_supports_incremental(config_pass):
     stream = get_stream_by_name("AdjustReport", config_pass)
     assert stream.supports_incremental

--- a/docs/integrations/sources/adjust.md
+++ b/docs/integrations/sources/adjust.md
@@ -46,6 +46,7 @@ If you use Airbyte Cloud and your organization restricts access to specific IPs,
 
 | Version | Date       | Pull Request                                             | Subject                                     |
 |---------|------------| -------------------------------------------------------- |---------------------------------------------|
+| 0.1.34 | 2026-09-05 | [PLACEHOLDER_PR_NUMBER](https://github.com/airbytehq/airbyte/pull/PLACEHOLDER_PR_NUMBER) | Fix `strftime` crash on non-`until_today` sync (fixes #69799) |
 | 0.1.33 | 2025-02-01 | [52916](https://github.com/airbytehq/airbyte/pull/52916) | Update dependencies |
 | 0.1.32 | 2025-01-25 | [52196](https://github.com/airbytehq/airbyte/pull/52196) | Update dependencies |
 | 0.1.31 | 2025-01-18 | [51733](https://github.com/airbytehq/airbyte/pull/51733) | Update dependencies |

--- a/docs/integrations/sources/adjust.md
+++ b/docs/integrations/sources/adjust.md
@@ -46,7 +46,7 @@ If you use Airbyte Cloud and your organization restricts access to specific IPs,
 
 | Version | Date       | Pull Request                                             | Subject                                     |
 |---------|------------| -------------------------------------------------------- |---------------------------------------------|
-| 0.1.34 | 2026-09-05 | [PLACEHOLDER_PR_NUMBER](https://github.com/airbytehq/airbyte/pull/PLACEHOLDER_PR_NUMBER) | Fix `strftime` crash on non-`until_today` sync (fixes #69799) |
+| 0.1.34 | 2026-09-05 | [85361](https://github.com/airbytehq/airbyte/pull/85361) | Fix `strftime` crash on non-`until_today` sync (fixes #69799) |
 | 0.1.33 | 2025-02-01 | [52916](https://github.com/airbytehq/airbyte/pull/52916) | Update dependencies |
 | 0.1.32 | 2025-01-25 | [52196](https://github.com/airbytehq/airbyte/pull/52196) | Update dependencies |
 | 0.1.31 | 2025-01-18 | [51733](https://github.com/airbytehq/airbyte/pull/51733) | Update dependencies |


### PR DESCRIPTION
## What

Fixes #69799. The Adjust source connector fails `check` and stream slicing for any config where `until_today` is false (the default), raising `jinja2.exceptions.UndefinedError: 'str object' has no attribute 'strftime'` before a single request is made. This makes the connector unusable for most configurations.

## How

The manifest's `end_datetime` expression called `.strftime(...)` on the result of `day_delta(1)`, but `day_delta()` already returns a formatted string (it applies `strftime` internally). Calling `.strftime()` again on that string fails. The fix passes the desired format directly to `day_delta(1, format=...)` instead of re-formatting its already-formatted return value.

Also bumped the connector version and added a changelog entry, per the standard connector contribution process. The existing test suite's `config_pass` fixture hardcoded `until_today: True`, so it never exercised the crashing branch — added a fixture and regression test for `until_today: False` that fails with the original bug and passes with the fix.

## Review guide

1. `airbyte-integrations/connectors/source-adjust/source_adjust/manifest.yaml` — the one-line fix
2. `airbyte-integrations/connectors/source-adjust/unit_tests/conftest.py` and `unit_tests/test_incremental_streams.py` — new regression test and fixture
3. `airbyte-integrations/connectors/source-adjust/metadata.yaml`, `pyproject.toml`, `docs/integrations/sources/adjust.md` — version bump and changelog

## User Impact

Users who configure the Adjust connector without explicitly setting `until_today` to `true` (the common case) can now connect and sync successfully, instead of every sync failing at `check`.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚
