### PR TITLE
docs: update agent connector docs pipeline to reference airbyte-agent-sdk

### DIFF
--- a/docs/community/contributing-to-airbyte/writing-docs.md
+++ b/docs/community/contributing-to-airbyte/writing-docs.md
@@ -175,7 +175,7 @@ The documentation pipeline involves three repositories and two GitHub Apps:
 
 2. **Generated repository (airbyte-agent-sdk)**: The [airbyte-agent-sdk](https://github.com/airbytehq/airbyte-agent-sdk) repository receives the SDK source and generated documentation. Each connector has its own directory under `connectors/` containing its documentation files. The sonar workflow tags each published version and creates a GitHub release in this repository.
 
-3. **Documentation repository (airbyte)**: The [sync-ai-connector-docs.yml](https://github.com/airbytehq/airbyte/blob/master/.github/workflows/sync-ai-connector-docs.yml) workflow runs every two hours (or on manual trigger). It checks out the airbyte-agent-sdk repository, copies all markdown files from `connectors/*/` to `docs/ai-agents/connectors/`, and creates an auto-merge pull request using the `octavia-bot` GitHub App. When the PR merges, Vercel deploys the updated docs automatically.
+3. **Documentation repository (airbyte)**: The [sync-ai-connector-docs.yml](https://github.com/airbytehq/airbyte/blob/master/.github/workflows/sync-ai-connector-docs.yml) workflow runs every two hours (or on manual trigger). It checks out the airbyte-agent-sdk repository, copies the markdown files (except `CHANGELOG.md`) from `connectors/*/` to `docs/ai-agents/connectors/`, and creates an auto-merge pull request using the `octavia-bot` GitHub App. When the PR merges, Vercel deploys the updated docs automatically.
 
 #### Key characteristics
 

--- a/docs/community/contributing-to-airbyte/writing-docs.md
+++ b/docs/community/contributing-to-airbyte/writing-docs.md
@@ -171,16 +171,16 @@ Agent connector documentation follows a different workflow than traditional conn
 
 The documentation pipeline involves three repositories and two GitHub Apps:
 
-1. **Source repository (sonar)**: Connector definitions live in the private [sonar](https://github.com/airbytehq/sonar) repository under `integrations/*/connector.yaml`. When changes merge to `main`, the [publish-connectors.yml](https://github.com/airbytehq/sonar/blob/main/.github/workflows/publish-connectors.yml) workflow generates Python packages including documentation files. The [BlessedConnectorGenerator](https://github.com/airbytehq/sonar/blob/main/connector-sdk/connector_sdk/codegen/generator.py) class uses Jinja2 templates ([README.md.jinja2](https://github.com/airbytehq/sonar/blob/main/connector-sdk/connector_sdk/codegen/templates/README.md.jinja2), [REFERENCE.md.jinja2](https://github.com/airbytehq/sonar/blob/main/connector-sdk/connector_sdk/codegen/templates/REFERENCE.md.jinja2)) to generate README.md and REFERENCE.md, while [generate-changelog.py](https://github.com/airbytehq/sonar/blob/main/scripts/connectors/generate-changelog.py) creates CHANGELOG.md entries. The `octavia-bot-hoard` GitHub App authenticates and pushes these generated files to the airbyte-agent-connectors repository.
+1. **Source repository (sonar)**: Connector definitions live in the private [sonar](https://github.com/airbytehq/sonar) repository under `integrations/*/connector.yaml`. When changes merge to `main`, the [publish-sdk.yml](https://github.com/airbytehq/sonar/blob/main/.github/workflows/publish-sdk.yml) workflow builds the unified `airbyte-agent-sdk` Python package, publishes it to PyPI, and generates per-connector documentation files. The [ConnectorGenerator](https://github.com/airbytehq/sonar/blob/main/connector-sdk/airbyte_agent_sdk/codegen/generator.py) class uses Jinja2 templates ([README.md.jinja2](https://github.com/airbytehq/sonar/blob/main/connector-sdk/airbyte_agent_sdk/codegen/templates/README.md.jinja2), [AUTH.md.jinja2](https://github.com/airbytehq/sonar/blob/main/connector-sdk/airbyte_agent_sdk/codegen/templates/AUTH.md.jinja2), [REFERENCE.md.jinja2](https://github.com/airbytehq/sonar/blob/main/connector-sdk/airbyte_agent_sdk/codegen/templates/REFERENCE.md.jinja2)) to generate README.md, AUTH.md, and REFERENCE.md. The `octavia-bot-hoard` GitHub App authenticates and pushes the package source and generated docs to the airbyte-agent-sdk repository.
 
-2. **Generated repository (airbyte-agent-connectors)**: The [airbyte-agent-connectors](https://github.com/airbytehq/airbyte-agent-connectors) repository receives the generated connector packages. Each connector has its own directory under `connectors/` containing the Python package and documentation files. The [publish.yml](https://github.com/airbytehq/airbyte-agent-connectors/blob/main/.github/workflows/publish.yml) workflow publishes packages to PyPI and creates GitHub releases.
+2. **Generated repository (airbyte-agent-sdk)**: The [airbyte-agent-sdk](https://github.com/airbytehq/airbyte-agent-sdk) repository receives the SDK source and generated documentation. Each connector has its own directory under `connectors/` containing its documentation files. The sonar workflow tags each published version and creates a GitHub release in this repository.
 
-3. **Documentation repository (airbyte)**: The [sync-ai-connector-docs.yml](https://github.com/airbytehq/airbyte/blob/master/.github/workflows/sync-ai-connector-docs.yml) workflow runs every two hours (or on manual trigger). It checks out the airbyte-agent-connectors repository, copies all markdown files from `connectors/*/` to `docs/ai-agents/connectors/`, and creates an auto-merge pull request using the `octavia-bot` GitHub App. When the PR merges, Vercel deploys the updated docs automatically.
+3. **Documentation repository (airbyte)**: The [sync-ai-connector-docs.yml](https://github.com/airbytehq/airbyte/blob/master/.github/workflows/sync-ai-connector-docs.yml) workflow runs every two hours (or on manual trigger). It checks out the airbyte-agent-sdk repository, copies all markdown files from `connectors/*/` to `docs/ai-agents/connectors/`, and creates an auto-merge pull request using the `octavia-bot` GitHub App. When the PR merges, Vercel deploys the updated docs automatically.
 
 #### Key characteristics
 
 - **Fully automated**: No manual steps are required. Changes to connector definitions in sonar automatically propagate to the public documentation.
-- **Two-hour sync cycle**: Documentation updates appear on docs.airbyte.com within two hours of changes merging to airbyte-agent-connectors.
+- **Two-hour sync cycle**: Documentation updates appear on docs.airbyte.com within two hours of changes landing in airbyte-agent-sdk.
 - **Bot-managed PRs**: The `octavia-bot-hoard` and `octavia-bot` GitHub Apps handle authentication and PR creation across repositories.
 - **Auto-merge enabled**: Documentation sync PRs are labeled for auto-merge, minimizing manual review overhead.
 
@@ -188,9 +188,8 @@ The documentation pipeline involves three repositories and two GitHub Apps:
 
 | Repository | Workflow | Purpose |
 | --- | --- | --- |
-| [sonar](https://github.com/airbytehq/sonar) | [publish-connectors.yml](https://github.com/airbytehq/sonar/blob/main/.github/workflows/publish-connectors.yml) | Generates connector packages and pushes to airbyte-agent-connectors |
-| [airbyte-agent-connectors](https://github.com/airbytehq/airbyte-agent-connectors) | [publish.yml](https://github.com/airbytehq/airbyte-agent-connectors/blob/main/.github/workflows/publish.yml) | Publishes packages to PyPI |
-| [airbyte](https://github.com/airbytehq/airbyte) | [sync-ai-connector-docs.yml](https://github.com/airbytehq/airbyte/blob/master/.github/workflows/sync-ai-connector-docs.yml) | Syncs docs from airbyte-agent-connectors to Docusaurus |
+| [sonar](https://github.com/airbytehq/sonar) | [publish-sdk.yml](https://github.com/airbytehq/sonar/blob/main/.github/workflows/publish-sdk.yml) | Builds and publishes the SDK package, generates connector docs, and pushes to airbyte-agent-sdk |
+| [airbyte](https://github.com/airbytehq/airbyte) | [sync-ai-connector-docs.yml](https://github.com/airbytehq/airbyte/blob/master/.github/workflows/sync-ai-connector-docs.yml) | Syncs docs from airbyte-agent-sdk to Docusaurus |
 
 ## Multiple instances
 


### PR DESCRIPTION
## What

The "How agent connector docs are delivered" section of the contributor guide still describes the retired `airbyte-agent-connectors` repository and a `publish-connectors.yml` workflow that no longer exists. Since the move to the unified `airbyte-agent-sdk` package, the source of truth is the public `airbyte-agent-sdk` repository, which is what `sync-ai-connector-docs.yml` actually checks out.

Noticed while working on Linear DOCS-12 (https://linear.app/airbyteio/issue/DOCS-12). Requested by Ian Alton.

## How

Text-only update to `docs/community/contributing-to-airbyte/writing-docs.md`, verified against the current sonar `publish-sdk.yml` / `sync-to-public-repo.sh` and the airbyte `sync-ai-connector-docs.yml`:

- sonar stage: `publish-connectors.yml` → `publish-sdk.yml`; `BlessedConnectorGenerator` (under `connector_sdk/`) → `ConnectorGenerator` (under `airbyte_agent_sdk/`); adds `AUTH.md.jinja2`; drops the nonexistent `generate-changelog.py` reference.
- generated-repo stage: `airbyte-agent-connectors` → `airbyte-agent-sdk`; publishing to PyPI and the GitHub release are done by the sonar workflow, so the per-repo `publish.yml` row is removed from the workflow table.
- sync stage / key characteristics: repo name only.

## Review guide

1. `docs/community/contributing-to-airbyte/writing-docs.md` (lines 174–192)

## User Impact

Contributors reading the guide get working links and the correct repository name. No site build changes.

## Can this PR be safely reverted and rolled back?
- [x] YES 💚
- [ ] NO ❌

Link to Devin session: https://app.devin.ai/sessions/f5bb2b1d981e4a79858b7244e5ed9c2a
Open in Devin Desktop: https://app.devin.ai/desktop/session/f5bb2b1d981e4a79858b7244e5ed9c2a?variant=devin
Requested by: @ian-at-airbyte