### PR TITLE
feat(source-linear): 🐙 add projectTeamIds field to issues stream

### DIFF
--- a/airbyte-integrations/connectors/source-linear/manifest.yaml
+++ b/airbyte-integrations/connectors/source-linear/manifest.yaml
@@ -55,7 +55,7 @@ definitions:
             customerTicketCount cycle { id } description descriptionState
             dueDate estimate identifier integrationSourceType labelIds number
             parent { id } previousIdentifiers priority priorityLabel
-            prioritySortOrder project { id } projectMilestone { id }
+            prioritySortOrder project { id teams { nodes { id } } } projectMilestone { id }
             reactionData snoozedBy { id } snoozedUntilAt sortOrder startedAt
             state { id } startedTriageAt subIssueSortOrder team { id } title
             trashed triagedAt updatedAt url attachments { nodes { id } }
@@ -158,6 +158,16 @@ definitions:
         field_pointers:
           - - project
             - id
+      - type: AddFields
+        fields:
+          - type: AddedFieldDefinition
+            path:
+              - projectTeamIds
+            value: "{{ record.project.teams.nodes | map(attribute='id') | list }}"
+      - type: RemoveFields
+        field_pointers:
+          - - project
+            - teams
       - type: AddFields
         fields:
           - type: AddedFieldDefinition
@@ -2355,6 +2365,14 @@ schemas:
         type:
           - object
           - "null"
+      projectTeamIds:
+        type:
+          - array
+          - "null"
+        items:
+          type:
+            - string
+            - "null"
       reactionData:
         type:
           - array

--- a/airbyte-integrations/connectors/source-linear/manifest.yaml
+++ b/airbyte-integrations/connectors/source-linear/manifest.yaml
@@ -163,7 +163,7 @@ definitions:
           - type: AddedFieldDefinition
             path:
               - projectTeamIds
-            value: "{{ record.project.teams.nodes | map(attribute='id') | list }}"
+            value: "{{ (record.project.teams.nodes | map(attribute='id') | list) if (record.project and record.project.teams) else [] }}"
       - type: RemoveFields
         field_pointers:
           - - project

--- a/airbyte-integrations/connectors/source-linear/metadata.yaml
+++ b/airbyte-integrations/connectors/source-linear/metadata.yaml
@@ -56,7 +56,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 1c5d8316-ed42-4473-8fbc-2626f03f070c
-  dockerImageTag: 1.0.0
+  dockerImageTag: 1.0.1
   dockerRepository: airbyte/source-linear
   githubIssueLabel: source-linear
   icon: icon.svg

--- a/airbyte-integrations/connectors/source-linear/unit_tests/test_incremental.py
+++ b/airbyte-integrations/connectors/source-linear/unit_tests/test_incremental.py
@@ -371,6 +371,44 @@ def test_initiative_to_projects_flattens_join_keys_and_paginates() -> None:
 
 
 @pytest.mark.parametrize(
+    ("project", "expected_project_team_ids"),
+    [
+        pytest.param(
+            {"id": "issue-1-project", "teams": {"nodes": [{"id": "team-1"}, {"id": "team-2"}]}},
+            ["team-1", "team-2"],
+            id="project-with-teams",
+        ),
+        pytest.param({"id": "issue-1-project"}, [], id="project-without-teams"),
+        pytest.param(None, [], id="project-null"),
+    ],
+)
+def test_issues_extract_project_team_ids(
+    project: Mapping[str, Any] | None,
+    expected_project_team_ids: list[str],
+) -> None:
+    """`projectTeamIds` collects the ids under `project.teams.nodes`, defaulting to [] when absent or null."""
+    source = YamlDeclarativeSource(path_to_yaml=MANIFEST_PATH, config=CONFIG)
+    streams_by_name = {stream.name: stream for stream in source.streams(config=CONFIG)}
+    record = {**_issue("issue-1", "2024-05-01T00:00:00.000Z"), "project": project}
+    request = _request(_build_full_request_body(streams_by_name["issues"], next_page_token=None))
+
+    with HttpMocker() as http_mocker:
+        http_mocker.post(request, _connection_response("issues", [record]))
+
+        output = read(
+            source=source,
+            config=CONFIG,
+            catalog=CatalogBuilder().with_stream("issues", SyncMode.full_refresh).build(),
+        )
+
+    assert len(output.records) == 1
+    data = output.records[0].record.data
+    assert data["projectTeamIds"] == expected_project_team_ids
+    # The nested `project.teams` connection is dropped after the ids are lifted out.
+    assert "teams" not in data.get("project", {})
+
+
+@pytest.mark.parametrize(
     ("response", "expected"),
     [
         pytest.param(

--- a/docs/integrations/sources/linear.md
+++ b/docs/integrations/sources/linear.md
@@ -225,7 +225,7 @@ If you use Airbyte Cloud and your organization restricts access to specific IPs,
 
 | Version | Date | Pull Request | Subject |
 | ------- | ---- | ------------ | ------- |
-| 1.0.1 | 2026-09-08 | [XXXXX](https://github.com/airbytehq/airbyte/pull/XXXXX) | Add `projectTeamIds` field to the `issues` stream |
+| 1.0.1 | 2026-09-08 | [85577](https://github.com/airbytehq/airbyte/pull/85577) | Add `projectTeamIds` field to the `issues` stream |
 | 1.0.0 | 2026-08-28 | [85095](https://github.com/airbytehq/airbyte/pull/85095) | Breaking: declare `date` and `date-time` formats on every temporal field, and drop the fields Linear deprecated in the `users`, `teams`, and `customer_statuses` queries (`teams.visibility` replaces `teams.private`). See the [migration guide](/integrations/sources/linear-migrations#upgrading-to-100). |
 | 0.4.0 | 2026-08-27 | [85056](https://github.com/airbytehq/airbyte/pull/85056) | Add initiatives, initiative-to-project relationships, project updates, and issue history streams |
 | 0.3.1 | 2026-08-26 | [85053](https://github.com/airbytehq/airbyte/pull/85053) | Add regression tests covering incremental cursor boundary behavior |

--- a/docs/integrations/sources/linear.md
+++ b/docs/integrations/sources/linear.md
@@ -225,6 +225,7 @@ If you use Airbyte Cloud and your organization restricts access to specific IPs,
 
 | Version | Date | Pull Request | Subject |
 | ------- | ---- | ------------ | ------- |
+| 1.0.1 | 2026-09-08 | [XXXXX](https://github.com/airbytehq/airbyte/pull/XXXXX) | Add `projectTeamIds` field to the `issues` stream |
 | 1.0.0 | 2026-08-28 | [85095](https://github.com/airbytehq/airbyte/pull/85095) | Breaking: declare `date` and `date-time` formats on every temporal field, and drop the fields Linear deprecated in the `users`, `teams`, and `customer_statuses` queries (`teams.visibility` replaces `teams.private`). See the [migration guide](/integrations/sources/linear-migrations#upgrading-to-100). |
 | 0.4.0 | 2026-08-27 | [85056](https://github.com/airbytehq/airbyte/pull/85056) | Add initiatives, initiative-to-project relationships, project updates, and issue history streams |
 | 0.3.1 | 2026-08-26 | [85053](https://github.com/airbytehq/airbyte/pull/85053) | Add regression tests covering incremental cursor boundary behavior |


### PR DESCRIPTION
## What

Adds a `projectTeamIds` field to the `issues` stream of `source-linear`. It exposes the IDs of the teams attached to an issue's project.

In Linear's data model an issue belongs to a single `project`, and a project can be associated with multiple teams (`Project.teams`, a connection). The connector already emits `projectId`; this adds the sibling `projectTeamIds` array so downstream consumers can join issues to their project's teams without a second sync/stream.

## How

Three changes in `manifest.yaml`, all following patterns already used by the `issues` stream:

1. **GraphQL query** — request the project's teams:
   `project { id }` → `project { id teams { nodes { id } } }`
2. **Transformation** — after the existing `projectId` extraction, add `projectTeamIds` from `record.project.teams.nodes | map(attribute='id') | list` (the same idiom used for `attachmentIds`, `labelIds`, `subscriberIds`, `relationIds`), then remove the nested `project.teams` object.
3. **Schema** — declare `projectTeamIds` as `array` of `string` (nullable), in alphabetical order in the `issues` schema.

Because `project` is nullable (an issue may have no project), I verified against the CDK's Jinja interpolation that a `null`/absent `project` yields `null` (matching the existing `projectId` behavior) rather than raising, and `null` is permitted by the `[array, "null"]` schema.

This is a purely additive, non-breaking change:
- `metadata.yaml`: `dockerImageTag` `1.0.0` → `1.0.1`
- `docs/integrations/sources/linear.md`: changelog entry for `1.0.1`

## Review guide

- `airbyte-integrations/connectors/source-linear/manifest.yaml`
- `airbyte-integrations/connectors/source-linear/metadata.yaml`
- `docs/integrations/sources/linear.md`

## Testing

- Ran the repo pre-commit hooks (prettier) on the changed files — passing.
- Validated the transformation expression against the CDK Jinja engine for project present / null / missing / empty-teams cases.