### PR TITLE
fix(docs): restore agent connector cross-link banners

### DIFF
--- a/docusaurus/src/plugins/agentConnectors.js
+++ b/docusaurus/src/plugins/agentConnectors.js
@@ -3,8 +3,9 @@
  * and exposes their slugs via global plugin data.
  *
  * The `AgentConnectorRegistry` React component reads this data with
- * `usePluginData("agent-connectors-plugin")` — no JSON file is written to disk
- * and no prebuild script is required. Docusaurus/Rspack invalidates the build
+ * `usePluginData("agent-connectors-plugin")`, and the `connectorTypeBanner`
+ * remark plugin calls `discoverAgentConnectorSlugs` directly — no JSON file is
+ * written to disk and no prebuild script is required. Docusaurus/Rspack invalidates the build
  * when `loadContent` re-runs (e.g. on restart or when watched files change).
  */
 const fs = require("fs");
@@ -45,3 +46,4 @@ function agentConnectorsPlugin(_context, _options) {
 }
 
 module.exports = agentConnectorsPlugin;
+module.exports.discoverAgentConnectorSlugs = discoverAgentConnectorSlugs;

--- a/docusaurus/src/remark/agentConnectorHeaderDecoration.js
+++ b/docusaurus/src/remark/agentConnectorHeaderDecoration.js
@@ -1,8 +1,15 @@
+const fs = require("fs");
+const path = require("path");
 const visit = require("unist-util-visit").visit;
 const { toAttributes } = require("../helpers/objects");
 
 const ICON_BASE_URL =
   "https://connectors.airbyte.com/files/metadata/airbyte";
+
+const SOURCES_DIR = path.resolve(__dirname, "../../../docs/integrations/sources");
+
+const hasDataReplicationPage = (slug) =>
+  fs.existsSync(path.join(SOURCES_DIR, `${slug}.md`));
 
 const isAgentConnectorPage = (vfile) => {
   return (
@@ -65,7 +72,7 @@ const plugin = () => {
         (ch.type === "heading" && ch.depth === 1),
     );
 
-    if (headingIdx !== -1) {
+    if (headingIdx !== -1 && hasDataReplicationPage(slug)) {
       const bannerNode = {
         type: "mdxJsxFlowElement",
         name: "ConnectorTypeBanner",

--- a/docusaurus/src/remark/connectorTypeBanner.js
+++ b/docusaurus/src/remark/connectorTypeBanner.js
@@ -1,14 +1,12 @@
 const { toAttributes } = require("../helpers/objects");
+const { discoverAgentConnectorSlugs } = require("../plugins/agentConnectors");
 const { isDocsPage } = require("./utils");
 
 let agentConnectorSlugs = null;
 
 function loadAgentConnectorSlugs() {
-  if (agentConnectorSlugs !== null) return agentConnectorSlugs;
-  try {
-    agentConnectorSlugs = require("../data/agent_connectors.json");
-  } catch {
-    agentConnectorSlugs = [];
+  if (agentConnectorSlugs === null) {
+    agentConnectorSlugs = discoverAgentConnectorSlugs();
   }
   return agentConnectorSlugs;
 }


### PR DESCRIPTION
## What

Follow-up to the agent connector bug bash in Linear [DOCS-13](https://linear.app/airbyteio/issue/DOCS-13/bug-bash-items-for-agent-connectors), requested by Ian Alton.

Of the three items in DOCS-13, only the cross-linking one is still a live defect:

- **Data replication pages don't link back to their agent connector** (e.g. `/integrations/sources/gitlab`). Still broken. `connectorTypeBanner.js` looked up agent connector slugs via `require("../data/agent_connectors.json")`, a generated manifest that no longer exists in the repo. The `catch` swallowed the error and returned `[]`, so the banner was silently never emitted on any replication page.
- **Agent pages link to non-existent replication pages.** New finding while verifying the above: `agentConnectorHeaderDecoration.js` unconditionally emits a banner to `/integrations/sources/<slug>`. Exa is the only agent connector with no replication counterpart, so https://docs.airbyte.com/ai-agents/connectors/exa/ currently links to a 404.
- **Changelog links 404** and **GitHub `issues` create/update mismatch**: verified as already resolved. The current generated READMEs no longer contain the old changelog links, and `docs/ai-agents/connectors/github/README.md` (v0.1.19) lists Issues `Create`/`Update`, matching the SDK capability catalog. No changes needed.

## How

- `connectorTypeBanner.js`: replace the JSON `require` with `discoverAgentConnectorSlugs()` from `src/plugins/agentConnectors.js`, so the remark plugin and the `AgentConnectorRegistry` plugin share the same source of truth (the directory listing of `docs/ai-agents/connectors/`).
- `agentConnectors.js`: export `discoverAgentConnectorSlugs`; comment update only otherwise.
- `agentConnectorHeaderDecoration.js`: only insert the inverse banner when `docs/integrations/sources/<slug>.md` exists.

```diff
- agentConnectorSlugs = require("../data/agent_connectors.json");
+ agentConnectorSlugs = discoverAgentConnectorSlugs();

- if (headingIdx !== -1) {
+ if (headingIdx !== -1 && hasDataReplicationPage(slug)) {
```

## Review guide

1. `docusaurus/src/remark/connectorTypeBanner.js`
2. `docusaurus/src/remark/agentConnectorHeaderDecoration.js`
3. `docusaurus/src/plugins/agentConnectors.js`

## Test plan

- Confirmed that every agent connector slug except `exa` has a matching `docs/integrations/sources/<slug>.md` (48/49), so the new guard only affects Exa.
- `cd docusaurus && pnpm install --frozen-lockfile --ignore-scripts && pnpm build` (exit 0). The `postman-code-generators` postinstall fails on my machine with a pnpm/yarn `packageManager` mismatch, hence `--ignore-scripts`; the build does not depend on it.
- Verified in `docusaurus/build/`:
  - `grep -l "For agentic operations" integrations/sources/*.html | wc -l` → 48, exactly the set of agent connector slugs minus `exa`. `gitlab.html`, `github.html`, `stripe.html` each link to `/ai-agents/connectors/<slug>/`; `postgres.html` has no banner.
  - `ai-agents/connectors/gitlab.html` and `github.html` still carry the inverse banner linking to `/integrations/sources/<slug>`.
  - `ai-agents/connectors/exa.html` contains no banner and no `/integrations/sources/exa` link.

## User Impact

Replication connector pages (GitLab, GitHub, Stripe, etc.) regain the "For agentic operations, see …" banner; the Exa agent page stops linking to a 404. No content changes.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚
- [ ] NO ❌


Link to Devin session: https://app.devin.ai/sessions/32fb913e9b254ddebeddbc0ee4af4e8a
Open in Devin Desktop: https://app.devin.ai/desktop/session/32fb913e9b254ddebeddbc0ee4af4e8a?variant=devin
Requested by: @ian-at-airbyte