### PR TITLE
docs(ai-agents): fix API interface overview bug-bash items

### DIFF
--- a/docs/ai-agents/interfaces/api/readme.md
+++ b/docs/ai-agents/interfaces/api/readme.md
@@ -3,13 +3,11 @@ plan: all
 sidebar_position: 4
 ---
 
-import SdkVsApi from '@site/static/_ai-agents-sdk-vs-api.md';
-
 # API
 
 The Agent API lets you manage connectors, credentials, and data operations programmatically over HTTP. Use it to integrate Airbyte Agents into any language or framework, or to build custom backend services that interact with third-party data sources.
 
-This section walks through the four operations most apps need: authenticate, add a connector, execute operations, and manage workspaces. Deeper endpoint details (every parameter, response schema, and error code) live in the [API reference](/ai-agents/reference/api).
+This section walks through the operations most apps need: authenticate, add a connector, execute operations, and manage workspaces. Deeper endpoint details (every parameter, response schema, and error code) live in the [API reference](/ai-agents/reference/api).
 
 ## When to use the API
 
@@ -20,19 +18,15 @@ This section walks through the four operations most apps need: authenticate, add
 
 If you're writing Python, the [SDK](../sdk/readme.md) wraps the same endpoints with a typed interface. If your agent speaks the Model Context Protocol, the [MCP server](../mcp/readme.md) gives you zero-install access. For shell scripts and CI, see the [CLI](../cli/readme.md).
 
-## Choose your interface
-
-<SdkVsApi />
-
 ## Base URL
 
 All API requests use the base URL `https://api.airbyte.ai`.
 
-If your account belongs to multiple organizations, generate your application token from the organization you want to target. The API resolves the target organization from the token, so you don't need to pass an extra header.
+If your account belongs to a single organization, the API resolves the target organization from your credentials and you don't need to pass an extra header. If your account belongs to multiple organizations, you must add an `X-Organization-Id: <organization_id>` header when you request an application token, or the API returns a `400` asking you to specify the organization. The value appears as `organization_id` on every workspace returned by [List workspaces](./workspaces.md#list-workspaces).
 
 ## How the pieces fit together
 
-The four pages in this section are designed to map one-to-one with the [SDK](../sdk/readme.md) section so the same mental model works in either environment.
+The pages in this section follow the same order as the [SDK](../sdk/readme.md) section, so the same mental model works in either environment.
 
 1. **[Authentication](./authentication/readme.md)**: Get an application token (and, when needed, a scoped token). This is how every subsequent call is authorized.
 

--- a/docs/ai-agents/interfaces/api/readme.md
+++ b/docs/ai-agents/interfaces/api/readme.md
@@ -22,7 +22,7 @@ If you're writing Python, the [SDK](../sdk/readme.md) wraps the same endpoints w
 
 All API requests use the base URL `https://api.airbyte.ai`.
 
-If your account belongs to a single organization, the API resolves the target organization from your credentials and you don't need to pass an extra header. If your account belongs to multiple organizations, you must add an `X-Organization-Id: <organization_id>` header when you request an application token, or the API returns a `400` asking you to specify the organization. The value appears as `organization_id` on every workspace returned by [List workspaces](./workspaces.md#list-workspaces).
+If your account belongs to a single organization, the API resolves the target organization from your credentials and you don't need to pass an extra header. If your account belongs to multiple organizations, you must add an `X-Organization-Id: <organization_id>` header when you request an application token, or the API returns a `400` asking you to specify the organization. To find the ID, run `airbyte-agent organizations list` with the [CLI](../cli/workspaces.md#list-organizations), or copy it from the `/organizations/<organization_id>` URL after you select the organization in [app.airbyte.ai](https://app.airbyte.ai).
 
 ## How the pieces fit together
 

--- a/docs/ai-agents/interfaces/sdk/readme.md
+++ b/docs/ai-agents/interfaces/sdk/readme.md
@@ -4,7 +4,6 @@ sidebar_position: 2
 ---
 
 import DocCardList from '@theme/DocCardList';
-import SdkVsApi from '@site/static/\_ai-agents-sdk-vs-api.md';
 
 # SDK
 
@@ -19,10 +18,6 @@ This section walks through authenticate, add a connector, and execute operations
 - You prefer in-process library calls over shelling out to a binary or making raw HTTP requests.
 
 If your agent already supports the Model Context Protocol, the [MCP server](../mcp/readme.md) gives you zero-install access. If you prefer a shell binary, see the [CLI](../cli/readme.md). For non-Python backends, use the [API](../api/readme.md) directly.
-
-## Choose your interface
-
-<SdkVsApi />
 
 ## Log in and sign up
 

--- a/docusaurus/static/_ai-agents-sdk-vs-api.md
+++ b/docusaurus/static/_ai-agents-sdk-vs-api.md
@@ -1,9 +1,0 @@
-You can use Airbyte Agents programmatically in several ways:
-
-- [**MCP server**](/ai-agents/interfaces/mcp): a remote, Airbyte-hosted server. Best for AI agents that speak the Model Context Protocol (Claude, ChatGPT, Cursor, VS Code). Zero install.
-- [**SDK**](/ai-agents/interfaces/sdk): a typed Python library. Best for Python apps, notebooks, scripts, and AI agents built with frameworks like Pydantic AI or LangChain.
-- [**CLI**](/ai-agents/interfaces/cli): a shell interface with composable JSON output. Best for scripts, CI jobs, and AI-agent harnesses that call command-line tools.
-- [**API**](/ai-agents/interfaces/api): an HTTP API. Best for non-Python backends, custom admin flows, and languages the SDK doesn't cover.
-- [**Web app**](/ai-agents/interfaces/ui): a browser UI at [app.airbyte.ai](https://app.airbyte.ai). Best for no-code exploration and scheduled automations.
-
-All interfaces share the same connectors, credentials, and [Context Store](/ai-agents/concepts/context-store). See [Choose how to use Airbyte Agents](/ai-agents/get-started/choose-how-to-use) for a detailed comparison.


### PR DESCRIPTION
## What
Resolves the three bug-bash findings from [DOCS-14](https://linear.app/airbyteio/issue/DOCS-14/bug-bash-items-for-api-interface-pages) on `docs/ai-agents/interfaces/api/readme.md`. Requested by Ian Alton.

## How
- Remove the "Choose your interface" block (and the `_ai-agents-sdk-vs-api.md` snippet it rendered) from the API and SDK overview pages. It duplicated the Interfaces landing page and the "When to use…" section directly above it, and reads oddly inside a sibling section.
- Correct the multi-org statement. Verified against the `POST /api/v1/account/applications/token` handler in `sonar`: with one org the API infers it from the credentials; with multiple orgs the request must carry `X-Organization-Id`, otherwise it returns `400`. Old text said the opposite (no header ever needed).
- Drop the "four pages … map one-to-one with the SDK" claim and the hard-coded "four" counts; the API section has Authentication (with a Build-your-own-OAuth sub-page) plus other pages that don't line up 1:1 with the SDK.

## Review guide
1. `docs/ai-agents/interfaces/api/readme.md`
2. `docs/ai-agents/interfaces/sdk/readme.md`
3. `docusaurus/static/_ai-agents-sdk-vs-api.md` (deleted, no remaining references)

## User Impact
API/SDK overview pages no longer give incorrect guidance about the `X-Organization-Id` header and lose one redundant section each. Link targets (`./workspaces.md#list-workspaces`) verified to exist. Docusaurus build was not run locally (deps not installed); relying on the docs build check in CI.

## Can this PR be safely reverted and rolled back?
- [x] YES 💚
- [ ] NO ❌

Link to Devin session: https://app.devin.ai/sessions/b7e1e87191434d83926e5150d81e7123
Open in Devin Desktop: https://app.devin.ai/desktop/session/b7e1e87191434d83926e5150d81e7123?variant=devin
Requested by: @ian-at-airbyte