### PR TITLE
ci(agent-sdk-docs): link Sub-modules entries in generated SDK reference

### DIFF
--- a/.github/workflows/agent-sdk-docs-generate.yml
+++ b/.github/workflows/agent-sdk-docs-generate.yml
@@ -253,6 +253,8 @@ jobs:
 
           linked = 0
           for md_path in base_dir.rglob("*.md"):
+              if md_path.name.lower() == "readme.md":
+                  continue
               lines = md_path.read_text(encoding="utf-8").splitlines(keepends=True)
               changed = False
               in_section = False
@@ -263,9 +265,11 @@ jobs:
                       continue
                   if not in_section or text == "" or set(text) == {"-"}:
                       continue
-                  m = re.fullmatch(r"\* (\w+(?:\.\w+)+)", text)
-                  if m is None:
+                  if not text.startswith("* "):
                       in_section = False
+                      continue
+                  m = re.fullmatch(r"\* (\w+(?:\.\w+)+)\s*", text)
+                  if m is None:
                       continue
                   url = _module_url(m.group(1))
                   if url is None:

--- a/.github/workflows/agent-sdk-docs-generate.yml
+++ b/.github/workflows/agent-sdk-docs-generate.yml
@@ -225,6 +225,60 @@ jobs:
           print("Cross-reference resolution complete")
           PYEOF
 
+      - name: Link Sub-module Lists
+        run: |
+          # pdoc3 renders each package's "Sub-modules" section as bare dotted
+          # module names, which Docusaurus shows as plain text. Rewrite each
+          # bullet into an absolute docs link. A package resolves to its
+          # directory URL (index.md); a leaf module resolves to the doc id
+          # assigned by the frontmatter step.
+          python3 << 'PYEOF'
+          import re
+          from pathlib import Path
+
+          base_dir = Path("docs/ai-agents/reference/sdk")
+          route_base = "/ai-agents/reference/sdk"
+
+          def _module_url(module: str) -> str | None:
+              parts = module.split(".")
+              if base_dir.joinpath(*parts, "index.md").is_file():
+                  return f"{route_base}/{'/'.join(parts)}"
+              leaf = base_dir.joinpath(*parts).with_suffix(".md")
+              if not leaf.is_file():
+                  return None
+              m = re.search(r"^id: (\S+)$", leaf.read_text(encoding="utf-8"), re.MULTILINE)
+              if m is None:
+                  return None
+              return f"{route_base}/{'/'.join(parts[:-1])}/{m.group(1)}"
+
+          linked = 0
+          for md_path in base_dir.rglob("*.md"):
+              lines = md_path.read_text(encoding="utf-8").splitlines(keepends=True)
+              changed = False
+              in_section = False
+              for i, line in enumerate(lines):
+                  text = line.rstrip("\n")
+                  if text == "Sub-modules":
+                      in_section = True
+                      continue
+                  if not in_section or text == "" or set(text) == {"-"}:
+                      continue
+                  m = re.fullmatch(r"\* (\w+(?:\.\w+)+)", text)
+                  if m is None:
+                      in_section = False
+                      continue
+                  url = _module_url(m.group(1))
+                  if url is None:
+                      print(f"Unresolved sub-module {m.group(1)} in {md_path}")
+                      continue
+                  lines[i] = f"* [{m.group(1)}]({url})\n"
+                  changed = True
+                  linked += 1
+              if changed:
+                  md_path.write_text("".join(lines), encoding="utf-8")
+          print(f"Linked {linked} sub-module entries")
+          PYEOF
+
       - name: Sanitize for MDX Compatibility
         run: |
           # Docusaurus uses MDX which interprets { and } as JSX expressions,


### PR DESCRIPTION
## What

In the generated SDK reference (`/ai-agents/reference/sdk/...`), every package page has a "Sub-modules" section that pdoc3 emits as bare dotted module names (`* airbyte_agent_sdk.connectors.shopify.connector`). Docusaurus renders these as plain text, so readers can't click through to the module pages.

Linear: https://linear.app/airbyteio/issue/DOCS-12 (item 3). Requested by Ian Alton.

The fix is in the generation workflow, not the committed output; the next scheduled run of `agent-sdk-docs-generate.yml` will regenerate the pages with links.

## How

Adds a `Link Sub-module Lists` step to `.github/workflows/agent-sdk-docs-generate.yml`, between the cross-reference resolver and MDX sanitization. It only touches bullets inside a `Sub-modules` section (heading line + `---` underline, until the first non-bullet line) and rewrites each to an absolute Docusaurus link:

```
* airbyte_agent_sdk.connectors.shopify           -> [..](/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/shopify)
* airbyte_agent_sdk.connectors.shopify.connector -> [..](/ai-agents/reference/sdk/airbyte_agent_sdk/connectors/shopify/airbyte_agent_sdk-connectors-shopify-connector)
```

URL rule (matches how Docusaurus serves the existing pages, verified against the live sitemap):
- package (`<path>/index.md` exists) → directory URL
- leaf module (`<path>.md` exists) → parent directory + the `id:` written by the `Add Docusaurus Frontmatter` step (read from the target file rather than re-derived)
- anything else is left as-is and logged

## Review guide

1. `.github/workflows/agent-sdk-docs-generate.yml` — the new step (`Link Sub-module Lists`)

Local verification: extracted the step's Python and ran it against a copy of the committed `docs/ai-agents/reference/sdk` tree — `Linked 261 sub-module entries`, 0 unresolved, no bare bullets left, and running the existing `Sanitize for MDX Compatibility` step afterwards leaves the links intact. `prettier --check` and YAML parse pass on the workflow file.

## User Impact

Sub-module lists on SDK reference pages become clickable. No change to any other content.

## Can this PR be safely reverted and rolled back?
- [x] YES 💚
- [ ] NO ❌

Link to Devin session: https://app.devin.ai/sessions/f5bb2b1d981e4a79858b7244e5ed9c2a
Open in Devin Desktop: https://app.devin.ai/desktop/session/f5bb2b1d981e4a79858b7244e5ed9c2a?variant=devin
Requested by: @ian-at-airbyte